### PR TITLE
tests: add missing mocks for get_interfaces_by_mac

### DIFF
--- a/cloudinit/sources/tests/test_oracle.py
+++ b/cloudinit/sources/tests/test_oracle.py
@@ -186,6 +186,7 @@ class TestDataSourceOracle(test_helpers.CiTestCase):
         self.assertEqual(self.my_md['uuid'], ds.get_instance_id())
         self.assertEqual(my_userdata, ds.userdata_raw)
 
+    @mock.patch(DS_PATH + ".get_interfaces_by_mac", mock.Mock(return_value={}))
     @mock.patch(DS_PATH + "._add_network_config_from_opc_imds",
                 side_effect=lambda network_config: network_config)
     @mock.patch(DS_PATH + ".cmdline.read_initramfs_config")
@@ -207,6 +208,7 @@ class TestDataSourceOracle(test_helpers.CiTestCase):
         self.assertEqual([mock.call()], m_initramfs_config.call_args_list)
         self.assertFalse(distro.generate_fallback_config.called)
 
+    @mock.patch(DS_PATH + ".get_interfaces_by_mac", mock.Mock(return_value={}))
     @mock.patch(DS_PATH + "._add_network_config_from_opc_imds",
                 side_effect=lambda network_config: network_config)
     @mock.patch(DS_PATH + ".cmdline.read_initramfs_config")

--- a/tests/unittests/test_datasource/test_opennebula.py
+++ b/tests/unittests/test_datasource/test_opennebula.py
@@ -355,6 +355,7 @@ class TestOpenNebulaDataSource(CiTestCase):
             util.find_devs_with = orig_find_devs_with
 
 
+@mock.patch(DS_PATH + '.net.get_interfaces_by_mac', mock.Mock(return_value={}))
 class TestOpenNebulaNetwork(unittest.TestCase):
 
     system_nics = ('eth0', 'ens3')


### PR DESCRIPTION
We currently have a test system where get_interfaces_by_mac raises an
exception, which is causing these tests to fail as they aren't mocking
get_interfaces_by_mac out.

LP: #1873910