### PR TITLE
Kernel doesn't have 'static' it has 'none'

### DIFF
--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -104,7 +104,7 @@ def _klibc_to_config_entry(content, mac_addrs=None):
     provided here.  There is no good documentation on this unfortunately.
 
     DEVICE=<name> is expected/required and PROTO should indicate if
-    this is 'static' or 'dhcp' or 'dhcp6' (LP: #1621507).
+    this is 'none' or 'dhcp' or 'dhcp6' (LP: #1621507).
     note that IPV6PROTO is also written by newer code to address the
     possibility of both ipv4 and ipv6 getting addresses.
     """
@@ -125,9 +125,9 @@ def _klibc_to_config_entry(content, mac_addrs=None):
         if data.get('filename'):
             proto = 'dhcp'
         else:
-            proto = 'static'
+            proto = 'none'
 
-    if proto not in ('static', 'dhcp', 'dhcp6'):
+    if proto not in ('none', 'dhcp', 'dhcp6'):
         raise ValueError("Unexpected value for PROTO: %s" % proto)
 
     iface = {
@@ -149,9 +149,9 @@ def _klibc_to_config_entry(content, mac_addrs=None):
         cur_proto = data.get(pre + 'PROTO', proto)
         subnet = {'type': cur_proto, 'control': 'manual'}
 
-        # only populate address for static types. While the rendered config
+        # only populate address for none types. While the rendered config
         # may have an address for dhcp, that is not really expected.
-        if cur_proto == 'static':
+        if cur_proto == 'none':
             subnet['address'] = data[pre + 'ADDR']
 
         # these fields go right on the subnet

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -21,8 +21,11 @@ disable_root: false
 disable_root: true
 {% endif %}
 
-{% if variant in ["centos", "fedora", "rhel"] %}
+{% if variant in ["amazon", "centos", "fedora", "rhel"] %}
 mount_default_fields: [~, ~, 'auto', 'defaults,nofail', '0', '2']
+{% if variant == "amazon" %}
+resize_rootfs: noblock
+{% endif %}
 resize_rootfs_tmp: /dev
 ssh_pwauth:   0
 
@@ -41,6 +44,13 @@ datasource_list: ['NoCloud', 'ConfigDrive', 'Azure', 'OpenStack', 'Ec2']
 #      metadata_urls: [ 'blah.com' ]
 #      timeout: 5 # (defaults to 50 seconds)
 #      max_wait: 10 # (defaults to 120 seconds)
+
+
+{% if variant == "amazon" %}
+# Amazon Linux relies on ec2-net-utils for network configuration
+network:
+  config: disabled
+{% endif %}
 
 # The modules that run in the 'init' stage
 cloud_init_modules:
@@ -133,7 +143,7 @@ cloud_final_modules:
 # (not accessible to handlers/transforms)
 system_info:
    # This will affect which distro class gets used
-{% if variant in ["arch", "centos", "debian", "fedora", "freebsd", "rhel", "suse", "ubuntu"] %}
+{% if variant in ["amazon", "arch", "centos", "debian", "fedora", "freebsd", "rhel", "suse", "ubuntu"] %}
    distro: {{ variant }}
 {% else %}
    # Unknown/fallback distro.
@@ -181,12 +191,18 @@ system_info:
          primary: http://ports.ubuntu.com/ubuntu-ports
          security: http://ports.ubuntu.com/ubuntu-ports
    ssh_svcname: ssh
-{% elif variant in ["arch", "centos", "fedora", "rhel", "suse"] %}
+{% elif variant in ["amazon", "arch", "centos", "fedora", "rhel", "suse"] %}
    # Default user name + that default users groups (if added/used)
    default_user:
+{% if variant == "amazon" %}
+     name: ec2-user
+     lock_passwd: True
+     gecos: EC2 Default User
+{% else %}
      name: {{ variant }}
      lock_passwd: True
      gecos: {{ variant }} Cloud User
+{% endif %}
 {% if variant == "suse" %}
      groups: [cdrom, users]
 {% elif variant == "arch" %}

--- a/tools/render-cloudcfg
+++ b/tools/render-cloudcfg
@@ -4,8 +4,8 @@ import argparse
 import os
 import sys
 
-VARIANTS = ["arch", "centos", "debian", "fedora", "freebsd", "rhel", "suse",
-            "ubuntu", "unknown"]
+VARIANTS = ["amazon", "arch", "centos", "debian", "fedora", "freebsd", "rhel",
+            "suse", "ubuntu", "unknown"]
 
 if "avoid-pep8-E402-import-not-top-of-file":
     _tdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))


### PR DESCRIPTION
This PR will fix cloud-init looking for the kernel to report back a value of static when it reports back none. This covers cases where there is no dhcp but users would still like to use cloud-init. 

https://bugs.launchpad.net/cloud-init/+bug/1785275