### PR TITLE
Fix mounting of vfat on *BSD

### DIFF
--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -740,7 +740,7 @@ class TestMountCb:
     )
     @mock.patch("cloudinit.util.is_Linux", autospec=True)
     @mock.patch("cloudinit.util.is_BSD", autospec=True)
-    @mock.patch("cloudinit.util.subp.subp", autospec=True)
+    @mock.patch("cloudinit.util.subp.subp")
     @mock.patch("cloudinit.temp_utils.tempdir", autospec=True)
     def test_normalize_mtype_on_bsd(self, m_tmpdir, m_subp, m_is_BSD, m_is_Linux, mtype, expected):
         m_is_BSD.return_value = True
@@ -754,10 +754,9 @@ class TestMountCb:
         callback = mock.Mock(autospec=True)
 
         util.mount_cb('/dev/fake0', callback, mtype=mtype)
-        m_subp.assert_any_call(
+        assert mock.call(
             ["mount", "-o", "ro", "-t", expected, "/dev/fake0", "/tmp/fake"],
-            update_env=None
-        )
+            update_env=None) in m_subp.call_args_list
 
     @pytest.mark.parametrize("invalid_mtype", [int(0), float(0.0), dict()])
     def test_typeerror_raised_for_invalid_mtype(self, invalid_mtype):

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -733,9 +733,14 @@ class TestMountCb:
     @pytest.mark.parametrize(
         "mtype,expected",
         [
+            # While the filesystem is called iso9660, the mount type is cd9660
             ("iso9660", "cd9660"),
+            # vfat is generally called "msdos" on BSD
             ("vfat", "msdos"),
+            # judging from man pages, only FreeBSD has this alias
             ("msdosfs", "msdos"),
+            # Test happy path
+            ("ufs", "ufs")
         ],
     )
     @mock.patch("cloudinit.util.is_Linux", autospec=True)

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -738,11 +738,11 @@ class TestMountCb:
             ("msdosfs", "msdos"),
         ],
     )
-    @mock.patch("cloudinit.util.is_Linux")
-    @mock.patch("cloudinit.util.is_BSD")
-    @mock.patch("cloudinit.util.subp.subp")
-    @mock.patch("cloudinit.temp_utils.tempdir")
-    def test_normalize_vfat_on_bsd(self, m_tmpdir, m_subp, m_is_BSD, m_is_Linux, mtype, expected):
+    @mock.patch("cloudinit.util.is_Linux", autospec=True)
+    @mock.patch("cloudinit.util.is_BSD", autospec=True)
+    @mock.patch("cloudinit.util.subp.subp", autospec=True)
+    @mock.patch("cloudinit.temp_utils.tempdir", autospec=True)
+    def test_normalize_mtype_on_bsd(self, m_tmpdir, m_subp, m_is_BSD, m_is_Linux, mtype, expected):
         m_is_BSD.return_value = True
         m_is_Linux.return_value = False
         m_tmpdir.return_value.__enter__ = mock.Mock(

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -747,7 +747,9 @@ class TestMountCb:
     @mock.patch("cloudinit.util.is_BSD", autospec=True)
     @mock.patch("cloudinit.util.subp.subp")
     @mock.patch("cloudinit.temp_utils.tempdir", autospec=True)
-    def test_normalize_mtype_on_bsd(self, m_tmpdir, m_subp, m_is_BSD, m_is_Linux, mtype, expected):
+    def test_normalize_mtype_on_bsd(
+        self, m_tmpdir, m_subp, m_is_BSD, m_is_Linux, mtype, expected
+    ):
         m_is_BSD.return_value = True
         m_is_Linux.return_value = False
         m_tmpdir.return_value.__enter__ = mock.Mock(

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -735,12 +735,12 @@ class TestMountCb:
     @mock.patch("cloudinit.temp_utils.tempdir")
     def test_normalize_vfat_on_bsd(self, m_tmpdir, m_subp, m_is_BSD):
         m_is_BSD.return_value = "SomeBSD"
-        m_tmpdir.__enter__ = mock.Mock(return_value="/tmp/fake")
-        m_tmpdir.__exit__ = mock.Mock(return_value=True)
+        m_tmpdir.return_value.__enter__ = mock.Mock(return_value="/tmp/fake")
+        m_tmpdir.return_value.__exit__ = mock.Mock(return_value=True)
         callback = mock.Mock()
 
         util.mount_cb('/dev/fake0', callback, mtype='vfat')
-        m_subp.assert_called_with(
+        m_subp.assert_any_call(
             ["mount", "-o", "ro", "-t", "msdos", "/dev/fake0", "/tmp/fake"],
             update_env=None
         )
@@ -750,12 +750,12 @@ class TestMountCb:
     @mock.patch("cloudinit.temp_utils.tempdir")
     def test_normalize_iso9660_on_bsd(self, m_tmpdir, m_subp, m_is_BSD):
         m_is_BSD.return_value = "SomeBSD"
-        m_tmpdir.__enter__ = mock.Mock(return_value="/tmp/fake")
-        m_tmpdir.__exit__ = mock.Mock(return_value=True)
+        m_tmpdir.return_value.__enter__ = mock.Mock(return_value="/tmp/fake")
+        m_tmpdir.return_value.__exit__ = mock.Mock(return_value=True)
         callback = mock.Mock()
 
         util.mount_cb('/dev/fake0', callback, mtype='iso9660')
-        m_subp.assert_called_with(
+        m_subp.assert_any_call(
             ["mount", "-o", "ro", "-t", "cd9660", "/dev/fake0", "/tmp/fake"],
             update_env=None
         )

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -730,6 +730,36 @@ class TestMountCb:
         """already_mounted_device_and_mountdict, but return only the device"""
         return already_mounted_device_and_mountdict[0]
 
+    @mock.patch("platform.system")
+    @mock.patch("cloudinit.util.subp.subp")
+    @mock.patch("cloudinit.temp_utils.tempdir")
+    def test_normalize_vfat_on_bsd(self, m_tmpdir, m_subp, m_is_BSD):
+        m_is_BSD.return_value = "SomeBSD"
+        m_tmpdir.__enter__ = mock.Mock(return_value="/tmp/fake")
+        m_tmpdir.__exit__ = mock.Mock(return_value=True)
+        callback = mock.Mock()
+
+        util.mount_cb('/dev/fake0', callback, mtype='vfat')
+        m_subp.assert_called_with(
+            ["mount", "-o", "ro", "-t", "msdos", "/dev/fake0", "/tmp/fake"],
+            update_env=None
+        )
+
+    @mock.patch("platform.system")
+    @mock.patch("cloudinit.util.subp.subp")
+    @mock.patch("cloudinit.temp_utils.tempdir")
+    def test_normalize_iso9660_on_bsd(self, m_tmpdir, m_subp, m_is_BSD):
+        m_is_BSD.return_value = "SomeBSD"
+        m_tmpdir.__enter__ = mock.Mock(return_value="/tmp/fake")
+        m_tmpdir.__exit__ = mock.Mock(return_value=True)
+        callback = mock.Mock()
+
+        util.mount_cb('/dev/fake0', callback, mtype='iso9660')
+        m_subp.assert_called_with(
+            ["mount", "-o", "ro", "-t", "cd9660", "/dev/fake0", "/tmp/fake"],
+            update_env=None
+        )
+
     @pytest.mark.parametrize("invalid_mtype", [int(0), float(0.0), dict()])
     def test_typeerror_raised_for_invalid_mtype(self, invalid_mtype):
         with pytest.raises(TypeError):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -416,9 +416,11 @@ def multi_log(text, console=True, stderr=True,
         else:
             log.log(log_level, text)
 
+
 @lru_cache()
 def is_Linux():
     return 'Linux' in platform.system()
+
 
 @lru_cache()
 def is_BSD():

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1667,10 +1667,12 @@ def mount_cb(device, callback, data=None, mtype=None,
             mtypes = ["auto"]
     elif platsys.endswith("bsd"):
         if mtypes is None:
-            mtypes = ['ufs', 'cd9660', 'vfat']
+            mtypes = ['ufs', 'cd9660', 'msdos']
         for index, mtype in enumerate(mtypes):
             if mtype == "iso9660":
                 mtypes[index] = "cd9660"
+            if mtype in ["vfat", "msdosfs", "msdos"]:
+                mtypes[index] = "msdos"
     else:
         # we cannot do a smart "auto", so just call 'mount' once with no -t
         mtypes = ['']

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -416,6 +416,9 @@ def multi_log(text, console=True, stderr=True,
         else:
             log.log(log_level, text)
 
+@lru_cache()
+def is_Linux():
+    return 'Linux' in platform.system()
 
 @lru_cache()
 def is_BSD():
@@ -1661,11 +1664,10 @@ def mount_cb(device, callback, data=None, mtype=None,
                 _type=type(mtype)))
 
     # clean up 'mtype' input a bit based on platform.
-    platsys = platform.system().lower()
-    if platsys == "linux":
+    if is_Linux():
         if mtypes is None:
             mtypes = ["auto"]
-    elif platsys.endswith("bsd"):
+    elif is_BSD():
         if mtypes is None:
             mtypes = ['ufs', 'cd9660', 'msdos']
         for index, mtype in enumerate(mtypes):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1671,7 +1671,7 @@ def mount_cb(device, callback, data=None, mtype=None,
         for index, mtype in enumerate(mtypes):
             if mtype == "iso9660":
                 mtypes[index] = "cd9660"
-            if mtype in ["vfat", "msdosfs", "msdos"]:
+            if mtype in ["vfat", "msdosfs"]:
                 mtypes[index] = "msdos"
     else:
         # we cannot do a smart "auto", so just call 'mount' once with no -t


### PR DESCRIPTION

## Proposed Commit Message
Fix mounting of vfat filesystems by normalizing the different names for vfat to "msdos" which works across BSDS.

## Additional Context

FreeBSD Bugzilla ref: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=250496
LP# https://bugs.launchpad.net/cloud-init/+bug/1901958

## Test Steps

This doesn't reproduce on Ubuntu.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
