### PR TITLE
openstack: consider product_name as valid chassis tag

### DIFF
--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -32,7 +32,8 @@ DMI_ASSET_TAG_OPENTELEKOM = 'OpenTelekomCloud'
 # See github.com/sapcc/helm-charts/blob/master/openstack/nova/values.yaml
 # -> compute.defaults.vmware.smbios_asset_tag for this value
 DMI_ASSET_TAG_SAPCCLOUD = 'SAP CCloud VM'
-VALID_DMI_ASSET_TAGS = [DMI_ASSET_TAG_OPENTELEKOM, DMI_ASSET_TAG_SAPCCLOUD]
+VALID_DMI_ASSET_TAGS = VALID_DMI_PRODUCT_NAMES
+VALID_DMI_ASSET_TAGS += [DMI_ASSET_TAG_OPENTELEKOM, DMI_ASSET_TAG_SAPCCLOUD]
 
 
 class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):

--- a/tests/unittests/test_datasource/test_openstack.py
+++ b/tests/unittests/test_datasource/test_openstack.py
@@ -548,6 +548,36 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
             ds.detect_openstack(accept_oracle=False),
             'Expected detect_openstack == False.')
 
+    def _test_detect_openstack_nova_compute_chassis_asset_tag(self, m_dmi,
+                                                              m_is_x86,
+                                                              chassis_tag):
+        """Return True on OpenStack reporting generic asset-tag."""
+        m_is_x86.return_value = True
+
+        def fake_dmi_read(dmi_key):
+            if dmi_key == 'system-product-name':
+                return 'Generic OpenStack Platform'
+            if dmi_key == 'chassis-asset-tag':
+                return chassis_tag
+            assert False, 'Unexpected dmi read of %s' % dmi_key
+
+        m_dmi.side_effect = fake_dmi_read
+        self.assertTrue(
+            ds.detect_openstack(),
+            'Expected detect_openstack == True on Generic OpenStack Platform')
+
+    @test_helpers.mock.patch(MOCK_PATH + 'util.read_dmi_data')
+    def test_detect_openstack_nova_chassis_asset_tag(self, m_dmi,
+                                                     m_is_x86):
+        self._test_detect_openstack_nova_compute_chassis_asset_tag(
+            m_dmi, m_is_x86, 'OpenStack Nova')
+
+    @test_helpers.mock.patch(MOCK_PATH + 'util.read_dmi_data')
+    def test_detect_openstack_compute_chassis_asset_tag(self, m_dmi,
+                                                        m_is_x86):
+        self._test_detect_openstack_nova_compute_chassis_asset_tag(
+            m_dmi, m_is_x86, 'OpenStack Compute')
+
     @test_helpers.mock.patch(MOCK_PATH + 'util.get_proc_env')
     @test_helpers.mock.patch(MOCK_PATH + 'util.read_dmi_data')
     def test_detect_openstack_by_proc_1_environ(self, m_dmi, m_proc_env,

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -1,3 +1,4 @@
+ader1990
 AlexBaranowski
 beezly
 bipinbachhao


### PR DESCRIPTION
Consider valid product names as valid chassis asset tags when detecting
OpenStack platform before crawling for OpenStack metadata.

As `ds-identify` tool uses product name as valid chassis asset tags,
let's replicate the behaviour in the OpenStack platform detection too.

This change should be backwards compatible and a temporary fix for the
current limitations on the OpenStack platform detection.

LP: #1895976