### PR TITLE
WIP: cc_resizefs: Fix accepted opts for FreeBSD newfs

### DIFF
--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -110,7 +110,25 @@ def _can_skip_resize_ufs(mount_point, devpth):
     for line in dumpfs_res.splitlines():
         if not line.startswith('#'):
             newfs_cmd = shlex.split(line)
-            opt_value = 'O:Ua:s:b:d:e:f:g:h:i:jk:m:o:L:'
+            # from the newfs man page:
+            # [-EJNUjlnt] [-L volname] [-O filesystem-type]
+            # [-S sector-size] [-T disktype] [-a maxcontig] [-b block-size]
+            # [-c blocks-per-cylinder-group] [-d max-extent-size]
+            # [-e maxbpg] [-f frag-size] [-g avgfilesize] [-h avgfpdir]
+            # [-i bytes] [-k held-for-metadata-blocks] [-m free-space]
+            # [-o optimization] [-p partition] [-r reserved] [-s size]
+            # special
+            opt_value = 'JUjltL:O:a:b:c:d:e:f:g:h:i:k:m:p:r:s:'
+            # you may notice that some options are skipped:
+            # -E: Erase the content of the disk before making the filesystem.
+            # -N: Cause the file system parameters to be printed out without
+            #     really creating the file system.
+            # -T disktype: For backward compatibility.
+            # -S sector-size: The following options override the standard
+            #    sizes-for the disk geometry. [...] Changing these defaults is
+            #    useful only when using newfs to build a file system whose raw
+            #    image will eventually be used on a different type of disk
+            #    than the one on which it is initially created.
             optlist, _args = getopt.getopt(newfs_cmd[1:], opt_value)
             for o, a in optlist:
                 if o == "-s":


### PR DESCRIPTION
## Proposed Commit Message

>  cc_resizefs: Fix accepted opts for FreeBSD newfs
>
> On FreeBSD , if a UFS has trim: (-t) or MAC multilabel: (-l) flag, resize FS fail.
>
> This pull-request adds these options to the dumpfs "parser", as well as
> other missing options, and fully documents what's where these options
> are coming from, and which ones we've left out, and why.

## Additional Context
FreeBSD Bugzilla: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=250496
LP# 1901958

## Test Steps

- Create a partition with `newfs -t -l` (among other useful options, such as `-Uj`)
- instruct cloud-init to resize the filesystem
- it fails

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly (there are none)
 - [ ] I have updated or added any documentation accordingly (i've added a long comment explaining what's going on)
