### PR TITLE
.travis.yml: correctly integration test the built .deb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -199,7 +199,7 @@ matrix:
                 fi
             # Use sudo to get a new shell where we're in the sbuild group
             - sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc'
-            - sg lxd -c 'CLOUD_INIT_IMAGE_SOURCE="$(ls *.deb)" tox -e integration-tests-ci' &
+            - sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci' &
             - |
               SECONDS=0
               while [ -e /proc/$! ]; do


### PR DESCRIPTION
## Proposed Commit Message
> .travis.yml: correctly integration test the built .deb
>
> `IMAGE_SOURCE` was renamed to `CLOUD_INIT_SOURCE` before the testing
> framework ever landed, but I did not mirror that change in .travis.yml
> before it landed.  This addresses that.

## Test Steps

Travis output should be inspected to confirm the built `.deb` is being used, something like:

```dosini
CLOUD_INIT_SOURCE=cloud-init_20.3-103-gb07ec7d3-1~bddeb~16.04.1_all.deb
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
