### PR TITLE
NoCloud: parse empty meta-data in _quick_read_instance_id.

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -249,7 +249,7 @@ def _quick_read_instance_id(dirs=None):
             md = util.load_yaml(data['meta-data'])
             if iid_key in md:
                 return md[iid_key]
-        except ValueError:
+        except (ValueError, TypeError):
             pass
 
     return None


### PR DESCRIPTION
In subiquity & riscv64 images i create empty meta-data file, to ensure that NoCloud datasource is triggered.

However, if there is config-drive in addition to NoCloud, and it is subsequent boot, check_instance_id is attempted.

That bobs out, as md is None, and the "iid_key in md" thus raises TypeError.

Alternative way to fix this would be to test that md is non-empty, i.e.

```
- if iid_key in md:
+ if md and iid_key in md:
```