### PR TITLE
cc_apt_configure/util: combine search_for_mirror implementations

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -763,25 +763,6 @@ def convert_to_v3_apt_format(cfg):
     return cfg
 
 
-def search_for_mirror(candidates):
-    """
-    Search through a list of mirror urls for one that works
-    This needs to return quickly.
-    """
-    if candidates is None:
-        return None
-
-    LOG.debug("search for mirror in candidates: '%s'", candidates)
-    for cand in candidates:
-        try:
-            if util.is_resolvable_url(cand):
-                LOG.debug("found working mirror: '%s'", cand)
-                return cand
-        except Exception:
-            pass
-    return None
-
-
 def search_for_mirror_dns(configured, mirrortype, cfg, cloud):
     """
     Try to resolve a list of predefines DNS names to pick mirrors
@@ -813,7 +794,7 @@ def search_for_mirror_dns(configured, mirrortype, cfg, cloud):
         for post in doms:
             mirror_list.append(mirrorfmt % (post))
 
-        mirror = search_for_mirror(mirror_list)
+        mirror = util.search_for_mirror(mirror_list)
 
     return mirror
 
@@ -876,7 +857,7 @@ def get_mirror(cfg, mirrortype, arch, cloud):
     # fallback to search if specified
     if mirror is None:
         # list of mirrors to try to resolve
-        mirror = search_for_mirror(mcfg.get("search", None))
+        mirror = util.search_for_mirror(mcfg.get("search", None))
 
     # fallback to search_dns if specified
     if mirror is None:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1230,9 +1230,14 @@ def search_for_mirror(candidates):
     Search through a list of mirror urls for one that works
     This needs to return quickly.
     """
+    if candidates is None:
+        return None
+
+    LOG.debug("search for mirror in candidates: '%s'", candidates)
     for cand in candidates:
         try:
             if is_resolvable_url(cand):
+                LOG.debug("found working mirror: '%s'", cand)
                 return cand
         except Exception:
             pass

--- a/tests/unittests/test_handler/test_handler_apt_source_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v3.py
@@ -670,7 +670,7 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
                "security": [{'arches': ["default"],
                              "search": ["sfailme", smir]}]}
 
-        with mock.patch.object(cc_apt_configure, 'search_for_mirror',
+        with mock.patch.object(cc_apt_configure.util, 'search_for_mirror',
                                side_effect=[pmir, smir]) as mocksearch:
             mirrors = cc_apt_configure.find_apt_mirror_info(cfg, None,
                                                             'amd64')
@@ -709,7 +709,7 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
         mockgm.assert_has_calls(calls)
 
         # should not be called, since primary is specified
-        with mock.patch.object(cc_apt_configure,
+        with mock.patch.object(cc_apt_configure.util,
                                'search_for_mirror') as mockse:
             mirrors = cc_apt_configure.find_apt_mirror_info(cfg, None, arch)
         mockse.assert_not_called()
@@ -974,7 +974,7 @@ deb http://ubuntu.com/ubuntu/ xenial-proposed main""")
         mocksdns.assert_has_calls(calls)
 
         # first return is for the non-dns call before
-        with mock.patch.object(cc_apt_configure, 'search_for_mirror',
+        with mock.patch.object(cc_apt_configure.util, 'search_for_mirror',
                                side_effect=[None, pmir, None, smir]) as mockse:
             mirrors = cc_apt_configure.find_apt_mirror_info(cfg, mycloud, arch)
 


### PR DESCRIPTION
These two implementations had drifted away from one another very
slightly.  Reconcile them and then remove the one in cc_apt_configure.