### PR TITLE
systemd: add Before=shutdown.target when Conflicts=shutdown.target is used

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -25,9 +25,11 @@ Before=sshd-keygen.service
 Before=sshd.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 Before=sysinit.target
+Before=shutdown.target
 Conflicts=shutdown.target
 {% endif %}
 {% if variant in ["suse"] %}
+Before=shutdown.target
 Conflicts=shutdown.target
 {% endif %}
 Before=systemd-user-sessions.service


### PR DESCRIPTION
Lintian spotted the following issue:

>   The specified systemd .service file contains both DefaultDependencies=no
>   and Conflicts=shutdown.target directives without Before=shutdown.target.
> 
>   This can lead to problems during shutdown because the service may linger
>   until the very end of shutdown sequence as nothing requests to stop it
>   before (due to DefaultDependencies=no).
> 
>   There is race condition between stopping units and systemd getting a
>   request to exit the main loop, so it may proceed with shutdown before
>   all pending stop jobs have been processed.

  Please add Before=shutdown.target.

[1] https://lintian.debian.org/tags/systemd-service-file-shutdown-problems.html