### PR TITLE
nocloud: drop work around for Linux 2.6

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -49,10 +49,6 @@ class DataSourceNoCloud(sources.DataSource):
                     devlist.append('/dev/' + dev)
                     devlist.append('/dev/' + dev + 'a')  # NetBSD 7
         else:
-            # Query optical drive to get it in blkid cache for 2.6 kernels
-            util.find_devs_with(path="/dev/sr0")
-            util.find_devs_with(path="/dev/sr1")
-
             fslist = util.find_devs_with("TYPE=vfat")
             fslist.extend(util.find_devs_with("TYPE=iso9660"))
 


### PR DESCRIPTION
These two lines were a requirement for RHEL6, and they have been added 7
years ago:

- https://github.com/canonical/cloud-init/commit/984c72e522c585c6d3f6b3d3aec39fb21dd84028
- https://github.com/canonical/cloud-init/commit/48a3b4ca0ba55699825d6eabe75d843286c23545

RHEL6 comes with Python 2.6, since Python3 is now a strong requirement, I
think it's save to remove this hack.