### PR TITLE
Hetzner: Fix instance_id / SMBIOS serial comparison

### DIFF
--- a/cloudinit/sources/DataSourceHetzner.py
+++ b/cloudinit/sources/DataSourceHetzner.py
@@ -82,7 +82,7 @@ class DataSourceHetzner(sources.DataSource):
         self.vendordata_raw = md.get("vendor_data", None)
 
         # instance-id and serial from SMBIOS should be identical
-        if self.metadata['instance-id'] != serial:
+        if self.get_instance_id() != serial:
             raise RuntimeError(
                 "SMBIOS serial does not match instance ID from metadata"
             )

--- a/tests/unittests/test_datasource/test_hetzner.py
+++ b/tests/unittests/test_datasource/test_hetzner.py
@@ -80,7 +80,8 @@ class TestDataSourceHetzner(CiTestCase):
     @mock.patch('cloudinit.sources.DataSourceHetzner.get_hcloud_data')
     def test_read_data(self, m_get_hcloud_data, m_usermd, m_readmd,
                        m_fallback_nic, m_net):
-        m_get_hcloud_data.return_value = (True, METADATA.get('instance-id'))
+        m_get_hcloud_data.return_value = (True,
+                                          str(METADATA.get('instance-id')))
         m_readmd.return_value = METADATA.copy()
         m_usermd.return_value = USERDATA
         m_fallback_nic.return_value = 'eth0'


### PR DESCRIPTION
## Proposed Commit Message
Fixes erroneous string/int comparison introduced in 1431c8a

## Test Steps
* Using the Hetzner DS from PR# 630 triggers a runtime error as the comparison fails due to int/str type mismatch
* Replace DS with updated DS and create a new snapshot
* Create new instance with updated DS

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
