### PR TITLE
util: rename get_architecture to get_dpkg_architecture

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -253,7 +253,7 @@ def get_default_mirrors(arch=None, target=None):
        architecture, for more see:
        https://wiki.ubuntu.com/UbuntuDevelopment/PackageArchive#Ports"""
     if arch is None:
-        arch = util.get_architecture(target)
+        arch = util.get_dpkg_architecture(target)
     if arch in PRIMARY_ARCHES:
         return PRIMARY_ARCH_MIRRORS.copy()
     if arch in PORTS_ARCHES:
@@ -303,7 +303,7 @@ def apply_apt(cfg, cloud, target):
     LOG.debug("handling apt config: %s", cfg)
 
     release = util.lsb_release(target=target)['codename']
-    arch = util.get_architecture(target)
+    arch = util.get_dpkg_architecture(target)
     mirrors = find_apt_mirror_info(cfg, cloud, arch=arch)
     LOG.debug("Apt Mirror info: %s", mirrors)
 
@@ -896,7 +896,7 @@ def find_apt_mirror_info(cfg, cloud, arch=None):
     """
 
     if arch is None:
-        arch = util.get_architecture()
+        arch = util.get_dpkg_architecture()
         LOG.debug("got arch for mirror selection: %s", arch)
     pmirror = get_mirror(cfg, "primary", arch, cloud)
     LOG.debug("got primary mirror: %s", pmirror)

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -205,7 +205,7 @@ class Distro(distros.Distro):
                          ["update"], freq=PER_INSTANCE)
 
     def get_primary_arch(self):
-        return util.get_architecture()
+        return util.get_dpkg_architecture()
 
 
 def _get_wrapper_prefix(cmd, mode):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -80,6 +80,11 @@ CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
 
 @lru_cache()
 def get_dpkg_architecture(target=None):
+    """Return the sanitized string output by `dpkg --print-architecture`.
+
+    N.B. This function is wrapped in functools.lru_cache, so repeated calls
+    won't shell out every time.
+    """
     out, _ = subp(['dpkg', '--print-architecture'], capture=True,
                   target=target)
     return out.strip()

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -79,7 +79,7 @@ CONTAINER_TESTS = (['systemd-detect-virt', '--quiet', '--container'],
 
 
 @lru_cache()
-def get_architecture(target=None):
+def get_dpkg_architecture(target=None):
     out, _ = subp(['dpkg', '--print-architecture'], capture=True,
                   target=target)
     return out.strip()

--- a/tests/cloud_tests/config.py
+++ b/tests/cloud_tests/config.py
@@ -114,7 +114,7 @@ def load_os_config(platform_name, os_name, require_enabled=False,
     feature_conf = main_conf['features']
     feature_groups = conf.get('feature_groups', [])
     overrides = merge_config(get(conf, 'features'), feature_overrides)
-    conf['arch'] = c_util.get_architecture()
+    conf['arch'] = c_util.get_dpkg_architecture()
     conf['features'] = merge_feature_groups(
         feature_conf, feature_groups, overrides)
 

--- a/tests/cloud_tests/platforms/nocloudkvm/platform.py
+++ b/tests/cloud_tests/platforms/nocloudkvm/platform.py
@@ -29,9 +29,13 @@ class NoCloudKVMPlatform(Platform):
         """
         (url, path) = s_util.path_from_mirror_url(img_conf['mirror_url'], None)
 
