### PR TITLE
integration_tests: implement citest tests run in Travis

### DIFF
--- a/tests/integration_tests/modules/test_apt_configure_sources_list.py
+++ b/tests/integration_tests/modules/test_apt_configure_sources_list.py
@@ -1,0 +1,50 @@
+"""Integration test for the apt module's ``sources_list`` functionality.
+
+This test specifies a ``sources_list`` and then checks that (a) the expected
+number of sources.list entries is present, and (b) that each expected line
+appears in the file.
+
+(This is ported from
+``tests/cloud_tests/testcases/modules/apt_configure_sources_list.yaml``.)"""
+import re
+
+import pytest
+
+
+USER_DATA = """\
+#cloud-config
+apt:
+  primary:
+    - arches: [default]
+      uri: http://archive.ubuntu.com/ubuntu
+  security:
+    - arches: [default]
+      uri: http://security.ubuntu.com/ubuntu
+  sources_list: |
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
+    deb $PRIMARY $RELEASE universe restricted
+    deb-src $PRIMARY $RELEASE universe restricted
+    deb $SECURITY $RELEASE-security multiverse
+    deb-src $SECURITY $RELEASE-security multiverse
+"""
+
+EXPECTED_REGEXES = [
+    r"deb http://archive.ubuntu.com/ubuntu [a-z].* main restricted",
+    r"deb-src http://archive.ubuntu.com/ubuntu [a-z].* main restricted",
+    r"deb http://archive.ubuntu.com/ubuntu [a-z].* universe restricted",
+    r"deb-src http://archive.ubuntu.com/ubuntu [a-z].* universe restricted",
+    r"deb http://security.ubuntu.com/ubuntu [a-z].*security multiverse",
+    r"deb-src http://security.ubuntu.com/ubuntu [a-z].*security multiverse",
+]
+
+
+class TestAptConfigureSourcesList:
+
+    @pytest.mark.user_data(USER_DATA)
+    def test_sources_list(self, client):
+        sources_list = client.read_from_file("/etc/apt/sources.list")
+        assert 6 == len(sources_list.rstrip().split('\n'))
+
+        for expected_re in EXPECTED_REGEXES:
+            assert re.search(expected_re, sources_list) is not None

--- a/tests/integration_tests/modules/test_ntp_servers.py
+++ b/tests/integration_tests/modules/test_ntp_servers.py
@@ -1,0 +1,57 @@
+"""Integration test for the ntp module's ``servers`` functionality with ntp.
+
+This test specifies the use of the `ntp` NTP client, and ensures that the given
+NTP servers are configured as expected.
+
+(This is ported from ``tests/cloud_tests/testcases/modules/ntp_servers.yaml``.)
+"""
+import re
+
+import yaml
+import pytest
+
+USER_DATA = """\
+#cloud-config
+ntp:
+  ntp_client: ntp
+  servers:
+      - 172.16.15.14
+      - 172.16.17.18
+"""
+
+EXPECTED_SERVERS = yaml.safe_load(USER_DATA)["ntp"]["servers"]
+
+
+@pytest.mark.user_data(USER_DATA)
+class TestNtpServers:
+
+    def test_ntp_installed(self, class_client):
+        """Test that `ntpd --version` succeeds, indicating installation."""
+        result = class_client.execute("ntpd --version")
+        assert 0 == result.return_code
+
+    def test_dist_config_file_is_empty(self, class_client):
+        """Test that the distributed config file is empty.
+
+        (This test is skipped on all currently supported Ubuntu releases, so
+        may not actually be needed any longer.)
+        """
+        if class_client.execute("test -e /etc/ntp.conf.dist").failed:
+            pytest.skip("/etc/ntp.conf.dist does not exist")
+        dist_file = class_client.read_from_file("/etc/ntp.conf.dist")
+        assert 0 == len(dist_file.strip().splitlines())
+
+    def test_ntp_entries(self, class_client):
+        ntp_conf = class_client.read_from_file("/etc/ntp.conf")
+        for expected_server in EXPECTED_SERVERS:
+            assert re.search(
+                r"^server {} iburst".format(expected_server),
+                ntp_conf,
+                re.MULTILINE
+            )
+
+    def test_ntpq_servers(self, class_client):
+        result = class_client.execute("ntpq -p -w -n")
+        assert result.ok
+        for expected_server in EXPECTED_SERVERS:
+            assert expected_server in result.stdout

--- a/tests/integration_tests/modules/test_set_password_list.py
+++ b/tests/integration_tests/modules/test_set_password_list.py
@@ -1,0 +1,121 @@
+"""Integration test for the set_password module.
+
+This test specifies a combination of user/password pairs, and ensures that the
+system has the correct passwords set.
+"""
+import crypt
+
+import pytest
+import yaml
+
+
+USER_DATA = """\
+#cloud-config
+ssh_pwauth: yes
+users:
+  - default
+  - name: tom
+    # md5 gotomgo
+    passwd: "$1$S7$tT1BEDIYrczeryDQJfdPe0"
+    lock_passwd: false
+  - name: dick
+    # md5 gocubsgo
+    passwd: "$1$ssisyfpf$YqvuJLfrrW6Cg/l53Pi1n1"
+    lock_passwd: false
+  - name: harry
+    # sha512 goharrygo
+    passwd: "$6$LF$9Z2p6rWK6TNC1DC6393ec0As.18KRAvKDbfsGJEdWN3sRQRwpdfoh37EQ3y\
+Uh69tP4GSrGW5XKHxMLiKowJgm/"
+    lock_passwd: false
+  - name: jane
+    # sha256 gojanego
+    passwd: "$5$iW$XsxmWCdpwIW8Yhv.Jn/R3uk6A4UaicfW5Xp7C9p9pg."
+    lock_passwd: false
+  - name: "mikey"
+    lock_passwd: false
+chpasswd:
+  list:
+    - tom:mypassword123!
+    - dick:RANDOM
+    - harry:RANDOM
+    - mikey:$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89
+"""
+
+USER_DATA_DICT = yaml.safe_load(USER_DATA)
+USERS_PASSWD_VALUES = {
+    user_dict["name"]: user_dict["passwd"]
+    for user_dict in USER_DATA_DICT["users"]
+    if "name" in user_dict and "passwd" in user_dict
+}
+
+
+@pytest.mark.user_data(USER_DATA)
+class TestPasswordList:
+    def _fetch_and_parse_etc_shadow(self, class_client):
+        """Fetch /etc/shadow and parse it into Python data structures
+
+        Returns: ({user: password}, [duplicate, users])
+        """
+        shadow_content = class_client.read_from_file("/etc/shadow")
+        users = {}
+        dupes = []
+        for line in shadow_content.splitlines():
+            user, encpw = line.split(":")[0:2]
+            if user in users:
+                dupes.append(user)
+            users[user] = encpw
+        return users, dupes
+
+    def test_no_duplicate_users_in_shadow(self, class_client):
+        """Confirm that set_passwords has not added duplicate shadow entries"""
+        _, dupes = self._fetch_and_parse_etc_shadow(class_client)
+
+        assert [] == dupes
+
+    def test_password_in_users_dict_set_correctly(self, class_client):
+        """Test that the password specified in the users dict is set."""
+        shadow_users, _ = self._fetch_and_parse_etc_shadow(class_client)
+        assert USERS_PASSWD_VALUES["jane"] == shadow_users["jane"]
+
+    def test_password_in_chpasswd_list_set_correctly(self, class_client):
+        """Test that a chpasswd password overrides one in the users dict."""
+        shadow_users, _ = self._fetch_and_parse_etc_shadow(class_client)
+        mikey_hash = "$5$xZ$B2YGGEx2AOf4PeW48KC6.QyT1W2B4rZ9Qbltudtha89"
+        assert mikey_hash == shadow_users["mikey"]
+
+    def test_random_passwords_set_correctly(self, class_client):
+        """Test that RANDOM chpasswd entries replace users dict passwords."""
+        shadow_users, _ = self._fetch_and_parse_etc_shadow(class_client)
+
+        # These should have been changed
+        assert shadow_users["harry"] != USERS_PASSWD_VALUES["harry"]
+        assert shadow_users["dick"] != USERS_PASSWD_VALUES["dick"]
+
+        # To random passwords
+        assert shadow_users["harry"].startswith("$")
+        assert shadow_users["dick"].startswith("$")
+
+        # Which are not the same
+        assert shadow_users["harry"] != shadow_users["dick"]
+
+    def test_explicit_password_set_correctly(self, class_client):
+        """Test that an explicitly-specified password is set correctly."""
+        shadow_users, _ = self._fetch_and_parse_etc_shadow(class_client)
+
+        fmt_and_salt = shadow_users["tom"].rsplit("$", 1)[0]
+        expected_value = crypt.crypt("mypassword123!", fmt_and_salt)
+
+        assert expected_value == shadow_users["tom"]
+
+    def test_shadow_expected_users(self, class_client):
+        """Test that the right set of users is in /etc/shadow."""
+        shadow = class_client.read_from_file("/etc/shadow")
+        for user_dict in USER_DATA_DICT["users"]:
+            if "name" in user_dict:
+                assert "{}:".format(user_dict["name"]) in shadow
+
+    def test_sshd_config(self, class_client):
+        """Test that SSH password auth is enabled."""
+        sshd_config = class_client.read_from_file("/etc/ssh/sshd_config")
+        # We look for the exact line match, to avoid a commented line matching
+        assert "PasswordAuthentication yes" in sshd_config.splitlines()

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -1,0 +1,79 @@
+"""Integration test for the user_groups module.
+
+This test specifies a number of users and groups via user-data, and confirms
+that they have been configured correctly in the system under test.
+"""
+import re
+
+import pytest
+
+
+USER_DATA = """\
+#cloud-config
+# Add groups to the system
+groups:
+  - secret: [root]
+  - cloud-users
+
+# Add users to the system. Users are added after groups are added.
+users:
+  - default
+  - name: foobar
+    gecos: Foo B. Bar
+    primary_group: foobar
+    groups: users
+    expiredate: 2038-01-19
+    lock_passwd: false
+    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYe\
+AHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
+  - name: barfoo
+    gecos: Bar B. Foo
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: [cloud-users, secret]
+    lock_passwd: true
+  - name: cloudy
+    gecos: Magic Cloud App Daemon User
+    inactive: true
+    system: true
+"""
+
+
+@pytest.mark.user_data(USER_DATA)
+class TestUsersGroups:
+    @pytest.mark.parametrize(
+        "getent_args,regex",
+        [
+            # Test the ubuntu group
+            (["group", "ubuntu"], r"ubuntu:x:[0-9]{4}:"),
+            # Test the cloud-users group
+            (["group", "cloud-users"], r"cloud-users:x:[0-9]{4}:barfoo"),
+            # Test the ubuntu user
+            (
+                ["passwd", "ubuntu"],
+                r"ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash",
+            ),
+            # Test the foobar user
+            (
+                ["passwd", "foobar"],
+                r"foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:",
+            ),
+            # Test the barfoo user
+            (
+                ["passwd", "barfoo"],
+                r"barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:",
+            ),
+            # Test the cloudy user
+            (["passwd", "cloudy"], r"cloudy:x:[0-9]{3,4}:"),
+        ],
+    )
+    def test_users_groups(self, regex, getent_args, class_client):
+        """Use getent to interrogate the various expected outcomes"""
+        result = class_client.execute(["getent"] + getent_args)
+        assert re.search(regex, result.stdout) is not None
+
+    def test_user_root_in_secret(self, class_client):
+        """Test root user is in 'secret' group."""
+        output = class_client.execute("groups root").stdout
+        _, groups_str = output.split(":", maxsplit=1)
+        groups = groups_str.split()
+        assert "secret" in groups


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: implement citest tests run in Travis
> 
> Specifically:
> * `apt_configure_sources_list`
> * `ntp_servers`
> * `set_password_list`
> * `users_groups`
>
> Although not currently run in Travis, `set_password_list_string` was
> ported over alongside `set_password_list` (as `test_set_password`).

## Test Steps

V e r y   w i d e:

```
GLOB sdist-make: /home/daniel/dev/cloud-init/setup.py
integration-tests recreate: /home/daniel/dev/cloud-init/.tox/integration-tests
integration-tests installdeps: -r/home/daniel/dev/cloud-init/integration-requirements.txt
integration-tests inst: /home/daniel/dev/cloud-init/.tox/.tmp/package/52/cloud-init-20.3.zip
integration-tests installed: adal==1.2.4,applicationinsights==0.11.9,argcomplete==1.12.1,attrs==20.2.0,azure-cli-core==2.9.1,azure-cli-nspkg==3.0.4,azure-cli-telemetry==1.0.6,azure-common==1.1.23,azure-core==1.8.2,azure-mgmt-compute==7.0.0,azure-mgmt-core==1.0.0,azure-mgmt-network==5.0.0,azure-mgmt-resource==4.0.0,azure-mgmt-storage==6.0.0,azure-nspkg==3.0.2,azure-storage==0.36.0,bcrypt==3.2.0,boto3==1.14.53,botocore==1.17.20,cachetools==4.1.1,certifi==2020.6.20,cffi==1.14.3,chardet==3.0.4,cloud-init @ file:///home/daniel/dev/cloud-init/.tox/.tmp/package/52/cloud-init-20.3.zip,colorama==0.4.3,configobj==5.0.6,configparser==4.0.2,cryptography==3.1,docutils==0.15.2,google-api-python-client==1.7.7,google-auth==1.22.1,google-auth-httplib2==0.0.4,httplib2==0.18.1,humanfriendly==8.2,idna==2.8,iniconfig==1.0.1,isodate==0.6.0,Jinja2==2.11.2,jmespath==0.10.0,jsonpatch==1.26,jsonpointer==2.0,jsonschema==3.2.0,knack==0.7.1,MarkupSafe==1.1.1,msal==1.0.0,msal-extensions==0.1.3,msrest==0.6.19,msrestazure==0.6.1,oauthlib==3.1.0,oci==2.17.0,packaging==20.4,paramiko==2.7.2,pbr==5.5.0,pkginfo==1.5.0.1,pluggy==0.13.1,portalocker==1.7.1,py==1.9.0,pyasn1==0.4.8,pyasn1-modules==0.2.8,pycloudlib @ git+https://github.com/canonical/pycloudlib.git@e6b2b3732a2a17d48bdf1167f56eb14576215d3c,pycparser==2.20,Pygments==2.7.1,PyJWT==1.7.1,pylxd==2.2.11,PyNaCl==1.4.0,pyOpenSSL==19.1.0,pyparsing==2.4.7,pyrsistent==0.17.3,pytest==6.1.1,python-dateutil==2.8.1,python-simplestreams @ git+https://git.launchpad.net/simplestreams@21c5bba2a5413c51e6b9131fc450e96f6b46090d,pytz==2020.1,PyYAML==5.1,requests==2.22.0,requests-oauthlib==1.3.0,requests-toolbelt==0.9.1,requests-unixsocket==0.2.0,rsa==4.6,s3transfer==0.3.3,six==1.15.0,tabulate==0.8.7,toml==0.10.1,uritemplate==3.0.1,urllib3==1.25.10,ws4py==0.5.1
integration-tests run-test-pre: PYTHONHASHSEED='3707415473'
integration-tests run-test: commands[0] | /home/daniel/dev/cloud-init/.tox/integration-tests/bin/python -m pytest --log-cli-level=INFO tests/integration_tests
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.8.6, pytest-6.1.1, py-1.9.0, pluggy-0.13.1
cachedir: .tox/integration-tests/.pytest_cache
rootdir: /home/daniel/dev/cloud-init, configfile: tox.ini
collected 27 items                                                                                                                                                                                                                                                                       

tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 
------------------------------------------------------------------------------------------------------------------------------------- live log setup -------------------------------------------------------------------------------------------------------------------------------------
INFO     integration_testing:conftest.py:50 Setting up environment for lxd_container
INFO     integration_testing:conftest.py:72 Done with environment setup
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:157 executing: cloud-init status --wait --long
INFO     integration_testing:platforms.py:74 Launched instance: LXDInstance(name=epic-mustang)
PASSED                                                                                                                                                                                                                                                                             [  3%]
tests/integration_tests/modules/test_apt_configure_sources_list.py::TestAptConfigureSourcesList::test_sources_list 
------------------------------------------------------------------------------------------------------------------------------------- live log setup -------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:157 executing: cloud-init status --wait --long
INFO     integration_testing:platforms.py:74 Launched instance: LXDInstance(name=popular-cicada)
PASSED                                                                                                                                                                                                                                                                             [  7%]
tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed 
------------------------------------------------------------------------------------------------------------------------------------- live log setup -------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:157 executing: cloud-init status --wait --long
INFO     integration_testing:platforms.py:74 Launched instance: LXDInstance(name=main-koi)
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'ntpd --version'
PASSED                                                                                                                                                                                                                                                                             [ 11%]
tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_dist_config_file_is_empty 
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'test -e /etc/ntp.conf.dist'
SKIPPED                                                                                                                                                                                                                                                                            [ 14%]
tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_entries PASSED                                                                                                                                                                                       [ 18%]
tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntpq_servers 
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'ntpq -p -w -n'
PASSED                                                                                                                                                                                                                                                                             [ 22%]
tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow 
------------------------------------------------------------------------------------------------------------------------------------- live log setup -------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:157 executing: cloud-init status --wait --long
INFO     integration_testing:platforms.py:74 Launched instance: LXDInstance(name=real-condor)
PASSED                                                                                                                                                                                                                                                                             [ 25%]
tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_users_dict_set_correctly PASSED                                                                                                                                                           [ 29%]
tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_password_in_chpasswd_list_set_correctly PASSED                                                                                                                                                        [ 33%]
tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_random_passwords_set_correctly PASSED                                                                                                                                                                 [ 37%]
tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_explicit_password_set_correctly PASSED                                                                                                                                                                [ 40%]
tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_shadow_expected_users PASSED                                                                                                                                                                          [ 44%]
tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_sshd_config PASSED                                                                                                                                                                                    [ 48%]
tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow 
------------------------------------------------------------------------------------------------------------------------------------- live log setup -------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:157 executing: cloud-init status --wait --long
INFO     integration_testing:platforms.py:74 Launched instance: LXDInstance(name=cunning-wahoo)
PASSED                                                                                                                                                                                                                                                                             [ 51%]
tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_users_dict_set_correctly PASSED                                                                                                                                                     [ 55%]
tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_password_in_chpasswd_list_set_correctly PASSED                                                                                                                                                  [ 59%]
tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_random_passwords_set_correctly PASSED                                                                                                                                                           [ 62%]
tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_explicit_password_set_correctly PASSED                                                                                                                                                          [ 66%]
tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_shadow_expected_users PASSED                                                                                                                                                                    [ 70%]
tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_sshd_config PASSED                                                                                                                                                                              [ 74%]
tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:] 
------------------------------------------------------------------------------------------------------------------------------------- live log setup -------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:157 executing: cloud-init status --wait --long
INFO     integration_testing:platforms.py:74 Launched instance: LXDInstance(name=flying-fish)
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: getent group ubuntu
PASSED                                                                                                                                                                                                                                                                             [ 77%]
tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args1-cloud-users:x:[0-9]{4}:barfoo] 
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: getent group cloud-users
PASSED                                                                                                                                                                                                                                                                             [ 81%]
tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args2-ubuntu:x:[0-9]{4}:[0-9]{4}:Ubuntu:/home/ubuntu:/bin/bash] 
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: getent passwd ubuntu
PASSED                                                                                                                                                                                                                                                                             [ 85%]
tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args3-foobar:x:[0-9]{4}:[0-9]{4}:Foo B. Bar:/home/foobar:] 
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: getent passwd foobar
PASSED                                                                                                                                                                                                                                                                             [ 88%]
tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args4-barfoo:x:[0-9]{4}:[0-9]{4}:Bar B. Foo:/home/barfoo:] 
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: getent passwd barfoo
PASSED                                                                                                                                                                                                                                                                             [ 92%]
tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args5-cloudy:x:[0-9]{3,4}:] 
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: getent passwd cloudy
PASSED                                                                                                                                                                                                                                                                             [ 96%]
tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_user_root_in_secret 
------------------------------------------------------------------------------------------------------------------------------------- live log call --------------------------------------------------------------------------------------------------------------------------------------
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'groups root'
PASSED                                                                                                                                                                                                                                                                             [100%]

==================================================================================================================================== warnings summary ====================================================================================================================================
tests/integration_tests/bugs/test_lp1886531.py::TestLp1886531::test_lp1886531
tests/integration_tests/modules/test_apt_configure_sources_list.py::TestAptConfigureSourcesList::test_sources_list
tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers::test_ntp_installed
tests/integration_tests/modules/test_set_password.py::TestPasswordList::test_no_duplicate_users_in_shadow
tests/integration_tests/modules/test_set_password.py::TestPasswordListString::test_no_duplicate_users_in_shadow
tests/integration_tests/modules/test_users_groups.py::TestUsersGroups::test_users_groups[getent_args0-ubuntu:x:[0-9]{4}:]
  /home/daniel/dev/cloud-init/.tox/integration-tests/lib/python3.8/site-packages/simplestreams/mirrors/__init__.py:206: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    LOG.warn("got ENOENT for (%s, %s), trying with trailing /",

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================================================= 26 passed, 1 skipped, 6 warnings in 370.28s (0:06:10) ==================================================================================================================
________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________
  integration-tests: commands succeeded
  congratulations :)
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
