### PR TITLE
YAML align indent sizes for docs readability 

### DIFF
--- a/doc/examples/cloud-config-apt.txt
+++ b/doc/examples/cloud-config-apt.txt
@@ -141,7 +141,7 @@ apt:
       # as above, allowing to have one config for different per arch mirrors
   # security is optional, if not defined it is set to the same value as primary
   security:
-      uri: http://security.ubuntu.com/ubuntu
+    uri: http://security.ubuntu.com/ubuntu
   # If search_dns is set for security the searched pattern is:
   #   <distro>-security-mirror
 
@@ -222,19 +222,19 @@ apt:
   # This allows merging between multiple input files than a list like:
   # cloud-config1
   # sources:
-  #    s1: {'key': 'key1', 'source': 'source1'}
+  #   s1: {'key': 'key1', 'source': 'source1'}
   # cloud-config2
   # sources:
-  #    s2: {'key': 'key2'}
-  #    s1: {'keyserver': 'foo'}
+  #   s2: {'key': 'key2'}
+  #   s1: {'keyserver': 'foo'}
   # This would be merged to
   # sources:
-  #    s1:
-  #        keyserver: foo
-  #        key: key1
-  #        source: source1
-  #    s2:
-  #        key: key2
+  #   s1:
+  #     keyserver: foo
+  #     key: key1
+  #     source: source1
+  #   s2:
+  #     key: key2
   #
   # The following examples number the subfeatures per sources entry to ease
   # identification in discussions.
@@ -314,15 +314,15 @@ apt:
       # As with keyid's this can be specified with or without some actual source
       # content.
       key: | # The value needs to start with -----BEGIN PGP PUBLIC KEY BLOCK-----
-         -----BEGIN PGP PUBLIC KEY BLOCK-----
-         Version: SKS 1.0.10
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Version: SKS 1.0.10
 
-         mI0ESpA3UQEEALdZKVIMq0j6qWAXAyxSlF63SvPVIgxHPb9Nk0DZUixn+akqytxG4zKCONz6
-         qLjoBBfHnynyVLfT4ihg9an1PqxRnTO+JKQxl8NgKGz6Pon569GtAOdWNKw15XKinJTDLjnj
-         9y96ljJqRcpV9t/WsIcdJPcKFR5voHTEoABE2aEXABEBAAG0GUxhdW5jaHBhZCBQUEEgZm9y
-         IEFsZXN0aWOItgQTAQIAIAUCSpA3UQIbAwYLCQgHAwIEFQIIAwQWAgMBAh4BAheAAAoJEA7H
-         5Qi+CcVxWZ8D/1MyYvfj3FJPZUm2Yo1zZsQ657vHI9+pPouqflWOayRR9jbiyUFIn0VdQBrP
-         t0FwvnOFArUovUWoKAEdqR8hPy3M3APUZjl5K4cMZR/xaMQeQRZ5CHpS4DBKURKAHC0ltS5o
-         uBJKQOZm5iltJp15cgyIkBkGe8Mx18VFyVglAZey
-         =Y2oI
-         -----END PGP PUBLIC KEY BLOCK-----
+        mI0ESpA3UQEEALdZKVIMq0j6qWAXAyxSlF63SvPVIgxHPb9Nk0DZUixn+akqytxG4zKCONz6
+        qLjoBBfHnynyVLfT4ihg9an1PqxRnTO+JKQxl8NgKGz6Pon569GtAOdWNKw15XKinJTDLjnj
+        9y96ljJqRcpV9t/WsIcdJPcKFR5voHTEoABE2aEXABEBAAG0GUxhdW5jaHBhZCBQUEEgZm9y
+        IEFsZXN0aWOItgQTAQIAIAUCSpA3UQIbAwYLCQgHAwIEFQIIAwQWAgMBAh4BAheAAAoJEA7H
+        5Qi+CcVxWZ8D/1MyYvfj3FJPZUm2Yo1zZsQ657vHI9+pPouqflWOayRR9jbiyUFIn0VdQBrP
+        t0FwvnOFArUovUWoKAEdqR8hPy3M3APUZjl5K4cMZR/xaMQeQRZ5CHpS4DBKURKAHC0ltS5o
+        uBJKQOZm5iltJp15cgyIkBkGe8Mx18VFyVglAZey
+        =Y2oI
+        -----END PGP PUBLIC KEY BLOCK-----

--- a/doc/examples/cloud-config-boot-cmds.txt
+++ b/doc/examples/cloud-config-boot-cmds.txt
@@ -11,5 +11,5 @@
 # - the INSTANCE_ID variable will be set to the current instance id.
 # - you can use 'cloud-init-per' command to help only run once
 bootcmd:
- - echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts
- - [ cloud-init-per, once, mymkfs, mkfs, /dev/vdb ]
+  - echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts
+  - [ cloud-init-per, once, mymkfs, mkfs, /dev/vdb ]

--- a/doc/examples/cloud-config-chef-oneiric.txt
+++ b/doc/examples/cloud-config-chef-oneiric.txt
@@ -48,38 +48,38 @@ apt:
 
 chef:
 
- # 11.10 will fail if install_type is "gems" (LP: #960576)
- install_type: "packages"
+  # 11.10 will fail if install_type is "gems" (LP: #960576)
+  install_type: "packages"
 
- # Chef settings
- server_url: "https://chef.yourorg.com:4000"
+  # Chef settings
+  server_url: "https://chef.yourorg.com:4000"
 
- # Node Name
- # Defaults to the instance-id if not present
- node_name: "your-node-name"
+  # Node Name
+  # Defaults to the instance-id if not present
+  node_name: "your-node-name"
 
- # Environment
- # Defaults to '_default' if not present
- environment: "production"
+  # Environment
+  # Defaults to '_default' if not present
+  environment: "production"
 
- # Default validation name is chef-validator
- validation_name: "yourorg-validator"
+  # Default validation name is chef-validator
+  validation_name: "yourorg-validator"
 
- # value of validation_cert is not used if validation_key defined,
- # but variable needs to be defined (LP: #960547)
- validation_cert: "unused"
- validation_key: |
-     -----BEGIN RSA PRIVATE KEY-----
-     YOUR-ORGS-VALIDATION-KEY-HERE
-     -----END RSA PRIVATE KEY-----
- 
- # A run list for a first boot json
- run_list:
-  - "recipe[apache2]"
-  - "role[db]"
+  # value of validation_cert is not used if validation_key defined,
+  # but variable needs to be defined (LP: #960547)
+  validation_cert: "unused"
+  validation_key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    YOUR-ORGS-VALIDATION-KEY-HERE
+    -----END RSA PRIVATE KEY-----
 
- # Specify a list of initial attributes used by the cookbooks
- initial_attributes:
+  # A run list for a first boot json
+  run_list:
+   - "recipe[apache2]"
+   - "role[db]"
+
+  # Specify a list of initial attributes used by the cookbooks
+  initial_attributes:
     apache:
       prefork:
         maxclients: 100

--- a/doc/examples/cloud-config-chef.txt
+++ b/doc/examples/cloud-config-chef.txt
@@ -52,55 +52,55 @@ apt:
 
 chef:
 
- # Valid values are 'gems' and 'packages' and 'omnibus'
- install_type: "packages"
+  # Valid values are 'gems' and 'packages' and 'omnibus'
+  install_type: "packages"
 
- # Boolean: run 'install_type' code even if chef-client
- #          appears already installed.
- force_install: false
+  # Boolean: run 'install_type' code even if chef-client
+  #          appears already installed.
+  force_install: false
 
- # Chef settings
- server_url: "https://chef.yourorg.com"
+  # Chef settings
+  server_url: "https://chef.yourorg.com"
 
- # Node Name
- # Defaults to the instance-id if not present
- node_name: "your-node-name"
+  # Node Name
+  # Defaults to the instance-id if not present
+  node_name: "your-node-name"
 
- # Environment
- # Defaults to '_default' if not present
- environment: "production"
+  # Environment
+  # Defaults to '_default' if not present
+  environment: "production"
 
- # Default validation name is chef-validator
- validation_name: "yourorg-validator"
- # if validation_cert's value is "system" then it is expected
- # that the file already exists on the system.
- validation_cert: |
-     -----BEGIN RSA PRIVATE KEY-----
-     YOUR-ORGS-VALIDATION-KEY-HERE
-     -----END RSA PRIVATE KEY-----
+  # Default validation name is chef-validator
+  validation_name: "yourorg-validator"
+  # if validation_cert's value is "system" then it is expected
+  # that the file already exists on the system.
+  validation_cert: |
+    -----BEGIN RSA PRIVATE KEY-----
+    YOUR-ORGS-VALIDATION-KEY-HERE
+    -----END RSA PRIVATE KEY-----
 
