### PR TITLE
network: Fix type and respect name when rendering vlan in sysconfig.

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -99,7 +99,8 @@ class ConfigMap(object):
     def __len__(self):
         return len(self._conf)
 
-    def str_skipped(self, key, val):
+    def skip_key_value(self, key, val):
+        """Skip the pair key, value if it matches a certain rule."""
         return False
 
     def to_string(self):
@@ -109,7 +110,7 @@ class ConfigMap(object):
             buf.write("\n")
         for key in sorted(self._conf.keys()):
             value = self._conf[key]
-            if self.str_skipped(key, value):
+            if self.skip_key_value(key, value):
                 continue
             if isinstance(value, bool):
                 value = self._bool_map[value]
@@ -273,7 +274,7 @@ class NetInterface(ConfigMap):
             c.routes = self.routes.copy()
         return c
 
-    def str_skipped(self, key, val):
+    def skip_key_value(self, key, val):
         if key == 'TYPE' and val == 'Vlan':
             return True
         return False
@@ -714,8 +715,8 @@ class Renderer(renderer.Renderer):
                 supported = _supported_vlan_names(rdev, iface['vlan_id'])
                 if iface_name not in supported:
                     LOG.warning(
-                        "Name '%s' not officially supported for vlan "
-                        "device backed by '%s'. Supported: %s",
+                        "Name '%s' for vlan '%s' is not officially supported"
+                        "by RHEL. Supported: %s",
                         iface_name, rdev, ' '.join(supported))
                 iface_cfg['PHYSDEV'] = rdev
 

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -714,7 +714,7 @@ class Renderer(renderer.Renderer):
                 rdev = iface['vlan-raw-device']
                 supported = _supported_vlan_names(rdev, iface['vlan_id'])
                 if iface_name not in supported:
-                    LOG.warning(
+                    LOG.info(
                         "Name '%s' for vlan '%s' is not officially supported"
                         "by RHEL. Supported: %s",
                         iface_name, rdev, ' '.join(supported))

--- a/tests/unittests/test_distros/test_netconfig.py
+++ b/tests/unittests/test_distros/test_netconfig.py
@@ -539,6 +539,87 @@ class TestNetCfgDistroRedhat(TestNetCfgDistroBase):
                                V1_NET_CFG_IPV6,
                                expected_cfgs=expected_cfgs.copy())
 
+    def test_vlan_render_unsupported(self):
+        """Render officially unsupported vlan names."""
+        cfg = {
+            'version': 2,
+            'ethernets': {
+                'eth0': {'addresses': ["192.10.1.2/24"],
+                         'match': {'macaddress': "00:16:3e:60:7c:df"}}},
+            'vlans': {
+                'infra0': {'addresses': ["10.0.1.2/16"],
+                           'id': 1001, 'link': 'eth0'}},
+        }
+        expected_cfgs = {
+            self.ifcfg_path('eth0'): dedent("""\
+                BOOTPROTO=none
+                DEVICE=eth0
+                HWADDR=00:16:3e:60:7c:df
+                IPADDR=192.10.1.2
+                NETMASK=255.255.255.0
+                NM_CONTROLLED=no
+                ONBOOT=yes
+                TYPE=Ethernet
+                USERCTL=no
+                """),
+            self.ifcfg_path('infra0'): dedent("""\
+                BOOTPROTO=none
+                DEVICE=infra0
+                IPADDR=10.0.1.2
+                NETMASK=255.255.0.0
+                NM_CONTROLLED=no
+                ONBOOT=yes
+                PHYSDEV=eth0
+                USERCTL=no
+                VLAN=yes
+                """),
+            self.control_path(): dedent("""\
+                NETWORKING=yes
+                """),
+        }
+        self._apply_and_verify(
+            self.distro.apply_network_config, cfg,
+            expected_cfgs=expected_cfgs)
+
+    def test_vlan_render(self):
+        cfg = {
+            'version': 2,
+            'ethernets': {
+                'eth0': {'addresses': ["192.10.1.2/24"]}},
+            'vlans': {
+                'eth0.1001': {'addresses': ["10.0.1.2/16"],
+                              'id': 1001, 'link': 'eth0'}},
+        }
+        expected_cfgs = {
+            self.ifcfg_path('eth0'): dedent("""\
+                BOOTPROTO=none
+                DEVICE=eth0
+                IPADDR=192.10.1.2
+                NETMASK=255.255.255.0
+                NM_CONTROLLED=no
+                ONBOOT=yes
+                TYPE=Ethernet
+                USERCTL=no
+                """),
+            self.ifcfg_path('eth0.1001'): dedent("""\
+                BOOTPROTO=none
+                DEVICE=eth0.1001
+                IPADDR=10.0.1.2
+                NETMASK=255.255.0.0
+                NM_CONTROLLED=no
+                ONBOOT=yes
+                PHYSDEV=eth0
+                USERCTL=no
+                VLAN=yes
+                """),
+            self.control_path(): dedent("""\
+                NETWORKING=yes
+                """),
+        }
+        self._apply_and_verify(
+            self.distro.apply_network_config, cfg,
+            expected_cfgs=expected_cfgs)
+
 
 class TestNetCfgDistroOpensuse(TestNetCfgDistroBase):
 

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1633,7 +1633,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PHYSDEV=bond0
-                TYPE=Ethernet
                 USERCTL=no
                 VLAN=yes"""),
             'ifcfg-br0': textwrap.dedent("""\
@@ -1677,7 +1676,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PHYSDEV=eth0
-                TYPE=Ethernet
                 USERCTL=no
                 VLAN=yes"""),
             'ifcfg-eth1': textwrap.dedent("""\
@@ -2286,7 +2284,6 @@ iface bond0 inet6 static
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PHYSDEV=en0
-                TYPE=Ethernet
                 USERCTL=no
                 VLAN=yes"""),
         },
@@ -3339,7 +3336,6 @@ USERCTL=no
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 PHYSDEV=eno1
-                TYPE=Ethernet
                 USERCTL=no
                 VLAN=yes
                 """)


### PR DESCRIPTION
Prior to this change, vlans were rendered in sysconfig with
'TYPE=Ethernet', and incorrectly renders the PHYSDEV based on
the name of the vlan device rather than the 'link' provided
in the network config.

The change here fixes:
 * rendering of TYPE=Ethernet for a vlan
 * adds a warning if the configured device name is not supported
   per the RHEL 7 docs "11.5. Naming Scheme for VLAN Interfaces"

Forward-ported to cloud-init-20.2: Minimal changes on the order of
things on cloudinit/net/sysconfig.py.

LP: #1788915
LP: #1826608
rhbz: #1861871

Signed-off-by: Scott Moser <smoser@brickies.net>
Signed-off-by: Eduardo Otubo <otubo@redhat.com>