### PR TITLE
lp-to-git-users: adding elafontaine

### DIFF
--- a/tools/.lp-to-git-user
+++ b/tools/.lp-to-git-user
@@ -1,6 +1,7 @@
 {
  "chad.smith": "blackboxsw",
  "d-info-e": "do3meli",
+ "eric-lafontaine1": "elafontaine"
  "harald-jensas": "hjensas",
  "i.galic": "igalic",
  "larsks": "larsks",


### PR DESCRIPTION
Hi, I would like to start contributing to Cloud-init.  I've tried following the process on the following  [link](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html).  But seems that we need to fork on launchpad through ssh, which I can't do from my location.  I instead looked at how people where starting to contribute and matched my lp user myself to my github user.

Please let me know if I need to do something different.