### PR TITLE
.travis.yml: only store new schroot if something has changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,14 +53,6 @@ matrix:
                   latest_file="$(basename $latest_file .rootfs)"
                   # Find all files with that prefix and copy them to our cache dir
                   sudo find /var/snap/lxd/common/lxd/images/ -name $latest_file* -print -exec cp {} "$TRAVIS_BUILD_DIR/lxd_images/" \;
-              - |
-                  # If a schroot exists (i.e. we didn't fail before its
-                  # creation), tar it up (to preserve ownership/permissions)
-                  # and move it into the cached dir; no need to compress it
-                  # because Travis will do that anyway
-                  if [ -e /var/lib/schroot/chroots/xenial-amd64 ]; then
-                    sudo tar --sparse --xattrs --xattrs-include=* -cf "$TRAVIS_BUILD_DIR/chroots/xenial-amd64.tar" -C /var/lib/schroot/chroots/xenial-amd64 .
-                  fi
           install:
             - git fetch --unshallow
             - sudo apt-get build-dep -y cloud-init
@@ -85,6 +77,7 @@ matrix:
             # Ubuntu LTS: Build
             - ./packages/bddeb -S
             - |
+                needs_caching=false
                 if [ -e "$TRAVIS_BUILD_DIR/chroots/xenial-amd64.tar" ]; then
                     # If we have a cached chroot, move it into place
                     sudo mkdir -p /var/lib/schroot/chroots/xenial-amd64
@@ -106,16 +99,24 @@ matrix:
                 EOM
                     sudo mv sbuild-xenial-amd64 /etc/schroot/chroot.d/
                     sudo chown root /etc/schroot/chroot.d/sbuild-xenial-amd64
-                    # And ensure it's up-to-date.  (TODO: At the moment, even
-                    # if there were no upgrades applied, because we tar up the
-                    # schroot, Travis always detects changes and so
-                    # recompresses/stores the cache every build.  If we only
-                    # replaced the cached tarball if upgrades occurred, we
-                    # could save an extra ~30s on most builds.)
+                    # And ensure it's up-to-date.
+                    before_pkgs="$(sudo schroot -c source:xenial-amd64 -d / dpkg -l | sha256sum)"
                     sudo schroot -c source:xenial-amd64 -d / -- sh -c "apt-get update && apt-get -qqy upgrade"
+                    after_pkgs=$(sudo schroot -c source:xenial-amd64 -d / dpkg -l | sha256sum)
+                    if [ "$before_pkgs" != "$after_pkgs" ]; then
+                        needs_caching=true
+                    fi
                 else
                     # Otherwise, create the chroot
                     sudo -E su $USER -c 'mk-sbuild xenial'
+                    needs_caching=true
+                fi
+                # If there are changes to the schroot (or it's entirely new),
+                # tar up the schroot (to preserve ownership/permissions) and
+                # move it into the cached dir; no need to compress it because
+                # Travis will do that anyway
+                if [ "$needs_caching" = "true" ]; then
+                    sudo tar --sparse --xattrs --xattrs-include=* -cf "$TRAVIS_BUILD_DIR/chroots/xenial-amd64.tar" -C /var/lib/schroot/chroots/xenial-amd64 .
                 fi
             # Use sudo to get a new shell where we're in the sbuild group
             - sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc'


### PR DESCRIPTION
Prior to this change, the process of tarring up would mean that Travis
would always detect that the cache had changed, and we would incur ~30s
of packing/transferring at the end of every build.

Instead, we now check if there was any change to the installed contents
of the schroot, and only generate a new tarball if there were changes.