### PR TITLE
util: remove unnecessary lru_cache import fallback

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -31,22 +31,21 @@ import string
 import subprocess
 import sys
 import time
-from urllib import parse
-
-from errno import ENOENT, ENOEXEC
-
 from base64 import b64decode, b64encode
+from errno import ENOENT, ENOEXEC
+from urllib import parse
 
 from cloudinit import importer
 from cloudinit import log as logging
-from cloudinit import mergers
-from cloudinit import safeyaml
-from cloudinit import temp_utils
-from cloudinit import type_utils
-from cloudinit import url_helper
-from cloudinit import version
-
-from cloudinit.settings import (CFG_BUILTIN)
+from cloudinit import (
+    mergers,
+    safeyaml,
+    temp_utils,
+    type_utils,
+    url_helper,
+    version,
+)
+from cloudinit.settings import CFG_BUILTIN
 
 try:
     from functools import lru_cache

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -33,6 +33,7 @@ import sys
 import time
 from base64 import b64decode, b64encode
 from errno import ENOENT, ENOEXEC
+from functools import lru_cache
 from urllib import parse
 
 from cloudinit import importer
@@ -46,16 +47,6 @@ from cloudinit import (
     version,
 )
 from cloudinit.settings import CFG_BUILTIN
-
-try:
-    from functools import lru_cache
-except ImportError:
-    def lru_cache():
-        """pass-thru replace for Python3's lru_cache()"""
-        def wrapper(f):
-            return f
-        return wrapper
-
 
 _DNS_REDIRECT_IP = None
 LOG = logging.getLogger(__name__)


### PR DESCRIPTION
functools.lru_cache has been present since Python 3.2, so we no longer need to handle its absence.

(Also sort util's imports while we're modifying them.)