### PR TITLE
tests: add groovy integration tests for ubuntu

### DIFF
--- a/tests/cloud_tests/releases.yaml
+++ b/tests/cloud_tests/releases.yaml
@@ -133,6 +133,22 @@ features:
 
 releases:
     # UBUNTU =================================================================
+    groovy:
+        # EOL: Jul 2021
+        default:
+            enabled: true
+            release: groovy
+            version: "20.10"
+            os: ubuntu
+            feature_groups:
+                - base
+                - debian_base
+                - ubuntu_specific
+        lxd:
+            sstreams_server: https://cloud-images.ubuntu.com/daily
+            alias: groovy
+            setup_overrides: null
+            override_templates: false
     focal:
         # EOL: Apr 2025
         default:


### PR DESCRIPTION
now that we've turned on jenkins CI for cloud-init. let's add the groovy release so we can test it.

without this fix our jenkins runner will see:
```
cloud_tests run: error: argument -n/--os-name: invalid choice: 'groovy' (choose from 'artful', 'bionic', 'centos66', 'centos70', 'cosmic', 'disco', 'eoan', 'focal', 'jessie', 'stretch', 'trusty', 'xenial')
ERROR: InvocationError: '/var/lib/jenkins/servers/server/workspace/cloud-init-integration-ec2-g/cloud-init/.tox/citest/bin/python -m tests.cloud_tests run --os-name=groovy --platform=ec2 --preserve-data --data-dir=results --verbose --deb=/var/lib/jenkins/servers/server/workspace/cloud-init-integration-ec2-g/cloud-init_20.2-2462-g0919bd4-0ubuntu1+1837~trunk~ubuntu20.10.1_all.deb'
```

Failure case here: https://jenkins.ubuntu.com/server/view/cloud-init,%20curtin,%20streams/job/cloud-init-integration-ec2-g/1/console