### PR TITLE
Prevent timeout on travis integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -199,7 +199,16 @@ matrix:
                 fi
             # Use sudo to get a new shell where we're in the sbuild group
             - sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc'
-            - sg lxd -c 'CLOUD_INIT_IMAGE_SOURCE="$(ls *.deb)" tox -e integration-tests'
+            - sg lxd -c 'CLOUD_INIT_IMAGE_SOURCE="$(ls *.deb)" tox -e integration-tests' &
+            - |
+              SECONDS=0
+              while [ -e /proc/$! ]; do
+                if [ "$SECONDS" -gt "570" ]; then
+                  echo -n '.'
+                  SECONDS=0
+                fi
+                sleep 10
+              done
         - python: 3.5
           env:
               TOXENV=xenial


### PR DESCRIPTION
## Proposed Commit Message
Prevent timeout on travis integration tests

Add a script in travis to output a dot every 10 minute during
and integration test run to prevent travis timeout.

## Additional Context
If a task gives no output for 10 minutes, travis will assume it hung and kill it. Integration tests can go for 10 minutes without outputting anything. This change adds an additional script to the travis task to output a every 10-ish minutes while integration tests are running.

## Test Steps
n/a

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
