### PR TITLE
query: do not handle non-decodable non-gzipped content

### DIFF
--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -86,14 +86,11 @@ def load_userdata(ud_file_path):
 
     @returns: String of uncompressed userdata if possible, otherwise bytes.
     """
+    bdata = util.load_file(ud_file_path, decode=False)
     try:
-        return util.load_file(ud_file_path)
+        return bdata.decode('utf-8')
     except UnicodeDecodeError:
-        encoded_data = util.load_file(ud_file_path, decode=False)
-        try:
-            return util.decomp_gzip(encoded_data, quiet=False)
-        except util.DecompressionError:
-            return encoded_data
+        return util.decomp_gzip(bdata, quiet=False, decode=True)
 
 
 def handle_args(name, args):

--- a/cloudinit/cmd/tests/test_query.py
+++ b/cloudinit/cmd/tests/test_query.py
@@ -144,11 +144,6 @@ class TestQuery:
             ('ud'.encode('utf-8'), 'ud', 'vd'.encode('utf-8'), 'vd'),
             (_gzip_data(b'ud'), 'ud', _gzip_data(b'vd'), 'vd'),
             (_gzip_data('ud'.encode('utf-8')), 'ud', _gzip_data(b'vd'), 'vd'),
-            (_gzip_data(b'ud') + b'invalid', 'ci-b64:',
-             _gzip_data(b'vd') + b'invalid', 'ci-b64:'),
-            # non-utf-8 encodable content
-            ('hi mom'.encode('utf-16'), 'ci-b64://5oAGkAIABtAG8AbQA=',
-             'hi pops'.encode('utf-16'), 'ci-b64://5oAGkAIABwAG8AcABzAA=='),
         )
     )
     def test_handle_args_root_processes_user_data(


### PR DESCRIPTION
Addressed review comments on https://github.com/canonical/cloud-init/pull/516
No need to handle binary file types that are not gzip'd or utf-8 decodable