### PR TITLE
[Docs] Clarify that `write_files` creates parent folders

### DIFF
--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -43,6 +43,7 @@ schema = {
     'title': 'write arbitrary files',
     'description': dedent("""\
         Write out arbitrary content to files, optionally setting permissions.
+        Parent folders in the path are created if absent.
         Content can be specified in plain text or binary. Data encoded with
         either base64 or binary gzip data can be specified and will be decoded
         before being written. For empty file creation, content can be omitted.


### PR DESCRIPTION
Clarify in documentation that `write_files` will create parent folders
for paths that do not already exist.

This obfuscates what the problem is when people erroneously create
files in `/tmp` despite the warnings in the documentation not to do so.
People naturally assume that their file is absent because the parent folder
did not exist for it to be created in, causing them to add a `runcmd` block
to create the folder, even though execution order means that this will not
occur until after `write_files` have all finished.

Might also consider adding an actual warning in log output if a `write_files`
block does this.