### PR TITLE
cmd: cloud-init query to handle compressed userdata

### DIFF
--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -65,7 +65,7 @@ def get_parser(parser=None):
     return parser
 
 
-def maybe_decode_decompress_userdata(ud_file_path):
+def load_userdata(ud_file_path):
     """Return a string of user-data from ud_file_path
 
     Attempt to decode or decompress if needed
@@ -136,12 +136,8 @@ def handle_args(name, args):
         instance_data['vendordata'] = (
             '<%s> file:%s' % (REDACT_SENSITIVE_VALUE, vendor_data_fn))
     else:
-        instance_data['userdata'] = maybe_decode_decompress_userdata(
-            user_data_fn
-        )
-        instance_data['vendordata'] = maybe_decode_decompress_userdata(
-            vendor_data_fn
-        )
+        instance_data['userdata'] = load_userdata(user_data_fn)
+        instance_data['vendordata'] = load_userdata(vendor_data_fn)
     if args.format:
         payload = '## template: jinja\n{fmt}'.format(fmt=args.format)
         rendered_payload = render_jinja_payload(

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -6,8 +6,11 @@ structure.
 Some instance-data values may be binary on some platforms, such as userdata and
 vendordata. Attempt to decompress and decode UTF-8 any binary values.
 
-Binary instance-data values which cannot be decompressed or decoded,
-will be base64-encoded and will have the prefix "ci-b64:" on the value.
+Any binary values in the instance metadata will be base64-encoded and prefixed
+with "ci-b64:" in the output. userdata and, where applicable, vendordata may
+be provided to the machine gzip-compressed (and therefore as binary data).
+query will attempt to decompress these to a string before emitting the JSON
+output; if this fails, they are treated as binary.
 """
 
 import argparse
@@ -90,7 +93,7 @@ def load_userdata(ud_file_path):
     except UnicodeDecodeError:
         encoded_data = util.load_file(ud_file_path, decode=False)
         try:
-            return util.decomp_gzip(encoded_data)
+            return util.decomp_gzip(encoded_data, quiet=False)
         except util.DecompressionError:
             return encoded_data
 

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -66,9 +66,14 @@ def get_parser(parser=None):
 
 
 def load_userdata(ud_file_path):
-    """Return a string of user-data from ud_file_path
+    """Attempt to return a string of user-data from ud_file_path
 
-    Attempt to decode or decompress if needed
+    Attempt to decode or decompress if needed.
+    If unable to decode the content, raw bytes will be returned,
+    which load_json base64-encodes, adding a ci-b64: prefix to the value when
+    emitting the JSON output.
+
+    @returns: String of uncompressed userdata if possible, otherwise bytes.
     """
     try:
         return util.load_file(ud_file_path)

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -63,8 +63,8 @@ def get_parser(parser=None):
               ' /var/lib/cloud/instance/vendor-data.txt'))
     parser.add_argument(
         'varname', type=str, nargs='?',
-        help=('A dot-delimited specific instance data variable to query from'
-              ' instance-data query. For example: v1.local_hostname. If the'
+        help=('A dot-delimited specific variable to query from'
+              ' instance-data. For example: v1.local_hostname. If the'
               ' value is not JSON serializable, it will be base64-encoded and'
               ' will contain the prefix "ci-b64:". '))
     parser.add_argument(
@@ -82,9 +82,7 @@ def load_userdata(ud_file_path):
     """Attempt to return a string of user-data from ud_file_path
 
     Attempt to decode or decompress if needed.
-    If unable to decode the content, raw bytes will be returned,
-    which load_json base64-encodes, adding a ci-b64: prefix to the value when
-    emitting the JSON output.
+    If unable to decode the content, raw bytes will be returned.
 
     @returns: String of uncompressed userdata if possible, otherwise bytes.
     """

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -1,6 +1,14 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-"""Query standardized instance metadata from the command line."""
+"""Query standardized instance metadata provided to machine, returning a JSON
+structure.
+
+Some instance-data values may be binary on some platforms, such as userdata and
+vendordata. Attempt to decompress and decode UTF-8 any binary values.
+
+Binary instance-data values which cannot be decompressed or decoded,
+will be base64-encoded and will have the prefix "ci-b64:" on the value.
+"""
 
 import argparse
 from errno import EACCES
@@ -30,7 +38,7 @@ def get_parser(parser=None):
     """
     if not parser:
         parser = argparse.ArgumentParser(
-            prog=NAME, description='Query cloud-init instance data')
+            prog=NAME, description=__doc__)
     parser.add_argument(
         '-d', '--debug', action='store_true', default=False,
         help='Add verbose messages during template render')
