### PR TITLE
integration_tests: introduce IntegrationInstance.restart

### DIFF
--- a/tests/integration_tests/bugs/test_lp1900837.py
+++ b/tests/integration_tests/bugs/test_lp1900837.py
@@ -22,7 +22,7 @@ class TestLogPermissionsNotResetOnReboot:
         assert "600" == _get_log_perms(client)
 
         # Reboot
-        client.instance.restart()
+        client.restart()
 
         # Check that permissions are not reset on reboot
         assert "600" == _get_log_perms(client)

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -35,6 +35,17 @@ class IntegrationInstance:
     def destroy(self):
         self.instance.delete()
 
+    def restart(self):
+        """Restart this instance (via cloud mechanism) and wait for boot.
+
+        This wraps pycloudlib's `BaseInstance.restart` to pass
+        `raise_on_cloudinit_failure=False` to `BaseInstance.wait`, mirroring
+        our launch behaviour.
+        """
+        self.instance.restart(wait=False)
+        log.info("Instance restarted; waiting for boot")
+        self.instance.wait(raise_on_cloudinit_failure=False)
+
     def execute(self, command, *, use_sudo=True) -> Result:
         if self.instance.username == 'root' and use_sudo is False:
             raise Exception('Root user cannot run unprivileged')


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: introduce IntegrationInstance.restart

This wraps pycloudlib's `BaseInstance.restart` and `BaseInstance.wait`
to pass the same parameters as on launch, to avoid cloud-init failures
on the _reboot_ raising an exception.
```

## Test Steps

The one modified test continues to pass (`IN_PLACE` used because it fails against the in-image cloud-init currently):

```
$ CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE pytest --log-cli-level=INFO tests/integration_tests/bugs/test_lp1900837.py
=========================================================== test session starts ============================================================
platform linux -- Python 3.8.6, pytest-6.1.0, py-1.9.0, pluggy-0.13.1
rootdir: /home/daniel/dev/cloud-init, configfile: tox.ini
plugins: xdist-2.1.0, forked-1.3.0, parallel-0.1.0, cov-2.8.1
collected 1 item                                                                                                                           

tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged 
-------------------------------------------------------------- live log setup --------------------------------------------------------------
2020-12-03 17:27:06 INFO Settings:
CLOUD_INIT_SOURCE=IN_PLACE
COLLECT_LOGS=ON_ERROR
EXISTING_INSTANCE_ID=None
GCE_PROJECT=ubuntu-oddbloke
GCE_REGION=us-central1
GCE_ZONE=a
INSTANCE_TYPE=None
KEEP_INSTANCE=False
LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
OCI_COMPARTMENT_ID=None
OS_IMAGE=focal
PLATFORM=lxd_container
2020-12-03 17:27:06 INFO Setting up environment for lxd_container
2020-12-03 17:27:06 INFO Done with environment setup
2020-12-03 17:27:06 INFO Launching instance with launch_kwargs:
image_id=ubuntu:3e9403fe7645000fc49ec89bca056c7fd53e9a142a3a9054ee02c13a2f14b6d0
user_data=None
wait=False
2020-12-03 17:27:11 INFO Mounting source /home/daniel/dev/cloud-init/cloudinit directly onto LXD container/vm named solid-gnat at /usr/lib/python3/dist-packages/cloudinit
2020-12-03 17:27:13 INFO executing: sh -c whoami
2020-12-03 17:27:14 INFO executing: sh -c 'cloud-init status --help'
2020-12-03 17:27:19 INFO executing: cloud-init status --wait --long
2020-12-03 17:27:34 INFO Launched instance: LXDInstance(name=solid-gnat)
-------------------------------------------------------------- live log call ---------------------------------------------------------------
2020-12-03 17:27:34 INFO executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
2020-12-03 17:27:35 INFO executing: sudo -- sh -c 'chmod 600 /var/log/cloud-init.log'
2020-12-03 17:27:35 INFO executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
2020-12-03 17:27:37 INFO Instance restarted; waiting for boot
2020-12-03 17:27:37 INFO executing: sh -c whoami
2020-12-03 17:27:37 INFO executing: sh -c 'cloud-init status --help'
2020-12-03 17:27:38 INFO executing: cloud-init status --wait --long
2020-12-03 17:27:40 INFO executing: sudo -- sh -c 'stat -c %a /var/log/cloud-init.log'
PASSED                                                                                                                               [100%]

============================================================= warnings summary =============================================================
tests/integration_tests/bugs/test_lp1900837.py::TestLogPermissionsNotResetOnReboot::test_permissions_unchanged
  /home/daniel/.virtualenvs/cloud-init/lib/python3.8/site-packages/simplestreams/mirrors/__init__.py:206: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    LOG.warn("got ENOENT for (%s, %s), trying with trailing /",

-- Docs: https://docs.pytest.org/en/stable/warnings.html
====================================================== 1 passed, 1 warning in 45.53s =======================================================
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly