### PR TITLE
add --no-tty option to gpg

### DIFF
--- a/cloudinit/gpg.py
+++ b/cloudinit/gpg.py
@@ -42,7 +42,7 @@ def recv_key(key, keyserver, retries=(1, 1)):
     @param retries: an iterable of sleep lengths for retries.
                     Use None to indicate no retries."""
     LOG.debug("Importing key '%s' from keyserver '%s'", key, keyserver)
-    cmd = ["gpg", "--keyserver=%s" % keyserver, "--recv-keys", key]
+    cmd = ["gpg", "--no-tty", "--keyserver=%s" % keyserver, "--recv-keys", key]
     if retries is None:
         retries = []
     trynum = 0

--- a/cloudinit/tests/test_gpg.py
+++ b/cloudinit/tests/test_gpg.py
@@ -49,6 +49,7 @@ class TestReceiveKeys(CiTestCase):
         m_subp.return_value = ('', '')
         gpg.recv_key(key, keyserver, retries=retries)
         m_subp.assert_called_once_with(
-            ['gpg', '--no-tty', '--keyserver=%s' % keyserver, '--recv-keys', key],
+            ['gpg', '--no-tty',
+             '--keyserver=%s' % keyserver, '--recv-keys', key],
             capture=True)
         m_sleep.assert_not_called()

--- a/cloudinit/tests/test_gpg.py
+++ b/cloudinit/tests/test_gpg.py
@@ -49,6 +49,6 @@ class TestReceiveKeys(CiTestCase):
         m_subp.return_value = ('', '')
         gpg.recv_key(key, keyserver, retries=retries)
         m_subp.assert_called_once_with(
-            ['gpg', '--keyserver=%s' % keyserver, '--recv-keys', key],
+            ['gpg', '--no-tty', '--keyserver=%s' % keyserver, '--recv-keys', key],
             capture=True)
         m_sleep.assert_not_called()

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -28,3 +28,4 @@ TheRealFalcon
 tomponline
 tsanghan
 WebSpider
+riedel

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -21,6 +21,7 @@ matthewruffell
 nishigori
 omBratteng
 onitake
+riedel
 slyon
 smoser
 sshedi
@@ -28,4 +29,3 @@ TheRealFalcon
 tomponline
 tsanghan
 WebSpider
-riedel


### PR DESCRIPTION
## Proposed Commit Message
Make sure the gpg works even if VM provides no /dev/tty (e.g. debian cloud init)

LP:#1813396

## Additional Context
fixes https://bugs.launchpad.net/cloud-init/+bug/1813396

## Test Steps
on a VM without a terminal mounted as /dev/tty define an external keyserver such used for docker

```
apt:
  sources:
   docker:
     source: 'deb [arch=amd64] https://download.docker.com/linux/debian stretch stable'
     keyserver: keyserver.ubuntu.com
     keyid: 0EBFCD88
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
