### PR TITLE
Document CloudStack data-server well-known hostname

### DIFF
--- a/doc/rtd/topics/datasources/cloudstack.rst
+++ b/doc/rtd/topics/datasources/cloudstack.rst
@@ -9,14 +9,19 @@ dhcp lease information given to the instance.
 For more details on meta-data and user-data,
 refer the `CloudStack Administrator Guide`_.
 
-URLs to access user-data and meta-data from the Virtual Machine. Here 10.1.1.1
-is the Virtual Router IP:
+URLs to access user-data and meta-data from the Virtual Machine.
+`data-server.` is a well-known hostname provided by the CloudStack virtual
+router that points to the next UserData server (which is usually also
+the virtual router).
 
 .. code:: bash
 
-    http://10.1.1.1/latest/user-data
-    http://10.1.1.1/latest/meta-data
-    http://10.1.1.1/latest/meta-data/{metadata type}
+    http://data-server./latest/user-data
+    http://data-server./latest/meta-data
+    http://data-server./latest/meta-data/{metadata type}
+
+If `data-server.` cannot be resolved, cloud-init will try to obtain the
+virtual router's address from the system's DHCP leases.
 
 Configuration
 -------------

--- a/doc/rtd/topics/datasources/cloudstack.rst
+++ b/doc/rtd/topics/datasources/cloudstack.rst
@@ -21,7 +21,8 @@ the virtual router).
     http://data-server./latest/meta-data/{metadata type}
 
 If `data-server.` cannot be resolved, cloud-init will try to obtain the
-virtual router's address from the system's DHCP leases.
+virtual router's address from the system's DHCP leases. If that fails,
+it will use the system's default gateway.
 
 Configuration
 -------------

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -7,3 +7,4 @@ nishigori
 smoser
 tomponline
 TheRealFalcon
+onitake

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -4,7 +4,7 @@ dhensby
 lucasmoura
 matthewruffell
 nishigori
+onitake
 smoser
 tomponline
 TheRealFalcon
-onitake


### PR DESCRIPTION
Since 19.4, cloud-init supports a more reliable approach to obtain the CloudStack user-data server address than DHCP: Via the well-known `data-server.` hostname.

I think this deserves to be documented.

Commit when the feature was added: 9662a8791e53bac40a3a37aa3f5bee3076f7d447

I also submitted a documentation PR to the CloudStack project, so they are in line: https://github.com/apache/cloudstack-documentation/pull/132