### PR TITLE
tox.ini: only select "ci" marked tests for CI runs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -151,7 +151,7 @@ commands = {[testenv:integration-tests]commands}
 passenv = {[testenv:integration-tests]passenv}
 deps = {[testenv:integration-tests]deps}
 setenv =
-    PYTEST_ADDOPTS="-k ci"
+    PYTEST_ADDOPTS="-m ci"
 
 [pytest]
 # TODO: s/--strict/--strict-markers/ once xenial support is dropped


### PR DESCRIPTION
## Proposed Commit Message
```
tox.ini: only select "ci" marked tests for CI runs

`-k` will select tests or marks whose names match.  `-m` selects only
tests which have the specified mark, so is more appropriate.
```

## Additional Context

This currently makes no difference: the only test selected based on this substring is already marked with `ci`, but this will save pain in the future.

## Test Steps

The Travis run should succeed and indicate that a subset of integration tests were selected.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly