### PR TITLE
Xiaofengw support cloudinit raw data feature

### DIFF
--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -753,7 +753,7 @@ def load_cloudinit_data(metaPath, userPath):
     cfg = {}
     ud = None
     network = None
-    # How to handle instance-id?
+
     md = load(util.load_file(metaPath).replace("\r", ""))
 
     if 'network' in md:

--- a/cloudinit/sources/helpers/vmware/imc/config.py
+++ b/cloudinit/sources/helpers/vmware/imc/config.py
@@ -27,6 +27,8 @@ class Config(object):
     UTC = 'DATETIME|UTC'
     POST_GC_STATUS = 'MISC|POST-GC-STATUS'
     DEFAULT_RUN_POST_SCRIPT = 'MISC|DEFAULT-RUN-POST-CUST-SCRIPT'
+    CLOUDINIT_META_DATA = 'CLOUDINIT|METADATA'
+    CLOUDINIT_USER_DATA = 'CLOUDINIT|USERDATA'
 
     def __init__(self, configFile):
         self._configFile = configFile
@@ -129,5 +131,15 @@ class Config(object):
         if defaultRunPostScript not in ('yes', 'no'):
             raise ValueError('defaultRunPostScript value should be yes/no')
         return defaultRunPostScript == 'yes'
+
+    @property
+    def meta_data_name(self):
+        """Return the name of cloud-init meta data."""
+        return self._configFile.get(Config.CLOUDINIT_META_DATA, None)
+
+    @property
+    def user_data_name(self):
+        """Return the name of cloud-init user data."""
+        return self._configFile.get(Config.CLOUDINIT_USER_DATA, None)
 
 # vi: ts=4 expandtab

--- a/cloudinit/sources/helpers/vmware/imc/guestcust_error.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_error.py
@@ -11,5 +11,6 @@ class GuestCustErrorEnum(object):
 
     GUESTCUST_ERROR_SUCCESS = 0
     GUESTCUST_ERROR_SCRIPT_DISABLED = 6
+    GUESTCUST_ERROR_WRONG_META_FORMAT = 9
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_datasource/test_ovf.py
+++ b/tests/unittests/test_datasource/test_ovf.py
@@ -140,16 +140,29 @@ class TestDatasourceOVF(CiTestCase):
             'DEBUG: No system-product-name found', self.logs.getvalue())
 
     def test_get_data_no_vmware_customization_disabled(self):
-        """When vmware customization is disabled via sys_cfg log a message."""
+        """When cloud-init workflow for vmware is disabled via sys_cfgi and
+        no meta data provided, log a message.
+        """
         paths = Paths({'cloud_dir': self.tdir})
         ds = self.datasource(
             sys_cfg={'disable_vmware_customization': True}, distro={},
             paths=paths)
+        conf_file = self.tmp_path('test-cust', self.tdir)
+        conf_content = dedent("""\
+            [CUSTOM-SCRIPT]
+            SCRIPT-NAME = test-script
+            [MISC]
+            MARKER-ID = 12345345
+            """)
+        util.write_file(conf_file, conf_content)
         retcode = wrap_and_call(
             'cloudinit.sources.DataSourceOVF',
             {'dmi.read_dmi_data': 'vmware',
              'transport_iso9660': NOT_FOUND,
-             'transport_vmware_guestinfo': NOT_FOUND},
+             'transport_vmware_guestinfo': NOT_FOUND,
+             'util.del_dir': True,
+             'search_file': self.tdir,
+             'wait_for_imc_file': conf_file},
             ds.get_data)
         self.assertFalse(retcode, 'Expected False return from ds.get_data')
         self.assertIn(
@@ -352,7 +365,7 @@ class TestDatasourceOVF(CiTestCase):
         """
         paths = Paths({'cloud_dir': self.tdir})
         ds = self.datasource(
-            sys_cfg={'disable_vmware_customization': False}, distro={},
+            sys_cfg={'disable_vmware_customization': True}, distro={},
             paths=paths)
         # Prepare the conf file
         conf_file = self.tmp_path('cust.cfg', self.tdir)
@@ -413,7 +426,7 @@ class TestDatasourceOVF(CiTestCase):
         """
         paths = Paths({'cloud_dir': self.tdir})
         ds = self.datasource(
-            sys_cfg={'disable_vmware_customization': False}, distro={},
+            sys_cfg={'disable_vmware_customization': True}, distro={},
             paths=paths)
         # Prepare the conf file
         conf_file = self.tmp_path('cust.cfg', self.tdir)
@@ -467,7 +480,7 @@ class TestDatasourceOVF(CiTestCase):
         """
         paths = Paths({'cloud_dir': self.tdir})
         ds = self.datasource(
-            sys_cfg={'disable_vmware_customization': False}, distro={},
+            sys_cfg={'disable_vmware_customization': True}, distro={},
             paths=paths)
 
         # Prepare the conf file
@@ -511,7 +524,7 @@ class TestDatasourceOVF(CiTestCase):
         """
         paths = Paths({'cloud_dir': self.tdir})
         ds = self.datasource(
-            sys_cfg={'disable_vmware_customization': False}, distro={},
+            sys_cfg={'disable_vmware_customization': True}, distro={},
             paths=paths)
         # Prepare the conf file
         conf_file = self.tmp_path('cust.cfg', self.tdir)
@@ -615,7 +628,7 @@ class TestDatasourceOVF(CiTestCase):
         """
         paths = Paths({'cloud_dir': self.tdir})
         ds = self.datasource(
-            sys_cfg={'disable_vmware_customization': False}, distro={},
+            sys_cfg={'disable_vmware_customization': True}, distro={},
             paths=paths)
 
         # Prepare the conf file

--- a/tests/unittests/test_vmware_config_file.py
+++ b/tests/unittests/test_vmware_config_file.py
@@ -525,5 +525,21 @@ class TestVmwareNetConfig(CiTestCase):
                    'gateway': '10.20.87.253'}]}],
             nc.generate())
 
+    def test_meta_data(self):
+        cf = ConfigFile("tests/data/vmware/cust-dhcp-2nic.cfg")
+        conf = Config(cf)
+        self.assertIsNone(conf.meta_data_name)
+        cf._insertKey("CLOUDINIT|METADATA", "test-metadata")
+        conf = Config(cf)
+        self.assertEqual("test-metadata", conf.meta_data_name)
+
+    def test_user_data(self):
+        cf = ConfigFile("tests/data/vmware/cust-dhcp-2nic.cfg")
+        conf = Config(cf)
+        self.assertIsNone(conf.user_data_name)
+        cf._insertKey("CLOUDINIT|USERDATA", "test-userdata")
+        conf = Config(cf)
+        self.assertEqual("test-userdata", conf.user_data_name)
+
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
VMware product will allow user to specify their cloud-init meta data and user data to customize the VM.

 ## summary: 
This feature will modify VMware datasource to read from meta data and user data which are specified by VMware vSphere user. If meta data/user data are found in cloud-init configuration directory, datasource will parse the meta data/network and user data from the configuration file, otherwise it will continue to parse  them from traditional customization configuration file as before. The supported meta data file is in json or yaml format. 

## Test Steps
Unit tests are added to test_ovf.py and ensure get_data() works as expected.
For the end to end test, user need to deploy latest version of VMware vSphere and customize the VM with cloud-init raw meta data and user data. It will be covered by our integration test.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
