### PR TITLE
cloudinit: remove global disable of pylint W0107 and fix errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -18,7 +18,6 @@ jobs=4
 # W0602(global-variable-not-assigned)
 # W0603(global-statement)
 # W0611(unused-import)
-# W0612(unused-variable)
 # W0613(unused-argument)
 # W0621(redefined-outer-name)
 # W0622(redefined-builtin)

--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,6 @@ jobs=4
 [MESSAGES CONTROL]
 
 # Errors and warings with some filtered:
-# W0107(unnecessary-pass)
 # W0201(attribute-defined-outside-init)
 # W0212(protected-access)
 # W0221(arguments-differ)
@@ -27,7 +26,7 @@ jobs=4
 # W0703(broad-except)
 # W1401(anomalous-backslash-in-string)
 
-disable=C, F, I, R, W0107, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401
+disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401
 
 
 [REPORTS]

--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -55,7 +55,6 @@ class SetHostnameError(Exception):
     This may happen if we attempt to set the hostname early in cloud-init's
     init-local timeframe as certain services may not be running yet.
     """
-    pass
 
 
 def handle(name, cfg, cloud, log, _args):

--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -92,7 +92,6 @@ class Networking(metaclass=abc.ABCMeta):
         Examples of non-physical network devices: bonds, bridges, tunnels,
         loopback devices.
         """
-        pass
 
     def is_renamed(self, devname: DeviceName) -> bool:
         return net.is_renamed(devname)
@@ -117,7 +116,6 @@ class Networking(metaclass=abc.ABCMeta):
             process entirely, if the device already exists.)
         :type exists: Optional[DeviceName]
         """
-        pass
 
     def wait_for_physdevs(
         self, netcfg: NetworkConfig, *, strict: bool = True
@@ -182,7 +180,6 @@ class BSDNetworking(Networking):
 
     def settle(self, *, exists=None) -> None:
         """BSD has no equivalent to `udevadm settle`; noop."""
-        pass
 
 
 class LinuxNetworking(Networking):

--- a/cloudinit/distros/ubuntu.py
+++ b/cloudinit/distros/ubuntu.py
@@ -49,7 +49,5 @@ class Distro(debian.Distro):
                     copy.deepcopy(PREFERRED_NTP_CLIENTS))
         return self._preferred_ntp_clients
 
-    pass
-
 
 # vi: ts=4 expandtab

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -29,12 +29,10 @@ class InitramfsNetworkConfigSource(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def is_applicable(self) -> bool:
         """Is this initramfs config source applicable to the current system?"""
-        pass
 
     @abc.abstractmethod
     def render_config(self) -> dict:
         """Render a v1 network config from the initramfs configuration"""
-        pass
 
 
 class KlibcNetworkConfigSource(InitramfsNetworkConfigSource):

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -31,12 +31,10 @@ class InvalidDHCPLeaseFileError(Exception):
     Current uses are DataSourceAzure and DataSourceEc2 during ephemeral
     boot to scrape metadata.
     """
-    pass
 
 
 class NoDHCPLeaseError(Exception):
     """Raised when unable to get a DHCP lease."""
-    pass
 
 
 class EphemeralDHCPv4(object):

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -35,7 +35,6 @@ class ReportingHandler(metaclass=abc.ABCMeta):
 
     def flush(self):
         """Ensure ReportingHandler has published all events"""
-        pass
 
 
 class LogHandler(ReportingHandler):

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -688,7 +688,6 @@ class DataSourceAzure(sources.DataSource):
             except UrlError:
                 # Teardown our EphemeralDHCPv4 context on failure as we retry
                 self._ephemeral_dhcp_ctx.clean_network()
-                pass
             finally:
                 if nl_sock:
                     nl_sock.close()

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -78,7 +78,6 @@ class DataSourceNotFoundException(Exception):
 
 class InvalidMetaDataException(Exception):
     """Raised when metadata is broken, unavailable or disabled."""
-    pass
 
 
 def process_instance_metadata(metadata, key_path='', sensitive_keys=()):
