### PR TITLE
conftest: introduce disable_subp_usage autouse fixture

### DIFF
--- a/cloudinit/conftest.py
+++ b/cloudinit/conftest.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 
-@pytest.fixture(autouse=True)
+@pytest.yield_fixture(autouse=True)
 def disable_subp_usage(request):
     """
     Across all (pytest) tests, ensure that util.subp is not invoked.

--- a/cloudinit/conftest.py
+++ b/cloudinit/conftest.py
@@ -1,0 +1,25 @@
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def disable_subp_usage():
+    """
+    Across all (pytest) tests, ensure that util.subp is not invoked.
+
+    Note that this can only catch invocations where the util module is imported
+    and ``util.subp(...)`` is called.  ``from cloudinit.util import subp``
+    imports happen before the patching here (or the CiTestCase monkey-patching)
+    happens, so are left untouched.
+
+    This mirrors the functionality of CiTestCase.allowed_subp.
+
+    TODO:
+        * Re-enable subp usage (i.e. allowed_subp=True)
+        * Enable select subp usage (i.e. allowed_subp=[...])
+    """
+
+    with mock.patch('cloudinit.util.subp', autospec=True) as m_subp:
+        m_subp.side_effect = AssertionError("Unexpectedly used util.subp")
+        yield

--- a/cloudinit/conftest.py
+++ b/cloudinit/conftest.py
@@ -13,8 +13,8 @@ def disable_subp_usage(request):
     imports happen before the patching here (or the CiTestCase monkey-patching)
     happens, so are left untouched.
 
-    To allow a particular test method or class to you can set the parameter
-    passed to this fixture to False using pytest.mark.parametrize::
+    To allow a particular test method or class to use util.subp you can set the
+    parameter passed to this fixture to False using pytest.mark.parametrize::
 
         @pytest.mark.parametrize("disable_subp_usage", [False], indirect=True)
         def test_whoami(self):

--- a/cloudinit/tests/test_conftest.py
+++ b/cloudinit/tests/test_conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from cloudinit import util
+
+
+class TestDisableSubpUsage:
+
+    def test_using_subp_raises_assertion_error(self):
+        with pytest.raises(AssertionError):
+            util.subp(["some", "args"])
+
+    def test_typeerrors_on_incorrect_usage(self):
+        with pytest.raises(TypeError):
+            util.subp()
+
+    @pytest.mark.parametrize('disable_subp_usage', [False], indirect=True)
+    def test_subp_usage_can_be_reenabled(self):
+        util.subp(['whoami'])


### PR DESCRIPTION
This mirrors the behaviour of CiTestCase.allowed_subp, by causing all calls to `util.subp` within pytest tests to raise an AssertionError. It also includes support for re-enabling `util.subp` on a per-test basis (which is not yet needed). It does not yet have support for selectively allowing calls, but that can be added once it is needed.