### PR TITLE
ec2: Do not log IMDSv2 token values, instead use REDACTED

### DIFF
--- a/cloudinit/ec2_utils.py
+++ b/cloudinit/ec2_utils.py
@@ -142,7 +142,8 @@ def skip_retry_on_codes(status_codes, _request_args, cause):
 def get_instance_userdata(api_version='latest',
                           metadata_address='http://169.254.169.254',
                           ssl_details=None, timeout=5, retries=5,
-                          headers_cb=None, exception_cb=None):
+                          headers_cb=None, headers_redact=None,
+                          exception_cb=None):
     ud_url = url_helper.combine_url(metadata_address, api_version)
     ud_url = url_helper.combine_url(ud_url, 'user-data')
     user_data = ''
@@ -155,7 +156,8 @@ def get_instance_userdata(api_version='latest',
                                              SKIP_USERDATA_CODES)
         response = url_helper.read_file_or_url(
             ud_url, ssl_details=ssl_details, timeout=timeout,
-            retries=retries, exception_cb=exception_cb, headers_cb=headers_cb)
+            retries=retries, exception_cb=exception_cb, headers_cb=headers_cb,
+            headers_redact=headers_redact)
         user_data = response.contents
     except url_helper.UrlError as e:
         if e.code not in SKIP_USERDATA_CODES:
@@ -169,11 +171,13 @@ def _get_instance_metadata(tree, api_version='latest',
                            metadata_address='http://169.254.169.254',
                            ssl_details=None, timeout=5, retries=5,
                            leaf_decoder=None, headers_cb=None,
+                           headers_redact=None,
                            exception_cb=None):
     md_url = url_helper.combine_url(metadata_address, api_version, tree)
     caller = functools.partial(
         url_helper.read_file_or_url, ssl_details=ssl_details,
         timeout=timeout, retries=retries, headers_cb=headers_cb,
+        headers_redact=headers_redact,
         exception_cb=exception_cb)
 
     def mcaller(url):
@@ -197,6 +201,7 @@ def get_instance_metadata(api_version='latest',
                           metadata_address='http://169.254.169.254',
                           ssl_details=None, timeout=5, retries=5,
                           leaf_decoder=None, headers_cb=None,
+                          headers_redact=None,
                           exception_cb=None):
     # Note, 'meta-data' explicitly has trailing /.
     # this is required for CloudStack (LP: #1356855)
@@ -204,6 +209,7 @@ def get_instance_metadata(api_version='latest',
                                   metadata_address=metadata_address,
                                   ssl_details=ssl_details, timeout=timeout,
                                   retries=retries, leaf_decoder=leaf_decoder,
+                                  headers_redact=headers_redact,
                                   headers_cb=headers_cb,
                                   exception_cb=exception_cb)
 
@@ -212,12 +218,14 @@ def get_instance_identity(api_version='latest',
                           metadata_address='http://169.254.169.254',
                           ssl_details=None, timeout=5, retries=5,
                           leaf_decoder=None, headers_cb=None,
+                          headers_redact=None,
                           exception_cb=None):
     return _get_instance_metadata(tree='dynamic/instance-identity',
                                   api_version=api_version,
                                   metadata_address=metadata_address,
                                   ssl_details=ssl_details, timeout=timeout,
                                   retries=retries, leaf_decoder=leaf_decoder,
+                                  headers_redact=headers_redact,
                                   headers_cb=headers_cb,
                                   exception_cb=exception_cb)
 # vi: ts=4 expandtab

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -282,9 +282,10 @@ def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
                 continue
             filtered_req_args[k] = v
             if k == 'headers':
-                filtered_req_args[k] = copy.deepcopy(req_args[k])
                 for hkey, _hval in v.items():
                     if hkey in headers_redact:
+                        filtered_req_args[k][hkey] = (
+                            copy.deepcopy(req_args[k][hkey]))
                         filtered_req_args[k][hkey] = 'REDACTED'
         try:
 

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -32,6 +32,7 @@ LOG = logging.getLogger(__name__)
 SSL_ENABLED = False
 CONFIG_ENABLED = False  # This was added in 0.7 (but taken out in >=1.0)
 _REQ_VER = None
+REDACTED = 'REDACTED'
 try:
     from distutils.version import LooseVersion
     import pkg_resources
@@ -286,7 +287,7 @@ def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
                     if hkey in headers_redact:
                         filtered_req_args[k][hkey] = (
                             copy.deepcopy(req_args[k][hkey]))
-                        filtered_req_args[k][hkey] = 'REDACTED'
+                        filtered_req_args[k][hkey] = REDACTED
         try:
 
             if log_req_resp:

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -429,6 +429,23 @@ class TestEc2(test_helpers.HttprettyTestCase):
         self.assertTrue(ds.get_data())
         self.assertFalse(ds.is_classic_instance())
 
+    def test_aws_token_redacted(self):
+        """Verify that aws tokens are redacted when logged."""
+        ds = self._setup_ds(
+            platform_data=self.valid_platform_data,
+            sys_cfg={'datasource': {'Ec2': {'strict_id': False}}},
+            md={'md': DEFAULT_METADATA})
+        self.assertTrue(ds.get_data())
+        all_logs = self.logs.getvalue().splitlines()
+        REDACT_TTL = "'X-aws-ec2-metadata-token-ttl-seconds': 'REDACTED'"
+        REDACT_TOK = "'X-aws-ec2-metadata-token': 'REDACTED'"
+        logs_with_redacted_ttl = [log for log in all_logs if REDACT_TTL in log]
+        logs_with_redacted = [log for log in all_logs if REDACT_TOK in log]
+        logs_with_token = [log for log in all_logs if 'API-TOKEN' in log]
+        self.assertEqual(1, len(logs_with_redacted_ttl))
+        self.assertEqual(79, len(logs_with_redacted))
+        self.assertEqual(0, len(logs_with_token))
+
     @mock.patch('cloudinit.net.dhcp.maybe_perform_dhcp_discovery')
     def test_valid_platform_with_strict_true(self, m_dhcp):
         """Valid platform data should return true with strict_id true."""


### PR DESCRIPTION
Instead of logging the token values used log the headers and replace the actual
values with the string 'REDACTED'.  This allows users to examine cloud-init.log
and see that the IMDSv2 token header is being used but avoids leaving the value
used in the log file itself.

LP: #1863943