### PR TITLE
if /sys is not available, use dmidecode

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -425,18 +425,6 @@ class TestDsIdentify(DsIdentifyBase):
         mydata['files'][cfgpath] = 'datasource_list: ["Ec2", "None"]\n'
         self._check_via_dict(mydata, rc=RC_FOUND, dslist=['Ec2', DS_NONE])
 
-    def test_dmi_decode(self):
-        """Test that dmidecode(8) works on systems which don't have /sys
-
-        This will be used on *BSD systems.
-        """
-        def printCallReturn(r):
-            _print_run_output(r.rc, r.stdout, r.stderr, r.cfg, r.files)
-
-        printCallReturn(
-            self._test_ds_found('Hetzner-dmidecode'))
-        raise Exception("BOOM")
-
     def test_aliyun_identified(self):
         """Test that Aliyun cloud is identified by product id."""
         self._test_ds_found('AliYun')
@@ -636,6 +624,21 @@ class TestDsIdentify(DsIdentifyBase):
     def test_e24cloud_not_active(self):
         """EC2: bobrightbox.com in product_serial is not brightbox'"""
         self._test_ds_not_found('Ec2-E24Cloud-negative')
+
+
+class TestBSDNoSys(DsIdentifyBase):
+    """Test *BSD code paths
+
+    FreeBSD doesn't have /sys so we use dmidecode(8) here
+    It also doesn't have systemd-detect-virt(8), so we use sysctl(8) to query
+    kern.vm_guest, and optionally map it"""
+
+    def test_dmi_decode(self):
+        """Test that dmidecode(8) works on systems which don't have /sys
+
+        This will be used on *BSD systems.
+        """
+        self._test_ds_found('Hetzner-dmidecode')
 
 
 class TestIsIBMProvisioning(DsIdentifyBase):

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -140,7 +140,8 @@ class DsIdentifyBase(CiTestCase):
             {'name': 'blkid', 'out': BLKID_EFI_ROOT},
             {'name': 'ovf_vmware_transport_guestinfo',
              'out': 'No value found', 'ret': 1},
-
+            {'name': 'dmi_decode', 'ret': 1,
+             'err': 'No dmidecode program. ERROR.'},
         ]
 
         written = [d['name'] for d in mocks]

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -721,8 +721,8 @@ def _print_run_output(rc, out, err, cfg, files):
         '-- cfg --', util.json_dumps(cfg)]))
     print('-- files --')
     for k, v in files.items():
-        #if "/_shwrap" in k:
-        #    continue
+        if "/_shwrap" in k:
+            continue
         print(' === %s ===' % k)
         for line in v.splitlines():
             print(" " + line)

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -430,7 +430,12 @@ class TestDsIdentify(DsIdentifyBase):
 
         This will be used on *BSD systems.
         """
-        self._test_ds_found('Hetzner-dmidecode')
+        def printCallReturn(r):
+            _print_run_output(r.rc, r.stdout, r.stderr, r.cfg, r.files)
+
+        printCallReturn(
+            self._test_ds_found('Hetzner-dmidecode'))
+        raise Exception("BOOM")
 
     def test_aliyun_identified(self):
         """Test that Aliyun cloud is identified by product id."""
@@ -713,8 +718,8 @@ def _print_run_output(rc, out, err, cfg, files):
         '-- cfg --', util.json_dumps(cfg)]))
     print('-- files --')
     for k, v in files.items():
-        if "/_shwrap" in k:
-            continue
+        #if "/_shwrap" in k:
+        #    continue
         print(' === %s ===' % k)
         for line in v.splitlines():
             print(" " + line)
@@ -934,8 +939,7 @@ VALID_CFG = {
     'Hetzner-dmidecode': {
         'ds': 'Hetzner',
         'mocks': [
-            {'name': 'dmi_decode', 'ret': 0,
-             'out': 'Hetzner\n'}
+            {'name': 'dmi_decode', 'ret': 0, 'RET': 'Hetzner'}
         ],
     },
     'IBMCloud-metadata': {

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -425,6 +425,13 @@ class TestDsIdentify(DsIdentifyBase):
         mydata['files'][cfgpath] = 'datasource_list: ["Ec2", "None"]\n'
         self._check_via_dict(mydata, rc=RC_FOUND, dslist=['Ec2', DS_NONE])
 
+    def test_dmi_decode(self):
+        """Test that dmidecode(8) works on systems which don't have /sys
+
+        This will be used on *BSD systems.
+        """
+        self._test_ds_found('Hetzner-dmidecode')
+
     def test_aliyun_identified(self):
         """Test that Aliyun cloud is identified by product id."""
         self._test_ds_found('AliYun')
@@ -923,6 +930,13 @@ VALID_CFG = {
     'Hetzner': {
         'ds': 'Hetzner',
         'files': {P_SYS_VENDOR: 'Hetzner\n'},
+    },
+    'Hetzner-dmidecode': {
+        'ds': 'Hetzner',
+        'mocks': [
+            {'name': 'dmi_decode', 'ret': 0,
+             'out': 'Hetzner\n'}
+        ],
     },
     'IBMCloud-metadata': {
         'ds': 'IBMCloud',

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -185,7 +185,8 @@ map_sysfs_to_dmi() {
         product_name) _RET="system-product-name";;
         product_uuid) _RET="system-uuid";;
         product_serial) _RET="system-serial-number";;
-        *) _RET=$(echo "$@" | tr '_' '-');;
+        chassis-asset-tag) _RET="chassis_asset_tag";;
+        *) return 1;;
     esac
 }
 

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -289,7 +289,11 @@ detect_virt() {
             virt="$out"
         fi
     elif [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" ]; then
-        out=$(sysctl -qn hw.vm_guest 2>/dev/null) && {
+        out=$(sysctl -qn kern.vm_guest 2>/dev/null) && {
+            # Map FreeBSD's name for Hyper-V to that of systemd-detect-virt
+            if [ "$out" = "hv" ]; then
+                out="microsoft"
+            fi
             virt="$out"
         }
     fi

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -201,8 +201,13 @@ dmi_decode() {
 get_dmi_field() {
     local path="${PATH_SYS_CLASS_DMI_ID}/$1"
     _RET="$UNAVAILABLE"
-    if [ -f "$path" ] && [ -r "$path" ]; then
-        read _RET < "${path}" || _RET="$ERROR"
+    if [ -f "${PATH_SYS_CLASS_DMI_ID}" ]; then
+        if [ -f "$path" ] && [ -r "$path" ]; then
+            read _RET < "${path}" || _RET="$ERROR"
+            return
+        fi
+        # if `/sys/class/dmi/id` exists, but not the object we're looking for,
+        # do *not* fallback to dmidecode!
         return
     fi
     dmi_decode "$1" || _RET="$ERROR"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -194,7 +194,7 @@ get_dmi_field() {
     local path="${PATH_SYS_CLASS_DMI_ID}/$1"
     if [ ! -f "$path" ] || [ ! -r "$path" ]; then
         map_sysfs_to_dmi "$1" || {
-            _RET="$UNAVAILABLE"
+            _RET="$ERROR: unknown field $1"
             return
         }
         local dmi_field="$_RET" dmi_value=""

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -287,7 +287,7 @@ detect_virt() {
         if [ $r -eq 0 ] || { [ $r -ne 0 ] && [ "$out" = "none" ]; }; then
             virt="$out"
         fi
-    elif [ "$DI_KERNEL_NAME" = "FreeBSD" ]; then
+    elif [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" ]; then
         out=$(sysctl -qn hw.vm_guest 2>/dev/null) && {
             virt="$out"
         }

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -179,10 +179,26 @@ debug() {
     echo "$@" 1>&3
 }
 
+map_sysfs_to_dmi() {
+    case "$@" in
+        sys_vendor) _RET="system-manufacturer";;
+        product_name) _RET="system-product-name";;
+        product_uuid) _RET="system-uuid";;
+        product_serial) _RET="system-serial-number";;
+        *) _RET=$(echo "$@" | tr '_' '-');;
+    esac
+}
+
 get_dmi_field() {
     local path="${PATH_SYS_CLASS_DMI_ID}/$1"
     if [ ! -f "$path" ] || [ ! -r "$path" ]; then
-        _RET="$UNAVAILABLE"
+        map_sysfs_to_dmi "$1"
+        local dmi_field="$_RET"
+        local dmi_value=$(dmidecode --quiet --string "$dmi_field") || {
+            _RET="$UNAVAILABLE"
+            return
+        }
+        _RET="$dmi_value"
         return
     fi
     read _RET < "${path}" || _RET="$ERROR"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -186,11 +186,11 @@ dmi_decode() {
         return 1
     }
     case "$1" in
-        sys_vendor) _RET="system-manufacturer";;
-        product_name) _RET="system-product-name";;
-        product_uuid) _RET="system-uuid";;
-        product_serial) _RET="system-serial-number";;
-        chassis_asset_tag) _RET="chassis-asset-tag";;
+        sys_vendor) dmi_field="system-manufacturer";;
+        product_name) dmi_field="system-product-name";;
+        product_uuid) dmi_field="system-uuid";;
+        product_serial) dmi_field="system-serial-number";;
+        chassis_asset_tag) dmi_field="chassis-asset-tag";;
         *) error "Unknown field $sys_field. Cannot call dmidecode."
            return 1;;
     esac

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -179,33 +179,34 @@ debug() {
     echo "$@" 1>&3
 }
 
-map_sysfs_to_dmi() {
-    case "$@" in
+dmi_decode() {
+    local sys_field="$1" dmi_field="" val=""
+    command -v dmidecode >/dev/null 2>&1 || {
+        warn "No dmidecode program. Cannot read $sys_field."
+        return 1
+    }
+    case "$1" in
         sys_vendor) _RET="system-manufacturer";;
         product_name) _RET="system-product-name";;
         product_uuid) _RET="system-uuid";;
         product_serial) _RET="system-serial-number";;
-        chassis-asset-tag) _RET="chassis_asset_tag";;
-        *) return 1;;
+        chassis_asset_tag) _RET="chassis-asset-tag";;
+        *) error "Unknown field $sys_field. Cannot call dmidecode."
+           return 1;;
     esac
+    val=$(dmidecode --quiet "--string=$dmi_field" 2>/dev/null) || return 1
+    _RET="$val"
 }
 
 get_dmi_field() {
     local path="${PATH_SYS_CLASS_DMI_ID}/$1"
-    if [ ! -f "$path" ] || [ ! -r "$path" ]; then
-        map_sysfs_to_dmi "$1" || {
-            _RET="$ERROR: unknown field $1"
-            return
-        }
-        local dmi_field="$_RET" dmi_value=""
-        dmi_value=$(dmidecode --quiet --string "$dmi_field") || {
-            _RET="$UNAVAILABLE"
-            return
-        }
-        _RET="$dmi_value"
+    _RET="$UNAVAILABLE"
+    if [ -f "$path" ] && [ -r "$path" ]; then
+        read _RET < "${path}" || _RET="$ERROR"
         return
     fi
-    read _RET < "${path}" || _RET="$ERROR"
+    dmi_decode "$1" || _RET="$ERROR"
+    return
 }
 
 block_dev_with_label() {

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -287,6 +287,10 @@ detect_virt() {
         if [ $r -eq 0 ] || { [ $r -ne 0 ] && [ "$out" = "none" ]; }; then
             virt="$out"
         fi
+    elif [ "$DI_KERNEL_NAME" = "FreeBSD" ]; then
+        out=$(sysctl -qn hw.vm_guest 2>/dev/null) && {
+            virt="$out"
+        }
     fi
     _RET="$virt"
 }

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -193,9 +193,12 @@ map_sysfs_to_dmi() {
 get_dmi_field() {
     local path="${PATH_SYS_CLASS_DMI_ID}/$1"
     if [ ! -f "$path" ] || [ ! -r "$path" ]; then
-        map_sysfs_to_dmi "$1"
-        local dmi_field="$_RET"
-        local dmi_value=$(dmidecode --quiet --string "$dmi_field") || {
+        map_sysfs_to_dmi "$1" || {
+            _RET="$UNAVAILABLE"
+            return
+        }
+        local dmi_field="$_RET" dmi_value=""
+        dmi_value=$(dmidecode --quiet --string "$dmi_field") || {
             _RET="$UNAVAILABLE"
             return
         }

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -299,21 +299,22 @@ detect_virt() {
         # https://github.com/freebsd/freebsd/blob/master/sys/kern/subr_param.c#L144-L160
         # https://www.freedesktop.org/software/systemd/man/systemd-detect-virt.html
         #
-        #  systemd-detect-virt | kern.vm_guest
+        #  systemd    | kern.vm_guest
         # ---------------------+---------------
-        #  none                | none
-        #  kvm                 | kvm
-        #  vmware              | vmware
-        #  microsoft           | hv
-        #  oracle              | vbox
-        #  xen                 | xen
-        #  parallels           | parallels
-        #  bhyve               | bhyve
-        #  *                   | generic <- this might be a problem
+        #  none       | none
+        #  kvm        | kvm
+        #  vmware     | vmware
+        #  microsoft  | hv
+        #  oracle     | vbox
+        #  xen        | xen
+        #  parallels  | parallels
+        #  bhyve      | bhyve
+        #  vm-other   | generic
         out=$(sysctl -qn kern.vm_guest 2>/dev/null) && {
             case "$out" in
                 hv) virt="microsoft" ;;
                 vbox) virt="oracle" ;;
+                generic) "vm-other";;
                 *) virt="$out"
             esac
         }

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -289,12 +289,28 @@ detect_virt() {
             virt="$out"
         fi
     elif [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" ]; then
+        # Map FreeBSD's vm_guest names to those systemd-detect-virt that
+        # don't match up. See
+        # https://github.com/freebsd/freebsd/blob/master/sys/kern/subr_param.c#L144-L160
+        # https://www.freedesktop.org/software/systemd/man/systemd-detect-virt.html
+        #
+        #  systemd-detect-virt | kern.vm_guest
+        # ---------------------+---------------
+        #  none                | none
+        #  kvm                 | kvm
+        #  vmware              | vmware
+        #  microsoft           | hv
+        #  oracle              | vbox
+        #  xen                 | xen
+        #  parallels           | parallels
+        #  bhyve               | bhyve
+        #  *                   | generic <- this might be a problem
         out=$(sysctl -qn kern.vm_guest 2>/dev/null) && {
-            # Map FreeBSD's name for Hyper-V to that of systemd-detect-virt
-            if [ "$out" = "hv" ]; then
-                out="microsoft"
-            fi
-            virt="$out"
+            case "$out" in
+                hv) virt="microsoft" ;;
+                vbox) virt="oracle" ;;
+                *) virt="$out"
+            esac
         }
     fi
     _RET="$virt"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -201,7 +201,7 @@ dmi_decode() {
 get_dmi_field() {
     local path="${PATH_SYS_CLASS_DMI_ID}/$1"
     _RET="$UNAVAILABLE"
-    if [ -f "${PATH_SYS_CLASS_DMI_ID}" ]; then
+    if [ -d "${PATH_SYS_CLASS_DMI_ID}" ]; then
         if [ -f "$path" ] && [ -r "$path" ]; then
             read _RET < "${path}" || _RET="$ERROR"
             return


### PR DESCRIPTION
On non-Linux systems, `/sys` won't be available.
In these cases, we can query `dmidecode(8)` directly.

To do this, we need a mapping function, since the names in
`/sys/class/dmi/id` do not match up with the ones dmidecode uses.

This pull request fixes LP#1852442