### PR TITLE
Update tooling for GitHub-based new releases

### DIFF
--- a/packages/bddeb
+++ b/packages/bddeb
@@ -177,6 +177,11 @@ def main():
 
         # output like 0.7.6-1022-g36e92d3
         ver_data = read_version()
+        if ver_data['is_release_branch_ci']:
+            # If we're performing CI for a new release branch, we don't yet
+            # have the tag required to generate version_long; use version
+            # instead.
+            ver_data['version_long'] = ver_data['version']
 
         # This is really only a temporary archive
         # since we will extract it then add in the debian
@@ -192,7 +197,9 @@ def main():
                 break
         if path is None:
             print("Creating a temp tarball using the 'make-tarball' helper")
-            run_helper('make-tarball', ['--long', '--output=' + tarball_fp])
+            run_helper('make-tarball',
+                       ['--version', ver_data['version_long'],
+                        '--output=' + tarball_fp])
 
         print("Extracting temporary tarball %r" % (tarball))
         cmd = ['tar', '-xvzf', tarball_fp, '-C', tdir]

--- a/tools/make-tarball
+++ b/tools/make-tarball
@@ -15,24 +15,27 @@ Usage: ${0##*/} [revision]
     options:
       -h | --help		print usage
       -o | --output FILE	write to file
+           --version VERSION	Override the version used in the tarball
            --orig-tarball	Write file cloud-init_<version>.orig.tar.gz
            --long		Use git describe --long for versioning
 EOF
 }
 
 short_opts="ho:v"
-long_opts="help,output:,orig-tarball,long"
+long_opts="help,output:,version:,orig-tarball,long"
 getopt_out=$(getopt --name "${0##*/}" \
     --options "${short_opts}" --long "${long_opts}" -- "$@") &&
     eval set -- "${getopt_out}" || { Usage 1>&2; exit 1; }
 
 long_opt=""
 orig_opt=""
+version=""
 while [ $# -ne 0 ]; do
     cur=$1; next=$2
     case "$cur" in
         -h|--help) Usage; exit 0;;
         -o|--output) output=$next; shift;;
+           --version) version=$next; shift;;
            --long) long_opt="--long";;
            --orig-tarball) orig_opt=".orig";;
         --) shift; break;;
@@ -41,7 +44,11 @@ while [ $# -ne 0 ]; do
 done
 
 rev=${1:-HEAD}
-version=$(git describe --abbrev=8 "--match=[0-9]*" ${long_opt} $rev)
+if [ -z "$version" ]; then
+    version=$(git describe --abbrev=8 "--match=[0-9]*" ${long_opt} $rev)
+elif [ ! -z "$long_opt" ]; then
+    echo "WARNING: --long has no effect when --version is passed" >&2
+fi
 
 archive_base="cloud-init-$version"
 if [ -z "$output" ]; then

--- a/tools/make-tarball
+++ b/tools/make-tarball
@@ -15,7 +15,7 @@ Usage: ${0##*/} [revision]
     options:
       -h | --help		print usage
       -o | --output FILE	write to file
-           --version VERSION	Override the version used in the tarball
+           --version VERSION	Set the version used in the tarball. Default value is determined with 'git describe'.
            --orig-tarball	Write file cloud-init_<version>.orig.tar.gz
            --long		Use git describe --long for versioning
 EOF
@@ -48,6 +48,7 @@ if [ -z "$version" ]; then
     version=$(git describe --abbrev=8 "--match=[0-9]*" ${long_opt} $rev)
 elif [ ! -z "$long_opt" ]; then
     echo "WARNING: --long has no effect when --version is passed" >&2
+    exit 1
 fi
 
 archive_base="cloud-init-$version"

--- a/tools/read-version
+++ b/tools/read-version
@@ -119,6 +119,7 @@ data = {
     'extra': extra,
     'commit': commit,
     'distance': distance,
+    'is_release_branch_ci': is_release_branch_ci,
 }
 
 if output_json:

--- a/tools/read-version
+++ b/tools/read-version
@@ -65,7 +65,13 @@ output_json = '--json' in sys.argv
 src_version = ci_version.version_string()
 version_long = None
 
-if is_gitdir(_tdir) and which("git"):
+# If we're performing CI for a new release branch (which our tooling creates
+# with an "upstream/" prefix), then we don't want to enforce strict version
+# matching because we know it will fail.
+is_release_branch_ci = (
+    os.environ.get("TRAVIS_PULL_REQUEST_BRANCH", "").startswith("upstream/")
+)
+if is_gitdir(_tdir) and which("git") and not is_release_branch_ci:
     flags = []
     if use_tags:
         flags = ['--tags']


### PR DESCRIPTION
Our [release process](https://github.com/CanonicalLtd/uss-tableflip/blob/master/doc/upstream_release_process.md) calls for a tag to be created locally (pointing at the "new release" commit) and pushed to the upstream repo so that CI can pass. The process then later calls for the "new release" commit to be pushed directly to upstream's master (instead of being merged by a CI system). This results in a correctly tagged commit in upstream's master, even though the tagging was performed before the commit landed in master.

As things stand, this doesn't work for us on GitHub. We have branch protection configured to stop us from pushing to master, so the only way to land new commits in master is via squash merge through the GitHub UI. This means that a _new_ commit is created in `master`, so the previously pushed tag points at a dangling commit.

This PR makes some changes to the version-related tooling to allow CI to run and pass against new upstream branches without a tag being required. This allows us to land the release commit (via squash merge) before creating a tag at all.

(The behaviour change is specifically scoped to pull requests, so we should see CI fail in master until we push the required tag; this will serve as a safeguard against missing tags in the same way that the version tooling has until now.)