### PR TITLE
Bump the integration-requirements versioned dependencies

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -6,16 +6,14 @@
 #
 
 # ec2 backend
-boto3==1.5.9
+boto3==1.14.53
 
 # ssh communication
-paramiko==2.4.2
-cryptography==2.4.2
-
+paramiko==2.7.2
+cryptography==3.1
 
 # lxd backend
-# 04/03/2018: enables use of lxd 3.0
-git+https://github.com/lxc/pylxd.git@4b8ab1802f9aee4eb29cf7b119dae0aa47150779
+pylxd==2.2.11
 
 # finds latest image information
 git+https://git.launchpad.net/simplestreams


### PR DESCRIPTION
During the ec2 integration test runs we occasionally see failures in
deleting test instances. Hopefully a newer boto3 will be more robust.

Also bump: paramiko, cryptography, pylxd (now pulling it from pypi).

Tested with a full Xenial EC2 cloud_tests run.