### PR TITLE
set_passwords: support for FreeBSD

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -179,20 +179,19 @@ def handle(_name, cfg, cloud, log, args):
         for line in plist:
             u, p = line.split(':', 1)
             if prog.match(p) is not None and ":" not in p:
-                hashed_plist_in.append("%s:%s" % (u, p))
+                hashed_plist_in.append(line)
                 hashed_users.append(u)
             else:
                 if p == "R" or p == "RANDOM":
                     p = rand_user_password()
-                    randlist.append("%s:%s" % (u, p))
-                plist_in.append("%s:%s" % (u, p))
+                    randlist.append(line)
+                plist_in.append(line)
                 users.append(u)
-
         ch_in = '\n'.join(plist_in) + '\n'
         if users:
             try:
                 log.debug("Changing password for %s:", users)
-                util.subp(['chpasswd'], ch_in)
+                chpasswd(cloud.distro, ch_in)
             except Exception as e:
                 errors.append(e)
                 util.logexc(
@@ -202,7 +201,7 @@ def handle(_name, cfg, cloud, log, args):
         if hashed_users:
             try:
                 log.debug("Setting hashed password for %s:", hashed_users)
-                util.subp(['chpasswd', '-e'], hashed_ch_in)
+                chpasswd(cloud.distro, hashed_ch_in, hashed=True)
             except Exception as e:
                 errors.append(e)
                 util.logexc(
@@ -218,7 +217,7 @@ def handle(_name, cfg, cloud, log, args):
             expired_users = []
             for u in users:
                 try:
-                    util.subp(['passwd', '--expire', u])
+                    cloud.distro.expire_passwd(u)
                     expired_users.append(u)
                 except Exception as e:
                     errors.append(e)
@@ -237,5 +236,15 @@ def handle(_name, cfg, cloud, log, args):
 
 def rand_user_password(pwlen=9):
     return util.rand_str(pwlen, select_from=PW_SET)
+
+
+def chpasswd(distro, plist_in, hashed=False):
+    if util.is_FreeBSD():
+        for pentry in plist_in.splitlines():
+            u, p = pentry.split(":")
+            distro.set_passwd(u, p, hashed=hashed)
+    else:
+        cmd = ['chpasswd'] + ['-e'] if hashed else []
+        util.subp(cmd, plist_in)
 
 # vi: ts=4 expandtab

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -244,7 +244,7 @@ def chpasswd(distro, plist_in, hashed=False):
             u, p = pentry.split(":")
             distro.set_passwd(u, p, hashed=hashed)
     else:
-        cmd = ['chpasswd'] + ['-e'] if hashed else []
+        cmd = ['chpasswd'] + (['-e'] if hashed else [])
         util.subp(cmd, plist_in)
 
 # vi: ts=4 expandtab

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -182,10 +182,12 @@ def handle(_name, cfg, cloud, log, args):
                 hashed_plist_in.append(line)
                 hashed_users.append(u)
             else:
+                # in this else branch, we potentially change the password
+                # hence, a deviation from .append(line)
                 if p == "R" or p == "RANDOM":
                     p = rand_user_password()
-                    randlist.append(line)
-                plist_in.append(line)
+                    randlist.append("%s:%s" % (u, p))
+                plist_in.append("%s:%s" % (u, p))
                 users.append(u)
         ch_in = '\n'.join(plist_in) + '\n'
         if users:

--- a/cloudinit/config/tests/test_set_passwords.py
+++ b/cloudinit/config/tests/test_set_passwords.py
@@ -125,5 +125,27 @@ class TestSetPasswordsHandle(CiTestCase):
             mock.call(['pw', 'usermod', 'ubuntu', '-p', '01-Jan-1970'])],
             m_subp.call_args_list)
 
+    @mock.patch(MODPATH + "util.is_FreeBSD")
+    @mock.patch(MODPATH + "util.subp")
+    def test_handle_on_chpasswd_list_creates_random_passwords(self, m_subp,
+                                                              m_is_freebsd):
+        """handle parses command set random passwords."""
+        m_is_freebsd.return_value = False
+        cloud = self.tmp_cloud(distro='ubuntu')
+        valid_random_pwds = [
+            'root:R',
+            'ubuntu:RANDOM']
+        cfg = {'chpasswd': {'expire': 'false', 'list': valid_random_pwds}}
+        with mock.patch(MODPATH + 'util.subp') as m_subp:
+            setpass.handle(
+                'IGNORED', cfg=cfg, cloud=cloud, log=self.logger, args=[])
+        self.assertIn(
+            'DEBUG: Handling input for chpasswd as list.',
+            self.logs.getvalue())
+        self.assertNotEqual(
+            [mock.call(['chpasswd'],
+             '\n'.join(valid_random_pwds) + '\n')],
+            m_subp.call_args_list)
+
 
 # vi: ts=4 expandtab

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -595,7 +595,7 @@ class Distro(object):
         try:
             util.subp(['passwd', '--expire', user])
         except Exception as e:
