### PR TITLE
Ubuntu/devel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (20.1-10-g71af48df-0ubuntu4) UNRELEASED; urgency=medium
+
+  * cherry-pick 9d7b35ce: cc_mounts: fix incorrect format specifiers
+    (#316) (LP: #1872836)
+
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 15 Apr 2020 15:07:49 -0600
+
 cloud-init (20.1-10-g71af48df-0ubuntu3) focal; urgency=medium
 
   * d/patches: redact openbsd netbsd from tests until new-upstream-snapshot

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-cloud-init (20.1-10-g71af48df-0ubuntu4) UNRELEASED; urgency=medium
+cloud-init (20.1-10-g71af48df-0ubuntu4) focal; urgency=medium
 
   * cherry-pick 9d7b35ce: cc_mounts: fix incorrect format specifiers
     (#316) (LP: #1872836)
 
- -- Chad Smith <chad.smith@canonical.com>  Wed, 15 Apr 2020 15:07:49 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 15 Apr 2020 15:09:04 -0600
 
 cloud-init (20.1-10-g71af48df-0ubuntu3) focal; urgency=medium
 

--- a/debian/patches/cpick-9d7b35ce-cc_mounts-fix-incorrect-format-specifiers-316
+++ b/debian/patches/cpick-9d7b35ce-cc_mounts-fix-incorrect-format-specifiers-316
@@ -1,0 +1,64 @@
+From 9d7b35ce23aaf8741dd49b16e359c96591be3c76 Mon Sep 17 00:00:00 2001
+From: Daniel Watkins <oddbloke@ubuntu.com>
+Date: Wed, 15 Apr 2020 16:53:08 -0400
+Subject: [PATCH] cc_mounts: fix incorrect format specifiers (#316)
+
+LP: #1872836
+---
+ cloudinit/config/cc_mounts.py         |  8 ++++----
+ cloudinit/config/tests/test_mounts.py | 22 ++++++++++++++++++++++
+ 2 files changed, 26 insertions(+), 4 deletions(-)
+ create mode 100644 cloudinit/config/tests/test_mounts.py
+
+--- a/cloudinit/config/cc_mounts.py
++++ b/cloudinit/config/cc_mounts.py
+@@ -223,20 +223,20 @@ def suggested_swapsize(memsize=None, max
+     return size
+ 
+ 
+-def create_swapfile(fname, size):
++def create_swapfile(fname: str, size: str) -> None:
+     """Size is in MiB."""
+ 
+-    errmsg = "Failed to create swapfile '%s' of size %dMB via %s: %s"
++    errmsg = "Failed to create swapfile '%s' of size %sMB via %s: %s"
+ 
+     def create_swap(fname, size, method):
+         LOG.debug("Creating swapfile in '%s' on fstype '%s' using '%s'",
+                   fname, fstype, method)
+ 
+         if method == "fallocate":
+-            cmd = ['fallocate', '-l', '%dM' % size, fname]
++            cmd = ['fallocate', '-l', '%sM' % size, fname]
+         elif method == "dd":
+             cmd = ['dd', 'if=/dev/zero', 'of=%s' % fname, 'bs=1M',
+-                   'count=%d' % size]
++                   'count=%s' % size]
+ 
+         try:
+             util.subp(cmd, capture=True)
+--- /dev/null
++++ b/cloudinit/config/tests/test_mounts.py
+@@ -0,0 +1,22 @@
++# This file is part of cloud-init. See LICENSE file for license information.
++from unittest import mock
++
++from cloudinit.config.cc_mounts import create_swapfile
++
++
++M_PATH = 'cloudinit.config.cc_mounts.'
++
++
++class TestCreateSwapfile:
++
++    @mock.patch(M_PATH + 'util.subp')
++    def test_happy_path(self, m_subp, tmpdir):
++        swap_file = tmpdir.join("swap-file")
++        fname = str(swap_file)
++
++        # Some of the calls to util.subp should create the swap file; this
++        # roughly approximates that
++        m_subp.side_effect = lambda *args, **kwargs: swap_file.write('')
++
++        create_swapfile(fname, '')
++        assert mock.call(['mkswap', fname]) in m_subp.call_args_list

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,4 @@ cpick-c478d0bf-distros-replace-invalid-characters-in-mirror-URLs-with
 cpick-1bbc4908-distros-drop-leading-trailing-hyphens-from-mirror-URL
 cpick-09fea85f-net-ignore-renderer-key-in-netplan-config-306
 fix-cpick-4fb6fd8a-net-ubuntu-focal-prioritize-netplan-over-eni.patch
+cpick-9d7b35ce-cc_mounts-fix-incorrect-format-specifiers-316


### PR DESCRIPTION
cherry pick for swap creation.


Performed and tested using uss-tableflip/scripts/(cherry-pick/build-package) with:
cd /tmp
git clone https://github.com/canonical/cloud-init.git
cd cloud-init
git checkout origin/ubuntu/devel -b ubuntu/devel
cherry-pick 9d7b35ce23aaf8741dd49b16e359c96591be3c76
dch --release --distribution=focal
git commit -m 'releasing cloud-init 20.1-10-g71af48df-0ubuntu4' debian/changelog 
build-package
