### PR TITLE
Fix launch_kwargs bug in integration tests

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -59,7 +59,8 @@ class IntegrationCloud(ABC):
             'user_data': user_data,
             'wait': False,
         }
-        kwargs.update(launch_kwargs)
+        if launch_kwargs:
+            kwargs.update(launch_kwargs)
         log.info(
             "Launching instance with launch_kwargs:\n{}".format(
                 "\n".join("{}={}".format(*item) for item in kwargs.items())


### PR DESCRIPTION
## Proposed Commit Message
Fix launch_kwargs bug in integration tests

Integration test instance  launch would previously fail if provided
launch_kwargs is None

## Additional Context
None

## Test Steps
`pytest tests/integration_tests/`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
