### PR TITLE
freebsd: ensure package update works

### DIFF
--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -18,6 +18,9 @@ class BSD(distros.Distro):
     group_add_cmd_prefix = []
     pkg_cmd_install_prefix = []
     pkg_cmd_remove_prefix = []
+    # There is no need to update the package cache on NetBSD and OpenBSD
+    # TODO neither freebsd nor netbsd handles a command 'upgrade'
+    pkg_cmd_update_prefix = None
 
     def __init__(self, name, cfg, paths):
         super().__init__(name, cfg, paths)
@@ -86,12 +89,14 @@ class BSD(distros.Distro):
         if pkgs is None:
             pkgs = []
 
-        # TODO neither freebsd nor netbsd handles a command 'upgrade'
-        # provided by cloudinit/config/cc_package_update_upgrade_install.py
         if command == 'install':
             cmd = self.pkg_cmd_install_prefix
         elif command == 'remove':
             cmd = self.pkg_cmd_remove_prefix
+        elif command == 'update':
+            if not self.pkg_cmd_update_prefix:
+                return
+            cmd = self.pkg_cmd_update_prefix
 
         if args and isinstance(args, str):
             cmd.append(args)

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -24,6 +24,7 @@ class Distro(cloudinit.distros.bsd.BSD):
     group_add_cmd_prefix = ['pw', 'group', 'add']
     pkg_cmd_install_prefix = ["pkg", "install"]
     pkg_cmd_remove_prefix = ["pkg", "remove"]
+    pkg_cmd_update_prefix = ["pkg", "update"]
 
     def _select_hostname(self, hostname, fqdn):
         # Should be FQDN if available. See rc.conf(5) in FreeBSD


### PR DESCRIPTION
Currently, `cc_package_update_upgrade_install.py` fails because
`package_command()` does not know how to do an update on FreeBSD.

```
2020-03-23 20:01:53,995 - util.py[DEBUG]: Package update failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/cloud_init-20.1-py3.7.egg/cloudinit/config/cc_package_update_upgrade_install.py", line 85, in handle
    cloud.distro.update_package_sources()
  File "/usr/local/lib/python3.7/site-packages/cloud_init-20.1-py3.7.egg/cloudinit/distros/freebsd.py", line 158, in update_package_sources
    ["update"], freq=PER_INSTANCE)
  File "/usr/local/lib/python3.7/site-packages/cloud_init-20.1-py3.7.egg/cloudinit/helpers.py", line 185, in run
    results = functor(*args)
  File "/usr/local/lib/python3.7/site-packages/cloud_init-20.1-py3.7.egg/cloudinit/distros/bsd.py", line 102, in package_command
    cmd.extend(pkglist)
UnboundLocalError: local variable 'cmd' referenced before assignment
```

This commit defines a new `pkg_cmd_update_prefix` key. If it's empty, we
don't do any update, otherwise we use the value to update the package
manager.