### PR TITLE
cloudinit: drop dependencies on unittest2 and contextlib2

### DIFF
--- a/cloudinit/config/tests/test_users_groups.py
+++ b/cloudinit/config/tests/test_users_groups.py
@@ -39,7 +39,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro='ubuntu', sys_cfg=sys_cfg, metadata=metadata)
         cc_users_groups.handle('modulename', cfg, cloud, None, None)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             m_user.call_args_list,
             [mock.call('ubuntu', groups='lxd,sudo', lock_passwd=True,
                        shell='/bin/bash'),
@@ -65,7 +65,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro='freebsd', sys_cfg=sys_cfg, metadata=metadata)
         cc_users_groups.handle('modulename', cfg, cloud, None, None)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             m_fbsd_user.call_args_list,
             [mock.call('freebsd', groups='wheel', lock_passwd=True,
                        shell='/bin/tcsh'),
@@ -86,7 +86,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro='ubuntu', sys_cfg=sys_cfg, metadata=metadata)
         cc_users_groups.handle('modulename', cfg, cloud, None, None)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             m_user.call_args_list,
             [mock.call('ubuntu', groups='lxd,sudo', lock_passwd=True,
                        shell='/bin/bash'),
@@ -107,7 +107,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro='ubuntu', sys_cfg=sys_cfg, metadata=metadata)
         cc_users_groups.handle('modulename', cfg, cloud, None, None)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             m_user.call_args_list,
             [mock.call('ubuntu', groups='lxd,sudo', lock_passwd=True,
                        shell='/bin/bash'),
@@ -146,7 +146,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro='ubuntu', sys_cfg=sys_cfg, metadata=metadata)
         cc_users_groups.handle('modulename', cfg, cloud, None, None)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             m_user.call_args_list,
             [mock.call('ubuntu', groups='lxd,sudo', lock_passwd=True,
                        shell='/bin/bash'),

--- a/cloudinit/net/tests/test_dhcp.py
+++ b/cloudinit/net/tests/test_dhcp.py
@@ -62,7 +62,7 @@ class TestParseDHCPLeasesFile(CiTestCase):
             {'interface': 'wlp3s0', 'fixed-address': '192.168.2.74',
              'subnet-mask': '255.255.255.0', 'routers': '192.168.2.1'}]
         write_file(lease_file, content)
-        self.assertItemsEqual(expected, parse_dhcp_lease_file(lease_file))
+        self.assertCountEqual(expected, parse_dhcp_lease_file(lease_file))
 
 
 class TestDHCPRFC3442(CiTestCase):
@@ -88,7 +88,7 @@ class TestDHCPRFC3442(CiTestCase):
              'renew': '4 2017/07/27 18:02:30',
              'expire': '5 2017/07/28 07:08:15'}]
         write_file(lease_file, content)
-        self.assertItemsEqual(expected, parse_dhcp_lease_file(lease_file))
+        self.assertCountEqual(expected, parse_dhcp_lease_file(lease_file))
 
     def test_parse_lease_finds_classless_static_routes(self):
         """
@@ -114,7 +114,7 @@ class TestDHCPRFC3442(CiTestCase):
              'renew': '4 2017/07/27 18:02:30',
              'expire': '5 2017/07/28 07:08:15'}]
         write_file(lease_file, content)
-        self.assertItemsEqual(expected, parse_dhcp_lease_file(lease_file))
+        self.assertCountEqual(expected, parse_dhcp_lease_file(lease_file))
 
     @mock.patch('cloudinit.net.dhcp.EphemeralIPv4Network')
     @mock.patch('cloudinit.net.dhcp.maybe_perform_dhcp_discovery')
@@ -324,7 +324,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
         """)
         write_file(self.tmp_path('dhcp.leases', tmpdir), lease_content)
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             [{'interface': 'eth9', 'fixed-address': '192.168.2.74',
               'subnet-mask': '255.255.255.0', 'routers': '192.168.2.1'}],
             dhcp_discovery(dhclient_script, 'eth9', tmpdir))
@@ -389,7 +389,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
         write_file(pid_file, "%d\n" % my_pid)
         m_getppid.return_value = 1  # Indicate that dhclient has daemonized
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             [{'interface': 'eth9', 'fixed-address': '192.168.2.74',
               'subnet-mask': '255.255.255.0', 'routers': '192.168.2.1'}],
             dhcp_discovery(dhclient_script, 'eth9', tmpdir))

--- a/cloudinit/net/tests/test_init.py
+++ b/cloudinit/net/tests/test_init.py
@@ -397,7 +397,7 @@ class TestGetDeviceList(CiTestCase):
         """get_devicelist returns a directory listing for SYS_CLASS_NET."""
         write_file(os.path.join(self.sysdir, 'eth0', 'operstate'), 'up')
         write_file(os.path.join(self.sysdir, 'eth1', 'operstate'), 'up')
-        self.assertItemsEqual(['eth0', 'eth1'], net.get_devicelist())
+        self.assertCountEqual(['eth0', 'eth1'], net.get_devicelist())
 
 
 class TestGetInterfaceMAC(CiTestCase):

--- a/cloudinit/sources/tests/test_init.py
+++ b/cloudinit/sources/tests/test_init.py
@@ -350,7 +350,7 @@ class TestDataSource(CiTestCase):
                 'region': 'myregion',
                 'some': {'security-credentials': {
                     'cred1': 'sekret', 'cred2': 'othersekret'}}})
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ('merged_cfg', 'security-credentials',),
             datasource.sensitive_metadata_keys)
         sys_info = {
@@ -401,7 +401,7 @@ class TestDataSource(CiTestCase):
                     'region': 'myregion',
                     'some': {'security-credentials': REDACT_SENSITIVE_VALUE}}}
         }
-        self.assertItemsEqual(expected, redacted)
+        self.assertCountEqual(expected, redacted)
         file_stat = os.stat(json_file)
         self.assertEqual(0o644, stat.S_IMODE(file_stat.st_mode))
 
@@ -426,7 +426,7 @@ class TestDataSource(CiTestCase):
                       "x86_64"],
             "variant": "ubuntu", "dist": ["ubuntu", "20.04", "focal"]}
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ('merged_cfg', 'security-credentials',),
             datasource.sensitive_metadata_keys)
         with mock.patch("cloudinit.util.system_info", return_value=sys_info):
@@ -476,7 +476,7 @@ class TestDataSource(CiTestCase):
                         'security-credentials':
                             {'cred1': 'sekret', 'cred2': 'othersekret'}}}}
         }
-        self.assertItemsEqual(expected, util.load_json(content))
+        self.assertCountEqual(expected, util.load_json(content))
         file_stat = os.stat(sensitive_json_file)
         self.assertEqual(0o600, stat.S_IMODE(file_stat.st_mode))
         self.assertEqual(expected, util.load_json(content))
