### PR TITLE
check connectivity before establishing Ephemeral Network connection

### DIFF
--- a/cloudinit/sources/DataSourceHetzner.py
+++ b/cloudinit/sources/DataSourceHetzner.py
@@ -50,10 +50,13 @@ class DataSourceHetzner(sources.DataSource):
         if not on_hetzner():
             return False
         nic = cloudnet.find_fallback_nic()
-        with cloudnet.EphemeralIPv4Network(nic, ip="169.254.0.1",
-                                           prefix_or_mask=16,
-                                           broadcast="169.254.255.255",
-                                           connectivity_url=self.metadata_address):
+        with cloudnet.EphemeralIPv4Network(
+                nic,
+                ip="169.254.0.1",
+                prefix_or_mask=16,
+                broadcast="169.254.255.255",
+                connectivity_url=self.metadata_address
+        ):
             md = hc_helper.read_metadata(
                 self.metadata_address, timeout=self.timeout,
                 sec_between=self.wait_retry, retries=self.retries)

--- a/cloudinit/sources/DataSourceHetzner.py
+++ b/cloudinit/sources/DataSourceHetzner.py
@@ -50,8 +50,10 @@ class DataSourceHetzner(sources.DataSource):
         if not on_hetzner():
             return False
         nic = cloudnet.find_fallback_nic()
-        with cloudnet.EphemeralIPv4Network(nic, "169.254.0.1", 16,
-                                           "169.254.255.255"):
+        with cloudnet.EphemeralIPv4Network(nic, ip="169.254.0.1",
+                                           prefix_or_mask=16,
+                                           broadcast="169.254.255.255",
+                                           connectivity_url=self.metadata_address):
             md = hc_helper.read_metadata(
                 self.metadata_address, timeout=self.timeout,
                 sec_between=self.wait_retry, retries=self.retries)

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -128,7 +128,8 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
 
         if self.perform_dhcp_setup:  # Setup networking in init-local stage.
             try:
-                with EphemeralDHCPv4(self.fallback_interface):
+                with EphemeralDHCPv4(self.fallback_interface,
+                                     connectivity_url=self.metadata_address):
                     results = util.log_time(
                         logfunc=LOG.debug, msg='Crawl of metadata service',
                         func=self._crawl_metadata)

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -212,7 +212,8 @@ class DataSourceScaleway(sources.DataSource):
         if self._fallback_interface is None:
             self._fallback_interface = net.find_fallback_nic()
         try:
-            with EphemeralDHCPv4(self._fallback_interface):
+            with EphemeralDHCPv4(self._fallback_interface,
+                                 connectivity_url=self.metadata_address):
                 util.log_time(
                     logfunc=LOG.debug, msg='Crawl of metadata service',
                     func=self._crawl_metadata)

--- a/tests/unittests/test_datasource/test_hetzner.py
+++ b/tests/unittests/test_datasource/test_hetzner.py
@@ -86,8 +86,9 @@ class TestDataSourceHetzner(CiTestCase):
         self.assertTrue(ret)
 
         m_net.assert_called_once_with(
-            'eth0', '169.254.0.1',
-            16, '169.254.255.255'
+            'eth0', ip='169.254.0.1',
+            prefix_or_mask=16, broadcast='169.254.255.255',
+            connectivity_url=ds.metadata_address
         )
 
         self.assertTrue(m_readmd.called)


### PR DESCRIPTION
a while ago (ef0611a51a98a273cfa37b0daeb3e9d151888b88) we added the
connectivity_url parameter to EphemeralIPv4Network and EphemeralDHCPv4,
so we wanna actually *use* it in our DataSources — or at least in the
ones where it makes sense to do so.