### PR TITLE
move uptime's else branch into its own function

### DIFF
--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -189,6 +189,21 @@ class TestUtil(CiTestCase):
         self.assertEqual(is_rw, False)
 
 
+class TestUptime(CiTestCase):
+
+    @mock.patch('cloudinit.util.boottime')
+    @mock.patch('cloudinit.util.os.path.exists')
+    @mock.patch('cloudinit.util.time.time')
+    def test_uptime_non_linux_path(self, m_time, m_exists, m_boottime):
+        boottime = 1000.0
+        uptime = 10.0
+        m_boottime.return_value = boottime
+        m_time.return_value = boottime + uptime
+        m_exists.return_value = False
+        result = util.uptime()
+        self.assertEqual(str(uptime), result)
+
+
 class TestShellify(CiTestCase):
 
     def test_input_dict_raises_type_error(self):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1826,7 +1826,7 @@ def boottime():
     libc = ctypes.CDLL('/lib/libc.so.7')
     size = ctypes.c_size_t()
     size.value = ctypes.sizeof(timeval)
-    buf = timeval
+    buf = timeval()
     if libc.sysctlbyname(b"kern.boottime" + NULL_BYTES, ctypes.byref(buf),
                          ctypes.byref(size), None, 0) != -1:
         return buf.tv_sec + buf.tv_usec / 1000000.0

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1807,6 +1807,13 @@ def time_rfc2822():
 
 
 def boottime():
+    """Use sysctlbyname(3) via ctypes to find kern.boottime
+
+    kern.boottime is of type struct timeval. Here we create a
+    private class to easier unpack it.
+
+    @return boottime: float to be compatible with linux
+    """
     import ctypes
 
     NULL_BYTES = b"\x00"
@@ -1822,7 +1829,7 @@ def boottime():
     buf = timeval
     if libc.sysctlbyname(b"kern.boottime" + NULL_BYTES, ctypes.byref(buf),
                          ctypes.byref(size), None, 0) != -1:
-        return buf.value
+        return buf.tv_sec + buf.tv_usec / 1000000.
     raise RuntimeError("Unable to retrieve kern.boottime on this system")
 
 
@@ -1837,6 +1844,7 @@ def uptime():
                 uptime_str = contents.split()[0]
         else:
             method = 'ctypes'
+            # This is the *BSD codepath
             now = time.time()
             bootup = boottime()
             uptime_str = now - bootup

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1805,6 +1805,7 @@ def time_rfc2822():
         ts = "??"
     return ts
 
+
 def boottime():
     import ctypes
 
@@ -1820,9 +1821,10 @@ def boottime():
     size.value = ctypes.sizeof(timeval)
     buf = timeval
     if libc.sysctlbyname(b"kern.boottime" + NULL_BYTES, ctypes.byref(buf),
-                      ctypes.byref(size), None, 0) != -1:
+                         ctypes.byref(size), None, 0) != -1:
         return buf.value
     raise RuntimeError("Unable to retrieve kern.boottime on this system")
+
 
 def uptime():
     uptime_str = '??'

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1829,7 +1829,7 @@ def boottime():
     buf = timeval
     if libc.sysctlbyname(b"kern.boottime" + NULL_BYTES, ctypes.byref(buf),
                          ctypes.byref(size), None, 0) != -1:
-        return buf.tv_sec + buf.tv_usec / 1000000.
+        return buf.tv_sec + buf.tv_usec / 1000000.0
     raise RuntimeError("Unable to retrieve kern.boottime on this system")
 
 
@@ -1847,7 +1847,7 @@ def uptime():
             # This is the *BSD codepath
             now = time.time()
             bootup = boottime()
-            uptime_str = now - bootup
+            uptime_str = str(now - bootup)
 
     except Exception:
         logexc(LOG, "Unable to read uptime using method: %s" % method)

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1845,9 +1845,7 @@ def uptime():
         else:
             method = 'ctypes'
             # This is the *BSD codepath
-            now = time.time()
-            bootup = boottime()
-            uptime_str = str(now - bootup)
+            uptime_str = str(time.time() - boottime())
 
     except Exception:
         logexc(LOG, "Unable to read uptime using method: %s" % method)


### PR DESCRIPTION
and fix the bugs: pass binary instead of string to sysctlbyname(), and
unpack the "return value" in a struct, rather than in single integer.

lp:1853160