### PR TITLE
net: ubuntu focal prioritize netplan over eni even if both present

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -162,6 +162,9 @@ system_info:
      groups: [adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video]
      sudo: ["ALL=(ALL) NOPASSWD:ALL"]
      shell: /bin/bash
+{# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
+   network:
+     renderers: ['netplan', 'eni', 'sysconfig']
    # Automatically discover the best ntp_client
    ntp_client: auto
    # Other config here will be given to the distro class and/or path classes

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -1,0 +1,57 @@
+"""Tests for tools/render-cloudcfg"""
+
+import os
+import sys
+
+import pytest
+
+from cloudinit import util
+
+# TODO(Look to align with tools.render-cloudcfg or cloudinit.distos.OSFAMILIES)
+DISTRO_VARIANTS = ["amazon", "arch", "centos", "debian", "fedora", "freebsd",
+                   "netbsd", "openbsd", "rhel", "suse", "ubuntu", "unknown"]
+
+
+class TestRenderCloudCfg:
+
+    cmd = [sys.executable, os.path.realpath('tools/render-cloudcfg')]
+    tmpl_path = os.path.realpath('config/cloud.cfg.tmpl')
+
+    @pytest.mark.parametrize('variant', (DISTRO_VARIANTS))
+    def test_variant_sets_distro_in_cloud_cfg(self, variant, tmpdir):
+        outfile = tmpdir.join('outcfg').strpath
+        util.subp(
+            self.cmd + ['--variant', variant, self.tmpl_path, outfile])
+        with open(outfile) as stream:
+            system_cfg = util.load_yaml(stream.read())
+        if variant == 'unknown':
+            variant = 'ubuntu'  # Unknown is defaulted to ubuntu
+        assert system_cfg['system_info']['distro'] == variant
+
+    @pytest.mark.parametrize('variant', (DISTRO_VARIANTS))
+    def test_variant_sets_default_user_in_cloud_cfg(self, variant, tmpdir):
+        outfile = tmpdir.join('outcfg').strpath
+        util.subp(
+            self.cmd + ['--variant', variant, self.tmpl_path, outfile])
+        with open(outfile) as stream:
+            system_cfg = util.load_yaml(stream.read())
+
+        default_user_exceptions = {
+            'amazon': 'ec2-user', 'debian': 'ubuntu', 'unknown': 'ubuntu'}
+        default_user = system_cfg['system_info']['default_user']['name']
+        assert default_user == default_user_exceptions.get(variant, variant)
+
+    @pytest.mark.parametrize('variant,renderers', (
+        ('freebsd', ['freebsd']), ('netbsd', ['netbsd']),
+        ('openbsd', ['openbsd']), ('ubuntu', ['netplan', 'eni', 'sysconfig']))
+    )
+    def test_variant_sets_network_renderer_priority_in_cloud_cfg(
+        self, variant, renderers, tmpdir
+    ):
+        outfile = tmpdir.join('outcfg').strpath
+        util.subp(
+            self.cmd + ['--variant', variant, self.tmpl_path, outfile])
+        with open(outfile) as stream:
+            system_cfg = util.load_yaml(stream.read())
+
+        assert renderers == system_cfg['system_info']['network']['renderers']


### PR DESCRIPTION
On Focal and later, Ubuntu will prioritize netplan renderer before eni, even if ifupdown

and netplan are both installed. ENI on Bionic and later is considered an unsupported
configuration and so cloud-init should generally prefer netplan to eni rendering because
/etc/network/interfaces config file on many cloud images disables including cloud-init's
/etc/network/interfaces.d/50-cloud-init.cfg file.

Ubuntu series-specific changes may be applied to Bionic and Eoan, but further
discussion is warranted about the best approach on released series.

LP: #1867029