### PR TITLE
Enable chef_license support for chef infra client

### DIFF
--- a/cloudinit/config/cc_chef.py
+++ b/cloudinit/config/cc_chef.py
@@ -50,6 +50,7 @@ file).
                            written to /etc/chef/client.rb)
 
     chef:
+      chef_license:
       client_key:
       encrypted_data_bag_secret:
       environment:
@@ -125,6 +126,7 @@ CHEF_RB_TPL_PATH_KEYS = frozenset([
     'file_cache_path',
     'pid_file',
     'encrypted_data_bag_secret',
+    'chef_license',
 ])
 CHEF_RB_TPL_KEYS = list(CHEF_RB_TPL_DEFAULTS.keys())
 CHEF_RB_TPL_KEYS.extend(CHEF_RB_TPL_BOOL_KEYS)

--- a/doc/examples/cloud-config-chef.txt
+++ b/doc/examples/cloud-config-chef.txt
@@ -52,6 +52,9 @@ apt:
 
 chef:
 
+  # Valid values are 'accept' and 'accept-no-persist'
+  chef_license: "accept"
+  
   # Valid values are 'gems' and 'packages' and 'omnibus'
   install_type: "packages"
 

--- a/templates/chef_client.rb.tmpl
+++ b/templates/chef_client.rb.tmpl
@@ -14,6 +14,9 @@ you need to add the following to config:
 The reason these are not in quotes is because they are ruby
 symbols that will be placed inside here, and not actual strings...
 #}
+{% if chef_license %}
+chef_license          "{{chef_license}}"
+{% endif%}
 {% if log_level %}
 log_level              {{log_level}}
 {% endif %}

--- a/tests/unittests/test_handler/test_handler_chef.py
+++ b/tests/unittests/test_handler/test_handler_chef.py
@@ -130,6 +130,7 @@ class TestChef(FilesystemMockingTestCase):
 
         # This should create a file of the format...
         # Created by cloud-init v. 0.7.6 on Sat, 11 Oct 2014 23:57:21 +0000
+        chef_license           "accept"
         log_level              :info
         ssl_verify_mode        :verify_none
         log_location           "/var/log/chef/client.log"
@@ -153,6 +154,7 @@ class TestChef(FilesystemMockingTestCase):
         util.write_file('/etc/cloud/templates/chef_client.rb.tmpl', tpl_file)
         cfg = {
             'chef': {
+                'chef_license': "accept",
                 'server_url': 'localhost',
                 'validation_name': 'bob',
                 'validation_key': "/etc/chef/vkey.pem",


### PR DESCRIPTION
**Enable chef_license support for chef infra client**

Latest versions of chef products needs us to accept the EULA license agreements.
Without accepting license cloud-init's chef module could not run chef-client.

This update enables cloud-init's chef  module to add chef_license setting in client.rb

LP: #1879403