### PR TITLE
tox.ini: bump pyflakes version to 2.1.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,7 +108,7 @@ deps = pycodestyle
 [testenv:pyflakes]
 commands = {envpython} -m pyflakes {posargs:cloudinit/ tests/ tools/}
 deps =
-    pyflakes==1.6.0
+    pyflakes==2.1.1
 
 [testenv:tip-pyflakes]
 commands = {envpython} -m pyflakes {posargs:cloudinit/ tests/ tools/}


### PR DESCRIPTION
pyflakes versions older than 2.1.0 are incompatible with Python 3.8
(which is the Python version in the current Ubuntu development release).
See https://github.com/PyCQA/pyflakes/issues/367 for details.

2.1.1 is the latest version ATM, so bump to that.