@@ -542,7 +542,7 @@ class TestDataSource(CiTestCase):
         json_file = self.tmp_path(INSTANCE_JSON_FILE, tmp)
         content = util.load_file(json_file)
         instance_json = util.load_json(content)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ['ds/meta_data/key2/key2.1'],
             instance_json['base64_encoded_keys'])
         self.assertEqual(

--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -13,10 +13,9 @@ import string
 import sys
 import tempfile
 import time
+import unittest
 from unittest import mock
-
-import unittest2
-from unittest2.util import strclass
+from unittest.util import strclass
 
 try:
     from contextlib import ExitStack, contextmanager
@@ -35,8 +34,8 @@ from cloudinit import util
 _real_subp = util.subp
 
 # Used for skipping tests
-SkipTest = unittest2.SkipTest
-skipIf = unittest2.skipIf
+SkipTest = unittest.SkipTest
+skipIf = unittest.skipIf
 
 
 # Makes the old path start
@@ -73,7 +72,7 @@ def retarget_many_wrapper(new_base, am, old_func):
     return wrapper
 
 
-class TestCase(unittest2.TestCase):
+class TestCase(unittest.TestCase):
 
     def reset_global_state(self):
         """Reset any global state to its original settings.
@@ -372,7 +371,7 @@ class HttprettyTestCase(CiTestCase):
         super(HttprettyTestCase, self).tearDown()
 
 
-class SchemaTestCaseMixin(unittest2.TestCase):
+class SchemaTestCaseMixin(unittest.TestCase):
 
     def assertSchemaValid(self, cfg, msg="Valid Schema failed validation."):
         """Assert the config is valid per self.schema.

--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -504,13 +504,4 @@ if not hasattr(mock.Mock, 'assert_not_called'):
             raise AssertionError(msg)
     mock.Mock.assert_not_called = __mock_assert_not_called
 
-
-# older unittest2.TestCase (centos6) have only the now-deprecated
-# assertRaisesRegexp. Simple assignment makes pylint complain, about
-# users of assertRaisesRegex so we use getattr to trick it.
-# https://github.com/PyCQA/pylint/issues/1946
-if not hasattr(unittest2.TestCase, 'assertRaisesRegex'):
-    unittest2.TestCase.assertRaisesRegex = (
-        getattr(unittest2.TestCase, 'assertRaisesRegexp'))
-
 # vi: ts=4 expandtab

--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -14,13 +14,9 @@ import sys
 import tempfile
 import time
 import unittest
+from contextlib import ExitStack, contextmanager
 from unittest import mock
 from unittest.util import strclass
-
-try:
-    from contextlib import ExitStack, contextmanager
-except ImportError:
-    from contextlib2 import ExitStack, contextmanager
 
 from cloudinit.config.schema import (
     SchemaValidationError, validate_cloudconfig_schema)

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -5,7 +5,6 @@
 # the packages/pkg-deps.json file as well.
 #
 
-unittest2
 # ec2 backend
 boto3==1.5.9
 

--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -10,9 +10,6 @@
             "2" : "python-yaml",
             "3" : "python3-yaml"
          },
-         "contextlib2" : {
-            "2" : "python-contextlib2"
-         },
          "pyserial" : {
             "2" : "python-serial",
             "3" : "python3-serial"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
 # Needed generally in tests
 httpretty>=0.7.1
 pytest
-unittest2
 pytest-cov
 
 # Only really needed on older versions of python

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,5 +4,4 @@ pytest
 pytest-cov
 
 # Only really needed on older versions of python
-contextlib2
 setuptools

--- a/tests/cloud_tests/testcases/__init__.py
+++ b/tests/cloud_tests/testcases/__init__.py
@@ -4,7 +4,7 @@
 
 import importlib
 import inspect
-import unittest2
+import unittest
 
 from cloudinit.util import read_conf
 
@@ -48,7 +48,7 @@ def get_test_class(test_name, test_data, test_conf):
 
         def __str__(self):
             return "%s (%s)" % (self._testMethodName,
-                                unittest2.util.strclass(self._realclass))
+                                unittest.util.strclass(self._realclass))
 
         @classmethod
         def setUpClass(cls):
