### PR TITLE
DataSourceAzure: Use ValueError when JSONDecodeError is not available

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1436,9 +1436,10 @@ def _get_metadata_from_imds(retries):
         report_diagnostic_event(msg)
         LOG.debug(msg)
         return {}
+    if
     try:
         return util.load_json(str(response))
-    except json.decoder.JSONDecodeError as e:
+    except ValueError as e:
         report_diagnostic_event('non-json imds response' % e)
         LOG.warning(
             'Ignoring non-json IMDS instance metadata: %s', str(response))

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1436,8 +1436,14 @@ def _get_metadata_from_imds(retries):
         LOG.debug(msg)
         return {}
     try:
+        import json
+        json_decode_error = json.decoder.JSONDecodeError
+    except ImportError, AttributeError:
+        json_decode_error = ValueError
+
+    try:
         return util.load_json(str(response))
-    except ValueError as e:
+    except json_decode_error as e:
         report_diagnostic_event('non-json imds response' % e)
         LOG.warning(
             'Ignoring non-json IMDS instance metadata: %s', str(response))

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1436,9 +1436,9 @@ def _get_metadata_from_imds(retries):
         LOG.debug(msg)
         return {}
     try:
-        import json
-        json_decode_error = json.decoder.JSONDecodeError
-    except (ImportError, AttributeError):
+        from json.decoder import JSONDecodeError
+        json_decode_error = JSONDecodeError
+    except ImportError:
         json_decode_error = ValueError
 
     try:

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -8,7 +8,6 @@ import base64
 import contextlib
 import crypt
 from functools import partial
-import json
 import os
 import os.path
 import re

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1438,7 +1438,7 @@ def _get_metadata_from_imds(retries):
     try:
         import json
         json_decode_error = json.decoder.JSONDecodeError
-    except ImportError, AttributeError:
+    except (ImportError, AttributeError):
         json_decode_error = ValueError
 
     try:

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1436,7 +1436,6 @@ def _get_metadata_from_imds(retries):
         report_diagnostic_event(msg)
         LOG.debug(msg)
         return {}
-    if
     try:
         return util.load_json(str(response))
     except ValueError as e:


### PR DESCRIPTION
JSONDecodeError is only available in Python 3.5+. When it isn't available (i.e. on Python 3.4, which cloud-init still supports) use the more generic ValueError.