### PR TITLE
add integration test for LP: #1900837

### DIFF
--- a/tests/integration_tests/bugs/test_lp1900837.py
+++ b/tests/integration_tests/bugs/test_lp1900837.py
@@ -1,0 +1,28 @@
+"""Integration test for LP: #1900836.
+
+This test mirrors the reproducing steps from the reported bug: it changes the
+permissions on cloud-init.log to 600 and confirms that they remain 600 after a
+reboot.
+"""
+import pytest
+
+
+def _get_log_perms(client):
+    return client.execute("stat -c %a /var/log/cloud-init.log")
+
+
+@pytest.mark.sru_2020_11
+class TestLogPermissionsNotResetOnReboot:
+    def test_permissions_unchanged(self, client):
+        # Confirm that the current permissions aren't 600
+        assert "644" == _get_log_perms(client)
+
+        # Set permissions to 600 and confirm our assertion passes pre-reboot
+        client.execute("chmod 600 /var/log/cloud-init.log")
+        assert "600" == _get_log_perms(client)
+
+        # Reboot
+        client.instance.restart()
+
+        # Check that permissions are not reset on reboot
+        assert "600" == _get_log_perms(client)

--- a/tox.ini
+++ b/tox.ini
@@ -169,3 +169,4 @@ markers =
     lxd_container: test will only run in LXD container
     user_data: the user data to be passed to the test instance
     instance_name: the name to be used for the test instance
+    sru_2020_11: test is part of the 2020/11 SRU verification


### PR DESCRIPTION
## Proposed Commit Message
```
add integration test for LP: #1900837

As the first test of this SRU cycle, this also introduces the
sru_2020_11 mark to allow us to easily identify the set of tests
generated for this SRU.
```

## Test Steps

I ran this test against every current Ubuntu release:

```sh
for release in xenial bionic focal groovy hirsute; do CLOUD_INIT_OS_IMAGE=$release pytest --log-cli-level=INFO tests/integration_tests/bugs/test_lp1900837.py; done
```

and it failed with:

```
FAILED tests/integration_tests/bugs/test_lp1900837.py::TestLp1900836::test_lp1900836 - AssertionError: assert '600' == '644'
```

in each case, as expected.

I then ran this test against every current Ubuntu release with cloud-init installed from the daily PPA (which includes the fix this is testing) and they all passed.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly