### PR TITLE
Default to UTF-8 in /var/log/cloud-init.log

### DIFF
--- a/config/cloud.cfg.d/05_logging.cfg
+++ b/config/cloud.cfg.d/05_logging.cfg
@@ -44,7 +44,7 @@ _log:
    class=FileHandler
    level=DEBUG
    formatter=arg0Formatter
-   args=('/var/log/cloud-init.log',)
+   args=('/var/log/cloud-init.log', 'a', 'UTF-8')
  - &log_syslog |
    [handler_cloudLogHandler]
    class=handlers.SysLogHandler


### PR DESCRIPTION
On a system with a non-utf8 default locale, the logger will silently not log anything if the message contains an unsupported character.

Specifically on Xenial, in the cloud-init process
```
import locale
print(locale.getpreferredencoding())
```
returns `ANSI_X3.4-1968`. 

Interesting to note, running the same code on the CLI after cloud-init has completed returns `UTF-8`.

The StreamLogger (i.e., the stdout/stderr logger) suffers from the same problem, but there's no (non-hacky) way to alter its encoding.