### PR TITLE
Add support to resize rootfs if using LVM

### DIFF
--- a/doc/examples/cloud-config-growpart.txt
+++ b/doc/examples/cloud-config-growpart.txt
@@ -13,6 +13,8 @@
 #
 # devices:
 #   a list of things to resize.
+#   if the devices are under LVM, the list should be a single entry,
+#   cloud-init will then extend the single entry, otherwise it will fail.
 #   items can be filesystem paths or devices (in /dev)
 #   examples:
 #     devices: [/, /dev/vdb1]

--- a/tests/unittests/test_handler/test_handler_growpart.py
+++ b/tests/unittests/test_handler/test_handler_growpart.py
@@ -172,6 +172,53 @@ class TestResize(unittest.TestCase):
         self.name = "growpart"
         self.log = logging.getLogger("TestResize")
 
+    def test_lvm_resize(self):
+        # LVM resize should work only if a single device is configured. More
+        # than one device should fail.
+        lvm_pass = ["/dev/XXdm-0"]
+        lvm_fail = ["/dev/XXdm-1", "/dev/YYdm-1"]
+        devstat_ret = Bunch(st_mode=25008, st_ino=6078, st_dev=5,
+                            st_nlink=1, st_uid=0, st_gid=6, st_size=0,
+                            st_atime=0, st_mtime=0, st_ctime=0)
+        real_stat = os.stat
+        resize_calls = []
+
+        class myresizer(object):
+            def resize(self, diskdev, partnum, partdev):
+                resize_calls.append((diskdev, partnum, partdev))
+                if partdev == "/dev/XXdm-0":
+                    return (1024, 2048)
+                return (1024, 1024)  # old size, new size
+
+        def mystat(path):
+            if path in lvm_pass or path in lvm_fail:
+                return devstat_ret
+            return real_stat(path)
+
+        try:
+            opinfo = cc_growpart.device_part_info
+            cc_growpart.device_part_info = simple_device_part_info_lvm
+            os.stat = mystat
+
+            resized = cc_growpart.resize_devices(myresizer(), lvm_pass)
+            not_resized = cc_growpart.resize_devices(myresizer(), lvm_fail)
+
+            def find(name, res):
+                for f in res:
+                    if f[0] == name:
+                        return f
+                return None
+
+            self.assertEqual(cc_growpart.RESIZE.CHANGED,
+                             find("/dev/XXdm-0", resized)[1])
+            self.assertEqual(cc_growpart.RESIZE.NOCHANGE,
+                             find("/dev/XXdm-1", not_resized)[1])
+            self.assertEqual(cc_growpart.RESIZE.NOCHANGE,
+                             find("/dev/YYdm-1", not_resized)[1])
+        finally:
+            cc_growpart.device_part_info = opinfo
+            os.stat = real_stat
+
     def test_simple_devices(self):
         # test simple device list
         # this patches out devent2dev, os.stat, and device_part_info
@@ -227,10 +274,19 @@ class TestResize(unittest.TestCase):
             os.stat = real_stat
 
 
+def simple_device_part_info_lvm(devpath):
+    # simple stupid return (/dev/vda, 1) for /dev/vda
+    ret = re.search("([^0-9]*)([0-9]*)$", devpath)
+    is_lvm = True
+    x = (ret.group(1), ret.group(2), is_lvm)
+    return x
+
+
 def simple_device_part_info(devpath):
     # simple stupid return (/dev/vda, 1) for /dev/vda
     ret = re.search("([^0-9]*)([0-9]*)$", devpath)
-    x = (ret.group(1), ret.group(2))
+    is_lvm = False
+    x = (ret.group(1), ret.group(2), is_lvm)
     return x
 
 


### PR DESCRIPTION
## Proposed Commit Message
This patch adds support to resize a single partition of a VM if it's using an
LVM underneath. The patch detects if it's LVM if the given block device
is a device mapper by its name (e.g. `/dev/dm-1`) and if it has slave
devices under it on `sysfs`. After that `syspath` is updated to the real
block device and `growpart` will be called to resize it (and automatically
its Physical Volume).

The Volume Group will be updated automatically and a final call to
extend the `rootfs` to the remaining space available will be made.

Using the same growpart configuration, the user can specify only one
device to be resized when using LVM and growpart, otherwise cloud-init
won't know which one should be resized and will fail.

rhbz: #1810878

Signed-off-by: Eduardo Otubo <otubo@redhat.com>

## Additional Context
The commit also includes changes to the documentation as well as to unit tests to support the changes. The unit test is a copy from the existing test but using `/dev/XXdm-0` variants for LVM tests.

## Test Steps
One can verify the fix by installing cloud-init on an instance using LVM and configure it to expand one single partition, e.g. the `rootfs`.

## Checklist:
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly