### PR TITLE
cloudinit: remove unneeded __future__ imports

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1,8 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """schema.py: Set of module functions for processing cloud-config schema."""
 
-from __future__ import print_function
-
 from cloudinit import importer
 from cloudinit.util import find_modules, load_file
 

--- a/cloudinit/serial.py
+++ b/cloudinit/serial.py
@@ -1,7 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from __future__ import absolute_import
-
 try:
     from serial import Serial
 except ImportError:

--- a/cloudinit/sources/DataSourceMAAS.py
+++ b/cloudinit/sources/DataSourceMAAS.py
@@ -6,8 +6,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from __future__ import print_function
-
 import hashlib
 import os
 import time

--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -1,7 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from __future__ import print_function
-
 import functools
 import httpretty
 import io

--- a/tests/unittests/test_cs_util.py
+++ b/tests/unittests/test_cs_util.py
@@ -1,7 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from __future__ import print_function
-
 from cloudinit.tests import helpers as test_helpers
 
 from cloudinit.cs_utils import Cepko

--- a/tests/unittests/test_datasource/test_smartos.py
+++ b/tests/unittests/test_datasource/test_smartos.py
@@ -12,8 +12,6 @@ order to validate return responses.
 
 '''
 
-from __future__ import print_function
-
 from binascii import crc32
 import json
 import multiprocessing

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -4,8 +4,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from __future__ import print_function
-
 from cloudinit.tests import helpers as test_helpers
 import textwrap
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1,7 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from __future__ import print_function
-
 import io
 import json
 import logging


### PR DESCRIPTION
We live in the future now.