### PR TITLE
test_data: fix faulty patch

### DIFF
--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -648,7 +648,9 @@ class TestConsumeUserDataHttp(TestConsumeUserData, helpers.HttprettyTestCase):
             util.load_file(ci.paths.get_ipath("cloud_config"))
 
     @mock.patch('cloudinit.url_helper.time.sleep')
-    @mock.patch('cloudinit.features.ERROR_ON_USER_DATA_FAILURE', False)
+    @mock.patch(
+        "cloudinit.user_data.features.ERROR_ON_USER_DATA_FAILURE", False
+    )
     def test_include_bad_url_no_fail(self, mock_sleep):
         """Test #include with a bad URL and failure disabled"""
         bad_url = 'http://bad/forbidden'


### PR DESCRIPTION
I've been seeing intermittent failures of this test, and I tracked it
down to something to do with`test_features.py`: running this test after
`test_features.py` causes the failure, but the inverse does not.

This fixed patch ensures that the test will pass regardless of ordering.