### PR TITLE
docs: fix line length and remove highlighting

### DIFF
--- a/doc/rtd/topics/tests.rst
+++ b/doc/rtd/topics/tests.rst
@@ -427,9 +427,9 @@ Azure Cloud
 -----------
 
 To run on Azure Cloud platform users login with Service Principal and export
-credentials file. Region is defaulted and can be set in ``tests/cloud_tests/platforms.yaml``.
-The Service Principal credentials are the standard authentication for Azure SDK
-to interact with Azure Services:
+credentials file. Region is defaulted and can be set in
+``tests/cloud_tests/platforms.yaml``. The Service Principal credentials are
+the standard authentication for Azure SDK to interact with Azure Services:
 
 Create Service Principal account or login
 
@@ -465,7 +465,6 @@ Export credentials
 Set region in platforms.yaml
 
 .. code-block:: yaml
-    :emphasize-lines: 3
 
     azurecloud:
         enabled: true


### PR DESCRIPTION
doc8 does not know about the ephasize-lines portion of code-block and
throws an error. As this is the only place right now I am going to
remove it untill we can find a better solution. rstcheck and
restructuredtext-lint have issues with sphinx declaritives, so
doc8 is still the best to use for now.