### PR TITLE
Multiple file fix for AuthorizedKeysFile config

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -221,7 +221,7 @@ def render_authorizedkeysfile_paths(value, homedir, username):
     macros = (("%h", homedir), ("%u", username), ("%%", "%"))
     if not value:
         value = "%h/.ssh/authorized_keys"
-    paths = re.split(r'(?<!\\) ', value)
+    paths = value.strip().split()
     rendered = []
     for path in paths:
         for macro, field in macros:

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -8,6 +8,7 @@
 
 import os
 import pwd
+import re
 
 from cloudinit import log as logging
 from cloudinit import util
@@ -160,19 +161,20 @@ class AuthKeyLineParser(object):
                            comment=comment, options=options)
 
 
-def parse_authorized_keys(fname):
+def parse_authorized_keys(fnames):
     lines = []
-    try:
-        if os.path.isfile(fname):
-            lines = util.load_file(fname).splitlines()
-    except (IOError, OSError):
-        util.logexc(LOG, "Error reading lines from %s", fname)
-        lines = []
-
     parser = AuthKeyLineParser()
     contents = []
-    for line in lines:
-        contents.append(parser.parse(line))
+    for fname in fnames:
+        try:
+            if os.path.isfile(fname):
+                lines = util.load_file(fname).splitlines()
+                for line in lines:
+                    contents.append(parser.parse(line))
+        except (IOError, OSError):
+            util.logexc(LOG, "Error reading lines from %s", fname)
+            lines = []
+
     return contents
 
 
@@ -211,32 +213,58 @@ def users_ssh_info(username):
     return (os.path.join(pw_ent.pw_dir, '.ssh'), pw_ent)
 
 
-def extract_authorized_keys(username):
+def render_authorizedkeysfile(value, homedir, username):
+    if value is None:
+        value = "%h/.ssh/authorized_keys"
+    for macro, field in (("%h", homedir), ("%u", username), ("%%", "%")):
+        value = value.replace(macro, field)
+        if not value.startswith("/"):
+            value = os.path.join(homedir, value)
+    return value
+
+
+def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
     (ssh_dir, pw_ent) = users_ssh_info(username)
-    auth_key_fn = None
+    auth_key_fns = []
     with util.SeLinuxGuard(ssh_dir, recursive=True):
         try:
+            default_authorizedkeys_file = "%h/.ssh/authorized_keys"
+
             # The 'AuthorizedKeysFile' may contain tokens
             # of the form %T which are substituted during connection set-up.
             # The following tokens are defined: %% is replaced by a literal
             # '%', %h is replaced by the home directory of the user being
             # authenticated and %u is replaced by the username of that user.
-            ssh_cfg = parse_ssh_config_map(DEF_SSHD_CFG)
-            auth_key_fn = ssh_cfg.get("authorizedkeysfile", '').strip()
-            if not auth_key_fn:
-                auth_key_fn = "%h/.ssh/authorized_keys"
-            auth_key_fn = auth_key_fn.replace("%h", pw_ent.pw_dir)
-            auth_key_fn = auth_key_fn.replace("%u", username)
-            auth_key_fn = auth_key_fn.replace("%%", '%')
-            if not auth_key_fn.startswith('/'):
-                auth_key_fn = os.path.join(pw_ent.pw_dir, auth_key_fn)
+            ssh_cfg = parse_ssh_config_map(sshd_cfg_file)
+            auth_key_fns = re.split(
+                    r'(?<!\\) ',
+                    ssh_cfg.get("authorizedkeysfile", '').strip())
+
+            if not auth_key_fns:
+                auth_key_fns[0] = default_authorizedkeys_file
+            elif len(auth_key_fns) > 1:
+                util.logexc(
+                        LOG,
+                        "Looks like there's more than one authorizedkeys file"
+                        " configured. Make sure there's no white spaces in"
+                        " their paths. If they do, escape with '\\'.")
+
+            for i in range(len(auth_key_fns)):
+                auth_key_fns[i] = render_authorizedkeysfile(
+                        auth_key_fns[i],
+                        pw_ent.pw_dir,
+                        username)
+                print(auth_key_fns[i])
+
         except (IOError, OSError):
             # Give up and use a default key filename
-            auth_key_fn = os.path.join(ssh_dir, 'authorized_keys')
+            auth_key_fns[0] = os.path.join(ssh_dir, 'authorized_keys')
             util.logexc(LOG, "Failed extracting 'AuthorizedKeysFile' in ssh "
                         "config from %r, using 'AuthorizedKeysFile' file "
-                        "%r instead", DEF_SSHD_CFG, auth_key_fn)
-    return (auth_key_fn, parse_authorized_keys(auth_key_fn))
+                        "%r instead", DEF_SSHD_CFG, auth_key_fns[0])
+
+    # always store all the keys in the user's private file
+    return (default_authorizedkeys_file, parse_authorized_keys(auth_key_fns))
 
 
 def setup_user_keys(keys, username, options=None):

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -220,7 +220,7 @@ def render_authorizedkeysfile_paths(value, homedir, username):
     macros = (("%h", homedir), ("%u", username), ("%%", "%"))
     if not value:
         value = "%h/.ssh/authorized_keys"
-    paths = value.strip().split()
+    paths = value.split()
     rendered = []
     for path in paths:
         for macro, field in macros:

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -8,7 +8,6 @@
 
 import os
 import pwd
-import re
 
 from cloudinit import log as logging
 from cloudinit import util

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -5,6 +5,7 @@ from mock import patch
 from cloudinit import ssh_util
 from cloudinit.tests import helpers as test_helpers
 from cloudinit import util
