### PR TITLE
integration_tests: introduce skipping of tests by OS

### DIFF
--- a/doc/rtd/topics/integration_tests.rst
+++ b/doc/rtd/topics/integration_tests.rst
@@ -14,6 +14,36 @@ laid out in :ref:`unit_testing` should be followed for integration tests.
 Setup is accomplished via a set of fixtures located in
 ``tests/integration_tests/conftest.py``.
 
+Image Selection
+===============
+
+Each integration testing run uses a single image as its basis.  This
+image is configured using the ``OS_IMAGE`` variable; see
+:ref:`Configuration` for details of how configuration works.
+
+``OS_IMAGE`` can take two types of value: an Ubuntu series name (e.g.
+"focal"), or an image specification.  If an Ubuntu series name is
+given, then the most recent image for that series on the target cloud
+will be used.  For other use cases, an image specification is used.
+
+In its simplest form, an image specification can simply be a cloud's
+image ID (e.g. "ami-deadbeef", "ubuntu:focal").  In this case, the
+image so-identified will be used as the basis for this testing run.
+
+This has a drawback, however: as we do not know what OS or release is
+within the image, the integration testing framework will run *all*
+tests against the image in question.  If it's a RHEL8 image, then we
+would expect Ubuntu-specific tests to fail (and vice versa).
+
+To address this, a full image specification can be given.  This is of
+the form: ``<image_id>[::<os>[::<release]]`` where ``image_id`` is a
+cloud's image ID, ``os`` is the OS name, and ``release`` is the OS
+release name.  So, for example, Ubuntu 18.04 (Bionic Beaver) on LXD is
+``ubuntu:bionic::ubuntu::bionic`` or RHEL 8 on Amazon is
+``ami-justanexample::rhel::8``.  When a full specification is given,
+only tests which are intended for use on that OS and release will be
+executed.
+
 Image Setup
 ===========
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -10,12 +10,13 @@ from pathlib import Path
 
 from tests.integration_tests import integration_settings
 from tests.integration_tests.clouds import (
+    AzureCloud,
     Ec2Cloud,
     GceCloud,
-    AzureCloud,
-    OciCloud,
+    ImageSpecification,
     LxdContainerCloud,
     LxdVmCloud,
+    OciCloud,
 )
 from tests.integration_tests.instances import IntegrationInstance
 
@@ -32,6 +33,7 @@ platforms = {
     'lxd_container': LxdContainerCloud,
     'lxd_vm': LxdVmCloud,
 }
+os_list = ["ubuntu"]
 
 session_start_time = datetime.datetime.now().strftime('%y%m%d%H%M%S')
 
@@ -59,6 +61,12 @@ def pytest_runtest_setup(item):
             pytest.skip(unsupported_message)
     if supported_platforms and current_platform not in supported_platforms:
         pytest.skip(unsupported_message)
+
+    image = ImageSpecification.from_os_image()
+    current_os = image.os
+    supported_os_set = set(os_list).intersection(test_marks)
+    if current_os and supported_os_set and current_os not in supported_os_set:
+        pytest.skip("Cannot run on OS {}".format(current_os))
 
 
 # disable_subp_usage is defined at a higher level, but we don't

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -22,8 +22,10 @@ PLATFORM = 'lxd_container'
 INSTANCE_TYPE = None
 
 # Determines the base image to use or generate new images from.
-# Can be the name of the OS if running a stock image,
-# otherwise the id of the image being used if using a custom image
+#
+# This can be the name of an Ubuntu release, or in the format
+# <image_id>[::<os>[::<release>]].  If given, os and release should describe
+# the image specified by image_id.
 OS_IMAGE = 'focal'
 
 # Populate if you want to use a pre-launched instance instead of

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -25,7 +25,8 @@ INSTANCE_TYPE = None
 #
 # This can be the name of an Ubuntu release, or in the format
 # <image_id>[::<os>[::<release>]].  If given, os and release should describe
-# the image specified by image_id.
+# the image specified by image_id.  (Ubuntu releases are converted to this
+# format internally; in this case, to "focal::ubuntu::focal".)
 OS_IMAGE = 'focal'
 
 # Populate if you want to use a pre-launched instance instead of

