### PR TITLE
cc_snap: apply validation to snap.commands properties

### DIFF
--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -121,7 +121,7 @@ schema = {
                     'additionalProperties': {
                         'oneOf': [
                             {'type': 'string'},
-                            {'type': 'array'},
+                            {'type': 'array', 'items': {'type': 'string'}},
                         ],
                     },
                 },

--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -85,6 +85,14 @@ schema = {
                 01: ['snap', 'install', 'vlc']
                 02: snap install vlc
                 03: 'snap install vlc'
+    """), dedent("""\
+        # You can use a list of commands
+        snap:
+            commands:
+                - ['install', 'vlc']
+                - ['snap', 'install', 'vlc']
+                - snap install vlc
+                - 'snap install vlc'
     """)],
     'frequency': PER_INSTANCE,
     'type': 'object',
@@ -110,6 +118,12 @@ schema = {
                     'additionalItems': False,  # Reject non-string & non-list
                     'minItems': 1,
                     'minProperties': 1,
+                    'additionalProperties': {
+                        'oneOf': [
+                            {'type': 'string'},
+                            {'type': 'array'},
+                        ],
+                    },
                 },
                 'squashfuse_in_container': {
                     'type': 'boolean'

--- a/cloudinit/config/tests/test_snap.py
+++ b/cloudinit/config/tests/test_snap.py
@@ -326,6 +326,22 @@ class TestSchema(CiTestCase, SchemaTestCaseMixin):
             " schemas\n",
             self.logs.getvalue())
 
+    @mock.patch('cloudinit.config.cc_snap.run_commands')
+    def test_schema_when_commands_list_values_are_invalid_type(self, _):
+        """Warnings when snap:commands list values are wrong type (e.g. int)"""
+        validate_cloudconfig_schema(
+            {'snap': {'commands': [["snap", "install", 123]]}}, schema)
+        validate_cloudconfig_schema(
+            {'snap': {'commands': {'01': ["snap", "install", 123]}}}, schema)
+        self.assertEqual(
+            "WARNING: Invalid config:\n"
+            "snap.commands.0: ['snap', 'install', 123] is not valid under any"
+            " of the given schemas\n",
+            "WARNING: Invalid config:\n"
+            "snap.commands.0: ['snap', 'install', 123] is not valid under any"
+            " of the given schemas\n",
+            self.logs.getvalue())
+
     @mock.patch('cloudinit.config.cc_snap.add_assertions')
     def test_warn_schema_assertions_is_not_list_or_dict(self, _):
         """Warn when snap:assertions config is not a list or dict."""

--- a/cloudinit/config/tests/test_snap.py
+++ b/cloudinit/config/tests/test_snap.py
@@ -310,6 +310,22 @@ class TestSchema(CiTestCase, SchemaTestCaseMixin):
             {'snap': {'commands': {'01': 'also valid'}}}, schema)
         self.assertEqual('', self.logs.getvalue())
 
+    @mock.patch('cloudinit.config.cc_snap.run_commands')
+    def test_schema_when_commands_values_are_invalid_type(self, _):
+        """Warnings when snap:commands values are invalid type (e.g. int)"""
+        validate_cloudconfig_schema(
+            {'snap': {'commands': [123]}}, schema)
+        validate_cloudconfig_schema(
+            {'snap': {'commands': {'01': 123}}}, schema)
+        self.assertEqual(
+            "WARNING: Invalid config:\n"
+            "snap.commands.0: 123 is not valid under any of the given"
+            " schemas\n"
+            "WARNING: Invalid config:\n"
+            "snap.commands.01: 123 is not valid under any of the given"
+            " schemas\n",
+            self.logs.getvalue())
+
     @mock.patch('cloudinit.config.cc_snap.add_assertions')
     def test_warn_schema_assertions_is_not_list_or_dict(self, _):
         """Warn when snap:assertions config is not a list or dict."""


### PR DESCRIPTION
Specifically, ensure that given values are either strings, or arrays of strings.