### PR TITLE
fixed minor bug with mkswap and minor issue with resolv_conf when use…

### DIFF
--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -982,7 +982,7 @@ def mkfs(fs_cfg):
 
         # File systems that support the -F flag
         if overwrite or device_type(device) == "disk":
-            fs_cmd.append(lookup_force_flag(fs_type))
+            fs_cmd += filter(None, [lookup_force_flag(fs_type)])
 
         # Add the extends FS options
         if fs_opts:

--- a/templates/resolv.conf.tmpl
+++ b/templates/resolv.conf.tmpl
@@ -23,8 +23,5 @@ sortlist {% for sort in sortlist %}{{sort}} {% endfor %}
 {% endif %}
 {% if options or flags %}
 
-options {% for flag in flags %}{{flag}} {% endfor %}
-{% for key, value in options.items() -%}
- {{key}}:{{value}}
-{% endfor %}
+options {% for flag in flags %}{{flag}} {% endfor %}{% for key, value in options.items() %}{{key}}:{{value}} {% endfor %}
 {% endif %}


### PR DESCRIPTION

The module cc_disk_setup.py fails when trying to initalize a swap partition with mkswap.
This is because 'lookup_force_flag' returns an empty string (''), which is taken as actual argument when launching mkswap , resulting in an error:

Unexpected error while running command.
Command: ['/usr/sbin/mkswap', '/dev/sdb', '']
Exit code: 1
Reason: -
Stdout: 
Stderr: mkswap: invalid block count argument: ''

Preventing swap to work (this can be seen when using vmware hypervisor)

This patch simply remove the empty argument.

It also fixes another little problem with the template used by resolv_conf module, when more than one non boolean options is used, resulting in wrong formatting, like this:

options rotate single-request attempts:1
timeout:1



