### PR TITLE
Revert "travis: only run CI on pull requests"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
     - pip install tox
 
 script:
-    - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then tox; fi'
+    - tox
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
Until we have a clear issue with CI throughput, let's make sure that
we're testing master.

This reverts commit 21967a2dedc781e05cf62c80fb730d0ed5973c8b.