### PR TITLE
Integration test for 570

### DIFF
--- a/tests/integration_tests/bugs/test_gh570.py
+++ b/tests/integration_tests/bugs/test_gh570.py
@@ -34,5 +34,5 @@ def test_nocloud_seedfrom_vendordata(client: IntegrationInstance):
         VENDOR_DATA,
     )
     client.execute('cloud-init clean --logs')
-    client.restart()
+    client.restart(raise_on_cloudinit_failure=True)
     assert 'seeded_vendordata_test_file' in client.execute('ls /var/tmp')

--- a/tests/integration_tests/bugs/test_gh570.py
+++ b/tests/integration_tests/bugs/test_gh570.py
@@ -1,0 +1,38 @@
+"""Integration test for #570.
+
+Test that we can add optional vendor-data to the seedfrom file in a
+NoCloud environment
+"""
+
+from tests.integration_tests.instances import IntegrationInstance
+import pytest
+
+VENDOR_DATA = """\
+#cloud-config
+runcmd:
+  - touch /var/tmp/seeded_vendordata_test_file
+"""
+
+
+# Only running on LXD because we need NoCloud for this test
+@pytest.mark.sru_2020_11
+@pytest.mark.lxd_container
+@pytest.mark.lxd_vm
+def test_nocloud_seedfrom_vendordata(client: IntegrationInstance):
+    seed_dir = '/var/tmp/test_seed_dir'
+    result = client.execute(
+        "mkdir {seed_dir} && "
+        "touch {seed_dir}/user-data && "
+        "touch {seed_dir}/meta-data && "
+        "echo 'seedfrom: {seed_dir}/' > "
+        "/var/lib/cloud/seed/nocloud-net/meta-data".format(seed_dir=seed_dir)
+    )
+    assert result.return_code == 0
+
+    client.write_to_file(
+        '{}/vendor-data'.format(seed_dir),
+        VENDOR_DATA,
+    )
+    client.execute('cloud-init clean --logs')
+    client.restart()
+    assert 'seeded_vendordata_test_file' in client.execute('ls /var/tmp')

--- a/tests/integration_tests/bugs/test_lp1900837.py
+++ b/tests/integration_tests/bugs/test_lp1900837.py
@@ -22,7 +22,7 @@ class TestLogPermissionsNotResetOnReboot:
         assert "600" == _get_log_perms(client)
 
         # Reboot
-        client.restart()
+        client.restart(raise_on_cloudinit_failure=True)
 
         # Check that permissions are not reset on reboot
         assert "600" == _get_log_perms(client)

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -35,7 +35,7 @@ class IntegrationInstance:
     def destroy(self):
         self.instance.delete()
 
-    def restart(self):
+    def restart(self, raise_on_cloudinit_failure=False):
         """Restart this instance (via cloud mechanism) and wait for boot.
 
         This wraps pycloudlib's `BaseInstance.restart` to pass
@@ -44,7 +44,9 @@ class IntegrationInstance:
         """
         self.instance.restart(wait=False)
         log.info("Instance restarted; waiting for boot")
-        self.instance.wait(raise_on_cloudinit_failure=False)
+        self.instance.wait(
+            raise_on_cloudinit_failure=raise_on_cloudinit_failure
+        )
 
     def execute(self, command, *, use_sudo=True) -> Result:
         if self.instance.username == 'root' and use_sudo is False:


### PR DESCRIPTION
## Proposed Commit Message
Integration test for #570

Test that we can add optional vendor-data to the seedfrom file in a
NoCloud environment.

Also added the option to pass `raise_on_cloudinit_failure` through
an instance restart so we get automatic failure checking when
we need to manually reboot.

## Additional Context
#570

## Test Steps
should fail:
pytest tests/integration_tests/bugs/test_gh570.py

should pass:
CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED pytest tests/integration_tests/bugs/test_gh570.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
