### PR TITLE
Ubuntu/xenial

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,22 +8,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: |
-        echo "::set-env name=CLA_SIGNED::$(grep -q ': \"${{ github.actor }}\"' ./tools/.lp-to-git-user && echo CLA signed || echo CLA not signed)"
-    - name: Add CLA label
+    - name: Check CLA signing status for ${{ github.event.pull_request.user.login }}
       run: |
-        # POST a new label to this issue
-        curl --request POST \
-        --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/labels \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-        --header 'content-type: application/json' \
-        --data '{"labels": ["${{env.CLA_SIGNED}}"]}'
-    - name: Comment about CLA signing
-      if: env.CLA_SIGNED == 'CLA not signed'
-      run: |
-        # POST a comment directing submitter to sign the CLA
-        curl --request POST \
-        --url https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.number }}/comments \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-        --header 'content-type: application/json' \
-        --data '{"body": "Hello ${{ github.actor }},\n\nThank you for your contribution to cloud-init.\n\nIn order for us to merge this pull request, you need\nto have signed the Contributor License Agreement (CLA).\nPlease ensure that you have signed the CLA by following our\nhacking guide at:\n\nhttps://cloudinit.readthedocs.io/en/latest/topics/hacking.html\n\nThanks,\nYour friendly cloud-init upstream\n"}'
+        cat > unsigned-cla.txt <<EOF
+          Hello ${{ github.event.pull_request.user.login }},
+
+          Thank you for your contribution to cloud-init.
+
+          In order for us to merge this pull request, you need
+          to have signed the Contributor License Agreement (CLA).
+          Please sign the CLA by following our
+          hacking guide at:
+            https://cloudinit.readthedocs.io/en/latest/topics/hacking.html
+
+          Thanks,
+          Your friendly cloud-init upstream
+        EOF
+
+        has_signed() {
+            username="$1"
+            grep -q ": \"$username\"" ./tools/.lp-to-git-user && return 0
+            grep -q "^$username$" ./tools/.github-cla-signers && return 0
+            return 1
+        }
+
+        if has_signed "${{ github.event.pull_request.user.login }}"; then
+            echo "Thanks ${{ github.event.pull_request.user.login }} for signing cloud-init's CLA"
+        else
+           cat unsigned-cla.txt
+           exit 1
+        fi

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Mark and close stale pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"  # Daily @ 00:00
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 14
+        days-before-close: 7
+        stale-pr-message: |
+          Hello! Thank you for this proposed change to cloud-init. This pull request is now marked as stale as it has not seen any activity in 14 days. If no activity occurs within the next 7 days, this pull request will automatically close.
+
+          If you are waiting for code review and you are seeing this message, apologies!  Please reply, tagging powersj, and he will ensure that someone takes a look soon.
+
+          (If the pull request is closed, please do feel free to reopen it if you wish to continue working on it.)
+        stale-pr-label: 'stale-pr'

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ stage
 *.cover
 .idea/
 .venv/
+.pc/
+.cache/
+.mypy_cache/
 
 # Ignore packaging artifacts
 cloud-init.dsc

--- a/.pylintrc
+++ b/.pylintrc
@@ -50,7 +50,6 @@ ignored-modules=
  http.client,
  httplib,
  pkg_resources,
- six.moves,
  # cloud_tests requirements.
  boto3,
  botocore,

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ matrix:
         - python: 3.6
           env:
               TOXENV=py3
-              NOSE_VERBOSE=2  # List all tests run by nose
+              PYTEST_ADDOPTS=-v  # List all tests run by pytest
         - install:
             - git fetch --unshallow
             - sudo apt-get build-dep -y cloud-init
             - sudo apt-get install -y --install-recommends sbuild ubuntu-dev-tools fakeroot tox
             # These are build deps but not pulled in by the build-dep call above
-            - sudo apt-get install -y --install-recommends dh-systemd python3-coverage python3-contextlib2
+            - sudo apt-get install -y --install-recommends dh-systemd python3-coverage python3-contextlib2 python3-pytest python3-pytest-cov
             - pip install .
             - pip install tox
             # bionic has lxd from deb installed, remove it first to ensure
@@ -46,8 +46,7 @@ matrix:
         - python: 3.5
           env:
               TOXENV=xenial
-              NOSE_VERBOSE=2  # List all tests run by nose
-          # Travis doesn't support Python 3.4 on bionic, so use xenial
+              PYTEST_ADDOPTS=-v  # List all tests run by pytest
           dist: xenial
         - python: 3.6
           env: TOXENV=pycodestyle

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,76 @@
+20.1
+ - ec2: Do not log IMDSv2 token values, instead use REDACTED (#219)
+   (LP: #1863943)
+ - utils: use SystemRandom when generating random password. (#204)
+   [Dimitri John Ledkov]
+ - docs: mount_default_files is a list of 6 items, not 7 (#212)
+ - azurecloud: fix issues with instances not starting (#205) (LP: #1861921)
+ - unittest: fix stderr leak in cc_set_password random unittest
+   output. (#208)
+ - cc_disk_setup: add swap filesystem force flag (#207)
+ - import sysvinit patches from freebsd-ports tree (#161) [Igor Galić]
+ - docs: fix typo (#195) [Edwin Kofler]
+ - sysconfig: distro-specific config rendering for BOOTPROTO option (#162)
+   [Robert Schweikert] (LP: #1800854)
+ - cloudinit: replace "from six import X" imports (except in util.py) (#183)
+ - run-container: use 'test -n' instead of 'test ! -z' (#202)
+   [Paride Legovini]
+ - net/cmdline: correctly handle static ip= config (#201)
+   [Dimitri John Ledkov] (LP: #1861412)
+ - Replace mock library with unittest.mock (#186)
+ - HACKING.rst: update CLA link (#199)
+ - Scaleway: Fix DatasourceScaleway to avoid backtrace (#128)
+   [Louis Bouchard]
+ - cloudinit/cmd/devel/net_convert.py: add missing space (#191)
+ - tools/run-container: drop support for python2 (#192) [Paride Legovini]
+ - Print ssh key fingerprints using sha256 hash (#188) (LP: #1860789)
+ - Make the RPM build use Python 3 (#190) [Paride Legovini]
+ - cc_set_password: increase random pwlength from 9 to 20 (#189)
+   (LP: #1860795)
+ - .travis.yml: use correct Python version for xenial tests (#185)
+ - cloudinit: remove ImportError handling for mock imports (#182)
+ - Do not use fallocate in swap file creation on xfs. (#70)
+   [Eduardo Otubo] (LP: #1781781)
+ - .readthedocs.yaml: install cloud-init when building docs (#181)
+   (LP: #1860450)
+ - Introduce an RTD config file, and pin the Sphinx version to the RTD
+   default (#180)
+ - Drop most of the remaining use of six (#179)
+ - Start removing dependency on six (#178)
+ - Add Rootbox & HyperOne to list of cloud in README (#176) [Adam Dobrawy]
+ - docs: add proposed SRU testing procedure (#167)
+ - util: rename get_architecture to get_dpkg_architecture (#173)
+ - Ensure util.get_architecture() runs only once (#172)
+ - Only use gpart if it is the BSD gpart (#131) [Conrad Hoffmann]
+ - freebsd: remove superflu exception mapping (#166) [Gonéri Le Bouder]
+ - ssh_auth_key_fingerprints_disable test: fix capitalization (#165)
+   [Paride Legovini]
+ - util: move uptime's else branch into its own boottime function (#53)
+   [Igor Galić] (LP: #1853160)
+ - workflows: add contributor license agreement checker (#155)
+ - net: fix rendering of 'static6' in network config (#77) (LP: #1850988)
+ - Make tests work with Python 3.8 (#139) [Conrad Hoffmann]
+ - fixed minor bug with mkswap in cc_disk_setup.py (#143) [andreaf74]
+ - freebsd: fix create_group() cmd (#146) [Gonéri Le Bouder]
+ - doc: make apt_update example consistent (#154)
+ - doc: add modules page toc with links (#153) (LP: #1852456)
+ - Add support for the amazon variant in cloud.cfg.tmpl (#119)
+   [Frederick Lefebvre]
+ - ci: remove Python 2.7 from CI runs (#137)
+ - modules: drop cc_snap_config config module (#134)
+ - migrate-lp-user-to-github: ensure Launchpad repo exists (#136)
+ - docs: add initial troubleshooting to FAQ (#104) [Joshua Powers]
+ - doc: update cc_set_hostname frequency and descrip (#109)
+   [Joshua Powers] (LP: #1827021)
+ - freebsd: introduce the freebsd renderer (#61) [Gonéri Le Bouder]
+ - cc_snappy: remove deprecated module (#127)
+ - HACKING.rst: clarify that everyone needs to do the LP->GH dance (#130)
+ - freebsd: cloudinit service requires devd (#132) [Gonéri Le Bouder]
+ - cloud-init: fix capitalisation of SSH (#126)
+ - doc: update cc_ssh clarify host and auth keys
+   [Joshua Powers] (LP: #1827021)
+ - ci: emit names of tests run in Travis (#120)
+
 19.4
  - doc: specify _ over - in cloud config modules
    [Joshua Powers] (LP: #1293254)

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -60,6 +60,9 @@ Do these things once
     git remote add GH_USER git@github.com:GH_USER/cloud-init.git
     git push GH_USER master
 
+* Read through the cloud-init `Code Review Process`_, so you understand
+  how your changes will end up in cloud-init's codebase.
+
 .. _GitHub: https://github.com
 .. _Launchpad: https://launchpad.net
 .. _repository: https://github.com/canonical/cloud-init
@@ -119,13 +122,15 @@ Do these things for each feature or bug
   - Click 'Create Pull Request`
 
 Then, someone in the `Ubuntu Server`_ team will review your changes and
-follow up in the pull request.
+follow up in the pull request.  Look at the `Code Review Process`_ doc
+to understand the following steps.
 
 Feel free to ping and/or join ``#cloud-init`` on freenode irc if you
 have any questions.
 
 .. _tox: https://tox.readthedocs.io/en/latest/
 .. _Ubuntu Server: https://github.com/orgs/canonical/teams/ubuntu-server
+.. _Code Review Process: https://cloudinit.readthedocs.io/en/latest/topics/code_review.html
 
 Design
 ======
@@ -138,3 +143,42 @@ Cloud Config Modules
 
 * Any new modules should use underscores in any new config options and not
   hyphens (e.g. `new_option` and *not* `new-option`).
+
+Unit Testing
+------------
+
+cloud-init uses `pytest`_ to run its tests, and has tests written both
+as ``unittest.TestCase`` sub-classes and as un-subclassed pytest tests.
+The following guidelines should be following:
+
+* For ease of organisation and greater accessibility for developers not
+  familiar with pytest, all cloud-init unit tests must be contained
+  within test classes
+
+  * Put another way, module-level test functions should not be used
+
+* pytest test classes should use `pytest fixtures`_ to share
+  functionality instead of inheritance
+* As all tests are contained within classes, it is acceptable to mix
+  ``TestCase`` test classes and pytest test classes within the same
+  test file
+
+  * These can be easily distinguished by their definition: pytest
+    classes will not use inheritance at all (e.g.
+    `TestGetPackageMirrorInfo`_), whereas ``TestCase`` classes will
+    subclass (indirectly) from ``TestCase`` (e.g.
+    `TestPrependBaseCommands`_)
+
+
+* pytest tests should use bare ``assert`` statements, to take advantage
+  of pytest's `assertion introspection`_
+
+  * For ``==`` and other commutative assertions, the expected value
+    should be placed before the value under test:
+    ``assert expected_value == function_under_test()``
+
+.. _pytest: https://docs.pytest.org/
+.. _pytest fixtures: https://docs.pytest.org/en/latest/fixture.html
+.. _TestGetPackageMirrorInfo: https://github.com/canonical/cloud-init/blob/42f69f410ab8850c02b1f53dd67c132aa8ef64f5/cloudinit/distros/tests/test_init.py\#L15
+.. _TestPrependBaseCommands: https://github.com/canonical/cloud-init/blob/master/cloudinit/tests/test_subp.py#L9
+.. _assertion introspection: https://docs.pytest.org/en/latest/assert.html

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ CWD=$(shell pwd)
 PYVER ?= $(shell for p in python3 python2; do \
 	out=$$(command -v $$p 2>&1) && echo $$p && exit; done; exit 1)
 
-noseopts ?= -v
-
 YAML_FILES=$(shell find cloudinit tests tools -name "*.yaml" -type f )
 YAML_FILES+=$(shell find doc/examples -name "cloud-config*.txt" -type f )
 
@@ -48,10 +46,10 @@ pyflakes3:
 	@$(CWD)/tools/run-pyflakes3
 
 unittest: clean_pyc
-	nosetests $(noseopts) tests/unittests cloudinit
+	python -m pytest -v tests/unittests cloudinit
 
 unittest3: clean_pyc
-	nosetests3 $(noseopts) tests/unittests cloudinit
+	python3 -m pytest -v tests/unittests cloudinit
 
 ci-deps-ubuntu:
 	@$(PYVER) $(CWD)/tools/read-dependencies --distro ubuntu --test-distro

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ get in contact with that distribution and send them our way!
 
 | Supported OSes | Supported Public Clouds | Supported Private Clouds |
 | --- | --- | --- |
-| Ubuntu<br />SLES/openSUSE<br />RHEL/CentOS<br />Fedora<br />Gentoo Linux<br />Debian<br />ArchLinux<br />FreeBSD<br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /> | Amazon Web Services<br />Microsoft Azure<br />Google Cloud Platform<br />Oracle Cloud Infrastructure<br />Softlayer<br />Rackspace Public Cloud<br />IBM Cloud<br />Digital Ocean<br />Bigstep<br />Hetzner<br />Joyent<br />CloudSigma<br />Alibaba Cloud<br />OVH<br />OpenNebula<br />Exoscale<br />Scaleway<br />CloudStack<br />AltCloud<br />SmartOS<br />HyperOne<br />Rootbox<br /> | Bare metal installs<br />OpenStack<br />LXD<br />KVM<br />Metal-as-a-Service (MAAS)<br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />|
+| Ubuntu<br />SLES/openSUSE<br />RHEL/CentOS<br />Fedora<br />Gentoo Linux<br />Debian<br />ArchLinux<br />FreeBSD<br />NetBSD<br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /> | Amazon Web Services<br />Microsoft Azure<br />Google Cloud Platform<br />Oracle Cloud Infrastructure<br />Softlayer<br />Rackspace Public Cloud<br />IBM Cloud<br />Digital Ocean<br />Bigstep<br />Hetzner<br />Joyent<br />CloudSigma<br />Alibaba Cloud<br />OVH<br />OpenNebula<br />Exoscale<br />Scaleway<br />CloudStack<br />AltCloud<br />SmartOS<br />HyperOne<br />Rootbox<br /> | Bare metal installs<br />OpenStack<br />LXD<br />KVM<br />Metal-as-a-Service (MAAS)<br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />|
 
 ## To start developing cloud-init
 

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -36,6 +36,7 @@ KNOWN_CLOUD_NAMES = [
     'OVF',
     'RbxCloud - (HyperOne, Rootbox, Rubikon)',
     'OpenTelekomCloud',
+    'SAP Converged Cloud',
     'Scaleway',
     'SmartOS',
     'VMware',

--- a/cloudinit/cmd/devel/tests/test_logs.py
+++ b/cloudinit/cmd/devel/tests/test_logs.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import os
-from six import StringIO
+from io import StringIO
 
 from cloudinit.cmd.devel import logs
 from cloudinit.sources import INSTANCE_JSON_SENSITIVE_FILE

--- a/cloudinit/cmd/devel/tests/test_render.py
+++ b/cloudinit/cmd/devel/tests/test_render.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from six import StringIO
 import os
+from io import StringIO
 
 from collections import namedtuple
 from cloudinit.cmd.devel import render

--- a/cloudinit/cmd/tests/test_clean.py
+++ b/cloudinit/cmd/tests/test_clean.py
@@ -5,7 +5,7 @@ from cloudinit.util import ensure_dir, sym_link, write_file
 from cloudinit.tests.helpers import CiTestCase, wrap_and_call, mock
 from collections import namedtuple
 import os
-from six import StringIO
+from io import StringIO
 
 mypaths = namedtuple('MyPaths', 'cloud_dir')
 

--- a/cloudinit/cmd/tests/test_cloud_id.py
+++ b/cloudinit/cmd/tests/test_cloud_id.py
@@ -4,7 +4,7 @@
 
 from cloudinit import util
 from collections import namedtuple
-from six import StringIO
+from io import StringIO
 
 from cloudinit.cmd import cloud_id
 

--- a/cloudinit/cmd/tests/test_main.py
+++ b/cloudinit/cmd/tests/test_main.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 import copy
 import os
-from six import StringIO
+from io import StringIO
 
 from cloudinit.cmd import main
 from cloudinit import safeyaml
@@ -17,8 +17,6 @@ myargs = namedtuple('MyArgs', 'debug files force local reporter subcommand')
 
 
 class TestMain(FilesystemMockingTestCase):
-
-    with_logs = True
 
     def setUp(self):
         super(TestMain, self).setUp()

--- a/cloudinit/cmd/tests/test_query.py
+++ b/cloudinit/cmd/tests/test_query.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import errno
-from six import StringIO
+from io import StringIO
 from textwrap import dedent
 import os
 

--- a/cloudinit/cmd/tests/test_status.py
+++ b/cloudinit/cmd/tests/test_status.py
@@ -2,7 +2,7 @@
 
 from collections import namedtuple
 import os
-from six import StringIO
+from io import StringIO
 from textwrap import dedent
 
 from cloudinit.atomic_helper import write_json

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -763,25 +763,6 @@ def convert_to_v3_apt_format(cfg):
     return cfg
 
 
-def search_for_mirror(candidates):
-    """
-    Search through a list of mirror urls for one that works
-    This needs to return quickly.
-    """
-    if candidates is None:
-        return None
-
-    LOG.debug("search for mirror in candidates: '%s'", candidates)
-    for cand in candidates:
-        try:
-            if util.is_resolvable_url(cand):
-                LOG.debug("found working mirror: '%s'", cand)
-                return cand
-        except Exception:
-            pass
-    return None
-
-
 def search_for_mirror_dns(configured, mirrortype, cfg, cloud):
     """
     Try to resolve a list of predefines DNS names to pick mirrors
@@ -813,7 +794,7 @@ def search_for_mirror_dns(configured, mirrortype, cfg, cloud):
         for post in doms:
             mirror_list.append(mirrorfmt % (post))
 
-        mirror = search_for_mirror(mirror_list)
+        mirror = util.search_for_mirror(mirror_list)
 
     return mirror
 
@@ -876,7 +857,7 @@ def get_mirror(cfg, mirrortype, arch, cloud):
     # fallback to search if specified
     if mirror is None:
         # list of mirrors to try to resolve
-        mirror = search_for_mirror(mcfg.get("search", None))
+        mirror = util.search_for_mirror(mcfg.get("search", None))
 
     # fallback to search_dns if specified
     if mirror is None:

--- a/cloudinit/config/cc_debug.py
+++ b/cloudinit/config/cc_debug.py
@@ -28,8 +28,7 @@ location that this cloud-init has been configured with when running.
 """
 
 import copy
-
-from six import StringIO
+from io import StringIO
 
 from cloudinit import type_utils
 from cloudinit import util

--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -163,7 +163,7 @@ def handle(_name, cfg, cloud, log, _args):
 def update_disk_setup_devices(disk_setup, tformer):
     # update 'disk_setup' dictionary anywhere were a device may occur
     # update it with the response from 'tformer'
-    for origname in disk_setup.keys():
+    for origname in list(disk_setup):
         transformed = tformer(origname)
         if transformed is None or transformed == origname:
             continue
@@ -825,6 +825,7 @@ def lookup_force_flag(fs):
         'btrfs': '-f',
         'xfs': '-f',
         'reiserfs': '-f',
+        'swap': '-f',
     }
 
     if 'ext' in fs.lower():

--- a/cloudinit/config/cc_landscape.py
+++ b/cloudinit/config/cc_landscape.py
@@ -56,8 +56,7 @@ The following default client config is provided, but can be overridden::
 """
 
 import os
-
-from six import BytesIO
+from io import BytesIO
 
 from configobj import ConfigObj
 

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -25,7 +25,7 @@ mountpoint (i.e. ``[ sda1 ]`` or ``[ sda1, null ]``).
 
 The ``mount_default_fields`` config key allows default options to be specified
 for the values in a ``mounts`` entry that are not specified, aside from the
-``fs_spec`` and the ``fs_file``. If specified, this must be a list containing 7
+``fs_spec`` and the ``fs_file``. If specified, this must be a list containing 6
 values. It defaults to::
 
     mount_default_fields: [none, none, "auto", "defaults,nobootwait", "0", "2"]

--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -19,6 +19,7 @@ keys to post. Available keys are:
     - ``pub_key_dsa``
     - ``pub_key_rsa``
     - ``pub_key_ecdsa``
+    - ``pub_key_ed25519``
     - ``instance_id``
     - ``hostname``
     - ``fdqn``
@@ -52,6 +53,7 @@ POST_LIST_ALL = [
     'pub_key_dsa',
     'pub_key_rsa',
     'pub_key_ecdsa',
+    'pub_key_ed25519',
     'instance_id',
     'hostname',
     'fqdn'
@@ -105,6 +107,7 @@ def handle(name, cfg, cloud, log, args):
         'pub_key_dsa': '/etc/ssh/ssh_host_dsa_key.pub',
         'pub_key_rsa': '/etc/ssh/ssh_host_rsa_key.pub',
         'pub_key_ecdsa': '/etc/ssh/ssh_host_ecdsa_key.pub',
+        'pub_key_ed25519': '/etc/ssh/ssh_host_ed25519_key.pub',
     }
 
     for (n, path) in pubkeys.items():

--- a/cloudinit/config/cc_puppet.py
+++ b/cloudinit/config/cc_puppet.py
@@ -77,11 +77,10 @@ See https://puppet.com/docs/puppet/latest/config_file_csr_attributes.html
                 pp_preshared_key: 342thbjkt82094y0uthhor289jnqthpc2290
 """
 
-from six import StringIO
-
 import os
 import socket
 import yaml
+from io import StringIO
 
 from cloudinit import helpers
 from cloudinit import util

--- a/cloudinit/config/cc_rightscale_userdata.py
+++ b/cloudinit/config/cc_rightscale_userdata.py
@@ -50,12 +50,11 @@ user scripts configuration directory, to be run later by ``cc_scripts_user``.
 #
 
 import os
+from urllib.parse import parse_qs
 
 from cloudinit.settings import PER_INSTANCE
 from cloudinit import url_helper as uhelp
 from cloudinit import util
-
-from six.moves.urllib_parse import parse_qs
 
 frequency = PER_INSTANCE
 

--- a/cloudinit/config/cc_seed_random.py
+++ b/cloudinit/config/cc_seed_random.py
@@ -61,8 +61,7 @@ used::
 
 import base64
 import os
-
-from six import BytesIO
+from io import BytesIO
 
 from cloudinit import log as logging
 from cloudinit.settings import PER_INSTANCE

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -241,7 +241,7 @@ def rand_user_password(pwlen=20):
 
 
 def chpasswd(distro, plist_in, hashed=False):
-    if util.is_FreeBSD():
+    if util.is_BSD():
         for pentry in plist_in.splitlines():
             u, p = pentry.split(":")
             distro.set_passwd(u, p, hashed=hashed)

--- a/cloudinit/config/cc_zypper_add_repo.py
+++ b/cloudinit/config/cc_zypper_add_repo.py
@@ -7,7 +7,6 @@
 
 import configobj
 import os
-from six import string_types
 from textwrap import dedent
 
 from cloudinit.config.schema import get_schema_doc
@@ -110,7 +109,7 @@ def _format_repo_value(val):
         return 1 if val else 0
     if isinstance(val, (list, tuple)):
         return "\n    ".join([_format_repo_value(v) for v in val])
-    if not isinstance(val, string_types):
+    if not isinstance(val, str):
         return str(val)
     return val
 

--- a/cloudinit/config/tests/test_disable_ec2_metadata.py
+++ b/cloudinit/config/tests/test_disable_ec2_metadata.py
@@ -15,8 +15,6 @@ DISABLE_CFG = {'disable_ec2_metadata': 'true'}
 
 class TestEC2MetadataRoute(CiTestCase):
 
-    with_logs = True
-
     @mock.patch('cloudinit.config.cc_disable_ec2_metadata.util.which')
     @mock.patch('cloudinit.config.cc_disable_ec2_metadata.util.subp')
     def test_disable_ifconfig(self, m_subp, m_which):

--- a/cloudinit/config/tests/test_resolv_conf.py
+++ b/cloudinit/config/tests/test_resolv_conf.py
@@ -1,0 +1,86 @@
+from unittest import mock
+
+import pytest
+
+from cloudinit.config.cc_resolv_conf import generate_resolv_conf
+
+
+EXPECTED_HEADER = """\
+# Your system has been configured with 'manage-resolv-conf' set to true.
+# As a result, cloud-init has written this file with configuration data
+# that it has been provided. Cloud-init, by default, will write this file
+# a single time (PER_ONCE).
+#\n\n"""
+
+
+class TestGenerateResolvConf:
+    @mock.patch("cloudinit.config.cc_resolv_conf.templater.render_to_file")
+    def test_default_target_fname_is_etc_resolvconf(self, m_render_to_file):
+        generate_resolv_conf("templates/resolv.conf.tmpl", mock.MagicMock())
+
+        assert [
+            mock.call(mock.ANY, "/etc/resolv.conf", mock.ANY)
+        ] == m_render_to_file.call_args_list
+
+    @mock.patch("cloudinit.config.cc_resolv_conf.templater.render_to_file")
+    def test_target_fname_is_used_if_passed(self, m_render_to_file):
+        generate_resolv_conf(
+            "templates/resolv.conf.tmpl", mock.MagicMock(), "/use/this/path"
+        )
+
+        assert [
+            mock.call(mock.ANY, "/use/this/path", mock.ANY)
+        ] == m_render_to_file.call_args_list
+
+    # Patch in templater so we can assert on the actual generated content
+    @mock.patch("cloudinit.templater.util.write_file")
+    # Parameterise with the value to be passed to generate_resolv_conf as the
+    # `params` parameter, and a list of the expected lines after the header as
+    # `extra_lines`.
+    @pytest.mark.parametrize(
+        "params,expected_extra_line",
+        [
+            # No options
+            ({}, None),
+            # Just a true flag
+            ({"options": {"foo": True}}, "options foo"),
+            # Just a false flag
+            ({"options": {"foo": False}}, None),
+            # Just an option
+            ({"options": {"foo": "some_value"}}, "options foo:some_value"),
+            # A true flag and an option
+            (
+                {"options": {"foo": "some_value", "bar": True}},
+                "options bar foo:some_value",
+            ),
+            # Two options
+            (
+                {"options": {"foo": "some_value", "bar": "other_value"}},
+                "options bar:other_value foo:some_value",
+            ),
+            # Everything
+            (
+                {
+                    "options": {
+                        "foo": "some_value",
+                        "bar": "other_value",
+                        "baz": False,
+                        "spam": True,
+                    }
+                },
+                "options spam bar:other_value foo:some_value",
+            ),
+        ],
+    )
+    def test_flags_and_options(
+        self, m_write_file, params, expected_extra_line
+    ):
+        generate_resolv_conf("templates/resolv.conf.tmpl", params)
+
+        expected_content = EXPECTED_HEADER
+        if expected_extra_line is not None:
+            # If we have any extra lines, expect a trailing newline
+            expected_content += "\n".join([expected_extra_line, ""])
+        assert [
+            mock.call(mock.ANY, expected_content, mode=mock.ANY)
+        ] == m_write_file.call_args_list

--- a/cloudinit/config/tests/test_set_passwords.py
+++ b/cloudinit/config/tests/test_set_passwords.py
@@ -1,6 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import mock
+from unittest import mock
 
 from cloudinit.config import cc_set_passwords as setpass
 from cloudinit.tests.helpers import CiTestCase
@@ -74,6 +74,10 @@ class TestSetPasswordsHandle(CiTestCase):
 
     with_logs = True
 
+    def setUp(self):
+        super(TestSetPasswordsHandle, self).setUp()
+        self.add_patch('cloudinit.config.cc_set_passwords.sys.stderr', 'm_err')
+
     def test_handle_on_empty_config(self, *args):
         """handle logs that no password has changed when config is empty."""
         cloud = self.tmp_cloud(distro='ubuntu')
@@ -108,12 +112,12 @@ class TestSetPasswordsHandle(CiTestCase):
              '\n'.join(valid_hashed_pwds) + '\n')],
             m_subp.call_args_list)
 
-    @mock.patch(MODPATH + "util.is_FreeBSD")
+    @mock.patch(MODPATH + "util.is_BSD")
     @mock.patch(MODPATH + "util.subp")
-    def test_freebsd_calls_custom_pw_cmds_to_set_and_expire_passwords(
-            self, m_subp, m_is_freebsd):
-        """FreeBSD calls custom pw commands instead of chpasswd and passwd"""
-        m_is_freebsd.return_value = True
+    def test_bsd_calls_custom_pw_cmds_to_set_and_expire_passwords(
+            self, m_subp, m_is_bsd):
+        """BSD don't use chpasswd"""
+        m_is_bsd.return_value = True
         cloud = self.tmp_cloud(distro='freebsd')
         valid_pwds = ['ubuntu:passw0rd']
         cfg = {'chpasswd': {'list': valid_pwds}}
@@ -125,12 +129,12 @@ class TestSetPasswordsHandle(CiTestCase):
             mock.call(['pw', 'usermod', 'ubuntu', '-p', '01-Jan-1970'])],
             m_subp.call_args_list)
 
-    @mock.patch(MODPATH + "util.is_FreeBSD")
+    @mock.patch(MODPATH + "util.is_BSD")
     @mock.patch(MODPATH + "util.subp")
     def test_handle_on_chpasswd_list_creates_random_passwords(self, m_subp,
-                                                              m_is_freebsd):
+                                                              m_is_bsd):
         """handle parses command set random passwords."""
-        m_is_freebsd.return_value = False
+        m_is_bsd.return_value = False
         cloud = self.tmp_cloud(distro='ubuntu')
         valid_random_pwds = [
             'root:R',

--- a/cloudinit/config/tests/test_snap.py
+++ b/cloudinit/config/tests/test_snap.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import re
-from six import StringIO
+from io import StringIO
 
 from cloudinit.config.cc_snap import (
     ASSERTIONS_FILE, add_assertions, handle, maybe_install_squashfuse,

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -1,0 +1,122 @@
+import platform
+
+from cloudinit import distros
+from cloudinit.distros import bsd_utils
+from cloudinit import helpers
+from cloudinit import log as logging
+from cloudinit import net
+from cloudinit import util
+
+LOG = logging.getLogger(__name__)
+
+
+class BSD(distros.Distro):
+    hostname_conf_fn = '/etc/rc.conf'
+    rc_conf_fn = "/etc/rc.conf"
+
+    # Set in BSD distro subclasses
+    group_add_cmd_prefix = []
+    pkg_cmd_install_prefix = []
+    pkg_cmd_remove_prefix = []
+    # There is no need to update the package cache on NetBSD and OpenBSD
+    # TODO neither freebsd nor netbsd handles a command 'upgrade'
+    pkg_cmd_update_prefix = None
+
+    def __init__(self, name, cfg, paths):
+        super().__init__(name, cfg, paths)
+        # This will be used to restrict certain
+        # calls from repeatly happening (when they
+        # should only happen say once per instance...)
+        self._runner = helpers.Runners(paths)
+        cfg['ssh_svcname'] = 'sshd'
+        self.osfamily = platform.system().lower()
+
+    def _read_system_hostname(self):
+        sys_hostname = self._read_hostname(self.hostname_conf_fn)
+        return (self.hostname_conf_fn, sys_hostname)
+
+    def _read_hostname(self, filename, default=None):
+        return bsd_utils.get_rc_config_value('hostname')
+
+    def _get_add_member_to_group_cmd(self, member_name, group_name):
+        raise NotImplementedError('Return list cmd to add member to group')
+
+    def _write_hostname(self, hostname, filename):
+        bsd_utils.set_rc_config_value('hostname', hostname, fn='/etc/rc.conf')
+
+    def create_group(self, name, members=None):
+        if util.is_group(name):
+            LOG.warning("Skipping creation of existing group '%s'", name)
+        else:
+            group_add_cmd = self.group_add_cmd_prefix + [name]
+            try:
+                util.subp(group_add_cmd)
+                LOG.info("Created new group %s", name)
+            except Exception:
+                util.logexc(LOG, "Failed to create group %s", name)
+
+        if not members:
+            members = []
+        for member in members:
+            if not util.is_user(member):
+                LOG.warning("Unable to add group member '%s' to group '%s'"
+                            "; user does not exist.", member, name)
+                continue
+            try:
+                util.subp(self._get_add_member_to_group_cmd(member, name))
+                LOG.info("Added user '%s' to group '%s'", member, name)
+            except Exception:
+                util.logexc(LOG, "Failed to add user '%s' to group '%s'",
+                            member, name)
+
+    def generate_fallback_config(self):
+        nconf = {'config': [], 'version': 1}
+        for mac, name in net.get_interfaces_by_mac().items():
+            nconf['config'].append(
+                {'type': 'physical', 'name': name,
+                 'mac_address': mac, 'subnets': [{'type': 'dhcp'}]})
+        return nconf
+
+    def install_packages(self, pkglist):
+        self.update_package_sources()
+        self.package_command('install', pkgs=pkglist)
+
+    def _get_pkg_cmd_environ(self):
+        """Return environment vars used in *BSD package_command operations"""
+        raise NotImplementedError('BSD subclasses return a dict of env vars')
+
+    def package_command(self, command, args=None, pkgs=None):
+        if pkgs is None:
+            pkgs = []
+
+        if command == 'install':
+            cmd = self.pkg_cmd_install_prefix
+        elif command == 'remove':
+            cmd = self.pkg_cmd_remove_prefix
+        elif command == 'update':
+            if not self.pkg_cmd_update_prefix:
+                return
+            cmd = self.pkg_cmd_update_prefix
+
+        if args and isinstance(args, str):
+            cmd.append(args)
+        elif args and isinstance(args, list):
+            cmd.extend(args)
+
+        pkglist = util.expand_package_list('%s-%s', pkgs)
+        cmd.extend(pkglist)
+
+        # Allow the output of this to flow outwards (ie not be captured)
+        util.subp(cmd, env=self._get_pkg_cmd_environ(), capture=False)
+
+    def _write_network_config(self, netconfig):
+        return self._supported_write_network_config(netconfig)
+
+    def set_timezone(self, tz):
+        distros.set_etc_timezone(tz=tz, tz_file=self._find_tz_file(tz))
+
+    def apply_locale(self, locale, out_fn=None):
+        LOG.debug('Cannot set the locale.')
+
+    def apply_network_config_names(self, netconfig):
+        LOG.debug('Cannot rename network interface.')

--- a/cloudinit/distros/bsd_utils.py
+++ b/cloudinit/distros/bsd_utils.py
@@ -1,0 +1,50 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import shlex
+
+from cloudinit import util
+
+# On NetBSD, /etc/rc.conf comes with a if block:
+#   if [ -r /etc/defaults/rc.conf ]; then
+# as a consequence, the file is not a regular key/value list
+# anymore and we cannot use cloudinit.distros.parsers.sys_conf
+# The module comes with a more naive parser, but is able to
+# preserve these if blocks.
+
+
+def _unquote(value):
+    if value[0] == value[-1] and value[0] in ['"', "'"]:
+        return value[1:-1]
+    return value
+
+
+def get_rc_config_value(key, fn='/etc/rc.conf'):
+    key_prefix = '{}='.format(key)
+    for line in util.load_file(fn).splitlines():
+        if line.startswith(key_prefix):
+            value = line.replace(key_prefix, '')
+            return _unquote(value)
+
+
+def set_rc_config_value(key, value, fn='/etc/rc.conf'):
+    lines = []
+    done = False
+    value = shlex.quote(value)
+    original_content = util.load_file(fn)
+    for line in original_content.splitlines():
+        if '=' in line:
+            k, v = line.split('=', 1)
+            if k == key:
+                v = value
+                done = True
+            lines.append('='.join([k, v]))
+        else:
+            lines.append(line)
+    if not done:
+        lines.append('='.join([key, value]))
+    new_content = '\n'.join(lines) + '\n'
+    if new_content != original_content:
+        util.write_file(fn, new_content)
+
+
+# vi: ts=4 expandtab

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -8,34 +8,23 @@ import os
 import re
 from io import StringIO
 
-from cloudinit import distros
-from cloudinit import helpers
+import cloudinit.distros.bsd
 from cloudinit import log as logging
-from cloudinit import net
-from cloudinit import ssh_util
 from cloudinit import util
-from cloudinit.distros import rhel_util
 from cloudinit.settings import PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
 
-class Distro(distros.Distro):
+class Distro(cloudinit.distros.bsd.BSD):
     usr_lib_exec = '/usr/local/lib'
-    rc_conf_fn = "/etc/rc.conf"
     login_conf_fn = '/etc/login.conf'
     login_conf_fn_bak = '/etc/login.conf.orig'
     ci_sudoers_fn = '/usr/local/etc/sudoers.d/90-cloud-init-users'
-    hostname_conf_fn = '/etc/rc.conf'
-
-    def __init__(self, name, cfg, paths):
-        distros.Distro.__init__(self, name, cfg, paths)
-        # This will be used to restrict certain
-        # calls from repeatly happening (when they
-        # should only happen say once per instance...)
-        self._runner = helpers.Runners(paths)
-        self.osfamily = 'freebsd'
-        cfg['ssh_svcname'] = 'sshd'
+    group_add_cmd_prefix = ['pw', 'group', 'add']
+    pkg_cmd_install_prefix = ["pkg", "install"]
+    pkg_cmd_remove_prefix = ["pkg", "remove"]
+    pkg_cmd_update_prefix = ["pkg", "update"]
 
     def _select_hostname(self, hostname, fqdn):
         # Should be FQDN if available. See rc.conf(5) in FreeBSD
@@ -43,45 +32,8 @@ class Distro(distros.Distro):
             return fqdn
         return hostname
 
-    def _read_system_hostname(self):
-        sys_hostname = self._read_hostname(self.hostname_conf_fn)
-        return (self.hostname_conf_fn, sys_hostname)
-
-    def _read_hostname(self, filename, default=None):
-        (_exists, contents) = rhel_util.read_sysconfig_file(filename)
-        if contents.get('hostname'):
-            return contents['hostname']
-        else:
-            return default
-
-    def _write_hostname(self, hostname, filename):
-        rhel_util.update_sysconfig_file(filename, {'hostname': hostname})
-
-    def create_group(self, name, members):
-        group_add_cmd = ['pw', 'group', 'add', name]
-        if util.is_group(name):
-            LOG.warning("Skipping creation of existing group '%s'", name)
-        else:
-            try:
-                util.subp(group_add_cmd)
-                LOG.info("Created new group %s", name)
-            except Exception:
-                util.logexc(LOG, "Failed to create group %s", name)
-                raise
-        if not members:
-            members = []
-
-        for member in members:
-            if not util.is_user(member):
-                LOG.warning("Unable to add group member '%s' to group '%s'"
-                            "; user does not exist.", member, name)
-                continue
-            try:
-                util.subp(['pw', 'usermod', '-n', name, '-G', member])
-                LOG.info("Added user '%s' to group '%s'", member, name)
-            except Exception:
-                util.logexc(LOG, "Failed to add user '%s' to group '%s'",
-                            member, name)
+    def _get_add_member_to_group_cmd(self, member_name, group_name):
+        return ['pw', 'usermod', '-n', member_name, '-G', group_name]
 
     def add_user(self, name, **kwargs):
         if util.is_user(name):
@@ -162,40 +114,8 @@ class Distro(distros.Distro):
             util.logexc(LOG, "Failed to lock user %s", name)
             raise
 
-    def create_user(self, name, **kwargs):
-        self.add_user(name, **kwargs)
-
-        # Set password if plain-text password provided and non-empty
-        if 'plain_text_passwd' in kwargs and kwargs['plain_text_passwd']:
-            self.set_passwd(name, kwargs['plain_text_passwd'])
-
-        # Default locking down the account. 'lock_passwd' defaults to True.
-        # lock account unless lock_password is False.
-        if kwargs.get('lock_passwd', True):
-            self.lock_passwd(name)
-
-        # Configure sudo access
-        if 'sudo' in kwargs and kwargs['sudo'] is not False:
-            self.write_sudo_rules(name, kwargs['sudo'])
-
-        # Import SSH keys
-        if 'ssh_authorized_keys' in kwargs:
-            keys = set(kwargs['ssh_authorized_keys']) or []
-            ssh_util.setup_user_keys(keys, name, options=None)
-
-    def generate_fallback_config(self):
-        nconf = {'config': [], 'version': 1}
-        for mac, name in net.get_interfaces_by_mac().items():
-            nconf['config'].append(
-                {'type': 'physical', 'name': name,
-                 'mac_address': mac, 'subnets': [{'type': 'dhcp'}]})
-        return nconf
-
-    def _write_network_config(self, netconfig):
-        return self._supported_write_network_config(netconfig)
-
     def apply_locale(self, locale, out_fn=None):
-        # Adjust the locals value to the new value
+        # Adjust the locales value to the new value
         newconf = StringIO()
         for line in util.load_file(self.login_conf_fn).splitlines():
             newconf.write(re.sub(r'^default:',
@@ -225,39 +145,17 @@ class Distro(distros.Distro):
         # /etc/rc.conf a line with the following format:
         #    ifconfig_OLDNAME_name=NEWNAME
         # FreeBSD network script will rename the interface automatically.
-        return
+        pass
 
-    def install_packages(self, pkglist):
-        self.update_package_sources()
-        self.package_command('install', pkgs=pkglist)
-
-    def package_command(self, command, args=None, pkgs=None):
-        if pkgs is None:
-            pkgs = []
-
+    def _get_pkg_cmd_environ(self):
+        """Return environment vars used in *BSD package_command operations"""
         e = os.environ.copy()
         e['ASSUME_ALWAYS_YES'] = 'YES'
-
-        cmd = ['pkg']
-        if args and isinstance(args, str):
-            cmd.append(args)
-        elif args and isinstance(args, list):
-            cmd.extend(args)
-
-        if command:
-            cmd.append(command)
-
-        pkglist = util.expand_package_list('%s-%s', pkgs)
-        cmd.extend(pkglist)
-
-        # Allow the output of this to flow outwards (ie not be captured)
-        util.subp(cmd, env=e, capture=False)
-
-    def set_timezone(self, tz):
-        distros.set_etc_timezone(tz=tz, tz_file=self._find_tz_file(tz))
+        return e
 
     def update_package_sources(self):
-        self._runner.run("update-sources", self.package_command,
-                         ["update"], freq=PER_INSTANCE)
+        self._runner.run(
+            "update-sources", self.package_command,
+            ["update"], freq=PER_INSTANCE)
 
 # vi: ts=4 expandtab

--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2019-2020 Gonéri Le Bouder
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import crypt
+import os
+import platform
+
+import cloudinit.distros.bsd
+from cloudinit import log as logging
+from cloudinit import util
+
+LOG = logging.getLogger(__name__)
+
+
+class NetBSD(cloudinit.distros.bsd.BSD):
+    """
+    Distro subclass for NetBSD.
+
+    (N.B. OpenBSD inherits from this class.)
+    """
+
+    ci_sudoers_fn = '/usr/pkg/etc/sudoers.d/90-cloud-init-users'
+
+    group_add_cmd_prefix = ["groupadd"]
+    pkg_cmd_install_prefix = ["pkg_add", "-U"]
+    pkg_cmd_remove_prefix = ['pkg_delete']
+
+    def _get_add_member_to_group_cmd(self, member_name, group_name):
+        return ['usermod', '-G', group_name, member_name]
+
+    def add_user(self, name, **kwargs):
+        if util.is_user(name):
+            LOG.info("User %s already exists, skipping.", name)
+            return False
+
+        adduser_cmd = ['useradd']
+        log_adduser_cmd = ['useradd']
+
+        adduser_opts = {
+            "homedir": '-d',
+            "gecos": '-c',
+            "primary_group": '-g',
+            "groups": '-G',
+            "shell": '-s',
+        }
+        adduser_flags = {
+            "no_user_group": '--no-user-group',
+            "system": '--system',
+            "no_log_init": '--no-log-init',
+        }
+
+        for key, val in kwargs.items():
+            if key in adduser_opts and val and isinstance(val, str):
+                adduser_cmd.extend([adduser_opts[key], val])
+
+            elif key in adduser_flags and val:
+                adduser_cmd.append(adduser_flags[key])
+                log_adduser_cmd.append(adduser_flags[key])
+
+        if 'no_create_home' not in kwargs or 'system' not in kwargs:
+            adduser_cmd += ['-m']
+            log_adduser_cmd += ['-m']
+
+        adduser_cmd += [name]
+        log_adduser_cmd += [name]
+
+        # Run the command
+        LOG.info("Adding user %s", name)
+        try:
+            util.subp(adduser_cmd, logstring=log_adduser_cmd)
+        except Exception:
+            util.logexc(LOG, "Failed to create user %s", name)
+            raise
+        # Set the password if it is provided
+        # For security consideration, only hashed passwd is assumed
+        passwd_val = kwargs.get('passwd', None)
+        if passwd_val is not None:
+            self.set_passwd(name, passwd_val, hashed=True)
+
+    def set_passwd(self, user, passwd, hashed=False):
+        if hashed:
+            hashed_pw = passwd
+        elif not hasattr(crypt, 'METHOD_BLOWFISH'):
+            # crypt.METHOD_BLOWFISH comes with Python 3.7 which is available
+            # on NetBSD 7 and 8.
+            LOG.error((
+                'Cannot set non-encrypted password for user %s. '
+                'Python >= 3.7 is required.'), user)
+            return
+        else:
+            method = crypt.METHOD_BLOWFISH  # pylint: disable=E1101
+            hashed_pw = crypt.crypt(
+                    passwd,
+                    crypt.mksalt(method))
+
+        try:
+            util.subp(['usermod', '-C', 'no', '-p', hashed_pw, user])
+        except Exception:
+            util.logexc(LOG, "Failed to set password for %s", user)
+            raise
+
+    def force_passwd_change(self, user):
+        try:
+            util.subp(['usermod', '-F', user])
+        except Exception:
+            util.logexc(LOG, "Failed to set pw expiration for %s", user)
+            raise
+
+    def lock_passwd(self, name):
+        try:
+            util.subp(['usermod', '-C', 'yes', name])
+        except Exception:
+            util.logexc(LOG, "Failed to lock user %s", name)
+            raise
+
+    def apply_locale(self, locale, out_fn=None):
+        LOG.debug('Cannot set the locale.')
+
+    def apply_network_config_names(self, netconfig):
+        LOG.debug('NetBSD cannot rename network interface.')
+
+    def _get_pkg_cmd_environ(self):
+        """Return env vars used in NetBSD package_command operations"""
+        os_release = platform.release()
+        os_arch = platform.machine()
+        e = os.environ.copy()
+        e['PKG_PATH'] = (
+                'http://cdn.netbsd.org/pub/pkgsrc/'
+                'packages/NetBSD/%s/%s/All') % (os_arch, os_release)
+        return e
+
+    def update_package_sources(self):
+        pass
+
+
+class Distro(NetBSD):
+    pass
+
+# vi: ts=4 expandtab

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -1,0 +1,47 @@
+# Copyright (C) 2019-2020 Gonéri Le Bouder
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import os
+import platform
+
+import cloudinit.distros.netbsd
+from cloudinit import log as logging
+from cloudinit import util
+
+LOG = logging.getLogger(__name__)
+
+
+class Distro(cloudinit.distros.netbsd.NetBSD):
+    hostname_conf_fn = '/etc/myname'
+
+    def _read_hostname(self, filename, default=None):
+        return util.load_file(self.hostname_conf_fn)
+
+    def _write_hostname(self, hostname, filename):
+        content = hostname + '\n'
+        util.write_file(self.hostname_conf_fn, content)
+
+    def _get_add_member_to_group_cmd(self, member_name, group_name):
+        return ['usermod', '-G', group_name, member_name]
+
+    def lock_passwd(self, name):
+        try:
+            util.subp(['usermod', '-p', '*', name])
+        except Exception:
+            util.logexc(LOG, "Failed to lock user %s", name)
+            raise
+
+    def _get_pkg_cmd_environ(self):
+        """Return env vars used in OpenBSD package_command operations"""
+        os_release = platform.release()
+        os_arch = platform.machine()
+        e = os.environ.copy()
+        e['PKG_PATH'] = (
+                'ftp://ftp.openbsd.org/pub/OpenBSD/{os_release}/'
+                'packages/{os_arch}/').format(
+                        os_arch=os_arch, os_release=os_release)
+        return e
+
+
+# vi: ts=4 expandtab

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -37,6 +37,7 @@ class Distro(distros.Distro):
     renderer_configs = {
         'sysconfig': {
             'control': 'etc/sysconfig/network/config',
+            'flavor': 'suse',
             'iface_templates': '%(base)s/network/ifcfg-%(name)s',
             'netrules_path': (
                 'etc/udev/rules.d/85-persistent-net-cloud-init.rules'),

--- a/cloudinit/distros/parsers/hostname.py
+++ b/cloudinit/distros/parsers/hostname.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from six import StringIO
+from io import StringIO
 
 from cloudinit.distros.parsers import chop_comment
 

--- a/cloudinit/distros/parsers/hosts.py
+++ b/cloudinit/distros/parsers/hosts.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from six import StringIO
+from io import StringIO
 
 from cloudinit.distros.parsers import chop_comment
 

--- a/cloudinit/distros/parsers/resolv_conf.py
+++ b/cloudinit/distros/parsers/resolv_conf.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from six import StringIO
+from io import StringIO
 
 from cloudinit.distros.parsers import chop_comment
 from cloudinit import log as logging

--- a/cloudinit/distros/tests/test_init.py
+++ b/cloudinit/distros/tests/test_init.py
@@ -1,0 +1,83 @@
+# Copyright (C) 2020 Canonical Ltd.
+#
+# Author: Daniel Watkins <oddbloke@ubuntu.com>
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+"""Tests for cloudinit/distros/__init__.py"""
+
+from unittest import mock
+
+import pytest
+
+from cloudinit.distros import _get_package_mirror_info
+
+
+class TestGetPackageMirrorInfo:
+    """
+    Tests for cloudinit.distros._get_package_mirror_info.
+
+    These supplement the tests in tests/unittests/test_distros/test_generic.py
+    which are more focused on testing a single production-like configuration.
+    These tests are more focused on specific aspects of the unit under test.
+    """
+
+    @pytest.mark.parametrize('mirror_info,expected', [
+        # Empty info gives empty return
+        ({}, {}),
+        # failsafe values used if present
+        ({'failsafe': {'primary': 'value', 'security': 'other'}},
+         {'primary': 'value', 'security': 'other'}),
+        # search values used if present
+        ({'search': {'primary': ['value'], 'security': ['other']}},
+         {'primary': ['value'], 'security': ['other']}),
+        # failsafe values used if search value not present
+        ({'search': {'primary': ['value']}, 'failsafe': {'security': 'other'}},
+         {'primary': ['value'], 'security': 'other'})
+    ])
+    def test_get_package_mirror_info_failsafe(self, mirror_info, expected):
+        """
+        Test the interaction between search and failsafe inputs
+
+        (This doesn't test the case where the mirror_filter removes all search
+        options; test_failsafe_used_if_all_search_results_filtered_out covers
+        that.)
+        """
+        assert expected == _get_package_mirror_info(mirror_info,
+                                                    mirror_filter=lambda x: x)
+
+    def test_failsafe_used_if_all_search_results_filtered_out(self):
+        """Test the failsafe option used if all search options eliminated."""
+        mirror_info = {
+            'search': {'primary': ['value']}, 'failsafe': {'primary': 'other'}
+        }
+        assert {'primary': 'other'} == _get_package_mirror_info(
+            mirror_info, mirror_filter=lambda x: False)
+
+    @pytest.mark.parametrize('availability_zone,region,patterns,expected', (
+        # Test ec2_region alone
+        ('fk-fake-1f', None, ['EC2-%(ec2_region)s'], ['EC2-fk-fake-1']),
+        # Test availability_zone alone
+        ('fk-fake-1f', None, ['AZ-%(availability_zone)s'], ['AZ-fk-fake-1f']),
+        # Test region alone
+        (None, 'fk-fake-1', ['RG-%(region)s'], ['RG-fk-fake-1']),
+        # Test that ec2_region is not available for non-matching AZs
+        ('fake-fake-1f', None,
+         ['EC2-%(ec2_region)s', 'AZ-%(availability_zone)s'],
+         ['AZ-fake-fake-1f']),
+        # Test that template order maintained
+        (None, 'fake-region', ['RG-%(region)s-2', 'RG-%(region)s-1'],
+         ['RG-fake-region-2', 'RG-fake-region-1']),
+    ))
+    def test_substitution(self, availability_zone, region, patterns, expected):
+        """Test substitution works as expected."""
+        m_data_source = mock.Mock(
+            availability_zone=availability_zone, region=region
+        )
+        mirror_info = {'search': {'primary': patterns}}
+
+        ret = _get_package_mirror_info(
+            mirror_info,
+            data_source=m_data_source,
+            mirror_filter=lambda x: x
+        )
+        assert {'primary': expected} == ret

--- a/cloudinit/ec2_utils.py
+++ b/cloudinit/ec2_utils.py
@@ -142,7 +142,8 @@ def skip_retry_on_codes(status_codes, _request_args, cause):
 def get_instance_userdata(api_version='latest',
                           metadata_address='http://169.254.169.254',
                           ssl_details=None, timeout=5, retries=5,
-                          headers_cb=None, exception_cb=None):
+                          headers_cb=None, headers_redact=None,
+                          exception_cb=None):
     ud_url = url_helper.combine_url(metadata_address, api_version)
     ud_url = url_helper.combine_url(ud_url, 'user-data')
     user_data = ''
@@ -155,7 +156,8 @@ def get_instance_userdata(api_version='latest',
                                              SKIP_USERDATA_CODES)
         response = url_helper.read_file_or_url(
             ud_url, ssl_details=ssl_details, timeout=timeout,
-            retries=retries, exception_cb=exception_cb, headers_cb=headers_cb)
+            retries=retries, exception_cb=exception_cb, headers_cb=headers_cb,
+            headers_redact=headers_redact)
         user_data = response.contents
     except url_helper.UrlError as e:
         if e.code not in SKIP_USERDATA_CODES:
@@ -169,11 +171,13 @@ def _get_instance_metadata(tree, api_version='latest',
                            metadata_address='http://169.254.169.254',
                            ssl_details=None, timeout=5, retries=5,
                            leaf_decoder=None, headers_cb=None,
+                           headers_redact=None,
                            exception_cb=None):
     md_url = url_helper.combine_url(metadata_address, api_version, tree)
     caller = functools.partial(
         url_helper.read_file_or_url, ssl_details=ssl_details,
         timeout=timeout, retries=retries, headers_cb=headers_cb,
+        headers_redact=headers_redact,
         exception_cb=exception_cb)
 
     def mcaller(url):
@@ -197,6 +201,7 @@ def get_instance_metadata(api_version='latest',
                           metadata_address='http://169.254.169.254',
                           ssl_details=None, timeout=5, retries=5,
                           leaf_decoder=None, headers_cb=None,
+                          headers_redact=None,
                           exception_cb=None):
     # Note, 'meta-data' explicitly has trailing /.
     # this is required for CloudStack (LP: #1356855)
@@ -204,6 +209,7 @@ def get_instance_metadata(api_version='latest',
                                   metadata_address=metadata_address,
                                   ssl_details=ssl_details, timeout=timeout,
                                   retries=retries, leaf_decoder=leaf_decoder,
+                                  headers_redact=headers_redact,
                                   headers_cb=headers_cb,
                                   exception_cb=exception_cb)
 
@@ -212,12 +218,14 @@ def get_instance_identity(api_version='latest',
                           metadata_address='http://169.254.169.254',
                           ssl_details=None, timeout=5, retries=5,
                           leaf_decoder=None, headers_cb=None,
+                          headers_redact=None,
                           exception_cb=None):
     return _get_instance_metadata(tree='dynamic/instance-identity',
                                   api_version=api_version,
                                   metadata_address=metadata_address,
                                   ssl_details=ssl_details, timeout=timeout,
                                   retries=retries, leaf_decoder=leaf_decoder,
+                                  headers_redact=headers_redact,
                                   headers_cb=headers_cb,
                                   exception_cb=exception_cb)
 # vi: ts=4 expandtab

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -12,10 +12,8 @@ from time import time
 
 import contextlib
 import os
-
-from six import StringIO
-from six.moves.configparser import (
-    NoSectionError, NoOptionError, RawConfigParser)
+from configparser import NoSectionError, NoOptionError, RawConfigParser
+from io import StringIO
 
 from cloudinit.settings import (PER_INSTANCE, PER_ALWAYS, PER_ONCE,
                                 CFG_ENV_NAME)

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -334,8 +334,18 @@ def find_fallback_nic(blacklist_drivers=None):
     """Return the name of the 'fallback' network device."""
     if util.is_FreeBSD():
         return find_fallback_nic_on_freebsd(blacklist_drivers)
+    elif util.is_NetBSD() or util.is_OpenBSD():
+        return find_fallback_nic_on_netbsd_or_openbsd(blacklist_drivers)
     else:
         return find_fallback_nic_on_linux(blacklist_drivers)
+
+
+def find_fallback_nic_on_netbsd_or_openbsd(blacklist_drivers=None):
+    values = list(sorted(
+        get_interfaces_by_mac().values(),
+        key=natural_sort_key))
+    if values:
+        return values[0]
 
 
 def find_fallback_nic_on_freebsd(blacklist_drivers=None):
@@ -799,6 +809,10 @@ def get_ib_interface_hwaddr(ifname, ethernet_format):
 def get_interfaces_by_mac():
     if util.is_FreeBSD():
         return get_interfaces_by_mac_on_freebsd()
+    elif util.is_NetBSD():
+        return get_interfaces_by_mac_on_netbsd()
+    elif util.is_OpenBSD():
+        return get_interfaces_by_mac_on_openbsd()
     else:
         return get_interfaces_by_mac_on_linux()
 
@@ -828,6 +842,36 @@ def get_interfaces_by_mac_on_freebsd():
                 yield (m.group('mac'), m.group('ifname'))
     results = {mac: ifname for mac, ifname in find_mac(flatten(out))}
     return results
+
+
+def get_interfaces_by_mac_on_netbsd():
+    ret = {}
+    re_field_match = (
+            r"(?P<ifname>\w+).*address:\s"
+            r"(?P<mac>([\da-f]{2}[:-]){5}([\da-f]{2})).*")
+    (out, _) = util.subp(['ifconfig', '-a'])
+    if_lines = re.sub(r'\n\s+', ' ', out).splitlines()
+    for line in if_lines:
+        m = re.match(re_field_match, line)
+        if m:
+            fields = m.groupdict()
+            ret[fields['mac']] = fields['ifname']
+    return ret
+
+
+def get_interfaces_by_mac_on_openbsd():
+    ret = {}
+    re_field_match = (
+        r"(?P<ifname>\w+).*lladdr\s"
+        r"(?P<mac>([\da-f]{2}[:-]){5}([\da-f]{2})).*")
+    (out, _) = util.subp(['ifconfig', '-a'])
+    if_lines = re.sub(r'\n\s+', ' ', out).splitlines()
+    for line in if_lines:
+        m = re.match(re_field_match, line)
+        if m:
+            fields = m.groupdict()
+            ret[fields['mac']] = fields['ifname']
+    return ret
 
 
 def get_interfaces_by_mac_on_linux():

--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -1,0 +1,165 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import re
+
+from cloudinit import log as logging
+from cloudinit import net
+from cloudinit import util
+from cloudinit.distros.parsers.resolv_conf import ResolvConf
+from cloudinit.distros import bsd_utils
+
+from . import renderer
+
+LOG = logging.getLogger(__name__)
+
+
+class BSDRenderer(renderer.Renderer):
+    resolv_conf_fn = 'etc/resolv.conf'
+    rc_conf_fn = 'etc/rc.conf'
+
+    def get_rc_config_value(self, key):
+        fn = util.target_path(self.target, self.rc_conf_fn)
+        bsd_utils.get_rc_config_value(key, fn=fn)
+
+    def set_rc_config_value(self, key, value):
+        fn = util.target_path(self.target, self.rc_conf_fn)
+        bsd_utils.set_rc_config_value(key, value, fn=fn)
+
+    def __init__(self, config=None):
+        if not config:
+            config = {}
+        self.target = None
+        self.interface_configurations = {}
+        self._postcmds = config.get('postcmds', True)
+
+    def _ifconfig_entries(self, settings, target=None):
+        ifname_by_mac = net.get_interfaces_by_mac()
+        for interface in settings.iter_interfaces():
+            device_name = interface.get("name")
+            device_mac = interface.get("mac_address")
+            if device_name and re.match(r'^lo\d+$', device_name):
+                continue
+            if device_mac not in ifname_by_mac:
+                LOG.info('Cannot find any device with MAC %s', device_mac)
+            elif device_mac and device_name:
+                cur_name = ifname_by_mac[device_mac]
+                if cur_name != device_name:
+                    LOG.info('netif service will rename interface %s to %s',
+                             cur_name, device_name)
+                    try:
+                        self.rename_interface(cur_name, device_name)
+                    except NotImplementedError:
+                        LOG.error((
+                            'Interface renaming is '
+                            'not supported on this OS'))
+                        device_name = cur_name
+
+            else:
+                device_name = ifname_by_mac[device_mac]
+
+            LOG.info('Configuring interface %s', device_name)
+
+            self.interface_configurations[device_name] = 'DHCP'
+
+            for subnet in interface.get("subnets", []):
+                if subnet.get('type') == 'static':
+                    if not subnet.get('netmask'):
+                        LOG.debug(
+                                'Skipping IP %s, because there is no netmask',
+                                subnet.get('address'))
+                        continue
+                    LOG.debug('Configuring dev %s with %s / %s', device_name,
+                              subnet.get('address'), subnet.get('netmask'))
+
+                    self.interface_configurations[device_name] = {
+                        'address': subnet.get('address'),
+                        'netmask': subnet.get('netmask'),
+                    }
+
+    def _route_entries(self, settings, target=None):
+        routes = list(settings.iter_routes())
+        for interface in settings.iter_interfaces():
+            subnets = interface.get("subnets", [])
+            for subnet in subnets:
+                if subnet.get('type') != 'static':
+                    continue
+                gateway = subnet.get('gateway')
+                if gateway and len(gateway.split('.')) == 4:
+                    routes.append({
+                        'network': '0.0.0.0',
+                        'netmask': '0.0.0.0',
+                        'gateway': gateway})
+                routes += subnet.get('routes', [])
+        for route in routes:
+            network = route.get('network')
+            if not network:
+                LOG.debug('Skipping a bad route entry')
+                continue
+            netmask = route.get('netmask')
+            gateway = route.get('gateway')
+            self.set_route(network, netmask, gateway)
+
+    def _resolve_conf(self, settings, target=None):
+        nameservers = settings.dns_nameservers
+        searchdomains = settings.dns_searchdomains
+        for interface in settings.iter_interfaces():
+            for subnet in interface.get("subnets", []):
+                if 'dns_nameservers' in subnet:
+                    nameservers.extend(subnet['dns_nameservers'])
+                if 'dns_search' in subnet:
+                    searchdomains.extend(subnet['dns_search'])
+        # Try to read the /etc/resolv.conf or just start from scratch if that
+        # fails.
+        try:
+            resolvconf = ResolvConf(util.load_file(util.target_path(
+                target, self.resolv_conf_fn)))
+            resolvconf.parse()
+        except IOError:
+            util.logexc(LOG, "Failed to parse %s, use new empty file",
+                        util.target_path(target, self.resolv_conf_fn))
+            resolvconf = ResolvConf('')
+            resolvconf.parse()
+
+        # Add some nameservers
+        for server in nameservers:
+            try:
+                resolvconf.add_nameserver(server)
+            except ValueError:
+                util.logexc(LOG, "Failed to add nameserver %s", server)
+
+        # And add any searchdomains.
+        for domain in searchdomains:
+            try:
+                resolvconf.add_search_domain(domain)
+            except ValueError:
+                util.logexc(LOG, "Failed to add search domain %s", domain)
+        util.write_file(
+            util.target_path(target, self.resolv_conf_fn),
+            str(resolvconf), 0o644)
+
+    def render_network_state(self, network_state, templates=None, target=None):
+        self._ifconfig_entries(settings=network_state)
+        self._route_entries(settings=network_state)
+        self._resolve_conf(settings=network_state)
+
+        self.write_config()
+        self.start_services(run=self._postcmds)
+
+    def dhcp_interfaces(self):
+        ic = self.interface_configurations.items
+        return [k for k, v in ic() if v == 'DHCP']
+
+    def start_services(self, run=False):
+        raise NotImplementedError()
+
+    def write_config(self, target=None):
+        raise NotImplementedError()
+
+    def set_gateway(self, gateway):
+        raise NotImplementedError()
+
+    def rename_interface(self, cur_name, device_name):
+        raise NotImplementedError()
+
+    def set_route(self, network, netmask, gateway):
+        raise NotImplementedError()

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -10,6 +10,7 @@ import base64
 import glob
 import gzip
 import io
+import logging
 import os
 
 from cloudinit import util
@@ -18,6 +19,8 @@ from . import get_devicelist
 from . import read_sys_net_safe
 
 _OPEN_ISCSI_INTERFACE_FILE = "/run/initramfs/open-iscsi.interface"
+
+KERNEL_CMDLINE_NETWORK_CONFIG_DISABLED = "disabled"
 
 
 class InitramfsNetworkConfigSource(metaclass=abc.ABCMeta):
@@ -101,9 +104,12 @@ def _klibc_to_config_entry(content, mac_addrs=None):
     provided here.  There is no good documentation on this unfortunately.
 
     DEVICE=<name> is expected/required and PROTO should indicate if
-    this is 'static' or 'dhcp' or 'dhcp6' (LP: #1621507).
+    this is 'none' (static) or 'dhcp' or 'dhcp6' (LP: #1621507).
     note that IPV6PROTO is also written by newer code to address the
     possibility of both ipv4 and ipv6 getting addresses.
+
+    Full syntax is documented at:
+    https://git.kernel.org/pub/scm/libs/klibc/klibc.git/plain/usr/kinit/ipconfig/README.ipconfig
     """
 
     if mac_addrs is None:
@@ -122,9 +128,9 @@ def _klibc_to_config_entry(content, mac_addrs=None):
         if data.get('filename'):
             proto = 'dhcp'
         else:
-            proto = 'static'
+            proto = 'none'
 
-    if proto not in ('static', 'dhcp', 'dhcp6'):
+    if proto not in ('none', 'dhcp', 'dhcp6'):
         raise ValueError("Unexpected value for PROTO: %s" % proto)
 
     iface = {
@@ -144,6 +150,9 @@ def _klibc_to_config_entry(content, mac_addrs=None):
 
         # PROTO for ipv4, IPV6PROTO for ipv6
         cur_proto = data.get(pre + 'PROTO', proto)
+        # ipconfig's 'none' is called 'static'
+        if cur_proto == 'none':
+            cur_proto = 'static'
         subnet = {'type': cur_proto, 'control': 'manual'}
 
         # only populate address for static types. While the rendered config
@@ -227,34 +236,35 @@ def read_initramfs_config():
     return None
 
 
-def _decomp_gzip(blob, strict=True):
-    # decompress blob. raise exception if not compressed unless strict=False.
+def _decomp_gzip(blob):
+    # decompress blob or return original blob
     with io.BytesIO(blob) as iobuf:
         gzfp = None
         try:
             gzfp = gzip.GzipFile(mode="rb", fileobj=iobuf)
             return gzfp.read()
         except IOError:
-            if strict:
-                raise
             return blob
         finally:
             if gzfp:
                 gzfp.close()
 
 
-def _b64dgz(b64str, gzipped="try"):
-    # decode a base64 string.  If gzipped is true, transparently uncompresss
-    # if gzipped is 'try', then try gunzip, returning the original on fail.
+def _b64dgz(data):
+    """Decode a string base64 encoding, if gzipped, uncompress as well
+
+    :return: decompressed unencoded string of the data or empty string on
+       unencoded data.
+    """
     try:
-        blob = base64.b64decode(b64str)
-    except TypeError:
-        raise ValueError("Invalid base64 text: %s" % b64str)
+        blob = base64.b64decode(data)
+    except (TypeError, ValueError):
+        logging.error(
+            "Expected base64 encoded kernel commandline parameter"
+            " network-config. Ignoring network-config=%s.", data)
+        return ''
 
-    if not gzipped:
-        return blob
-
-    return _decomp_gzip(blob, strict=gzipped != "try")
+    return _decomp_gzip(blob)
 
 
 def read_kernel_cmdline_config(cmdline=None):
@@ -267,6 +277,8 @@ def read_kernel_cmdline_config(cmdline=None):
             if tok.startswith("network-config="):
                 data64 = tok.split("=", 1)[1]
         if data64:
+            if data64 == KERNEL_CMDLINE_NETWORK_CONFIG_DISABLED:
+                return {"config": "disabled"}
             return util.load_yaml(_b64dgz(data64))
 
     return None

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -10,6 +10,7 @@ import os
 import re
 import signal
 import time
+from io import StringIO
 
 from cloudinit.net import (
     EphemeralIPv4Network, find_fallback_nic, get_devicelist,
@@ -17,7 +18,6 @@ from cloudinit.net import (
 from cloudinit.net.network_state import mask_and_ipv4_to_bcast_addr as bcip
 from cloudinit import temp_utils
 from cloudinit import util
-from six import StringIO
 
 LOG = logging.getLogger(__name__)
 

--- a/cloudinit/net/freebsd.py
+++ b/cloudinit/net/freebsd.py
@@ -1,156 +1,29 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import re
-
 from cloudinit import log as logging
-from cloudinit import net
+import cloudinit.net.bsd
 from cloudinit import util
-from cloudinit.distros import rhel_util
-from cloudinit.distros.parsers.resolv_conf import ResolvConf
-
-from . import renderer
 
 LOG = logging.getLogger(__name__)
 
 
-class Renderer(renderer.Renderer):
-    resolv_conf_fn = 'etc/resolv.conf'
-    rc_conf_fn = 'etc/rc.conf'
+class Renderer(cloudinit.net.bsd.BSDRenderer):
 
     def __init__(self, config=None):
-        if not config:
-            config = {}
-        self.dhcp_interfaces = []
-        self._postcmds = config.get('postcmds', True)
+        self._route_cpt = 0
+        super(Renderer, self).__init__()
 
-    def _update_rc_conf(self, settings, target=None):
-        fn = util.target_path(target, self.rc_conf_fn)
-        rhel_util.update_sysconfig_file(fn, settings)
+    def rename_interface(self, cur_name, device_name):
+        self.set_rc_config_value('ifconfig_%s_name' % cur_name, device_name)
 
-    def _write_ifconfig_entries(self, settings, target=None):
-        ifname_by_mac = net.get_interfaces_by_mac()
-        for interface in settings.iter_interfaces():
-            device_name = interface.get("name")
-            device_mac = interface.get("mac_address")
-            if device_name and re.match(r'^lo\d+$', device_name):
-                continue
-            if device_mac not in ifname_by_mac:
-                LOG.info('Cannot find any device with MAC %s', device_mac)
-            elif device_mac and device_name:
-                cur_name = ifname_by_mac[device_mac]
-                if cur_name != device_name:
-                    LOG.info('netif service will rename interface %s to %s',
-                             cur_name, device_name)
-                    self._update_rc_conf(
-                        {'ifconfig_%s_name' % cur_name: device_name},
-                        target=target)
+    def write_config(self):
+        for device_name, v in self.interface_configurations.items():
+            if isinstance(v, dict):
+                self.set_rc_config_value(
+                    'ifconfig_' + device_name,
+                    v.get('address') + ' netmask ' + v.get('netmask'))
             else:
-                device_name = ifname_by_mac[device_mac]
-
-            LOG.info('Configuring interface %s', device_name)
-            ifconfig = 'DHCP'  # default
-
-            for subnet in interface.get("subnets", []):
-                if ifconfig != 'DHCP':
-                    LOG.info('The FreeBSD provider only set the first subnet.')
-                    break
-                if subnet.get('type') == 'static':
-                    if not subnet.get('netmask'):
-                        LOG.debug(
-                                'Skipping IP %s, because there is no netmask',
-                                subnet.get('address'))
-                        continue
-                    LOG.debug('Configuring dev %s with %s / %s', device_name,
-                              subnet.get('address'), subnet.get('netmask'))
-                # Configure an ipv4 address.
-                    ifconfig = (
-                            subnet.get('address') + ' netmask ' +
-                            subnet.get('netmask'))
-
-            if ifconfig == 'DHCP':
-                self.dhcp_interfaces.append(device_name)
-            self._update_rc_conf(
-                {'ifconfig_' + device_name: ifconfig},
-                target=target)
-
-    def _write_route_entries(self, settings, target=None):
-        routes = list(settings.iter_routes())
-        for interface in settings.iter_interfaces():
-            subnets = interface.get("subnets", [])
-            for subnet in subnets:
-                if subnet.get('type') != 'static':
-                    continue
-                gateway = subnet.get('gateway')
-                if gateway and len(gateway.split('.')) == 4:
-                    routes.append({
-                        'network': '0.0.0.0',
-                        'netmask': '0.0.0.0',
-                        'gateway': gateway})
-                routes += subnet.get('routes', [])
-        route_cpt = 0
-        for route in routes:
-            network = route.get('network')
-            if not network:
-                LOG.debug('Skipping a bad route entry')
-                continue
-            netmask = route.get('netmask')
-            gateway = route.get('gateway')
-            route_cmd = "-route %s/%s %s" % (network, netmask, gateway)
-            if network == '0.0.0.0':
-                self._update_rc_conf(
-                    {'defaultrouter': gateway}, target=target)
-            else:
-                self._update_rc_conf(
-                    {'route_net%d' % route_cpt: route_cmd}, target=target)
-                route_cpt += 1
-
-    def _write_resolve_conf(self, settings, target=None):
-        nameservers = settings.dns_nameservers
-        searchdomains = settings.dns_searchdomains
-        for interface in settings.iter_interfaces():
-            for subnet in interface.get("subnets", []):
-                if 'dns_nameservers' in subnet:
-                    nameservers.extend(subnet['dns_nameservers'])
-                if 'dns_search' in subnet:
-                    searchdomains.extend(subnet['dns_search'])
-        # Try to read the /etc/resolv.conf or just start from scratch if that
-        # fails.
-        try:
-            resolvconf = ResolvConf(util.load_file(util.target_path(
-                target, self.resolv_conf_fn)))
-            resolvconf.parse()
-        except IOError:
-            util.logexc(LOG, "Failed to parse %s, use new empty file",
-                        util.target_path(target, self.resolv_conf_fn))
-            resolvconf = ResolvConf('')
-            resolvconf.parse()
-
-        # Add some nameservers
-        for server in nameservers:
-            try:
-                resolvconf.add_nameserver(server)
-            except ValueError:
-                util.logexc(LOG, "Failed to add nameserver %s", server)
-
-        # And add any searchdomains.
-        for domain in searchdomains:
-            try:
-                resolvconf.add_search_domain(domain)
-            except ValueError:
-                util.logexc(LOG, "Failed to add search domain %s", domain)
-        util.write_file(
-            util.target_path(target, self.resolv_conf_fn),
-            str(resolvconf), 0o644)
-
-    def _write_network(self, settings, target=None):
-        self._write_ifconfig_entries(settings, target=target)
-        self._write_route_entries(settings, target=target)
-        self._write_resolve_conf(settings, target=target)
-
-        self.start_services(run=self._postcmds)
-
-    def render_network_state(self, network_state, templates=None, target=None):
-        self._write_network(network_state, target=target)
+                self.set_rc_config_value('ifconfig_' + device_name, 'DHCP')
 
     def start_services(self, run=False):
         if not run:
@@ -165,10 +38,20 @@ class Renderer(renderer.Renderer):
         # - dhclient: it cannot stop the dhclient started by the netif service.
         # In both case, the situation is ok, and we can proceed.
         util.subp(['service', 'routing', 'restart'], capture=True, rcs=[0, 1])
-        for dhcp_interface in self.dhcp_interfaces:
+
+        for dhcp_interface in self.dhcp_interfaces():
             util.subp(['service', 'dhclient', 'restart', dhcp_interface],
                       rcs=[0, 1],
                       capture=True)
+
+    def set_route(self, network, netmask, gateway):
+        if network == '0.0.0.0':
+            self.set_rc_config_value('defaultrouter', gateway)
+        else:
+            route_name = 'route_net%d' % self._route_cpt
+            route_cmd = "-route %s/%s %s" % (network, netmask, gateway)
+            self.set_rc_config_value(route_name, route_cmd)
+            self._route_cpt += 1
 
 
 def available(target=None):

--- a/cloudinit/net/netbsd.py
+++ b/cloudinit/net/netbsd.py
@@ -1,0 +1,42 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from cloudinit import log as logging
+from cloudinit import util
+import cloudinit.net.bsd
+
+LOG = logging.getLogger(__name__)
+
+
+class Renderer(cloudinit.net.bsd.BSDRenderer):
+
+    def __init__(self, config=None):
+        super(Renderer, self).__init__()
+
+    def write_config(self):
+        if self.dhcp_interfaces():
+            self.set_rc_config_value('dhcpcd', 'YES')
+            self.set_rc_config_value(
+                    'dhcpcd_flags',
+                    ' '.join(self.dhcp_interfaces()))
+        for device_name, v in self.interface_configurations.items():
+            if isinstance(v, dict):
+                self.set_rc_config_value(
+                    'ifconfig_' + device_name,
+                    v.get('address') + ' netmask ' + v.get('netmask'))
+
+    def start_services(self, run=False):
+        if not run:
+            LOG.debug("netbsd generate postcmd disabled")
+            return
+
+        util.subp(['service', 'network', 'restart'], capture=True)
+        if self.dhcp_interfaces():
+            util.subp(['service', 'dhcpcd', 'restart'], capture=True)
+
+    def set_route(self, network, netmask, gateway):
+        if network == '0.0.0.0':
+            self.set_rc_config_value('defaultroute', gateway)
+
+
+def available(target=None):
+    return util.is_NetBSD()

--- a/cloudinit/net/openbsd.py
+++ b/cloudinit/net/openbsd.py
@@ -1,0 +1,44 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from cloudinit import log as logging
+from cloudinit import util
+import cloudinit.net.bsd
+
+LOG = logging.getLogger(__name__)
+
+
+class Renderer(cloudinit.net.bsd.BSDRenderer):
+
+    def write_config(self):
+        for device_name, v in self.interface_configurations.items():
+            if_file = 'etc/hostname.{}'.format(device_name)
+            fn = util.target_path(self.target, if_file)
+            if device_name in self.dhcp_interfaces():
+                content = 'dhcp\n'
+            elif isinstance(v, dict):
+                try:
+                    content = "inet {address} {netmask}\n".format(
+                            address=v['address'],
+                            netmask=v['netmask'])
+                except KeyError:
+                    LOG.error(
+                        "Invalid static configuration for %s",
+                        device_name)
+            util.write_file(fn, content)
+
+    def start_services(self, run=False):
+        if not self._postcmds:
+            LOG.debug("openbsd generate postcmd disabled")
+            return
+        util.subp(['sh', '/etc/netstart'], capture=True)
+
+    def set_route(self, network, netmask, gateway):
+        if network == '0.0.0.0':
+            if_file = 'etc/mygate'
+            fn = util.target_path(self.target, if_file)
+            content = gateway + '\n'
+            util.write_file(fn, content)
+
+
+def available(target=None):
+    return util.is_OpenBSD()

--- a/cloudinit/net/renderers.py
+++ b/cloudinit/net/renderers.py
@@ -2,18 +2,23 @@
 
 from . import eni
 from . import freebsd
+from . import netbsd
 from . import netplan
 from . import RendererNotFoundError
+from . import openbsd
 from . import sysconfig
 
 NAME_TO_RENDERER = {
     "eni": eni,
     "freebsd": freebsd,
+    "netbsd": netbsd,
     "netplan": netplan,
+    "openbsd": openbsd,
     "sysconfig": sysconfig,
 }
 
-DEFAULT_PRIORITY = ["eni", "sysconfig", "netplan", "freebsd"]
+DEFAULT_PRIORITY = ["eni", "sysconfig", "netplan", "freebsd",
+                    "netbsd", "openbsd"]
 
 
 def search(priority=None, target=None, first=False):

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -1,5 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import copy
 import io
 import os
 import re
@@ -85,6 +86,9 @@ class ConfigMap(object):
     def __getitem__(self, key):
         return self._conf[key]
 
+    def get(self, key):
+        return self._conf.get(key)
+
     def __contains__(self, key):
         return key in self._conf
 
@@ -107,6 +111,9 @@ class ConfigMap(object):
                 value = str(value)
             buf.write("%s=%s\n" % (key, _quote_value(value)))
         return buf.getvalue()
+
+    def update(self, updates):
+        self._conf.update(updates)
 
 
 class Route(ConfigMap):
@@ -268,13 +275,29 @@ class Renderer(renderer.Renderer):
     #      s1-networkscripts-interfaces.html (or other docs for
     #                                         details about this)
 
-    iface_defaults = tuple([
-        ('ONBOOT', True),
-        ('USERCTL', False),
-        ('NM_CONTROLLED', False),
-        ('BOOTPROTO', 'none'),
-        ('STARTMODE', 'auto'),
-    ])
+    iface_defaults = {
+        'rhel': {'ONBOOT': True, 'USERCTL': False, 'NM_CONTROLLED': False,
+                 'BOOTPROTO': 'none'},
+        'suse': {'BOOTPROTO': 'static', 'STARTMODE': 'auto'},
+    }
+
+    cfg_key_maps = {
+        'rhel': {
+            'accept-ra': 'IPV6_FORCE_ACCEPT_RA',
+            'bridge_stp': 'STP',
+            'bridge_ageing': 'AGEING',
+            'bridge_bridgeprio': 'PRIO',
+            'mac_address': 'HWADDR',
+            'mtu': 'MTU',
+        },
+        'suse': {
+            'bridge_stp': 'BRIDGE_STP',
+            'bridge_ageing': 'BRIDGE_AGEINGTIME',
+            'bridge_bridgeprio': 'BRIDGE_PRIORITY',
+            'mac_address': 'LLADDR',
+            'mtu': 'MTU',
+        },
+    }
 
     # If these keys exist, then their values will be used to form
     # a BONDING_OPTS grouping; otherwise no grouping will be set.
@@ -296,12 +319,6 @@ class Renderer(renderer.Renderer):
         ('bond_primary_reselect', "primary_reselect=%s"),
     ])
 
-    bridge_opts_keys = tuple([
-        ('bridge_stp', 'STP'),
-        ('bridge_ageing', 'AGEING'),
-        ('bridge_bridgeprio', 'PRIO'),
-    ])
-
     templates = {}
 
     def __init__(self, config=None):
@@ -319,65 +336,101 @@ class Renderer(renderer.Renderer):
             'iface_templates': config.get('iface_templates'),
             'route_templates': config.get('route_templates'),
         }
+        self.flavor = config.get('flavor', 'rhel')
 
     @classmethod
-    def _render_iface_shared(cls, iface, iface_cfg):
-        for k, v in cls.iface_defaults:
-            iface_cfg[k] = v
+    def _render_iface_shared(cls, iface, iface_cfg, flavor):
+        flavor_defaults = copy.deepcopy(cls.iface_defaults.get(flavor, {}))
+        iface_cfg.update(flavor_defaults)
 
-        for (old_key, new_key) in [('mac_address', 'HWADDR'), ('mtu', 'MTU')]:
+        for old_key in ('mac_address', 'mtu', 'accept-ra'):
             old_value = iface.get(old_key)
             if old_value is not None:
                 # only set HWADDR on physical interfaces
                 if (old_key == 'mac_address' and
                    iface['type'] not in ['physical', 'infiniband']):
                     continue
-                iface_cfg[new_key] = old_value
-
-        if iface['accept-ra'] is not None:
-            iface_cfg['IPV6_FORCE_ACCEPT_RA'] = iface['accept-ra']
+                new_key = cls.cfg_key_maps[flavor].get(old_key)
+                if new_key:
+                    iface_cfg[new_key] = old_value
 
     @classmethod
-    def _render_subnets(cls, iface_cfg, subnets, has_default_route):
+    def _render_subnets(cls, iface_cfg, subnets, has_default_route, flavor):
         # setting base values
-        iface_cfg['BOOTPROTO'] = 'none'
+        if flavor == 'suse':
+            iface_cfg['BOOTPROTO'] = 'static'
+            if 'BRIDGE' in iface_cfg:
+                iface_cfg['BOOTPROTO'] = 'dhcp'
+                iface_cfg.drop('BRIDGE')
+        else:
+            iface_cfg['BOOTPROTO'] = 'none'
 
         # modifying base values according to subnets
         for i, subnet in enumerate(subnets, start=len(iface_cfg.children)):
             mtu_key = 'MTU'
             subnet_type = subnet.get('type')
             if subnet_type == 'dhcp6' or subnet_type == 'ipv6_dhcpv6-stateful':
-                # TODO need to set BOOTPROTO to dhcp6 on SUSE
-                iface_cfg['IPV6INIT'] = True
-                # Configure network settings using DHCPv6
-                iface_cfg['DHCPV6C'] = True
+                if flavor == 'suse':
+                    # User wants dhcp for both protocols
+                    if iface_cfg['BOOTPROTO'] == 'dhcp4':
+                        iface_cfg['BOOTPROTO'] = 'dhcp'
+                    else:
+                        # Only IPv6 is DHCP, IPv4 may be static
+                        iface_cfg['BOOTPROTO'] = 'dhcp6'
+                    iface_cfg['DHCLIENT6_MODE'] = 'managed'
+                else:
+                    iface_cfg['IPV6INIT'] = True
+                    # Configure network settings using DHCPv6
+                    iface_cfg['DHCPV6C'] = True
             elif subnet_type == 'ipv6_dhcpv6-stateless':
-                iface_cfg['IPV6INIT'] = True
-                # Configure network settings using SLAAC from RAs and optional
-                # info from dhcp server using DHCPv6
-                iface_cfg['IPV6_AUTOCONF'] = True
-                iface_cfg['DHCPV6C'] = True
-                # Use Information-request to get only stateless configuration
-                # parameters (i.e., without address).
-                iface_cfg['DHCPV6C_OPTIONS'] = '-S'
+                if flavor == 'suse':
+                    # User wants dhcp for both protocols
+                    if iface_cfg['BOOTPROTO'] == 'dhcp4':
+                        iface_cfg['BOOTPROTO'] = 'dhcp'
+                    else:
+                        # Only IPv6 is DHCP, IPv4 may be static
+                        iface_cfg['BOOTPROTO'] = 'dhcp6'
+                    iface_cfg['DHCLIENT6_MODE'] = 'info'
+                else:
+                    iface_cfg['IPV6INIT'] = True
+                    # Configure network settings using SLAAC from RAs and
+                    # optional info from dhcp server using DHCPv6
+                    iface_cfg['IPV6_AUTOCONF'] = True
+                    iface_cfg['DHCPV6C'] = True
+                    # Use Information-request to get only stateless
+                    # configuration parameters (i.e., without address).
+                    iface_cfg['DHCPV6C_OPTIONS'] = '-S'
             elif subnet_type == 'ipv6_slaac':
-                iface_cfg['IPV6INIT'] = True
-                # Configure network settings using SLAAC from RAs
-                iface_cfg['IPV6_AUTOCONF'] = True
+                if flavor == 'suse':
+                    # User wants dhcp for both protocols
+                    if iface_cfg['BOOTPROTO'] == 'dhcp4':
+                        iface_cfg['BOOTPROTO'] = 'dhcp'
+                    else:
+                        # Only IPv6 is DHCP, IPv4 may be static
+                        iface_cfg['BOOTPROTO'] = 'dhcp6'
+                    iface_cfg['DHCLIENT6_MODE'] = 'info'
+                else:
+                    iface_cfg['IPV6INIT'] = True
+                    # Configure network settings using SLAAC from RAs
+                    iface_cfg['IPV6_AUTOCONF'] = True
             elif subnet_type in ['dhcp4', 'dhcp']:
+                bootproto_in = iface_cfg['BOOTPROTO']
                 iface_cfg['BOOTPROTO'] = 'dhcp'
+                if flavor == 'suse' and subnet_type == 'dhcp4':
+                    # If dhcp6 is already specified the user wants dhcp
+                    # for both protocols
+                    if bootproto_in != 'dhcp6':
+                        # Only IPv4 is DHCP, IPv6 may be static
+                        iface_cfg['BOOTPROTO'] = 'dhcp4'
             elif subnet_type in ['static', 'static6']:
+                # RH info
                 # grep BOOTPROTO sysconfig.txt -A2 | head -3
                 # BOOTPROTO=none|bootp|dhcp
                 # 'bootp' or 'dhcp' cause a DHCP client
                 # to run on the device. Any other
                 # value causes any static configuration
                 # in the file to be applied.
-                # ==> the following should not be set to 'static'
-                # but should remain 'none'
-                # if iface_cfg['BOOTPROTO'] == 'none':
-                #    iface_cfg['BOOTPROTO'] = 'static'
-                if subnet_is_ipv6(subnet):
+                if subnet_is_ipv6(subnet) and flavor != 'suse':
                     mtu_key = 'IPV6_MTU'
                     iface_cfg['IPV6INIT'] = True
                 if 'mtu' in subnet:
@@ -388,18 +441,31 @@ class Renderer(renderer.Renderer):
                             'Network config: ignoring %s device-level mtu:%s'
                             ' because ipv4 subnet-level mtu:%s provided.',
                             iface_cfg.name, iface_cfg[mtu_key], subnet['mtu'])
-                    iface_cfg[mtu_key] = subnet['mtu']
+                    if subnet_is_ipv6(subnet):
+                        if flavor == 'suse':
+                            # TODO(rjschwei) write mtu setting to
+                            # /etc/sysctl.d/
+                            pass
+                        else:
+                            iface_cfg[mtu_key] = subnet['mtu']
+                    else:
+                        iface_cfg[mtu_key] = subnet['mtu']
             elif subnet_type == 'manual':
-                # If the subnet has an MTU setting, then ONBOOT=True
-                # to apply the setting
-                iface_cfg['ONBOOT'] = mtu_key in iface_cfg
+                if flavor == 'suse':
+                    LOG.debug('Unknown subnet type setting "%s"', subnet_type)
+                else:
+                    # If the subnet has an MTU setting, then ONBOOT=True
+                    # to apply the setting
+                    iface_cfg['ONBOOT'] = mtu_key in iface_cfg
             else:
                 raise ValueError("Unknown subnet type '%s' found"
                                  " for interface '%s'" % (subnet_type,
                                                           iface_cfg.name))
             if subnet.get('control') == 'manual':
-                iface_cfg['ONBOOT'] = False
-                iface_cfg['STARTMODE'] = 'manual'
+                if flavor == 'suse':
+                    iface_cfg['STARTMODE'] = 'manual'
+                else:
+                    iface_cfg['ONBOOT'] = False
 
         # set IPv4 and IPv6 static addresses
         ipv4_index = -1
@@ -408,13 +474,14 @@ class Renderer(renderer.Renderer):
             subnet_type = subnet.get('type')
             # metric may apply to both dhcp and static config
             if 'metric' in subnet:
-                iface_cfg['METRIC'] = subnet['metric']
-            # TODO(hjensas): Including dhcp6 here is likely incorrect. DHCPv6
-            # does not ever provide a default gateway, the default gateway
-            # come from RA's. (https://github.com/openSUSE/wicked/issues/570)
-            if subnet_type in ['dhcp', 'dhcp4', 'dhcp6']:
-                if has_default_route and iface_cfg['BOOTPROTO'] != 'none':
-                    iface_cfg['DHCLIENT_SET_DEFAULT_ROUTE'] = False
+                if flavor != 'suse':
+                    iface_cfg['METRIC'] = subnet['metric']
+            if subnet_type in ['dhcp', 'dhcp4']:
+                # On SUSE distros 'DHCLIENT_SET_DEFAULT_ROUTE' is a global
+                # setting in /etc/sysconfig/network/dhcp
+                if flavor != 'suse':
+                    if has_default_route and iface_cfg['BOOTPROTO'] != 'none':
+                        iface_cfg['DHCLIENT_SET_DEFAULT_ROUTE'] = False
                 continue
             elif subnet_type in IPV6_DYNAMIC_TYPES:
                 continue
@@ -423,14 +490,21 @@ class Renderer(renderer.Renderer):
                     ipv6_index = ipv6_index + 1
                     ipv6_cidr = "%s/%s" % (subnet['address'], subnet['prefix'])
                     if ipv6_index == 0:
-                        iface_cfg['IPV6ADDR'] = ipv6_cidr
-                        iface_cfg['IPADDR6'] = ipv6_cidr
+                        if flavor == 'suse':
+                            iface_cfg['IPADDR6'] = ipv6_cidr
+                        else:
+                            iface_cfg['IPV6ADDR'] = ipv6_cidr
                     elif ipv6_index == 1:
-                        iface_cfg['IPV6ADDR_SECONDARIES'] = ipv6_cidr
-                        iface_cfg['IPADDR6_0'] = ipv6_cidr
+                        if flavor == 'suse':
+                            iface_cfg['IPADDR6_1'] = ipv6_cidr
+                        else:
+                            iface_cfg['IPV6ADDR_SECONDARIES'] = ipv6_cidr
                     else:
-                        iface_cfg['IPV6ADDR_SECONDARIES'] += " " + ipv6_cidr
-                        iface_cfg['IPADDR6_%d' % ipv6_index] = ipv6_cidr
+                        if flavor == 'suse':
+                            iface_cfg['IPADDR6_%d' % ipv6_index] = ipv6_cidr
+                        else:
+                            iface_cfg['IPV6ADDR_SECONDARIES'] += \
+                                                        " " + ipv6_cidr
                 else:
                     ipv4_index = ipv4_index + 1
                     suff = "" if ipv4_index == 0 else str(ipv4_index)
@@ -438,17 +512,17 @@ class Renderer(renderer.Renderer):
                     iface_cfg['NETMASK' + suff] = \
                         net_prefix_to_ipv4_mask(subnet['prefix'])
 
-                if 'gateway' in subnet:
+                if 'gateway' in subnet and flavor != 'suse':
                     iface_cfg['DEFROUTE'] = True
                     if is_ipv6_addr(subnet['gateway']):
                         iface_cfg['IPV6_DEFAULTGW'] = subnet['gateway']
                     else:
                         iface_cfg['GATEWAY'] = subnet['gateway']
 
-                if 'dns_search' in subnet:
+                if 'dns_search' in subnet and flavor != 'suse':
                     iface_cfg['DOMAIN'] = ' '.join(subnet['dns_search'])
 
-                if 'dns_nameservers' in subnet:
+                if 'dns_nameservers' in subnet and flavor != 'suse':
                     if len(subnet['dns_nameservers']) > 3:
                         # per resolv.conf(5) MAXNS sets this to 3.
                         LOG.debug("%s has %d entries in dns_nameservers. "
@@ -458,7 +532,12 @@ class Renderer(renderer.Renderer):
                         iface_cfg['DNS' + str(i)] = k
 
     @classmethod
-    def _render_subnet_routes(cls, iface_cfg, route_cfg, subnets):
+    def _render_subnet_routes(cls, iface_cfg, route_cfg, subnets, flavor):
+        # TODO(rjschwei): route configuration on SUSE distro happens via
+        # ifroute-* files, see lp#1812117. SUSE currently carries a local
+        # patch in their package.
+        if flavor == 'suse':
+            return
         for _, subnet in enumerate(subnets, start=len(iface_cfg.children)):
             subnet_type = subnet.get('type')
             for route in subnet.get('routes', []):
@@ -486,14 +565,7 @@ class Renderer(renderer.Renderer):
                     # TODO(harlowja): add validation that no other iface has
                     # also provided the default route?
                     iface_cfg['DEFROUTE'] = True
-                    # TODO(hjensas): Including dhcp6 here is likely incorrect.
-                    # DHCPv6 does not ever provide a default gateway, the
-                    # default gateway come from RA's.
-                    # (https://github.com/openSUSE/wicked/issues/570)
-                    if iface_cfg['BOOTPROTO'] in ('dhcp', 'dhcp4', 'dhcp6'):
-                        # NOTE(hjensas): DHCLIENT_SET_DEFAULT_ROUTE is SuSE
-                        # only. RHEL, CentOS, Fedora does not implement this
-                        # option.
+                    if iface_cfg['BOOTPROTO'] in ('dhcp', 'dhcp4'):
                         iface_cfg['DHCLIENT_SET_DEFAULT_ROUTE'] = True
                     if 'gateway' in route:
                         if is_ipv6:
@@ -537,7 +609,9 @@ class Renderer(renderer.Renderer):
             iface_cfg['BONDING_OPTS'] = " ".join(bond_opts)
 
     @classmethod
-    def _render_physical_interfaces(cls, network_state, iface_contents):
+    def _render_physical_interfaces(
+            cls, network_state, iface_contents, flavor
+    ):
         physical_filter = renderer.filter_by_physical
         for iface in network_state.iter_interfaces(physical_filter):
             iface_name = iface['name']
@@ -546,12 +620,15 @@ class Renderer(renderer.Renderer):
             route_cfg = iface_cfg.routes
 
             cls._render_subnets(
-                iface_cfg, iface_subnets, network_state.has_default_route
+                iface_cfg, iface_subnets, network_state.has_default_route,
+                flavor
             )
-            cls._render_subnet_routes(iface_cfg, route_cfg, iface_subnets)
+            cls._render_subnet_routes(
+                iface_cfg, route_cfg, iface_subnets, flavor
+            )
 
     @classmethod
-    def _render_bond_interfaces(cls, network_state, iface_contents):
+    def _render_bond_interfaces(cls, network_state, iface_contents, flavor):
         bond_filter = renderer.filter_by_type('bond')
         slave_filter = renderer.filter_by_attr('bond-master')
         for iface in network_state.iter_interfaces(bond_filter):
@@ -565,17 +642,24 @@ class Renderer(renderer.Renderer):
             master_cfgs.extend(iface_cfg.children)
             for master_cfg in master_cfgs:
                 master_cfg['BONDING_MASTER'] = True
-                master_cfg.kind = 'bond'
+                if flavor != 'suse':
+                    master_cfg.kind = 'bond'
 
             if iface.get('mac_address'):
-                iface_cfg['MACADDR'] = iface.get('mac_address')
+                if flavor == 'suse':
+                    iface_cfg['LLADDR'] = iface.get('mac_address')
+                else:
+                    iface_cfg['MACADDR'] = iface.get('mac_address')
 
             iface_subnets = iface.get("subnets", [])
             route_cfg = iface_cfg.routes
             cls._render_subnets(
-                iface_cfg, iface_subnets, network_state.has_default_route
+                iface_cfg, iface_subnets, network_state.has_default_route,
+                flavor
             )
-            cls._render_subnet_routes(iface_cfg, route_cfg, iface_subnets)
+            cls._render_subnet_routes(
+                iface_cfg, route_cfg, iface_subnets, flavor
+            )
 
             # iter_interfaces on network-state is not sorted to produce
             # consistent numbers we need to sort.
@@ -585,28 +669,44 @@ class Renderer(renderer.Renderer):
                  if slave_iface['bond-master'] == iface_name])
 
             for index, bond_slave in enumerate(bond_slaves):
-                slavestr = 'BONDING_SLAVE%s' % index
+                if flavor == 'suse':
+                    slavestr = 'BONDING_SLAVE_%s' % index
+                else:
+                    slavestr = 'BONDING_SLAVE%s' % index
                 iface_cfg[slavestr] = bond_slave
 
                 slave_cfg = iface_contents[bond_slave]
-                slave_cfg['MASTER'] = iface_name
-                slave_cfg['SLAVE'] = True
+                if flavor == 'suse':
+                    slave_cfg['BOOTPROTO'] = 'none'
+                    slave_cfg['STARTMODE'] = 'hotplug'
+                else:
+                    slave_cfg['MASTER'] = iface_name
+                    slave_cfg['SLAVE'] = True
 
     @classmethod
-    def _render_vlan_interfaces(cls, network_state, iface_contents):
+    def _render_vlan_interfaces(cls, network_state, iface_contents, flavor):
         vlan_filter = renderer.filter_by_type('vlan')
         for iface in network_state.iter_interfaces(vlan_filter):
             iface_name = iface['name']
             iface_cfg = iface_contents[iface_name]
-            iface_cfg['VLAN'] = True
-            iface_cfg['PHYSDEV'] = iface_name[:iface_name.rfind('.')]
+            if flavor == 'suse':
+                vlan_id = iface.get('vlan_id')
+                if vlan_id:
+                    iface_cfg['VLAN_ID'] = vlan_id
+                iface_cfg['ETHERDEVICE'] = iface_name[:iface_name.rfind('.')]
+            else:
+                iface_cfg['VLAN'] = True
+                iface_cfg['PHYSDEV'] = iface_name[:iface_name.rfind('.')]
 
             iface_subnets = iface.get("subnets", [])
             route_cfg = iface_cfg.routes
             cls._render_subnets(
-                iface_cfg, iface_subnets, network_state.has_default_route
+                iface_cfg, iface_subnets, network_state.has_default_route,
+                flavor
             )
-            cls._render_subnet_routes(iface_cfg, route_cfg, iface_subnets)
+            cls._render_subnet_routes(
+                iface_cfg, route_cfg, iface_subnets, flavor
+            )
 
     @staticmethod
     def _render_dns(network_state, existing_dns_path=None):
@@ -643,19 +743,39 @@ class Renderer(renderer.Renderer):
         return out
 
     @classmethod
-    def _render_bridge_interfaces(cls, network_state, iface_contents):
+    def _render_bridge_interfaces(cls, network_state, iface_contents, flavor):
+        bridge_key_map = {
+            old_k: new_k for old_k, new_k in cls.cfg_key_maps[flavor].items()
+            if old_k.startswith('bridge')}
         bridge_filter = renderer.filter_by_type('bridge')
+
         for iface in network_state.iter_interfaces(bridge_filter):
             iface_name = iface['name']
             iface_cfg = iface_contents[iface_name]
-            iface_cfg.kind = 'bridge'
-            for old_key, new_key in cls.bridge_opts_keys:
+            if flavor != 'suse':
+                iface_cfg.kind = 'bridge'
+            for old_key, new_key in bridge_key_map.items():
                 if old_key in iface:
                     iface_cfg[new_key] = iface[old_key]
 
-            if iface.get('mac_address'):
-                iface_cfg['MACADDR'] = iface.get('mac_address')
+            if flavor == 'suse':
+                if 'BRIDGE_STP' in iface_cfg:
+                    if iface_cfg.get('BRIDGE_STP'):
+                        iface_cfg['BRIDGE_STP'] = 'on'
+                    else:
+                        iface_cfg['BRIDGE_STP'] = 'off'
 
+            if iface.get('mac_address'):
+                key = 'MACADDR'
+                if flavor == 'suse':
+                    key = 'LLADDRESS'
+                iface_cfg[key] = iface.get('mac_address')
+
+            if flavor == 'suse':
+                if iface.get('bridge_ports', []):
+                    iface_cfg['BRIDGE_PORTS'] = '%s' % " ".join(
+                        iface.get('bridge_ports')
+                    )
             # Is this the right key to get all the connected interfaces?
             for bridged_iface_name in iface.get('bridge_ports', []):
                 # Ensure all bridged interfaces are correctly tagged
@@ -664,17 +784,23 @@ class Renderer(renderer.Renderer):
                 bridged_cfgs = [bridged_cfg]
                 bridged_cfgs.extend(bridged_cfg.children)
                 for bridge_cfg in bridged_cfgs:
-                    bridge_cfg['BRIDGE'] = iface_name
+                    bridge_value = iface_name
+                    if flavor == 'suse':
+                        bridge_value = 'yes'
+                    bridge_cfg['BRIDGE'] = bridge_value
 
             iface_subnets = iface.get("subnets", [])
             route_cfg = iface_cfg.routes
             cls._render_subnets(
-                iface_cfg, iface_subnets, network_state.has_default_route
+                iface_cfg, iface_subnets, network_state.has_default_route,
+                flavor
             )
-            cls._render_subnet_routes(iface_cfg, route_cfg, iface_subnets)
+            cls._render_subnet_routes(
+                iface_cfg, route_cfg, iface_subnets, flavor
+            )
 
     @classmethod
-    def _render_ib_interfaces(cls, network_state, iface_contents):
+    def _render_ib_interfaces(cls, network_state, iface_contents, flavor):
         ib_filter = renderer.filter_by_type('infiniband')
         for iface in network_state.iter_interfaces(ib_filter):
             iface_name = iface['name']
@@ -683,12 +809,15 @@ class Renderer(renderer.Renderer):
             iface_subnets = iface.get("subnets", [])
             route_cfg = iface_cfg.routes
             cls._render_subnets(
-                iface_cfg, iface_subnets, network_state.has_default_route
+                iface_cfg, iface_subnets, network_state.has_default_route,
+                flavor
             )
-            cls._render_subnet_routes(iface_cfg, route_cfg, iface_subnets)
+            cls._render_subnet_routes(
+                iface_cfg, route_cfg, iface_subnets, flavor
+            )
 
     @classmethod
-    def _render_sysconfig(cls, base_sysconf_dir, network_state,
+    def _render_sysconfig(cls, base_sysconf_dir, network_state, flavor,
                           templates=None):
         '''Given state, return /etc/sysconfig files + contents'''
         if not templates:
@@ -699,13 +828,17 @@ class Renderer(renderer.Renderer):
                 continue
             iface_name = iface['name']
             iface_cfg = NetInterface(iface_name, base_sysconf_dir, templates)
-            cls._render_iface_shared(iface, iface_cfg)
+            if flavor == 'suse':
+                iface_cfg.drop('DEVICE')
+                # If type detection fails it is considered a bug in SUSE
+                iface_cfg.drop('TYPE')
+            cls._render_iface_shared(iface, iface_cfg, flavor)
             iface_contents[iface_name] = iface_cfg
-        cls._render_physical_interfaces(network_state, iface_contents)
-        cls._render_bond_interfaces(network_state, iface_contents)
-        cls._render_vlan_interfaces(network_state, iface_contents)
-        cls._render_bridge_interfaces(network_state, iface_contents)
-        cls._render_ib_interfaces(network_state, iface_contents)
+        cls._render_physical_interfaces(network_state, iface_contents, flavor)
+        cls._render_bond_interfaces(network_state, iface_contents, flavor)
+        cls._render_vlan_interfaces(network_state, iface_contents, flavor)
+        cls._render_bridge_interfaces(network_state, iface_contents, flavor)
+        cls._render_ib_interfaces(network_state, iface_contents, flavor)
         contents = {}
         for iface_name, iface_cfg in iface_contents.items():
             if iface_cfg or iface_cfg.children:
@@ -727,7 +860,7 @@ class Renderer(renderer.Renderer):
         file_mode = 0o644
         base_sysconf_dir = util.target_path(target, self.sysconf_dir)
         for path, data in self._render_sysconfig(base_sysconf_dir,
-                                                 network_state,
+                                                 network_state, self.flavor,
                                                  templates=templates).items():
             util.write_file(path, data, file_mode)
         if self.dns_path:

--- a/cloudinit/net/tests/test_init.py
+++ b/cloudinit/net/tests/test_init.py
@@ -3,10 +3,10 @@
 import copy
 import errno
 import httpretty
-import mock
 import os
 import requests
 import textwrap
+from unittest import mock
 
 import cloudinit.net as net
 from cloudinit.util import ensure_file, write_file, ProcessExecutionError
@@ -340,8 +340,6 @@ class TestGenerateFallbackConfig(CiTestCase):
 
 
 class TestNetFindFallBackNic(CiTestCase):
-
-    with_logs = True
 
     def setUp(self):
         super(TestNetFindFallBackNic, self).setUp()
@@ -995,8 +993,6 @@ class TestExtractPhysdevs(CiTestCase):
 
 class TestWaitForPhysdevs(CiTestCase):
 
-    with_logs = True
-
     def setUp(self):
         super(TestWaitForPhysdevs, self).setUp()
         self.add_patch('cloudinit.net.get_interfaces_by_mac',
@@ -1070,8 +1066,6 @@ class TestWaitForPhysdevs(CiTestCase):
 
 
 class TestNetFailOver(CiTestCase):
-
-    with_logs = True
 
     def setUp(self):
         super(TestNetFailOver, self).setUp()

--- a/cloudinit/net/tests/test_network_state.py
+++ b/cloudinit/net/tests/test_network_state.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import mock
+from unittest import mock
+
 from cloudinit.net import network_state
 from cloudinit.tests.helpers import CiTestCase
 

--- a/cloudinit/signal_handler.py
+++ b/cloudinit/signal_handler.py
@@ -9,8 +9,7 @@
 import inspect
 import signal
 import sys
-
-from six import StringIO
+from io import StringIO
 
 from cloudinit import log as logging
 from cloudinit import util

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -71,11 +71,11 @@ class DataSourceConfigDrive(openstack.SourceMixin, sources.DataSource):
         if not found:
             dslist = self.sys_cfg.get('datasource_list')
             for dev in find_candidate_devs(dslist=dslist):
-                try:
-                    if util.is_FreeBSD() and dev.startswith("/dev/cd"):
+                mtype = None
+                if util.is_BSD():
+                    if dev.startswith("/dev/cd"):
                         mtype = "cd9660"
-                    else:
-                        mtype = None
+                try:
                     results = util.mount_cb(dev, read_config_drive,
                                             mtype=mtype)
                     found = dev

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -29,8 +29,10 @@ STRICT_ID_PATH = ("datasource", "Ec2", "strict_id")
 STRICT_ID_DEFAULT = "warn"
 
 API_TOKEN_ROUTE = 'latest/api/token'
-API_TOKEN_DISABLED = '_ec2_disable_api_token'
 AWS_TOKEN_TTL_SECONDS = '21600'
+AWS_TOKEN_PUT_HEADER = 'X-aws-ec2-metadata-token'
+AWS_TOKEN_REQ_HEADER = AWS_TOKEN_PUT_HEADER + '-ttl-seconds'
+AWS_TOKEN_REDACT = [AWS_TOKEN_PUT_HEADER, AWS_TOKEN_REQ_HEADER]
 
 
 class CloudNames(object):
@@ -60,7 +62,7 @@ class DataSourceEc2(sources.DataSource):
 
     # Priority ordered list of additional metadata versions which will be tried
     # for extended metadata content. IPv6 support comes in 2016-09-02
-    extended_metadata_versions = ['2016-09-02']
+    extended_metadata_versions = ['2018-09-24', '2016-09-02']
 
     # Setup read_url parameters per get_url_params.
     url_max_wait = 120
@@ -158,7 +160,8 @@ class DataSourceEc2(sources.DataSource):
         for api_ver in self.extended_metadata_versions:
             url = url_tmpl.format(self.metadata_address, api_ver)
             try:
-                resp = uhelp.readurl(url=url, headers=headers)
+                resp = uhelp.readurl(url=url, headers=headers,
+                                     headers_redact=AWS_TOKEN_REDACT)
             except uhelp.UrlError as e:
                 LOG.debug('url %s raised exception %s', url, e)
             else:
@@ -180,6 +183,7 @@ class DataSourceEc2(sources.DataSource):
                 self.identity = ec2.get_instance_identity(
                     api_version, self.metadata_address,
                     headers_cb=self._get_headers,
+                    headers_redact=AWS_TOKEN_REDACT,
                     exception_cb=self._refresh_stale_aws_token_cb).get(
                         'document', {})
             return self.identity.get(
@@ -188,6 +192,12 @@ class DataSourceEc2(sources.DataSource):
             return self.metadata['instance-id']
 
     def _maybe_fetch_api_token(self, mdurls, timeout=None, max_wait=None):
+        """ Get an API token for EC2 Instance Metadata Service.
+
+        On EC2. IMDS will always answer an API token, unless
+        the instance owner has disabled the IMDS HTTP endpoint or
+        the network topology conflicts with the configured hop-limit.
+        """
         if self.cloud_name != CloudNames.AWS:
             return
 
@@ -200,16 +210,32 @@ class DataSourceEc2(sources.DataSource):
             urls.append(cur)
             url2base[cur] = url
 
-        # use the self._status_cb to check for Read errors, which means
-        # we can't reach the API token URL, so we should disable IMDSv2
+        # use the self._imds_exception_cb to check for Read errors
         LOG.debug('Fetching Ec2 IMDSv2 API Token')
-        url, response = uhelp.wait_for_url(
-            urls=urls, max_wait=1, timeout=1, status_cb=self._status_cb,
-            headers_cb=self._get_headers, request_method=request_method)
+
+        response = None
+        url = None
+        url_params = self.get_url_params()
+        try:
+            url, response = uhelp.wait_for_url(
+                urls=urls, max_wait=url_params.max_wait_seconds,
+                timeout=url_params.timeout_seconds, status_cb=LOG.warning,
+                headers_cb=self._get_headers,
+                exception_cb=self._imds_exception_cb,
+                request_method=request_method,
+                headers_redact=AWS_TOKEN_REDACT)
+        except uhelp.UrlError:
+            # We use the raised exception to interupt the retry loop.
+            # Nothing else to do here.
+            pass
 
         if url and response:
             self._api_token = response
             return url2base[url]
+
+        # If we get here, then wait_for_url timed out, waiting for IMDS
+        # or the IMDS HTTP endpoint is disabled
+        return None
 
     def wait_for_metadata_service(self):
         mcfg = self.ds_cfg
@@ -234,9 +260,11 @@ class DataSourceEc2(sources.DataSource):
 
         # try the api token path first
         metadata_address = self._maybe_fetch_api_token(mdurls)
-        if not metadata_address:
-            if self._api_token == API_TOKEN_DISABLED:
-                LOG.warning('Retrying with IMDSv1')
+        # When running on EC2, we always access IMDS with an API token.
+        # If we could not get an API token, then we assume the IMDS
+        # endpoint was disabled and we move on without a data source.
+        # Fallback to IMDSv1 if not running on EC2
+        if not metadata_address and self.cloud_name != CloudNames.AWS:
             # if we can't get a token, use instance-id path
             urls = []
             url2base = {}
@@ -252,7 +280,8 @@ class DataSourceEc2(sources.DataSource):
             url, _ = uhelp.wait_for_url(
                 urls=urls, max_wait=url_params.max_wait_seconds,
                 timeout=url_params.timeout_seconds, status_cb=LOG.warning,
-                headers_cb=self._get_headers, request_method=request_method)
+                headers_redact=AWS_TOKEN_REDACT, headers_cb=self._get_headers,
+                request_method=request_method)
 
             if url:
                 metadata_address = url2base[url]
@@ -260,6 +289,8 @@ class DataSourceEc2(sources.DataSource):
         if metadata_address:
             self.metadata_address = metadata_address
             LOG.debug("Using metadata source: '%s'", self.metadata_address)
+        elif self.cloud_name == CloudNames.AWS:
+            LOG.warning("IMDS's HTTP endpoint is probably disabled")
         else:
             LOG.critical("Giving up on md from %s after %s seconds",
                          urls, int(time.time() - start_time))
@@ -374,13 +405,16 @@ class DataSourceEc2(sources.DataSource):
                 logfunc=LOG.debug, msg='Re-crawl of metadata service',
                 func=self.get_data)
 
-        # Limit network configuration to only the primary/fallback nic
         iface = self.fallback_interface
-        macs_to_nics = {net.get_interface_mac(iface): iface}
         net_md = self.metadata.get('network')
         if isinstance(net_md, dict):
+            # SRU_BLOCKER: xenial, bionic and eoan should default
+            # apply_full_imds_network_config to False to retain original
+            # behavior on those releases.
             result = convert_ec2_metadata_network_config(
-                net_md, macs_to_nics=macs_to_nics, fallback_nic=iface)
+                net_md, fallback_nic=iface,
+                full_network_config=util.get_cfg_option_bool(
+                    self.ds_cfg, 'apply_full_imds_network_config', True))
 
             # RELEASE_BLOCKER: xenial should drop the below if statement,
             # because the issue being addressed doesn't exist pre-netplan.
@@ -420,6 +454,7 @@ class DataSourceEc2(sources.DataSource):
         if not self.wait_for_metadata_service():
             return {}
         api_version = self.get_metadata_api_version()
+        redact = AWS_TOKEN_REDACT
         crawled_metadata = {}
         if self.cloud_name == CloudNames.AWS:
             exc_cb = self._refresh_stale_aws_token_cb
@@ -429,14 +464,17 @@ class DataSourceEc2(sources.DataSource):
         try:
             crawled_metadata['user-data'] = ec2.get_instance_userdata(
                 api_version, self.metadata_address,
-                headers_cb=self._get_headers, exception_cb=exc_cb_ud)
+                headers_cb=self._get_headers, headers_redact=redact,
+                exception_cb=exc_cb_ud)
             crawled_metadata['meta-data'] = ec2.get_instance_metadata(
                 api_version, self.metadata_address,
-                headers_cb=self._get_headers, exception_cb=exc_cb)
+                headers_cb=self._get_headers, headers_redact=redact,
+                exception_cb=exc_cb)
             if self.cloud_name == CloudNames.AWS:
                 identity = ec2.get_instance_identity(
                     api_version, self.metadata_address,
-                    headers_cb=self._get_headers, exception_cb=exc_cb)
+                    headers_cb=self._get_headers, headers_redact=redact,
+                    exception_cb=exc_cb)
                 crawled_metadata['dynamic'] = {'instance-identity': identity}
         except Exception:
             util.logexc(
@@ -455,11 +493,12 @@ class DataSourceEc2(sources.DataSource):
         if self.cloud_name != CloudNames.AWS:
             return None
         LOG.debug("Refreshing Ec2 metadata API token")
-        request_header = {'X-aws-ec2-metadata-token-ttl-seconds': seconds}
+        request_header = {AWS_TOKEN_REQ_HEADER: seconds}
         token_url = '{}/{}'.format(self.metadata_address, API_TOKEN_ROUTE)
         try:
-            response = uhelp.readurl(
-                token_url, headers=request_header, request_method="PUT")
+            response = uhelp.readurl(token_url, headers=request_header,
+                                     headers_redact=AWS_TOKEN_REDACT,
+                                     request_method="PUT")
         except uhelp.UrlError as e:
             LOG.warning(
                 'Unable to get API token: %s raised exception %s',
@@ -484,11 +523,29 @@ class DataSourceEc2(sources.DataSource):
             self._api_token = None
         return True  # always retry
 
-    def _status_cb(self, msg, exc=None):
-        LOG.warning(msg)
-        if 'Read timed out' in msg:
-            LOG.warning('Cannot use Ec2 IMDSv2 API tokens, using IMDSv1')
-            self._api_token = API_TOKEN_DISABLED
+    def _imds_exception_cb(self, msg, exception=None):
+        """Fail quickly on proper AWS if IMDSv2 rejects API token request
+
+        Guidance from Amazon is that if IMDSv2 had disabled token requests
+        by returning a 403, or cloud-init malformed requests resulting in
+        other 40X errors, we want the datasource detection to fail quickly
+        without retries as those symptoms will likely not be resolved by
+        retries.
+
+        Exceptions such as requests.ConnectionError due to IMDS being
+        temporarily unroutable or unavailable will still retry due to the
+        callsite wait_for_url.
+        """
+        if isinstance(exception, uhelp.UrlError):
+            # requests.ConnectionError will have exception.code == None
+            if exception.code and exception.code >= 400:
+                if exception.code == 403:
+                    LOG.warning('Ec2 IMDS endpoint returned a 403 error. '
+                                'HTTP endpoint is disabled. Aborting.')
+                else:
+                    LOG.warning('Fatal error while requesting '
+                                'Ec2 IMDSv2 API tokens')
+                raise exception
 
     def _get_headers(self, url=''):
         """Return a dict of headers for accessing a url.
@@ -496,12 +553,10 @@ class DataSourceEc2(sources.DataSource):
         If _api_token is unset on AWS, attempt to refresh the token via a PUT
         and then return the updated token header.
         """
-        if self.cloud_name != CloudNames.AWS or (self._api_token ==
-                                                 API_TOKEN_DISABLED):
+        if self.cloud_name != CloudNames.AWS:
             return {}
         # Request a 6 hour token if URL is API_TOKEN_ROUTE
-        request_token_header = {
-            'X-aws-ec2-metadata-token-ttl-seconds': AWS_TOKEN_TTL_SECONDS}
+        request_token_header = {AWS_TOKEN_REQ_HEADER: AWS_TOKEN_TTL_SECONDS}
         if API_TOKEN_ROUTE in url:
             return request_token_header
         if not self._api_token:
@@ -511,7 +566,7 @@ class DataSourceEc2(sources.DataSource):
             self._api_token = self._refresh_api_token()
             if not self._api_token:
                 return {}
-        return {'X-aws-ec2-metadata-token': self._api_token}
+        return {AWS_TOKEN_PUT_HEADER: self._api_token}
 
 
 class DataSourceEc2Local(DataSourceEc2):
@@ -667,9 +722,10 @@ def _collect_platform_data():
     return data
 
 
-def convert_ec2_metadata_network_config(network_md, macs_to_nics=None,
-                                        fallback_nic=None):
-    """Convert ec2 metadata to network config version 1 data dict.
+def convert_ec2_metadata_network_config(
+        network_md, macs_to_nics=None, fallback_nic=None,
+        full_network_config=True):
+    """Convert ec2 metadata to network config version 2 data dict.
 
     @param: network_md: 'network' portion of EC2 metadata.
        generally formed as {"interfaces": {"macs": {}} where
@@ -679,26 +735,102 @@ def convert_ec2_metadata_network_config(network_md, macs_to_nics=None,
        not provided, get_interfaces_by_mac is called to get it from the OS.
     @param: fallback_nic: Optionally provide the primary nic interface name.
        This nic will be guaranteed to minimally have a dhcp4 configuration.
+    @param: full_network_config: Boolean set True to configure all networking
+       presented by IMDS. This includes rendering secondary IPv4 and IPv6
+       addresses on all NICs and rendering network config on secondary NICs.
+       If False, only the primary nic will be configured and only with dhcp
+       (IPv4/IPv6).
 
-    @return A dict of network config version 1 based on the metadata and macs.
+    @return A dict of network config version 2 based on the metadata and macs.
     """
-    netcfg = {'version': 1, 'config': []}
+    netcfg = {'version': 2, 'ethernets': {}}
     if not macs_to_nics:
         macs_to_nics = net.get_interfaces_by_mac()
     macs_metadata = network_md['interfaces']['macs']
-    for mac, nic_name in macs_to_nics.items():
+
+    if not full_network_config:
+        for mac, nic_name in macs_to_nics.items():
+            if nic_name == fallback_nic:
+                break
+        dev_config = {'dhcp4': True,
+                      'dhcp6': False,
+                      'match': {'macaddress': mac.lower()},
+                      'set-name': nic_name}
+        nic_metadata = macs_metadata.get(mac)
+        if nic_metadata.get('ipv6s'):  # Any IPv6 addresses configured
+            dev_config['dhcp6'] = True
+        netcfg['ethernets'][nic_name] = dev_config
+        return netcfg
+    # Apply network config for all nics and any secondary IPv4/v6 addresses
+    nic_idx = 1
+    for mac, nic_name in sorted(macs_to_nics.items()):
         nic_metadata = macs_metadata.get(mac)
         if not nic_metadata:
             continue  # Not a physical nic represented in metadata
-        nic_cfg = {'type': 'physical', 'name': nic_name, 'subnets': []}
-        nic_cfg['mac_address'] = mac
-        if (nic_name == fallback_nic or nic_metadata.get('public-ipv4s') or
-                nic_metadata.get('local-ipv4s')):
-            nic_cfg['subnets'].append({'type': 'dhcp4'})
-        if nic_metadata.get('ipv6s'):
-            nic_cfg['subnets'].append({'type': 'dhcp6'})
-        netcfg['config'].append(nic_cfg)
+        dhcp_override = {'route-metric': nic_idx * 100}
+        nic_idx += 1
+        dev_config = {'dhcp4': True, 'dhcp4-overrides': dhcp_override,
+                      'dhcp6': False,
+                      'match': {'macaddress': mac.lower()},
+                      'set-name': nic_name}
+        if nic_metadata.get('ipv6s'):  # Any IPv6 addresses configured
+            dev_config['dhcp6'] = True
+            dev_config['dhcp6-overrides'] = dhcp_override
+        dev_config['addresses'] = get_secondary_addresses(nic_metadata, mac)
+        if not dev_config['addresses']:
+            dev_config.pop('addresses')  # Since we found none configured
+        netcfg['ethernets'][nic_name] = dev_config
+    # Remove route-metric dhcp overrides if only one nic configured
+    if len(netcfg['ethernets']) == 1:
+        for nic_name in netcfg['ethernets'].keys():
+            netcfg['ethernets'][nic_name].pop('dhcp4-overrides')
+            netcfg['ethernets'][nic_name].pop('dhcp6-overrides', None)
     return netcfg
+
+
+def get_secondary_addresses(nic_metadata, mac):
+    """Parse interface-specific nic metadata and return any secondary IPs
+
+    :return: List of secondary IPv4 or IPv6 addresses to configure on the
+    interface
+    """
+    ipv4s = nic_metadata.get('local-ipv4s')
+    ipv6s = nic_metadata.get('ipv6s')
+    addresses = []
+    # In version < 2018-09-24 local_ipv4s or ipv6s is a str with one IP
+    if bool(isinstance(ipv4s, list) and len(ipv4s) > 1):
+        addresses.extend(
+            _get_secondary_addresses(
+                nic_metadata, 'subnet-ipv4-cidr-block', mac, ipv4s, '24'))
+    if bool(isinstance(ipv6s, list) and len(ipv6s) > 1):
+        addresses.extend(
+            _get_secondary_addresses(
+                nic_metadata, 'subnet-ipv6-cidr-block', mac, ipv6s, '128'))
+    return sorted(addresses)
+
+
+def _get_secondary_addresses(nic_metadata, cidr_key, mac, ips, default_prefix):
+    """Return list of IP addresses as CIDRs for secondary IPs
+
+    The CIDR prefix will be default_prefix if cidr_key is absent or not
+    parseable in nic_metadata.
+    """
+    addresses = []
+    cidr = nic_metadata.get(cidr_key)
+    prefix = default_prefix
+    if not cidr or len(cidr.split('/')) != 2:
+        ip_type = 'ipv4' if 'ipv4' in cidr_key else 'ipv6'
+        LOG.warning(
+            'Could not parse %s %s for mac %s. %s network'
+            ' config prefix defaults to /%s',
+            cidr_key, cidr, mac, ip_type, prefix)
+    else:
+        prefix = cidr.split('/')[1]
+    # We know we have > 1 ips for in metadata for this IP type
+    for ip in ips[1:]:
+        addresses.append(
+            '{ip}/{prefix}'.format(ip=ip, prefix=prefix))
+    return addresses
 
 
 # Used to match classes to dependencies

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -40,6 +40,14 @@ class DataSourceNoCloud(sources.DataSource):
             devlist = [
                 p for p in ['/dev/msdosfs/' + label, '/dev/iso9660/' + label]
                 if os.path.exists(p)]
+        elif util.is_NetBSD():
+            out, _err = util.subp(['sysctl', '-n', 'hw.disknames'], rcs=[0])
+            devlist = []
+            for dev in out.split():
+                mscdlabel_out, _ = util.subp(['mscdlabel', dev], rcs=[0, 1])
+                if ('label "%s"' % label) in mscdlabel_out:
+                    devlist.append('/dev/' + dev)
+                    devlist.append('/dev/' + dev + 'a')  # NetBSD 7
         else:
             # Query optical drive to get it in blkid cache for 2.6 kernels
             util.find_devs_with(path="/dev/sr0")

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -37,7 +37,8 @@ from cloudinit.sources.helpers.vmware.imc.guestcust_util import (
     enable_nics,
     get_nics_to_enable,
     set_customization_status,
-    get_tools_config
+    get_tools_config,
+    set_gc_status
 )
 
 LOG = logging.getLogger(__name__)
@@ -140,6 +141,8 @@ class DataSourceOVF(sources.DataSource):
             try:
                 cf = ConfigFile(vmwareImcConfigFilePath)
                 self._vmware_cust_conf = Config(cf)
+                set_gc_status(self._vmware_cust_conf, "Started")
+
                 (md, ud, cfg) = read_vmware_imc(self._vmware_cust_conf)
                 self._vmware_nics_to_enable = get_nics_to_enable(nicspath)
                 imcdirpath = os.path.dirname(vmwareImcConfigFilePath)
@@ -171,7 +174,8 @@ class DataSourceOVF(sources.DataSource):
                     "Error parsing the customization Config File",
                     e,
                     GuestCustEvent.GUESTCUST_EVENT_CUSTOMIZE_FAILED,
-                    vmwareImcConfigFilePath)
+                    vmwareImcConfigFilePath,
+                    self._vmware_cust_conf)
 
             if special_customization:
                 if customscript:
@@ -183,7 +187,8 @@ class DataSourceOVF(sources.DataSource):
                             "Error executing pre-customization script",
                             e,
                             GuestCustEvent.GUESTCUST_EVENT_CUSTOMIZE_FAILED,
-                            vmwareImcConfigFilePath)
+                            vmwareImcConfigFilePath,
+                            self._vmware_cust_conf)
 
             try:
                 LOG.debug("Preparing the Network configuration")
@@ -197,7 +202,8 @@ class DataSourceOVF(sources.DataSource):
                     "Error preparing Network Configuration",
                     e,
                     GuestCustEvent.GUESTCUST_EVENT_NETWORK_SETUP_FAILED,
-                    vmwareImcConfigFilePath)
+                    vmwareImcConfigFilePath,
+                    self._vmware_cust_conf)
 
             if special_customization:
                 LOG.debug("Applying password customization")
@@ -215,7 +221,8 @@ class DataSourceOVF(sources.DataSource):
                         "Error applying Password Configuration",
                         e,
                         GuestCustEvent.GUESTCUST_EVENT_CUSTOMIZE_FAILED,
-                        vmwareImcConfigFilePath)
+                        vmwareImcConfigFilePath,
+                        self._vmware_cust_conf)
 
                 if customscript:
                     try:
@@ -228,7 +235,8 @@ class DataSourceOVF(sources.DataSource):
                             "Error executing post-customization script",
                             e,
                             GuestCustEvent.GUESTCUST_EVENT_CUSTOMIZE_FAILED,
-                            vmwareImcConfigFilePath)
+                            vmwareImcConfigFilePath,
+                            self._vmware_cust_conf)
 
             if product_marker:
                 try:
@@ -240,7 +248,8 @@ class DataSourceOVF(sources.DataSource):
                         "Error creating marker files",
                         e,
                         GuestCustEvent.GUESTCUST_EVENT_CUSTOMIZE_FAILED,
-                        vmwareImcConfigFilePath)
+                        vmwareImcConfigFilePath,
+                        self._vmware_cust_conf)
 
             self._vmware_cust_found = True
             found.append('vmware-tools')
@@ -252,6 +261,7 @@ class DataSourceOVF(sources.DataSource):
             set_customization_status(
                 GuestCustStateEnum.GUESTCUST_STATE_DONE,
                 GuestCustErrorEnum.GUESTCUST_ERROR_SUCCESS)
+            set_gc_status(self._vmware_cust_conf, "Successful")
 
         else:
             np = [('com.vmware.guestInfo', transport_vmware_guestinfo),
@@ -646,7 +656,7 @@ def setup_marker_files(markerid, marker_dir):
     open(markerfile, 'w').close()
 
 
-def _raise_error_status(prefix, error, event, config_file):
+def _raise_error_status(prefix, error, event, config_file, conf):
     """
     Raise error and send customization status to the underlying VMware
     Virtualization Platform. Also, cleanup the imc directory.
@@ -655,6 +665,7 @@ def _raise_error_status(prefix, error, event, config_file):
     set_customization_status(
         GuestCustStateEnum.GUESTCUST_STATE_RUNNING,
         event)
+    set_gc_status(conf, prefix)
     util.del_dir(os.path.dirname(config_file))
     raise error
 

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -29,7 +29,10 @@ DMI_PRODUCT_NOVA = 'OpenStack Nova'
 DMI_PRODUCT_COMPUTE = 'OpenStack Compute'
 VALID_DMI_PRODUCT_NAMES = [DMI_PRODUCT_NOVA, DMI_PRODUCT_COMPUTE]
 DMI_ASSET_TAG_OPENTELEKOM = 'OpenTelekomCloud'
-VALID_DMI_ASSET_TAGS = [DMI_ASSET_TAG_OPENTELEKOM]
+# See github.com/sapcc/helm-charts/blob/master/openstack/nova/values.yaml
+# -> compute.defaults.vmware.smbios_asset_tag for this value
+DMI_ASSET_TAG_SAPCCLOUD = 'SAP CCloud VM'
+VALID_DMI_ASSET_TAGS = [DMI_ASSET_TAG_OPENTELEKOM, DMI_ASSET_TAG_SAPCCLOUD]
 
 
 class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -15,16 +15,18 @@ Notes:
  * Both bare-metal and vms provide chassis-asset-tag of OracleCloud.com
 """
 
-from cloudinit.url_helper import combine_url, readurl, UrlError
-from cloudinit.net import dhcp, get_interfaces_by_mac, is_netfail_master
-from cloudinit import net
-from cloudinit import sources
-from cloudinit import util
-from cloudinit.net import cmdline
-from cloudinit import log as logging
-
 import json
 import re
+
+from cloudinit import log as logging
+from cloudinit import net, sources, util
+from cloudinit.net import (
+    cmdline,
+    dhcp,
+    get_interfaces_by_mac,
+    is_netfail_master,
+)
+from cloudinit.url_helper import UrlError, combine_url, readurl
 
 LOG = logging.getLogger(__name__)
 
@@ -248,15 +250,9 @@ class DataSourceOracle(sources.DataSource):
     @property
     def network_config(self):
         """Network config is read from initramfs provided files
+
         If none is present, then we fall back to fallback configuration.
-
-        One thing to note here is that this method is not currently
-        considered at all if there is is kernel/initramfs provided
-        data.  In that case, stages considers that the cmdline data
-        overrides datasource provided data and does not consult here.
-
-        We nonetheless return cmdline provided config if present
-        and fallback to generate fallback."""
+        """
         if self._network_config == sources.UNSET:
             # this is v1
             self._network_config = cmdline.read_initramfs_config()

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -89,26 +89,26 @@ def process_instance_metadata(metadata, key_path='', sensitive_keys=()):
     @return Dict copy of processed metadata.
     """
     md_copy = copy.deepcopy(metadata)
-    md_copy['base64_encoded_keys'] = []
-    md_copy['sensitive_keys'] = []
+    base64_encoded_keys = []
+    sens_keys = []
     for key, val in metadata.items():
         if key_path:
             sub_key_path = key_path + '/' + key
         else:
             sub_key_path = key
         if key in sensitive_keys or sub_key_path in sensitive_keys:
-            md_copy['sensitive_keys'].append(sub_key_path)
+            sens_keys.append(sub_key_path)
         if isinstance(val, str) and val.startswith('ci-b64:'):
-            md_copy['base64_encoded_keys'].append(sub_key_path)
+            base64_encoded_keys.append(sub_key_path)
             md_copy[key] = val.replace('ci-b64:', '')
         if isinstance(val, dict):
             return_val = process_instance_metadata(
                 val, sub_key_path, sensitive_keys)
-            md_copy['base64_encoded_keys'].extend(
-                return_val.pop('base64_encoded_keys'))
-            md_copy['sensitive_keys'].extend(
-                return_val.pop('sensitive_keys'))
+            base64_encoded_keys.extend(return_val.pop('base64_encoded_keys'))
+            sens_keys.extend(return_val.pop('sensitive_keys'))
             md_copy[key] = return_val
+    md_copy['base64_encoded_keys'] = sorted(base64_encoded_keys)
+    md_copy['sensitive_keys'] = sorted(sens_keys)
     return md_copy
 
 
@@ -193,7 +193,7 @@ class DataSource(metaclass=abc.ABCMeta):
 
     # N-tuple of keypaths or keynames redact from instance-data.json for
     # non-root users
-    sensitive_metadata_keys = ('security-credentials',)
+    sensitive_metadata_keys = ('merged_cfg', 'security-credentials',)
 
     def __init__(self, sys_cfg, distro, paths, ud_proc=None):
         self.sys_cfg = sys_cfg
@@ -218,14 +218,15 @@ class DataSource(metaclass=abc.ABCMeta):
     def __str__(self):
         return type_utils.obj_name(self)
 
-    def _get_standardized_metadata(self):
+    def _get_standardized_metadata(self, instance_data):
         """Return a dictionary of standardized metadata keys."""
         local_hostname = self.get_hostname()
         instance_id = self.get_instance_id()
         availability_zone = self.availability_zone
         # In the event of upgrade from existing cloudinit, pickled datasource
         # will not contain these new class attributes. So we need to recrawl
-        # metadata to discover that content.
+        # metadata to discover that content
+        sysinfo = instance_data["sys_info"]
         return {
             'v1': {
                 '_beta_keys': ['subplatform'],
@@ -233,14 +234,22 @@ class DataSource(metaclass=abc.ABCMeta):
                 'availability_zone': availability_zone,
                 'cloud-name': self.cloud_name,
                 'cloud_name': self.cloud_name,
+                'distro': sysinfo["dist"][0],
+                'distro_version': sysinfo["dist"][1],
+                'distro_release': sysinfo["dist"][2],
                 'platform': self.platform_type,
                 'public_ssh_keys': self.get_public_ssh_keys(),
+                'python_version': sysinfo["python"],
                 'instance-id': instance_id,
                 'instance_id': instance_id,
+                'kernel_release': sysinfo["uname"][2],
                 'local-hostname': local_hostname,
                 'local_hostname': local_hostname,
+                'machine': sysinfo["uname"][4],
                 'region': self.region,
-                'subplatform': self.subplatform}}
+                'subplatform': self.subplatform,
+                'system_platform': sysinfo["platform"],
+                'variant': sysinfo["variant"]}}
 
     def clear_cached_attrs(self, attr_defaults=()):
         """Reset any cached metadata attributes to datasource defaults.
@@ -299,9 +308,15 @@ class DataSource(metaclass=abc.ABCMeta):
                 ec2_metadata = getattr(self, 'ec2_metadata')
                 if ec2_metadata != UNSET:
                     instance_data['ds']['ec2_metadata'] = ec2_metadata
-        instance_data.update(
-            self._get_standardized_metadata())
         instance_data['ds']['_doc'] = EXPERIMENTAL_TEXT
+        # Add merged cloud.cfg and sys info for jinja templates and cli query
+        instance_data['merged_cfg'] = copy.deepcopy(self.sys_cfg)
+        instance_data['merged_cfg']['_doc'] = (
+            'Merged cloud-init system config from /etc/cloud/cloud.cfg and'
+            ' /etc/cloud/cloud.cfg.d/')
+        instance_data['sys_info'] = util.system_info()
+        instance_data.update(
+            self._get_standardized_metadata(instance_data))
         try:
             # Process content base64encoding unserializable values
             content = util.json_dumps(instance_data)
@@ -315,12 +330,12 @@ class DataSource(metaclass=abc.ABCMeta):
         except UnicodeDecodeError as e:
             LOG.warning('Error persisting instance-data.json: %s', str(e))
             return False
-        json_file = os.path.join(self.paths.run_dir, INSTANCE_JSON_FILE)
-        write_json(json_file, processed_data)  # World readable
         json_sensitive_file = os.path.join(self.paths.run_dir,
                                            INSTANCE_JSON_SENSITIVE_FILE)
-        write_json(json_sensitive_file,
-                   redact_sensitive_keys(processed_data), mode=0o600)
+        write_json(json_sensitive_file, processed_data, mode=0o600)
+        json_file = os.path.join(self.paths.run_dir, INSTANCE_JSON_FILE)
+        # World readable
+        write_json(json_file, redact_sensitive_keys(processed_data))
         return True
 
     def _get_data(self):

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -68,6 +68,7 @@ KNOWN_PHYSICAL_TYPES = (
     None,
     'bgpovs',  # not present in OpenStack upstream but used on OVH cloud.
     'bridge',
+    'cascading',  # not present in OpenStack upstream, used on OpenTelekomCloud
     'dvs',
     'ethernet',
     'hw_veb',

--- a/cloudinit/sources/helpers/tests/test_openstack.py
+++ b/cloudinit/sources/helpers/tests/test_openstack.py
@@ -1,0 +1,44 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+# ./cloudinit/sources/helpers/tests/test_openstack.py
+
+from cloudinit.sources.helpers import openstack
+from cloudinit.tests import helpers as test_helpers
+
+
+class TestConvertNetJson(test_helpers.CiTestCase):
+
+    def test_phy_types(self):
+        """Verify the different known physical types are handled."""
+        # network_data.json example from
+        # https://docs.openstack.org/nova/latest/user/metadata.html
+        mac0 = "fa:16:3e:9c:bf:3d"
+        net_json = {
+            "links": [
+                {"ethernet_mac_address": mac0, "id": "tapcd9f6d46-4a",
+                 "mtu": None, "type": "bridge",
+                 "vif_id": "cd9f6d46-4a3a-43ab-a466-994af9db96fc"}
+            ],
+            "networks": [
+                {"id": "network0", "link": "tapcd9f6d46-4a",
+                 "network_id": "99e88329-f20d-4741-9593-25bf07847b16",
+                 "type": "ipv4_dhcp"}
+            ],
+            "services": [{"address": "8.8.8.8", "type": "dns"}]
+        }
+        macs = {mac0: 'eth0'}
+
+        expected = {
+            'version': 1,
+            'config': [
+                {'mac_address': 'fa:16:3e:9c:bf:3d',
+                 'mtu': None, 'name': 'eth0',
+                 'subnets': [{'type': 'dhcp4'}],
+                 'type': 'physical'},
+                {'address': '8.8.8.8', 'type': 'nameserver'}]}
+
+        for t in openstack.KNOWN_PHYSICAL_TYPES:
+            net_json["links"][0]["type"] = t
+            self.assertEqual(
+                expected,
+                openstack.convert_net_json(network_json=net_json,
+                                           known_macs=macs))

--- a/cloudinit/sources/helpers/vmware/imc/config.py
+++ b/cloudinit/sources/helpers/vmware/imc/config.py
@@ -25,6 +25,7 @@ class Config(object):
     SUFFIX = 'DNS|SUFFIX|'
     TIMEZONE = 'DATETIME|TIMEZONE'
     UTC = 'DATETIME|UTC'
+    POST_GC_STATUS = 'MISC|POST-GC-STATUS'
 
     def __init__(self, configFile):
         self._configFile = configFile
@@ -104,4 +105,14 @@ class Config(object):
     def custom_script_name(self):
         """Return the name of custom (pre/post) script."""
         return self._configFile.get(Config.CUSTOM_SCRIPT, None)
+
+    @property
+    def post_gc_status(self):
+        """Return whether to post guestinfo.gc.status VMX property."""
+        postGcStatus = self._configFile.get(Config.POST_GC_STATUS, 'no')
+        postGcStatus = postGcStatus.lower()
+        if postGcStatus not in ('yes', 'no'):
+            raise ValueError('PostGcStatus value should be yes/no')
+        return postGcStatus == 'yes'
+
 # vi: ts=4 expandtab

--- a/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
@@ -154,4 +154,13 @@ def get_tools_config(section, key, defaultVal):
     return retValue
 
 
+# Sets message to the VMX guestinfo.gc.status property to the
+# underlying VMware Virtualization Platform.
+def set_gc_status(config, gcMsg):
+    if config and config.post_gc_status:
+        rpc = "info-set guestinfo.gc.status %s" % gcMsg
+        return send_rpc(rpc)
+    return None
+
+
 # vi: ts=4 expandtab

--- a/cloudinit/sources/tests/test_init.py
+++ b/cloudinit/sources/tests/test_init.py
@@ -55,6 +55,7 @@ class InvalidDataSourceTestSubclassNet(DataSource):
 class TestDataSource(CiTestCase):
 
     with_logs = True
+    maxDiff = None
 
     def setUp(self):
         super(TestDataSource, self).setUp()
@@ -288,27 +289,47 @@ class TestDataSource(CiTestCase):
         tmp = self.tmp_dir()
         datasource = DataSourceTestSubclassNet(
             self.sys_cfg, self.distro, Paths({'run_dir': tmp}))
-        datasource.get_data()
+        sys_info = {
+            "python": "3.7",
+            "platform":
+                "Linux-5.4.0-24-generic-x86_64-with-Ubuntu-20.04-focal",
+            "uname": ["Linux", "myhost", "5.4.0-24-generic", "SMP blah",
+                      "x86_64"],
+            "variant": "ubuntu", "dist": ["ubuntu", "20.04", "focal"]}
+        with mock.patch("cloudinit.util.system_info", return_value=sys_info):
+            datasource.get_data()
         json_file = self.tmp_path(INSTANCE_JSON_FILE, tmp)
         content = util.load_file(json_file)
         expected = {
             'base64_encoded_keys': [],
-            'sensitive_keys': [],
+            'merged_cfg': REDACT_SENSITIVE_VALUE,
+            'sensitive_keys': ['merged_cfg'],
+            'sys_info': sys_info,
             'v1': {
                 '_beta_keys': ['subplatform'],
                 'availability-zone': 'myaz',
                 'availability_zone': 'myaz',
                 'cloud-name': 'subclasscloudname',
                 'cloud_name': 'subclasscloudname',
+                'distro': 'ubuntu',
+                'distro_release': 'focal',
+                'distro_version': '20.04',
                 'instance-id': 'iid-datasource',
                 'instance_id': 'iid-datasource',
                 'local-hostname': 'test-subclass-hostname',
                 'local_hostname': 'test-subclass-hostname',
+                'kernel_release': '5.4.0-24-generic',
+                'machine': 'x86_64',
                 'platform': 'mytestsubclass',
                 'public_ssh_keys': [],
+                'python_version': '3.7',
                 'region': 'myregion',
-                'subplatform': 'unknown'},
+                'system_platform':
+                    'Linux-5.4.0-24-generic-x86_64-with-Ubuntu-20.04-focal',
+                'subplatform': 'unknown',
+                'variant': 'ubuntu'},
             'ds': {
+
                 '_doc': EXPERIMENTAL_TEXT,
                 'meta_data': {'availability_zone': 'myaz',
                               'local-hostname': 'test-subclass-hostname',
@@ -318,8 +339,8 @@ class TestDataSource(CiTestCase):
         self.assertEqual(0o644, stat.S_IMODE(file_stat.st_mode))
         self.assertEqual(expected, util.load_json(content))
 
-    def test_get_data_writes_json_instance_data_sensitive(self):
-        """get_data writes INSTANCE_JSON_SENSITIVE_FILE as readonly root."""
+    def test_get_data_writes_redacted_public_json_instance_data(self):
+        """get_data writes redacted content to public INSTANCE_JSON_FILE."""
         tmp = self.tmp_dir()
         datasource = DataSourceTestSubclassNet(
             self.sys_cfg, self.distro, Paths({'run_dir': tmp}),
@@ -329,33 +350,49 @@ class TestDataSource(CiTestCase):
                 'region': 'myregion',
                 'some': {'security-credentials': {
                     'cred1': 'sekret', 'cred2': 'othersekret'}}})
-        self.assertEqual(
-            ('security-credentials',), datasource.sensitive_metadata_keys)
-        datasource.get_data()
+        self.assertItemsEqual(
+            ('merged_cfg', 'security-credentials',),
+            datasource.sensitive_metadata_keys)
+        sys_info = {
+            "python": "3.7",
+            "platform":
+                "Linux-5.4.0-24-generic-x86_64-with-Ubuntu-20.04-focal",
+            "uname": ["Linux", "myhost", "5.4.0-24-generic", "SMP blah",
+                      "x86_64"],
+            "variant": "ubuntu", "dist": ["ubuntu", "20.04", "focal"]}
+        with mock.patch("cloudinit.util.system_info", return_value=sys_info):
+            datasource.get_data()
         json_file = self.tmp_path(INSTANCE_JSON_FILE, tmp)
-        sensitive_json_file = self.tmp_path(INSTANCE_JSON_SENSITIVE_FILE, tmp)
         redacted = util.load_json(util.load_file(json_file))
-        self.assertEqual(
-            {'cred1': 'sekret', 'cred2': 'othersekret'},
-            redacted['ds']['meta_data']['some']['security-credentials'])
-        content = util.load_file(sensitive_json_file)
         expected = {
             'base64_encoded_keys': [],
-            'sensitive_keys': ['ds/meta_data/some/security-credentials'],
+            'merged_cfg': REDACT_SENSITIVE_VALUE,
+            'sensitive_keys': [
+                'ds/meta_data/some/security-credentials', 'merged_cfg'],
+            'sys_info': sys_info,
             'v1': {
                 '_beta_keys': ['subplatform'],
                 'availability-zone': 'myaz',
                 'availability_zone': 'myaz',
                 'cloud-name': 'subclasscloudname',
                 'cloud_name': 'subclasscloudname',
+                'distro': 'ubuntu',
+                'distro_release': 'focal',
+                'distro_version': '20.04',
                 'instance-id': 'iid-datasource',
                 'instance_id': 'iid-datasource',
                 'local-hostname': 'test-subclass-hostname',
                 'local_hostname': 'test-subclass-hostname',
+                'kernel_release': '5.4.0-24-generic',
+                'machine': 'x86_64',
                 'platform': 'mytestsubclass',
                 'public_ssh_keys': [],
+                'python_version': '3.7',
                 'region': 'myregion',
-                'subplatform': 'unknown'},
+                'system_platform':
+                    'Linux-5.4.0-24-generic-x86_64-with-Ubuntu-20.04-focal',
+                'subplatform': 'unknown',
+                'variant': 'ubuntu'},
             'ds': {
                 '_doc': EXPERIMENTAL_TEXT,
                 'meta_data': {
@@ -364,8 +401,82 @@ class TestDataSource(CiTestCase):
                     'region': 'myregion',
                     'some': {'security-credentials': REDACT_SENSITIVE_VALUE}}}
         }
-        self.maxDiff = None
-        self.assertEqual(expected, util.load_json(content))
+        self.assertItemsEqual(expected, redacted)
+        file_stat = os.stat(json_file)
+        self.assertEqual(0o644, stat.S_IMODE(file_stat.st_mode))
+
+    def test_get_data_writes_json_instance_data_sensitive(self):
+        """
+        get_data writes unmodified data to sensitive file as root-readonly.
+        """
+        tmp = self.tmp_dir()
+        datasource = DataSourceTestSubclassNet(
+            self.sys_cfg, self.distro, Paths({'run_dir': tmp}),
+            custom_metadata={
+                'availability_zone': 'myaz',
+                'local-hostname': 'test-subclass-hostname',
+                'region': 'myregion',
+                'some': {'security-credentials': {
+                    'cred1': 'sekret', 'cred2': 'othersekret'}}})
+        sys_info = {
+            "python": "3.7",
+            "platform":
+                "Linux-5.4.0-24-generic-x86_64-with-Ubuntu-20.04-focal",
+            "uname": ["Linux", "myhost", "5.4.0-24-generic", "SMP blah",
+                      "x86_64"],
+            "variant": "ubuntu", "dist": ["ubuntu", "20.04", "focal"]}
+
+        self.assertItemsEqual(
+            ('merged_cfg', 'security-credentials',),
+            datasource.sensitive_metadata_keys)
+        with mock.patch("cloudinit.util.system_info", return_value=sys_info):
+            datasource.get_data()
+        sensitive_json_file = self.tmp_path(INSTANCE_JSON_SENSITIVE_FILE, tmp)
+        content = util.load_file(sensitive_json_file)
+        expected = {
+            'base64_encoded_keys': [],
+            'merged_cfg': {
+                 '_doc': (
+                     'Merged cloud-init system config from '
+                     '/etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/'),
+                 'datasource': {'_undef': {'key1': False}}},
+            'sensitive_keys': [
+                'ds/meta_data/some/security-credentials', 'merged_cfg'],
+            'sys_info': sys_info,
+            'v1': {
+                '_beta_keys': ['subplatform'],
+                'availability-zone': 'myaz',
+                'availability_zone': 'myaz',
+                'cloud-name': 'subclasscloudname',
+                'cloud_name': 'subclasscloudname',
+                'distro': 'ubuntu',
+                'distro_release': 'focal',
+                'distro_version': '20.04',
+                'instance-id': 'iid-datasource',
+                'instance_id': 'iid-datasource',
+                'kernel_release': '5.4.0-24-generic',
+                'local-hostname': 'test-subclass-hostname',
+                'local_hostname': 'test-subclass-hostname',
+                'machine': 'x86_64',
+                'platform': 'mytestsubclass',
+                'public_ssh_keys': [],
+                'python_version': '3.7',
+                'region': 'myregion',
+                'subplatform': 'unknown',
+                'system_platform':
+                    'Linux-5.4.0-24-generic-x86_64-with-Ubuntu-20.04-focal',
+                'variant': 'ubuntu'},
+            'ds': {
+                '_doc': EXPERIMENTAL_TEXT,
+                'meta_data': {
+                    'availability_zone': 'myaz',
+                    'local-hostname': 'test-subclass-hostname',
+                    'region': 'myregion',
+                    'some': {
+                        'security-credentials':
+                            {'cred1': 'sekret', 'cred2': 'othersekret'}}}}
+        }
+        self.assertItemsEqual(expected, util.load_json(content))
         file_stat = os.stat(sensitive_json_file)
         self.assertEqual(0o600, stat.S_IMODE(file_stat.st_mode))
         self.assertEqual(expected, util.load_json(content))

--- a/cloudinit/sources/tests/test_oracle.py
+++ b/cloudinit/sources/tests/test_oracle.py
@@ -1,19 +1,20 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from cloudinit.sources import DataSourceOracle as oracle
-from cloudinit.sources import BrokenMetadata, NetworkConfigSource
-from cloudinit import helpers
-
-from cloudinit.tests import helpers as test_helpers
-
-from textwrap import dedent
 import argparse
 import copy
-import httpretty
 import json
-import mock
 import os
 import uuid
+from textwrap import dedent
+from unittest import mock
+
+import httpretty
+
+from cloudinit import helpers
+from cloudinit.sources import BrokenMetadata
+from cloudinit.sources import DataSourceOracle as oracle
+from cloudinit.sources import NetworkConfigSource
+from cloudinit.tests import helpers as test_helpers
 
 DS_PATH = "cloudinit.sources.DataSourceOracle"
 MD_VER = "2013-10-17"
@@ -587,8 +588,6 @@ class TestNetworkConfigFromOpcImds(test_helpers.CiTestCase):
 
 
 class TestNetworkConfigFiltersNetFailover(test_helpers.CiTestCase):
-
-    with_logs = True
 
     def setUp(self):
         super(TestNetworkConfigFiltersNetFailover, self).setUp()

--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -13,8 +13,8 @@ import string
 import sys
 import tempfile
 import time
+from unittest import mock
 
-import mock
 import unittest2
 from unittest2.util import strclass
 
@@ -363,6 +363,7 @@ class FilesystemMockingTestCase(ResourceUsingTestCase):
             root = self.tmp_dir()
         self.patchUtils(root)
         self.patchOS(root)
+        self.patchOpen(root)
         return root
 
     @contextmanager

--- a/cloudinit/tests/test_dhclient_hook.py
+++ b/cloudinit/tests/test_dhclient_hook.py
@@ -7,8 +7,8 @@ from cloudinit.tests.helpers import CiTestCase, dir2dict, populate_dir
 
 import argparse
 import json
-import mock
 import os
+from unittest import mock
 
 
 class TestDhclientHook(CiTestCase):

--- a/cloudinit/tests/test_gpg.py
+++ b/cloudinit/tests/test_gpg.py
@@ -1,11 +1,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Test gpg module."""
 
+from unittest import mock
+
 from cloudinit import gpg
 from cloudinit import util
 from cloudinit.tests.helpers import CiTestCase
-
-import mock
 
 
 @mock.patch("cloudinit.gpg.time.sleep")

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -6,6 +6,7 @@ import base64
 import logging
 import json
 import platform
+import pytest
 
 import cloudinit.util as util
 
@@ -419,12 +420,6 @@ class TestGetLinuxDistro(CiTestCase):
         if path == '/etc/redhat-release':
             return 1
 
-    @classmethod
-    def freebsd_version_exists(self, path):
-        """Side effect function """
-        if path == '/bin/freebsd-version':
-            return 1
-
     @mock.patch('cloudinit.util.load_file')
     def test_get_linux_distro_quoted_name(self, m_os_release, m_path_exists):
         """Verify we get the correct name if the os-release file has
@@ -443,11 +438,18 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(('ubuntu', '16.04', 'xenial'), dist)
 
-    @mock.patch('cloudinit.util.subp')
-    def test_get_linux_freebsd(self, m_subp, m_path_exists):
+    @mock.patch('platform.system')
+    @mock.patch('platform.release')
+    @mock.patch('cloudinit.util._parse_redhat_release')
+    def test_get_linux_freebsd(self, m_parse_redhat_release,
+                               m_platform_release,
+                               m_platform_system, m_path_exists):
         """Verify we get the correct name and release name on FreeBSD."""
-        m_path_exists.side_effect = TestGetLinuxDistro.freebsd_version_exists
-        m_subp.return_value = ("12.0-RELEASE-p10\n", '')
+        m_path_exists.return_value = False
+        m_platform_release.return_value = '12.0-RELEASE-p10'
+        m_platform_system.return_value = 'FreeBSD'
+        m_parse_redhat_release.return_value = {}
+        util.is_BSD.cache_clear()
         dist = util.get_linux_distro()
         self.assertEqual(('freebsd', '12.0-RELEASE-p10', ''), dist)
 
@@ -538,27 +540,36 @@ class TestGetLinuxDistro(CiTestCase):
         self.assertEqual(
             ('opensuse-tumbleweed', '20180920', platform.machine()), dist)
 
+    @mock.patch('platform.system')
     @mock.patch('platform.dist', create=True)
-    def test_get_linux_distro_no_data(self, m_platform_dist, m_path_exists):
+    def test_get_linux_distro_no_data(self, m_platform_dist,
+                                      m_platform_system, m_path_exists):
         """Verify we get no information if os-release does not exist"""
         m_platform_dist.return_value = ('', '', '')
+        m_platform_system.return_value = "Linux"
         m_path_exists.return_value = 0
         dist = util.get_linux_distro()
         self.assertEqual(('', '', ''), dist)
 
+    @mock.patch('platform.system')
     @mock.patch('platform.dist', create=True)
-    def test_get_linux_distro_no_impl(self, m_platform_dist, m_path_exists):
+    def test_get_linux_distro_no_impl(self, m_platform_dist,
+                                      m_platform_system, m_path_exists):
         """Verify we get an empty tuple when no information exists and
         Exceptions are not propagated"""
         m_platform_dist.side_effect = Exception()
+        m_platform_system.return_value = "Linux"
         m_path_exists.return_value = 0
         dist = util.get_linux_distro()
         self.assertEqual(('', '', ''), dist)
 
+    @mock.patch('platform.system')
     @mock.patch('platform.dist', create=True)
-    def test_get_linux_distro_plat_data(self, m_platform_dist, m_path_exists):
+    def test_get_linux_distro_plat_data(self, m_platform_dist,
+                                        m_platform_system, m_path_exists):
         """Verify we get the correct platform information"""
         m_platform_dist.return_value = ('foo', '1.1', 'aarch64')
+        m_platform_system.return_value = "Linux"
         m_path_exists.return_value = 0
         dist = util.get_linux_distro()
         self.assertEqual(('foo', '1.1', 'aarch64'), dist)
@@ -596,5 +607,100 @@ class TestIsLXD(CiTestCase):
         m_exists.return_value = False
         self.assertFalse(util.is_lxd())
         m_exists.assert_called_once_with('/dev/lxd/sock')
+
+
+class TestReadCcFromCmdline:
+
+    @pytest.mark.parametrize(
+        "cmdline,expected_cfg",
+        [
+            # Return None if cmdline has no cc:<YAML>end_cc content.
+            (CiTestCase.random_string(), None),
+            # Return None if YAML content is empty string.
+            ('foo cc: end_cc bar', None),
+            # Return expected dictionary without trailing end_cc marker.
+            ('foo cc: ssh_pwauth: true', {'ssh_pwauth': True}),
+            # Return expected dictionary w escaped newline and no end_cc.
+            ('foo cc: ssh_pwauth: true\\n', {'ssh_pwauth': True}),
+            # Return expected dictionary of yaml between cc: and end_cc.
+            ('foo cc: ssh_pwauth: true end_cc bar', {'ssh_pwauth': True}),
+            # Return dict with list value w escaped newline, no end_cc.
+            (
+                'cc: ssh_import_id: [smoser, kirkland]\\n',
+                {'ssh_import_id': ['smoser', 'kirkland']}
+            ),
+            # Parse urlencoded brackets in yaml content.
+            (
+                'cc: ssh_import_id: %5Bsmoser, kirkland%5D end_cc',
+                {'ssh_import_id': ['smoser', 'kirkland']}
+            ),
+            # Parse complete urlencoded yaml content.
+            (
+                'cc: ssh_import_id%3A%20%5Buser1%2C%20user2%5D end_cc',
+                {'ssh_import_id': ['user1', 'user2']}
+            ),
+            # Parse nested dictionary in yaml content.
+            (
+                'cc: ntp: {enabled: true, ntp_client: myclient} end_cc',
+                {'ntp': {'enabled': True, 'ntp_client': 'myclient'}}
+            ),
+            # Parse single mapping value in yaml content.
+            ('cc: ssh_import_id: smoser end_cc', {'ssh_import_id': 'smoser'}),
+            # Parse multiline content with multiple mapping and nested lists.
+            (
+                ('cc: ssh_import_id: [smoser, bob]\\n'
+                 'runcmd: [ [ ls, -l ], echo hi ] end_cc'),
+                {'ssh_import_id': ['smoser', 'bob'],
+                 'runcmd': [['ls', '-l'], 'echo hi']}
+            ),
+            # Parse multiline encoded content w/ mappings and nested lists.
+            (
+                ('cc: ssh_import_id: %5Bsmoser, bob%5D\\n'
+                 'runcmd: [ [ ls, -l ], echo hi ] end_cc'),
+                {'ssh_import_id': ['smoser', 'bob'],
+                 'runcmd': [['ls', '-l'], 'echo hi']}
+            ),
+            # test encoded escaped newlines work.
+            #
+            # unquote(encoded_content)
+            # 'ssh_import_id: [smoser, bob]\\nruncmd: [ [ ls, -l ], echo hi ]'
+            (
+                ('cc: ' +
+                 ('ssh_import_id%3A%20%5Bsmoser%2C%20bob%5D%5Cn'
+                  'runcmd%3A%20%5B%20%5B%20ls%2C%20-l%20%5D%2C'
+                  '%20echo%20hi%20%5D') + ' end_cc'),
+                {'ssh_import_id': ['smoser', 'bob'],
+                 'runcmd': [['ls', '-l'], 'echo hi']}
+            ),
+            # test encoded newlines work.
+            #
+            # unquote(encoded_content)
+            # 'ssh_import_id: [smoser, bob]\nruncmd: [ [ ls, -l ], echo hi ]'
+            (
+                ("cc: " +
+                    ('ssh_import_id%3A%20%5Bsmoser%2C%20bob%5D%0A'
+                     'runcmd%3A%20%5B%20%5B%20ls%2C%20-l%20%5D%2C'
+                     '%20echo%20hi%20%5D') + ' end_cc'),
+                {'ssh_import_id': ['smoser', 'bob'],
+                 'runcmd': [['ls', '-l'], 'echo hi']}
+            ),
+            # Parse and merge multiple yaml content sections.
+            (
+                ('cc:ssh_import_id: [smoser, bob] end_cc '
+                 'cc: runcmd: [ [ ls, -l ] ] end_cc'),
+                {'ssh_import_id': ['smoser', 'bob'],
+                 'runcmd': [['ls', '-l']]}
+            ),
+            # Parse and merge multiple encoded yaml content sections.
+            (
+                ('cc:ssh_import_id%3A%20%5Bsmoser%5D end_cc '
+                 'cc:runcmd%3A%20%5B%20%5B%20ls%2C%20-l%20%5D%20%5D end_cc'),
+                {'ssh_import_id': ['smoser'], 'runcmd': [['ls', '-l']]}
+            ),
+        ]
+    )
+    def test_read_conf_from_cmdline_config(self, expected_cfg, cmdline):
+        assert expected_cfg == util.read_conf_from_cmdline(cmdline=cmdline)
+
 
 # vi: ts=4 expandtab

--- a/cloudinit/tests/test_version.py
+++ b/cloudinit/tests/test_version.py
@@ -1,9 +1,9 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from unittest import mock
+
 from cloudinit.tests.helpers import CiTestCase
 from cloudinit import version
-
-import mock
 
 
 class TestExportsFeatures(CiTestCase):

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -8,6 +8,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import copy
 import json
 import os
 import time
@@ -31,6 +32,7 @@ LOG = logging.getLogger(__name__)
 SSL_ENABLED = False
 CONFIG_ENABLED = False  # This was added in 0.7 (but taken out in >=1.0)
 _REQ_VER = None
+REDACTED = 'REDACTED'
 try:
     from distutils.version import LooseVersion
     import pkg_resources
@@ -189,9 +191,9 @@ def _get_ssl_args(url, ssl_details):
 
 
 def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
-            headers=None, headers_cb=None, ssl_details=None,
-            check_status=True, allow_redirects=True, exception_cb=None,
-            session=None, infinite=False, log_req_resp=True,
+            headers=None, headers_cb=None, headers_redact=None,
+            ssl_details=None, check_status=True, allow_redirects=True,
+            exception_cb=None, session=None, infinite=False, log_req_resp=True,
             request_method=None):
     """Wrapper around requests.Session to read the url and retry if necessary
 
@@ -207,6 +209,7 @@ def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
     :param headers: Optional dict of headers to send during request
     :param headers_cb: Optional callable returning a dict of values to send as
         headers during request
+    :param headers_redact: Optional list of header names to redact from the log
     :param ssl_details: Optional dict providing key_file, ca_certs, and
         cert_file keys for use on in ssl connections.
     :param check_status: Optional boolean set True to raise when HTTPError
@@ -233,6 +236,8 @@ def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
     req_args['method'] = request_method
     if timeout is not None:
         req_args['timeout'] = max(float(timeout), 0)
+    if headers_redact is None:
+        headers_redact = []
     # It doesn't seem like config
     # was added in older library versions (or newer ones either), thus we
     # need to manually do the retries if it wasn't...
@@ -276,7 +281,14 @@ def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
         for (k, v) in req_args.items():
             if k == 'data':
                 continue
-            filtered_req_args[k] = v
+            if k == 'headers' and headers_redact:
+                matched_headers = [k for k in headers_redact if v.get(k)]
+                if matched_headers:
+                    filtered_req_args[k] = copy.deepcopy(v)
+                    for key in matched_headers:
+                        filtered_req_args[k][key] = REDACTED
+            else:
+                filtered_req_args[k] = v
         try:
 
             if log_req_resp:
@@ -329,8 +341,8 @@ def readurl(url, data=None, timeout=None, retries=0, sec_between=1,
     return None  # Should throw before this...
 
 
-def wait_for_url(urls, max_wait=None, timeout=None,
-                 status_cb=None, headers_cb=None, sleep_time=1,
+def wait_for_url(urls, max_wait=None, timeout=None, status_cb=None,
+                 headers_cb=None, headers_redact=None, sleep_time=1,
                  exception_cb=None, sleep_time_cb=None, request_method=None):
     """
     urls:      a list of urls to try
@@ -342,6 +354,7 @@ def wait_for_url(urls, max_wait=None, timeout=None,
     status_cb: call method with string message when a url is not available
     headers_cb: call method with single argument of url to get headers
                 for request.
+    headers_redact: a list of header names to redact from the log
     exception_cb: call method with 2 arguments 'msg' (per status_cb) and
                   'exception', the exception that occurred.
     sleep_time_cb: call method with 2 arguments (response, loop_n) that
@@ -405,8 +418,9 @@ def wait_for_url(urls, max_wait=None, timeout=None,
                     headers = {}
 
                 response = readurl(
-                    url, headers=headers, timeout=timeout,
-                    check_status=False, request_method=request_method)
+                    url, headers=headers, headers_redact=headers_redact,
+                    timeout=timeout, check_status=False,
+                    request_method=request_method)
                 if not response.contents:
                     reason = "empty response [%s]" % (response.code)
                     url_exc = UrlError(ValueError(reason), code=response.code,

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -15,6 +15,7 @@ import glob
 import grp
 import gzip
 import hashlib
+import io
 import json
 import os
 import os.path
@@ -30,13 +31,11 @@ import string
 import subprocess
 import sys
 import time
+from urllib import parse
 
 from errno import ENOENT, ENOEXEC
 
 from base64 import b64decode, b64encode
-from six.moves.urllib import parse as urlparse
-
-import six
 
 from cloudinit import importer
 from cloudinit import log as logging
@@ -118,7 +117,7 @@ def target_path(target, path=None):
     # return 'path' inside target, accepting target as None
     if target in (None, ""):
         target = "/"
-    elif not isinstance(target, six.string_types):
+    elif not isinstance(target, str):
         raise ValueError("Unexpected input for target: %s" % target)
     else:
         target = os.path.abspath(target)
@@ -138,14 +137,14 @@ def target_path(target, path=None):
 
 def decode_binary(blob, encoding='utf-8'):
     # Converts a binary type into a text type using given encoding.
-    if isinstance(blob, six.string_types):
+    if isinstance(blob, str):
         return blob
     return blob.decode(encoding)
 
 
 def encode_text(text, encoding='utf-8'):
     # Converts a text string into a binary type using given encoding.
-    if isinstance(text, six.binary_type):
+    if isinstance(text, bytes):
         return text
     return text.encode(encoding)
 
@@ -175,8 +174,7 @@ def fully_decoded_payload(part):
     # bytes, first try to decode to str via CT charset, and failing that, try
     # utf-8 using surrogate escapes.
     cte_payload = part.get_payload(decode=True)
-    if (six.PY3 and
-            part.get_content_maintype() == 'text' and
+    if (part.get_content_maintype() == 'text' and
             isinstance(cte_payload, bytes)):
         charset = part.get_charset()
         if charset and charset.input_codec:
@@ -240,7 +238,7 @@ class ProcessExecutionError(IOError):
         else:
             self.description = description
 
-        if not isinstance(exit_code, six.integer_types):
+        if not isinstance(exit_code, int):
             self.exit_code = self.empty_attr
         else:
             self.exit_code = exit_code
@@ -281,7 +279,7 @@ class ProcessExecutionError(IOError):
         """
         if data is bytes object, decode
         """
-        return text.decode() if isinstance(text, six.binary_type) else text
+        return text.decode() if isinstance(text, bytes) else text
 
     def _indent_text(self, text, indent_level=8):
         """
@@ -290,7 +288,7 @@ class ProcessExecutionError(IOError):
         cr = '\n'
         indent = ' ' * indent_level
         # if input is bytes, return bytes
-        if isinstance(text, six.binary_type):
+        if isinstance(text, bytes):
             cr = cr.encode()
             indent = indent.encode()
         # remove any newlines at end of text first to prevent unneeded blank
@@ -322,9 +320,6 @@ class SeLinuxGuard(object):
             return
 
         path = os.path.realpath(self.path)
-        # path should be a string, not unicode
-        if six.PY2:
-            path = str(path)
         try:
             stats = os.lstat(path)
             self.selinux.matchpathcon(path, stats[stat.ST_MODE])
@@ -369,7 +364,7 @@ def is_true(val, addons=None):
     check_set = TRUE_STRINGS
     if addons:
         check_set = list(check_set) + addons
-    if six.text_type(val).lower().strip() in check_set:
+    if str(val).lower().strip() in check_set:
         return True
     return False
 
@@ -380,7 +375,7 @@ def is_false(val, addons=None):
     check_set = FALSE_STRINGS
     if addons:
         check_set = list(check_set) + addons
-    if six.text_type(val).lower().strip() in check_set:
+    if str(val).lower().strip() in check_set:
         return True
     return False
 
@@ -397,9 +392,10 @@ def translate_bool(val, addons=None):
 
 
 def rand_str(strlen=32, select_from=None):
+    r = random.SystemRandom()
     if not select_from:
         select_from = string.ascii_letters + string.digits
-    return "".join([random.choice(select_from) for _x in range(0, strlen)])
+    return "".join([r.choice(select_from) for _x in range(0, strlen)])
 
 
 def rand_dict_key(dictionary, postfix=None):
@@ -440,7 +436,7 @@ def uniq_merge_sorted(*lists):
 def uniq_merge(*lists):
     combined_list = []
     for a_list in lists:
-        if isinstance(a_list, six.string_types):
+        if isinstance(a_list, str):
             a_list = a_list.strip().split(",")
             # Kickout the empty ones
             a_list = [a for a in a_list if len(a)]
@@ -463,7 +459,7 @@ def clean_filename(fn):
 
 def decomp_gzip(data, quiet=True, decode=True):
     try:
-        buf = six.BytesIO(encode_text(data))
+        buf = io.BytesIO(encode_text(data))
         with contextlib.closing(gzip.GzipFile(None, "rb", 1, buf)) as gh:
             # E1101 is https://github.com/PyCQA/pylint/issues/1444
             if decode:
@@ -474,7 +470,7 @@ def decomp_gzip(data, quiet=True, decode=True):
         if quiet:
             return data
         else:
-            raise DecompressionError(six.text_type(e))
+            raise DecompressionError(str(e))
 
 
 def extract_usergroup(ug_pair):
@@ -547,8 +543,23 @@ def is_ipv4(instr):
 
 
 @lru_cache()
+def is_BSD():
+    return 'BSD' in platform.system()
+
+
+@lru_cache()
 def is_FreeBSD():
     return system_info()['variant'] == "freebsd"
+
+
+@lru_cache()
+def is_NetBSD():
+    return system_info()['variant'] == "netbsd"
+
+
+@lru_cache()
+def is_OpenBSD():
+    return system_info()['variant'] == "openbsd"
 
 
 def get_cfg_option_bool(yobj, key, default=False):
@@ -561,7 +572,7 @@ def get_cfg_option_str(yobj, key, default=None):
     if key not in yobj:
         return default
     val = yobj[key]
-    if not isinstance(val, six.string_types):
+    if not isinstance(val, str):
         val = str(val)
     return val
 
@@ -624,10 +635,9 @@ def get_linux_distro():
                     flavor = match.groupdict()['codename']
         if distro_name == 'rhel':
             distro_name = 'redhat'
-    elif os.path.exists('/bin/freebsd-version'):
-        distro_name = 'freebsd'
-        distro_version, _ = subp(['uname', '-r'])
-        distro_version = distro_version.strip()
+    elif is_BSD():
+        distro_name = platform.system().lower()
+        distro_version = platform.release()
     else:
         dist = ('', '', '')
         try:
@@ -655,7 +665,7 @@ def system_info():
         'system': platform.system(),
         'release': platform.release(),
         'python': platform.python_version(),
-        'uname': platform.uname(),
+        'uname': list(platform.uname()),
         'dist': get_linux_distro()
     }
     system = info['system'].lower()
@@ -674,7 +684,7 @@ def system_info():
             var = 'suse'
         else:
             var = 'linux'
-    elif system in ('windows', 'darwin', "freebsd"):
+    elif system in ('windows', 'darwin', "freebsd", "netbsd", "openbsd"):
         var = system
 
     info['variant'] = var
@@ -702,7 +712,7 @@ def get_cfg_option_list(yobj, key, default=None):
     if isinstance(val, (list)):
         cval = [v for v in val]
         return cval
-    if not isinstance(val, six.string_types):
+    if not isinstance(val, str):
         val = str(val)
     return [val]
 
@@ -723,7 +733,7 @@ def get_cfg_by_path(yobj, keyp, default=None):
     @return: The value of the item at keyp."
         is not found."""
 
-    if isinstance(keyp, six.string_types):
+    if isinstance(keyp, str):
         keyp = keyp.split("/")
     cur = yobj
     for tok in keyp:
@@ -821,7 +831,7 @@ def make_url(scheme, host, port=None,
     pieces.append(query or '')
     pieces.append(fragment or '')
 
-    return urlparse.urlunparse(pieces)
+    return parse.urlunparse(pieces)
 
 
 def mergemanydict(srcs, reverse=False):
@@ -1030,7 +1040,7 @@ def read_conf_with_confd(cfgfile):
     if "conf_d" in cfg:
         confd = cfg['conf_d']
         if confd:
-            if not isinstance(confd, six.string_types):
+            if not isinstance(confd, str):
                 raise TypeError(("Config file %s contains 'conf_d' "
                                  "with non-string type %s") %
                                 (cfgfile, type_utils.obj_name(confd)))
@@ -1048,7 +1058,7 @@ def read_conf_with_confd(cfgfile):
 
 
 def read_conf_from_cmdline(cmdline=None):
-    # return a dictionary or config on the cmdline or None
+    # return a dictionary of config on the cmdline or None
     return load_yaml(read_cc_from_cmdline(cmdline=cmdline))
 
 
@@ -1056,11 +1066,12 @@ def read_cc_from_cmdline(cmdline=None):
     # this should support reading cloud-config information from
     # the kernel command line.  It is intended to support content of the
     # format:
-    #  cc: <yaml content here> [end_cc]
+    #  cc: <yaml content here|urlencoded yaml content> [end_cc]
     # this would include:
     # cc: ssh_import_id: [smoser, kirkland]\\n
     # cc: ssh_import_id: [smoser, bob]\\nruncmd: [ [ ls, -l ], echo hi ] end_cc
     # cc:ssh_import_id: [smoser] end_cc cc:runcmd: [ [ ls, -l ] ] end_cc
+    # cc:ssh_import_id: %5Bsmoser%5D end_cc
     if cmdline is None:
         cmdline = get_cmdline()
 
@@ -1075,9 +1086,9 @@ def read_cc_from_cmdline(cmdline=None):
         end = cmdline.find(tag_end, begin + begin_l)
         if end < 0:
             end = clen
-        tokens.append(cmdline[begin + begin_l:end].lstrip().replace("\\n",
-                                                                    "\n"))
-
+        tokens.append(
+            parse.unquote(
+                cmdline[begin + begin_l:end].lstrip()).replace("\\n", "\n"))
         begin = cmdline.find(tag_begin, end + end_l)
 
     return '\n'.join(tokens)
@@ -1222,7 +1233,7 @@ def is_resolvable_url(url):
     """determine if this url is resolvable (existing or ip)."""
     return log_time(logfunc=LOG.debug, msg="Resolving URL: " + url,
                     func=is_resolvable,
-                    args=(urlparse.urlparse(url).hostname,))
+                    args=(parse.urlparse(url).hostname,))
 
 
 def search_for_mirror(candidates):
@@ -1230,9 +1241,14 @@ def search_for_mirror(candidates):
     Search through a list of mirror urls for one that works
     This needs to return quickly.
     """
+    if candidates is None:
+        return None
+
+    LOG.debug("search for mirror in candidates: '%s'", candidates)
     for cand in candidates:
         try:
             if is_resolvable_url(cand):
+                LOG.debug("found working mirror: '%s'", cand)
                 return cand
         except Exception:
             pass
@@ -1253,6 +1269,42 @@ def close_stdin():
         os.dup2(fp.fileno(), sys.stdin.fileno())
 
 
+def find_devs_with_netbsd(criteria=None, oformat='device',
+                          tag=None, no_cache=False, path=None):
+    if not path:
+        path = "/dev/cd0"
+    cmd = ["mscdlabel", path]
+    out, _ = subp(cmd, capture=True, decode="replace", rcs=[0, 1])
+    result = out.split()
+    if result and len(result) > 2:
+        if criteria == "TYPE=iso9660" and "ISO" in result:
+            return [path]
+        if criteria == "LABEL=CONFIG-2" and '"config-2"' in result:
+            return [path]
+    return []
+
+
+def find_devs_with_openbsd(criteria=None, oformat='device',
+                           tag=None, no_cache=False, path=None):
+    out, _err = subp(['sysctl', '-n', 'hw.disknames'], rcs=[0])
+    devlist = []
+    for entry in out.split(','):
+        if not entry.endswith(':'):
+            # ffs partition with a serial, not a config-drive
+            continue
+        if entry == 'fd0:':
+            continue
+        part_id = 'a' if entry.startswith('cd') else 'i'
+        devlist.append(entry[:-1] + part_id)
+    if criteria == "TYPE=iso9660":
+        devlist = [i for i in devlist if i.startswith('cd')]
+    elif criteria in ["LABEL=CONFIG-2", "TYPE=vfat"]:
+        devlist = [i for i in devlist if not i.startswith('cd')]
+    elif criteria:
+        LOG.debug("Unexpected criteria: %s", criteria)
+    return ['/dev/' + i for i in devlist]
+
+
 def find_devs_with(criteria=None, oformat='device',
                    tag=None, no_cache=False, path=None):
     """
@@ -1262,6 +1314,13 @@ def find_devs_with(criteria=None, oformat='device',
       LABEL=<label>
       UUID=<uuid>
     """
+    if is_NetBSD():
+        return find_devs_with_netbsd(criteria, oformat,
+                                     tag, no_cache, path)
+    elif is_OpenBSD():
+        return find_devs_with_openbsd(criteria, oformat,
+                                      tag, no_cache, path)
+
     blk_id_cmd = ['blkid']
     options = []
     if criteria:
@@ -1354,7 +1413,7 @@ def uniq_list(in_list):
 
 def load_file(fname, read_cb=None, quiet=False, decode=True):
     LOG.debug("Reading from %s (quiet=%s)", fname, quiet)
-    ofh = six.BytesIO()
+    ofh = io.BytesIO()
     try:
         with open(fname, 'rb') as ifh:
             pipe_in_out(ifh, ofh, chunk_cb=read_cb)
@@ -1820,7 +1879,7 @@ def boottime():
             ("tv_sec", ctypes.c_int64),
             ("tv_usec", ctypes.c_int64)
         ]
-    libc = ctypes.CDLL('/lib/libc.so.7')
+    libc = ctypes.CDLL('libc.so')
     size = ctypes.c_size_t()
     size.value = ctypes.sizeof(timeval)
     buf = timeval()
@@ -2050,13 +2109,13 @@ def subp(args, data=None, rcs=None, env=None, capture=True,
     # Popen converts entries in the arguments array from non-bytes to bytes.
     # When locale is unset it may use ascii for that encoding which can
     # cause UnicodeDecodeErrors. (LP: #1751051)
-    if isinstance(args, six.binary_type):
+    if isinstance(args, bytes):
         bytes_args = args
-    elif isinstance(args, six.string_types):
+    elif isinstance(args, str):
         bytes_args = args.encode("utf-8")
     else:
         bytes_args = [
-            x if isinstance(x, six.binary_type) else x.encode("utf-8")
+            x if isinstance(x, bytes) else x.encode("utf-8")
             for x in args]
     try:
         sp = subprocess.Popen(bytes_args, stdout=stdout,
@@ -2135,10 +2194,10 @@ def shellify(cmdlist, add_header=True):
         if isinstance(args, (list, tuple)):
             fixed = []
             for f in args:
-                fixed.append("'%s'" % (six.text_type(f).replace("'", escaped)))
+                fixed.append("'%s'" % (str(f).replace("'", escaped)))
             content = "%s%s\n" % (content, ' '.join(fixed))
             cmds_made += 1
-        elif isinstance(args, six.string_types):
+        elif isinstance(args, str):
             content = "%s%s\n" % (content, args)
             cmds_made += 1
         else:
@@ -2264,7 +2323,7 @@ def expand_package_list(version_fmt, pkgs):
 
     pkglist = []
     for pkg in pkgs:
-        if isinstance(pkg, six.string_types):
+        if isinstance(pkg, str):
             pkglist.append(pkg)
             continue
 
@@ -2764,7 +2823,7 @@ def read_dmi_data(key):
 
 def message_from_string(string):
     if sys.version_info[:2] < (2, 7):
-        return email.message_from_file(six.StringIO(string))
+        return email.message_from_file(io.StringIO(string))
     return email.message_from_string(string)
 
 

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "19.4"
+__VERSION__ = "20.1"
 _PACKAGED_VERSION = '@@PACKAGED_VERSION@@'
 
 FEATURES = [

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -2,7 +2,7 @@
 # The top level settings are used as module
 # and system configuration.
 
-{% if variant in ["freebsd"] %}
+{% if variant.endswith("bsd") %}
 syslog_fix_perms: root:wheel
 {% elif variant in ["suse"] %}
 syslog_fix_perms: root:root
@@ -33,7 +33,7 @@ ssh_pwauth:   0
 # This will cause the set+update hostname module to not operate (if true)
 preserve_hostname: false
 
-{% if variant in ["freebsd"] %}
+{% if variant.endswith("bsd") %}
 # This should not be required, but leave it in place until the real cause of
 # not finding -any- datasources is resolved.
 datasource_list: ['NoCloud', 'ConfigDrive', 'Azure', 'OpenStack', 'Ec2']
@@ -55,18 +55,22 @@ network:
 # The modules that run in the 'init' stage
 cloud_init_modules:
  - migrator
+{% if variant not in ["netbsd"] %}
  - seed_random
+{% endif %}
  - bootcmd
  - write-files
+{% if variant not in ["netbsd"] %}
  - growpart
  - resizefs
-{% if variant not in ["freebsd"] %}
+{% endif %}
+{% if variant not in ["freebsd", "netbsd"] %}
  - disk_setup
  - mounts
 {% endif %}
  - set_hostname
  - update_hostname
-{% if variant not in ["freebsd"] %}
+{% if variant not in ["freebsd", "netbsd"] %}
  - update_etc_hosts
  - ca-certs
  - rsyslog
@@ -100,7 +104,7 @@ cloud_config_modules:
 {% if variant in ["suse"] %}
  - zypper-add-repo
 {% endif %}
-{% if variant not in ["freebsd"] %}
+{% if variant not in ["freebsd", "netbsd"] %}
  - ntp
 {% endif %}
  - timezone
@@ -121,7 +125,7 @@ cloud_final_modules:
 {% if variant in ["ubuntu", "unknown"] %}
  - ubuntu-drivers
 {% endif %}
-{% if variant not in ["freebsd"] %}
+{% if variant not in ["freebsd", "netbsd"] %}
  - puppet
  - chef
  - mcollective
@@ -143,7 +147,7 @@ cloud_final_modules:
 # (not accessible to handlers/transforms)
 system_info:
    # This will affect which distro class gets used
-{% if variant in ["amazon", "arch", "centos", "debian", "fedora", "freebsd", "rhel", "suse", "ubuntu"] %}
+{% if variant in ["amazon", "arch", "centos", "debian", "fedora", "freebsd", "netbsd", "openbsd", "rhel", "suse", "ubuntu"] %}
    distro: {{ variant }}
 {% else %}
    # Unknown/fallback distro.
@@ -226,4 +230,24 @@ system_info:
      groups: [wheel]
      sudo: ["ALL=(ALL) NOPASSWD:ALL"]
      shell: /bin/tcsh
+{% elif variant in ["netbsd"] %}
+   default_user:
+     name: netbsd
+     lock_passwd: True
+     gecos: NetBSD
+     groups: [wheel]
+     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+     shell: /bin/sh
+{% elif variant in ["openbsd"] %}
+   default_user:
+     name: openbsd
+     lock_passwd: True
+     gecos: OpenBSD
+     groups: [wheel]
+     sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+     shell: /bin/ksh
+{% endif %}
+{% if variant in ["freebsd", "netbsd", "openbsd"] %}
+   network:
+      renderers: ['{{ variant }}']
 {% endif %}

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,10 @@ cloud-init (19.4-51-g8409dd7d-0ubuntu1~16.04.1) UNRELEASED; urgency=medium
 
   * refresh patches:
    + debian/patches/ubuntu-advantage-revert-tip.patch
-  * New upstream snapshot. (LP: #SRU_BUG_NUMBER_HERE)
+  * refresh patches:
+   + debian/patches/ec2-classic-dont-reapply-networking.patch
+   + debian/patches/openstack-no-network-config.patch
+   + debian/patches/stable-release-no-jsonschema-dep.patch
     - HACKING.rst: update CLA link (#199)
     - Scaleway: Fix DatasourceScaleway to avoid backtrace (#128)
       [Louis Bouchard]
@@ -28,7 +31,7 @@ cloud-init (19.4-51-g8409dd7d-0ubuntu1~16.04.1) UNRELEASED; urgency=medium
       Build-Depends because, currently, the Ubuntu package builds will still
       use it for testing.
 
- -- Ryan Harper <ryan.harper@canonical.com>  Wed, 29 Jan 2020 11:52:19 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 26 Mar 2020 16:12:56 -0600
 
 cloud-init (19.4-33-gbb4131a2-0ubuntu1~16.04.1) xenial; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (19.4-51-g8409dd7d-0ubuntu1~16.04.1) UNRELEASED; urgency=medium
+cloud-init (20.1-50-g7f9f33db-0ubuntu1~16.04.1) UNRELEASED; urgency=medium
 
   * refresh patches:
    + debian/patches/ubuntu-advantage-revert-tip.patch
@@ -30,8 +30,85 @@ cloud-init (19.4-51-g8409dd7d-0ubuntu1~16.04.1) UNRELEASED; urgency=medium
     - This fixes upstream daily builds.  python3-nose is not removed from
       Build-Depends because, currently, the Ubuntu package builds will still
       use it for testing.
+  * New upstream snapshot. (LP: #SRU_BUG_NUMBER_HERE)
+    - Identify SAP Converged Cloud as OpenStack [Silvio Knizek]
+    - add Openbsd support (#147) [Gonéri Le Bouder]
+    - HACKING.rst: add examples of the two test class types (#278)
+    - VMWware: support to update guest info gc status if enabled (#261)
+      [xiaofengw-vmware]
+    - Add lp-to-git mapping for kgarloff (#279)
+    - set_passwords: avoid chpasswd on BSD (#268) [Gonéri Le Bouder]
+    - HACKING.rst: add Unit Testing design section (#277)
+    - util: read_cc_from_cmdline handle urlencoded yaml content (#275)
+    - distros/tests/test_init: add tests for _get_package_mirror_info (#272)
+    - HACKING.rst: add links to new Code Review Process doc (#276)
+    - freebsd: ensure package update works (#273) [Gonéri Le Bouder]
+    - doc: introduce Code Review Process documentation (#160)
+    - tools: use python3 (#274)
+    - cc_disk_setup: fix RuntimeError (#270)
+    - cc_apt_configure/util: combine search_for_mirror implementations (#271)
+    - bsd: boottime does not depend on the libc soname (#269)
+      [Gonéri Le Bouder]
+    - test_oracle,DataSourceOracle: sort imports (#266)
+    - DataSourceOracle: update .network_config docstring (#257)
+    - cloudinit/tests: remove unneeded with_logs configuration (#263)
+    - .travis.yml: drop stale comment (#255)
+    - .gitignore: add more common directories (#258)
+    - ec2: render network on all NICs and add secondary IPs as static (#114)
+    - ec2 json validation: fix the reference to the 'merged_cfg' key (#256)
+      [Paride Legovini]
+    - releases.yaml: quote the Ubuntu version numbers (#254) [Paride Legovini]
+    - cloudinit: remove six from packaging/tooling (#253)
+    - util/netbsd: drop six usage (#252)
+    - workflows: introduce stale pull request workflow (#125)
+    - cc_resolv_conf: introduce tests and stabilise output across Python
+      versions (#251)
+    - fix minor issue with resolv_conf template (#144) [andreaf74]
+    - doc: CloudInit also support NetBSD (#250) [Gonéri Le Bouder]
+    - Add Netbsd support (#62) [Gonéri Le Bouder]
+    - tox.ini: avoid substition syntax that causes a traceback on xenial (#245)
+    - Add pub_key_ed25519 to cc_phone_home (#237) [Daniel Hensby]
+    - Introduce and use of a list of GitHub usernames that have signed CLA
+      (#244)
+    - workflows/cla.yml: use correct username for CLA check (#243)
+    - tox.ini: use xenial version of jsonpatch in CI (#242)
+    - workflows: CLA validation altered to fail status on pull_request (#164)
+    - tox.ini: bump pyflakes version to 2.1.1 (#239)
+    - cloudinit: move to pytest for running tests (#211)
+    - instance-data: add cloud-init merged_cfg and sys_info keys to json (#214)
+    - ec2: Do not fallback to IMDSv1 on EC2 (#216)
+    - instance-data: write redacted cfg to instance-data.json (#233)
+    - net: support network-config:disabled on the kernel commandline (#232)
+    - ec2: only redact token request headers in logs, avoid altering request
+      (#230)
+    - docs: typo fixed: dta → data [Alexey Vazhnov]
+    - Fixes typo on Amazon Web Services (#217) [Nick Wales]
+    - Fix docs for OpenStack DMI Asset Tag (#228) [Mark T. Voelker]
+    - Add physical network type: cascading to openstack helpers (#200)
+      [sab-systems]
+    - tests: add focal integration tests for ubuntu (#225)
+    - Release 20.1 (#222)
+    - Update tooling for GitHub-based new releases (#223)
+    - ec2: Do not log IMDSv2 token values, instead use REDACTED (#219)
+    - utils: use SystemRandom when generating random password. (#204)
+      [Dimitri John Ledkov]
+    - docs: mount_default_files is a list of 6 items, not 7 (#212)
+    - azurecloud: fix issues with instances not starting (#205)
+    - unittest: fix stderr leak in cc_set_password random unittest
+      output. (#208)
+    - cc_disk_setup: add swap filesystem force flag (#207)
+    - import sysvinit patches from freebsd-ports tree (#161) [Igor Galić]
+    - docs: fix typo (#195) [Edwin Kofler]
+    - sysconfig: distro-specific config rendering for BOOTPROTO option (#162)
+      [Robert Schweikert]
+    - cloudinit: replace "from six import X" imports (except in util.py) (#183)
+    - run-container: use 'test -n' instead of 'test ! -z' (#202)
+      [Paride Legovini]
+    - net/cmdline: correctly handle static ip= config (#201)
+      [Dimitri John Ledkov]
+    - Replace mock library with unittest.mock (#186)
 
- -- Chad Smith <chad.smith@canonical.com>  Thu, 26 Mar 2020 16:12:56 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 26 Mar 2020 16:12:57 -0600
 
 cloud-init (19.4-33-gbb4131a2-0ubuntu1~16.04.1) xenial; urgency=medium
 

--- a/debian/patches/ec2-classic-dont-reapply-networking.patch
+++ b/debian/patches/ec2-classic-dont-reapply-networking.patch
@@ -9,10 +9,10 @@ Last-Update: 2019-03-08
 This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 --- a/cloudinit/sources/DataSourceEc2.py
 +++ b/cloudinit/sources/DataSourceEc2.py
-@@ -381,17 +381,6 @@ class DataSourceEc2(sources.DataSource):
-         if isinstance(net_md, dict):
-             result = convert_ec2_metadata_network_config(
-                 net_md, macs_to_nics=macs_to_nics, fallback_nic=iface)
+@@ -415,17 +415,6 @@ class DataSourceEc2(sources.DataSource):
+                 net_md, fallback_nic=iface,
+                 full_network_config=util.get_cfg_option_bool(
+                     self.ds_cfg, 'apply_full_imds_network_config', True))
 -
 -            # RELEASE_BLOCKER: xenial should drop the below if statement,
 -            # because the issue being addressed doesn't exist pre-netplan.

--- a/debian/patches/openstack-no-network-config.patch
+++ b/debian/patches/openstack-no-network-config.patch
@@ -15,7 +15,7 @@ Author: Chad Smith <chad.smith@canonical.com>
 
 --- a/cloudinit/sources/DataSourceOpenStack.py
 +++ b/cloudinit/sources/DataSourceOpenStack.py
-@@ -98,10 +98,9 @@ class DataSourceOpenStack(openstack.Sour
+@@ -101,10 +101,9 @@ class DataSourceOpenStack(openstack.Sour
          if self._network_config != sources.UNSET:
              return self._network_config
  
@@ -30,7 +30,7 @@ Author: Chad Smith <chad.smith@canonical.com>
          if self.network_json == sources.UNSET:
 --- a/tests/unittests/test_datasource/test_openstack.py
 +++ b/tests/unittests/test_datasource/test_openstack.py
-@@ -345,6 +345,7 @@ class TestOpenStackDataSource(test_helpe
+@@ -344,6 +344,7 @@ class TestOpenStackDataSource(test_helpe
              settings.CFG_BUILTIN, None, helpers.Paths({'run_dir': self.tmp}))
          sample_json = {'links': [{'ethernet_mac_address': 'mymac'}],
                         'networks': [], 'services': []}

--- a/debian/patches/stable-release-no-jsonschema-dep.patch
+++ b/debian/patches/stable-release-no-jsonschema-dep.patch
@@ -9,13 +9,10 @@ Author: Scott Moser <smoser@ubuntu.com>
 
 --- a/requirements.txt
 +++ b/requirements.txt
-@@ -31,7 +31,8 @@ requests
+@@ -31,4 +31,5 @@ requests
  jsonpatch
  
  # For validating cloud-config sections per schema definitions
 -jsonschema
 +## Do not add dependencies to a stable release (SRU).
 +#jsonschema
- 
- # For Python 2/3 compatibility
- six

--- a/doc/examples/cloud-config-disk-setup.txt
+++ b/doc/examples/cloud-config-disk-setup.txt
@@ -64,7 +64,7 @@ fs_setup:
       filesystem: ext4
       device: ephemeral0.0
 
-# Cavaut for SmartOS: if ephemeral disk is not defined, then the disk will
+# Caveat for SmartOS: if ephemeral disk is not defined, then the disk will
 #    not be automatically added to the mounts.
 
 

--- a/doc/examples/cloud-config-mount-points.txt
+++ b/doc/examples/cloud-config-mount-points.txt
@@ -34,7 +34,7 @@ mounts:
 
 # mount_default_fields
 # These values are used to fill in any entries in 'mounts' that are not
-# complete.  This must be an array, and must have 7 fields.
+# complete.  This must be an array, and must have 6 fields.
 mount_default_fields: [ None, None, "auto", "defaults,nofail", "0", "2" ]
 
 

--- a/doc/examples/kernel-cmdline.txt
+++ b/doc/examples/kernel-cmdline.txt
@@ -3,16 +3,19 @@ configuration that comes from the kernel command line has higher priority
 than configuration in /etc/cloud/cloud.cfg
 
 The format is:
-  cc: <yaml content here> [end_cc]
+  cc: <yaml content here|URL encoded yaml content> [end_cc]
 
 cloud-config will consider any content after 'cc:' to be cloud-config
 data.  If an 'end_cc' string is present, then it will stop reading there.
 otherwise it considers everthing after 'cc:' to be cloud-config content.
 
-In order to allow carriage returns, you must enter '\\n', literally, 
+In order to allow carriage returns, you must enter '\\n', literally,
 on the command line two backslashes followed by a letter 'n'.
+
+The yaml content may also be URL encoded (urllib.parse.quote()).
 
 Here are some examples:
  root=/dev/sda1 cc: ssh_import_id: [smoser, kirkland]\\n
  root=LABEL=uec-rootfs cc: ssh_import_id: [smoser, bob]\\nruncmd: [ [ ls, -l ], echo hi ] end_cc
  cc:ssh_import_id: [smoser] end_cc cc:runcmd: [ [ ls, -l ] ] end_cc root=/dev/sda1
+ cc:ssh_import_id: %5Bsmoser%5D end_cc cc:runcmd: %5B %5B ls, -l %5D %5D end_cc root=/dev/sda1

--- a/doc/rtd/index.rst
+++ b/doc/rtd/index.rst
@@ -68,6 +68,7 @@ Having trouble? We would like to help!
    :caption: Development
 
    topics/hacking.rst
+   topics/code_review.rst
    topics/security.rst
    topics/debugging.rst
    topics/logging.rst

--- a/doc/rtd/topics/availability.rst
+++ b/doc/rtd/topics/availability.rst
@@ -14,8 +14,8 @@ distributions and clouds, both public and private.
 Distributions
 =============
 
-Cloud-init has support across all major Linux distributions and
-FreeBSD:
+Cloud-init has support across all major Linux distributions, FreeBSD
+and NetBSD:
 
 - Ubuntu
 - SLES/openSUSE
@@ -25,6 +25,7 @@ FreeBSD:
 - Debian
 - ArchLinux
 - FreeBSD
+- NetBSD
 
 Clouds
 ======

--- a/doc/rtd/topics/code_review.rst
+++ b/doc/rtd/topics/code_review.rst
@@ -1,0 +1,256 @@
+*******************
+Code Review Process
+*******************
+
+In order to manage incoming pull requests effectively, and provide
+timely feedback and/or acceptance this document serves as a guideline
+for the review process and outlines the expectations for those
+submitting code to the project as well as those reviewing the code.
+Code is reviewed for acceptance by at least one core team member (later
+referred to as committers), but comments and suggestions from others
+are encouraged and welcome.
+
+The process is intended to provide timely and actionable feedback for
+any submission.
+
+Asking For Help
+===============
+
+cloud-init contributors, potential contributors, community members and
+users are encouraged to ask for any help that they need.  If you have
+questions about the code review process, or at any point during the
+code review process, these are the available avenues:
+
+* if you have an open Pull Request, comment on that pull request
+* join the ``#cloud-init`` channel on the Freenode IRC network and ask
+  away
+* send an email to the cloud-init mailing list,
+  cloud-init@lists.launchpad.net
+
+These are listed in rough order of preference, but use whichever of
+them you are most comfortable with.
+
+Goals
+=====
+
+This process has the following goals:
+
+* Ensure code reviews occur in a timely fashion and provide actionable
+  feedback if changes are desired.
+* Ensure the minimization of ancillary problems to increase the
+  efficiency for those reviewing the submitted code
+
+Role Definitions
+================
+
+Any code review process will have (at least) two involved parties.  For
+our purposes, these parties are referred to as **Proposer** and
+**Reviewer**.  (We also have the **Committer** role which is a special
+case of the **Reviewer** role.)  The terms are defined here (and the
+use of the singular form is not meant to imply that they refer to a
+single person):
+
+Proposer
+   The person proposing a pull request (hereafter known as a PR).
+
+Reviewer
+   A person who is reviewing a PR.
+
+Committer
+   A cloud-init core developer (i.e. a person who has permission to
+   merge PRs into master).
+
+Prerequisites For Landing Pull Requests
+=======================================
+
+Before a PR can be landed into master, the following conditions *must*
+be met:
+
+* the CLA has been signed by the **Proposer** (or is covered by an
+  entity-level CLA signature)
+* all required status checks are passing
+* at least one "Approve" review from a **Committer**
+* no "Request changes" reviews from any **Committer**
+
+The following conditions *should* be met:
+
+* any Python functions/methods/classes have docstrings added/updated
+* any changes to config module behaviour are captured in the
+  documentation of the config module
+* any Python code added has corresponding unit tests
+* no "Request changes" reviews from any **Reviewer**
+
+These conditions can be relaxed at the discretion of the
+**Committers** on a case-by-case basis.  Generally, for accountability,
+this should not be the decision of a single **Committer**, and the
+decision should be documented in comments on the PR.
+
+(To take a specific example, the ``cc_phone_home`` module had no tests
+at the time `PR #237
+<https://github.com/canonical/cloud-init/pull/237>`_ was submitted, so
+the **Proposer** was not expected to write a full set of tests for
+their minor modification, but they were expected to update the config
+module docs.)
+
+Non-Committer Reviews
+=====================
+
+Reviews from non-**Committers** are *always* welcome.  Please feel
+empowered to review PRs and leave your thoughts and comments on any
+submitted PRs, regardless of the **Proposer**.
+
+Much of the below process is written in terms of the **Committers**.
+This is not intended to reflect that reviews should only come from that
+group, but acknowledges that we are ultimately responsible for
+maintaining the standards of the codebase.  It would be entirely
+reasonable (and very welcome) for a **Reviewer** to only examine part
+of a PR, but it would not be appropriate for a **Committer** to merge a
+PR without full scrutiny.
+
+Opening Phase
+=============
+
+In this phase, the **Proposer** is responsible for opening a pull
+request and meeting the prerequisites laid out above.
+
+If they need help understanding the prerequisites, or help meeting the
+prerequisites, then they can (and should!) ask for help.  See the
+:ref:`Asking For Help` section above for the ways to do that.
+
+These are the steps that comprise the opening phase:
+
+1. The **Proposer** opens PR
+
+2. CI runs automatically, and if
+
+   CI fails
+      The **Proposer** is expected to fix CI failures.  If the
+      **Proposer** doesn't understand the nature of the failures they
+      are seeing, they should comment in the PR to request assistance,
+      or use another way of :ref:`Asking For Help`.
+
+      (Note that if assistance is not requested, the **Committers**
+      will assume that the **Proposer** is working on addressing the
+      failures themselves.  If you require assistance, please do ask
+      for help!)
+
+   CI passes
+      Move on to the :ref:`Review phase`.
+
+Review Phase
+============
+
+In this phase, the **Proposer** and the **Reviewers** will iterate
+together to, hopefully, get the PR merged into the cloud-init codebase.
+There are three potential outcomes: merged, rejected permanently, and
+temporarily closed.  (The first two are covered in this section; see
+:ref:`Inactive Pull Requests` for details about temporary closure.)
+
+(In the below, when the verbs "merge" or "squash merge" are used, they
+should be understood to mean "squash merged using the GitHub UI", which
+is the only way that changes can land in cloud-init's master branch.)
+
+These are the steps that comprise the review phase:
+
+1. **The Committers** assign a **Committer** to the PR
+
+   This **Committer** is expected to shepherd the PR to completion (and
+   merge it, if that is the outcome reached).  This means that they
+   will perform an initial review, and monitor the PR to ensure that
+   the **Proposer** is receiving any assistance that they require.  The
+   **Committers** will perform this assignment on a daily basis.
+
+   This assignment is intended to ensure that the **Proposer** has a
+   clear point of contact with a cloud-init core developer, and that
+   they get timely feedback after submitting a PR.  It *is not*
+   intended to preclude reviews from any other **Reviewers**, nor to
+   imply that the **Committer** has ownership over the review process.
+
+   The assigned **Committer** may choose to delegate the code review of
+   a PR to another **Reviewer** if they think that they would be better
+   suited.
+
+   (Note that, in GitHub terms, this is setting an Assignee, not
+   requesting a review.)
+
+2. That **Committer** performs an initial review of the PR, resulting
+   in one of the following:
+
+   Approve
+     If the submitted PR meets all of the :ref:`Prerequisites for
+     Landing Pull Requests` and passes code review, then the
+     **Committer** will squash merge immediately.
+
+     There may be circumstances where a PR should not be merged
+     immediately.  The ``wip`` label will be applied to PRs for which
+     this is true.  Only **Committers** are able to apply labels to
+     PRs, so anyone who believes that this label should be applied to a
+     PR should request its application in a comment on the PR.
+
+     The review process is **DONE**.
+
+   Approve (with nits)
+     If the **Proposer** submits their PR with "Allow edits from
+     maintainer" enabled, and the only changes the **Committer**
+     requests are minor "nits", the **Committer** can push fixes for
+     those nits and *immediately* squash merge.  If the **Committer**
+     does not wish to fix these nits but believes they should block a
+     straight-up Approve, then their review should be "Needs Changes"
+     instead.
+
+     A nit is understood to be something like a minor style issue or a
+     spelling error, generally confined to a single line of code.
+
+     If a **Committer** is unsure as to whether their requested change
+     is a nit, they should not treat it as a nit.
+
+     (If a **Proposer** wants to opt-out of this, then they should
+     uncheck "Allow edits from maintainer" when submitting their PR.)
+
+     The review process is **DONE**.
+
+   Outright rejection
+     The **Committer** will close the PR, with useful messaging for the
+     **Proposer** as to why this has happened.
+
+     This is reserved for cases where the proposed change is completely
+     unfit for landing, and there is no reasonable path forward.  This
+     should only be used sparingly, as there are very few cases where
+     proposals are completely unfit.
+
+     If a different approach to the same problem is planned, it should
+     be submitted as a separate PR.  The **Committer** should include
+     this information in their message when the PR is closed.
+
+     The review process is **DONE**.
+
+   Needs Changes
+     The **Committer** will give the **Proposer** a clear idea of what
+     is required for an Approve vote or, for more complex PRs, what the
+     next steps towards an Approve vote are.
+
+     The **Proposer** will ask questions if they don't understand, or
+     disagree with, the **Committer**'s review comments.
+
+     Once consensus has been reached, the **Proposer** will address the
+     review comments.
+
+     Once the review comments are addressed (as well as, potentially,
+     in the interim), CI will run.  If CI fails, the **Proposer** is
+     expected to fix CI failures.  If CI passes, the **Proposer**
+     should indicate that the PR is ready for re-review (by @ing the
+     assigned reviewer), effectively moving back to the start of this
+     section.
+
+Inactive Pull Requests
+======================
+
+PRs will be temporarily closed if they have been waiting on
+**Proposer** action for a certain amount of time without activity.  A
+PR will be marked as stale (with an explanatory comment) after 14 days
+of inactivity.  It will be closed after a further 7 days of inactivity.
+
+These closes are not considered permanent, and the closing message
+should reflect this for the **Proposer**. However, if a PR is reopened,
+it should effectively enter the :ref:`Opening phase` again, as it may
+need some work done to get CI passing again.

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -42,6 +42,7 @@ Note that there are multiple versions of this data provided, cloud-init
 by default uses **2009-04-04** but newer versions can be supported with
 relative ease (newer versions have more data exposed, while maintaining
 backward compatibility with the previous versions).
+Version **2016-09-02** is required for secondary IP address support.
 
 To see which versions are supported from your cloud provider use the following
 URL:
@@ -80,6 +81,15 @@ The settings that may be configured are:
  * **timeout**: the timeout value provided to urlopen for each individual http
    request.  This is used both when selecting a metadata_url and when crawling
    the metadata service. (default: 50)
+ * **apply_full_imds_network_config**: Boolean (default: True) to allow
+   cloud-init to configure any secondary NICs and secondary IPs described by
+   the metadata service. All network interfaces are configured with DHCP (v4)
+   to obtain an primary IPv4 address and route. Interfaces which have a
+   non-empty 'ipv6s' list will also enable DHCPv6 to obtain a primary IPv6
+   address and route. The DHCP response (v4 and v6) return an IP that matches
+   the first element of local-ipv4s and ipv6s lists respectively. All
+   additional values (secondary addresses) in the static ip lists will be
+   added to interface.
 
 An example configuration with the default values is provided below:
 
@@ -90,6 +100,7 @@ An example configuration with the default values is provided below:
     metadata_urls: ["http://169.254.169.254:80", "http://instance-data:8773"]
     max_wait: 120
     timeout: 50
+    apply_full_imds_network_config: true
 
 Notes
 -----
@@ -101,5 +112,13 @@ Notes
    generated only in the first boot of the instance.
    The check for the instance type is performed by is_classic_instance()
    method.
+
+ * For EC2 instances with multiple network interfaces (NICs) attached, dhcp4
+   will be enabled to obtain the primary private IPv4 address of those NICs.
+   Wherever dhcp4 or dhcp6 is enabled for a NIC, a dhcp route-metric will be
+   added with the value of ``<device-number + 1> * 100`` to ensure dhcp
+   routes on the primary NIC are preferred to any secondary NICs.
+   For example: the primary NIC will have a DHCP route-metric of 100,
+   the next NIC will be 200.
 
 .. vi: textwidth=78

--- a/doc/rtd/topics/datasources/openstack.rst
+++ b/doc/rtd/topics/datasources/openstack.rst
@@ -19,7 +19,8 @@ checks the following environment attributes as a potential OpenStack platform:
 
    * **/proc/1/environ**: Nova-lxd contains *product_name=OpenStack Nova*
    * **DMI product_name**: Either *Openstack Nova* or *OpenStack Compute*
-   * **DMI chassis_asset_tag** is *OpenTelekomCloud*
+   * **DMI chassis_asset_tag** is *OpenTelekomCloud*, *SAP CCloud VM*,
+     *OpenStack Nova* (since 19.2) or *OpenStack Compute* (since 19.2)
 
 
 Configuration

--- a/doc/rtd/topics/format.rst
+++ b/doc/rtd/topics/format.rst
@@ -126,7 +126,7 @@ Begins with: ``#cloud-config`` or ``Content-Type: text/cloud-config`` when
 using a MIME archive.
 
 .. note::
-   New in cloud-init v. 18.4: Cloud config dta can also render cloud instance
+   New in cloud-init v. 18.4: Cloud config data can also render cloud instance
    metadata variables using jinja templating. See
    :ref:`instance_metadata` for more information.
 

--- a/doc/rtd/topics/network-config.rst
+++ b/doc/rtd/topics/network-config.rst
@@ -25,16 +25,22 @@ For example, OpenStack may provide network config in the MetaData Service.
 
 **System Config**
 
-A ``network:`` entry in /etc/cloud/cloud.cfg.d/* configuration files.
+A ``network:`` entry in ``/etc/cloud/cloud.cfg.d/*`` configuration files.
 
 **Kernel Command Line**
 
-``ip=`` or ``network-config=<YAML config string>``
+``ip=`` or ``network-config=<Base64 encoded YAML config string>``
 
 User-data cannot change an instance's network configuration.  In the absence
 of network configuration in any of the above sources , `Cloud-init`_ will
 write out a network configuration that will issue a DHCP request on a "first"
 network interface.
+
+.. note::
+
+  The network-config value is expected to be a Base64 encoded YAML string in
+  :ref:`network_config_v1` or :ref:`network_config_v2` format. Optionally it
+  can be compressed with ``gzip`` prior to Base64 encoding.
 
 
 Disabling Network Configuration
@@ -48,19 +54,19 @@ on other methods, such as embedded configuration or other customizations.
 
 **Kernel Command Line**
 
-`Cloud-init`_ will check for a parameter ``network-config`` and the
-value is expected to be YAML string in the :ref:`network_config_v1` format.
-The YAML string may optionally be ``Base64`` encoded, and optionally
-compressed with ``gzip``.
+`Cloud-init`_ will check additionally check for the parameter
+``network-config=disabled`` which will automatically disable any network
+configuration.
 
 Example disabling kernel command line entry: ::
 
-  network-config={config: disabled}
+  network-config=disabled
 
 
 **cloud config**
 
-In the combined cloud-init configuration dictionary. ::
+In the combined cloud-init configuration dictionary, merged from
+``/etc/cloud/cloud.cfg`` and ``/etc/cloud/cloud.cfg.d/*``::
 
   network:
     config: disabled
@@ -191,7 +197,7 @@ supplying an updated configuration in cloud-config. ::
 
   system_info:
     network:
-      renderers: ['netplan', 'eni', 'sysconfig', 'freebsd']
+      renderers: ['netplan', 'eni', 'sysconfig', 'freebsd', 'netbsd', 'openbsd']
 
 
 Network Configuration Tools

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -177,6 +177,11 @@ def main():
 
         # output like 0.7.6-1022-g36e92d3
         ver_data = read_version()
+        if ver_data['is_release_branch_ci']:
+            # If we're performing CI for a new release branch, we don't yet
+            # have the tag required to generate version_long; use version
+            # instead.
+            ver_data['version_long'] = ver_data['version']
 
         # This is really only a temporary archive
         # since we will extract it then add in the debian
@@ -192,7 +197,9 @@ def main():
                 break
         if path is None:
             print("Creating a temp tarball using the 'make-tarball' helper")
-            run_helper('make-tarball', ['--long', '--output=' + tarball_fp])
+            run_helper('make-tarball',
+                       ['--version', ver_data['version_long'],
+                        '--output=' + tarball_fp])
 
         print("Extracting temporary tarball %r" % (tarball))
         cmd = ['tar', '-xvzf', tarball_fp, '-C', tdir]

--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -45,11 +45,11 @@
          "pyserial" : {
             "2" : "pyserial"
          },
+         "pytest": {
+             "3": "python36-pytest"
+         },
          "requests" : {
             "3" : "python36-requests"
-         },
-         "six" : {
-            "3" : "python36-six"
          }
       },
       "requires" : [

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,3 @@ jsonpatch
 
 # For validating cloud-config sections per schema definitions
 jsonschema
-
-# For Python 2/3 compatibility
-six

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ import os
 import shutil
 import sys
 import tempfile
+import platform
 
 import setuptools
 from setuptools.command.install import install
@@ -136,6 +137,7 @@ if '--distro' in sys.argv:
 INITSYS_FILES = {
     'sysvinit': [f for f in glob('sysvinit/redhat/*') if is_f(f)],
     'sysvinit_freebsd': [f for f in glob('sysvinit/freebsd/*') if is_f(f)],
+    'sysvinit_netbsd': [f for f in glob('sysvinit/netbsd/*') if is_f(f)],
     'sysvinit_deb': [f for f in glob('sysvinit/debian/*') if is_f(f)],
     'sysvinit_openrc': [f for f in glob('sysvinit/gentoo/*') if is_f(f)],
     'sysvinit_suse': [f for f in glob('sysvinit/suse/*') if is_f(f)],
@@ -152,6 +154,7 @@ INITSYS_FILES = {
 INITSYS_ROOTS = {
     'sysvinit': 'etc/rc.d/init.d',
     'sysvinit_freebsd': 'usr/local/etc/rc.d',
+    'sysvinit_netbsd': 'usr/local/etc/rc.d',
     'sysvinit_deb': 'etc/init.d',
     'sysvinit_openrc': 'etc/init.d',
     'sysvinit_suse': 'etc/init.d',
@@ -228,7 +231,7 @@ class InitsysInstallData(install):
         if self.init_system and isinstance(self.init_system, str):
             self.init_system = self.init_system.split(",")
 
-        if len(self.init_system) == 0:
+        if len(self.init_system) == 0 and not platform.system().endswith('BSD'):
             self.init_system = ['systemd']
 
         bad = [f for f in self.init_system if f not in INITSYS_TYPES]
@@ -272,7 +275,7 @@ data_files = [
     (USR + '/share/doc/cloud-init/examples/seed',
         [f for f in glob('doc/examples/seed/*') if is_f(f)]),
 ]
-if os.uname()[0] != 'FreeBSD':
+if not platform.system().endswith('BSD'):
     data_files.extend([
         (ETC + '/NetworkManager/dispatcher.d/',
          ['tools/hook-network-manager']),

--- a/sysvinit/freebsd/cloudconfig
+++ b/sysvinit/freebsd/cloudconfig
@@ -22,4 +22,7 @@ cloudconfig_start()
 }
 
 load_rc_config $name
+
+: ${cloudconfig_enable="NO"}
+
 run_rc_command "$1"

--- a/sysvinit/freebsd/cloudfinal
+++ b/sysvinit/freebsd/cloudfinal
@@ -22,4 +22,7 @@ cloudfinal_start()
 }
 
 load_rc_config $name
+
+: ${cloudfinal_enable="NO"}
+
 run_rc_command "$1"

--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # PROVIDE: cloudinit
-# REQUIRE: FILESYSTEMS NETWORKING cloudinitlocal devd
+# REQUIRE: FILESYSTEMS NETWORKING cloudinitlocal ldconfig devd
 # BEFORE:  cloudconfig cloudfinal
 
 . /etc/rc.subr
@@ -22,4 +22,7 @@ cloudinit_start()
 }
 
 load_rc_config $name
+
+: ${cloudinit_enable="NO"}
+
 run_rc_command "$1"

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -22,4 +22,7 @@ cloudlocal_start()
 }
 
 load_rc_config $name
+
+: ${cloudinitlocal_enable="NO"}
+
 run_rc_command "$1"

--- a/sysvinit/netbsd/cloudconfig
+++ b/sysvinit/netbsd/cloudconfig
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# PROVIDE: cloudconfig
+# REQUIRE: cloudinit
+# BEFORE: sshd
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="cloudinit"
+start_cmd="start_cloud_init"
+start_cloud_init()
+{
+    /usr/pkg/bin/cloud-init modules --mode config
+}
+
+load_rc_config $name
+run_rc_command "$1"

--- a/sysvinit/netbsd/cloudfinal
+++ b/sysvinit/netbsd/cloudfinal
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# PROVIDE: cloudfinal
+# REQUIRE: LOGIN cloudconfig
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="cloudinit"
+start_cmd="start_cloud_init"
+start_cloud_init()
+{
+    /usr/pkg/bin/cloud-init modules --mode final
+}
+
+load_rc_config $name
+run_rc_command "$1"

--- a/sysvinit/netbsd/cloudinit
+++ b/sysvinit/netbsd/cloudinit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# PROVIDE: cloudinit
+# REQUIRE: cloudinitlocal
+
+$_rc_subr_loaded . /etc/rc.subr
+
+name="cloudinit"
+start_cmd="start_cloud_init"
+start_cloud_init()
+{
+    /usr/pkg/bin/cloud-init init
+}
+
+load_rc_config $name
+run_rc_command "$1"

--- a/sysvinit/netbsd/cloudinitlocal
+++ b/sysvinit/netbsd/cloudinitlocal
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# PROVIDE: cloudinitlocal
+# REQUIRE: NETWORKING
+
+# After NETWORKING because we don't want staticroute to wipe
+# the route set by the DHCP client toward the meta-data server.
+$_rc_subr_loaded . /etc/rc.subr
+
+name="cloudinitlocal"
+start_cmd="start_cloud_init_local"
+start_cloud_init_local()
+{
+    /usr/pkg/bin/cloud-init init -l
+}
+
+load_rc_config $name
+run_rc_command "$1"

--- a/templates/resolv.conf.tmpl
+++ b/templates/resolv.conf.tmpl
@@ -21,10 +21,18 @@ domain {{domain}}
 
 sortlist {% for sort in sortlist %}{{sort}} {% endfor %}
 {% endif %}
+{#
+    Flags and options are required to be on the 
+    same line preceded by "options" keyword
+#}
 {% if options or flags %}
 
-options {% for flag in flags %}{{flag}} {% endfor %}
-{% for key, value in options.items() -%}
- {{key}}:{{value}}
+options
+{%- for flag in flags %}
+ {{flag-}}
+{% endfor %}
+
+{%- for key, value in options.items()|sort %}
+ {{key}}:{{value-}}
 {% endfor %}
 {% endif %}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,12 +1,8 @@
 # Needed generally in tests
 httpretty>=0.7.1
-mock
-nose
+pytest
 unittest2
-coverage
-
-# Only needed if you want to know the test times
-# nose-timer
+pytest-cov
 
 # Only really needed on older versions of python
 contextlib2

--- a/tests/cloud_tests/__init__.py
+++ b/tests/cloud_tests/__init__.py
@@ -22,7 +22,8 @@ def _initialize_logging():
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        '%(asctime)s - %(pathname)s:%(funcName)s:%(lineno)s '
+        '[%(levelname)s]: %(message)s')
 
     console = logging.StreamHandler()
     console.setLevel(logging.DEBUG)

--- a/tests/cloud_tests/platforms/azurecloud/platform.py
+++ b/tests/cloud_tests/platforms/azurecloud/platform.py
@@ -74,8 +74,9 @@ class AzureCloudPlatform(Platform):
         @param user_data: test user-data to pass to instance
         @return_value: cloud_tests.instances instance
         """
-        user_data = str(base64.b64encode(
-            user_data.encode('utf-8')), 'utf-8')
+        if user_data is not None:
+            user_data = str(base64.b64encode(
+                user_data.encode('utf-8')), 'utf-8')
 
         return AzureCloudInstance(self, properties, config, features,
                                   image_id, user_data)

--- a/tests/cloud_tests/releases.yaml
+++ b/tests/cloud_tests/releases.yaml
@@ -30,8 +30,10 @@ default_release_config:
         mirror_url: https://cloud-images.ubuntu.com/daily
         mirror_dir: '/srv/citest/images'
         keyring: /usr/share/keyrings/ubuntu-cloudimage-keyring.gpg
-        # The OS version formatted as Major.Minor is used to compare releases
-        version: null   # Each release needs to define this, for example 16.04
+        # The OS version formatted as Major.Minor is used to compare releases.
+        # Each release needs to define this, for example "16.04". Quoting is
+        # necessary to ensure the version is treated as a string.
+        version: null
 
     ec2:
         # Choose from: [ebs, instance-store]
@@ -131,12 +133,28 @@ features:
 
 releases:
     # UBUNTU =================================================================
+    focal:
+        # EOL: Apr 2025
+        default:
+            enabled: true
+            release: focal
+            version: "20.04"
+            os: ubuntu
+            feature_groups:
+                - base
+                - debian_base
+                - ubuntu_specific
+        lxd:
+            sstreams_server: https://cloud-images.ubuntu.com/daily
+            alias: focal
+            setup_overrides: null
+            override_templates: false
     eoan:
         # EOL: Jul 2020
         default:
             enabled: true
             release: eoan
-            version: 19.10
+            version: "19.10"
             os: ubuntu
             feature_groups:
                 - base
@@ -152,7 +170,7 @@ releases:
         default:
             enabled: true
             release: disco
-            version: 19.04
+            version: "19.04"
             os: ubuntu
             feature_groups:
                 - base
@@ -168,7 +186,7 @@ releases:
         default:
             enabled: true
             release: cosmic
-            version: 18.10
+            version: "18.10"
             os: ubuntu
             feature_groups:
                 - base
@@ -184,7 +202,7 @@ releases:
         default:
             enabled: true
             release: bionic
-            version: 18.04
+            version: "18.04"
             os: ubuntu
             feature_groups:
                 - base
@@ -200,7 +218,7 @@ releases:
         default:
             enabled: true
             release: artful
-            version: 17.10
+            version: "17.10"
             os: ubuntu
             feature_groups:
                 - base
@@ -216,7 +234,7 @@ releases:
         default:
             enabled: true
             release: xenial
-            version: 16.04
+            version: "16.04"
             os: ubuntu
             feature_groups:
                 - base
@@ -232,7 +250,7 @@ releases:
         default:
             enabled: true
             release: trusty
-            version: 14.04
+            version: "14.04"
             os: ubuntu
             feature_groups:
                 - base

--- a/tests/cloud_tests/setup_image.py
+++ b/tests/cloud_tests/setup_image.py
@@ -229,7 +229,7 @@ def setup_image(args, image):
     except Exception as e:
         info = "N/A (%s)" % e
 
-    LOG.info('setting up %s (%s)', image, info)
+    LOG.info('setting up image %s (info %s)', image, info)
     res = stage.run_stage(
         'set up for {}'.format(image), calls, continue_after_error=False)
     return res

--- a/tests/cloud_tests/testcases/base.py
+++ b/tests/cloud_tests/testcases/base.py
@@ -172,9 +172,7 @@ class CloudTestCase(unittest2.TestCase):
                 'Skipping instance-data.json test.'
                 ' OS: %s not bionic or newer' % self.os_name)
         instance_data = json.loads(out)
-        self.assertItemsEqual(
-            [],
-            instance_data['base64_encoded_keys'])
+        self.assertItemsEqual(['merged_cfg'], instance_data['sensitive_keys'])
         ds = instance_data.get('ds', {})
         v1_data = instance_data.get('v1', {})
         metadata = ds.get('meta-data', {})
@@ -201,6 +199,23 @@ class CloudTestCase(unittest2.TestCase):
         self.assertIn('i-', v1_data['instance_id'])
         self.assertIn('ip-', v1_data['local_hostname'])
         self.assertIsNotNone(v1_data['region'], 'expected ec2 region')
+        self.assertIsNotNone(
+            re.match(r'\d\.\d+\.\d+-\d+-aws', v1_data['kernel_release']))
+        self.assertEqual(
+            'redacted for non-root user', instance_data['merged_cfg'])
+        self.assertEqual(self.os_cfg['os'], v1_data['variant'])
+        self.assertEqual(self.os_cfg['os'], v1_data['distro'])
+        self.assertEqual(
+            self.os_cfg['os'], instance_data["sys_info"]['dist'][0],
+            "Unexpected sys_info dist value")
+        self.assertEqual(self.os_name, v1_data['distro_release'])
+        self.assertEqual(
+            str(self.os_cfg['version']), v1_data['distro_version'])
+        self.assertEqual('x86_64', v1_data['machine'])
+        self.assertIsNotNone(
+            re.match(r'3.\d\.\d', v1_data['python_version']),
+            "unexpected python version: {ver}".format(
+                ver=v1_data["python_version"]))
 
     def test_instance_data_json_lxd(self):
         """Validate instance-data.json content by lxd platform.
@@ -237,6 +252,23 @@ class CloudTestCase(unittest2.TestCase):
         self.assertIsNone(
             v1_data['region'],
             'found unexpected lxd region %s' % v1_data['region'])
+        self.assertIsNotNone(
+            re.match(r'\d\.\d+\.\d+-\d+', v1_data['kernel_release']))
+        self.assertEqual(
+            'redacted for non-root user', instance_data['merged_cfg'])
+        self.assertEqual(self.os_cfg['os'], v1_data['variant'])
+        self.assertEqual(self.os_cfg['os'], v1_data['distro'])
+        self.assertEqual(
+            self.os_cfg['os'], instance_data["sys_info"]['dist'][0],
+            "Unexpected sys_info dist value")
+        self.assertEqual(self.os_name, v1_data['distro_release'])
+        self.assertEqual(
+            str(self.os_cfg['version']), v1_data['distro_version'])
+        self.assertEqual('x86_64', v1_data['machine'])
+        self.assertIsNotNone(
+            re.match(r'3.\d\.\d', v1_data['python_version']),
+            "unexpected python version: {ver}".format(
+                ver=v1_data["python_version"]))
 
     def test_instance_data_json_kvm(self):
         """Validate instance-data.json content by nocloud-kvm platform.
@@ -278,6 +310,23 @@ class CloudTestCase(unittest2.TestCase):
         self.assertIsNone(
             v1_data['region'],
             'found unexpected lxd region %s' % v1_data['region'])
+        self.assertIsNotNone(
+            re.match(r'\d\.\d+\.\d+-\d+', v1_data['kernel_release']))
+        self.assertEqual(
+            'redacted for non-root user', instance_data['merged_cfg'])
+        self.assertEqual(self.os_cfg['os'], v1_data['variant'])
+        self.assertEqual(self.os_cfg['os'], v1_data['distro'])
+        self.assertEqual(
+            self.os_cfg['os'], instance_data["sys_info"]['dist'][0],
+            "Unexpected sys_info dist value")
+        self.assertEqual(self.os_name, v1_data['distro_release'])
+        self.assertEqual(
+                str(self.os_cfg['version']), v1_data['distro_version'])
+        self.assertEqual('x86_64', v1_data['machine'])
+        self.assertIsNotNone(
+            re.match(r'3.\d\.\d', v1_data['python_version']),
+            "unexpected python version: {ver}".format(
+                ver=v1_data["python_version"]))
 
 
 class PasswordListTest(CloudTestCase):

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -5,9 +5,8 @@
 import gzip
 import logging
 import os
+from io import BytesIO, StringIO
 from unittest import mock
-
-from six import BytesIO, StringIO
 
 from email import encoders
 from email.mime.application import MIMEApplication

--- a/tests/unittests/test_datasource/test_aliyun.py
+++ b/tests/unittests/test_datasource/test_aliyun.py
@@ -2,8 +2,8 @@
 
 import functools
 import httpretty
-import mock
 import os
+from unittest import mock
 
 from cloudinit import helpers
 from cloudinit.sources import DataSourceAliYun as ay

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -383,8 +383,6 @@ class TestGetMetadataFromIMDS(HttprettyTestCase):
 
 class TestAzureDataSource(CiTestCase):
 
-    with_logs = True
-
     def setUp(self):
         super(TestAzureDataSource, self).setUp()
         self.tmp = self.tmp_dir()

--- a/tests/unittests/test_datasource/test_cloudsigma.py
+++ b/tests/unittests/test_datasource/test_cloudsigma.py
@@ -3,6 +3,7 @@
 import copy
 
 from cloudinit.cs_utils import Cepko
+from cloudinit import distros
 from cloudinit import helpers
 from cloudinit import sources
 from cloudinit.sources import DataSourceCloudSigma
@@ -47,8 +48,11 @@ class DataSourceCloudSigmaTest(test_helpers.CiTestCase):
         self.paths = helpers.Paths({'run_dir': self.tmp_dir()})
         self.add_patch(DS_PATH + '.is_running_in_cloudsigma',
                        "m_is_container", return_value=True)
+
+        distro_cls = distros.fetch("ubuntu")
+        distro = distro_cls("ubuntu", cfg={}, paths=self.paths)
         self.datasource = DataSourceCloudSigma.DataSourceCloudSigma(
-            "", "", paths=self.paths)
+            sys_cfg={}, distro=distro, paths=self.paths)
         self.datasource.cepko = CepkoMock(SERVER_CONTEXT)
 
     def test_get_hostname(self):

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -3,7 +3,8 @@
 import copy
 import httpretty
 import json
-import mock
+import requests
+from unittest import mock
 
 from cloudinit import helpers
 from cloudinit.sources import DataSourceEc2 as ec2
@@ -112,6 +113,122 @@ DEFAULT_METADATA = {
     "services": {"domain": "amazonaws.com", "partition": "aws"},
 }
 
+# collected from api version 2018-09-24/ with
+# python3 -c 'import json
+# from cloudinit.ec2_utils import get_instance_metadata as gm
+# print(json.dumps(gm("2018-09-24"), indent=1, sort_keys=True))'
+
+NIC1_MD_IPV4_IPV6_MULTI_IP = {
+    "device-number": "0",
+    "interface-id": "eni-0d6335689899ce9cc",
+    "ipv4-associations": {
+        "18.218.219.181": "172.31.44.13"
+    },
+    "ipv6s": [
+        "2600:1f16:292:100:c187:593c:4349:136",
+        "2600:1f16:292:100:f153:12a3:c37c:11f9",
+        "2600:1f16:292:100:f152:2222:3333:4444"
+    ],
+    "local-hostname": ("ip-172-31-44-13.us-east-2."
+                       "compute.internal"),
+    "local-ipv4s": [
+        "172.31.44.13",
+        "172.31.45.70"
+    ],
+    "mac": "0a:07:84:3d:6e:38",
+    "owner-id": "329910648901",
+    "public-hostname": ("ec2-18-218-219-181.us-east-2."
+                        "compute.amazonaws.com"),
+    "public-ipv4s": "18.218.219.181",
+    "security-group-ids": "sg-0c387755222ba8d2e",
+    "security-groups": "launch-wizard-4",
+    "subnet-id": "subnet-9d7ba0d1",
+    "subnet-ipv4-cidr-block": "172.31.32.0/20",
+    "subnet_ipv6_cidr_blocks": "2600:1f16:292:100::/64",
+    "vpc-id": "vpc-a07f62c8",
+    "vpc-ipv4-cidr-block": "172.31.0.0/16",
+    "vpc-ipv4-cidr-blocks": "172.31.0.0/16",
+    "vpc_ipv6_cidr_blocks": "2600:1f16:292:100::/56"
+}
+
+NIC2_MD = {
+    "device_number": "1",
+    "interface_id": "eni-043cdce36ded5e79f",
+    "local_hostname": "ip-172-31-47-221.us-east-2.compute.internal",
+    "local_ipv4s": "172.31.47.221",
+    "mac": "0a:75:69:92:e2:16",
+    "owner_id": "329910648901",
+    "security_group_ids": "sg-0d68fef37d8cc9b77",
+    "security_groups": "launch-wizard-17",
+    "subnet_id": "subnet-9d7ba0d1",
+    "subnet_ipv4_cidr_block": "172.31.32.0/20",
+    "vpc_id": "vpc-a07f62c8",
+    "vpc_ipv4_cidr_block": "172.31.0.0/16",
+    "vpc_ipv4_cidr_blocks": "172.31.0.0/16"
+}
+
+SECONDARY_IP_METADATA_2018_09_24 = {
+    "ami-id": "ami-0986c2ac728528ac2",
+    "ami-launch-index": "0",
+    "ami-manifest-path": "(unknown)",
+    "block-device-mapping": {
+        "ami": "/dev/sda1",
+        "root": "/dev/sda1"
+    },
+    "events": {
+        "maintenance": {
+            "history": "[]",
+            "scheduled": "[]"
+        }
+    },
+    "hostname": "ip-172-31-44-13.us-east-2.compute.internal",
+    "identity-credentials": {
+        "ec2": {
+            "info": {
+                "AccountId": "329910648901",
+                "Code": "Success",
+                "LastUpdated": "2019-07-06T14:22:56Z"
+            }
+        }
+    },
+    "instance-action": "none",
+    "instance-id": "i-069e01e8cc43732f8",
+    "instance-type": "t2.micro",
+    "local-hostname": "ip-172-31-44-13.us-east-2.compute.internal",
+    "local-ipv4": "172.31.44.13",
+    "mac": "0a:07:84:3d:6e:38",
+    "metrics": {
+        "vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+    },
+    "network": {
+        "interfaces": {
+            "macs": {
+                "0a:07:84:3d:6e:38": NIC1_MD_IPV4_IPV6_MULTI_IP,
+            }
+        }
+    },
+    "placement": {
+        "availability-zone": "us-east-2c"
+    },
+    "profile": "default-hvm",
+    "public-hostname": (
+        "ec2-18-218-219-181.us-east-2.compute.amazonaws.com"),
+    "public-ipv4": "18.218.219.181",
+    "public-keys": {
+        "yourkeyname,e": [
+            "ssh-rsa AAAAW...DZ yourkeyname"
+        ]
+    },
+    "reservation-id": "r-09b4917135cdd33be",
+    "security-groups": "launch-wizard-4",
+    "services": {
+        "domain": "amazonaws.com",
+        "partition": "aws"
+    }
+}
+
+M_PATH_NET = 'cloudinit.sources.DataSourceEc2.net.'
+
 
 def _register_ssh_keys(rfunc, base_url, keys_data):
     """handle ssh key inconsistencies.
@@ -200,6 +317,7 @@ def register_mock_metaserver(base_url, data):
 
 class TestEc2(test_helpers.HttprettyTestCase):
     with_logs = True
+    maxDiff = None
 
     valid_platform_data = {
         'uuid': 'ec212f79-87d1-2f1d-588f-d86dc0fd5412',
@@ -265,30 +383,23 @@ class TestEc2(test_helpers.HttprettyTestCase):
                         register_mock_metaserver(instance_id_url, None)
         return ds
 
-    def test_network_config_property_returns_version_1_network_data(self):
-        """network_config property returns network version 1 for metadata.
-
-        Only one device is configured even when multiple exist in metadata.
-        """
+    def test_network_config_property_returns_version_2_network_data(self):
+        """network_config property returns network version 2 for metadata"""
         ds = self._setup_ds(
             platform_data=self.valid_platform_data,
             sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
             md={'md': DEFAULT_METADATA})
-        find_fallback_path = (
-            'cloudinit.sources.DataSourceEc2.net.find_fallback_nic')
+        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
         with mock.patch(find_fallback_path) as m_find_fallback:
             m_find_fallback.return_value = 'eth9'
             ds.get_data()
 
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
-        expected = {'version': 1, 'config': [
-            {'mac_address': '06:17:04:d7:26:09', 'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}],
-             'type': 'physical'}]}
-        patch_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
-        get_interface_mac_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': '06:17:04:d7:26:09'}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
+        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
+        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
             with mock.patch(find_fallback_path) as m_find_fallback:
                 with mock.patch(get_interface_mac_path) as m_get_mac:
@@ -297,30 +408,59 @@ class TestEc2(test_helpers.HttprettyTestCase):
                     m_get_mac.return_value = mac1
                     self.assertEqual(expected, ds.network_config)
 
-    def test_network_config_property_set_dhcp4_on_private_ipv4(self):
-        """network_config property configures dhcp4 on private ipv4 nics.
+    def test_network_config_property_set_dhcp4(self):
+        """network_config property configures dhcp4 on nics with local-ipv4s.
 
-        Only one device is configured even when multiple exist in metadata.
+        Only one device is configured based on get_interfaces_by_mac even when
+        multiple MACs exist in metadata.
         """
         ds = self._setup_ds(
             platform_data=self.valid_platform_data,
             sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
             md={'md': DEFAULT_METADATA})
-        find_fallback_path = (
-            'cloudinit.sources.DataSourceEc2.net.find_fallback_nic')
+        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
         with mock.patch(find_fallback_path) as m_find_fallback:
             m_find_fallback.return_value = 'eth9'
             ds.get_data()
 
         mac1 = '06:17:04:d7:26:0A'  # IPv4 only in DEFAULT_METADATA
-        expected = {'version': 1, 'config': [
-            {'mac_address': '06:17:04:d7:26:0A', 'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}],
-             'type': 'physical'}]}
-        patch_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
-        get_interface_mac_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': mac1.lower()}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': False}}}
+        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
+        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
+        with mock.patch(patch_path) as m_get_interfaces_by_mac:
+            with mock.patch(find_fallback_path) as m_find_fallback:
+                with mock.patch(get_interface_mac_path) as m_get_mac:
+                    m_get_interfaces_by_mac.return_value = {mac1: 'eth9'}
+                    m_find_fallback.return_value = 'eth9'
+                    m_get_mac.return_value = mac1
+                    self.assertEqual(expected, ds.network_config)
+
+    def test_network_config_property_secondary_private_ips(self):
+        """network_config property configures any secondary ipv4 addresses.
+
+        Only one device is configured based on get_interfaces_by_mac even when
+        multiple MACs exist in metadata.
+        """
+        ds = self._setup_ds(
+            platform_data=self.valid_platform_data,
+            sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
+            md={'md': SECONDARY_IP_METADATA_2018_09_24})
+        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
+        with mock.patch(find_fallback_path) as m_find_fallback:
+            m_find_fallback.return_value = 'eth9'
+            ds.get_data()
+
+        mac1 = '0a:07:84:3d:6e:38'  # 1 secondary IPv4 and 2 secondary IPv6
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': mac1}, 'set-name': 'eth9',
+            'addresses': ['172.31.45.70/20',
+                          '2600:1f16:292:100:f152:2222:3333:4444/128',
+                          '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
+            'dhcp4': True, 'dhcp6': True}}}
+        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
+        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
             with mock.patch(find_fallback_path) as m_find_fallback:
                 with mock.patch(get_interface_mac_path) as m_get_mac:
@@ -356,21 +496,18 @@ class TestEc2(test_helpers.HttprettyTestCase):
         register_mock_metaserver(
             'http://169.254.169.254/2009-04-04/meta-data/', DEFAULT_METADATA)
         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
-        get_interface_mac_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
+        get_interface_mac_path = M_PATH_NET + 'get_interfaces_by_mac'
         ds.fallback_nic = 'eth9'
-        with mock.patch(get_interface_mac_path) as m_get_interface_mac:
-            m_get_interface_mac.return_value = mac1
+        with mock.patch(get_interface_mac_path) as m_get_interfaces_by_mac:
+            m_get_interfaces_by_mac.return_value = {mac1: 'eth9'}
             nc = ds.network_config  # Will re-crawl network metadata
             self.assertIsNotNone(nc)
         self.assertIn(
             'Refreshing stale metadata from prior to upgrade',
             self.logs.getvalue())
-        expected = {'version': 1, 'config': [
-            {'mac_address': '06:17:04:d7:26:09',
-             'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}],
-             'type': 'physical'}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': mac1}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(expected, ds.network_config)
 
     def test_ec2_get_instance_id_refreshes_identity_on_upgrade(self):
@@ -428,6 +565,69 @@ class TestEc2(test_helpers.HttprettyTestCase):
             md={'md': DEFAULT_METADATA})
         self.assertTrue(ds.get_data())
         self.assertFalse(ds.is_classic_instance())
+
+    def test_aws_inaccessible_imds_service_fails_with_retries(self):
+        """Inaccessibility of http://169.254.169.254 are retried."""
+        ds = self._setup_ds(
+            platform_data=self.valid_platform_data,
+            sys_cfg={'datasource': {'Ec2': {'strict_id': False}}},
+            md=None)
+
+        conn_error = requests.exceptions.ConnectionError(
+           '[Errno 113] no route to host')
+
+        mock_success = mock.MagicMock(contents=b'fakesuccess')
+        mock_success.ok.return_value = True
+
+        with mock.patch('cloudinit.url_helper.readurl') as m_readurl:
+            m_readurl.side_effect = (conn_error, conn_error, mock_success)
+            with mock.patch('cloudinit.url_helper.time.sleep'):
+                self.assertTrue(ds.wait_for_metadata_service())
+
+        # Just one /latest/api/token request
+        self.assertEqual(3, len(m_readurl.call_args_list))
+        for readurl_call in m_readurl.call_args_list:
+            self.assertIn('latest/api/token', readurl_call[0][0])
+
+    def test_aws_token_403_fails_without_retries(self):
+        """Verify that 403s fetching AWS tokens are not retried."""
+        ds = self._setup_ds(
+            platform_data=self.valid_platform_data,
+            sys_cfg={'datasource': {'Ec2': {'strict_id': False}}},
+            md=None)
+        token_url = self.data_url('latest', data_item='api/token')
+        httpretty.register_uri(httpretty.PUT, token_url, body={}, status=403)
+        self.assertFalse(ds.get_data())
+        # Just one /latest/api/token request
+        logs = self.logs.getvalue()
+        failed_put_log = '"PUT /latest/api/token HTTP/1.1" 403 0'
+        expected_logs = [
+            'WARNING: Ec2 IMDS endpoint returned a 403 error. HTTP endpoint is'
+            ' disabled. Aborting.',
+            "WARNING: IMDS's HTTP endpoint is probably disabled",
+            failed_put_log
+        ]
+        for log in expected_logs:
+            self.assertIn(log, logs)
+        self.assertEqual(
+            1, len([l for l in logs.splitlines() if failed_put_log in l]))
+
+    def test_aws_token_redacted(self):
+        """Verify that aws tokens are redacted when logged."""
+        ds = self._setup_ds(
+            platform_data=self.valid_platform_data,
+            sys_cfg={'datasource': {'Ec2': {'strict_id': False}}},
+            md={'md': DEFAULT_METADATA})
+        self.assertTrue(ds.get_data())
+        all_logs = self.logs.getvalue().splitlines()
+        REDACT_TTL = "'X-aws-ec2-metadata-token-ttl-seconds': 'REDACTED'"
+        REDACT_TOK = "'X-aws-ec2-metadata-token': 'REDACTED'"
+        logs_with_redacted_ttl = [log for log in all_logs if REDACT_TTL in log]
+        logs_with_redacted = [log for log in all_logs if REDACT_TOK in log]
+        logs_with_token = [log for log in all_logs if 'API-TOKEN' in log]
+        self.assertEqual(1, len(logs_with_redacted_ttl))
+        self.assertEqual(81, len(logs_with_redacted))
+        self.assertEqual(0, len(logs_with_token))
 
     @mock.patch('cloudinit.net.dhcp.maybe_perform_dhcp_discovery')
     def test_valid_platform_with_strict_true(self, m_dhcp):
@@ -547,6 +747,44 @@ class TestEc2(test_helpers.HttprettyTestCase):
         self.assertIn('Crawl of metadata service took', self.logs.getvalue())
 
 
+class TestGetSecondaryAddresses(test_helpers.CiTestCase):
+
+    mac = '06:17:04:d7:26:ff'
+    with_logs = True
+
+    def test_md_with_no_secondary_addresses(self):
+        """Empty list is returned when nic metadata contains no secondary ip"""
+        self.assertEqual([], ec2.get_secondary_addresses(NIC2_MD, self.mac))
+
+    def test_md_with_secondary_v4_and_v6_addresses(self):
+        """All secondary addresses are returned from nic metadata"""
+        self.assertEqual(
+            ['172.31.45.70/20', '2600:1f16:292:100:f152:2222:3333:4444/128',
+             '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
+            ec2.get_secondary_addresses(NIC1_MD_IPV4_IPV6_MULTI_IP, self.mac))
+
+    def test_invalid_ipv4_ipv6_cidr_metadata_logged_with_defaults(self):
+        """Any invalid subnet-ipv(4|6)-cidr-block values use defaults"""
+        invalid_cidr_md = copy.deepcopy(NIC1_MD_IPV4_IPV6_MULTI_IP)
+        invalid_cidr_md['subnet-ipv4-cidr-block'] = "something-unexpected"
+        invalid_cidr_md['subnet-ipv6-cidr-block'] = "not/sure/what/this/is"
+        self.assertEqual(
+            ['172.31.45.70/24', '2600:1f16:292:100:f152:2222:3333:4444/128',
+             '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
+            ec2.get_secondary_addresses(invalid_cidr_md, self.mac))
+        expected_logs = [
+           "WARNING: Could not parse subnet-ipv4-cidr-block"
+           " something-unexpected for mac 06:17:04:d7:26:ff."
+           " ipv4 network config prefix defaults to /24",
+           "WARNING: Could not parse subnet-ipv6-cidr-block"
+           " not/sure/what/this/is for mac 06:17:04:d7:26:ff."
+           " ipv6 network config prefix defaults to /128"
+        ]
+        logs = self.logs.getvalue()
+        for log in expected_logs:
+            self.assertIn(log, logs)
+
+
 class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
     def setUp(self):
@@ -554,16 +792,16 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         self.mac1 = '06:17:04:d7:26:09'
         self.network_metadata = {
             'interfaces': {'macs': {
-                self.mac1: {'public-ipv4s': '172.31.2.16'}}}}
+                self.mac1: {'mac': self.mac1, 'public-ipv4s': '172.31.2.16'}}}}
 
     def test_convert_ec2_metadata_network_config_skips_absent_macs(self):
         """Any mac absent from metadata is skipped by network config."""
         macs_to_nics = {self.mac1: 'eth9', 'DE:AD:BE:EF:FF:FF': 'vitualnic2'}
 
         # DE:AD:BE:EF:FF:FF represented by OS but not in metadata
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -577,15 +815,15 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
             network_metadata_ipv6['interfaces']['macs'][self.mac1])
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         nic1_metadata.pop('public-ipv4s')
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9', 'subnets': [{'type': 'dhcp6'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
                 network_metadata_ipv6, macs_to_nics))
 
-    def test_convert_ec2_metadata_network_config_handles_local_dhcp4(self):
+    def test_convert_ec2_metadata_network_config_local_only_dhcp4(self):
         """Config dhcp4 when there are no public addresses in public-ipv4s."""
         macs_to_nics = {self.mac1: 'eth9'}
         network_metadata_ipv6 = copy.deepcopy(self.network_metadata)
@@ -593,9 +831,9 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
             network_metadata_ipv6['interfaces']['macs'][self.mac1])
         nic1_metadata['local-ipv4s'] = '172.3.3.15'
         nic1_metadata.pop('public-ipv4s')
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -610,16 +848,16 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['public-ipv4s'] = ''
 
         # When no ipv4 or ipv6 content but fallback_nic set, set dhcp4 config.
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
                 network_metadata_ipv6, macs_to_nics, fallback_nic='eth9'))
 
     def test_convert_ec2_metadata_network_config_handles_local_v4_and_v6(self):
-        """When dhcp6 is public and dhcp4 is set to local enable both."""
+        """When ipv6s and local-ipv4s are non-empty, enable dhcp6 and dhcp4."""
         macs_to_nics = {self.mac1: 'eth9'}
         network_metadata_both = copy.deepcopy(self.network_metadata)
         nic1_metadata = (
@@ -627,10 +865,35 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
         nic1_metadata.pop('public-ipv4s')
         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
+        self.assertEqual(
+            expected,
+            ec2.convert_ec2_metadata_network_config(
+                network_metadata_both, macs_to_nics))
+
+    def test_convert_ec2_metadata_network_config_handles_multiple_nics(self):
+        """DHCP route-metric increases on secondary NICs for IPv4 and IPv6."""
+        mac2 = '06:17:04:d7:26:0a'
+        macs_to_nics = {self.mac1: 'eth9', mac2: 'eth10'}
+        network_metadata_both = copy.deepcopy(self.network_metadata)
+        # Add 2nd nic info
+        network_metadata_both['interfaces']['macs'][mac2] = NIC2_MD
+        nic1_metadata = (
+            network_metadata_both['interfaces']['macs'][self.mac1])
+        nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
+        nic1_metadata.pop('public-ipv4s')  # No public-ipv4 IPs in cfg
+        nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
+        expected = {'version': 2, 'ethernets': {
+            'eth9': {
+                'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+                'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
+                'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}},
+            'eth10': {
+                'match': {'macaddress': mac2}, 'set-name': 'eth10',
+                'dhcp4': True, 'dhcp4-overrides': {'route-metric': 200},
+                'dhcp6': False}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -643,10 +906,9 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
         nic1_metadata = (
             network_metadata_both['interfaces']['macs'][self.mac1])
         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}]}]}
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
+            'dhcp4': True, 'dhcp6': True}}}
         self.assertEqual(
             expected,
             ec2.convert_ec2_metadata_network_config(
@@ -654,12 +916,10 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
 
     def test_convert_ec2_metadata_gets_macs_from_get_interfaces_by_mac(self):
         """Convert Ec2 Metadata calls get_interfaces_by_mac by default."""
-        expected = {'version': 1, 'config': [
-            {'mac_address': self.mac1, 'type': 'physical',
-             'name': 'eth9',
-             'subnets': [{'type': 'dhcp4'}]}]}
-        patch_path = (
-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
+        expected = {'version': 2, 'ethernets': {'eth9': {
+            'match': {'macaddress': self.mac1},
+            'set-name': 'eth9', 'dhcp4': True, 'dhcp6': False}}}
+        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
         with mock.patch(patch_path) as m_get_interfaces_by_mac:
             m_get_interfaces_by_mac.return_value = {self.mac1: 'eth9'}
             self.assertEqual(

--- a/tests/unittests/test_datasource/test_gce.py
+++ b/tests/unittests/test_datasource/test_gce.py
@@ -7,11 +7,11 @@
 import datetime
 import httpretty
 import json
-import mock
 import re
+from unittest import mock
+from urllib.parse import urlparse
 
 from base64 import b64encode, b64decode
-from six.moves.urllib_parse import urlparse
 
 from cloudinit import distros
 from cloudinit import helpers

--- a/tests/unittests/test_datasource/test_maas.py
+++ b/tests/unittests/test_datasource/test_maas.py
@@ -1,11 +1,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 from copy import copy
-import mock
 import os
 import shutil
 import tempfile
 import yaml
+from unittest import mock
 
 from cloudinit.sources import DataSourceMAAS
 from cloudinit import url_helper
@@ -158,7 +158,6 @@ class TestMAASDataSource(CiTestCase):
 
 @mock.patch("cloudinit.sources.DataSourceMAAS.url_helper.OauthUrlHelper")
 class TestGetOauthHelper(CiTestCase):
-    with_logs = True
     base_cfg = {'consumer_key': 'FAKE_CONSUMER_KEY',
                 'token_key': 'FAKE_TOKEN_KEY',
                 'token_secret': 'FAKE_TOKEN_SECRET',

--- a/tests/unittests/test_distros/test_bsd_utils.py
+++ b/tests/unittests/test_distros/test_bsd_utils.py
@@ -1,0 +1,66 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import cloudinit.distros.bsd_utils as bsd_utils
+
+from cloudinit.tests.helpers import (CiTestCase, ExitStack, mock)
+
+RC_FILE = """
+if something; then
+    do something here
+fi
+hostname={hostname}
+"""
+
+
+class TestBsdUtils(CiTestCase):
+
+    def setUp(self):
+        super().setUp()
+        patches = ExitStack()
+        self.addCleanup(patches.close)
+
+        self.load_file = patches.enter_context(
+            mock.patch.object(bsd_utils.util, 'load_file'))
+
+        self.write_file = patches.enter_context(
+            mock.patch.object(bsd_utils.util, 'write_file'))
+
+    def test_get_rc_config_value(self):
+        self.load_file.return_value = 'hostname=foo\n'
+        self.assertEqual(bsd_utils.get_rc_config_value('hostname'), 'foo')
+        self.load_file.assert_called_with('/etc/rc.conf')
+
+        self.load_file.return_value = 'hostname=foo'
+        self.assertEqual(bsd_utils.get_rc_config_value('hostname'), 'foo')
+
+        self.load_file.return_value = 'hostname="foo"'
+        self.assertEqual(bsd_utils.get_rc_config_value('hostname'), 'foo')
+
+        self.load_file.return_value = "hostname='foo'"
+        self.assertEqual(bsd_utils.get_rc_config_value('hostname'), 'foo')
+
+        self.load_file.return_value = 'hostname=\'foo"'
+        self.assertEqual(bsd_utils.get_rc_config_value('hostname'), "'foo\"")
+
+        self.load_file.return_value = ''
+        self.assertEqual(bsd_utils.get_rc_config_value('hostname'), None)
+
+        self.load_file.return_value = RC_FILE.format(hostname='foo')
+        self.assertEqual(bsd_utils.get_rc_config_value('hostname'), "foo")
+
+    def test_set_rc_config_value_unchanged(self):
+        # bsd_utils.set_rc_config_value('hostname', 'foo')
+        # self.write_file.assert_called_with('/etc/rc.conf', 'hostname=foo\n')
+
+        self.load_file.return_value = RC_FILE.format(hostname='foo')
+        self.write_file.assert_not_called()
+
+    def test_set_rc_config_value(self):
+        bsd_utils.set_rc_config_value('hostname', 'foo')
+        self.write_file.assert_called_with('/etc/rc.conf', 'hostname=foo\n')
+
+        self.load_file.return_value = RC_FILE.format(hostname='foo')
+        bsd_utils.set_rc_config_value('hostname', 'bar')
+        self.write_file.assert_called_with(
+                '/etc/rc.conf',
+                RC_FILE.format(hostname='bar'))

--- a/tests/unittests/test_distros/test_netconfig.py
+++ b/tests/unittests/test_distros/test_netconfig.py
@@ -2,7 +2,7 @@
 
 import copy
 import os
-from six import StringIO
+from io import StringIO
 from textwrap import dedent
 from unittest import mock
 
@@ -485,7 +485,6 @@ class TestNetCfgDistroRedhat(TestNetCfgDistroBase):
                 NETMASK=255.255.255.0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -494,7 +493,6 @@ class TestNetCfgDistroRedhat(TestNetCfgDistroBase):
                 DEVICE=eth1
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -513,13 +511,11 @@ class TestNetCfgDistroRedhat(TestNetCfgDistroBase):
                 BOOTPROTO=none
                 DEFROUTE=yes
                 DEVICE=eth0
-                IPADDR6=2607:f0d0:1002:0011::2/64
                 IPV6ADDR=2607:f0d0:1002:0011::2/64
                 IPV6INIT=yes
                 IPV6_DEFAULTGW=2607:f0d0:1002:0011::1
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -528,7 +524,6 @@ class TestNetCfgDistroRedhat(TestNetCfgDistroBase):
                 DEVICE=eth1
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -573,26 +568,14 @@ class TestNetCfgDistroOpensuse(TestNetCfgDistroBase):
         """Opensuse uses apply_network_config and renders sysconfig"""
         expected_cfgs = {
             self.ifcfg_path('eth0'): dedent("""\
-                BOOTPROTO=none
-                DEFROUTE=yes
-                DEVICE=eth0
-                GATEWAY=192.168.1.254
+                BOOTPROTO=static
                 IPADDR=192.168.1.5
                 NETMASK=255.255.255.0
-                NM_CONTROLLED=no
-                ONBOOT=yes
                 STARTMODE=auto
-                TYPE=Ethernet
-                USERCTL=no
                 """),
             self.ifcfg_path('eth1'): dedent("""\
-                BOOTPROTO=dhcp
-                DEVICE=eth1
-                NM_CONTROLLED=no
-                ONBOOT=yes
+                BOOTPROTO=dhcp4
                 STARTMODE=auto
-                TYPE=Ethernet
-                USERCTL=no
                 """),
         }
         self._apply_and_verify(self.distro.apply_network_config,
@@ -603,27 +586,13 @@ class TestNetCfgDistroOpensuse(TestNetCfgDistroBase):
         """Opensuse uses apply_network_config and renders sysconfig w/ipv6"""
         expected_cfgs = {
             self.ifcfg_path('eth0'): dedent("""\
-                BOOTPROTO=none
-                DEFROUTE=yes
-                DEVICE=eth0
+                BOOTPROTO=static
                 IPADDR6=2607:f0d0:1002:0011::2/64
-                IPV6ADDR=2607:f0d0:1002:0011::2/64
-                IPV6INIT=yes
-                IPV6_DEFAULTGW=2607:f0d0:1002:0011::1
-                NM_CONTROLLED=no
-                ONBOOT=yes
                 STARTMODE=auto
-                TYPE=Ethernet
-                USERCTL=no
             """),
             self.ifcfg_path('eth1'): dedent("""\
-                BOOTPROTO=dhcp
-                DEVICE=eth1
-                NM_CONTROLLED=no
-                ONBOOT=yes
+                BOOTPROTO=dhcp4
                 STARTMODE=auto
-                TYPE=Ethernet
-                USERCTL=no
             """),
         }
         self._apply_and_verify(self.distro.apply_network_config,

--- a/tests/unittests/test_distros/test_user_data_normalize.py
+++ b/tests/unittests/test_distros/test_user_data_normalize.py
@@ -1,12 +1,13 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from unittest import mock
+
 from cloudinit import distros
 from cloudinit.distros import ug_util
 from cloudinit import helpers
 from cloudinit import settings
 
 from cloudinit.tests.helpers import TestCase
-import mock
 
 
 bcfg = {

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -447,6 +447,10 @@ class TestDsIdentify(DsIdentifyBase):
         """Open Telecom identification."""
         self._test_ds_found('OpenStack-OpenTelekom')
 
+    def test_openstack_sap_ccloud(self):
+        """SAP Converged Cloud identification"""
+        self._test_ds_found('OpenStack-SAPCCloud')
+
     def test_openstack_asset_tag_nova(self):
         """OpenStack identification via asset tag OpenStack Nova."""
         self._test_ds_found('OpenStack-AssetTag-Nova')
@@ -833,6 +837,12 @@ VALID_CFG = {
         'ds': 'OpenStack',
         'files': {P_CHASSIS_ASSET_TAG: 'OpenTelekomCloud\n'},
         'mocks': [MOCK_VIRT_IS_XEN],
+    },
+    'OpenStack-SAPCCloud': {
+        # SAP CCloud hosts use OpenStack on VMware
+        'ds': 'OpenStack',
+        'files': {P_CHASSIS_ASSET_TAG: 'SAP CCloud VM\n'},
+        'mocks': [MOCK_VIRT_IS_VMWARE],
     },
     'OpenStack-AssetTag-Nova': {
         # VMware vSphere can't modify product-name, LP: #1669875

--- a/tests/unittests/test_filters/test_launch_index.py
+++ b/tests/unittests/test_filters/test_launch_index.py
@@ -1,10 +1,9 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import copy
+from itertools import filterfalse
 
 from cloudinit.tests import helpers
-
-from six.moves import filterfalse
 
 from cloudinit.filters import launch_index
 from cloudinit import user_data as ud

--- a/tests/unittests/test_handler/test_handler_apt_source_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v3.py
@@ -670,7 +670,7 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
                "security": [{'arches': ["default"],
                              "search": ["sfailme", smir]}]}
 
-        with mock.patch.object(cc_apt_configure, 'search_for_mirror',
+        with mock.patch.object(cc_apt_configure.util, 'search_for_mirror',
                                side_effect=[pmir, smir]) as mocksearch:
             mirrors = cc_apt_configure.find_apt_mirror_info(cfg, None,
                                                             'amd64')
@@ -709,7 +709,7 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
         mockgm.assert_has_calls(calls)
 
         # should not be called, since primary is specified
-        with mock.patch.object(cc_apt_configure,
+        with mock.patch.object(cc_apt_configure.util,
                                'search_for_mirror') as mockse:
             mirrors = cc_apt_configure.find_apt_mirror_info(cfg, None, arch)
         mockse.assert_not_called()
@@ -974,7 +974,7 @@ deb http://ubuntu.com/ubuntu/ xenial-proposed main""")
         mocksdns.assert_has_calls(calls)
 
         # first return is for the non-dns call before
-        with mock.patch.object(cc_apt_configure, 'search_for_mirror',
+        with mock.patch.object(cc_apt_configure.util, 'search_for_mirror',
                                side_effect=[None, pmir, None, smir]) as mockse:
             mirrors = cc_apt_configure.find_apt_mirror_info(cfg, mycloud, arch)
 

--- a/tests/unittests/test_handler/test_handler_disk_setup.py
+++ b/tests/unittests/test_handler/test_handler_disk_setup.py
@@ -222,4 +222,22 @@ class TestMkfsCommandHandling(CiTestCase):
              '-L', 'without_cmd', '-F', 'are', 'added'],
             shell=False)
 
+    @mock.patch('cloudinit.config.cc_disk_setup.util.which')
+    def test_mkswap(self, m_which, subp, *args):
+        """mkfs observes extra_opts and overwrite settings when cmd is not
+        present."""
+        m_which.side_effect = iter([None, '/sbin/mkswap'])
+        cc_disk_setup.mkfs({
+            'filesystem': 'swap',
+            'device': '/dev/xdb1',
+            'label': 'swap',
+            'overwrite': True,
+        })
+
+        self.assertEqual([mock.call('mkfs.swap'), mock.call('mkswap')],
+                         m_which.call_args_list)
+        subp.assert_called_once_with(
+            ['/sbin/mkswap', '/dev/xdb1', '-L', 'swap', '-f'], shell=False)
+
+#
 # vi: ts=4 expandtab

--- a/tests/unittests/test_handler/test_handler_locale.py
+++ b/tests/unittests/test_handler/test_handler_locale.py
@@ -17,20 +17,17 @@ from cloudinit.tests import helpers as t_help
 
 from configobj import ConfigObj
 
-from six import BytesIO
-
 import logging
-import mock
 import os
 import shutil
 import tempfile
+from io import BytesIO
+from unittest import mock
 
 LOG = logging.getLogger(__name__)
 
 
 class TestLocale(t_help.FilesystemMockingTestCase):
-
-    with_logs = True
 
     def setUp(self):
         super(TestLocale, self).setUp()

--- a/tests/unittests/test_handler/test_handler_mcollective.py
+++ b/tests/unittests/test_handler/test_handler_mcollective.py
@@ -10,8 +10,8 @@ import configobj
 import logging
 import os
 import shutil
-from six import BytesIO
 import tempfile
+from io import BytesIO
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unittests/test_handler/test_handler_puppet.py
+++ b/tests/unittests/test_handler/test_handler_puppet.py
@@ -16,8 +16,6 @@ LOG = logging.getLogger(__name__)
 @mock.patch('cloudinit.config.cc_puppet.os')
 class TestAutostartPuppet(CiTestCase):
 
-    with_logs = True
-
     def test_wb_autostart_puppet_updates_puppet_default(self, m_os, m_util):
         """Update /etc/default/puppet to autostart if it exists."""
 

--- a/tests/unittests/test_handler/test_handler_seed_random.py
+++ b/tests/unittests/test_handler/test_handler_seed_random.py
@@ -12,8 +12,7 @@ from cloudinit.config import cc_seed_random
 
 import gzip
 import tempfile
-
-from six import BytesIO
+from io import BytesIO
 
 from cloudinit import cloud
 from cloudinit import distros

--- a/tests/unittests/test_handler/test_handler_set_hostname.py
+++ b/tests/unittests/test_handler/test_handler_set_hostname.py
@@ -13,8 +13,8 @@ from configobj import ConfigObj
 import logging
 import os
 import shutil
-from six import BytesIO
 import tempfile
+from io import BytesIO
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unittests/test_handler/test_handler_timezone.py
+++ b/tests/unittests/test_handler/test_handler_timezone.py
@@ -18,8 +18,8 @@ from cloudinit.tests import helpers as t_help
 from configobj import ConfigObj
 import logging
 import shutil
-from six import BytesIO
 import tempfile
+from io import BytesIO
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unittests/test_handler/test_handler_yum_add_repo.py
+++ b/tests/unittests/test_handler/test_handler_yum_add_repo.py
@@ -7,8 +7,8 @@ from cloudinit.tests import helpers
 
 import logging
 import shutil
-from six import StringIO
 import tempfile
+from io import StringIO
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unittests/test_handler/test_handler_zypper_add_repo.py
+++ b/tests/unittests/test_handler/test_handler_zypper_add_repo.py
@@ -2,6 +2,7 @@
 
 import glob
 import os
+from io import StringIO
 
 from cloudinit.config import cc_zypper_add_repo
 from cloudinit import util
@@ -10,7 +11,6 @@ from cloudinit.tests import helpers
 from cloudinit.tests.helpers import mock
 
 import logging
-from six import StringIO
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unittests/test_handler/test_schema.py
+++ b/tests/unittests/test_handler/test_schema.py
@@ -10,7 +10,7 @@ from cloudinit.tests.helpers import CiTestCase, mock, skipUnlessJsonSchema
 
 from copy import copy
 import os
-from six import StringIO
+from io import StringIO
 from textwrap import dedent
 from yaml import safe_load
 

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -81,7 +81,7 @@ DHCP6_EXPECTED_1 = {
 
 STATIC_CONTENT_1 = """
 DEVICE='eth1'
-PROTO='static'
+PROTO='none'
 IPV4ADDR='10.0.0.2'
 IPV4BROADCAST='10.0.0.255'
 IPV4NETMASK='255.255.255.0'
@@ -489,18 +489,11 @@ OS_SAMPLES = [
              """
 # Created by cloud-init on instance boot automatically, do not edit.
 #
-BOOTPROTO=none
-DEFROUTE=yes
-DEVICE=eth0
-GATEWAY=172.19.3.254
-HWADDR=fa:16:3e:ed:9a:59
+BOOTPROTO=static
 IPADDR=172.19.1.34
+LLADDR=fa:16:3e:ed:9a:59
 NETMASK=255.255.252.0
-NM_CONTROLLED=no
-ONBOOT=yes
 STARTMODE=auto
-TYPE=Ethernet
-USERCTL=no
 """.lstrip()),
             ('etc/resolv.conf',
              """
@@ -532,7 +525,6 @@ IPADDR=172.19.1.34
 NETMASK=255.255.252.0
 NM_CONTROLLED=no
 ONBOOT=yes
-STARTMODE=auto
 TYPE=Ethernet
 USERCTL=no
 """.lstrip()),
@@ -591,20 +583,13 @@ dns = none
              """
 # Created by cloud-init on instance boot automatically, do not edit.
 #
-BOOTPROTO=none
-DEFROUTE=yes
-DEVICE=eth0
-GATEWAY=172.19.3.254
-HWADDR=fa:16:3e:ed:9a:59
+BOOTPROTO=static
 IPADDR=172.19.1.34
 IPADDR1=10.0.0.10
+LLADDR=fa:16:3e:ed:9a:59
 NETMASK=255.255.252.0
 NETMASK1=255.255.255.0
-NM_CONTROLLED=no
-ONBOOT=yes
 STARTMODE=auto
-TYPE=Ethernet
-USERCTL=no
 """.lstrip()),
             ('etc/resolv.conf',
              """
@@ -638,7 +623,6 @@ NETMASK=255.255.252.0
 NETMASK1=255.255.255.0
 NM_CONTROLLED=no
 ONBOOT=yes
-STARTMODE=auto
 TYPE=Ethernet
 USERCTL=no
 """.lstrip()),
@@ -717,25 +701,14 @@ dns = none
              """
 # Created by cloud-init on instance boot automatically, do not edit.
 #
-BOOTPROTO=none
-DEFROUTE=yes
-DEVICE=eth0
-GATEWAY=172.19.3.254
-HWADDR=fa:16:3e:ed:9a:59
+BOOTPROTO=static
 IPADDR=172.19.1.34
 IPADDR6=2001:DB8::10/64
-IPADDR6_0=2001:DB9::10/64
+IPADDR6_1=2001:DB9::10/64
 IPADDR6_2=2001:DB10::10/64
-IPV6ADDR=2001:DB8::10/64
-IPV6ADDR_SECONDARIES="2001:DB9::10/64 2001:DB10::10/64"
-IPV6INIT=yes
-IPV6_DEFAULTGW=2001:DB8::1
+LLADDR=fa:16:3e:ed:9a:59
 NETMASK=255.255.252.0
-NM_CONTROLLED=no
-ONBOOT=yes
 STARTMODE=auto
-TYPE=Ethernet
-USERCTL=no
 """.lstrip()),
             ('etc/resolv.conf',
              """
@@ -764,9 +737,6 @@ DEVICE=eth0
 GATEWAY=172.19.3.254
 HWADDR=fa:16:3e:ed:9a:59
 IPADDR=172.19.1.34
-IPADDR6=2001:DB8::10/64
-IPADDR6_0=2001:DB9::10/64
-IPADDR6_2=2001:DB10::10/64
 IPV6ADDR=2001:DB8::10/64
 IPV6ADDR_SECONDARIES="2001:DB9::10/64 2001:DB10::10/64"
 IPV6INIT=yes
@@ -774,7 +744,6 @@ IPV6_DEFAULTGW=2001:DB8::1
 NETMASK=255.255.252.0
 NM_CONTROLLED=no
 ONBOOT=yes
-STARTMODE=auto
 TYPE=Ethernet
 USERCTL=no
 """.lstrip()),
@@ -884,14 +853,25 @@ NETWORK_CONFIGS = {
                             via: 65.61.151.37
                         set-name: eth99
         """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-eth1': textwrap.dedent("""\
+                BOOTPROTO=static
+                LLADDR=cf:d6:af:48:e8:80
+                STARTMODE=auto"""),
+            'ifcfg-eth99': textwrap.dedent("""\
+                BOOTPROTO=dhcp4
+                LLADDR=c0:d6:9f:2c:e8:80
+                IPADDR=192.168.21.3
+                NETMASK=255.255.255.0
+                STARTMODE=auto"""),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-eth1': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=eth1
                 HWADDR=cf:d6:af:48:e8:80
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no"""),
             'ifcfg-eth99': textwrap.dedent("""\
@@ -909,7 +889,6 @@ NETWORK_CONFIGS = {
                 METRIC=10000
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no"""),
         },
@@ -963,6 +942,12 @@ NETWORK_CONFIGS = {
                         dhcp4: true
                         dhcp6: true
         """).rstrip(' '),
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0':  textwrap.dedent("""\
+                BOOTPROTO=dhcp
+                DHCLIENT6_MODE=managed
+                STARTMODE=auto""")
+        },
         'yaml': textwrap.dedent("""\
             version: 1
             config:
@@ -1013,24 +998,49 @@ NETWORK_CONFIGS = {
                     address: 2001:1::1/64
                     mtu: 1500
         """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0': textwrap.dedent("""\
+                BOOTPROTO=static
+                IPADDR=192.168.14.2
+                IPADDR6=2001:1::1/64
+                NETMASK=255.255.255.0
+                STARTMODE=auto
+                MTU=9000
+                """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-iface0': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=iface0
                 IPADDR=192.168.14.2
-                IPADDR6=2001:1::1/64
                 IPV6ADDR=2001:1::1/64
                 IPV6INIT=yes
                 NETMASK=255.255.255.0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 MTU=9000
                 IPV6_MTU=1500
                 """),
         },
+    },
+    'v6_and_v4': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0':  textwrap.dedent("""\
+                BOOTPROTO=dhcp
+                DHCLIENT6_MODE=managed
+                STARTMODE=auto""")
+        },
+        'yaml': textwrap.dedent("""\
+            version: 1
+            config:
+              - type: 'physical'
+                name: 'iface0'
+                subnets:
+                  - type: dhcp6
+                  - type: dhcp4
+        """).rstrip(' '),
     },
     'dhcpv6_only': {
         'expected_eni': textwrap.dedent("""\
@@ -1055,7 +1065,14 @@ NETWORK_CONFIGS = {
                 subnets:
                 - {'type': 'dhcp6'}
         """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0': textwrap.dedent("""\
+                BOOTPROTO=dhcp6
+                DHCLIENT6_MODE=managed
+                STARTMODE=auto
+                """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-iface0': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=iface0
@@ -1064,7 +1081,6 @@ NETWORK_CONFIGS = {
                 DEVICE=iface0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -1103,7 +1119,14 @@ NETWORK_CONFIGS = {
                     dhcp6: true
                     accept-ra: true
         """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0': textwrap.dedent("""\
+                BOOTPROTO=dhcp6
+                DHCLIENT6_MODE=managed
+                STARTMODE=auto
+            """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-iface0': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=iface0
@@ -1113,7 +1136,6 @@ NETWORK_CONFIGS = {
                 DEVICE=iface0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
             """),
@@ -1152,7 +1174,14 @@ NETWORK_CONFIGS = {
                     dhcp6: true
                     accept-ra: false
         """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0': textwrap.dedent("""\
+                BOOTPROTO=dhcp6
+                DHCLIENT6_MODE=managed
+                STARTMODE=auto
+            """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-iface0': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=iface0
@@ -1162,7 +1191,6 @@ NETWORK_CONFIGS = {
                 DEVICE=iface0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
             """),
@@ -1192,7 +1220,14 @@ NETWORK_CONFIGS = {
               subnets:
               - {'type': 'ipv6_slaac'}
         """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0': textwrap.dedent("""\
+                BOOTPROTO=dhcp6
+                DHCLIENT6_MODE=info
+                STARTMODE=auto
+            """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-iface0': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=iface0
@@ -1201,7 +1236,6 @@ NETWORK_CONFIGS = {
                 DEVICE=iface0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
             """),
@@ -1231,7 +1265,14 @@ NETWORK_CONFIGS = {
             subnets:
             - {'type': 'ipv6_dhcpv6-stateless'}
     """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0': textwrap.dedent("""\
+            BOOTPROTO=dhcp6
+            DHCLIENT6_MODE=info
+            STARTMODE=auto
+            """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-iface0': textwrap.dedent("""\
             BOOTPROTO=none
             DEVICE=iface0
@@ -1242,7 +1283,6 @@ NETWORK_CONFIGS = {
             DEVICE=iface0
             NM_CONTROLLED=no
             ONBOOT=yes
-            STARTMODE=auto
             TYPE=Ethernet
             USERCTL=no
             """),
@@ -1273,7 +1313,14 @@ NETWORK_CONFIGS = {
             - {'type': 'ipv6_dhcpv6-stateful'}
             accept-ra: true
     """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-iface0': textwrap.dedent("""\
+            BOOTPROTO=dhcp6
+            DHCLIENT6_MODE=managed
+            STARTMODE=auto
+            """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-iface0': textwrap.dedent("""\
             BOOTPROTO=none
             DEVICE=iface0
@@ -1283,7 +1330,6 @@ NETWORK_CONFIGS = {
             DEVICE=iface0
             NM_CONTROLLED=no
             ONBOOT=yes
-            STARTMODE=auto
             TYPE=Ethernet
             USERCTL=no
             """),
@@ -1478,7 +1524,80 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                             - sacchromyces.maas
                             - brettanomyces.maas
         """).rstrip(' '),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-bond0': textwrap.dedent("""\
+                BONDING_MASTER=yes
+                BONDING_OPTS="mode=active-backup """
+                                           """xmit_hash_policy=layer3+4 """
+                                           """miimon=100"
+                BONDING_SLAVE_0=eth1
+                BONDING_SLAVE_1=eth2
+                BOOTPROTO=dhcp6
+                DHCLIENT6_MODE=managed
+                LLADDR=aa:bb:cc:dd:ee:ff
+                STARTMODE=auto"""),
+            'ifcfg-bond0.200': textwrap.dedent("""\
+                BOOTPROTO=dhcp4
+                ETHERDEVICE=bond0
+                STARTMODE=auto
+                VLAN_ID=200"""),
+            'ifcfg-br0': textwrap.dedent("""\
+                BRIDGE_AGEINGTIME=250
+                BOOTPROTO=static
+                IPADDR=192.168.14.2
+                IPADDR6=2001:1::1/64
+                LLADDRESS=bb:bb:bb:bb:bb:aa
+                NETMASK=255.255.255.0
+                BRIDGE_PRIORITY=22
+                BRIDGE_PORTS='eth3 eth4'
+                STARTMODE=auto
+                BRIDGE_STP=off"""),
+            'ifcfg-eth0': textwrap.dedent("""\
+                BOOTPROTO=static
+                LLADDR=c0:d6:9f:2c:e8:80
+                STARTMODE=auto"""),
+            'ifcfg-eth0.101': textwrap.dedent("""\
+                BOOTPROTO=static
+                IPADDR=192.168.0.2
+                IPADDR1=192.168.2.10
+                MTU=1500
+                NETMASK=255.255.255.0
+                NETMASK1=255.255.255.0
+                ETHERDEVICE=eth0
+                STARTMODE=auto
+                VLAN_ID=101"""),
+            'ifcfg-eth1': textwrap.dedent("""\
+                BOOTPROTO=none
+                LLADDR=aa:d6:9f:2c:e8:80
+                STARTMODE=hotplug"""),
+            'ifcfg-eth2': textwrap.dedent("""\
+                BOOTPROTO=none
+                LLADDR=c0:bb:9f:2c:e8:80
+                STARTMODE=hotplug"""),
+            'ifcfg-eth3': textwrap.dedent("""\
+                BOOTPROTO=static
+                BRIDGE=yes
+                LLADDR=66:bb:9f:2c:e8:80
+                STARTMODE=auto"""),
+            'ifcfg-eth4': textwrap.dedent("""\
+                BOOTPROTO=static
+                BRIDGE=yes
+                LLADDR=98:bb:9f:2c:e8:80
+                STARTMODE=auto"""),
+            'ifcfg-eth5': textwrap.dedent("""\
+                BOOTPROTO=dhcp
+                LLADDR=98:bb:9f:2c:e8:8a
+                STARTMODE=manual"""),
+            'ifcfg-ib0': textwrap.dedent("""\
+                BOOTPROTO=static
+                LLADDR=a0:00:02:20:fe:80:00:00:00:00:00:00:ec:0d:9a:03:00:15:e2:c1
+                IPADDR=192.168.200.7
+                MTU=9000
+                NETMASK=255.255.255.0
+                STARTMODE=auto
+                TYPE=InfiniBand"""),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-bond0': textwrap.dedent("""\
                 BONDING_MASTER=yes
                 BONDING_OPTS="mode=active-backup """
@@ -1493,7 +1612,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 MACADDR=aa:bb:cc:dd:ee:ff
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Bond
                 USERCTL=no"""),
             'ifcfg-bond0.200': textwrap.dedent("""\
@@ -1503,7 +1621,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PHYSDEV=bond0
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 VLAN=yes"""),
@@ -1513,7 +1630,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 DEFROUTE=yes
                 DEVICE=br0
                 IPADDR=192.168.14.2
-                IPADDR6=2001:1::1/64
                 IPV6ADDR=2001:1::1/64
                 IPV6INIT=yes
                 IPV6_DEFAULTGW=2001:4800:78ff:1b::1
@@ -1522,7 +1638,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PRIO=22
-                STARTMODE=auto
                 STP=no
                 TYPE=Bridge
                 USERCTL=no"""),
@@ -1532,7 +1647,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 HWADDR=c0:d6:9f:2c:e8:80
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no"""),
             'ifcfg-eth0.101': textwrap.dedent("""\
@@ -1551,7 +1665,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PHYSDEV=eth0
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 VLAN=yes"""),
@@ -1562,7 +1675,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 MASTER=bond0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 SLAVE=yes
                 TYPE=Ethernet
                 USERCTL=no"""),
@@ -1573,7 +1685,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 MASTER=bond0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 SLAVE=yes
                 TYPE=Ethernet
                 USERCTL=no"""),
@@ -1584,7 +1695,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 HWADDR=66:bb:9f:2c:e8:80
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no"""),
             'ifcfg-eth4': textwrap.dedent("""\
@@ -1594,7 +1704,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 HWADDR=98:bb:9f:2c:e8:80
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no"""),
             'ifcfg-eth5': textwrap.dedent("""\
@@ -1604,7 +1713,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 HWADDR=98:bb:9f:2c:e8:8a
                 NM_CONTROLLED=no
                 ONBOOT=no
-                STARTMODE=manual
                 TYPE=Ethernet
                 USERCTL=no"""),
             'ifcfg-ib0': textwrap.dedent("""\
@@ -1616,7 +1724,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 NETMASK=255.255.255.0
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=InfiniBand
                 USERCTL=no"""),
         },
@@ -2012,58 +2119,29 @@ iface bond0 inet6 static
                                            """fail_over_mac=active """
                                            """primary=bond0s0 """
                                            """primary_reselect=always"
-        BONDING_SLAVE0=bond0s0
-        BONDING_SLAVE1=bond0s1
-        BOOTPROTO=none
-        DEFROUTE=yes
-        DEVICE=bond0
-        GATEWAY=192.168.0.1
-        MACADDR=aa:bb:cc:dd:e8:ff
+        BONDING_SLAVE_0=bond0s0
+        BONDING_SLAVE_1=bond0s1
+        BOOTPROTO=static
+        LLADDR=aa:bb:cc:dd:e8:ff
         IPADDR=192.168.0.2
         IPADDR1=192.168.1.2
         IPADDR6=2001:1::1/92
-        IPV6ADDR=2001:1::1/92
-        IPV6INIT=yes
         MTU=9000
         NETMASK=255.255.255.0
         NETMASK1=255.255.255.0
-        NM_CONTROLLED=no
-        ONBOOT=yes
         STARTMODE=auto
-        TYPE=Bond
-        USERCTL=no
         """),
             'ifcfg-bond0s0': textwrap.dedent("""\
         BOOTPROTO=none
-        DEVICE=bond0s0
-        HWADDR=aa:bb:cc:dd:e8:00
-        MASTER=bond0
-        NM_CONTROLLED=no
-        ONBOOT=yes
-        SLAVE=yes
-        STARTMODE=auto
-        TYPE=Ethernet
-        USERCTL=no
-        """),
-            'ifroute-bond0': textwrap.dedent("""\
-        ADDRESS0=10.1.3.0
-        GATEWAY0=192.168.0.3
-        NETMASK0=255.255.255.0
+        LLADDR=aa:bb:cc:dd:e8:00
+        STARTMODE=hotplug
         """),
             'ifcfg-bond0s1': textwrap.dedent("""\
         BOOTPROTO=none
-        DEVICE=bond0s1
-        HWADDR=aa:bb:cc:dd:e8:01
-        MASTER=bond0
-        NM_CONTROLLED=no
-        ONBOOT=yes
-        SLAVE=yes
-        STARTMODE=auto
-        TYPE=Ethernet
-        USERCTL=no
+        LLADDR=aa:bb:cc:dd:e8:01
+        STARTMODE=hotplug
         """),
         },
-
         'expected_sysconfig_rhel': {
             'ifcfg-bond0': textwrap.dedent("""\
         BONDING_MASTER=yes
@@ -2082,7 +2160,6 @@ iface bond0 inet6 static
         MACADDR=aa:bb:cc:dd:e8:ff
         IPADDR=192.168.0.2
         IPADDR1=192.168.1.2
-        IPADDR6=2001:1::1/92
         IPV6ADDR=2001:1::1/92
         IPV6INIT=yes
         MTU=9000
@@ -2090,7 +2167,6 @@ iface bond0 inet6 static
         NETMASK1=255.255.255.0
         NM_CONTROLLED=no
         ONBOOT=yes
-        STARTMODE=auto
         TYPE=Bond
         USERCTL=no
         """),
@@ -2102,7 +2178,6 @@ iface bond0 inet6 static
         NM_CONTROLLED=no
         ONBOOT=yes
         SLAVE=yes
-        STARTMODE=auto
         TYPE=Ethernet
         USERCTL=no
         """),
@@ -2125,7 +2200,6 @@ iface bond0 inet6 static
         NM_CONTROLLED=no
         ONBOOT=yes
         SLAVE=yes
-        STARTMODE=auto
         TYPE=Ethernet
         USERCTL=no
         """),
@@ -2156,14 +2230,32 @@ iface bond0 inet6 static
                        netmask: '::'
                        network: '::'
             """),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            # TODO RJS: unknown proper BOOTPROTO setting ask Marius
+            'ifcfg-en0': textwrap.dedent("""\
+                BOOTPROTO=static
+                LLADDR=aa:bb:cc:dd:e8:00
+                STARTMODE=auto"""),
+            'ifcfg-en0.99': textwrap.dedent("""\
+                BOOTPROTO=static
+                IPADDR=192.168.2.2
+                IPADDR1=192.168.1.2
+                IPADDR6=2001:1::bbbb/96
+                MTU=2222
+                NETMASK=255.255.255.0
+                NETMASK1=255.255.255.0
+                STARTMODE=auto
+                ETHERDEVICE=en0
+                VLAN_ID=99
+            """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-en0': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=en0
                 HWADDR=aa:bb:cc:dd:e8:00
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no"""),
             'ifcfg-en0.99': textwrap.dedent("""\
@@ -2173,7 +2265,6 @@ iface bond0 inet6 static
                 GATEWAY=192.168.1.1
                 IPADDR=192.168.2.2
                 IPADDR1=192.168.1.2
-                IPADDR6=2001:1::bbbb/96
                 IPV6ADDR=2001:1::bbbb/96
                 IPV6INIT=yes
                 IPV6_DEFAULTGW=2001:1::1
@@ -2183,7 +2274,6 @@ iface bond0 inet6 static
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PHYSDEV=en0
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 VLAN=yes"""),
@@ -2216,7 +2306,32 @@ iface bond0 inet6 static
                 subnets:
                   - type: static
                     address: 192.168.2.2/24"""),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-br0': textwrap.dedent("""\
+                BOOTPROTO=static
+                IPADDR=192.168.2.2
+                NETMASK=255.255.255.0
+                STARTMODE=auto
+                BRIDGE_STP=off
+                BRIDGE_PRIORITY=22
+                BRIDGE_PORTS='eth0 eth1'
+                """),
+            'ifcfg-eth0': textwrap.dedent("""\
+                BOOTPROTO=static
+                BRIDGE=yes
+                LLADDR=52:54:00:12:34:00
+                IPADDR6=2001:1::100/96
+                STARTMODE=auto
+                """),
+            'ifcfg-eth1': textwrap.dedent("""\
+                BOOTPROTO=static
+                BRIDGE=yes
+                LLADDR=52:54:00:12:34:01
+                IPADDR6=2001:1::101/96
+                STARTMODE=auto
+                """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-br0': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=br0
@@ -2225,7 +2340,6 @@ iface bond0 inet6 static
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PRIO=22
-                STARTMODE=auto
                 STP=no
                 TYPE=Bridge
                 USERCTL=no
@@ -2235,12 +2349,10 @@ iface bond0 inet6 static
                 BRIDGE=br0
                 DEVICE=eth0
                 HWADDR=52:54:00:12:34:00
-                IPADDR6=2001:1::100/96
                 IPV6ADDR=2001:1::100/96
                 IPV6INIT=yes
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -2249,12 +2361,10 @@ iface bond0 inet6 static
                 BRIDGE=br0
                 DEVICE=eth1
                 HWADDR=52:54:00:12:34:01
-                IPADDR6=2001:1::101/96
                 IPV6ADDR=2001:1::101/96
                 IPV6INIT=yes
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -2320,7 +2430,27 @@ iface bond0 inet6 static
                             macaddress: 52:54:00:12:34:ff
                         set-name: eth2
             """),
-        'expected_sysconfig': {
+        'expected_sysconfig_opensuse': {
+            'ifcfg-eth0': textwrap.dedent("""\
+                BOOTPROTO=static
+                LLADDR=52:54:00:12:34:00
+                IPADDR=192.168.1.2
+                NETMASK=255.255.255.0
+                STARTMODE=manual
+                """),
+            'ifcfg-eth1': textwrap.dedent("""\
+                BOOTPROTO=static
+                LLADDR=52:54:00:12:34:aa
+                MTU=1480
+                STARTMODE=auto
+                """),
+            'ifcfg-eth2': textwrap.dedent("""\
+                BOOTPROTO=static
+                LLADDR=52:54:00:12:34:ff
+                STARTMODE=manual
+                """),
+        },
+        'expected_sysconfig_rhel': {
             'ifcfg-eth0': textwrap.dedent("""\
                 BOOTPROTO=none
                 DEVICE=eth0
@@ -2329,7 +2459,6 @@ iface bond0 inet6 static
                 NETMASK=255.255.255.0
                 NM_CONTROLLED=no
                 ONBOOT=no
-                STARTMODE=manual
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -2340,7 +2469,6 @@ iface bond0 inet6 static
                 MTU=1480
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -2350,7 +2478,6 @@ iface bond0 inet6 static
                 HWADDR=52:54:00:12:34:ff
                 NM_CONTROLLED=no
                 ONBOOT=no
-                STARTMODE=manual
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -2681,7 +2808,7 @@ class TestRhelSysConfigRendering(CiTestCase):
     header = ('# Created by cloud-init on instance boot automatically, '
               'do not edit.\n#\n')
 
-    expected_name = 'expected_sysconfig'
+    expected_name = 'expected_sysconfig_rhel'
 
     def _get_renderer(self):
         distro_cls = distros.fetch('rhel')
@@ -2768,7 +2895,6 @@ DEVICE=eth1000
 HWADDR=07-1c-c6-75-a4-be
 NM_CONTROLLED=no
 ONBOOT=yes
-STARTMODE=auto
 TYPE=Ethernet
 USERCTL=no
 """.lstrip()
@@ -2890,7 +3016,6 @@ IPADDR=10.0.2.15
 NETMASK=255.255.255.0
 NM_CONTROLLED=no
 ONBOOT=yes
-STARTMODE=auto
 TYPE=Ethernet
 USERCTL=no
 """
@@ -2922,7 +3047,6 @@ MTU=1500
 NETMASK=255.255.240.0
 NM_CONTROLLED=no
 ONBOOT=yes
-STARTMODE=auto
 TYPE=Ethernet
 USERCTL=no
 """
@@ -2937,7 +3061,6 @@ HWADDR=fa:16:3e:b1:ca:29
 MTU=9000
 NM_CONTROLLED=no
 ONBOOT=yes
-STARTMODE=auto
 TYPE=Ethernet
 USERCTL=no
 """
@@ -2963,7 +3086,6 @@ BOOTPROTO=dhcp
 DEVICE=eth0
 NM_CONTROLLED=no
 ONBOOT=yes
-STARTMODE=auto
 TYPE=Ethernet
 USERCTL=no
 """
@@ -2972,10 +3094,9 @@ USERCTL=no
         self.assertEqual(resolvconf_content, found['/etc/resolv.conf'])
 
     def test_bond_config(self):
-        expected_name = 'expected_sysconfig_rhel'
         entry = NETWORK_CONFIGS['bond']
         found = self._render_and_read(network_config=yaml.load(entry['yaml']))
-        self._compare_files_to_expected(entry[expected_name], found)
+        self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)
 
     def test_vlan_config(self):
@@ -3163,14 +3284,12 @@ USERCTL=no
                    GATEWAY=192.168.42.1
                    HWADDR=52:54:00:ab:cd:ef
                    IPADDR=192.168.42.100
-                   IPADDR6=2001:db8::100/32
                    IPV6ADDR=2001:db8::100/32
                    IPV6INIT=yes
                    IPV6_DEFAULTGW=2001:db8::1
                    NETMASK=255.255.255.0
                    NM_CONTROLLED=no
                    ONBOOT=yes
-                   STARTMODE=auto
                    TYPE=Ethernet
                    USERCTL=no
                    """),
@@ -3196,7 +3315,6 @@ USERCTL=no
                 DEVICE=eno1
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -3209,7 +3327,6 @@ USERCTL=no
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PHYSDEV=eno1
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 VLAN=yes
@@ -3240,7 +3357,6 @@ USERCTL=no
                 NETMASK=255.255.255.192
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Bond
                 USERCTL=no
                 """),
@@ -3252,7 +3368,6 @@ USERCTL=no
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 SLAVE=yes
-                STARTMODE=auto
                 TYPE=Bond
                 USERCTL=no
                 """),
@@ -3264,7 +3379,6 @@ USERCTL=no
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 SLAVE=yes
-                STARTMODE=auto
                 TYPE=Bond
                 USERCTL=no
                 """)
@@ -3288,7 +3402,6 @@ USERCTL=no
                 METRIC=100
                 NM_CONTROLLED=no
                 ONBOOT=yes
-                STARTMODE=auto
                 TYPE=Ethernet
                 USERCTL=no
                 """),
@@ -3311,7 +3424,7 @@ class TestOpenSuseSysConfigRendering(CiTestCase):
     header = ('# Created by cloud-init on instance boot automatically, '
               'do not edit.\n#\n')
 
-    expected_name = 'expected_sysconfig'
+    expected_name = 'expected_sysconfig_opensuse'
 
     def _get_renderer(self):
         distro_cls = distros.fetch('opensuse')
@@ -3383,92 +3496,89 @@ class TestOpenSuseSysConfigRendering(CiTestCase):
             expected_content = """
 # Created by cloud-init on instance boot automatically, do not edit.
 #
-BOOTPROTO=dhcp
-DEVICE=eth1000
-HWADDR=07-1c-c6-75-a4-be
-NM_CONTROLLED=no
-ONBOOT=yes
+BOOTPROTO=dhcp4
+LLADDR=07-1c-c6-75-a4-be
 STARTMODE=auto
-TYPE=Ethernet
-USERCTL=no
 """.lstrip()
             self.assertEqual(expected_content, content)
 
-    def test_multiple_ipv4_default_gateways(self):
-        """ValueError is raised when duplicate ipv4 gateways exist."""
-        net_json = {
-            "services": [{"type": "dns", "address": "172.19.0.12"}],
-            "networks": [{
-                "network_id": "dacd568d-5be6-4786-91fe-750c374b78b4",
-                "type": "ipv4", "netmask": "255.255.252.0",
-                "link": "tap1a81968a-79",
-                "routes": [{
-                    "netmask": "0.0.0.0",
-                    "network": "0.0.0.0",
-                    "gateway": "172.19.3.254",
-                }, {
-                    "netmask": "0.0.0.0",  # A second default gateway
-                    "network": "0.0.0.0",
-                    "gateway": "172.20.3.254",
-                }],
-                "ip_address": "172.19.1.34", "id": "network0"
-            }],
-            "links": [
-                {
-                    "ethernet_mac_address": "fa:16:3e:ed:9a:59",
-                    "mtu": None, "type": "bridge", "id":
-                    "tap1a81968a-79",
-                    "vif_id": "1a81968a-797a-400f-8a80-567f997eb93f"
-                },
-            ],
-        }
-        macs = {'fa:16:3e:ed:9a:59': 'eth0'}
-        render_dir = self.tmp_dir()
-        network_cfg = openstack.convert_net_json(net_json, known_macs=macs)
-        ns = network_state.parse_net_config_data(network_cfg,
-                                                 skip_broken=False)
-        renderer = self._get_renderer()
-        with self.assertRaises(ValueError):
-            renderer.render_network_state(ns, target=render_dir)
-        self.assertEqual([], os.listdir(render_dir))
-
-    def test_multiple_ipv6_default_gateways(self):
-        """ValueError is raised when duplicate ipv6 gateways exist."""
-        net_json = {
-            "services": [{"type": "dns", "address": "172.19.0.12"}],
-            "networks": [{
-                "network_id": "public-ipv6",
-                "type": "ipv6", "netmask": "",
-                "link": "tap1a81968a-79",
-                "routes": [{
-                    "gateway": "2001:DB8::1",
-                    "netmask": "::",
-                    "network": "::"
-                }, {
-                    "gateway": "2001:DB9::1",
-                    "netmask": "::",
-                    "network": "::"
-                }],
-                "ip_address": "2001:DB8::10", "id": "network1"
-            }],
-            "links": [
-                {
-                    "ethernet_mac_address": "fa:16:3e:ed:9a:59",
-                    "mtu": None, "type": "bridge", "id":
-                    "tap1a81968a-79",
-                    "vif_id": "1a81968a-797a-400f-8a80-567f997eb93f"
-                },
-            ],
-        }
-        macs = {'fa:16:3e:ed:9a:59': 'eth0'}
-        render_dir = self.tmp_dir()
-        network_cfg = openstack.convert_net_json(net_json, known_macs=macs)
-        ns = network_state.parse_net_config_data(network_cfg,
-                                                 skip_broken=False)
-        renderer = self._get_renderer()
-        with self.assertRaises(ValueError):
-            renderer.render_network_state(ns, target=render_dir)
-        self.assertEqual([], os.listdir(render_dir))
+    # TODO(rjschwei): re-enable test once route writing is implemented
+    # for SUSE distros
+#    def test_multiple_ipv4_default_gateways(self):
+#        """ValueError is raised when duplicate ipv4 gateways exist."""
+#        net_json = {
+#            "services": [{"type": "dns", "address": "172.19.0.12"}],
+#            "networks": [{
+#                "network_id": "dacd568d-5be6-4786-91fe-750c374b78b4",
+#                "type": "ipv4", "netmask": "255.255.252.0",
+#                "link": "tap1a81968a-79",
+#                "routes": [{
+#                    "netmask": "0.0.0.0",
+#                    "network": "0.0.0.0",
+#                    "gateway": "172.19.3.254",
+#                }, {
+#                    "netmask": "0.0.0.0",  # A second default gateway
+#                    "network": "0.0.0.0",
+#                    "gateway": "172.20.3.254",
+#                }],
+#                "ip_address": "172.19.1.34", "id": "network0"
+#            }],
+#            "links": [
+#                {
+#                    "ethernet_mac_address": "fa:16:3e:ed:9a:59",
+#                    "mtu": None, "type": "bridge", "id":
+#                    "tap1a81968a-79",
+#                    "vif_id": "1a81968a-797a-400f-8a80-567f997eb93f"
+#                },
+#            ],
+#        }
+#        macs = {'fa:16:3e:ed:9a:59': 'eth0'}
+#        render_dir = self.tmp_dir()
+#        network_cfg = openstack.convert_net_json(net_json, known_macs=macs)
+#        ns = network_state.parse_net_config_data(network_cfg,
+#                                                 skip_broken=False)
+#        renderer = self._get_renderer()
+#        with self.assertRaises(ValueError):
+#            renderer.render_network_state(ns, target=render_dir)
+#        self.assertEqual([], os.listdir(render_dir))
+#
+#    def test_multiple_ipv6_default_gateways(self):
+#        """ValueError is raised when duplicate ipv6 gateways exist."""
+#        net_json = {
+#            "services": [{"type": "dns", "address": "172.19.0.12"}],
+#            "networks": [{
+#                "network_id": "public-ipv6",
+#                "type": "ipv6", "netmask": "",
+#                "link": "tap1a81968a-79",
+#                "routes": [{
+#                    "gateway": "2001:DB8::1",
+#                    "netmask": "::",
+#                    "network": "::"
+#                }, {
+#                    "gateway": "2001:DB9::1",
+#                    "netmask": "::",
+#                    "network": "::"
+#                }],
+#                "ip_address": "2001:DB8::10", "id": "network1"
+#            }],
+#            "links": [
+#                {
+#                    "ethernet_mac_address": "fa:16:3e:ed:9a:59",
+#                    "mtu": None, "type": "bridge", "id":
+#                    "tap1a81968a-79",
+#                    "vif_id": "1a81968a-797a-400f-8a80-567f997eb93f"
+#                },
+#            ],
+#        }
+#        macs = {'fa:16:3e:ed:9a:59': 'eth0'}
+#        render_dir = self.tmp_dir()
+#        network_cfg = openstack.convert_net_json(net_json, known_macs=macs)
+#        ns = network_state.parse_net_config_data(network_cfg,
+#                                                 skip_broken=False)
+#        renderer = self._get_renderer()
+#        with self.assertRaises(ValueError):
+#            renderer.render_network_state(ns, target=render_dir)
+#        self.assertEqual([], os.listdir(render_dir))
 
     def test_openstack_rendering_samples(self):
         for os_sample in OS_SAMPLES:
@@ -3501,18 +3611,11 @@ USERCTL=no
         expected = """\
 # Created by cloud-init on instance boot automatically, do not edit.
 #
-BOOTPROTO=none
-DEFROUTE=yes
-DEVICE=interface0
-GATEWAY=10.0.2.2
-HWADDR=52:54:00:12:34:00
+BOOTPROTO=static
 IPADDR=10.0.2.15
+LLADDR=52:54:00:12:34:00
 NETMASK=255.255.255.0
-NM_CONTROLLED=no
-ONBOOT=yes
 STARTMODE=auto
-TYPE=Ethernet
-USERCTL=no
 """
         self.assertEqual(expected, found[nspath + 'ifcfg-interface0'])
         # The configuration has no nameserver information make sure we
@@ -3537,12 +3640,7 @@ USERCTL=no
 # Created by cloud-init on instance boot automatically, do not edit.
 #
 BOOTPROTO=dhcp
-DEVICE=eth0
-NM_CONTROLLED=no
-ONBOOT=yes
 STARTMODE=auto
-TYPE=Ethernet
-USERCTL=no
 """
         self.assertEqual(expected, found[nspath + 'ifcfg-eth0'])
         # a dhcp only config should not modify resolv.conf
@@ -3609,6 +3707,30 @@ USERCTL=no
 
     def test_dhcpv6_only_config(self):
         entry = NETWORK_CONFIGS['dhcpv6_only']
+        found = self._render_and_read(network_config=yaml.load(entry['yaml']))
+        self._compare_files_to_expected(entry[self.expected_name], found)
+        self._assert_headers(found)
+
+    def test_simple_render_ipv6_slaac(self):
+        entry = NETWORK_CONFIGS['ipv6_slaac']
+        found = self._render_and_read(network_config=yaml.load(entry['yaml']))
+        self._compare_files_to_expected(entry[self.expected_name], found)
+        self._assert_headers(found)
+
+    def test_dhcpv6_stateless_config(self):
+        entry = NETWORK_CONFIGS['dhcpv6_stateless']
+        found = self._render_and_read(network_config=yaml.load(entry['yaml']))
+        self._compare_files_to_expected(entry[self.expected_name], found)
+        self._assert_headers(found)
+
+    def test_render_v4_and_v6(self):
+        entry = NETWORK_CONFIGS['v4_and_v6']
+        found = self._render_and_read(network_config=yaml.load(entry['yaml']))
+        self._compare_files_to_expected(entry[self.expected_name], found)
+        self._assert_headers(found)
+
+    def test_render_v6_and_v4(self):
+        entry = NETWORK_CONFIGS['v6_and_v4']
         found = self._render_and_read(network_config=yaml.load(entry['yaml']))
         self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)
@@ -3895,6 +4017,8 @@ class TestEniNetworkStateToEni(CiTestCase):
 
 
 class TestCmdlineConfigParsing(CiTestCase):
+    with_logs = True
+
     simple_cfg = {
         'config': [{"type": "physical", "name": "eth0",
                     "mac_address": "c0:d6:9f:2c:e8:80",
@@ -3943,6 +4067,21 @@ class TestCmdlineConfigParsing(CiTestCase):
         raw_cmdline = 'ro network-config=' + encoded_text + ' root=foo'
         found = cmdline.read_kernel_cmdline_config(cmdline=raw_cmdline)
         self.assertEqual(found, self.simple_cfg)
+
+    def test_cmdline_with_net_config_disabled(self):
+        raw_cmdline = 'ro network-config=disabled root=foo'
+        found = cmdline.read_kernel_cmdline_config(cmdline=raw_cmdline)
+        self.assertEqual(found, {'config': 'disabled'})
+
+    def test_cmdline_with_net_config_unencoded_logs_error(self):
+        """network-config cannot be unencoded besides 'disabled'."""
+        raw_cmdline = 'ro network-config={config:disabled} root=foo'
+        found = cmdline.read_kernel_cmdline_config(cmdline=raw_cmdline)
+        self.assertIsNone(found)
+        expected_log = (
+            'ERROR: Expected base64 encoded kernel commandline parameter'
+            ' network-config. Ignoring network-config={config:disabled}.')
+        self.assertIn(expected_log, self.logs.getvalue())
 
     def test_cmdline_with_b64_gz(self):
         data = _gzip_data(json.dumps(self.simple_cfg).encode())

--- a/tests/unittests/test_reporting.py
+++ b/tests/unittests/test_reporting.py
@@ -2,11 +2,11 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from unittest import mock
+
 from cloudinit import reporting
 from cloudinit.reporting import events
 from cloudinit.reporting import handlers
-
-import mock
 
 from cloudinit.tests.helpers import TestCase
 

--- a/tests/unittests/test_reporting_hyperv.py
+++ b/tests/unittests/test_reporting_hyperv.py
@@ -8,7 +8,7 @@ import os
 import struct
 import time
 import re
-import mock
+from unittest import mock
 
 from cloudinit import util
 from cloudinit.tests.helpers import CiTestCase

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from mock import patch
 from collections import namedtuple
+from unittest.mock import patch
 
 from cloudinit import ssh_util
 from cloudinit.tests import helpers as test_helpers

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -737,7 +737,6 @@ class TestReadSeeded(helpers.TestCase):
 
 
 class TestSubp(helpers.CiTestCase):
-    with_logs = True
     allowed_subp = [BASH, 'cat', helpers.CiTestCase.SUBP_SHELL_TRUE,
                     BOGUS_COMMAND, sys.executable]
 
@@ -1171,5 +1170,24 @@ class TestGetProcEnv(helpers.TestCase):
         my_pid = os.getpid()
         my_ppid = os.getppid()
         self.assertEqual(my_ppid, util.get_proc_ppid(my_pid))
+
+
+@mock.patch('cloudinit.util.subp')
+def test_find_devs_with_openbsd(m_subp):
+    m_subp.return_value = (
+        'cd0:,sd0:630d98d32b5d3759,sd1:,fd0:', ''
+    )
+    devlist = util.find_devs_with_openbsd()
+    assert devlist == ['/dev/cd0a', '/dev/sd1i']
+
+
+@mock.patch('cloudinit.util.subp')
+def test_find_devs_with_openbsd_with_criteria(m_subp):
+    m_subp.return_value = (
+        'cd0:,sd0:630d98d32b5d3759,sd1:,fd0:', ''
+    )
+    devlist = util.find_devs_with_openbsd(criteria="TYPE=iso9660")
+    assert devlist == ['/dev/cd0a']
+
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_vmware/test_guestcust_util.py
+++ b/tests/unittests/test_vmware/test_guestcust_util.py
@@ -6,8 +6,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 from cloudinit import util
+from cloudinit.sources.helpers.vmware.imc.config import Config
+from cloudinit.sources.helpers.vmware.imc.config_file import ConfigFile
 from cloudinit.sources.helpers.vmware.imc.guestcust_util import (
     get_tools_config,
+    set_gc_status,
 )
 from cloudinit.tests.helpers import CiTestCase, mock
 
@@ -68,5 +71,28 @@ class TestGuestCustUtil(CiTestCase):
                 self.assertEqual(
                     get_tools_config('section', 'key', 'defaultVal'),
                     'e-f')
+
+    def test_set_gc_status(self):
+        """
+        This test is designed to verify the behavior of set_gc_status
+        """
+        # config is None, return None
+        self.assertEqual(set_gc_status(None, 'Successful'), None)
+
+        # post gc status is NO, return None
+        cf = ConfigFile("tests/data/vmware/cust-dhcp-2nic.cfg")
+        conf = Config(cf)
+        self.assertEqual(set_gc_status(conf, 'Successful'), None)
+
+        # post gc status is YES, subp is called to execute command
+        cf._insertKey("MISC|POST-GC-STATUS", "YES")
+        conf = Config(cf)
+        with mock.patch.object(util, 'subp',
+                               return_value=('ok', b'')) as mockobj:
+            self.assertEqual(
+                set_gc_status(conf, 'Successful'), ('ok', b''))
+            mockobj.assert_called_once_with(
+                ['vmware-rpctool', 'info-set guestinfo.gc.status Successful'],
+                rcs=[0])
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_vmware_config_file.py
+++ b/tests/unittests/test_vmware_config_file.py
@@ -348,6 +348,14 @@ class TestVmwareConfigFile(CiTestCase):
         conf = Config(cf)
         self.assertEqual("test-script", conf.custom_script_name)
 
+    def test_post_gc_status(self):
+        cf = ConfigFile("tests/data/vmware/cust-dhcp-2nic.cfg")
+        conf = Config(cf)
+        self.assertFalse(conf.post_gc_status)
+        cf._insertKey("MISC|POST-GC-STATUS", "YES")
+        conf = Config(cf)
+        self.assertTrue(conf.post_gc_status)
+
 
 class TestVmwareNetConfig(CiTestCase):
     """Test conversion of vmware config to cloud-init config."""

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -1,0 +1,1 @@
+dhensby

--- a/tools/.lp-to-git-user
+++ b/tools/.lp-to-git-user
@@ -13,6 +13,8 @@
  "goneri": "goneri",
  "harald-jensas": "hjensas",
  "i.galic": "igalic",
+ "kgarloff": "garloff",
+ "killermoehre": "killermoehre",
  "larsks": "larsks",
  "legovini": "paride",
  "louis": "karibou",

--- a/tools/build-on-freebsd
+++ b/tools/build-on-freebsd
@@ -29,7 +29,6 @@ pkgs="
     $py_prefix-oauthlib
     $py_prefix-requests
     $py_prefix-serial
-    $py_prefix-six
     $py_prefix-yaml
     sudo
 "

--- a/tools/build-on-netbsd
+++ b/tools/build-on-netbsd
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+fail() { echo "FAILED:" "$@" 1>&2; exit 1; }
+
+# Check dependencies:
+depschecked=/tmp/c-i.dependencieschecked
+pkgs="
+   bash
+   dmidecode
+   py37-configobj
+   py37-jinja2
+   py37-oauthlib
+   py37-requests
+   py37-setuptools
+   py37-yaml
+   sudo
+"
+[ -f "$depschecked" ] || pkg_add ${pkgs} || fail "install packages"
+
+touch $depschecked
+
+# Build the code and install in /usr/pkg/:
+python3.7 setup.py build
+python3.7 setup.py install -O1 --distro netbsd --skip-build --init-system sysvinit_netbsd
+mv -v /usr/local/etc/rc.d/cloud* /etc/rc.d
+
+# Enable cloud-init in /etc/rc.conf:
+sed -i.bak -e "/^cloud.*=.*/d" /etc/rc.conf
+echo '
+# You can safely remove the following lines starting with "cloud"
+cloudinitlocal="YES"
+cloudinit="YES"
+cloudconfig="YES"
+cloudfinal="YES"' >> /etc/rc.conf
+
+echo "Installation completed."

--- a/tools/build-on-openbsd
+++ b/tools/build-on-openbsd
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+fail() { echo "FAILED:" "$@" 1>&2; exit 1; }
+
+# Check dependencies:
+depschecked=/tmp/c-i.dependencieschecked
+pkgs="
+   bash
+   dmidecode
+   py3-configobj
+   py3-jinja2
+   py3-jsonschema
+   py3-oauthlib
+   py3-requests
+   py3-setuptools
+   py3-six
+   py3-yaml
+   sudo--
+"
+[ -f "$depschecked" ] || pkg_add ${pkgs} || fail "install packages"
+
+touch $depschecked
+
+python3 setup.py build
+python3 setup.py install -O1 --distro openbsd --skip-build
+
+echo "Installation completed."

--- a/tools/ccfg-merge-debug
+++ b/tools/ccfg-merge-debug
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from cloudinit import handlers
 from cloudinit.handlers import cloud_config as cc_part

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1062,6 +1062,10 @@ dscheck_OpenStack() {
         return ${DS_FOUND}
     fi
 
+    if dmi_chassis_asset_tag_matches "SAP CCloud VM"; then
+        return ${DS_FOUND}
+    fi
+
     # LP: #1669875 : allow identification of OpenStack by asset tag
     if dmi_chassis_asset_tag_matches "$nova"; then
         return ${DS_FOUND}

--- a/tools/make-mime.py
+++ b/tools/make-mime.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 import argparse
 import sys

--- a/tools/make-tarball
+++ b/tools/make-tarball
@@ -15,24 +15,27 @@ Usage: ${0##*/} [revision]
     options:
       -h | --help		print usage
       -o | --output FILE	write to file
+           --version VERSION	Set the version used in the tarball. Default value is determined with 'git describe'.
            --orig-tarball	Write file cloud-init_<version>.orig.tar.gz
            --long		Use git describe --long for versioning
 EOF
 }
 
 short_opts="ho:v"
-long_opts="help,output:,orig-tarball,long"
+long_opts="help,output:,version:,orig-tarball,long"
 getopt_out=$(getopt --name "${0##*/}" \
     --options "${short_opts}" --long "${long_opts}" -- "$@") &&
     eval set -- "${getopt_out}" || { Usage 1>&2; exit 1; }
 
 long_opt=""
 orig_opt=""
+version=""
 while [ $# -ne 0 ]; do
     cur=$1; next=$2
     case "$cur" in
         -h|--help) Usage; exit 0;;
         -o|--output) output=$next; shift;;
+           --version) version=$next; shift;;
            --long) long_opt="--long";;
            --orig-tarball) orig_opt=".orig";;
         --) shift; break;;
@@ -41,7 +44,12 @@ while [ $# -ne 0 ]; do
 done
 
 rev=${1:-HEAD}
-version=$(git describe --abbrev=8 "--match=[0-9]*" ${long_opt} $rev)
+if [ -z "$version" ]; then
+    version=$(git describe --abbrev=8 "--match=[0-9]*" ${long_opt} $rev)
+elif [ ! -z "$long_opt" ]; then
+    echo "WARNING: --long has no effect when --version is passed" >&2
+    exit 1
+fi
 
 archive_base="cloud-init-$version"
 if [ -z "$output" ]; then

--- a/tools/mock-meta.py
+++ b/tools/mock-meta.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Provides a somewhat random, somewhat compat, somewhat useful mock version of
 # http://docs.amazonwebservices.com

--- a/tools/pipremove
+++ b/tools/pipremove
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import subprocess
 import sys
 

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """List pip dependencies or system package dependencies for cloud-init."""
 
 # You might be tempted to rewrite this as a shell script, but you

--- a/tools/read-version
+++ b/tools/read-version
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import json
@@ -65,7 +65,13 @@ output_json = '--json' in sys.argv
 src_version = ci_version.version_string()
 version_long = None
 
-if is_gitdir(_tdir) and which("git"):
+# If we're performing CI for a new release branch (which our tooling creates
+# with an "upstream/" prefix), then we don't want to enforce strict version
+# matching because we know it will fail.
+is_release_branch_ci = (
+    os.environ.get("TRAVIS_PULL_REQUEST_BRANCH", "").startswith("upstream/")
+)
+if is_gitdir(_tdir) and which("git") and not is_release_branch_ci:
     flags = []
     if use_tags:
         flags = ['--tags']
@@ -113,6 +119,7 @@ data = {
     'extra': extra,
     'commit': commit,
     'distance': distance,
+    'is_release_branch_ci': is_release_branch_ci,
 }
 
 if output_json:

--- a/tools/render-cloudcfg
+++ b/tools/render-cloudcfg
@@ -4,8 +4,9 @@ import argparse
 import os
 import sys
 
-VARIANTS = ["amazon", "arch", "centos", "debian", "fedora", "freebsd", "rhel",
-            "suse", "ubuntu", "unknown"]
+VARIANTS = ["amazon", "arch", "centos", "debian", "fedora", "freebsd",
+            "netbsd", "openbsd", "rhel", "suse", "ubuntu", "unknown"]
+
 
 if "avoid-pep8-E402-import-not-top-of-file":
     _tdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))

--- a/tools/run-container
+++ b/tools/run-container
@@ -287,8 +287,8 @@ prep() {
     install_packages "$@"
 }
 
-nose() {
-    python3 -m nose "$@"
+pytest() {
+    python3 -m pytest "$@"
 }
 
 is_done_cloudinit() {
@@ -347,7 +347,7 @@ wait_for_boot() {
     run_self_inside "$name" wait_inside "$name" "$wtime" "$VERBOSITY" ||
         { errorrc "wait inside $name failed."; return; }
 
-    if [ ! -z "${http_proxy-}" ]; then
+    if [ -n "${http_proxy-}" ]; then
         if [ "$OS_NAME" = "centos" ]; then
             debug 1 "configuring proxy ${http_proxy}"
             inside "$name" sh -c "echo proxy=$http_proxy >> /etc/yum.conf"
@@ -478,10 +478,10 @@ main() {
 
     if [ -n "$unittest" ]; then
         debug 1 "running unit tests."
-        run_self_inside_as_cd "$name" "$user" "$cdir" nose \
+        run_self_inside_as_cd "$name" "$user" "$cdir" pytest \
             tests/unittests cloudinit/ || {
-                errorrc "nosetests failed.";
-                errors[${#errors[@]}]="nosetests"
+                errorrc "pytest failed.";
+                errors[${#errors[@]}]="pytest"
             }
     fi
 
@@ -557,7 +557,7 @@ main() {
 }
 
 case "${1:-}" in
-    prep|os_info|wait_inside|nose) _n=$1; shift; "$_n" "$@";;
+    prep|os_info|wait_inside|pytest) _n=$1; shift; "$_n" "$@";;
     *) main "$@";;
 esac
 

--- a/tools/tox-venv
+++ b/tools/tox-venv
@@ -116,7 +116,7 @@ Usage: ${0##*/} [--no-create] tox-environment [command [args]]
    be read from tox.ini.  This allows you to do:
       tox-venv py27 - tests/some/sub/dir
    and have the 'command' read correctly and have that execute:
-      python -m nose tests/some/sub/dir
+      python -m pytest tests/some/sub/dir
 EOF
 
     if [ -f "$tox_ini" ]; then

--- a/tools/validate-yaml.py
+++ b/tools/validate-yaml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """Try to read a YAML file and report any errors.
 """

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py3, xenial, pycodestyle, pyflakes, pylint
+envlist = py3, xenial-dev, pycodestyle, pyflakes, pylint
 recreate = True
 
 [testenv]
-commands = python -m nose {posargs:tests/unittests cloudinit}
+commands = {envpython} -m pytest {posargs:tests/unittests cloudinit}
 setenv =
     LC_ALL = en_US.utf-8
 passenv=
-    NOSE_VERBOSE
+    PYTEST_ADDOPTS
 
 [testenv:pycodestyle]
 basepython = python3
@@ -32,22 +32,15 @@ commands = {envpython} -m pylint {posargs:cloudinit tests tools}
 [testenv:py3]
 basepython = python3
 deps =
-    nose-timer
     -r{toxinidir}/test-requirements.txt
-commands = {envpython} -m nose --with-timer --timer-top-n 10 \
-           {posargs:--with-coverage --cover-erase --cover-branches \
-            --cover-inclusive --cover-package=cloudinit \
+commands = {envpython} -m pytest \
+            --durations 10 \
+            {posargs:--cov=cloudinit --cov-branch \
             tests/unittests cloudinit}
 
 [testenv:py27]
 basepython = python2.7
 deps = -r{toxinidir}/test-requirements.txt
-
-[testenv:py26]
-deps = -r{toxinidir}/test-requirements.txt
-commands = nosetests {posargs:tests/unittests cloudinit}
-setenv =
-    LC_ALL = C
 
 [flake8]
 #H102  Apache 2.0 license header not found
@@ -62,11 +55,15 @@ commands =
     {envpython} -m sphinx {posargs:doc/rtd doc/rtd_html}
     doc8 doc/rtd
 
-[testenv:xenial]
-commands =
-  python ./tools/pipremove jsonschema
-  python -m nose {posargs:tests/unittests cloudinit}
-basepython = python3
+[xenial-shared-deps]
+# The version of pytest in xenial doesn't work with Python 3.8, so we define
+# two xenial environments: [testenv:xenial] runs the tests with exactly the
+# version of pytest present in xenial, and is used in CI.  [testenv:xenial-dev]
+# runs the tests with the lowest version of pytest that works with Python 3.8,
+# 3.0.7, but keeps the other dependencies at xenial's level.
+#
+# (This section is not a testenv, it is used to maintain a single definition of
+# the dependencies shared between the two xenial testenvs.)
 deps =
     # requirements
     jinja2==2.8
@@ -75,46 +72,44 @@ deps =
     pyserial==3.0.1
     configobj==5.0.6
     requests==2.9.1
+    # test-requirements
+    httpretty==0.9.6
+    mock==1.3.0
+    unittest2==1.1.0
+    contextlib2==0.5.1
+
+[testenv:xenial]
+# When updating this commands definition, also update the definition in
+# [testenv:xenial-dev].  See the comment there for details.
+commands =
+  python ./tools/pipremove jsonschema
+  python -m pytest {posargs:tests/unittests cloudinit}
+basepython = python3
+deps =
+    # Refer to the comment in [xenial-shared-deps] for details
+    {[xenial-shared-deps]deps}
+    jsonpatch==1.10
+    pytest==2.8.7
+
+[testenv:xenial-dev]
+# This should be:
+#   commands = {[testenv:xenial]commands}
+# but the version of pytest in xenial has a bug
+# (https://github.com/tox-dev/tox/issues/208) which means that the {posargs}
+# substitution variable is misparsed and causes a traceback.  Ensure that any
+# changes here are reflected in [testenv:xenial].
+commands =
+  python ./tools/pipremove jsonschema
+  python -m pytest {posargs:tests/unittests cloudinit}
+basepython = {[testenv:xenial]basepython}
+deps =
+    # Refer to the comment in [xenial-shared-deps] for details
+    {[xenial-shared-deps]deps}
     # jsonpatch in xenial is 1.10, not 1.19 (#839779). The oldest version
     # to work with python3.6 is 1.16 as found in Artful.  To keep default
     # invocation of 'tox' happy, accept the difference in version here.
     jsonpatch==1.16
-    six==1.10.0
-    # test-requirements
-    httpretty==0.9.6
-    mock==1.3.0
-    nose==1.3.7
-    unittest2==1.1.0
-    contextlib2==0.5.1
-
-[testenv:centos6]
-basepython = python2.6
-commands = nosetests {posargs:tests/unittests cloudinit}
-deps =
-    # requirements
-    argparse==1.2.1
-    jinja2==2.2.1
-    pyyaml==3.10
-    oauthlib==0.6.0
-    configobj==4.6.0
-    requests==2.6.0
-    jsonpatch==1.2
-    six==1.9.0
-    -r{toxinidir}/test-requirements.txt
-
-[testenv:opensusel150]
-basepython = python2.7
-commands = nosetests {posargs:tests/unittests cloudinit}
-deps =
-    # requirements
-    jinja2==2.10
-    PyYAML==3.12
-    oauthlib==2.0.6
-    configobj==5.0.6
-    requests==2.18.4
-    jsonpatch==1.16
-    six==1.11.0
-    -r{toxinidir}/test-requirements.txt
+    pytest==3.0.7
 
 [testenv:tip-pycodestyle]
 commands = {envpython} -m pycodestyle {posargs:cloudinit/ tests/ tools/}
@@ -123,7 +118,7 @@ deps = pycodestyle
 [testenv:pyflakes]
 commands = {envpython} -m pyflakes {posargs:cloudinit/ tests/ tools/}
 deps =
-    pyflakes==1.6.0
+    pyflakes==2.1.1
 
 [testenv:tip-pyflakes]
 commands = {envpython} -m pyflakes {posargs:cloudinit/ tests/ tools/}


### PR DESCRIPTION
Performed new-upstream-snapshot -v --skip-release (since we aren't pushing this for release yet).

This allows me to refresh failing quilt patches in debian/patches.

Since I had to refresh both ec2 patch and stable*requirements patch I added a common comment prefix SRU_FIX to we can easily see resolved differences in behavior in the cloud-init codebase via a grep.

Followed quilt refresh steps https://github.com/CanonicalLtd/uss-tableflip/blob/master/doc/ubuntu_release_process.md#when-the-daily-recipe-build-fails and manually changed the patch comment.