### PR TITLE
.travis.yml: allow 30 minutes of inactivity in cloud tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ matrix:
             - sudo -E su $USER -c 'mk-sbuild xenial'
             - sudo -E su $USER -c 'sbuild --nolog --verbose --dist=xenial cloud-init_*.dsc'
             # Ubuntu LTS: Integration
-            - sg lxd -c 'tox -e citest -- run --verbose --preserve-data --data-dir results --os-name xenial --test modules/apt_configure_sources_list.yaml --test modules/ntp_servers --test modules/set_password_list --test modules/user_groups --deb cloud-init_*_all.deb'
+            - travis_wait 30 sg lxd -c 'tox -e citest -- run --verbose --preserve-data --data-dir results --os-name xenial --test modules/apt_configure_sources_list.yaml --test modules/ntp_servers --test modules/set_password_list --test modules/user_groups --deb cloud-init_*_all.deb'
         - python: 3.5
           env:
               TOXENV=xenial


### PR DESCRIPTION
We're seeing CI failures currently because a LXD image takes more than
10 minutes to download if the transatlantic link to Canonical's DC is
heavily contested.

This uses a helper provided by Travis[0] to avoid cancellation due to
lack of output for 30 minutes, which should be sufficient to download an
image even at the lowest speeds we've been seeing.

[0] https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received