### PR TITLE
test_persistence: add VersionIsPoppedFromState test

### DIFF
--- a/cloudinit/tests/test_persistence.py
+++ b/cloudinit/tests/test_persistence.py
@@ -99,6 +99,16 @@ class VersionDefaultsToZero(CloudInitPickleMixin, metaclass=_Collector):
         assert 0 == ci_pkl_version
 
 
+class VersionIsPoppedFromState(CloudInitPickleMixin, metaclass=_Collector):
+    """Test _ci_pkl_version is popped from state before being restored."""
+
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        # `self._ci_pkl_version` returns the type's _ci_pkl_version if it isn't
+        # in instance state, so we need to explicitly check self.__dict__.
+        sentinel = mock.sentinel.default
+        assert self.__dict__.get("_ci_pkl_version", sentinel) == sentinel
+
+
 class TestPickleMixin:
     def test_unpickle_called(self):
         """Test that self._unpickle is called on unpickle."""


### PR DESCRIPTION
## Proposed Commit Message
> test_persistence: add VersionIsPoppedFromState test

## Additional Context

Filling the gap pointed out by @blackboxsw: https://github.com/canonical/cloud-init/pull/659#discussion_r525529152 (Thanks Chad!)

## Test Steps

Unit testing change only; Travis is sufficient.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
