### PR TITLE
.travis.yml: use $TRAVIS_BUILD_DIR for lxd_image caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ matrix:
                   # This might be <hash>.rootfs or <hash>, normalise
                   latest_file="$(basename $latest_file .rootfs)"
                   # Find all files with that prefix and copy them to our cache dir
-                  sudo find /var/snap/lxd/common/lxd/images/ -name $latest_file* -print -exec cp {} lxd_images/ \;
+                  sudo find /var/snap/lxd/common/lxd/images/ -name $latest_file* -print -exec cp {} "$TRAVIS_BUILD_DIR/lxd_images/" \;
               - |
                   # If a schroot exists (i.e. we didn't fail before its
                   # creation), tar it up (to preserve ownership/permissions)
@@ -77,7 +77,7 @@ matrix:
             - sudo lxd init --auto
             - sudo mkdir --mode=1777 -p /var/snap/lxd/common/consoles
             # Move any cached lxd images into lxd's image dir
-            - sudo find lxd_images/ -type f -print -exec mv {} /var/snap/lxd/common/lxd/images/ \;
+            - sudo find "$TRAVIS_BUILD_DIR/lxd_images/" -type f -print -exec mv {} /var/snap/lxd/common/lxd/images/ \;
             - sudo usermod -a -G lxd $USER
             - sudo sbuild-adduser $USER
             - cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc


### PR DESCRIPTION
This makes us more robust, as our caching won't start breaking if other
parts of the Travis build change directory for us.