@@ -62,9 +62,9 @@ def get_suite(test_name, data, conf):
 
     @return_value: a test suite
     """
-    suite = unittest2.TestSuite()
+    suite = unittest.TestSuite()
     suite.addTest(
-        unittest2.defaultTestLoader.loadTestsFromTestCase(
+        unittest.defaultTestLoader.loadTestsFromTestCase(
             get_test_class(test_name, data, conf)))
     return suite
 

--- a/tests/cloud_tests/testcases/base.py
+++ b/tests/cloud_tests/testcases/base.py
@@ -172,7 +172,7 @@ class CloudTestCase(unittest2.TestCase):
                 'Skipping instance-data.json test.'
                 ' OS: %s not bionic or newer' % self.os_name)
         instance_data = json.loads(out)
-        self.assertItemsEqual(['merged_cfg'], instance_data['sensitive_keys'])
+        self.assertCountEqual(['merged_cfg'], instance_data['sensitive_keys'])
         ds = instance_data.get('ds', {})
         v1_data = instance_data.get('v1', {})
         metadata = ds.get('meta-data', {})
@@ -237,7 +237,7 @@ class CloudTestCase(unittest2.TestCase):
                 ' OS: %s not bionic or newer' % self.os_name)
         instance_data = json.loads(out)
         v1_data = instance_data.get('v1', {})
-        self.assertItemsEqual([], sorted(instance_data['base64_encoded_keys']))
+        self.assertCountEqual([], sorted(instance_data['base64_encoded_keys']))
         self.assertEqual('unknown', v1_data['cloud_name'])
         self.assertEqual('lxd', v1_data['platform'])
         self.assertEqual(
@@ -291,7 +291,7 @@ class CloudTestCase(unittest2.TestCase):
                 ' OS: %s not bionic or newer' % self.os_name)
         instance_data = json.loads(out)
         v1_data = instance_data.get('v1', {})
-        self.assertItemsEqual([], instance_data['base64_encoded_keys'])
+        self.assertCountEqual([], instance_data['base64_encoded_keys'])
         self.assertEqual('unknown', v1_data['cloud_name'])
         self.assertEqual('nocloud', v1_data['platform'])
         subplatform = v1_data['subplatform']

--- a/tests/cloud_tests/testcases/base.py
+++ b/tests/cloud_tests/testcases/base.py
@@ -5,15 +5,15 @@
 import crypt
 import json
 import re
-import unittest2
+import unittest
 
 
 from cloudinit import util as c_util
 
-SkipTest = unittest2.SkipTest
+SkipTest = unittest.SkipTest
 
 
-class CloudTestCase(unittest2.TestCase):
+class CloudTestCase(unittest.TestCase):
     """Base test class for verifiers."""
 
     # data gets populated in get_suite.setUpClass

--- a/tests/cloud_tests/testcases/modules/ntp_chrony.py
+++ b/tests/cloud_tests/testcases/modules/ntp_chrony.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 """cloud-init Integration Test Verify Script."""
-import unittest2
+import unittest
 
 from tests.cloud_tests.testcases import base
 
@@ -13,7 +13,7 @@ class TestNtpChrony(base.CloudTestCase):
         """Skip this suite of tests on lxd and artful or older."""
         if self.platform == 'lxd':
             if self.is_distro('ubuntu') and self.os_version_cmp('artful') <= 0:
-                raise unittest2.SkipTest(
+                raise unittest.SkipTest(
                     'No support for chrony on containers <= artful.'
                     ' LP: #1589780')
         return super(TestNtpChrony, self).setUp()

--- a/tests/cloud_tests/verify.py
+++ b/tests/cloud_tests/verify.py
@@ -3,7 +3,7 @@
 """Verify test results."""
 
 import os
-import unittest2
+import unittest
 
 from tests.cloud_tests import (config, LOG, util, testcases)
 
@@ -18,7 +18,7 @@ def verify_data(data_dir, platform, os_name, tests):
     @return_value: {<test_name>: {passed: True/False, failures: []}}
     """
     base_dir = os.sep.join((data_dir, platform, os_name))
-    runner = unittest2.TextTestRunner(verbosity=util.current_verbosity())
+    runner = unittest.TextTestRunner(verbosity=util.current_verbosity())
     res = {}
     for test_name in tests:
         LOG.debug('verifying test data for %s', test_name)

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -109,7 +109,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         cloudconfig_handler = CloudConfigPartHandler(self.paths)
         h = JinjaTemplatePartHandler(
             self.paths, sub_handlers=[script_handler, cloudconfig_handler])
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ['text/cloud-config', 'text/cloud-config-jsonp',
              'text/x-shellscript'],
             h.sub_handlers)
@@ -120,7 +120,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         cloudconfig_handler = CloudConfigPartHandler(self.paths)
         h = JinjaTemplatePartHandler(
             self.paths, sub_handlers=[script_handler, cloudconfig_handler])
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ['text/cloud-config', 'text/cloud-config-jsonp',
              'text/x-shellscript'],
             h.sub_handlers)
@@ -302,7 +302,7 @@ class TestConvertJinjaInstanceData(CiTestCase):
         expected_data.update({'v1key1': 'v1.1', 'v2key1': 'v2.1'})
 
         converted_data = convert_jinja_instance_data(data=data)
