### PR TITLE
ssh_auth_key_fingerprints_disable test: fix capitalization

### DIFF
--- a/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_disable.py
+++ b/tests/cloud_tests/testcases/modules/ssh_auth_key_fingerprints_disable.py
@@ -11,6 +11,6 @@ class TestSshKeyFingerprintsDisable(base.CloudTestCase):
         """Verify disabled."""
         out = self.get_data_file('cloud-init.log')
         self.assertIn('Skipping module named ssh-authkey-fingerprints, '
-                      'logging of ssh fingerprints disabled', out)
+                      'logging of SSH fingerprints disabled', out)
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
Adapt the test to the new capitalization introduced in
8116493950e7c47af0ce66fc1bb5d799ce5e477a.