### PR TITLE
.travis.yml: use a known-working version of lxd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
             # pylxd talks only to the lxd from snap
             - sudo apt remove --purge lxd lxd-client
             - sudo rm -Rf /var/lib/lxd
-            - sudo snap install lxd
+            - sudo snap install --channel=4.6/stable lxd
             - sudo lxd init --auto
             - sudo mkdir --mode=1777 -p /var/snap/lxd/common/consoles
             # Move any cached lxd images into lxd's image dir


### PR DESCRIPTION
## Proposed Commit Message
> .travis.yml: use a known-working version of lxd
>
> The latest lxd 4.7 snap causes failures; while we're diagnosing those
> and addressing the issues (either upstream or in our code), pin at lxd
> 4.6 so we can continue to land PRs in cloud-init trunk.

## Additional Context

https://travis-ci.com/github/canonical/cloud-init/jobs/421338811 is an example of one of these failures, the relevant log line:

```
2020-10-30 10:07:15,285 - /home/travis/build/canonical/cloud-init/tests/cloud_tests/stage.py:run_stage:102 [ERROR]: stage: collect test data for xenial encountered error: Create instance from copy: The container is already frozen
```

https://github.com/lxc/lxd/commit/1cb7475c22a02f5317641c746c87430b0d561551 recently landed in lxd master, which looks like it could be related.

We aren't seeing failures in the new integration testing framework (which doesn't use pylxd), so this change is only applied to the older citest path.

## Test Steps

Travis being green will indicate this worked.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
