### PR TITLE
Add ability to keep snapshotted images in integration tests

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -166,11 +166,16 @@ class IntegrationCloud(ABC):
 
     def delete_snapshot(self):
         if self.snapshot_id:
-            log.info(
-                'Deleting snapshot image created for this testrun: %s',
-                self.snapshot_id
-            )
-            self.cloud_instance.delete_image(self.snapshot_id)
+            if self.settings.KEEP_IMAGE:
+                log.info(
+                    'NOT deleting snapshot image created for this testrun '
+                    'because KEEP_IMAGE is True: %s', self.snapshot_id)
+            else:
+                log.info(
+                    'Deleting snapshot image created for this testrun: %s',
+                    self.snapshot_id
+                )
+                self.cloud_instance.delete_image(self.snapshot_id)
 
 
 class Ec2Cloud(IntegrationCloud):

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -7,6 +7,8 @@ import os
 
 # Keep instance (mostly for debugging) when test is finished
 KEEP_INSTANCE = False
+# Keep snapshot image (mostly for debugging) when test is finished
+KEEP_IMAGE = False
 
 # One of:
 #  lxd_container


### PR DESCRIPTION
## Proposed Commit Message
Add ability to keep snapshotted images in integration tests

For SRU test development, every single time we start a new test run,
we need to first install the PROPOSED version and create an image
snapshot. Instead of automatically deleting a snapshot, add an
integration setting to allow us to keep the snapshot. The end of the
test run will log the image name which can then be used as the
OS_IMAGE in subsequent test runs.

## Test Steps
n/a

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
