### PR TITLE
Add physical network type: cascading to openstack helpers

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -68,7 +68,7 @@ KNOWN_PHYSICAL_TYPES = (
     None,
     'bgpovs',  # not present in OpenStack upstream but used on OVH cloud.
     'bridge',
-    'cascading',  # not present in OpenStack upstream but used on OpenTelekomCloud
+    'cascading',  # not present in OpenStack upstream, used on OpenTelekomCloud
     'dvs',
     'ethernet',
     'hw_veb',

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -68,6 +68,7 @@ KNOWN_PHYSICAL_TYPES = (
     None,
     'bgpovs',  # not present in OpenStack upstream but used on OVH cloud.
     'bridge',
+    'cascading',  # not present in OpenStack upstream but used on OpenTelekomCloud
     'dvs',
     'ethernet',
     'hw_veb',

--- a/cloudinit/sources/helpers/tests/test_openstack.py
+++ b/cloudinit/sources/helpers/tests/test_openstack.py
@@ -1,0 +1,45 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+# ./cloudinit/sources/helpers/tests/test_openstack.py
+
+from cloudinit.sources.helpers import openstack
+from cloudinit.tests import helpers as test_helpers
+
+
+class TestConvertNetJson(test_helpers.CiTestCase):
+
+    def test_phy_types(self):
+        """Verify the different known physical types are handled."""
+        # network_data.json example from
+        # https://docs.openstack.org/nova/latest/user/metadata.html
+        mac0 = "fa:16:3e:9c:bf:3d"
+        net_json = {
+            "links": [
+                {"ethernet_mac_address": mac0, "id": "tapcd9f6d46-4a",
+                 "mtu": None, "type": "bridge",
+                 "vif_id": "cd9f6d46-4a3a-43ab-a466-994af9db96fc"}
+            ],
+            "networks": [
+                {"id": "network0", "link": "tapcd9f6d46-4a",
+                 "network_id": "99e88329-f20d-4741-9593-25bf07847b16",
+                 "type": "ipv4_dhcp"}
+            ],
+            "services": [{"address": "8.8.8.8", "type": "dns"}]
+        }
+        macs = {mac0: 'eth0'}
+
+        expected = {
+            'version': 1,
+            'config': [
+                {'mac_address': 'fa:16:3e:9c:bf:3d',
+                 'mtu': None, 'name': 'eth0',
+                 'subnets': [{'type': 'dhcp4'}],
+                 'type': 'physical'},
+                {'address': '8.8.8.8', 'type': 'nameserver'}]}
+
+        for t in openstack.KNOWN_PHYSICAL_TYPES:
+            net_json["links"][0]["type"] = t
+            self.assertEqual(
+                expected,
+                openstack.convert_net_json(network_json=net_json,
+                                           known_macs=macs))
+

--- a/cloudinit/sources/helpers/tests/test_openstack.py
+++ b/cloudinit/sources/helpers/tests/test_openstack.py
@@ -42,4 +42,3 @@ class TestConvertNetJson(test_helpers.CiTestCase):
                 expected,
                 openstack.convert_net_json(network_json=net_json,
                                            known_macs=macs))
-


### PR DESCRIPTION
OpenTelekom Cloud is based on cascading OpenStack.
The type of network interfaces used for KVM instances 
here is:'cascading'.

This commit adds 'cascading' to the list of KNOWN_PHYSICAL_TYPES.
