### PR TITLE
Azure: Clean up and refactor report_diagnostic_event

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -648,11 +648,6 @@ class DataSourceAzure(sources.DataSource):
                     if self.imds_poll_counter == self.imds_logging_threshold:
                         # Reducing the logging frequency as we are polling IMDS
                         self.imds_logging_threshold *= 2
-                        report_diagnostic_event(
-                            "Call to IMDS with arguments %s failed "
-                            "with status code %s after %s retries" %
-                            (msg, exception.code, self.imds_poll_counter),
-                            logger_func=LOG.warning)
                         LOG.debug("Backing off logging threshold for the same "
                                   "exception to %d",
                                   self.imds_logging_threshold)
@@ -660,7 +655,7 @@ class DataSourceAzure(sources.DataSource):
                                                 "Exception: %s and code: %s" %
                                                 (msg, exception.cause,
                                                  exception.code),
-                                                logger_func=LOG.warning)
+                                                logger_func=LOG.debug)
                     self.imds_poll_counter += 1
                     return True
                 else:

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -478,7 +478,8 @@ class DataSourceAzure(sources.DataSource):
             raise sources.InvalidMetaDataException(msg)
 
         if found == ddir:
-            LOG.debug("using files cached in %s", ddir)
+            report_diagnostic_event(
+                "using files cached in %s" % ddir, logger_func=LOG.debug)
 
         seed = _get_random_seed()
         if seed:
@@ -587,14 +588,14 @@ class DataSourceAzure(sources.DataSource):
         except KeyError:
             log_msg = 'Unable to get keys from IMDS, falling back to OVF'
             LOG.debug(log_msg)
-            report_diagnostic_event(log_msg)
+            report_diagnostic_event(log_msg, logger_func=LOG.debug)
             try:
                 ssh_keys = self.metadata['public-keys']
                 LOG.debug('Retrieved keys from OVF')
             except KeyError:
                 log_msg = 'No keys available from OVF'
                 LOG.debug(log_msg)
-                report_diagnostic_event(log_msg)
+                report_diagnostic_event(log_msg, logger_func=LOG.debug)
 
         return ssh_keys
 

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -323,9 +323,8 @@ class GoalState:
 
         for attr in ("container_id", "instance_id", "incarnation"):
             if getattr(self, attr) is None:
-                msg = 'Missing %s in GoalState XML'
-                report_diagnostic_event(
-                    msg % attr, logger_func=LOG.warning)
+                msg = 'Missing %s in GoalState XML' % attr
+                report_diagnostic_event(msg, logger_func=LOG.warning)
                 raise InvalidGoalStateXMLException(msg)
 
         self.certificates_xml = None

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -181,7 +181,7 @@ def get_system_info():
 
 
 def report_diagnostic_event(
-        msg: str, logger_func=None) -> events.ReportingEvent:
+        msg: str, *, logger_func=None) -> events.ReportingEvent:
     """Report a diagnostic event"""
     if callable(logger_func):
         logger_func(msg)

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -288,7 +288,8 @@ class InvalidGoalStateXMLException(Exception):
 
 class GoalState:
 
-    def __init__(self, unparsed_xml, azure_endpoint_client):
+    def __init__(self, unparsed_xml: str,
+                 azure_endpoint_client: AzureEndpointHttpClient) -> None:
         """Parses a GoalState XML string and returns a GoalState object.
 
         @param unparsed_xml: string representing a GoalState XML.
@@ -478,7 +479,10 @@ class GoalStateHealthReporter:
 
     PROVISIONING_SUCCESS_STATUS = 'Ready'
 
-    def __init__(self, goal_state, azure_endpoint_client, endpoint):
+    def __init__(
+            self, goal_state: GoalState,
+            azure_endpoint_client: AzureEndpointHttpClient,
+            endpoint: str) -> None:
         """Creates instance that will report provisioning status to an endpoint
 
         @param goal_state: An instance of class GoalState that contains
@@ -495,7 +499,7 @@ class GoalStateHealthReporter:
         self._endpoint = endpoint
 
     @azure_ds_telemetry_reporter
-    def send_ready_signal(self):
+    def send_ready_signal(self) -> None:
         document = self.build_report(
             incarnation=self._goal_state.incarnation,
             container_id=self._goal_state.container_id,
@@ -513,8 +517,8 @@ class GoalStateHealthReporter:
         LOG.info('Reported ready to Azure fabric.')
 
     def build_report(
-            self, incarnation, container_id, instance_id,
-            status, substatus=None, description=None):
+            self, incarnation: str, container_id: str, instance_id: str,
+            status: str, substatus=None, description=None) -> str:
         health_detail = ''
         if substatus is not None:
             health_detail = self.HEALTH_DETAIL_SUBSECTION_XML_TEMPLATE.format(
@@ -530,7 +534,7 @@ class GoalStateHealthReporter:
         return health_report
 
     @azure_ds_telemetry_reporter
-    def _post_health_report(self, document):
+    def _post_health_report(self, document: str) -> None:
         push_log_to_kvp()
 
         # Whenever report_diagnostic_event(diagnostic_msg) is invoked in code,
@@ -726,7 +730,7 @@ class WALinuxAgentShim:
         return endpoint_ip_address
 
     @azure_ds_telemetry_reporter
-    def register_with_azure_and_fetch_data(self, pubkey_info=None):
+    def register_with_azure_and_fetch_data(self, pubkey_info=None) -> dict:
         """Gets the VM's GoalState from Azure, uses the GoalState information
         to report ready/send the ready signal/provisioning complete signal to
         Azure, and then uses pubkey_info to filter and obtain the user's
@@ -750,7 +754,7 @@ class WALinuxAgentShim:
         return {'public-keys': ssh_keys}
 
     @azure_ds_telemetry_reporter
-    def _fetch_goal_state_from_azure(self):
+    def _fetch_goal_state_from_azure(self) -> GoalState:
         """Fetches the GoalState XML from the Azure endpoint, parses the XML,
         and returns a GoalState object.
 
@@ -760,7 +764,7 @@ class WALinuxAgentShim:
         return self._parse_raw_goal_state_xml(unparsed_goal_state_xml)
 
     @azure_ds_telemetry_reporter
-    def _get_raw_goal_state_xml_from_azure(self):
+    def _get_raw_goal_state_xml_from_azure(self) -> str:
         """Fetches the GoalState XML from the Azure endpoint and returns
         the XML as a string.
 
@@ -780,7 +784,8 @@ class WALinuxAgentShim:
         return response.contents
 
     @azure_ds_telemetry_reporter
-    def _parse_raw_goal_state_xml(self, unparsed_goal_state_xml):
+    def _parse_raw_goal_state_xml(
+            self, unparsed_goal_state_xml: str) -> GoalState:
         """Parses a GoalState XML string and returns a GoalState object.
 
         @param unparsed_goal_state_xml: GoalState XML string
@@ -803,7 +808,8 @@ class WALinuxAgentShim:
         return goal_state
 
     @azure_ds_telemetry_reporter
-    def _get_user_pubkeys(self, goal_state, pubkey_info):
+    def _get_user_pubkeys(
+            self, goal_state: GoalState, pubkey_info: list) -> list:
         """Gets and filters the VM admin user's authorized pubkeys.
 
         The admin user in this case is the username specified as "admin"
@@ -838,7 +844,7 @@ class WALinuxAgentShim:
         return ssh_keys
 
     @staticmethod
-    def _filter_pubkeys(keys_by_fingerprint, pubkey_info):
+    def _filter_pubkeys(keys_by_fingerprint: dict, pubkey_info: list) -> list:
         """ Filter and return only the user's actual pubkeys.
 
         @param keys_by_fingerprint: pubkey fingerprint -> pubkey value dict

--- a/tests/unittests/test_reporting_hyperv.py
+++ b/tests/unittests/test_reporting_hyperv.py
@@ -188,25 +188,33 @@ class TextKvpReporter(CiTestCase):
         if not re.search("variant=" + pattern, evt_msg):
             raise AssertionError("missing distro variant string")
 
-    def test_report_diagnostic_event(self):
+    def test_report_diagnostic_event_without_logger_func(self):
         reporter = HyperVKvpReportingHandler(kvp_file_path=self.tmp_file_path)
-
+        diagnostic_msg = "test_diagnostic"
         reporter.publish_event(
-            azure.report_diagnostic_event("test_diagnostic", mock.MagicMock()))
+            azure.report_diagnostic_event(diagnostic_msg))
         reporter.q.join()
         kvps = list(reporter._iterate_kvps(0))
         self.assertEqual(1, len(kvps))
         evt_msg = kvps[0]['value']
 
