### PR TITLE
Integration test for lp-1813396

### DIFF
--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -1,21 +1,22 @@
 """Integration test for lp-1813396
 
-Ensure gpg works even if VM provides no /dev/tty"""
+Ensure gpg is called with no tty flag.
+"""
 
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.log_utils import ordered_items_in_text
+from tests.integration_tests.log_utils import verify_ordered_items_in_text
 
 
 USER_DATA = """\
 #cloud-config
 apt:
   sources:
-    docker:
-      source: 'deb [arch=amd64] https://download.docker.com/linux/debian stretch stable'
+    cloudinit:
+      source: 'deb [arch=amd64] http://ppa.launchpad.net/cloud-init-dev/daily/ubuntu focal main'
       keyserver: keyserver.ubuntu.com
-      keyid: 0EBFCD88
+      keyid: E4D304DF
 """  # noqa: E501
 
 
@@ -25,9 +26,9 @@ def test_gpg_no_tty(client: IntegrationInstance):
     log = client.read_from_file('/var/log/cloud-init.log')
     to_verify = [
         "Running command ['gpg', '--no-tty', "
-        "'--keyserver=keyserver.ubuntu.com', '--recv-keys', '0EBFCD88'] "
+        "'--keyserver=keyserver.ubuntu.com', '--recv-keys', 'E4D304DF'] "
         "with allowed return codes [0] (shell=False, capture=True)",
-        "Imported key '0EBFCD88' from keyserver 'keyserver.ubuntu.com'",
+        "Imported key 'E4D304DF' from keyserver 'keyserver.ubuntu.com'",
         "finish: modules-config/config-apt-configure: SUCCESS",
     ]
-    assert ordered_items_in_text(to_verify, log)
+    verify_ordered_items_in_text(to_verify, log)

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -1,0 +1,33 @@
+"""Integration test for lp-1813396
+
+Ensure gpg works even if VM provides no /dev/tty"""
+
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.log_utils import ordered_items_in_text
+
+
+USER_DATA = """\
+#cloud-config
+apt:
+  sources:
+    docker:
+      source: 'deb [arch=amd64] https://download.docker.com/linux/debian stretch stable'
+      keyserver: keyserver.ubuntu.com
+      keyid: 0EBFCD88
+"""  # noqa: E501
+
+
+@pytest.mark.sru_2020_11
+@pytest.mark.user_data(USER_DATA)
+def test_gpg_no_tty(client: IntegrationInstance):
+    log = client.read_from_file('/var/log/cloud-init.log')
+    to_verify = [
+        "Running command ['gpg', '--no-tty', "
+        "'--keyserver=keyserver.ubuntu.com', '--recv-keys', '0EBFCD88'] "
+        "with allowed return codes [0] (shell=False, capture=True)",
+        "Imported key '0EBFCD88' from keyserver 'keyserver.ubuntu.com'",
+        "finish: modules-config/config-apt-configure: SUCCESS",
+    ]
+    assert ordered_items_in_text(to_verify, log)

--- a/tests/integration_tests/log_utils.py
+++ b/tests/integration_tests/log_utils.py
@@ -1,13 +1,11 @@
-def ordered_items_in_text(to_verify: list, text: str) -> bool:
-    """Return if all items in list appear in order in text.
+def verify_ordered_items_in_text(to_verify: list, text: str):
+    """Assert all items in list appear in order in text.
 
     Examples:
-      ordered_items_in_text(['a', '1'], 'ab1')  # Returns True
-      ordered_items_in_text(['1', 'a'], 'ab1')  # Returns False
+      verify_ordered_items_in_text(['a', '1'], 'ab1')  # passes
+      verify_ordered_items_in_text(['1', 'a'], 'ab1')  # raises AssertionError
     """
     index = 0
     for item in to_verify:
         index = text[index:].find(item)
-        if index < 0:
-            return False
-    return True
+        assert index > -1, "Expected item not found: '{}'".format(item)

--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -9,7 +9,7 @@ import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.log_utils import ordered_items_in_text
+from tests.integration_tests.log_utils import verify_ordered_items_in_text
 
 USER_DATA = """\
 #cloud-config
@@ -80,8 +80,7 @@ class TestPowerChange:
             "running 'init-local'",
             'config-power-state-change already ran',
         ]
-        assert ordered_items_in_text(lines_to_check, log), (
-            'Expected data not in logs')
+        assert verify_ordered_items_in_text(lines_to_check, log)
 
     @pytest.mark.user_data(USER_DATA.format(delay='0', mode='poweroff',
                                             timeout='0', condition='false'))

--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -80,7 +80,7 @@ class TestPowerChange:
             "running 'init-local'",
             'config-power-state-change already ran',
         ]
-        assert verify_ordered_items_in_text(lines_to_check, log)
+        verify_ordered_items_in_text(lines_to_check, log)
 
     @pytest.mark.user_data(USER_DATA.format(delay='0', mode='poweroff',
                                             timeout='0', condition='false'))


### PR DESCRIPTION
## Proposed Commit Message
Integration test for lp-1813396 and #669 

Ensure gpg is called with no tty flag.
Also, refactored the "ordered_items_in_text" to assert if the line
is missing and provide a more useful error message.

## Additional Context
#669


## Test Steps
fail:
CLOUD_INIT_CLOUD_INIT_SOURCE=NONE pytest tests/integration_tests/bugs/test_lp1813396.py
pass:
CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED pytest tests/integration_tests/bugs/test_lp1813396.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
