### PR TITLE
allow get_linux_distro() to return 'freebsd' for FreeBSD

### DIFF
--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -392,7 +392,6 @@ class TestGetLinuxDistro(CiTestCase):
         if hasattr(util.get_linux_distro, "cache_clear"):
             util.get_linux_distro.cache_clear()
 
-
     @classmethod
     def os_release_exists(self, path):
         """Side effect function"""

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -388,7 +388,9 @@ class TestUdevadmSettle(CiTestCase):
 class TestGetLinuxDistro(CiTestCase):
 
     def setUp(self):
-        util.get_linux_distro.cache_clear()
+        # python2 has no lru_cache, and therefore, no cache_clear()
+        if hasattr(util.get_linux_distro, "cache_clear"):
+            util.get_linux_distro.cache_clear()
 
 
     @classmethod

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -388,7 +388,8 @@ class TestUdevadmSettle(CiTestCase):
 class TestGetLinuxDistro(CiTestCase):
 
     def setUp(self):
-        self.patch_cache_dict = mock.patch.dict(util._CACHED_RESPONSES, values={}, clear=True)
+        self.patch_cache_dict = mock.patch.dict(util._CACHED_RESPONSES,
+                                                values={}, clear=True)
         self.patch_cache_dict.start()
 
     def tearDown(self):

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -406,6 +406,12 @@ class TestGetLinuxDistro(CiTestCase):
         if path == '/etc/redhat-release':
             return 1
 
+    @classmethod
+    def freebsd_version_exists(self, path):
+        """Side effect function """
+        if path == '/bin/freebsd-version':
+            return 1
+
     @mock.patch('cloudinit.util.load_file')
     def test_get_linux_distro_quoted_name(self, m_os_release, m_path_exists):
         """Verify we get the correct name if the os-release file has
@@ -423,6 +429,14 @@ class TestGetLinuxDistro(CiTestCase):
         m_path_exists.side_effect = TestGetLinuxDistro.os_release_exists
         dist = util.get_linux_distro()
         self.assertEqual(('ubuntu', '16.04', 'xenial'), dist)
+
+    @mock.patch('cloudinit.util.subp')
+    def test_get_linux_freebsd(self, m_subp, m_path_exists):
+        """Verify we get the correct name and release name on FreeBSD."""
+        m_path_exists.side_effect = TestGetLinuxDistro.freebsd_version_exists
+        m_subp.return_value = ("12.0-RELEASE-p10\n", '')
+        dist = util.get_linux_distro()
+        self.assertEqual(('freebsd', '12.0-RELEASE-p10', ''), dist)
 
     @mock.patch('cloudinit.util.load_file')
     def test_get_linux_centos6(self, m_os_release, m_path_exists):

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -387,6 +387,13 @@ class TestUdevadmSettle(CiTestCase):
 @mock.patch('os.path.exists')
 class TestGetLinuxDistro(CiTestCase):
 
+    def setUp(self):
+        self.patch_cache_dict = mock.patch.dict(util._CACHED_RESPONSES, values={}, clear=True)
+        self.patch_cache_dict.start()
+
+    def tearDown(self):
+        self.patch_cache_dict.stop()
+
     @classmethod
     def os_release_exists(self, path):
         """Side effect function"""

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -388,12 +388,8 @@ class TestUdevadmSettle(CiTestCase):
 class TestGetLinuxDistro(CiTestCase):
 
     def setUp(self):
-        self.patch_cache_dict = mock.patch.dict(util._CACHED_RESPONSES,
-                                                values={}, clear=True)
-        self.patch_cache_dict.start()
+        util.get_linux_distro.cache_clear()
 
-    def tearDown(self):
-        self.patch_cache_dict.stop()
 
     @classmethod
     def os_release_exists(self, path):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -82,7 +82,6 @@ except ImportError:
         return wrapper
 
 
-
 @lru_cache()
 def get_architecture(target=None):
     out, _ = subp(['dpkg', '--print-architecture'], capture=True,

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1388,10 +1388,7 @@ def load_file(fname, read_cb=None, quiet=False, decode=True):
 
 
 @memoize
-def get_cmdline():
-    if 'DEBUG_PROC_CMDLINE' in os.environ:
-        return os.environ["DEBUG_PROC_CMDLINE"]
-
+def _get_cmdline():
     if is_container():
         try:
             contents = load_file("/proc/1/cmdline")
@@ -1407,6 +1404,13 @@ def get_cmdline():
             cmdline = ""
 
     return cmdline
+
+
+def get_cmdline():
+    if 'DEBUG_PROC_CMDLINE' in os.environ:
+        return os.environ["DEBUG_PROC_CMDLINE"]
+
+    return _get_cmdline()
 
 
 def pipe_in_out(in_fh, out_fh, chunk_size=1024, chunk_cb=None):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -71,28 +71,26 @@ CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
 _CACHED_RESPONSES = {}
 
 
-def memoize(f):
-    """
-    Function used to cache responses from functions decorated with it.
-    """
+try:
+    from functools import lru_cache
+except ImportError:
+    def lru_cache(f):
+        """pass-thru replace for Python3's lru_cache()"""
+        def wrapper(*x):
+            return f(*x)
 
-    def helper(*x):
-        global _CACHED_RESPONSES
-        if (f, x) not in _CACHED_RESPONSES:
-            _CACHED_RESPONSES[(f, x)] = f(*x)
-        return _CACHED_RESPONSES[(f, x)]
-
-    return helper
+        return wrapper
 
 
-@memoize
+
+@lru_cache()
 def get_architecture(target=None):
     out, _ = subp(['dpkg', '--print-architecture'], capture=True,
                   target=target)
     return out.strip()
 
 
-@memoize
+@lru_cache()
 def _lsb_release(target=None):
     fmap = {'Codename': 'codename', 'Description': 'description',
             'Distributor ID': 'id', 'Release': 'release'}
@@ -556,7 +554,7 @@ def is_ipv4(instr):
     return len(toks) == 4
 
 
-@memoize
+@lru_cache()
 def is_FreeBSD():
     return system_info()['variant'] == "freebsd"
 
@@ -606,7 +604,7 @@ def _parse_redhat_release(release_file=None):
     return {}
 
 
-@memoize
+@lru_cache()
 def get_linux_distro():
     distro_name = ''
     distro_version = ''
@@ -658,7 +656,7 @@ def get_linux_distro():
     return (distro_name, distro_version, flavor)
 
 
-@memoize
+@lru_cache()
 def system_info():
     info = {
         'platform': platform.platform(),
@@ -1388,7 +1386,7 @@ def load_file(fname, read_cb=None, quiet=False, decode=True):
         return contents
 
 
-@memoize
+@lru_cache()
 def _get_cmdline():
     if is_container():
         try:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -622,6 +622,9 @@ def get_linux_distro():
                     flavor = match.groupdict()['codename']
         if distro_name == 'rhel':
             distro_name = 'redhat'
+    elif os.path.exists('/bin/freebsd-version'):
+        distro_name = 'freebsd'
+        distro_version = subp(['/bin/freebsd-version'])
     else:
         dist = ('', '', '')
         try:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -624,7 +624,7 @@ def get_linux_distro():
             distro_name = 'redhat'
     elif os.path.exists('/bin/freebsd-version'):
         distro_name = 'freebsd'
-        distro_version = subp(['/bin/freebsd-version'])
+        distro_version = subp(['uname', '-r'])
     else:
         dist = ('', '', '')
         try:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -68,10 +68,6 @@ CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
                    ['running-in-container'],
                    ['lxc-is-container'])
 
-PROC_CMDLINE = None
-
-_LSB_RELEASE = {}
-
 _CACHED_RESPONSES = {}
 
 
@@ -1391,13 +1387,10 @@ def load_file(fname, read_cb=None, quiet=False, decode=True):
         return contents
 
 
+@memoize
 def get_cmdline():
     if 'DEBUG_PROC_CMDLINE' in os.environ:
         return os.environ["DEBUG_PROC_CMDLINE"]
