### PR TITLE
VMware: Support parsing FORCE-RUN-POST-CUST-SCRIPT

### DIFF
--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -152,14 +152,18 @@ class DataSourceOVF(sources.DataSource):
                     product_marker, os.path.join(self.paths.cloud_dir, 'data'))
                 special_customization = product_marker and not hasmarkerfile
                 customscript = self._vmware_cust_conf.custom_script_name
-                custScriptConfig = get_tools_config(
-                    CONFGROUPNAME_GUESTCUSTOMIZATION,
-                    GUESTCUSTOMIZATION_ENABLE_CUST_SCRIPTS,
-                    "false")
-                if custScriptConfig.lower() != "true":
-                    # Update the customization status if there is a
-                    # custom script is disabled
-                    if special_customization and customscript:
+
+                # In case there is a custom script, check whether VMware
+                # Tools configuration allow the custom script to run.
+                if (special_customization and customscript and
+                        not self._vmware_cust_conf.force_run_post_script):
+                    custScriptConfig = get_tools_config(
+                        CONFGROUPNAME_GUESTCUSTOMIZATION,
+                        GUESTCUSTOMIZATION_ENABLE_CUST_SCRIPTS,
+                        "false")
+                    if custScriptConfig.lower() != "true":
+                        # Update the customization status if custom script is
+                        # disabled
                         msg = "Custom script is disabled by VM Administrator"
                         LOG.debug(msg)
                         set_customization_status(

--- a/cloudinit/sources/helpers/vmware/imc/config.py
+++ b/cloudinit/sources/helpers/vmware/imc/config.py
@@ -26,6 +26,7 @@ class Config(object):
     TIMEZONE = 'DATETIME|TIMEZONE'
     UTC = 'DATETIME|UTC'
     POST_GC_STATUS = 'MISC|POST-GC-STATUS'
+    FORCE_RUN_POST_SCRIPT = 'MISC|FORCE-RUN-POST-CUST-SCRIPT'
 
     def __init__(self, configFile):
         self._configFile = configFile
@@ -114,5 +115,18 @@ class Config(object):
         if postGcStatus not in ('yes', 'no'):
             raise ValueError('PostGcStatus value should be yes/no')
         return postGcStatus == 'yes'
+
+    @property
+    def force_run_post_script(self):
+        """
+        Return whether to run post custom script
+        despite of VMware Tools configuration
+        """
+        forceRunPostScript = self._configFile.get(Config.FORCE_RUN_POST_SCRIPT,
+                                                  'no')
+        forceRunPostScript = forceRunPostScript.lower()
+        if forceRunPostScript not in ('yes', 'no'):
+            raise ValueError('forceRunPostScript value should be yes/no')
+        return forceRunPostScript == 'yes'
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_datasource/test_ovf.py
+++ b/tests/unittests/test_datasource/test_ovf.py
@@ -220,6 +220,47 @@ class TestDatasourceOVF(CiTestCase):
         self.assertIn('Custom script is disabled by VM Administrator',
                       str(context.exception))
 
+    def test_get_data_force_run_post_script_is_yes(self):
+        """If FORCE-RUN-POST-CUST-SCRIPT is yes, custom script could run even
+        if custom script is disabled by VMware tools configuration
+        """
+        paths = Paths({'cloud_dir': self.tdir})
+        ds = self.datasource(
+            sys_cfg={'disable_vmware_customization': False}, distro={},
+            paths=paths)
+        # Prepare the conf file
+        conf_file = self.tmp_path('test-cust', self.tdir)
+        # set FORCE-RUN-POST-CUST-SCRIPT = yes so that custom script can run
+        # despite of the VMware Tools configuration
+        conf_content = dedent("""\
+            [CUSTOM-SCRIPT]
+            SCRIPT-NAME = test-script
+            [MISC]
+            MARKER-ID = 12345346
+            FORCE-RUN-POST-CUST-SCRIPT = yes
+            """)
+        util.write_file(conf_file, conf_content)
+
+        # Mock custom script is disabled by VMware Tools by
+        # return false when calling get_tools_config
+        with mock.patch(MPATH + 'get_tools_config', return_value='false'):
+            with mock.patch(MPATH + 'set_customization_status',
+                            return_value=('msg', b'')):
+                with self.assertRaises(CustomScriptNotFound) as context:
+                    wrap_and_call(
+                        'cloudinit.sources.DataSourceOVF',
+                        {'util.read_dmi_data': 'vmware',
+                         'util.del_dir': True,
+                         'search_file': self.tdir,
+                         'wait_for_imc_cfg_file': conf_file,
+                         'get_nics_to_enable': ''},
+                        ds.get_data)
+        # Verify custom script still runs although it is
+        # disabled by VMware Tools
+        customscript = self.tmp_path('test-script', self.tdir)
+        self.assertIn('Script %s not found!!' % customscript,
+                      str(context.exception))
+
     def test_get_data_non_vmware_seed_platform_info(self):
         """Platform info properly reports when on non-vmware platforms."""
         paths = Paths({'cloud_dir': self.tdir, 'run_dir': self.tdir})

--- a/tests/unittests/test_vmware_config_file.py
+++ b/tests/unittests/test_vmware_config_file.py
@@ -356,6 +356,20 @@ class TestVmwareConfigFile(CiTestCase):
         conf = Config(cf)
         self.assertTrue(conf.post_gc_status)
 
+    def test_no_force_run_post_script(self):
+        cf = ConfigFile("tests/data/vmware/cust-dhcp-2nic.cfg")
+        conf = Config(cf)
+        self.assertFalse(conf.force_run_post_script)
+        cf._insertKey("MISC|FORCE-RUN-POST-CUST-SCRIPT", "NO")
+        conf = Config(cf)
+        self.assertFalse(conf.force_run_post_script)
+
+    def test_yes_force_run_post_script(self):
+        cf = ConfigFile("tests/data/vmware/cust-dhcp-2nic.cfg")
+        cf._insertKey("MISC|FORCE-RUN-POST-CUST-SCRIPT", "yes")
+        conf = Config(cf)
+        self.assertTrue(conf.force_run_post_script)
+
 
 class TestVmwareNetConfig(CiTestCase):
     """Test conversion of vmware config to cloud-init config."""


### PR DESCRIPTION
vCloud product wants to run custom script despite of VMware Tools configuration, so we introduce a new flag FORCE-RUN-POST-CUST-SCRIPT. If it is yes, custom script run no matter enable-custom-scripts is true or false.