### PR TITLE
Use dd to create the swap file for ext4 instead of fallocate

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -264,7 +264,7 @@ def create_swapfile(fname: str, size: str) -> None:
     fstype = util.get_mount_info(swap_dir)[1]
 
     if (fstype == "xfs" and
-            util.kernel_version() < (4, 18)) or fstype == "btrfs":
+            util.kernel_version() < (4, 18)) or fstype in ["btrfs", "ext4"]:
         create_swap(fname, size, "dd")
     else:
         try:

--- a/tests/unittests/test_handler/test_handler_mounts.py
+++ b/tests/unittests/test_handler/test_handler_mounts.py
@@ -236,7 +236,9 @@ class TestSwapFileCreation(test_helpers.FilesystemMockingTestCase):
 
         cc_mounts.handle(None, self.cc, self.mock_cloud, self.mock_log, [])
         self.m_subp_subp.assert_has_calls([
-            mock.call(['fallocate', '-l', '0M', self.swap_path], capture=True),
+            mock.call(['dd', 'if=/dev/zero',
+                       'of=' + self.swap_path,
+                       'bs=1M', 'count=0'], capture=True),
             mock.call(['mkswap', self.swap_path]),
             mock.call(['swapon', '-a'])])
 


### PR DESCRIPTION
## Proposed Commit Message
Replace fallocate with dd for ext4 when creating a swap file to avoid holes.

## Additional Context
If you create a swap file with fallocate on an ext4 filesystem, you could cause a failure due to holes in the swap file. When you run `swapon` on a file with holes, it will fail. The repro can be found when deploying a VM.

Note: this seems to happen only in newer kernel versions (tested with 5.7+). But it is worth mentioning that the man pages for swapon clearly warn of this behavior:

```
NOTES
       You should not use swapon on a file with holes.  This can be seen in the system log as

              swapon: swapfile has holes.

       The  swap  file  implementation  in the kernel expects to be able to write to the file directly, without the assistance of the filesystem.  This is a problem on preallocated files
       (e.g.  fallocate(1)) on filesystems like XFS or ext4, and on copy-on-write filesystems like btrfs.

       It is recommended to use dd(1) and /dev/zero to avoid holes on XFS and ext4.
```

## Test Steps
```
$ az group create -l eastus -n rg
$ az vm create -g rg -n vm --image "debian:debian-11-daily:11:latest" --custom-data ./cloud-init.cfg [... more VM create options that aren't relevant to this issue ...]
```

The content of `cloud-init.cfg` is:

```yaml
#cloud-config
swap:
  filename: /mnt/swapfile
  size: 536870912
  maxsize: 536870912
```

The cloud-init logs have the following failure illustrating the issue:

