### PR TITLE
cloudinit/tests: remove unneeded with_logs configuration

### DIFF
--- a/cloudinit/cmd/tests/test_main.py
+++ b/cloudinit/cmd/tests/test_main.py
@@ -18,8 +18,6 @@ myargs = namedtuple('MyArgs', 'debug files force local reporter subcommand')
 
 class TestMain(FilesystemMockingTestCase):
 
-    with_logs = True
-
     def setUp(self):
         super(TestMain, self).setUp()
         self.new_root = self.tmp_dir()

--- a/cloudinit/config/tests/test_disable_ec2_metadata.py
+++ b/cloudinit/config/tests/test_disable_ec2_metadata.py
@@ -15,8 +15,6 @@ DISABLE_CFG = {'disable_ec2_metadata': 'true'}
 
 class TestEC2MetadataRoute(CiTestCase):
 
-    with_logs = True
-
     @mock.patch('cloudinit.config.cc_disable_ec2_metadata.util.which')
     @mock.patch('cloudinit.config.cc_disable_ec2_metadata.util.subp')
     def test_disable_ifconfig(self, m_subp, m_which):

--- a/cloudinit/net/tests/test_init.py
+++ b/cloudinit/net/tests/test_init.py
@@ -341,8 +341,6 @@ class TestGenerateFallbackConfig(CiTestCase):
 
 class TestNetFindFallBackNic(CiTestCase):
 
-    with_logs = True
-
     def setUp(self):
         super(TestNetFindFallBackNic, self).setUp()
         sys_mock = mock.patch('cloudinit.net.get_sys_class_path')
@@ -995,8 +993,6 @@ class TestExtractPhysdevs(CiTestCase):
 
 class TestWaitForPhysdevs(CiTestCase):
 
-    with_logs = True
-
     def setUp(self):
         super(TestWaitForPhysdevs, self).setUp()
         self.add_patch('cloudinit.net.get_interfaces_by_mac',
@@ -1070,8 +1066,6 @@ class TestWaitForPhysdevs(CiTestCase):
 
 
 class TestNetFailOver(CiTestCase):
-
-    with_logs = True
 
     def setUp(self):
         super(TestNetFailOver, self).setUp()

--- a/cloudinit/sources/tests/test_oracle.py
+++ b/cloudinit/sources/tests/test_oracle.py
@@ -588,8 +588,6 @@ class TestNetworkConfigFromOpcImds(test_helpers.CiTestCase):
 
 class TestNetworkConfigFiltersNetFailover(test_helpers.CiTestCase):
 
-    with_logs = True
-
     def setUp(self):
         super(TestNetworkConfigFiltersNetFailover, self).setUp()
         self.add_patch(DS_PATH + '.get_interfaces_by_mac',

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -383,8 +383,6 @@ class TestGetMetadataFromIMDS(HttprettyTestCase):
 
 class TestAzureDataSource(CiTestCase):
 
-    with_logs = True
-
     def setUp(self):
         super(TestAzureDataSource, self).setUp()
         self.tmp = self.tmp_dir()

--- a/tests/unittests/test_datasource/test_maas.py
+++ b/tests/unittests/test_datasource/test_maas.py
@@ -158,7 +158,6 @@ class TestMAASDataSource(CiTestCase):
 
 @mock.patch("cloudinit.sources.DataSourceMAAS.url_helper.OauthUrlHelper")
 class TestGetOauthHelper(CiTestCase):
-    with_logs = True
     base_cfg = {'consumer_key': 'FAKE_CONSUMER_KEY',
                 'token_key': 'FAKE_TOKEN_KEY',
                 'token_secret': 'FAKE_TOKEN_SECRET',

--- a/tests/unittests/test_handler/test_handler_locale.py
+++ b/tests/unittests/test_handler/test_handler_locale.py
@@ -29,8 +29,6 @@ LOG = logging.getLogger(__name__)
 
 class TestLocale(t_help.FilesystemMockingTestCase):
 
-    with_logs = True
-
     def setUp(self):
         super(TestLocale, self).setUp()
         self.new_root = tempfile.mkdtemp()

--- a/tests/unittests/test_handler/test_handler_puppet.py
+++ b/tests/unittests/test_handler/test_handler_puppet.py
@@ -16,8 +16,6 @@ LOG = logging.getLogger(__name__)
 @mock.patch('cloudinit.config.cc_puppet.os')
 class TestAutostartPuppet(CiTestCase):
 
-    with_logs = True
-
     def test_wb_autostart_puppet_updates_puppet_default(self, m_os, m_util):
         """Update /etc/default/puppet to autostart if it exists."""
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -737,7 +737,6 @@ class TestReadSeeded(helpers.TestCase):
 
 
 class TestSubp(helpers.CiTestCase):
-    with_logs = True
     allowed_subp = [BASH, 'cat', helpers.CiTestCase.SUBP_SHELL_TRUE,
                     BOGUS_COMMAND, sys.executable]
 


### PR DESCRIPTION
These classes don't use `self.logs` anywhere in their body, so we can
remove the `with_logs = True` setting from them.

These instances were found using astpath[0], with the following
invocation:

```
astpath "//Name[@id='with_logs' and not(ancestor::ClassDef//Attribute[@attr='logs'])]"
```

[0] https://github.com/hchasestevens/astpath