### PR TITLE
Detect kernel version before swap file creation

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -65,7 +65,7 @@ swap file is created.
 from string import whitespace
 
 import logging
-import os.path
+import os
 import re
 
 from cloudinit import type_utils
@@ -248,10 +248,11 @@ def create_swapfile(fname, size):
     util.ensure_dir(swap_dir)
 
     fstype = util.get_mount_info(swap_dir)[1]
-    kernel_version = float(re.sub('.*?(-?\d+(\.\d+)?).*', r'\1',
-        str(os.uname()[2])))
+    kernel_version = re.sub(r'.*?(\d+(\.\d+)?).*', r'\1', str(os.uname()[2]))
+    kernel_version = str.split(kernel_version, '.')
+    kernel_version = tuple(map(int, kernel_version))
 
-    if (fstype == "xfs" and kernel_version <= 4.18) or fstype == "btrfs":
+    if (fstype == "xfs" and kernel_version <= (4,18)) or fstype == "btrfs":
         create_swap(fname, size, "dd")
     else:
         try:

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -252,7 +252,7 @@ def create_swapfile(fname, size):
     kernel_version = str.split(kernel_version, '.')
     kernel_version = tuple(map(int, kernel_version))
 
-    if (fstype == "xfs" and kernel_version <= (4,18)) or fstype == "btrfs":
+    if (fstype == "xfs" and kernel_version <= (4, 18)) or fstype == "btrfs":
         create_swap(fname, size, "dd")
     else:
         try:

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -248,8 +248,10 @@ def create_swapfile(fname, size):
     util.ensure_dir(swap_dir)
 
     fstype = util.get_mount_info(swap_dir)[1]
+    kernel_version = float(re.sub('.*?(-?\d+(\.\d+)?).*', r'\1',
+        str(os.uname()[2])))
 
-    if fstype in ("xfs", "btrfs"):
+    if (fstype == "xfs" and kernel_version <= 4.18) or fstype == "btrfs":
         create_swap(fname, size, "dd")
     else:
         try:


### PR DESCRIPTION
According to man page `man 8 swapon', "Preallocated swap files are
supported on XFS since Linux 4.18". This patch checks for kernel version
before attepting to create swapfile, using dd for XFS only on kernel
versions <= 4.18 or btrfs.

Signed-off-by: Eduardo Otubo <otubo@redhat.com>