### PR TITLE
unittest: fix stderr leak in cc_set_password random unittest output.

### DIFF
--- a/cloudinit/config/tests/test_set_passwords.py
+++ b/cloudinit/config/tests/test_set_passwords.py
@@ -74,6 +74,10 @@ class TestSetPasswordsHandle(CiTestCase):
 
     with_logs = True
 
+    def setUp(self):
+        super(TestSetPasswordsHandle, self).setUp()
+        self.add_patch('cloudinit.config.cc_set_passwords.sys.stderr', 'm_err')
+
     def test_handle_on_empty_config(self, *args):
         """handle logs that no password has changed when config is empty."""
         cloud = self.tmp_cloud(distro='ubuntu')


### PR DESCRIPTION
When running tox we see stderr output from one of the cc_set_password tests.
This patch mocks out the write to sys.stderr so we no longer see that message
while running unittests.