### PR TITLE
Ensure util.get_architecture() runs only once

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -309,7 +309,7 @@ def apply_apt(cfg, cloud, target):
 
     if util.is_false(cfg.get('preserve_sources_list', False)):
         generate_sources_list(cfg, release, mirrors, cloud)
-        rename_apt_lists(mirrors, target=target, arch=arch)
+        rename_apt_lists(mirrors, target, arch)
 
     try:
         apply_apt_config(cfg, APT_PROXY_FN, APT_CONFIG_FN)
@@ -427,10 +427,8 @@ def mirrorurl_to_apt_fileprefix(mirror):
     return string
 
 
-def rename_apt_lists(new_mirrors, target=None, arch=None):
+def rename_apt_lists(new_mirrors, target, arch):
     """rename_apt_lists - rename apt lists to preserve old cache data"""
-    if not arch:
-        arch = util.get_architecture(target)
     default_mirrors = get_default_mirrors(arch)
 
     pre = util.target_path(target, APT_LISTS)

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -309,7 +309,7 @@ def apply_apt(cfg, cloud, target):
 
     if util.is_false(cfg.get('preserve_sources_list', False)):
         generate_sources_list(cfg, release, mirrors, cloud)
-        rename_apt_lists(mirrors, target)
+        rename_apt_lists(mirrors, target=target, arch=arch)
 
     try:
         apply_apt_config(cfg, APT_PROXY_FN, APT_CONFIG_FN)
@@ -427,9 +427,11 @@ def mirrorurl_to_apt_fileprefix(mirror):
     return string
 
 
-def rename_apt_lists(new_mirrors, target=None):
+def rename_apt_lists(new_mirrors, target=None, arch=None):
     """rename_apt_lists - rename apt lists to preserve old cache data"""
-    default_mirrors = get_default_mirrors(util.get_architecture(target))
+    if not arch:
+        arch = util.get_architecture(target)
+    default_mirrors = get_default_mirrors(arch)
 
     pre = util.target_path(target, APT_LISTS)
     for (name, omirror) in default_mirrors.items():

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -205,8 +205,7 @@ class Distro(distros.Distro):
                          ["update"], freq=PER_INSTANCE)
 
     def get_primary_arch(self):
-        (arch, _err) = util.subp(['dpkg', '--print-architecture'])
-        return str(arch).strip()
+        return util.get_architecture()
 
 
 def _get_wrapper_prefix(cmd, mode):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -79,22 +79,14 @@ CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
 
 
 @lru_cache()
-def _get_architecture(target=None):
+def get_architecture(target=None):
     out, _ = subp(['dpkg', '--print-architecture'], capture=True,
                   target=target)
     return out.strip()
 
 
-def get_architecture(target=None):
-    if target_path(target) != "/":
-        # do not use or update cache if target is provided
-        return _get_architecture(target)
-
-    return _get_architecture()
-
-
 @lru_cache()
-def _lsb_release(target=None):
+def lsb_release(target=None):
     fmap = {'Codename': 'codename', 'Description': 'description',
             'Distributor ID': 'id', 'Release': 'release'}
 
@@ -115,14 +107,6 @@ def _lsb_release(target=None):
         data = dict((v, "UNAVAILABLE") for v in fmap.values())
 
     return data
-
-
-def lsb_release(target=None):
-    if target_path(target) != "/":
-        # do not use or update cache if target is provided
-        return _lsb_release(target)
-
-    return _lsb_release()
 
 
 def target_path(target, path=None):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -79,10 +79,18 @@ CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
 
 
 @lru_cache()
-def get_architecture(target=None):
+def _get_architecture(target=None):
     out, _ = subp(['dpkg', '--print-architecture'], capture=True,
                   target=target)
     return out.strip()
+
+
+def get_architecture(target=None):
+    if target_path(target) != "/":
+        # do not use or update cache if target is provided
+        return _get_architecture(target)
+
+    return _get_architecture()
 
 
 @lru_cache()

--- a/tests/unittests/test_handler/test_handler_apt_source_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v3.py
@@ -487,7 +487,7 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
         with mock.patch.object(os, 'rename') as mockren:
             with mock.patch.object(glob, 'glob',
                                    return_value=[fromfn]):
-                cc_apt_configure.rename_apt_lists(mirrors, TARGET)
+                cc_apt_configure.rename_apt_lists(mirrors, TARGET, arch)
 
         mockren.assert_any_call(fromfn, tofn)
 
@@ -496,7 +496,8 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
         target = os.path.join(self.tmp, "rename_non_slash")
         apt_lists_d = os.path.join(target, "./" + cc_apt_configure.APT_LISTS)
 
-        m_get_architecture.return_value = 'amd64'
+        arch = 'amd64'
+        m_get_architecture.return_value = arch
 
         mirror_path = "some/random/path/"
         primary = "http://test.ubuntu.com/" + mirror_path
@@ -532,7 +533,7 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
             fpath = os.path.join(apt_lists_d, opre + suff)
             util.write_file(fpath, content=fpath)
 
-        cc_apt_configure.rename_apt_lists(mirrors, target)
+        cc_apt_configure.rename_apt_lists(mirrors, target, arch)
         found = sorted(os.listdir(apt_lists_d))
         self.assertEqual(expected, found)
 


### PR DESCRIPTION
util.get_architecture() recently was wrapped using python3's lru_cache()
which will cache the result so we only invoke 'dpkg --print-architecture'
once.  In practice, cloud-init.log will show multiple invocations of the
command.  The source of this was that the debian Distro object implements
the get_primary_arch() with this command, but it was not calling it from
util, but issuing a util.subp() directly.  This branch also updates
cc_apt_configure methods to fetch the arch value from the distro class,
and then ensure that the methods apt_configure calls pass the arch value
around.

- drop lsb_release and get_architecture wrappers as lru_cache()
  handles multiple values in its cache.