### PR TITLE
test-requirements.txt: pin pytest to <6

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 # Needed generally in tests
 httpretty>=0.7.1
-pytest
+pytest<6
 pytest-cov
 
 # Only really needed on older versions of python

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 # Needed generally in tests
 httpretty>=0.7.1
+# Temporarily pin pytest until https://github.com/pytest-dev/pytest/pull/7566 is released
 pytest<6
 pytest-cov
 


### PR DESCRIPTION
pylint is emitting errors with pytest 6.x which are not observed on
pytest 5.x.  While that is resolved, pin to a lower pytest version.