### PR TITLE
ssh exit with non-zero status on disabled user

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -44,7 +44,7 @@ VALID_KEY_TYPES = (
 DISABLE_USER_OPTS = (
     "no-port-forwarding,no-agent-forwarding,"
     "no-X11-forwarding,command=\"echo \'Please login as the user \\\"$USER\\\""
-    " rather than the user \\\"$DISABLE_USER\\\".\';echo;sleep 10\"")
+    " rather than the user \\\"$DISABLE_USER\\\".\';echo;sleep 10;exit 1\"")
 
 
 class AuthKeyLine(object):

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -236,7 +236,7 @@ disable_root: false
 # The string '$USER' will be replaced with the username of the default user.
 # The string '$DISABLE_USER' will be replaced with the username to disable.
 #
-# disable_root_opts: no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command="echo 'Please login as the user \"$USER\" rather than the user \"$DISABLE_USER\".';echo;sleep 10"
+# disable_root_opts: no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command="echo 'Please login as the user \"$USER\" rather than the user \"$DISABLE_USER\".';echo;sleep 10;exit 1"
 
 # disable ssh access for non-root-users
 # To disable ssh access for non-root users, ssh_redirect_user: true can be


### PR DESCRIPTION
Hello,

it is confusing for scripts, where a disabled user has been specified,
that ssh exits with a zero status by default without indication anything failed.

I think exitting with a non-zero status would make more clear in scripts
and automated setups where things failed, thus making noticing the issue and
debugging easier.