### PR TITLE
Kernel doesn't have 'static' it has 'none'

### DIFF
--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -127,6 +127,9 @@ def _klibc_to_config_entry(content, mac_addrs=None):
         else:
             proto = 'static'
 
+    if proto == 'none':
+        proto = 'static'
+
     if proto not in ('static', 'dhcp', 'dhcp6'):
         raise ValueError("Unexpected value for PROTO: %s" % proto)
 


### PR DESCRIPTION
Credit for this patch kevindtimm@gmail.com
https://launchpadlibrarian.net/385938425/0001-change-none-to-static-for-ip-address-in-GRUB_CMDLINE.patch

Closes bug : https://bugs.launchpad.net/cloud-init/+bug/1785275

Abandon PR https://github.com/canonical/cloud-init/pull/138 in favor of this one