### PR TITLE
Keep the customized network configuration during apply_netwok_config stage

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -695,6 +695,12 @@ class Init(object):
                     # refresh netcfg after update
                     netcfg, src = self._find_networking_config()
 
+            if self.datasource is NULL_DATA_SOURCE and not self.is_new_instance():
+                # Nothing to do to keep customized network configuration
+                LOG.info("Keep the customized network configuration during apply_netwok_config stage,"
+                         "while the datasource is None and not the first time to exec.")
+                return
+
         # ensure all physical devices in config are present
         net.wait_for_physdevs(netcfg)
 


### PR DESCRIPTION
Keep the customized network configuration during apply_network_config stage when the instance without any datasource.
For example:
An instance has been created without config drive,but the subnet disable dhcp. The owner login it from vnc, and customized the network configuration with "STATIC IP, IPADDR=192.168.1.100". After network config, the owner reboot this instance, and the customzied network configuration will be canceled to 'CLOUN INIT DEFAULT NETWORK CONFIG'.

This commit will keep customized network configuration unchanged to increase robustness.