### PR TITLE
ds-identify: respect NoCloud fs_label setting

### DIFF
--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -677,6 +677,8 @@ dscheck_MAAS() {
 
 dscheck_NoCloud() {
     local fslabel="cidata CIDATA" d=""
+    local _RET='' _RET_fname=''
+    check_config fs_label && fslabel="$_RET"
     case " ${DI_KERNEL_CMDLINE} " in
         *\ ds=nocloud*) return ${DS_FOUND};;
     esac


### PR DESCRIPTION
This relies on the check_config() function to search for the fs_label value,
which is hackish but widely used within ds-identify.

https://bugs.launchpad.net/cloud-init/+bug/1880499