### PR TITLE
test: ignore flake8 E402 errors in cmd/main.py

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,12 +48,13 @@ deps = -r{toxinidir}/test-requirements.txt
 # E126: continuation line over-indented for hanging indent
 # E226: missing whitespace around arithmetic operator
 # E241: multiple spaces after ‘,’
-# E402: module level import not at top of file
 # E741: do not use variables named ‘l’, ‘O’, or ‘I’
 # W503: line break before binary operator
 # W504: line break after binary operator
-ignore=E121,E123,E126,E226,E241,E402,E741,W503,W504
+ignore=E121,E123,E126,E226,E241,E741,W503,W504
 exclude = .venv,.tox,dist,doc,*egg,.git,build,tools
+per-file-ignores =
+    cloudinit/cmd/main.py:E402
 
 [testenv:doc]
 basepython = python3


### PR DESCRIPTION
This puts an ignore on the imports not at the top of the file errors
for the cmd/main.py file. The reason for the ignore instead of fix
is that the file is using imp to grab a lock and patch logging
before further imports are completed.