### PR TITLE
cloudinit: fix tip-pylint failures and bump pinned pylint version

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -398,7 +398,10 @@ class ConfigDriveReader(BaseReader):
                 except IOError:
                     raise BrokenMetadata("Failed to read: %s" % path)
                 try:
-                    md[key] = translator(contents)
+                    # Disable not-callable pylint check; pylint isn't able to
+                    # determine that every member of FILES_V1 has a callable in
+                    # the appropriate position
+                    md[key] = translator(contents)  # pylint: disable=E1102
                 except Exception as e:
                     raise BrokenMetadata("Failed to process "
                                          "path %s: %s" % (path, e))

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1874,8 +1874,8 @@ def make_header(comment_char="#", base='created'):
     return header
 
 
-def abs_join(*paths):
-    return os.path.abspath(os.path.join(*paths))
+def abs_join(base, *paths):
+    return os.path.abspath(os.path.join(base, *paths))
 
 
 # shellify, takes a list of commands

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
 basepython = python3
 deps =
     # requirements
-    pylint==2.3.1
+    pylint==2.5.3
     # test-requirements because unit tests are now present in cloudinit tree
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt


### PR DESCRIPTION
Specifically:

* disable E1102 in `cloudinit/sources/helpers/openstack.py` for reasons
  described in a comment, and
* refactor `util.abs_join` to require at least one positional argument; this
  matches `os.path.join`'s signature, and that mismatch is what was
  causing pylint to emit a warning
* bump to pylint 2.4.2