### PR TITLE
doc: make apt_update example consistent

### DIFF
--- a/doc/examples/cloud-config-update-apt.txt
+++ b/doc/examples/cloud-config-update-apt.txt
@@ -5,4 +5,4 @@
 #
 # Default: false
 # Aliases: apt_update
-package_update: false
+package_update: true


### PR DESCRIPTION
Other options near it use the non-default value, so the inconsistency
has lead to confusion for readers.