### PR TITLE
cloudinit: replace use of mock library with unittest.mock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
             - sudo -E su $USER -c 'sbuild --nolog --verbose --dist=xenial cloud-init_*.dsc'
             # Ubuntu LTS: Integration
             - sg lxd -c 'tox -e citest -- run --verbose --preserve-data --data-dir results --os-name xenial --test modules/apt_configure_sources_list.yaml --test modules/ntp_servers --test modules/set_password_list --test modules/user_groups --deb cloud-init_*_all.deb'
-        - python: 3.4
+        - python: 3.5
           env:
               TOXENV=xenial
               NOSE_VERBOSE=2  # List all tests run by nose

--- a/cloudinit/config/tests/test_set_passwords.py
+++ b/cloudinit/config/tests/test_set_passwords.py
@@ -1,6 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import mock
+from unittest import mock
 
 from cloudinit.config import cc_set_passwords as setpass
 from cloudinit.tests.helpers import CiTestCase

--- a/cloudinit/net/tests/test_init.py
+++ b/cloudinit/net/tests/test_init.py
@@ -3,10 +3,10 @@
 import copy
 import errno
 import httpretty
-import mock
 import os
 import requests
 import textwrap
+from unittest import mock
 
 import cloudinit.net as net
 from cloudinit.util import ensure_file, write_file, ProcessExecutionError

--- a/cloudinit/net/tests/test_network_state.py
+++ b/cloudinit/net/tests/test_network_state.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import mock
+from unittest import mock
+
 from cloudinit.net import network_state
 from cloudinit.tests.helpers import CiTestCase
 

--- a/cloudinit/sources/tests/test_oracle.py
+++ b/cloudinit/sources/tests/test_oracle.py
@@ -11,9 +11,9 @@ import argparse
 import copy
 import httpretty
 import json
-import mock
 import os
 import uuid
+from unittest import mock
 
 DS_PATH = "cloudinit.sources.DataSourceOracle"
 MD_VER = "2013-10-17"

--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -13,8 +13,8 @@ import string
 import sys
 import tempfile
 import time
+from unittest import mock
 
-import mock
 import unittest2
 from unittest2.util import strclass
 

--- a/cloudinit/tests/test_dhclient_hook.py
+++ b/cloudinit/tests/test_dhclient_hook.py
@@ -7,8 +7,8 @@ from cloudinit.tests.helpers import CiTestCase, dir2dict, populate_dir
 
 import argparse
 import json
-import mock
 import os
+from unittest import mock
 
 
 class TestDhclientHook(CiTestCase):

--- a/cloudinit/tests/test_gpg.py
+++ b/cloudinit/tests/test_gpg.py
@@ -1,11 +1,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Test gpg module."""
 
+from unittest import mock
+
 from cloudinit import gpg
 from cloudinit import util
 from cloudinit.tests.helpers import CiTestCase
-
-import mock
 
 
 @mock.patch("cloudinit.gpg.time.sleep")

--- a/cloudinit/tests/test_version.py
+++ b/cloudinit/tests/test_version.py
@@ -1,9 +1,9 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from unittest import mock
+
 from cloudinit.tests.helpers import CiTestCase
 from cloudinit import version
-
-import mock
 
 
 class TestExportsFeatures(CiTestCase):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 # Needed generally in tests
 httpretty>=0.7.1
-mock
 nose
 unittest2
 coverage

--- a/tests/unittests/test_datasource/test_aliyun.py
+++ b/tests/unittests/test_datasource/test_aliyun.py
@@ -2,8 +2,8 @@
 
 import functools
 import httpretty
-import mock
 import os
+from unittest import mock
 
 from cloudinit import helpers
 from cloudinit.sources import DataSourceAliYun as ay

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -3,7 +3,7 @@
 import copy
 import httpretty
 import json
-import mock
+from unittest import mock
 
 from cloudinit import helpers
 from cloudinit.sources import DataSourceEc2 as ec2

--- a/tests/unittests/test_datasource/test_gce.py
+++ b/tests/unittests/test_datasource/test_gce.py
@@ -7,8 +7,8 @@
 import datetime
 import httpretty
 import json
-import mock
 import re
+from unittest import mock
 
 from base64 import b64encode, b64decode
 from six.moves.urllib_parse import urlparse

--- a/tests/unittests/test_datasource/test_maas.py
+++ b/tests/unittests/test_datasource/test_maas.py
@@ -1,11 +1,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 from copy import copy
-import mock
 import os
 import shutil
 import tempfile
 import yaml
+from unittest import mock
 
 from cloudinit.sources import DataSourceMAAS
 from cloudinit import url_helper

--- a/tests/unittests/test_distros/test_user_data_normalize.py
+++ b/tests/unittests/test_distros/test_user_data_normalize.py
@@ -1,12 +1,13 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from unittest import mock
+
 from cloudinit import distros
 from cloudinit.distros import ug_util
 from cloudinit import helpers
 from cloudinit import settings
 
 from cloudinit.tests.helpers import TestCase
-import mock
 
 
 bcfg = {

--- a/tests/unittests/test_handler/test_handler_locale.py
+++ b/tests/unittests/test_handler/test_handler_locale.py
@@ -20,10 +20,10 @@ from configobj import ConfigObj
 from six import BytesIO
 
 import logging
-import mock
 import os
 import shutil
 import tempfile
+from unittest import mock
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unittests/test_reporting.py
+++ b/tests/unittests/test_reporting.py
@@ -2,11 +2,11 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from unittest import mock
+
 from cloudinit import reporting
 from cloudinit.reporting import events
 from cloudinit.reporting import handlers
-
-import mock
 
 from cloudinit.tests.helpers import TestCase
 

--- a/tests/unittests/test_reporting_hyperv.py
+++ b/tests/unittests/test_reporting_hyperv.py
@@ -8,7 +8,7 @@ import os
 import struct
 import time
 import re
-import mock
+from unittest import mock
 
 from cloudinit import util
 from cloudinit.tests.helpers import CiTestCase

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from mock import patch
 from collections import namedtuple
+from unittest.mock import patch
 
 from cloudinit import ssh_util
 from cloudinit.tests import helpers as test_helpers


### PR DESCRIPTION
As we're on Python 3, we can rely on the presence of unittest.mock.