### PR TITLE
bddeb: apply the debian/patches before running read-dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
             - sudo apt-get build-dep -y cloud-init
             - sudo apt-get install -y --install-recommends sbuild ubuntu-dev-tools fakeroot tox
             # These are build deps but not pulled in by the build-dep call above
-            - sudo apt-get install -y --install-recommends dh-systemd python3-coverage python3-contextlib2
+            - sudo apt-get install -y --install-recommends dh-systemd python3-coverage python3-contextlib2 python3-pytest python3-pytest-cov
             - pip install .
             - pip install tox
             # bionic has lxd from deb installed, remove it first to ensure

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -81,15 +81,20 @@ def write_debian_folder(root, templ_data, is_python2, cloud_util_deps):
                              util.abs_join(deb_dir, 'changelog'),
                              params=templ_data)
 
+    util.subp(['dpkg-source', '--before-build', root])
+
     # Write out the control file template
     reqs_output = run_helper(
         'read-dependencies',
-        args=['--distro', 'debian', '--python-version', pyver])
+        ['--requirements-file', root + '/requirements.txt',
+         '--distro', 'debian', '--python-version', pyver])
     reqs = reqs_output.splitlines()
     test_reqs = run_helper(
         'read-dependencies',
-        ['--requirements-file', 'test-requirements.txt',
+        ['--requirements-file', root + '/test-requirements.txt',
          '--system-pkg-names', '--python-version', pyver]).splitlines()
+
+    util.subp(['dpkg-source', '--after-build', root])
 
     requires = ['cloud-utils | cloud-guest-utils'] if cloud_util_deps else []
     # We consolidate all deps as Build-Depends as our package build runs all


### PR DESCRIPTION
New dependencies can be added (or removed) by quilt patches in
debian/patches. By applying all the patches before calculating the
dependencies we take these changes into account.

LP: #1880569