### PR TITLE
Delete image snapshots created for integration tests

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -64,7 +64,10 @@ def session_cloud():
     cloud = platforms[integration_settings.PLATFORM]()
     cloud.emit_settings_to_log()
     yield cloud
-    cloud.destroy()
+    try:
+        cloud.delete_snapshot()
+    finally:
+        cloud.destroy()
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -65,9 +65,9 @@ class IntegrationInstance:
         version = self.execute('cloud-init -v').split()[-1]
         log.info('Installed cloud-init version: %s', version)
         self.instance.clean()
-        image_id = self.snapshot()
-        log.info('Created new image: %s', image_id)
-        self.cloud.image_id = image_id
+        snapshot_id = self.snapshot()
+        log.info('Created new image: %s', snapshot_id)
+        self.cloud.snapshot_id = snapshot_id
 
     def install_proposed_image(self):
         log.info('Installing proposed image')


### PR DESCRIPTION
## Proposed Commit Message
Delete image snapshots created for integration tests

## Additional Context
For integration testing, any time we use a PPA, proposed, or deb image as our cloud init source, we create a snapshot of setup instance to be the image source for the test run. I originally left deleting that snapshot image as a todo since we weren't using those methods much. With the upcoming SRU we'll be using them a ton, so I figured it was finally time to add it.

## Test Steps
Run cloud-init integration tests with CLOUD_INIT_SOURCE = 'PROPOSED'. When the tests are done running, list the custom images for the particular cloud in use (e.g., `lxc image list` for lxd) and verify no snapshot image exists for that particular test run.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
