### PR TITLE
.travis.yml: revert to installing ubuntu-dev-tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
                   sudo find /var/snap/lxd/common/lxd/images/ -name $latest_file* -print -exec cp {} "$TRAVIS_BUILD_DIR/lxd_images/" \;
           install:
             - git fetch --unshallow
-            - sudo apt-get install -y --install-recommends sbuild devscripts fakeroot tox debhelper
+            - sudo apt-get install -y --install-recommends sbuild ubuntu-dev-tools fakeroot tox debhelper
             - pip install .
             - pip install tox
             # bionic has lxd from deb installed, remove it first to ensure


### PR DESCRIPTION
My previous testing was insufficient: there is a branch of testing that
requires mk-sbuild, which is shipped in ubuntu-dev-tools itself.