### PR TITLE
Integration test for gh-632.

### DIFF
--- a/tests/integration_tests/bugs/test_gh632.py
+++ b/tests/integration_tests/bugs/test_gh632.py
@@ -1,0 +1,30 @@
+"""Integration test for gh-632.
+
+Verify that if cloud-init is using DataSourceRbxCloud, there is
+no traceback if the metadata disk cannot be found.
+"""
+
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+
+
+@pytest.mark.sru_2020_11
+def test_datasource_rbx_no_stacktrace(client: IntegrationInstance):
+    client.write_to_file(
+        '/etc/cloud/cloud.cfg.d/90_dpkg.cfg',
+        'datasource_list: [ RbxCloud, NoCloud ]\n',
+    )
+    client.write_to_file(
+        '/etc/cloud/ds-identify.cfg',
+        'policy: enabled\n',
+    )
+    client.execute('cloud-init clean --logs')
+    client.restart()
+
+    log = client.read_from_file('/var/log/cloud-init.log')
+    assert 'WARNING' not in log
+    assert 'Traceback' not in log
+    assert 'Failed to load metadata and userdata' not in log
+    assert ("Getting data from <class 'cloudinit.sources.DataSourceRbxCloud."
+            "DataSourceRbxCloud'> failed") not in log


### PR DESCRIPTION
## Proposed Commit Message
Integration test for gh-632

Verify that if cloud-init is using DataSourceRbxCloud, there is
no traceback if the metadata disk cannot be found.

## Additional Context
#632

## Test Steps
fail:
CLOUD_INIT_CLOUD_INIT_SOURCE=NONE pytest tests/integration_tests/bugs/test_gh632.py
pass:
CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED pytest tests/integration_tests/bugs/test_gh632.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
