### PR TITLE
Add Python 3.9 compatibility.

### DIFF
--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -8,7 +8,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import collections
 import io
 import logging
 import logging.config
@@ -16,6 +15,11 @@ import logging.handlers
 import os
 import sys
 import time
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 # Logging levels for easy access
 CRITICAL = logging.CRITICAL
@@ -78,7 +82,7 @@ def setupLogging(cfg=None):
         for a_cfg in cfg['log_cfgs']:
             if isinstance(a_cfg, str):
                 log_cfgs.append(a_cfg)
-            elif isinstance(a_cfg, (collections.Iterable)):
+            elif isinstance(a_cfg, (Iterable)):
                 cfg_str = [str(c) for c in a_cfg]
                 log_cfgs.append('\n'.join(cfg_str))
             else:

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ elif os.path.isfile('/etc/system-release-cpe'):
     with open('/etc/system-release-cpe') as f:
         cpe_data = f.read().rstrip().split(':')
 
-        if cpe_data[1] == "\o":
+        if cpe_data[1] == r"\o":
             # URI formated CPE
             inc = 0
         else:


### PR DESCRIPTION
* Importing ABC from collections module directly was removed in Python 3.9.
* Fix warnings regarding invalid deprecation warnings.