### PR TITLE
Update documentation for 'groups' directive

### DIFF
--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -12,6 +12,9 @@ groups:
 #       applicable on already-existing users:
 #       - 'plain_text_passwd', 'hashed_passwd', 'lock_passwd', 'sudo',
 #         'ssh_authorized_keys', 'ssh_redirect_user'.
+# Note: 'groups' will only take one argument and add the user to one
+#       additional group. Multiple groups must be handled via the 'groups'
+#       directive (see above).
 users:
   - default
   - name: foobar
@@ -26,7 +29,7 @@ users:
   - name: barfoo
     gecos: Bar B. Foo
     sudo: ALL=(ALL) NOPASSWD:ALL
-    groups: users, admin
+    groups: users
     ssh_import_id: None
     lock_passwd: true
     ssh_authorized_keys:
@@ -52,7 +55,7 @@ users:
 #           /home/<username>
 #   primary_group: define the primary group. Defaults to a new group created
 #           named after the user.
-#   groups:  Optional. Additional groups to add the user to. Defaults to none
+#   groups:  Optional. One additional group to add the user to. Defaults to none
 #   selinux_user:  Optional. The SELinux user for the user's login, such as
 #           "staff_u". When this is omitted the system will select the default
 #           SELinux user.


### PR DESCRIPTION
Hi,

I'm not sure whether this is actually a bug, bug the 'groups' sub-property of 'user' does not add the user to multiple groups. It only adds the user to the first group in that list in addition to its primary username == groupname  group. If you want to add a user to multiple groups, you must use the top-level 'groups' directive.

Thx,
Matthias

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on an actual Ubuntu Server image,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
