### PR TITLE
Enable use of the caplog fixture in pytest tests, and add a cc_final_message test using it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
             - cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
           script:
             # Ubuntu LTS: Build
-            - ./packages/bddeb -S -d
+            - ./packages/bddeb -S -d --release xenial
             - |
                 needs_caching=false
                 if [ -e "$TRAVIS_BUILD_DIR/chroots/xenial-amd64.tar" ]; then

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -218,11 +218,12 @@ The following guidelines should be followed:
     [#fixture-list]_:
 
     * ``cache``
-    * ``capsys``
     * ``capfd``
-    * ``record_xml_property``
+    * ``caplog`` (provided by ``python3-pytest-catchlog`` on xenial)
+    * ``capsys``
     * ``monkeypatch``
     * ``pytestconfig``
+    * ``record_xml_property``
     * ``recwarn``
     * ``tmpdir_factory``
     * ``tmpdir``
@@ -328,9 +329,9 @@ variable annotations specified in `PEP-526`_ were introduced in Python
 .. [#fixture-list] This list of fixtures (with markup) can be
    reproduced by running::
 
-     py.test-3 --fixtures -q | grep "^[^ ]" | grep -v no | sed 's/.*/* ``\0``/'
+     py.test-3 --fixtures -q | grep "^[^ -]" | grep -v '\(no\|capturelog\)' | sort | sed 's/.*/* ``\0``/'
 
-   in a xenial lxd container with python3-pytest installed.
+   in a xenial lxd container with python3-pytest-catchlog installed.
 
 Feature Flags
 -------------

--- a/cloudinit/config/tests/test_final_message.py
+++ b/cloudinit/config/tests/test_final_message.py
@@ -1,4 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+import logging
 from unittest import mock
 
 import pytest
@@ -12,10 +13,19 @@ class TestHandle:
     # contents).
 
     @pytest.mark.parametrize(
-        "instance_dir_exists,file_is_written", [(True, True), (False, False)]
+        "instance_dir_exists,file_is_written,expected_log_substring",
+        [
+            (True, True, None),
+            (False, False, "Failed to write boot finished file "),
+        ],
     )
     def test_boot_finished_written(
-        self, instance_dir_exists, file_is_written, tmpdir
+        self,
+        instance_dir_exists,
+        file_is_written,
+        expected_log_substring,
+        caplog,
+        tmpdir,
     ):
         instance_dir = tmpdir.join("var/lib/cloud/instance")
         if instance_dir_exists:
@@ -26,8 +36,11 @@ class TestHandle:
             paths=mock.Mock(boot_finished=boot_finished.strpath)
         )
 
-        handle(None, {}, m_cloud, mock.Mock(), [])
+        handle(None, {}, m_cloud, logging.getLogger(), [])
 
         # We should not change the status of the instance directory
         assert instance_dir_exists == instance_dir.exists()
         assert file_is_written == boot_finished.exists()
+
+        if expected_log_substring:
+            assert expected_log_substring in caplog.text

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -91,6 +91,8 @@ def write_debian_folder(root, templ_data, cloud_util_deps):
     # NOTE: python package was moved to the front after debuild -S would fail with
     # 'Please add apropriate interpreter' errors (as in debian bug 861132)
     requires.extend(['python3'] + reqs + test_reqs)
+    if templ_data['debian_release'] == 'xenial':
+        requires.append('python3-pytest-catchlog')
     templater.render_to_file(util.abs_join(find_root(),
                                            'packages', 'debian', 'control.in'),
                              util.abs_join(deb_dir, 'control'),

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,7 @@ deps =
     # test-requirements
     httpretty==0.9.6
     mock==1.3.0
+    pytest-catchlog==1.2.1
 
 [testenv:xenial]
 # When updating this commands definition, also update the definition in


### PR DESCRIPTION
`caplog` is only available in `pytest` itself from 3.0 onwards. In xenial, we only have pytest 2.8.7. However, in xenial we do have `pytest-catchlog` available (as `python3-pytest-catchlog`), so we use that where appropriate.