### PR TITLE
redhat spec: add missing BuildRequires

### DIFF
--- a/packages/redhat/cloud-init.spec.in
+++ b/packages/redhat/cloud-init.spec.in
@@ -39,10 +39,7 @@ Requires(post):     chkconfig
 Requires(preun):    chkconfig
 %endif
 
-# These are runtime dependencies, but declared as BuildRequires so that
-# - tests can be run here.
-# - parts of cloud-init such (setup.py) use these dependencies.
-{% for r in requires %}
+{% for r in buildrequires %}
 BuildRequires:  {{r}}
 {% endfor %}
 
@@ -57,8 +54,10 @@ Requires:  python-argparse
 %endif
 
 
-# Install 'dynamic' runtime reqs from *requirements.txt and pkg-deps.json
+# Install 'dynamic' runtime reqs from *requirements.txt and pkg-deps.json.
+# Install them as BuildRequires too as they're used for testing.
 {% for r in requires %}
+BuildRequires:  {{r}}
 Requires:       {{r}}
 {% endfor %}
 


### PR DESCRIPTION
456fb55744a1acc6bd2f464b7656a9c33d0b7ac5 made tools/read-dependencies
and package/brpm distinguish between build dependencies and runtime
dependencies, however packages/redhat/cloud-init.spec.in expects all
the dependencies to be in the 'requires' list, thus missing some build
dependencies.

This change makes cloud-init.spec use 'buildrequires' too.