### PR TITLE
d/control: drop alternate dependency on ifupdown

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Architecture: all
 Depends: cloud-guest-utils | cloud-utils,
          isc-dhcp-client,
          iproute2,
-         netplan.io | ifupdown,
+         netplan.io,
          procps,
          python3,
          python3-requests,


### PR DESCRIPTION
Drop alternate dependency on ifupdown as it is no longer supported in
Ubuntu.