### PR TITLE
make suse and sles support 127.0.1.1

### DIFF
--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -144,6 +144,9 @@ class Distro(distros.Distro):
                 return default
             return hostname
 
+    def _get_localhost_ip(self):
+        return "127.0.1.1"
+
     def _read_hostname_conf(self, filename):
         conf = HostnameConf(util.load_file(filename))
         conf.parse()

--- a/templates/hosts.suse.tmpl
+++ b/templates/hosts.suse.tmpl
@@ -13,7 +13,7 @@ you need to add the following to config:
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
 #
 # The following lines are desirable for IPv4 capable hosts
-127.0.0.1 {{fqdn}} {{hostname}}
+127.0.1.1 {{fqdn}} {{hostname}}
 127.0.0.1 localhost.localdomain localhost
 127.0.0.1 localhost4.localdomain4 localhost4
 

--- a/tests/unittests/test_handler/test_handler_etc_hosts.py
+++ b/tests/unittests/test_handler/test_handler_etc_hosts.py
@@ -44,8 +44,8 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_update_etc_hosts.handle('test', cfg, cc, LOG, [])
         contents = util.load_file('%s/etc/hosts' % self.tmp)
-        if '127.0.0.1\tcloud-init.test.us\tcloud-init' not in contents:
-            self.assertIsNone('No entry for 127.0.0.1 in etc/hosts')
+        if '127.0.1.1\tcloud-init.test.us\tcloud-init' not in contents:
+            self.assertIsNone('No entry for 127.0.1.1 in etc/hosts')
         if '192.168.1.1\tblah.blah.us\tblah' not in contents:
             self.assertIsNone('Default etc/hosts content modified')
 
@@ -64,7 +64,7 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_update_etc_hosts.handle('test', cfg, cc, LOG, [])
         contents = util.load_file('%s/etc/hosts' % self.tmp)
-        if '127.0.0.1 cloud-init.test.us cloud-init' not in contents:
-            self.assertIsNone('No entry for 127.0.0.1 in etc/hosts')
+        if '127.0.1.1 cloud-init.test.us cloud-init' not in contents:
+            self.assertIsNone('No entry for 127.0.1.1 in etc/hosts')
         if '::1 cloud-init.test.us cloud-init' not in contents:
             self.assertIsNone('No entry for 127.0.0.1 in etc/hosts')


### PR DESCRIPTION
Same as ubuntu-debian as link below, make sles-suse also support 127.0.1.1
http://www.leonardoborda.com/blog/127-0-1-1-ubuntu-debian/

Tested on the local sles, changed the local hosts.suse.tmpl and opensuse.py files and then changed the hostname or set the static ip, the 127.0.1.1 was set in the /etc/hosts 