### PR TITLE
DataSourceOpenNebula: exclude SRANDOM from context output

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -350,7 +350,8 @@ def parse_shell_config(content, keylist=None, bash=None, asuser=None,
     # exclude vars in bash that change on their own or that we used
     excluded = (
         "EPOCHREALTIME", "EPOCHSECONDS", "RANDOM", "LINENO", "SECONDS", "_",
-        "__v")
+        "SRANDOM", "__v",
+    )
     preset = {}
     ret = {}
     target = None


### PR DESCRIPTION
## Proposed Commit Message
> DataSourceOpenNebula: exclude SRANDOM from context output
>
> This is a new builtin variable that appeared in Ubuntu in
> 5.1~rc2-1ubuntu1 and started causing daily build failures.

## Additional Context
Build failure: https://launchpadlibrarian.net/506884236/buildlog_ubuntu-hirsute-amd64.cloud-init_20.3-2645-g38ba6b30-0ubuntu1+1861~trunk~ubuntu21.04.1_BUILDING.txt.gz

## Test Steps

Tested a build with this commit locally (after confirming the failure reproduced in such a build from master):

```
+------------------------------------------------------------------------------+
| Summary                                                                      |
+------------------------------------------------------------------------------+

Build Architecture: amd64
Build Type: binary
Build-Space: 17236
Build-Time: 38
Distribution: hirsute
Host Architecture: amd64
Install-Time: 62
Job: cloud-init_20.3-84-g26734134-1~bddeb~21.04.1.dsc
Lintian: warn
Machine Architecture: amd64
Package: cloud-init
Package-Time: 105
Source-Version: 20.3-84-g26734134-1~bddeb~21.04.1
Space: 17236
Status: successful
Version: 20.3-84-g26734134-1~bddeb~21.04.1
--------------------------------------------------------------------------------
Finished at 2020-11-13T21:50:41Z
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly