### PR TITLE
tools: use python3

### DIFF
--- a/tools/ccfg-merge-debug
+++ b/tools/ccfg-merge-debug
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 from cloudinit import handlers
 from cloudinit.handlers import cloud_config as cc_part

--- a/tools/ccfg-merge-debug
+++ b/tools/ccfg-merge-debug
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from cloudinit import handlers
 from cloudinit.handlers import cloud_config as cc_part

--- a/tools/make-mime.py
+++ b/tools/make-mime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import sys

--- a/tools/make-mime.py
+++ b/tools/make-mime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import argparse
 import sys

--- a/tools/mock-meta.py
+++ b/tools/mock-meta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Provides a somewhat random, somewhat compat, somewhat useful mock version of
 # http://docs.amazonwebservices.com

--- a/tools/mock-meta.py
+++ b/tools/mock-meta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # Provides a somewhat random, somewhat compat, somewhat useful mock version of
 # http://docs.amazonwebservices.com

--- a/tools/pipremove
+++ b/tools/pipremove
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import subprocess
 import sys
 

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """List pip dependencies or system package dependencies for cloud-init."""
 
 # You might be tempted to rewrite this as a shell script, but you

--- a/tools/read-version
+++ b/tools/read-version
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import json

--- a/tools/validate-yaml.py
+++ b/tools/validate-yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Try to read a YAML file and report any errors.
 """


### PR DESCRIPTION
Switch tools/ to use python3 instead of python.  At minimum this
fixes building deb on python3 only releases like Focal. Applied
via shell commands:

 $ grep 'usr/bin/.*python' tools/* 2>/dev/null | \
     grep -v python3 | awk -F':' '{print $1}' | \
     xargs -i sed -i -e '0,/python/s/python/python3/' {}