### PR TITLE
ec2: render network on all NICs and add secondary IPs as static

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -806,10 +806,6 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
 
         # v2 routes are bound to the interface, in v1 we add them under
         # the first subnet since there isn't an equivalent interface level.
-        # Ordering of subnet config for ipv4 vs ipv6 definitions does not
-        # matter on internal net state. The network renderers, such as netplan,
-        # emit that network config up in the specific interface scope instead
-        # of individual subnet addresses.
         if len(subnets) and len(routes):
             subnets[0]['routes'] = routes
 

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -806,6 +806,10 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
 
         # v2 routes are bound to the interface, in v1 we add them under
         # the first subnet since there isn't an equivalent interface level.
+        # Ordering of subnet config for ipv4 vs ipv6 definitions does not 
+        # matter on internal net state. The network renderers, such as netplan,
+        # emit that network config up in the specific interface scope instead
+        # of individual subnet addresses. 
         if len(subnets) and len(routes):
             subnets[0]['routes'] = routes
 

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -806,10 +806,10 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
 
         # v2 routes are bound to the interface, in v1 we add them under
         # the first subnet since there isn't an equivalent interface level.
-        # Ordering of subnet config for ipv4 vs ipv6 definitions does not 
+        # Ordering of subnet config for ipv4 vs ipv6 definitions does not
         # matter on internal net state. The network renderers, such as netplan,
         # emit that network config up in the specific interface scope instead
