### PR TITLE
Set metadata URL as absolute hostname

### DIFF
--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -15,7 +15,7 @@ from cloudinit import util
 
 LOG = logging.getLogger(__name__)
 
-MD_V1_URL = 'http://metadata.google.internal/computeMetadata/v1/'
+MD_V1_URL = 'http://metadata.google.internal./computeMetadata/v1/'
 BUILTIN_DS_CONFIG = {'metadata_url': MD_V1_URL}
 REQUIRED_FIELDS = ('instance-id', 'availability-zone', 'local-hostname')
 


### PR DESCRIPTION
This commit changes the GCE metadata hostname from `metadata.google.internal` to `metadata.google.internal.` (with a trailing dot) to combat the resolver library's tendency to resolve `${hostname} + ${search_domain}`, potentially resulting in a form a DNS hijacking for the metadata source.

i.e. if I control the hostname, I control the domain part in the search domains, and I can control the metadata source (where `metadata.google.internal` does not resolve, but `metadata.google.internal.domain.controlled.by.me` does resolve.

Since we're not in GCE, `metadata.google.internal` does not resolve for us. However, `internal.nl` is claimed by a domain broker, and they're serving a HTML body on `*.internal.nl`, including `metadata.google.internal.nl`, short-circuiting our user-data.