### PR TITLE
Fix a typo in apt pipelining module

### DIFF
--- a/cloudinit/config/cc_apt_pipelining.py
+++ b/cloudinit/config/cc_apt_pipelining.py
@@ -9,7 +9,7 @@ Apt Pipelining
 --------------
 **Summary:** configure apt pipelining
 
-This module configures apt's ``Acquite::http::Pipeline-Depth`` option, whcih
+This module configures apt's ``Acquite::http::Pipeline-Depth`` option, which
 controls how apt handles HTTP pipelining. It may be useful for pipelining to be
 disabled, because some web servers, such as S3 do not pipeline properly (LP:
 #948461). The ``apt_pipelining`` config key may be set to ``false`` to disable

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -5,6 +5,7 @@ candlerb
 dermotbradley
 dhensby
 eandersson
+izzyleung
 landon912
 lucasmoura
 marlluslustosa
@@ -15,4 +16,3 @@ smoser
 TheRealFalcon
 tomponline
 tsanghan
-izzyleung

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -15,3 +15,4 @@ smoser
 TheRealFalcon
 tomponline
 tsanghan
+izzyleung


### PR DESCRIPTION
Changed `whcih` to `which`.