### PR TITLE
Prototype for integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ cloud-init_*.dsc
 cloud-init_*.orig.tar.gz
 cloud-init_*.tar.xz
 cloud-init_*.upload
+
+# user test settings
+tests/integration_tests/user_settings.py

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -15,7 +15,7 @@ paramiko==2.4.2
 cryptography==2.4.2
 
 # lxd backend
-pylxd
+pylxd==2.2.11
 
 # finds latest image information
 git+https://git.launchpad.net/simplestreams

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -4,6 +4,8 @@
 # Note: Changes to this requirements may require updates to
 # the packages/pkg-deps.json file as well.
 #
+pytest
+git+https://github.com/canonical/pycloudlib.git
 
 # ec2 backend
 boto3==1.5.9
@@ -12,10 +14,8 @@ boto3==1.5.9
 paramiko==2.4.2
 cryptography==2.4.2
 
-
 # lxd backend
-# 04/03/2018: enables use of lxd 3.0
-git+https://github.com/lxc/pylxd.git@4b8ab1802f9aee4eb29cf7b119dae0aa47150779
+pylxd
 
 # finds latest image information
 git+https://git.launchpad.net/simplestreams

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -1,0 +1,67 @@
+import os
+import pytest
+
+from tests.integration_tests import integration_settings
+from tests.integration_tests.platforms import (
+    dynamic_client,
+    LxdContainerClient,
+    ALL_PLATFORMS,
+)
+
+
+def pytest_runtest_setup(item):
+    """
+    A test can take any number of marks to specify the platforms it can
+    run on. If a platform(s) is specified and we're not running on that
+    platform, then skip the test. If platform specific marks are not
+    specified, then we assume the test can be run anywhere
+    """
+    supported_platforms = set(ALL_PLATFORMS).intersection(
+        mark.name for mark in item.iter_markers())
+    current_platform = integration_settings.PLATFORM
+    if supported_platforms and current_platform not in supported_platforms:
+        pytest.skip('Cannot run on platform {}'.format(current_platform))
+
+
+# disable_subp_usage is defined at a higher level, but we don't
+# want it applied here
+@pytest.fixture()
+def disable_subp_usage(request):
+    pass
+
+
+@pytest.fixture(scope='session', autouse=True)
+def common_environment():
+    """
+    Setup the target environment with the correct version of cloud-init
+    so we can launch instances / run tests with the correct image
+    """
+    client = dynamic_client()
+    print('Setting up environment for {}'.format(client.datasource))
+    if integration_settings.IMAGE_SOURCE == 'NONE':
+        pass  # that was easy
+    elif integration_settings.IMAGE_SOURCE == 'IN_PLACE':
+        # pylxd version of
+        # "lxc config device add my-cloud-test host-cloud-init disk
+        # source=<path_to_repo>/cloudinit
+        # path=/usr/lib/python3/dist-packages/cloudinit"
+        if not isinstance(client, LxdContainerClient):
+            raise ValueError('IN_PLACE as IMAGE_SOURCE only works for LXD')
+        raise NotImplementedError  # Still not done
+    elif integration_settings.IMAGE_SOURCE == 'CURRENT':
+        raise NotImplementedError
+    elif integration_settings.IMAGE_SOURCE == 'COMMIT':
+        raise NotImplementedError
+    elif integration_settings.IMAGE_SOURCE == 'PROPOSED':
+        client.launch()
+        client.generate_proposed_image()
+    elif integration_settings.IMAGE_SOURCE == 'PPA':
+        raise NotImplementedError
+    elif os.path.isfile(str(integration_settings.IMAGE_SOURCE)):
+        # Push deb to remote and install it...see existing impl
+        raise NotImplementedError  # Not done yet
+    if client.instance:
+        # Even if we're keeping instances, we don't want to keep this
+        # one around as it was just for image creation
+        client.destroy()
+    print('Done with environment setup')

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -1,0 +1,85 @@
+import os
+
+##################################################################
+# LAUNCH SETTINGS
+##################################################################
+
+# Keep instance (mostly for debugging) when test is finished
+KEEP_INSTANCE = False
+
+# One of "lxd_container', 'oracle', ... more to come
+PLATFORM = 'lxd_container'
+
+# The cloud-specific instance type to run. E.g., a1.medium on AWS
+# If the pycloudlib instance provides a default, this can be left None
+INSTANCE_TYPE = None
+
+# Determines the base image to use or generate new images from.
+# Can be the name of the OS if running a stock image,
+# otherwise the id of the image being used if using a custom image
+OS_IMAGE = 'focal'
+
+# Populate if you want to use a pre-launched instance instead of
+# creating a new one. The exact contents will be platform dependent
+EXISTING_INSTANCE_ID = None
+
+##################################################################
+# IMAGE GENERATION SETTINGS
+##################################################################
+
+# Depending on where we are in the development / test / SRU cycle, we'll want
+# different methods of getting the source code to our SUT. Because of
+# this there are a number of different ways to initialize
+# the target environment.
+
+# Can be any of the following:
+# NONE
+#   Don't modify the target environment at all. This will run
+#   cloud-init with whatever code was baked into the image
+# IN_PLACE
+#   LXD/VM only. Mount the source code as-is directly into
+#   the container to override the pre-existing cloud-init code
+# CURRENT
+#   Build and install a deb of the code as it currently exists,
+#   including uncommitted code
+# COMMIT
+#   Build and install a deb from a particular commit hash
+# PROPOSED
+#   Install from the proposed repo
+# PPA
+#   Install from a PPA
+# <file path>
+#   A path to a valid package to be uploaded and installed
+# <image id>
+#   A pre-existing (platform dependent) image id
+IMAGE_SOURCE = 'NONE'
+
+##################################################################
+# ORACLE SPECIFIC SETTINGS
+##################################################################
+# Compartment-id found at
+# https://console.us-phoenix-1.oraclecloud.com/a/identity/compartments
+# Required for Oracle
+ORACLE_COMPARTMENT_ID = None
+
+##################################################################
+# USER SETTINGS OVERRIDES
+##################################################################
+# Bring in any user-file defined settings
+try:
+    from tests.integration_tests.user_settings import *
+except:  # noqa
+    pass
+
+##################################################################
+# ENVIRONMENT SETTINGS OVERRIDES
+##################################################################
+# Any of the settings in this file can be overridden with an
+# environment variable of the same name prepended with CLOUD_INIT_
+# E.g., CLOUD_INIT_PLATFORM
+# Perhaps a bit too hacky, but it works :)
+current_settings = [var for var in locals() if var.isupper()]
+for setting in current_settings:
+    globals()[setting] = os.getenv(
+        'CLOUD_INIT_{}'.format(setting), globals()[setting]
+    )

--- a/tests/integration_tests/platforms.py
+++ b/tests/integration_tests/platforms.py
@@ -1,0 +1,168 @@
+from io import StringIO
+
+from pycloudlib import OCI, LXD
+from pycloudlib.cloud import BaseCloud
+from pycloudlib.instance import BaseInstance
+
+from tests.integration_tests import integration_settings
+
+try:
+    from typing import Callable, Optional
+except ImportError:
+    pass
+
+ALL_PLATFORMS = [
+    'lxd_container',
+    'oracle'
+]
+
+current_image = None
+
+
+def set_current_image(image):
+    global current_image
+    current_image = image
+
+
+class IntegrationClient:
+    client = None  # type: Optional[BaseCloud]
+    instance = None  # type: Optional[BaseInstance]
+    datasource = None  # type: Optional[str]
+
+    def __init__(self, user_data=None, instance_type=None, wait=True,
+                 settings=integration_settings, launch_kwargs=None):
+        self.user_data = user_data
+        self.instance_type = settings.INSTANCE_TYPE if \
+            instance_type is None else instance_type
+        self.wait = wait
+        self.settings = settings
+        self.launch_kwargs = launch_kwargs if launch_kwargs else {}
+
+    def _get_image(self):
+        if current_image:
+            return current_image
+        image_id = self.settings.OS_IMAGE
+        try:
+            image_id = self.client.released_image(self.settings.OS_IMAGE)
+        except (ValueError, IndexError):
+            pass
+        return image_id
+
+    def launch(self):
+        if self.settings.EXISTING_INSTANCE_ID:
+            print('Not launching instance due to EXISTING_INSTANCE_ID. '
+                  'Instance id: {}'.format(self.settings.EXISTING_INSTANCE_ID))
+            self.instance = self.client.get_instance(
+                self.settings.EXISTING_INSTANCE_ID
+            )
+            return
+        image_id = self._get_image()
+        launch_args = {
+            'image_id': image_id,
+            'user_data': self.user_data,
+            'wait': self.wait,
+        }
+        if self.instance_type:
+            launch_args['instance_type'] = self.instance_type
+        launch_args.update(self.launch_kwargs)
+        self.instance = self.client.launch(**launch_args)
+        print('Launched instance: {}'.format(self.instance))
+
+    def destroy(self):
+        self.instance.delete()
+
+    def exec(self, command):
+        return self.instance.execute(command)
+
+    def get_file(self, remote_file, local_file=None):
+        if not local_file:
+            local_file = StringIO()
+        self.instance.pull_file(remote_file, local_file)
+        return local_file
+
+    def put_file(self, local_path, remote_path):
+        self.instance.push_file(local_path, remote_path)
+
+    def snapshot(self):
+        return self.client.snapshot(self.instance, clean=True, wait=True)
+
+    def generate_proposed_image(self, sudo=False):
+        print('Generating proposed image')
+        remote_script = (
+            '{sudo} echo deb "http://archive.ubuntu.com/ubuntu '
+            '$(lsb_release -sc)-proposed main" | '
+            '{sudo} tee /etc/apt/sources.list.d/proposed.list\n'
+            '{sudo} apt-get update -q\n'
+            '{sudo} apt-get install -qy cloud-init'
+        ).format(sudo='sudo' if sudo else '')
+        self.exec(remote_script)
+        version = self.exec('cloud-init -v').split()[-1]
+        print('Installed cloud-init version: {}'.format(version))
+        self.instance.clean()
+        image_id = self.snapshot()
+        print('Created proposed image: {}'.format(image_id))
+        set_current_image(image_id)
+
+    def __enter__(self):
+        self.launch()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if not self.settings.KEEP_INSTANCE:
+            self.destroy()
+
+
+class OracleClient(IntegrationClient):
+    datasource = 'oracle'
+
+    def __init__(self, user_data=None, instance_type=None, wait=True,
+                 settings=integration_settings, launch_kwargs=None):
+        super(OracleClient, self).__init__(
+            user_data,
+            instance_type,
+            wait,
+            settings,
+            launch_kwargs
+        )
+        self.client = OCI(
+            tag='OCI Integration Test',
+            compartment_id=self.settings.ORACLE_COMPARTMENT_ID
+        )
+
+    def generate_proposed_image(self, sudo=True):
+        super(OracleClient, self).generate_proposed_image(sudo)
+
+
+class LxdContainerClient(IntegrationClient):
+    datasource = 'lxd_container'
+
+    def __init__(self, user_data=None, instance_type=None, wait=True,
+                 settings=integration_settings, launch_kwargs=None):
+        super(LxdContainerClient, self).__init__(
+            user_data,
+            instance_type,
+            wait,
+            settings,
+            launch_kwargs
+        )
+        self.client = LXD(
+            tag='LXD Integration Test'
+        )
+
+
+client_name_to_class = {
+    'oracle': OracleClient,
+    'lxd_container': LxdContainerClient
+}
+
+try:
+    dynamic_client = client_name_to_class[
+        integration_settings.PLATFORM
+    ]  # type: Callable[..., IntegrationClient]
+except KeyError:
+    raise ValueError(
+        "{} is an invalid PLATFORM specified in settings. "
+        "Must be one of {}".format(
+            integration_settings.PLATFORM, ALL_PLATFORMS
+        )
+    )

--- a/tests/integration_tests/platforms.py
+++ b/tests/integration_tests/platforms.py
@@ -117,7 +117,7 @@ class OracleClient(IntegrationClient):
 
     def __init__(self, user_data=None, instance_type=None, wait=True,
                  settings=integration_settings, launch_kwargs=None):
-        super(OracleClient, self).__init__(
+        super().__init__(
             user_data,
             instance_type,
             wait,
@@ -130,7 +130,7 @@ class OracleClient(IntegrationClient):
         )
 
     def generate_proposed_image(self, sudo=True):
-        super(OracleClient, self).generate_proposed_image(sudo)
+        super().generate_proposed_image(sudo)
 
 
 class LxdContainerClient(IntegrationClient):
@@ -138,7 +138,7 @@ class LxdContainerClient(IntegrationClient):
 
     def __init__(self, user_data=None, instance_type=None, wait=True,
                  settings=integration_settings, launch_kwargs=None):
-        super(LxdContainerClient, self).__init__(
+        super().__init__(
             user_data,
             instance_type,
             wait,

--- a/tests/integration_tests/test_simple.py
+++ b/tests/integration_tests/test_simple.py
@@ -1,0 +1,24 @@
+import pytest
+
+from tests.integration_tests.platforms import (
+    dynamic_client, OracleClient, LxdContainerClient
+)
+
+
+class TestSimple:
+    @pytest.mark.lxd_container
+    def test_lxd_client(self):
+        with LxdContainerClient() as client:
+            print('I can only run on LXD')
+            print(client.exec('cloud-init -v'))
+
+    def test_dynamic(self):
+        with dynamic_client() as client:
+            print('I can run anywhere')
+            print(client.exec('cloud-init -v'))
+
+    @pytest.mark.oracle
+    def test_oracle_client(self):
+        with OracleClient() as client:
+            print('I can only run on Oracle')
+            print(client.exec('cloud-init -v'))

--- a/tox.ini
+++ b/tox.ini
@@ -140,3 +140,5 @@ addopts = --strict
 markers =
     allow_subp_for: allow subp usage for the given commands (disable_subp_usage)
     allow_all_subp: allow all subp usage (disable_subp_usage)
+    oracle: test will only run on Oracle platform
+    lxd_container: test will only run in LXD container


### PR DESCRIPTION
# Goal
Provide a framework/library for integration testing so that tests can be defined in a way that is independent of the system under test (SUT), when possible, and run as any other pytest test.

# Design
* SUT-independent. I.e., A single test should be able to run in a container, a VM, AWS, or any other cloud when possible
* Implemented as a series of classes that can be called from any arbitrary pytest test
* Uses pytest marks to specify tests that require a specific cloud
* Fixtures at the class and module level should allow us to perform common/costly setup for a number of tests. E.g., A fixture can allow us to launch a single GCE instance, run 10 tests on that specific instance, then teardown

# What about cloud tests?
Since we already have cloud tests, why not just modify and use those?
* Pytest provides a means of test organization, collecting, and running. It is mature and actively maintained. Our cloud tests implement a small subset of these features from scratch with less functionality and robustness
* It is harder to both write, run, and reason about individual tests using the cloud tests
* Much of the functionality in cloud_tests can be kept. Most of it involves managing the state of various cloud instances and images. This functionality can be moved into pycloudlib where appropriate
* The tests themselves can be easily trasferred into a pytest framework

# The Prototype
This is currently a working bare-bones prototype of the basic infrastructure and some small simple tests showing how it can be used. It requires [my branch of pycloudlib](https://github.com/TheRealFalcon/pycloudlib/tree/refactor-api) (`pip install -e` is your friend). Currently only LXD containers and Oracle are implemented.

* [test_simple.py](https://github.com/canonical/cloud-init/compare/master...TheRealFalcon:integration_testing?expand=1#diff-0cd6124346e6a333d55095fc22bc4f65) : Start here and work backwards. This isn't a file that would get committed...just an example of how tests can be written
* [platforms.py](https://github.com/canonical/cloud-init/compare/master...TheRealFalcon:integration_testing?expand=1#diff-741e658ee2a749f088a7ca6e3219db48) : Where all the platform-specific code lives. It should all be tied together through a single interface and mostly call out to pycloudlib
* [conftest.py](https://github.com/canonical/cloud-init/compare/master...TheRealFalcon:integration_testing?expand=1#diff-173d48fc6f2b7b5e88c31feb1f09eebe) : Setting up the image used by the SUT will happen here. The code in the `common_environment` fixture is explained in the settings file.
* [integration_settings.py](https://github.com/canonical/cloud-init/compare/master...TheRealFalcon:integration_testing?expand=1#diff-493a5e0d26916c22b422f48844070f24) : This would obviously expand to include more cloud-specific options/defaults. I've tried to make it flexible enough that it could easily used locally with LXD tests for quick feedback, but also adapted to run long-running cloud tests with official images on jenkins.

# Example test runs
A run using default settings. By default it skips image creation, and it uses LXD so automatically skips the test marked for Oracle but runs the non-marked test.
```
(cloud-init) newt:cloud-init (integration_testing*) $ python3 -m pytest -sv tests/integration_tests/test_simple.py
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /home/james/envs/cloud-init/bin/python3
cachedir: .pytest_cache
rootdir: /home/james/cloud-init, inifile: tox.ini
plugins: cov-2.9.0
collected 3 items

tests/integration_tests/test_simple.py::TestSimple::test_lxd_client Setting up environment for lxd_container
Done with environment setup
Launched instance: LXDInstance(name=keen-yeti)
I can only run on LXD and Oracle
/usr/bin/cloud-init 20.1-10-g71af48df-0ubuntu5
PASSED
tests/integration_tests/test_simple.py::TestSimple::test_dynamic Launched instance: LXDInstance(name=enjoyed-mongoose)
I can run anywhere
/usr/bin/cloud-init 20.1-10-g71af48df-0ubuntu5
PASSED
tests/integration_tests/test_simple.py::TestSimple::test_oracle_client SKIPPED

================================================================================================= warnings summary ==================================================================================================
tests/integration_tests/test_simple.py::TestSimple::test_lxd_client
tests/integration_tests/test_simple.py::TestSimple::test_dynamic
  /home/james/envs/cloud-init/lib/python3.5/site-packages/simplestreams/mirrors/__init__.py:207: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self.prefix, path)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
================================================================================ 2 passed, 1 skipped, 2 warnings in 69.13s (0:01:09) ================================================================================
```

A second test run. This time we use env vars to specify we want to use the proposed image on Oracle. It skips the LXD-specific test, sets up the environment by launching an instance, installing the proposed cloud-init, and creating the proposed image. It then launches a new instance with the proposed image to run the actual tests. Note the cloud-init version on the newly launched instance matches what currently lives in proposed.
```
(cloud-init) newt:cloud-init (integration_testing*) $ CLOUD_INIT_IMAGE_SOURCE='PROPOSED' CLOUD_INIT_PLATFORM='oracle' CLOUD_INIT_ORACLE_COMPARTMENT_ID='ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa' python3 -m pytest -sv tests/integration_tests/test_simple.py
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.5.9, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- /home/james/envs/cloud-init/bin/python3
cachedir: .pytest_cache
rootdir: /home/james/cloud-init, inifile: tox.ini
plugins: cov-2.9.0
collected 3 items

tests/integration_tests/test_simple.py::TestSimple::test_lxd_client SKIPPED
tests/integration_tests/test_simple.py::TestSimple::test_dynamic Setting up environment for oracle
Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6sycxj3wn3j6e2kvpjdvfxmvu7zllotqohop256c6ytvli4a, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
Generating proposed image
Installed cloud-init version: 20.2-45-g5f7825e2-0ubuntu1~20.04.1
Created proposed image: ocid1.image.oc1.phx.aaaaaaaaifpe7rbngkkp5r3ykh2ecroqebusxjulvpmhn2qiylutkxomii5q
Done with environment setup
Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc5vansmrspso25tz5pyfngjsyombafj3lm4q4aztcmxra, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
I can run anywhere
/usr/bin/cloud-init 20.2-45-g5f7825e2-0ubuntu1~20.04.1
PASSED
tests/integration_tests/test_simple.py::TestSimple::test_oracle_client Launched instance: OciInstance(instance_id=ocid1.instance.oc1.phx.anyhqljrniwq6syc64oqllbimt5764nhviqvzbfnizlvogdvbunzpcildrza, compartment_id=ocid1.compartment.oc1..aaaaaaaanz4b63fdemmuag77dg2pi22xfyhrpq46hcgdd3dozkvqfzwwjwxa
I can only run on Oracle
/usr/bin/cloud-init 20.2-45-g5f7825e2-0ubuntu1~20.04.1
PASSED

===================================================================================== 2 passed, 1 skipped in 1034.03s (0:17:14) =====================================================================================
```