### PR TITLE
Bionic: debian/cloud-init.postinst: fix NVME grub install device on upgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.2) UNRELEASED; urgency=medium
+
+  * d/cloud-init.postinst: fix the grub install device for NVMe-rooted
+    instances on upgrade.  (LP: #1889555)
+
+ -- Daniel Watkins <oddbloke@ubuntu.com>  Thu, 30 Jul 2020 15:42:00 -0400
+
 cloud-init (20.2-45-g5f7825e2-0ubuntu1~18.04.1) bionic; urgency=medium
 
   * New upstream snapshot. (LP: #1881018)

--- a/debian/cloud-init.postinst
+++ b/debian/cloud-init.postinst
@@ -283,6 +283,49 @@ cleanup_ureadahead() {
         /etc/init/ureadahead.conf.disabled /etc/init/ureadahead.conf
 }
 
+fix_lp1889555() {
+    local oldver="$1" last_bad_ver="20.2-45-g5f7825e2-0ubuntu1~18.04.1"
+    dpkg --compare-versions "$oldver" le-nl "$last_bad_ver" || return 0
+
+    # if cloud-init's grub module did not run, then it did not break anything.
+    [ -f /var/lib/cloud/instance/sem/config_grub_dpkg ] || return 0
+
+    # Don't do anything unless we have grub
+    [ -x /usr/sbin/grub-install ] || return 0
+
+    # Make sure that we are not chrooted.
+    [ "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)" ] && return 0
+
+    # Check if we are in a container, i.e. LXC
+    if systemd-detect-virt --quiet --container || lxc-is-container 2>/dev/null; then
+        return 0
+    fi
+
+    # This bug only applies to NVMe devices
+    [ -e /dev/nvme0 ] || return 0
+
+    db_get grub-pc/install_devices && grub_cfg_dev=${RET} || return 0
+
+    # If the current setting is not the (potentially-incorrect) default we
+    # expect, this implies user intervention so leave things alone
+    [ "$grub_cfg_dev" = "/dev/sda" ] || return 0
+
+    correct_idev="$(python3 -c "import logging; from cloudinit.config.cc_grub_dpkg import fetch_idevs; print(fetch_idevs(logging.getLogger()))")" || return 0
+
+    # If correct_idev is the empty string, we failed to determine the correct
+    # install device; do nothing
+    [ -z "$correct_idev" ] && return 0
+
+    # If the correct_idev is already configured, do nothing
+    [ "$grub_cfg_dev" = "$correct_idev" ] && return 0
+
+    echo "Reconfiguring grub install device due to mismatch (LP: #1889555)"
+    echo "   grub should use $correct_idev but is configured for $grub_cfg_dev"
+    db_set grub-pc/install_devices "$correct_idev"
+    db_set grub-pc/install_devices_empty "false"
+}
+
+
 if [ "$1" = "configure" ]; then
    if db_get cloud-init/datasources; then
       values="$RET"
@@ -312,6 +355,7 @@ EOF
    fix_azure_upgrade_1611074 "$2"
 
    cleanup_ureadahead "$2"
+   fix_lp1889555 "$2"
 fi
 
 #DEBHELPER#


### PR DESCRIPTION
Bionic version of #514 

============================================================================================

In [0] we landed a change to the determination of the grub install device
for new instance launches, specifically to fix the grub install device
determined for instances booting from NVMe drives.  However, for running
NVMe-root instances to successfully install grub updates which change
the ABI between the core and its modules, we also need to fix the grub
install device that the previous (incorrect) code determined.

This commit performs that fixing, on upgrade.

[0] https://github.com/canonical/cloud-init/commit/fc07d633f7cb694423349a2c4b10c91c4b4981a2

LP: #1889555