### PR TITLE
bddeb: new --packaging-branch argument to pull packaging from branch

### DIFF
--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -182,7 +182,7 @@ def subp(args, data=None, rcs=None, env=None, capture=True,
         call this fuction with a single string argument before starting
         and after finishing.
     :param cwd:
-        changee the working directory to cwd before executing the command.
+        change the working directory to cwd before executing the command.
 
     :return
         if not capturing, return is (None, None)

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -144,7 +144,7 @@ class ProcessExecutionError(IOError):
 def subp(args, data=None, rcs=None, env=None, capture=True,
          combine_capture=False, shell=False,
          logstring=False, decode="replace", target=None, update_env=None,
-         status_cb=None):
+         status_cb=None, cwd=None):
     """Run a subprocess.
 
     :param args: command to run in a list. [cmd, arg1, arg2...]
@@ -181,6 +181,8 @@ def subp(args, data=None, rcs=None, env=None, capture=True,
     :param status_cb:
         call this fuction with a single string argument before starting
         and after finishing.
+    :param cwd:
+        changee the working directory to cwd before executing the command.
 
     :return
         if not capturing, return is (None, None)
@@ -254,7 +256,7 @@ def subp(args, data=None, rcs=None, env=None, capture=True,
     try:
         sp = subprocess.Popen(bytes_args, stdout=stdout,
                               stderr=stderr, stdin=stdin,
-                              env=env, shell=shell)
+                              env=env, shell=shell, cwd=cwd)
         (out, err) = sp.communicate(data)
     except OSError as e:
         if status_cb:

--- a/doc/rtd/topics/cloud_tests.rst
+++ b/doc/rtd/topics/cloud_tests.rst
@@ -151,17 +151,20 @@ cloud-init located in a different directory, use the option ``--cloud-init
 Bddeb
 -----
 
-The ``bddeb`` command can be used to generate a deb file. This is used by
-the tree_run and tree_collect commands to build a deb of the current
-working tree. It can also be used a user to generate a deb for use in other
-situations and avoid needing to have all the build and test dependencies
-installed locally.
+The ``bddeb`` command can be used to generate a deb file. This is used by the
+tree_run and tree_collect commands to build a deb of the current working tree
+using the packaging template contained in the ``packages/debian/`` directory.
+It can also be used to generate a deb for use in other situations and avoid
+needing to have all the build and test dependencies installed locally.
 
 * ``--bddeb-args``: arguments to pass through to bddeb
 * ``--build-os``: distribution to use as build system (default is xenial)
 * ``--build-platform``: platform to use for build system (default is lxd)
 * ``--cloud-init``: path to base of cloud-init tree (default is '.')
 * ``--deb``: path to write output deb to (default is '.')
+* ``--packaging-branch``: import the ``debian/`` packaging directory
+  from the specified branch (default: ``ubuntu/devel``) instead of using
+  the packaging template. When importing the ``debian/patches`` are excluded.
 
 Setup Image
 -----------

--- a/doc/rtd/topics/cloud_tests.rst
+++ b/doc/rtd/topics/cloud_tests.rst
@@ -164,7 +164,7 @@ needing to have all the build and test dependencies installed locally.
 * ``--deb``: path to write output deb to (default is '.')
 * ``--packaging-branch``: import the ``debian/`` packaging directory
   from the specified branch (default: ``ubuntu/devel``) instead of using
-  the packaging template. When importing the ``debian/patches`` are excluded.
+  the packaging template.
 
 Setup Image
 -----------

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -5,6 +5,7 @@ import csv
 import json
 import os
 import shutil
+import subprocess
 import sys
 
 UNRELEASED = "UNRELEASED"
@@ -20,6 +21,7 @@ def find_root():
         return os.path.abspath(top_dir)
     raise OSError(("Unable to determine where your cloud-init topdir is."
                    " set CLOUD_INIT_TOP_D?"))
+
 
 if "avoid-pep8-E402-import-not-top-of-file":
     # Use the util functions from cloudinit
@@ -99,6 +101,36 @@ def write_debian_folder(root, templ_data, cloud_util_deps):
                              params={'build_depends': ','.join(requires)})
 
 
+def write_debian_folder_from_branch(root, templ_data, branch):
+    """Import a debian package directory from a branch."""
+    print("Importing debian/ from branch %s to %r" % (branch, root))
+
+    p_dumpdeb = subprocess.Popen(
+        ["git", "archive", branch, "debian"], stdout=subprocess.PIPE
+    )
+    subprocess.check_call(
+        ["tar", "-C", root, "--exclude", "debian/patches", "-x"],
+        stdin=p_dumpdeb.stdout
+    )
+
+    print("Adding new entry to debian/changelog")
+    full_deb_version = (
+        templ_data["version_long"] + "-1~bddeb" + templ_data["release_suffix"]
+    )
+    subp.subp(
+        [
+            "dch",
+            "--distribution",
+            templ_data["debian_release"],
+            "--newversion",
+            full_deb_version,
+            "--controlmaint",
+            "Snapshot build.",
+        ],
+        cwd=root
+    )
+
+
 def read_version():
     return json.loads(run_helper('read-version', ['--json']))
 
@@ -140,12 +172,51 @@ def get_parser():
 
     parser.add_argument("--signuser", default=False, action='store',
                         help="user to sign, see man dpkg-genchanges")
+
+    parser.add_argument("--packaging-branch", nargs="?", metavar="BRANCH",
+                        const="ubuntu/devel", type=str,
+                        help=(
+                            "Import packaging from %(metavar)s instead of"
+                            " using the packages/debian/* templates"
+                            " (default: %(const)s)"
+                        ))
+
     return parser
 
 
 def main():
     parser = get_parser()
     args = parser.parse_args()
+
+    if args.packaging_branch:
+        try:
+            subp.subp(
+                [
+                    "git",
+                    "show-ref",
+                    "--quiet",
+                    "--verify",
+                    "refs/heads/" + args.packaging_branch,
+                ]
+            )
+        except subp.ProcessExecutionError:
+            print("Couldn't find branch '%s'." % args.packaging_branch)
+            return 1
+        try:
+            subp.subp(
+                [
+                    "git",
+                    "cat-file",
+                    "-e",
+                    args.packaging_branch + ":debian/control",
+                ]
+            )
+        except subp.ProcessExecutionError:
+            print(
+                "Couldn't find debian/control in branch '%s'."
+                " Is it a packaging branch?" % args.packaging_branch
+            )
+            return 1
 
     if not args.sign:
         args.debuild_args.extend(['-us', '-uc'])
@@ -198,7 +269,14 @@ def main():
         xdir = util.abs_join(tdir, "cloud-init-%s" % ver_data['version_long'])
         templ_data.update(ver_data)
 
-        write_debian_folder(xdir, templ_data, cloud_util_deps=args.cloud_utils)
+        if args.packaging_branch:
+            write_debian_folder_from_branch(
+                xdir, templ_data, args.packaging_branch
+            )
+        else:
+            write_debian_folder(
+                xdir, templ_data, cloud_util_deps=args.cloud_utils
+            )
 
         print("Running 'debuild %s' in %r" % (' '.join(args.debuild_args),
                                               xdir))

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -109,7 +109,7 @@ def write_debian_folder_from_branch(root, templ_data, branch):
         ["git", "archive", branch, "debian"], stdout=subprocess.PIPE
     )
     subprocess.check_call(
-        ["tar", "-C", root, "-x"],
+        ["tar", "-v", "-C", root, "-x"],
         stdin=p_dumpdeb.stdout
     )
 

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -103,7 +103,7 @@ def write_debian_folder(root, templ_data, cloud_util_deps):
 
 def write_debian_folder_from_branch(root, templ_data, branch):
     """Import a debian package directory from a branch."""
-    print("Importing debian/ from branch %s to %r" % (branch, root))
+    print("Importing debian/ from branch %s to %s" % (branch, root))
 
     p_dumpdeb = subprocess.Popen(
         ["git", "archive", branch, "debian"], stdout=subprocess.PIPE

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -200,6 +200,7 @@ def main():
             )
         except subp.ProcessExecutionError:
             print("Couldn't find branch '%s'." % args.packaging_branch)
+            print("You may need to checkout the branch from the git remote.")
             return 1
         try:
             subp.subp(

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -22,7 +22,6 @@ def find_root():
     raise OSError(("Unable to determine where your cloud-init topdir is."
                    " set CLOUD_INIT_TOP_D?"))
 
-
 if "avoid-pep8-E402-import-not-top-of-file":
     # Use the util functions from cloudinit
     sys.path.insert(0, find_root())

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -109,7 +109,7 @@ def write_debian_folder_from_branch(root, templ_data, branch):
         ["git", "archive", branch, "debian"], stdout=subprocess.PIPE
     )
     subprocess.check_call(
-        ["tar", "-C", root, "--exclude", "debian/patches", "-x"],
+        ["tar", "-C", root, "-x"],
         stdin=p_dumpdeb.stdout
     )
 


### PR DESCRIPTION
bddeb builds a .deb package using the template packaging files in
packages/debian/.

The new --packaging-branch flag allows to specify a git branch
where to pull the packaging (i.e. the debian/ directory) from.
This is useful to build a .deb package from master with the very
same packaging which is used for the uploads.