### PR TITLE
Add integration test for power_state_change module

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -123,14 +123,13 @@ class IntegrationCloud(ABC):
             return image.image_id
 
     def _perform_launch(self, launch_kwargs):
-        wait = launch_kwargs.pop('wait', True)
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
-        if wait:
-            pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         return pycloudlib_instance
 
-    def launch(self, user_data=None, launch_kwargs=None,
+    def launch(self, user_data=None, launch_kwargs=None, wait=True,
                settings=integration_settings):
+        if launch_kwargs is None:
+            launch_kwargs = {}
         if self.settings.EXISTING_INSTANCE_ID:
             log.info(
                 'Not launching instance due to EXISTING_INSTANCE_ID. '
@@ -139,12 +138,15 @@ class IntegrationCloud(ABC):
                 self.settings.EXISTING_INSTANCE_ID
             )
             return
+        if 'wait' in launch_kwargs:
+            raise Exception("Specify 'wait' directly to launch, "
+                            "not in 'launch_kwargs'")
         kwargs = {
             'image_id': self.image_id,
             'user_data': user_data,
+            'wait': False,
         }
-        if launch_kwargs:
-            kwargs.update(launch_kwargs)
+        kwargs.update(launch_kwargs)
         log.info(
             "Launching instance with launch_kwargs:\n{}".format(
                 "\n".join("{}={}".format(*item) for item in kwargs.items())
@@ -152,7 +154,8 @@ class IntegrationCloud(ABC):
         )
 
         pycloudlib_instance = self._perform_launch(kwargs)
-
+        if wait:
+            pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         log.info('Launched instance: %s', pycloudlib_instance)
         return self.get_instance(pycloudlib_instance, settings)
 
@@ -259,7 +262,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
 
     def _perform_launch(self, launch_kwargs):
         launch_kwargs['inst_type'] = launch_kwargs.pop('instance_type', None)
-        wait = launch_kwargs.pop('wait', True)
+        launch_kwargs.pop('wait')
         release = launch_kwargs.pop('image_id')
 
         try:
@@ -276,8 +279,6 @@ class _LxdIntegrationCloud(IntegrationCloud):
         if self.settings.CLOUD_INIT_SOURCE == 'IN_PLACE':
             self._mount_source(pycloudlib_instance)
         pycloudlib_instance.start(wait=False)
-        if wait:
-            pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         return pycloudlib_instance
 
 

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -123,8 +123,10 @@ class IntegrationCloud(ABC):
             return image.image_id
 
     def _perform_launch(self, launch_kwargs):
+        wait = launch_kwargs.pop('wait', True)
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
-        pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
+        if wait:
+            pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         return pycloudlib_instance
 
     def launch(self, user_data=None, launch_kwargs=None,
@@ -140,7 +142,6 @@ class IntegrationCloud(ABC):
         kwargs = {
             'image_id': self.image_id,
             'user_data': user_data,
-            'wait': False,
         }
         if launch_kwargs:
             kwargs.update(launch_kwargs)
@@ -258,7 +259,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
 
     def _perform_launch(self, launch_kwargs):
         launch_kwargs['inst_type'] = launch_kwargs.pop('instance_type', None)
-        launch_kwargs.pop('wait')
+        wait = launch_kwargs.pop('wait', True)
         release = launch_kwargs.pop('image_id')
 
         try:
@@ -275,7 +276,8 @@ class _LxdIntegrationCloud(IntegrationCloud):
         if self.settings.CLOUD_INIT_SOURCE == 'IN_PLACE':
             self._mount_source(pycloudlib_instance)
         pycloudlib_instance.start(wait=False)
-        pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
+        if wait:
+            pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         return pycloudlib_instance
 
 

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -176,7 +176,7 @@ def _collect_logs(instance: IntegrationInstance, node_id: str,
 
 
 @contextmanager
-def _client(request, fixture_utils, session_cloud):
+def _client(request, fixture_utils, session_cloud: IntegrationCloud):
     """Fixture implementation for the client fixtures.
 
     Launch the dynamic IntegrationClient instance using any provided

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -71,6 +71,8 @@ def pytest_runtest_setup(item):
     supported_os_set = set(os_list).intersection(test_marks)
     if current_os and supported_os_set and current_os not in supported_os_set:
         pytest.skip("Cannot run on OS {}".format(current_os))
+    if 'unstable' in test_marks:
+        pytest.skip('Test marked unstable. Manually remove mark to run it')
 
 
 # disable_subp_usage is defined at a higher level, but we don't

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -71,7 +71,7 @@ def pytest_runtest_setup(item):
     supported_os_set = set(os_list).intersection(test_marks)
     if current_os and supported_os_set and current_os not in supported_os_set:
         pytest.skip("Cannot run on OS {}".format(current_os))
-    if 'unstable' in test_marks:
+    if 'unstable' in test_marks and not integration_settings.RUN_UNSTABLE:
         pytest.skip('Test marked unstable. Manually remove mark to run it')
 
 

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -53,6 +53,14 @@ class IntegrationInstance:
         self.instance = instance
         self.settings = settings
 
+    @property
+    def running(self):
+        # TODO: Implement something better in pycloudlib
+        try:
+            return True if self.execute('true').return_code == 0 else False
+        except Exception:
+            return False
+
     def destroy(self):
         self.instance.delete()
 

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -53,14 +53,6 @@ class IntegrationInstance:
         self.instance = instance
         self.settings = settings
 
-    @property
-    def running(self):
-        # TODO: Implement something better in pycloudlib
-        try:
-            return True if self.execute('true').return_code == 0 else False
-        except Exception:
-            return False
-
     def destroy(self):
         self.instance.delete()
 

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -9,6 +9,8 @@ import os
 KEEP_INSTANCE = False
 # Keep snapshot image (mostly for debugging) when test is finished
 KEEP_IMAGE = False
+# Run tests marked as unstable. Expect failures and dragons.
+RUN_UNSTABLE = False
 
 # One of:
 #  lxd_container

--- a/tests/integration_tests/log_utils.py
+++ b/tests/integration_tests/log_utils.py
@@ -1,4 +1,4 @@
-def ordered_items_in_text(to_verify: list, text: str):
+def ordered_items_in_text(to_verify: list, text: str) -> bool:
     """Return if all items in list appear in order in text.
 
     Examples:

--- a/tests/integration_tests/log_utils.py
+++ b/tests/integration_tests/log_utils.py
@@ -1,0 +1,13 @@
+def ordered_items_in_text(to_verify: list, text: str):
+    """Return if all items in list appear in order in text.
+
+    Examples:
+      ordered_items_in_text(['a', '1'], 'ab1')  # Returns True
+      ordered_items_in_text(['1', 'a'], 'ab1')  # Returns False
+    """
+    index = 0
+    for item in to_verify:
+        index = text[index:].find(item)
+        if index < 0:
+            return False
+    return True

--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -46,8 +46,13 @@ def _can_connect(instance):
     return instance.execute('true').ok
 
 
+# This test is marked unstable because even though it should be able to
+# run anywhere, I can only get it to run in an lxd container, and even then
+# occasionally some timing issues will crop up.
+@pytest.mark.unstable
 @pytest.mark.sru_2020_11
 @pytest.mark.ubuntu
+@pytest.mark.lxd_container
 class TestPowerChange:
     @pytest.mark.parametrize('mode,delay,timeout,expected', [
         ('poweroff', 'now', '10', 'will execute: shutdown -P now msg'),
@@ -74,7 +79,8 @@ class TestPowerChange:
             "running 'init-local'",
             'config-power-state-change already ran',
         ]
-        assert ordered_items_in_text(lines_to_check, log)
+        assert ordered_items_in_text(lines_to_check, log), (
+            'Expected data not in logs')
 
     @pytest.mark.user_data(USER_DATA.format(delay='0', mode='poweroff',
                                             timeout='0', condition='false'))

--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -3,8 +3,9 @@
 Test that the power state config options work as expected.
 """
 
-import pytest
 import time
+
+import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance

--- a/tox.ini
+++ b/tox.ini
@@ -180,3 +180,4 @@ markers =
     instance_name: the name to be used for the test instance
     sru_2020_11: test is part of the 2020/11 SRU verification
     ubuntu: this test should run on Ubuntu
+    unstable: skip this test because it is flakey


### PR DESCRIPTION
## Proposed Commit Message
Add integration test for power_state_change module

## Additional Context
Based on https://github.com/canonical/cloud-init/pull/567 , but not naming the test after it because the changes that affected Ubuntu were only a refactor.

In the test, I've included adding a timeout to the user_data, but I don't know of a way to actually test it because the power state module is the last module to run, so even with a timeout of 1, cloud-init finishes before the timeout is triggered.

## Test Steps
pytest tests/integration_tests/modules/test_power_state_change.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
