### PR TITLE
freebsd: cloudinit service requires devd

### DIFF
--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # PROVIDE: cloudinit
-# REQUIRE: FILESYSTEMS NETWORKING cloudinitlocal
+# REQUIRE: FILESYSTEMS NETWORKING cloudinitlocal devd
 # BEFORE:  cloudconfig cloudfinal
 
 . /etc/rc.subr


### PR DESCRIPTION
Depends on devd to be sure the NIC device drivers are loaded in time.