### PR TITLE
net: ignore 'renderer' key in netplan config

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -312,7 +312,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
 
     def parse_config_v2(self, skip_broken=True):
         for command_type, command in self._config.items():
-            if command_type == 'version':
+            if command_type in ['version', 'renderer']:
                 continue
             try:
                 handler = self.command_handlers[command_type]

--- a/cloudinit/net/tests/test_network_state.py
+++ b/cloudinit/net/tests/test_network_state.py
@@ -45,4 +45,14 @@ class TestNetworkStateParseConfig(CiTestCase):
         self.assertNotEqual(None, result)
 
 
+class TestNetworkStateParseConfigV2(CiTestCase):
+
+    def test_version_2_ignores_renderer_key(self):
+        ncfg = {'version': 2, 'renderer': 'networkd', 'ethernets': {}}
+        nsi = network_state.NetworkStateInterpreter(version=ncfg['version'],
+                                                    config=ncfg)
+        nsi.parse_config(skip_broken=False)
+        self.assertEqual(ncfg, nsi.as_dict()['config'])
+
+
 # vi: ts=4 expandtab


### PR DESCRIPTION
Accept netplan config with 'renderer' keys.

LP: #1870421