### PR TITLE
.travis.yml: introduce caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 dist: bionic
 
+cache: pip
+
 install:
     # Required so `git describe` will definitely find a tag; see
     # https://github.com/travis-ci/travis-ci/issues/7422

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 language: python
 dist: bionic
 
+# We use two different caching strategies.  The default is to cache pip
+# packages (as most of our jobs use pip packages), which is configured here.
+# For the integration tests, we instead want to cache the lxd images.  The
+# directory in which the images are stored (/var/snap/lxd/common/lxd/images/)
+# is not readable/writeable by the default user (which is a requirement for
+# caching), so we instead cache the `lxd_images/` directory and move out of
+# that before we run tests and back in once tests are complete.  To avoid our
+# cache growing without bound, we move all images out of the cached directory
+# (so it is empty) and only copy the most recent lxd image back into the cache.
+# (We cache the lxd images because this saves a few seconds in the general
+# case, but provides substantial speed-ups when cloud-images.ubuntu.com, the
+# source of the images, is under heavy load.)
 cache: pip
 
 install:
@@ -20,6 +32,17 @@ matrix:
               TOXENV=py3
               PYTEST_ADDOPTS=-v  # List all tests run by pytest
         - if: NOT branch =~ /^ubuntu\//
+          cache:
+              - directories:
+                  - lxd_images
+          before_cache:
+              - |
+                  # Find the most recent image file
+                  latest_file="$(sudo ls -Art /var/snap/lxd/common/lxd/images/ | tail -n 1)"
+                  # This might be <hash>.rootfs or <hash>, normalise
+                  latest_file="$(basename $latest_file .rootfs)"
+                  # Find all files with that prefix and copy them to our cache dir
+                  sudo find /var/snap/lxd/common/lxd/images/ -name $latest_file* -print -exec cp {} lxd_images/ \;
           install:
             - git fetch --unshallow
             - sudo apt-get build-dep -y cloud-init
@@ -35,6 +58,8 @@ matrix:
             - sudo snap install lxd
             - sudo lxd init --auto
             - sudo mkdir --mode=1777 -p /var/snap/lxd/common/consoles
+            # Move any cached lxd images into lxd's image dir
+            - sudo find lxd_images/ -type f -print -exec mv {} /var/snap/lxd/common/lxd/images/ \;
             - sudo usermod -a -G lxd $USER
             - sudo sbuild-adduser $USER
             - cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,15 @@ dist: bionic
 # For the integration tests, we instead want to cache the lxd images.  The
 # directory in which the images are stored (/var/snap/lxd/common/lxd/images/)
 # is not readable/writeable by the default user (which is a requirement for
-# caching), so we instead cache the `lxd_images/` directory and move out of
-# that before we run tests and back in once tests are complete.  To avoid our
-# cache growing without bound, we move all images out of the cached directory
-# (so it is empty) and only copy the most recent lxd image back into the cache.
-# (We cache the lxd images because this saves a few seconds in the general
+# caching), so we instead cache the `lxd_images/` directory.  We move lxd
+# images out of there before we run tests and back in once tests are complete.
+# We _move_ the images out and only copy the most recent lxd image back into
+# the cache, to avoid our cache growing without bound.  (We only need the most
+# recent lxd image because the integration tests only use a single image.)
+#
+# We cache the lxd images because this saves a few seconds in the general
 # case, but provides substantial speed-ups when cloud-images.ubuntu.com, the
-# source of the images, is under heavy load.)
+# source of the images, is under heavy load.
 cache: pip
 
 install:


### PR DESCRIPTION
This introduces caching of pip dependencies by default, and caching of lxd images in the integration tests. (See the inline comment for more details.)