### PR TITLE
openbsd: set_passwd should not unlock user

### DIFF
--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -95,10 +95,11 @@ class NetBSD(cloudinit.distros.bsd.BSD):
                     crypt.mksalt(method))
 
         try:
-            util.subp(['usermod', '-C', 'no', '-p', hashed_pw, user])
+            util.subp(['usermod', '-p', hashed_pw, user])
         except Exception:
             util.logexc(LOG, "Failed to set password for %s", user)
             raise
+        self.unlock_passwd(user)
 
     def force_passwd_change(self, user):
         try:
@@ -112,6 +113,13 @@ class NetBSD(cloudinit.distros.bsd.BSD):
             util.subp(['usermod', '-C', 'yes', name])
         except Exception:
             util.logexc(LOG, "Failed to lock user %s", name)
+            raise
+
+    def unlock_passwd(self, name):
+        try:
+            util.subp(['usermod', '-C', 'no', name])
+        except Exception:
+            util.logexc(LOG, "Failed to unlock user %s", name)
             raise
 
     def apply_locale(self, locale, out_fn=None):

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -32,6 +32,9 @@ class Distro(cloudinit.distros.netbsd.NetBSD):
             util.logexc(LOG, "Failed to lock user %s", name)
             raise
 
+    def unlock_passwd(self, name):
+        pass
+
     def _get_pkg_cmd_environ(self):
         """Return env vars used in OpenBSD package_command operations"""
         os_release = platform.release()


### PR DESCRIPTION
`usermode -C no foo` does not work on OpenBSD. Unlike NetBSD, we don't
actually need to unlock the user.