### PR TITLE
.travis.yml: don't run integration test on ubuntu/* branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ matrix:
           env:
               TOXENV=py3
               PYTEST_ADDOPTS=-v  # List all tests run by pytest
-        - install:
+        - if: NOT branch =~ /^ubuntu\//
+          install:
             - git fetch --unshallow
             - sudo apt-get build-dep -y cloud-init
             - sudo apt-get install -y --install-recommends sbuild ubuntu-dev-tools fakeroot tox


### PR DESCRIPTION
The integration test doesn't work against the ubuntu/* branches because
it uses the tooling designed to work against master.  This means that
ubuntu/* branches always report failures in Travis, which doesn't give
us any signal.