### PR TITLE
Change from redhat to rhel in systemd generator tmpl

### DIFF
--- a/systemd/cloud-init-generator.tmpl
+++ b/systemd/cloud-init-generator.tmpl
@@ -83,7 +83,7 @@ default() {
 
 check_for_datasource() {
     local ds_rc=""
-{% if variant in ["redhat", "fedora", "centos"] %}
+{% if variant in ["rhel", "fedora", "centos"] %}
     local dsidentify="/usr/libexec/cloud-init/ds-identify"
 {% else %}
     local dsidentify="/usr/lib/cloud-init/ds-identify"


### PR DESCRIPTION
The name `redhat' is not used but rather `rhel' to identify the distro.

Signed-off-by: Eduardo Otubo <otubo@redhat.com>