@@ -52,8 +60,10 @@ def get_parser(parser=None):
               ' /var/lib/cloud/instance/vendor-data.txt'))
     parser.add_argument(
         'varname', type=str, nargs='?',
-        help=('A dot-delimited instance data variable to query from'
-              ' instance-data query. For example: v2.local_hostname'))
+        help=('A dot-delimited specific instance data variable to query from'
+              ' instance-data query. For example: v1.local_hostname. If the'
+              ' value is not JSON serializable, it will be base64-encoded and'
+              ' will contain the prefix "ci-b64:". '))
     parser.add_argument(
         '-a', '--all', action='store_true', default=False, dest='dump_all',
         help='Dump all available instance-data')

--- a/cloudinit/cmd/tests/test_query.py
+++ b/cloudinit/cmd/tests/test_query.py
@@ -1,195 +1,197 @@
-# This file is part of cloud-init. See LICENSE file for license information.
+# This file is part of cloud-init. See LICENSE file for license inforselfmation.
 
 import errno
 from io import StringIO
 from textwrap import dedent
 import os
 
+import pytest
+
 from collections import namedtuple
 from cloudinit.cmd import query
 from cloudinit.helpers import Paths
 from cloudinit.sources import (
     REDACT_SENSITIVE_VALUE, INSTANCE_JSON_FILE, INSTANCE_JSON_SENSITIVE_FILE)
-from cloudinit.tests.helpers import CiTestCase, mock
-from cloudinit.util import ensure_dir, write_file
+from cloudinit.tests.helpers import mock
+from cloudinit.util import ensure_dir
 
 
-class TestQuery(CiTestCase):
-
-    with_logs = True
+class TestQuery:
 
     args = namedtuple(
         'queryargs',
         ('debug dump_all format instance_data list_keys user_data vendor_data'
          ' varname'))
 
-    def setUp(self):
-        super(TestQuery, self).setUp()
-        self.tmp = self.tmp_dir()
-        self.instance_data = self.tmp_path('instance-data', dir=self.tmp)
-
-    def test_handle_args_error_on_missing_param(self):
+    def test_handle_args_error_on_missing_param(self, caplog):
         """Error when missing required parameters and print usage."""
         args = self.args(
             debug=False, dump_all=False, format=None, instance_data=None,
             list_keys=False, user_data=None, vendor_data=None, varname=None)
         with mock.patch('sys.stderr', new_callable=StringIO) as m_stderr:
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-                self.assertEqual(1, query.handle_args('anyname', args))
+                assert 1 == query.handle_args('anyname', args)
         expected_error = (
-            'ERROR: Expected one of the options: --all, --format, --list-keys'
+            'Expected one of the options: --all, --format, --list-keys'
             ' or varname\n')
-        self.assertIn(expected_error, self.logs.getvalue())
-        self.assertIn('usage: query', m_stdout.getvalue())
-        self.assertIn(expected_error, m_stderr.getvalue())
+        logs = caplog.text
+        assert expected_error in logs
+        assert 'usage: query' in m_stdout.getvalue()
+        assert expected_error in m_stderr.getvalue()
 
-    def test_handle_args_error_on_missing_instance_data(self):
+    def test_handle_args_error_on_missing_instance_data(self, tmpdir, caplog):
         """When instance_data file path does not exist, log an error."""
-        absent_fn = self.tmp_path('absent', dir=self.tmp)
+        absent_fn = tmpdir.join('absent')
         args = self.args(
             debug=False, dump_all=True, format=None, instance_data=absent_fn,
             list_keys=False, user_data='ud', vendor_data='vd', varname=None)
         with mock.patch('sys.stderr', new_callable=StringIO) as m_stderr:
-            self.assertEqual(1, query.handle_args('anyname', args))
-        self.assertIn(
-            'ERROR: Missing instance-data file: %s' % absent_fn,
-            self.logs.getvalue())
-        self.assertIn(
-            'ERROR: Missing instance-data file: %s' % absent_fn,
-            m_stderr.getvalue())
+            assert 1 == query.handle_args('anyname', args)
 
-    def test_handle_args_error_when_no_read_permission_instance_data(self):
+        msg = 'Missing instance-data file: %s' % absent_fn
+        assert msg in caplog.text
+        assert msg in m_stderr.getvalue()
+
+    def test_handle_args_error_when_no_read_permission_instance_data(
+        self, tmpdir, caplog
+    ):
         """When instance_data file is unreadable, log an error."""
