### PR TITLE
Fix 'Users and Groups' configuration documentation

### DIFF
--- a/cloudinit/config/cc_users_groups.py
+++ b/cloudinit/config/cc_users_groups.py
@@ -78,6 +78,13 @@ config keys for an entry in ``users`` are as follows:
     If specifying a sudo rule for a user, ensure that the syntax for the rule
     is valid, as it is not checked by cloud-init.
 
+.. note::
+    Most of these configuration options will not be honored if the user
+    already exists. Following options are the exceptions and they are
+    applicable on already-existing users:
+    - 'plain_text_passwd', 'hashed_passwd', 'lock_passwd', 'sudo',
+      'ssh_authorized_keys', 'ssh_redirect_user'.
+
 **Internal name:** ``cc_users_groups``
 
 **Module frequency:** per instance

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -7,6 +7,11 @@ groups:
   - cloud-users
 
 # Add users to the system. Users are added after groups are added.
+# Note: Most of these configuration options will not be honored if the user
+#       already exists. Following options are the exceptions and they are
+#       applicable on already-existing users:
+#       - 'plain_text_passwd', 'hashed_passwd', 'lock_passwd', 'sudo',
+#         'ssh_authorized_keys', 'ssh_redirect_user'.
 users:
   - default
   - name: foobar

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -14,6 +14,7 @@ matthewruffell
 nishigori
 onitake
 smoser
+sshedi
 TheRealFalcon
 tomponline
 tsanghan


### PR DESCRIPTION
Few of the 'User and Groups' configurations in cloud-config have no effect on
already existing users. This was not documented earlier.

This change set adds that information to documentation.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>