### PR TITLE
bsd: boottime does not depend on the libc soname

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1839,7 +1839,7 @@ def boottime():
             ("tv_sec", ctypes.c_int64),
             ("tv_usec", ctypes.c_int64)
         ]
-    libc = ctypes.CDLL('/lib/libc.so.7')
+    libc = ctypes.CDLL('libc.so')
     size = ctypes.c_size_t()
     size.value = ctypes.sizeof(timeval)
     buf = timeval()


### PR DESCRIPTION
On NetBSD and OpenBSD, the libc soname and location are different. There
is no reason to be to specific. Python is able to propely open the share
library by itself.