### PR TITLE
util: rename write_file's copy_mode parameter to preserve_mode

### DIFF
--- a/cloudinit/atomic_helper.py
+++ b/cloudinit/atomic_helper.py
@@ -11,10 +11,10 @@ LOG = logging.getLogger(__name__)
 
 
 def write_file(filename, content, mode=_DEF_PERMS,
-               omode="wb", copy_mode=False):
+               omode="wb", preserve_mode=False):
     # open filename in mode 'omode', write content, set permissions to 'mode'
 
-    if copy_mode:
+    if preserve_mode:
         try:
             file_stat = os.stat(filename)
             mode = stat.S_IMODE(file_stat.st_mode)

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -346,7 +346,7 @@ def update_ssh_config(updates, fname=DEF_SSHD_CFG):
         util.write_file(
             fname, "\n".join(
                 [str(line) for line in lines]
-            ) + "\n", copy_mode=True)
+            ) + "\n", preserve_mode=True)
     return len(changed) != 0
 
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1800,7 +1800,7 @@ def chmod(path, mode):
             os.chmod(path, real_mode)
 
 
-def write_file(filename, content, mode=0o644, omode="wb", copy_mode=False):
+def write_file(filename, content, mode=0o644, omode="wb", preserve_mode=False):
     """
     Writes a file with the given content and sets the file mode as specified.
     Restores the SELinux context if possible.
@@ -1809,9 +1809,11 @@ def write_file(filename, content, mode=0o644, omode="wb", copy_mode=False):
     @param content: The content to write to the file.
     @param mode: The filesystem mode to set on the file.
     @param omode: The open mode used when opening the file (w, wb, a, etc.)
+    @param preserve_mode: If True and `filename` exists, preserve `filename`s
+                          current mode instead of applying `mode`.
     """
 
-    if copy_mode:
+    if preserve_mode:
         try:
             file_stat = os.stat(filename)
             mode = stat.S_IMODE(file_stat.st_mode)

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -110,29 +110,29 @@ class TestWriteFile(helpers.TestCase):
         file_stat = os.stat(path)
         self.assertEqual(0o666, stat.S_IMODE(file_stat.st_mode))
 
-    def test_copy_mode_no_existing(self):
-        """Verify that file is created with mode 0o644 if copy_mode
+    def test_preserve_mode_no_existing(self):
+        """Verify that file is created with mode 0o644 if preserve_mode
         is true and there is no prior existing file."""
         path = os.path.join(self.tmp, "NewFile.txt")
         contents = "Hey there"
 
-        util.write_file(path, contents, copy_mode=True)
+        util.write_file(path, contents, preserve_mode=True)
 
         self.assertTrue(os.path.exists(path))
         self.assertTrue(os.path.isfile(path))
         file_stat = os.stat(path)
         self.assertEqual(0o644, stat.S_IMODE(file_stat.st_mode))
 
-    def test_copy_mode_with_existing(self):
+    def test_preserve_mode_with_existing(self):
         """Verify that file is created using mode of existing file
-        if copy_mode is true."""
+        if preserve_mode is true."""
         path = os.path.join(self.tmp, "NewFile.txt")
         contents = "Hey there"
 
         open(path, 'w').close()
         os.chmod(path, 0o666)
 
-        util.write_file(path, contents, copy_mode=True)
+        util.write_file(path, contents, preserve_mode=True)
 
         self.assertTrue(os.path.exists(path))
         self.assertTrue(os.path.isfile(path))


### PR DESCRIPTION
When updating the docstring to include it, I realised that the current
name is somewhat misleading; this makes it a little easier to
understand, I think.