### PR TITLE
Fix label fatboot

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -41,6 +41,7 @@ class DataSourceNoCloud(sources.DataSource):
 
         label_list = util.find_devs_with("LABEL=%s" % label.upper())
         label_list.extend(util.find_devs_with("LABEL=%s" % label.lower()))
+        label_list.extend( util.find_devs_with("LABEL_FATBOOT=%s" % label))
 
         devlist = list(set(fslist) & set(label_list))
         devlist.sort(reverse=True)

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -41,7 +41,7 @@ class DataSourceNoCloud(sources.DataSource):
 
         label_list = util.find_devs_with("LABEL=%s" % label.upper())
         label_list.extend(util.find_devs_with("LABEL=%s" % label.lower()))
-        label_list.extend( util.find_devs_with("LABEL_FATBOOT=%s" % label))
+        label_list.extend(util.find_devs_with("LABEL_FATBOOT=%s" % label))
 
         devlist = list(set(fslist) & set(label_list))
         devlist.sort(reverse=True)

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1111,6 +1111,7 @@ def close_stdin():
 
 def find_devs_with_freebsd(criteria=None, oformat='device',
                            tag=None, no_cache=False, path=None):
+    devlist = []
     if not criteria:
         return glob.glob("/dev/msdosfs/*") + glob.glob("/dev/iso9660/*")
     if criteria.startswith("LABEL="):

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -577,6 +577,10 @@ class TestDsIdentify(DsIdentifyBase):
         """NoCloud is found with uppercase filesystem label."""
         self._test_ds_found('NoCloudUpper')
 
+    def test_nocloud_fatboot(self):
+        """NoCloud fatboot label - LP: #184166."""
+        self._test_ds_found('NoCloud-fatboot')
+
     def test_nocloud_seed(self):
         """Nocloud seed directory."""
         self._test_ds_found('NoCloud-seed')
@@ -811,6 +815,20 @@ VALID_CFG = {
              'out': blkid_out(
                  BLKID_UEFI_UBUNTU +
                  [{'DEVNAME': 'vdb', 'TYPE': 'iso9660', 'LABEL': 'CIDATA'}])},
