### PR TITLE
.travis.yml: run a doc build during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -128,3 +128,5 @@ matrix:
           env: TOXENV=flake8
         - python: 3.6
           env: TOXENV=pylint
+        - python: 3.6
+          env: TOXENV=doc


### PR DESCRIPTION
We have doc8 configured, so we should use it to gate documentation
changes.