### PR TITLE
instance-data: write redacted cfg to instance-data.json

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -315,12 +315,12 @@ class DataSource(metaclass=abc.ABCMeta):
         except UnicodeDecodeError as e:
             LOG.warning('Error persisting instance-data.json: %s', str(e))
             return False
-        json_file = os.path.join(self.paths.run_dir, INSTANCE_JSON_FILE)
-        write_json(json_file, processed_data)  # World readable
         json_sensitive_file = os.path.join(self.paths.run_dir,
                                            INSTANCE_JSON_SENSITIVE_FILE)
-        write_json(json_sensitive_file,
-                   redact_sensitive_keys(processed_data), mode=0o600)
+        write_json(json_sensitive_file, processed_data, mode=0o600)
+        json_file = os.path.join(self.paths.run_dir, INSTANCE_JSON_FILE)
+        # World readable
+        write_json(json_file, redact_sensitive_keys(processed_data))
         return True
 
     def _get_data(self):

--- a/cloudinit/sources/tests/test_init.py
+++ b/cloudinit/sources/tests/test_init.py
@@ -318,7 +318,7 @@ class TestDataSource(CiTestCase):
         self.assertEqual(0o644, stat.S_IMODE(file_stat.st_mode))
         self.assertEqual(expected, util.load_json(content))
 
-    def test_get_data_writes_redacted_json_instance_data(self):
+    def test_get_data_writes_redacted_public_json_instance_data(self):
         """get_data writes redacted content to public INSTANCE_JSON_FILE."""
         tmp = self.tmp_dir()
         datasource = DataSourceTestSubclassNet(
@@ -364,7 +364,9 @@ class TestDataSource(CiTestCase):
         self.assertEqual(0o644, stat.S_IMODE(file_stat.st_mode))
 
     def test_get_data_writes_json_instance_data_sensitive(self):
-        """get_data writes INSTANCE_JSON_SENSITIVE_FILE as readonly root."""
+        """
+        get_data writes unmodified data to sensitive file as root-readonly.
+        """
         tmp = self.tmp_dir()
         datasource = DataSourceTestSubclassNet(
             self.sys_cfg, self.distro, Paths({'run_dir': tmp}),
@@ -402,8 +404,9 @@ class TestDataSource(CiTestCase):
                     'availability_zone': 'myaz',
                     'local-hostname': 'test-subclass-hostname',
                     'region': 'myregion',
-                    'some': {'security-credentials':
-                                 {'cred1': 'sekret', 'cred2': 'othersekret'}}}}
+                    'some': {
+                        'security-credentials':
+                            {'cred1': 'sekret', 'cred2': 'othersekret'}}}}
         }
         self.assertEqual(expected, util.load_json(content))
         file_stat = os.stat(sensitive_json_file)

--- a/cloudinit/sources/tests/test_init.py
+++ b/cloudinit/sources/tests/test_init.py
@@ -336,7 +336,7 @@ class TestDataSource(CiTestCase):
         sensitive_json_file = self.tmp_path(INSTANCE_JSON_SENSITIVE_FILE, tmp)
         redacted = util.load_json(util.load_file(json_file))
         self.assertEqual(
-            {'cred1': 'sekret', 'cred2': 'othersekret'},
+            REDACT_SENSITIVE_VALUE,
             redacted['ds']['meta_data']['some']['security-credentials'])
         content = util.load_file(sensitive_json_file)
         expected = {
@@ -362,7 +362,8 @@ class TestDataSource(CiTestCase):
                     'availability_zone': 'myaz',
                     'local-hostname': 'test-subclass-hostname',
                     'region': 'myregion',
-                    'some': {'security-credentials': REDACT_SENSITIVE_VALUE}}}
+                    'some': {'security-credentials':
+                                 {'cred1': 'sekret', 'cred2': 'othersekret'}}}}
         }
         self.maxDiff = None
         self.assertEqual(expected, util.load_json(content))


### PR DESCRIPTION
When cloud-init persisted instance metadata to instance-data.json
if failed to redact the sensitive value. Currently, the only sensitive key
'security-credentials' is omitted as cloud-init does not fetch this value
from IMDS.

Fix this by properly redacting the content from the public
instance-metadata.json file while retaining the value in the root-only
instance-data-sensitive.json file.

LP: #1865947