### PR TITLE
Make mount in place for tests work

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod
 import logging
 
 from pycloudlib import EC2, GCE, Azure, OCI, LXD
-import pycloudlib
 
 import cloudinit
 from cloudinit.subp import subp

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -155,10 +155,18 @@ class LxdContainerCloud(IntegrationCloud):
         return pycloudlib_instance
 
     def _mount_source(self, instance):
+        container_path = '/usr/lib/python3/dist-packages/cloudinit'
+        format_variables = {
+            'name': instance.name,
+            'cloudinit_path': cloudinit.__path__[0],
+            'container_path': container_path,
+        }
+        log.info(
+            'Mounting source {cloudinit_path} directly onto LXD container/vm '
+            'named {name} at {container_path}'.format(**format_variables))
         command = (
             'lxc config device add {name} host-cloud-init disk '
             'source={cloudinit_path} '
-            'path=/usr/lib/python3/dist-packages/cloudinit'
-        ).format(
-            name=instance.name, cloudinit_path=cloudinit.__path__[0])
+            'path={container_path}'
+        ).format(**format_variables)
         subp(command.split())

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -80,7 +80,7 @@ def setup_image(session_cloud):
         if session_cloud.datasource != 'lxd_container':
             raise ValueError(
                 'IN_PLACE as CLOUD_INIT_SOURCE only works for LXD')
-        # The mount needs to happen after the instance is launched, so
+        # The mount needs to happen after the instance is created, so
         # no further action needed here
     elif integration_settings.CLOUD_INIT_SOURCE == 'PROPOSED':
         client = session_cloud.launch()

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -5,8 +5,6 @@ from tempfile import NamedTemporaryFile
 
 from pycloudlib.instance import BaseInstance
 
-import cloudinit
-from cloudinit.subp import subp
 from tests.integration_tests import integration_settings
 
 try:
@@ -140,18 +138,3 @@ class IntegrationOciInstance(IntegrationInstance):
 
 class IntegrationLxdContainerInstance(IntegrationInstance):
     use_sudo = False
-
-    def __init__(self, cloud: 'IntegrationCloud', instance: BaseInstance,
-                 settings=integration_settings):
-        super().__init__(cloud, instance, settings)
-        if self.settings.CLOUD_INIT_SOURCE == 'IN_PLACE':
-            self._mount_source()
-
-    def _mount_source(self):
-        command = (
-            'lxc config device add {name} host-cloud-init disk '
-            'source={cloudinit_path} '
-            'path=/usr/lib/python3/dist-packages/cloudinit'
-        ).format(
-            name=self.instance.name, cloudinit_path=cloudinit.__path__[0])
-        subp(command.split())


### PR DESCRIPTION
## Proposed Commit Message
Make mount in place for tests work

IMAGE_SOURCE = 'IN_PLACE' wasn't working previously. Replaced
LXD launch with an init, then mount, then start.

## Additional Context
n/a

## Test Steps
At the beginning of the `main_init` function of `cloudinit/main.py`, raise an Exception. Save but do not commit. 

Run:
CLOUD_INIT_CLOUD_INIT_SOURCE=NONE pytest tests/integration_tests/modules/test_runcmd.py
Verify that test passes

Run:
CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE pytest tests/integration_tests/modules/test_runcmd.py
Verify that test fails

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
