### PR TITLE
DataSourceAzure: update password for the default user if the user exists

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1391,7 +1391,7 @@ def read_azure_ovf(contents):
     if password:
         defuser['lock_passwd'] = False
         if DEF_PASSWD_REDACTION != password:
-            defuser['passwd'] = encrypt_pass(password)
+            defuser['passwd'] = cfg['password'] = encrypt_pass(password)
 
     if defuser:
         cfg['system_info'] = {'default_user': defuser}

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -1080,6 +1080,9 @@ scbus-1 on xpt0 bus 0
                          crypt.crypt(odata['UserPassword'],
                                      defuser['passwd'][0:pos]))
 
+        # the same hashed value should also be present in cfg['password']
+        self.assertEqual(defuser['passwd'], dsrc.cfg['password'])
+
     def test_user_not_locked_if_password_redacted(self):
         odata = {'HostName': "myhost", 'UserName': "myuser",
                  'UserPassword': dsaz.DEF_PASSWD_REDACTION}


### PR DESCRIPTION
## Proposed Commit Message
DataSourceAzure: update password for the default user if the user exists

cc_set_password will only update the password for the default user if
cfg['password'] is set. The existing code of datasource Azure will fail 
to update the default user's password because it does not set that 
metadata. If the default user doesn't exist in the image, the current 
code works fine because the password is set during user create and 
not in cc_set_password

## Additional Context

## Test Steps
+ Deploy the latest bionic image on Azure with password
+ Prepare an image but do not delete the user (waagent -deprovision)
+ Deploy a new VM from the prepared image with a new password
+ Observe that the password is not set appropriately (and that the
   previous password continued to work)
+ Apply this patch and go through the steps again and verify
   that new password is set.
## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
