### PR TITLE
Adapt the package building scripts to use Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,15 @@ CWD=$(shell pwd)
 YAML_FILES=$(shell find cloudinit tests tools -name "*.yaml" -type f )
 YAML_FILES+=$(shell find doc/examples -name "cloud-config*.txt" -type f )
 
+PYTHON = python3
 PIP_INSTALL := pip install
 
 ifeq ($(distro),)
   distro = redhat
 endif
 
-READ_VERSION=$(shell python3 $(CWD)/tools/read-version || echo read-version-failed)
-CODE_VERSION=$(shell python3 -c "from cloudinit import version; print(version.version_string())")
+READ_VERSION=$(shell $(PYTHON) $(CWD)/tools/read-version || echo read-version-failed)
+CODE_VERSION=$(shell $(PYTHON) -c "from cloudinit import version; print(version.version_string())")
 
 
 all: check
@@ -29,10 +30,10 @@ unittest: clean_pyc
 	python3 -m pytest -v tests/unittests cloudinit
 
 ci-deps-ubuntu:
-	@python3 $(CWD)/tools/read-dependencies --distro ubuntu --test-distro
+	@$(PYTHON) $(CWD)/tools/read-dependencies --distro ubuntu --test-distro
 
 ci-deps-centos:
-	@python3 $(CWD)/tools/read-dependencies --distro centos --test-distro
+	@$(PYTHON) $(CWD)/tools/read-dependencies --distro centos --test-distro
 
 pip-requirements:
 	@echo "Installing cloud-init dependencies..."
@@ -51,7 +52,7 @@ check_version:
 	    else true; fi
 
 config/cloud.cfg:
-	python3 ./tools/render-cloudcfg config/cloud.cfg.tmpl config/cloud.cfg
+	$(PYTHON) ./tools/render-cloudcfg config/cloud.cfg.tmpl config/cloud.cfg
 
 clean_pyc:
 	@find . -type f -name "*.pyc" -delete
@@ -61,26 +62,26 @@ clean: clean_pyc
 	rm -rf doc/rtd_html .tox .coverage
 
 yaml:
-	@python3 $(CWD)/tools/validate-yaml.py $(YAML_FILES)
+	@$(PYTHON) $(CWD)/tools/validate-yaml.py $(YAML_FILES)
 
 rpm:
-	python3 ./packages/brpm --distro=$(distro)
+	$(PYTHON) ./packages/brpm --distro=$(distro)
 
 srpm:
-	python3 ./packages/brpm --srpm --distro=$(distro)
+	$(PYTHON) ./packages/brpm --srpm --distro=$(distro)
 
 deb:
 	@which debuild || \
 		{ echo "Missing devscripts dependency. Install with:"; \
 		  echo sudo apt-get install devscripts; exit 1; }
 
-	python3 ./packages/bddeb
+	$(PYTHON) ./packages/bddeb
 
 deb-src:
 	@which debuild || \
 		{ echo "Missing devscripts dependency. Install with:"; \
 		  echo sudo apt-get install devscripts; exit 1; }
-	python3 ./packages/bddeb -S -d
+	$(PYTHON) ./packages/bddeb -S -d
 
 doc:
 	tox -e doc

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ pep8:
 	@$(CWD)/tools/run-pep8
 
 pyflakes:
-	@$(CWD)/tools/run-pyflakes3
+	@$(CWD)/tools/run-pyflakes
 
 unittest: clean_pyc
 	python3 -m pytest -v tests/unittests cloudinit

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ YAML_FILES=$(shell find cloudinit tests tools -name "*.yaml" -type f )
 YAML_FILES+=$(shell find doc/examples -name "cloud-config*.txt" -type f )
 
 PYTHON = python3
-PIP_INSTALL := pip install
+PIP_INSTALL := pip3 install
 
 ifeq ($(distro),)
   distro = redhat

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -59,15 +59,9 @@ def run_helper(helper, args=None, strip=True):
     return stdout
 
 
-def write_debian_folder(root, templ_data, is_python2, cloud_util_deps):
+def write_debian_folder(root, templ_data, cloud_util_deps):
     """Create a debian package directory with all rendered template files."""
     print("Creating a debian/ folder in %r" % (root))
-    if is_python2:
-        pyver = "2"
-        python = "python"
-    else:
-        pyver = "3"
-        python = "python3"
 
     deb_dir = util.abs_join(root, 'debian')
 
