### PR TITLE
Fixes KeyError for bridge with no "parameters:" setting

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -722,10 +722,10 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
             item_params = dict((key, value) for (key, value) in
                                item_cfg.items() if key not in
                                NETWORK_V2_KEY_FILTER)
-            # we accept the fixed spelling, but write the old for compatability
+            # we accept the fixed spelling, but write the old for compatibility
             # Xenial does not have an updated netplan which supports the
             # correct spelling.  LP: #1756701
-            params = item_params['parameters']
+            params = item_params.get('parameters', {})
             grat_value = params.pop('gratuitous-arp', None)
             if grat_value:
                 params['gratuitious-arp'] = grat_value
@@ -734,8 +734,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
                 'type': cmd_type,
                 'name': item_name,
                 cmd_type + '_interfaces': item_cfg.get('interfaces'),
-                'params': dict((v2key_to_v1[k], v) for k, v in
-                               item_params.get('parameters', {}).items())
+                'params': dict((v2key_to_v1[k], v) for k, v in params.items())
             }
             if 'mtu' in item_cfg:
                 v1_cmd['mtu'] = item_cfg['mtu']

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -426,6 +426,11 @@ network:
             mtu: 9000
             parameters:
                 gratuitous-arp: 2
+        bond2:
+            interfaces:
+            - ens5
+            macaddress: 68:05:ca:64:d3:6e
+            mtu: 9000
     ethernets:
         ens3:
             dhcp4: false
@@ -437,6 +442,11 @@ network:
             dhcp6: false
             match:
                 macaddress: 52:54:00:11:22:ff
+        ens5:
+            dhcp4: false
+            dhcp6: false
+            match:
+                macaddress: 52:54:00:99:11:99
     version: 2
 """
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -1,5 +1,6 @@
 beezly
 bipinbachhao
+candlerb
 dhensby
 lucasmoura
 matthewruffell


### PR DESCRIPTION
LP #1879673

Reason: commit ded1ec81 introduced a regression whereby a bridge with no "parameters:" setting caused a KeyError exception.