-        noread_fn = self.tmp_path('unreadable', dir=self.tmp)
-        write_file(noread_fn, 'thou shall not pass')
+        noread_fn = tmpdir.join('unreadable')
+        noread_fn.write('thou shall not pass')
         args = self.args(
             debug=False, dump_all=True, format=None, instance_data=noread_fn,
             list_keys=False, user_data='ud', vendor_data='vd', varname=None)
         with mock.patch('sys.stderr', new_callable=StringIO) as m_stderr:
             with mock.patch('cloudinit.cmd.query.util.load_file') as m_load:
                 m_load.side_effect = OSError(errno.EACCES, 'Not allowed')
-                self.assertEqual(1, query.handle_args('anyname', args))
-        self.assertIn(
-            "ERROR: No read permission on '%s'. Try sudo" % noread_fn,
-            self.logs.getvalue())
-        self.assertIn(
-            "ERROR: No read permission on '%s'. Try sudo" % noread_fn,
-            m_stderr.getvalue())
+                assert 1 == query.handle_args('anyname', args)
+        msg = "No read permission on '%s'. Try sudo" % noread_fn
+        assert msg in caplog.text
+        assert msg in m_stderr.getvalue()
 
-    def test_handle_args_defaults_instance_data(self):
+    def test_handle_args_defaults_instance_data(self, tmpdir, caplog):
         """When no instance_data argument, default to configured run_dir."""
         args = self.args(
             debug=False, dump_all=True, format=None, instance_data=None,
             list_keys=False, user_data=None, vendor_data=None, varname=None)
-        run_dir = self.tmp_path('run_dir', dir=self.tmp)
+        run_dir = tmpdir.join('run_dir')
         ensure_dir(run_dir)
         paths = Paths({'run_dir': run_dir})
-        self.add_patch('cloudinit.cmd.query.read_cfg_paths', 'm_paths')
-        self.m_paths.return_value = paths
         with mock.patch('sys.stderr', new_callable=StringIO) as m_stderr:
-            self.assertEqual(1, query.handle_args('anyname', args))
-        json_file = os.path.join(run_dir, INSTANCE_JSON_FILE)
-        self.assertIn(
-            'ERROR: Missing instance-data file: %s' % json_file,
-            self.logs.getvalue())
-        self.assertIn(
-            'ERROR: Missing instance-data file: %s' % json_file,
-            m_stderr.getvalue())
+            with mock.patch('cloudinit.cmd.query.read_cfg_paths') as m_paths:
+                m_paths.return_value = paths
+                assert 1 == query.handle_args('anyname', args)
+        json_file = run_dir.join(INSTANCE_JSON_FILE)
+        msg = 'Missing instance-data file: %s' % json_file.strpath
+        assert msg in caplog.text
+        assert msg in m_stderr.getvalue()
 
-    def test_handle_args_root_fallsback_to_instance_data(self):
+    def test_handle_args_root_fallsback_to_instance_data(self, tmpdir):
         """When no instance_data argument, root falls back to redacted json."""
         args = self.args(
             debug=False, dump_all=True, format=None, instance_data=None,
             list_keys=False, user_data=None, vendor_data=None, varname=None)
-        run_dir = self.tmp_path('run_dir', dir=self.tmp)
+        run_dir = tmpdir.join('run_dir')
         ensure_dir(run_dir)
         paths = Paths({'run_dir': run_dir})
-        self.add_patch('cloudinit.cmd.query.read_cfg_paths', 'm_paths')
-        self.m_paths.return_value = paths
         with mock.patch('sys.stderr', new_callable=StringIO) as m_stderr:
-            with mock.patch('os.getuid') as m_getuid:
-                m_getuid.return_value = 0
-                self.assertEqual(1, query.handle_args('anyname', args))
-        json_file = os.path.join(run_dir, INSTANCE_JSON_FILE)
-        sensitive_file = os.path.join(run_dir, INSTANCE_JSON_SENSITIVE_FILE)
-        self.assertIn(
+            with mock.patch('cloudinit.cmd.query.read_cfg_paths') as m_paths:
+                m_paths.return_value = paths
+                with mock.patch('os.getuid') as m_getuid:
+                    m_getuid.return_value = 0
+                    assert 1 == query.handle_args('anyname', args)
+        json_file = run_dir.join(INSTANCE_JSON_FILE)
+        sensitive_file = run_dir.join(INSTANCE_JSON_SENSITIVE_FILE)
+        msg = (
             'WARNING: Missing root-readable %s. Using redacted %s instead.' % (
-                sensitive_file, json_file),
-            m_stderr.getvalue())
+                sensitive_file.strpath, json_file.strpath
+            )
+        )
+        assert msg in m_stderr.getvalue()
 
