### PR TITLE
net: support network-config:disabled on the kernel commandline

### DIFF
--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -10,6 +10,7 @@ import base64
 import glob
 import gzip
 import io
+import logging
 import os
 
 from cloudinit import util
@@ -252,12 +253,16 @@ def _decomp_gzip(blob):
 def _b64dgz(data):
     """Decode a string base64 encoding, if gzipped, uncompress as well
 
-    :return: decompressed unencoded string of the data
+    :return: decompressed unencoded string of the data or empty string on
+       unencoded data.
     """
     try:
         blob = base64.b64decode(data)
     except (TypeError, ValueError):
-        raise ValueError("Invalid base64 text: %s" % data)
+        logging.error(
+            "Expected base64 encoded kernel commandline parameter"
+            " network-config. Ignoring network-config=%s.", data)
+        return ''
 
     return _decomp_gzip(blob)
 

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -250,14 +250,14 @@ def _decomp_gzip(blob):
 
 
 def _b64dgz(data):
-    """Decode a base64 string if encoded, if gzipped transparently uncompress
+    """Decode a string base64 encoding, if gzipped, uncompress as well
 
-    :return decompressed unencoded string of the data
+    :return: decompressed unencoded string of the data
     """
     try:
         blob = base64.b64decode(data)
     except (TypeError, ValueError):
-        return data
+        raise ValueError("Invalid base64 text: %s" % data)
 
     return _decomp_gzip(blob)
 

--- a/doc/rtd/topics/network-config.rst
+++ b/doc/rtd/topics/network-config.rst
@@ -39,8 +39,8 @@ network interface.
 .. note::
 
   The network-config value is expected to be a Base64 encoded YAML string in
-  :ref:`network_config_v1` format. Optionally it can be compressed with
-  `gzip` prior to Base64 encoding.
+  :ref:`network_config_v1` or :ref:`network_config_v2` format. Optionally it
+  can be compressed with ``gzip`` prior to Base64 encoding.
 
 
 Disabling Network Configuration

--- a/doc/rtd/topics/network-config.rst
+++ b/doc/rtd/topics/network-config.rst
@@ -25,16 +25,22 @@ For example, OpenStack may provide network config in the MetaData Service.
 
 **System Config**
 
-A ``network:`` entry in /etc/cloud/cloud.cfg.d/* configuration files.
+A ``network:`` entry in ``/etc/cloud/cloud.cfg.d/*`` configuration files.
 
 **Kernel Command Line**
 
-``ip=`` or ``network-config=<YAML config string>``
+``ip=`` or ``network-config=<Base64 encoded YAML config string>``
 
 User-data cannot change an instance's network configuration.  In the absence
 of network configuration in any of the above sources , `Cloud-init`_ will
 write out a network configuration that will issue a DHCP request on a "first"
 network interface.
+
+.. note::
+
+  The network-config value is expected to be a Base64 encoded YAML string in
+  :ref:`network_config_v1` format. Optionally it can be compressed with
+  `gzip` prior to Base64 encoding.
 
 
 Disabling Network Configuration
@@ -48,19 +54,19 @@ on other methods, such as embedded configuration or other customizations.
 
 **Kernel Command Line**
 
-`Cloud-init`_ will check for a parameter ``network-config`` and the
-value is expected to be YAML string in the :ref:`network_config_v1` format.
-The YAML string may optionally be ``Base64`` encoded, and optionally
-compressed with ``gzip``.
+`Cloud-init`_ will check additionally check for the parameter
+``network-config=disabled`` which will automatically disable any network
+configuration.
 
 Example disabling kernel command line entry: ::
 
-  network-config={config: disabled}
+  network-config=disabled
 
 
 **cloud config**
 
-In the combined cloud-init configuration dictionary. ::
+In the combined cloud-init configuration dictionary, merged from
+``/etc/cloud/cloud.cfg`` and ``/etc/cloud/cloud.cfg.d/*``::
 
   network:
     config: disabled

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4066,6 +4066,11 @@ class TestCmdlineConfigParsing(CiTestCase):
         found = cmdline.read_kernel_cmdline_config(cmdline=raw_cmdline)
         self.assertEqual(found, self.simple_cfg)
 
+    def test_cmdline_with_net_config_disabled(self):
+        raw_cmdline = 'ro network-config=disabled root=foo'
+        found = cmdline.read_kernel_cmdline_config(cmdline=raw_cmdline)
+        self.assertEqual(found, {'config': 'disabled'})
+
     def test_cmdline_with_b64_gz(self):
         data = _gzip_data(json.dumps(self.simple_cfg).encode())
         encoded_text = base64.b64encode(data).decode()


### PR DESCRIPTION
Allow disabling cloud-init's network configuration via an plain text
kernel cmdline

Cloud-init docs indicate that users can disable cloud-init networking
via kernel command line parameter 'network-config=<YAML>'.  This does
not work unless the <YAML> payload base64 encoded.  Document the base64
encoding requirement and add a plain-text value for disabling
cloud-init network config:

    network-config=disabled

Also:
 - Log an error and ignore any plain-text network-config payloads that
   are not specifically 'network-config=disabled'.
 - Log a warning if network-config kernel param is invalid yaml but do
   not raise an exception, allowing boot to continue and use fallback
   networking.

LP: #1862702
