### PR TITLE
Fixing the problem of the new name LABEL_FATBOOT in news SO, like Debian Buster (10) and Ubuntu 20.04

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -41,6 +41,7 @@ class DataSourceNoCloud(sources.DataSource):
 
         label_list = util.find_devs_with("LABEL=%s" % label.upper())
         label_list.extend(util.find_devs_with("LABEL=%s" % label.lower()))
+        label_list.extend( util.find_devs_with("LABEL_FATBOOT=%s" % label))
 
         devlist = list(set(fslist) & set(label_list))
         devlist.sort(reverse=True)

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -268,6 +268,8 @@ read_fs_info() {
                 dev=${line#DEVNAME=};;
             LABEL=*) label="${line#LABEL=}";
                      labels="${labels}${line#LABEL=}${delim}";;
+            LABEL_FATBOOT=*) label="${line#LABEL_FATBOOT=}";
+		             labels="${labels}${line#LABEL_FATBOOT=}${delim}";;
             TYPE=*) ftype=${line#TYPE=};;
             UUID=*) uuids="${uuids}${line#UUID=}$delim";;
         esac


### PR DESCRIPTION
Fixing an issue originally created https://github.com/vatesfr/xen-orchestra/issues/4449.
This fix was also proposed as a form of patches [here](https://bugs.launchpad.net/cloud-init/+bug/1841466/comments/5).
Now he will be able to recognize both "LABEL" and "LABEL_FATBOOT".
These two patches solve the problem. Both in the DataSourceNoCloud.py and in the ds-identify.
Tested cloudinit version: 20.2
Debian 10 (Buster)

Location of each file (after installation):

/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceNoCloud.py
/usr/lib/cloud-init/ds-identify