+        ],
+        'files': {
+            'dev/vdb': 'pretend iso content for cidata\n',
+        }
+    },
+    'NoCloud-fatboot': {
+        'ds': 'NoCloud',
+        'mocks': [
+            MOCK_VIRT_IS_XEN,
+            {'name': 'blkid', 'ret': 0,
+             'out': blkid_out(
+                 BLKID_UEFI_UBUNTU +
+                 [{'DEVNAME': 'xvdb', 'TYPE': 'vfat', 'SEC_TYPE': 'msdos',
+                   'UUID': '355a-4FC2', 'LABEL_FATBOOT': 'cidata'}])},
         ],
         'files': {
             'dev/vdb': 'pretend iso content for cidata\n',

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -967,96 +967,125 @@ class TestGetProcEnv(helpers.TestCase):
         self.assertEqual(my_ppid, util.get_proc_ppid(my_pid))
 
 
-@mock.patch('cloudinit.subp.subp')
-def test_find_devs_with_openbsd(m_subp):
-    m_subp.return_value = (
-        'cd0:,sd0:630d98d32b5d3759,sd1:,fd0:', ''
-    )
-    devlist = util.find_devs_with_openbsd()
-    assert devlist == ['/dev/cd0a', '/dev/sd1i']
+class TestFindDevs:
+    @mock.patch('cloudinit.subp.subp')
+    def test_find_devs_with(self, m_subp):
+        m_subp.return_value = (
+            '/dev/sda1: UUID="some-uuid" TYPE="ext4" PARTUUID="some-partid"',
+            ''
+        )
+        devlist = util.find_devs_with()
+        assert devlist == [
+            '/dev/sda1: UUID="some-uuid" TYPE="ext4" PARTUUID="some-partid"']
 
+        devlist = util.find_devs_with("LABEL_FATBOOT=A_LABEL")
+        assert devlist == [
+            '/dev/sda1: UUID="some-uuid" TYPE="ext4" PARTUUID="some-partid"']
 
-@mock.patch('cloudinit.subp.subp')
-def test_find_devs_with_openbsd_with_criteria(m_subp):
-    m_subp.return_value = (
-        'cd0:,sd0:630d98d32b5d3759,sd1:,fd0:', ''
-    )
-    devlist = util.find_devs_with_openbsd(criteria="TYPE=iso9660")
-    assert devlist == ['/dev/cd0a']
+    @mock.patch('cloudinit.subp.subp')
+    def test_find_devs_with_openbsd(self, m_subp):
+        m_subp.return_value = (
+            'cd0:,sd0:630d98d32b5d3759,sd1:,fd0:', ''
+        )
+        devlist = util.find_devs_with_openbsd()
+        assert devlist == ['/dev/cd0a', '/dev/sd1i']
 
+    @mock.patch('cloudinit.subp.subp')
+    def test_find_devs_with_openbsd_with_criteria(self, m_subp):
+        m_subp.return_value = (
+            'cd0:,sd0:630d98d32b5d3759,sd1:,fd0:', ''
+        )
+        devlist = util.find_devs_with_openbsd(criteria="TYPE=iso9660")
+        assert devlist == ['/dev/cd0a']
 
-@mock.patch('glob.glob')
-def test_find_devs_with_freebsd(m_glob):
-    def fake_glob(pattern):
-        msdos = ["/dev/msdosfs/EFISYS"]
-        iso9660 = ["/dev/iso9660/config-2"]
-        if pattern == "/dev/msdosfs/*":
-            return msdos
-        elif pattern == "/dev/iso9660/*":
-            return iso9660
-        raise Exception
-    m_glob.side_effect = fake_glob
+        # lp: #1841466
+        devlist = util.find_devs_with_openbsd(criteria="LABEL_FATBOOT=A_LABEL")
+        assert devlist == ['/dev/cd0a', '/dev/sd1i']
 
-    devlist = util.find_devs_with_freebsd()
-    assert set(devlist) == set([
-        '/dev/iso9660/config-2', '/dev/msdosfs/EFISYS'])
-    devlist = util.find_devs_with_freebsd(criteria="TYPE=iso9660")
-    assert devlist == ['/dev/iso9660/config-2']
-    devlist = util.find_devs_with_freebsd(criteria="TYPE=vfat")
-    assert devlist == ['/dev/msdosfs/EFISYS']
+    @mock.patch('glob.glob')
+    def test_find_devs_with_freebsd(self, m_glob):
+        def fake_glob(pattern):
+            msdos = ["/dev/msdosfs/EFISYS"]
+            iso9660 = ["/dev/iso9660/config-2"]
+            if pattern == "/dev/msdosfs/*":
+                return msdos
+            elif pattern == "/dev/iso9660/*":
+                return iso9660
+            raise Exception
+        m_glob.side_effect = fake_glob
 
+        devlist = util.find_devs_with_freebsd()
+        assert set(devlist) == set([
+            '/dev/iso9660/config-2', '/dev/msdosfs/EFISYS'])
 
-@mock.patch("cloudinit.subp.subp")
-def test_find_devs_with_netbsd(m_subp):
-    side_effect_values = [
-        ("ld0 dk0 dk1 cd0", ""),
-        (
+        devlist = util.find_devs_with_freebsd(criteria="TYPE=iso9660")
+        assert devlist == ['/dev/iso9660/config-2']
+
+        devlist = util.find_devs_with_freebsd(criteria="TYPE=vfat")
+        assert devlist == ['/dev/msdosfs/EFISYS']
+
+        # lp: #1841466
+        devlist = util.find_devs_with_freebsd(criteria="LABEL_FATBOOT=A_LABEL")
+        assert devlist == []
+
+    @mock.patch("cloudinit.subp.subp")
+    def test_find_devs_with_netbsd(self, m_subp):
+        side_effect_values = [
+            ("ld0 dk0 dk1 cd0", ""),
             (
-                "mscdlabel: CDIOREADTOCHEADER: "
-                "Inappropriate ioctl for device\n"
-                "track (ctl=4) at sector 0\n"
-                "disklabel not written\n"
+                (
+                    "mscdlabel: CDIOREADTOCHEADER: "
+                    "Inappropriate ioctl for device\n"
+                    "track (ctl=4) at sector 0\n"
+                    "disklabel not written\n"
+                ),
+                "",
             ),
-            "",
-        ),
-        (
             (
-                "mscdlabel: CDIOREADTOCHEADER: "
-                "Inappropriate ioctl for device\n"
-                "track (ctl=4) at sector 0\n"
-                "disklabel not written\n"
+                (
+                    "mscdlabel: CDIOREADTOCHEADER: "
+                    "Inappropriate ioctl for device\n"
+                    "track (ctl=4) at sector 0\n"
+                    "disklabel not written\n"
+                ),
+                "",
             ),
-            "",
-        ),
-        (
             (
-                "mscdlabel: CDIOREADTOCHEADER: "
-                "Inappropriate ioctl for device\n"
-                "track (ctl=4) at sector 0\n"
-                "disklabel not written\n"
+                (
+                    "mscdlabel: CDIOREADTOCHEADER: "
+                    "Inappropriate ioctl for device\n"
+                    "track (ctl=4) at sector 0\n"
+                    "disklabel not written\n"
+                ),
+                "",
             ),
-            "",
-        ),
-        (
             (
-                "track (ctl=4) at sector 0\n"
-                'ISO filesystem, label "config-2", '
-                "creation time: 2020/03/31 17:29\n"
-                "adding as 'a'\n"
+                (
+                    "track (ctl=4) at sector 0\n"
+                    'ISO filesystem, label "config-2", '
+                    "creation time: 2020/03/31 17:29\n"
+                    "adding as 'a'\n"
+                ),
+                "",
             ),
-            "",
-        ),
-    ]
-    m_subp.side_effect = side_effect_values
-    devlist = util.find_devs_with_netbsd()
-    assert set(devlist) == set(
-        ["/dev/ld0", "/dev/dk0", "/dev/dk1", "/dev/cd0"]
-    )
-    m_subp.side_effect = side_effect_values
-    devlist = util.find_devs_with_netbsd(criteria="TYPE=iso9660")
-    assert devlist == ["/dev/cd0"]
-    m_subp.side_effect = side_effect_values
-    devlist = util.find_devs_with_netbsd(criteria="TYPE=vfat")
-    assert devlist == ["/dev/ld0", "/dev/dk0", "/dev/dk1"]
+        ]
+        m_subp.side_effect = side_effect_values
+        devlist = util.find_devs_with_netbsd()
+        assert set(devlist) == set(
+            ["/dev/ld0", "/dev/dk0", "/dev/dk1", "/dev/cd0"]
+        )
+
+        m_subp.side_effect = side_effect_values
+        devlist = util.find_devs_with_netbsd(criteria="TYPE=iso9660")
+        assert devlist == ["/dev/cd0"]
+
+        m_subp.side_effect = side_effect_values
+        devlist = util.find_devs_with_netbsd(criteria="TYPE=vfat")
+        assert devlist == ["/dev/ld0", "/dev/dk0", "/dev/dk1"]
+
+        # lp: #1841466
+        m_subp.side_effect = side_effect_values
+        devlist = util.find_devs_with_netbsd(criteria="LABEL_FATBOOT=A_LABEL")
+        assert devlist == ['/dev/ld0', '/dev/dk0', '/dev/dk1', '/dev/cd0']
 
 # vi: ts=4 expandtab

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -7,6 +7,7 @@ dhensby
 eandersson
 landon912
 lucasmoura
+marlluslustosa
 matthewruffell
 nishigori
 onitake

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -269,7 +269,7 @@ read_fs_info() {
             LABEL=*) label="${line#LABEL=}";
                      labels="${labels}${line#LABEL=}${delim}";;
             LABEL_FATBOOT=*) label="${line#LABEL_FATBOOT=}";
-		             labels="${labels}${line#LABEL_FATBOOT=}${delim}";;
+                     labels="${labels}${line#LABEL_FATBOOT=}${delim}";;
             TYPE=*) ftype=${line#TYPE=};;
             UUID=*) uuids="${uuids}${line#UUID=}$delim";;
         esac

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -268,6 +268,8 @@ read_fs_info() {
                 dev=${line#DEVNAME=};;
             LABEL=*) label="${line#LABEL=}";
                      labels="${labels}${line#LABEL=}${delim}";;
+            LABEL_FATBOOT=*) label="${line#LABEL_FATBOOT=}";
+		             labels="${labels}${line#LABEL_FATBOOT=}${delim}";;
             TYPE=*) ftype=${line#TYPE=};;
             UUID=*) uuids="${uuids}${line#UUID=}$delim";;
         esac

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -266,10 +266,9 @@ read_fs_info() {
                     isodevs="${isodevs},${dev}=$label"
                 ftype=""; dev=""; label="";
                 dev=${line#DEVNAME=};;
-            LABEL=*) label="${line#LABEL=}";
-                     labels="${labels}${line#LABEL=}${delim}";;
-            LABEL_FATBOOT=*) label="${line#LABEL_FATBOOT=}";
-                     labels="${labels}${line#LABEL_FATBOOT=}${delim}";;
+            LABEL=*|LABEL_FATBOOT=*)
+                label="${line#*=}";
+                labels="${labels}${label}${delim}";;
             TYPE=*) ftype=${line#TYPE=};;
             UUID=*) uuids="${uuids}${line#UUID=}$delim";;
         esac


### PR DESCRIPTION
Continuation of #500.

Proposed squashed commit message:
```
Recognize LABEL_FATBOOT labels

Update DataSourceNoCloud and ds-identify to recognize LABEL_FATBOOT labels from blkid.
Also updated associated tests.

LP: #1841466
```

