### PR TITLE
Revert ".travis.yml: use a known-working version of lxd (#643)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
             # pylxd talks only to the lxd from snap
             - sudo apt remove --purge lxd lxd-client
             - sudo rm -Rf /var/lib/lxd
-            - sudo snap install --channel=4.6/stable lxd
+            - sudo snap install lxd
             - sudo lxd init --auto
             - sudo mkdir --mode=1777 -p /var/snap/lxd/common/consoles
             # Move any cached lxd images into lxd's image dir


### PR DESCRIPTION
## Proposed Commit Message
> Revert ".travis.yml: use a known-working version of lxd (#643)"
>
> This reverts commit f72d0cb7a03cc311700ea8795edf2454172c7414.
>
> A new release of lxd has been released to the stable channel, which
> includes a fix for the issue we were previously working around.

## Additional Context

See https://github.com/canonical/cloud-init/pull/643 for background. Our issue should be fixed with https://github.com/lxc/lxd/commit/4d5751993136a31ede7196a831a5037d05f3217b which stgraber confirmed to me via IRC is now in the stable channel.

## Test Steps

If Travis passes, we're good.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
