### PR TITLE
split integration and cloud_tests requirements

### DIFF
--- a/cloud-tests-requirements.txt
+++ b/cloud-tests-requirements.txt
@@ -1,0 +1,28 @@
+# PyPI requirements for cloud-init cloud tests
+# https://cloudinit.readthedocs.io/en/latest/topics/cloud_tests.html
+#
+# Note: Changes to this requirements may require updates to
+# the packages/pkg-deps.json file as well.
+#
+
+# ec2 backend
+boto3==1.14.53
+
+# ssh communication
+paramiko==2.7.2
+cryptography==3.1
+
+# lxd backend
+pylxd==2.2.11
+
+# finds latest image information
+git+https://git.launchpad.net/simplestreams
+
+# azure backend
+azure-storage==0.36.0
+msrestazure==0.6.1
+azure-common==1.1.23
+azure-mgmt-compute==7.0.0
+azure-mgmt-network==5.0.0
+azure-mgmt-resource==4.0.0
+azure-mgmt-storage==6.0.0

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,30 +1,5 @@
 # PyPI requirements for cloud-init integration testing
-# https://cloudinit.readthedocs.io/en/latest/topics/tests.html
+# https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-# Note: Changes to this requirements may require updates to
-# the packages/pkg-deps.json file as well.
-#
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git
 pytest
-git+https://github.com/canonical/pycloudlib.git
-
-# ec2 backend
-boto3==1.14.53
-
-# ssh communication
-paramiko==2.7.2
-cryptography==3.1
-
-# lxd backend
-pylxd==2.2.11
-
-# finds latest image information
-git+https://git.launchpad.net/simplestreams
-
-# azure backend
-azure-storage==0.36.0
-msrestazure==0.6.1
-azure-common==1.1.23
-azure-mgmt-compute==7.0.0
-azure-mgmt-network==5.0.0
-azure-mgmt-resource==4.0.0
-azure-mgmt-storage==6.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     pylint==2.6.0
     # test-requirements because unit tests are now present in cloudinit tree
     -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/cloud-tests-requirements.txt
     -r{toxinidir}/integration-requirements.txt
 commands = {envpython} -m pylint {posargs:cloudinit tests tools}
 
@@ -128,6 +129,7 @@ deps =
     pylint
     # test-requirements
     -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/cloud-tests-requirements.txt
     -r{toxinidir}/integration-requirements.txt
 
 [testenv:citest]
@@ -135,7 +137,7 @@ basepython = python3
 commands = {envpython} -m tests.cloud_tests {posargs}
 passenv = HOME TRAVIS
 deps =
-    -r{toxinidir}/integration-requirements.txt
+    -r{toxinidir}/cloud-tests-requirements.txt
 
 [testenv:integration-tests]
 basepython = python3


### PR DESCRIPTION
## Proposed Commit Message
> split integration and cloud_tests requirements
>
> The cloud_tests and the integration_tests (via pycloudlib) have
> conflicting requirements. This commit splits up their requirements
> files, so we can accurately express the requirements for each.

## Test Steps

Testing is being tracked in the corresponding `pycloudlib` PR: https://github.com/canonical/pycloudlib/pull/42

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
