### PR TITLE
debian: add reference to the manpages

### DIFF
--- a/packages/debian/manpages
+++ b/packages/debian/manpages
@@ -1,3 +1,3 @@
-cloud-id.1
-cloud-init-per.1
-cloud-init.1
+doc/man/cloud-id.1
+doc/man/cloud-init-per.1
+doc/man/cloud-init.1

--- a/packages/debian/manpages
+++ b/packages/debian/manpages
@@ -1,0 +1,3 @@
+cloud-id.1
+cloud-init-per.1
+cloud-init.1


### PR DESCRIPTION
Once the manpages are reviewed and added, this will add them to the debian directory. A package build will then pick up and deliver the pages.

Confirmed in a Bionic multipass instance.