### PR TITLE
Fallback to cached datasource if no valid datasource

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -280,7 +280,7 @@ def main_init(name, args):
     mode = sources.DSMODE_LOCAL if args.local else sources.DSMODE_NETWORK
 
     if mode == sources.DSMODE_NETWORK:
-        existing = "trust"
+        existing = "check"
         sys.stderr.write("%s\n" % (netinfo.debug_info()))
         LOG.debug(("Checking to see if files that we need already"
                    " exist from a previous run that would allow us"
@@ -320,7 +320,8 @@ def main_init(name, args):
 
     # Stage 5
     try:
-        init.fetch(existing=existing)
+        init.fetch(existing=existing,
+                   fallback=(mode == sources.DSMODE_NETWORK))
         # if in network mode, and the datasource is local
         # then work was done at that stage.
         if mode == sources.DSMODE_NETWORK and init.datasource.dsmode != mode:


### PR DESCRIPTION
commit message:
```
If no valid datasource was found after the search for
network datasources, we assume our datasource has gone
away and try to use the last cached datasource if
it hasn't been removed from the configuration.

An example where this is useful is when the EC2
IMDS endpoint gets disabled after the 1st boot.
```

some notes about this change:
1. This change *extends* the life of ```instance_link``` (/var/lib/cloud/instance) so that remains after we have failed to find a working network datasource
2. To mitigate **#1**, we switch the non-local init to set ```existing=check```, so that it will only reuse a cache that would have been left behind without the change in **#1**.
3. To make sure we only use the fallback **after** ```find_source()``` has failed in non-local mode, we add a fallback boolean to ```fetch()``` that is only set to true if ```mode == sources.DSMODE_NETWORK```
4. I considered moving most the code inside the ```except sources.DataSourceNotFoundException``` block to a function but it seemed easier to understand inside the context of ```_get_data_source()```.  I also considered modifying ```_restore_from_checked_cache()``` to handle this use case and just calling it again inside the ```except``` block. Thoughts? 
5. My initial intent was to only set ```fallback = (mode == sources.DSMODE_NETWORK)``` if a new config option was set to minimise the blast radius of this change.  But in the end, I felt the change made sense as a default.  I'm happy to reconsider.