### PR TITLE
RbxCloud: Add support for FreeBSD

### DIFF
--- a/cloudinit/sources/DataSourceRbxCloud.py
+++ b/cloudinit/sources/DataSourceRbxCloud.py
@@ -44,7 +44,7 @@ def int2ip(addr):
 
 def _sub_arp(cmd):
     """
-    Uses the prefered cloud-init subprocess def of subp.subp
+    Uses the preferred cloud-init subprocess def of subp.subp
     and runs arping.  Breaking this to a separate function
     for later use in mocking and unittests
     """
@@ -72,17 +72,13 @@ def gratuitous_arp(items, distro):
 
 def get_md():
     rbx_data = None
-    devices = [
-        dev
-        for dev, bdata in util.blkid().items()
-        if bdata.get('LABEL', '').upper() == 'CLOUDMD'
-    ]
+    devices = util.find_devs_with('LABEL=CLOUDMD')
     for device in devices:
         try:
             rbx_data = util.mount_cb(
                 device=device,
                 callback=read_user_data_callback,
-                mtype=['vfat', 'fat']
+                mtype=['vfat', 'fat', 'msdosfs']
             )
             if rbx_data:
                 break
@@ -190,7 +186,6 @@ def read_user_data_callback(mount_dir):
                     'passwd': hash,
                     'lock_passwd': False,
                     'ssh_authorized_keys': ssh_keys,
-                    'shell': '/bin/bash'
                 }
             },
             'network_config': network,

--- a/cloudinit/sources/DataSourceRbxCloud.py
+++ b/cloudinit/sources/DataSourceRbxCloud.py
@@ -72,7 +72,10 @@ def gratuitous_arp(items, distro):
 
 def get_md():
     rbx_data = None
-    devices = util.find_devs_with('LABEL=CLOUDMD')
+    devices = set(
+        util.find_devs_with('LABEL=CLOUDMD') +
+        util.find_devs_with('LABEL=cloudmd')
+    )
     for device in devices:
         try:
             rbx_data = util.mount_cb(

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -273,6 +273,10 @@ class TestDsIdentify(DsIdentifyBase):
         """Rbx datasource has a disk with LABEL=CLOUDMD."""
         self._test_ds_found('RbxCloud')
 
+    def test_rbx_cloud_lower(self):
+        """Rbx datasource has a disk with LABEL=cloudmd."""
+        self._test_ds_found('RbxCloudLower')
+
     def test_config_drive_upper(self):
         """ConfigDrive datasource has a disk with LABEL=CONFIG-2."""
         self._test_ds_found('ConfigDriveUpper')
@@ -945,6 +949,18 @@ VALID_CFG = {
                   {'DEVNAME': 'vda2', 'TYPE': 'ext4',
                    'LABEL': 'cloudimg-rootfs', 'PARTUUID': uuid4()},
                   {'DEVNAME': 'vdb', 'TYPE': 'vfat', 'LABEL': 'CLOUDMD'}]
+             )},
+        ],
+    },
+    'RbxCloudLower': {
+        'ds': 'RbxCloud',
+        'mocks': [
+            {'name': 'blkid', 'ret': 0,
+             'out': blkid_out(
+                 [{'DEVNAME': 'vda1', 'TYPE': 'vfat', 'PARTUUID': uuid4()},
+                  {'DEVNAME': 'vda2', 'TYPE': 'ext4',
+                   'LABEL': 'cloudimg-rootfs', 'PARTUUID': uuid4()},
+                  {'DEVNAME': 'vdb', 'TYPE': 'vfat', 'LABEL': 'cloudmd'}]
              )},
         ],
     },


### PR DESCRIPTION
Changes are made that simplify code and aim to properly support FreeBSD:

- use `util.find_devs_with` instead call directly `blkid`, because on FreeBSD is not supported well and `util.find_devs_with` have solution for FreeBSD for that
- introduction of an additional name on FAT file system, which is used in FreeBSD
- drop shell to use default value, because FreeBSD – by default – does not have `/bin/bash`