### PR TITLE
ds-identify: Call blkid with a list of devices.

### DIFF
--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -271,10 +271,21 @@ ensure_sane_path() {
 blkid_export() {
     # call 'blkid -c /dev/null export', set DI_BLKID_EXPORT_OUT
     cached "$DI_BLKID_EXPORT_OUT" && return 0
-    local out="" ret=0
-    out=$(blkid -c /dev/null -o export) && DI_BLKID_EXPORT_OUT="$out" || {
+    local out="" ret=0 devs="" dev="" bn=""
+    for dev in /sys/class/block/*; do
+        bn=${dev##*/}
+        case "$bn" in
+            dm-[0-9]*|md[0-9]*) continue;;
+        esac
+        devs="${devs} /dev/$bn"
+    done
+    devs=${devs# }
+    [ -n "$devs" ] || warn "All devs in /sys/class/block/* were skipped."
+
+    out=$(blkid -c /dev/null -o export $devs) &&
+        DI_BLKID_EXPORT_OUT="$out" || {
         ret=$?
-        error "failed running [$ret]: blkid -c /dev/null -o export"
+        error "failed running [$ret]: blkid -c /dev/null -o export $devs"
         DI_BLKID_EXPORT_OUT="$UNAVAILABLE"
     }
     return $ret


### PR DESCRIPTION
## Proposed Commit Message
ds-identify: Call blkid with a list of devices.

On a system with many block devices (or "virtual" block devices such as
lvm/device-mapper ... ), running blkid can be very slow.  ds-identify is
using it to identify filesystems that may have a config disk of different
types.

If we accept limiting the search to "real" block devices based on name,
then we dramatically reduce ds-identify's load in early boot when lvm and
other devices are coming up.

This limits the search by name to those devices that do not match:

    dm-* md*

For reference, running blkid on non-existant block device still exits
success if it found any devices.  This will fail:

    $ blkid -c /dev/null -o export /dev/does-not-exist ; echo $?
    2

But this will succeed as long as any device in the list existed:

    $ blkid -c /dev/null -o export /dev/sd* /dev/does-not-exist ; echo $?
    0

## Test Steps
Test is inherent to system boot on any of the following platforms: NoCloud, ConfigDrive (OpenStack), OpenNebula, RbxCloud, IBMCloud.

Verify no regression caused by re-running ds-identify on booted system.

    $ DEBUG_LEVEL=1 DI_LOG=stderr /usr/lib/cloud-init/ds-identify --force
    ...
    FS_LABELS=...
    ISO9660_DEVS=...
    Found single datasource: XXXX

The 'XXX' should identify the correct datasource (whatever was previously used).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topi
cs/hacking.html)
 - [X] I have updated or added any unit tests accordingly: no tests through this path :cry: 
 - [X] I have updated or added any documentation accordingly: no previous doc on limits of a block device used for config disk.
