### PR TITLE
integration_tests: various launch improvements

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -60,6 +60,11 @@ class IntegrationCloud(ABC):
             'wait': False,
         }
         kwargs.update(launch_kwargs)
+        log.info(
+            "Launching instance with launch_kwargs:\n{}".format(
+                "\n".join("{}={}".format(*item) for item in kwargs.items())
+            )
+        )
         pycloudlib_instance = self.cloud_instance.launch(**kwargs)
         pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         log.info('Launched instance: %s', pycloudlib_instance)

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -54,13 +54,13 @@ class IntegrationCloud(ABC):
                 self.settings.EXISTING_INSTANCE_ID
             )
             return
-        launch_kwargs = {
+        kwargs = {
             'image_id': self.image_id,
             'user_data': user_data,
             'wait': False,
         }
-        launch_kwargs.update(launch_kwargs)
-        pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
+        kwargs.update(launch_kwargs)
+        pycloudlib_instance = self.cloud_instance.launch(**kwargs)
         pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         log.info('Launched instance: %s', pycloudlib_instance)
         return self.get_instance(pycloudlib_instance, settings)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -111,7 +111,15 @@ def _client(request, fixture_utils, session_cloud):
     """
     user_data = fixture_utils.closest_marker_first_arg_or(
         request, 'user_data', None)
-    with session_cloud.launch(user_data=user_data) as instance:
+    name = fixture_utils.closest_marker_first_arg_or(
+        request, 'instance_name', None
+    )
+    launch_kwargs = {}
+    if name is not None:
+        launch_kwargs = {"name": name}
+    with session_cloud.launch(
+        user_data=user_data, launch_kwargs=launch_kwargs
+    ) as instance:
         yield instance
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -158,3 +158,4 @@ markers =
     oci: test will only run on OCI platform
     lxd_container: test will only run in LXD container
     user_data: the user data to be passed to the test instance
+    instance_name: the name to be used for the test instance


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: various launch improvements
>
> * fix passing launch_kwargs to session_cloud.launch
> * log the launch_kwargs before launching instances
> * add support for specifying instance name for tests

## Additional Context

These commits are also part of my WIP PR for pickling (https://github.com/canonical/cloud-init/pull/609/), but they are useful improvements nonetheless (and it's preferable to review them separately). This does not include all the integration testing commits from that PR: I don't think that `mode` is the right parameter for `pull_from_file` (because there's no situation where you would want the temporary file opened as anything other than readable) so I'll modify https://github.com/canonical/cloud-init/pull/609/commits/8af1c4b52baba2a601e35a0a69ccfb7eba019f18 and submit it separately once I'm happy with it.

## Test Steps

I have run the integration tests locally. An example of the output is:

```
bugs/test_lp1886531.py::TestLp1886531::test_lp1886531 
----- live log setup -----
INFO     integration_testing:conftest.py:76 Setting up environment for lxd_container
INFO     integration_testing:conftest.py:102 Done with environment setup
INFO     integration_testing:clouds.py:63 Launching instance with launch_kwargs:
image_id=ubuntu:98f390c5e26031f059d6f49c48c12e3c245cb475fe7424af3728a0dc88e60064
user_data=#cloud-config
bootcmd:
- rm /etc/fstab

wait=False
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:157 executing: cloud-init status --wait --long
INFO     integration_testing:clouds.py:70 Launched instance: LXDInstance(name=composed-crane)
PASSED
```

I'm not entirely convinced that having `user_data` alongside the other `launch_kwargs` is ideal: it's multi-line unlike the other values. What do people think?

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly