### PR TITLE
network_state: handle empty v1 config

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -69,7 +69,7 @@ def parse_net_config_data(net_config, skip_broken=True):
         # pass the whole net-config as-is
         config = net_config
 
-    if version and config:
+    if version and config is not None:
         nsi = NetworkStateInterpreter(version=version, config=config)
         nsi.parse_config(skip_broken=skip_broken)
         state = nsi.get_network_state()

--- a/cloudinit/net/tests/test_network_state.py
+++ b/cloudinit/net/tests/test_network_state.py
@@ -6,6 +6,7 @@ from cloudinit.tests.helpers import CiTestCase
 
 netstate_path = 'cloudinit.net.network_state'
 
+
 class TestNetworkStateParseConfig(CiTestCase):
 
     def setUp(self):

--- a/cloudinit/net/tests/test_network_state.py
+++ b/cloudinit/net/tests/test_network_state.py
@@ -1,0 +1,46 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import mock
+from cloudinit.net import network_state
+from cloudinit.tests.helpers import CiTestCase
+
+netstate_path = 'cloudinit.net.network_state'
+
+class TestNetworkStateParseConfig(CiTestCase):
+
+    def setUp(self):
+        super(TestNetworkStateParseConfig, self).setUp()
+        nsi_path = netstate_path + '.NetworkStateInterpreter'
+        self.add_patch(nsi_path, 'm_nsi')
+
+    def test_missing_version_returns_none(self):
+        ncfg = {}
+        self.assertEqual(None, network_state.parse_net_config_data(ncfg))
+
+    def test_unknown_versions_returns_none(self):
+        ncfg = {'version': 13.2}
+        self.assertEqual(None, network_state.parse_net_config_data(ncfg))
+
+    def test_version_2_passes_self_as_config(self):
+        ncfg = {'version': 2, 'otherconfig': {}, 'somemore': [1, 2, 3]}
+        network_state.parse_net_config_data(ncfg)
+        self.assertEqual([mock.call(version=2, config=ncfg)],
+                         self.m_nsi.call_args_list)
+
+    def test_valid_config_gets_network_state(self):
+        ncfg = {'version': 2, 'otherconfig': {}, 'somemore': [1, 2, 3]}
+        result = network_state.parse_net_config_data(ncfg)
+        self.assertNotEqual(None, result)
+
+    def test_empty_v1_config_gets_network_state(self):
+        ncfg = {'version': 1, 'config': []}
+        result = network_state.parse_net_config_data(ncfg)
+        self.assertNotEqual(None, result)
+
+    def test_empty_v2_config_gets_network_state(self):
+        ncfg = {'version': 2}
+        result = network_state.parse_net_config_data(ncfg)
+        self.assertNotEqual(None, result)
+
+
+# vi: ts=4 expandtab


### PR DESCRIPTION
Sending a valid but empty v1 network config resulted in a
stacktrace during execution.  Update the network_state
parse path to specific check if the 'config' key is None
(not present) versus being present but explicitly empty.
Also add some network_state unittests.

LP: #1852496