### PR TITLE
get_interfaces: don't exclude Open vSwitch bridge/bond members

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -121,9 +121,16 @@ def master_is_bridge_or_bond(devname):
         return False
     bonding_path = os.path.join(master_path, "bonding")
     bridge_path = os.path.join(master_path, "bridge")
+    return (os.path.exists(bonding_path) or os.path.exists(bridge_path))
+
+
+def master_is_openvswitch(devname):
+    """Return a bool indicating if devname's master is openvswitch"""
+    master_path = get_master(devname)
+    if master_path is None:
+        return False
     ovs_path = sys_dev_path(devname, path="upper_ovs-system")
-    return (os.path.exists(bonding_path) or os.path.exists(bridge_path) or
-            os.path.exists(ovs_path))
+    return os.path.exists(ovs_path)
 
 
 def is_netfailover(devname, driver=None):
@@ -864,8 +871,10 @@ def get_interfaces(blacklist_drivers=None) -> list:
             continue
         if is_bond(name):
             continue
-        if get_master(name) is not None and not master_is_bridge_or_bond(name):
-            continue
+        if get_master(name) is not None:
+            if (not master_is_bridge_or_bond(name) and
+                    not master_is_openvswitch(name)):
+                continue
         if is_netfailover(name):
             continue
         mac = get_interface_mac(name)

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -121,7 +121,9 @@ def master_is_bridge_or_bond(devname):
         return False
     bonding_path = os.path.join(master_path, "bonding")
     bridge_path = os.path.join(master_path, "bridge")
-    return (os.path.exists(bonding_path) or os.path.exists(bridge_path))
+    ovs_path = sys_dev_path(devname, path="upper_ovs-system")
+    return (os.path.exists(bonding_path) or os.path.exists(bridge_path) or
+            os.path.exists(ovs_path))
 
 
 def is_netfailover(devname, driver=None):

--- a/cloudinit/net/tests/test_init.py
+++ b/cloudinit/net/tests/test_init.py
@@ -165,40 +165,52 @@ class TestReadSysNet(CiTestCase):
     def test_master_is_bridge_or_bond(self):
         bridge_mac = 'aa:bb:cc:aa:bb:cc'
         bond_mac = 'cc:bb:aa:cc:bb:aa'
-        ovs_mac = 'bb:cc:aa:bb:cc:aa'
 
         # No master => False
         write_file(os.path.join(self.sysdir, 'eth1', 'address'), bridge_mac)
         write_file(os.path.join(self.sysdir, 'eth2', 'address'), bond_mac)
-        write_file(os.path.join(self.sysdir, 'eth3', 'address'), ovs_mac)
 
         self.assertFalse(net.master_is_bridge_or_bond('eth1'))
         self.assertFalse(net.master_is_bridge_or_bond('eth2'))
-        self.assertFalse(net.master_is_bridge_or_bond('eth3'))
 
-        # masters without bridge/bonding/ovs-system => False
+        # masters without bridge/bonding => False
         write_file(os.path.join(self.sysdir, 'br0', 'address'), bridge_mac)
         write_file(os.path.join(self.sysdir, 'bond0', 'address'), bond_mac)
-        write_file(os.path.join(self.sysdir, 'ovs-system', 'address'), ovs_mac)
 
         os.symlink('../br0', os.path.join(self.sysdir, 'eth1', 'master'))
         os.symlink('../bond0', os.path.join(self.sysdir, 'eth2', 'master'))
-        os.symlink('../ovs-system', os.path.join(self.sysdir, 'eth3',
-                   'master'))
 
         self.assertFalse(net.master_is_bridge_or_bond('eth1'))
         self.assertFalse(net.master_is_bridge_or_bond('eth2'))
-        self.assertFalse(net.master_is_bridge_or_bond('eth3'))
 
-        # masters with bridge/bonding/ovs-system => True
+        # masters with bridge/bonding => True
         write_file(os.path.join(self.sysdir, 'br0', 'bridge'), '')
         write_file(os.path.join(self.sysdir, 'bond0', 'bonding'), '')
-        os.symlink('../ovs-system', os.path.join(self.sysdir, 'eth3',
-                   'upper_ovs-system'))
 
         self.assertTrue(net.master_is_bridge_or_bond('eth1'))
         self.assertTrue(net.master_is_bridge_or_bond('eth2'))
-        self.assertTrue(net.master_is_bridge_or_bond('eth3'))
+
+    def test_master_is_openvswitch(self):
+        ovs_mac = 'bb:cc:aa:bb:cc:aa'
+
+        # No master => False
+        write_file(os.path.join(self.sysdir, 'eth1', 'address'), ovs_mac)
+
+        self.assertFalse(net.master_is_bridge_or_bond('eth1'))
+
+        # masters without ovs-system => False
+        write_file(os.path.join(self.sysdir, 'ovs-system', 'address'), ovs_mac)
+
+        os.symlink('../ovs-system', os.path.join(self.sysdir, 'eth1',
+                   'master'))
+
+        self.assertFalse(net.master_is_openvswitch('eth1'))
+
+        # masters with ovs-system => True
+        os.symlink('../ovs-system', os.path.join(self.sysdir, 'eth1',
+                   'upper_ovs-system'))
+
+        self.assertTrue(net.master_is_openvswitch('eth1'))
 
     def test_is_vlan(self):
         """is_vlan is True when /sys/net/devname/uevent has DEVTYPE=vlan."""

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -18,6 +18,7 @@ matthewruffell
 nishigori
 omBratteng
 onitake
+slyon
 smoser
 sshedi
 TheRealFalcon


### PR DESCRIPTION
## Proposed Commit Message
If an OVS bridge was used as the only/primary interface, the 'init'
stage failed with the following error, leaving the system with a broken
SSH setup:

```
Cloud-init v. 20.3-2-g371b392c-0ubuntu1~20.04.1 running 'init' at Fri, 09 Oct 2020 11:00:25 +0000. Up 18.61 seconds.
ci-info: +++++++++++++++++++++++++++++++++++++++++Net device info++++++++++++++++++++++++++++++++++++++++++
ci-info: +------------+-------+------------------------------+---------------+--------+-------------------+
ci-info: |   Device   |   Up  |           Address            |      Mask     | Scope  |     Hw-Address    |
ci-info: +------------+-------+------------------------------+---------------+--------+-------------------+
ci-info: |    ens4    |  True |              .               |       .       |   .    | 52:54:00:d9:08:1c |
ci-info: |     lo     |  True |          127.0.0.1           |   255.0.0.0   |  host  |         .         |
ci-info: |     lo     |  True |           ::1/128            |       .       |  host  |         .         |
ci-info: |   ovs-br   |  True |         172.16.99.24         | 255.255.255.0 | global | 8a:9f:21:67:58:40 |
ci-info: |   ovs-br   |  True | fe80::889f:21ff:fe67:5840/64 |       .       |  link  | 8a:9f:21:67:58:40 |
ci-info: | ovs-system | False |              .               |       .       |   .    | 1e:01:ef:a1:74:63 |
ci-info: +------------+-------+------------------------------+---------------+--------+-------------------+
ci-info: +++++++++++++++++++++++++++++Route IPv4 info+++++++++++++++++++++++++++++
ci-info: +-------+-------------+-------------+---------------+-----------+-------+
ci-info: | Route | Destination |   Gateway   |    Genmask    | Interface | Flags |
ci-info: +-------+-------------+-------------+---------------+-----------+-------+
ci-info: |   0   |   0.0.0.0   | 172.16.99.1 |    0.0.0.0    |   ovs-br  |   UG  |
ci-info: |   1   | 172.16.99.0 |   0.0.0.0   | 255.255.255.0 |   ovs-br  |   U   |
ci-info: +-------+-------------+-------------+---------------+-----------+-------+
ci-info: +++++++++++++++++++Route IPv6 info+++++++++++++++++++
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: | Route | Destination | Gateway | Interface | Flags |
ci-info: +-------+-------------+---------+-----------+-------+
ci-info: |   1   |  fe80::/64  |    ::   |   ovs-br  |   U   |
ci-info: |   3   |    local    |    ::   |   ovs-br  |   U   |
ci-info: |   4   |   ff00::/8  |    ::   |   ovs-br  |   U   |
ci-info: |   5   |   ff00::/8  |    ::   |    ens4   |   U   |
ci-info: +-------+-------------+---------+-----------+-------+
2020-10-09 11:00:26,374 - networking.py[WARNING]: Not all expected physical devices present: {'52:54:00:d9:08:1c'}
2020-10-09 11:00:26,383 - util.py[WARNING]: failed stage init
failed run of stage init
------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 653, in status_wrapper
    ret = functor(name, args)
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 362, in main_init
    init.apply_network_config(bring_up=bool(mode != sources.DSMODE_LOCAL))
  File "/usr/lib/python3/dist-packages/cloudinit/stages.py", line 699, in apply_network_config
    self.distro.networking.wait_for_physdevs(netcfg)
  File "/usr/lib/python3/dist-packages/cloudinit/distros/networking.py", line 172, in wait_for_physdevs
    raise RuntimeError(msg)
RuntimeError: Not all expected physical devices present: {'52:54:00:d9:08:1c'}
------------------------------------------------------------
```
## Additional Context
Related to: https://github.com/CanonicalLtd/netplan/pull/165
Fixes: https://bugs.launchpad.net/netplan/+bug/1898997

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on an actual Ubuntu Server image,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