@@ -83,30 +77,23 @@ def write_debian_folder(root, templ_data, is_python2, cloud_util_deps):
 
     # Write out the control file template
     reqs_output = run_helper(
-        'read-dependencies',
-        args=['--distro', 'debian', '--python-version', pyver])
+        'read-dependencies', args=['--distro', 'debian'])
     reqs = reqs_output.splitlines()
     test_reqs = run_helper(
         'read-dependencies',
         ['--requirements-file', 'test-requirements.txt',
-         '--system-pkg-names', '--python-version', pyver]).splitlines()
+         '--system-pkg-names']).splitlines()
 
     requires = ['cloud-utils | cloud-guest-utils'] if cloud_util_deps else []
     # We consolidate all deps as Build-Depends as our package build runs all
     # tests so we need all runtime dependencies anyway.
     # NOTE: python package was moved to the front after debuild -S would fail with
     # 'Please add apropriate interpreter' errors (as in debian bug 861132)
-    requires.extend([python] + reqs + test_reqs)
+    requires.extend(['python3'] + reqs + test_reqs)
     templater.render_to_file(util.abs_join(find_root(),
                                            'packages', 'debian', 'control.in'),
                              util.abs_join(deb_dir, 'control'),
-                             params={'build_depends': ','.join(requires),
-                                     'python': python})
-
-    templater.render_to_file(util.abs_join(find_root(),
-                                           'packages', 'debian', 'rules.in'),
-                             util.abs_join(deb_dir, 'rules'),
-                             params={'python': python, 'pyver': pyver})
+                             params={'build_depends': ','.join(requires)})
 
 
 def read_version():
@@ -208,8 +195,7 @@ def main():
         xdir = util.abs_join(tdir, "cloud-init-%s" % ver_data['version_long'])
         templ_data.update(ver_data)
 
-        write_debian_folder(xdir, templ_data, is_python2=args.python2,
-                            cloud_util_deps=args.cloud_utils)
+        write_debian_folder(xdir, templ_data, cloud_util_deps=args.cloud_utils)
 
         print("Running 'debuild %s' in %r" % (' '.join(args.debuild_args),
                                               xdir))

--- a/packages/brpm
+++ b/packages/brpm
@@ -42,7 +42,7 @@ def run_helper(helper, args=None, strip=True):
     return stdout
 
 
-def read_dependencies(distro, requirements_file='requirements.txt'):
+def read_dependencies(distro):
     """Returns the Python package depedencies from requirements.txt files.
 
     @returns a tuple of (requirements, test_requirements)

--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -10,11 +10,10 @@ Standards-Version: 3.9.6
 Package: cloud-init
 Architecture: all
 Depends: ${misc:Depends},
-         ${${python}:Depends},
+         ${python3:Depends},
          iproute2,
          isc-dhcp-client
 Recommends: eatmydata, sudo, software-properties-common, gdisk
-XB-Python-Version: ${python:Versions}
 Description: Init scripts for cloud instances
  Cloud instances need special scripts to run during initialisation
  to retrieve and install ssh keys and to let the user run various scripts.

--- a/packages/debian/rules
+++ b/packages/debian/rules
@@ -1,4 +1,3 @@
-## template:basic
 #!/usr/bin/make -f
 INIT_SYSTEM ?= systemd
 export PYBUILD_INSTALL_ARGS=--init-system=$(INIT_SYSTEM)

--- a/packages/debian/rules.in
+++ b/packages/debian/rules.in
@@ -2,11 +2,10 @@
 #!/usr/bin/make -f
 INIT_SYSTEM ?= systemd
 export PYBUILD_INSTALL_ARGS=--init-system=$(INIT_SYSTEM)
-PYVER ?= python${pyver}
 DEB_VERSION := $(shell dpkg-parsechangelog --show-field=Version)
 
 %:
-	dh $@ --with $(PYVER),systemd --buildsystem pybuild
+	dh $@ --with python3,systemd --buildsystem pybuild
 
 override_dh_install:
 	dh_install
@@ -19,7 +18,7 @@ override_dh_install:
 
 override_dh_auto_test:
 ifeq (,$(findstring nocheck,$(DEB_BUILD_OPTIONS)))
-	http_proxy= make PYVER=python${pyver} check
+	http_proxy= make check
 else
 	@echo check disabled by DEB_BUILD_OPTIONS=$(DEB_BUILD_OPTIONS)
 endif

--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -13,15 +13,28 @@
          "procps"
       ]
    },
-   "redhat" : {
+   "centos" : {
       "build-requires" : [
          "python3-devel"
       ],
       "renames" : {
-         "httpretty" : "",
-         "unittest2" : "",
-         "contextlib2" : ""
+         "unittest2" : "OMIT: LP: #1867151 Missing CentOS pkg deps",
+         "contextlib2" : "OMIT: LP: #1867151 Missing CentOS pkg deps"
       },
+      "requires" : [
+         "e2fsprogs",
+         "iproute",
+         "net-tools",
+         "procps",
+         "rsyslog",
+         "shadow-utils",
+         "sudo"
+      ]
+   },
+   "redhat" : {
+      "build-requires" : [
+         "python3-devel"
+      ],
       "requires" : [
          "e2fsprogs",
          "iproute",

--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -6,14 +6,8 @@
          "dh-systemd"
       ],
       "renames" : {
-         "pyyaml" : {
-            "2" : "python-yaml",
-            "3" : "python3-yaml"
-         },
-         "pyserial" : {
-            "2" : "python-serial",
-            "3" : "python3-serial"
-         }
+         "pyyaml" : "python3-yaml",
+         "pyserial" : "python3-serial"
       },
       "requires" : [
          "procps"
@@ -21,33 +15,12 @@
    },
    "redhat" : {
       "build-requires" : [
-         "python-devel",
-         "python-setuptools"
+         "python3-devel"
       ],
       "renames" : {
-         "jinja2" : {
-            "3" : "python36-jinja2"
-         },
-         "jsonschema" : {
-            "3" : "python36-jsonschema"
-         },
-         "pyflakes" : {
-            "2" : "pyflakes",
-            "3" : "python36-pyflakes"
-         },
-         "pyyaml" : {
-            "2" : "PyYAML",
-            "3" : "python36-PyYAML"
-         },
-         "pyserial" : {
-            "2" : "pyserial"
-         },
-         "pytest": {
-             "3": "python36-pytest"
-         },
-         "requests" : {
-            "3" : "python36-requests"
-         }
+         "httpretty" : "",
+         "unittest2" : "",
+         "contextlib2" : ""
       },
       "requires" : [
          "e2fsprogs",
@@ -61,9 +34,6 @@
    },
    "suse" : {
       "renames" : {
-         "pyyaml" : {
-            "2" : "python-yaml"
-         }
       },
       "build-requires" : [
          "fdupes",

--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -17,10 +17,6 @@
       "build-requires" : [
          "python3-devel"
       ],
-      "renames" : {
-         "unittest2" : "OMIT: LP: #1867151 Missing CentOS pkg deps",
-         "contextlib2" : "OMIT: LP: #1867151 Missing CentOS pkg deps"
-      },
       "requires" : [
          "e2fsprogs",
          "iproute",

--- a/packages/redhat/cloud-init.spec.in
+++ b/packages/redhat/cloud-init.spec.in
@@ -1,6 +1,4 @@
 ## template: jinja
-%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
-
 %define use_systemd (0%{?fedora} && 0%{?fedora} >= 18) || (0%{?rhel} && 0%{?rhel} >= 7)
 
 %if %{use_systemd}
@@ -94,11 +92,11 @@ ssh keys and to let the user run various scripts.
 {% endfor %}
 
 %build
-%{__python} setup.py build
+%{__python3} setup.py build
 
 %install
 
-%{__python} setup.py install -O1 \
+%{__python3} setup.py install -O1 \
             --skip-build --root $RPM_BUILD_ROOT \
             --init-system=%{init_system}
 
@@ -109,7 +107,7 @@ cp -p tools/21-cloudinit.conf \
       $RPM_BUILD_ROOT/%{_sysconfdir}/rsyslog.d/21-cloudinit.conf
 
 # Remove the tests
-rm -rf $RPM_BUILD_ROOT%{python_sitelib}/tests
+rm -rf $RPM_BUILD_ROOT%{python3_sitelib}/tests
 
 # Required dirs...
 mkdir -p $RPM_BUILD_ROOT/%{_sharedstatedir}/cloud
@@ -213,4 +211,4 @@ fi
 %dir %{_sharedstatedir}/cloud
 
 # Python code is here...
-%{python_sitelib}/*
+%{python3_sitelib}/*

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -9,7 +9,7 @@ try:
     from argparse import ArgumentParser
 except ImportError:
     raise RuntimeError(
-        'Could not import python-argparse. Please install python-argparse '
+        'Could not import argparse. Please install python3-argparse '
         'package to continue')
 
 import json
@@ -73,8 +73,8 @@ DISTRO_INSTALL_PKG_CMD = {
 # List of base system packages required to enable ci automation
 CI_SYSTEM_BASE_PKGS = {
     'common': ['make', 'sudo', 'tar'],
-    'redhat': ['python-tox'],
-    'centos': ['python-tox'],
+    'redhat': ['python3-tox'],
+    'centos': ['python3-tox'],
     'ubuntu': ['devscripts', 'python3-dev', 'libssl-dev', 'tox', 'sbuild'],
     'debian': ['devscripts', 'python3-dev', 'libssl-dev', 'tox', 'sbuild']}
 
@@ -99,7 +99,7 @@ def get_parser():
     parser.add_argument(
         '-s', '--system-pkg-names', action='store_true', default=False,
         dest='system_pkg_names',
-        help='The name of the distro to generate package deps for.')
+        help='Generate distribution package names (python3-pkgname).')
     parser.add_argument(
         '-i', '--install', action='store_true', default=False,
         dest='install',
@@ -109,12 +109,6 @@ def get_parser():
         dest='test_distro',
         help='Additionally install continuous integration system packages '
              'required for build and test automation.')
-    parser.add_argument(
-        '-v', '--python-version', type=str, dest='python_version',
-        default=None, choices=["2", "3"],
-        help='Override the version of python we want to generate system '
-             'package dependencies for. Defaults to the version of python '
-             'this script is called with')
     return parser
 
 
@@ -155,27 +149,20 @@ def parse_pip_requirements(requirements_path):
     return dep_names
 
 
-def translate_pip_to_system_pkg(pip_requires, renames, python_ver):
+def translate_pip_to_system_pkg(pip_requires, renames):
     """Translate pip package names to distro-specific package names.
 
     @param pip_requires: List of versionless pip package names to translate.
     @param renames: Dict containg special case renames from pip name to system
         package name for the distro.
