### PR TITLE
cc_final_message: don't create directories when writing boot-finished

### DIFF
--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -78,7 +78,7 @@ def handle(_name, cfg, cloud, log, args):
     boot_fin_fn = cloud.paths.boot_finished
     try:
         contents = "%s - %s - v. %s\n" % (uptime, ts, cver)
-        util.write_file(boot_fin_fn, contents)
+        util.write_file(boot_fin_fn, contents, ensure_dir_exists=False)
     except Exception:
         util.logexc(log, "Failed to write boot finished file %s", boot_fin_fn)
 

--- a/cloudinit/config/tests/test_final_message.py
+++ b/cloudinit/config/tests/test_final_message.py
@@ -1,0 +1,31 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+from unittest import mock
+
+import pytest
+
+from cloudinit.config.cc_final_message import handle
+
+
+class TestHandle:
+    # TODO: Expand these tests to cover full functionality; currently they only
+    # cover the logic around how the boot-finished file is written (and not its
+    # contents).
+
+    @pytest.mark.parametrize(
+        "instance_dir_exists,file_is_written", [(True, True), (False, False)]
+    )
+    def test_boot_finished_written(
+        self, instance_dir_exists, file_is_written, tmpdir
+    ):
+        instance_dir = tmpdir.join("var/lib/cloud/instance")
+        if instance_dir_exists:
+            instance_dir.ensure_dir()
+        boot_finished = instance_dir.join("boot-finished")
+
+        m_cloud = mock.Mock(paths=mock.Mock(boot_finished=boot_finished))
+
+        handle(None, {}, m_cloud, mock.Mock(), [])
+
+        # We should not change the status of the instance directory
+        assert instance_dir_exists == instance_dir.exists()
+        assert file_is_written == boot_finished.exists()


### PR DESCRIPTION
If the instance symlink doesn't exist, then we shouldn't create a
directory in its place, because that breaks future boots.

LP: #1883903