### PR TITLE
cloud_tests: add hirsute release definition

### DIFF
--- a/tests/cloud_tests/releases.yaml
+++ b/tests/cloud_tests/releases.yaml
@@ -133,6 +133,22 @@ features:
 
 releases:
     # UBUNTU =================================================================
+    hirsute:
+        # EOL: Jan 2022
+        default:
+            enabled: true
+            release: hirsute
+            version: "21.04"
+            os: ubuntu
+            feature_groups:
+                - base
+                - debian_base
+                - ubuntu_specific
+        lxd:
+            sstreams_server: https://cloud-images.ubuntu.com/daily
+            alias: hirsute
+            setup_overrides: null
+            override_templates: false
     groovy:
         # EOL: Jul 2021
         default:


### PR DESCRIPTION
## Proposed Commit Message
> cloud_tests: add hirsute release definition

## Additional Context

Spotted in our integration testing.

## Test Steps

On master:

```
$ tox -e citest -- run --verbose --preserve-data --data-dir results --os-name hirsute --test modules/ntp.yaml
...
usage: cloud_tests run [-h] [-p PLATFORM] [-n NAME] [-t FILE] [--feature-override FEATURE_OVERRIDE] [-v] [-q] [-r FILE] [-d DIR] [--preserve-instance] [--preserve-data] [--deb FILE] [--rpm FILE] [--script DATA] [--repo NAME] [--ppa NAME] [-u] [--upgrade-full]
cloud_tests run: error: argument -n/--os-name: invalid choice: 'hirsute' (choose from 'artful', 'bionic', 'centos66', 'centos70', 'cosmic', 'disco', 'eoan', 'focal', 'groovy', 'jessie', 'stretch', 'trusty', 'xenial')
ERROR: InvocationError for command /home/daniel/dev/cloud-init/.tox/citest/bin/python -m tests.cloud_tests run --verbose --preserve-data --data-dir results --os-name hirsute --test modules/ntp.yaml (exited with code 2)
```

With this branch:

```
$ tox -e citest -- run --verbose --preserve-data --data-dir results --os-name hirsute --test modules/ntp.yaml
...
2020-11-10 15:36:49,236 - /home/daniel/dev/cloud-init/tests/cloud_tests/__main__.py:main:54 [DEBUG]: running with args: Namespace(data_dir='/home/daniel/dev/cloud-init/results', deb=None, feature_override={}, os_name=['hirsute'], platform=['lxd'], ppa=None, preserve_data=True, preserve_instance=False, quiet=False, repo=None, result=None, rpm=None, script=None, subcmd='run', test_config=['/home/daniel/dev/cloud-init/tests/cloud_tests/testcases/modules/ntp.yaml'], upgrade=False, upgrade_full=False, verbose=True)
...
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly