### PR TITLE
CiTestCase: stop using and remove sys_exit helper

### DIFF
--- a/cloudinit/cmd/tests/test_clean.py
+++ b/cloudinit/cmd/tests/test_clean.py
@@ -167,7 +167,6 @@ class TestClean(CiTestCase):
             wrap_and_call(
                 'cloudinit.cmd.clean',
                 {'Init': {'side_effect': self.init_class},
-                 'sys.exit': {'side_effect': self.sys_exit},
                  'sys.argv': {'new': ['clean', '--logs']}},
                 clean.main)
 

--- a/cloudinit/cmd/tests/test_status.py
+++ b/cloudinit/cmd/tests/test_status.py
@@ -382,7 +382,6 @@ class TestStatus(CiTestCase):
                 wrap_and_call(
                     'cloudinit.cmd.status',
                     {'sys.argv': {'new': ['status']},
-                     'sys.exit': {'side_effect': self.sys_exit},
                      '_is_cloudinit_disabled': (False, ''),
                      'Init': {'side_effect': self.init_class}},
                     status.main)

--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -212,16 +212,6 @@ class CiTestCase(TestCase):
             dir = self.tmp_dir()
         return os.path.normpath(os.path.abspath(os.path.join(dir, path)))
 
-    def sys_exit(self, code):
-        """Provide a wrapper around sys.exit for python 2.6
-
-        In 2.6, this code would produce 'cm.exception' with value int(2)
-        rather than the SystemExit that was raised by sys.exit(2).
-            with assertRaises(SystemExit) as cm:
-                sys.exit(2)
-        """
-        raise SystemExit(code)
-
     def tmp_cloud(self, distro, sys_cfg=None, metadata=None):
         """Create a cloud with tmp working directory paths.
 

--- a/tests/unittests/test_handler/test_schema.py
+++ b/tests/unittests/test_handler/test_schema.py
@@ -345,12 +345,10 @@ class MainTest(CiTestCase):
 
     def test_main_missing_args(self):
         """Main exits non-zero and reports an error on missing parameters."""
-        with mock.patch('sys.exit', side_effect=self.sys_exit):
-            with mock.patch('sys.argv', ['mycmd']):
-                with mock.patch('sys.stderr', new_callable=StringIO) as \
-                        m_stderr:
-                    with self.assertRaises(SystemExit) as context_manager:
-                        main()
+        with mock.patch('sys.argv', ['mycmd']):
+            with mock.patch('sys.stderr', new_callable=StringIO) as m_stderr:
+                with self.assertRaises(SystemExit) as context_manager:
+                    main()
         self.assertEqual(1, context_manager.exception.code)
         self.assertEqual(
             'Expected either --config-file argument or --doc\n',
@@ -359,12 +357,10 @@ class MainTest(CiTestCase):
     def test_main_absent_config_file(self):
         """Main exits non-zero when config file is absent."""
         myargs = ['mycmd', '--annotate', '--config-file', 'NOT_A_FILE']
-        with mock.patch('sys.exit', side_effect=self.sys_exit):
-            with mock.patch('sys.argv', myargs):
-                with mock.patch('sys.stderr', new_callable=StringIO) as \
-                        m_stderr:
-                    with self.assertRaises(SystemExit) as context_manager:
-                        main()
+        with mock.patch('sys.argv', myargs):
+            with mock.patch('sys.stderr', new_callable=StringIO) as m_stderr:
+                with self.assertRaises(SystemExit) as context_manager:
+                    main()
         self.assertEqual(1, context_manager.exception.code)
         self.assertEqual(
             'Configfile NOT_A_FILE does not exist\n',


### PR DESCRIPTION
This shim was required to support Python 2.6, so we no longer need it.