-        # of individual subnet addresses. 
+        # of individual subnet addresses.
         if len(subnets) and len(routes):
             subnets[0]['routes'] = routes
 

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -752,7 +752,9 @@ def convert_ec2_metadata_network_config(
         LOG.debug(
             'Skipping network configuration for secondary NICs and IPs.'
             'Datasource apply_network_config value is set False')
-        mac, nic_name = macs_to_nics[fallback_nic]
+        for mac, nic_name in macs_to_nics.items():
+            if nic_name == fallback_nic:
+                break
         dev_config = {'dhcp4': True,
                       'dhcp6': False,
                       'match': {'macaddress': mac.lower()},

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -727,7 +727,7 @@ def _collect_platform_data():
 def convert_ec2_metadata_network_config(
         network_md, macs_to_nics=None, fallback_nic=None,
         config_secondary_ips=True):
-    """Convert ec2 metadata to network config version 1 data dict.
+    """Convert ec2 metadata to network config version 2 data dict.
 
     @param: network_md: 'network' portion of EC2 metadata.
        generally formed as {"interfaces": {"macs": {}} where

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -409,12 +409,12 @@ class DataSourceEc2(sources.DataSource):
         net_md = self.metadata.get('network')
         if isinstance(net_md, dict):
             # SRU_BLOCKER: xenial, bionic and eoan should default
-            # apply_network_config to False to retain original behavior on
-            # those releases.
+            # apply_full_imds_network_config to False to retain original
+            # behavior on those releases.
             result = convert_ec2_metadata_network_config(
                 net_md, fallback_nic=iface,
                 full_network_config=util.get_cfg_option_bool(
-                    self.ds_cfg, 'apply_network_config', True))
+                    self.ds_cfg, 'apply_full_imds_network_config', True))
 
             # RELEASE_BLOCKER: xenial should drop the below if statement,
             # because the issue being addressed doesn't exist pre-netplan.

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -749,9 +749,6 @@ def convert_ec2_metadata_network_config(
     macs_metadata = network_md['interfaces']['macs']
 
     if not apply_network_config:
-        LOG.debug(
-            'Skipping network configuration for secondary NICs and IPs.'
-            'Datasource apply_network_config value is set False')
         for mac, nic_name in macs_to_nics.items():
             if nic_name == fallback_nic:
                 break

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -777,14 +777,14 @@ def convert_ec2_metadata_network_config(
         if nic_metadata.get('ipv6s'):  # Any IPv6 addresses configured
             dev_config['dhcp6'] = True
             dev_config['dhcp6-overrides'] = dhcp_override
-        dev_config['addresses'] = get_secondary_addresses(nic_metadata)
+        dev_config['addresses'] = get_secondary_addresses(nic_metadata, mac)
         if not dev_config['addresses']:
             dev_config.pop('addresses')  # Since we found none configured
         netcfg['ethernets'][nic_name] = dev_config
     return netcfg
 
 
-def get_secondary_addresses(nic_metadata):
+def get_secondary_addresses(nic_metadata, mac):
     """Parse interface-specific nic metadata and return and any secondary IPs
 
     :return: List of secondary IPv4 or IPv6 addresses to configure on the
@@ -815,9 +815,9 @@ def get_secondary_addresses(nic_metadata):
         prefix = md_vals['prefix_default']
         if not cidr or len(cidr.split('/')) != 2:
             LOG.warning(
-                'Could not parse %s %s. %s network'
+                'Could not parse %s %s for mac %s. %s network'
                 ' config prefix defaults to /%s',
-                md_vals['cidr_key'], cidr, ip_type, prefix)
+                md_vals['cidr_key'], cidr, mac, ip_type, prefix)
         else:
             prefix = cidr.split('/')[1]
         # We know we have > 1 ips for in metadata for this IP type

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -80,6 +80,9 @@ The settings that may be configured are:
  * **timeout**: the timeout value provided to urlopen for each individual http
    request.  This is used both when selecting a metadata_url and when crawling
    the metadata service. (default: 50)
+ * **configure_secondary_ips**: Boolean (default: True) to allow cloud-init
+   to configure any secondary IPs described by the metadata service.
+   On Ubuntu Xenial, Bionic and Eoan the default is False.
 
 An example configuration with the default values is provided below:
 

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -81,13 +81,15 @@ The settings that may be configured are:
  * **timeout**: the timeout value provided to urlopen for each individual http
    request.  This is used both when selecting a metadata_url and when crawling
    the metadata service. (default: 50)
- * **apply_network_conig**: Boolean (default: True) to allow cloud-init
-   to configure any secondary NICs and secondoary IPs described by the
-   metadata service. Each network interface will enable dhcp4 to obtain
-   primary address and route. Secondary IPv4/IPv6 addresses are configured as
-   static IP addresses on the NIC if either ``local-ipv4s`` or ``ipv6s``
-   contain multiple addresses in the list. Each address greater than one
-   represented in that metadata is a secondary address.
+ * **apply_network_config**: Boolean (default: True) to allow cloud-init
+   to configure any secondary NICs and secondary IPs described by the
+   metadata service. All network interfaces are configured with DHCP (v4) to
+   obtain an primary IPv4 address and route. Interfaces which have a
+   non-empty 'ipv6s' list will also enable DHCPv6 to obtain a primary IPv6
+   address and route. The DHCP response (v4 and v6) return an IP that matches
+   the first element of local-ipv4s and ipv6s lists respectively. All
+   additional values (secondary addresses) in the static ip lists will be
+   added to interface.
 
 An example configuration with the default values is provided below:
 
@@ -98,6 +100,7 @@ An example configuration with the default values is provided below:
     metadata_urls: ["http://169.254.169.254:80", "http://instance-data:8773"]
     max_wait: 120
     timeout: 50
+    apply_network_config: true
 
 Notes
 -----
@@ -113,7 +116,8 @@ Notes
  * For EC2 instances with multiple network interfaces (NICs) attached, dhcp4
    will be enabled to obtain the primary private IPv4 address of those NICs.
    Wherever dhcp4 or dhcp6 is enabled for a NIC, a dhcp route-metric will be
-   added with the value of ``<interface_num + 1> * 100`` to ensure dhcp
+   added with the value of ``<device-number + 1> * 100`` to ensure dhcp
    routes on the primary NIC are preferred to any secondary NICs.
+   For example: eth0 will have a DHCP route-metric of 100, eth1 will be 200.
 
 .. vi: textwidth=78

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -118,6 +118,7 @@ Notes
    Wherever dhcp4 or dhcp6 is enabled for a NIC, a dhcp route-metric will be
    added with the value of ``<device-number + 1> * 100`` to ensure dhcp
    routes on the primary NIC are preferred to any secondary NICs.
-   For example: eth0 will have a DHCP route-metric of 100, eth1 will be 200.
+   For example: the primary NIC will have a DHCP route-metric of 100,
+   the next NIC will be 200.
 
 .. vi: textwidth=78

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -81,13 +81,13 @@ The settings that may be configured are:
  * **timeout**: the timeout value provided to urlopen for each individual http
    request.  This is used both when selecting a metadata_url and when crawling
    the metadata service. (default: 50)
- * **configure_secondary_ips**: Boolean (default: True) to allow cloud-init
-   to configure any secondary IPs described by the metadata service. Each
-   network interface will enable dhcp4 to obtain primary address and route.
-   Secondary IPv4/IPv6 addresses are configured as static IP addresses on the
-   NIC if either ``local-ipv4s`` or ``ipv6s`` contain multiple addresses in the
-   list. Each address greater than one represented in that metadata is a
-   secondary address.
+ * **apply_network_conig**: Boolean (default: True) to allow cloud-init
+   to configure any secondary NICs and secondoary IPs described by the
+   metadata service. Each network interface will enable dhcp4 to obtain
+   primary address and route. Secondary IPv4/IPv6 addresses are configured as
+   static IP addresses on the NIC if either ``local-ipv4s`` or ``ipv6s``
+   contain multiple addresses in the list. Each address greater than one
+   represented in that metadata is a secondary address.
 
 An example configuration with the default values is provided below:
 

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -82,7 +82,6 @@ The settings that may be configured are:
    the metadata service. (default: 50)
  * **configure_secondary_ips**: Boolean (default: True) to allow cloud-init
    to configure any secondary IPs described by the metadata service.
-   On Ubuntu Xenial, Bionic and Eoan the default is False.
 
 An example configuration with the default values is provided below:
 

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -42,6 +42,7 @@ Note that there are multiple versions of this data provided, cloud-init
 by default uses **2009-04-04** but newer versions can be supported with
 relative ease (newer versions have more data exposed, while maintaining
 backward compatibility with the previous versions).
+Version **2016-09-02** is required for secondary IP address support.
 
 To see which versions are supported from your cloud provider use the following
 URL:
@@ -81,7 +82,12 @@ The settings that may be configured are:
    request.  This is used both when selecting a metadata_url and when crawling
    the metadata service. (default: 50)
  * **configure_secondary_ips**: Boolean (default: True) to allow cloud-init
-   to configure any secondary IPs described by the metadata service.
+   to configure any secondary IPs described by the metadata service. Each
+   network interface will enable dhcp4 to obtain primary address and route.
+   Secondary IPv4/IPv6 addresses are configured as static IP addresses on the
+   NIC if either ``local-ipv4s`` or ``ipv6s`` contain multiple addresses in the
+   list. Each address greater than one represented in that metadata is a
+   secondary address.
 
 An example configuration with the default values is provided below:
 
@@ -103,5 +109,11 @@ Notes
    generated only in the first boot of the instance.
    The check for the instance type is performed by is_classic_instance()
    method.
+
+ * For EC2 instances with multiple network interfaces (NICs) attached, dhcp4
+   will be enabled to obtain the primary private IPv4 address of those NICs.
+   Wherever dhcp4 or dhcp6 is enabled for a NIC, a dhcp route-metric will be
+   added with the value of ``<interface_num + 1> * 100`` to ensure dhcp
+   routes on the primary NIC are preferred to any secondary NICs.
 
 .. vi: textwidth=78

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -81,10 +81,10 @@ The settings that may be configured are:
  * **timeout**: the timeout value provided to urlopen for each individual http
    request.  This is used both when selecting a metadata_url and when crawling
    the metadata service. (default: 50)
- * **apply_network_config**: Boolean (default: True) to allow cloud-init
-   to configure any secondary NICs and secondary IPs described by the
-   metadata service. All network interfaces are configured with DHCP (v4) to
-   obtain an primary IPv4 address and route. Interfaces which have a
+ * **apply_full_imds_network_config**: Boolean (default: True) to allow
+   cloud-init to configure any secondary NICs and secondary IPs described by
+   the metadata service. All network interfaces are configured with DHCP (v4)
+   to obtain an primary IPv4 address and route. Interfaces which have a
    non-empty 'ipv6s' list will also enable DHCPv6 to obtain a primary IPv6
    address and route. The DHCP response (v4 and v6) return an IP that matches
    the first element of local-ipv4s and ipv6s lists respectively. All
@@ -100,7 +100,7 @@ An example configuration with the default values is provided below:
     metadata_urls: ["http://169.254.169.254:80", "http://instance-data:8773"]
     max_wait: 120
     timeout: 50
-    apply_network_config: true
+    apply_full_imds_network_config: true
 
 Notes
 -----

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -394,7 +394,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': '06:17:04:d7:26:09'}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': True}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
@@ -422,7 +423,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
         mac1 = '06:17:04:d7:26:0A'  # IPv4 only in DEFAULT_METADATA
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': mac1.lower()}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': False}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': False}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
@@ -453,7 +455,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
             'addresses': ['172.31.45.70/20',
                           '2600:1f16:292:100:f153:12a3:c37c:11f9/128',
                           '2600:1f16:292:100:f152:2222:3333:4444/128'],
-            'dhcp4': True, 'dhcp6': True}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
@@ -462,7 +465,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
                     m_get_interfaces_by_mac.return_value = {mac1: 'eth9'}
                     m_find_fallback.return_value = 'eth9'
                     m_get_mac.return_value = mac1
-                    self.assertItemsEqual(expected, ds.network_config)
+                    self.assertEqual(expected, ds.network_config)
 
     def test_network_config_property_is_cached_in_datasource(self):
         """network_config property is cached in DataSourceEc2."""
@@ -502,7 +505,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
             self.logs.getvalue())
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': mac1}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': True}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         self.assertEqual(expected, ds.network_config)
 
     def test_ec2_get_instance_id_refreshes_identity_on_upgrade(self):
@@ -758,7 +762,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         # DE:AD:BE:EF:FF:FF represented by OS but not in metadata
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': False}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -774,7 +779,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata.pop('public-ipv4s')
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': True}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -790,7 +796,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata.pop('public-ipv4s')
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': False}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -807,7 +814,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         # When no ipv4 or ipv6 content but fallback_nic set, set dhcp4 config.
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': False}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -824,7 +832,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': True}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -845,11 +854,13 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         expected = {'version': 2, 'ethernets': {
             'eth9': {
                 'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
-                'dhcp4': True, 'dhcp6': True},
+                'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+                'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}},
             'eth10': {
                 'match': {'macaddress': mac2.lower()}, 'set-name': 'eth10',
-                'dhcp4': True, 'dhcp6': False}}}
-        self.assertItemsEqual(
+                'dhcp4': True, 'dhcp4-overrides': {'route-metric': 200},
+                'dhcp6': False}}}
+        self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
                 network_metadata_both, macs_to_nics))
@@ -863,7 +874,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp6': True}}}
+            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -873,7 +885,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         """Convert Ec2 Metadata calls get_interfaces_by_mac by default."""
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1.lower()},
-            'set-name': 'eth9', 'dhcp4': True, 'dhcp6': False}}}
+            'set-name': 'eth9', 'dhcp4': True,
+            'dhcp4-overrides': {'route-metric': 100}, 'dhcp6': False}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
             m_get_interfaces_by_mac.return_value = {self.mac1: 'eth9'}

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -758,7 +758,7 @@ class TestGetSecondaryAddresses(test_helpers.CiTestCase):
     def test_md_with_secondary_v4_and_v6_addresses(self):
         """All secondary addresses are returned from nic metadata"""
         self.assertEqual(
-            ['172.31.45.70/20','2600:1f16:292:100:f152:2222:3333:4444/128',
+            ['172.31.45.70/20', '2600:1f16:292:100:f152:2222:3333:4444/128',
              '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
             ec2.get_secondary_addresses(NIC1_MD_IPV4_IPV6_MULTI_IP))
 

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -117,6 +117,56 @@ DEFAULT_METADATA = {
 # python3 -c 'import json
 # from cloudinit.ec2_utils import get_instance_metadata as gm
 # print(json.dumps(gm("2018-09-24"), indent=1, sort_keys=True))'
+
+NIC1_MD_IPV4_IPV6_MULTI_IP = {
+    "device-number": "0",
+    "interface-id": "eni-0d6335689899ce9cc",
+    "ipv4-associations": {
+        "18.218.219.181": "172.31.44.13"
+    },
+    "ipv6s": [
+        "2600:1f16:292:100:c187:593c:4349:136",
+        "2600:1f16:292:100:f153:12a3:c37c:11f9",
+        "2600:1f16:292:100:f152:2222:3333:4444"
+    ],
+    "local-hostname": ("ip-172-31-44-13.us-east-2."
+                       "compute.internal"),
+    "local-ipv4s": [
+        "172.31.44.13",
+        "172.31.45.70"
+    ],
+    "mac": "0a:07:84:3d:6e:38",
+    "owner-id": "329910648901",
+    "public-hostname": ("ec2-18-218-219-181.us-east-2."
+                        "compute.amazonaws.com"),
+    "public-ipv4s": "18.218.219.181",
+    "security-group-ids": "sg-0c387755222ba8d2e",
+    "security-groups": "launch-wizard-4",
+    "subnet-id": "subnet-9d7ba0d1",
+    "subnet-ipv4-cidr-block": "172.31.32.0/20",
+    "subnet_ipv6_cidr_blocks": "2600:1f16:292:100::/64",
+    "vpc-id": "vpc-a07f62c8",
+    "vpc-ipv4-cidr-block": "172.31.0.0/16",
+    "vpc-ipv4-cidr-blocks": "172.31.0.0/16",
+    "vpc_ipv6_cidr_blocks": "2600:1f16:292:100::/56"
+}
+
+NIC2_MD = {
+    "device_number": "1",
+    "interface_id": "eni-043cdce36ded5e79f",
+    "local_hostname": "ip-172-31-47-221.us-east-2.compute.internal",
+    "local_ipv4s": "172.31.47.221",
+    "mac": "0a:75:69:92:e2:16",
+    "owner_id": "329910648901",
+    "security_group_ids": "sg-0d68fef37d8cc9b77",
+    "security_groups": "launch-wizard-17",
+    "subnet_id": "subnet-9d7ba0d1",
+    "subnet_ipv4_cidr_block": "172.31.32.0/20",
+    "vpc_id": "vpc-a07f62c8",
+    "vpc_ipv4_cidr_block": "172.31.0.0/16",
+    "vpc_ipv4_cidr_blocks": "172.31.0.0/16"
+}
+
 SECONDARY_IP_METADATA_2018_09_24 = {
     "ami-id": "ami-0986c2ac728528ac2",
     "ami-launch-index": "0",
@@ -153,38 +203,7 @@ SECONDARY_IP_METADATA_2018_09_24 = {
     "network": {
         "interfaces": {
             "macs": {
-                "0a:07:84:3d:6e:38": {
-                    "device-number": "0",
-                    "interface-id": "eni-0d6335689899ce9cc",
-                    "ipv4-associations": {
-                        "18.218.219.181": "172.31.44.13"
-                    },
-                    "ipv6s": [
-                        "2600:1f16:292:100:c187:593c:4349:136",
-                        "2600:1f16:292:100:f153:12a3:c37c:11f9",
-                        "2600:1f16:292:100:f152:2222:3333:4444"
-                    ],
-                    "local-hostname": ("ip-172-31-44-13.us-east-2."
-                                       "compute.internal"),
-                    "local-ipv4s": [
-                        "172.31.44.13",
-                        "172.31.45.70"
-                    ],
-                    "mac": "0a:07:84:3d:6e:38",
-                    "owner-id": "329910648901",
-                    "public-hostname": ("ec2-18-218-219-181.us-east-2."
-                                        "compute.amazonaws.com"),
-                    "public-ipv4s": "18.218.219.181",
-                    "security-group-ids": "sg-0c387755222ba8d2e",
-                    "security-groups": "launch-wizard-4",
-                    "subnet-id": "subnet-9d7ba0d1",
-                    "subnet-ipv4-cidr-block": "172.31.32.0/20",
-                    "subnet_ipv6_cidr_blocks": "2600:1f16:292:100::/64",
-                    "vpc-id": "vpc-a07f62c8",
-                    "vpc-ipv4-cidr-block": "172.31.0.0/16",
-                    "vpc-ipv4-cidr-blocks": "172.31.0.0/16",
-                    "vpc_ipv6_cidr_blocks": "2600:1f16:292:100::/56"
-                }
+                "0a:07:84:3d:6e:38": NIC1_MD_IPV4_IPV6_MULTI_IP,
             }
         }
     },
@@ -206,22 +225,6 @@ SECONDARY_IP_METADATA_2018_09_24 = {
         "domain": "amazonaws.com",
         "partition": "aws"
     }
-}
-
-NIC2_MD = {
-    "device_number": "1",
-    "interface_id": "eni-043cdce36ded5e79f",
-    "local_hostname": "ip-172-31-47-221.us-east-2.compute.internal",
-    "local_ipv4s": "172.31.47.221",
-    "mac": "0a:75:69:92:e2:16",
-    "owner_id": "329910648901",
-    "security_group_ids": "sg-0d68fef37d8cc9b77",
-    "security_groups": "launch-wizard-17",
-    "subnet_id": "subnet-9d7ba0d1",
-    "subnet_ipv4_cidr_block": "172.31.32.0/20",
-    "vpc_id": "vpc-a07f62c8",
-    "vpc_ipv4_cidr_block": "172.31.0.0/16",
-    "vpc_ipv4_cidr_blocks": "172.31.0.0/16"
 }
 
 M_PATH_NET = 'cloudinit.sources.DataSourceEc2.net.'
@@ -453,8 +456,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': mac1}, 'set-name': 'eth9',
             'addresses': ['172.31.45.70/20',
-                          '2600:1f16:292:100:f153:12a3:c37c:11f9/128',
-                          '2600:1f16:292:100:f152:2222:3333:4444/128'],
+                          '2600:1f16:292:100:f152:2222:3333:4444/128',
+                          '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
             'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
             'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
@@ -494,10 +497,10 @@ class TestEc2(test_helpers.HttprettyTestCase):
         register_mock_metaserver(
             'http://169.254.169.254/2009-04-04/meta-data/', DEFAULT_METADATA)
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
-        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
+        get_interface_mac_path = M_PATH_NET + 'get_interfaces_by_mac'
         ds.fallback_nic = 'eth9'
         with mock.patch(get_interface_mac_path) as m_get_interface_mac:
-            m_get_interface_mac.return_value = mac1
+            m_get_interface_mac.return_value = {mac1: 'eth9'}
             nc = ds.network_config  # Will re-crawl network metadata
             self.assertIsNotNone(nc)
         self.assertIn(
@@ -744,6 +747,20 @@ class TestEc2(test_helpers.HttprettyTestCase):
             prefix_or_mask='255.255.255.0', router='192.168.2.1',
             static_routes=None)
         self.assertIn('Crawl of metadata service took', self.logs.getvalue())
+
+
+class TestGetSecondaryAddresses(test_helpers.CiTestCase):
+
+    def test_md_with_no_secondary_addresses(self):
+        """Empty list is returned when nic metadata contains no secondary ip"""
+        self.assertEqual([], ec2.get_secondary_addresses(NIC2_MD))
+
+    def test_md_with_ipv4_and_ipv6_addresses(self):
+        """All secondary addresses are returned from nic metadata"""
+        self.assertEqual(
+            ['172.31.45.70/20','2600:1f16:292:100:f152:2222:3333:4444/128',
+             '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
+            ec2.get_secondary_addresses(NIC1_MD_IPV4_IPV6_MULTI_IP))
 
 
 class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -452,7 +452,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
             m_find_fallback.return_value = 'eth9'
             ds.get_data()
 
-        mac1 = '0a:07:84:3d:6e:38'  # IPv4 with 1 secondary IP
+        mac1 = '0a:07:84:3d:6e:38'  # 1 secondary IPv4 and 2 secondary IPv6
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': mac1}, 'set-name': 'eth9',
             'addresses': ['172.31.45.70/20',
@@ -499,8 +499,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
         get_interface_mac_path = M_PATH_NET + 'get_interfaces_by_mac'
         ds.fallback_nic = 'eth9'
-        with mock.patch(get_interface_mac_path) as m_get_interface_mac:
-            m_get_interface_mac.return_value = {mac1: 'eth9'}
+        with mock.patch(get_interface_mac_path) as m_get_interfaces_by_mac:
+            m_get_interfaces_by_mac.return_value = {mac1: 'eth9'}
             nc = ds.network_config  # Will re-crawl network metadata
             self.assertIsNotNone(nc)
         self.assertIn(
@@ -755,7 +755,7 @@ class TestGetSecondaryAddresses(test_helpers.CiTestCase):
         """Empty list is returned when nic metadata contains no secondary ip"""
         self.assertEqual([], ec2.get_secondary_addresses(NIC2_MD))
 
-    def test_md_with_ipv4_and_ipv6_addresses(self):
+    def test_md_with_secondary_v4_and_v6_addresses(self):
         """All secondary addresses are returned from nic metadata"""
         self.assertEqual(
             ['172.31.45.70/20','2600:1f16:292:100:f152:2222:3333:4444/128',

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -113,6 +113,119 @@ DEFAULT_METADATA = {
     "services": {"domain": "amazonaws.com", "partition": "aws"},
 }
 
+# collected from api version 2018-09-24/ with
+# python3 -c 'import json
+# from cloudinit.ec2_utils import get_instance_metadata as gm
+# print(json.dumps(gm("2018-09-24"), indent=1, sort_keys=True))'
+SECONDARY_IP_METADATA_2018_09_24 = {
+    "ami-id": "ami-0986c2ac728528ac2",
+    "ami-launch-index": "0",
+    "ami-manifest-path": "(unknown)",
+    "block-device-mapping": {
+        "ami": "/dev/sda1",
+        "root": "/dev/sda1"
+    },
+    "events": {
+        "maintenance": {
+            "history": "[]",
+            "scheduled": "[]"
+        }
+    },
+    "hostname": "ip-172-31-44-13.us-east-2.compute.internal",
+    "identity-credentials": {
+        "ec2": {
+            "info": {
+                "AccountId": "329910648901",
+                "Code": "Success",
+                "LastUpdated": "2019-07-06T14:22:56Z"
+            }
+        }
+    },
+    "instance-action": "none",
+    "instance-id": "i-069e01e8cc43732f8",
+    "instance-type": "t2.micro",
+    "local-hostname": "ip-172-31-44-13.us-east-2.compute.internal",
+    "local-ipv4": "172.31.44.13",
+    "mac": "0a:07:84:3d:6e:38",
+    "metrics": {
+        "vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    },
+    "network": {
+        "interfaces": {
+            "macs": {
+                "0a:07:84:3d:6e:38": {
+                    "device-number": "0",
+                    "interface-id": "eni-0d6335689899ce9cc",
+                    "ipv4-associations": {
+                        "18.218.219.181": "172.31.44.13"
+                    },
+                    "ipv6s": [
+                        "2600:1f16:292:100:c187:593c:4349:136",
+                        "2600:1f16:292:100:f153:12a3:c37c:11f9",
+                        "2600:1f16:292:100:f152:2222:3333:4444"
+                    ],
+                    "local-hostname": ("ip-172-31-44-13.us-east-2."
+                                       "compute.internal"),
+                    "local-ipv4s": [
+                        "172.31.44.13",
+                        "172.31.45.70"
+                    ],
+                    "mac": "0a:07:84:3d:6e:38",
+                    "owner-id": "329910648901",
+                    "public-hostname": ("ec2-18-218-219-181.us-east-2."
+                                        "compute.amazonaws.com"),
+                    "public-ipv4s": "18.218.219.181",
+                    "security-group-ids": "sg-0c387755222ba8d2e",
+                    "security-groups": "launch-wizard-4",
+                    "subnet-id": "subnet-9d7ba0d1",
+                    "subnet-ipv4-cidr-block": "172.31.32.0/20",
+                    "subnet_ipv6_cidr_blocks": "2600:1f16:292:100::/64",
+                    "vpc-id": "vpc-a07f62c8",
+                    "vpc-ipv4-cidr-block": "172.31.0.0/16",
+                    "vpc-ipv4-cidr-blocks": "172.31.0.0/16",
+                    "vpc_ipv6_cidr_blocks": "2600:1f16:292:100::/56"
+                }
+            }
+        }
+    },
+    "placement": {
+        "availability-zone": "us-east-2c"
+    },
+    "profile": "default-hvm",
+    "public-hostname": (
+        "ec2-18-218-219-181.us-east-2.compute.amazonaws.com"),
+    "public-ipv4": "18.218.219.181",
+    "public-keys": {
+        "yourkeyname,e": [
+            "ssh-rsa AAAAW...DZ yourkeyname"
+        ]
+    },
+    "reservation-id": "r-09b4917135cdd33be",
+    "security-groups": "launch-wizard-4",
+    "services": {
+        "domain": "amazonaws.com",
+        "partition": "aws"
+    }
+}
+
+NIC2_MD = {
+    "device_number": "1",
+    "interface_id": "eni-043cdce36ded5e79f",
+    "local_hostname": "ip-172-31-47-221.us-east-2.compute.internal",
+    "local_ipv4s": "172.31.47.221",
+    "mac": "0a:75:69:92:e2:16",
+    "owner_id": "329910648901",
+    "security_group_ids": "sg-0d68fef37d8cc9b77",
+    "security_groups": "launch-wizard-17",
+    "subnet_id": "subnet-9d7ba0d1",
+    "subnet_ipv4_cidr_block": "172.31.32.0/20",
+    "vpc_id": "vpc-a07f62c8",
+    "vpc_ipv4_cidr_block": "172.31.0.0/16",
+    "vpc_ipv4_cidr_blocks": "172.31.0.0/16"
+}
+
+M_PATH_NET = 'cloudinit.sources.DataSourceEc2.net.'
+
 
 def _register_ssh_keys(rfunc, base_url, keys_data):
     """handle ssh key inconsistencies.
@@ -267,30 +380,23 @@ class TestEc2(test_helpers.HttprettyTestCase):
                         register_mock_metaserver(instance_id_url, None)
         return ds
 
-    def test_network_config_property_returns_version_1_network_data(self):
-        """network_config property returns network version 1 for metadata.
-
-        Only one device is configured even when multiple exist in metadata.
-        """
+    def test_network_config_property_returns_version_2_network_data(self):
+        """network_config property returns network version 2 for metadata"""
         ds = self._setup_ds(
             platform_data=self.valid_platform_data,
             sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
             md={'md': DEFAULT_METADATA})
-        find_fallback_path = (
-            'cloudinit.sources.DataSourceEc2.net.find_fallback_nic')
+        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
         with mock.patch(find_fallback_path) as m_find_fallback:
             m_find_fallback.return_value = 'eth9'
             ds.get_data()
 
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
-        expected = {'version': 1, 'config': [
-            {'mac_address': '06:17:04:d7:26:09', 'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}],
-             'type': 'physical'}]}
-        patch_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
-        get_interface_mac_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': '06:17:04:d7:26:09'}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
+        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
+        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
             with mock.patch(find_fallback_path) as m_find_fallback:
                 with mock.patch(get_interface_mac_path) as m_get_mac:
@@ -308,21 +414,48 @@ class TestEc2(test_helpers.HttprettyTestCase):
             platform_data=self.valid_platform_data,
             sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
             md={'md': DEFAULT_METADATA})
-        find_fallback_path = (
-            'cloudinit.sources.DataSourceEc2.net.find_fallback_nic')
+        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
         with mock.patch(find_fallback_path) as m_find_fallback:
             m_find_fallback.return_value = 'eth9'
             ds.get_data()
 
         mac1 = '06:17:04:d7:26:0A'  # IPv4 only in DEFAULT_METADATA
-        expected = {'version': 1, 'config': [
-            {'mac_address': '06:17:04:d7:26:0A', 'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}],
-             'type': 'physical'}]}
-        patch_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
-        get_interface_mac_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': mac1.lower()}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': False}}}
+        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
+        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
+        with mock.patch(patch_path) as m_get_interfaces_by_mac:
+            with mock.patch(find_fallback_path) as m_find_fallback:
+                with mock.patch(get_interface_mac_path) as m_get_mac:
+                    m_get_interfaces_by_mac.return_value = {mac1: 'eth9'}
+                    m_find_fallback.return_value = 'eth9'
+                    m_get_mac.return_value = mac1
+                    self.assertEqual(expected, ds.network_config)
+
+    def test_network_config_property_secondary_private_ips(self):
+        """network_config property configures any secondary ipv4 addresses.
+
+        Only one device is configured even when multiple exist in metadata.
+        """
+        ds = self._setup_ds(
+            platform_data=self.valid_platform_data,
+            sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
+            md={'md': SECONDARY_IP_METADATA_2018_09_24})
+        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
+        with mock.patch(find_fallback_path) as m_find_fallback:
+            m_find_fallback.return_value = 'eth9'
+            ds.get_data()
+
+        mac1 = '0a:07:84:3d:6e:38'  # IPv4 with 1 secondary IP
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': mac1}, 'set-name': 'eth9',
+            'addresses': ['172.31.45.70/20',
+                          '2600:1f16:292:100:f153:12a3:c37c:11f9/128',
+                          '2600:1f16:292:100:f152:2222:3333:4444/128'],
+            'dhcp4': True, 'dhcp6': True}}}
+        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
+        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
             with mock.patch(find_fallback_path) as m_find_fallback:
                 with mock.patch(get_interface_mac_path) as m_get_mac:
