### PR TITLE
integration_tests: include timestamp in log output

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -164,6 +164,8 @@ setenv =
 # TODO: s/--strict/--strict-markers/ once xenial support is dropped
 testpaths = cloudinit tests/unittests
 addopts = --strict
+log_format = %(asctime)s %(levelname)-9s %(name)s:%(filename)s:%(lineno)d %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
 markers =
     allow_subp_for: allow subp usage for the given commands (disable_subp_usage)
     allow_all_subp: allow all subp usage (disable_subp_usage)


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: include timestamp in log output

## Test Steps

Before:

```
INFO     integration_testing:clouds.py:73 Detected image: image_id=focal os=ubuntu release=focal
```

After:

```
2020-12-09 22:26:03 INFO      integration_testing:clouds.py:73 Detected image: image_id=focal os=ubuntu release=focal
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
