### PR TITLE
Fix cloud config on chef example

### DIFF
--- a/doc/examples/cloud-config-chef.txt
+++ b/doc/examples/cloud-config-chef.txt
@@ -13,7 +13,8 @@
 # Key from https://packages.chef.io/chef.asc
 apt:
   sources:
-    source1: "deb http://packages.chef.io/repos/apt/stable $RELEASE main"
+    source1:
+      source: "deb http://packages.chef.io/repos/apt/stable $RELEASE main"
     key: |
       -----BEGIN PGP PUBLIC KEY BLOCK-----
       Version: GnuPG v1.4.12 (Darwin)


### PR DESCRIPTION
As stated in this launchpad [bug](https://bugs.launchpad.net/cloud-init/+bug/1892947), there is a mistake in the chef example regarding cloud config. This PR fixes that