### PR TITLE
Fix metadata check when local-hostname is null

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -568,7 +568,7 @@ class DataSource(object):
         defhost = "localhost"
         domain = defdomain
 
-        if not self.metadata or 'local-hostname' not in self.metadata:
+        if not self.metadata or not self.metadata.get('local-hostname'):
             if metadata_only:
                 return None
             # this is somewhat questionable really.


### PR DESCRIPTION
If I run cloud-init with a config drive containing a metadata file which has
local-hostname set to null, I get the following traceback:

Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/cloudinit/sources/__init__.py", line 447, in find_source
    if s.get_data():
  File "/usr/lib/python2.7/site-packages/cloudinit/sources/__init__.py", line 132, in get_data
    self._get_standardized_metadata())
  File "/usr/lib/python2.7/site-packages/cloudinit/sources/__init__.py", line 110, in _get_standardized_metadata
    'local-hostname': self.get_hostname(),
  File "/usr/lib/python2.7/site-packages/cloudinit/sources/__init__.py", line 317, in get_hostname
    if util.is_ipv4(lhost):
  File "/usr/lib/python2.7/site-packages/cloudinit/util.py", line 544, in is_ipv4
    toks = instr.split('.')

Tested on CentOS 7.7, cloud-init 18.5.

This change fixes the issue by ignoring the local-hostname field if it is
absent or null.

LP: #1852100