### PR TITLE
docs: clear up apt config sections

### DIFF
--- a/doc/examples/cloud-config-add-apt-repos.txt
+++ b/doc/examples/cloud-config-add-apt-repos.txt
@@ -1,6 +1,10 @@
 #cloud-config
 
-# Add apt repositories
+# Add primary apt repositories
+#
+# To add 3rd party repositories, see cloud-config-apt.txt or the
+# Additional apt configuration and repositories section.
+#
 #
 # Default: auto select based on cloud metadata
 #  in ec2, the default is <region>.archive.ubuntu.com

--- a/doc/rtd/topics/examples.rst
+++ b/doc/rtd/topics/examples.rst
@@ -60,8 +60,8 @@ Setup and run `puppet`_
    :language: yaml
    :linenos:
 
-Add apt repositories
-====================
+Add primary apt repositories
+============================
 
 .. literalinclude:: ../../examples/cloud-config-add-apt-repos.txt
    :language: yaml
@@ -135,8 +135,8 @@ Configure instances ssh-keys
    :language: yaml
    :linenos:
 
-Additional apt configuration
-============================
+Additional apt configuration and repositories
+=============================================
 
 .. literalinclude:: ../../examples/cloud-config-apt.txt
     :language: yaml


### PR DESCRIPTION
More clearly differentiate between the primary apt repo configuration
and any 3rd party apt configuration.

LP: #1832823