### PR TITLE
Adding BOOTPROTO = dhcp to render sysconfig dhcp6 stateful on RHEL

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -396,6 +396,12 @@ class Renderer(renderer.Renderer):
                         # Only IPv6 is DHCP, IPv4 may be static
                         iface_cfg['BOOTPROTO'] = 'dhcp6'
                     iface_cfg['DHCLIENT6_MODE'] = 'managed'
+                # only if rhel AND dhcpv6 stateful
+                elif (flavor == 'rhel' and
+                        subnet_type == 'ipv6_dhcpv6-stateful'):
+                    iface_cfg['BOOTPROTO'] = 'dhcp'
+                    iface_cfg['DHCPV6C'] = True
+                    iface_cfg['IPV6INIT'] = True
                 else:
                     iface_cfg['IPV6INIT'] = True
                     # Configure network settings using DHCPv6

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1365,7 +1365,7 @@ NETWORK_CONFIGS = {
         },
         'expected_sysconfig_rhel': {
             'ifcfg-iface0': textwrap.dedent("""\
-            BOOTPROTO=none
+            BOOTPROTO=dhcp
             DEVICE=iface0
             DHCPV6C=yes
             IPV6INIT=yes


### PR DESCRIPTION
## Proposed Commit Message
Adding BOOTPROTO = dhcp to render sysconfig dhcp6 stateful on RHEL

BOOTPROTO needs to be set to 'dhcp' on RHEL so NetworkManager can
properly acquire ipv6 address.

rhbz: #1859695

Signed-off-by: Eduardo Otubo <otubo@redhat.com>

## Additional Context
The original [bz 1859695](https://bugzilla.redhat.com/show_bug.cgi?id=1859695) is mostly marked as private but the bug as noticed while configuring an internal IPv6 network on Openstack between the instance and an NFS storage. No patch required or bug noticed if the instance was configured with a regular ipv6/dhcp interface.

## Test Steps
(as described on the above mentioned BZ)
Steps to Reproduce:
1. Create StorageNFS network with IPv6 CIDR and address range defined
2. Create a Nova instance with 2 NICs, 2nd NIC connected to StorageNFS network
3. Login to VM and examin Eth1 IP address

Actual results:
The Nova assigned IPv6 address was not assigned to device Eth1


Expected results:
Expected the Nova assigned IP address to be assigned to Eth1 interface

## Checklist:
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
