### PR TITLE
Pin pycloudlib to a working commit

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@e6b2b3732a2a17d48bdf1167f56eb14576215d3c
 pytest


### PR DESCRIPTION
## Proposed Commit Message
Pin pycloudlib to a working commit

## Additional Context
Pycloudlib is currently causing integration tests to fail. Until we get proper pycloudlib versioning, I think we should pin commits so that a change in pycloudlib doesn't break tests.

## Test Steps
n/a

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
