### PR TITLE
cc_growpart: Add realpath translation and adjust logging

### DIFF
--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -172,7 +172,7 @@ class ResizeGrowPart(object):
         try:
             out, _err = util.subp(["growpart", '-v', diskdev, partnum],
                                   rcs=[0, 1])
-            LOG.debug('growpart: %s', out)
+            util.multi_log('growpart: %s' % out, stderr=False, log=LOG)
             return self.get_size(out)
         except util.ProcessExecutionError as e:
             util.logexc(LOG, "Failed: growpart error: %s", e)

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -169,16 +169,19 @@ class ResizeGrowPart(object):
         return (before, after)
 
     def resize(self, diskdev, partnum, partdev):
+        out = None
         try:
             out, _err = util.subp(["growpart", '-v', diskdev, partnum],
                                   rcs=[0, 1])
-            util.multi_log('growpart: %s' % out, stderr=False, log=LOG)
-            return self.get_size(out)
         except util.ProcessExecutionError as e:
             util.logexc(LOG, "Failed: growpart error: %s", e)
             raise ResizeFailedException(e)
+
+        util.multi_log('growpart: %s' % out, stderr=False, log=LOG)
+        try:
+            return self.get_size(out)
         except ValueError as e:
-            util.logexc(LOG, "get_size error: %s", e)
+            util.logexc(LOG, "Failed: get_size error: %s", e)
             raise ResizeFailedException(e)
 
 

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -170,14 +170,13 @@ class ResizeGrowPart(object):
 
     def resize(self, diskdev, partnum, partdev):
         try:
-            out, err = util.subp(["growpart", '-v', diskdev, partnum])
+            out, _err = util.subp(["growpart", '-v', diskdev, partnum],
+                                  rcs=[0, 1])
             LOG.debug('growpart: %s', out)
             return self.get_size(out)
         except util.ProcessExecutionError as e:
-            if e.exit_code != 1:
-                util.logexc(LOG, "Failed: growpart %s %s: %s",
-                            diskdev, partnum, err)
-                raise ResizeFailedException(e)
+            util.logexc(LOG, "Failed: growpart error: %s", e)
+            raise ResizeFailedException(e)
         except ValueError as e:
             util.logexc(LOG, "get_size error: %s", e)
             raise ResizeFailedException(e)

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -93,6 +93,10 @@ GROWPART_CHANGED = (r".*old:\ size=(?P<old_size>\d+)\ end=(?P<old_end>\d+)\ "
                     r"new:\ size=(?P<new_size>\d+)(\s|\S)"
                     r"end=(?P<new_end>\d+)")
 
+# Linux hard-codes sector size to 512 for user-space
+# https://lkml.org/lkml/2015/8/17/269
+SECTOR_SIZE_SHIFT = 9  # 512
+
 
 def resizer_factory(mode):
     resize_class = None
@@ -165,6 +169,12 @@ class ResizeGrowPart(object):
 
         except AttributeError:
             raise ValueError(noparse)
+
+        # Convert sectors to bytes.  growpart reports size in sectors
+        if before:
+            before = str(int(before) << SECTOR_SIZE_SHIFT)
+        if after:
+            after = str(int(after) << SECTOR_SIZE_SHIFT)
 
         return (before, after)
 

--- a/tests/unittests/test_handler/test_handler_growpart.py
+++ b/tests/unittests/test_handler/test_handler_growpart.py
@@ -249,31 +249,15 @@ class TestGetSize(CiTestCase):
     def setUp(self):
         super(TestGetSize, self).setUp()
         self.root = self.tmp_dir()
-        self.add_patch('cloudinit.config.cc_growpart.util.subp', 'm_subp')
-        self.m_subp.return_value = ("", "")
-        self.mydisk = self.root + "/mydisk"
         self.mypart = self.root + "/mydiskp1"
-        util.write_file(self.mydisk, "")
         util.write_file(self.mypart, "Dang JJ!")
 
     def test_get_size(self):
-        self.assertEqual(8, cc_growpart.get_size(self.mydisk, self.mypart))
-        self.assertEqual(1, self.m_subp.call_count)
+        self.assertEqual(8, cc_growpart.get_size(self.mypart))
 
-    def test_get_size_retry(self):
-        self.m_subp.side_effect = iter([
-            util.ProcessExecutionError(stdout="", stderr="Error", exit_code=1),
-            ("", "")
-        ])
-        cc_growpart.get_size(self.mydisk, self.mypart)
-        self.assertEqual(2, self.m_subp.call_count)
-
-    def test_get_size_retry_raise(self):
-        self.m_subp.side_effect = (
-            util.ProcessExecutionError(stdout="", stderr="Error", exit_code=1))
-        with self.assertRaises(util.ProcessExecutionError):
-            cc_growpart.get_size(self.mydisk, self.mypart)
-        self.assertEqual(4, self.m_subp.call_count)
+    def test_get_size_errors(self):
+        with self.assertRaises(OSError):
+           cc_growpart.get_size(self.random_string())
 
 
 def simple_device_part_info(devpath):

--- a/tests/unittests/test_handler/test_handler_growpart.py
+++ b/tests/unittests/test_handler/test_handler_growpart.py
@@ -277,6 +277,7 @@ class TestResizeGrowPart(CiTestCase):
         super(TestResizeGrowPart, self).setUp()
         self.resizer = cc_growpart.ResizeGrowPart()
         self.add_patch('cloudinit.config.cc_growpart.util.subp', 'm_subp')
+        self.add_patch('cloudinit.config.cc_growpart.util.multi_log', 'm_mlog')
 
     def test_get_size(self):
         self.assertEqual(('1021952', '2045919'),

--- a/tests/unittests/test_handler/test_handler_growpart.py
+++ b/tests/unittests/test_handler/test_handler_growpart.py
@@ -280,15 +280,15 @@ class TestResizeGrowPart(CiTestCase):
         self.add_patch('cloudinit.config.cc_growpart.util.multi_log', 'm_mlog')
 
     def test_get_size(self):
-        self.assertEqual(('1021952', '2045919'),
+        self.assertEqual(('523239424', '1047510528'),
                          self.resizer.get_size(GROWPART_CHANGED_1))
 
     def test_get_size_older_release(self):
-        self.assertEqual(('1021952', '2045919'),
+        self.assertEqual(('523239424', '1047510528'),
                          self.resizer.get_size(GROWPART_CHANGED_2))
 
     def test_get_size_no_change(self):
-        self.assertEqual(('83883999', '83883999'),
+        self.assertEqual(('42948607488', '42948607488'),
                          self.resizer.get_size(GROWPART_NOCHANGE_1))
 
     def test_get_size_error_raises_valueerror_exception(self):
@@ -306,7 +306,7 @@ class TestResizeGrowPart(CiTestCase):
         partnum = "1"
         partdev = "%sp%s" % (diskdev, partnum)
         self.m_subp.return_value = (GROWPART_CHANGED_1, "")
-        self.assertEqual(('1021952', '2045919'),
+        self.assertEqual(('523239424', '1047510528'),
                          self.resizer.resize(diskdev, partnum, partdev))
         self.assertEqual(1, len(self.m_subp.call_args_list))
         self.assertEqual(
@@ -318,7 +318,7 @@ class TestResizeGrowPart(CiTestCase):
         partnum = "1"
         partdev = "%sp%s" % (diskdev, partnum)
         self.m_subp.return_value = (GROWPART_NOCHANGE_1, "")
-        self.assertEqual(("83883999", "83883999"),
+        self.assertEqual(('42948607488', '42948607488'),
                          self.resizer.resize(diskdev, partnum, partdev))
         self.assertEqual(1, len(self.m_subp.call_args_list))
         self.assertEqual(


### PR DESCRIPTION
Growpart has its own internal logic for selecting which underlying
tools to use to modify the target device partition table.  This
information is not visible in cloud-init logging which makes it difficult
to understand what may have occurred when debugging.  Adding the
'--verbose' flag and logging the output will emit useful information
about which tool was used (sfdisk vs. sgdisk).

On some platforms the target device may point to a symbolic link,
e.g. /dev/disk/by-partuuid/XXXX;  These symbolic links may be
unavailable during partition changes due to udev behavior.  Use
os.path.realpath to expand the symbolic links to the real device
path (e.g. /dev/sda1); note this is already done when cloud-init
calculates the path to the partition.

ResizeGrowpart will now parse the output from growpart to report
the before and after size change (or no change at all) after running
growpart.

LP: #1834875