### PR TITLE
integration_tests: port lxd_bridge test from cloud_tests

### DIFF
--- a/tests/integration_tests/modules/test_lxd_bridge.py
+++ b/tests/integration_tests/modules/test_lxd_bridge.py
@@ -1,0 +1,46 @@
+"""Integration tests for LXD bridge creation.
+
+(This is ported from
+``tests/cloud_tests/testcases/modules/lxd_bridge.yaml``.)
+"""
+import pytest
+import yaml
+
+
+USER_DATA = """\
+#cloud-config
+lxd:
+  init:
+    storage_backend: dir
+  bridge:
+    mode: new
+    name: lxdbr0
+    ipv4_address: 10.100.100.1
+    ipv4_netmask: 24
+    ipv4_dhcp_first: 10.100.100.100
+    ipv4_dhcp_last: 10.100.100.200
+    ipv4_nat: true
+    domain: lxd
+"""
+
+
+@pytest.mark.user_data(USER_DATA)
+class TestLxdBridge:
+
+    @pytest.mark.parametrize("binary_name", ["lxc", "lxd"])
+    def test_binaries_installed(self, class_client, binary_name):
+        """Check that the expected LXD binaries are installed"""
+        assert class_client.execute(["which", binary_name]).ok
+
+    @pytest.mark.sru_2020_11
+    def test_bridge(self, class_client):
+        """Check that the given bridge is configured"""
+        cloud_init_log = class_client.read_from_file("/var/log/cloud-init.log")
+        assert "WARN" not in cloud_init_log
+
+        # The bridge should exist
+        assert class_client.execute("ip addr show lxdbr0")
+
+        raw_network_config = class_client.execute("lxc network show lxdbr0")
+        network_config = yaml.safe_load(raw_network_config)
+        assert "10.100.100.1/24" == network_config["config"]["ipv4.address"]


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: port lxd_bridge test from cloud_tests

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

`pytest --log-cli-level=INFO tests/integration_tests/modules/test_lxd_bridge.py` fails:

```
>       assert "WARN" not in cloud_init_log
E       assert "WARN" not in cloud-init.log string; unexpectedly found on these lines:
E         2020-12-08 22:48:08,461 - util.py[WARNING]: Running module lxd (<module 'cloudinit.config.cc_lxd' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_lxd.py'>) failed

tests/integration_tests/modules/test_lxd_bridge.py:39: AssertionError
```

`CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED pytest --log-cli-level=INFO tests/integration_tests/modules/test_lxd_bridge.py` passes.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
