### PR TITLE
Make tests work with Python 3.8

### DIFF
--- a/cloudinit/analyze/tests/test_boot.py
+++ b/cloudinit/analyze/tests/test_boot.py
@@ -12,17 +12,17 @@ class TestDistroChecker(CiTestCase):
     @mock.patch('cloudinit.util.system_info', return_value={'dist': ('', '',
                                                                      ''),
                                                             'system': ''})
-    @mock.patch('platform.linux_distribution', return_value=('', '', ''))
+    @mock.patch('cloudinit.util.get_linux_distro', return_value=('', '', ''))
     @mock.patch('cloudinit.util.is_FreeBSD', return_value=False)
-    def test_blank_distro(self, m_sys_info, m_linux_distribution, m_free_bsd):
+    def test_blank_distro(self, m_sys_info, m_get_linux_distro, m_free_bsd):
         self.assertEqual(err_code, dist_check_timestamp())
 
     @mock.patch('cloudinit.util.system_info', return_value={'dist': ('', '',
                                                                      '')})
-    @mock.patch('platform.linux_distribution', return_value=('', '', ''))
+    @mock.patch('cloudinit.util.get_linux_distro', return_value=('', '', ''))
     @mock.patch('cloudinit.util.is_FreeBSD', return_value=True)
     def test_freebsd_gentoo_cant_find(self, m_sys_info,
-                                      m_linux_distribution, m_is_FreeBSD):
+                                      m_get_linux_distro, m_is_FreeBSD):
         self.assertEqual(err_code, dist_check_timestamp())
 
     @mock.patch('cloudinit.util.subp', return_value=(0, 1))

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -523,7 +523,7 @@ class TestGetLinuxDistro(CiTestCase):
         self.assertEqual(
             ('opensuse-tumbleweed', '20180920', platform.machine()), dist)
 
-    @mock.patch('platform.dist')
+    @mock.patch('platform.dist', create=True)
     def test_get_linux_distro_no_data(self, m_platform_dist, m_path_exists):
         """Verify we get no information if os-release does not exist"""
         m_platform_dist.return_value = ('', '', '')
@@ -531,7 +531,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(('', '', ''), dist)
 
-    @mock.patch('platform.dist')
+    @mock.patch('platform.dist', create=True)
     def test_get_linux_distro_no_impl(self, m_platform_dist, m_path_exists):
         """Verify we get an empty tuple when no information exists and
         Exceptions are not propagated"""
@@ -540,7 +540,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(('', '', ''), dist)
 
-    @mock.patch('platform.dist')
+    @mock.patch('platform.dist', create=True)
     def test_get_linux_distro_plat_data(self, m_platform_dist, m_path_exists):
         """Verify we get the correct platform information"""
         m_platform_dist.return_value = ('foo', '1.1', 'aarch64')

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -636,7 +636,7 @@ def get_linux_distro():
         dist = ('', '', '')
         try:
             # Will be removed in 3.7
-            dist = platform.dist()  # pylint: disable=W1505
+            dist = platform.dist()  # pylint: disable=W1505,E1101
         except Exception:
             pass
         finally:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -635,7 +635,7 @@ def get_linux_distro():
     else:
         dist = ('', '', '')
         try:
-            # Will be removed in 3.7
+            # Was removed in 3.8
             dist = platform.dist()  # pylint: disable=W1505,E1101
         except Exception:
             pass


### PR DESCRIPTION
Several tests depend on `platform.dist`, a.k.a. `platform.linux_distribution`. This function was removed in Python 3.8. To make the tests work, move some of them to mocking the internal `util.get_linux_distro` instead. For the tests for `util.get_linux_distro` itself, allow mock to create the function if it doesn't exist. The function's behavior in absence of `platform.dist` is already tested by `test_get_linux_distro_no_impl`.