-    def test_handle_args_root_uses_instance_sensitive_data(self):
+    def test_handle_args_root_uses_instance_sensitive_data(self, tmpdir):
         """When no instance_data argument, root uses sensitive json."""
-        user_data = self.tmp_path('user-data', dir=self.tmp)
-        vendor_data = self.tmp_path('vendor-data', dir=self.tmp)
-        write_file(user_data, 'ud')
-        write_file(vendor_data, 'vd')
-        run_dir = self.tmp_path('run_dir', dir=self.tmp)
-        sensitive_file = os.path.join(run_dir, INSTANCE_JSON_SENSITIVE_FILE)
-        write_file(sensitive_file, '{"my-var": "it worked"}')
+        user_data = tmpdir.join('user-data')
+        vendor_data = tmpdir.join('vendor-data')
+        user_data.write('ud')
+        vendor_data.write('vd')
+        run_dir = tmpdir.join('run_dir')
+        sensitive_file = run_dir.join(INSTANCE_JSON_SENSITIVE_FILE)
         ensure_dir(run_dir)
+        sensitive_file.write('{"my-var": "it worked"}')
         paths = Paths({'run_dir': run_dir})
-        self.add_patch('cloudinit.cmd.query.read_cfg_paths', 'm_paths')
-        self.m_paths.return_value = paths
         args = self.args(
             debug=False, dump_all=True, format=None, instance_data=None,
             list_keys=False, user_data=user_data, vendor_data=vendor_data,
             varname=None)
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
-            with mock.patch('os.getuid') as m_getuid:
-                m_getuid.return_value = 0
-                self.assertEqual(0, query.handle_args('anyname', args))
-        self.assertEqual(
+            with mock.patch('cloudinit.cmd.query.read_cfg_paths') as m_paths:
+                m_paths.return_value = paths
+                with mock.patch('os.getuid') as m_getuid:
+                    m_getuid.return_value = 0
+                    assert 0 == query.handle_args('anyname', args)
+        expected = (
             '{\n "my_var": "it worked",\n "userdata": "ud",\n '
-            '"vendordata": "vd"\n}\n', m_stdout.getvalue())
+            '"vendordata": "vd"\n}\n'
+        )
+        assert expected == m_stdout.getvalue()
 
-    def test_handle_args_dumps_all_instance_data(self):
+    def test_handle_args_dumps_all_instance_data(self, tmpdir):
         """When --all is specified query will dump all instance data vars."""
-        write_file(self.instance_data, '{"my-var": "it worked"}')
+        instance_data = tmpdir.join('instance-data')
+        instance_data.write('{"my-var": "it worked"}')
         args = self.args(
             debug=False, dump_all=True, format=None,
-            instance_data=self.instance_data, list_keys=False,
+            instance_data=instance_data, list_keys=False,
             user_data='ud', vendor_data='vd', varname=None)
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             with mock.patch('os.getuid') as m_getuid:
                 m_getuid.return_value = 100
-                self.assertEqual(0, query.handle_args('anyname', args))
-        self.assertEqual(
+                assert 0 == query.handle_args('anyname', args)
+        expected = (
             '{\n "my_var": "it worked",\n "userdata": "<%s> file:ud",\n'
             ' "vendordata": "<%s> file:vd"\n}\n' % (
-                REDACT_SENSITIVE_VALUE, REDACT_SENSITIVE_VALUE),
-            m_stdout.getvalue())
+                REDACT_SENSITIVE_VALUE, REDACT_SENSITIVE_VALUE
+            )
+        )
+        assert expected == m_stdout.getvalue()
 
-    def test_handle_args_returns_top_level_varname(self):
+    def test_handle_args_returns_top_level_varname(self, tmpdir):
         """When the argument varname is passed, report its value."""
-        write_file(self.instance_data, '{"my-var": "it worked"}')
+        instance_data = tmpdir.join('instance-data')
+        instance_data.write('{"my-var": "it worked"}')
         args = self.args(
             debug=False, dump_all=True, format=None,
-            instance_data=self.instance_data, list_keys=False,
+            instance_data=instance_data, list_keys=False,
             user_data='ud', vendor_data='vd', varname='my_var')
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             with mock.patch('os.getuid') as m_getuid:
                 m_getuid.return_value = 100
