### PR TITLE
Include fails silently and new feature flag functionality

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -324,6 +324,13 @@ variable annotations specified in `PEP-526`_ were introduced in Python
 
    in a xenial lxd container with python3-pytest installed.
 
+Feature Flags
+-------------
+
+.. automodule:: cloudinit.features
+   :members:
+
+
 Ongoing Refactors
 =================
 

--- a/cloudinit/features.py
+++ b/cloudinit/features.py
@@ -1,0 +1,33 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+"""
+Feature flags are used as a way to easily toggle configuration
+**at build time**. They are provided to accommodate feature deprecation and
+downstream configuration changes.
+
+Currently used upstream values for feature flags are set in
+``cloudinit/features.py``. Overrides to these values (typically via quilt
+patch) can be placed
+in a file called ``feature_overrides.py`` in the same directory. Any value
+set in ``feature_overrides.py`` will override the original value set
+in ``features.py``.
+
+Each flag should include a short comment regarding the reason for
+the flag and intended lifetime.
+
+Tests are required for new feature flags, and tests must verify
+all valid states of a flag, not just the default state.
+"""
+
+ERROR_ON_USER_DATA_FAILURE = True
+"""
+If there is a failure in obtaining user data (i.e., #include or
+decompress fails), old behavior is to log a warning and proceed.
+After the 20.2 release, we instead raise an exception.
+This flag can be removed after Focal is no longer supported
+"""
+
+try:
+    # pylint: disable=wildcard-import
+    from cloudinit.feature_overrides import *  # noqa
+except ImportError:
+    pass

--- a/cloudinit/tests/test_features.py
+++ b/cloudinit/tests/test_features.py
@@ -1,0 +1,60 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+# pylint: disable=no-member,no-name-in-module
+"""
+This file is for testing the feature flag functionality itself,
+NOT for testing any individual feature flag
+"""
+import pytest
+import sys
+from pathlib import Path
+
+import cloudinit
+
+
+@pytest.yield_fixture()
+def create_override(request):
+    """
+    Create a feature overrides file and do some module wizardry to make
+    it seem like we're importing the features file for the first time.
+
+    After creating the override file with the values passed by the test,
+    we need to reload cloudinit.features
+    to get all of the current features (including the overridden ones).
+    Once the test is complete, we remove the file we created and set
+    features and feature_overrides modules to how they were before
+    the test started
+    """
+    override_path = Path(cloudinit.__file__).parent / 'feature_overrides.py'
+    if override_path.exists():
+        raise Exception("feature_overrides.py unexpectedly exists! "
+                        "Remove it to run this test.")
+    with override_path.open('w') as f:
+        for key, value in request.param.items():
+            f.write('{} = {}\n'.format(key, value))
+
+    sys.modules.pop('cloudinit.features', None)
+
+    yield
+
+    override_path.unlink()
+    sys.modules.pop('cloudinit.feature_overrides', None)
+
+
+class TestFeatures:
+    def test_feature_without_override(self):
+        from cloudinit.features import ERROR_ON_USER_DATA_FAILURE
+        assert ERROR_ON_USER_DATA_FAILURE is True
+
+    @pytest.mark.parametrize('create_override',
+                             [{'ERROR_ON_USER_DATA_FAILURE': False}],
+                             indirect=True)
+    def test_feature_with_override(self, create_override):
+        from cloudinit.features import ERROR_ON_USER_DATA_FAILURE
+        assert ERROR_ON_USER_DATA_FAILURE is False
+
+    @pytest.mark.parametrize('create_override',
+                             [{'SPAM': True}],
+                             indirect=True)
+    def test_feature_only_in_override(self, create_override):
+        from cloudinit.features import SPAM
+        assert SPAM is True

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -639,6 +639,31 @@ class TestConsumeUserDataHttp(TestConsumeUserData, helpers.HttprettyTestCase):
         self.reRoot()
         ci = stages.Init()
         ci.datasource = FakeDataSource(blob)
+        ci.fetch()
+        with self.assertRaises(Exception) as context:
+            ci.consume_data()
+        self.assertIn('403', str(context.exception))
+
+        with self.assertRaises(FileNotFoundError):
+            util.load_file(ci.paths.get_ipath("cloud_config"))
+
+    @mock.patch('cloudinit.url_helper.time.sleep')
+    @mock.patch('cloudinit.features.ERROR_ON_USER_DATA_FAILURE', False)
+    def test_include_bad_url_no_fail(self, mock_sleep):
+        """Test #include with a bad URL and failure disabled"""
+        bad_url = 'http://bad/forbidden'
+        bad_data = '#cloud-config\nbad: true\n'
+        httpretty.register_uri(httpretty.GET, bad_url, bad_data, status=403)
+
+        included_url = 'http://hostname/path'
+        included_data = '#cloud-config\nincluded: true\n'
+        httpretty.register_uri(httpretty.GET, included_url, included_data)
+
+        blob = '#include\n%s\n%s' % (bad_url, included_url)
+
+        self.reRoot()
+        ci = stages.Init()
+        ci.datasource = FakeDataSource(blob)
         log_file = self.capture_log(logging.WARNING)
         ci.fetch()
         ci.consume_data()


### PR DESCRIPTION
WIP PR is for discussion, not review.

If an `#include` line fails, we only get a warning in the stdout log, but no failure in the `result.json`. For more background, see https://bugs.launchpad.net/cloud-init/+bug/1734939

I replaced the possible log warnings with exceptions (including a similar warning for a failed decompression I saw in the same file). I now get this in the `result.json` (the URL intentionally has an extra character at the end):
```{
 "v1": {
  "datasource": "DataSourceNoCloud [seed=ds_config][dsmode=net]",
  "errors": [
   "404 Client Error: Not Found for url: https://raw.githubusercontent.com/canonical/cloud-init/master/doc/examples/cloud-config-run-cmds.txtd"
  ]
 }
}
```

Is this too blunt an instrument? Previously, if one piece failed, we'd log the warning and continue. Raising an exception stops any additional processing. Do we want that? I was initially thinking no, but if you have a later piece that relies on an earlier piece having run, you probably don't want the later piece being run, do you?

Is there currently any other way of signaling errors without raising exceptions?

If we do want to use exception, is `Exception` ok here, or would custom exceptions be useful here?