### PR TITLE
integration_tests: don't error on cloud-init failure

### DIFF
--- a/tests/integration_tests/platforms.py
+++ b/tests/integration_tests/platforms.py
@@ -28,12 +28,11 @@ class IntegrationClient(ABC):
     use_sudo = True
     current_image = None
 
-    def __init__(self, user_data=None, instance_type=None, wait=True,
+    def __init__(self, user_data=None, instance_type=None,
                  settings=integration_settings, launch_kwargs=None):
         self.user_data = user_data
         self.instance_type = settings.INSTANCE_TYPE if \
             instance_type is None else instance_type
-        self.wait = wait
         self.settings = settings
         self.launch_kwargs = launch_kwargs if launch_kwargs else {}
         self.client = self._get_client()
@@ -65,12 +64,13 @@ class IntegrationClient(ABC):
         launch_args = {
             'image_id': image_id,
             'user_data': self.user_data,
-            'wait': self.wait,
+            'wait': False,
         }
         if self.instance_type:
             launch_args['instance_type'] = self.instance_type
         launch_args.update(self.launch_kwargs)
         self.instance = self.client.launch(**launch_args)
+        self.instance.wait(raise_on_cloudinit_failure=False)
         log.info('Launched instance: %s', self.instance)
 
     def destroy(self):


### PR DESCRIPTION
## Proposed Commit Message

> integration_tests: don't error on cloud-init failure
>
> pycloudlib's default behaviour is to raise an exception if cloud-init
> fails to run in an instance being launched.  For cloud-init testing, we
> want our test assertions to flag up failures, so we disable this
> behaviour for instances we launch.

## Additional Context

~~This must not land before https://github.com/canonical/pycloudlib/pull/37 lands; it is marked `wip` for now.~~ (Now landed.)

## Test Steps

For both of these, apply #592 to your tree (so you have a test to run), then run `CLOUD_INIT_OS_IMAGE=ubuntu:09768724e1c1 pytest tests/integration_tests/bugs --log-cli-level=INFO` (that image causes the test in #592 to fail, so we can compare output).

Before this change, the failure happens during launch of the test instance (which is happening during test setup, so is reported as an ERROR):

```
______________________ ERROR at setup of TestLp1886531.test_lp1886531 ______________________

request = <SubRequest 'client' for <Function test_lp1886531>>
fixture_utils = <class 'conftest._FixtureUtils'>

    @pytest.yield_fixture
    def client(request, fixture_utils):
        """Provide a client that runs for every test."""
>       with _client(request, fixture_utils) as client:

tests/integration_tests/conftest.py:91: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.8/contextlib.py:113: in __enter__
    return next(self.gen)
tests/integration_tests/conftest.py:84: in _client
    with dynamic_client(user_data=user_data) as instance:
tests/integration_tests/platforms.py:151: in __enter__
    self.launch()
tests/integration_tests/platforms.py:212: in launch
    super().launch()
tests/integration_tests/platforms.py:73: in launch
    self.instance = self.client.launch(**launch_args)
../pycloudlib/pycloudlib/lxd/cloud.py:165: in launch
    instance.start(wait)
../pycloudlib/pycloudlib/lxd/instance.py:262: in start
    self.wait()
../pycloudlib/pycloudlib/instance.py:102: in wait
    self._wait_for_cloudinit(raise_on_failure=raise_on_cloudinit_failure)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = LXDInstance(name=obliging-drake)

    def _wait_for_cloudinit(self, *, raise_on_failure: bool):
        """Wait until cloud-init has finished.
    
        :param raise_on_failure:
            When `True`, if the process waiting for cloud-init exits non-zero
            then this method will raise an `OSError`.
        """
        self._log.debug('_wait_for_cloudinit to complete')
        has_wait = "--wait" in self.execute("cloud-init status --help").stdout
    
        if has_wait:
            cmd = ["cloud-init", "status", "--wait"]
        else:
            # runlevel 'N 2' supports distros without recent cloud-init
            # (e.g. trusty).
            runlevel_result = (
                '[ "$(runlevel)" = "N 2" ] && '
                "[ -f /run/cloud-init/result.json ]"
            )
            cmd = (
                "i=0; while [ $i -lt {} ] && i=$(($i+1)); do {} && exit 0;"
                " sleep 1; done; exit 1".format(
                    self.boot_timeout, runlevel_result
                )
            )
        result = self.execute(cmd, description='waiting for start')
    
        if raise_on_failure and result.failed:
>           raise OSError(
                'cloud-init failed to start: out: %s error: %s' % (
                     result.stdout, result.stderr
                )
            )
E           OSError: cloud-init failed to start: out: 
E           status: error error:

../pycloudlib/pycloudlib/instance.py:401: OSError
```

whereas afterwards we can see that our test assertion is what causes the failure:

```
_______________________________ TestLp1886531.test_lp1886531 _______________________________

self = <test_lp1886531.TestLp1886531 object at 0x7f0c07d74af0>
client = <tests.integration_tests.platforms.LxdContainerClient object at 0x7f0c07d74370>

    @pytest.mark.user_data(USER_DATA)
    def test_lp1886531(self, client):
        log_content = client.read_from_file("/var/log/cloud-init.log")
>       assert "WARNING" not in log_content
E       AssertionError: assert 'WARNING' not in '2020-10-02 ...atasources\n'
E         'WARNING' is contained here:
E           2020-10-02 14:33:42,833 - util.py[DEBUG]: Cloud-init v. 20.1-10-g71af48df-0ubuntu5 running 'init-local' at Fri, 02 Oct 2020 14:33:42 +0000. Up 2.06 seconds.
E           2020-10-02 14:33:42,833 - main.py[DEBUG]: No kernel command line url found.
E           2020-10-02 14:33:42,833 - main.py[DEBUG]: Closing stdin.
E           2020-10-02 14:33:42,838 - util.py[DEBUG]: Writing to /var/log/cloud-init.log - ab: [644] 0 bytes
E           2020-10-02 14:33:42,840 - util.py[DEBUG]: Changing the ownership of /var/log/cloud-init.log to 104:4
E           2020-10-02 14:33:42,840 - util.py[DEBUG]: Attempting to remove /var/lib/...
E         
E         ...Full output truncated (439 lines hidden), use '-vv' to show

tests/integration_tests/bugs/test_lp1886531.py:27: AssertionError
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly