### PR TITLE
azurecloud: fix issues with instances not starting

### DIFF
--- a/tests/cloud_tests/__init__.py
+++ b/tests/cloud_tests/__init__.py
@@ -22,7 +22,8 @@ def _initialize_logging():
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        '%(asctime)s - %(pathname)s:%(funcName)s:%(lineno)s '
+        '[%(levelname)s]: %(message)s')
 
     console = logging.StreamHandler()
     console.setLevel(logging.DEBUG)

--- a/tests/cloud_tests/platforms/azurecloud/platform.py
+++ b/tests/cloud_tests/platforms/azurecloud/platform.py
@@ -74,8 +74,9 @@ class AzureCloudPlatform(Platform):
         @param user_data: test user-data to pass to instance
         @return_value: cloud_tests.instances instance
         """
-        user_data = str(base64.b64encode(
-            user_data.encode('utf-8')), 'utf-8')
+        if user_data is not None:
+            user_data = str(base64.b64encode(
+                user_data.encode('utf-8')), 'utf-8')
 
         return AzureCloudInstance(self, properties, config, features,
                                   image_id, user_data)

--- a/tests/cloud_tests/setup_image.py
+++ b/tests/cloud_tests/setup_image.py
@@ -229,7 +229,7 @@ def setup_image(args, image):
     except Exception as e:
         info = "N/A (%s)" % e
 
-    LOG.info('setting up %s (%s)', image, info)
+    LOG.info('setting up image %s (info %s)', image, info)
     res = stage.run_stage(
         'set up for {}'.format(image), calls, continue_after_error=False)
     return res


### PR DESCRIPTION
The azurecloud platform did not always start instances
during collect runs.  This was a result of two issues. First
the image class _instance method did not invoke the start()
method which then allowed collect stage to attempt to run
scripts without an endpoint.  Second, azurecloud used the
image_id as both an instance handle (which is typically
vmName in azure api) as well as an image handle (for image
capture).  Resolve this by adding a .vm_name property to
the AzureCloudInstance and reference this property in
AzureCloudImage.

Also in this branch

- Fix error encoding user-data when value is None
- Add additional logging in AzureCloud platform
- Update logging format to print pathname,funcName and line number
  This greatly eases debugging.

LP: #1861921