### PR TITLE
Add "tsanghan" as contributor and "ssh-ed25519" to cc_ssh_authkey_fingerprints

### DIFF
--- a/cloudinit/config/cc_ssh_authkey_fingerprints.py
+++ b/cloudinit/config/cc_ssh_authkey_fingerprints.py
@@ -60,7 +60,9 @@ def _gen_fingerprint(b64_text, hash_meth='sha256'):
 def _is_printable_key(entry):
     if any([entry.keytype, entry.base64, entry.comment, entry.options]):
         if (entry.keytype and
-                entry.keytype.lower().strip() in ['ssh-dss', 'ssh-rsa']):
+                entry.keytype.lower().strip() in ['ssh-dss',
+                                                  'ssh-rsa',
+                                                  'ssh-ed25519']):
             return True
     return False
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -12,3 +12,4 @@ onitake
 smoser
 TheRealFalcon
 tomponline
+tsanghan


### PR DESCRIPTION
1) Add "tsanghan" as contributor
2) Currently, cc_ssh_authkey_fingerprints does not displaying ssh ed25519 keys fingerprint. Added 'ssh-ed25591' to _is_printable_key() function.