### PR TITLE
cloud_tests: emit dots on Travis while fetching images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
             - sudo -E su $USER -c 'mk-sbuild xenial'
             - sudo -E su $USER -c 'sbuild --nolog --verbose --dist=xenial cloud-init_*.dsc'
             # Ubuntu LTS: Integration
-            - travis_wait 30 sg lxd -c 'tox -e citest -- run --verbose --preserve-data --data-dir results --os-name xenial --test modules/apt_configure_sources_list.yaml --test modules/ntp_servers --test modules/set_password_list --test modules/user_groups --deb cloud-init_*_all.deb'
+            - sg lxd -c 'tox -e citest -- run --verbose --preserve-data --data-dir results --os-name xenial --test modules/apt_configure_sources_list.yaml --test modules/ntp_servers --test modules/set_password_list --test modules/user_groups --deb cloud-init_*_all.deb'
         - python: 3.5
           env:
               TOXENV=xenial

--- a/tests/cloud_tests/platforms/__init__.py
+++ b/tests/cloud_tests/platforms/__init__.py
@@ -6,6 +6,7 @@ from .ec2 import platform as ec2
 from .lxd import platform as lxd
 from .nocloudkvm import platform as nocloudkvm
 from .azurecloud import platform as azurecloud
+from ..util import emit_dots_on_travis
 
 PLATFORMS = {
     'ec2': ec2.EC2Platform,
@@ -17,7 +18,8 @@ PLATFORMS = {
 
 def get_image(platform, config):
     """Get image from platform object using os_name."""
-    return platform.get_image(config)
+    with emit_dots_on_travis():
+        return platform.get_image(config)
 
 
 def get_instance(snapshot, *args, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -134,6 +134,6 @@ deps =
 [testenv:citest]
 basepython = python3
 commands = {envpython} -m tests.cloud_tests {posargs}
-passenv = HOME
+passenv = HOME TRAVIS
 deps =
     -r{toxinidir}/integration-requirements.txt


### PR DESCRIPTION
This ensures that Travis will not kill our tests if fetching images is
taking a long time.

In implementation turns, this introduces a context manager which will
spin up a multiprocessing.Process in the background and print a dot to
stdout every 10 seconds.  The process is terminated when the context
manager exits.