### PR TITLE
Start removing dependency on six

### DIFF
--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -5,7 +5,6 @@
 import argparse
 from errno import EACCES
 import os
-import six
 import sys
 
 from cloudinit.handlers.jinja_template import (
@@ -149,7 +148,7 @@ def handle_args(name, args):
             response = '\n'.join(sorted(response.keys()))
     elif args.list_keys:
         response = '\n'.join(sorted(response.keys()))
-    if not isinstance(response, six.string_types):
+    if not isinstance(response, str):
         response = util.json_dumps(response)
     print(response)
     return 0

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -10,7 +10,6 @@
 
 import abc
 import os
-import six
 
 from cloudinit.settings import (PER_ALWAYS, PER_INSTANCE, FREQUENCIES)
 
@@ -60,8 +59,7 @@ INCLUSION_SRCH = sorted(list(INCLUSION_TYPES_MAP.keys()),
                         key=(lambda e: 0 - len(e)))
 
 
-@six.add_metaclass(abc.ABCMeta)
-class Handler(object):
+class Handler(metaclass=abc.ABCMeta):
 
     def __init__(self, frequency, version=2):
         self.handler_version = version
@@ -159,7 +157,7 @@ def _extract_first_or_bytes(blob, size):
     # Extract the first line or upto X symbols for text objects
     # Extract first X bytes for binary objects
     try:
-        if isinstance(blob, six.string_types):
+        if isinstance(blob, str):
             start = blob.split("\n", 1)[0]
         else:
             # We want to avoid decoding the whole blob (it might be huge)

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -11,12 +11,11 @@
 import abc
 import os
 
-from cloudinit.settings import (PER_ALWAYS, PER_INSTANCE, FREQUENCIES)
-
 from cloudinit import importer
 from cloudinit import log as logging
 from cloudinit import type_utils
 from cloudinit import util
+from cloudinit.settings import (PER_ALWAYS, PER_INSTANCE, FREQUENCIES)
 
 LOG = logging.getLogger(__name__)
 

--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -8,15 +8,13 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import collections
+import io
 import logging
 import logging.config
 import logging.handlers
-
-import collections
-import io
 import os
 import sys
-
 import time
 
 # Logging levels for easy access

--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -13,11 +13,9 @@ import logging.config
 import logging.handlers
 
 import collections
+import io
 import os
 import sys
-
-import six
-from six import StringIO
 
 import time
 
@@ -74,13 +72,13 @@ def setupLogging(cfg=None):
 
     log_cfgs = []
     log_cfg = cfg.get('logcfg')
-    if log_cfg and isinstance(log_cfg, six.string_types):
+    if log_cfg and isinstance(log_cfg, str):
         # If there is a 'logcfg' entry in the config,
         # respect it, it is the old keyname
         log_cfgs.append(str(log_cfg))
     elif "log_cfgs" in cfg:
         for a_cfg in cfg['log_cfgs']:
-            if isinstance(a_cfg, six.string_types):
+            if isinstance(a_cfg, str):
                 log_cfgs.append(a_cfg)
             elif isinstance(a_cfg, (collections.Iterable)):
                 cfg_str = [str(c) for c in a_cfg]
@@ -100,7 +98,7 @@ def setupLogging(cfg=None):
                 # is acting as a file)
                 pass
             else:
-                log_cfg = StringIO(log_cfg)
+                log_cfg = io.StringIO(log_cfg)
             # Attempt to load its config
             logging.config.fileConfig(log_cfg)
             # The first one to work wins!

--- a/cloudinit/mergers/__init__.py
+++ b/cloudinit/mergers/__init__.py
@@ -6,8 +6,6 @@
 
 import re
 
-import six
-
 from cloudinit import importer
 from cloudinit import log as logging
 from cloudinit import type_utils
@@ -85,7 +83,7 @@ def dict_extract_mergers(config):
         raw_mergers = config.pop('merge_type', None)
     if raw_mergers is None:
         return parsed_mergers
-    if isinstance(raw_mergers, six.string_types):
+    if isinstance(raw_mergers, str):
         return string_extract_mergers(raw_mergers)
     for m in raw_mergers:
         if isinstance(m, (dict)):

--- a/cloudinit/mergers/m_dict.py
+++ b/cloudinit/mergers/m_dict.py
@@ -4,8 +4,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import six
-
 DEF_MERGE_TYPE = 'no_replace'
 MERGE_TYPES = ('replace', DEF_MERGE_TYPE,)
 
@@ -47,7 +45,7 @@ class Merger(object):
                 return new_v
             if isinstance(new_v, (list, tuple)) and self._recurse_array:
                 return self._merger.merge(old_v, new_v)
-            if isinstance(new_v, six.string_types) and self._recurse_str:
+            if isinstance(new_v, str) and self._recurse_str:
                 return self._merger.merge(old_v, new_v)
             if isinstance(new_v, (dict)) and self._recurse_dict:
                 return self._merger.merge(old_v, new_v)

--- a/cloudinit/mergers/m_list.py
+++ b/cloudinit/mergers/m_list.py
@@ -4,8 +4,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import six
-
 DEF_MERGE_TYPE = 'replace'
 MERGE_TYPES = ('append', 'prepend', DEF_MERGE_TYPE, 'no_replace')
 
@@ -63,7 +61,7 @@ class Merger(object):
                 return old_v
             if isinstance(new_v, (list, tuple)) and self._recurse_array:
                 return self._merger.merge(old_v, new_v)
-            if isinstance(new_v, six.string_types) and self._recurse_str:
+            if isinstance(new_v, str) and self._recurse_str:
                 return self._merger.merge(old_v, new_v)
             if isinstance(new_v, (dict)) and self._recurse_dict:
                 return self._merger.merge(old_v, new_v)

--- a/cloudinit/mergers/m_str.py
+++ b/cloudinit/mergers/m_str.py
@@ -4,8 +4,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import six
-
 
 class Merger(object):
     def __init__(self, _merger, opts):
@@ -23,13 +21,10 @@ class Merger(object):
     # perform the following action, if appending we will
     # merge them together, otherwise we will just return value.
     def _on_str(self, value, merge_with):
-        if not isinstance(value, six.string_types):
+        if not isinstance(value, str):
             return merge_with
         if not self._append:
             return merge_with
-        if isinstance(value, six.text_type):
-            return value + six.text_type(merge_with)
-        else:
-            return value + six.binary_type(merge_with)
+        return value + merge_with
 
 # vi: ts=4 expandtab

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -12,8 +12,6 @@ import gzip
 import io
 import os
 
-import six
-
 from cloudinit import util
 
 from . import get_devicelist
@@ -22,8 +20,7 @@ from . import read_sys_net_safe
 _OPEN_ISCSI_INTERFACE_FILE = "/run/initramfs/open-iscsi.interface"
 
 
-@six.add_metaclass(abc.ABCMeta)
-class InitramfsNetworkConfigSource(object):
+class InitramfsNetworkConfigSource(metaclass=abc.ABCMeta):
     """ABC for net config sources that read config written by initramfses"""
 
     @abc.abstractmethod

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -4,8 +4,8 @@ import abc
 import uuid
 import fcntl
 import json
-import six
 import os
+import queue
 import struct
 import threading
 import time
@@ -14,12 +14,6 @@ from cloudinit import log as logging
 from cloudinit.registry import DictRegistry
 from cloudinit import (url_helper, util)
 from datetime import datetime
-from six.moves.queue import Empty as QueueEmptyError
-
-if six.PY2:
-    from multiprocessing.queues import JoinableQueue as JQueue
-else:
-    from queue import Queue as JQueue
 
 LOG = logging.getLogger(__name__)
 
@@ -28,8 +22,7 @@ class ReportException(Exception):
     pass
 
 
-@six.add_metaclass(abc.ABCMeta)
-class ReportingHandler(object):
+class ReportingHandler(metaclass=abc.ABCMeta):
     """Base class for report handlers.
 
     Implement :meth:`~publish_event` for controlling what
@@ -141,7 +134,7 @@ class HyperVKvpReportingHandler(ReportingHandler):
             self._kvp_file_path)
 
         self._event_types = event_types
-        self.q = JQueue()
+        self.q = queue.Queue()
         self.incarnation_no = self._get_incarnation_no()
         self.event_key_prefix = u"{0}|{1}".format(self.EVENT_PREFIX,
                                                   self.incarnation_no)
@@ -303,7 +296,7 @@ class HyperVKvpReportingHandler(ReportingHandler):
                         # get all the rest of the events in the queue
                         event = self.q.get(block=False)
                         items_from_queue += 1
-                    except QueueEmptyError:
+                    except queue.Empty:
                         event = None
                 try:
                     self._append_kvp_item(encoded_data)

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -1,7 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import abc
-import uuid
 import fcntl
 import json
 import os
@@ -9,11 +8,12 @@ import queue
 import struct
 import threading
 import time
+import uuid
+from datetime import datetime
 
 from cloudinit import log as logging
 from cloudinit.registry import DictRegistry
 from cloudinit import (url_helper, util)
-from datetime import datetime
 
 LOG = logging.getLogger(__name__)
 

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -15,8 +15,6 @@ import os
 import re
 import time
 
-import six
-
 from cloudinit import log as logging
 from cloudinit import sources
 from cloudinit import util
@@ -458,7 +456,7 @@ def maybe_cdrom_device(devname):
     """
     if not devname:
         return False
-    elif not isinstance(devname, six.string_types):
+    elif not isinstance(devname, str):
         raise ValueError("Unexpected input for devname: %s" % devname)
 
     # resolve '..' and multi '/' elements

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -8,17 +8,15 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from xml.dom import minidom
-
 import base64
 import os
 import re
 import time
+from xml.dom import minidom
 
 from cloudinit import log as logging
 from cloudinit import sources
 from cloudinit import util
-
 from cloudinit.sources.helpers.vmware.imc.config \
     import Config
 from cloudinit.sources.helpers.vmware.imc.config_custom_script \

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -13,7 +13,6 @@ from collections import namedtuple
 import copy
 import json
 import os
-import six
 
 from cloudinit.atomic_helper import write_json
 from cloudinit import importer
@@ -136,8 +135,7 @@ URLParams = namedtuple(
     'URLParms', ['max_wait_seconds', 'timeout_seconds', 'num_retries'])
 
 
-@six.add_metaclass(abc.ABCMeta)
-class DataSource(object):
+class DataSource(metaclass=abc.ABCMeta):
 
     dsmode = DSMODE_NETWORK
     default_locale = 'en_US.UTF-8'
@@ -436,7 +434,7 @@ class DataSource(object):
             return self._cloud_name
         if self.metadata and self.metadata.get(METADATA_CLOUD_NAME_KEY):
             cloud_name = self.metadata.get(METADATA_CLOUD_NAME_KEY)
-            if isinstance(cloud_name, six.string_types):
+            if isinstance(cloud_name, str):
                 self._cloud_name = cloud_name.lower()
             else:
                 self._cloud_name = self._get_cloud_name().lower()
@@ -718,8 +716,8 @@ def normalize_pubkey_data(pubkey_data):
     if not pubkey_data:
         return keys
 
-    if isinstance(pubkey_data, six.string_types):
-        return str(pubkey_data).splitlines()
+    if isinstance(pubkey_data, str):
+        return pubkey_data.splitlines()
 
     if isinstance(pubkey_data, (list, set)):
         return list(pubkey_data)
@@ -729,7 +727,7 @@ def normalize_pubkey_data(pubkey_data):
             # lp:506332 uec metadata service responds with
             # data that makes boto populate a string for 'klist' rather
             # than a list.
-            if isinstance(klist, six.string_types):
+            if isinstance(klist, str):
                 klist = [klist]
             if isinstance(klist, (list, set)):
                 for pkey in klist:
@@ -837,7 +835,7 @@ def convert_vendordata(data, recurse=True):
     """
     if not data:
         return None
-    if isinstance(data, six.string_types):
+    if isinstance(data, str):
         return data
     if isinstance(data, list):
         return copy.deepcopy(data)

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -9,20 +9,19 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import abc
-from collections import namedtuple
 import copy
 import json
 import os
+from collections import namedtuple
 
-from cloudinit.atomic_helper import write_json
 from cloudinit import importer
 from cloudinit import log as logging
 from cloudinit import net
-from cloudinit.event import EventType
 from cloudinit import type_utils
 from cloudinit import user_data as ud
 from cloudinit import util
-
+from cloudinit.atomic_helper import write_json
+from cloudinit.event import EventType
 from cloudinit.filters import launch_index
 from cloudinit.reporting import events
 

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -18,7 +18,6 @@ from cloudinit import net
 from cloudinit import sources
 from cloudinit import url_helper
 from cloudinit import util
-
 from cloudinit.sources import BrokenMetadata
 
 # See https://docs.openstack.org/user-guide/cli-config-drive.html

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -12,8 +12,6 @@ import copy
 import functools
 import os
 
-import six
-
 from cloudinit import ec2_utils
 from cloudinit import log as logging
 from cloudinit import net
@@ -163,8 +161,7 @@ class SourceMixin(object):
             return device
 
 
-@six.add_metaclass(abc.ABCMeta)
-class BaseReader(object):
+class BaseReader(metaclass=abc.ABCMeta):
 
     def __init__(self, base_path):
         self.base_path = base_path
@@ -227,7 +224,7 @@ class BaseReader(object):
         """
 
         load_json_anytype = functools.partial(
-            util.load_json, root_types=(dict, list) + six.string_types)
+            util.load_json, root_types=(dict, list, str))
 
         def datafiles(version):
             files = {}

--- a/cloudinit/type_utils.py
+++ b/cloudinit/type_utils.py
@@ -10,29 +10,18 @@
 
 import types
 
-import six
 
-
-if six.PY3:
-    _NAME_TYPES = (
-        types.ModuleType,
-        types.FunctionType,
-        types.LambdaType,
-        type,
-    )
-else:
-    _NAME_TYPES = (
-        types.TypeType,
-        types.ModuleType,
-        types.FunctionType,
-        types.LambdaType,
-        types.ClassType,
-    )
+_NAME_TYPES = (
+    types.ModuleType,
+    types.FunctionType,
+    types.LambdaType,
+    type,
+)
 
 
 def obj_name(obj):
     if isinstance(obj, _NAME_TYPES):
-        return six.text_type(obj.__name__)
+        return str(obj.__name__)
     else:
         if not hasattr(obj, '__class__'):
             return repr(obj)

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -10,16 +10,16 @@
 
 import json
 import os
-import requests
 import time
-
 from email.utils import parsedate
 from errno import ENOENT
 from functools import partial
 from http.client import NOT_FOUND
 from itertools import count
-from requests import exceptions
 from urllib.parse import urlparse, urlunparse, quote
+
+import requests
+from requests import exceptions
 
 from cloudinit import log as logging
 from cloudinit import version

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -11,30 +11,20 @@
 import json
 import os
 import requests
