### PR TITLE
fix unlocking method on FreeBSD

### DIFF
--- a/cloudinit/config/tests/test_users_groups.py
+++ b/cloudinit/config/tests/test_users_groups.py
@@ -46,6 +46,32 @@ class TestHandleUsersGroups(CiTestCase):
              mock.call('me2', default=False)])
         m_group.assert_not_called()
 
+    @mock.patch('cloudinit.distros.freebsd.Distro.create_group')
+    @mock.patch('cloudinit.distros.freebsd.Distro.create_user')
+    def test_handle_users_in_cfg_calls_create_users_on_bsd(
+            self,
+            _user,
+            _group,
+            m_user,
+            m_group,
+    ):
+        """When users in config, create users with freebsd.create_user."""
+        cfg = {'users': ['default', {'name': 'me2'}]}  # merged cloud-config
+        # System config defines a default user for the distro.
+        sys_cfg = {'default_user': {'name': 'freebsd', 'lock_passwd': True,
+                                    'groups': ['wheel'],
+                                    'shell': '/bin/tcsh'}}
+        metadata = {}
+        cloud = self.tmp_cloud(
+            distro='freebsd', sys_cfg=sys_cfg, metadata=metadata)
+        cc_users_groups.handle('modulename', cfg, cloud, None, None)
+        self.assertItemsEqual(
+            m_user.call_args_list,
+            [mock.call('freebsd', groups='wheel', lock_passwd=True,
+                       shell='/bin/tcsh'),
+             mock.call('me2', default=False)])
+        m_group.assert_not_called()
+
     def test_users_with_ssh_redirect_user_passes_keys(self, m_user, m_group):
         """When ssh_redirect_user is True pass default user and cloud keys."""
         cfg = {

--- a/cloudinit/config/tests/test_users_groups.py
+++ b/cloudinit/config/tests/test_users_groups.py
@@ -50,10 +50,10 @@ class TestHandleUsersGroups(CiTestCase):
     @mock.patch('cloudinit.distros.freebsd.Distro.create_user')
     def test_handle_users_in_cfg_calls_create_users_on_bsd(
             self,
-            f_user,
-            f_group,
-            l_user,
-            l_group,
+            m_fbsd_user,
+            m_fbsd_group,
+            m_linux_user,
+            m_linux_group,
     ):
         """When users in config, create users with freebsd.create_user."""
         cfg = {'users': ['default', {'name': 'me2'}]}  # merged cloud-config
@@ -66,13 +66,13 @@ class TestHandleUsersGroups(CiTestCase):
             distro='freebsd', sys_cfg=sys_cfg, metadata=metadata)
         cc_users_groups.handle('modulename', cfg, cloud, None, None)
         self.assertItemsEqual(
-            f_user.call_args_list,
+            m_fbsd_user.call_args_list,
             [mock.call('freebsd', groups='wheel', lock_passwd=True,
                        shell='/bin/tcsh'),
              mock.call('me2', default=False)])
-        f_group.assert_not_called()
-        l_group.assert_not_called()
-        l_user.assert_not_called()
+        m_fbsd_group.assert_not_called()
+        m_linux_group.assert_not_called()
+        m_linux_user.assert_not_called()
 
     def test_users_with_ssh_redirect_user_passes_keys(self, m_user, m_group):
         """When ssh_redirect_user is True pass default user and cloud keys."""

--- a/cloudinit/config/tests/test_users_groups.py
+++ b/cloudinit/config/tests/test_users_groups.py
@@ -50,10 +50,10 @@ class TestHandleUsersGroups(CiTestCase):
     @mock.patch('cloudinit.distros.freebsd.Distro.create_user')
     def test_handle_users_in_cfg_calls_create_users_on_bsd(
             self,
-            _user,
-            _group,
-            m_user,
-            m_group,
+            f_user,
+            f_group,
+            l_user,
+            l_group,
     ):
         """When users in config, create users with freebsd.create_user."""
         cfg = {'users': ['default', {'name': 'me2'}]}  # merged cloud-config
@@ -66,11 +66,13 @@ class TestHandleUsersGroups(CiTestCase):
             distro='freebsd', sys_cfg=sys_cfg, metadata=metadata)
         cc_users_groups.handle('modulename', cfg, cloud, None, None)
         self.assertItemsEqual(
-            m_user.call_args_list,
+            f_user.call_args_list,
             [mock.call('freebsd', groups='wheel', lock_passwd=True,
                        shell='/bin/tcsh'),
              mock.call('me2', default=False)])
-        m_group.assert_not_called()
+        f_group.assert_not_called()
+        l_group.assert_not_called()
+        l_user.assert_not_called()
 
     def test_users_with_ssh_redirect_user_passes_keys(self, m_user, m_group):
         """When ssh_redirect_user is True pass default user and cloud keys."""

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -256,7 +256,7 @@ class Distro(distros.Distro):
 
     def lock_passwd(self, name):
         try:
-            util.subp(['pw', 'usermod', name, '-h', '-'])
+            util.subp(['pw', 'lock', name])
         except Exception as e:
             util.logexc(LOG, "Failed to lock user %s", name)
             raise e


### PR DESCRIPTION
on FreeBSD, lock_passwd is implemented as `pw usermod <user> -h -`

This does not lock the account. It prompts for a password change on the console during cloud-init run.

To lock an account, we have to execute: `pw lock <name>`.

-----
Fixes LP # 1854594