### PR TITLE
Ubuntu/devel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 cloud-init (20.1-10-g71af48df-0ubuntu13) UNRELEASED; urgency=medium
 
+  * d/patches: redact openbsd netbsd from tests until new-upstream-snapshot
+    - fix-cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
   * cherry-pick 986f37b0: cloudinit: move to pytest for running tests

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (20.1-10-g71af48df-0ubuntu10) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu11) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
@@ -12,8 +12,10 @@ cloud-init (20.1-10-g71af48df-0ubuntu10) UNRELEASED; urgency=medium
   * cherry-pick 2566fdbe: net: introduce is_ip_address function (#288)
   * cherry-pick 4f825b3e: cloudinit: refactor util.is_ipv4 to
     net.is_ipv4_address
+  * cherry-pick c478d0bf: distros: replace invalid characters in mirror
+    URLs with (LP: #1868232)
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:34 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:37 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (20.1-10-g71af48df-0ubuntu13) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu3) focal; urgency=medium
 
   * d/patches: redact openbsd netbsd from tests until new-upstream-snapshot
     - fix-cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni
@@ -21,7 +21,7 @@ cloud-init (20.1-10-g71af48df-0ubuntu13) UNRELEASED; urgency=medium
   * cherry-pick 09fea85f: net: ignore 'renderer' key in netplan config
     (#306) (LP: #1870421)
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:43 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:57:52 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-cloud-init (20.1-10-g71af48df-0ubuntu3) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu4) UNRELEASED; urgency=medium
 
-  * drop cherry pick included in master commit c4be3c60eb
-    - ec2-render-network-on-all-NICs-and-add-secondary-IPs-as
+  * cherry-pick 6600c642: ec2: render network on all NICs and add
+    secondary IPs as (LP: #1866930)
 
- -- Chad Smith <chad.smith@canonical.com>  Mon, 23 Mar 2020 14:35:12 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:01 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (20.1-10-g71af48df-0ubuntu8) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu9) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
@@ -9,8 +9,9 @@ cloud-init (20.1-10-g71af48df-0ubuntu8) UNRELEASED; urgency=medium
   * cherry-pick 04771d75: cc_disk_setup: fix RuntimeError (#270) (LP:
     #1868327)
   * cherry-pick c5e949c0: distros/tests/test_init: add tests for
+  * cherry-pick 2566fdbe: net: introduce is_ip_address function (#288)
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:28 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:32 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,13 @@
-cloud-init (20.1-10-g71af48df-0ubuntu5) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu6) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
   * cherry-pick 986f37b0: cloudinit: move to pytest for running tests
     (#211)
+  * cherry-pick 4fb6fd8a: net: ubuntu focal prioritize netplan over eni
+    even if both (LP: #1867029)
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:22 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:24 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (20.1-10-g71af48df-0ubuntu9) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu10) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
@@ -10,8 +10,10 @@ cloud-init (20.1-10-g71af48df-0ubuntu9) UNRELEASED; urgency=medium
     #1868327)
   * cherry-pick c5e949c0: distros/tests/test_init: add tests for
   * cherry-pick 2566fdbe: net: introduce is_ip_address function (#288)
+  * cherry-pick 4f825b3e: cloudinit: refactor util.is_ipv4 to
+    net.is_ipv4_address
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:32 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:34 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (20.1-10-g71af48df-0ubuntu7) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu8) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
@@ -8,8 +8,9 @@ cloud-init (20.1-10-g71af48df-0ubuntu7) UNRELEASED; urgency=medium
     even if both (LP: #1867029)
   * cherry-pick 04771d75: cc_disk_setup: fix RuntimeError (#270) (LP:
     #1868327)
+  * cherry-pick c5e949c0: distros/tests/test_init: add tests for
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:26 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:28 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,11 @@
-cloud-init (20.1-10-g71af48df-0ubuntu4) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu5) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
+  * cherry-pick 986f37b0: cloudinit: move to pytest for running tests
+    (#211)
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:01 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:22 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (20.1-10-g71af48df-0ubuntu12) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu13) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
@@ -16,8 +16,10 @@ cloud-init (20.1-10-g71af48df-0ubuntu12) UNRELEASED; urgency=medium
     URLs with (LP: #1868232)
   * cherry-pick 1bbc4908: distros: drop leading/trailing hyphens from
     mirror URL labels
+  * cherry-pick 09fea85f: net: ignore 'renderer' key in netplan config
+    (#306) (LP: #1870421)
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:40 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:43 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (20.1-10-g71af48df-0ubuntu6) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu7) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
@@ -6,8 +6,10 @@ cloud-init (20.1-10-g71af48df-0ubuntu6) UNRELEASED; urgency=medium
     (#211)
   * cherry-pick 4fb6fd8a: net: ubuntu focal prioritize netplan over eni
     even if both (LP: #1867029)
+  * cherry-pick 04771d75: cc_disk_setup: fix RuntimeError (#270) (LP:
+    #1868327)
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:24 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:26 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (20.1-10-g71af48df-0ubuntu11) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu12) UNRELEASED; urgency=medium
 
   * cherry-pick 6600c642: ec2: render network on all NICs and add
     secondary IPs as (LP: #1866930)
@@ -14,8 +14,10 @@ cloud-init (20.1-10-g71af48df-0ubuntu11) UNRELEASED; urgency=medium
     net.is_ipv4_address
   * cherry-pick c478d0bf: distros: replace invalid characters in mirror
     URLs with (LP: #1868232)
+  * cherry-pick 1bbc4908: distros: drop leading/trailing hyphens from
+    mirror URL labels
 
- -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:37 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 Apr 2020 13:55:40 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu2) focal; urgency=medium
 

--- a/debian/patches/cpick-04771d75-cc_disk_setup-fix-RuntimeError-270
+++ b/debian/patches/cpick-04771d75-cc_disk_setup-fix-RuntimeError-270
@@ -1,0 +1,25 @@
+From 04771d75a8670f07ae4c75b5892e3b795e9d1a07 Mon Sep 17 00:00:00 2001
+From: Daniel Watkins <oddbloke@ubuntu.com>
+Date: Mon, 23 Mar 2020 17:22:42 -0400
+Subject: [PATCH] cc_disk_setup: fix RuntimeError (#270)
+
+Addresses "Runtime Error: dictionary keys changed during iteration".
+
+Co-authored-by: Noah Meyerhans <noahm@debian.org>
+
+LP: #1868327
+---
+ cloudinit/config/cc_disk_setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+--- a/cloudinit/config/cc_disk_setup.py
++++ b/cloudinit/config/cc_disk_setup.py
+@@ -163,7 +163,7 @@ def handle(_name, cfg, cloud, log, _args
+ def update_disk_setup_devices(disk_setup, tformer):
+     # update 'disk_setup' dictionary anywhere were a device may occur
+     # update it with the response from 'tformer'
+-    for origname in disk_setup.keys():
++    for origname in list(disk_setup):
+         transformed = tformer(origname)
+         if transformed is None or transformed == origname:
+             continue

--- a/debian/patches/cpick-09fea85f-net-ignore-renderer-key-in-netplan-config-306
+++ b/debian/patches/cpick-09fea85f-net-ignore-renderer-key-in-netplan-config-306
@@ -1,0 +1,39 @@
+From 09fea85fd1f6fd944f4cdd8b97e283090178ae88 Mon Sep 17 00:00:00 2001
+From: Ryan Harper <ryan.harper@canonical.com>
+Date: Fri, 3 Apr 2020 12:58:08 -0500
+Subject: [PATCH] net: ignore 'renderer' key in netplan config (#306)
+
+LP: #1870421
+---
+ cloudinit/net/network_state.py            |  2 +-
+ cloudinit/net/tests/test_network_state.py | 10 ++++++++++
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+--- a/cloudinit/net/network_state.py
++++ b/cloudinit/net/network_state.py
+@@ -312,7 +312,7 @@ class NetworkStateInterpreter(metaclass=
+ 
+     def parse_config_v2(self, skip_broken=True):
+         for command_type, command in self._config.items():
+-            if command_type == 'version':
++            if command_type in ['version', 'renderer']:
+                 continue
+             try:
+                 handler = self.command_handlers[command_type]
+--- a/cloudinit/net/tests/test_network_state.py
++++ b/cloudinit/net/tests/test_network_state.py
+@@ -45,4 +45,14 @@ class TestNetworkStateParseConfig(CiTest
+         self.assertNotEqual(None, result)
+ 
+ 
++class TestNetworkStateParseConfigV2(CiTestCase):
++
++    def test_version_2_ignores_renderer_key(self):
++        ncfg = {'version': 2, 'renderer': 'networkd', 'ethernets': {}}
++        nsi = network_state.NetworkStateInterpreter(version=ncfg['version'],
++                                                    config=ncfg)
++        nsi.parse_config(skip_broken=False)
++        self.assertEqual(ncfg, nsi.as_dict()['config'])
++
++
+ # vi: ts=4 expandtab

--- a/debian/patches/cpick-1bbc4908-distros-drop-leading-trailing-hyphens-from-mirror-URL
+++ b/debian/patches/cpick-1bbc4908-distros-drop-leading-trailing-hyphens-from-mirror-URL
@@ -1,0 +1,54 @@
+From 1bbc4908ff7a2be19483811b3b6fee6ebc916235 Mon Sep 17 00:00:00 2001
+From: Daniel Watkins <oddbloke@ubuntu.com>
+Date: Tue, 31 Mar 2020 17:04:17 -0400
+Subject: [PATCH] distros: drop leading/trailing hyphens from mirror URL labels
+ (#296)
+
+* distros/tests/test_init: drop needless brackets/indentation
+
+* distros: drop leading/trailing hyphens from mirror URL labels
+---
+ cloudinit/distros/__init__.py        |  5 +++++
+ cloudinit/distros/tests/test_init.py | 14 ++++++++------
+ 2 files changed, 13 insertions(+), 6 deletions(-)
+
+--- a/cloudinit/distros/__init__.py
++++ b/cloudinit/distros/__init__.py
+@@ -816,6 +816,11 @@ def _sanitize_mirror_url(url: str):
+         lambda hostname: ''.join(
+             c if c in acceptable_chars else "-" for c in hostname
+         ),
++
++        # Drop leading/trailing hyphens from each part of the hostname
++        lambda hostname: '.'.join(
++            part.strip('-') for part in hostname.split('.')
++        ),
+     ]
+ 
+     return _apply_hostname_transformations_to_url(url, transformations)
+--- a/cloudinit/distros/tests/test_init.py
++++ b/cloudinit/distros/tests/test_init.py
+@@ -109,15 +109,17 @@ class TestGetPackageMirrorInfo:
+          ['http://%(region)s.in.hostname/should/be/filtered',
+           'http://but.not.in.the.path/%(region)s'],
+          ['http://but.not.in.the.path/inv[lid']),
+-    ) + (
++        (None, '-some-region-',
++         ['http://-lead-ing.%(region)s.trail-ing-.example.com/ubuntu'],
++         ['http://lead-ing.some-region.trail-ing.example.com/ubuntu']),
++    ) + tuple(
+         # Dynamically generate a test case for each non-LDH
+         # (Letters/Digits/Hyphen) ASCII character, testing that it is
+         # substituted with a hyphen
+-        tuple(
+-            (None, 'fk{0}fake{0}1'.format(invalid_char),
+-             ['http://%(region)s/ubuntu'], ['http://fk-fake-1/ubuntu'])
+-            for invalid_char in INVALID_URL_CHARS))
+-    )
++        (None, 'fk{0}fake{0}1'.format(invalid_char),
++         ['http://%(region)s/ubuntu'], ['http://fk-fake-1/ubuntu'])
++        for invalid_char in INVALID_URL_CHARS
++    ))
+     def test_substitution(self, availability_zone, region, patterns, expected):
+         """Test substitution works as expected."""
+         m_data_source = mock.Mock(

--- a/debian/patches/cpick-2566fdbe-net-introduce-is_ip_address-function-288
+++ b/debian/patches/cpick-2566fdbe-net-introduce-is_ip_address-function-288
@@ -1,0 +1,105 @@
+From 2566fdbee06cf5708cfcd988a65fb81cdf794dbf Mon Sep 17 00:00:00 2001
+From: Daniel Watkins <oddbloke@ubuntu.com>
+Date: Fri, 27 Mar 2020 22:47:01 -0400
+Subject: [PATCH] net: introduce is_ip_address function (#288)
+
+This will be required for the mirror URL sanitisation work,
+---
+ cloudinit/net/__init__.py        | 19 +++++++++++++++++-
+ cloudinit/net/tests/test_init.py | 33 ++++++++++++++++++++++++++++----
+ 2 files changed, 47 insertions(+), 5 deletions(-)
+
+--- a/cloudinit/net/__init__.py
++++ b/cloudinit/net/__init__.py
+@@ -6,13 +6,14 @@
+ # This file is part of cloud-init. See LICENSE file for license information.
+ 
+ import errno
++import ipaddress
+ import logging
+ import os
+ import re
+ from functools import partial
+ 
+-from cloudinit.net.network_state import mask_to_net_prefix
+ from cloudinit import util
++from cloudinit.net.network_state import mask_to_net_prefix
+ from cloudinit.url_helper import UrlError, readurl
+ 
+ LOG = logging.getLogger(__name__)
+@@ -916,6 +917,22 @@ def has_url_connectivity(url):
+         return False
+     return True
+ 
++
++def is_ip_address(s: str) -> bool:
++    """Returns a bool indicating if ``s`` is an IP address.
++
++    :param s:
++        The string to test.
++
++    :return:
++        A bool indicating if the string contains an IP address or not.
++    """
++    try:
++        ipaddress.ip_address(s)
++    except ValueError:
++        return False
++    return True
++
+ 
+ class EphemeralIPv4Network(object):
+     """Context manager which sets up temporary static network configuration.
+--- a/cloudinit/net/tests/test_init.py
++++ b/cloudinit/net/tests/test_init.py
+@@ -2,16 +2,19 @@
+ 
+ import copy
+ import errno
+-import httpretty
++import ipaddress
+ import os
+-import requests
+ import textwrap
+ from unittest import mock
+ 
++import httpretty
++import pytest
++import requests
++
+ import cloudinit.net as net
+-from cloudinit.util import ensure_file, write_file, ProcessExecutionError
+-from cloudinit.tests.helpers import CiTestCase, HttprettyTestCase
+ from cloudinit import safeyaml as yaml
++from cloudinit.tests.helpers import CiTestCase, HttprettyTestCase
++from cloudinit.util import ProcessExecutionError, ensure_file, write_file
+ 
+ 
+ class TestSysDevPath(CiTestCase):
+@@ -1297,4 +1300,26 @@ class TestNetFailOver(CiTestCase):
+         m_standby.return_value = False
+         self.assertFalse(net.is_netfailover(devname, driver))
+ 
++
++class TestIsIpAddress:
++    """Tests for net.is_ip_address.
++
++    Instead of testing with values we rely on the ipaddress stdlib module to
++    handle all values correctly, so simply test that is_ip_address defers to
++    the ipaddress module correctly.
++    """
++
++    @pytest.mark.parametrize('ip_address_side_effect,expected_return', (
++        (ValueError, False),
++        (lambda _: ipaddress.IPv4Address('192.168.0.1'), True),
++        (lambda _: ipaddress.IPv6Address('2001:db8::'), True),
++    ))
++    def test_is_ip_address(self, ip_address_side_effect, expected_return):
++        with mock.patch('cloudinit.net.ipaddress.ip_address',
++                        side_effect=ip_address_side_effect) as m_ip_address:
++            ret = net.is_ip_address(mock.sentinel.ip_address_in)
++        assert expected_return == ret
++        expected_call = mock.call(mock.sentinel.ip_address_in)
++        assert [expected_call] == m_ip_address.call_args_list
++
+ # vi: ts=4 expandtab

--- a/debian/patches/cpick-4f825b3e-cloudinit-refactor-util.is_ipv4-to-net.is_ipv4_address
+++ b/debian/patches/cpick-4f825b3e-cloudinit-refactor-util.is_ipv4-to-net.is_ipv4_address
@@ -1,0 +1,103 @@
+From 4f825b3e6d8fde5c239d29639b04d2bea6d95d0e Mon Sep 17 00:00:00 2001
+From: Daniel Watkins <oddbloke@ubuntu.com>
+Date: Mon, 30 Mar 2020 23:02:44 -0400
+Subject: [PATCH] cloudinit: refactor util.is_ipv4 to net.is_ipv4_address
+ (#292)
+
+This also simplifies the implementation to rely on the stdlib, instead
+of our own NIH checking.
+---
+ cloudinit/net/__init__.py        | 16 ++++++++++++++++
+ cloudinit/net/tests/test_init.py | 22 ++++++++++++++++++++++
+ cloudinit/sources/__init__.py    |  2 +-
+ cloudinit/util.py                | 14 --------------
+ 4 files changed, 39 insertions(+), 15 deletions(-)
+
+--- a/cloudinit/net/__init__.py
++++ b/cloudinit/net/__init__.py
+@@ -934,6 +934,22 @@ def is_ip_address(s: str) -> bool:
+     return True
+ 
+ 
++def is_ipv4_address(s: str) -> bool:
++    """Returns a bool indicating if ``s`` is an IPv4 address.
++
++    :param s:
++        The string to test.
++
++    :return:
++        A bool indicating if the string contains an IPv4 address or not.
++    """
++    try:
++        ipaddress.IPv4Address(s)
++    except ValueError:
++        return False
++    return True
++
++
+ class EphemeralIPv4Network(object):
+     """Context manager which sets up temporary static network configuration.
+ 
+--- a/cloudinit/net/tests/test_init.py
++++ b/cloudinit/net/tests/test_init.py
+@@ -1322,4 +1322,26 @@ class TestIsIpAddress:
+         expected_call = mock.call(mock.sentinel.ip_address_in)
+         assert [expected_call] == m_ip_address.call_args_list
+ 
++
++class TestIsIpv4Address:
++    """Tests for net.is_ipv4_address.
++
++    Instead of testing with values we rely on the ipaddress stdlib module to
++    handle all values correctly, so simply test that is_ipv4_address defers to
++    the ipaddress module correctly.
++    """
++
++    @pytest.mark.parametrize('ipv4address_mock,expected_return', (
++        (mock.Mock(side_effect=ValueError), False),
++        (mock.Mock(return_value=ipaddress.IPv4Address('192.168.0.1')), True),
++    ))
++    def test_is_ip_address(self, ipv4address_mock, expected_return):
++        with mock.patch('cloudinit.net.ipaddress.IPv4Address',
++                        ipv4address_mock) as m_ipv4address:
++            ret = net.is_ipv4_address(mock.sentinel.ip_address_in)
++        assert expected_return == ret
++        expected_call = mock.call(mock.sentinel.ip_address_in)
++        assert [expected_call] == m_ipv4address.call_args_list
++
++
+ # vi: ts=4 expandtab
+--- a/cloudinit/sources/__init__.py
++++ b/cloudinit/sources/__init__.py
+@@ -602,7 +602,7 @@ class DataSource(metaclass=abc.ABCMeta):
+             # if there is an ipv4 address in 'local-hostname', then
+             # make up a hostname (LP: #475354) in format ip-xx.xx.xx.xx
+             lhost = self.metadata['local-hostname']
+-            if util.is_ipv4(lhost):
++            if net.is_ipv4_address(lhost):
+                 toks = []
+                 if resolve_ip:
+                     toks = util.gethostbyaddr(lhost)
+--- a/cloudinit/util.py
++++ b/cloudinit/util.py
+@@ -533,20 +533,6 @@ def multi_log(text, console=True, stderr
+             log.log(log_level, text)
+ 
+ 
+-def is_ipv4(instr):
+-    """determine if input string is a ipv4 address. return boolean."""
+-    toks = instr.split('.')
+-    if len(toks) != 4:
+-        return False
+-
+-    try:
+-        toks = [x for x in toks if 0 <= int(x) < 256]
+-    except Exception:
+-        return False
+-
+-    return len(toks) == 4
+-
+-
+ @lru_cache()
+ def is_FreeBSD():
+     return system_info()['variant'] == "freebsd"

--- a/debian/patches/cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni-even-if
+++ b/debian/patches/cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni-even-if
@@ -1,0 +1,204 @@
+From 4fb6fd8a046a6bcce01216c386f3b691a2c466bb Mon Sep 17 00:00:00 2001
+From: Chad Smith <chad.smith@canonical.com>
+Date: Mon, 30 Mar 2020 21:24:51 -0600
+Subject: [PATCH] net: ubuntu focal prioritize netplan over eni even if both
+ present (#267)
+
+On Focal and later, Ubuntu will prioritize netplan renderer over eni,
+even if ifupdown and netplan are both installed.
+
+ENI on Focal and later is considered an unsupported configuration so
+cloud-init should generally prefer netplan. On many cloud images,
+the /etc/network/interfaces config file does not include the dir
+/etc/network/interfaces.d thereby ignoring cloud-init's
+/etc/network/interfaces.d/50-cloud-init.cfg file.
+
+LP: #1867029
+---
+ config/cloud.cfg.tmpl                   |  3 +
+ tests/unittests/test_net.py             | 86 +++++++++++++------------
+ tests/unittests/test_render_cloudcfg.py | 57 ++++++++++++++++
+ 3 files changed, 106 insertions(+), 40 deletions(-)
+ create mode 100644 tests/unittests/test_render_cloudcfg.py
+
+--- a/config/cloud.cfg.tmpl
++++ b/config/cloud.cfg.tmpl
+@@ -158,6 +158,9 @@ system_info:
+      groups: [adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video]
+      sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+      shell: /bin/bash
++{# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
++   network:
++     renderers: ['netplan', 'eni', 'sysconfig']
+    # Automatically discover the best ntp_client
+    ntp_client: auto
+    # Other config here will be given to the distro class and/or path classes
+--- a/tests/unittests/test_net.py
++++ b/tests/unittests/test_net.py
+@@ -24,6 +24,7 @@ import re
+ import textwrap
+ from yaml.serializer import Serializer
+ 
++import pytest
+ 
+ DHCP_CONTENT_1 = """
+ DEVICE='eth0'
+@@ -4671,6 +4672,51 @@ class TestEniRoundTrip(CiTestCase):
+             files['/etc/network/interfaces'].splitlines())
+ 
+ 
++class TestRenderersSelect:
++
++    @pytest.mark.parametrize(
++        'renderer_selected,netplan,eni,nm,scfg,sys', (
++            # -netplan -ifupdown -nm -scfg -sys raises error
++            (net.RendererNotFoundError, False, False, False, False, False),
++            # -netplan +ifupdown -nm -scfg -sys selects eni
++            ('eni', False, True, False, False, False),
++            # +netplan +ifupdown -nm -scfg -sys selects eni
++            ('eni', True, True, False, False, False),
++            # +netplan -ifupdown -nm -scfg -sys selects netplan
++            ('netplan', True, False, False, False, False),
++            # Ubuntu with Network-Manager installed
++            # +netplan -ifupdown +nm -scfg -sys selects netplan
++            ('netplan', True, False, True, False, False),
++            # Centos/OpenSuse with Network-Manager installed selects sysconfig
++            # -netplan -ifupdown +nm -scfg +sys selects netplan
++            ('sysconfig', False, False, True, False, True),
++        ),
++    )
++    @mock.patch("cloudinit.net.renderers.netplan.available")
++    @mock.patch("cloudinit.net.renderers.sysconfig.available")
++    @mock.patch("cloudinit.net.renderers.sysconfig.available_sysconfig")
++    @mock.patch("cloudinit.net.renderers.sysconfig.available_nm")
++    @mock.patch("cloudinit.net.renderers.eni.available")
++    def test_valid_renderer_from_defaults_depending_on_availability(
++        self, m_eni_avail, m_nm_avail, m_scfg_avail, m_sys_avail,
++        m_netplan_avail, renderer_selected, netplan, eni, nm, scfg, sys
++    ):
++        """Assert proper renderer per DEFAULT_PRIORITY given availability."""
++        m_eni_avail.return_value = eni          # ifupdown pkg presence
++        m_nm_avail.return_value = nm            # network-manager presence
++        m_scfg_avail.return_value = scfg        # sysconfig presence
++        m_sys_avail.return_value = sys          # sysconfig/ifup/down presence
++        m_netplan_avail.return_value = netplan  # netplan presence
++        if isinstance(renderer_selected, str):
++            (renderer_name, _rnd_class) = renderers.select(
++                priority=renderers.DEFAULT_PRIORITY
++            )
++            assert renderer_selected == renderer_name
++        else:
++            with pytest.raises(renderer_selected):
++                renderers.select(priority=renderers.DEFAULT_PRIORITY)
++
++
+ class TestNetRenderers(CiTestCase):
+     @mock.patch("cloudinit.net.renderers.sysconfig.available")
+     @mock.patch("cloudinit.net.renderers.eni.available")
+@@ -4714,46 +4760,6 @@ class TestNetRenderers(CiTestCase):
+         self.assertRaises(net.RendererNotFoundError, renderers.select,
+                           priority=['sysconfig', 'eni'])
+ 
+-    @mock.patch("cloudinit.net.renderers.netplan.available")
+-    @mock.patch("cloudinit.net.renderers.sysconfig.available")
+-    @mock.patch("cloudinit.net.renderers.sysconfig.available_sysconfig")
+-    @mock.patch("cloudinit.net.renderers.sysconfig.available_nm")
+-    @mock.patch("cloudinit.net.renderers.eni.available")
+-    @mock.patch("cloudinit.net.renderers.sysconfig.util.get_linux_distro")
+-    def test_sysconfig_selected_on_sysconfig_enabled_distros(self, m_distro,
+-                                                             m_eni, m_sys_nm,
+-                                                             m_sys_scfg,
+-                                                             m_sys_avail,
+-                                                             m_netplan):
+-        """sysconfig only selected on specific distros (rhel/sles)."""
+-
+-        # Ubuntu with Network-Manager installed
+-        m_eni.return_value = False        # no ifupdown (ifquery)
+-        m_sys_scfg.return_value = False   # no sysconfig/ifup/ifdown
+-        m_sys_nm.return_value = True      # network-manager is installed
+-        m_netplan.return_value = True     # netplan is installed
+-        m_sys_avail.return_value = False  # no sysconfig on Ubuntu
+-        m_distro.return_value = ('ubuntu', None, None)
+-        self.assertEqual('netplan', renderers.select(priority=None)[0])
+-
+-        # Centos with Network-Manager installed
+-        m_eni.return_value = False       # no ifupdown (ifquery)
+-        m_sys_scfg.return_value = False  # no sysconfig/ifup/ifdown
+-        m_sys_nm.return_value = True     # network-manager is installed
+-        m_netplan.return_value = False   # netplan is not installed
+-        m_sys_avail.return_value = True  # sysconfig is available on centos
+-        m_distro.return_value = ('centos', None, None)
+-        self.assertEqual('sysconfig', renderers.select(priority=None)[0])
+-
+-        # OpenSuse with Network-Manager installed
+-        m_eni.return_value = False       # no ifupdown (ifquery)
+-        m_sys_scfg.return_value = False  # no sysconfig/ifup/ifdown
+-        m_sys_nm.return_value = True     # network-manager is installed
+-        m_netplan.return_value = False   # netplan is not installed
+-        m_sys_avail.return_value = True  # sysconfig is available on opensuse
+-        m_distro.return_value = ('opensuse', None, None)
+-        self.assertEqual('sysconfig', renderers.select(priority=None)[0])
+-
+     @mock.patch("cloudinit.net.sysconfig.available_sysconfig")
+     @mock.patch("cloudinit.util.get_linux_distro")
+     def test_sysconfig_available_uses_variant_mapping(self, m_distro, m_avail):
+--- /dev/null
++++ b/tests/unittests/test_render_cloudcfg.py
+@@ -0,0 +1,57 @@
++"""Tests for tools/render-cloudcfg"""
++
++import os
++import sys
++
++import pytest
++
++from cloudinit import util
++
++# TODO(Look to align with tools.render-cloudcfg or cloudinit.distos.OSFAMILIES)
++DISTRO_VARIANTS = ["amazon", "arch", "centos", "debian", "fedora", "freebsd",
++                   "netbsd", "openbsd", "rhel", "suse", "ubuntu", "unknown"]
++
++
++class TestRenderCloudCfg:
++
++    cmd = [sys.executable, os.path.realpath('tools/render-cloudcfg')]
++    tmpl_path = os.path.realpath('config/cloud.cfg.tmpl')
++
++    @pytest.mark.parametrize('variant', (DISTRO_VARIANTS))
++    def test_variant_sets_distro_in_cloud_cfg(self, variant, tmpdir):
++        outfile = tmpdir.join('outcfg').strpath
++        util.subp(
++            self.cmd + ['--variant', variant, self.tmpl_path, outfile])
++        with open(outfile) as stream:
++            system_cfg = util.load_yaml(stream.read())
++        if variant == 'unknown':
++            variant = 'ubuntu'  # Unknown is defaulted to ubuntu
++        assert system_cfg['system_info']['distro'] == variant
++
++    @pytest.mark.parametrize('variant', (DISTRO_VARIANTS))
++    def test_variant_sets_default_user_in_cloud_cfg(self, variant, tmpdir):
++        outfile = tmpdir.join('outcfg').strpath
++        util.subp(
++            self.cmd + ['--variant', variant, self.tmpl_path, outfile])
++        with open(outfile) as stream:
++            system_cfg = util.load_yaml(stream.read())
++
++        default_user_exceptions = {
++            'amazon': 'ec2-user', 'debian': 'ubuntu', 'unknown': 'ubuntu'}
++        default_user = system_cfg['system_info']['default_user']['name']
++        assert default_user == default_user_exceptions.get(variant, variant)
++
++    @pytest.mark.parametrize('variant,renderers', (
++        ('freebsd', ['freebsd']), ('netbsd', ['netbsd']),
++        ('openbsd', ['openbsd']), ('ubuntu', ['netplan', 'eni', 'sysconfig']))
++    )
++    def test_variant_sets_network_renderer_priority_in_cloud_cfg(
++        self, variant, renderers, tmpdir
++    ):
++        outfile = tmpdir.join('outcfg').strpath
++        util.subp(
++            self.cmd + ['--variant', variant, self.tmpl_path, outfile])
++        with open(outfile) as stream:
++            system_cfg = util.load_yaml(stream.read())
++
++        assert renderers == system_cfg['system_info']['network']['renderers']

--- a/debian/patches/cpick-6600c642-ec2-render-network-on-all-NICs-and-add-secondary-IPs-as
+++ b/debian/patches/cpick-6600c642-ec2-render-network-on-all-NICs-and-add-secondary-IPs-as
@@ -1,0 +1,706 @@
+From 6600c642af3817fe5e0170cb7b4eeac4be3c60eb Mon Sep 17 00:00:00 2001
+From: Chad Smith <chad.smith@canonical.com>
+Date: Wed, 18 Mar 2020 13:33:37 -0600
+Subject: [PATCH] ec2: render network on all NICs and add secondary IPs as
+ static (#114)
+
+Add support for rendering secondary static IPv4/IPv6 addresses on
+any NIC attached to the machine. In order to see secondary IP
+addresses in Ec2 IMDS network config, cloud-init now reads metadata
+version 2018-09-24. Metadata services which do not support the Ec2
+API version will not get secondary IP addresses configured.
+
+In order to discover secondary IP address config, cloud-init now
+relies on metadata API Parse local-ipv4s, ipv6s,
+subnet-ipv4-cidr-block and subnet-ipv6-cidr-block metadata keys to
+determine additional IPs and appropriate subnet prefix to set for a
+nic.
+
+Also add the datasource config option apply_full_imds_netork_config
+which defaults to true to allow cloud-init to automatically configure
+secondary IP addresses. Setting this option to false will tell
+cloud-init to avoid setting up secondary IP addresses.
+
+Also in this branch:
+ - Shift Ec2 datasource to emit network config v2 instead of v1.
+
+LP: #1866930
+---
+ cloudinit/sources/DataSourceEc2.py          | 116 +++++--
+ doc/rtd/topics/datasources/ec2.rst          |  19 ++
+ tests/unittests/test_datasource/test_ec2.py | 329 ++++++++++++++++----
+ 3 files changed, 379 insertions(+), 85 deletions(-)
+
+--- a/cloudinit/sources/DataSourceEc2.py
++++ b/cloudinit/sources/DataSourceEc2.py
+@@ -62,7 +62,7 @@ class DataSourceEc2(sources.DataSource):
+ 
+     # Priority ordered list of additional metadata versions which will be tried
+     # for extended metadata content. IPv6 support comes in 2016-09-02
+-    extended_metadata_versions = ['2016-09-02']
++    extended_metadata_versions = ['2018-09-24', '2016-09-02']
+ 
+     # Setup read_url parameters per get_url_params.
+     url_max_wait = 120
+@@ -405,13 +405,16 @@ class DataSourceEc2(sources.DataSource):
+                 logfunc=LOG.debug, msg='Re-crawl of metadata service',
+                 func=self.get_data)
+ 
+-        # Limit network configuration to only the primary/fallback nic
+         iface = self.fallback_interface
+-        macs_to_nics = {net.get_interface_mac(iface): iface}
+         net_md = self.metadata.get('network')
+         if isinstance(net_md, dict):
++            # SRU_BLOCKER: xenial, bionic and eoan should default
++            # apply_full_imds_network_config to False to retain original
++            # behavior on those releases.
+             result = convert_ec2_metadata_network_config(
+-                net_md, macs_to_nics=macs_to_nics, fallback_nic=iface)
++                net_md, fallback_nic=iface,
++                full_network_config=util.get_cfg_option_bool(
++                    self.ds_cfg, 'apply_full_imds_network_config', True))
+ 
+             # RELEASE_BLOCKER: xenial should drop the below if statement,
+             # because the issue being addressed doesn't exist pre-netplan.
+@@ -719,9 +722,10 @@ def _collect_platform_data():
+     return data
+ 
+ 
+-def convert_ec2_metadata_network_config(network_md, macs_to_nics=None,
+-                                        fallback_nic=None):
+-    """Convert ec2 metadata to network config version 1 data dict.
++def convert_ec2_metadata_network_config(
++        network_md, macs_to_nics=None, fallback_nic=None,
++        full_network_config=True):
++    """Convert ec2 metadata to network config version 2 data dict.
+ 
+     @param: network_md: 'network' portion of EC2 metadata.
+        generally formed as {"interfaces": {"macs": {}} where
+@@ -731,28 +735,104 @@ def convert_ec2_metadata_network_config(
+        not provided, get_interfaces_by_mac is called to get it from the OS.
+     @param: fallback_nic: Optionally provide the primary nic interface name.
+        This nic will be guaranteed to minimally have a dhcp4 configuration.
++    @param: full_network_config: Boolean set True to configure all networking
++       presented by IMDS. This includes rendering secondary IPv4 and IPv6
++       addresses on all NICs and rendering network config on secondary NICs.
++       If False, only the primary nic will be configured and only with dhcp
++       (IPv4/IPv6).
+ 
+-    @return A dict of network config version 1 based on the metadata and macs.
++    @return A dict of network config version 2 based on the metadata and macs.
+     """
+-    netcfg = {'version': 1, 'config': []}
++    netcfg = {'version': 2, 'ethernets': {}}
+     if not macs_to_nics:
+         macs_to_nics = net.get_interfaces_by_mac()
+     macs_metadata = network_md['interfaces']['macs']
+-    for mac, nic_name in macs_to_nics.items():
++
++    if not full_network_config:
++        for mac, nic_name in macs_to_nics.items():
++            if nic_name == fallback_nic:
++                break
++        dev_config = {'dhcp4': True,
++                      'dhcp6': False,
++                      'match': {'macaddress': mac.lower()},
++                      'set-name': nic_name}
++        nic_metadata = macs_metadata.get(mac)
++        if nic_metadata.get('ipv6s'):  # Any IPv6 addresses configured
++            dev_config['dhcp6'] = True
++        netcfg['ethernets'][nic_name] = dev_config
++        return netcfg
++    # Apply network config for all nics and any secondary IPv4/v6 addresses
++    nic_idx = 1
++    for mac, nic_name in sorted(macs_to_nics.items()):
+         nic_metadata = macs_metadata.get(mac)
+         if not nic_metadata:
+             continue  # Not a physical nic represented in metadata
+-        nic_cfg = {'type': 'physical', 'name': nic_name, 'subnets': []}
+-        nic_cfg['mac_address'] = mac
+-        if (nic_name == fallback_nic or nic_metadata.get('public-ipv4s') or
+-                nic_metadata.get('local-ipv4s')):
+-            nic_cfg['subnets'].append({'type': 'dhcp4'})
+-        if nic_metadata.get('ipv6s'):
+-            nic_cfg['subnets'].append({'type': 'dhcp6'})
+-        netcfg['config'].append(nic_cfg)
++        dhcp_override = {'route-metric': nic_idx * 100}
++        nic_idx += 1
++        dev_config = {'dhcp4': True, 'dhcp4-overrides': dhcp_override,
++                      'dhcp6': False,
++                      'match': {'macaddress': mac.lower()},
++                      'set-name': nic_name}
++        if nic_metadata.get('ipv6s'):  # Any IPv6 addresses configured
++            dev_config['dhcp6'] = True
++            dev_config['dhcp6-overrides'] = dhcp_override
++        dev_config['addresses'] = get_secondary_addresses(nic_metadata, mac)
++        if not dev_config['addresses']:
++            dev_config.pop('addresses')  # Since we found none configured
++        netcfg['ethernets'][nic_name] = dev_config
++    # Remove route-metric dhcp overrides if only one nic configured
++    if len(netcfg['ethernets']) == 1:
++        for nic_name in netcfg['ethernets'].keys():
++            netcfg['ethernets'][nic_name].pop('dhcp4-overrides')
++            netcfg['ethernets'][nic_name].pop('dhcp6-overrides', None)
+     return netcfg
+ 
+ 
++def get_secondary_addresses(nic_metadata, mac):
++    """Parse interface-specific nic metadata and return any secondary IPs
++
++    :return: List of secondary IPv4 or IPv6 addresses to configure on the
++    interface
++    """
++    ipv4s = nic_metadata.get('local-ipv4s')
++    ipv6s = nic_metadata.get('ipv6s')
++    addresses = []
++    # In version < 2018-09-24 local_ipv4s or ipv6s is a str with one IP
++    if bool(isinstance(ipv4s, list) and len(ipv4s) > 1):
++        addresses.extend(
++            _get_secondary_addresses(
++                nic_metadata, 'subnet-ipv4-cidr-block', mac, ipv4s, '24'))
++    if bool(isinstance(ipv6s, list) and len(ipv6s) > 1):
++        addresses.extend(
++            _get_secondary_addresses(
++                nic_metadata, 'subnet-ipv6-cidr-block', mac, ipv6s, '128'))
++    return sorted(addresses)
++
++
++def _get_secondary_addresses(nic_metadata, cidr_key, mac, ips, default_prefix):
++    """Return list of IP addresses as CIDRs for secondary IPs
++
++    The CIDR prefix will be default_prefix if cidr_key is absent or not
++    parseable in nic_metadata.
++    """
++    addresses = []
++    cidr = nic_metadata.get(cidr_key)
++    prefix = default_prefix
++    if not cidr or len(cidr.split('/')) != 2:
++        ip_type = 'ipv4' if 'ipv4' in cidr_key else 'ipv6'
++        LOG.warning(
++            'Could not parse %s %s for mac %s. %s network'
++            ' config prefix defaults to /%s',
++            cidr_key, cidr, mac, ip_type, prefix)
++    else:
++        prefix = cidr.split('/')[1]
++    # We know we have > 1 ips for in metadata for this IP type
++    for ip in ips[1:]:
++        addresses.append(
++            '{ip}/{prefix}'.format(ip=ip, prefix=prefix))
++    return addresses
++
++
+ # Used to match classes to dependencies
+ datasources = [
+     (DataSourceEc2Local, (sources.DEP_FILESYSTEM,)),  # Run at init-local
+--- a/doc/rtd/topics/datasources/ec2.rst
++++ b/doc/rtd/topics/datasources/ec2.rst
+@@ -42,6 +42,7 @@ Note that there are multiple versions of
+ by default uses **2009-04-04** but newer versions can be supported with
+ relative ease (newer versions have more data exposed, while maintaining
+ backward compatibility with the previous versions).
++Version **2016-09-02** is required for secondary IP address support.
+ 
+ To see which versions are supported from your cloud provider use the following
+ URL:
+@@ -80,6 +81,15 @@ The settings that may be configured are:
+  * **timeout**: the timeout value provided to urlopen for each individual http
+    request.  This is used both when selecting a metadata_url and when crawling
+    the metadata service. (default: 50)
++ * **apply_full_imds_network_config**: Boolean (default: True) to allow
++   cloud-init to configure any secondary NICs and secondary IPs described by
++   the metadata service. All network interfaces are configured with DHCP (v4)
++   to obtain an primary IPv4 address and route. Interfaces which have a
++   non-empty 'ipv6s' list will also enable DHCPv6 to obtain a primary IPv6
++   address and route. The DHCP response (v4 and v6) return an IP that matches
++   the first element of local-ipv4s and ipv6s lists respectively. All
++   additional values (secondary addresses) in the static ip lists will be
++   added to interface.
+ 
+ An example configuration with the default values is provided below:
+ 
+@@ -90,6 +100,7 @@ An example configuration with the defaul
+     metadata_urls: ["http://169.254.169.254:80", "http://instance-data:8773"]
+     max_wait: 120
+     timeout: 50
++    apply_full_imds_network_config: true
+ 
+ Notes
+ -----
+@@ -102,4 +113,12 @@ Notes
+    The check for the instance type is performed by is_classic_instance()
+    method.
+ 
++ * For EC2 instances with multiple network interfaces (NICs) attached, dhcp4
++   will be enabled to obtain the primary private IPv4 address of those NICs.
++   Wherever dhcp4 or dhcp6 is enabled for a NIC, a dhcp route-metric will be
++   added with the value of ``<device-number + 1> * 100`` to ensure dhcp
++   routes on the primary NIC are preferred to any secondary NICs.
++   For example: the primary NIC will have a DHCP route-metric of 100,
++   the next NIC will be 200.
++
+ .. vi: textwidth=78
+--- a/tests/unittests/test_datasource/test_ec2.py
++++ b/tests/unittests/test_datasource/test_ec2.py
+@@ -113,6 +113,122 @@ DEFAULT_METADATA = {
+     "services": {"domain": "amazonaws.com", "partition": "aws"},
+ }
+ 
++# collected from api version 2018-09-24/ with
++# python3 -c 'import json
++# from cloudinit.ec2_utils import get_instance_metadata as gm
++# print(json.dumps(gm("2018-09-24"), indent=1, sort_keys=True))'
++
++NIC1_MD_IPV4_IPV6_MULTI_IP = {
++    "device-number": "0",
++    "interface-id": "eni-0d6335689899ce9cc",
++    "ipv4-associations": {
++        "18.218.219.181": "172.31.44.13"
++    },
++    "ipv6s": [
++        "2600:1f16:292:100:c187:593c:4349:136",
++        "2600:1f16:292:100:f153:12a3:c37c:11f9",
++        "2600:1f16:292:100:f152:2222:3333:4444"
++    ],
++    "local-hostname": ("ip-172-31-44-13.us-east-2."
++                       "compute.internal"),
++    "local-ipv4s": [
++        "172.31.44.13",
++        "172.31.45.70"
++    ],
++    "mac": "0a:07:84:3d:6e:38",
++    "owner-id": "329910648901",
++    "public-hostname": ("ec2-18-218-219-181.us-east-2."
++                        "compute.amazonaws.com"),
++    "public-ipv4s": "18.218.219.181",
++    "security-group-ids": "sg-0c387755222ba8d2e",
++    "security-groups": "launch-wizard-4",
++    "subnet-id": "subnet-9d7ba0d1",
++    "subnet-ipv4-cidr-block": "172.31.32.0/20",
++    "subnet_ipv6_cidr_blocks": "2600:1f16:292:100::/64",
++    "vpc-id": "vpc-a07f62c8",
++    "vpc-ipv4-cidr-block": "172.31.0.0/16",
++    "vpc-ipv4-cidr-blocks": "172.31.0.0/16",
++    "vpc_ipv6_cidr_blocks": "2600:1f16:292:100::/56"
++}
++
++NIC2_MD = {
++    "device_number": "1",
++    "interface_id": "eni-043cdce36ded5e79f",
++    "local_hostname": "ip-172-31-47-221.us-east-2.compute.internal",
++    "local_ipv4s": "172.31.47.221",
++    "mac": "0a:75:69:92:e2:16",
++    "owner_id": "329910648901",
++    "security_group_ids": "sg-0d68fef37d8cc9b77",
++    "security_groups": "launch-wizard-17",
++    "subnet_id": "subnet-9d7ba0d1",
++    "subnet_ipv4_cidr_block": "172.31.32.0/20",
++    "vpc_id": "vpc-a07f62c8",
++    "vpc_ipv4_cidr_block": "172.31.0.0/16",
++    "vpc_ipv4_cidr_blocks": "172.31.0.0/16"
++}
++
++SECONDARY_IP_METADATA_2018_09_24 = {
++    "ami-id": "ami-0986c2ac728528ac2",
++    "ami-launch-index": "0",
++    "ami-manifest-path": "(unknown)",
++    "block-device-mapping": {
++        "ami": "/dev/sda1",
++        "root": "/dev/sda1"
++    },
++    "events": {
++        "maintenance": {
++            "history": "[]",
++            "scheduled": "[]"
++        }
++    },
++    "hostname": "ip-172-31-44-13.us-east-2.compute.internal",
++    "identity-credentials": {
++        "ec2": {
++            "info": {
++                "AccountId": "329910648901",
++                "Code": "Success",
++                "LastUpdated": "2019-07-06T14:22:56Z"
++            }
++        }
++    },
++    "instance-action": "none",
++    "instance-id": "i-069e01e8cc43732f8",
++    "instance-type": "t2.micro",
++    "local-hostname": "ip-172-31-44-13.us-east-2.compute.internal",
++    "local-ipv4": "172.31.44.13",
++    "mac": "0a:07:84:3d:6e:38",
++    "metrics": {
++        "vhostmd": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
++    },
++    "network": {
++        "interfaces": {
++            "macs": {
++                "0a:07:84:3d:6e:38": NIC1_MD_IPV4_IPV6_MULTI_IP,
++            }
++        }
++    },
++    "placement": {
++        "availability-zone": "us-east-2c"
++    },
++    "profile": "default-hvm",
++    "public-hostname": (
++        "ec2-18-218-219-181.us-east-2.compute.amazonaws.com"),
++    "public-ipv4": "18.218.219.181",
++    "public-keys": {
++        "yourkeyname,e": [
++            "ssh-rsa AAAAW...DZ yourkeyname"
++        ]
++    },
++    "reservation-id": "r-09b4917135cdd33be",
++    "security-groups": "launch-wizard-4",
++    "services": {
++        "domain": "amazonaws.com",
++        "partition": "aws"
++    }
++}
++
++M_PATH_NET = 'cloudinit.sources.DataSourceEc2.net.'
++
+ 
+ def _register_ssh_keys(rfunc, base_url, keys_data):
+     """handle ssh key inconsistencies.
+@@ -267,30 +383,23 @@ class TestEc2(test_helpers.HttprettyTest
+                         register_mock_metaserver(instance_id_url, None)
+         return ds
+ 
+-    def test_network_config_property_returns_version_1_network_data(self):
+-        """network_config property returns network version 1 for metadata.
+-
+-        Only one device is configured even when multiple exist in metadata.
+-        """
++    def test_network_config_property_returns_version_2_network_data(self):
++        """network_config property returns network version 2 for metadata"""
+         ds = self._setup_ds(
+             platform_data=self.valid_platform_data,
+             sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
+             md={'md': DEFAULT_METADATA})
+-        find_fallback_path = (
+-            'cloudinit.sources.DataSourceEc2.net.find_fallback_nic')
++        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
+         with mock.patch(find_fallback_path) as m_find_fallback:
+             m_find_fallback.return_value = 'eth9'
+             ds.get_data()
+ 
+         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': '06:17:04:d7:26:09', 'name': 'eth9',
+-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}],
+-             'type': 'physical'}]}
+-        patch_path = (
+-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
+-        get_interface_mac_path = (
+-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': '06:17:04:d7:26:09'}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': True}}}
++        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
++        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
+         with mock.patch(patch_path) as m_get_interfaces_by_mac:
+             with mock.patch(find_fallback_path) as m_find_fallback:
+                 with mock.patch(get_interface_mac_path) as m_get_mac:
+@@ -299,30 +408,59 @@ class TestEc2(test_helpers.HttprettyTest
+                     m_get_mac.return_value = mac1
+                     self.assertEqual(expected, ds.network_config)
+ 
+-    def test_network_config_property_set_dhcp4_on_private_ipv4(self):
+-        """network_config property configures dhcp4 on private ipv4 nics.
++    def test_network_config_property_set_dhcp4(self):
++        """network_config property configures dhcp4 on nics with local-ipv4s.
+ 
+-        Only one device is configured even when multiple exist in metadata.
++        Only one device is configured based on get_interfaces_by_mac even when
++        multiple MACs exist in metadata.
+         """
+         ds = self._setup_ds(
+             platform_data=self.valid_platform_data,
+             sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
+             md={'md': DEFAULT_METADATA})
+-        find_fallback_path = (
+-            'cloudinit.sources.DataSourceEc2.net.find_fallback_nic')
++        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
+         with mock.patch(find_fallback_path) as m_find_fallback:
+             m_find_fallback.return_value = 'eth9'
+             ds.get_data()
+ 
+         mac1 = '06:17:04:d7:26:0A'  # IPv4 only in DEFAULT_METADATA
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': '06:17:04:d7:26:0A', 'name': 'eth9',
+-             'subnets': [{'type': 'dhcp4'}],
+-             'type': 'physical'}]}
+-        patch_path = (
+-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
+-        get_interface_mac_path = (
+-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': mac1.lower()}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': False}}}
++        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
++        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
++        with mock.patch(patch_path) as m_get_interfaces_by_mac:
++            with mock.patch(find_fallback_path) as m_find_fallback:
++                with mock.patch(get_interface_mac_path) as m_get_mac:
++                    m_get_interfaces_by_mac.return_value = {mac1: 'eth9'}
++                    m_find_fallback.return_value = 'eth9'
++                    m_get_mac.return_value = mac1
++                    self.assertEqual(expected, ds.network_config)
++
++    def test_network_config_property_secondary_private_ips(self):
++        """network_config property configures any secondary ipv4 addresses.
++
++        Only one device is configured based on get_interfaces_by_mac even when
++        multiple MACs exist in metadata.
++        """
++        ds = self._setup_ds(
++            platform_data=self.valid_platform_data,
++            sys_cfg={'datasource': {'Ec2': {'strict_id': True}}},
++            md={'md': SECONDARY_IP_METADATA_2018_09_24})
++        find_fallback_path = M_PATH_NET + 'find_fallback_nic'
++        with mock.patch(find_fallback_path) as m_find_fallback:
++            m_find_fallback.return_value = 'eth9'
++            ds.get_data()
++
++        mac1 = '0a:07:84:3d:6e:38'  # 1 secondary IPv4 and 2 secondary IPv6
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': mac1}, 'set-name': 'eth9',
++            'addresses': ['172.31.45.70/20',
++                          '2600:1f16:292:100:f152:2222:3333:4444/128',
++                          '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
++            'dhcp4': True, 'dhcp6': True}}}
++        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
++        get_interface_mac_path = M_PATH_NET + 'get_interface_mac'
+         with mock.patch(patch_path) as m_get_interfaces_by_mac:
+             with mock.patch(find_fallback_path) as m_find_fallback:
+                 with mock.patch(get_interface_mac_path) as m_get_mac:
+@@ -358,21 +496,18 @@ class TestEc2(test_helpers.HttprettyTest
+         register_mock_metaserver(
+             'http://169.254.169.254/2009-04-04/meta-data/', DEFAULT_METADATA)
+         mac1 = '06:17:04:d7:26:09'  # Defined in DEFAULT_METADATA
+-        get_interface_mac_path = (
+-            'cloudinit.sources.DataSourceEc2.net.get_interface_mac')
++        get_interface_mac_path = M_PATH_NET + 'get_interfaces_by_mac'
+         ds.fallback_nic = 'eth9'
+-        with mock.patch(get_interface_mac_path) as m_get_interface_mac:
+-            m_get_interface_mac.return_value = mac1
++        with mock.patch(get_interface_mac_path) as m_get_interfaces_by_mac:
++            m_get_interfaces_by_mac.return_value = {mac1: 'eth9'}
+             nc = ds.network_config  # Will re-crawl network metadata
+             self.assertIsNotNone(nc)
+         self.assertIn(
+             'Refreshing stale metadata from prior to upgrade',
+             self.logs.getvalue())
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': '06:17:04:d7:26:09',
+-             'name': 'eth9',
+-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}],
+-             'type': 'physical'}]}
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': mac1}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': True}}}
+         self.assertEqual(expected, ds.network_config)
+ 
+     def test_ec2_get_instance_id_refreshes_identity_on_upgrade(self):
+@@ -491,7 +626,7 @@ class TestEc2(test_helpers.HttprettyTest
+         logs_with_redacted = [log for log in all_logs if REDACT_TOK in log]
+         logs_with_token = [log for log in all_logs if 'API-TOKEN' in log]
+         self.assertEqual(1, len(logs_with_redacted_ttl))
+-        self.assertEqual(79, len(logs_with_redacted))
++        self.assertEqual(81, len(logs_with_redacted))
+         self.assertEqual(0, len(logs_with_token))
+ 
+     @mock.patch('cloudinit.net.dhcp.maybe_perform_dhcp_discovery')
+@@ -612,6 +747,44 @@ class TestEc2(test_helpers.HttprettyTest
+         self.assertIn('Crawl of metadata service took', self.logs.getvalue())
+ 
+ 
++class TestGetSecondaryAddresses(test_helpers.CiTestCase):
++
++    mac = '06:17:04:d7:26:ff'
++    with_logs = True
++
++    def test_md_with_no_secondary_addresses(self):
++        """Empty list is returned when nic metadata contains no secondary ip"""
++        self.assertEqual([], ec2.get_secondary_addresses(NIC2_MD, self.mac))
++
++    def test_md_with_secondary_v4_and_v6_addresses(self):
++        """All secondary addresses are returned from nic metadata"""
++        self.assertEqual(
++            ['172.31.45.70/20', '2600:1f16:292:100:f152:2222:3333:4444/128',
++             '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
++            ec2.get_secondary_addresses(NIC1_MD_IPV4_IPV6_MULTI_IP, self.mac))
++
++    def test_invalid_ipv4_ipv6_cidr_metadata_logged_with_defaults(self):
++        """Any invalid subnet-ipv(4|6)-cidr-block values use defaults"""
++        invalid_cidr_md = copy.deepcopy(NIC1_MD_IPV4_IPV6_MULTI_IP)
++        invalid_cidr_md['subnet-ipv4-cidr-block'] = "something-unexpected"
++        invalid_cidr_md['subnet-ipv6-cidr-block'] = "not/sure/what/this/is"
++        self.assertEqual(
++            ['172.31.45.70/24', '2600:1f16:292:100:f152:2222:3333:4444/128',
++             '2600:1f16:292:100:f153:12a3:c37c:11f9/128'],
++            ec2.get_secondary_addresses(invalid_cidr_md, self.mac))
++        expected_logs = [
++           "WARNING: Could not parse subnet-ipv4-cidr-block"
++           " something-unexpected for mac 06:17:04:d7:26:ff."
++           " ipv4 network config prefix defaults to /24",
++           "WARNING: Could not parse subnet-ipv6-cidr-block"
++           " not/sure/what/this/is for mac 06:17:04:d7:26:ff."
++           " ipv6 network config prefix defaults to /128"
++        ]
++        logs = self.logs.getvalue()
++        for log in expected_logs:
++            self.assertIn(log, logs)
++
++
+ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
+ 
+     def setUp(self):
+@@ -619,16 +792,16 @@ class TestConvertEc2MetadataNetworkConfi
+         self.mac1 = '06:17:04:d7:26:09'
+         self.network_metadata = {
+             'interfaces': {'macs': {
+-                self.mac1: {'public-ipv4s': '172.31.2.16'}}}}
++                self.mac1: {'mac': self.mac1, 'public-ipv4s': '172.31.2.16'}}}}
+ 
+     def test_convert_ec2_metadata_network_config_skips_absent_macs(self):
+         """Any mac absent from metadata is skipped by network config."""
+         macs_to_nics = {self.mac1: 'eth9', 'DE:AD:BE:EF:FF:FF': 'vitualnic2'}
+ 
+         # DE:AD:BE:EF:FF:FF represented by OS but not in metadata
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': self.mac1, 'type': 'physical',
+-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': False}}}
+         self.assertEqual(
+             expected,
+             ec2.convert_ec2_metadata_network_config(
+@@ -642,15 +815,15 @@ class TestConvertEc2MetadataNetworkConfi
+             network_metadata_ipv6['interfaces']['macs'][self.mac1])
+         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
+         nic1_metadata.pop('public-ipv4s')
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': self.mac1, 'type': 'physical',
+-             'name': 'eth9', 'subnets': [{'type': 'dhcp6'}]}]}
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': True}}}
+         self.assertEqual(
+             expected,
+             ec2.convert_ec2_metadata_network_config(
+                 network_metadata_ipv6, macs_to_nics))
+ 
+-    def test_convert_ec2_metadata_network_config_handles_local_dhcp4(self):
++    def test_convert_ec2_metadata_network_config_local_only_dhcp4(self):
+         """Config dhcp4 when there are no public addresses in public-ipv4s."""
+         macs_to_nics = {self.mac1: 'eth9'}
+         network_metadata_ipv6 = copy.deepcopy(self.network_metadata)
+@@ -658,9 +831,9 @@ class TestConvertEc2MetadataNetworkConfi
+             network_metadata_ipv6['interfaces']['macs'][self.mac1])
+         nic1_metadata['local-ipv4s'] = '172.3.3.15'
+         nic1_metadata.pop('public-ipv4s')
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': self.mac1, 'type': 'physical',
+-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': False}}}
+         self.assertEqual(
+             expected,
+             ec2.convert_ec2_metadata_network_config(
+@@ -675,16 +848,16 @@ class TestConvertEc2MetadataNetworkConfi
+         nic1_metadata['public-ipv4s'] = ''
+ 
+         # When no ipv4 or ipv6 content but fallback_nic set, set dhcp4 config.
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': self.mac1, 'type': 'physical',
+-             'name': 'eth9', 'subnets': [{'type': 'dhcp4'}]}]}
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': False}}}
+         self.assertEqual(
+             expected,
+             ec2.convert_ec2_metadata_network_config(
+                 network_metadata_ipv6, macs_to_nics, fallback_nic='eth9'))
+ 
+     def test_convert_ec2_metadata_network_config_handles_local_v4_and_v6(self):
+-        """When dhcp6 is public and dhcp4 is set to local enable both."""
++        """When ipv6s and local-ipv4s are non-empty, enable dhcp6 and dhcp4."""
+         macs_to_nics = {self.mac1: 'eth9'}
+         network_metadata_both = copy.deepcopy(self.network_metadata)
+         nic1_metadata = (
+@@ -692,10 +865,35 @@ class TestConvertEc2MetadataNetworkConfi
+         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
+         nic1_metadata.pop('public-ipv4s')
+         nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': self.mac1, 'type': 'physical',
+-             'name': 'eth9',
+-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}]}]}
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': True}}}
++        self.assertEqual(
++            expected,
++            ec2.convert_ec2_metadata_network_config(
++                network_metadata_both, macs_to_nics))
++
++    def test_convert_ec2_metadata_network_config_handles_multiple_nics(self):
++        """DHCP route-metric increases on secondary NICs for IPv4 and IPv6."""
++        mac2 = '06:17:04:d7:26:0a'
++        macs_to_nics = {self.mac1: 'eth9', mac2: 'eth10'}
++        network_metadata_both = copy.deepcopy(self.network_metadata)
++        # Add 2nd nic info
++        network_metadata_both['interfaces']['macs'][mac2] = NIC2_MD
++        nic1_metadata = (
++            network_metadata_both['interfaces']['macs'][self.mac1])
++        nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
++        nic1_metadata.pop('public-ipv4s')  # No public-ipv4 IPs in cfg
++        nic1_metadata['local-ipv4s'] = '10.0.0.42'  # Local ipv4 only on vpc
++        expected = {'version': 2, 'ethernets': {
++            'eth9': {
++                'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
++                'dhcp4': True, 'dhcp4-overrides': {'route-metric': 100},
++                'dhcp6': True, 'dhcp6-overrides': {'route-metric': 100}},
++            'eth10': {
++                'match': {'macaddress': mac2}, 'set-name': 'eth10',
++                'dhcp4': True, 'dhcp4-overrides': {'route-metric': 200},
++                'dhcp6': False}}}
+         self.assertEqual(
+             expected,
+             ec2.convert_ec2_metadata_network_config(
+@@ -708,10 +906,9 @@ class TestConvertEc2MetadataNetworkConfi
+         nic1_metadata = (
+             network_metadata_both['interfaces']['macs'][self.mac1])
+         nic1_metadata['ipv6s'] = '2620:0:1009:fd00:e442:c88d:c04d:dc85/64'
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': self.mac1, 'type': 'physical',
+-             'name': 'eth9',
+-             'subnets': [{'type': 'dhcp4'}, {'type': 'dhcp6'}]}]}
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': self.mac1}, 'set-name': 'eth9',
++            'dhcp4': True, 'dhcp6': True}}}
+         self.assertEqual(
+             expected,
+             ec2.convert_ec2_metadata_network_config(
+@@ -719,12 +916,10 @@ class TestConvertEc2MetadataNetworkConfi
+ 
+     def test_convert_ec2_metadata_gets_macs_from_get_interfaces_by_mac(self):
+         """Convert Ec2 Metadata calls get_interfaces_by_mac by default."""
+-        expected = {'version': 1, 'config': [
+-            {'mac_address': self.mac1, 'type': 'physical',
+-             'name': 'eth9',
+-             'subnets': [{'type': 'dhcp4'}]}]}
+-        patch_path = (
+-            'cloudinit.sources.DataSourceEc2.net.get_interfaces_by_mac')
++        expected = {'version': 2, 'ethernets': {'eth9': {
++            'match': {'macaddress': self.mac1},
++            'set-name': 'eth9', 'dhcp4': True, 'dhcp6': False}}}
++        patch_path = M_PATH_NET + 'get_interfaces_by_mac'
+         with mock.patch(patch_path) as m_get_interfaces_by_mac:
+             m_get_interfaces_by_mac.return_value = {self.mac1: 'eth9'}
+             self.assertEqual(

--- a/debian/patches/cpick-986f37b0-cloudinit-move-to-pytest-for-running-tests-211
+++ b/debian/patches/cpick-986f37b0-cloudinit-move-to-pytest-for-running-tests-211
@@ -1,0 +1,269 @@
+From 986f37b017134ced5d9dd38b420350916297002b Mon Sep 17 00:00:00 2001
+From: Daniel Watkins <oddbloke@ubuntu.com>
+Date: Tue, 10 Mar 2020 13:26:05 -0400
+Subject: [PATCH] cloudinit: move to pytest for running tests (#211)
+
+As the nose docs[0] themselves note, it has been in maintenance mode for the past several years. pytest is an actively developed, featureful and popular alternative that the nose docs themselves recommend. See [1] for more details about the thinking here.
+
+(This PR also removes stale tox definitions, instead of modifying them.)
+
+[0] https://nose.readthedocs.io/en/latest/
+[1] https://lists.launchpad.net/cloud-init/msg00245.html
+---
+ .travis.yml            |  6 ++--
+ Makefile               |  6 ++--
+ packages/pkg-deps.json |  3 ++
+ test-requirements.txt  |  7 ++--
+ tools/run-container    | 12 +++----
+ tools/tox-venv         |  2 +-
+ tox.ini                | 73 +++++++++++++++++-------------------------
+ 7 files changed, 46 insertions(+), 63 deletions(-)
+
+--- a/.travis.yml
++++ b/.travis.yml
+@@ -16,13 +16,13 @@ matrix:
+         - python: 3.6
+           env:
+               TOXENV=py3
+-              NOSE_VERBOSE=2  # List all tests run by nose
++              PYTEST_ADDOPTS=-v  # List all tests run by pytest
+         - install:
+             - git fetch --unshallow
+             - sudo apt-get build-dep -y cloud-init
+             - sudo apt-get install -y --install-recommends sbuild ubuntu-dev-tools fakeroot tox
+             # These are build deps but not pulled in by the build-dep call above
+-            - sudo apt-get install -y --install-recommends dh-systemd python3-coverage python3-contextlib2
++            - sudo apt-get install -y --install-recommends dh-systemd python3-coverage python3-contextlib2 python3-pytest python3-pytest-cov
+             - pip install .
+             - pip install tox
+             # bionic has lxd from deb installed, remove it first to ensure
+@@ -46,7 +46,7 @@ matrix:
+         - python: 3.5
+           env:
+               TOXENV=xenial
+-              NOSE_VERBOSE=2  # List all tests run by nose
++              PYTEST_ADDOPTS=-v  # List all tests run by pytest
+           # Travis doesn't support Python 3.4 on bionic, so use xenial
+           dist: xenial
+         - python: 3.6
+--- a/Makefile
++++ b/Makefile
+@@ -2,8 +2,6 @@ CWD=$(shell pwd)
+ PYVER ?= $(shell for p in python3 python2; do \
+ 	out=$$(command -v $$p 2>&1) && echo $$p && exit; done; exit 1)
+ 
+-noseopts ?= -v
+-
+ YAML_FILES=$(shell find cloudinit tests tools -name "*.yaml" -type f )
+ YAML_FILES+=$(shell find doc/examples -name "cloud-config*.txt" -type f )
+ 
+@@ -48,10 +46,10 @@ pyflakes3:
+ 	@$(CWD)/tools/run-pyflakes3
+ 
+ unittest: clean_pyc
+-	nosetests $(noseopts) tests/unittests cloudinit
++	python -m pytest -v tests/unittests cloudinit
+ 
+ unittest3: clean_pyc
+-	nosetests3 $(noseopts) tests/unittests cloudinit
++	python3 -m pytest -v tests/unittests cloudinit
+ 
+ ci-deps-ubuntu:
+ 	@$(PYVER) $(CWD)/tools/read-dependencies --distro ubuntu --test-distro
+--- a/packages/pkg-deps.json
++++ b/packages/pkg-deps.json
+@@ -45,6 +45,9 @@
+          "pyserial" : {
+             "2" : "pyserial"
+          },
++         "pytest": {
++             "3": "python36-pytest"
++         },
+          "requests" : {
+             "3" : "python36-requests"
+          },
+--- a/test-requirements.txt
++++ b/test-requirements.txt
+@@ -1,11 +1,8 @@
+ # Needed generally in tests
+ httpretty>=0.7.1
+-nose
++pytest
+ unittest2
+-coverage
+-
+-# Only needed if you want to know the test times
+-# nose-timer
++pytest-cov
+ 
+ # Only really needed on older versions of python
+ contextlib2
+--- a/tools/run-container
++++ b/tools/run-container
+@@ -287,8 +287,8 @@ prep() {
+     install_packages "$@"
+ }
+ 
+-nose() {
+-    python3 -m nose "$@"
++pytest() {
++    python3 -m pytest "$@"
+ }
+ 
+ is_done_cloudinit() {
+@@ -478,10 +478,10 @@ main() {
+ 
+     if [ -n "$unittest" ]; then
+         debug 1 "running unit tests."
+-        run_self_inside_as_cd "$name" "$user" "$cdir" nose \
++        run_self_inside_as_cd "$name" "$user" "$cdir" pytest \
+             tests/unittests cloudinit/ || {
+-                errorrc "nosetests failed.";
+-                errors[${#errors[@]}]="nosetests"
++                errorrc "pytest failed.";
++                errors[${#errors[@]}]="pytest"
+             }
+     fi
+ 
+@@ -557,7 +557,7 @@ main() {
+ }
+ 
+ case "${1:-}" in
+-    prep|os_info|wait_inside|nose) _n=$1; shift; "$_n" "$@";;
++    prep|os_info|wait_inside|pytest) _n=$1; shift; "$_n" "$@";;
+     *) main "$@";;
+ esac
+ 
+--- a/tools/tox-venv
++++ b/tools/tox-venv
+@@ -116,7 +116,7 @@ Usage: ${0##*/} [--no-create] tox-enviro
+    be read from tox.ini.  This allows you to do:
+       tox-venv py27 - tests/some/sub/dir
+    and have the 'command' read correctly and have that execute:
+-      python -m nose tests/some/sub/dir
++      python -m pytest tests/some/sub/dir
+ EOF
+ 
+     if [ -f "$tox_ini" ]; then
+--- a/tox.ini
++++ b/tox.ini
+@@ -1,13 +1,13 @@
+ [tox]
+-envlist = py3, xenial, pycodestyle, pyflakes, pylint
++envlist = py3, xenial-dev, pycodestyle, pyflakes, pylint
+ recreate = True
+ 
+ [testenv]
+-commands = python -m nose {posargs:tests/unittests cloudinit}
++commands = {envpython} -m pytest {posargs:tests/unittests cloudinit}
+ setenv =
+     LC_ALL = en_US.utf-8
+ passenv=
+-    NOSE_VERBOSE
++    PYTEST_ADDOPTS
+ 
+ [testenv:pycodestyle]
+ basepython = python3
+@@ -32,23 +32,16 @@ commands = {envpython} -m pylint {posarg
+ [testenv:py3]
+ basepython = python3
+ deps =
+-    nose-timer
+     -r{toxinidir}/test-requirements.txt
+-commands = {envpython} -m nose --with-timer --timer-top-n 10 \
+-           {posargs:--with-coverage --cover-erase --cover-branches \
+-            --cover-inclusive --cover-package=cloudinit \
++commands = {envpython} -m pytest \
++            --durations 10 \
++            {posargs:--cov=cloudinit --cov-branch \
+             tests/unittests cloudinit}
+ 
+ [testenv:py27]
+ basepython = python2.7
+ deps = -r{toxinidir}/test-requirements.txt
+ 
+-[testenv:py26]
+-deps = -r{toxinidir}/test-requirements.txt
+-commands = nosetests {posargs:tests/unittests cloudinit}
+-setenv =
+-    LC_ALL = C
+-
+ [flake8]
+ #H102  Apache 2.0 license header not found
+ ignore=H404,H405,H105,H301,H104,H403,H101,H102,H106,H304
+@@ -62,11 +55,15 @@ commands =
+     {envpython} -m sphinx {posargs:doc/rtd doc/rtd_html}
+     doc8 doc/rtd
+ 
+-[testenv:xenial]
+-commands =
+-  python ./tools/pipremove jsonschema
+-  python -m nose {posargs:tests/unittests cloudinit}
+-basepython = python3
++[xenial-shared-deps]
++# The version of pytest in xenial doesn't work with Python 3.8, so we define
++# two xenial environments: [testenv:xenial] runs the tests with exactly the
++# version of pytest present in xenial, and is used in CI.  [testenv:xenial-dev]
++# runs the tests with the lowest version of pytest that works with Python 3.8,
++# 3.0.7, but keeps the other dependencies at xenial's level.
++#
++# (This section is not a testenv, it is used to maintain a single definition of
++# the dependencies shared between the two xenial testenvs.)
+ deps =
+     # requirements
+     jinja2==2.8
+@@ -83,38 +80,26 @@ deps =
+     # test-requirements
+     httpretty==0.9.6
+     mock==1.3.0
+-    nose==1.3.7
+     unittest2==1.1.0
+     contextlib2==0.5.1
+ 
+-[testenv:centos6]
+-basepython = python2.6
+-commands = nosetests {posargs:tests/unittests cloudinit}
+-deps =
+-    # requirements
+-    argparse==1.2.1
+-    jinja2==2.2.1
+-    pyyaml==3.10
+-    oauthlib==0.6.0
+-    configobj==4.6.0
+-    requests==2.6.0
+-    jsonpatch==1.2
+-    six==1.9.0
+-    -r{toxinidir}/test-requirements.txt
+-
+-[testenv:opensusel150]
+-basepython = python2.7
+-commands = nosetests {posargs:tests/unittests cloudinit}
++[testenv:xenial]
++commands =
++  python ./tools/pipremove jsonschema
++  python -m pytest {posargs:tests/unittests cloudinit}
++basepython = python3
+ deps =
+-    # requirements
+-    jinja2==2.10
+-    PyYAML==3.12
+-    oauthlib==2.0.6
+-    configobj==5.0.6
+-    requests==2.18.4
+-    jsonpatch==1.16
+-    six==1.11.0
+-    -r{toxinidir}/test-requirements.txt
++    # Refer to the comment in [xenial-shared-deps] for details
++    {[xenial-shared-deps]deps}
++    pytest==2.8.7
++
++[testenv:xenial-dev]
++commands = {[testenv:xenial]commands}
++basepython = {[testenv:xenial]basepython}
++deps =
++    # Refer to the comment in [xenial-shared-deps] for details
++    {[xenial-shared-deps]deps}
++    pytest==3.0.7
+ 
+ [testenv:tip-pycodestyle]
+ commands = {envpython} -m pycodestyle {posargs:cloudinit/ tests/ tools/}

--- a/debian/patches/cpick-c478d0bf-distros-replace-invalid-characters-in-mirror-URLs-with
+++ b/debian/patches/cpick-c478d0bf-distros-replace-invalid-characters-in-mirror-URLs-with
@@ -1,0 +1,281 @@
+From c478d0bff412c67280dfe8f08568de733f9425a1 Mon Sep 17 00:00:00 2001
+From: Daniel Watkins <oddbloke@ubuntu.com>
+Date: Tue, 31 Mar 2020 13:52:21 -0400
+Subject: [PATCH] distros: replace invalid characters in mirror URLs with
+ hyphens (#291)
+
+This modifies _get_package_mirror_info to convert the hostnames of generated mirror URLs to their IDNA form, and then iterate through them replacing any invalid characters (i.e. anything other than letters, digits or a hyphen) with a hyphen.
+
+This commit introduces the following changes in behaviour:
+
+* generated mirror URLs with Unicode characters in their hostnames will have their hostnames converted to their all-ASCII IDNA form
+* generated mirror URLs with invalid-for-hostname characters in their hostname will have those characters converted to hyphens
+* generated mirror URLs which cannot be parsed by `urllib.parse.urlsplit` will not be considered for use
+  * other configured patterns will still be considered
+  * if all configured patterns fail to produce a URL that parses then the fallback mirror URL will be used
+
+LP: #1868232
+---
+ cloudinit/distros/__init__.py        | 109 ++++++++++++++++++++++++++-
+ cloudinit/distros/tests/test_init.py |  84 ++++++++++++++++-----
+ 2 files changed, 174 insertions(+), 19 deletions(-)
+
+--- a/cloudinit/distros/__init__.py
++++ b/cloudinit/distros/__init__.py
+@@ -13,6 +13,8 @@ import abc
+ import os
+ import re
+ import stat
++import string
++import urllib.parse
+ from io import StringIO
+ 
+ from cloudinit import importer
+@@ -50,6 +52,9 @@ _EC2_AZ_RE = re.compile('^[a-z][a-z]-(?:
+ # Default NTP Client Configurations
+ PREFERRED_NTP_CLIENTS = ['chrony', 'systemd-timesyncd', 'ntp', 'ntpdate']
+ 
++# Letters/Digits/Hyphen characters, for use in domain name validation
++LDH_ASCII_CHARS = string.ascii_letters + string.digits + "-"
++
+ 
+ class Distro(metaclass=abc.ABCMeta):
+ 
+@@ -720,6 +725,102 @@ class Distro(metaclass=abc.ABCMeta):
+                 LOG.info("Added user '%s' to group '%s'", member, name)
+ 
+ 
++def _apply_hostname_transformations_to_url(url: str, transformations: list):
++    """
++    Apply transformations to a URL's hostname, return transformed URL.
++
++    This is a separate function because unwrapping and rewrapping only the
++    hostname portion of a URL is complex.
++
++    :param url:
++        The URL to operate on.
++    :param transformations:
++        A list of ``(str) -> Optional[str]`` functions, which will be applied
++        in order to the hostname portion of the URL.  If any function
++        (regardless of ordering) returns None, ``url`` will be returned without
++        any modification.
++
++    :return:
++        A string whose value is ``url`` with the hostname ``transformations``
++        applied, or ``None`` if ``url`` is unparseable.
++    """
++    try:
++        parts = urllib.parse.urlsplit(url)
++    except ValueError:
++        # If we can't even parse the URL, we shouldn't use it for anything
++        return None
++    new_hostname = parts.hostname
++
++    for transformation in transformations:
++        new_hostname = transformation(new_hostname)
++        if new_hostname is None:
++            # If a transformation returns None, that indicates we should abort
++            # processing and return `url` unmodified
++            return url
++
++    new_netloc = new_hostname
++    if parts.port is not None:
++        new_netloc = "{}:{}".format(new_netloc, parts.port)
++    return urllib.parse.urlunsplit(parts._replace(netloc=new_netloc))
++
++
++def _sanitize_mirror_url(url: str):
++    """
++    Given a mirror URL, replace or remove any invalid URI characters.
++
++    This performs the following actions on the URL's hostname:
++      * Checks if it is an IP address, returning the URL immediately if it is
++      * Converts it to its IDN form (see below for details)
++      * Replaces any non-Letters/Digits/Hyphen (LDH) characters in it with
++        hyphens
++      * TODO: Remove any leading/trailing hyphens from each domain name label
++
++    Before we replace any invalid domain name characters, we first need to
++    ensure that any valid non-ASCII characters in the hostname will not be
++    replaced, by ensuring the hostname is in its Internationalized domain name
++    (IDN) representation (see RFC 5890).  This conversion has to be applied to
++    the whole hostname (rather than just the substitution variables), because
++    the Punycode algorithm used by IDNA transcodes each part of the hostname as
++    a whole string (rather than encoding individual characters).  It cannot be
++    applied to the whole URL, because (a) the Punycode algorithm expects to
++    operate on domain names so doesn't output a valid URL, and (b) non-ASCII
++    characters in non-hostname parts of the URL aren't encoded via Punycode.
++
++    To put this in RFC 5890's terminology: before we remove or replace any
++    characters from our domain name (which we do to ensure that each label is a
++    valid LDH Label), we first ensure each label is in its A-label form.
++
++    (Note that Python's builtin idna encoding is actually IDNA2003, not
++    IDNA2008.  This changes the specifics of how some characters are encoded to
++    ASCII, but doesn't affect the logic here.)
++
++    :param url:
++        The URL to operate on.
++
++    :return:
++        A sanitized version of the URL, which will have been IDNA encoded if
++        necessary, or ``None`` if the generated string is not a parseable URL.
++    """
++    # Acceptable characters are LDH characters, plus "." to separate each label
++    acceptable_chars = LDH_ASCII_CHARS + "."
++    transformations = [
++        # This is an IP address, not a hostname, so no need to apply the
++        # transformations
++        lambda hostname: None if net.is_ip_address(hostname) else hostname,
++
++        # Encode with IDNA to get the correct characters (as `bytes`), then
++        # decode with ASCII so we return a `str`
++        lambda hostname: hostname.encode('idna').decode('ascii'),
++
++        # Replace any unacceptable characters with "-"
++        lambda hostname: ''.join(
++            c if c in acceptable_chars else "-" for c in hostname
++        ),
++    ]
++
++    return _apply_hostname_transformations_to_url(url, transformations)
++
++
+ def _get_package_mirror_info(mirror_info, data_source=None,
+                              mirror_filter=util.search_for_mirror):
+     # given a arch specific 'mirror_info' entry (from package_mirrors)
+@@ -748,9 +849,13 @@ def _get_package_mirror_info(mirror_info
+         mirrors = []
+         for tmpl in searchlist:
+             try:
+-                mirrors.append(tmpl % subst)
++                mirror = tmpl % subst
+             except KeyError:
+-                pass
++                continue
++
++            mirror = _sanitize_mirror_url(mirror)
++            if mirror is not None:
++                mirrors.append(mirror)
+ 
+         found = mirror_filter(mirrors)
+         if found:
+--- a/cloudinit/distros/tests/test_init.py
++++ b/cloudinit/distros/tests/test_init.py
+@@ -9,7 +9,18 @@ from unittest import mock
+ 
+ import pytest
+ 
+-from cloudinit.distros import _get_package_mirror_info
++from cloudinit.distros import _get_package_mirror_info, LDH_ASCII_CHARS
++
++
++# Define a set of characters we would expect to be replaced
++INVALID_URL_CHARS = [
++    chr(x) for x in range(127) if chr(x) not in LDH_ASCII_CHARS
++]
++for separator in [":", ".", "/", "#", "?", "@", "[", "]"]:
++    # Remove from the set characters that either separate hostname parts (":",
++    # "."), terminate hostnames ("/", "#", "?", "@"), or cause Python to be
++    # unable to parse URLs ("[", "]").
++    INVALID_URL_CHARS.remove(separator)
+ 
+ 
+ class TestGetPackageMirrorInfo:
+@@ -25,14 +36,16 @@ class TestGetPackageMirrorInfo:
+         # Empty info gives empty return
+         ({}, {}),
+         # failsafe values used if present
+-        ({'failsafe': {'primary': 'value', 'security': 'other'}},
+-         {'primary': 'value', 'security': 'other'}),
++        ({'failsafe': {'primary': 'http://value', 'security': 'http://other'}},
++         {'primary': 'http://value', 'security': 'http://other'}),
+         # search values used if present
+-        ({'search': {'primary': ['value'], 'security': ['other']}},
+-         {'primary': ['value'], 'security': ['other']}),
++        ({'search': {'primary': ['http://value'],
++                     'security': ['http://other']}},
++         {'primary': ['http://value'], 'security': ['http://other']}),
+         # failsafe values used if search value not present
+-        ({'search': {'primary': ['value']}, 'failsafe': {'security': 'other'}},
+-         {'primary': ['value'], 'security': 'other'})
++        ({'search': {'primary': ['http://value']},
++          'failsafe': {'security': 'http://other'}},
++         {'primary': ['http://value'], 'security': 'http://other'})
+     ])
+     def test_get_package_mirror_info_failsafe(self, mirror_info, expected):
+         """
+@@ -48,26 +61,63 @@ class TestGetPackageMirrorInfo:
+     def test_failsafe_used_if_all_search_results_filtered_out(self):
+         """Test the failsafe option used if all search options eliminated."""
+         mirror_info = {
+-            'search': {'primary': ['value']}, 'failsafe': {'primary': 'other'}
++            'search': {'primary': ['http://value']},
++            'failsafe': {'primary': 'http://other'}
+         }
+-        assert {'primary': 'other'} == _get_package_mirror_info(
++        assert {'primary': 'http://other'} == _get_package_mirror_info(
+             mirror_info, mirror_filter=lambda x: False)
+ 
+     @pytest.mark.parametrize('availability_zone,region,patterns,expected', (
+         # Test ec2_region alone
+-        ('fk-fake-1f', None, ['EC2-%(ec2_region)s'], ['EC2-fk-fake-1']),
++        ('fk-fake-1f', None, ['http://EC2-%(ec2_region)s/ubuntu'],
++         ['http://ec2-fk-fake-1/ubuntu']),
+         # Test availability_zone alone
+-        ('fk-fake-1f', None, ['AZ-%(availability_zone)s'], ['AZ-fk-fake-1f']),
++        ('fk-fake-1f', None, ['http://AZ-%(availability_zone)s/ubuntu'],
++         ['http://az-fk-fake-1f/ubuntu']),
+         # Test region alone
+-        (None, 'fk-fake-1', ['RG-%(region)s'], ['RG-fk-fake-1']),
++        (None, 'fk-fake-1', ['http://RG-%(region)s/ubuntu'],
++         ['http://rg-fk-fake-1/ubuntu']),
+         # Test that ec2_region is not available for non-matching AZs
+         ('fake-fake-1f', None,
+-         ['EC2-%(ec2_region)s', 'AZ-%(availability_zone)s'],
+-         ['AZ-fake-fake-1f']),
++         ['http://EC2-%(ec2_region)s/ubuntu',
++          'http://AZ-%(availability_zone)s/ubuntu'],
++         ['http://az-fake-fake-1f/ubuntu']),
+         # Test that template order maintained
+-        (None, 'fake-region', ['RG-%(region)s-2', 'RG-%(region)s-1'],
+-         ['RG-fake-region-2', 'RG-fake-region-1']),
+-    ))
++        (None, 'fake-region',
++         ['http://RG-%(region)s-2/ubuntu', 'http://RG-%(region)s-1/ubuntu'],
++         ['http://rg-fake-region-2/ubuntu', 'http://rg-fake-region-1/ubuntu']),
++        # Test that non-ASCII hostnames are IDNA encoded;
++        # "IDNA-ТεЅТ̣".encode('idna') == b"xn--idna--4kd53hh6aba3q"
++        (None, 'ТεЅТ̣', ['http://www.IDNA-%(region)s.com/ubuntu'],
++         ['http://www.xn--idna--4kd53hh6aba3q.com/ubuntu']),
++        # Test that non-ASCII hostnames with a port are IDNA encoded;
++        # "IDNA-ТεЅТ̣".encode('idna') == b"xn--idna--4kd53hh6aba3q"
++        (None, 'ТεЅТ̣', ['http://www.IDNA-%(region)s.com:8080/ubuntu'],
++         ['http://www.xn--idna--4kd53hh6aba3q.com:8080/ubuntu']),
++        # Test that non-ASCII non-hostname parts of URLs are unchanged
++        (None, 'ТεЅТ̣', ['http://www.example.com/%(region)s/ubuntu'],
++         ['http://www.example.com/ТεЅТ̣/ubuntu']),
++        # Test that IPv4 addresses are unchanged
++        (None, 'fk-fake-1', ['http://192.168.1.1:8080/%(region)s/ubuntu'],
++         ['http://192.168.1.1:8080/fk-fake-1/ubuntu']),
++        # Test that IPv6 addresses are unchanged
++        (None, 'fk-fake-1',
++         ['http://[2001:67c:1360:8001::23]/%(region)s/ubuntu'],
++         ['http://[2001:67c:1360:8001::23]/fk-fake-1/ubuntu']),
++        # Test that unparseable URLs are filtered out of the mirror list
++        (None, 'inv[lid',
++         ['http://%(region)s.in.hostname/should/be/filtered',
++          'http://but.not.in.the.path/%(region)s'],
++         ['http://but.not.in.the.path/inv[lid']),
++    ) + (
++        # Dynamically generate a test case for each non-LDH
++        # (Letters/Digits/Hyphen) ASCII character, testing that it is
++        # substituted with a hyphen
++        tuple(
++            (None, 'fk{0}fake{0}1'.format(invalid_char),
++             ['http://%(region)s/ubuntu'], ['http://fk-fake-1/ubuntu'])
++            for invalid_char in INVALID_URL_CHARS))
++    )
+     def test_substitution(self, availability_zone, region, patterns, expected):
+         """Test substitution works as expected."""
+         m_data_source = mock.Mock(

--- a/debian/patches/cpick-c5e949c0-distros-tests-test_init-add-tests-for
+++ b/debian/patches/cpick-c5e949c0-distros-tests-test_init-add-tests-for
@@ -1,0 +1,99 @@
+From c5e949c02a1d5226ae9b1cb39846db19d223c6c2 Mon Sep 17 00:00:00 2001
+From: Daniel Watkins <oddbloke@ubuntu.com>
+Date: Wed, 25 Mar 2020 09:44:16 -0400
+Subject: [PATCH] distros/tests/test_init: add tests for
+ _get_package_mirror_info (#272)
+
+---
+ cloudinit/distros/tests/__init__.py  |  0
+ cloudinit/distros/tests/test_init.py | 83 ++++++++++++++++++++++++++++
+ 2 files changed, 83 insertions(+)
+ create mode 100644 cloudinit/distros/tests/__init__.py
+ create mode 100644 cloudinit/distros/tests/test_init.py
+
+--- /dev/null
++++ b/cloudinit/distros/tests/test_init.py
+@@ -0,0 +1,83 @@
++# Copyright (C) 2020 Canonical Ltd.
++#
++# Author: Daniel Watkins <oddbloke@ubuntu.com>
++#
++# This file is part of cloud-init. See LICENSE file for license information.
++"""Tests for cloudinit/distros/__init__.py"""
++
++from unittest import mock
++
++import pytest
++
++from cloudinit.distros import _get_package_mirror_info
++
++
++class TestGetPackageMirrorInfo:
++    """
++    Tests for cloudinit.distros._get_package_mirror_info.
++
++    These supplement the tests in tests/unittests/test_distros/test_generic.py
++    which are more focused on testing a single production-like configuration.
++    These tests are more focused on specific aspects of the unit under test.
++    """
++
++    @pytest.mark.parametrize('mirror_info,expected', [
++        # Empty info gives empty return
++        ({}, {}),
++        # failsafe values used if present
++        ({'failsafe': {'primary': 'value', 'security': 'other'}},
++         {'primary': 'value', 'security': 'other'}),
++        # search values used if present
++        ({'search': {'primary': ['value'], 'security': ['other']}},
++         {'primary': ['value'], 'security': ['other']}),
++        # failsafe values used if search value not present
++        ({'search': {'primary': ['value']}, 'failsafe': {'security': 'other'}},
++         {'primary': ['value'], 'security': 'other'})
++    ])
++    def test_get_package_mirror_info_failsafe(self, mirror_info, expected):
++        """
++        Test the interaction between search and failsafe inputs
++
++        (This doesn't test the case where the mirror_filter removes all search
++        options; test_failsafe_used_if_all_search_results_filtered_out covers
++        that.)
++        """
++        assert expected == _get_package_mirror_info(mirror_info,
++                                                    mirror_filter=lambda x: x)
++
++    def test_failsafe_used_if_all_search_results_filtered_out(self):
++        """Test the failsafe option used if all search options eliminated."""
++        mirror_info = {
++            'search': {'primary': ['value']}, 'failsafe': {'primary': 'other'}
++        }
++        assert {'primary': 'other'} == _get_package_mirror_info(
++            mirror_info, mirror_filter=lambda x: False)
++
++    @pytest.mark.parametrize('availability_zone,region,patterns,expected', (
++        # Test ec2_region alone
++        ('fk-fake-1f', None, ['EC2-%(ec2_region)s'], ['EC2-fk-fake-1']),
++        # Test availability_zone alone
++        ('fk-fake-1f', None, ['AZ-%(availability_zone)s'], ['AZ-fk-fake-1f']),
++        # Test region alone
++        (None, 'fk-fake-1', ['RG-%(region)s'], ['RG-fk-fake-1']),
++        # Test that ec2_region is not available for non-matching AZs
++        ('fake-fake-1f', None,
++         ['EC2-%(ec2_region)s', 'AZ-%(availability_zone)s'],
++         ['AZ-fake-fake-1f']),
++        # Test that template order maintained
++        (None, 'fake-region', ['RG-%(region)s-2', 'RG-%(region)s-1'],
++         ['RG-fake-region-2', 'RG-fake-region-1']),
++    ))
++    def test_substitution(self, availability_zone, region, patterns, expected):
++        """Test substitution works as expected."""
++        m_data_source = mock.Mock(
++            availability_zone=availability_zone, region=region
++        )
++        mirror_info = {'search': {'primary': patterns}}
++
++        ret = _get_package_mirror_info(
++            mirror_info,
++            data_source=m_data_source,
++            mirror_filter=lambda x: x
++        )
++        assert {'primary': expected} == ret

--- a/debian/patches/fix-cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni.patch
+++ b/debian/patches/fix-cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni.patch
@@ -1,0 +1,40 @@
+Description: Drop netbsd and openbsd from cherry pick tests
+ Support for netbsd and openbsd is on in upstream until new-upstream-snapshot.
+Author: Chad Smith <chad.smith@canonical.com>
+Origin: backport
+Forwarded: not-needed
+Last-Update: 2020-04-03
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Index: cloud-init/tests/unittests/test_render_cloudcfg.py
+===================================================================
+--- cloud-init.orig/tests/unittests/test_render_cloudcfg.py
++++ cloud-init/tests/unittests/test_render_cloudcfg.py
+@@ -9,7 +9,7 @@ from cloudinit import util
+ 
+ # TODO(Look to align with tools.render-cloudcfg or cloudinit.distos.OSFAMILIES)
+ DISTRO_VARIANTS = ["amazon", "arch", "centos", "debian", "fedora", "freebsd",
+-                   "netbsd", "openbsd", "rhel", "suse", "ubuntu", "unknown"]
++                   "rhel", "suse", "ubuntu", "unknown"]
+ 
+ 
+ class TestRenderCloudCfg:
+@@ -40,18 +40,3 @@ class TestRenderCloudCfg:
+             'amazon': 'ec2-user', 'debian': 'ubuntu', 'unknown': 'ubuntu'}
+         default_user = system_cfg['system_info']['default_user']['name']
+         assert default_user == default_user_exceptions.get(variant, variant)
+-
+-    @pytest.mark.parametrize('variant,renderers', (
+-        ('freebsd', ['freebsd']), ('netbsd', ['netbsd']),
+-        ('openbsd', ['openbsd']), ('ubuntu', ['netplan', 'eni', 'sysconfig']))
+-    )
+-    def test_variant_sets_network_renderer_priority_in_cloud_cfg(
+-        self, variant, renderers, tmpdir
+-    ):
+-        outfile = tmpdir.join('outcfg').strpath
+-        util.subp(
+-            self.cmd + ['--variant', variant, self.tmpl_path, outfile])
+-        with open(outfile) as stream:
+-            system_cfg = util.load_yaml(stream.read())
+-
+-        assert renderers == system_cfg['system_info']['network']['renderers']

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+cpick-6600c642-ec2-render-network-on-all-NICs-and-add-secondary-IPs-as

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@ cpick-4f825b3e-cloudinit-refactor-util.is_ipv4-to-net.is_ipv4_address
 cpick-c478d0bf-distros-replace-invalid-characters-in-mirror-URLs-with
 cpick-1bbc4908-distros-drop-leading-trailing-hyphens-from-mirror-URL
 cpick-09fea85f-net-ignore-renderer-key-in-netplan-config-306
+fix-cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ cpick-04771d75-cc_disk_setup-fix-RuntimeError-270
 cpick-c5e949c0-distros-tests-test_init-add-tests-for
 cpick-2566fdbe-net-introduce-is_ip_address-function-288
 cpick-4f825b3e-cloudinit-refactor-util.is_ipv4-to-net.is_ipv4_address
+cpick-c478d0bf-distros-replace-invalid-characters-in-mirror-URLs-with

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 cpick-6600c642-ec2-render-network-on-all-NICs-and-add-secondary-IPs-as
+cpick-986f37b0-cloudinit-move-to-pytest-for-running-tests-211

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@ cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni-even-if
 cpick-04771d75-cc_disk_setup-fix-RuntimeError-270
 cpick-c5e949c0-distros-tests-test_init-add-tests-for
 cpick-2566fdbe-net-introduce-is_ip_address-function-288
+cpick-4f825b3e-cloudinit-refactor-util.is_ipv4-to-net.is_ipv4_address

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ cpick-6600c642-ec2-render-network-on-all-NICs-and-add-secondary-IPs-as
 cpick-986f37b0-cloudinit-move-to-pytest-for-running-tests-211
 cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni-even-if
 cpick-04771d75-cc_disk_setup-fix-RuntimeError-270
+cpick-c5e949c0-distros-tests-test_init-add-tests-for

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,3 +6,4 @@ cpick-c5e949c0-distros-tests-test_init-add-tests-for
 cpick-2566fdbe-net-introduce-is_ip_address-function-288
 cpick-4f825b3e-cloudinit-refactor-util.is_ipv4-to-net.is_ipv4_address
 cpick-c478d0bf-distros-replace-invalid-characters-in-mirror-URLs-with
+cpick-1bbc4908-distros-drop-leading-trailing-hyphens-from-mirror-URL

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,4 @@ cpick-2566fdbe-net-introduce-is_ip_address-function-288
 cpick-4f825b3e-cloudinit-refactor-util.is_ipv4-to-net.is_ipv4_address
 cpick-c478d0bf-distros-replace-invalid-characters-in-mirror-URLs-with
 cpick-1bbc4908-distros-drop-leading-trailing-hyphens-from-mirror-URL
+cpick-09fea85f-net-ignore-renderer-key-in-netplan-config-306

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 cpick-6600c642-ec2-render-network-on-all-NICs-and-add-secondary-IPs-as
 cpick-986f37b0-cloudinit-move-to-pytest-for-running-tests-211
 cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni-even-if
+cpick-04771d75-cc_disk_setup-fix-RuntimeError-270

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 cpick-6600c642-ec2-render-network-on-all-NICs-and-add-secondary-IPs-as
 cpick-986f37b0-cloudinit-move-to-pytest-for-running-tests-211
+cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni-even-if

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@ cpick-986f37b0-cloudinit-move-to-pytest-for-running-tests-211
 cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni-even-if
 cpick-04771d75-cc_disk_setup-fix-RuntimeError-270
 cpick-c5e949c0-distros-tests-test_init-add-tests-for
+cpick-2566fdbe-net-introduce-is_ip_address-function-288


### PR DESCRIPTION
This branch is created for release of 3 feature/bug fixes into focal.

In order to release, we need to re-apply the already released cherry-pick for ec2 full networking because we droppped to fix daily recipe builds. Then we add our other new cherry-picks to that list for this second cherry pick release.

We can't use `new-upstream-snapshot --update-patches-only` because that presupposes that our next release will be performing a full new-upstream-snapshot, which is untrue during feature freeze.

Instead we manually perform the following:
```
cat > picks.sh <<EOF
#!/bin/bash
cd /tmp
git clone git@github.com:canonical/cloud-init.git
cd cloud-init
git checkout origin/ubuntu/devel -b ubuntu/devel

# re-apply previously released cherry picks
# ec2: render network on all NICs and add secondary IPs as static (#114)
# NOTE: interactively drop the comment dropped ec2-secondary-nics-cpick
cherry-pick 6600c642

# New cherry picks for 2nd cherry pick release
# move to pytest for test runs
cherry-pick 986f37b01
# Netplan over ENI prioritization
cherry-pick  4fb6fd8a046a6bcce01216c386f3b691a2c466bb

# Azure cc_disk_setup dictkeys runtime error
cherry-pick 04771d75a8670f07ae4c75b5892e3b795e9d1a07

# Picks related to support of dropping underscores from hostnames
cherry-pick c5e949c02a1d5226ae9b1cb39846db19d223c6c2
cherry-pick 2566fdbee06cf5708cfcd988a65fb81cdf794dbf
cherry-pick 4f825b3e6d8fde5c239d29639b04d2bea6d95d0e
cherry-pick c478d0bff412c67280dfe8f08568de733f9425a1
cherry-pick 1bbc4908ff7a2be19483811b3b6fee6ebc916235


# network_state ignoring 'renderer' key from configv2 PR #306
cherry-pick 09fea85fd1f6fd944f4cdd8b97e283090178ae88


# Need to fix 4fb6fd8a as test relied on unrelated bsd changes
quilt push -a
quilt new fix-cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni.patch
quilt edit tests/unittests/test_render_cloudcfg.py

# delete "openbsd", "netbsd" from line 12
# drop last unit test line 43 TO the end
quilt refresh
quilt header --dep3 -e
# content of edited dep3:
# Description: Drop netbsd and openbsd from cherry pick tests
#  Support for netbsd and openbsd is on in upstream until new-upstream-snapshot.
# Author: Chad Smith <chad.smith@canonical.com>
# Origin: backport
# Forwarded: not-needed
# Last-Update: 2020-04-03
# ---
# This patch header follows DEP-3: http://dep.debian.net/deps/dep3/


quilt pop -a
git add debian/patches

vi debian/changelog
# add the following line
# * d/patches: redact openbsd netbsd from tests until new-upstream-snapshot
#   - fix-cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni
git commit -am 'add debian/patches to redact openbsd/netbsd from unit tests'

# release with all cpicks to focal
dch --release --distribution=focal
# NOTE: interactively change version 0ubuntu3 -> 0ubuntu3
git commit -m "releasing cloud-init version 20.1-10-g71af48df-0ubuntu3" debian/changelog
EOF
bash ./picks.sh
git push <your_origin> ubuntu/devel
```