### PR TITLE
Integration test for gh-671

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@d1c63026c76ed3ef02dc21982f9f7eeea2606f2a
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@72e800b8e99c5b735348c4778f19f92cf6c63de0
 pytest

--- a/tests/integration_tests/bugs/test_gh671.py
+++ b/tests/integration_tests/bugs/test_gh671.py
@@ -1,0 +1,55 @@
+"""Integration test for gh-671.
+
+Verify that on Azure that if a default user and password are specified
+through the Azure API that a change in the default password overwrites
+the old password
+"""
+
+import crypt
+
+import pytest
+
+from tests.integration_tests.clouds import IntegrationCloud
+
+OLD_PASSWORD = 'DoIM33tTheComplexityRequirements!??'
+NEW_PASSWORD = 'DoIM33tTheComplexityRequirementsNow!??'
+
+
+def _check_password(instance, unhashed_password):
+    shadow_password = instance.execute('getent shadow ubuntu').split(':')[1]
+    salt = shadow_password.rsplit('$', 1)[0]
+    hashed_password = crypt.crypt(unhashed_password, salt)
+    assert shadow_password == hashed_password
+
+
+@pytest.mark.azure
+@pytest.mark.sru_2020_11
+def test_update_default_password(setup_image, session_cloud: IntegrationCloud):
+    os_profile = {
+        'os_profile': {
+            'admin_password': '',
+            'linux_configuration': {
+                'disable_password_authentication': False
+            }
+        }
+    }
+    os_profile['os_profile']['admin_password'] = OLD_PASSWORD
+    instance1 = session_cloud.launch(launch_kwargs={'vm_params': os_profile})
+
+    _check_password(instance1, OLD_PASSWORD)
+
+    snapshot_id = instance1.cloud.cloud_instance.snapshot(
+        instance1.instance,
+        delete_provisioned_user=False
+    )
+
+    os_profile['os_profile']['admin_password'] = NEW_PASSWORD
+    try:
+        with session_cloud.launch(launch_kwargs={
+            'image_id': snapshot_id,
+            'vm_params': os_profile,
+        }) as instance2:
+            _check_password(instance2, NEW_PASSWORD)
+    finally:
+        session_cloud.cloud_instance.delete_image(snapshot_id)
+        instance1.destroy()


### PR DESCRIPTION
## Proposed Commit Message
Integration test for gh-671

Verify that on Azure that if a default user and password are specified
through the Azure API that a change in the default password overwrites
the old password

## Additional Context
#671 

## Test Steps
fail:
CLOUD_INIT_PLATFORM=azure CLOUD_INIT_CLOUD_INIT_SOURCE=NONE pytest tests/integration_tests/bugs/test_gh671.py

pass:
CLOUD_INIT_PLATFORM=azure CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED pytest tests/integration_tests/bugs/test_gh671.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