@@ -358,8 +491,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
         register_mock_metaserver(
             'http://169.254.169.254/2009-04-04/meta-data/', DEFAULT_METADATA)
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
-        get_interface_mac_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
+        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         ds.fallback_nic = 'eth9'
         with mock.patch(get_interface_mac_path) as m_get_interface_mac:
             m_get_interface_mac.return_value = mac1
@@ -368,11 +500,9 @@ class TestEc2(test_helpers.HttprettyTestCase):
         self.assertIn(
             'Refreshing stale metadata from prior to upgrade',
             self.logs.getvalue())
-        expected = {'version': 1, 'config': [
-            {'mac_address': '06:17:04:d7:26:09',
-             'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}],
-             'type': 'physical'}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': mac1}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(expected, ds.network_config)
 
     def test_ec2_get_instance_id_refreshes_identity_on_upgrade(self):
@@ -491,7 +621,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
         logs_with_redacted = [log for log in all_logs if REDACT_TOK in log]
         logs_with_token = [log for log in all_logs if 'API-TOKEN' in log]
         self.assertEqual(1, len(logs_with_redacted_ttl))
-        self.assertEqual(79, len(logs_with_redacted))
+        self.assertEqual(81, len(logs_with_redacted))
         self.assertEqual(0, len(logs_with_token))
 
     @mock.patch('cloudinit.net.dhcp.maybe_perform_dhcp_discovery')
@@ -616,19 +746,19 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
     def setUp(self):
         super(TestConvertEc2MetadataNetworkConfig, self).setUp()
-        self.mac1 = '06:17:04:d7:26:09'
+        self.mac1 = '06:17:04:D7:26:09'
         self.network_metadata = {
             'interfaces': {'macs': {
-                self.mac1: {'public-ipv4s': '172.31.2.16'}}}}
+                self.mac1: {'mac': self.mac1, 'public-ipv4s': '172.31.2.16'}}}}
 
     def test_convert_ec2_metadata_network_config_skips_absent_macs(self):
         """Any mac absent from metadata is skipped by network config."""
         macs_to_nics = {self.mac1: 'eth9', 'DE:AD:BE:EF:FF:FF': 'vitualnic2'}
 
         # DE:AD:BE:EF:FF:FF represented by OS but not in metadata
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -642,9 +772,9 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
             network_metadata_ipv6['interfaces']['macs'][self.mac1])
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         nic1_metadata.pop('public-ipv4s')
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9', 'subnets': [{'type': 'dhcp6'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -658,9 +788,9 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
             network_metadata_ipv6['interfaces']['macs'][self.mac1])
         nic1_metadata['local-ipv4s'] = '172.3.3.15'
         nic1_metadata.pop('public-ipv4s')
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -675,9 +805,9 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['public-ipv4s'] = ''
 
         # When no ipv4 or ipv6 content but fallback_nic set, set dhcp4 config.
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -692,11 +822,34 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         nic1_metadata.pop('public-ipv4s')
         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
+            expected,
+            ec2.convert_ec2_metadata_network_config(
+                network_metadata_both, macs_to_nics))
+
+    def test_convert_ec2_metadata_network_config_handles_multiple_nics(self):
+        """When dhcp6 is public and dhcp4 is set to local enable both."""
+        mac2 = '06:17:04:D7:26:0A'
+        macs_to_nics = {self.mac1: 'eth9', mac2: 'eth10'}
+        network_metadata_both = copy.deepcopy(self.network_metadata)
+        # Add 2nd nic info
+        network_metadata_both['interfaces']['macs'][mac2] = NIC2_MD
+        nic1_metadata = (
+            network_metadata_both['interfaces']['macs'][self.mac1])
+        nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
+        nic1_metadata.pop('public-ipv4s')  # No public-ipv4 IPs in cfg
+        nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
+        expected = {'version': 2, 'ethernets': {
+            'eth9': {
+                'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+                'dhcp4': True, 'dhcp6': True},
+            'eth10': {
+                'match': {'macaddress': mac2.lower()}, 'set-name': 'eth10',
+                'dhcp4': True, 'dhcp6': False}}}
+        self.assertItemsEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
                 network_metadata_both, macs_to_nics))
@@ -708,10 +861,9 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata = (
             network_metadata_both['interfaces']['macs'][self.mac1])
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -719,12 +871,10 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
     def test_convert_ec2_metadata_gets_macs_from_get_interfaces_by_mac(self):
         """Convert Ec2 Metadata calls get_interfaces_by_mac by default."""
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}]}]}
-        patch_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1.lower()},
+            'set-name': 'eth9', 'dhcp4': True, 'dhcp6': False}}}
+        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
             m_get_interfaces_by_mac.return_value = {self.mac1: 'eth9'}
             self.assertEqual(

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -462,7 +462,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
                     m_get_interfaces_by_mac.return_value = {mac1: 'eth9'}
                     m_find_fallback.return_value = 'eth9'
                     m_get_mac.return_value = mac1
-                    self.assertEqual(expected, ds.network_config)
+                    self.assertItemsEqual(expected, ds.network_config)
 
     def test_network_config_property_is_cached_in_datasource(self):
         """network_config property is cached in DataSourceEc2."""

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -767,7 +767,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
     def setUp(self):
         super(TestConvertEc2MetadataNetworkConfig, self).setUp()
-        self.mac1 = '06:17:04:D7:26:09'
+        self.mac1 = '06:17:04:d7:26:09'
         self.network_metadata = {
             'interfaces': {'macs': {
                 self.mac1: {'mac': self.mac1, 'public-ipv4s': '172.31.2.16'}}}}
@@ -778,7 +778,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
         # DE:AD:BE:EF:FF:FF represented by OS but not in metadata
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
             'dhcp6': False}}}
         self.assertEqual(
@@ -795,7 +795,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         nic1_metadata.pop('public-ipv4s')
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
             'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         self.assertEqual(
@@ -812,7 +812,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['local-ipv4s'] = '172.3.3.15'
         nic1_metadata.pop('public-ipv4s')
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
             'dhcp6': False}}}
         self.assertEqual(
@@ -830,7 +830,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
         # When no ipv4 or ipv6 content but fallback_nic set, set dhcp4 config.
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
             'dhcp6': False}}}
         self.assertEqual(
@@ -839,7 +839,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                 network_metadata_ipv6, macs_to_nics, fallback_nic='eth9'))
 
     def test_convert_ec2_metadata_network_config_handles_local_v4_and_v6(self):
