### PR TITLE
Nocloud/OVF seedfrom vendordata

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -157,13 +157,14 @@ class DataSourceNoCloud(sources.DataSource):
 
             # This could throw errors, but the user told us to do it
             # so if errors are raised, let them raise
-            (md_seed, ud) = util.read_seeded(seedfrom, timeout=None)
+            (md_seed, ud, vd) = util.read_seeded(seedfrom, timeout=None)
             LOG.debug("Using seeded cache data from %s", seedfrom)
 
             # Values in the command line override those from the seed
             mydata['meta-data'] = util.mergemanydict([mydata['meta-data'],
                                                       md_seed])
             mydata['user-data'] = ud
+            mydata['vendor-data'] = vd
             found.append(seedfrom)
 
         # Now that we have exhausted any other places merge in the defaults

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -73,6 +73,7 @@ class DataSourceOVF(sources.DataSource):
         found = []
         md = {}
         ud = ""
+        vd = ""
         vmwareImcConfigFilePath = None
         nicspath = None
 
@@ -304,7 +305,7 @@ class DataSourceOVF(sources.DataSource):
                           seedfrom, self)
                 return False
 
-            (md_seed, ud) = util.read_seeded(seedfrom, timeout=None)
+            (md_seed, ud, vd) = util.read_seeded(seedfrom, timeout=None)
             LOG.debug("Using seeded cache data from %s", seedfrom)
 
             md = util.mergemanydict([md, md_seed])
@@ -316,6 +317,7 @@ class DataSourceOVF(sources.DataSource):
         self.seed = ",".join(found)
         self.metadata = md
         self.userdata_raw = ud
+        self.vendordata_raw = vd
         self.cfg = cfg
         return True
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -860,11 +860,15 @@ def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
     if ud_resp.ok():
         ud = ud_resp.contents
 
-    vd_resp = url_helper.read_file_or_url(vd_url, timeout=timeout,
-                                          retries=retries)
     vd = None
-    if vd_resp.ok():
-        vd = vd_resp.contents
+    try:
+        vd_resp = url_helper.read_file_or_url(vd_url, timeout=timeout,
+                                          retries=retries)
+    except url_helper.UrlError:
+        pass
+    else:
+        if vd_resp.ok():
+            vd = vd_resp.contents
 
     return (md, ud, vd)
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -761,8 +761,9 @@ def del_dir(path):
 # 'meta-data' entries
 def read_optional_seed(fill, base="", ext="", timeout=5):
     try:
-        (md, ud) = read_seeded(base, ext, timeout)
+        (md, ud, vd) = read_seeded(base, ext, timeout)
         fill['user-data'] = ud
+        fill['vendor-data'] = vd
         fill['meta-data'] = md
         return True
     except url_helper.UrlError as e:
@@ -840,9 +841,11 @@ def load_yaml(blob, default=None, allowed=(dict,)):
 def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
     if base.find("%s") >= 0:
         ud_url = base % ("user-data" + ext)
+        vd_url = base % ("vendor-data" + ext)
         md_url = base % ("meta-data" + ext)
     else:
         ud_url = "%s%s%s" % (base, "user-data", ext)
+        vd_url = "%s%s%s" % (base, "vendor-data", ext)
         md_url = "%s%s%s" % (base, "meta-data", ext)
 
     md_resp = url_helper.read_file_or_url(md_url, timeout=timeout,
@@ -857,7 +860,13 @@ def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
     if ud_resp.ok():
         ud = ud_resp.contents
 
-    return (md, ud)
+    vd_resp = url_helper.read_file_or_url(vd_url, timeout=timeout,
+                                          retries=retries)
+    vd = None
+    if vd_resp.ok():
+        vd = vd_resp.contents
+
+    return (md, ud, vd)
 
 
 def read_conf_d(confd):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -864,11 +864,13 @@ def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
     try:
         vd_resp = url_helper.read_file_or_url(vd_url, timeout=timeout,
                                               retries=retries)
-    except url_helper.UrlError:
-        pass
+    except url_helper.UrlError as e:
+        LOG.debug("Error in vendor-data response: %s", e)
     else:
         if vd_resp.ok():
             vd = vd_resp.contents
+        else:
+            LOG.debug("Error in vendor-data response")
 
     return (md, ud, vd)
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -863,7 +863,7 @@ def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
     vd = None
     try:
         vd_resp = url_helper.read_file_or_url(vd_url, timeout=timeout,
-                                          retries=retries)
+                                              retries=retries)
     except url_helper.UrlError:
         pass
     else:

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -735,13 +735,16 @@ class TestReadSeeded(helpers.TestCase):
 
     def test_unicode_not_messed_up(self):
         ud = b"userdatablob"
+        vd = b"vendordatablob"
         helpers.populate_dir(
-            self.tmp, {'meta-data': "key1: val1", 'user-data': ud})
+            self.tmp, {'meta-data': "key1: val1", 'user-data': ud,
+                'vendor-data': vd})
         sdir = self.tmp + os.path.sep
-        (found_md, found_ud) = util.read_seeded(sdir)
+        (found_md, found_ud, found_vd) = util.read_seeded(sdir)
 
         self.assertEqual(found_md, {'key1': 'val1'})
         self.assertEqual(found_ud, ud)
+        self.assertEqual(found_vd, vd)
 
 
 class TestEncode(helpers.TestCase):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -747,6 +747,25 @@ class TestReadSeeded(helpers.TestCase):
         self.assertEqual(found_vd, vd)
 
 
+class TestReadSeededWithoutVendorData(helpers.TestCase):
+    def setUp(self):
+        super(TestReadSeededWithoutVendorData, self).setUp()
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def test_unicode_not_messed_up(self):
+        ud = b"userdatablob"
+        vd = None
+        helpers.populate_dir(
+            self.tmp, {'meta-data': "key1: val1", 'user-data': ud})
+        sdir = self.tmp + os.path.sep
+        (found_md, found_ud, found_vd) = util.read_seeded(sdir)
+
+        self.assertEqual(found_md, {'key1': 'val1'})
+        self.assertEqual(found_ud, ud)
+        self.assertEqual(found_vd, vd)
+
+
 class TestEncode(helpers.TestCase):
     """Test the encoding functions"""
     def test_decode_binary_plain_text_with_hex(self):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -738,7 +738,7 @@ class TestReadSeeded(helpers.TestCase):
         vd = b"vendordatablob"
         helpers.populate_dir(
             self.tmp, {'meta-data': "key1: val1", 'user-data': ud,
-                'vendor-data': vd})
+                       'vendor-data': vd})
         sdir = self.tmp + os.path.sep
         (found_md, found_ud, found_vd) = util.read_seeded(sdir)
 


### PR DESCRIPTION
This PR modifies the `util.seedfrom` helper function to query optional vendor-data. I started with the idea of implementing for NoCloud, but as OVF is using the same helper, I figured it would be easier to do it for both.