### PR TITLE
cc_mounts: handle missing fstab

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -379,17 +379,18 @@ def handle(_name, cfg, cloud, log, _args):
     fstab_devs = {}
     fstab_removed = []
 
-    for line in util.load_file(FSTAB_PATH).splitlines():
-        if MNT_COMMENT in line:
-            fstab_removed.append(line)
-            continue
+    if os.path.exists(FSTAB_PATH):
+        for line in util.load_file(FSTAB_PATH).splitlines():
+            if MNT_COMMENT in line:
+                fstab_removed.append(line)
+                continue
 
-        try:
-            toks = WS.split(line)
-        except Exception:
-            pass
-        fstab_devs[toks[0]] = line
-        fstab_lines.append(line)
+            try:
+                toks = WS.split(line)
+            except Exception:
+                pass
+            fstab_devs[toks[0]] = line
+            fstab_lines.append(line)
 
     for i in range(len(cfgmnt)):
         # skip something that wasn't a list

--- a/tests/unittests/test_handler/test_handler_mounts.py
+++ b/tests/unittests/test_handler/test_handler_mounts.py
@@ -183,6 +183,18 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
 
         return dev
 
+    def test_no_fstab(self):
+        """ Handle images which do not include an fstab. """
+        self.assertFalse(os.path.exists(cc_mounts.FSTAB_PATH))
+        fstab_expected_content = (
+            '%s\tnone\tswap\tsw,comment=cloudconfig\t'
+            '0\t0\n' % (self.swap_path,)
+        )
+        cc_mounts.handle(None, {}, self.mock_cloud, self.mock_log, [])
+        with open(cc_mounts.FSTAB_PATH, 'r') as fd:
+            fstab_new_content = fd.read()
+            self.assertEqual(fstab_expected_content, fstab_new_content)
+
     def test_swap_integrity(self):
         '''Ensure that the swap file is correctly created and can
         swapon successfully. Fixing the corner case of:


### PR DESCRIPTION
Do not fail if /etc/fstab is not present.  Some images, like container
rootfs may not include this file by default.

LP: #1886531