### PR TITLE
cloudinit: minor pylint fixes

### DIFF
--- a/cloudinit/config/tests/test_snap.py
+++ b/cloudinit/config/tests/test_snap.py
@@ -345,7 +345,7 @@ class TestSchema(CiTestCase, SchemaTestCaseMixin):
     def test_duplicates_are_fine_array_array(self):
         """Duplicated commands array/array entries are allowed."""
         self.assertSchemaValid(
-            {'commands': [["echo", "bye"], ["echo" "bye"]]},
+            {'commands': [["echo", "bye"], ["echo", "bye"]]},
             "command entries can be duplicate.")
 
     def test_duplicates_are_fine_array_string(self):

--- a/cloudinit/config/tests/test_ubuntu_drivers.py
+++ b/cloudinit/config/tests/test_ubuntu_drivers.py
@@ -16,6 +16,13 @@ OLD_UBUNTU_DRIVERS_ERROR_STDERR = (
     "(choose from 'list', 'autoinstall', 'devices', 'debug')\n")
 
 
+# The tests in this module call helper methods which are decorated with
+# mock.patch.  pylint doesn't understand that mock.patch passes parameters to
+# the decorated function, so it incorrectly reports that we aren't passing
+# values for all parameters.  Instead of annotating every single call, we
+# disable it for the entire module:
+#  pylint: disable=no-value-for-parameter
+
 class AnyTempScriptAndDebconfFile(object):
 
     def __init__(self, tmp_dir, debconf_file):

--- a/cloudinit/sources/helpers/tests/test_netlink.py
+++ b/cloudinit/sources/helpers/tests/test_netlink.py
@@ -87,7 +87,7 @@ class TestParseNetlinkMessage(CiTestCase):
         data = None
         with self.assertRaises(AssertionError) as context:
             read_rta_oper_state(data)
-        self.assertTrue('data is none', str(context.exception))
+        self.assertEqual('data is none', str(context.exception))
 
     def test_read_invalid_rta_operstate_none(self):
         '''read_rta_oper_state returns none if operstate is none'''

--- a/cloudinit/tests/test_conftest.py
+++ b/cloudinit/tests/test_conftest.py
@@ -13,6 +13,8 @@ class TestDisableSubpUsage:
 
     def test_typeerrors_on_incorrect_usage(self):
         with pytest.raises(TypeError):
+            # We are intentionally passing no value for a parameter, so:
+            #  pylint: disable=no-value-for-parameter
             util.subp()
 
     @pytest.mark.parametrize('disable_subp_usage', [False], indirect=True)


### PR DESCRIPTION
We recently discovered that pylint is failing to report some errors when
invoked across our entire codebase (see
https://github.com/PyCQA/pylint/issues/3611).  I've run pylint across
every Python file under cloudinit/[0], and this commit fixes the issues
so-discovered.

[0] find cloudinit/ -name "*.py" | xargs -n 1 -t .tox/pylint/bin/python -m pylint