### PR TITLE
Make wakeonlan Network Config v2 setting actually work

### DIFF
--- a/cloudinit/net/eni.py
+++ b/cloudinit/net/eni.py
@@ -401,6 +401,10 @@ class Renderer(renderer.Renderer):
         sections = []
         subnets = iface.get('subnets', {})
         accept_ra = iface.pop('accept-ra', None)
+        ethernet_wol = iface.pop('wakeonlan', None)
+        if ethernet_wol:
+            # Specify WOL setting 'g' for using "Magic Packet"
+            iface['ethernet-wol'] = 'g'
         if subnets:
             for index, subnet in enumerate(subnets):
                 ipv4_subnet_mtu = None

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -369,6 +369,9 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
         accept_ra = command.get('accept-ra', None)
         if accept_ra is not None:
             accept_ra = util.is_true(accept_ra)
+        wakeonlan = command.get('wakeonlan', None)
+        if wakeonlan is not None:
+            wakeonlan = util.is_true(wakeonlan)
         iface.update({
             'name': command.get('name'),
             'type': command.get('type'),
@@ -379,7 +382,8 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
             'address': None,
             'gateway': None,
             'subnets': subnets,
-            'accept-ra': accept_ra
+            'accept-ra': accept_ra,
+            'wakeonlan': wakeonlan,
         })
         self._network_state['interfaces'].update({command.get('name'): iface})
         self.dump_network_state()

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -367,6 +367,11 @@ class Renderer(renderer.Renderer):
                 if new_key:
                     iface_cfg[new_key] = old_value
 
+        # only set WakeOnLan for physical interfaces
+        if ('wakeonlan' in iface and iface['wakeonlan'] and
+                iface['type'] == 'physical'):
+            iface_cfg['ETHTOOL_OPTS'] = 'wol g'
+
     @classmethod
     def _render_subnets(cls, iface_cfg, subnets, has_default_route, flavor):
         # setting base values


### PR DESCRIPTION

## Proposed Commit Message

Add code so that specifying "wakeonlan: true" actually results in relevant
configuration entry appearing in /etc/network/interfaces, NetPlan, and
sysconfig for RHEL and OpenSuse.

Add testcases for the above.

## Additional Context


## Test Steps

In a Network Config v2 YAML file specify the following:

```
version: 2
ethernets:
    eth0:
        dhcp4: true
        wakeonlan: true
```

Then check the resultant Netplan file to see if wakeonlan specified there.

Wakeonlan is not supported in a v1 config file.

## Checklist:

 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
