### PR TITLE
Fix docs for OpenStack DMI Asset Tag

### DIFF
--- a/doc/rtd/topics/datasources/openstack.rst
+++ b/doc/rtd/topics/datasources/openstack.rst
@@ -19,7 +19,8 @@ checks the following environment attributes as a potential OpenStack platform:
 
    * **/proc/1/environ**: Nova-lxd contains *product_name=OpenStack Nova*
    * **DMI product_name**: Either *Openstack Nova* or *OpenStack Compute*
-   * **DMI chassis_asset_tag** is *OpenTelekomCloud*
+   * **DMI chassis_asset_tag** is *OpenTelekomCloud* or *OpenStack Nova*
+     (since 19.2) or *OpenStack Compute* (since 19.2)
 
 
 Configuration


### PR DESCRIPTION
In cloud-init 19.2, we added the ability for cloud-init to detect
OpenStack platforms by checking for "OpenStack Compute" or "OpenStack
Nova" in the chassis asset tag.  However, this was never reflected
in the documentation.  This patch updates the datasources documentation
for OpenStack to reflect the possibility of using the chassis asset tag.

LP: #1669875