```
2020-10-14 15:12:02,686 - cc_mounts.py[DEBUG]: Creating swapfile in '/mnt/swapfile' on fstype 'ext4' using 'fallocate' 
2020-10-14 15:12:02,686 - util.py[DEBUG]: Running command ['fallocate', '-l', '512M', '/mnt/swapfile'] with allowed return codes [0] (shell=False, capture=True) 
2020-10-14 15:12:02,761 - util.py[DEBUG]: Running command ['mkswap', '/mnt/swapfile'] with allowed return codes [0] (shell=False, capture=True) 
2020-10-14 15:12:02,796 - util.py[DEBUG]: Setting up swap file took 0.110 seconds 
2020-10-14 15:12:02,796 - util.py[DEBUG]: Reading from /proc/mounts (quiet=False) 
2020-10-14 15:12:02,797 - util.py[DEBUG]: Read 2342 bytes from /proc/mounts 
2020-10-14 15:12:02,797 - util.py[DEBUG]: Fetched {'sysfs': {'fstype': 'sysfs', 'mountpoint': '/sys', 'opts': 'rw,nosuid,nodev,noexec,relatime'}, 'proc': {'fstype': 'proc', 'mountpoint': '/proc', 'opts': 'rw,nosuid,nodev,noexec,relatime'}, 'udev': {'fstype': 'devtmpfs', 'mountpoint': '/dev', 'opts': 'rw,nosuid,noexec,relatime,size=1751100k,nr_inodes=437775,mode=755'}, 'devpts': {'fstype': 'devpts', 'mountpoint': '/dev/pts', 'opts': 'rw,nosuid,noexec,relatime,gid=5,mode=620,ptmxmode=000'}, 'tmpfs': {'fstype': 'tmpfs', 'mountpoint': '/sys/fs/cgroup', 'opts': 'ro,nosuid,nodev,noexec,size=4096k,nr_inodes=1024,mode=755'}, '/dev/sda1': {'fstype': 'ext4', 'mountpoint': '/', 'opts': 'rw,relatime,discard,errors=remount-ro'}, 'securityfs': {'fstype': 'securityfs', 'mountpoint': '/sys/kernel/security', 'opts': 'rw,nosuid,nodev,noexec,relatime'}, 'cgroup2': {'fstype': 'cgroup2', 'mountpoint': '/sys/fs/cgroup/unified', 'opts': 'rw,nosuid,nodev,noexec,relatime,nsdelegate'}, 'cgroup': {'fstype': 'cgroup', 'mountpoint': '/sys/fs/cgroup/freezer', 'opts': 'rw,nosuid,nodev,noexec,relatime,freezer'}, 'pstore': {'fstype': 'pstore', 'mountpoint': '/sys/fs/pstore', 'opts': 'rw,nosuid,nodev,noexec,relatime'}, 'none': {'fstype': 'bpf', 'mountpoint': '/sys/fs/bpf', 'opts': 'rw,nosuid,nodev,noexec,relatime,mode=700'}, 'systemd-1': {'fstype': 'autofs', 'mountpoint': '/proc/sys/fs/binfmt_misc', 'opts': 'rw,relatime,fd=29,pgrp=1,timeout=0,minproto=5,maxproto=5,direct,pipe_ino=10213'}, 'hugetlbfs': {'fstype': 'hugetlbfs', 'mountpoint': '/dev/hugepages', 'opts': 'rw,relatime,pagesize=2M'}, 'mqueue': {'fstype': 'mqueue', 'mountpoint': '/dev/mqueue', 'opts': 'rw,nosuid,nodev,noexec,relatime'}, 'debugfs': {'fstype': 'debugfs', 'mountpoint': '/sys/kernel/debug', 'opts': 'rw,nosuid,nodev,noexec,relatime'}, 'tracefs': {'fstype': 'tracefs', 'mountpoint': '/sys/kernel/tracing', 'opts': 'rw,nosuid,nodev,noexec,relatime'}, '/dev/sda15': {'fstype': 'vfat', 'mountpoint': '/boot/efi', 'opts': 'rw,relatime,fmask=0022,dmask=0022,codepage=437,iocharset=ascii,shortname=mixed,utf8,errors=remount-ro'}} mounts from proc 
2020-10-14 15:12:02,797 - util.py[DEBUG]: Writing to /etc/fstab - wb: [644] 325 bytes 
2020-10-14 15:12:02,808 - cc_mounts.py[DEBUG]: Changes to fstab: ['+ /dev/disk/cloud/azure_resource-part1 /mnt auto defaults,nofail,comment=cloudconfig 0 2', '+ /mnt/swapfile none swap sw,comment=cloudconfig 0 0'] 
2020-10-14 15:12:02,808 - util.py[DEBUG]: Running command ['swapon', '-a'] with allowed return codes [0] (shell=False, capture=True) 
2020-10-14 15:12:02,834 - cc_mounts.py[WARNING]: Activate mounts: FAIL:swapon -a 
2020-10-14 15:12:02,834 - util.py[WARNING]: Activate mounts: FAIL:swapon -a 
2020-10-14 15:12:02,835 - util.py[DEBUG]: Activate mounts: FAIL:swapon -a 
Traceback (most recent call last): 
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_mounts.py", line 541, in handle 
    util.subp(cmd) 
  File "/usr/lib/python3/dist-packages/cloudinit/util.py", line 2160, in subp 
    raise ProcessExecutionError(stdout=out, stderr=err, 
cloudinit.util.ProcessExecutionError: Unexpected error while running command. 
Command: ['swapon', '-a'] 
Exit code: 255 
Reason: - 
Stdout:  
Stderr: swapon: /mnt/swapfile: swapon failed: Invalid argument 
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
