### PR TITLE
Fix/read deps for brpm

### DIFF
--- a/packages/brpm
+++ b/packages/brpm
@@ -46,15 +46,19 @@ def run_helper(helper, args=None, strip=True):
 def read_dependencies(distro):
     """Returns the Python package depedencies from requirements.txt files.
 
-    @returns a tuple of (requirements, test_requirements)
+    @returns a tuple of (build_deps, run_deps, test_deps)
     """
-    pkg_deps = run_helper(
-        'read-dependencies', args=['--distro', distro]).splitlines()
+    build_deps = run_helper(
+        'read-dependencies',args=[
+            '--distro', distro, '--build-requires']).splitlines()
+    run_deps = run_helper(
+        'read-dependencies', args=[
+            '--distro', distro, '--runtime-requires']).splitlines()
     test_deps = run_helper(
         'read-dependencies', args=[
             '--requirements-file', 'test-requirements.txt',
             '--system-pkg-names']).splitlines()
-    return (pkg_deps, test_deps)
+    return (build_deps, run_deps, test_deps)
 
 
 def read_version():
@@ -84,9 +88,9 @@ def generate_spec_contents(args, version_data, tmpl_fn, top_dir, arc_fn):
         rpm_upstream_version = version_data['version']
     subs['rpm_upstream_version'] = rpm_upstream_version
 
-    deps, test_deps = read_dependencies(distro=args.distro)
-    subs['buildrequires'] = deps + test_deps
-    subs['requires'] = deps
+    build_deps, run_deps, test_deps = read_dependencies(distro=args.distro)
+    subs['buildrequires'] = build_deps + test_deps
+    subs['requires'] = run_deps
 
     if args.boot == 'sysvinit':
         subs['sysvinit'] = True

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -102,6 +102,13 @@ def get_parser():
         '-d', '--distro', type=str, choices=DISTRO_PKG_TYPE_MAP.keys(),
         help='The name of the distro to generate package deps for.')
     parser.add_argument(
+        '-b', '--build-requires', action='store_true', default=False,
+        dest='build_requires', help='Print only buildtime required packages')
+    parser.add_argument(
+        '-R', '--runtime-requires', action='store_true', default=False,
+        dest='runtime_requires',
+        help='Print only runtime required packages')
+    parser.add_argument(
         '--dry-run', action='store_true', default=False, dest='dry_run',
         help='Dry run the install, making no package changes.')
     parser.add_argument(
@@ -222,15 +229,23 @@ def main(distro):
     translated_pip_names = translate_pip_to_system_pkg(
         pip_pkg_names, renames)
     all_deps = []
+    select_requires = [args.build_requires, args.runtime_requires]
     if args.distro:
-        all_deps.extend(
-            translated_pip_names + deps_from_json['requires'] +
-            deps_from_json['build-requires'])
+        if all(select_requires) or not any(select_requires):
+            all_deps.extend(
+                translated_pip_names + deps_from_json['requires'] +
+                deps_from_json['build-requires'])
+        else:
+            if args.build_requires:
+                all_deps.extend(deps_from_json['build-requires'])
+            else:
+                all_deps.extend(deps_from_json['requires'])
     else:
         if args.system_pkg_names:
             all_deps = translated_pip_names
         else:
             all_deps = pip_pkg_names
+    all_deps = sorted(all_deps)
     if args.install:
         pkg_install(all_deps, args.distro, args.test_distro, args.dry_run)
     else:

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -101,13 +101,14 @@ def get_parser():
     parser.add_argument(
         '-d', '--distro', type=str, choices=DISTRO_PKG_TYPE_MAP.keys(),
         help='The name of the distro to generate package deps for.')
-    parser.add_argument(
-        '-b', '--build-requires', action='store_true', default=False,
-        dest='build_requires', help='Print only buildtime required packages')
-    parser.add_argument(
+    deptype = parser.add_mutually_exclusive_group()
+    deptype.add_argument(
         '-R', '--runtime-requires', action='store_true', default=False,
         dest='runtime_requires',
         help='Print only runtime required packages')
+    deptype.add_argument(
+        '-b', '--build-requires', action='store_true', default=False,
+        dest='build_requires', help='Print only buildtime required packages')
     parser.add_argument(
         '--dry-run', action='store_true', default=False, dest='dry_run',
         help='Dry run the install, making no package changes.')
@@ -231,7 +232,7 @@ def main(distro):
     all_deps = []
     select_requires = [args.build_requires, args.runtime_requires]
     if args.distro:
-        if all(select_requires) or not any(select_requires):
+        if not any(select_requires):
             all_deps.extend(
                 translated_pip_names + deps_from_json['requires'] +
                 deps_from_json['build-requires'])
@@ -239,7 +240,8 @@ def main(distro):
             if args.build_requires:
                 all_deps.extend(deps_from_json['build-requires'])
             else:
-                all_deps.extend(deps_from_json['requires'])
+                all_deps.extend(
+                    translated_pip_names + deps_from_json['requires'])
     else:
         if args.system_pkg_names:
             all_deps = translated_pip_names


### PR DESCRIPTION
tools/read-dependencies:
  - Add  parameters --build-requires, --runtime-requires
  - Sort dependency output before printing
package/brpm
  - use --build-requires, --runtime-requires to separate build/vs runtime package reqs.

LP: #1886107