### PR TITLE
Some test_upgrade fixes

### DIFF
--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -1,5 +1,6 @@
 import logging
 import pytest
+import time
 from pathlib import Path
 
 from tests.integration_tests.clouds import ImageSpecification, IntegrationCloud
@@ -40,6 +41,19 @@ def _output_to_compare(instance, file_path, netcfg_path):
             f.write(instance.execute(command) + '\n')
 
 
+def _restart(instance):
+    # work around pad.lv/1890528
+    try:
+        instance.restart(raise_on_cloudinit_failure=True)
+    except OSError as e:
+        for _ in range(10):
+            time.sleep(5)
+            result = instance.execute('cloud-init status --wait --long')
+            if result.ok:
+                return
+        raise e
+
+
 @pytest.mark.sru_2020_11
 def test_upgrade(session_cloud: IntegrationCloud):
     source = get_validated_source()
@@ -50,9 +64,7 @@ def test_upgrade(session_cloud: IntegrationCloud):
         return  # type checking doesn't understand that skip raises
 
     launch_kwargs = {
-        'name': 'integration-upgrade-test',
         'image_id': session_cloud._get_initial_image(),
-        'wait': True,
     }
 
     image = ImageSpecification.from_os_image()
@@ -60,7 +72,8 @@ def test_upgrade(session_cloud: IntegrationCloud):
     # Get the paths to write test logs
     output_dir = Path(session_cloud.settings.LOCAL_LOG_PATH)
     output_dir.mkdir(parents=True, exist_ok=True)
-    base_filename = 'test_upgrade_{os}_{{stage}}_{time}.log'.format(
+    base_filename = 'test_upgrade_{platform}_{os}_{{stage}}_{time}.log'.format(
+        platform=session_cloud.settings.PLATFORM,
         os=image.release,
         time=session_start_time,
     )
@@ -75,12 +88,12 @@ def test_upgrade(session_cloud: IntegrationCloud):
             netcfg_path = '/etc/network/interfaces.d/50-cloud-init.cfg'
 
     with session_cloud.launch(
-        launch_kwargs=launch_kwargs, user_data=USER_DATA
+        launch_kwargs=launch_kwargs, user_data=USER_DATA, wait=True,
     ) as instance:
         _output_to_compare(instance, before_path, netcfg_path)
         instance.install_new_cloud_init(source, take_snapshot=False)
         instance.execute('hostname something-else')
-        instance.restart(raise_on_cloudinit_failure=True)
+        _restart(instance)
         _output_to_compare(instance, after_path, netcfg_path)
 
     log.info('Wrote upgrade test logs to %s and %s', before_path, after_path)

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -42,7 +42,7 @@ def _output_to_compare(instance, file_path, netcfg_path):
 
 
 def _restart(instance):
-    # work around pad.lv/1890528
+    # work around pad.lv/1908287
     try:
         instance.restart(raise_on_cloudinit_failure=True)
     except OSError as e:


### PR DESCRIPTION
## Proposed Commit Message
Some test_upgrade fixes

- workaround pad.lv/1890528 for restarting instances
- move wait param from launch_kwargs to launch call
- remove name param as it's not universally supported
- add platfrom to log names

## Additional Context
n/a

## Test Steps
pytest tests/integration_tests/test_upgrade.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
