### PR TITLE
LXD VM support in integration tests

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@e6b2b3732a2a17d48bdf1167f56eb14576215d3c
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@9211c0e5b34794595565d4626bc41ddbe14994f2
 pytest

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -144,8 +144,11 @@ class OciCloud(IntegrationCloud):
         )
 
 
-class _LxdIntegrationCloud(IntegrationCloud, ABC):
+class _LxdIntegrationCloud(IntegrationCloud):
     integration_instance_cls = IntegrationLxdInstance
+
+    def _get_cloud_instance(self):
+        return self.pycloudlib_instance_cls(tag=self.instance_tag)
 
     @staticmethod
     def _get_or_set_profile_list(release):
@@ -194,13 +197,14 @@ class _LxdIntegrationCloud(IntegrationCloud, ABC):
 
 class LxdContainerCloud(_LxdIntegrationCloud):
     datasource = 'lxd_container'
-
-    def _get_cloud_instance(self):
-        return LXDContainer(tag='lxd-container-integration-test')
+    pycloudlib_instance_cls = LXDContainer
+    instance_tag = 'lxd-container-integration-test'
 
 
 class LxdVmCloud(_LxdIntegrationCloud):
     datasource = 'lxd_vm'
+    pycloudlib_instance_cls = LXDVirtualMachine
+    instance_tag = 'lxd-vm-integration-test'
     _profile_list = None
 
     def _get_or_set_profile_list(self, release):
@@ -209,6 +213,3 @@ class LxdVmCloud(_LxdIntegrationCloud):
         self._profile_list = self.cloud_instance.build_necessary_profiles(
             release)
         return self._profile_list
-
-    def _get_cloud_instance(self):
-        return LXDVirtualMachine(tag='lxd-vm-integration-test')

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -12,6 +12,7 @@ from tests.integration_tests.clouds import (
     AzureCloud,
     OciCloud,
     LxdContainerCloud,
+    LxdVmCloud,
 )
 
 
@@ -25,6 +26,7 @@ platforms = {
     'azure': AzureCloud,
     'oci': OciCloud,
     'lxd_container': LxdContainerCloud,
+    'lxd_vm': LxdVmCloud,
 }
 
 
@@ -78,7 +80,7 @@ def setup_image(session_cloud):
     if integration_settings.CLOUD_INIT_SOURCE == 'NONE':
         pass  # that was easy
     elif integration_settings.CLOUD_INIT_SOURCE == 'IN_PLACE':
-        if session_cloud.datasource != 'lxd_container':
+        if session_cloud.datasource not in ['lxd_container', 'lxd_vm']:
             raise ValueError(
                 'IN_PLACE as CLOUD_INIT_SOURCE only works for LXD')
         # The mount needs to happen after the instance is created, so

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -125,5 +125,5 @@ class IntegrationOciInstance(IntegrationInstance):
     pass
 
 
-class IntegrationLxdContainerInstance(IntegrationInstance):
+class IntegrationLxdInstance(IntegrationInstance):
     use_sudo = False

--- a/tox.ini
+++ b/tox.ini
@@ -167,6 +167,7 @@ markers =
     azure: test will only run on Azure platform
     oci: test will only run on OCI platform
     lxd_container: test will only run in LXD container
+    lxd_vm: test will only run in LXD VM
     user_data: the user data to be passed to the test instance
     instance_name: the name to be used for the test instance
     sru_2020_11: test is part of the 2020/11 SRU verification


### PR DESCRIPTION
## Proposed Commit Message
LXD VM support in integration tests

## Additional Context
n/a

## Test Steps
In integration settings, set `PLATFORM = 'lxd_vm`. Run
pytest -s tests/integration_tests
and notice tests run in LXD VMs rather than LXD containers.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
