### PR TITLE
conftest: add docs and tests regarding CiTestCase's subp functionality

### DIFF
--- a/cloudinit/conftest.py
+++ b/cloudinit/conftest.py
@@ -21,7 +21,9 @@ def disable_subp_usage(request):
             util.subp(["whoami"])
 
     This fixture (roughly) mirrors the functionality of
-    CiTestCase.allowed_subp.
+    CiTestCase.allowed_subp.  N.B. While autouse fixtures do affect non-pytest
+    tests, CiTestCase's allowed_subp does take precedence (and we have
+    TestDisableSubpUsageInTestSubclass to confirm that).
 
     TODO:
         * Enable select subp usage (i.e. allowed_subp=[...])

--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -144,6 +144,9 @@ class CiTestCase(TestCase):
         if 'args' in kwargs:
             cmd = kwargs['args']
         else:
+            if not args:
+                raise TypeError(
+                    "subp() missing 1 required positional argument: 'args'")
             cmd = args[0]
 
         if not isinstance(cmd, str):

--- a/cloudinit/tests/test_conftest.py
+++ b/cloudinit/tests/test_conftest.py
@@ -1,9 +1,11 @@
 import pytest
 
 from cloudinit import util
+from cloudinit.tests.helpers import CiTestCase
 
 
 class TestDisableSubpUsage:
+    """Test that the disable_subp_usage fixture behaves as expected."""
 
     def test_using_subp_raises_assertion_error(self):
         with pytest.raises(AssertionError):
@@ -16,3 +18,23 @@ class TestDisableSubpUsage:
     @pytest.mark.parametrize('disable_subp_usage', [False], indirect=True)
     def test_subp_usage_can_be_reenabled(self):
         util.subp(['whoami'])
+
+
+class TestDisableSubpUsageInTestSubclass(CiTestCase):
+    """Test that disable_subp_usage doesn't impact CiTestCase's subp logic."""
+
+    def test_using_subp_raises_assertion_error(self):
+        with pytest.raises(Exception):
+            util.subp(["some", "args"])
+
+    def test_typeerrors_on_incorrect_usage(self):
+        with pytest.raises(IndexError):
+            util.subp()
+
+    def test_subp_usage_can_be_reenabled(self):
+        _old_allowed_subp = self.allow_subp
+        self.allowed_subp = True
+        try:
+            util.subp(['whoami'])
+        finally:
+            self.allowed_subp = _old_allowed_subp

--- a/cloudinit/tests/test_conftest.py
+++ b/cloudinit/tests/test_conftest.py
@@ -28,7 +28,7 @@ class TestDisableSubpUsageInTestSubclass(CiTestCase):
             util.subp(["some", "args"])
 
     def test_typeerrors_on_incorrect_usage(self):
-        with pytest.raises(IndexError):
+        with pytest.raises(TypeError):
             util.subp()
 
     def test_subp_usage_can_be_reenabled(self):

--- a/cloudinit/tests/test_conftest.py
+++ b/cloudinit/tests/test_conftest.py
@@ -23,7 +23,7 @@ class TestDisableSubpUsage:
 class TestDisableSubpUsageInTestSubclass(CiTestCase):
     """Test that disable_subp_usage doesn't impact CiTestCase's subp logic."""
 
-    def test_using_subp_raises_assertion_error(self):
+    def test_using_subp_raises_exception(self):
         with pytest.raises(Exception):
             util.subp(["some", "args"])
 
@@ -35,6 +35,6 @@ class TestDisableSubpUsageInTestSubclass(CiTestCase):
         _old_allowed_subp = self.allow_subp
         self.allowed_subp = True
         try:
-            util.subp(['whoami'])
+            util.subp(['bash', '-c', 'true'])
         finally:
             self.allowed_subp = _old_allowed_subp


### PR DESCRIPTION
And fix up an inconsistency in `tests/helpers.py` too by raising a `TypeError` when subp is called with no arguments as it does under normal operation:

```py
>>> from cloudinit.util import subp
>>> subp()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: subp() missing 1 required positional argument: 'args'
```