### PR TITLE
Fix CloudStack Virtual Router address lookup on RHEL/CentOS 8 with NetworkManager

### DIFF
--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -256,7 +256,17 @@ def get_vr_address():
                 if len(words) > 2:
                     dhcptok = words[2]
                     LOG.debug("Found DHCP identifier %s", dhcptok)
-                    latest_address = dhcptok
+                    return dhcptok
+
+    # Try NetworkManager lease files format next...
+    with open(lease_file, "r") as fd:
+        for line in fd:
+            if "SERVER_ADDRESS" in line:
+                words = line.strip().split("=")
+                if len(words) == 2:
+                    dhcptok = words[1]
+                    LOG.debug("Found DHCP identifier %s", dhcptok)
+                    return dhcptok
     if not latest_address:
         # No virtual router found, fallback on default gateway
         LOG.debug("No DHCP found, using default gateway")

--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -257,11 +257,8 @@ def get_vr_address():
                     dhcptok = words[2]
                     LOG.debug("Found DHCP identifier %s", dhcptok)
                     return dhcptok
-
-    # Try NetworkManager lease files format next...
-    with open(lease_file, "r") as fd:
-        for line in fd:
-            if "SERVER_ADDRESS" in line:
+            # Try NetworkManager lease files format next...
+            elif "SERVER_ADDRESS" in line:
                 words = line.strip().split("=")
                 if len(words) == 2:
                     dhcptok = words[1]


### PR DESCRIPTION
## What will be changed?

With this change cloud-init will be able to determine `CloudStack` Virtual Router address on minimal RHEL/CentOS 8 installations.

## Why do this change?

The current implementation does not support new (not sure, I'm not really so familiar with it) NetworkManager DHCP lease files format.

Here is example of such lease file:

```
ADDRESS=10.10.220.191
NETMASK=255.255.255.0
ROUTER=10.10.220.1
SERVER_ADDRESS=10.10.220.244
NEXT_SERVER=10.10.220.244
BROADCAST=10.10.220.255
T1=1362600
T2=2384550
LIFETIME=2725200
DNS=10.10.220.240 10.10.220.160
DOMAINNAME=localdomain
HOSTNAME=localhost
CLIENTID=011e002c000144
```

As you can see, there are no `dhcp-server-identifier` options, but `SERVER_ADDRESS` is here.

## Where is the problem?

I'd say, Red Hat bug [1650342](https://bugzilla.redhat.com/show_bug.cgi?id=1650342) describes this: there is no `systemd-networkd` support in RHEL/CentOS 8 and the previously working integration with [networkd](https://github.com/canonical/cloud-init/blob/master/cloudinit/sources/DataSourceCloudStack.py#L240) does not work anymore.