### PR TITLE
Add update_etc_hosts as default module on *BSD

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -71,7 +71,7 @@ cloud_init_modules:
  - set_hostname
  - update_hostname
  - update_etc_hosts
-{% if variant not in ["freebsd", "netbsd"] %}
+{% if variant.endswith("bsd") %}
  - ca-certs
  - rsyslog
 {% endif %}

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -71,7 +71,7 @@ cloud_init_modules:
  - set_hostname
  - update_hostname
  - update_etc_hosts
-{% if variant.endswith("bsd") %}
+{% if not variant.endswith("bsd") %}
  - ca-certs
  - rsyslog
 {% endif %}

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -70,8 +70,8 @@ cloud_init_modules:
 {% endif %}
  - set_hostname
  - update_hostname
-{% if variant not in ["freebsd", "netbsd"] %}
  - update_etc_hosts
+{% if variant not in ["freebsd", "netbsd"] %}
  - ca-certs
  - rsyslog
 {% endif %}

--- a/templates/hosts.freebsd.tmpl
+++ b/templates/hosts.freebsd.tmpl
@@ -11,14 +11,13 @@ you need to add the following to config:
 # a.) make changes to the master file in /etc/cloud/templates/hosts.freebsd.tmpl
 # b.) change or remove the value of 'manage_etc_hosts' in
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
-# 
-# The following lines are desirable for IPv4 capable hosts
-127.0.0.1 {{fqdn}} {{hostname}}
-127.0.0.1 localhost.localdomain localhost
-127.0.0.1 localhost4.localdomain4 localhost4
 
 # The following lines are desirable for IPv6 capable hosts
 ::1 {{fqdn}} {{hostname}}
 ::1 localhost.localdomain localhost
 ::1 localhost6.localdomain6 localhost6
 
+# The following lines are desirable for IPv4 capable hosts
+127.0.0.1 {{fqdn}} {{hostname}}
+127.0.0.1 localhost.localdomain localhost
+127.0.0.1 localhost4.localdomain4 localhost4


### PR DESCRIPTION
If I understand correctly, Cloud-init adopts the default configuration to run all supported modules on a given distro. For unknown reasons, the update_etc_hosts module does not run on FreeBSD and NetBSD, although:
- module `update_etc_hosts` has sense and retains functionality,
- module `update_etc_hosts` is working on the platform, in accordance with its documentation and manual tests.

In our environment, we assume that all images should have  `/etc/hosts` file managed by default. FreeBSD is an exception due default Cloud-init config.

According Git history @goneri provided recently support for NetBSD and follow that configuration, so I ask him for review.

This distinction has been made to this configuration file in a change 41d46bfb85929c79dabcec3cf21c8d71401fd2b8 but that patch follow earlier configuration file
https://github.com/canonical/cloud-init/blob/e7c95208451422cfd3da7edfbd67dd271e7aa337/config/cloud.cfg-freebsd which turned it off in the patch https://github.com/canonical/cloud-init/commit/c36d75552221e165f84493c5105318c088b44514. However, assumptions behind disable this module no longer seem valid.