@@ -511,7 +510,6 @@ class DataSource(metaclass=abc.ABCMeta):
             (e.g. 'ssh-rsa') and key_value is the key itself
             (e.g. 'AAAAB3NzaC1y...').
         """
-        pass
 
     def _remap_device(self, short_name):
         # LP: #611137

--- a/cloudinit/sources/helpers/netlink.py
+++ b/cloudinit/sources/helpers/netlink.py
@@ -55,7 +55,6 @@ NetlinkHeader = namedtuple('NetlinkHeader', ['length', 'type', 'flags', 'seq',
 
 class NetlinkCreateSocketError(RuntimeError):
     '''Raised if netlink socket fails during create or bind.'''
-    pass
 
 
 def create_bound_netlink_socket():

--- a/cloudinit/sources/helpers/vmware/imc/config_file.py
+++ b/cloudinit/sources/helpers/vmware/imc/config_file.py
@@ -22,7 +22,6 @@ class ConfigFile(ConfigSource, dict):
 
     def __init__(self, filename):
         self._loadConfigFile(filename)
-        pass
 
     def _insertKey(self, key, val):
         """

--- a/cloudinit/sources/helpers/vmware/imc/config_namespace.py
+++ b/cloudinit/sources/helpers/vmware/imc/config_namespace.py
@@ -10,6 +10,5 @@ from .config_source import ConfigSource
 
 class ConfigNamespace(ConfigSource):
     """Specifies the Config Namespace."""
-    pass
 
 # vi: ts=4 expandtab

--- a/cloudinit/sources/helpers/vmware/imc/config_source.py
+++ b/cloudinit/sources/helpers/vmware/imc/config_source.py
@@ -8,6 +8,5 @@
 
 class ConfigSource(object):
     """Specifies a source for the Config Content."""
-    pass
 
 # vi: ts=4 expandtab

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -947,7 +947,6 @@ def _pkl_load(fname):
     except Exception as e:
         if os.path.isfile(fname):
             LOG.warning("failed loading pickle in %s: %s", fname, e)
-        pass
 
     # This is allowed so just return nothing successfully loaded...
     if not pickle_contents:

--- a/tests/cloud_tests/platforms/azurecloud/instance.py
+++ b/tests/cloud_tests/platforms/azurecloud/instance.py
@@ -80,7 +80,6 @@ class AzureCloudInstance(Instance):
         except CloudError:
             LOG.debug(('image not found, launching instance with base image, '
                        'image_id=%s'), self.image_id)
-            pass
 
         vm_params = {
             'name': self.vm_name,
@@ -169,7 +168,6 @@ class AzureCloudInstance(Instance):
                     sleep(15)
                 else:
                     LOG.warning('Could not find console log: %s', e)
-                    pass
 
         LOG.debug('stopping instance %s', self.image_id)
         vm_deallocate = \

--- a/tests/cloud_tests/platforms/images.py
+++ b/tests/cloud_tests/platforms/images.py
@@ -52,6 +52,5 @@ class Image(TargetBase):
 
     def destroy(self):
         """Clean up data associated with image."""
-        pass
 
 # vi: ts=4 expandtab

--- a/tests/cloud_tests/platforms/snapshots.py
+++ b/tests/cloud_tests/platforms/snapshots.py
@@ -40,6 +40,5 @@ class Snapshot(object):
 
     def destroy(self):
         """Clean up snapshot data."""
-        pass
 
 # vi: ts=4 expandtab

--- a/tests/cloud_tests/testcases/base.py
+++ b/tests/cloud_tests/testcases/base.py
@@ -34,7 +34,6 @@ class CloudTestCase(unittest.TestCase):
     @classmethod
     def maybeSkipTest(cls):
         """Present to allow subclasses to override and raise a skipTest."""
-        pass
 
     def assertPackageInstalled(self, name, version=None):
         """Check dpkg-query --show output for matching package name.

--- a/tests/unittests/test_datasource/test_ibmcloud.py
+++ b/tests/unittests/test_datasource/test_ibmcloud.py
@@ -15,13 +15,6 @@ mock = test_helpers.mock
 D_PATH = "cloudinit.sources.DataSourceIBMCloud."
 
 
-class TestIBMCloud(test_helpers.CiTestCase):
-    """Test the datasource."""
-    def setUp(self):
-        super(TestIBMCloud, self).setUp()
-        pass
-
-
 @mock.patch(D_PATH + "_is_xen", return_value=True)
 @mock.patch(D_PATH + "_is_ibm_provisioning")
 @mock.patch(D_PATH + "util.blkid")

--- a/tests/unittests/test_reporting.py
+++ b/tests/unittests/test_reporting.py
@@ -349,7 +349,6 @@ class TestReportingEventStack(TestCase):
         with parent:
             with child:
                 pass
-            pass
         self.assertEqual(report_start.call_count, 0)
         self.assertEqual(report_finish.call_count, 0)
 


### PR DESCRIPTION
This includes removing a test class which contained no tests but wasn't
detected as empty because of an errant pass statement.

(Also update the comment in .pylintrc to match what we actually filter.)