### PR TITLE
cc_set_password: remove unecessary stderr message

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -78,7 +78,6 @@ password.
 """
 
 import re
-import sys
 
 from cloudinit.distros import ug_util
 from cloudinit import log as logging
@@ -209,11 +208,6 @@ def handle(_name, cfg, cloud, log, args):
                 util.logexc(
                     log, "Failed to set hashed passwords with chpasswd for %s",
                     hashed_users)
-
-        if len(randlist):
-            blurb = ("Set the following 'random' passwords\n",
-                     '\n'.join(randlist))
-            sys.stderr.write("%s\n%s\n" % blurb)
 
         if expire:
             expired_users = []


### PR DESCRIPTION
When running unittests I seeing the following message printed out:

Set the following 'random' passwords
root:uZneWdgE6
ubuntu:cx7Sm9QRM

Turns out that was debug messaging I think and not actually required or doing anything useful.