-    @param python_ver: Optional python version string "2" or "3". When None,
-     use the python version that is calling this script via sys.version_info.
     """
-    if python_ver is None:
-        python_ver = str(sys.version_info[0])
-    if python_ver == "2":
-        prefix = "python-"
-    else:
-        prefix = "python3-"
+    prefix = "python3-"
     standard_pkg_name = "{0}{1}"
     translated_names = []
     for pip_name in pip_requires:
         pip_name = pip_name.lower()
         # Find a rename if present for the distro package and python version
-        rename = renames.get(pip_name, {}).get(python_ver, None)
+        rename = renames.get(pip_name, {})
         if rename:
             translated_names.append(rename)
         else:
@@ -222,7 +209,7 @@ def main(distro):
     deps_from_json = get_package_deps_from_json(topd, args.distro)
     renames = deps_from_json.get('renames', {})
     translated_pip_names = translate_pip_to_system_pkg(
-        pip_pkg_names, renames, args.python_version)
+        pip_pkg_names, renames)
     all_deps = []
     if args.distro:
         all_deps.extend(

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -126,6 +126,9 @@ def get_package_deps_from_json(topdir, distro):
         deps = json.loads(stream.read())
     if distro is None:
         return {}
+    if deps.get(distro):  # If we have a specific distro defined, use it.
+        return deps[distro]
+    # Use generic distro dependency map via DISTRO_PKG_TYPE_MAP
     return deps[DISTRO_PKG_TYPE_MAP[distro]]
 
 
@@ -162,7 +165,9 @@ def translate_pip_to_system_pkg(pip_requires, renames):
     for pip_name in pip_requires:
         pip_name = pip_name.lower()
         # Find a rename if present for the distro package and python version
-        rename = renames.get(pip_name, {})
+        rename = renames.get(pip_name, "")
+        if rename.startswith("OMIT:"):
+            continue
         if rename:
             translated_names.append(rename)
         else:

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -166,8 +166,6 @@ def translate_pip_to_system_pkg(pip_requires, renames):
         pip_name = pip_name.lower()
         # Find a rename if present for the distro package and python version
         rename = renames.get(pip_name, "")
-        if rename.startswith("OMIT:"):
-            continue
         if rename:
             translated_names.append(rename)
         else:

--- a/tools/run-container
+++ b/tools/run-container
@@ -464,10 +464,6 @@ main() {
     }
 
     local rdcmd=(python3 tools/read-dependencies "--distro=${OS_NAME}" --install --test-distro)
-    if [[ ${OS_NAME} == centos ]]; then
-        error "WARNING: Unable to install all CentOS for test dependencies (missing deps, LP: #1867151)."
-        unittest=""
-    fi
     inside_as_cd "$name" root "$cdir" "${rdcmd[@]}" || {
         errorrc "FAIL: failed to install dependencies with read-dependencies"
         return

--- a/tools/run-container
+++ b/tools/run-container
@@ -463,9 +463,9 @@ main() {
         return
     }
 
-    inside_as_cd "$name" root "$cdir" \
-        python3 ./tools/read-dependencies "--distro=${OS_NAME}" \
-            --test-distro || {
+    local rdcmd=(python3 tools/read-dependencies "--distro=${OS_NAME}" --install)
+    [[ ${OS_NAME} =~ (ubuntu|debian) ]] && rdcmd+=('--test-distro')
+    inside_as_cd "$name" root "$cdir" "${rdcmd[@]}" || {
         errorrc "FAIL: failed to install dependencies with read-dependencies"
         return
     }

--- a/tools/run-container
+++ b/tools/run-container
@@ -464,7 +464,11 @@ main() {
     }
 
     local rdcmd=(python3 tools/read-dependencies "--distro=${OS_NAME}" --install)
-    [[ ${OS_NAME} =~ (ubuntu|debian) ]] && rdcmd+=('--test-distro')
+    if [[ ${OS_NAME} == centos ]]; then
+        error "WARNING: Can't setup CentOS for testing (missing deps, LP: #1867151)."
+    else
+        rdcmd+=('--test-distro')
+    fi
     inside_as_cd "$name" root "$cdir" "${rdcmd[@]}" || {
         errorrc "FAIL: failed to install dependencies with read-dependencies"
         return

--- a/tools/run-container
+++ b/tools/run-container
@@ -463,11 +463,10 @@ main() {
         return
     }
 
-    local rdcmd=(python3 tools/read-dependencies "--distro=${OS_NAME}" --install)
+    local rdcmd=(python3 tools/read-dependencies "--distro=${OS_NAME}" --install --test-distro)
     if [[ ${OS_NAME} == centos ]]; then
-        error "WARNING: Can't setup CentOS for testing (missing deps, LP: #1867151)."
-    else
-        rdcmd+=('--test-distro')
+        error "WARNING: Unable to install all CentOS for test dependencies (missing deps, LP: #1867151)."
+        unittest=""
     fi
     inside_as_cd "$name" root "$cdir" "${rdcmd[@]}" || {
         errorrc "FAIL: failed to install dependencies with read-dependencies"

--- a/tools/run-pyflakes
+++ b/tools/run-pyflakes
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-PYTHON_VERSION=${PYTHON_VERSION:-2}
 CR="
 "
 pycheck_dirs=( "cloudinit/" "tests/" "tools/" )
@@ -12,7 +11,7 @@ else
    files=( "$@" )
 fi
 
-cmd=( "python${PYTHON_VERSION}" -m "pyflakes" "${files[@]}" )
+cmd=( "python3" -m "pyflakes" "${files[@]}" )
 
 echo "Running: " "${cmd[@]}" 1>&2
 exec "${cmd[@]}"

--- a/tools/run-pyflakes3
+++ b/tools/run-pyflakes3
@@ -1,2 +1,0 @@
-#!/bin/sh
-PYTHON_VERSION=3 exec "${0%/*}/run-pyflakes" "$@"


### PR DESCRIPTION
Changes:
 - Do not template debian/rules as python3 is the only supported version
 - Drop six from requirements.txt
 - Makefile: drop everything related to Python 2
 - run-container: install the CI deps only on ubuntu|debian
 - read-version: update the shebang to use Python 3
 - brpm: read_dependencies(): drop unused argument
 - read-dependencies: switch to Py3 and drop the --python-version option
 - pkg-deps.json: drop the Python version field and update the redhat deps
 - Update RPM the spec file to use Python 3 when building the RPM
 - bddeb: drop support for Python 2