-        if "test_diagnostic" not in evt_msg:
+        if diagnostic_msg not in evt_msg:
             raise AssertionError("missing expected diagnostic message")
 
-    def test_report_diagnostic_event_calls_logger_func(self):
+    def test_report_diagnostic_event_with_logger_func(self):
         reporter = HyperVKvpReportingHandler(kvp_file_path=self.tmp_file_path)
         logger_func = mock.MagicMock()
         diagnostic_msg = "test_diagnostic"
         reporter.publish_event(
-            azure.report_diagnostic_event(diagnostic_msg, logger_func))
+            azure.report_diagnostic_event(diagnostic_msg,
+                                          logger_func=logger_func))
+        reporter.q.join()
+        kvps = list(reporter._iterate_kvps(0))
+        self.assertEqual(1, len(kvps))
+        evt_msg = kvps[0]['value']
+
+        if diagnostic_msg not in evt_msg:
+            raise AssertionError("missing expected diagnostic message")
         logger_func.assert_called_once_with(diagnostic_msg)
 
     def test_report_compressed_event(self):

--- a/tests/unittests/test_reporting_hyperv.py
+++ b/tests/unittests/test_reporting_hyperv.py
@@ -192,7 +192,7 @@ class TextKvpReporter(CiTestCase):
         reporter = HyperVKvpReportingHandler(kvp_file_path=self.tmp_file_path)
 
         reporter.publish_event(
-            azure.report_diagnostic_event("test_diagnostic"))
+            azure.report_diagnostic_event("test_diagnostic", mock.MagicMock()))
         reporter.q.join()
         kvps = list(reporter._iterate_kvps(0))
         self.assertEqual(1, len(kvps))
@@ -200,6 +200,14 @@ class TextKvpReporter(CiTestCase):
 
         if "test_diagnostic" not in evt_msg:
             raise AssertionError("missing expected diagnostic message")
+
+    def test_report_diagnostic_event_calls_logger_func(self):
+        reporter = HyperVKvpReportingHandler(kvp_file_path=self.tmp_file_path)
+        logger_func = mock.MagicMock()
+        diagnostic_msg = "test_diagnostic"
+        reporter.publish_event(
+            azure.report_diagnostic_event(diagnostic_msg, logger_func))
+        logger_func.assert_called_once_with(diagnostic_msg)
 
     def test_report_compressed_event(self):
         reporter = HyperVKvpReportingHandler(kvp_file_path=self.tmp_file_path)


### PR DESCRIPTION
## Proposed Commit Message

Azure helper: Refactor report_diagnostic_event and logging

## Additional Context

Across the cloud-init Azure datasource codebase, one of the `LOG` functions (`debug`, `warning`, and `error`) is always invoked whenever `report_diagnostic_event` is invoked. This changes `report_diagnostic_event` so that a logger function can be passed in, and then invoked within `report_diagnostic_event`.

## Test Steps
* Deploy an Azure VM (from any cloud-init enabled Ubuntu LTS image)
* Apply this PR's patch
* Reboot
* Check for a common message that is both (1) reported to KVP diagnostics and (2) logged to `cloud-init.log`. A good candidate is the `found datasource in` diagnostic message.
* Observe within `cloud-init.log` the logged diagnostic messages.
* Observe within `/var/lib/hyperv/.kvp_pool_1` (KVP diagnostics file) the logged diagnostic messages.
* See https://paste.ubuntu.com/p/TxpVCfckQc/

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly