### PR TITLE
Disable bouncing hostname when setting hostname fails

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -275,7 +275,14 @@ def temporary_hostname(temp_hostname, cfg, hostname_command='hostname'):
        (previous_hostname == temp_hostname and policy != 'force')):
         yield None
         return
-    set_hostname(temp_hostname, hostname_command)
+    try:
+        set_hostname(temp_hostname, hostname_command)
+    except Exception as e:
+        msg = 'Failed setting temporary hostname: %s' % e
+        report_diagnostic_event(msg)
+        LOG.warning(msg)
+        yield None
+        return
     try:
         yield previous_hostname
     finally:

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -1524,6 +1524,17 @@ class TestAzureBounce(CiTestCase):
 
         self.assertEqual(0, self.set_hostname.call_count)
 
+    @mock.patch(MOCKPATH + 'perform_hostname_bounce')
+    def test_set_hostname_failed_disable_bounce(
+            self, perform_hostname_bounce):
+        cfg = {'set_hostname': True, 'hostname_bounce': {'policy': 'force'}}
+        self.get_hostname.return_value = "old-hostname"
+        self.set_hostname.side_effect = Exception
+        data = self.get_ovf_env_with_dscfg('some-hostname', cfg)
+        self._get_ds(data).get_data()
+
+        self.assertEqual(0, perform_hostname_bounce.call_count)
+
 
 class TestLoadAzureDsDir(CiTestCase):
     """Tests for load_azure_ds_dir."""


### PR DESCRIPTION
DataSourceAzure: Gracefully handle the case of set hostname failure during provisioning