### PR TITLE
yum_add_repo: Add Centos to the supported distro list

### DIFF
--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -18,7 +18,7 @@ entry, the config entry will be skipped.
 
 **Module frequency:** per always
 
-**Supported distros:** fedora, rhel
+**Supported distros:** centos, fedora, rhel
 
 **Config keys**::
 
@@ -36,7 +36,7 @@ from configparser import ConfigParser
 
 from cloudinit import util
 
-distros = ['fedora', 'rhel']
+distros = ['centos', 'fedora', 'rhel']
 
 
 def _canonicalize_id(repo_id):


### PR DESCRIPTION
Users of Centos who want to add yum repos, like they do on Fedora
or RHEL get this unfortunate message:

  Skipping modules 'yum-add-repo' because they are not verified
  on distro 'centos'.  To run anyway, add them to
  'unverified_modules' in config

Centos certainly supports yum, add it to the supported distro
list in the module.