### PR TITLE
Add support for NFS/EFS mounts

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -74,6 +74,8 @@ from cloudinit import util
 # Shortname matches 'sda', 'sda1', 'xvda', 'hda', 'sdb', xvdb, vda, vdd1, sr0
 DEVICE_NAME_FILTER = r"^([x]{0,1}[shv]d[a-z][0-9]*|sr[0-9]+)$"
 DEVICE_NAME_RE = re.compile(DEVICE_NAME_FILTER)
+NETWORK_NAME_FILTER = r"^.+:/.*"
+NETWORK_NAME_RE = re.compile(NETWORK_NAME_FILTER)
 WS = re.compile("[%s]+" % (whitespace))
 FSTAB_PATH = "/etc/fstab"
 MNT_COMMENT = "comment=cloudconfig"
@@ -92,6 +94,11 @@ def is_meta_device_name(name):
             return True
     return False
 
+def is_network_device(name):
+    # return true if this is a network device
+    if NETWORK_NAME_RE.match(name):
+        return True
+    return False
 
 def _get_nth_partition_for_device(device_path, partition_number):
     potential_suffixes = [str(partition_number), 'p%s' % (partition_number,),
@@ -121,6 +128,9 @@ def sanitize_devname(startname, transformer, log):
     if devname == "ephemeral":
         devname = "ephemeral0"
         log.debug("Adjusted mount option from ephemeral to ephemeral0")
+
+    if is_network_device(startname):
+        return startname
 
     device_path, partition_number = util.expand_dotted_devname(devname)
 

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -94,11 +94,13 @@ def is_meta_device_name(name):
             return True
     return False
 
+
 def is_network_device(name):
     # return true if this is a network device
     if NETWORK_NAME_RE.match(name):
         return True
     return False
+
 
 def _get_nth_partition_for_device(device_path, partition_number):
     potential_suffixes = [str(partition_number), 'p%s' % (partition_number,),

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -74,6 +74,7 @@ from cloudinit import util
 # Shortname matches 'sda', 'sda1', 'xvda', 'hda', 'sdb', xvdb, vda, vdd1, sr0
 DEVICE_NAME_FILTER = r"^([x]{0,1}[shv]d[a-z][0-9]*|sr[0-9]+)$"
 DEVICE_NAME_RE = re.compile(DEVICE_NAME_FILTER)
+# Name matches 'server:/path'
 NETWORK_NAME_FILTER = r"^.+:/.*"
 NETWORK_NAME_RE = re.compile(NETWORK_NAME_FILTER)
 WS = re.compile("[%s]+" % (whitespace))

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -75,7 +75,7 @@ from cloudinit import util
 DEVICE_NAME_FILTER = r"^([x]{0,1}[shv]d[a-z][0-9]*|sr[0-9]+)$"
 DEVICE_NAME_RE = re.compile(DEVICE_NAME_FILTER)
 # Name matches 'server:/path'
-NETWORK_NAME_FILTER = r"^.+:/.*"
+NETWORK_NAME_FILTER = r"^.+:.*"
 NETWORK_NAME_RE = re.compile(NETWORK_NAME_FILTER)
 WS = re.compile("[%s]+" % (whitespace))
 FSTAB_PATH = "/etc/fstab"

--- a/tests/unittests/test_handler/test_handler_mounts.py
+++ b/tests/unittests/test_handler/test_handler_mounts.py
@@ -133,6 +133,7 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
             disk_path,
             cc_mounts.sanitize_devname(disk_path, None, mock.Mock()))
 
+
 class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
 
     swap_path = '/dev/sdb1'

--- a/tests/unittests/test_handler/test_handler_mounts.py
+++ b/tests/unittests/test_handler/test_handler_mounts.py
@@ -127,6 +127,11 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
             cc_mounts.sanitize_devname(
                 'ephemeral0.1', lambda x: disk_path, mock.Mock()))
 
+    def test_network_device_returns_network_device(self):
+        disk_path = 'netdevice:/path'
+        self.assertEqual(
+            disk_path,
+            cc_mounts.sanitize_devname(disk_path, None, mock.Mock()))
 
 class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
 


### PR DESCRIPTION
The cc_mounts module does not support NFS mounts in the form of `hostname:/` or `hostname:/path`.


This PR adds support for NFS-style paths in the fs_spec field.

LP: #1870370