### PR TITLE
Do not reset to dhcp network when DS is None

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -22,6 +22,7 @@ from cloudinit.handlers.shell_script import ShellScriptPartHandler
 from cloudinit.handlers.upstart_job import UpstartJobPartHandler
 
 from cloudinit.event import EventType
+from cloudinit.sources import DataSourceNone
 from cloudinit.sources import NetworkConfigSource
 
 from cloudinit import cloud
@@ -678,7 +679,7 @@ class Init(object):
         netcfg, src = self._find_networking_config()
         # Data source shouldn't reset to fallback when config drive is not
         # available
-        LOG.debug("self.datasource is %s" % self.datasource)
+        LOG.debug("self.datasource is {}".format(self.datasource))
         if ((self.datasource is NULL_DATA_SOURCE) or (
                 self.datasource is 'DataSourceNone')):
             LOG.info("Data source is None. Skipping network config")
@@ -694,7 +695,7 @@ class Init(object):
                     return
             except BaseException:
                 LOG.info("in except block")
-                if (isinstance(self.datasource, dsnone.DataSourceNone)):
+                if (isinstance(self.datasource, DataSourceNone)):
                     LOG.info(
                         "Data source is an instance of DataSourceNone. "
                         "Skipping network config")

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -676,6 +676,30 @@ class Init(object):
     def apply_network_config(self, bring_up):
         # get a network config
         netcfg, src = self._find_networking_config()
+        # Data source shouldn't reset to fallback when config drive is not
+        # available
+        LOG.debug("self.datasource is %s" % self.datasource)
+        if ((self.datasource is NULL_DATA_SOURCE) or (
+                self.datasource is 'DataSourceNone')):
+            LOG.info("Data source is None. Skipping network config")
+            return
+
+        if self.datasource:
+            try:
+                if ((self.datasource.dsname is "None") or (
+                            self.datasource.dsname is None)):
+                    LOG.info(
+                        "Data source is an instance of DataSourceNone. "
+                        "Skipping network config")
+                    return
+            except BaseException:
+                LOG.info("in except block")
+                if (isinstance(self.datasource, dsnone.DataSourceNone)):
+                    LOG.info(
+                        "Data source is an instance of DataSourceNone. "
+                        "Skipping network config")
+                    return
+
         if netcfg is None:
             LOG.info("network config is disabled by %s", src)
             return

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -22,3 +22,4 @@ sshedi
 TheRealFalcon
 tomponline
 tsanghan
+vijarad1


### PR DESCRIPTION
As per below bug in launchpad
We use config drive(/dev/sr0) as a data source to configure network
interfaces in the guest but configdrive is not always available and may be
removed after couple of hours from the hypervisor.

On a first boot cloudinit uses data provided in config drive and updates system
level network scripts /etc/sysconfig/ifcfg-* (Static configuration of networks)
files and also configures the interface in the guest.

As long as the configdrive is available, reboots will relay on system scripts
for the configuring network but once configdrive is removed,
datasource becomes None meaning it neither system script nor config drive
which makes cloud init to configure default network which is DHCP

LP: #1893770
https://bugs.launchpad.net/cloud-init/+bug/1893770

