### PR TITLE
integration_tests: improve cloud-init.log assertions

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -104,3 +104,29 @@ def class_client(request, fixture_utils):
     """Provide a client that runs once per class."""
     with _client(request, fixture_utils) as client:
         yield client
+
+
+def pytest_assertrepr_compare(op, left, right):
+    """Custom integration test assertion explanations.
+
+    See
+    https://docs.pytest.org/en/stable/assert.html#defining-your-own-explanation-for-failed-assertions
+    for pytest's documentation.
+    """
+    if op == "not in" and isinstance(left, str) and isinstance(right, str):
+        # This stanza emits an improved assertion message if we're testing for
+        # the presence of a string within a cloud-init log: it will report only
+        # the specific lines containing the string (instead of the full log,
+        # the default behaviour).
+        potential_log_lines = right.splitlines()
+        first_line = potential_log_lines[0]
+        if "DEBUG" in first_line and "Cloud-init" in first_line:
+            # We are looking at a cloud-init log, so just pick out the relevant
+            # lines
+            found_lines = [
+                line for line in potential_log_lines if left in line
+            ]
+            return [
+                '"{}" not in cloud-init.log string; unexpectedly found on'
+                " these lines:".format(left)
+            ] + found_lines


### PR DESCRIPTION
## Proposed Commit Message

> integration_tests: improve cloud-init.log assertions

## Test Steps

With https://github.com/canonical/cloud-init/pull/592 also in tree, `CLOUD_INIT_OS_IMAGE=ubuntu:09768724e1c1 pytest -s tests/integration_tests/bugs` will demonstrate the assertion output this modifies. Before this change:

```
>       assert "WARNING" not in log_content
E       AssertionError: assert 'WARNING' not in '2020-10-01 ...atasources\n'
E         'WARNING' is contained here:
E           2020-10-01 20:49:47,402 - util.py[DEBUG]: Cloud-init v. 20.1-10-g71af48df-0ubuntu5 running 'init-local' at Thu, 01 Oct 2020 20:49:47 +0000. Up 2.06 seconds.
E           2020-10-01 20:49:47,402 - main.py[DEBUG]: No kernel command line url found.
E           2020-10-01 20:49:47,402 - main.py[DEBUG]: Closing stdin.
E           2020-10-01 20:49:47,407 - util.py[DEBUG]: Writing to /var/log/cloud-init.log - ab: [644] 0 bytes
E           2020-10-01 20:49:47,408 - util.py[DEBUG]: Changing the ownership of /var/log/cloud-init.log to 104:4
E           2020-10-01 20:49:47,409 - util.py[DEBUG]: Attempting to remove /var/lib/...
E         
E         ...Full output truncated (439 lines hidden), use '-vv' to show

tests/integration_tests/bugs/test_lp1886531.py:27: AssertionError
```

whereas after this change:

```
E       assert "WARNING" not in cloud-init.log string; unexpectedly found on these lines:
E         2020-10-01 20:48:59,040 - util.py[WARNING]: Running module mounts (<module 'cloudinit.config.cc_mounts' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_mounts.py'>) failed
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly