### PR TITLE
replace usage of dmidecode with kenv on FreeBSD

### DIFF
--- a/tools/build-on-freebsd
+++ b/tools/build-on-freebsd
@@ -21,7 +21,6 @@ py_prefix=$(${PYTHON} -c 'import sys; print("py%d%d" % (sys.version_info.major, 
 depschecked=/tmp/c-i.dependencieschecked
 pkgs="
     bash
-    dmidecode
     e2fsprogs
     $py_prefix-Jinja2
     $py_prefix-boto

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -180,13 +180,43 @@ debug() {
     echo "$@" 1>&3
 }
 
+get_kenv_field() {
+    local sys_field="$1" kenv_field="" val=""
+    command -v kenv >/dev/null 2>&1 || {
+        warn "No kenv program. Cannot read $sys_field."
+        return 1
+    }
+    case "$sys_field" in
+        board_asset_tag) kenv_field="smbios.planar.tag";;
+        board_vendor) kenv_field='smbios.planar.maker';;
+        board_name) kenv_field='smbios.planar.product';;
+        board_serial) kenv_field='smbios.planar.serial';;
+        board_version) kenv_field='smbios.planar.version';;
+        bios_date) kenv_field='smbios.bios.reldate';;
+        bios_vendor) kenv_field='smbios.bios.vendor';;
+        bios_version) kenv_field='smbios.bios.version';;
+        chassis_asset_tag) kenv_field='smbios.chassis.tag';;
+        chassis_vendor) kenv_field='smbios.chassis.maker';;
+        chassis_serial) kenv_field='smbios.chassis.serial';;
+        chassis_version) kenv_field='smbios.chassis.version';;
+        sys_vendor) kenv_field='smbios.system.maker';;
+        product_name) kenv_field='smbios.system.product';;
+        product_serial) kenv_field='smbios.system.serial';;
+        product_uuid) kenv_field='smbios.system.uuid';;
+        *) error "Unknown field $sys_field. Cannot call kenv."
+           return 1;;
+    esac
+    val=$(kenv -q "$kenv_field" 2>/dev/null) || return 1
+    _RET="$val"
+}
+
 dmi_decode() {
     local sys_field="$1" dmi_field="" val=""
     command -v dmidecode >/dev/null 2>&1 || {
         warn "No dmidecode program. Cannot read $sys_field."
         return 1
     }
-    case "$1" in
+    case "$sys_field" in
         sys_vendor) dmi_field="system-manufacturer";;
         product_name) dmi_field="system-product-name";;
         product_uuid) dmi_field="system-uuid";;
@@ -200,8 +230,14 @@ dmi_decode() {
 }
 
 get_dmi_field() {
-    local path="${PATH_SYS_CLASS_DMI_ID}/$1"
     _RET="$UNAVAILABLE"
+
+    if [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" ]; then
+        get_kenv_field "$1" || _RET="$ERROR"
+        return $?
+    fi
+
+    local path="${PATH_SYS_CLASS_DMI_ID}/$1"
     if [ -d "${PATH_SYS_CLASS_DMI_ID}" ]; then
         if [ -f "$path" ] && [ -r "$path" ]; then
             read _RET < "${path}" || _RET="$ERROR"
@@ -1310,10 +1346,10 @@ dscheck_IBMCloud() {
 }
 
 collect_info() {
+    read_uname_info
     read_virt
     read_pid1_product_name
     read_kernel_cmdline
-    read_uname_info
     read_config
     read_datasource_list
     read_dmi_sys_vendor


### PR DESCRIPTION
## Proposed Commit Message

FreeBSD lets us read out kernel parameters with `kenv(1)`, a user-space utility that's shipped in "base"
We can use it in place of `dmidecode(8)`, thus removing the dependency on sysutils/dmidecode, and the restrictions to i386 and x86_64 architectures that this utility imposes on FreeBSD.

## Additional Context

I added this code, and while it opened the doors for more BSD stuff to be added, I'd like to remedy this restriction.
I'd also like to remind that @goneri already pointed this path out a year ago: https://github.com/canonical/cloud-init/pull/42#discussion_r353283759

## Test Steps

run `kenv | grep smbios` on your favourite FreeBSD machine, and notice that unlike `dmidecode` you can just run it without being root!

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
