### PR TITLE
printing the error stream of the dhclient process before killing it

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -222,7 +222,7 @@ def dhcp_discovery(dhclient_cmd_path, interface, cleandir):
     util.subp(['ip', 'link', 'set', 'dev', interface, 'up'], capture=True)
     cmd = [sandbox_dhclient_cmd, '-1', '-v', '-lf', lease_file,
            '-pf', pid_file, interface, '-sf', '/bin/true']
-    pout, perr = util.subp(cmd, capture=True)
+    pout = util.subp(cmd, capture=True)
 
     # Wait for pid file and lease file to appear, and for the process
     # named by the pid file to daemonize (have pid 1 as its parent). If we
@@ -248,7 +248,8 @@ def dhcp_discovery(dhclient_cmd_path, interface, cleandir):
         else:
             ppid = util.get_proc_ppid(pid)
             if ppid == 1:
-                LOG.debug('dhclient error stream: %s', perr)
+                if len(pout) == 2:
+                    LOG.debug('dhclient error stream: %s', pout[1])
                 LOG.debug('killing dhclient with pid=%s', pid)
                 os.kill(pid, signal.SIGKILL)
                 return parse_dhcp_lease_file(lease_file)

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -222,7 +222,7 @@ def dhcp_discovery(dhclient_cmd_path, interface, cleandir):
     util.subp(['ip', 'link', 'set', 'dev', interface, 'up'], capture=True)
     cmd = [sandbox_dhclient_cmd, '-1', '-v', '-lf', lease_file,
            '-pf', pid_file, interface, '-sf', '/bin/true']
-    pout = util.subp(cmd, capture=True)
+    _out, err = util.subp(cmd, capture=True)
 
     # Wait for pid file and lease file to appear, and for the process
     # named by the pid file to daemonize (have pid 1 as its parent). If we
@@ -248,8 +248,7 @@ def dhcp_discovery(dhclient_cmd_path, interface, cleandir):
         else:
             ppid = util.get_proc_ppid(pid)
             if ppid == 1:
-                if len(pout) == 2:
-                    LOG.debug('dhclient error stream: %s', pout[1])
+                LOG.debug('dhclient error stream: %s', err)
                 LOG.debug('killing dhclient with pid=%s', pid)
                 os.kill(pid, signal.SIGKILL)
                 return parse_dhcp_lease_file(lease_file)

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -222,7 +222,7 @@ def dhcp_discovery(dhclient_cmd_path, interface, cleandir):
     util.subp(['ip', 'link', 'set', 'dev', interface, 'up'], capture=True)
     cmd = [sandbox_dhclient_cmd, '-1', '-v', '-lf', lease_file,
            '-pf', pid_file, interface, '-sf', '/bin/true']
-    util.subp(cmd, capture=True)
+    pout, perr = util.subp(cmd, capture=True)
 
     # Wait for pid file and lease file to appear, and for the process
     # named by the pid file to daemonize (have pid 1 as its parent). If we
@@ -248,6 +248,7 @@ def dhcp_discovery(dhclient_cmd_path, interface, cleandir):
         else:
             ppid = util.get_proc_ppid(pid)
             if ppid == 1:
+                LOG.debug('dhclient error stream: %s', perr)
                 LOG.debug('killing dhclient with pid=%s', pid)
                 os.kill(pid, signal.SIGKILL)
                 return parse_dhcp_lease_file(lease_file)

--- a/cloudinit/net/tests/test_dhcp.py
+++ b/cloudinit/net/tests/test_dhcp.py
@@ -309,6 +309,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
 
         Lease processing still occurs and no proc kill is attempted.
         """
+        m_subp.return_value = ('', '')
         tmpdir = self.tmp_dir()
         dhclient_script = os.path.join(tmpdir, 'dhclient.orig')
         script_content = '#!/bin/bash\necho fake-dhclient'
@@ -344,6 +345,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
                                                                   m_kill,
                                                                   m_getppid):
         """dhcp_discovery waits for the presence of pidfile and dhcp.leases."""
+        m_subp.return_value = ('', '')
         tmpdir = self.tmp_dir()
         dhclient_script = os.path.join(tmpdir, 'dhclient.orig')
         script_content = '#!/bin/bash\necho fake-dhclient'
@@ -370,6 +372,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
 
         It also returns the parsed dhcp.leases file generated in the sandbox.
         """
+        m_subp.return_value = ('', '')
         tmpdir = self.tmp_dir()
         dhclient_script = os.path.join(tmpdir, 'dhclient.orig')
         script_content = '#!/bin/bash\necho fake-dhclient'

--- a/cloudinit/net/tests/test_dhcp.py
+++ b/cloudinit/net/tests/test_dhcp.py
@@ -418,7 +418,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
                  'eth9', '-sf', '/bin/true'], capture=True)])
         m_kill.assert_has_calls([mock.call(my_pid, signal.SIGKILL)])
 
-    @mock.patch('cloudinit.net.dhcp.util.subp')
+    @mock.patch('cloudinit.net.dhcp.subp.subp')
     @mock.patch('cloudinit.net.dhcp.maybe_perform_dhcp_discovery')
     def test_dhcp_discovery_error_stream(
             self, m_dhcp, m_subp):

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -628,6 +628,10 @@ class DataSourceAzure(sources.DataSource):
                           exception)
                 return False
 
+        def dhcp_log_cb(out, err):
+            report_diagnostic_event("dhclient output stream: %s" % out)
+            report_diagnostic_event("dhclient error stream: %s" % err)
+
         LOG.debug("Wait for vnetswitch to happen")
         while True:
             try:
@@ -636,10 +640,9 @@ class DataSourceAzure(sources.DataSource):
                         name="obtain-dhcp-lease",
                         description="obtain dhcp lease",
                         parent=azure_ds_reporter):
-                    self._ephemeral_dhcp_ctx = EphemeralDHCPv4()
+                    self._ephemeral_dhcp_ctx = EphemeralDHCPv4(
+                        dhcp_log_func=dhcp_log_cb)
                     lease = self._ephemeral_dhcp_ctx.obtain_lease()
-                    err = self._ephemeral_dhcp_ctx.dhcp_error
-                    report_diagnostic_event(err)
 
                 if vnet_switched:
                     dhcp_attempts += 1

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -636,6 +636,8 @@ class DataSourceAzure(sources.DataSource):
                         parent=azure_ds_reporter):
                     self._ephemeral_dhcp_ctx = EphemeralDHCPv4()
                     lease = self._ephemeral_dhcp_ctx.obtain_lease()
+                    err = self._ephemeral_dhcp_ctx.dhcp_error
+                    report_diagnostic_event(err)
 
                 if vnet_switched:
                     dhcp_attempts += 1

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -35,7 +35,8 @@ from cloudinit.sources.helpers.azure import (
     get_system_info,
     report_diagnostic_event,
     EphemeralDHCPv4WithReporting,
-    is_byte_swapped)
+    is_byte_swapped,
+    dhcp_log_cb)
 
 LOG = logging.getLogger(__name__)
 
@@ -627,10 +628,6 @@ class DataSourceAzure(sources.DataSource):
                 LOG.debug("poll IMDS failed with an unexpected exception: %s",
                           exception)
                 return False
