### PR TITLE
config/cloud.cfg.d: update README

### DIFF
--- a/config/cloud.cfg.d/README
+++ b/config/cloud.cfg.d/README
@@ -1,3 +1,3 @@
-# All files in this directory will be read by cloud-init
-# They are read in lexical order.  Later files overwrite values in
+# All files with the '.cfg' extension in this directory will be read by
+# cloud-init. They are read in lexical order. Later files overwrite values in
 # earlier files.


### PR DESCRIPTION
Update README to specify that only files with the '.cfg' extension are
read in this folder.

LP: #1855006