### PR TITLE
cloud_tests: don't pass --python-version to read-dependencies

### DIFF
--- a/tests/cloud_tests/bddeb.py
+++ b/tests/cloud_tests/bddeb.py
@@ -55,7 +55,7 @@ def build_deb(args, instance):
     LOG.debug('installing deps')
     deps_path = os.path.join(extract_dir, 'tools', 'read-dependencies')
     instance.execute([deps_path, '--install', '--test-distro',
-                      '--distro', 'ubuntu', '--python-version', '3'])
+                      '--distro', 'ubuntu'])
 
     LOG.debug('building deb in remote system at: %s', output_link)
     bddeb_args = args.bddeb_args.split() if args.bddeb_args else []


### PR DESCRIPTION
We dropped that parameter in https://github.com/canonical/cloud-init/commit/4d2684848722cb2d469ad4fa60999bf81cf7056e