### PR TITLE
tolerate more mime types for cc part of user-data.

### DIFF
--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -25,6 +25,7 @@ LOG = logging.getLogger(__name__)
 NOT_MULTIPART_TYPE = handlers.NOT_MULTIPART_TYPE
 PART_FN_TPL = handlers.PART_FN_TPL
 OCTET_TYPE = handlers.OCTET_TYPE
+INCLUDE_MAP = handlers.INCLUSION_TYPES_MAP
 
 # Saves typing errors
 CONTENT_TYPE = 'Content-Type'
@@ -115,7 +116,8 @@ class UserDataProcessor(object):
             # Attempt to figure out the payloads content-type
             if not ctype_orig:
                 ctype_orig = UNDEF_TYPE
-            if ctype_orig in TYPE_NEEDED:
+            if ctype_orig in TYPE_NEEDED or (ctype_orig in
+                                             INCLUDE_MAP.values()):
                 ctype = find_ctype(payload)
             if ctype is None:
                 ctype = ctype_orig

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -30,7 +30,7 @@ OCTET_TYPE = handlers.OCTET_TYPE
 CONTENT_TYPE = 'Content-Type'
 
 # Various special content types that cause special actions
-TYPE_NEEDED = ["text/plain", "text/x-not-multipart", "text/x-shellscript", "text/x-yaml"]
+TYPE_NEEDED = ["text/plain", "text/x-not-multipart"]
 INCLUDE_TYPES = ['text/x-include-url', 'text/x-include-once-url']
 ARCHIVE_TYPES = ["text/cloud-config-archive"]
 UNDEF_TYPE = "text/plain"

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -30,8 +30,7 @@ OCTET_TYPE = handlers.OCTET_TYPE
 CONTENT_TYPE = 'Content-Type'
 
 # Various special content types that cause special actions
-TYPE_NEEDED = ["text/plain", "text/x-not-multipart",
-               "text/x-shellscript", "text/x-yaml"]
+TYPE_NEEDED = ["text/plain", "text/x-not-multipart", "text/x-shellscript", "text/x-yaml"]
 INCLUDE_TYPES = ['text/x-include-url', 'text/x-include-once-url']
 ARCHIVE_TYPES = ["text/cloud-config-archive"]
 UNDEF_TYPE = "text/plain"

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -30,7 +30,8 @@ OCTET_TYPE = handlers.OCTET_TYPE
 CONTENT_TYPE = 'Content-Type'
 
 # Various special content types that cause special actions
-TYPE_NEEDED = ["text/plain", "text/x-not-multipart", "text/x-shellscript", "text/x-yaml"]
+TYPE_NEEDED = ["text/plain", "text/x-not-multipart",
+               "text/x-shellscript", "text/x-yaml"]
 INCLUDE_TYPES = ['text/x-include-url', 'text/x-include-once-url']
 ARCHIVE_TYPES = ["text/cloud-config-archive"]
 UNDEF_TYPE = "text/plain"

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -30,7 +30,7 @@ OCTET_TYPE = handlers.OCTET_TYPE
 CONTENT_TYPE = 'Content-Type'
 
 # Various special content types that cause special actions
-TYPE_NEEDED = ["text/plain", "text/x-not-multipart"]
+TYPE_NEEDED = ["text/plain", "text/x-not-multipart", "text/x-shellscript", "text/x-yaml"]
 INCLUDE_TYPES = ['text/x-include-url', 'text/x-include-once-url']
 ARCHIVE_TYPES = ["text/cloud-config-archive"]
 UNDEF_TYPE = "text/plain"


### PR DESCRIPTION
Some cloud environments pass multipart user-data as text/x-shellscript.
(I have observed this from old heat on OTC.)
We need to make sure that it is accepted by cloud-init as user-data.
Note that more intelligent logic might pass it correctly as text/x-yaml
which cloud-init should tolerate as well.

Signed-off-by: Kurt Garloff <scs@garloff.de>