### PR TITLE
Fix name of ntp service to ntpd on CentOS and RHEL.

### DIFF
--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -80,6 +80,14 @@ DISTRO_CLIENT_CONFIG = {
             'confpath': '/etc/chrony/chrony.conf',
         },
     },
+    'rhel': {
+        'ntp': {
+            'service_name': 'ntpd',
+        },
+        'chrony': {
+            'service_name': 'chronyd',
+        },
+    },
     'opensuse': {
         'chrony': {
             'service_name': 'chronyd',


### PR DESCRIPTION
The service installed by the CentOS and RHEL 'ntp' package is
  ntpd.service
not
  ntp.service

Fix that for those two distros.

LP: #1897915