### PR TITLE
Added 6 more ssh key types in cc_ssh_authkey_fingerprints

### DIFF
--- a/cloudinit/config/cc_ssh_authkey_fingerprints.py
+++ b/cloudinit/config/cc_ssh_authkey_fingerprints.py
@@ -59,8 +59,17 @@ def _gen_fingerprint(b64_text, hash_meth='sha256'):
 
 def _is_printable_key(entry):
     if any([entry.keytype, entry.base64, entry.comment, entry.options]):
-        if (entry.keytype and
-                entry.keytype.lower().strip() in ['ssh-dss', 'ssh-rsa']):
+        if (entry.keytype and entry.keytype.lower().strip()
+                in ['ssh-dss',
+                    'ssh-rsa',
+                    'ssh-ed25519',
+                    'ecdsa-sha2-nistp521',
+                    'ecdsa-sha2-nistp384',
+                    'ecdsa-sha2-nistp256',
+                    'sk-ssh-ed25519@openssh.com',
+                    'sk-ecdsa-sha2-nistp256@openssh.com']):
+            # key types from
+            # https://man.openbsd.org/sshd#AUTHORIZED_KEYS_FILE_FORMAT
             return True
     return False
 


### PR DESCRIPTION
Added 6 more ssh key types in function _is_printable_key() in cc_ssh_authkey_fingerprints module.
Please reference [https://man.openbsd.org/sshd#AUTHORIZED_KEYS_FILE_FORMAT](https://man.openbsd.org/sshd#AUTHORIZED_KEYS_FILE_FORMAT) for openssh supported key types list.