-            util.logexc(log, "Failed to set 'expire' for %s", user)
+            util.logexc(LOG, "Failed to set 'expire' for %s", user)
             raise e
 
     def set_passwd(self, user, passwd, hashed=False):

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -591,6 +591,13 @@ class Distro(object):
             util.logexc(LOG, 'Failed to disable password for user %s', name)
             raise e
 
+    def expire_passwd(self, user):
+        try:
+            util.subp(['passwd', '--expire', user])
+        except Exception as e:
+            util.logexc(log, "Failed to set 'expire' for %s", user)
+            raise e
+
     def set_passwd(self, user, passwd, hashed=False):
         pass_string = '%s:%s' % (user, passwd)
         cmd = ['chpasswd']

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -234,6 +234,13 @@ class Distro(distros.Distro):
         if passwd_val is not None:
             self.set_passwd(name, passwd_val, hashed=True)
 
+    def expire_passwd(self, user):
+        try:
+            util.subp(['pw', 'usermod', user, '-p', '01-Jan-1970'])
+        except Exception as e:
+            util.logexc(log, "Failed to set pw expiration for %s", user)
+            raise e
+
     def set_passwd(self, user, passwd, hashed=False):
         if hashed:
             hash_opt = "-H"

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -238,7 +238,7 @@ class Distro(distros.Distro):
         try:
             util.subp(['pw', 'usermod', user, '-p', '01-Jan-1970'])
         except Exception as e:
-            util.logexc(log, "Failed to set pw expiration for %s", user)
+            util.logexc(LOG, "Failed to set pw expiration for %s", user)
             raise e
 
     def set_passwd(self, user, passwd, hashed=False):

--- a/tests/unittests/test_distros/test_generic.py
+++ b/tests/unittests/test_distros/test_generic.py
@@ -244,5 +244,23 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         with self.assertRaises(NotImplementedError):
             d.get_locale()
 
+    def test_expire_passwd_uses_chpasswd(self):
+        """Test ubuntu.expire_passwd uses the passwd command."""
+        for d_name in ("ubuntu", "rhel"):
+            cls = distros.fetch(d_name)
+            d = cls(d_name, {}, None)
+            with mock.patch("cloudinit.util.subp") as m_subp:
+                d.expire_passwd("myuser")
+            m_subp.assert_called_once_with(["passwd", "--expire", "myuser"])
+
+    def test_expire_passwd_freebsd_uses_pw_command(self):
+        """Test FreeBSD.expire_passwd uses the pw command."""
+        cls = distros.fetch("freebsd")
+        d = cls("freebsd", {}, None)
+        with mock.patch("cloudinit.util.subp") as m_subp:
+            d.expire_passwd("myuser")
+        m_subp.assert_called_once_with(
+            ["pw", "usermod", "myuser", "-p", "01-Jan-1970"])
+
 
 # vi: ts=4 expandtab

--- a/tools/build-on-freebsd
+++ b/tools/build-on-freebsd
@@ -18,7 +18,6 @@ py_prefix=$(${PYTHON} -c 'import sys; print("py%d%d" % (sys.version_info.major, 
 depschecked=/tmp/c-i.dependencieschecked
 pkgs="
     bash
-    chpasswd
     dmidecode
     e2fsprogs
     $py_prefix-Jinja2


### PR DESCRIPTION
Add FreeBSD support to `cc_set_passwords`.
FreeBSD does not come with chpasswd binary, a chpasswd port[1] exists
but it's not the same tool than the one from Linux[2].

Finally, NetBSD and OpenBSD don't have the chpasswd binary at all, so
an abstraction layer will be needed.

[1]: https://www.freshports.org/www/chpasswd/
[2]: https://github.com/shadow-maint/shadow/blob/master/src/chpasswd.c