### PR TITLE
Add mention of vendor-data to no-cloud format documentation

### DIFF
--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -53,6 +53,12 @@ These user-data and meta-data files are expected to be in the following format.
 Basically, user-data is simply user-data and meta-data is a yaml formatted file
 representing what you'd find in the EC2 metadata service.
 
+You may also optionally provide a vendor-data file in the following format.
+
+::
+
+  /vendor-data
+
 Given a disk ubuntu 12.04 cloud image in 'disk.img', you can create a
 sufficient disk by following the example below.
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -10,3 +10,4 @@ onitake
 smoser
 tomponline
 TheRealFalcon
+landon912


### PR DESCRIPTION
Add mention of ability to optionally provide a vendor-data file for no-cloud format. 