-        filter = filters.get_filters(['arch=%s' % c_util.get_architecture(),
-                                      'release=%s' % img_conf['release'],
-                                      'ftype=disk1.img'])
+        filter = filters.get_filters(
+            [
+                'arch=%s' % c_util.get_dpkg_architecture(),
+                'release=%s' % img_conf['release'],
+                'ftype=disk1.img',
+            ]
+        )
         mirror_config = {'filters': filter,
                          'keep_items': False,
                          'max_items': 1,

--- a/tests/unittests/test_handler/test_handler_apt_configure_sources_list_v1.py
+++ b/tests/unittests/test_handler/test_handler_apt_configure_sources_list_v1.py
@@ -78,7 +78,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         get_rel = rpatcher.start()
         get_rel.return_value = {'codename': "fakerelease"}
         self.addCleanup(rpatcher.stop)
-        apatcher = mock.patch("cloudinit.util.get_architecture")
+        apatcher = mock.patch("cloudinit.util.get_dpkg_architecture")
         get_arch = apatcher.start()
         get_arch.return_value = 'amd64'
         self.addCleanup(apatcher.stop)

--- a/tests/unittests/test_handler/test_handler_apt_configure_sources_list_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_configure_sources_list_v3.py
@@ -106,7 +106,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         get_rel = rpatcher.start()
         get_rel.return_value = {'codename': "fakerel"}
         self.addCleanup(rpatcher.stop)
-        apatcher = mock.patch("cloudinit.util.get_architecture")
+        apatcher = mock.patch("cloudinit.util.get_dpkg_architecture")
         get_arch = apatcher.start()
         get_arch.return_value = 'amd64'
         self.addCleanup(apatcher.stop)

--- a/tests/unittests/test_handler/test_handler_apt_source_v1.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v1.py
@@ -77,7 +77,7 @@ class TestAptSourceConfig(TestCase):
         get_rel = rpatcher.start()
         get_rel.return_value = {'codename': self.release}
         self.addCleanup(rpatcher.stop)
-        apatcher = mock.patch("cloudinit.util.get_architecture")
+        apatcher = mock.patch("cloudinit.util.get_dpkg_architecture")
         get_arch = apatcher.start()
         get_arch.return_value = 'amd64'
         self.addCleanup(apatcher.stop)

--- a/tests/unittests/test_handler/test_handler_apt_source_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v3.py
@@ -453,14 +453,14 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
         self.assertFalse(os.path.isfile(self.aptlistfile2))
         self.assertFalse(os.path.isfile(self.aptlistfile3))
 
-    @mock.patch("cloudinit.config.cc_apt_configure.util.get_architecture")
-    def test_apt_v3_list_rename(self, m_get_architecture):
+    @mock.patch("cloudinit.config.cc_apt_configure.util.get_dpkg_architecture")
+    def test_apt_v3_list_rename(self, m_get_dpkg_architecture):
         """test_apt_v3_list_rename - Test find mirror and apt list renaming"""
         pre = "/var/lib/apt/lists"
         # filenames are archive dependent
 
         arch = 's390x'
-        m_get_architecture.return_value = arch
+        m_get_dpkg_architecture.return_value = arch
         component = "ubuntu-ports"
         archive = "ports.ubuntu.com"
 
@@ -491,13 +491,13 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
 
         mockren.assert_any_call(fromfn, tofn)
 
-    @mock.patch("cloudinit.config.cc_apt_configure.util.get_architecture")
-    def test_apt_v3_list_rename_non_slash(self, m_get_architecture):
+    @mock.patch("cloudinit.config.cc_apt_configure.util.get_dpkg_architecture")
+    def test_apt_v3_list_rename_non_slash(self, m_get_dpkg_architecture):
         target = os.path.join(self.tmp, "rename_non_slash")
         apt_lists_d = os.path.join(target, "./" + cc_apt_configure.APT_LISTS)
 
         arch = 'amd64'
-        m_get_architecture.return_value = arch
+        m_get_dpkg_architecture.return_value = arch
 
         mirror_path = "some/random/path/"
         primary = "http://test.ubuntu.com/" + mirror_path
@@ -626,10 +626,12 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
         self.assertEqual(mirrors['SECURITY'],
                          smir)
 
-    @mock.patch("cloudinit.config.cc_apt_configure.util.get_architecture")
-    def test_apt_v3_get_def_mir_non_intel_no_arch(self, m_get_architecture):
+    @mock.patch("cloudinit.config.cc_apt_configure.util.get_dpkg_architecture")
+    def test_apt_v3_get_def_mir_non_intel_no_arch(
+        self, m_get_dpkg_architecture
+    ):
         arch = 'ppc64el'
-        m_get_architecture.return_value = arch
+        m_get_dpkg_architecture.return_value = arch
         expected = {'PRIMARY': 'http://ports.ubuntu.com/ubuntu-ports',
                     'SECURITY': 'http://ports.ubuntu.com/ubuntu-ports'}
         self.assertEqual(expected, cc_apt_configure.get_default_mirrors())


### PR DESCRIPTION
This makes it clearer that we should only use this in code paths that
will definitely have dpkg available to them.