### PR TITLE
Fix the ProcessExecutionError issue during running "vmware-toolbox-cmd config get deployPkg enable-custom-scripts"

### DIFF
--- a/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
@@ -133,23 +133,30 @@ def get_tools_config(section, key, defaultVal):
             'vmware-toolbox-cmd not installed, returning default value')
         return defaultVal
 
-    retValue = defaultVal
     cmd = ['vmware-toolbox-cmd', 'config', 'get', section, key]
 
     try:
         (outText, _) = util.subp(cmd)
-        m = re.match(r'([^=]+)=(.*)', outText)
-        if m:
-            retValue = m.group(2).strip()
-            logger.debug("Get tools config: [%s] %s = %s",
-                         section, key, retValue)
-        else:
-            logger.debug(
-                "Tools config: [%s] %s is not found, return default value: %s",
-                section, key, retValue)
     except util.ProcessExecutionError as e:
-        logger.error("Failed running %s[%s]", cmd, e.exit_code)
-        logger.exception(e)
+        if e.exit_code == 69:
+            logger.debug(
+                "vmware-toolbox-cmd returned 69 (unavailable) for cmd: %s."
+                " Return default value: %s", " ".join(cmd), defaultVal)
+        else:
+            logger.error("Failed running %s[%s]", cmd, e.exit_code)
+            logger.exception(e)
+        return defaultVal
+
+    retValue = defaultVal
+    m = re.match(r'([^=]+)=(.*)', outText)
+    if m:
+        retValue = m.group(2).strip()
+        logger.debug("Get tools config: [%s] %s = %s",
+                     section, key, retValue)
+    else:
+        logger.debug(
+            "Tools config: [%s] %s is not found, return default value: %s",
+            section, key, retValue)
 
     return retValue
 


### PR DESCRIPTION
During guest os customization based on cloud-init on Photon, in the cloud-init.log found the ProcessExecutionError raised. The reason is that for the default setting on photon, there is no /etc/vmware-tools/tools.conf. When tools.cfg does not exist, running cmd : "vmware-toolbox-cmd config get deployPkg enable-custom-scripts", the return code will be EX_UNAVAILABLE(69)
cloud-init only take 0 is the normal action, so raise a ProcessExecutionError, to fix this add 69 to the rcs.

Details of the log when the issue happened:
2020-05-08 04:07:51,689 - util.py[DEBUG]: Running command ['vmware-toolbox-cmd', 'config', 'get', 'deployPkg', 'enable-custom-scripts'] with allowed return codes [0] (shell=False, capture=True)
2020-05-08 04:07:51,725 - guestcust_util.py[ERROR]: Failed running ['vmware-toolbox-cmd', 'config', 'get', 'deployPkg', 'enable-custom-scripts'][69]
2020-05-08 04:07:51,725 - guestcust_util.py[ERROR]: Unexpected error while running command.
Command: ['vmware-toolbox-cmd', 'config', 'get', 'deployPkg', 'enable-custom-scripts']
Exit code: 69
Reason: -
Stdout: [deployPkg] enable-custom-scripts UNSET
Stderr: 
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/cloudinit/sources/helpers/vmware/imc/guestcust_util.py", line 140, in get_tools_config
    (outText, _) = util.subp(cmd)
  File "/usr/lib/python3.7/site-packages/cloudinit/util.py", line 2069, in subp
    cmd=args)
cloudinit.util.ProcessExecutionError: Unexpected error while running command.
Command: ['vmware-toolbox-cmd', 'config', 'get', 'deployPkg', 'enable-custom-scripts']
Exit code: 69
Reason: -
Stdout: [deployPkg] enable-custom-scripts UNSET
Stderr: 

Tested the fix on the Photon which the tools.cfg does not exist by default.
The cloud-init.log showed:
Tested on photon. when the tools.conf does not exist, it will show
"2020-06-08 11:15:31,577 - util.py[DEBUG]: Running command ['vmware-toolbox-cmd', 'config', 'get', 'deployPkg', 'enable-custom-scripts'] with allowed return codes [0] (shell=False, capture=True)
2020-06-08 11:15:31,593 - guestcust_util.py[DEBUG]: vmware-toolbox-cmd returned 69 (unavailable) for cmd: vmware-toolbox-cmd config get deployPkg enable-custom-scripts. Return default value: false" 