### PR TITLE
Fixing the problem of the new name LABEL_FATBOOT

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -41,6 +41,7 @@ class DataSourceNoCloud(sources.DataSource):
 
         label_list = util.find_devs_with("LABEL=%s" % label.upper())
         label_list.extend(util.find_devs_with("LABEL=%s" % label.lower()))
+        label_list.extend( util.find_devs_with("LABEL_FATBOOT=%s" % label))
 
         devlist = list(set(fslist) & set(label_list))
         devlist.sort(reverse=True)

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -268,6 +268,8 @@ read_fs_info() {
                 dev=${line#DEVNAME=};;
             LABEL=*) label="${line#LABEL=}";
                      labels="${labels}${line#LABEL=}${delim}";;
+            LABEL_FATBOOT=*) label="${line#LABEL_FATBOOT=}";
+		             labels="${labels}${line#LABEL_FATBOOT=}${delim}";;
             TYPE=*) ftype=${line#TYPE=};;
             UUID=*) uuids="${uuids}${line#UUID=}$delim";;
         esac


### PR DESCRIPTION
Fixing an issue originally created vatesfr/xen-orchestra#4449.

This fix was also proposed as a form of patches here.
Now he will be able to recognize both "LABEL" and "LABEL_FATBOOT".

These two patches solve the problem. Both in the DataSourceNoCloud.py and in the ds-identify.

LP: #496 