-                self.assertEqual(0, query.handle_args('anyname', args))
-        self.assertEqual('it worked\n', m_stdout.getvalue())
+                assert 0 == query.handle_args('anyname', args)
+        assert 'it worked\n' == m_stdout.getvalue()
 
-    def test_handle_args_returns_nested_varname(self):
+    def test_handle_args_returns_nested_varname(self, tmpdir):
         """If user_data file is a jinja template render instance-data vars."""
-        write_file(self.instance_data,
-                   '{"v1": {"key-2": "value-2"}, "my-var": "it worked"}')
+        instance_data = tmpdir.join('instance-data')
+        instance_data.write(
+            '{"v1": {"key-2": "value-2"}, "my-var": "it worked"}'
+        )
         args = self.args(
             debug=False, dump_all=False, format=None,
-            instance_data=self.instance_data, user_data='ud', vendor_data='vd',
+            instance_data=instance_data, user_data='ud', vendor_data='vd',
             list_keys=False, varname='v1.key_2')
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             with mock.patch('os.getuid') as m_getuid:
                 m_getuid.return_value = 100
-                self.assertEqual(0, query.handle_args('anyname', args))
-        self.assertEqual('value-2\n', m_stdout.getvalue())
+                assert 0 == query.handle_args('anyname', args)
+        assert 'value-2\n' == m_stdout.getvalue()
 
-    def test_handle_args_returns_standardized_vars_to_top_level_aliases(self):
+    def test_handle_args_returns_standardized_vars_to_top_level_aliases(
+        self, tmpdir
+    ):
         """Any standardized vars under v# are promoted as top-level aliases."""
-        write_file(
-            self.instance_data,
+        instance_data = tmpdir.join('instance-data')
+        instance_data.write(
             '{"v1": {"v1_1": "val1.1"}, "v2": {"v2_2": "val2.2"},'
             ' "top": "gun"}')
         expected = dedent("""\
@@ -209,65 +211,71 @@ class TestQuery(CiTestCase):
         """)
         args = self.args(
             debug=False, dump_all=True, format=None,
-            instance_data=self.instance_data, user_data='ud', vendor_data='vd',
+            instance_data=instance_data, user_data='ud', vendor_data='vd',
             list_keys=False, varname=None)
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             with mock.patch('os.getuid') as m_getuid:
                 m_getuid.return_value = 100
-                self.assertEqual(0, query.handle_args('anyname', args))
-        self.assertEqual(expected, m_stdout.getvalue())
+                assert 0 == query.handle_args('anyname', args)
+        assert expected == m_stdout.getvalue()
 
-    def test_handle_args_list_keys_sorts_top_level_keys_when_no_varname(self):
+    def test_handle_args_list_keys_sorts_top_level_keys_when_no_varname(
+        self, tmpdir
+    ):
         """Sort all top-level keys when only --list-keys provided."""
-        write_file(
-            self.instance_data,
+        instance_data = tmpdir.join('instance-data')
+        instance_data.write(
             '{"v1": {"v1_1": "val1.1"}, "v2": {"v2_2": "val2.2"},'
             ' "top": "gun"}')
         expected = 'top\nuserdata\nv1\nv1_1\nv2\nv2_2\nvendordata\n'
         args = self.args(
             debug=False, dump_all=False, format=None,
-            instance_data=self.instance_data, list_keys=True, user_data='ud',
+            instance_data=instance_data, list_keys=True, user_data='ud',
             vendor_data='vd', varname=None)
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             with mock.patch('os.getuid') as m_getuid:
                 m_getuid.return_value = 100
-                self.assertEqual(0, query.handle_args('anyname', args))
-        self.assertEqual(expected, m_stdout.getvalue())
+                assert 0 == query.handle_args('anyname', args)
+        assert expected == m_stdout.getvalue()
 
-    def test_handle_args_list_keys_sorts_nested_keys_when_varname(self):
+    def test_handle_args_list_keys_sorts_nested_keys_when_varname(
+        self, tmpdir
+    ):
         """Sort all nested keys of varname object when --list-keys provided."""
-        write_file(
-            self.instance_data,
+        instance_data = tmpdir.join('instance-data')
+        instance_data.write(
             '{"v1": {"v1_1": "val1.1", "v1_2": "val1.2"}, "v2":' +
             ' {"v2_2": "val2.2"}, "top": "gun"}')
         expected = 'v1_1\nv1_2\n'
         args = self.args(
             debug=False, dump_all=False, format=None,
-            instance_data=self.instance_data, list_keys=True,
+            instance_data=instance_data, list_keys=True,
             user_data='ud', vendor_data='vd', varname='v1')
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             with mock.patch('os.getuid') as m_getuid:
                 m_getuid.return_value = 100
-                self.assertEqual(0, query.handle_args('anyname', args))
-        self.assertEqual(expected, m_stdout.getvalue())
+                assert 0 == query.handle_args('anyname', args)
+        assert expected == m_stdout.getvalue()
 
-    def test_handle_args_list_keys_errors_when_varname_is_not_a_dict(self):
+    def test_handle_args_list_keys_errors_when_varname_is_not_a_dict(
+        self, tmpdir
+    ):
         """Raise an error when --list-keys and varname specify a non-list."""
-        write_file(
-            self.instance_data,
+        instance_data = tmpdir.join('instance-data')
+        instance_data.write(
             '{"v1": {"v1_1": "val1.1", "v1_2": "val1.2"}, "v2": ' +
             '{"v2_2": "val2.2"}, "top": "gun"}')
-        expected_error = "ERROR: --list-keys provided but 'top' is not a dict"
+        expected_error = "--list-keys provided but 'top' is not a dict"
         args = self.args(
             debug=False, dump_all=False, format=None,
-            instance_data=self.instance_data, list_keys=True, user_data='ud',
+            instance_data=instance_data, list_keys=True, user_data='ud',
             vendor_data='vd', varname='top')
         with mock.patch('sys.stderr', new_callable=StringIO) as m_stderr:
             with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
                 with mock.patch('os.getuid') as m_getuid:
                     m_getuid.return_value = 100
-                    self.assertEqual(1, query.handle_args('anyname', args))
-        self.assertEqual('', m_stdout.getvalue())
-        self.assertIn(expected_error, m_stderr.getvalue())
+                    assert 1 == query.handle_args('anyname', args)
+        assert '' == m_stdout.getvalue()
+        assert expected_error in m_stderr.getvalue()
 
 # vi: ts=4 expandtab

--- a/cloudinit/cmd/tests/test_query.py
+++ b/cloudinit/cmd/tests/test_query.py
@@ -118,7 +118,7 @@ class TestQuery(CiTestCase):
             m_stderr.getvalue())
 
     def test_handle_args_root_uses_instance_sensitive_data(self):
-        """When no instance_data argument, root uses semsitive json."""
+        """When no instance_data argument, root uses sensitive json."""
         user_data = self.tmp_path('user-data', dir=self.tmp)
         vendor_data = self.tmp_path('vendor-data', dir=self.tmp)
         write_file(user_data, 'ud')
@@ -132,14 +132,14 @@ class TestQuery(CiTestCase):
         self.m_paths.return_value = paths
         args = self.args(
             debug=False, dump_all=True, format=None, instance_data=None,
-            list_keys=False, user_data=vendor_data, vendor_data=vendor_data,
+            list_keys=False, user_data=user_data, vendor_data=vendor_data,
             varname=None)
         with mock.patch('sys.stdout', new_callable=StringIO) as m_stdout:
             with mock.patch('os.getuid') as m_getuid:
                 m_getuid.return_value = 0
                 self.assertEqual(0, query.handle_args('anyname', args))
         self.assertEqual(
-            '{\n "my_var": "it worked",\n "userdata": "vd",\n '
+            '{\n "my_var": "it worked",\n "userdata": "ud",\n '
             '"vendordata": "vd"\n}\n', m_stdout.getvalue())
 
     def test_handle_args_dumps_all_instance_data(self):


### PR DESCRIPTION
cloud-init query tries to directly load and decode
raw user-data from /var/lib/cloud/instance/user-data.txt.

This results in UnicodeDecodeErrors on some platforms which
provide compressed content.

Avoid UnicodeDecoderErrors when parsing compressed user-data at
/var/lib/cloud/instance/user-data.txt.

LP: #1889938

To reproduce:
```
juju bootstrap aws/us-east-1.
juju deploy ubuntu
juju ssh ubuntu/0 
sudo cloud-init query --all

OR 
lxc launch ubuntu-daily:xenial my-test
lxc exec my-test bash
gzip /var/lib/cloud/instance/user-data.txt
mv /var/lib/cloud/instance/user-data.txt.gz /var/lib/cloud/instance/user-data.txt
cloud-init query --all