### PR TITLE
cloudinit: remove ImportError handling for mock imports

### DIFF
--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -5,11 +5,7 @@
 import gzip
 import logging
 import os
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from six import BytesIO, StringIO
 

--- a/tests/unittests/test_distros/test_generic.py
+++ b/tests/unittests/test_distros/test_generic.py
@@ -8,11 +8,7 @@ from cloudinit.tests import helpers
 import os
 import shutil
 import tempfile
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 unknown_arch_info = {
     'arches': ['default'],

--- a/tests/unittests/test_distros/test_netconfig.py
+++ b/tests/unittests/test_distros/test_netconfig.py
@@ -4,11 +4,7 @@ import copy
 import os
 from six import StringIO
 from textwrap import dedent
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from cloudinit import distros
 from cloudinit.distros.parsers.sys_conf import SysConf

--- a/tests/unittests/test_handler/test_handler_apt_configure_sources_list_v1.py
+++ b/tests/unittests/test_handler/test_handler_apt_configure_sources_list_v1.py
@@ -7,11 +7,7 @@ import logging
 import os
 import shutil
 import tempfile
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from cloudinit import cloud
 from cloudinit import distros

--- a/tests/unittests/test_handler/test_handler_apt_configure_sources_list_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_configure_sources_list_v3.py
@@ -7,12 +7,8 @@ import logging
 import os
 import shutil
 import tempfile
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-from mock import call
+from unittest import mock
+from unittest.mock import call
 
 from cloudinit import cloud
 from cloudinit import distros

--- a/tests/unittests/test_handler/test_handler_apt_source_v1.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v1.py
@@ -9,12 +9,8 @@ import os
 import re
 import shutil
 import tempfile
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-from mock import call
+from unittest import mock
+from unittest.mock import call
 
 from cloudinit.config import cc_apt_configure
 from cloudinit import gpg

--- a/tests/unittests/test_handler/test_handler_apt_source_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v3.py
@@ -11,13 +11,8 @@ import shutil
 import socket
 import tempfile
 
-from unittest import TestCase
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-from mock import call
+from unittest import TestCase, mock
+from unittest.mock import call
 
 from cloudinit import cloud
 from cloudinit import distros

--- a/tests/unittests/test_handler/test_handler_ca_certs.py
+++ b/tests/unittests/test_handler/test_handler_ca_certs.py
@@ -11,11 +11,8 @@ import logging
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 try:
     from contextlib import ExitStack
 except ImportError:

--- a/tests/unittests/test_handler/test_handler_growpart.py
+++ b/tests/unittests/test_handler/test_handler_growpart.py
@@ -11,11 +11,8 @@ import logging
 import os
 import re
 import unittest
+from unittest import mock
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 try:
     from contextlib import ExitStack
 except ImportError:

--- a/tests/unittests/test_handler/test_handler_lxd.py
+++ b/tests/unittests/test_handler/test_handler_lxd.py
@@ -5,10 +5,7 @@ from cloudinit.sources import DataSourceNoCloud
 from cloudinit import (distros, helpers, cloud)
 from cloudinit.tests import helpers as t_help
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 class TestLxd(t_help.CiTestCase):

--- a/tests/unittests/test_handler/test_handler_mounts.py
+++ b/tests/unittests/test_handler/test_handler_mounts.py
@@ -1,15 +1,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import os.path
+from unittest import mock
 
 from cloudinit.config import cc_mounts
 
 from cloudinit.tests import helpers as test_helpers
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):

--- a/tests/unittests/test_handler/test_handler_spacewalk.py
+++ b/tests/unittests/test_handler/test_handler_spacewalk.py
@@ -6,11 +6,7 @@ from cloudinit import util
 from cloudinit.tests import helpers
 
 import logging
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -12,14 +12,10 @@ import stat
 import sys
 import tempfile
 import yaml
+from unittest import mock
 
 from cloudinit import importer, util
 from cloudinit.tests import helpers
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 BASH = util.which('bash')


### PR DESCRIPTION
We only run on Python 3 now, so we can unambiguously expect
unittest.mock to exist.