### PR TITLE
doc/rtd/topics/faq: Updates LXD docs links to current site

### DIFF
--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -223,8 +223,8 @@ values or the LXD `Custom Network Configuration`_ document for more about
 custom network config.
 
 .. _LXD: https://linuxcontainers.org/
-.. _Instance Configuration: https://lxd.readthedocs.io/en/latest/instances/
-.. _Custom Network Configuration: https://lxd.readthedocs.io/en/latest/cloud-init/
+.. _Instance Configuration: https://linuxcontainers.org/lxd/docs/master/instances
+.. _Custom Network Configuration: https://linuxcontainers.org/lxd/docs/master/cloud-init
 
 Where can I learn more?
 ========================================

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -2,4 +2,5 @@ beezly
 dhensby
 lucasmoura
 nishigori
+tomponline
 TheRealFalcon


### PR DESCRIPTION
We are longer using lxd.readthedocs.io

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>