+from cloudinit import distros
 
 
 VALID_CONTENT = {
@@ -55,6 +56,45 @@ TEST_OPTIONS = (
     "no-port-forwarding,no-agent-forwarding,no-X11-forwarding,"
     'command="echo \'Please login as the user \"ubuntu\" rather than the'
     'user \"root\".\';echo;sleep 10"')
+
+
+class MyBaseDistro(distros.Distro):
+    # MyBaseDistro is here to test TestMultipleSshAuthorizedKeysFile
+    # And for that we need to create a new user
+
+    def __init__(self, name="basedistro", cfg=None, paths=None):
+        if not cfg:
+            cfg = {}
+        if not paths:
+            paths = {}
+        super(MyBaseDistro, self).__init__(name, cfg, paths)
+
+    def install_packages(self, pkglist):
+        raise NotImplementedError()
+
+    def _write_network(self, settings):
+        raise NotImplementedError()
+
+    def package_command(self, cmd, args=None, pkgs=None):
+        raise NotImplementedError()
+
+    def update_package_sources(self):
+        raise NotImplementedError()
+
+    def apply_locale(self, locale, out_fn=None):
+        raise NotImplementedError()
+
+    def set_timezone(self, tz):
+        raise NotImplementedError()
+
+    def _read_hostname(self, filename, default=None):
+        raise NotImplementedError()
+
+    def _write_hostname(self, hostname, filename):
+        raise NotImplementedError()
+
+    def _read_system_hostname(self):
+        raise NotImplementedError()
 
 
 class TestAuthKeyLineParser(test_helpers.CiTestCase):
@@ -325,5 +365,77 @@ class TestUpdateSshConfig(test_helpers.CiTestCase):
         self.assertEqual(self.cfgdata, util.load_file(mycfg))
         m_write_file.assert_not_called()
 
+
+class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
+    username = 'foouser'
+    dist = MyBaseDistro()
+    dist.create_user(username)
+    key_entries = []
+
+    def test_multiple_authorizedkeys_file_order1(self):
+        authorized_keys = self.tmp_path('/tmp/authorized_keys')
+        util.write_file(authorized_keys, VALID_CONTENT['rsa'])
+
+        user_keys = self.tmp_path('/tmp/user_keys')
+        util.write_file(user_keys, VALID_CONTENT['dsa'])
+
+        sshd_config = self.tmp_path('/tmp/sshd_config')
+        util.write_file(
+                sshd_config,
+                "AuthorizedKeysFile /tmp/authorized_keys /tmp/user_keys")
+
+        (auth_key_fn, auth_key_entries) = ssh_util.extract_authorized_keys(
+                self.username, sshd_config)
+        content = ssh_util.update_authorized_keys(
+                auth_key_entries,
+                self.key_entries)
+
+        self.assertEqual(auth_key_fn, "%h/.ssh/authorized_keys")
+        self.assertTrue(VALID_CONTENT['rsa'] in content)
+        self.assertTrue(VALID_CONTENT['dsa'] in content)
+
+    def test_multiple_authorizedkeys_file_order2(self):
+        authorized_keys = self.tmp_path('/tmp/authorized_keys')
+        util.write_file(authorized_keys, VALID_CONTENT['rsa'])
+
+        user_keys = self.tmp_path('/tmp/user_keys')
+        util.write_file(user_keys, VALID_CONTENT['dsa'])
+
+        sshd_config = self.tmp_path('/tmp/sshd_config')
+        util.write_file(
+                sshd_config,
+                "AuthorizedKeysFile /tmp/user_keys /tmp/authorized_keys")
+
+        (auth_key_fn, auth_key_entries) = ssh_util.extract_authorized_keys(
+                self.username, sshd_config)
+        content = ssh_util.update_authorized_keys(
+                auth_key_entries, self.key_entries)
+
+        self.assertEqual(auth_key_fn, "%h/.ssh/authorized_keys")
+        self.assertTrue(VALID_CONTENT['rsa'] in content)
+        self.assertTrue(VALID_CONTENT['dsa'] in content)
+
+    def test_white_spaces(self):
+        authorized_keys = self.tmp_path('/tmp/authorized_keys')
+        util.write_file(authorized_keys, VALID_CONTENT['rsa'])
+
+        user_keys = self.tmp_path('/tmp/user\\ keys')
+        util.write_file(user_keys, VALID_CONTENT['dsa'])
+
+        sshd_config = self.tmp_path('/tmp/sshd_config')
+        util.write_file(
+                sshd_config,
+                "AuthorizedKeysFile /tmp/authorized_keys /tmp/user\\ keys")
+
+        (auth_key_fn, auth_key_entries) = ssh_util.extract_authorized_keys(
+                self.username,
+                sshd_config)
+        content = ssh_util.update_authorized_keys(
+                auth_key_entries,
+                self.key_entries)
+
+        self.assertEqual(auth_key_fn, "%h/.ssh/authorized_keys")
+        self.assertTrue(VALID_CONTENT['rsa'] in content)
+        self.assertTrue(VALID_CONTENT['dsa'] in content)
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
Currently cloud-init does not know how to handle multiple file
configuration on section AuthorizedKeysFile of ssh configuration.
cloud-init will mess up the home user directory by creating bogus
folders inside it.

This patch provides a fix for this erroneous behavior. It gathers all
keys from all the files listed on the section AuthorizedKeysFile of ssh
configuration and merge all of them inside home user
~/.ssh/authorized_keys of the vm deployed.

Resolves: rhbz#1642008

Signed-off-by: Eduardo Otubo <otubo@redhat.com>