### PR TITLE
Fix PermissionError undefined in helpers.py - fix LP-1831146

### DIFF
--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -12,6 +12,7 @@ from time import time
 
 import contextlib
 import os
+import six
 
 from six import StringIO
 from six.moves.configparser import (
@@ -25,6 +26,10 @@ from cloudinit import type_utils
 from cloudinit import util
 
 LOG = logging.getLogger(__name__)
+
+if six.PY2:
+    class PermissionError(OSError):
+        pass
 
 
 class LockFailure(Exception):


### PR DESCRIPTION
CentOS 7 ships with Python 2.7 by default, so I believe we have to support Python 2.7 still.