### PR TITLE
Drop vestigial update_resolve_conf_file function.

### DIFF
--- a/cloudinit/distros/rhel_util.py
+++ b/cloudinit/distros/rhel_util.py
@@ -8,7 +8,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from cloudinit.distros.parsers.resolv_conf import ResolvConf
 from cloudinit.distros.parsers.sys_conf import SysConf
 
 from cloudinit import log as logging
@@ -49,30 +48,5 @@ def read_sysconfig_file(fn):
     except IOError:
         contents = []
     return (exists, SysConf(contents))
-
-
-# Helper function to update RHEL/SUSE /etc/resolv.conf
-def update_resolve_conf_file(fn, dns_servers, search_servers):
-    try:
-        r_conf = ResolvConf(util.load_file(fn))
-        r_conf.parse()
-    except IOError:
-        util.logexc(LOG, "Failed at parsing %s reverting to an empty "
-                    "instance", fn)
-        r_conf = ResolvConf('')
-        r_conf.parse()
-    if dns_servers:
-        for s in dns_servers:
-            try:
-                r_conf.add_nameserver(s)
-            except ValueError:
-                util.logexc(LOG, "Failed at adding nameserver %s", s)
-    if search_servers:
-        for s in search_servers:
-            try:
-                r_conf.add_search_domain(s)
-            except ValueError:
-                util.logexc(LOG, "Failed at adding search domain %s", s)
-    util.write_file(fn, str(r_conf), 0o644)
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_distros/test_resolv.py
+++ b/tests/unittests/test_distros/test_resolv.py
@@ -1,12 +1,10 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 from cloudinit.distros.parsers import resolv_conf
-from cloudinit.distros import rhel_util
 
 from cloudinit.tests.helpers import TestCase
 
 import re
-import tempfile
 
 
 BASE_RESOLVE = '''
@@ -23,10 +21,6 @@ class TestResolvHelper(TestCase):
         rp = resolv_conf.ResolvConf(BASE_RESOLVE)
         rp_r = str(rp).strip()
         self.assertEqual(BASE_RESOLVE, rp_r)
-
-    def test_write_works(self):
-        with tempfile.NamedTemporaryFile() as fh:
-            rhel_util.update_resolve_conf_file(fh.name, [], [])
 
     def test_local_domain(self):
         rp = resolv_conf.ResolvConf(BASE_RESOLVE)


### PR DESCRIPTION
update_resolve_conf_file is no longer used.  The last reference
to it was removed in c3680475f9c970, which was itself a "remove dead
code" commit.