### PR TITLE
net: IPv6, accept_ra, slaac, stateless

### DIFF
--- a/tests/unittests/test_datasource/test_configdrive.py
+++ b/tests/unittests/test_datasource/test_configdrive.py
@@ -547,7 +547,8 @@ class TestNetJson(CiTestCase):
                  'mtu': None,
                  'name': 'enp0s2',
                  'subnets': [{'type': 'ipv6_dhcpv6-stateful'}],
-                 'type': 'physical'}
+                 'type': 'physical',
+                 'accept-ra': True}
             ],
         }
         conv_data = openstack.convert_net_json(in_data, known_macs=KNOWN_MACS)


### PR DESCRIPTION
Router advertisements are required for the default route
to be set up, thus accept_ra should be enabled for
dhcpv6-stateful.

sysconf: IPV6_FORCE_ACCEPT_RA controls accept_ra sysctl.
eni: mode static and mode dhcp 'accept_ra' controls sysctl.

Add 'accept-ra: true|false' parameter to config v1 and
v2. When True: accept_ra is set to '1'. When False:
accept_ra is set to '0'. When not defined in config the
value is left to the operating system default.

This change also extend the IPv6 support to distinguish
between slaac and dhcpv6-stateless. SLAAC is autoconfig
without any options from DHCP, while stateless auto-configures
the address and the uses DHCP for other options.

LP: #1806014
LP: #1808647