### PR TITLE
Ensure proper root permissions in integration tests

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@9211c0e5b34794595565d4626bc41ddbe14994f2
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@4b8d2cd5ac6316810ce16d081842da575625ca4f
 pytest

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -59,7 +59,7 @@ class IntegrationInstance:
         self.execute('mv {} {}'.format(tmp_path, remote_path))
 
     def read_from_file(self, remote_path) -> str:
-        result = self.execute('/bin/cat {}'.format(remote_path))
+        result = self.execute('cat {}'.format(remote_path))
         if result.failed:
             # TODO: Raise here whatever pycloudlib raises when it has
             # a consistent error response

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -1,8 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import logging
 import os
-import random
-import string
 import uuid
 from tempfile import NamedTemporaryFile
 

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -3,6 +3,7 @@ import logging
 import os
 import random
 import string
+import uuid
 from tempfile import NamedTemporaryFile
 
 from pycloudlib.instance import BaseInstance
@@ -22,8 +23,7 @@ log = logging.getLogger('integration_testing')
 
 
 def _get_tmp_path():
-    tmp_filename = ''.join([random.choice(
-        string.ascii_letters + string.digits) for _ in range(20)])
+    tmp_filename = str(uuid.uuid4())
     return '/var/tmp/{}.tmp'.format(tmp_filename)
 
 

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -40,6 +40,8 @@ class IntegrationInstance:
         self.instance.delete()
 
     def execute(self, command, *, use_sudo=None) -> Result:
+        if self.instance.username == 'root' and use_sudo is False:
+            raise Exception('Root user cannot run unprivileged')
         if use_sudo is None:
             use_sudo = self.use_sudo
         return self.instance.execute(command, use_sudo=use_sudo)

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -44,12 +44,7 @@ class IntegrationInstance:
         self.instance.delete()
 
     def execute(self, command) -> Result:
-        if self.use_sudo:
-            if isinstance(command, str):
-                command = 'sudo {}'.format(command)
-            elif isinstance(command, list):
-                command = ['sudo'] + command
-        return self.instance.execute(command)
+        return self.instance.execute(command, use_sudo=self.use_sudo)
 
     def pull_file(self, remote_path, local_path):
         # First copy to a temporary directory because of permissions issues

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -70,7 +70,10 @@ class TestUsersGroups:
     def test_users_groups(self, regex, getent_args, class_client):
         """Use getent to interrogate the various expected outcomes"""
         result = class_client.execute(["getent"] + getent_args)
-        assert re.search(regex, result.stdout) is not None
+        assert re.search(regex, result.stdout) is not None, (
+            "'getent {}' resulted in '{}', "
+            "but expected to match regex {}".format(
+                ' '.join(getent_args), result.stdout, regex))
 
     def test_user_root_in_secret(self, class_client):
         """Test root user is in 'secret' group."""

--- a/tests/integration_tests/modules/test_write_files.py
+++ b/tests/integration_tests/modules/test_write_files.py
@@ -51,8 +51,8 @@ class TestWriteFiles:
     @pytest.mark.parametrize(
         "cmd,expected_out", (
             ("file /root/file_b64", ASCII_TEXT),
-            ("md5sum /root/file_binary", "3801184b97bb8c6e63fa0e1eae2920d7"),
-            ("sha256sum /root/file_binary", (
+            ("md5sum </root/file_binary", "3801184b97bb8c6e63fa0e1eae2920d7"),
+            ("sha256sum </root/file_binary", (
                 "2c791c4037ea5bd7e928d6a87380f8ba"
                 "7a803cd83d5e4f269e28f5090f0f2c9a"
             )),

--- a/tests/integration_tests/modules/test_write_files.py
+++ b/tests/integration_tests/modules/test_write_files.py
@@ -51,8 +51,8 @@ class TestWriteFiles:
     @pytest.mark.parametrize(
         "cmd,expected_out", (
             ("file /root/file_b64", ASCII_TEXT),
-            ("md5sum </root/file_binary", "3801184b97bb8c6e63fa0e1eae2920d7"),
-            ("sha256sum </root/file_binary", (
+            ("md5sum /root/file_binary", "3801184b97bb8c6e63fa0e1eae2920d7"),
+            ("sha256sum /root/file_binary", (
                 "2c791c4037ea5bd7e928d6a87380f8ba"
                 "7a803cd83d5e4f269e28f5090f0f2c9a"
             )),


### PR DESCRIPTION
## Proposed Commit Message
Ensure proper root permissions in integration tests

Tests previously assumed that when executing commands and transferring
files that user will have root permissions. This change updated
integration testing infrastructure so that is true.

## Additional Context
n/a

## Test Steps
pytest tests/integration_tests/

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
