### PR TITLE
Ensure overriding test vars with env vars works for booleans

### DIFF
--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -1,6 +1,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import os
 
+from distutils.util import strtobool
+
 ##################################################################
 # LAUNCH SETTINGS
 ##################################################################
@@ -109,6 +111,12 @@ except ImportError:
 # Perhaps a bit too hacky, but it works :)
 current_settings = [var for var in locals() if var.isupper()]
 for setting in current_settings:
-    globals()[setting] = os.getenv(
+    env_setting = os.getenv(
         'CLOUD_INIT_{}'.format(setting), globals()[setting]
     )
+    if isinstance(env_setting, str):
+        try:
+            env_setting = bool(strtobool(env_setting.strip()))
+        except ValueError:
+            pass
+    globals()[setting] = env_setting


### PR DESCRIPTION
## Proposed Commit Message
Ensure overriding test vars with env vars works for booleans

## Additional Context
n/a

## Test Steps
CLOUD_INIT_KEEP_INSTANCE=False pytest <any_test>
Ensure the instance isn't kept around.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
