### PR TITLE
Add support to EC2 for identifying Vultr cloud.

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -41,6 +41,7 @@ class CloudNames(object):
     BRIGHTBOX = "brightbox"
     ZSTACK = "zstack"
     E24CLOUD = "e24cloud"
+    VULTR = "vultr"
     # UNKNOWN indicates no positive id.  If strict_id is 'warn' or 'false',
     # then an attempt at the Ec2 Metadata service will be made.
     UNKNOWN = "unknown"
@@ -666,11 +667,16 @@ def identify_e24cloud(data):
         return CloudNames.E24CLOUD
 
 
+def identify_vultr(data):
+    if data['vendor'] == 'Vultr':
+        return CloudNames.VULTR
+
+
 def identify_platform():
     # identify the platform and return an entry in CloudNames.
     data = _collect_platform_data()
     checks = (identify_aws, identify_brightbox, identify_zstack,
-              identify_e24cloud, lambda x: CloudNames.UNKNOWN)
+              identify_e24cloud, identify_vultr, lambda x: CloudNames.UNKNOWN)
     for checker in checks:
         try:
             result = checker(data)

--- a/doc/rtd/topics/datasources.rst
+++ b/doc/rtd/topics/datasources.rst
@@ -47,6 +47,7 @@ The following is a list of documents for each supported datasource:
    datasources/ovf.rst
    datasources/rbxcloud.rst
    datasources/smartos.rst
+   datasources/vultr.rst
    datasources/zstack.rst
 
 

--- a/doc/rtd/topics/datasources/vultr.rst
+++ b/doc/rtd/topics/datasources/vultr.rst
@@ -1,0 +1,15 @@
+.. _datasource_vultr:
+
+Vultr
+=====
+`Vultr <https://www.vultr.com>` platform provides an AWS Ec2 metadata
+service clone.  It identifies itself to guests using the dmi
+system-manufacturer (/sys/class/dmi/id/sys_vendor) with 'Vultr'.
+
+Vultr also has a native metadata service running at
+http://169.254.169.254/v1 for more information, see `Vultr doc`_.
+
+Cloud-init only supports vultr through the EC2 metadata service.
+
+.. _Vultr doc: https://www.vultr.com/metadata/#metadata
+.. vi: textwidth=78

--- a/tests/unittests/test_datasource/test_ec2.py
+++ b/tests/unittests/test_datasource/test_ec2.py
@@ -971,8 +971,20 @@ class TesIdentifyPlatform(test_helpers.CiTestCase):
 
     @mock.patch('cloudinit.sources.DataSourceEc2._collect_platform_data')
     def test_identify_e24cloud_negative(self, m_collect):
-        """e24cloud identified if vendor is e24cloud"""
+        """e24cloud must be specific. Do not match e24cloud*"""
         m_collect.return_value = self.collmock(vendor='e24cloudyday')
+        self.assertEqual(ec2.CloudNames.UNKNOWN, ec2.identify_platform())
+
+    @mock.patch('cloudinit.sources.DataSourceEc2._collect_platform_data')
+    def test_identify_vultr(self, m_collect):
+        """vultr identified if vendor is Vultr"""
+        m_collect.return_value = self.collmock(vendor='Vultr')
+        self.assertEqual(ec2.CloudNames.VULTR, ec2.identify_platform())
+
+    @mock.patch('cloudinit.sources.DataSourceEc2._collect_platform_data')
+    def test_identify_vultr_negative(self, m_collect):
+        """vultr must be specific. Do not match vultr*"""
+        m_collect.return_value = self.collmock(vendor='Vultricardo')
         self.assertEqual(ec2.CloudNames.UNKNOWN, ec2.identify_platform())
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -637,8 +637,16 @@ class TestDsIdentify(DsIdentifyBase):
         self._test_ds_found('Ec2-E24Cloud')
 
     def test_e24cloud_not_active(self):
-        """EC2: bobrightbox.com in product_serial is not brightbox'"""
+        """EC2: e24cloud in sys_vendor is specific. Do not match e24cloud*"""
         self._test_ds_not_found('Ec2-E24Cloud-negative')
+
+    def test_vultr_is_ec2(self):
+        """EC2: vultr cloud identified by sys_vendor."""
+        self._test_ds_found('Ec2-Vultr')
+
+    def test_vultr_not_active(self):
+        """EC2: vultr in sys_vendor is specific. Do not match vultr*"""
+        self._test_ds_not_found('Ec2-Vultr-negative')
 
 
 class TestBSDNoSys(DsIdentifyBase):
@@ -1079,7 +1087,15 @@ VALID_CFG = {
     'Ec2-E24Cloud-negative': {
         'ds': 'Ec2',
         'files': {P_SYS_VENDOR: 'e24cloudyday\n'},
-    }
+    },
+    'Ec2-Vultr': {
+        'ds': 'Ec2',
+        'files': {P_SYS_VENDOR: 'Vultr\n'},
+    },
+    'Ec2-Vultr-negative': {
+        'ds': 'Ec2',
+        'files': {P_SYS_VENDOR: 'Vultricardo\n'},
+    },
 }
 
 # vi: ts=4 expandtab

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -960,6 +960,7 @@ ec2_identify_platform() {
     local vendor="${DI_DMI_SYS_VENDOR}"
     case "$vendor" in
         e24cloud) _RET="E24cloud"; return 0;;
+        Vultr) _RET="Vultr"; return 0;;
     esac
 
     # AWS http://docs.aws.amazon.com/AWSEC2/


### PR DESCRIPTION


## Proposed Commit Message
Add support to EC2 for identifying Vultr cloud.

Vultr.com cloud runs a ec2 compatible metadata service.
This correctly identifies that cloud so that users do not see an
EC2 strict warning.

LP: #1901458

## Additional Context
As reported in bug [LP: #1901458](https://bugs.launchpad.net/bugs/1901458), Vultr will show the ec2 strict warning.

It seems that it would be better to have native support for vultr's metadata service documented https://www.vultr.com/metadata/#metadata . 


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on an actual Ubuntu Server image,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:

 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
