### PR TITLE
Change default authorizedkeys file

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -262,7 +262,7 @@ def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
 
         except (IOError, OSError):
             # Give up and use a default key filename
-            auth_key_fns[0] = default_authorizedkeys_file
+            auth_key_fns.append(default_authorizedkeys_file)
             util.logexc(LOG, "Failed extracting 'AuthorizedKeysFile' in SSH "
                         "config from %r, using 'AuthorizedKeysFile' file "
                         "%r instead", DEF_SSHD_CFG, auth_key_fns[0])

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -267,8 +267,8 @@ def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
                         "config from %r, using 'AuthorizedKeysFile' file "
                         "%r instead", DEF_SSHD_CFG, auth_key_fns[0])
 
-    # always store all the keys in the user's private file
-    return (default_authorizedkeys_file, parse_authorized_keys(auth_key_fns))
+    # always store all the keys in the first file configured on sshd_config
+    return (auth_key_fns[0], parse_authorized_keys(auth_key_fns))
 
 
 def setup_user_keys(keys, username, options=None):

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -593,7 +593,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
             fpw.pw_name, sshd_config)
         content = ssh_util.update_authorized_keys(auth_key_entries, [])
 
-        self.assertEqual("%s/.ssh/authorized_keys" % fpw.pw_dir, auth_key_fn)
+        self.assertEqual(authorized_keys, auth_key_fn)
         self.assertTrue(VALID_CONTENT['rsa'] in content)
         self.assertTrue(VALID_CONTENT['dsa'] in content)
 
@@ -610,7 +610,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         sshd_config = self.tmp_path('sshd_config')
         util.write_file(
             sshd_config,
-            "AuthorizedKeysFile %s %s" % (authorized_keys, user_keys)
+            "AuthorizedKeysFile %s %s" % (user_keys, authorized_keys)
         )
 
         (auth_key_fn, auth_key_entries) = ssh_util.extract_authorized_keys(
@@ -618,7 +618,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         )
         content = ssh_util.update_authorized_keys(auth_key_entries, [])
 
-        self.assertEqual("%s/.ssh/authorized_keys" % fpw.pw_dir, auth_key_fn)
+        self.assertEqual(user_keys, auth_key_fn)
         self.assertTrue(VALID_CONTENT['rsa'] in content)
         self.assertTrue(VALID_CONTENT['dsa'] in content)
 


### PR DESCRIPTION
## Proposed Commit Message
The following commit merged all ssh keys into a default user file
`~/.ssh/authorized_keys` in sshd_config had multiple files configured for
AuthorizedKeysFile:

commit f1094b1a539044c0193165a41501480de0f8df14
Author: Eduardo Otubo <otubo@redhat.com>
Date:   Thu Dec 5 17:37:35 2019 +0100

    Multiple file fix for AuthorizedKeysFile config (#60)

This commit ignored the case when sshd_config would have a single file for
AuthorizedKeysFile, but a non default configuration, for example
`~/.ssh/authorized_keys_foobar`. In this case cloud-init would grab all keys
from this file and write a new one, the default `~/.ssh/authorized_keys`
causing the bug.

rhbz: #1862967

Signed-off-by: Eduardo Otubo <otubo@redhat.com>

## Additional Context
None

## Test Steps
1. Prepare a VM with cloud-init enabled
2. Modify `/etc/ssh/sshd_config` to remove default `.ssh/authorized_keys` and change to another file e.g.:
```
# cat /etc/ssh/sshd_config | grep AuthorizedKeysFile
AuthorizedKeysFile .ssh/authorized_keys2
```
3. Remove /var/lib/cloud/instance/sem/config_ssh
4. systemctl restart cloud-init ; systemctl restart sshd
5. Try to ssh login through the cloud-init created user

Actual results:
Cannot login: `Permission denied (publickey,gssapi-keyex,gssapi-with-mic)`
The public key is written into `.ssh/authorized_keys` but not `.ssh/authorized_keys2`

Expected results:
Can login successfully. The public key is written into `.ssh/authorized_keys2`

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly


