### PR TITLE
rpmlint complains about Python shebang on 644 file

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 #
 # Copyright (C) 2012 Canonical Ltd.
 # Copyright (C) 2012 Hewlett-Packard Development Company, L.P.


### PR DESCRIPTION
## Proposed Commit Message
Fedora build system's rpmlint is complaining ther's a file with a
shebang but no executable flag set. No need to have shebang on this
file.

Signed-off-by: Eduardo Otubo <otubo@redhat.com>

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
