### PR TITLE
Partially revert "fix unlocking method on FreeBSD"

### DIFF
--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -256,7 +256,7 @@ class Distro(distros.Distro):
 
     def lock_passwd(self, name):
         try:
-            util.subp(['pw', 'lock', name])
+            util.subp(['pw', 'usermod', name, '-h', '-'])
         except Exception as e:
             util.logexc(LOG, "Failed to lock user %s", name)
             raise e


### PR DESCRIPTION
Specifically, revert the changes to logic which are incorrect.  The
testing introduced is for a separate part of the codebase, so is
retained.

This (partially) reverts commit
e2840f1771158748780a768f6bfbb117cd7610c6.