### PR TITLE
cc_ssh_import_id: support space separated list of users

### DIFF
--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -28,6 +28,10 @@ either ``lp:`` for launchpad or ``gh:`` for github to the username.
         - user
         - gh:user
         - lp:user
+
+    ssh_import_id: lp:user2
+
+    ssh_import_id: lp:user1 user2 user3
 """
 
 from cloudinit.distros import ug_util
@@ -56,13 +60,16 @@ def handle(_name, cfg, cloud, log, args):
     for (user, user_cfg) in users.items():
         import_ids = []
         if user_cfg['default']:
-            import_ids = util.get_cfg_option_list(cfg, "ssh_import_id", [])
+            import_ids = cfg.get("ssh_import_id", [])
         else:
-            try:
-                import_ids = user_cfg['ssh_import_id']
-            except Exception:
-                log.debug("User %s is not configured for ssh_import_id", user)
-                continue
+            import_ids = user_cfg.get('ssh_import_id', [])
+
+        if not import_ids:
+            continue
+
+        # handle space separated list
+        if isinstance(import_ids, str):
+            import_ids = import_ids.split(" ")
 
         try:
             import_ids = util.uniq_merge(import_ids)

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -67,9 +67,9 @@ def handle(_name, cfg, cloud, log, args):
         if not import_ids:
             continue
 
-        # handle space separated list
+        # handle whitespace separated list
         if isinstance(import_ids, str):
-            import_ids = import_ids.split(" ")
+            import_ids = import_ids.split()
 
         try:
             import_ids = util.uniq_merge(import_ids)

--- a/cloudinit/config/tests/test_ssh_import_id.py
+++ b/cloudinit/config/tests/test_ssh_import_id.py
@@ -1,0 +1,106 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import os.path
+
+from cloudinit.config import cc_ssh_import_id
+from cloudinit.tests.helpers import CiTestCase, mock
+import logging
+
+LOG = logging.getLogger(__name__)
+
+MODPATH = "cloudinit.config.cc_ssh_import_id."
+
+class DummyCloud(object):
+    distro = 'dummy'
+
+class TestHandleSshImportId(CiTestCase):
+    """Test cc_ssh_import_id handling of import-id config."""
+
+    @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
+    @mock.patch(MODPATH + 'import_ssh_ids')
+    def test_handle_import_converts_string_to_list(self, m_import, m_ugroups):
+        """Test ssh_import_id cfg space separated string converts to list."""
+        mycloud = DummyCloud()
+        mycfg = {'ssh_import_id': 'foo bar baz'}
+        m_ugroups.return_value = ({'ubuntu': {'default': True}}, None)
+        cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
+        m_import.has_calls([
+            mock.call(['foo', 'bar', 'baz'], 'ubuntu', LOG)])
+
+    @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
+    @mock.patch(MODPATH + 'import_ssh_ids')
+    def test_handle_import_converts_string_to_list_user_cfg(self, m_import,
+                                                            m_ugroups):
+        """Test ssh_import_id user_cfg space sep string converts to list."""
+        mycloud = DummyCloud()
+        mycfg = {}
+        m_ugroups.return_value = (
+            {'ubuntu': {
+                'default': True,
+                'ssh_import_id': 'foo bar baz'}}, None)
+        cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
+        m_import.has_calls([
+            mock.call(['foo', 'bar', 'baz'], 'ubuntu', LOG)])
+
+
+    @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
+    @mock.patch(MODPATH + 'import_ssh_ids')
+    def test_handle_import_single_string_user_cfg(self, m_import, m_ugroups):
+        """Test ssh_import_id user cfg space separated string converts to list.
+        """
+        mycloud = DummyCloud()
+        mycfg = {}
+        m_ugroups.return_value = (
+            {'ubuntu': {'default': True, 'ssh_import_id': 'foo'}}, None)
+        cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
+        m_import.has_calls([
+            mock.call(['foo'], 'ubuntu', LOG)])
+
+    @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
+    @mock.patch(MODPATH + 'import_ssh_ids')
+    def test_handle_import_lists(self, m_import, m_ugroups):
+        """Test ssh_import_id cfg space separated string converts to list."""
+        mycloud = DummyCloud()
+        mycfg = {'ssh_import_id': ['foo', 'bar', 'baz']}
+        m_ugroups.return_value = ({'ubuntu': {'default': True}}, None)
+        cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
+        m_import.has_calls([
+            mock.call(['foo', 'bar', 'baz'], 'ubuntu', LOG)])
+
+    @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
+    @mock.patch(MODPATH + 'import_ssh_ids')
+    def test_handle_import_lists_user_cfg(self, m_import, m_ugroups):
+        """Test ssh_import_id user cfg space separated string converts to list.
+        """
+        mycloud = DummyCloud()
+        mycfg = {}
+        m_ugroups.return_value = (
+            {'ubuntu': {'default': True,
+                        'ssh_import_id': ['foo', 'bar', 'baz']}}, None)
+        cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
+        m_import.has_calls([
+            mock.call(['foo', 'bar', 'baz'], 'ubuntu', LOG)])
+
+
+    @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
+    @mock.patch(MODPATH + 'import_ssh_ids')
+    def test_handle_import_empty_list(self, m_import, m_ugroups):
+        """Test ssh_import_id cfg space separated string converts to list."""
+        mycloud = DummyCloud()
+        mycfg = {'ssh_import_id': []}
+        m_ugroups.return_value = ({'ubuntu': {'default': True}}, None)
+        cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
+        self.assertEqual(m_import.call_count, 0)
+
+    @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
+    @mock.patch(MODPATH + 'import_ssh_ids')
+    def test_handle_import_empty_list_user(self, m_import, m_ugroups):
+        """Test ssh_import_id user cfg space separated string converts to list.
+        """
+        mycloud = DummyCloud()
+        mycfg = {}
+        m_ugroups.return_value = (
+            {'ubuntu': {'default': True, 'ssh_import_id': []}}, None)
+        cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
+        self.assertEqual(m_import.call_count, 0)
+

--- a/cloudinit/config/tests/test_ssh_import_id.py
+++ b/cloudinit/config/tests/test_ssh_import_id.py
@@ -1,7 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import os.path
-
 from cloudinit.config import cc_ssh_import_id
 from cloudinit.tests.helpers import CiTestCase, mock
 import logging
@@ -10,8 +8,10 @@ LOG = logging.getLogger(__name__)
 
 MODPATH = "cloudinit.config.cc_ssh_import_id."
 
+
 class DummyCloud(object):
     distro = 'dummy'
+
 
 class TestHandleSshImportId(CiTestCase):
     """Test cc_ssh_import_id handling of import-id config."""
@@ -41,7 +41,6 @@ class TestHandleSshImportId(CiTestCase):
         cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
         m_import.has_calls([
             mock.call(['foo', 'bar', 'baz'], 'ubuntu', LOG)])
-
 
     @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
     @mock.patch(MODPATH + 'import_ssh_ids')
@@ -81,7 +80,6 @@ class TestHandleSshImportId(CiTestCase):
         m_import.has_calls([
             mock.call(['foo', 'bar', 'baz'], 'ubuntu', LOG)])
 
-
     @mock.patch(MODPATH + 'ug_util.normalize_users_groups')
     @mock.patch(MODPATH + 'import_ssh_ids')
     def test_handle_import_empty_list(self, m_import, m_ugroups):
@@ -103,4 +101,3 @@ class TestHandleSshImportId(CiTestCase):
             {'ubuntu': {'default': True, 'ssh_import_id': []}}, None)
         cc_ssh_import_id.handle(None, mycfg, mycloud, LOG, [])
         self.assertEqual(m_import.call_count, 0)
-


### PR DESCRIPTION
Add support for parsing a space separated list of users. This adds
to a single string which becomes a list, and supports platform
consoles which cannot utilize [] keys for building yaml list.