### PR TITLE
ec2: only redact token request headers in logs, avoid altering request

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -281,13 +281,14 @@ def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
         for (k, v) in req_args.items():
             if k == 'data':
                 continue
-            filtered_req_args[k] = v
-            if k == 'headers':
-                for hkey, _hval in v.items():
-                    if hkey in headers_redact:
-                        filtered_req_args[k][hkey] = (
-                            copy.deepcopy(req_args[k][hkey]))
-                        filtered_req_args[k][hkey] = REDACTED
+            if k == 'headers' and headers_redact:
+                matched_headers = [k for k in headers_redact if v.get(k)]
+                if matched_headers:
+                    filtered_req_args[k] = copy.deepcopy(v)
+                    for key in matched_headers:
+                        filtered_req_args[k][key] = REDACTED
+            else:
+                filtered_req_args[k] = v
         try:
 
             if log_req_resp:


### PR DESCRIPTION
Our header redact logic was redacting both logged request headers and
the actual source request. This results in DataSourceEc2 sending the
invalid header "X-aws-ec2-metadata-token-ttl-seconds: REDACTED" which
gets an HTTP status response of 400.

Cloud-init retries this failed token request for 2 minutes before
falling back to IMDSv1.

LP: #1865882