### PR TITLE
stages: don't reset permissions of cloud-init.log every boot

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -148,7 +148,7 @@ class Init(object):
         util.ensure_dirs(self._initial_subdirs())
         log_file = util.get_cfg_option_str(self.cfg, 'def_log_file')
         if log_file:
-            util.ensure_file(log_file)
+            util.ensure_file(log_file, preserve_mode=True)
             perms = self.cfg.get('syslog_fix_perms')
             if not perms:
                 perms = {}

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -771,4 +771,35 @@ class TestMountCb:
         ] == callback.call_args_list
 
 
+@mock.patch("cloudinit.util.write_file")
+class TestEnsureFile:
+    """Tests for ``cloudinit.util.ensure_file``."""
+
+    def test_parameters_passed_through(self, m_write_file):
+        """Test the parameters in the signature are passed to write_file."""
+        util.ensure_file(mock.sentinel.path, mode=mock.sentinel.mode)
+
+        assert 1 == m_write_file.call_count
+        args, kwargs = m_write_file.call_args
+        assert (mock.sentinel.path,) == args
+        assert mock.sentinel.mode == kwargs["mode"]
+
+    def test_mode_defaults_to_world_readable(self, m_write_file):
+        """Test that mode defaults to ensuring world-readable files."""
+        util.ensure_file(mock.sentinel.path)
+
+        assert 1 == m_write_file.call_count
+        args, kwargs = m_write_file.call_args
+        assert 0o644 == kwargs["mode"]
+
+    def test_static_parameters_are_passed(self, m_write_file):
+        """Test that the static write_files parameters are passed correctly."""
+        util.ensure_file(mock.sentinel.path)
+
+        assert 1 == m_write_file.call_count
+        args, kwargs = m_write_file.call_args
+        assert "" == kwargs["content"]
+        assert "ab" == kwargs["omode"]
+
+
 # vi: ts=4 expandtab

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -799,11 +799,11 @@ class TestEnsureFile:
         ],
     )
     def test_defaults(self, m_write_file, kwarg, expected):
-        """Test that mode defaults to ensuring world-readable files."""
+        """Test that ensure_file defaults appropriately."""
         util.ensure_file(mock.sentinel.path)
 
         assert 1 == m_write_file.call_count
-        args, kwargs = m_write_file.call_args
+        _args, kwargs = m_write_file.call_args
         assert expected == kwargs[kwarg]
 
     def test_static_parameters_are_passed(self, m_write_file):
@@ -811,7 +811,7 @@ class TestEnsureFile:
         util.ensure_file(mock.sentinel.path)
 
         assert 1 == m_write_file.call_count
-        args, kwargs = m_write_file.call_args
+        _args, kwargs = m_write_file.call_args
         assert "" == kwargs["content"]
         assert "ab" == kwargs["omode"]
 

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -777,20 +777,34 @@ class TestEnsureFile:
 
     def test_parameters_passed_through(self, m_write_file):
         """Test the parameters in the signature are passed to write_file."""
-        util.ensure_file(mock.sentinel.path, mode=mock.sentinel.mode)
+        util.ensure_file(
+            mock.sentinel.path,
+            mode=mock.sentinel.mode,
+            preserve_mode=mock.sentinel.preserve_mode,
+        )
 
         assert 1 == m_write_file.call_count
         args, kwargs = m_write_file.call_args
         assert (mock.sentinel.path,) == args
         assert mock.sentinel.mode == kwargs["mode"]
+        assert mock.sentinel.preserve_mode == kwargs["preserve_mode"]
 
-    def test_mode_defaults_to_world_readable(self, m_write_file):
+    @pytest.mark.parametrize(
+        "kwarg,expected",
+        [
+            # Files should be world-readable by default
+            ("mode", 0o644),
+            # The previous behaviour of not preserving mode should be retained
+            ("preserve_mode", False),
+        ],
+    )
+    def test_defaults(self, m_write_file, kwarg, expected):
         """Test that mode defaults to ensuring world-readable files."""
         util.ensure_file(mock.sentinel.path)
 
         assert 1 == m_write_file.call_count
         args, kwargs = m_write_file.call_args
-        assert 0o644 == kwargs["mode"]
+        assert expected == kwargs[kwarg]
 
     def test_static_parameters_are_passed(self, m_write_file):
         """Test that the static write_files parameters are passed correctly."""

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1804,7 +1804,9 @@ def append_file(path, content):
     write_file(path, content, omode="ab", mode=None)
 
 
-def ensure_file(path, mode=0o644, *, preserve_mode=False):
+def ensure_file(
+    path, mode: int = 0o644, *, preserve_mode: bool = False
+) -> None:
     write_file(
         path, content='', omode="ab", mode=mode, preserve_mode=preserve_mode
     )

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1804,8 +1804,10 @@ def append_file(path, content):
     write_file(path, content, omode="ab", mode=None)
 
 
-def ensure_file(path, mode=0o644):
-    write_file(path, content='', omode="ab", mode=mode)
+def ensure_file(path, mode=0o644, *, preserve_mode=False):
+    write_file(
+        path, content='', omode="ab", mode=mode, preserve_mode=preserve_mode
+    )
 
 
 def safe_int(possible_int):


### PR DESCRIPTION
## Proposed Commit Message
> stages: don't reset permissions of cloud-init.log every boot
>
> `ensure_file` needed modification to support doing this, so this commit
> also includes the following changes:
>
> * test_util: add tests for util.ensure_file
> * util: add preserve_mode parameter to ensure_file
> * util: add (partial) type annotations to ensure_file
> 
> LP: #1900837

## Test Steps

### Current cloud-init

First, change the permissions of the log file:

```sh
$ stat -c "%a" /var/log/cloud-init.log
644
$ chmod 600 /var/log/cloud-init.log
$ stat -c "%a" /var/log/cloud-init.log
600
```

Then reboot, and confirm that we see the bug with this reproducer:

```sh
$ stat -c "%a" /var/log/cloud-init.log
644
```

### This PR

Having built a bionic package from this PR branch, following the same steps:

```sh
$ stat -c "%a" /var/log/cloud-init.log
644
$ chmod 600 /var/log/cloud-init.log
$ stat -c "%a" /var/log/cloud-init.log
600
```

And after reboot, the permissions are unchanged, as we would expect:

```sh
$ stat -c "%a" /var/log/cloud-init.log
600
```

### Default Behaviour

To confirm that the log file is still created with world-readable permissions by default with the cloud-init from this PR, we remove the file and reboot:

```sh
$ rm /var/log/cloud-init.log
$ reboot
...
$ stat -c "%a" /var/log/cloud-init.log
644
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
