### PR TITLE
ec2: Add support for AWS IMDS v2 (session-oriented)

### DIFF
--- a/cloudinit/ec2_utils.py
+++ b/cloudinit/ec2_utils.py
@@ -134,25 +134,28 @@ class MetadataMaterializer(object):
         return joined
 
 
-def _skip_retry_on_codes(status_codes, _request_args, cause):
+def skip_retry_on_codes(status_codes, _request_args, cause):
     """Returns False if cause.code is in status_codes."""
     return cause.code not in status_codes
 
 
 def get_instance_userdata(api_version='latest',
                           metadata_address='http://169.254.169.254',
-                          ssl_details=None, timeout=5, retries=5):
+                          ssl_details=None, timeout=5, retries=5,
+                          headers_cb=None, exception_cb=None):
     ud_url = url_helper.combine_url(metadata_address, api_version)
     ud_url = url_helper.combine_url(ud_url, 'user-data')
     user_data = ''
     try:
-        # It is ok for userdata to not exist (thats why we are stopping if
-        # NOT_FOUND occurs) and just in that case returning an empty string.
-        exception_cb = functools.partial(_skip_retry_on_codes,
-                                         SKIP_USERDATA_CODES)
+        if not exception_cb:
+            # It is ok for userdata to not exist (thats why we are stopping if
+            # NOT_FOUND occurs) and just in that case returning an empty
+            # string.
+            exception_cb = functools.partial(skip_retry_on_codes,
+                                             SKIP_USERDATA_CODES)
         response = url_helper.read_file_or_url(
             ud_url, ssl_details=ssl_details, timeout=timeout,
-            retries=retries, exception_cb=exception_cb)
+            retries=retries, exception_cb=exception_cb, headers_cb=headers_cb)
         user_data = response.contents
     except url_helper.UrlError as e:
         if e.code not in SKIP_USERDATA_CODES:
@@ -165,11 +168,13 @@ def get_instance_userdata(api_version='latest',
 def _get_instance_metadata(tree, api_version='latest',
                            metadata_address='http://169.254.169.254',
                            ssl_details=None, timeout=5, retries=5,
-                           leaf_decoder=None):
+                           leaf_decoder=None, headers_cb=None,
+                           exception_cb=None):
     md_url = url_helper.combine_url(metadata_address, api_version, tree)
     caller = functools.partial(
         url_helper.read_file_or_url, ssl_details=ssl_details,
-        timeout=timeout, retries=retries)
+        timeout=timeout, retries=retries, headers_cb=headers_cb,
+        exception_cb=exception_cb)
 
     def mcaller(url):
         return caller(url).contents
@@ -191,22 +196,28 @@ def _get_instance_metadata(tree, api_version='latest',
 def get_instance_metadata(api_version='latest',
                           metadata_address='http://169.254.169.254',
                           ssl_details=None, timeout=5, retries=5,
-                          leaf_decoder=None):
+                          leaf_decoder=None, headers_cb=None,
+                          exception_cb=None):
     # Note, 'meta-data' explicitly has trailing /.
     # this is required for CloudStack (LP: #1356855)
     return _get_instance_metadata(tree='meta-data/', api_version=api_version,
                                   metadata_address=metadata_address,
                                   ssl_details=ssl_details, timeout=timeout,
-                                  retries=retries, leaf_decoder=leaf_decoder)
+                                  retries=retries, leaf_decoder=leaf_decoder,
+                                  headers_cb=headers_cb,
+                                  exception_cb=exception_cb)
 
 
 def get_instance_identity(api_version='latest',
                           metadata_address='http://169.254.169.254',
                           ssl_details=None, timeout=5, retries=5,
-                          leaf_decoder=None):
+                          leaf_decoder=None, headers_cb=None,
+                          exception_cb=None):
     return _get_instance_metadata(tree='dynamic/instance-identity',
                                   api_version=api_version,
                                   metadata_address=metadata_address,
                                   ssl_details=ssl_details, timeout=timeout,
-                                  retries=retries, leaf_decoder=leaf_decoder)
+                                  retries=retries, leaf_decoder=leaf_decoder,
+                                  headers_cb=headers_cb,
+                                  exception_cb=exception_cb)
 # vi: ts=4 expandtab

--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -93,7 +93,7 @@ class DataSourceCloudStack(sources.DataSource):
         urls = [uhelp.combine_url(self.metadata_address,
                                   'latest/meta-data/instance-id')]
         start_time = time.time()
-        url = uhelp.wait_for_url(
+        url, _response = uhelp.wait_for_url(
             urls=urls, max_wait=url_params.max_wait_seconds,
             timeout=url_params.timeout_seconds, status_cb=LOG.warning)
 

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -29,7 +29,7 @@ STRICT_ID_PATH = ("datasource", "Ec2", "strict_id")
 STRICT_ID_DEFAULT = "warn"
 
 API_TOKEN_ROUTE = 'latest/api/token'
-
+AWS_TOKEN_TTL_SECONDS='21600'
 
 class CloudNames(object):
     ALIYUN = "aliyun"

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -174,7 +174,6 @@ class DataSourceEc2(sources.DataSource):
             if not getattr(self, 'identity', None):
                 # If re-using cached datasource, it's get_data run didn't
                 # setup self.identity. So we need to do that now.
-                headers = self._get_headers()
                 api_version = self.get_metadata_api_version()
                 self.identity = ec2.get_instance_identity(
                     api_version, self.metadata_address,

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -418,7 +418,7 @@ class DataSourceEc2(sources.DataSource):
         crawled_metadata['_metadata_api_version'] = api_version
         return crawled_metadata
 
-    def _refresh_api_token(self, seconds='21600'):
+    def _refresh_api_token(self, seconds=AWS_TOKEN_TTL_SECONDS):
         """Request new metadata API token.
         @param seconds: The lifetime of the token in seconds
 

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -439,7 +439,8 @@ class DataSourceEc2(sources.DataSource):
         return response.contents
 
     def _skip_or_refresh_stale_aws_token_cb(self, msg, exception):
-        retry = ec2.skip_retry_on_codes(ec2.SKIP_USERDATA_CODES, msg, exception)
+        retry = ec2.skip_retry_on_codes(
+            ec2.SKIP_USERDATA_CODES, msg, exception)
         if not retry:
             return False  # False raises exception
         return self._refresh_stale_aws_token_cb(msg, exception)

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -29,7 +29,8 @@ STRICT_ID_PATH = ("datasource", "Ec2", "strict_id")
 STRICT_ID_DEFAULT = "warn"
 
 API_TOKEN_ROUTE = 'latest/api/token'
-AWS_TOKEN_TTL_SECONDS='21600'
+AWS_TOKEN_TTL_SECONDS = '21600'
+
 
 class CloudNames(object):
     ALIYUN = "aliyun"
@@ -440,7 +441,8 @@ class DataSourceEc2(sources.DataSource):
         return response.contents
 
     def _skip_or_refresh_stale_aws_token_cb(self, msg, exception):
-        """Callback will not retry on SKIP_USERDATA_CODES or if no token is available"""
+        """Callback will not retry on SKIP_USERDATA_CODES or if no token
+           is available."""
         retry = ec2.skip_retry_on_codes(
             ec2.SKIP_USERDATA_CODES, msg, exception)
         if not retry:

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -465,7 +465,7 @@ class DataSourceEc2(sources.DataSource):
             return {}
         # Request a 6 hour token if URL is API_TOKEN_ROUTE
         request_token_header = {
-            'X-aws-ec2-metadata-token-ttl-seconds': '21600'}
+            'X-aws-ec2-metadata-token-ttl-seconds': AWS_TOKEN_TTL_SECONDS}
         if API_TOKEN_ROUTE in url:
             return request_token_header
         if not self._api_token:

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -453,7 +453,7 @@ class DataSourceEc2(sources.DataSource):
             # With _api_token as None, _get_headers will _refresh_api_token.
             LOG.debug("Clearing cached Ec2 API token due to expiry")
             self._api_token = None
-        return True
+        return True  # always retry
 
     def _get_headers(self, url=''):
         """Return a dict of headers for accessing a url.

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -440,6 +440,7 @@ class DataSourceEc2(sources.DataSource):
         return response.contents
 
     def _skip_or_refresh_stale_aws_token_cb(self, msg, exception):
+        """Callback will not retry on SKIP_USERDATA_CODES or if no token is available"""
         retry = ec2.skip_retry_on_codes(
             ec2.SKIP_USERDATA_CODES, msg, exception)
         if not retry:

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -29,7 +29,7 @@ STRICT_ID_PATH = ("datasource", "Ec2", "strict_id")
 STRICT_ID_DEFAULT = "warn"
 
 API_TOKEN_ROUTE = 'latest/api/token'
-API_TOKEN_DISABLED = '_ec2_dsiable_api_token'
+API_TOKEN_DISABLED = '_ec2_disable_api_token'
 AWS_TOKEN_TTL_SECONDS = '21600'
 
 

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -177,7 +177,9 @@ class DataSourceEc2(sources.DataSource):
                 headers = self._get_headers()
                 api_version = self.get_metadata_api_version()
                 self.identity = ec2.get_instance_identity(
-                    api_version, self.metadata_address, headers).get(
+                    api_version, self.metadata_address,
+                    headers_cb=self._get_headers,
+                    exception_cb=self._refresh_stale_aws_token_cb).get(
                         'document', {})
             return self.identity.get(
                 'instanceId', self.metadata['instance-id'])

--- a/cloudinit/sources/DataSourceExoscale.py
+++ b/cloudinit/sources/DataSourceExoscale.py
@@ -61,7 +61,7 @@ class DataSourceExoscale(sources.DataSource):
         metadata_url = "{}/{}/meta-data/instance-id".format(
             self.metadata_url, self.api_version)
 
-        url = url_helper.wait_for_url(
+        url, _response = url_helper.wait_for_url(
             urls=[metadata_url],
             max_wait=self.url_max_wait,
             timeout=self.url_timeout,

--- a/cloudinit/sources/DataSourceMAAS.py
+++ b/cloudinit/sources/DataSourceMAAS.py
@@ -136,7 +136,7 @@ class DataSourceMAAS(sources.DataSource):
             url = url[:-1]
         check_url = "%s/%s/meta-data/instance-id" % (url, MD_VERSION)
         urls = [check_url]
-        url = self.oauth_helper.wait_for_url(
+        url, _response = self.oauth_helper.wait_for_url(
             urls=urls, max_wait=max_wait, timeout=timeout)
 
         if url:

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -76,7 +76,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
 
         url_params = self.get_url_params()
         start_time = time.time()
-        avail_url = url_helper.wait_for_url(
+        avail_url, _response = url_helper.wait_for_url(
             urls=md_urls, max_wait=url_params.max_wait_seconds,
             timeout=url_params.timeout_seconds)
         if avail_url:

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -101,7 +101,7 @@ def read_file_or_url(url, timeout=5, retries=10,
             raise UrlError(cause=e, code=code, headers=None, url=url)
         return FileResponse(file_path, contents=contents)
     else:
-        return readurl(url, timeout=timeout, retries=retries, headers=headers,
+        return readurl(url, timeout=timeout, retries=retries,
                        headers_cb=headers_cb, data=data,
                        sec_between=sec_between, ssl_details=ssl_details,
                        exception_cb=exception_cb)
@@ -310,7 +310,7 @@ def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
 
 def wait_for_url(urls, max_wait=None, timeout=None,
                  status_cb=None, headers_cb=None, sleep_time=1,
-                 exception_cb=None, sleep_time_cb=None):
+                 exception_cb=None, sleep_time_cb=None, request_method=None):
     """
     urls:      a list of urls to try
     max_wait:  roughly the maximum time to wait before giving up
@@ -381,8 +381,9 @@ def wait_for_url(urls, max_wait=None, timeout=None,
                 else:
                     headers = {}
 
-                response = readurl(url, headers=headers, timeout=timeout,
-                                   check_status=False)
+                response = readurl(
+                    url, headers=headers, timeout=timeout,
+                    check_status=False, request_method=request_method)
                 if not response.contents:
                     reason = "empty response [%s]" % (response.code)
                     url_exc = UrlError(ValueError(reason), code=response.code,
@@ -392,7 +393,7 @@ def wait_for_url(urls, max_wait=None, timeout=None,
                     url_exc = UrlError(ValueError(reason), code=response.code,
                                        headers=response.headers, url=url)
                 else:
-                    return url
+                    return url, response.contents
             except UrlError as e:
                 reason = "request error [%s]" % e
                 url_exc = e
@@ -421,7 +422,7 @@ def wait_for_url(urls, max_wait=None, timeout=None,
                   sleep_time)
         time.sleep(sleep_time)
 
-    return False
+    return False, None
 
 
 class OauthUrlHelper(object):

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -325,6 +325,8 @@ def wait_for_url(urls, max_wait=None, timeout=None,
                   'exception', the exception that occurred.
     sleep_time_cb: call method with 2 arguments (response, loop_n) that
                    generates the next sleep time.
+    request_method: indicate the type of HTTP request, GET, PUT, or POST
+    returns: tuple of (url, response contents), on failure, (False, None)
 
     the idea of this routine is to wait for the EC2 metadata service to
     come up.  On both Eucalyptus and EC2 we have seen the case where

--- a/tests/unittests/test_datasource/test_cloudstack.py
+++ b/tests/unittests/test_datasource/test_cloudstack.py
@@ -10,6 +10,8 @@ from cloudinit.tests.helpers import CiTestCase, ExitStack, mock
 import os
 import time
 
+MOD_PATH = 'cloudinit.sources.DataSourceCloudStack'
+DS_PATH = MOD_PATH + '.DataSourceCloudStack'
 
 class TestCloudStackPasswordFetching(CiTestCase):
 
@@ -17,9 +19,10 @@ class TestCloudStackPasswordFetching(CiTestCase):
         super(TestCloudStackPasswordFetching, self).setUp()
         self.patches = ExitStack()
         self.addCleanup(self.patches.close)
-        mod_name = 'cloudinit.sources.DataSourceCloudStack'
+        mod_name = MOD_PATH
         self.patches.enter_context(mock.patch('{0}.ec2'.format(mod_name)))
-        self.patches.enter_context(mock.patch('{0}.uhelp'.format(mod_name)))
+        uhelp = self.patches.enter_context(
+            mock.patch('{0}.uhelp'.format(mod_name)))
         default_gw = "192.201.20.0"
         get_latest_lease = mock.MagicMock(return_value=None)
         self.patches.enter_context(mock.patch(
@@ -56,7 +59,9 @@ class TestCloudStackPasswordFetching(CiTestCase):
         ds.get_data()
         self.assertEqual({}, ds.get_config_obj())
 
-    def test_password_sets_password(self):
+    @mock.patch(DS_PATH + '.wait_for_metadata_service')
+    def test_password_sets_password(self, m_wait):
+        m_wait.return_value = True
         password = 'SekritSquirrel'
         self._set_password_server_response(password)
         ds = DataSourceCloudStack(
@@ -64,7 +69,9 @@ class TestCloudStackPasswordFetching(CiTestCase):
         ds.get_data()
         self.assertEqual(password, ds.get_config_obj()['password'])
 
-    def test_bad_request_doesnt_stop_ds_from_working(self):
+    @mock.patch(DS_PATH + '.wait_for_metadata_service')
+    def test_bad_request_doesnt_stop_ds_from_working(self, m_wait):
+        m_wait.return_value = True
         self._set_password_server_response('bad_request')
         ds = DataSourceCloudStack(
             {}, None, helpers.Paths({'run_dir': self.tmp}))
@@ -79,7 +86,9 @@ class TestCloudStackPasswordFetching(CiTestCase):
                     request_types.append(arg.split()[1])
         self.assertEqual(expected_request_types, request_types)
 
-    def test_valid_response_means_password_marked_as_saved(self):
+    @mock.patch(DS_PATH + '.wait_for_metadata_service')
+    def test_valid_response_means_password_marked_as_saved(self, m_wait):
+        m_wait.return_value = True
         password = 'SekritSquirrel'
         subp = self._set_password_server_response(password)
         ds = DataSourceCloudStack(
@@ -92,7 +101,9 @@ class TestCloudStackPasswordFetching(CiTestCase):
         subp = self._set_password_server_response(response_string)
         ds = DataSourceCloudStack(
             {}, None, helpers.Paths({'run_dir': self.tmp}))
-        ds.get_data()
+        with mock.patch(DS_PATH + '.wait_for_metadata_service') as m_wait:
+            m_wait.return_value = True
+            ds.get_data()
         self.assertRequestTypesSent(subp, ['send_my_password'])
 
     def test_password_not_saved_if_empty(self):

--- a/tests/unittests/test_datasource/test_cloudstack.py
+++ b/tests/unittests/test_datasource/test_cloudstack.py
@@ -13,6 +13,7 @@ import time
 MOD_PATH = 'cloudinit.sources.DataSourceCloudStack'
 DS_PATH = MOD_PATH + '.DataSourceCloudStack'
 
+
 class TestCloudStackPasswordFetching(CiTestCase):
 
     def setUp(self):
@@ -21,8 +22,7 @@ class TestCloudStackPasswordFetching(CiTestCase):
         self.addCleanup(self.patches.close)
         mod_name = MOD_PATH
         self.patches.enter_context(mock.patch('{0}.ec2'.format(mod_name)))
-        uhelp = self.patches.enter_context(
-            mock.patch('{0}.uhelp'.format(mod_name)))
+        self.patches.enter_context(mock.patch('{0}.uhelp'.format(mod_name)))
         default_gw = "192.201.20.0"
         get_latest_lease = mock.MagicMock(return_value=None)
         self.patches.enter_context(mock.patch(

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -191,7 +191,9 @@ def register_mock_metaserver(base_url, data):
             register(base_url, 'not found', status=404)
 
     def myreg(*argc, **kwargs):
-        return httpretty.register_uri(httpretty.GET, *argc, **kwargs)
+        url = argc[0]
+        method = httpretty.PUT if ec2.API_TOKEN_ROUTE in url else httpretty.GET
+        return httpretty.register_uri(method, *argc, **kwargs)
 
     register_helper(myreg, base_url, data)
 
@@ -237,6 +239,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
         if md:
             all_versions = (
                 [ds.min_metadata_version] + ds.extended_metadata_versions)
+            token_url = self.data_url('latest', data_item='api/token')
+            register_mock_metaserver(token_url, 'API-TOKEN')
             for version in all_versions:
                 metadata_url = self.data_url(version) + '/'
                 if version == md_version:


### PR DESCRIPTION
AWS not supports a new version of fetching Instance Metadata[1].
Update cloud-init's ec2 utility functions and update ec2 derived
datasources accordingly.  For DataSourceEc2 (versus ec2-look-alikes)
cloud-init will issue the PUT request to obtain an API token for
the maximum lifetime and then all subsequent interactions with the
IMDS will include the token in the header.