-
-        def dhcp_log_cb(out, err):
-            report_diagnostic_event("dhclient output stream: %s" % out)
-            report_diagnostic_event("dhclient error stream: %s" % err)
 
         LOG.debug("Wait for vnetswitch to happen")
         while True:

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -626,10 +626,16 @@ def get_metadata_from_fabric(fallback_lease_file=None, dhcp_opts=None,
         shim.clean_up()
 
 
+def dhcp_log_cb(out, err):
+    report_diagnostic_event("dhclient output stream: %s" % out)
+    report_diagnostic_event("dhclient error stream: %s" % err)
+
+
 class EphemeralDHCPv4WithReporting(object):
     def __init__(self, reporter, nic=None):
         self.reporter = reporter
-        self.ephemeralDHCPv4 = EphemeralDHCPv4(iface=nic)
+        self.ephemeralDHCPv4 = EphemeralDHCPv4(
+            iface=nic, dhcp_log_func=dhcp_log_cb)
 
     def __enter__(self):
         with events.ReportEventStack(

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -721,7 +721,7 @@ scbus-1 on xpt0 bus 0
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
             'unknown-245': '624c3620'}
-        m_dhcp.return_value = [lease]
+        m_dhcp.return_value = [lease], ''
         m_media_switch.return_value = None
 
         reprovision_ovfenv = construct_valid_ovf_env()
@@ -1980,7 +1980,7 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
-            'unknown-245': '624c3620'}]
+            'unknown-245': '624c3620'}], ''
         m_media_switch.return_value = None
         dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
         with mock.patch(MOCKPATH + 'REPORTED_READY_MARKER_FILE', report_file):
@@ -2014,7 +2014,7 @@ class TestAzureDataSourcePreprovisioning(CiTestCase):
         m_media_switch.return_value = None
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
-            'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0'}]
+            'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0'}], ''
         url = 'http://{0}/metadata/reprovisiondata?api-version=2017-04-02'
         host = "169.254.169.254"
         full_url = url.format(host)
@@ -2047,7 +2047,7 @@ class TestAzureDataSourcePreprovisioning(CiTestCase):
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
-            'unknown-245': '624c3620'}]
+            'unknown-245': '624c3620'}], ''
         url = 'http://{0}/metadata/reprovisiondata?api-version=2017-04-02'
         host = "169.254.169.254"
         full_url = url.format(host)

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -726,7 +726,7 @@ scbus-1 on xpt0 bus 0
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
             'unknown-245': '624c3620'}
-        m_dhcp.return_value = [lease], ''
+        m_dhcp.return_value = [lease]
         m_media_switch.return_value = None
 
         reprovision_ovfenv = construct_valid_ovf_env()
@@ -1985,7 +1985,7 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
-            'unknown-245': '624c3620'}], ''
+            'unknown-245': '624c3620'}]
         m_media_switch.return_value = None
         dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
         with mock.patch(MOCKPATH + 'REPORTED_READY_MARKER_FILE', report_file):
@@ -2019,7 +2019,7 @@ class TestAzureDataSourcePreprovisioning(CiTestCase):
         m_media_switch.return_value = None
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
-            'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0'}], ''
+            'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0'}]
         url = 'http://{0}/metadata/reprovisiondata?api-version=2017-04-02'
         host = "169.254.169.254"
         full_url = url.format(host)
