### PR TITLE
Add wait-for-disk functionality to disk_setup (#1832645)

### DIFF
--- a/doc/examples/cloud-config-disk-setup.txt
+++ b/doc/examples/cloud-config-disk-setup.txt
@@ -98,6 +98,7 @@ disk_setup:
 #       table_type: 'mbr'
 #       layout: <LAYOUT|BOOL>
 #       overwrite: <BOOL>
+#       timeout: <INT>
 #
 # Where:
 #   <DEVICE>: The name of the device. 'ephemeralX' and 'swap' are special
@@ -159,6 +160,10 @@ disk_setup:
 #               'true' is cowboy mode. There are no checks and things are
 #                   done blindly. USE with caution, you can do things you
 #                   really, really don't want to do.
+#
+#   timeout=<INT>: Seconds to wait for a disk to appear. If omitted, no wait
+#               is performed. This is useful if a cloud provider has late or
+#               inconsistent disk attachments and you need a delay.
 #
 #
 # fs_setup: Setup the file system


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
Add wait-for-disk functionality to disk_setup

In a cloud environment, sometimes disks will attach while cloud-init is
running and get missed. This adds a configurable timeout to wait for
those disks.

LP: #1832645

> summary: no more than 70 characters
>
> A description of what the change being made is and why it is being
> made, if the summary line is insufficient.  The blank line above is
> required. This should be wrapped at 72 characters, but otherwise has
> no particular length requirements.
>
> If you need to write multiple paragraphs, feel free.
>
> LP: #NNNNNNN (replace with the appropriate bug reference or remove
> this line entirely if there is no associated bug)

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
