### PR TITLE
.readthedocs.yaml: install cloud-init when building docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,3 +5,4 @@ formats: all
 python:
     install:
         - requirements: doc-requirements.txt
+        - path: .


### PR DESCRIPTION
This should ensure that all its dependencies are installed during doc
generation.

LP: #1860450