### PR TITLE
changelog: drop unredacted LP reference from changelog entry

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -106,7 +106,7 @@ cloud-init (20.4-0ubuntu1~18.04.1) bionic; urgency=medium
     - conftest.py: remove top-level import of httpretty (#599)
     - tox.ini: add integration-tests testenv definition (#595)
     - PULL_REQUEST_TEMPLATE.md: empty checkboxes need a space (#597)
-    - add integration test for LP: #1886531 (#592)
+    - add integration test for #1886531 (#592)
     - Initial implementation of integration testing infrastructure (#581)
       [James Falcon]
     - Fix name of ntp and chrony service on CentOS and RHEL. (#589)


### PR DESCRIPTION
SRU review found a stray LP: # in a commit message that needs to be redacted to avoid triggering inclusion as SRU validation
I filed this against log2dch to ensure we don't hit this when using new-upstream-stapshot during SRUs https://github.com/canonical/uss-tableflip/issues/69