### PR TITLE
Keep the customized network configuration

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -695,6 +695,13 @@ class Init(object):
                     # refresh netcfg after update
                     netcfg, src = self._find_networking_config()
 
+        if (self.datasource is NULL_DATA_SOURCE and
+            not self.is_new_instance()):
+            # Nothing to do, to keep the customized network configuration.
+            LOG.info("Not the first time to execute 'apply_network_config'."
+                     "Keep the customized network configuration.")
+            return
+
         # ensure all physical devices in config are present
         net.wait_for_physdevs(netcfg)
 


### PR DESCRIPTION
Keep the customized network configuration  in apply_network_config stages, When the instance without any datasource.
For example:
An instance without any datasoure has been created, and user customized network configuration.
When it boots next time, the customized network configuration will be changed to cloud-init default config.