### PR TITLE
Run cmds in write_files test as sudo

### DIFF
--- a/tests/integration_tests/modules/test_write_files.py
+++ b/tests/integration_tests/modules/test_write_files.py
@@ -50,15 +50,16 @@ class TestWriteFiles:
 
     @pytest.mark.parametrize(
         "cmd,expected_out", (
-            ("file /root/file_b64", ASCII_TEXT),
-            ("md5sum </root/file_binary", "3801184b97bb8c6e63fa0e1eae2920d7"),
-            ("sha256sum </root/file_binary", (
+            ("sudo file /root/file_b64", ASCII_TEXT),
+            ("sudo sh -c 'md5sum </root/file_binary'",
+             "3801184b97bb8c6e63fa0e1eae2920d7"),
+            ("sudo sh -c 'sha256sum </root/file_binary'", (
                 "2c791c4037ea5bd7e928d6a87380f8ba"
                 "7a803cd83d5e4f269e28f5090f0f2c9a"
             )),
-            ("file /root/file_gzip",
+            ("sudo file /root/file_gzip",
              "POSIX shell script, ASCII text executable"),
-            ("file /root/file_text", ASCII_TEXT),
+            ("sudo file /root/file_text", ASCII_TEXT),
         )
     )
     def test_write_files(self, cmd, expected_out, class_client):


### PR DESCRIPTION
We are updating how pycloudlib run the `exec cmds`. By default, LXD is running all of the commands as root. We are changing that behavior. However, this will impact the `test_write_files`  test, which is being updated in this PR.