### PR TITLE
Integration test for gh-626

### DIFF
--- a/tests/integration_tests/bugs/test_gh626.py
+++ b/tests/integration_tests/bugs/test_gh626.py
@@ -1,0 +1,42 @@
+"""Integration test for gh-626.
+
+Ensure if wakeonlan is specified in the network config that it is rendered
+in the /etc/network/interfaces or netplan config.
+"""
+
+import pytest
+import yaml
+
+from tests.integration_tests.clouds import ImageSpecification
+from tests.integration_tests.instances import IntegrationInstance
+
+
+NETWORK_CONFIG = """\
+version: 2
+ethernets:
+  eth0:
+    dhcp4: true
+    wakeonlan: true
+"""
+
+EXPECTED_ENI_END = """\
+iface eth0 inet dhcp
+    ethernet-wol g"""
+
+
+@pytest.mark.sru_2020_11
+@pytest.mark.lxd_container
+@pytest.mark.lxd_vm
+@pytest.mark.lxd_config_dict({
+    'user.network-config': NETWORK_CONFIG
+})
+def test_wakeonlan(client: IntegrationInstance):
+    if ImageSpecification.from_os_image().release == 'xenial':
+        eni = client.execute('cat /etc/network/interfaces.d/50-cloud-init.cfg')
+        assert eni.endswith(EXPECTED_ENI_END)
+        return
+
+    netplan_cfg = client.execute('cat /etc/netplan/50-cloud-init.yaml')
+    netplan_yaml = yaml.safe_load(netplan_cfg)
+    assert 'wakeonlan' in netplan_yaml['network']['ethernets']['eth0']
+    assert netplan_yaml['network']['ethernets']['eth0']['wakeonlan'] is True


### PR DESCRIPTION
## Proposed Commit Message
Integration test for gh-626

Ensure if wakeonlan is specified in the network config that it is
rendered in the /etc/network/interfaces or netplan config.

## Additional Context
See #626

## Test Steps
pytest tests/integration_tests/bugs/test_gh626.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
