### PR TITLE
cloud-init.service.tmpl: use "rhel" instead of "redhat"

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -10,7 +10,7 @@ After=systemd-networkd-wait-online.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 After=networking.service
 {% endif %}
-{% if variant in ["centos", "fedora", "redhat"] %}
+{% if variant in ["centos", "fedora", "rhel"] %}
 After=network.service
 After=NetworkManager.service
 {% endif %}


### PR DESCRIPTION
We use "rhel" consistently everywhere else.