@@ -2052,7 +2052,7 @@ class TestAzureDataSourcePreprovisioning(CiTestCase):
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
-            'unknown-245': '624c3620'}], ''
+            'unknown-245': '624c3620'}]
         url = 'http://{0}/metadata/reprovisiondata?api-version=2017-04-02'
         host = "169.254.169.254"
         full_url = url.format(host)

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -735,7 +735,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
-            'broadcast-address': '192.168.2.255'}], ''
+            'broadcast-address': '192.168.2.255'}]
         self.datasource = ec2.DataSourceEc2Local
         ds = self._setup_ds(
             platform_data=self.valid_platform_data,
@@ -744,7 +744,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
 
         ret = ds.get_data()
         self.assertTrue(ret)
-        m_dhcp.assert_called_once_with('eth9', capture=True)
+        m_dhcp.assert_called_once_with('eth9', None)
         m_net.assert_called_once_with(
             broadcast='192.168.2.255', interface='eth9', ip='192.168.2.9',
             prefix_or_mask='255.255.255.0', router='192.168.2.1',

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -735,7 +735,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
-            'broadcast-address': '192.168.2.255'}]
+            'broadcast-address': '192.168.2.255'}], ''
         self.datasource = ec2.DataSourceEc2Local
         ds = self._setup_ds(
             platform_data=self.valid_platform_data,
@@ -744,7 +744,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
 
         ret = ds.get_data()
         self.assertTrue(ret)
-        m_dhcp.assert_called_once_with('eth9')
+        m_dhcp.assert_called_once_with('eth9', capture=True)
         m_net.assert_called_once_with(
             broadcast='192.168.2.255', interface='eth9', ip='192.168.2.9',
             prefix_or_mask='255.255.255.0', router='192.168.2.1',

--- a/tests/unittests/test_datasource/test_openstack.py
+++ b/tests/unittests/test_datasource/test_openstack.py
@@ -261,7 +261,7 @@ class TestOpenStackDataSource(test_helpers.HttprettyTestCase):
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
-            'broadcast-address': '192.168.2.255'}]
+            'broadcast-address': '192.168.2.255'}], ''
 
         self.assertIsNone(ds_os_local.version)
         mock_path = MOCK_PATH + 'detect_openstack'
@@ -279,7 +279,7 @@ class TestOpenStackDataSource(test_helpers.HttprettyTestCase):
         self.assertEqual(2, len(ds_os_local.files))
         self.assertEqual(VENDOR_DATA, ds_os_local.vendordata_pure)
         self.assertIsNone(ds_os_local.vendordata_raw)
-        m_dhcp.assert_called_with('eth9')
+        m_dhcp.assert_called_with('eth9', capture=True)
 
     def test_bad_datasource_meta(self):
         os_files = copy.deepcopy(OS_FILES)

--- a/tests/unittests/test_datasource/test_openstack.py
+++ b/tests/unittests/test_datasource/test_openstack.py
@@ -261,7 +261,7 @@ class TestOpenStackDataSource(test_helpers.HttprettyTestCase):
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
             'routers': '192.168.2.1', 'subnet-mask': '255.255.255.0',
-            'broadcast-address': '192.168.2.255'}], ''
+            'broadcast-address': '192.168.2.255'}]
 
         self.assertIsNone(ds_os_local.version)
         mock_path = MOCK_PATH + 'detect_openstack'
@@ -279,7 +279,7 @@ class TestOpenStackDataSource(test_helpers.HttprettyTestCase):
         self.assertEqual(2, len(ds_os_local.files))
         self.assertEqual(VENDOR_DATA, ds_os_local.vendordata_pure)
         self.assertIsNone(ds_os_local.vendordata_raw)
-        m_dhcp.assert_called_with('eth9', capture=True)
+        m_dhcp.assert_called_with('eth9', None)
 
     def test_bad_datasource_meta(self):
         os_files = copy.deepcopy(OS_FILES)


### PR DESCRIPTION
Logging the error stream of the dhclient process is very handy when debugging the dhclient issues since it shows different DHCP signals. Here's a sample from the cloud-init.log of how this could look like:

```
2020-05-15 22:18:04,599 - dhcp.py[DEBUG]: dhclient error stream: Internet Systems Consortium DHCP Client 4.3.5
Copyright 2004-2016 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/eth0/00:0d:3a:6e:d4:52
Sending on   LPF/eth0/00:0d:3a:6e:d4:52
Sending on   Socket/fallback
DHCPDISCOVER on eth0 to 255.255.255.255 port 67 interval 3 (xid=0xc988334c)
DHCPREQUEST of 10.0.0.22 on eth0 to 255.255.255.255 port 67 (xid=0x4c3388c9)
DHCPOFFER of 10.0.0.22 from 168.63.129.16
DHCPACK of 10.0.0.22 from 168.63.129.16
bound to 10.0.0.22 -- renewal in 4294967295 seconds.
```