- # A run list for a first boot json, an example (not required)
- run_list:
-  - "recipe[apache2]"
-  - "role[db]"
+  # A run list for a first boot json, an example (not required)
+  run_list:
+   - "recipe[apache2]"
+   - "role[db]"
 
- # Specify a list of initial attributes used by the cookbooks
- initial_attributes:
+  # Specify a list of initial attributes used by the cookbooks
+  initial_attributes:
     apache:
       prefork:
         maxclients: 100
       keepalive: "off"
 
- # if install_type is 'omnibus', change the url to download
- omnibus_url: "https://www.chef.io/chef/install.sh"
+  # if install_type is 'omnibus', change the url to download
+  omnibus_url: "https://www.chef.io/chef/install.sh"
 
- # if install_type is 'omnibus', pass pinned version string
- # to the install script
- omnibus_version: "12.3.0"
+  # if install_type is 'omnibus', pass pinned version string
+  # to the install script
+  omnibus_version: "12.3.0"
 
- # If encrypted data bags are used, the client needs to have a secrets file
- # configured to decrypt them
- encrypted_data_bag_secret: "/etc/chef/encrypted_data_bag_secret"
+  # If encrypted data bags are used, the client needs to have a secrets file
+  # configured to decrypt them
+  encrypted_data_bag_secret: "/etc/chef/encrypted_data_bag_secret"
 
 # Capture all subprocess output into a logfile
 # Useful for troubleshooting cloud-init issues

--- a/doc/examples/cloud-config-chef.txt
+++ b/doc/examples/cloud-config-chef.txt
@@ -81,8 +81,8 @@ chef:
 
   # A run list for a first boot json, an example (not required)
   run_list:
-   - "recipe[apache2]"
-   - "role[db]"
+    - "recipe[apache2]"
+    - "role[db]"
 
   # Specify a list of initial attributes used by the cookbooks
   initial_attributes:

--- a/doc/examples/cloud-config-datasources.txt
+++ b/doc/examples/cloud-config-datasources.txt
@@ -38,10 +38,10 @@ datasource:
     # these are optional, but allow you to basically provide a datasource
     # right here
     user-data: |
-       # This is the user-data verbatim
+      # This is the user-data verbatim
     meta-data:
-       instance-id: i-87018aed
-       local-hostname: myhost.internal
+      instance-id: i-87018aed
+      local-hostname: myhost.internal
 
   Azure:
     agent_command: [service, walinuxagent, start]

--- a/doc/examples/cloud-config-disk-setup.txt
+++ b/doc/examples/cloud-config-disk-setup.txt
@@ -6,47 +6,47 @@
 # (Not implemented yet, but provided for future documentation)
 
 disk_setup:
-   ephmeral0:
-       table_type: 'mbr'
-       layout: True
-       overwrite: False
+  ephmeral0:
+    table_type: 'mbr'
+    layout: True
+    overwrite: False
 
 fs_setup:
-   - label: None,
-     filesystem: ext3
-     device: ephemeral0
-     partition: auto
+  - label: None,
+    filesystem: ext3
+    device: ephemeral0
+    partition: auto
 
 # Default disk definitions for Microsoft Azure
 # ------------------------------------------
 
 device_aliases: {'ephemeral0': '/dev/sdb'}
 disk_setup:
-    ephemeral0:
-         table_type: mbr
-         layout: True
-         overwrite: False
+  ephemeral0:
+    table_type: mbr
+    layout: True
+    overwrite: False
 
 fs_setup:
-    - label: ephemeral0
-      filesystem: ext4
-      device: ephemeral0.1
-      replace_fs: ntfs
+  - label: ephemeral0
+    filesystem: ext4
+    device: ephemeral0.1
+    replace_fs: ntfs
 
 
 # Data disks definitions for Microsoft Azure
 # ------------------------------------------
 
 disk_setup:
-    /dev/disk/azure/scsi1/lun0:
-        table_type: gpt
-        layout: True
-        overwrite: True
+  /dev/disk/azure/scsi1/lun0:
+    table_type: gpt
+    layout: True
+    overwrite: True
 
 fs_setup:
-    - device: /dev/disk/azure/scsi1/lun0
-      partition: 1
-      filesystem: ext4
+  - device: /dev/disk/azure/scsi1/lun0
+    partition: 1
+    filesystem: ext4
 
 
 # Default disk definitions for SmartOS
@@ -54,15 +54,15 @@ fs_setup:
 
 device_aliases: {'ephemeral0': '/dev/vdb'}
 disk_setup:
-    ephemeral0:
-         table_type: mbr
-         layout: False
-         overwrite: False
+  ephemeral0:
+    table_type: mbr
+    layout: False
+    overwrite: False
 
 fs_setup:
-    - label: ephemeral0
-      filesystem: ext4
-      device: ephemeral0.0
+  - label: ephemeral0
+    filesystem: ext4
+    device: ephemeral0.0
 
 # Caveat for SmartOS: if ephemeral disk is not defined, then the disk will
 #    not be automatically added to the mounts.
@@ -77,87 +77,87 @@ fs_setup:
 # The disk_setup directive instructs Cloud-init to partition a disk. The format is:
 
 disk_setup:
-   ephmeral0:
-       table_type: 'mbr'
-       layout: 'auto'
-   /dev/xvdh:
-       table_type: 'mbr'
-       layout:
-           - 33
-           - [33, 82]
-           - 33
-       overwrite: True
+  ephmeral0:
+    table_type: 'mbr'
+    layout: 'auto'
+  /dev/xvdh:
+    table_type: 'mbr'
+    layout:
+      - 33
+      - [33, 82]
+      - 33
+    overwrite: True
 
 # The format is a list of dicts of dicts. The first value is the name of the
 # device and the subsequent values define how to create and layout the
 # partition.
 # The general format is:
-#    disk_setup:
-#        <DEVICE>:
-#            table_type: 'mbr'
-#            layout: <LAYOUT|BOOL>
-#            overwrite: <BOOL>
+#   disk_setup:
+#     <DEVICE>:
+#       table_type: 'mbr'
+#       layout: <LAYOUT|BOOL>
+#       overwrite: <BOOL>
 #
 # Where:
-#    <DEVICE>: The name of the device. 'ephemeralX' and 'swap' are special
-#                values which are specific to the cloud. For these devices
-#                Cloud-init will look up what the real devices is and then
-#                use it.
+#   <DEVICE>: The name of the device. 'ephemeralX' and 'swap' are special
+#               values which are specific to the cloud. For these devices
+#               Cloud-init will look up what the real devices is and then
+#               use it.
 #
-#                For other devices, the kernel device name is used. At this
-#                time only simply kernel devices are supported, meaning
-#                that device mapper and other targets may not work.
+#               For other devices, the kernel device name is used. At this
+#               time only simply kernel devices are supported, meaning
+#               that device mapper and other targets may not work.
 #
-#                Note: At this time, there is no handling or setup of
-#                device mapper targets.
+#               Note: At this time, there is no handling or setup of
+#               device mapper targets.
 #
-#    table_type=<TYPE>: Currently the following are supported:
-#                    'mbr': default and setups a MS-DOS partition table
-#                    'gpt': setups a GPT partition table
+#   table_type=<TYPE>: Currently the following are supported:
+#                   'mbr': default and setups a MS-DOS partition table
+#                   'gpt': setups a GPT partition table
 #
-#                Note: At this time only 'mbr' and 'gpt' partition tables
-#                    are allowed. It is anticipated in the future that
-#                    we'll also have "RAID" to create a mdadm RAID.
+#               Note: At this time only 'mbr' and 'gpt' partition tables
+#                   are allowed. It is anticipated in the future that
+#                   we'll also have "RAID" to create a mdadm RAID.
 #
-#    layout={...}: The device layout. This is a list of values, with the
-#                percentage of disk that partition will take.
-#                Valid options are:
-#                    [<SIZE>, [<SIZE>, <PART_TYPE]]
+#   layout={...}: The device layout. This is a list of values, with the
+#               percentage of disk that partition will take.
+#               Valid options are:
+#                   [<SIZE>, [<SIZE>, <PART_TYPE]]
 #
-#                Where <SIZE> is the _percentage_ of the disk to use, while
-#                <PART_TYPE> is the numerical value of the partition type.
+#               Where <SIZE> is the _percentage_ of the disk to use, while
+#               <PART_TYPE> is the numerical value of the partition type.
 #
