### PR TITLE
correctly set usr_lib_exec path for FreeBSD distro

### DIFF
--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -25,6 +25,7 @@ LOG = logging.getLogger(__name__)
 
 
 class Distro(distros.Distro):
+    usr_lib_exec = '/usr/local/lib'
     rc_conf_fn = "/etc/rc.conf"
     login_conf_fn = '/etc/login.conf'
     login_conf_fn_bak = '/etc/login.conf.orig'


### PR DESCRIPTION
on FreeBSD our helpers live in /usr/local/lib/cloud-init/

lp: #1852491