### PR TITLE
tox: avoid tox testenv subsvars for xenial support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -139,6 +139,12 @@ passenv = HOME TRAVIS
 deps =
     -r{toxinidir}/cloud-tests-requirements.txt
 
+# Until Xenial tox support is dropped or bumps to tox:2.3.2, reflect changes to
+# deps into testenv:integration-tests-ci: commands, passenv and deps.
+# This is due to (https://github.com/tox-dev/tox/issues/208) which means that
+# the {posargs} handling and substitutions won't do what we want until tox 2.3.2
+# Once Xenial is dropped, integration-tests-ci can use proper substitution
+# commands = {[testenv:integration-tests]commands}
 [testenv:integration-tests]
 basepython = python3
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
@@ -147,9 +153,10 @@ deps =
     -r{toxinidir}/integration-requirements.txt
 
 [testenv:integration-tests-ci]
-commands = {[testenv:integration-tests]commands}
-passenv = {[testenv:integration-tests]passenv}
-deps = {[testenv:integration-tests]deps}
+commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
+passenv = CLOUD_INIT_*
+deps =
+    -r{toxinidir}/integration-requirements.txt
 setenv =
     PYTEST_ADDOPTS="-m ci"
 


### PR DESCRIPTION
## Proposed Commit Message
> Commit cd752df added substvars in tip which causes tracesbacks
>  on Xenial because tox 2.3.1 still suffers from
>    https://github.com/tox-dev/tox/issues/208.
>
> As a result we cannot use testenv substvars if we want to support
> running tox on xenial systems.
> 
> Drop the {[testenv:integration-tests]*} substitutions to avoid
> tracebacks when running `tox -e xenial-dev` which has the signature:
>
>   "No support for the %s substitution type" % sub_type)
>    tox.ConfigError: ConfigError: No support for the posargs
>     substitution type

## Additional Context
None


### Test Steps
```
cat > doit.sh <<EOF
git clone https://github.com/canonical/cloud-init
apt-get update
apt-get install tox -y
cd cloud-init
tox -e xenial-dev
EOF
lxc launch ubuntu-dialy:xenial test-x
lxc file push doit.sh test-x/
lxc exec test-x -- bash  /doit.sh


# note exception
```
Apply this patch. 
re-run tox -e xenial-dev

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly  **N/A** 
 - [ ] I have updated or added any documentation accordingly  **N/A**
