### PR TITLE
ci: remove Python 2.7 from CI runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,10 +43,6 @@ matrix:
             - sudo -E su $USER -c 'sbuild --nolog --verbose --dist=xenial cloud-init_*.dsc'
             # Ubuntu LTS: Integration
             - sg lxd -c 'tox -e citest -- run --verbose --preserve-data --data-dir results --os-name xenial --test modules/apt_configure_sources_list.yaml --test modules/ntp_servers --test modules/set_password_list --test modules/user_groups --deb cloud-init_*_all.deb'
-        - python: 2.7
-          env:
-              TOXENV=py27
-              NOSE_VERBOSE=2  # List all tests run by nose
         - python: 3.4
           env:
               TOXENV=xenial

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py3, xenial, pycodestyle, pyflakes, pylint
+envlist = py3, xenial, pycodestyle, pyflakes, pylint
 recreate = True
 
 [testenv]


### PR DESCRIPTION
Specifically, drop it from the default list of environments that tox will run, and from Travis.

Per https://lists.launchpad.net/cloud-init/msg00236.html, 19.4 was the last release with official Python 2.7 support.

(We retain the configuration in tox.ini for now, for any remaining Python 2.7 needs.)