-#                The following setups two partitions, with the first
-#                partition having a swap label, taking 1/3 of the disk space
-#                and the remainder being used as the second partition.
-#                    /dev/xvdh':
-#                        table_type: 'mbr'
-#                        layout:
-#                            - [33,82]
-#                            - 66
-#                        overwrite: True
+#               The following setups two partitions, with the first
+#               partition having a swap label, taking 1/3 of the disk space
+#               and the remainder being used as the second partition.
+#                   /dev/xvdh':
+#                       table_type: 'mbr'
+#                       layout:
+#                           - [33,82]
+#                           - 66
+#                       overwrite: True
 #
-#                When layout is "true" it means single partition the entire
-#                device.
+#               When layout is "true" it means single partition the entire
+#               device.
 #
-#                When layout is "false" it means don't partition or ignore
-#                existing partitioning.
+#               When layout is "false" it means don't partition or ignore
+#               existing partitioning.
 #
-#                If layout is set to "true" and overwrite is set to "false",
-#                it will skip partitioning the device without a failure.
+#               If layout is set to "true" and overwrite is set to "false",
+#               it will skip partitioning the device without a failure.
 #
-#    overwrite=<BOOL>: This describes whether to ride with saftey's on and
-#                everything holstered.
+#   overwrite=<BOOL>: This describes whether to ride with saftey's on and
+#               everything holstered.
 #
-#                'false' is the default, which means that:
-#                    1. The device will be checked for a partition table
-#                    2. The device will be checked for a file system
-#                    3. If either a partition of file system is found, then
-#                        the operation will be _skipped_.
+#               'false' is the default, which means that:
+#                   1. The device will be checked for a partition table
+#                   2. The device will be checked for a file system
+#                   3. If either a partition of file system is found, then
+#                       the operation will be _skipped_.
 #
-#                'true' is cowboy mode. There are no checks and things are
-#                    done blindly. USE with caution, you can do things you
-#                    really, really don't want to do.
+#               'true' is cowboy mode. There are no checks and things are
+#                   done blindly. USE with caution, you can do things you
+#                   really, really don't want to do.
 #
 #
 # fs_setup: Setup the file system
@@ -166,101 +166,101 @@ disk_setup:
 # fs_setup describes the how the file systems are supposed to look.
 
 fs_setup:
-   - label: ephemeral0
-     filesystem: 'ext3'
-     device: 'ephemeral0'
-     partition: 'auto'
-   - label: mylabl2
-     filesystem: 'ext4'
-     device: '/dev/xvda1'
-   - cmd: mkfs -t %(filesystem)s -L %(label)s %(device)s
-     label: mylabl3
-     filesystem: 'btrfs'
-     device: '/dev/xvdh'
+  - label: ephemeral0
+    filesystem: 'ext3'
+    device: 'ephemeral0'
+    partition: 'auto'
+  - label: mylabl2
+    filesystem: 'ext4'
+    device: '/dev/xvda1'
+  - cmd: mkfs -t %(filesystem)s -L %(label)s %(device)s
+    label: mylabl3
+    filesystem: 'btrfs'
+    device: '/dev/xvdh'
 
 # The general format is:
-#    fs_setup:
-#        - label: <LABEL>
-#          filesystem: <FS_TYPE>
-#          device: <DEVICE>
-#          partition: <PART_VALUE>
-#          overwrite: <OVERWRITE>
-#          replace_fs: <FS_TYPE>
+#   fs_setup:
+#     - label: <LABEL>
+#       filesystem: <FS_TYPE>
+#       device: <DEVICE>
+#       partition: <PART_VALUE>
+#       overwrite: <OVERWRITE>
+#       replace_fs: <FS_TYPE>
 #
 # Where:
-#     <LABEL>: The file system label to be used. If set to None, no label is
-#        used.
+#   <LABEL>: The file system label to be used. If set to None, no label is
+#     used.
 #
-#    <FS_TYPE>: The file system type. It is assumed that the there
-#        will be a "mkfs.<FS_TYPE>" that behaves likes "mkfs". On a standard
-#        Ubuntu Cloud Image, this means that you have the option of ext{2,3,4},
-#        and vfat by default.
+#   <FS_TYPE>: The file system type. It is assumed that the there
+#     will be a "mkfs.<FS_TYPE>" that behaves likes "mkfs". On a standard
+#     Ubuntu Cloud Image, this means that you have the option of ext{2,3,4},
+#     and vfat by default.
 #
-#    <DEVICE>: The device name. Special names of 'ephemeralX' or 'swap'
-#        are allowed and the actual device is acquired from the cloud datasource.
-#        When using 'ephemeralX' (i.e. ephemeral0), make sure to leave the
-#        label as 'ephemeralX' otherwise there may be issues with the mounting
-#        of the ephemeral storage layer.
+#   <DEVICE>: The device name. Special names of 'ephemeralX' or 'swap'
+#     are allowed and the actual device is acquired from the cloud datasource.
+#     When using 'ephemeralX' (i.e. ephemeral0), make sure to leave the
+#     label as 'ephemeralX' otherwise there may be issues with the mounting
+#     of the ephemeral storage layer.
 #
-#        If you define the device as 'ephemeralX.Y' then Y will be interpetted
-#        as a partition value. However, ephermalX.0 is the _same_ as ephemeralX.
+#     If you define the device as 'ephemeralX.Y' then Y will be interpetted
+#     as a partition value. However, ephermalX.0 is the _same_ as ephemeralX.
 #
-#    <PART_VALUE>:
-#        Partition definitions are overwriten if you use the '<DEVICE>.Y' notation.
+#   <PART_VALUE>:
+#     Partition definitions are overwriten if you use the '<DEVICE>.Y' notation.
 #
-#        The valid options are:
-#        "auto|any": tell cloud-init not to care whether there is a partition
-#            or not. Auto will use the first partition that does not contain a
-#            file system already. In the absence of a partition table, it will
-#            put it directly on the disk.
+#     The valid options are:
+#     "auto|any": tell cloud-init not to care whether there is a partition
+#       or not. Auto will use the first partition that does not contain a
+#       file system already. In the absence of a partition table, it will
+#       put it directly on the disk.
 #
-#            "auto": If a file system that matches the specification in terms of
-#            label, type and device, then cloud-init will skip the creation of
-#            the file system.
+#       "auto": If a file system that matches the specification in terms of
+#       label, type and device, then cloud-init will skip the creation of
+#       the file system.
 #
-#            "any": If a file system that matches the file system type and device,
-#            then cloud-init will skip the creation of the file system.
+#       "any": If a file system that matches the file system type and device,
+#       then cloud-init will skip the creation of the file system.
 #
-#            Devices are selected based on first-detected, starting with partitions
-#            and then the raw disk. Consider the following:
-#                NAME     FSTYPE LABEL
-#                xvdb
-#                |-xvdb1  ext4
-#                |-xvdb2
-#                |-xvdb3  btrfs  test
-#                \-xvdb4  ext4   test
+#       Devices are selected based on first-detected, starting with partitions
+#       and then the raw disk. Consider the following:
+#           NAME     FSTYPE LABEL
+#           xvdb
+#           |-xvdb1  ext4
+#           |-xvdb2
+#           |-xvdb3  btrfs  test
+#           \-xvdb4  ext4   test
 #
-#            If you ask for 'auto', label of 'test, and file system of 'ext4'
-#            then cloud-init will select the 2nd partition, even though there
-#            is a partition match at the 4th partition.
+#         If you ask for 'auto', label of 'test, and file system of 'ext4'
+#         then cloud-init will select the 2nd partition, even though there
+#         is a partition match at the 4th partition.
 #
-#            If you ask for 'any' and a label of 'test', then cloud-init will
-#            select the 1st partition.
+#         If you ask for 'any' and a label of 'test', then cloud-init will
+#         select the 1st partition.
 #
-#            If you ask for 'auto' and don't define label, then cloud-init will
-#            select the 1st partition.
+#         If you ask for 'auto' and don't define label, then cloud-init will
+#         select the 1st partition.
 #
-#            In general, if you have a specific partition configuration in mind,
-#            you should define either the device or the partition number. 'auto'
-#            and 'any' are specifically intended for formating ephemeral storage or
-#            for simple schemes.
+#         In general, if you have a specific partition configuration in mind,
+#         you should define either the device or the partition number. 'auto'
+#         and 'any' are specifically intended for formating ephemeral storage or
+#         for simple schemes.
 #
-#        "none": Put the file system directly on the device.
+#       "none": Put the file system directly on the device.
 #
-#        <NUM>: where NUM is the actual partition number.
+#       <NUM>: where NUM is the actual partition number.
 #
-#    <OVERWRITE>: Defines whether or not to overwrite any existing
-#        filesystem.
+#   <OVERWRITE>: Defines whether or not to overwrite any existing
+#     filesystem.
 #
