### PR TITLE
fix 'passwd' field documentation

### DIFF
--- a/cloudinit/config/cc_users_groups.py
+++ b/cloudinit/config/cc_users_groups.py
@@ -78,6 +78,9 @@ config keys for an entry in ``users`` are as follows:
     If specifying a sudo rule for a user, ensure that the syntax for the rule
     is valid, as it is not checked by cloud-init.
 
+.. note::
+    None of the above configurations are applied on already existing user.
+
 **Internal name:** ``cc_users_groups``
 
 **Module frequency:** per instance

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -7,6 +7,7 @@ groups:
   - cloud-users
 
 # Add users to the system. Users are added after groups are added.
+# Note: None of these configurations are applied on already existing user.
 users:
   - default
   - name: foobar

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -11,6 +11,7 @@ matthewruffell
 nishigori
 onitake
 smoser
+sshedi
 TheRealFalcon
 tomponline
 tsanghan


### PR DESCRIPTION
'passwd' field in cloud-config has no effect on an already existing
user. This was not documented earlier.

This change set adds that information to documentation.

LP: #1889545

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>