### PR TITLE
tox.ini: avoid substition syntax that causes a traceback on xenial

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,8 @@ deps =
     contextlib2==0.5.1
 
 [testenv:xenial]
+# When updating this commands definition, also update the definition in
+# [testenv:xenial-dev].  See the comment there for details.
 commands =
   python ./tools/pipremove jsonschema
   python -m pytest {posargs:tests/unittests cloudinit}
@@ -91,7 +93,15 @@ deps =
     pytest==2.8.7
 
 [testenv:xenial-dev]
-commands = {[testenv:xenial]commands}
+# This should be:
+#   commands = {[testenv:xenial]commands}
+# but the version of pytest in xenial has a bug
+# (https://github.com/tox-dev/tox/issues/208) which means that the {posargs}
+# substitution variable is misparsed and causes a traceback.  Ensure that any
+# changes here are reflected in [testenv:xenial].
+commands =
+  python ./tools/pipremove jsonschema
+  python -m pytest {posargs:tests/unittests cloudinit}
 basepython = {[testenv:xenial]basepython}
 deps =
     # Refer to the comment in [xenial-shared-deps] for details


### PR DESCRIPTION
See the added comment for details.