### PR TITLE
Collect logs from integration test runs

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -47,14 +47,14 @@ class IntegrationInstance:
     def pull_file(self, remote_path, local_path):
         # First copy to a temporary directory because of permissions issues
         tmp_path = _get_tmp_path()
-        self.instance.execute('cp {} {}'.format(remote_path, tmp_path))
-        self.instance.pull_file(tmp_path, local_path)
+        self.instance.execute('cp {} {}'.format(str(remote_path), tmp_path))
+        self.instance.pull_file(tmp_path, str(local_path))
 
     def push_file(self, local_path, remote_path):
         # First push to a temporary directory because of permissions issues
         tmp_path = _get_tmp_path()
-        self.instance.push_file(local_path, tmp_path)
-        self.execute('mv {} {}'.format(tmp_path, remote_path))
+        self.instance.push_file(str(local_path), tmp_path)
+        self.execute('mv {} {}'.format(tmp_path, str(remote_path)))
 
     def read_from_file(self, remote_path) -> str:
         result = self.execute('cat {}'.format(remote_path))

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -56,9 +56,13 @@ EXISTING_INSTANCE_ID = None
 CLOUD_INIT_SOURCE = 'NONE'
 
 # Before an instance is torn down, we run `cloud-init collect-logs`
-# and transfer them locally. These settings specify whether to collect these
-# logs at all, and if so, where do we put them on the local filesystem
-COLLECT_LOGS = True
+# and transfer them locally. These settings specify when to collect these
+# logs and where to put them on the local filesystem
+# One of:
+#   'ALWAYS'
+#   'ON_ERROR'
+#   'NEVER'
+COLLECT_LOGS = 'ON_ERROR'
 LOCAL_LOG_PATH = '/tmp/cloud_init_test_logs'
 
 ##################################################################

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -55,6 +55,12 @@ EXISTING_INSTANCE_ID = None
 #   A path to a valid package to be uploaded and installed
 CLOUD_INIT_SOURCE = 'NONE'
 
+# Before an instance is torn down, we run `cloud-init collect-logs`
+# and transfer them locally. These settings specify whether to collect these
+# logs at all, and if so, where do we put them on the local filesystem
+COLLECT_LOGS = True
+LOCAL_LOG_PATH = '/tmp/cloud_init_test_logs'
+
 ##################################################################
 # GCE SPECIFIC SETTINGS
 ##################################################################


### PR DESCRIPTION
## Proposed Commit Message
Collect logs from integration test runs

During teardown of every cloud instance, run 'cloud-init collect-logs',
then transfer and unpack locally. Two new integration settings have
been added to specify when to perform this action (ALWAYS, 
ON_ERROR, NEVER), and where to store these logs.

## Additional Context
Note that it runs once per client, so if you're using the class client, you'll get one set of the logs for the entire class. Currently logs take about 5M of space locally. The entire tree of files created after a single test run can be seen here: https://paste.ubuntu.com/p/v4rF9m9tPF/ . It includes a couple `test_example` runs that don't exist in the repo because I was testing parameterized tests.

## Test Steps
Without overriding `COLLECT_LOGS` or `LOCAL_LOG_PATH` in the integration test settings, run:
`pytest -s tests/integration_tests`
A timestamped directory should get created at `/tmp/cloud_init_test_logs` containing all of the logging information collected from each test instance run during tests.


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
