### PR TITLE
fix comment in tools/build-on-freebsd

### DIFF
--- a/tools/build-on-freebsd
+++ b/tools/build-on-freebsd
@@ -1,7 +1,10 @@
 #!/bin/sh
-# Since there is no official FreeBSD port yet, we need some way of building and
-# installing cloud-init. This script takes care of building and installing. It
-# will optionally make a first run at the end.
+# The official way to install cloud-init on FreeBSD is via the net/cloud-init
+# port or the (appropriately py-flavoured) package.
+# This script provides a communication medium between the cloud-init maintainers
+# and the cloud-init port maintainers as to what dependencies have changed.
+# It also provides a quick and dirty way of building and installing, and will
+# optionally make a first run at the end.
 
 set -eux
 


### PR DESCRIPTION
## Proposed Commit Message

tools/build-on-freebsd: Fix top comment explaining the purpose of the script

since there *is* an official port for cloud-init in FreeBSD, this script has a different purpose.
It's an interface between cloud-init maintainers, and the FreeBSD port maintainers for quickly seeing which dependencies have changed.

## Additional Context

This fixes LP# 1799674

## Test Steps
This is a documentation bug.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
