### PR TITLE
Create tests to validate schema examples

### DIFF
--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -61,9 +61,9 @@ schema = {
         snap:
             assertions:
               00: |
-              signed_assertion_blob_here
+                signed_assertion_blob_here
               02: |
-              signed_assertion_blob_here
+                signed_assertion_blob_here
             commands:
               00: snap create-user --sudoer --known <snap-user>@mydomain.com
               01: snap install canonical-livepatch

--- a/tests/unittests/test_handler/test_schema.py
+++ b/tests/unittests/test_handler/test_schema.py
@@ -10,6 +10,7 @@ from cloudinit.tests.helpers import CiTestCase, mock, skipUnlessJsonSchema
 
 from copy import copy
 import os
+import pytest
 from io import StringIO
 from textwrap import dedent
 from yaml import safe_load
@@ -110,6 +111,23 @@ class ValidateCloudConfigSchemaTest(CiTestCase):
         self.assertEqual(
             "Cloud config schema errors: p1: '-1' is not a 'hostname'",
             str(context_mgr.exception))
+
+
+class TestCloudConfigExamples:
+
+    SCHEMA = get_schema()
+    PARAMS = [
+        (schema["id"], example)
+        for schema in SCHEMA["allOf"] for example in schema["examples"]]
+
+    @pytest.mark.parametrize("schema_id,example", PARAMS)
+    def test_validateconfig_schema_of_example(self, schema_id, example):
+        """ For a given example in a config module we test if it is valid
+        according to the unified schema of all config modules
+        """
+        config_load = safe_load(example)
+        validate_cloudconfig_schema(
+            config_load, TestCloudConfigExamples.SCHEMA, strict=True)
 
 
 class ValidateCloudConfigFileTest(CiTestCase):

--- a/tests/unittests/test_handler/test_schema.py
+++ b/tests/unittests/test_handler/test_schema.py
@@ -121,6 +121,7 @@ class TestCloudConfigExamples:
         for schema in SCHEMA["allOf"] for example in schema["examples"]]
 
     @pytest.mark.parametrize("schema_id,example", PARAMS)
+    @skipUnlessJsonSchema()
     def test_validateconfig_schema_of_example(self, schema_id, example):
         """ For a given example in a config module we test if it is valid
         according to the unified schema of all config modules


### PR DESCRIPTION
Following this [launchpad bug](https://bugs.launchpad.net/cloud-init/+bug/1876412), we need to validate if the examples provided in the config module are conforming to the concatenated schema of all config modules. The rationale behind that is not only to verify if the examples are correctly written but to assert that no config schema is interfering with each other.

Also, but looking at the [validate_cloudconfig_schema](https://github.com/canonical/cloud-init/blob/master/cloudinit/config/schema.py#L76), I believe that will raise the `SchemaValidationError` by using `strict=True`, so I have only called the function pasisng the right schemas to compare.

LP: #1876412