### PR TITLE
Update cli.rst

### DIFF
--- a/doc/rtd/topics/cli.rst
+++ b/doc/rtd/topics/cli.rst
@@ -164,7 +164,7 @@ declared to run in various boot stages in the file
 
 * *cloud_init_modules*
 * *cloud_config_modules*
-* *cloud_init_modules*
+* *cloud_final_modules*
 
 Can be run on the command line, but each module is gated to run only once due
 to semaphores in ``/var/lib/cloud/``.


### PR DESCRIPTION
Added cloud_final_modules in place of cloud_init_modules under the heading 'modules'. cloud_init_modules was wrongly appearing twice.