### PR TITLE
workflows: remove cla not signed label once signed

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,6 +1,8 @@
 name: Verify Contributor License Agreement
 
-on: [pull_request]
+on:
+  schedule:
+    - '*/5 * * * *'
 
 jobs:
   cla-validate:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,14 +15,14 @@ jobs:
         # POST a new label to this issue
         curl --request POST \
         --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'authorization: token ${{ secrets.GITHUB_TOKEN }}' \
         --header 'content-type: application/json' \
         --data '{"labels": ["${{env.CLA_SIGNED}}"]}'
     - name: Remove CLA not signed label
       if: env.CLA_SIGNED == 'CLA signed'
       run: |
         curl --request DELETE \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'authorization: token ${{ secrets.GITHUB_TOKEN }}' \
         --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels/CLA+not+signed
     - name: Comment about CLA signing
       if: env.CLA_SIGNED == 'CLA not signed'
@@ -30,6 +30,6 @@ jobs:
         # POST a comment directing submitter to sign the CLA
         curl --request POST \
         --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'authorization: token ${{ secrets.GITHUB_TOKEN }}' \
         --header 'content-type: application/json' \
         --data '{"body": "Hello ${{ github.actor }},\n\nThank you for your contribution to cloud-init.\n\nIn order for us to merge this pull request, you need\nto have signed the Contributor License Agreement (CLA).\nPlease ensure that you have signed the CLA by following our\nhacking guide at:\n\nhttps://cloudinit.readthedocs.io/en/latest/topics/hacking.html\n\nThanks,\nYour friendly cloud-init upstream\n"}'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,7 +2,7 @@ name: Verify Contributor License Agreement
 
 on:
   schedule:
-    - '*/5 * * * *'
+    - cron: '*/5 * * * *'
 
 jobs:
   cla-validate:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -24,6 +24,9 @@ jobs:
         curl --request DELETE \
         --header 'authorization: token ${{ secrets.GITHUB_TOKEN }}' \
         --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels/CLA+not+signed
+        curl --request GET \
+        --header 'authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+        --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments 
     - name: Comment about CLA signing
       if: env.CLA_SIGNED == 'CLA not signed'
       run: |

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,6 +18,12 @@ jobs:
         --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
         --header 'content-type: application/json' \
         --data '{"labels": ["${{env.CLA_SIGNED}}"]}'
+    - name: Remove CLA not signed label
+      if: env.CLA_SIGNED == 'CLA signed'
+      run: |
+        curl --request DELETE \
+        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels/CLA+not+signed
     - name: Comment about CLA signing
       if: env.CLA_SIGNED == 'CLA not signed'
       run: |

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,8 +1,8 @@
 name: Verify Contributor License Agreement
 
-on:
-  schedule:
-    - cron: '*/5 * * * *'
+on: [pull_request]
+#  schedule:
+#    - cron: '*/5 * * * *'
 
 jobs:
   cla-validate:
@@ -12,6 +12,12 @@ jobs:
     - uses: actions/checkout@v1
     - run: |
         echo "::set-env name=CLA_SIGNED::$(grep -q ': \"${{ github.actor }}\"' ./tools/.lp-to-git-user && echo CLA signed || echo CLA not signed)"
+    - name: List pulls
+      run: |
+        curl --request GET \
+        --header 'authorization: token ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'content-type: application/json' \
+        --url https://api.github.com/repos/${{ github.repository }}/pulls?state=open
     - name: Add CLA label
       run: |
         # POST a new label to this issue


### PR DESCRIPTION
Add a minor additional workflow step to remove 'CLA not signed' label if present, once signed.

Also, it seems we need to sort permissions and schedule for this labeling
labels can't be applied from CI actions during pull_requests. We get this response.
 {
  "message": "Resource not accessible by integration",
  "documentation_url": "https://developer.github.com/v3/issues/labels/#add-labels-to-an-issue"
}