### PR TITLE
docs: Add security.md to readthedocs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,8 +50,8 @@ determined time for disclosure has arrived the following will occur:
 * An email is sent to the [public cloud-init mailing list](https://lists.launchpad.net/cloud-init/)
 
 The disclosure timeframe is coordinated with the reporter and members of the
-  cloud-init-security list. This depends on a number of factors:
-  
+cloud-init-security list. This depends on a number of factors:
+
 * The reporter might have their own disclosure timeline (e.g. Google Project
   Zero and many others use a 90-days after initial report OR when a fix
   becomes public)

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,0 +1,4 @@
+doc8
+m2r
+sphinx
+sphinx_rtd_theme

--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -35,7 +35,7 @@ extensions = [
 ]
 
 # The suffix of source filenames.
-source_suffix = ['.rst', '.md']
+source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'

--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -28,13 +28,14 @@ copyright = '2019, Canonical Ltd.'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
+    'm2r',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.viewcode',
 ]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = 'index'

--- a/doc/rtd/index.rst
+++ b/doc/rtd/index.rst
@@ -67,6 +67,7 @@ Having trouble? We would like to help!
    :caption: Development
 
    topics/hacking.rst
+   topics/security.rst
    topics/debugging.rst
    topics/logging.rst
    topics/dir_layout.rst

--- a/doc/rtd/topics/security.rst
+++ b/doc/rtd/topics/security.rst
@@ -1,0 +1,5 @@
+.. _security:
+
+.. mdinclude:: ../../../SECURITY.md
+
+.. vi: textwidth=78

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ exclude = .venv,.tox,dist,doc,*egg,.git,build,tools
 basepython = python3
 deps =
     doc8
+    m2r
     sphinx
     sphinx_rtd_theme
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -55,10 +55,7 @@ exclude = .venv,.tox,dist,doc,*egg,.git,build,tools
 [testenv:doc]
 basepython = python3
 deps =
-    doc8
-    m2r
-    sphinx
-    sphinx_rtd_theme
+    -r{toxinidir}/doc-requirements.txt
 commands =
     {envpython} -m sphinx {posargs:doc/rtd doc/rtd_html}
     doc8 doc/rtd


### PR DESCRIPTION
This enables the ability to show the security policy on both GitHub and
on the readthedocs site. To do this, enable the ability to import
Markdown based files and translate them to rst.