### PR TITLE
conftest.py: remove top-level import of httpretty

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,16 @@
+"""Global conftest.py
+
+This conftest is used for unit tests in ``cloudinit/`` and ``tests/unittests/``
+as well as the integration tests in ``tests/integration_tests/``.
+
+Any imports that are performed at the top-level here must be installed wherever
+any of these tests run: that is to say, they must be listed in
+``integration-requirements.txt`` and in ``test-requirements.txt``.
+"""
 import os
 from unittest import mock
 
 import pytest
-import httpretty as _httpretty
 
 from cloudinit import helpers, subp
 
@@ -156,6 +164,8 @@ def httpretty():
     unset http_proxy in os.environ if present (to work around
     https://github.com/gabrielfalcao/HTTPretty/issues/122).
     """
+    import httpretty as _httpretty
+
     restore_proxy = os.environ.pop("http_proxy", None)
     _httpretty.HTTPretty.allow_net_connect = False
     _httpretty.reset()

--- a/tox.ini
+++ b/tox.ini
@@ -141,10 +141,8 @@ deps =
 basepython = python3
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
 passenv = CLOUD_INIT_*
-# test-requirements.txt is required for ./conftest.py to import successfully
 deps =
     -r{toxinidir}/integration-requirements.txt
-    -r{toxinidir}/test-requirements.txt
 
 [pytest]
 # TODO: s/--strict/--strict-markers/ once xenial support is dropped


### PR DESCRIPTION
## Proposed Commit Message
> conftest.py: remove top-level import of httpretty
> 
> This means that the integration tests do not need to install
> test-requirements.txt in order to successfully import `conftest.py`.

## Test Steps

`tox -e integration-tests` still works.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
