### PR TITLE
rbxcloud: gracefully handle arping errors

### DIFF
--- a/cloudinit/sources/DataSourceRbxCloud.py
+++ b/cloudinit/sources/DataSourceRbxCloud.py
@@ -55,11 +55,18 @@ def gratuitous_arp(items, distro):
     if distro.name in ['fedora', 'centos', 'rhel']:
         source_param = '-s'
     for item in items:
-        _sub_arp([
-            '-c', '2',
-            source_param, item['source'],
-            item['destination']
-        ])
+        try:
+            _sub_arp([
+                '-c', '2',
+                source_param, item['source'],
+                item['destination']
+            ])
+        except util.ProcessExecutionError as error:
+            # warning, because the system is able to function properly
+            # despite no success - some ARP table may be waiting for
+            # expiration, but the system may continue
+            LOG.warning('Failed to arping from "%s" to "%s": %s',
+                        item['source'], item['destination'], error)
 
 
 def get_md():


### PR DESCRIPTION
I am co-worker of RbxCloud provider.

We have noticed that in the case of a specific network configuration, the current arping execution for IP addresses ended with .1, .2 and .3 fails, as it is not supported. In future network hardware of platform, .2 and .3 IP addresses will probably not be required and not supported at all.

Currently, no arping to all IP address does not mean no network communication, but degraded service until ARP lease. For this reason, this error should not stop the datasource, but only be logged in.

This behavior also allows us to gracefully discontinue use of .2 and .3 IP addresses in all future network configurations. It also means that the message should be logged in instead of stopping datasource completely.