### PR TITLE
tox.ini: pin correct version of httpretty in xenial{,-dev} envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -77,8 +77,6 @@ deps =
     configobj==5.0.6
     requests==2.9.1
     # test-requirements
-    httpretty==0.9.6
-    mock==1.3.0
     pytest-catchlog==1.2.1
 
 [testenv:xenial]
@@ -91,6 +89,7 @@ basepython = python3
 deps =
     # Refer to the comment in [xenial-shared-deps] for details
     {[xenial-shared-deps]deps}
+    httpretty==0.8.6
     jsonpatch==1.10
     pytest==2.8.7
 
@@ -108,6 +107,10 @@ basepython = {[testenv:xenial]basepython}
 deps =
     # Refer to the comment in [xenial-shared-deps] for details
     {[xenial-shared-deps]deps}
+    # httpretty in xenial is 0.8.6, not 0.9.5.  The oldest version to work with
+    # Python 3.7+ is 0.9.5, because it is the first to include this commit:
+    # https://github.com/gabrielfalcao/HTTPretty/commit/5776d97da3992b9071db5e21faf175f6e8729060
+    httpretty==0.9.5
     # jsonpatch in xenial is 1.10, not 1.19 (#839779). The oldest version
     # to work with python3.6 is 1.16 as found in Artful.  To keep default
     # invocation of 'tox' happy, accept the difference in version here.


### PR DESCRIPTION
The version was bumped in c7248059dd2faaaadfbcef5c83e8e8ea166d6767 to
support running on Python 3.7+ systems.  Now that we have separate
`xenial` and `xenial-dev` tox environments, we can restore the correct
pinning for `xenial` without breaking `xenial-dev` on developer
machines.

Also drop the `mock` dependency from `xenial-shared-deps`; its removal
was missed in 5f8f85bb38cc972d3d2c705a1ec73db3f690f323.