### PR TITLE
CiTestCase: remove now-unneeded parse_and_read helper method

### DIFF
--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -23,11 +23,6 @@ try:
 except ImportError:
     from contextlib2 import ExitStack, contextmanager
 
-try:
-    from configparser import ConfigParser
-except ImportError:
-    from ConfigParser import ConfigParser
-
 from cloudinit.config.schema import (
     SchemaValidationError, validate_cloudconfig_schema)
 from cloudinit import cloud
@@ -113,16 +108,6 @@ class TestCase(unittest2.TestCase):
         p = m.start()
         self.addCleanup(m.stop)
         setattr(self, attr, p)
-
-    # prefer python3 read_file over readfp but allow fallback
-    def parse_and_read(self, contents):
-        parser = ConfigParser()
-        if hasattr(parser, 'read_file'):
-            parser.read_file(contents)
-        elif hasattr(parser, 'readfp'):
-            # pylint: disable=W1505
-            parser.readfp(contents)
-        return parser
 
 
 class CiTestCase(TestCase):

--- a/tests/unittests/test_handler/test_handler_yum_add_repo.py
+++ b/tests/unittests/test_handler/test_handler_yum_add_repo.py
@@ -1,9 +1,9 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import configparser
 import logging
 import shutil
 import tempfile
-from io import StringIO
 
 from cloudinit import util
 from cloudinit.config import cc_yum_add_repo
@@ -53,7 +53,8 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_yum_add_repo.handle('yum_add_repo', cfg, None, LOG, [])
         contents = util.load_file("/etc/yum.repos.d/epel_testing.repo")
-        parser = self.parse_and_read(StringIO(contents))
+        parser = configparser.ConfigParser()
+        parser.read_string(contents)
         expected = {
             'epel_testing': {
                 'name': 'Extra Packages for Enterprise Linux 5 - Testing',
@@ -89,7 +90,8 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_yum_add_repo.handle('yum_add_repo', cfg, None, LOG, [])
         contents = util.load_file("/etc/yum.repos.d/puppetlabs_products.repo")
-        parser = self.parse_and_read(StringIO(contents))
+        parser = configparser.ConfigParser()
+        parser.read_string(contents)
         expected = {
             'puppetlabs_products': {
                 'name': 'Puppet Labs Products El 6 - $basearch',

--- a/tests/unittests/test_handler/test_handler_yum_add_repo.py
+++ b/tests/unittests/test_handler/test_handler_yum_add_repo.py
@@ -1,14 +1,13 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from cloudinit.config import cc_yum_add_repo
-from cloudinit import util
-
-from cloudinit.tests import helpers
-
 import logging
 import shutil
 import tempfile
 from io import StringIO
+
+from cloudinit import util
+from cloudinit.config import cc_yum_add_repo
+from cloudinit.tests import helpers
 
 LOG = logging.getLogger(__name__)
 

--- a/tests/unittests/test_handler/test_handler_zypper_add_repo.py
+++ b/tests/unittests/test_handler/test_handler_zypper_add_repo.py
@@ -1,9 +1,9 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import configparser
 import glob
 import logging
 import os
-from io import StringIO
 
 from cloudinit import util
 from cloudinit.config import cc_zypper_add_repo
@@ -64,7 +64,8 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         root_d = self.tmp_dir()
         cc_zypper_add_repo._write_repos(cfg['repos'], root_d)
         contents = util.load_file("%s/testing-foo.repo" % root_d)
-        parser = self.parse_and_read(StringIO(contents))
+        parser = configparser.ConfigParser()
+        parser.read_string(contents)
         expected = {
             'testing-foo': {
                 'name': 'test-foo',

--- a/tests/unittests/test_handler/test_handler_zypper_add_repo.py
+++ b/tests/unittests/test_handler/test_handler_zypper_add_repo.py
@@ -1,16 +1,14 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import glob
+import logging
 import os
 from io import StringIO
 
-from cloudinit.config import cc_zypper_add_repo
 from cloudinit import util
-
+from cloudinit.config import cc_zypper_add_repo
 from cloudinit.tests import helpers
 from cloudinit.tests.helpers import mock
-
-import logging
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
(And sort some imports where I was changing them.)