### PR TITLE
docs: fix line length and ignore error

### DIFF
--- a/doc/rtd/topics/tests.rst
+++ b/doc/rtd/topics/tests.rst
@@ -427,9 +427,9 @@ Azure Cloud
 -----------
 
 To run on Azure Cloud platform users login with Service Principal and export
-credentials file. Region is defaulted and can be set in ``tests/cloud_tests/platforms.yaml``.
-The Service Principal credentials are the standard authentication for Azure SDK
-to interact with Azure Services:
+credentials file. Region is defaulted and can be set in
+``tests/cloud_tests/platforms.yaml``. The Service Principal credentials are
+the standard authentication for Azure SDK to interact with Azure Services:
 
 Create Service Principal account or login
 

--- a/tox.ini
+++ b/tox.ini
@@ -60,7 +60,7 @@ deps =
     sphinx_rtd_theme
 commands =
     {envpython} -m sphinx {posargs:doc/rtd doc/rtd_html}
-    doc8 doc/rtd
+    doc8 --ignore D000 doc/rtd/
 
 [testenv:xenial]
 commands =


### PR DESCRIPTION
doc8 does not know about the ephasize-lines portion of code-block, this
ignores that error. rstcheck and restructuredtext-lint have issues with
sphinx declaritives, so doc8 is still the best to use for now.