### PR TITLE
Test acceptance of x-shellscript as cloud-config.

### DIFF
--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -25,6 +25,7 @@ LOG = logging.getLogger(__name__)
 NOT_MULTIPART_TYPE = handlers.NOT_MULTIPART_TYPE
 PART_FN_TPL = handlers.PART_FN_TPL
 OCTET_TYPE = handlers.OCTET_TYPE
+INCLUDE_MAP = handlers.INCLUSION_TYPES_MAP
 
 # Saves typing errors
 CONTENT_TYPE = 'Content-Type'
@@ -115,7 +116,8 @@ class UserDataProcessor(object):
             # Attempt to figure out the payloads content-type
             if not ctype_orig:
                 ctype_orig = UNDEF_TYPE
-            if ctype_orig in TYPE_NEEDED:
+            if ctype_orig in TYPE_NEEDED or (ctype_orig in
+                                             INCLUDE_MAP.values()):
                 ctype = find_ctype(payload)
             if ctype is None:
                 ctype = ctype_orig

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -57,6 +57,40 @@ def gzip_text(text):
     f.close()
     return contents.getvalue()
 
+    def test_cloud_config_as_x_shell_script(self):
+        blob_cc = '''
+#cloud-config
+a: b
+c: d
+'''
+        message_cc = MIMEBase("text", "x-shellscript")
+        message_cc.set_payload(blob_cc)
+
+        blob_jp = '''
+#cloud-config-jsonp
+[
+     { "op": "replace", "path": "/a", "value": "c" },
+     { "op": "remove", "path": "/c" }
+]
+'''
+
+        message_jp = MIMEBase('text', "cloud-config-jsonp")
+        message_jp.set_payload(blob_jp)
+
+        message = MIMEMultipart()
+        message.attach(message_cc)
+        message.attach(message_jp)
+
+        self.reRoot()
+        ci = stages.Init()
+        ci.datasource = FakeDataSource(str(message))
+        ci.fetch()
+        ci.consume_data()
+        cc_contents = util.load_file(ci.paths.get_ipath("cloud_config"))
+        cc = util.load_yaml(cc_contents)
+        self.assertEqual(1, len(cc))
+        self.assertEqual('c', cc['a'])
+
 
 # FIXME: these tests shouldn't be checking log output??
 # Weirddddd...

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -57,6 +57,7 @@ def gzip_text(text):
     f.close()
     return contents.getvalue()
 
+
 # FIXME: these tests shouldn't be checking log output??
 # Weirddddd...
 class TestConsumeUserData(helpers.FilesystemMockingTestCase):
@@ -245,7 +246,6 @@ c: d
         cc = util.load_yaml(cc_contents)
         self.assertEqual(1, len(cc))
         self.assertEqual('c', cc['a'])
-
 
     def test_vendor_user_yaml_cloud_config(self):
         vendor_blob = '''

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -57,41 +57,6 @@ def gzip_text(text):
     f.close()
     return contents.getvalue()
 
-    def test_cloud_config_as_x_shell_script(self):
-        blob_cc = '''
-#cloud-config
-a: b
-c: d
-'''
-        message_cc = MIMEBase("text", "x-shellscript")
-        message_cc.set_payload(blob_cc)
-
-        blob_jp = '''
-#cloud-config-jsonp
-[
-     { "op": "replace", "path": "/a", "value": "c" },
-     { "op": "remove", "path": "/c" }
-]
-'''
-
-        message_jp = MIMEBase('text', "cloud-config-jsonp")
-        message_jp.set_payload(blob_jp)
-
-        message = MIMEMultipart()
-        message.attach(message_cc)
-        message.attach(message_jp)
-
-        self.reRoot()
-        ci = stages.Init()
-        ci.datasource = FakeDataSource(str(message))
-        ci.fetch()
-        ci.consume_data()
-        cc_contents = util.load_file(ci.paths.get_ipath("cloud_config"))
-        cc = util.load_yaml(cc_contents)
-        self.assertEqual(1, len(cc))
-        self.assertEqual('c', cc['a'])
-
-
 # FIXME: these tests shouldn't be checking log output??
 # Weirddddd...
 class TestConsumeUserData(helpers.FilesystemMockingTestCase):
@@ -246,6 +211,41 @@ c: d
         cc = util.load_yaml(cc_contents)
         self.assertEqual(1, len(cc))
         self.assertEqual('c', cc['a'])
+
+    def test_cloud_config_as_x_shell_script(self):
+        blob_cc = '''
+#cloud-config
+a: b
+c: d
+'''
+        message_cc = MIMEBase("text", "x-shellscript")
+        message_cc.set_payload(blob_cc)
+
+        blob_jp = '''
+#cloud-config-jsonp
+[
+     { "op": "replace", "path": "/a", "value": "c" },
+     { "op": "remove", "path": "/c" }
+]
+'''
+
+        message_jp = MIMEBase('text', "cloud-config-jsonp")
+        message_jp.set_payload(blob_jp)
+
+        message = MIMEMultipart()
+        message.attach(message_cc)
+        message.attach(message_jp)
+
+        self.reRoot()
+        ci = stages.Init()
+        ci.datasource = FakeDataSource(str(message))
+        ci.fetch()
+        ci.consume_data()
+        cc_contents = util.load_file(ci.paths.get_ipath("cloud_config"))
+        cc = util.load_yaml(cc_contents)
+        self.assertEqual(1, len(cc))
+        self.assertEqual('c', cc['a'])
+
 
     def test_vendor_user_yaml_cloud_config(self):
         vendor_blob = '''


### PR DESCRIPTION
Don't pull just yet -- this is the testcase first, adding the fix as second step (TDD).
So this will fail the CI and the subsequent patch should fix it ...

Test case from Ryan Harper in discussion of PR#234
(https://github.com/canonical/cloud-init/pull/234).
This should demonstrate that cloud-init (without the subsequent
patches) will fail to accept multipart user-data documents
with the cloud-config piece (mis)declared as text/x-shellscript.

This happens on old heat on OpenTelekomCloud.

Let's watch this fail the CI and then add the fix ...

Signed-off-by: Kurt Garloff <kurt@garloff.de>