### PR TITLE
Skip bond interfaces by get_interfaces

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -622,6 +622,8 @@ def get_interfaces():
             continue
         if is_vlan(name):
             continue
+        if is_bond(name):
+            continue
         mac = get_interface_mac(name)
         # some devices may not have a mac (tun0)
         if not mac:


### PR DESCRIPTION
Usually bonds inherit mac address from one of
physical interface

Closes-bug: 1812857