### PR TITLE
integration_tests: emit settings to log during setup

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -48,6 +48,7 @@ def setup_image():
     """
     client = dynamic_client()
     log.info('Setting up environment for %s', client.datasource)
+    client.emit_settings_to_log()
     if integration_settings.CLOUD_INIT_SOURCE == 'NONE':
         pass  # that was easy
     elif integration_settings.CLOUD_INIT_SOURCE == 'IN_PLACE':

--- a/tests/integration_tests/platforms.py
+++ b/tests/integration_tests/platforms.py
@@ -38,6 +38,17 @@ class IntegrationClient(ABC):
         self.launch_kwargs = launch_kwargs if launch_kwargs else {}
         self.client = self._get_client()
 
+    def emit_settings_to_log(self) -> None:
+        log.info(
+            "\n".join(
+                ["Settings:"]
+                + [
+                    "{}={}".format(key, getattr(self.settings, key))
+                    for key in sorted(self.settings.current_settings)
+                ]
+            )
+        )
+
     @abstractmethod
     def _get_client(self):
         raise NotImplementedError


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: emit settings to log during setup

## Test Steps

Log output now looks like this:

```
tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 
------------ live log setup ------------
INFO     integration_testing:conftest.py:50 Setting up environment for lxd_container
INFO     integration_testing:platforms.py:42 Settings:
CLOUD_INIT_SOURCE=NONE
EXISTING_INSTANCE_ID=None
GCE_PROJECT=None
GCE_REGION=us-central1
GCE_ZONE=a
INSTANCE_TYPE=None
KEEP_INSTANCE=False
OCI_COMPARTMENT_ID=None
OS_IMAGE=focal
PLATFORM=lxd_container
INFO     integration_testing:conftest.py:73 Done with environment setup
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