-import six
 import time
 
 from email.utils import parsedate
 from errno import ENOENT
 from functools import partial
+from http.client import NOT_FOUND
 from itertools import count
 from requests import exceptions
-
-from six.moves.urllib.parse import (
-    urlparse, urlunparse,
-    quote as urlquote)
+from urllib.parse import urlparse, urlunparse, quote
 
 from cloudinit import log as logging
 from cloudinit import version
 
 LOG = logging.getLogger(__name__)
-
-if six.PY2:
-    import httplib
-    NOT_FOUND = httplib.NOT_FOUND
-else:
-    import http.client
-    NOT_FOUND = http.client.NOT_FOUND
 
 
 # Check if requests has ssl support (added in requests >= 0.8.8)
@@ -71,7 +61,7 @@ def combine_url(base, *add_ons):
         path = url_parsed[2]
         if path and not path.endswith("/"):
             path += "/"
-        path += urlquote(str(add_on), safe="/:")
+        path += quote(str(add_on), safe="/:")
         url_parsed[2] = path
         return urlunparse(url_parsed)
 

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -9,7 +9,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import os
-
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.nonmultipart import MIMENonMultipart

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -15,8 +15,6 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.nonmultipart import MIMENonMultipart
 from email.mime.text import MIMEText
 
-import six
-
 from cloudinit import handlers
 from cloudinit import log as logging
 from cloudinit.url_helper import read_file_or_url, UrlError
@@ -259,7 +257,7 @@ class UserDataProcessor(object):
             #    filename and type not be present
             # or
             #  scalar(payload)
-            if isinstance(ent, six.string_types):
+            if isinstance(ent, str):
                 ent = {'content': ent}
             if not isinstance(ent, (dict)):
                 # TODO(harlowja) raise?
@@ -269,13 +267,13 @@ class UserDataProcessor(object):
             mtype = ent.get('type')
             if not mtype:
                 default = ARCHIVE_UNDEF_TYPE
-                if isinstance(content, six.binary_type):
+                if isinstance(content, bytes):
                     default = ARCHIVE_UNDEF_BINARY_TYPE
                 mtype = handlers.type_from_starts_with(content, default)
 
             maintype, subtype = mtype.split('/', 1)
             if maintype == "text":
-                if isinstance(content, six.binary_type):
+                if isinstance(content, bytes):
                     content = content.decode()
                 msg = MIMEText(content, _subtype=subtype)
             else:
@@ -348,7 +346,7 @@ def convert_string(raw_data, content_type=NOT_MULTIPART_TYPE):
         msg.set_payload(data)
         return msg
 
-    if isinstance(raw_data, six.text_type):
+    if isinstance(raw_data, str):
         bdata = raw_data.encode('utf-8')
     else:
         bdata = raw_data


### PR DESCRIPTION
cloud-init master no longer supports Python 2, so we no longer need to depend on the six library. This PR drops the usage of six in some parts of the codebase, to start us down that path.

(It also sorts imports where I was touching them anyway.)