### PR TITLE
ci: emit names of tests run in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ matrix:
     fast_finish: true
     include:
         - python: 3.6
-          env: TOXENV=py3
+          env:
+              TOXENV=py3
+              NOSE_VERBOSE=2  # List all tests run by nose
         - install:
             - git fetch --unshallow
             - sudo apt-get build-dep -y cloud-init
@@ -42,9 +44,13 @@ matrix:
             # Ubuntu LTS: Integration
             - sg lxd -c 'tox -e citest -- run --verbose --preserve-data --data-dir results --os-name xenial --test modules/apt_configure_sources_list.yaml --test modules/ntp_servers --test modules/set_password_list --test modules/user_groups --deb cloud-init_*_all.deb'
         - python: 2.7
-          env: TOXENV=py27
+          env:
+              TOXENV=py27
+              NOSE_VERBOSE=2  # List all tests run by nose
         - python: 3.4
-          env: TOXENV=xenial
+          env:
+              TOXENV=xenial
+              NOSE_VERBOSE=2  # List all tests run by nose
           # Travis doesn't support Python 3.4 on bionic, so use xenial
           dist: xenial
         - python: 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ recreate = True
 commands = python -m nose {posargs:tests/unittests cloudinit}
 setenv =
     LC_ALL = en_US.utf-8
+passenv=
+    NOSE_VERBOSE
 
 [testenv:pycodestyle]
 basepython = python3


### PR DESCRIPTION
This makes it easier to debug differences in test behaviour between
Travis and local developer environments.