### PR TITLE
net/networking: remove unused functions/methods

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -486,13 +486,10 @@ categories:
   * ``interface_has_own_mac``
   * ``is_bond``
   * ``is_bridge``
-  * ``is_connected``
   * ``is_physical``
-  * ``is_present``
   * ``is_renamed``
   * ``is_up``
   * ``is_vlan``
-  * ``is_wireless``
   * ``wait_for_physdevs``
 
 * those that directly access ``/sys`` (via helpers) but may be

--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -79,14 +79,8 @@ class Networking(metaclass=abc.ABCMeta):
     def is_bridge(self, devname: DeviceName) -> bool:
         return net.is_bridge(devname)
 
-    def is_connected(self, devname: DeviceName) -> bool:
-        return net.is_connected(devname)
-
     def is_physical(self, devname: DeviceName) -> bool:
         return net.is_physical(devname)
-
-    def is_present(self, devname: DeviceName) -> bool:
-        return net.is_present(devname)
 
     def is_renamed(self, devname: DeviceName) -> bool:
         return net.is_renamed(devname)
@@ -96,9 +90,6 @@ class Networking(metaclass=abc.ABCMeta):
 
     def is_vlan(self, devname: DeviceName) -> bool:
         return net.is_vlan(devname)
-
-    def is_wireless(self, devname: DeviceName) -> bool:
-        return net.is_wireless(devname)
 
     def master_is_bridge_or_bond(self, devname: DeviceName) -> bool:
         return net.master_is_bridge_or_bond(devname)

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -99,10 +99,6 @@ def is_up(devname):
     return read_sys_net_safe(devname, "operstate", translate=translate)
 
 
-def is_wireless(devname):
-    return os.path.exists(sys_dev_path(devname, "wireless"))
-
-
 def is_bridge(devname):
     return os.path.exists(sys_dev_path(devname, "bridge"))
 
@@ -266,26 +262,8 @@ def is_vlan(devname):
     return 'DEVTYPE=vlan' in uevent.splitlines()
 
 
-def is_connected(devname):
-    # is_connected isn't really as simple as that.  2 is
-    # 'physically connected'. 3 is 'not connected'. but a wlan interface will
-    # always show 3.
-    iflink = read_sys_net_safe(devname, "iflink")
-    if iflink == "2":
-        return True
-    if not is_wireless(devname):
-        return False
-    LOG.debug("'%s' is wireless, basing 'connected' on carrier", devname)
-    return read_sys_net_safe(devname, "carrier",
-                             translate={'0': False, '1': True})
-
-
 def is_physical(devname):
     return os.path.exists(sys_dev_path(devname, "device"))
-
-
-def is_present(devname):
-    return os.path.exists(sys_dev_path(devname))
 
 
 def device_driver(devname):

--- a/cloudinit/net/tests/test_init.py
+++ b/cloudinit/net/tests/test_init.py
@@ -143,12 +143,6 @@ class TestReadSysNet(CiTestCase):
             write_file(os.path.join(self.sysdir, 'eth0', 'operstate'), state)
             self.assertFalse(net.is_up('eth0'))
 
-    def test_is_wireless(self):
-        """is_wireless is True when /sys/net/devname/wireless exists."""
-        self.assertFalse(net.is_wireless('eth0'))
-        ensure_file(os.path.join(self.sysdir, 'eth0', 'wireless'))
-        self.assertTrue(net.is_wireless('eth0'))
-
     def test_is_bridge(self):
         """is_bridge is True when /sys/net/devname/bridge exists."""
         self.assertFalse(net.is_bridge('eth0'))
@@ -204,31 +198,11 @@ class TestReadSysNet(CiTestCase):
         write_file(os.path.join(self.sysdir, 'eth0', 'uevent'), content)
         self.assertTrue(net.is_vlan('eth0'))
 
-    def test_is_connected_when_physically_connected(self):
-        """is_connected is True when /sys/net/devname/iflink reports 2."""
-        self.assertFalse(net.is_connected('eth0'))
-        write_file(os.path.join(self.sysdir, 'eth0', 'iflink'), "2")
-        self.assertTrue(net.is_connected('eth0'))
-
-    def test_is_connected_when_wireless_and_carrier_active(self):
-        """is_connected is True if wireless /sys/net/devname/carrier is 1."""
-        self.assertFalse(net.is_connected('eth0'))
-        ensure_file(os.path.join(self.sysdir, 'eth0', 'wireless'))
-        self.assertFalse(net.is_connected('eth0'))
-        write_file(os.path.join(self.sysdir, 'eth0', 'carrier'), "1")
-        self.assertTrue(net.is_connected('eth0'))
-
     def test_is_physical(self):
         """is_physical is True when /sys/net/devname/device exists."""
         self.assertFalse(net.is_physical('eth0'))
         ensure_file(os.path.join(self.sysdir, 'eth0', 'device'))
         self.assertTrue(net.is_physical('eth0'))
-
-    def test_is_present(self):
-        """is_present is True when /sys/net/devname exists."""
-        self.assertFalse(net.is_present('eth0'))
-        ensure_file(os.path.join(self.sysdir, 'eth0', 'device'))
-        self.assertTrue(net.is_present('eth0'))
 
 
 class TestGenerateFallbackConfig(CiTestCase):


### PR DESCRIPTION
Namely, is_connected, is_wireless and is_present.  None of these are
used in the cloud-init codebase, so remove the dead code (instead of
refactoring it).