### PR TITLE
Explicit set IPV6_AUTOCONF and IPV6_FORCE_ACCEPT_RA on static6

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -820,8 +820,8 @@ def _normalize_subnet(subnet):
 
     if subnet.get('type') in ('static', 'static6'):
         normal_subnet.update(
-            _normalize_net_keys(normal_subnet, address_keys=('address',
-                'ip_address',)))
+            _normalize_net_keys(normal_subnet, address_keys=(
+                'address', 'ip_address',)))
     normal_subnet['routes'] = [_normalize_route(r)
                                for r in subnet.get('routes', [])]
 

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -820,7 +820,8 @@ def _normalize_subnet(subnet):
 
     if subnet.get('type') in ('static', 'static6'):
         normal_subnet.update(
-            _normalize_net_keys(normal_subnet, address_keys=('address',)))
+            _normalize_net_keys(normal_subnet, address_keys=('address',
+                'ip_address',)))
     normal_subnet['routes'] = [_normalize_route(r)
                                for r in subnet.get('routes', [])]
 

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -463,6 +463,10 @@ class Renderer(renderer.Renderer):
                             iface_cfg[mtu_key] = subnet['mtu']
                     else:
                         iface_cfg[mtu_key] = subnet['mtu']
+
+                if subnet_is_ipv6(subnet) and flavor == 'rhel':
+                    iface_cfg['IPV6_FORCE_ACCEPT_RA'] = False
+                    iface_cfg['IPV6_AUTOCONF'] = False
             elif subnet_type == 'manual':
                 if flavor == 'suse':
                     LOG.debug('Unknown subnet type setting "%s"', subnet_type)

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -602,9 +602,15 @@ def convert_net_json(network_json=None, known_macs=None):
             elif network['type'] in ['ipv6_slaac', 'ipv6_dhcpv6-stateless',
                                      'ipv6_dhcpv6-stateful']:
                 subnet.update({'type': network['type']})
-            elif network['type'] in ['ipv4', 'ipv6']:
+            elif network['type'] in ['ipv4', 'static']:
                 subnet.update({
                     'type': 'static',
+                    'address': network.get('ip_address'),
+                })
+            elif network['type'] in ['ipv6', 'static6']:
+                cfg.update({'accept-ra': False})
+                subnet.update({
+                    'type': 'static6',
                     'address': network.get('ip_address'),
                 })
 

--- a/tests/unittests/test_distros/test_netconfig.py
+++ b/tests/unittests/test_distros/test_netconfig.py
@@ -514,7 +514,9 @@ class TestNetCfgDistroRedhat(TestNetCfgDistroBase):
                 DEVICE=eth0
                 IPV6ADDR=2607:f0d0:1002:0011::2/64
                 IPV6INIT=yes
+                IPV6_AUTOCONF=no
                 IPV6_DEFAULTGW=2607:f0d0:1002:0011::1
+                IPV6_FORCE_ACCEPT_RA=no
                 NM_CONTROLLED=no
                 ONBOOT=yes
                 TYPE=Ethernet


### PR DESCRIPTION
## Proposed Commit Message
The static and static6 subnet types for network_data.json were
being ignored by the Openstack handler, this would cause the code to
break and not function properly.

As of today, if a static6 configuration is chosen, the interface will
still eventually be available to receive router advertisements or be set
from NetworkManager to wait for them and cycle the interface in negative
case.

It is safe to assume that if the interface is manually configured to use
static ipv6 address, there's no need to wait for router advertisements.
This patch will set automatically IPV6_AUTOCONF and IPV6_FORCE_ACCEPT_RA
both to "no" in this case.

This patch fixes the specific behavior only for RHEL flavor and
sysconfig renderer. It also introduces new unit tests for the specific
case as well as adjusts some existent tests to be compatible with the
new options. This patch also addresses this problem by assigning the 
appropriate subnet type for each case on the openstack handler.

rhbz: #1889635
rhbz: #1889635

Signed-off-by: Eduardo Otubo <otubo@redhat.com>

## Additional Context
This behavior was noticed while running tests for the PowerVM support on cloud-init (#584).

As a formality I posted only the first commit message on the "Proposed Commit Message" above. But it would be better if both patches could be merged separately, only to maintain the logical link between them.

## Test Steps
The bug can be verified by using the following `network_data.json` file:
```json
{
    "services": [
        {
            "type": "dns",
            "address": "9.0.128.50"
        },
        {
            "type": "dns",
            "address": "9.12.16.2"
        }
    ],
    "networks": [
        {
            "network_id": "2deaa60f-e9f4-4264-a25c-329aac1a77b1",
            "netmask": "255.255.255.0",
            "link": "tap6604fdd5-23",
            "mode": "auto",
            "routes": [
                {
                    "netmask": "0.0.0.0",
                    "network": "0.0.0.0",
                    "gateway": "60.0.0.1"
                }
            ],
            "ip_address": "60.0.0.247",
            "type": "ipv4",
            "id": "network0",
            "services": [
                {
                    "type": "dns",
                    "address": "9.0.128.50"
                },
                {
                    "type": "dns",
                    "address": "9.12.16.2"
                }
            ]
        },
        {
            "network_id": "mgmt",
            "netmask": "ffff:ffff:ffff:ffff::",
            "link": "interface1",
            "mode": "link-local",
            "routes": [],
            "ip_address": "fe80::c096:67ff:fe5c:6e84",
            "type": "static6",
            "id": "network1",
            "services": [],
            "accept-ra": "false"
        }
    ],
    "links": [
        {
            "ethernet_mac_address": "fa:61:e3:d8:59:20",
            "mtu": 1500,
            "type": "vif",
            "id": "tap6604fdd5-23",
            "vif_id": "6604fdd5-2312-433d-942e-729fa177fa66"
        },
        {
            "ethernet_mac_address": "c2:96:67:5c:6e:84",
            "mtu": null,
            "type": "vif",
            "id": "interface1",
            "vif_id": "mgmt_vif"
        }
    ]
}
```
With the net-convert tool:
```
cloud-init devel net-convert  -p ./network_data.json -k network_data.json -D rhel -d ./  -O sysconfig
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
