### PR TITLE
workflows: adjust to status_check on pull_request as github actions can't label during CI

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,22 +8,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: |
-        echo "::set-env name=CLA_SIGNED::$(grep -q ': \"${{ github.actor }}\"' ./tools/.lp-to-git-user && echo CLA signed || echo CLA not signed)"
-    - name: Add CLA label
+    - name: Check CLA signing status for ${{ github.actor}}
       run: |
-        # POST a new label to this issue
-        curl --request POST \
-        --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-        --header 'content-type: application/json' \
-        --data '{"labels": ["${{env.CLA_SIGNED}}"]}'
-    - name: Comment about CLA signing
-      if: env.CLA_SIGNED == 'CLA not signed'
-      run: |
-        # POST a comment directing submitter to sign the CLA
-        curl --request POST \
-        --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-        --header 'content-type: application/json' \
-        --data '{"body": "Hello ${{ github.actor }},\n\nThank you for your contribution to cloud-init.\n\nIn order for us to merge this pull request, you need\nto have signed the Contributor License Agreement (CLA).\nPlease ensure that you have signed the CLA by following our\nhacking guide at:\n\nhttps://cloudinit.readthedocs.io/en/latest/topics/hacking.html\n\nThanks,\nYour friendly cloud-init upstream\n"}'
+        cat > unsigned-cla.txt <<EOF
+          Hello ${{ github.actor }},
+
+          Thank you for your contribution to cloud-init.
+
+          In order for us to merge this pull request, you need
+          to have signed the Contributor License Agreement (CLA).
+          Please sign the CLA by following our
+          hacking guide at:
+            https://cloudinit.readthedocs.io/en/latest/topics/hacking.html
+
+          Thanks,
+          Your friendly cloud-init upstream
+        EOF
+        grep -q ': \"${{ github.actor }}\"' ./tools/.lp-to-git-user && \
+           echo "Thanks ${{ github.actor }} for signing cloud-init's CLA" || \
+           (cat unsigned-cla.txt && exit 1)


### PR DESCRIPTION
Github api doesn't allow each pull_request CI run to drive label
changes.

Thus, convert the job to a schedule and drive the labeling while
walking through all open pull requests.

For each PR, check if the author has signed CLA:
* If unsigned, add "CLA not signed" label and add a comment telling them about CLA
* If signed, add "CLA signed" label and remove "CLA not signed"


Note a working run triggers on pull_request from my local repo:
https://github.com/blackboxsw/cloud-init/commit/944e6ae1d90a0a606a9c3f170236831eb5d2bd00/checks?check_suite_id=393562692