### PR TITLE
docs: mount_default_files is a list of 6 items, not 7

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -25,7 +25,7 @@ mountpoint (i.e. ``[ sda1 ]`` or ``[ sda1, null ]``).
 
 The ``mount_default_fields`` config key allows default options to be specified
 for the values in a ``mounts`` entry that are not specified, aside from the
-``fs_spec`` and the ``fs_file``. If specified, this must be a list containing 7
+``fs_spec`` and the ``fs_file``. If specified, this must be a list containing 6
 values. It defaults to::
 
     mount_default_fields: [none, none, "auto", "defaults,nobootwait", "0", "2"]

--- a/doc/examples/cloud-config-mount-points.txt
+++ b/doc/examples/cloud-config-mount-points.txt
@@ -34,7 +34,7 @@ mounts:
 
 # mount_default_fields
 # These values are used to fill in any entries in 'mounts' that are not
-# complete.  This must be an array, and must have 7 fields.
+# complete.  This must be an array, and must have 6 fields.
 mount_default_fields: [ None, None, "auto", "defaults,nofail", "0", "2" ]
 
 


### PR DESCRIPTION
Minor doc cleanup noticed when someone hit a swapfile device setup issue.