### PR TITLE
Don't use FDQN as hostname on RHEL and derivatives

### DIFF
--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -91,10 +91,10 @@ class Distro(distros.Distro):
             rhel_util.update_sysconfig_file(out_fn, host_cfg)
 
     def _select_hostname(self, hostname, fqdn):
-        # Should be fqdn if we can use it
-        # See: https://www.centos.org/docs/5/html/Deployment_Guide-en-US/ch-sysconfig.html#s2-sysconfig-network # noqa
-        if fqdn:
-            return fqdn
+        # Red Hat recommend using the FDQN: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/ch-configure_host_names#sec-Recommended_Naming_Practices # noqa
+        # However the hostname can be up to 64 bytes and
+        # the FDQN can be up to 255 bytes (RFC 1035),
+        # so the hostname is used.
         return hostname
 
     def _read_system_hostname(self):


### PR DESCRIPTION
Cloud-init currently uses the FDQN for the hostname per Red Hat recommendation:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/networking_guide/ch-configure_host_names#sec-Recommended_Naming_Practices

The FDQN can be up to 255 bytes (RFC 1035), but the hostname can be up to 64 bytes, so cloud-init fails on centos if the FDQN is > 64 characters.

This PR changes cloud-init to use the short hostname rather than FDQN, as per other distros. It's no longer necessary for `rhel.py` to override `_select_hostname`, but I left it in with a comment to reduce the risk of it being regressed in future.

I've verified that the hostname remains unchanged after reboot, per https://bugs.launchpad.net/cloud-init/+bug/1724414/comments/2.

LP: #1724414