-        self.assertItemsEqual(
+        self.assertCountEqual(
             ['ds', 'v1', 'v2', 'v1key1', 'v2key1'], converted_data.keys())
         self.assertEqual(
             expected_data,

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -528,14 +528,14 @@ scbus-1 on xpt0 bus 0
 
         def tags_exists(x, y):
             for tag in x.keys():
-                self.assertIn(tag, y)
+                assert tag in y
             for tag in y.keys():
-                self.assertIn(tag, x)
+                assert tag in x
 
         def tags_equal(x, y):
             for x_val in x.values():
                 y_val = y.get(x_val.tag)
-                self.assertEqual(x_val.text, y_val.text)
+                assert x_val.text == y_val.text
 
         old_cnt = create_tag_index(oxml)
         new_cnt = create_tag_index(nxml)

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -649,7 +649,7 @@ scbus-1 on xpt0 bus 0
 
         crawled_metadata = dsrc.crawl_metadata()
 
-        self.assertItemsEqual(
+        self.assertCountEqual(
             crawled_metadata.keys(),
             ['cfg', 'files', 'metadata', 'userdata_raw'])
         self.assertEqual(crawled_metadata['cfg'], expected_cfg)

--- a/tests/unittests/test_datasource/test_azure_helper.py
+++ b/tests/unittests/test_datasource/test_azure_helper.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import os
-import unittest2
+import unittest
 from textwrap import dedent
 
 from cloudinit.sources.helpers import azure as azure_helper
@@ -332,7 +332,7 @@ class TestOpenSSLManagerActions(CiTestCase):
         path = 'tests/data/azure'
         return os.path.join(path, name)
 
-    @unittest2.skip("todo move to cloud_test")
+    @unittest.skip("todo move to cloud_test")
     def test_pubkey_extract(self):
         cert = load_file(self._data_file('pubkey_extract_cert'))
         good_key = load_file(self._data_file('pubkey_extract_ssh_key'))
@@ -344,7 +344,7 @@ class TestOpenSSLManagerActions(CiTestCase):
         fingerprint = sslmgr._get_fingerprint_from_cert(cert)
         self.assertEqual(good_fingerprint, fingerprint)
 
-    @unittest2.skip("todo move to cloud_test")
+    @unittest.skip("todo move to cloud_test")
     @mock.patch.object(azure_helper.OpenSSLManager, '_decrypt_certs_from_xml')
     def test_parse_certificates(self, mock_decrypt_certs):
         """Azure control plane puts private keys as well as certificates

--- a/tests/unittests/test_datasource/test_smartos.py
+++ b/tests/unittests/test_datasource/test_smartos.py
@@ -22,7 +22,7 @@ import os.path
 import re
 import signal
 import stat
-import unittest2
+import unittest
 import uuid
 
 from cloudinit import serial
@@ -1095,11 +1095,11 @@ class TestNetworkConversion(CiTestCase):
         self.assertEqual(expected, found)
 
 
-@unittest2.skipUnless(get_smartos_environ() == SMARTOS_ENV_KVM,
-                      "Only supported on KVM and bhyve guests under SmartOS")
-@unittest2.skipUnless(os.access(SERIAL_DEVICE, os.W_OK),
-                      "Requires write access to " + SERIAL_DEVICE)
-@unittest2.skipUnless(HAS_PYSERIAL is True, "pyserial not available")
+@unittest.skipUnless(get_smartos_environ() == SMARTOS_ENV_KVM,
+                     "Only supported on KVM and bhyve guests under SmartOS")
+@unittest.skipUnless(os.access(SERIAL_DEVICE, os.W_OK),
+                     "Requires write access to " + SERIAL_DEVICE)
+@unittest.skipUnless(HAS_PYSERIAL is True, "pyserial not available")
 class TestSerialConcurrency(CiTestCase):
     """
        This class tests locking on an actual serial port, and as such can only

--- a/tests/unittests/test_handler/test_handler_ca_certs.py
+++ b/tests/unittests/test_handler/test_handler_ca_certs.py
@@ -11,12 +11,8 @@ import logging
 import shutil
 import tempfile
 import unittest
+from contextlib import ExitStack
 from unittest import mock
-
-try:
-    from contextlib import ExitStack
-except ImportError:
-    from contextlib2 import ExitStack
 
 
 class TestNoConfig(unittest.TestCase):

--- a/tests/unittests/test_handler/test_handler_chef.py
+++ b/tests/unittests/test_handler/test_handler_chef.py
@@ -65,18 +65,18 @@ class TestInstallChefOmnibus(HttprettyTestCase):
         cc_chef.install_chef_from_omnibus()
         expected_kwargs = {'retries': cc_chef.OMNIBUS_URL_RETRIES,
                            'url': cc_chef.OMNIBUS_URL}
-        self.assertItemsEqual(expected_kwargs, m_rdurl.call_args_list[0][1])
+        self.assertCountEqual(expected_kwargs, m_rdurl.call_args_list[0][1])
         cc_chef.install_chef_from_omnibus(retries=10)
         expected_kwargs = {'retries': 10,
                            'url': cc_chef.OMNIBUS_URL}
-        self.assertItemsEqual(expected_kwargs, m_rdurl.call_args_list[1][1])
+        self.assertCountEqual(expected_kwargs, m_rdurl.call_args_list[1][1])
         expected_subp_kwargs = {
             'args': ['-v', '2.0'],
             'basename': 'chef-omnibus-install',
             'blob': m_rdurl.return_value.contents,
             'capture': False
         }
-        self.assertItemsEqual(
+        self.assertCountEqual(
             expected_subp_kwargs,
             m_subp_blob.call_args_list[0][1])
 
@@ -97,7 +97,7 @@ class TestInstallChefOmnibus(HttprettyTestCase):
             'blob': response,
             'capture': False
         }
-        self.assertItemsEqual(expected_kwargs, called_kwargs)
+        self.assertCountEqual(expected_kwargs, called_kwargs)
 
 
 class TestChef(FilesystemMockingTestCase):

--- a/tests/unittests/test_handler/test_handler_growpart.py
+++ b/tests/unittests/test_handler/test_handler_growpart.py
@@ -11,12 +11,8 @@ import logging
 import os
 import re
 import unittest
+from contextlib import ExitStack
 from unittest import mock
-
-try:
-    from contextlib import ExitStack
-except ImportError:
-    from contextlib2 import ExitStack
 
 # growpart:
 #   mode: auto  # off, on, auto, 'growpart'

--- a/tests/unittests/test_handler/test_schema.py
+++ b/tests/unittests/test_handler/test_schema.py
@@ -20,7 +20,7 @@ class GetSchemaTest(CiTestCase):
     def test_get_schema_coalesces_known_schema(self):
         """Every cloudconfig module with schema is listed in allOf keyword."""
         schema = get_schema()
-        self.assertItemsEqual(
+        self.assertCountEqual(
             [
                 'cc_bootcmd',
                 'cc_ntp',
@@ -38,7 +38,7 @@ class GetSchemaTest(CiTestCase):
             schema['$schema'])
         # FULL_SCHEMA is updated by the get_schema call
         from cloudinit.config.schema import FULL_SCHEMA
-        self.assertItemsEqual(['id', '$schema', 'allOf'], FULL_SCHEMA.keys())
+        self.assertCountEqual(['id', '$schema', 'allOf'], FULL_SCHEMA.keys())
 
     def test_get_schema_returns_global_when_set(self):
         """When FULL_SCHEMA global is already set, get_schema returns it."""

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,6 @@ deps =
     # test-requirements
     httpretty==0.9.6
     mock==1.3.0
-    unittest2==1.1.0
     contextlib2==0.5.1
 
 [testenv:xenial]

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,6 @@ deps =
     # test-requirements
     httpretty==0.9.6
     mock==1.3.0
-    contextlib2==0.5.1
 
 [testenv:xenial]
 # When updating this commands definition, also update the definition in


### PR DESCRIPTION
These libraries provide backports of Python 3's stdlib components to Python 2. As we only support Python 3, we can simply use the stdlib now. This pull request does the following:

* removes some unneeded compatibility code for the old spelling of `assertRaisesRegex`
* replaces invocations of the Python 2-only `assertItemsEqual` with its new name, `assertCountEqual`
* replaces all usage of `unittest2` with `unittest`
* replaces all usage of `contextlib2` with `contextlib`
* drops `unittest2` and `contextlib2` from requirements files and tox.ini