### PR TITLE
Make the RPM build use Python 3

### DIFF
--- a/packages/brpm
+++ b/packages/brpm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import glob

--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -29,27 +29,27 @@
       ],
       "renames" : {
          "jinja2" : {
-            "3" : "python34-jinja2"
+            "3" : "python36-jinja2"
          },
          "jsonschema" : {
-            "3" : "python34-jsonschema"
+            "3" : "python36-jsonschema"
          },
          "pyflakes" : {
             "2" : "pyflakes",
-            "3" : "python34-pyflakes"
+            "3" : "python36-pyflakes"
          },
          "pyyaml" : {
             "2" : "PyYAML",
-            "3" : "python34-PyYAML"
+            "3" : "python36-PyYAML"
          },
          "pyserial" : {
             "2" : "pyserial"
          },
          "requests" : {
-            "3" : "python34-requests"
+            "3" : "python36-requests"
          },
          "six" : {
-            "3" : "python34-six"
+            "3" : "python36-six"
          }
       },
       "requires" : [


### PR DESCRIPTION
The Python 2 deprecation broke the RPM build; the scripts have to be adapted
to use Python 3. Changes:

 1. Make packages/brpm use python3 as its interpreter.
 2. Satisfy the Py3 dependencies using python36-* packages instead of
    python34-* packages.

Change (2) is not strictly necessary, but adapts the dependencies to CentOS 7,
our default CentOS test target.