### PR TITLE
Do not use fallocate in swap file creation on xfs.

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -247,9 +247,6 @@ def create_swapfile(fname, size):
     swap_dir = os.path.dirname(fname)
     util.ensure_dir(swap_dir)
 
-    """Return the type of the filesystem that path is on.
-    If path is a mount point itself, then the type of the filesystem mounted
-    on path rather than its parent dir."""
     fstype = util.get_mount_info(swap_dir)[1]
 
     if fstype in ("xfs", "btrfs"):

--- a/tests/unittests/test_handler/test_handler_mounts.py
+++ b/tests/unittests/test_handler/test_handler_mounts.py
@@ -181,6 +181,18 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
 
         return dev
 
+    def test_swap_integrity(self):
+        '''Ensure that the swap file is correctly created and can
+        swapon succsesfully. Fixing the corener case of:
+        kernel: swapon: swapfile has holes'''
+
+        fstab = '/swap.img swap swap defaults 0 0\n'
+
+        with open(cc_mounts.FSTAB_PATH, 'w') as fd:
+            fd.write(fstab)
+        cc = {'swap': ['filename: /swap.img', 'size: 512', 'maxsize: 512']}
+        cc_mounts.handle(None, cc, self.mock_cloud, self.mock_log, [])
+
     def test_fstab_no_swap_device(self):
         '''Ensure that cloud-init adds a discovered swap partition
         to /etc/fstab.'''

--- a/tests/unittests/test_handler/test_handler_mounts.py
+++ b/tests/unittests/test_handler/test_handler_mounts.py
@@ -183,7 +183,7 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
 
     def test_swap_integrity(self):
         '''Ensure that the swap file is correctly created and can
-        swapon succsesfully. Fixing the corener case of:
+        swapon successfully. Fixing the corner case of:
         kernel: swapon: swapfile has holes'''
 
         fstab = '/swap.img swap swap defaults 0 0\n'


### PR DESCRIPTION
When creating a swap file on an xfs filesystem, fallocate cannot be used.
Doing so results in failure of swapon and a message like:
 swapon: swapfile has holes

The solution here is to maintain a list (currently containing only XFS)
of filesystems where fallocate cannot be used. The, on those fileystems
use the slower but functional 'dd' method.

Based on initial pull request:
https://code.launchpad.net/~adobrawy/cloud-init/+git/cloud-init/+merge/354680

And further comments from Scott Moser:
http://paste.ubuntu.com/p/8pVhczVqG3/

Signed-off-by: Eduardo Otubo <otubo@redhat.com>