-#        "true": Indiscriminately destroy any pre-existing file system. Use at
-#            your own peril.
+#     "true": Indiscriminately destroy any pre-existing file system. Use at
+#         your own peril.
 #
-#        "false": If an existing file system exists, skip the creation.
+#     "false": If an existing file system exists, skip the creation.
 #
-#    <REPLACE_FS>: This is a special directive, used for Microsoft Azure that
-#        instructs cloud-init to replace a file system of <FS_TYPE>. NOTE:
-#        unless you define a label, this requires the use of the 'any' partition
-#        directive.
+#   <REPLACE_FS>: This is a special directive, used for Microsoft Azure that
+#     instructs cloud-init to replace a file system of <FS_TYPE>. NOTE:
+#     unless you define a label, this requires the use of the 'any' partition
+#     directive.
 #
 # Behavior Caveat: The default behavior is to _check_ if the file system exists.
-#    If a file system matches the specification, then the operation is a no-op.
+#   If a file system matches the specification, then the operation is a no-op.

--- a/doc/examples/cloud-config-disk-setup.txt
+++ b/doc/examples/cloud-config-disk-setup.txt
@@ -130,12 +130,12 @@ disk_setup:
 #               The following setups two partitions, with the first
 #               partition having a swap label, taking 1/3 of the disk space
 #               and the remainder being used as the second partition.
-#                   /dev/xvdh':
-#                       table_type: 'mbr'
-#                       layout:
-#                           - [33,82]
-#                           - 66
-#                       overwrite: True
+#                 /dev/xvdh':
+#                   table_type: 'mbr'
+#                   layout:
+#                     - [33,82]
+#                     - 66
+#                   overwrite: True
 #
 #               When layout is "true" it means single partition the entire
 #               device.

--- a/doc/examples/cloud-config-mcollective.txt
+++ b/doc/examples/cloud-config-mcollective.txt
@@ -5,45 +5,45 @@
 # Make sure that this file is valid yaml before starting instances.
 # It should be passed as user-data when starting the instance.
 mcollective:
- # Every key present in the conf object will be added to server.cfg:
- # key: value
- #
- # For example the configuration below will have the following key
- # added to server.cfg:
- # plugin.stomp.host: dbhost
- conf:
-   plugin.stomp.host: dbhost
-   # This will add ssl certs to mcollective
-   # WARNING WARNING WARNING
-   # The ec2 metadata service is a network service, and thus is readable
-   # by non-root users on the system (ie: 'ec2metadata --user-data')
-   # If you want security for this, please use include-once + SSL urls
-   public-cert: |
-     -----BEGIN CERTIFICATE-----
-     MIICCTCCAXKgAwIBAgIBATANBgkqhkiG9w0BAQUFADANMQswCQYDVQQDDAJjYTAe
-     Fw0xMDAyMTUxNzI5MjFaFw0xNTAyMTQxNzI5MjFaMA0xCzAJBgNVBAMMAmNhMIGf
-     MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCu7Q40sm47/E1Pf+r8AYb/V/FWGPgc
-     b014OmNoX7dgCxTDvps/h8Vw555PdAFsW5+QhsGr31IJNI3kSYprFQcYf7A8tNWu
-     1MASW2CfaEiOEi9F1R3R4Qlz4ix+iNoHiUDTjazw/tZwEdxaQXQVLwgTGRwVa+aA
-     qbutJKi93MILLwIDAQABo3kwdzA4BglghkgBhvhCAQ0EKxYpUHVwcGV0IFJ1Ynkv
-     T3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwDwYDVR0TAQH/BAUwAwEB/zAd
-     BgNVHQ4EFgQUu4+jHB+GYE5Vxo+ol1OAhevspjAwCwYDVR0PBAQDAgEGMA0GCSqG
-     SIb3DQEBBQUAA4GBAH/rxlUIjwNb3n7TXJcDJ6MMHUlwjr03BDJXKb34Ulndkpaf
-     +GAlzPXWa7bO908M9I8RnPfvtKnteLbvgTK+h+zX1XCty+S2EQWk29i2AdoqOTxb
-     hppiGMp0tT5Havu4aceCXiy2crVcudj3NFciy8X66SoECemW9UYDCb9T5D0d
-     -----END CERTIFICATE-----
-   private-cert: |
-     -----BEGIN CERTIFICATE-----
-     MIICCTCCAXKgAwIBAgIBATANBgkqhkiG9w0BAQUFADANMQswCQYDVQQDDAJjYTAe
-     Fw0xMDAyMTUxNzI5MjFaFw0xNTAyMTQxNzI5MjFaMA0xCzAJBgNVBAMMAmNhMIGf
-     MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCu7Q40sm47/E1Pf+r8AYb/V/FWGPgc
-     b014OmNoX7dgCxTDvps/h8Vw555PdAFsW5+QhsGr31IJNI3kSYprFQcYf7A8tNWu
-     1MASW2CfaEiOEi9F1R3R4Qlz4ix+iNoHiUDTjazw/tZwEdxaQXQVLwgTGRwVa+aA
-     qbutJKi93MILLwIDAQABo3kwdzA4BglghkgBhvhCAQ0EKxYpUHVwcGV0IFJ1Ynkv
-     T3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwDwYDVR0TAQH/BAUwAwEB/zAd
-     BgNVHQ4EFgQUu4+jHB+GYE5Vxo+ol1OAhevspjAwCwYDVR0PBAQDAgEGMA0GCSqG
-     SIb3DQEBBQUAA4GBAH/rxlUIjwNb3n7TXJcDJ6MMHUlwjr03BDJXKb34Ulndkpaf
-     +GAlzPXWa7bO908M9I8RnPfvtKnteLbvgTK+h+zX1XCty+S2EQWk29i2AdoqOTxb
-     hppiGMp0tT5Havu4aceCXiy2crVcudj3NFciy8X66SoECemW9UYDCb9T5D0d
-     -----END CERTIFICATE-----
+  # Every key present in the conf object will be added to server.cfg:
+  # key: value
+  #
+  # For example the configuration below will have the following key
+  # added to server.cfg:
+  # plugin.stomp.host: dbhost
+  conf:
+    plugin.stomp.host: dbhost
+    # This will add ssl certs to mcollective
+    # WARNING WARNING WARNING
+    # The ec2 metadata service is a network service, and thus is readable
+    # by non-root users on the system (ie: 'ec2metadata --user-data')
+    # If you want security for this, please use include-once + SSL urls
+    public-cert: |
+      -----BEGIN CERTIFICATE-----
+      MIICCTCCAXKgAwIBAgIBATANBgkqhkiG9w0BAQUFADANMQswCQYDVQQDDAJjYTAe
+      Fw0xMDAyMTUxNzI5MjFaFw0xNTAyMTQxNzI5MjFaMA0xCzAJBgNVBAMMAmNhMIGf
+      MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCu7Q40sm47/E1Pf+r8AYb/V/FWGPgc
+      b014OmNoX7dgCxTDvps/h8Vw555PdAFsW5+QhsGr31IJNI3kSYprFQcYf7A8tNWu
+      1MASW2CfaEiOEi9F1R3R4Qlz4ix+iNoHiUDTjazw/tZwEdxaQXQVLwgTGRwVa+aA
+      qbutJKi93MILLwIDAQABo3kwdzA4BglghkgBhvhCAQ0EKxYpUHVwcGV0IFJ1Ynkv
+      T3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwDwYDVR0TAQH/BAUwAwEB/zAd
+      BgNVHQ4EFgQUu4+jHB+GYE5Vxo+ol1OAhevspjAwCwYDVR0PBAQDAgEGMA0GCSqG
+      SIb3DQEBBQUAA4GBAH/rxlUIjwNb3n7TXJcDJ6MMHUlwjr03BDJXKb34Ulndkpaf
+      +GAlzPXWa7bO908M9I8RnPfvtKnteLbvgTK+h+zX1XCty+S2EQWk29i2AdoqOTxb
+      hppiGMp0tT5Havu4aceCXiy2crVcudj3NFciy8X66SoECemW9UYDCb9T5D0d
+      -----END CERTIFICATE-----
+    private-cert: |
+      -----BEGIN CERTIFICATE-----
+      MIICCTCCAXKgAwIBAgIBATANBgkqhkiG9w0BAQUFADANMQswCQYDVQQDDAJjYTAe
+      Fw0xMDAyMTUxNzI5MjFaFw0xNTAyMTQxNzI5MjFaMA0xCzAJBgNVBAMMAmNhMIGf
+      MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCu7Q40sm47/E1Pf+r8AYb/V/FWGPgc
+      b014OmNoX7dgCxTDvps/h8Vw555PdAFsW5+QhsGr31IJNI3kSYprFQcYf7A8tNWu
+      1MASW2CfaEiOEi9F1R3R4Qlz4ix+iNoHiUDTjazw/tZwEdxaQXQVLwgTGRwVa+aA
+      qbutJKi93MILLwIDAQABo3kwdzA4BglghkgBhvhCAQ0EKxYpUHVwcGV0IFJ1Ynkv
+      T3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwDwYDVR0TAQH/BAUwAwEB/zAd
+      BgNVHQ4EFgQUu4+jHB+GYE5Vxo+ol1OAhevspjAwCwYDVR0PBAQDAgEGMA0GCSqG
+      SIb3DQEBBQUAA4GBAH/rxlUIjwNb3n7TXJcDJ6MMHUlwjr03BDJXKb34Ulndkpaf
+      +GAlzPXWa7bO908M9I8RnPfvtKnteLbvgTK+h+zX1XCty+S2EQWk29i2AdoqOTxb
+      hppiGMp0tT5Havu4aceCXiy2crVcudj3NFciy8X66SoECemW9UYDCb9T5D0d
+      -----END CERTIFICATE-----
 

