### PR TITLE
Remove top-level random import to allow VM to boot faster

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -21,7 +21,8 @@ import os
 import os.path
 import platform
 import pwd
-import random
+# import random Do not import random, see commit for details.
+# (i.e. is_resolvable called to get the meta-data service on dhcp discovery)
 import re
 import shlex
 import shutil
@@ -401,6 +402,7 @@ def translate_bool(val, addons=None):
 
 
 def rand_str(strlen=32, select_from=None):
+    import random
     if not select_from:
         select_from = string.ascii_letters + string.digits
     return "".join([random.choice(select_from) for _x in range(0, strlen)])


### PR DESCRIPTION
Hi folks,
This is a problem I've observed on a Centos 7 machine and didn't find a bug for it yet.  I'm thinking of doing so during the day depending on the discussion that will happen here.

As the machine starts, the VM doesn't have the /dev/urandom initialised
yet.  This cause the init-local dhcp discovery to wait on /dev/urandom to reach
the meta-data server and start configuring the server, all to resolve
169.254.169.254 which shouldn't need resolution.  The impact of this is
80 sec on Redhat based OS.

As python import are cached anyway and random is only used in "rand_str"
, putting the import within the function that needs it makes sense at
the moment of writing.

https://docs.python.org/3/reference/import.html#the-module-cache

May come a time where we might want to have a test to make sure random
and other packages having similar effect never gets imported as a
top-level package in this file being used throughout cloud-init to avoid
this problem again.