### PR TITLE
testing: use flake8 again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,6 @@ matrix:
               PYTEST_ADDOPTS=-v  # List all tests run by pytest
           dist: xenial
         - python: 3.6
-          env: TOXENV=pycodestyle
-        - python: 3.6
-          env: TOXENV=pyflakes
+          env: TOXENV=flake8
         - python: 3.6
           env: TOXENV=pylint

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3, xenial-dev, pycodestyle, pyflakes, pylint
+envlist = py3, xenial-dev, flake8, pylint
 recreate = True
 
 [testenv]
@@ -9,11 +9,11 @@ setenv =
 passenv=
     PYTEST_ADDOPTS
 
-[testenv:pycodestyle]
+[testenv:flake8]
 basepython = python3
 deps =
-    pycodestyle==2.4.0
-commands = {envpython} -m pycodestyle {posargs:cloudinit/ tests/ tools/}
+    flake8==3.8.2
+commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/}
 
 # https://github.com/gabrielfalcao/HTTPretty/issues/223
 setenv =
@@ -43,8 +43,16 @@ basepython = python2.7
 deps = -r{toxinidir}/test-requirements.txt
 
 [flake8]
-#H102  Apache 2.0 license header not found
-ignore=H404,H405,H105,H301,H104,H403,H101,H102,H106,H304
+# E121: continuation line under-indented for hanging indent
+# E123: closing bracket does not match indentation of opening bracket’s line
+# E126: continuation line over-indented for hanging indent
+# E226: missing whitespace around arithmetic operator
+# E241: multiple spaces after ‘,’
+# E402: module level import not at top of file
+# E741: do not use variables named ‘l’, ‘O’, or ‘I’
+# W503: line break before binary operator
+# W504: line break after binary operator
+ignore=E121,E123,E126,E226,E241,E402,E741,W503,W504
 exclude = .venv,.tox,dist,doc,*egg,.git,build,tools
 
 [testenv:doc]
@@ -109,18 +117,9 @@ deps =
     jsonpatch==1.16
     pytest==3.0.7
 
-[testenv:tip-pycodestyle]
-commands = {envpython} -m pycodestyle {posargs:cloudinit/ tests/ tools/}
-deps = pycodestyle
-
-[testenv:pyflakes]
-commands = {envpython} -m pyflakes {posargs:cloudinit/ tests/ tools/}
-deps =
-    pyflakes==2.1.1
-
-[testenv:tip-pyflakes]
-commands = {envpython} -m pyflakes {posargs:cloudinit/ tests/ tools/}
-deps = pyflakes
+[testenv:tip-flake8]
+commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/}
+deps = flake8
 
 [testenv:tip-pylint]
 commands = {envpython} -m pylint {posargs:cloudinit tests tools}


### PR DESCRIPTION
Instead of running pycodestyle and pyflakes seperately, use flake8 to
get the benefits of pyflakes and also stylistic checks as well as the
ability to configure the settings for the project.