### PR TITLE
test_persistence: simplify VersionIsPoppedFromState

### DIFF
--- a/cloudinit/tests/test_persistence.py
+++ b/cloudinit/tests/test_persistence.py
@@ -105,8 +105,7 @@ class VersionIsPoppedFromState(CloudInitPickleMixin, metaclass=_Collector):
     def _unpickle(self, ci_pkl_version: int) -> None:
         # `self._ci_pkl_version` returns the type's _ci_pkl_version if it isn't
         # in instance state, so we need to explicitly check self.__dict__.
-        sentinel = mock.sentinel.default
-        assert self.__dict__.get("_ci_pkl_version", sentinel) == sentinel
+        assert "_ci_pkl_version" not in self.__dict__
 
 
 class TestPickleMixin:


### PR DESCRIPTION
## Proposed Commit Message
> test_persistence: simplify VersionIsPoppedFromState

## Additional Context

This was still up on my screen from yesterday, and I noticed this simplification.

## Test Steps

Travis is sufficient.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly