### PR TITLE
- Handle additional identifier for SLES For HPC

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -551,7 +551,8 @@ def system_info():
         elif linux_dist == 'redhat':
             var = 'rhel'
         elif linux_dist in (
-                'opensuse', 'opensuse-tumbleweed', 'opensuse-leap', 'sles'):
+                'opensuse', 'opensuse-tumbleweed', 'opensuse-leap',
+                'sles', 'sle_hpc'):
             var = 'suse'
         else:
             var = 'linux'


### PR DESCRIPTION
  + Identifies itself as "sle_hpc" in os-release. We need to recognize this
    to set the proper variant.