-        """When dhcp6 is public and dhcp4 is set to local enable both."""
+        """When ipv6s and local-ipv4s are non-empty, enable dhcp6 and dhcp4."""
         macs_to_nics = {self.mac1: 'eth9'}
         network_metadata_both = copy.deepcopy(self.network_metadata)
         nic1_metadata = (
@@ -848,7 +848,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata.pop('public-ipv4s')
         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
             'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         self.assertEqual(
@@ -857,8 +857,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                 network_metadata_both, macs_to_nics))
 
     def test_convert_ec2_metadata_network_config_handles_multiple_nics(self):
-        """When dhcp6 is public and dhcp4 is set to local enable both."""
-        mac2 = '06:17:04:D7:26:0A'
+        """DHCP route-metric increases on secondary NICs for IPv4 and IPv6."""
+        mac2 = '06:17:04:d7:26:0a'
         macs_to_nics = {self.mac1: 'eth9', mac2: 'eth10'}
         network_metadata_both = copy.deepcopy(self.network_metadata)
         # Add 2nd nic info
@@ -870,11 +870,11 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
         expected = {'version': 2, 'ethernets': {
             'eth9': {
-                'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+                'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
                 'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
                 'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}},
             'eth10': {
-                'match': {'macaddress': mac2.lower()}, 'set-name': 'eth10',
+                'match': {'macaddress': mac2}, 'set-name': 'eth10',
                 'dhcp4': True, 'dhcp4-overrides': {'route-metric': 200},
                 'dhcp6': False}}}
         self.assertEqual(
@@ -890,7 +890,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
             network_metadata_both['interfaces']['macs'][self.mac1])
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1.lower()}, 'set-name': 'eth9',
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
             'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
             'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
         self.assertEqual(
@@ -901,7 +901,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
     def test_convert_ec2_metadata_gets_macs_from_get_interfaces_by_mac(self):
         """Convert Ec2 Metadata calls get_interfaces_by_mac by default."""
         expected = {'version': 2, 'ethernets': {'eth9': {
-            'match': {'macaddress': self.mac1.lower()},
+            'match': {'macaddress': self.mac1},
             'set-name': 'eth9', 'dhcp4': True,
             'dhcp4-overrides': {'route-metric': 100}, 'dhcp6': False}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -397,8 +397,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': '06:17:04:d7:26:09'}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
+            'dhcp4': True, 'dhcp6': True}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
@@ -409,10 +408,11 @@ class TestEc2(test_helpers.HttprettyTestCase):
                     m_get_mac.return_value = mac1
                     self.assertEqual(expected, ds.network_config)
 
-    def test_network_config_property_set_dhcp4_on_private_ipv4(self):
-        """network_config property configures dhcp4 on private ipv4 nics.
+    def test_network_config_property_set_dhcp4(self):
+        """network_config property configures dhcp4 on nics with local-ipv4s.
 
-        Only one device is configured even when multiple exist in metadata.
+        Only one device is configured based on get_interfaces_by_mac even when
+        multiple MACs exist in metadata.
         """
         ds = self._setup_ds(
             platform_data=self.valid_platform_data,
@@ -426,8 +426,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
         mac1 = '06:17:04:d7:26:0A'  # IPv4 only in DEFAULT_METADATA
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': mac1.lower()}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': False}}}
+            'dhcp4': True, 'dhcp6': False}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
@@ -441,7 +440,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
     def test_network_config_property_secondary_private_ips(self):
         """network_config property configures any secondary ipv4 addresses.
 
-        Only one device is configured even when multiple exist in metadata.
+        Only one device is configured based on get_interfaces_by_mac even when
+        multiple MACs exist in metadata.
         """
         ds = self._setup_ds(
             platform_data=self.valid_platform_data,
@@ -458,8 +458,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
             'addresses': ['172.31.45.70/20',
                           '2600:1f16:292:100:f152:2222:3333:4444/128',
                           '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
+            'dhcp4': True, 'dhcp6': True}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
@@ -508,8 +507,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
             self.logs.getvalue())
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': mac1}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(expected, ds.network_config)
 
     def test_ec2_get_instance_id_refreshes_identity_on_upgrade(self):
@@ -803,8 +801,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         # DE:AD:BE:EF:FF:FF represented by OS but not in metadata
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': False}}}
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -820,14 +817,13 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata.pop('public-ipv4s')
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
                 network_metadata_ipv6, macs_to_nics))
 
-    def test_convert_ec2_metadata_network_config_handles_local_dhcp4(self):
+    def test_convert_ec2_metadata_network_config_local_only_dhcp4(self):
         """Config dhcp4 when there are no public addresses in public-ipv4s."""
         macs_to_nics = {self.mac1: 'eth9'}
         network_metadata_ipv6 = copy.deepcopy(self.network_metadata)
@@ -837,8 +833,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata.pop('public-ipv4s')
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': False}}}
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -855,8 +850,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         # When no ipv4 or ipv6 content but fallback_nic set, set dhcp4 config.
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': False}}}
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -873,8 +867,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -915,8 +908,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
-            'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
-            'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}}}}
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -926,8 +918,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         """Convert Ec2 Metadata calls get_interfaces_by_mac by default."""
         expected = {'version': 2, 'ethernets': {'eth9': {
             'match': {'macaddress': self.mac1},
-            'set-name': 'eth9', 'dhcp4': True,
-            'dhcp4-overrides': {'route-metric': 100}, 'dhcp6': False}}}
+            'set-name': 'eth9', 'dhcp4': True, 'dhcp6': False}}}
         patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
             m_get_interfaces_by_mac.return_value = {self.mac1: 'eth9'}


### PR DESCRIPTION
On Ec2, cloud-init will configure networking on all attached NICs,
instead of just the primary NIC.

Also add support for rendering secondary static IPv4/IPv6 addresses on
any NIC attached to the machine.

For network config, cloud-init now reads Ec2 IMDS metadata API version
2018-09-24. Ec2-lookalike platforms which do not support this version
will not get secondary IP addresses configured.

Secondary IPs are listed in IMDS  API keys local-ipv4s, ipv6s,
subnet-ipv4-cidr-block and subnet-ipv6-cidr-block in order to set
proper static IP and CIDR prefix.
    
Also in this branch:
  - Shift DataSourceEc2.network_config to emit v2 instead of v1.
  - Add an `apply_network_config` Ec2 datasource config option which
    allows images to disable network config for secondary NICs and
    secondary IP addresses by setting `apply_network_config: false`

LP: #1866930