### PR TITLE
RPM build: disable the dynamic mirror URLs when using a proxy

### DIFF
--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -34,6 +34,13 @@ MAYBE_RELIABLE_YUM_INSTALL = [
     'sh', '-c',
     """
     error() { echo "$@" 1>&2; }
+    configure_repos_for_proxy_use() {
+        grep -q "^proxy=" /etc/yum.conf || return 0
+        error ":: http proxy in use => forcing the use of fixed URLs in /etc/yum.repos.d/*.repo"
+        sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo
+        sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo
+    }
+    configure_repos_for_proxy_use
     n=0; max=10;
     bcmd="yum install --downloadonly --assumeyes --setopt=keepcache=1"
     while n=$(($n+1)); do
@@ -48,6 +55,7 @@ MAYBE_RELIABLE_YUM_INSTALL = [
     done
     error ":: running yum install --cacheonly --assumeyes $*"
     yum install --cacheonly --assumeyes "$@"
+    configure_repos_for_proxy_use
     """,
     'reliable-yum-install']
 

--- a/tools/run-container
+++ b/tools/run-container
@@ -371,9 +371,8 @@ wait_for_boot() {
         if [ "$OS_NAME" = "centos" ]; then
             debug 1 "configuring proxy ${http_proxy}"
             inside "$name" sh -c "echo proxy=$http_proxy >> /etc/yum.conf"
-            inside "$name" sed -i s/enabled=1/enabled=0/ \
-                /etc/yum/pluginconf.d/fastestmirror.conf
-            inside "$name" sh -c "sed -i '/^#baseurl=/s/#// ; s/^mirrorlist/#mirrorlist/' /etc/yum.repos.d/*.repo"
+            inside "$name" sh -c "sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo"
+            inside "$name" sh -c "sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo"
         else
             debug 1 "do not know how to configure proxy on $OS_NAME"
         fi


### PR DESCRIPTION
When using an http proxy make sure to disable all the dynamic mirror
URLs. In particular:

 - Uncomment the baseurl in /etc/yum.repos.d/*.repo.
 - Comment out the mirrorlist and metalink URLs in *.repo.
 - Replace the dynamic download.fedoraproject.org host with
   dl.fedoraproject.org, which is static.
 - Run the above as part of the MAYBE_RELIABLE_YUM_INSTALL command,
   as installing packages may add new repos (e.g. EPEL).
 - Stop disabling fastestmirror, not needed when doing the above.