### PR TITLE
util: read_cc_from_cmdline handle urlencoded yaml content

### DIFF
--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -681,6 +681,34 @@ class TestReadCcFromCmdline(CiTestCase):
                           'runcmd': [['ls', '-l'], 'echo hi']},
                          util.read_conf_from_cmdline(cmdline=cmdline))
 
+    def test_multiline_encoded_content_with_escaped_newlines(self):
+        """ test encoded escaped newlines work.
+
+        unquote(encoded_content)
+        'ssh_import_id: [smoser, bob]\\nruncmd: [ [ ls, -l ], echo hi ]'
+        """
+        encoded_content = (
+            'ssh_import_id%3A%20%5Bsmoser%2C%20bob%5D%5Cn'
+            'runcmd%3A%20%5B%20%5B%20ls%2C%20-l%20%5D%2C%20echo%20hi%20%5D')
+        cmdline = "cc: " + encoded_content +  " end_cc"
+        self.assertEqual({'ssh_import_id': ['smoser', 'bob'],
+                          'runcmd': [['ls', '-l'], 'echo hi']},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_multiline_encoded_content_with_newlines(self):
+        """ test encoded newlines work.
+
+        unquote(encoded_content)
+        'ssh_import_id: [smoser, bob]\nruncmd: [ [ ls, -l ], echo hi ]'
+        """
+        encoded_content = (
+            'ssh_import_id%3A%20%5Bsmoser%2C%20bob%5D%0A'
+            'runcmd%3A%20%5B%20%5B%20ls%2C%20-l%20%5D%2C%20echo%20hi%20%5D')
+        cmdline = "cc: " + encoded_content +  " end_cc"
+        self.assertEqual({'ssh_import_id': ['smoser', 'bob'],
+                          'runcmd': [['ls', '-l'], 'echo hi']},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
     def test_multi_section_tokens(self):
         """Parse and merge multiple yaml content sections."""
         cmdline = "cc:ssh_import_id: [smoser, bob] end_cc "

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -605,4 +605,98 @@ class TestIsLXD(CiTestCase):
         self.assertFalse(util.is_lxd())
         m_exists.assert_called_once_with('/dev/lxd/sock')
 
+
+class TestReadCcFromCmdline(CiTestCase):
+    def test_returns_none_with_no_marker(self):
+        """Return None if cmdline has no cc:<YAML>end_cc content."""
+        self.assertIsNone(
+            util.read_conf_from_cmdline(cmdline=self.random_string()))
+
+    def test_empty_yaml_content(self):
+        """Return None if YAML content is empty string."""
+        cmdline = 'foo cc: end_cc bar'
+        self.assertIsNone(util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_mapping_content_no_end_marker(self):
+        """Return expected dictionary without trailing end_cc marker."""
+        cmdline = 'foo cc: ssh_pwauth: true'
+        self.assertEqual({'ssh_pwauth': True},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_mapping_content_no_end_marker_trailing_newline(self):
+        """Return expected dictionary w escaped newline and no end_cc."""
+        cmdline = "foo cc: ssh_pwauth: true\\n"
+        self.assertEqual({'ssh_pwauth': True},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_mapping_using_start_end_end_marker(self):
+        """Return expected dictionary of yaml between cc: and end_cc."""
+        cmdline = "foo cc: ssh_pwauth: true end_cc bar"
+        self.assertEqual({'ssh_pwauth': True},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_mapping_with_list_no_end_marker_newline(self):
+        """Return dict with list value w escaped newline, no end_cc."""
+        cmdline = "cc: ssh_import_id: [smoser, kirkland]\\n"
+        self.assertEqual({'ssh_import_id': ['smoser', 'kirkland']},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_mapping_list_with_urlencoded_brackets(self):
+        """Parse urlencoded brackets in yaml content."""
+        cmdline = "cc: ssh_import_id: %5Bsmoser, kirkland%5D end_cc"
+        self.assertEqual({'ssh_import_id': ['smoser', 'kirkland']},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_mapping_urlencoded(self):
+        """Parse complete urlencoded yaml content."""
+        cmdline = "cc: ssh_import_id%3A%20%5Buser1%2C%20user2%5D end_cc"
+        self.assertEqual({'ssh_import_id': ['user1', 'user2']},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_nested_mappings(self):
+        """Parse nested dictionary in yaml content."""
+        cmdline = "cc: ntp: {enabled: true, ntp_client: myclient} end_cc"
+        self.assertEqual({'ntp': {'enabled': True, 'ntp_client': 'myclient'}},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_mapping_list_with_no_brackets_single_entry(self):
+        """Parse single mapping value in yaml content."""
+        cmdline = "cc: ssh_import_id: smoser end_cc"
+        self.assertEqual({'ssh_import_id': 'smoser'},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_multiline_content(self):
+        """Parse multiline content with multiple mapping and nested lists."""
+        cmdline = ("cc: ssh_import_id: [smoser, bob]\\n"
+                   "runcmd: [ [ ls, -l ], echo hi ] end_cc")
+        self.assertEqual({'ssh_import_id': ['smoser', 'bob'],
+                          'runcmd': [['ls', '-l'], 'echo hi']},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_multiline_encoded_content(self):
+        """Parse multiline encoded content w/ mappings and nested lists."""
+        cmdline = ("cc: ssh_import_id: %5Bsmoser, bob%5D\\n"
+                   "runcmd: [ [ ls, -l ], echo hi ] end_cc")
+        self.assertEqual({'ssh_import_id': ['smoser', 'bob'],
+                          'runcmd': [['ls', '-l'], 'echo hi']},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+
+    def test_multi_section_tokens(self):
+        """Parse and merge multiple yaml content sections."""
+        cmdline = "cc:ssh_import_id: [smoser, bob] end_cc "
+        cmdline += "cc: runcmd: [ [ ls, -l ] ] end_cc"
+        self.assertEqual({'ssh_import_id': ['smoser', 'bob'],
+                          'runcmd': [['ls', '-l']]},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+    def test_multi_section_encoded_tokens(self):
+        """Parse and merge multiple encoded yaml content sections."""
+        cmdline = "'cc:ssh_import_id%3A%20%5Bsmoser%5D end_cc "
+        cmdline += "cc:runcmd%3A%20%5B%20%5B%20ls%2C%20-l%20%5D%20%5D end_cc"
+        self.assertEqual({'ssh_import_id': ['smoser'],
+                          'runcmd': [['ls', '-l']]},
+                         util.read_conf_from_cmdline(cmdline=cmdline))
+
+
 # vi: ts=4 expandtab

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -681,7 +681,6 @@ class TestReadCcFromCmdline(CiTestCase):
                           'runcmd': [['ls', '-l'], 'echo hi']},
                          util.read_conf_from_cmdline(cmdline=cmdline))
 
-
     def test_multi_section_tokens(self):
         """Parse and merge multiple yaml content sections."""
         cmdline = "cc:ssh_import_id: [smoser, bob] end_cc "

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1078,7 +1078,7 @@ def read_cc_from_cmdline(cmdline=None):
             end = clen
         tokens.append(
             parse.unquote(
-                cmdline[begin + begin_l:end].lstrip().replace("\\n", "\n")))
+                cmdline[begin + begin_l:end].lstrip()).replace("\\n", "\n"))
         begin = cmdline.find(tag_begin, end + end_l)
 
     return '\n'.join(tokens)

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1048,7 +1048,7 @@ def read_conf_with_confd(cfgfile):
 
 
 def read_conf_from_cmdline(cmdline=None):
-    # return a dictionary or config on the cmdline or None
+    # return a dictionary of config on the cmdline or None
     return load_yaml(read_cc_from_cmdline(cmdline=cmdline))
 
 
@@ -1056,11 +1056,12 @@ def read_cc_from_cmdline(cmdline=None):
     # this should support reading cloud-config information from
     # the kernel command line.  It is intended to support content of the
     # format:
-    #  cc: <yaml content here> [end_cc]
+    #  cc: <yaml content here|urlencoded yaml content> [end_cc]
     # this would include:
     # cc: ssh_import_id: [smoser, kirkland]\\n
     # cc: ssh_import_id: [smoser, bob]\\nruncmd: [ [ ls, -l ], echo hi ] end_cc
     # cc:ssh_import_id: [smoser] end_cc cc:runcmd: [ [ ls, -l ] ] end_cc
+    # cc:ssh_import_id: %5Bsmoser%5D end_cc
     if cmdline is None:
         cmdline = get_cmdline()
 
@@ -1075,9 +1076,9 @@ def read_cc_from_cmdline(cmdline=None):
         end = cmdline.find(tag_end, begin + begin_l)
         if end < 0:
             end = clen
-        tokens.append(cmdline[begin + begin_l:end].lstrip().replace("\\n",
-                                                                    "\n"))
-
+        tokens.append(
+            parse.unquote(
+                cmdline[begin + begin_l:end].lstrip().replace("\\n", "\n")))
         begin = cmdline.find(tag_begin, end + end_l)
 
     return '\n'.join(tokens)

--- a/doc/examples/kernel-cmdline.txt
+++ b/doc/examples/kernel-cmdline.txt
@@ -3,16 +3,19 @@ configuration that comes from the kernel command line has higher priority
 than configuration in /etc/cloud/cloud.cfg
 
 The format is:
-  cc: <yaml content here> [end_cc]
+  cc: <yaml content here|URL encoded yaml content> [end_cc]
 
 cloud-config will consider any content after 'cc:' to be cloud-config
 data.  If an 'end_cc' string is present, then it will stop reading there.
 otherwise it considers everthing after 'cc:' to be cloud-config content.
 
-In order to allow carriage returns, you must enter '\\n', literally, 
+In order to allow carriage returns, you must enter '\\n', literally,
 on the command line two backslashes followed by a letter 'n'.
+
+The yaml content may also be URL encoded (urllib.parse.quote()).
 
 Here are some examples:
  root=/dev/sda1 cc: ssh_import_id: [smoser, kirkland]\\n
  root=LABEL=uec-rootfs cc: ssh_import_id: [smoser, bob]\\nruncmd: [ [ ls, -l ], echo hi ] end_cc
  cc:ssh_import_id: [smoser] end_cc cc:runcmd: [ [ ls, -l ] ] end_cc root=/dev/sda1
+ cc:ssh_import_id: %5Bsmoser%5D end_cc cc:runcmd: %5B %5B ls, -l %5D %5D end_cc root=/dev/sda1


### PR DESCRIPTION
Add support for additional escaping of formatting characters
in the YAML content between the 'cc:' and 'end_cc' tokens.  On
s390x legacy terminals the use of square brackets [] are not
available limiting the ability to indicate lists of values in
yaml content. Using #5B and #5D, [ and ] respectively enables
s390x users to pass list yaml content into cloud-init via
command line interface.

- Add unittests for read_conf_from_cmdline
- Fix typo in docstring for read_conf_from_cmdline
- Update cc: end_cc kernel command line example