### PR TITLE
Add an Amazon distro in the redhat OS family

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -36,7 +36,7 @@ ALL_DISTROS = 'all'
 
 OSFAMILIES = {
     'debian': ['debian', 'ubuntu'],
-    'redhat': ['centos', 'fedora', 'rhel'],
+    'redhat': ['amazon', 'centos', 'fedora', 'rhel'],
     'gentoo': ['gentoo'],
     'freebsd': ['freebsd'],
     'suse': ['opensuse', 'sles'],

--- a/cloudinit/distros/amazon.py
+++ b/cloudinit/distros/amazon.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2012 Canonical Ltd.
+# Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
+# Copyright (C) 2012 Yahoo! Inc.
+# Copyright (C) 2014 Amazon.com, Inc. or its affiliates.
+#
+# Author: Scott Moser <scott.moser@canonical.com>
+# Author: Juerg Haefliger <juerg.haefliger@hp.com>
+# Author: Joshua Harlow <harlowja@yahoo-inc.com>
+# Author: Andrew Jorgensen <ajorgens@amazon.com>
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from cloudinit.distros import rhel
+
+from cloudinit import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+class Distro(rhel.Distro):
+
+    def update_package_sources(self):
+        return None
+
+
+# vi: ts=4 expandtab


### PR DESCRIPTION
This is the 1st part of adding an Amazon distro definition to cloud-init.

From original work by: Andrew Jorgensen <ajorgens@amazon.com>

Reviewed-by: Matt Nierzwicki <nierzwic@amazon.com>
Reviewed-by: Ethan Faust <efaust@amazon.com>