### PR TITLE
freebsd: py37-serial is now py37-pyserial

### DIFF
--- a/tools/build-on-freebsd
+++ b/tools/build-on-freebsd
@@ -28,7 +28,7 @@ pkgs="
     $py_prefix-jsonschema
     $py_prefix-oauthlib
     $py_prefix-requests
-    $py_prefix-serial
+    $py_prefix-pyserial
     $py_prefix-yaml
     sudo
 "


### PR DESCRIPTION
The package has been renamed.

See: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=246546