### PR TITLE
enable Puppet, Chef mcollective in default config

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -125,11 +125,9 @@ cloud_final_modules:
 {% if variant in ["ubuntu", "unknown"] %}
  - ubuntu-drivers
 {% endif %}
-{% if variant not in ["freebsd", "netbsd"] %}
  - puppet
  - chef
  - mcollective
-{% endif %}
  - salt-minion
  - rightscale_userdata
  - scripts-vendor


### PR DESCRIPTION
these config management things work on BSD, they also claim to work on all distros, so enabling them!

ref: https://bugs.launchpad.net/cloud-init/+bug/1880279