### PR TITLE
user-data: only verify mime-types for TYPE_NEEDED and x-shellscript

### DIFF
--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -126,8 +126,12 @@ class UserDataProcessor(object):
             # Attempt to figure out the payloads content-type
             if not ctype_orig:
                 ctype_orig = UNDEF_TYPE
-            if ctype_orig in TYPE_NEEDED or (ctype_orig in
-                                             INCLUDE_MAP.values()):
+            # There are known cases where mime-type text/x-shellscript included
+            # non shell-script content that was user-data instead.  It is safe
+            # to check the true MIME type for x-shellscript type since all
+            # shellscript payloads must have a #! header.  The other MIME types
+            # that cloud-init supports do not have the same guarantee.
+            if ctype_orig in TYPE_NEEDED + ['text/x-shellscript']:
                 ctype = find_ctype(payload)
             if ctype is None:
                 ctype = ctype_orig


### PR DESCRIPTION
Commit d00126c167fc06d913d99cfc184bf3402cb8cf53 regressed cloud-init
handling in multipart MIME user-data.  Specifically, cloud-init would
examine the payload of the MIME part to determine what the content
type and subsequently which handler to use.  This meant that user-data
which had shellscript payloads (starts with #!) were always handled
as shellscripts, rather than their declared MIME type and affected
when the payload was handled.

One failing scenario was a MIME part with text/cloud-boothook type
declared and a shellscript payload.  This was run at shellscript
processing time rather than boothook time resulting in an change in
behavior from previous cloud-init releases.

To continue to support known scenarios where clouds have specifed
a MIME type of text/x-shellscript but provided a payload of something
other than shellscripts, we're changing the lookup logic to check for
the TYPES_NEEDED (text/plain, text/x-not-multipart) and only
text/x-shellscript.

It is safe to check text/x-shellscript parts as all shellscripts must
include the #! marker and will be detected as text/x-shellscript types.
If the content is missing the #! marker, it will not be excuted.  If
the content is detected as something cloud-init supports, such as
 #cloud-config the appropriate cloud-init handler will be used.

This change will fix hanldling for parts which were shellscripts but
ran with the wrong handler due to ignoring of the provided mime-type.

LP: #1888822