### PR TITLE
Revert "test-requirements.txt: pin pytest to <6 (#512)"

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
 # Needed generally in tests
 httpretty>=0.7.1
-# Temporarily pin pytest until https://github.com/pytest-dev/pytest/pull/7566 is released
-pytest<6
+pytest
 pytest-cov
 
 # Only really needed on older versions of python


### PR DESCRIPTION
pytest 6.0.1 fixes the issue we had with pytest 6.0.0.

This reverts commit db5c1c81840638cfe6f08bbd40982b86dd3ecef7.