### PR TITLE
tox.ini: use xenial version of jsonpatch in CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -72,10 +72,6 @@ deps =
     pyserial==3.0.1
     configobj==5.0.6
     requests==2.9.1
-    # jsonpatch in xenial is 1.10, not 1.19 (#839779). The oldest version
-    # to work with python3.6 is 1.16 as found in Artful.  To keep default
-    # invocation of 'tox' happy, accept the difference in version here.
-    jsonpatch==1.16
     six==1.10.0
     # test-requirements
     httpretty==0.9.6
@@ -91,6 +87,7 @@ basepython = python3
 deps =
     # Refer to the comment in [xenial-shared-deps] for details
     {[xenial-shared-deps]deps}
+    jsonpatch==1.10
     pytest==2.8.7
 
 [testenv:xenial-dev]
@@ -99,6 +96,10 @@ basepython = {[testenv:xenial]basepython}
 deps =
     # Refer to the comment in [xenial-shared-deps] for details
     {[xenial-shared-deps]deps}
+    # jsonpatch in xenial is 1.10, not 1.19 (#839779). The oldest version
+    # to work with python3.6 is 1.16 as found in Artful.  To keep default
+    # invocation of 'tox' happy, accept the difference in version here.
+    jsonpatch==1.16
     pytest==3.0.7
 
 [testenv:tip-pycodestyle]


### PR DESCRIPTION
Now that we can distinguish between CI xenial dependencies and
needed-to-run-on-dev-machine xenial depedencies, we can return to
testing with the correct jsonpatch version.