### PR TITLE
doc: clarify growpart gpart support is for BSD

### DIFF
--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -22,11 +22,11 @@ mountpoint in the filesystem or a path to the block device in ``/dev``.
 
 The utility to use for resizing can be selected using the ``mode`` config key.
 If ``mode`` key is set to ``auto``, then any available utility (either
-``growpart`` or ``gpart``) will be used. If neither utility is available, no
-error will be raised. If ``mode`` is set to ``growpart``, then the ``growpart``
-utility will be used. If this utility is not available on the system, this will
-result in an error. If ``mode`` is set to ``off`` or ``false``, then
-``cc_growpart`` will take no action.
+``growpart`` or BSD ``gpart``) will be used. If neither utility is available,
+no error will be raised. If ``mode`` is set to ``growpart``, then the
+``growpart`` utility will be used. If this utility is not available on the
+system, this will result in an error. If ``mode`` is set to ``off`` or
+``false``, then ``cc_growpart`` will take no action.
 
 There is some functionality overlap between this module and the ``growroot``
 functionality of ``cloud-initramfs-tools``. However, there are some situations


### PR DESCRIPTION
This might help avoid some confusion, as a tool with the same name
exists in most Linux distributions, but cannot be used for this purpose:
https://github.com/baruch/gpart