### PR TITLE
Azure: Add netplan driver filter when using hv_netvsc driver

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -18,6 +18,7 @@ import xml.etree.ElementTree as ET
 from cloudinit import log as logging
 from cloudinit import net
 from cloudinit.event import EventType
+from cloudinit.net import device_driver
 from cloudinit.net.dhcp import EphemeralDHCPv4
 from cloudinit import sources
 from cloudinit.sources.helpers import netlink
@@ -1387,9 +1388,16 @@ def parse_network_config(imds_metadata):
                                 ip=privateIp, prefix=netPrefix))
                 if dev_config:
                     mac = ':'.join(re.findall(r'..', intf['macAddress']))
-                    dev_config.update(
-                        {'match': {'macaddress': mac.lower()},
-                         'set-name': nicname})
+                    dev_config.update({
+                        'match': {'macaddress': mac.lower()},
+                        'set-name': nicname
+                    })
+                    # With netvsc, we can get two interfaces that
+                    # share the same MAC, so we need to make sure
+                    # our match condition also contains the driver
+                    driver = device_driver(nicname)
+                    if driver and driver == 'hv_netvsc':
+                        dev_config['match']['driver'] = driver
                     netconfig['ethernets'][nicname] = dev_config
             evt.description = "network config from imds"
         else:

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -278,6 +278,23 @@ class TestParseNetworkConfig(CiTestCase):
         }
         self.assertEqual(expected, dsaz.parse_network_config(imds_data))
 
+    @mock.patch('cloudinit.sources.DataSourceAzure.device_driver',
+                return_value='hv_netvsc')
+    def test_match_driver_for_netvsc(self, m_driver):
+        """parse_network_config emits driver when using netvsc."""
+        expected = {'ethernets': {
+            'eth0': {
+                'dhcp4': True,
+                'dhcp4-overrides': {'route-metric': 100},
+                'dhcp6': False,
+                'match': {
+                    'macaddress': '00:0d:3a:04:75:98',
+                    'driver': 'hv_netvsc',
+                },
+                'set-name': 'eth0'
+            }}, 'version': 2}
+        self.assertEqual(expected, dsaz.parse_network_config(NETWORK_METADATA))
+
 
 class TestGetMetadataFromIMDS(HttprettyTestCase):
 


### PR DESCRIPTION
Commit message:
```
Azure: Add netplan driver filter when using hv_netvsc driver

This fixes a long delay during boot of some instances. For Azure instance types using SR-IOV via the Hyper-V netvsc network driver, two network interfaces are created that share the same MAC, but only the virtual device should be configured and used. Updating the netplan configuration to filter on the hv_netvsc driver prevents netplan from trying to figure both devices.

LP: #1830740
```
