### PR TITLE
integration_tests: add logging of CLOUD_INIT_SOURCE

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -74,6 +74,9 @@ def setup_image(session_cloud):
     """
     client = None
     log.info('Setting up environment for %s', session_cloud.datasource)
+    log.info(
+        'Using CLOUD_INIT_SOURCE: %s', integration_settings.CLOUD_INIT_SOURCE
+    )
     if integration_settings.CLOUD_INIT_SOURCE == 'NONE':
         pass  # that was easy
     elif integration_settings.CLOUD_INIT_SOURCE == 'IN_PLACE':

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -148,6 +148,7 @@ class IntegrationLxdContainerInstance(IntegrationInstance):
             self._mount_source()
 
     def _mount_source(self):
+        log.info("Mounting source directory IN_PLACE...")
         command = (
             'lxc config device add {name} host-cloud-init disk '
             'source={cloudinit_path} '


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: add logging of CLOUD_INIT_SOURCE
>
> And a log call specifically when IN_PLACE mounting happens.

## Test Steps

From a local test run invoked with `CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE pytest --log-cli-level=INFO tests/integration_tests/bugs/test_lp1886531.py`:

```
INFO     integration_testing:conftest.py:76 Setting up environment for lxd_container
INFO     integration_testing:conftest.py:77 Using CLOUD_INIT_SOURCE: IN_PLACE
INFO     integration_testing:conftest.py:103 Done with environment setup
INFO     integration_testing:clouds.py:64 Launching instance with launch_kwargs:
image_id=ubuntu:d1cad2fbac21768f6ab2633a6e55c7fea118aba942dab0ab79c556ac5b1b149e
user_data=None
wait=False
name=pickle-check
INFO     pycloudlib.instance:instance.py:157 executing: sh -c 'cloud-init status --help'
INFO     pycloudlib.instance:instance.py:157 executing: cloud-init status --wait --long
INFO     integration_testing:clouds.py:71 Launched instance: LXDInstance(name=pickle-check)
INFO     integration_testing:instances.py:151 Mounting source directory IN_PLACE...
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
