### PR TITLE
distros: handle a potential mirror filtering error case

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -750,6 +750,10 @@ def _apply_hostname_transformations_to_url(url: str, transformations: list):
         # If we can't even parse the URL, we shouldn't use it for anything
         return None
     new_hostname = parts.hostname
+    if new_hostname is None:
+        # The URL given doesn't have a hostname component, so (a) we can't
+        # transform it, and (b) it won't work as a mirror; return None.
+        return None
 
     for transformation in transformations:
         new_hostname = transformation(new_hostname)


### PR DESCRIPTION
As written, it's possible that the first transformation for a mirror
hostname could be passed None if the parsed mirror URL didn't have a
hostname component, when the defined interface is that the
transformations will be passed strings.

This isn't an error currently, because the first transformation happens
to gracefully handle being passed None.  It returns None, so the
pipeline processing ends there.

This was caught when testing out mypy on the cloud-init codebase.