### PR TITLE
tox.ini: add integration-tests testenv definition

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -137,6 +137,15 @@ passenv = HOME TRAVIS
 deps =
     -r{toxinidir}/integration-requirements.txt
 
+[testenv:integration-tests]
+basepython = python3
+commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
+passenv = CLOUD_INIT_*
+# test-requirements.txt is required for ./conftest.py to import successfully
+deps =
+    -r{toxinidir}/integration-requirements.txt
+    -r{toxinidir}/test-requirements.txt
+
 [pytest]
 # TODO: s/--strict/--strict-markers/ once xenial support is dropped
 testpaths = cloudinit tests/unittests


### PR DESCRIPTION
## Proposed Commit Message

> tox.ini: add integration-tests testenv definition

## Test Steps

With the test from #592 added to the branch (so we have something to run), the output (without package installation preamble) is:

```
integration-tests run-test-pre: PYTHONHASHSEED='3602795599'
integration-tests run-test: commands[0] | /home/daniel/dev/cloud-init/.tox/integration-tests/bin/python -m pytest --log-cli-level=INFO tests/integration_tests
=================================== test session starts ====================================
platform linux -- Python 3.8.6, pytest-6.1.0, py-1.9.0, pluggy-0.13.1
cachedir: .tox/integration-tests/.pytest_cache
rootdir: /home/daniel/dev/cloud-init, configfile: tox.ini
plugins: cov-2.10.1
collected 1 item                                                                           

tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 
-------------------------------------- live log setup --------------------------------------
INFO     integration_testing:conftest.py:50 Setting up environment for lxd_container
INFO     integration_testing:conftest.py:72 Done with environment setup
INFO     pycloudlib.instance:instance.py:145 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:145 executing: cloud-init status --wait
INFO     integration_testing:platforms.py:74 Launched instance: LXDInstance(name=still-hippo)
PASSED                                                                               [100%]

===================================== warnings summary =====================================
tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531
  /home/daniel/dev/cloud-init/.tox/integration-tests/lib/python3.8/site-packages/simplestreams/mirrors/__init__.py:206: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    LOG.warn("got ENOENT for (%s, %s), trying with trailing /",

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================== 1 passed, 1 warning in 57.64s ===============================
_________________________________________ summary __________________________________________
  integration-tests: commands succeeded
  congratulations :)
```

And we can see that the environment variables are passed through (this run fails because it's using an older image which doesn't include the fix which #592 covers):

```
integration-tests run-test-pre: PYTHONHASHSEED='3614659998'
integration-tests run-test: commands[0] | /home/daniel/dev/cloud-init/.tox/integration-tests/bin/python -m pytest --log-cli-level=INFO tests/integration_tests
=================================== test session starts ====================================
platform linux -- Python 3.8.6, pytest-6.1.0, py-1.9.0, pluggy-0.13.1
cachedir: .tox/integration-tests/.pytest_cache
rootdir: /home/daniel/dev/cloud-init, configfile: tox.ini
plugins: cov-2.10.1
collected 1 item                                                                           

tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 
-------------------------------------- live log setup --------------------------------------
INFO     integration_testing:conftest.py:50 Setting up environment for lxd_container
INFO     integration_testing:conftest.py:72 Done with environment setup
INFO     pycloudlib.instance:instance.py:145 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:145 executing: cloud-init status --wait
ERROR                                                                                [100%]

========================================== ERRORS ==========================================
______________________ ERROR at setup of TestLp1886531.test_lp1886531 ______________________

request = <SubRequest 'client' for <Function test_lp1886531>>
fixture_utils = <class 'conftest._FixtureUtils'>

    @pytest.yield_fixture
    def client(request, fixture_utils):
        """Provide a client that runs for every test."""
>       with _client(request, fixture_utils) as client:

tests/integration_tests/conftest.py:91: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
tests/integration_tests/conftest.py:84: in _client
    with dynamic_client(user_data=user_data) as instance:
tests/integration_tests/platforms.py:151: in __enter__
    self.launch()
tests/integration_tests/platforms.py:212: in launch
    super().launch()
tests/integration_tests/platforms.py:73: in launch
    self.instance = self.client.launch(**launch_args)
.tox/integration-tests/lib/python3.8/site-packages/pycloudlib/lxd/cloud.py:165: in launch
    instance.start(wait)
.tox/integration-tests/lib/python3.8/site-packages/pycloudlib/lxd/instance.py:262: in start
    self.wait()
.tox/integration-tests/lib/python3.8/site-packages/pycloudlib/lxd/instance.py:266: in wait
    self._wait_for_system()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LXDInstance(name=loyal-salmon)

    def _wait_for_system(self):
        """Wait until system is fully booted and cloud-init has finished."""
        self._log.debug('wait_for_system cloud-init completion')
    
        has_wait = "--wait" in self.execute("cloud-init status --help").stdout
    
        if has_wait:
            cmd = ["cloud-init", "status", "--wait"]
        else:
            # runlevel 'N 2' supports distros without recent cloud-init
            # (e.g. trusty).
            runlevel_result = (
                '[ "$(runlevel)" = "N 2" ] && '
                "[ -f /run/cloud-init/result.json ]"
            )
            cmd = (
                "i=0; while [ $i -lt {} ] && i=$(($i+1)); do {} && exit 0;"
                " sleep 1; done; exit 1".format(
                    self.boot_timeout, runlevel_result
                )
            )
        result = self.execute(cmd, description='waiting for start')
    
        if result.failed:
>           raise OSError(
                'cloud-init failed to start: out: %s error: %s' % (
                     result.stdout, result.stderr
                )
            )
E           OSError: cloud-init failed to start: out: ....
E           status: error error:

.tox/integration-tests/lib/python3.8/site-packages/pycloudlib/instance.py:385: OSError
---------------------------------- Captured stdout setup -----------------------------------
Setting up environment for lxd_container
Done with environment setup
------------------------------------ Captured log setup ------------------------------------
INFO     integration_testing:conftest.py:50 Setting up environment for lxd_container
INFO     integration_testing:conftest.py:72 Done with environment setup
INFO     pycloudlib.instance:instance.py:145 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:145 executing: cloud-init status --wait
===================================== warnings summary =====================================
tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531
  /home/daniel/dev/cloud-init/.tox/integration-tests/lib/python3.8/site-packages/simplestreams/mirrors/__init__.py:206: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    LOG.warn("got ENOENT for (%s, %s), trying with trailing /",

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================= short test summary info ==================================
ERROR tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 - OSE...
=============================== 1 warning, 1 error in 34.61s ===============================
ERROR: InvocationError for command /home/daniel/dev/cloud-init/.tox/integration-tests/bin/python -m pytest --log-cli-level=INFO tests/integration_tests (exited with code 1)
_________________________________________ summary __________________________________________
ERROR:   integration-tests: commands failed
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly