### PR TITLE
Remove race condition between cloud-init and NetworkManager

### DIFF
--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -16,6 +16,7 @@ RemainAfterExit=yes
 TimeoutSec=0
 KillMode=process
 TasksMax=infinity
+ExecStartPost=/usr/bin/systemctl try-restart NetworkManager.service
 
 # Output needs to appear in instance console output
 StandardOutput=journal+console


### PR DESCRIPTION
cloud-init service is set to start before NetworkManager service starts,
but this does not avoid a race condition between them. NetworkManager
starts before cloud-init can write `dns=none' to the file:
/etc/NetworkManager/conf.d/99-cloud-init.conf. This way NetworkManager
doesn't read the configuration and erases all resolv.conf values upon
shutdown. On the next reboot neither cloud-init or NetworkManager will
write anything to resolv.conf, leaving it blank.

This patch introduces a NM reload (try-restart) at the end of cloud-init
start up so it won't erase resolv.conf upon first shutdown.

Signed-off-by: Eduardo Otubo <otubo@redhat.com>