--- a/tests/integration_tests/modules/test_apt_configure_sources_list.py
+++ b/tests/integration_tests/modules/test_apt_configure_sources_list.py
@@ -40,6 +40,7 @@ EXPECTED_REGEXES = [
 
 
 @pytest.mark.ci
+@pytest.mark.ubuntu
 class TestAptConfigureSourcesList:
 
     @pytest.mark.user_data(USER_DATA)

--- a/tests/integration_tests/modules/test_package_update_upgrade_install.py
+++ b/tests/integration_tests/modules/test_package_update_upgrade_install.py
@@ -26,6 +26,7 @@ package_upgrade: true
 """
 
 
+@pytest.mark.ubuntu
 @pytest.mark.user_data(USER_DATA)
 class TestPackageUpdateUpgradeInstall:
 

--- a/tests/integration_tests/modules/test_snap.py
+++ b/tests/integration_tests/modules/test_snap.py
@@ -20,6 +20,7 @@ snap:
 
 
 @pytest.mark.ci
+@pytest.mark.ubuntu
 class TestSnap:
 
     @pytest.mark.user_data(USER_DATA)

--- a/tests/integration_tests/modules/test_ssh_import_id.py
+++ b/tests/integration_tests/modules/test_ssh_import_id.py
@@ -3,6 +3,10 @@
 This test specifies ssh keys to be imported by the ``ssh_import_id`` module
 and then checks that if the ssh keys were successfully imported.
 
+TODO:
+* This test assumes that SSH keys will be imported into the /home/ubuntu; this
+  will need modification to run on other OSes.
+
 (This is ported from
 ``tests/cloud_tests/testcases/modules/ssh_import_id.yaml``.)"""
 
@@ -18,6 +22,7 @@ ssh_import_id:
 
 
 @pytest.mark.ci
+@pytest.mark.ubuntu
 class TestSshImportId:
 
     @pytest.mark.user_data(USER_DATA)

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -2,6 +2,10 @@
 
 This test specifies a number of users and groups via user-data, and confirms
 that they have been configured correctly in the system under test.
+
+TODO:
+* This test assumes that the "ubuntu" user will be created when "default" is
+  specified; this will need modification to run on other OSes.
 """
 import re
 
@@ -41,6 +45,7 @@ AHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
 @pytest.mark.ci
 @pytest.mark.user_data(USER_DATA)
 class TestUsersGroups:
+    @pytest.mark.ubuntu
     @pytest.mark.parametrize(
         "getent_args,regex",
         [

--- a/tox.ini
+++ b/tox.ini
@@ -179,3 +179,4 @@ markers =
     user_data: the user data to be passed to the test instance
     instance_name: the name to be used for the test instance
     sru_2020_11: test is part of the 2020/11 SRU verification
+    ubuntu: this test should run on Ubuntu


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: introduce skipping of tests by OS

This introduces an optional, more complex OS_IMAGE format (`<image
id>::<os>::<release>`) which allows the specification of the OS/OS
release which the given image ID corresponds to.  This information is
used to skip tests which do not apply to the image.
 
This commit is comprised of the following discrete changes:
* introduce the IntegrationImage class, to handle parsing and storing
   the new OS_IMAGE format
* support inferring the OS and OS release of Ubuntu series, so that we
  can continue to set OS_IMAGE to just a series name and have test
  skipping work
* add documentation on Image Selection to integration_tests.rst
* introduce the actual skipping behaviour based on OS marks
* apply the `ubuntu` mark to all tests that should be skipped on
  non-Ubuntu operating systems
```

## Additional Context

See the added "Image Selection" doc section for an overview.

## Test Steps

Travis should continue to pass, and it should be observed that tests are skipped on non-Ubuntu releases. This can be seen by using an Ubuntu image but lying about its origin with a full `OS_IMAGE` specification:

```
$ CLOUD_INIT_OS_IMAGE="ubuntu:focal::notubuntu::noreally" pytest --log-cli-level=INFO tests/integration_tests/ -rsXx
...
INFO     integration_testing:clouds.py:74 Detected image: image_id=ubuntu:focal os=notubuntu release=noreally
...
=== short test summary info ===
SKIPPED [12] tests/integration_tests/conftest.py:69: Cannot run on OS notubuntu
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