-
-    global PROC_CMDLINE
-    if PROC_CMDLINE is not None:
-        return PROC_CMDLINE
 
     if is_container():
         try:
@@ -1413,7 +1406,6 @@ def get_cmdline():
         except Exception:
             cmdline = ""
 
-    PROC_CMDLINE = cmdline
     return cmdline
 
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -74,10 +74,10 @@ _CACHED_RESPONSES = {}
 try:
     from functools import lru_cache
 except ImportError:
-    def lru_cache(f):
+    def lru_cache():
         """pass-thru replace for Python3's lru_cache()"""
-        def wrapper(*x):
-            return f(*x)
+        def wrapper(f):
+            return f
 
         return wrapper
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -636,7 +636,8 @@ def get_linux_distro():
             distro_name = 'redhat'
     elif os.path.exists('/bin/freebsd-version'):
         distro_name = 'freebsd'
-        distro_version = subp(['uname', '-r'])
+        distro_version, _ = subp(['uname', '-r'])
+        distro_version = distro_version.strip()
     else:
         dist = ('', '', '')
         try:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -50,6 +50,16 @@ from cloudinit import version
 
 from cloudinit.settings import (CFG_BUILTIN)
 
+try:
+    from functools import lru_cache
+except ImportError:
+    def lru_cache():
+        """pass-thru replace for Python3's lru_cache()"""
+        def wrapper(f):
+            return f
+        return wrapper
+
+
 _DNS_REDIRECT_IP = None
 LOG = logging.getLogger(__name__)
 
@@ -67,19 +77,6 @@ FALSE_STRINGS = ('off', '0', 'no', 'false')
 CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
                    ['running-in-container'],
                    ['lxc-is-container'])
-
-_CACHED_RESPONSES = {}
-
-
-try:
-    from functools import lru_cache
-except ImportError:
-    def lru_cache():
-        """pass-thru replace for Python3's lru_cache()"""
-        def wrapper(f):
-            return f
-
-        return wrapper
 
 
 @lru_cache()

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4615,7 +4615,6 @@ class TestNetRenderers(CiTestCase):
         m_distro.return_value = ('opensuse', None, None)
         self.assertEqual('sysconfig', renderers.select(priority=None)[0])
 
-    @mock.patch.dict("cloudinit.util._CACHED_RESPONSES", values={}, clear=True)
     @mock.patch("cloudinit.net.sysconfig.available_sysconfig")
     @mock.patch("cloudinit.util.get_linux_distro")
     def test_sysconfig_available_uses_variant_mapping(self, m_distro, m_avail):
@@ -4631,6 +4630,8 @@ class TestNetRenderers(CiTestCase):
         ]
         for (distro_name, distro_version, flavor) in distro_values:
             m_distro.return_value = (distro_name, distro_version, flavor)
+            if hasattr(util.system_info, "cache_clear"):
+                util.system_info.cache_clear()
             result = sysconfig.available()
             self.assertTrue(result)
 

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4593,8 +4593,8 @@ class TestNetRenderers(CiTestCase):
         m_sys_scfg.return_value = False   # no sysconfig/ifup/ifdown
         m_sys_nm.return_value = True      # network-manager is installed
         m_netplan.return_value = True     # netplan is installed
-        m_distro.return_value = ('ubuntu', None, None)
         m_sys_avail.return_value = False  # no sysconfig on Ubuntu
+        m_distro.return_value = ('ubuntu', None, None)
         self.assertEqual('netplan', renderers.select(priority=None)[0])
 
         # Centos with Network-Manager installed
@@ -4602,8 +4602,8 @@ class TestNetRenderers(CiTestCase):
         m_sys_scfg.return_value = False  # no sysconfig/ifup/ifdown
         m_sys_nm.return_value = True     # network-manager is installed
         m_netplan.return_value = False   # netplan is not installed
-        m_distro.return_value = ('centos', None, None)
         m_sys_avail.return_value = True  # sysconfig is available on centos
+        m_distro.return_value = ('centos', None, None)
         self.assertEqual('sysconfig', renderers.select(priority=None)[0])
 
         # OpenSuse with Network-Manager installed
@@ -4611,8 +4611,8 @@ class TestNetRenderers(CiTestCase):
         m_sys_scfg.return_value = False  # no sysconfig/ifup/ifdown
         m_sys_nm.return_value = True     # network-manager is installed
         m_netplan.return_value = False   # netplan is not installed
-        m_distro.return_value = ('opensuse', None, None)
         m_sys_avail.return_value = True  # sysconfig is available on opensuse
+        m_distro.return_value = ('opensuse', None, None)
         self.assertEqual('sysconfig', renderers.select(priority=None)[0])
 
     @mock.patch.dict("cloudinit.util._CACHED_RESPONSES", values={}, clear=True)

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4589,19 +4589,19 @@ class TestNetRenderers(CiTestCase):
         """sysconfig only selected on specific distros (rhel/sles)."""
 
         # Ubuntu with Network-Manager installed
-        m_eni.return_value = False       # no ifupdown (ifquery)
-        m_sys_scfg.return_value = False  # no sysconfig/ifup/ifdown
-        m_sys_nm.return_value = True     # network-manager is installed
-        m_netplan.return_value = True    # netplan is installed
+        m_eni.return_value = False        # no ifupdown (ifquery)
+        m_sys_scfg.return_value = False   # no sysconfig/ifup/ifdown
+        m_sys_nm.return_value = True      # network-manager is installed
+        m_netplan.return_value = True     # netplan is installed
         m_distro.return_value = ('ubuntu', None, None)
-        m_sys_avail.return_value = False # no sysconfig on Ubuntu
+        m_sys_avail.return_value = False  # no sysconfig on Ubuntu
         self.assertEqual('netplan', renderers.select(priority=None)[0])
 
         # Centos with Network-Manager installed
         m_eni.return_value = False       # no ifupdown (ifquery)
         m_sys_scfg.return_value = False  # no sysconfig/ifup/ifdown
         m_sys_nm.return_value = True     # network-manager is installed
-        m_netplan.return_value = False    # netplan is not installed
+        m_netplan.return_value = False   # netplan is not installed
         m_distro.return_value = ('centos', None, None)
         m_sys_avail.return_value = True  # sysconfig is available on centos
         self.assertEqual('sysconfig', renderers.select(priority=None)[0])
@@ -4610,7 +4610,7 @@ class TestNetRenderers(CiTestCase):
         m_eni.return_value = False       # no ifupdown (ifquery)
         m_sys_scfg.return_value = False  # no sysconfig/ifup/ifdown
         m_sys_nm.return_value = True     # network-manager is installed
-        m_netplan.return_value = False    # netplan is not installed
+        m_netplan.return_value = False   # netplan is not installed
         m_distro.return_value = ('opensuse', None, None)
         m_sys_avail.return_value = True  # sysconfig is available on opensuse
         self.assertEqual('sysconfig', renderers.select(priority=None)[0])


### PR DESCRIPTION
a lot of our code assumes that we're on Linux, and all it needs to know
then is which exact distro it's on. We have structured our code such,
that FreeBSD *is* a distro, so before resorting to return nothing on
FreeBSD whenever get_linux_distro() is queried, we check if we're on
FreeBSD, and return distro_name = 'freebsd' and 'distro_version' with
the result of `uname -r`.

LP: #1815030

----

Since `is_FreeBSD()` is used a lot, which uses `system_info()`, which uses `get_linux_distro()` we add caching, by decorating the following functions with `@lru_cache`:

- get_architecture()
- _lsb_release()
- is_FreeBSD
- get_linux_distro
- system_info()
- _get_cmdline()

Since [functools](https://docs.python.org/3/library/functools.html) only exists in Python 3, only python 3 will benefit from this improvement. For python 2, our shim is just a pass-thru. Too bad, but, also… https://pythonclock.org/

The main motivation here was, at first, to cache more, following the style of _lsb_release.
That is now consolidated under this very same roof.

LP: #1815030