--- a/doc/examples/cloud-config-mount-points.txt
+++ b/doc/examples/cloud-config-mount-points.txt
@@ -41,6 +41,6 @@ mount_default_fields: [ None, None, "auto", "defaults,nofail", "0", "2" ]
 # swap can also be set up by the 'mounts' module
 # default is to not create any swap files, because 'size' is set to 0
 swap:
-   filename: /swap.img
-   size: "auto" # or size in bytes
-   maxsize: size in bytes
+  filename: /swap.img
+  size: "auto" # or size in bytes
+  maxsize: size in bytes

--- a/doc/examples/cloud-config-phone-home.txt
+++ b/doc/examples/cloud-config-phone-home.txt
@@ -5,10 +5,10 @@
 # url
 # default: none
 # phone_home:
-#  url: http://my.foo.bar/$INSTANCE/
-#  post: all
-#  tries: 10
+#   url: http://my.foo.bar/$INSTANCE/
+#   post: all
+#   tries: 10
 #
 phone_home:
- url: http://my.example.com/$INSTANCE_ID/
- post: [ pub_key_dsa, pub_key_rsa, pub_key_ecdsa, instance_id ]
+  url: http://my.example.com/$INSTANCE_ID/
+  post: [ pub_key_dsa, pub_key_rsa, pub_key_ecdsa, instance_id ]

--- a/doc/examples/cloud-config-power-state.txt
+++ b/doc/examples/cloud-config-power-state.txt
@@ -33,8 +33,8 @@
 #            for future use.
 #
 power_state:
- delay: "+30"
- mode: poweroff
- message: Bye Bye
- timeout: 30
- condition: True
+  delay: "+30"
+  mode: poweroff
+  message: Bye Bye
+  timeout: 30
+  condition: True

--- a/doc/examples/cloud-config-puppet.txt
+++ b/doc/examples/cloud-config-puppet.txt
@@ -5,47 +5,47 @@
 # Make sure that this file is valid yaml before starting instances.
 # It should be passed as user-data when starting the instance.
 puppet:
- # Every key present in the conf object will be added to puppet.conf:
- # [name]
- # subkey=value
- #
- # For example the configuration below will have the following section
- # added to puppet.conf:
- # [puppetd]
- # server=puppetmaster.example.org
- # certname=i-0123456.ip-X-Y-Z.cloud.internal
- #
- # The puppmaster ca certificate will be available in 
- # /var/lib/puppet/ssl/certs/ca.pem
- conf:
-   agent:
-     server: "puppetmaster.example.org"
-     # certname supports substitutions at runtime:
-     #   %i: instanceid 
-     #       Example: i-0123456
-     #   %f: fqdn of the machine
-     #       Example: ip-X-Y-Z.cloud.internal
-     #
-     # NB: the certname will automatically be lowercased as required by puppet
-     certname: "%i.%f"
-   # ca_cert is a special case. It won't be added to puppet.conf.
-   # It holds the puppetmaster certificate in pem format. 
-   # It should be a multi-line string (using the | yaml notation for 
-   # multi-line strings).
-   # The puppetmaster certificate is located in 
-   # /var/lib/puppet/ssl/ca/ca_crt.pem on the puppetmaster host.
-   #
-   ca_cert: |
-     -----BEGIN CERTIFICATE-----
-     MIICCTCCAXKgAwIBAgIBATANBgkqhkiG9w0BAQUFADANMQswCQYDVQQDDAJjYTAe
-     Fw0xMDAyMTUxNzI5MjFaFw0xNTAyMTQxNzI5MjFaMA0xCzAJBgNVBAMMAmNhMIGf
-     MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCu7Q40sm47/E1Pf+r8AYb/V/FWGPgc
-     b014OmNoX7dgCxTDvps/h8Vw555PdAFsW5+QhsGr31IJNI3kSYprFQcYf7A8tNWu
-     1MASW2CfaEiOEi9F1R3R4Qlz4ix+iNoHiUDTjazw/tZwEdxaQXQVLwgTGRwVa+aA
-     qbutJKi93MILLwIDAQABo3kwdzA4BglghkgBhvhCAQ0EKxYpUHVwcGV0IFJ1Ynkv
-     T3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwDwYDVR0TAQH/BAUwAwEB/zAd
-     BgNVHQ4EFgQUu4+jHB+GYE5Vxo+ol1OAhevspjAwCwYDVR0PBAQDAgEGMA0GCSqG
-     SIb3DQEBBQUAA4GBAH/rxlUIjwNb3n7TXJcDJ6MMHUlwjr03BDJXKb34Ulndkpaf
-     +GAlzPXWa7bO908M9I8RnPfvtKnteLbvgTK+h+zX1XCty+S2EQWk29i2AdoqOTxb
-     hppiGMp0tT5Havu4aceCXiy2crVcudj3NFciy8X66SoECemW9UYDCb9T5D0d
-     -----END CERTIFICATE-----
+  # Every key present in the conf object will be added to puppet.conf:
+  # [name]
+  # subkey=value
+  #
+  # For example the configuration below will have the following section
+  # added to puppet.conf:
+  # [puppetd]
+  # server=puppetmaster.example.org
+  # certname=i-0123456.ip-X-Y-Z.cloud.internal
+  #
+  # The puppmaster ca certificate will be available in 
+  # /var/lib/puppet/ssl/certs/ca.pem
+  conf:
+    agent:
+      server: "puppetmaster.example.org"
+      # certname supports substitutions at runtime:
+      #   %i: instanceid 
+      #       Example: i-0123456
+      #   %f: fqdn of the machine
+      #       Example: ip-X-Y-Z.cloud.internal
+      #
+      # NB: the certname will automatically be lowercased as required by puppet
+      certname: "%i.%f"
+    # ca_cert is a special case. It won't be added to puppet.conf.
+    # It holds the puppetmaster certificate in pem format. 
+    # It should be a multi-line string (using the | yaml notation for 
+    # multi-line strings).
+    # The puppetmaster certificate is located in 
+    # /var/lib/puppet/ssl/ca/ca_crt.pem on the puppetmaster host.
+    #
+    ca_cert: |
+      -----BEGIN CERTIFICATE-----
+      MIICCTCCAXKgAwIBAgIBATANBgkqhkiG9w0BAQUFADANMQswCQYDVQQDDAJjYTAe
+      Fw0xMDAyMTUxNzI5MjFaFw0xNTAyMTQxNzI5MjFaMA0xCzAJBgNVBAMMAmNhMIGf
+      MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCu7Q40sm47/E1Pf+r8AYb/V/FWGPgc
+      b014OmNoX7dgCxTDvps/h8Vw555PdAFsW5+QhsGr31IJNI3kSYprFQcYf7A8tNWu
+      1MASW2CfaEiOEi9F1R3R4Qlz4ix+iNoHiUDTjazw/tZwEdxaQXQVLwgTGRwVa+aA
+      qbutJKi93MILLwIDAQABo3kwdzA4BglghkgBhvhCAQ0EKxYpUHVwcGV0IFJ1Ynkv
+      T3BlblNTTCBHZW5lcmF0ZWQgQ2VydGlmaWNhdGUwDwYDVR0TAQH/BAUwAwEB/zAd
+      BgNVHQ4EFgQUu4+jHB+GYE5Vxo+ol1OAhevspjAwCwYDVR0PBAQDAgEGMA0GCSqG
+      SIb3DQEBBQUAA4GBAH/rxlUIjwNb3n7TXJcDJ6MMHUlwjr03BDJXKb34Ulndkpaf
+      +GAlzPXWa7bO908M9I8RnPfvtKnteLbvgTK+h+zX1XCty+S2EQWk29i2AdoqOTxb
+      hppiGMp0tT5Havu4aceCXiy2crVcudj3NFciy8X66SoECemW9UYDCb9T5D0d
+      -----END CERTIFICATE-----

--- a/doc/examples/cloud-config-reporting.txt
+++ b/doc/examples/cloud-config-reporting.txt
@@ -4,14 +4,14 @@
 ## A 'webhook' and a 'log' type.
 ## It also disables the built in default 'log'
 reporting:
-   smtest:
-     type: webhook
-     endpoint: "http://myhost:8000/"
-     consumer_key: "ckey_foo"
-     consumer_secret: "csecret_foo"
-     token_key: "tkey_foo"
-     token_secret: "tkey_foo"
-   smlogger:
-     type: log
-     level: WARN
-   log: null
+  smtest:
+    type: webhook
+    endpoint: "http://myhost:8000/"
+    consumer_key: "ckey_foo"
+    consumer_secret: "csecret_foo"
+    token_key: "tkey_foo"
+    token_secret: "tkey_foo"
+  smlogger:
+    type: log
+    level: WARN
+  log: null

--- a/doc/examples/cloud-config-rh_subscription.txt
+++ b/doc/examples/cloud-config-rh_subscription.txt
@@ -14,36 +14,36 @@
 #     /etc/rhsm/rhs.conf file
 
 rh_subscription:
-    username: joe@foo.bar
+  username: joe@foo.bar
 
-    ## Quote your password if it has symbols to be safe
-    password: '1234abcd'
+  ## Quote your password if it has symbols to be safe
+  password: '1234abcd'
 
-    ## If you prefer, you can use the activation key and 
-    ## org instead of username and password. Be sure to
-    ## comment out username and password
+  ## If you prefer, you can use the activation key and 
+  ## org instead of username and password. Be sure to
+  ## comment out username and password
 
-    #activation-key: foobar
-    #org: 12345
+  #activation-key: foobar
+  #org: 12345
 
-    ## Uncomment to auto-attach subscriptions to your system 
-    #auto-attach: True
+  ## Uncomment to auto-attach subscriptions to your system 
+  #auto-attach: True
 
-    ## Uncomment to set the service level for your 
-    ##   subscriptions
-    #service-level: self-support
+  ## Uncomment to set the service level for your 
+  ##   subscriptions
+  #service-level: self-support
 
-    ## Uncomment to add pools (needs to be a list of IDs)
-    #add-pool: []
+  ## Uncomment to add pools (needs to be a list of IDs)
+  #add-pool: []
 
-    ## Uncomment to add or remove yum repos
-    ##   (needs to be a list of repo IDs)
-    #enable-repo: []
-    #disable-repo: []
+  ## Uncomment to add or remove yum repos
+  ##   (needs to be a list of repo IDs)
+  #enable-repo: []
+  #disable-repo: []
 
-    ## Uncomment to alter the baseurl in /etc/rhsm/rhsm.conf
-    #rhsm-baseurl: http://url
+  ## Uncomment to alter the baseurl in /etc/rhsm/rhsm.conf
+  #rhsm-baseurl: http://url
 
-    ## Uncomment to alter the server hostname in 
-    ##  /etc/rhsm/rhsm.conf
-    #server-hostname: foo.bar.com
+  ## Uncomment to alter the server hostname in 
+  ##  /etc/rhsm/rhsm.conf
+  #server-hostname: foo.bar.com

--- a/doc/examples/cloud-config-rsyslog.txt
+++ b/doc/examples/cloud-config-rsyslog.txt
@@ -17,7 +17,7 @@ rsyslog:
     - content: "*.*   @@192.0.2.1:10514"
       filename: 01-example.conf
     - content: |
-       *.*   @@syslogd.example.com
+        *.*   @@syslogd.example.com
   config_dir: /etc/rsyslog.d
   config_filename: 20-cloud-config.conf
   service_reload_command: [your, syslog, reload, command]
@@ -32,7 +32,7 @@ rsyslog:
 #   - content: "*.*   @@192.0.2.1:10514"
 #     filename: 01-example.conf
 #   - content: |
-#      *.*   @@syslogd.example.com
+#       *.*   @@syslogd.example.com
 # rsyslog_filename: 20-cloud-config.conf
 # rsyslog_dir: /etc/rsyslog.d
 

--- a/doc/examples/cloud-config-rsyslog.txt
+++ b/doc/examples/cloud-config-rsyslog.txt
@@ -5,22 +5,22 @@
 ## Example:
 #cloud-config
 rsyslog:
- remotes:
-  # udp to host 'maas.mydomain' port 514
-  maashost: maas.mydomain
-  # udp to ipv4 host on port 514
-  maas: "@[10.5.1.56]:514"
-  # tcp to host ipv6 host on port 555
-  maasipv6: "*.* @@[FE80::0202:B3FF:FE1E:8329]:555"
- configs:
-   - "*.* @@192.158.1.1"
-   - content: "*.*   @@192.0.2.1:10514"
-     filename: 01-example.conf
-   - content: |
-      *.*   @@syslogd.example.com
- config_dir: /etc/rsyslog.d
- config_filename: 20-cloud-config.conf
- service_reload_command: [your, syslog, reload, command]
+  remotes:
+    # udp to host 'maas.mydomain' port 514
+    maashost: maas.mydomain
+    # udp to ipv4 host on port 514
+    maas: "@[10.5.1.56]:514"
+    # tcp to host ipv6 host on port 555
+    maasipv6: "*.* @@[FE80::0202:B3FF:FE1E:8329]:555"
+  configs:
+    - "*.* @@192.158.1.1"
+    - content: "*.*   @@192.0.2.1:10514"
+      filename: 01-example.conf
+    - content: |
+       *.*   @@syslogd.example.com
+  config_dir: /etc/rsyslog.d
+  config_filename: 20-cloud-config.conf
+  service_reload_command: [your, syslog, reload, command]
 
 ## Additionally the following legacy format is supported
 ## it is converted into the format above before use.
@@ -28,11 +28,11 @@ rsyslog:
 ##  rsyslog_dir -> rsyslog/config_dir
 ##  rsyslog -> rsyslog/configs
 # rsyslog:
-#  - "*.* @@192.158.1.1"
-#  - content: "*.*   @@192.0.2.1:10514"
-#    filename: 01-example.conf
-#  - content: |
-#     *.*   @@syslogd.example.com
+#   - "*.* @@192.158.1.1"
+#   - content: "*.*   @@192.0.2.1:10514"
+#     filename: 01-example.conf
+#   - content: |
+#      *.*   @@syslogd.example.com
 # rsyslog_filename: 20-cloud-config.conf
 # rsyslog_dir: /etc/rsyslog.d
 

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -84,7 +84,7 @@ users:
 #       use <default_username> instead. This option only disables cloud
 #       provided public-keys. An error will be raised if ssh_authorized_keys
 #       or ssh_import_id is provided for the same user.
-# 
+#
 #       ssh_authorized_keys.
 #   sudo: Defaults to none. Accepts a sudo rule string, a list of sudo rule
 #         strings or False to explicitly deny sudo usage. Examples:
@@ -120,10 +120,10 @@ users:
 # to have the 'ubuntu' user in addition to other users, you need to instruct
 # cloud-init that you also want the default user. To do this use the following
 # syntax:
-#    users:
-#      - default
-#      - bob
-#      - ....
+#   users:
+#     - default
+#     - bob
+#     - ....
 #  foobar: ...
 #
 # users[0] (the first user in users) overrides the user directive.
@@ -131,10 +131,10 @@ users:
 # The 'default' user above references the distro's config:
 # system_info:
 #   default_user:
-#    name: Ubuntu
-#    plain_text_passwd: 'ubuntu'
-#    home: /home/ubuntu
-#    shell: /bin/bash
-#    lock_passwd: True
-#    gecos: Ubuntu
-#    groups: [adm, audio, cdrom, dialout, floppy, video, plugdev, dip, netdev]
+#     name: Ubuntu
+#     plain_text_passwd: 'ubuntu'
+#     home: /home/ubuntu
+#     shell: /bin/bash
+#     lock_passwd: True
+#     gecos: Ubuntu
+#     groups: [adm, audio, cdrom, dialout, floppy, video, plugdev, dip, netdev]

--- a/doc/examples/cloud-config-vendor-data.txt
+++ b/doc/examples/cloud-config-vendor-data.txt
@@ -7,8 +7,8 @@
 # vendordata. Users of the end system are given ultimate control.
 #
 vendor_data:
-    enabled: True
-    prefix: /usr/bin/ltrace
+  enabled: True
+  prefix: /usr/bin/ltrace
 
 # enabled: whether it is enabled or not
 # prefix: the command to run before any vendor scripts.

--- a/doc/examples/cloud-config-write-files.txt
+++ b/doc/examples/cloud-config-write-files.txt
@@ -8,26 +8,26 @@
 #
 # Note: Content strings here are truncated for example purposes.
 write_files:
--   encoding: b64
-    content: CiMgVGhpcyBmaWxlIGNvbnRyb2xzIHRoZSBzdGF0ZSBvZiBTRUxpbnV4...
-    owner: root:root
-    path: /etc/sysconfig/selinux
-    permissions: '0644'
--   content: |
-        # My new /etc/sysconfig/samba file
+- encoding: b64
+  content: CiMgVGhpcyBmaWxlIGNvbnRyb2xzIHRoZSBzdGF0ZSBvZiBTRUxpbnV4...
+  owner: root:root
+  path: /etc/sysconfig/selinux
+  permissions: '0644'
+- content: |
+    # My new /etc/sysconfig/samba file
 
-        SMBDOPTIONS="-D"
-    path: /etc/sysconfig/samba
--   content: !!binary |
-        f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAwARAAAAAAABAAAAAAAAAAJAVAAAAAAAAAAAAAEAAOAAI
-        AEAAHgAdAAYAAAAFAAAAQAAAAAAAAABAAEAAAAAAAEAAQAAAAAAAwAEAAAAAAADAAQAAAAAAAAgA
-        AAAAAAAAAwAAAAQAAAAAAgAAAAAAAAACQAAAAAAAAAJAAAAAAAAcAAAAAAAAABwAAAAAAAAAAQAA
-        ....
-    path: /bin/arch
-    permissions: '0555'
--   encoding: gzip
-    content: !!binary |
-        H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
-    path: /usr/bin/hello
-    permissions: '0755'
+    SMBDOPTIONS="-D"
+  path: /etc/sysconfig/samba
+- content: !!binary |
+    f0VMRgIBAQAAAAAAAAAAAAIAPgABAAAAwARAAAAAAABAAAAAAAAAAJAVAAAAAAAAAAAAAEAAOAAI
+    AEAAHgAdAAYAAAAFAAAAQAAAAAAAAABAAEAAAAAAAEAAQAAAAAAAwAEAAAAAAADAAQAAAAAAAAgA
+    AAAAAAAAAwAAAAQAAAAAAgAAAAAAAAACQAAAAAAAAAJAAAAAAAAcAAAAAAAAABwAAAAAAAAAAQAA
+    ....
+  path: /bin/arch
+  permissions: '0555'
+- encoding: gzip
+  content: !!binary |
+    H4sIAIDb/U8C/1NW1E/KzNMvzuBKTc7IV8hIzcnJVyjPL8pJ4QIA6N+MVxsAAAA=
+  path: /usr/bin/hello
+  permissions: '0755'
 

--- a/doc/examples/cloud-config-yum-repo.txt
+++ b/doc/examples/cloud-config-yum-repo.txt
@@ -6,15 +6,15 @@
 # The following example adds the file /etc/yum.repos.d/epel_testing.repo
 # which can then subsequently be used by yum for later operations.
 yum_repos:
-    # The name of the repository
-    epel-testing:
-        # Any repository configuration options
-        # See: man yum.conf
-        #
-        # This one is required!
-        baseurl: http://download.fedoraproject.org/pub/epel/testing/5/$basearch
-        enabled: false
-        failovermethod: priority
-        gpgcheck: true
-        gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
-        name: Extra Packages for Enterprise Linux 5 - Testing
+  # The name of the repository
+  epel-testing:
+    # Any repository configuration options
+    # See: man yum.conf
+    #
+    # This one is required!
+    baseurl: http://download.fedoraproject.org/pub/epel/testing/5/$basearch
+    enabled: false
+    failovermethod: priority
+    gpgcheck: true
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
+    name: Extra Packages for Enterprise Linux 5 - Testing

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -192,8 +192,8 @@ cloud_config_modules:
 
 # ssh_import_id: [ user1, user2 ]
 # ssh_import_id will feed the list in that variable to
-#   ssh-import-id, so that public keys stored in launchpad
-#   can easily be imported into the configured user
+# ssh-import-id, so that public keys stored in launchpad
+# can easily be imported into the configured user
 # This can be a single string ('smoser') or a list ([smoser, kirkland])
 ssh_import_id: [smoser]
 

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -192,8 +192,8 @@ cloud_config_modules:
 
 # ssh_import_id: [ user1, user2 ]
 # ssh_import_id will feed the list in that variable to
-#  ssh-import-id, so that public keys stored in launchpad
-#  can easily be imported into the configured user
+#   ssh-import-id, so that public keys stored in launchpad
+#   can easily be imported into the configured user
 # This can be a single string ('smoser') or a list ([smoser, kirkland])
 ssh_import_id: [smoser]
 
@@ -202,14 +202,14 @@ ssh_import_id: [smoser]
 # See debconf-set-selections man page.
 #
 # Default: none
-# 
+#
 debconf_selections: |     # Need to preserve newlines
-        # Force debconf priority to critical.
-        debconf debconf/priority select critical
+  # Force debconf priority to critical.
+  debconf debconf/priority select critical
 
-        # Override default frontend to readline, but allow user to select.
-        debconf debconf/frontend select readline
-        debconf debconf/frontend seen false
+  # Override default frontend to readline, but allow user to select.
+  debconf debconf/frontend select readline
+  debconf debconf/frontend seen false
 
 # manage byobu defaults
 # byobu_by_default:
@@ -375,11 +375,11 @@ final_message: "The system is finally up, after $UPTIME seconds"
 # the special entry "&1" for an error means "same location as stdout"
 #  (Note, that '&1' has meaning in yaml, so it must be quoted)
 output:
- init: "> /var/log/my-cloud-init.log"
- config: [ ">> /tmp/foo.out", "> /tmp/foo.err" ]
- final:
-   output: "| tee /tmp/final.stdout | tee /tmp/bar.stdout"
-   error: "&1"
+  init: "> /var/log/my-cloud-init.log"
+  config: [ ">> /tmp/foo.out", "> /tmp/foo.err" ]
+  final:
+    output: "| tee /tmp/final.stdout | tee /tmp/bar.stdout"
+    error: "&1"
 
 
 # phone_home: if this dictionary is present, then the phone_home
@@ -392,8 +392,8 @@ output:
 #  tries: 10
 #
 phone_home:
- url: http://my.example.com/$INSTANCE_ID/
- post: [ pub_key_dsa, pub_key_rsa, pub_key_ecdsa, instance_id ]
+  url: http://my.example.com/$INSTANCE_ID/
+  post: [ pub_key_dsa, pub_key_rsa, pub_key_ecdsa, instance_id ]
 
 # timezone: set the timezone for this instance
 # the value of 'timezone' must exist in /usr/share/zoneinfo
@@ -407,7 +407,7 @@ timezone: US/Eastern
 # then 'L' will be initially created with root:root ownership (during
 # cloud-init), and then at cloud-config time (when syslog is available)
 # the syslog daemon will be unable to write to the file.
-# 
+#
 # to remedy this situation, 'def_log_file' can be set to a filename
 # and syslog_fix_perms to a string containing "<user>:<group>"
 # if syslog_fix_perms is a list, it will iterate through and use the
@@ -446,11 +446,11 @@ syslog_fix_perms: syslog:root
 # to set hashed password, here account 'user3' has a password it set to
 # 'cloud-init', hashed with SHA-256:
 # chpasswd:
-#  list: |
-#    user1:password1
-#    user2:RANDOM
-#    user3:$5$eriogqzq$Dg7PxHsKGzziuEGkZgkLvacjuEFeljJ.rLf.hZqKQLA
-#  expire: True
+#   list: |
+#     user1:password1
+#     user2:RANDOM
+#     user3:$5$eriogqzq$Dg7PxHsKGzziuEGkZgkLvacjuEFeljJ.rLf.hZqKQLA
+#   expire: True
 # ssh_pwauth: [ True, False, "" or "unchanged" ]
 #
 # Hashed passwords can be generated in multiple ways, example with python3:
@@ -510,7 +510,7 @@ manual_cache_clean: False
 # power_state can be used to make the system shutdown, reboot or
 # halt after boot is finished.  This same thing can be acheived by
 # user-data scripts or by runcmd by simply invoking 'shutdown'.
-# 
+#
 # Doing it this way ensures that cloud-init is entirely finished with
 # modules that would be executed, and avoids any error/log messages
 # that may go to the console as a result of system services like
@@ -521,6 +521,6 @@ manual_cache_clean: False
 # mode: required. must be one of 'poweroff', 'halt', 'reboot'
 # message: provided as the message argument to 'shutdown'. default is none.
 power_state:
- delay: 30
- mode: poweroff
- message: Bye Bye
+  delay: 30
+  mode: poweroff
+  message: Bye Bye

--- a/doc/examples/kernel-cmdline.txt
+++ b/doc/examples/kernel-cmdline.txt
@@ -15,7 +15,7 @@ on the command line two backslashes followed by a letter 'n'.
 The yaml content may also be URL encoded (urllib.parse.quote()).
 
 Here are some examples:
- root=/dev/sda1 cc: ssh_import_id: [smoser, kirkland]\\n
- root=LABEL=uec-rootfs cc: ssh_import_id: [smoser, bob]\\nruncmd: [ [ ls, -l ], echo hi ] end_cc
- cc:ssh_import_id: [smoser] end_cc cc:runcmd: [ [ ls, -l ] ] end_cc root=/dev/sda1
- cc:ssh_import_id: %5Bsmoser%5D end_cc cc:runcmd: %5B %5B ls, -l %5D %5D end_cc root=/dev/sda1
+  root=/dev/sda1 cc: ssh_import_id: [smoser, kirkland]\\n
+  root=LABEL=uec-rootfs cc: ssh_import_id: [smoser, bob]\\nruncmd: [ [ ls, -l ], echo hi ] end_cc
+  cc:ssh_import_id: [smoser] end_cc cc:runcmd: [ [ ls, -l ] ] end_cc root=/dev/sda1
+  cc:ssh_import_id: %5Bsmoser%5D end_cc cc:runcmd: %5B %5B ls, -l %5D %5D end_cc root=/dev/sda1

--- a/doc/rtd/topics/datasources/azure.rst
+++ b/doc/rtd/topics/datasources/azure.rst
@@ -114,19 +114,19 @@ An example configuration with the default values is provided below:
 .. sourcecode:: yaml
 
   datasource:
-   Azure:
-    agent_command: __builtin__
-    apply_network_config: true
-    data_dir: /var/lib/waagent
-    dhclient_lease_file: /var/lib/dhcp/dhclient.eth0.leases
-    disk_aliases:
+    Azure:
+      agent_command: __builtin__
+      apply_network_config: true
+      data_dir: /var/lib/waagent
+      dhclient_lease_file: /var/lib/dhcp/dhclient.eth0.leases
+      disk_aliases:
         ephemeral0: /dev/disk/cloud/azure_resource
-    hostname_bounce:
+      hostname_bounce:
         interface: eth0
         command: builtin
         policy: true
         hostname_command: hostname
-    set_hostname: true
+      set_hostname: true
 
 
 Userdata

--- a/doc/rtd/topics/datasources/cloudstack.rst
+++ b/doc/rtd/topics/datasources/cloudstack.rst
@@ -37,11 +37,11 @@ An example configuration with the default values is provided below:
 .. sourcecode:: yaml
 
   datasource:
-   CloudStack:
-    max_wait: 120
-    timeout: 50
-    datasource_list:
-      - CloudStack
+    CloudStack:
+      max_wait: 120
+      timeout: 50
+      datasource_list:
+        - CloudStack
 
 
 .. _Apache CloudStack: http://cloudstack.apache.org/

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -96,11 +96,11 @@ An example configuration with the default values is provided below:
 .. sourcecode:: yaml
 
   datasource:
-   Ec2:
-    metadata_urls: ["http://169.254.169.254:80", "http://instance-data:8773"]
-    max_wait: 120
-    timeout: 50
-    apply_full_imds_network_config: true
+    Ec2:
+      metadata_urls: ["http://169.254.169.254:80", "http://instance-data:8773"]
+      max_wait: 120
+      timeout: 50
+      apply_full_imds_network_config: true
 
 Notes
 -----

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -133,12 +133,12 @@ be network configuration based on the filename.
   version: 2
   ethernets:
     interface0:
-       match:
-           mac_address: "52:54:00:12:34:00"
-       set-name: interface0
-       addresses:
-       - 192.168.1.10/255.255.255.0
-       gateway4: 192.168.1.254
+      match:
+        mac_address: "52:54:00:12:34:00"
+      set-name: interface0
+      addresses:
+      - 192.168.1.10/255.255.255.0
+      gateway4: 192.168.1.254
 
 
 .. _iso9660: https://en.wikipedia.org/wiki/ISO_9660

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -137,7 +137,7 @@ be network configuration based on the filename.
         mac_address: "52:54:00:12:34:00"
       set-name: interface0
       addresses:
-      - 192.168.1.10/255.255.255.0
+        - 192.168.1.10/255.255.255.0
       gateway4: 192.168.1.254
 
 

--- a/doc/rtd/topics/datasources/openstack.rst
+++ b/doc/rtd/topics/datasources/openstack.rst
@@ -51,12 +51,12 @@ An example configuration with the default values is provided below:
 .. sourcecode:: yaml
 
   datasource:
-   OpenStack:
-    metadata_urls: ["http://169.254.169.254"]
-    max_wait: -1
-    timeout: 10
-    retries: 5
-    apply_network_config: True
+    OpenStack:
+      metadata_urls: ["http://169.254.169.254"]
+      max_wait: -1
+      timeout: 10
+      retries: 5
+      apply_network_config: True
 
 
 Vendor Data

--- a/doc/rtd/topics/tests.rst
+++ b/doc/rtd/topics/tests.rst
@@ -467,11 +467,11 @@ Set region in platforms.yaml
 .. code-block:: yaml
 
     azurecloud:
-        enabled: true
-        region: West US 2
-        vm_size: Standard_DS1_v2
-        storage_sku: standard_lrs
-        tag: ci
+      enabled: true
+      region: West US 2
+      vm_size: Standard_DS1_v2
+      storage_sku: standard_lrs
+      tag: ci
 
 
 Architecture
@@ -546,38 +546,38 @@ The following demonstrates merge behavior:
 .. code-block:: yaml
 
     defaults:
-        list_item:
-         - list_entry_1
-         - list_entry_2
-        int_item_1: 123
-        int_item_2: 234
-        dict_item:
-            subkey_1: 1
-            subkey_2: 2
-            subkey_dict:
-                subsubkey_1: a
-                subsubkey_2: b
+      list_item:
+       - list_entry_1
+       - list_entry_2
+      int_item_1: 123
+      int_item_2: 234
+      dict_item:
+        subkey_1: 1
+        subkey_2: 2
+        subkey_dict:
+          subsubkey_1: a
+          subsubkey_2: b
 
     overrides:
-        list_item:
-         - overridden_list_entry
-        int_item_1: 0
-        dict_item:
-            subkey_2: false
-            subkey_dict:
-                subsubkey_2: 'new value'
+      list_item:
+       - overridden_list_entry
+      int_item_1: 0
+      dict_item:
+        subkey_2: false
+        subkey_dict:
+          subsubkey_2: 'new value'
 
     result:
-        list_item:
-         - overridden_list_entry
-        int_item_1: 0
-        int_item_2: 234
-        dict_item:
-            subkey_1: 1
-            subkey_2: false
-            subkey_dict:
-                subsubkey_1: a
-                subsubkey_2: 'new value'
+      list_item:
+       - overridden_list_entry
+      int_item_1: 0
+      int_item_2: 234
+      dict_item:
+        subkey_1: 1
+        subkey_2: false
+        subkey_dict:
+          subsubkey_1: a
+          subsubkey_2: 'new value'
 
 
 Image Config

--- a/doc/rtd/topics/tests.rst
+++ b/doc/rtd/topics/tests.rst
@@ -547,8 +547,8 @@ The following demonstrates merge behavior:
 
     defaults:
       list_item:
-       - list_entry_1
-       - list_entry_2
+        - list_entry_1
+        - list_entry_2
       int_item_1: 123
       int_item_2: 234
       dict_item:
@@ -560,7 +560,7 @@ The following demonstrates merge behavior:
 
     overrides:
       list_item:
-       - overridden_list_entry
+        - overridden_list_entry
       int_item_1: 0
       dict_item:
         subkey_2: false
@@ -569,7 +569,7 @@ The following demonstrates merge behavior:
 
     result:
       list_item:
-       - overridden_list_entry
+        - overridden_list_entry
       int_item_1: 0
       int_item_2: 234
       dict_item:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -1,2 +1,3 @@
 beezly
 dhensby
+nishigori


### PR DESCRIPTION
This proposal has been aligned in a human readable.

- There are [no changes to this except for spac](https://github.com/canonical/cloud-init/pull/323/files?w=1)
- The indentation size is not specifically defined in the YAML RFC
  - `$ make yaml` has passed on my-machine
  
I set the indentation size to the largest number of articles in the repository (dictionary: `2`)
