### PR TITLE
Refactor 'device_part_info' for distro & fix for Alpine

### DIFF
--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -1,4 +1,5 @@
 import platform
+import re
 
 from cloudinit import distros
 from cloudinit.distros import bsd_utils
@@ -127,3 +128,10 @@ class BSD(distros.Distro):
 
     def apply_network_config_names(self, netconfig):
         LOG.debug('Cannot rename network interface.')
+
+    def device_part_info(self, devpath):
+        # FreeBSD doesn't know of sysfs so just get everything we need from
+        # the device, like /dev/vtbd0p2.
+        freebsd_part = "/dev/" + util.find_freebsd_part(devpath)
+        m = re.search('^(/dev/.+)p([0-9])$', freebsd_part)
+        return (m.group(1), m.group(2))


### PR DESCRIPTION
I found a problem that Alpine does not provide `/dev/block` which is required by the current device_part_info implementation for proper operation.

Here is revelant cloud-init log:
```
test-alpine:/var/log$ cat cloud-init.log | grep 'grow'
2020-08-28 20:20:00,979 - stages.py[DEBUG]: Running module growpart (<module 'cloudinit.config.cc_growpart' from '/usr/lib/python3.8/site-packages/cloudinit/config/cc_growpart.py'>) with frequency always
2020-08-28 20:20:00,980 - handlers.py[DEBUG]: start: init-network/config-growpart: running config-growpart with frequency always
2020-08-28 20:20:00,980 - helpers.py[DEBUG]: Running config-growpart using lock (<cloudinit.helpers.DummyLock object at 0x7ff9f968c4f0>)
2020-08-28 20:20:00,980 - cc_growpart.py[DEBUG]: No 'growpart' entry in cfg.  Using default: {'mode': 'auto', 'devices': ['/'], 'ignore_growroot_disabled': False}
2020-08-28 20:20:00,981 - subp.py[DEBUG]: Running command ['growpart', '--help'] with allowed return codes [0] (shell=False, capture=True)
2020-08-28 20:20:01,014 - subp.py[DEBUG]: Running command ['growpart', '--dry-run', '/dev/block/8:0', '4'] with allowed return codes [0] (shell=False, capture=True)
2020-08-28 20:20:01,036 - util.py[WARNING]: Failed growpart --dry-run for (/dev/block/8:0, 4)
2020-08-28 20:20:01,061 - util.py[DEBUG]: Failed growpart --dry-run for (/dev/block/8:0, 4)
  File "/usr/lib/python3.8/site-packages/cloudinit/config/cc_growpart.py", line 146, in resize
    subp.subp(["growpart", '--dry-run', diskdev, partnum])
Command: ['growpart', '--dry-run', '/dev/block/8:0', '4']
2020-08-28 20:20:01,067 - cc_growpart.py[DEBUG]: '/' FAILED: failed to resize: disk=/dev/block/8:0, ptnum=4: Unexpected error while running command.
Command: ['growpart', '--dry-run', '/dev/block/8:0', '4']
2020-08-28 20:20:01,069 - handlers.py[DEBUG]: finish: init-network/config-growpart: SUCCESS: config-growpart ran successfully
```
```
$ growpart /dev/block/8:0 4
FAILED: /dev/block/8:0: does not exist
$ ls -lah /dev/block/
ls: cannot access '/dev/block/': No such file or directory
```

In the wild that issue is known and some patch prepared, but never go upstream and never merged to alpine package also. See https://gitlab.alpinelinux.org/alpine/aports/-/issues/6128 . 

I would like to ask for comments on the general direction of the changes. After they are submitted, it will be happy to apply review comments or add tests for the change to be accepted.