### PR TITLE
test: fix all flake8 E741 errors

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -582,7 +582,7 @@ class Distro(metaclass=abc.ABCMeta):
         # passwd must use short '-l' due to SLES11 lacking long form '--lock'
         lock_tools = (['passwd', '-l', name], ['usermod', '--lock', name])
         try:
-            cmd = next(l for l in lock_tools if util.which(l[0]))
+            cmd = next(tool for tool in lock_tools if util.which(tool[0]))
         except StopIteration:
             raise RuntimeError((
                 "Unable to lock user account '%s'. No tools available. "

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -824,13 +824,13 @@ def get_interfaces_by_mac_on_freebsd():
     # flatten each interface block in a single line
     def flatten(out):
         curr_block = ''
-        for l in out.split('\n'):
-            if l.startswith('\t'):
-                curr_block += l
+        for line in out.split('\n'):
+            if line.startswith('\t'):
+                curr_block += line
             else:
                 if curr_block:
                     yield curr_block
-                curr_block = l
+                curr_block = line
         yield curr_block
 
     # looks for interface and mac in a list of flatten block

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -417,9 +417,9 @@ def read_context_disk_dir(source_dir, asuser=None):
 
     if ssh_key_var:
         lines = context.get(ssh_key_var).splitlines()
-        results['metadata']['public-keys'] = [l for l in lines
-                                              if len(l) and not
-                                              l.startswith("#")]
+        results['metadata']['public-keys'] = [
+            line for line in lines if len(line) and not line.startswith("#")
+        ]
 
     # custom hostname -- try hostname or leave cloud-init
     # itself create hostname from IP address later

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -411,8 +411,11 @@ class ConfigDriveReader(BaseReader):
         keydata = meta_js.get('public-keys', keydata)
         if keydata:
             lines = keydata.splitlines()
-            md['public-keys'] = [l for l in lines
-                                 if len(l) and not l.startswith("#")]
+            md['public-keys'] = [
+                line
+                for line in lines
+                if len(line) and not line.startswith("#")
+            ]
 
         # config-drive-v1 has no way for openstack to provide the instance-id
         # so we copy that into metadata from the user input
@@ -674,11 +677,13 @@ def convert_net_json(network_json=None, known_macs=None):
                 raise ValueError("Unable to find a system nic for %s" % d)
             d['name'] = known_macs[mac]
 
-        for cfg, key, fmt, target in link_updates:
-            if isinstance(target, (list, tuple)):
-                cfg[key] = [fmt % link_id_info[l]['name'] for l in target]
+        for cfg, key, fmt, targets in link_updates:
+            if isinstance(targets, (list, tuple)):
+                cfg[key] = [
+                    fmt % link_id_info[target]['name'] for target in targets
+                ]
             else:
-                cfg[key] = fmt % link_id_info[target]['name']
+                cfg[key] = fmt % link_id_info[targets]['name']
 
     # Infiniband interfaces may be referenced in network_data.json by a 6 byte
     # Ethernet MAC-style address, and we use that address to look up the

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -344,7 +344,9 @@ def update_ssh_config(updates, fname=DEF_SSHD_CFG):
     changed = update_ssh_config_lines(lines=lines, updates=updates)
     if changed:
         util.write_file(
-            fname, "\n".join([str(l) for l in lines]) + "\n", copy_mode=True)
+            fname, "\n".join(
+                [str(line) for line in lines]
+            ) + "\n", copy_mode=True)
     return len(changed) != 0
 
 

--- a/tests/cloud_tests/platforms/instances.py
+++ b/tests/cloud_tests/platforms/instances.py
@@ -132,8 +132,8 @@ class Instance(TargetBase):
         """
         def clean_test(test):
             """Clean formatting for system ready test testcase."""
-            return ' '.join(l for l in test.strip().splitlines()
-                            if not l.lstrip().startswith('#'))
+            return ' '.join(line for line in test.strip().splitlines()
+                            if not line.lstrip().startswith('#'))
 
         boot_timeout = self.config['boot_timeout']
         tests = [self.config['system_ready_script']]

--- a/tests/cloud_tests/testcases/base.py
+++ b/tests/cloud_tests/testcases/base.py
@@ -141,8 +141,8 @@ class CloudTestCase(unittest.TestCase):
     def test_no_warnings_in_log(self):
         """Unexpected warnings should not be found in the log."""
         warnings = [
-            l for l in self.get_data_file('cloud-init.log').splitlines()
-            if 'WARN' in l]
+            line for line in self.get_data_file('cloud-init.log').splitlines()
+            if 'WARN' in line]
         joined_warnings = '\n'.join(warnings)
         for expected_warning in self.expected_warnings:
             self.assertIn(

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -612,7 +612,9 @@ class TestEc2(test_helpers.HttprettyTestCase):
         for log in expected_logs:
             self.assertIn(log, logs)
         self.assertEqual(
-            1, len([l for l in logs.splitlines() if failed_put_log in l]))
+            1,
+            len([line for line in logs.splitlines() if failed_put_log in line])
+        )
 
     def test_aws_token_redacted(self):
         """Verify that aws tokens are redacted when logged."""

--- a/tests/unittests/test_datasource/test_ovf.py
+++ b/tests/unittests/test_datasource/test_ovf.py
@@ -48,7 +48,7 @@ def fill_properties(props, template=OVF_ENV_CONTENT):
     for key, val in props.items():
         lines.append(prop_tmpl.format(key=key, val=val))
     indent = "        "
-    properties = ''.join([indent + l + "\n" for l in lines])
+    properties = ''.join([indent + line + "\n" for line in lines])
     return template.format(properties=properties)
 
 

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -611,8 +611,10 @@ class TestDsIdentify(DsIdentifyBase):
         ret = self._check_via_dict(
             cust, RC_FOUND,
             func=".", args=[os.path.join(rootd, mpp)], rootd=rootd)
-        line = [l for l in ret.stdout.splitlines() if l.startswith(pre)][0]
-        toks = line.replace(pre, "").split(":")
+        match = [
+            line for line in ret.stdout.splitlines() if line.startswith(pre)
+        ][0]
+        toks = match.replace(pre, "").split(":")
         expected = ["/sbin", "/bin", "/usr/sbin", "/usr/bin", "/mycust/path"]
         self.assertEqual(expected, [p for p in expected if p in toks],
                          "path did not have expected tokens")

--- a/tests/unittests/test_handler/test_handler_apt_source_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v3.py
@@ -1033,7 +1033,9 @@ class TestDebconfSelections(TestCase):
         # assumes called with *args value.
         selections = m_set_sel.call_args_list[0][0][0].decode()
 
-        missing = [l for l in lines if l not in selections.splitlines()]
+        missing = [
+            line for line in lines if line not in selections.splitlines()
+        ]
         self.assertEqual([], missing)
 
     @mock.patch("cloudinit.config.cc_apt_configure.dpkg_reconfigure")

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -299,7 +299,7 @@ class TestUpdateSshConfigLines(test_helpers.CiTestCase):
         lines = ssh_util.parse_ssh_config_lines(list(self.exlines))
         result = ssh_util.update_ssh_config_lines(lines, updates)
         self.assertEqual([], result)
-        self.assertEqual(self.exlines, [str(l) for l in lines])
+        self.assertEqual(self.exlines, [str(line) for line in lines])
 
     def test_keycase_not_modified(self):
         """Original case of key should not be changed on update.

--- a/tox.ini
+++ b/tox.ini
@@ -49,10 +49,9 @@ deps = -r{toxinidir}/test-requirements.txt
 # E226: missing whitespace around arithmetic operator
 # E241: multiple spaces after ‘,’
 # E402: module level import not at top of file
-# E741: do not use variables named ‘l’, ‘O’, or ‘I’
 # W503: line break before binary operator
 # W504: line break after binary operator
-ignore=E121,E123,E126,E226,E241,E402,E741,W503,W504
+ignore=E121,E123,E126,E226,E241,E402,W503,W504
 exclude = .venv,.tox,dist,doc,*egg,.git,build,tools
 
 [testenv:doc]


### PR DESCRIPTION
This removes the use of variables named ‘l’, ‘O’, or ‘I’. Generally
these are used in list comprehension to read the line of lines.