### PR TITLE
LXD: detach network from profile before deleting it

### DIFF
--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -281,17 +281,25 @@ def maybe_cleanup_default(net_name, did_init, create, attach,
         return
 
     fail_assume_enoent = "failed. Assuming it did not exist."
+    failed = "failed."
     succeeded = "succeeded."
     if create:
-        msg = "Deletion of lxd network '%s' %s"
+        msg = "Detach of lxd network '%s' from profile '%s' %s"
         try:
             _lxc(["network", "detach-profile", net_name, profile])
-            _lxc(["network", "delete", net_name])
-            LOG.debug(msg, net_name, succeeded)
+            LOG.debug(msg, net_name, profile, succeeded)
         except subp.ProcessExecutionError as e:
             if e.exit_code != 1:
                 raise e
-            LOG.debug(msg, net_name, fail_assume_enoent)
+            LOG.debug(msg, net_name, profile, fail_assume_enoent)
+        else:
+            msg = "Deletion of lxd network '%s' %s"
+            try:
+                _lxc(["network", "delete", net_name])
+                LOG.debug(msg, net_name, succeeded)
+            except subp.ProcessExecutionError as e:
+                LOG.debug(msg, net_name, failed)
+                raise e
 
     if attach:
         msg = "Removal of device '%s' from profile '%s' %s"

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -281,7 +281,6 @@ def maybe_cleanup_default(net_name, did_init, create, attach,
         return
 
     fail_assume_enoent = "failed. Assuming it did not exist."
-    failed = "failed."
     succeeded = "succeeded."
     if create:
         msg = "Detach of lxd network '%s' from profile '%s' %s"
@@ -294,12 +293,8 @@ def maybe_cleanup_default(net_name, did_init, create, attach,
             LOG.debug(msg, net_name, profile, fail_assume_enoent)
         else:
             msg = "Deletion of lxd network '%s' %s"
-            try:
-                _lxc(["network", "delete", net_name])
-                LOG.debug(msg, net_name, succeeded)
-            except subp.ProcessExecutionError as e:
-                LOG.debug(msg, net_name, failed)
-                raise e
+            _lxc(["network", "delete", net_name])
+            LOG.debug(msg, net_name, succeeded)
 
     if attach:
         msg = "Removal of device '%s' from profile '%s' %s"

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -285,6 +285,7 @@ def maybe_cleanup_default(net_name, did_init, create, attach,
     if create:
         msg = "Deletion of lxd network '%s' %s"
         try:
+            _lxc(["network", "detach-profile", net_name, profile])
             _lxc(["network", "delete", net_name])
             LOG.debug(msg, net_name, succeeded)
         except subp.ProcessExecutionError as e:

--- a/tests/unittests/test_handler/test_handler_lxd.py
+++ b/tests/unittests/test_handler/test_handler_lxd.py
@@ -214,7 +214,7 @@ class TestLxdMaybeCleanupDefault(t_help.CiTestCase):
         """deletion of network should occur if create is True."""
         cc_lxd.maybe_cleanup_default(
             net_name=self.defnet, did_init=True, create=True, attach=False)
-        m_lxc.assert_called_once_with(["network", "delete", self.defnet])
+        m_lxc.assert_called_with(["network", "delete", self.defnet])
 
     @mock.patch("cloudinit.config.cc_lxd._lxc")
     def test_device_removed_if_attach_true(self, m_lxc):


### PR DESCRIPTION
When cleaning up the bridge network created by default by LXD as part
of the `lxd init` process detach the network its profile before deleting
it. LXD will otherwise refuse to delete it with error:

  Error: The network is currently in use.

Discussion with LXD upstream: lxc/lxd#7804.

LP: #1776958