### PR TITLE
Do not change permissions for system-wide folders with ssh authorized_keys

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -268,9 +268,11 @@ def setup_user_keys(keys, username, options=None):
 
     # Extract the old and make the new
     (auth_key_fn, auth_key_entries) = extract_authorized_keys(username)
+    key_dir = os.path.dirname(auth_key_fn)
     with util.SeLinuxGuard(ssh_dir, recursive=True):
         content = update_authorized_keys(auth_key_entries, key_entries)
-        util.ensure_dir(os.path.dirname(auth_key_fn), mode=0o700)
+        if not os.path.exists(key_dir):
+            util.ensure_dir(key_dir, mode=0o700)
         util.write_file(auth_key_fn, content, mode=0o600)
         util.chownbyid(auth_key_fn, pwent.pw_uid, pwent.pw_gid)
 


### PR DESCRIPTION
cloud-init’s code by default makes a wrong assumption that all users using private `.ssh` folder for authorized_keys.
But `AuthorizedKeysFile` directive in sshd_config could be used to have a system-wide folder with user keys, which are managed by the configuration management systems, for example puppet.
The idea is to have a configuration like `AuthorizedKeysFile /etc/ssh/authorized_keys/%u` to prevent users manage their authorized_keys or to rootkit other users from user who had a sudo permissions on host.
Folder `/etc/ssh/authorized_keys/` and all files inside are owned by root because user shouldn’t be able to modify this files. When cloud-init change mode to 700 for such folder it breaks whole concept.
For private `.ssh` folder cloud-init sets permission on line https://github.com/canonical/cloud-init/blob/master/cloudinit/ssh_util.py#L260 there is no need to set this permission again for system-wide folder.

**Steps to reproduce:**

1. Launch new EC2 instance
2. Create a new system user, for example `test-user`
3. `mkdir /etc/ssh/authorized_keys/`
4. `chmod 755 /etc/ssh/authorized_keys/`
5. `chown root /etc/ssh/authorized_keys/`
6. Modify `/etc/ssh/sshd_config` file:
```
AuthorizedKeysFile /etc/ssh/authorized_keys/%u
```
7. Put ssh public key for `test-user` into `/etc/ssh/authorized_keys/test-user`
8. Restart sshd
9. Check that you can login as test-user via ssh
10. Create AMI from running instance
11. Launch new EC2 from created AMI.
12. Cloud-init will be smart enough to put authorized_keys file into preconfigured folder `/etc/ssh/authorized_keys/` but after `chmod 700` user `test-user` will not be able to login into newly launched instance.