### PR TITLE
integration_tests: restrict test_lxd_bridge appropriately

### DIFF
--- a/tests/integration_tests/modules/test_lxd_bridge.py
+++ b/tests/integration_tests/modules/test_lxd_bridge.py
@@ -24,6 +24,7 @@ lxd:
 """
 
 
+@pytest.mark.no_container
 @pytest.mark.user_data(USER_DATA)
 class TestLxdBridge:
 
@@ -32,6 +33,7 @@ class TestLxdBridge:
         """Check that the expected LXD binaries are installed"""
         assert class_client.execute(["which", binary_name]).ok
 
+    @pytest.mark.not_xenial
     @pytest.mark.sru_2020_11
     def test_bridge(self, class_client):
         """Check that the given bridge is configured"""


### PR DESCRIPTION
## Proposed Commit Message
>  integration_tests: restrict test_lxd_bridge appropriately
>
> On xenial, the bridge test fails because xenial's LXD doesn't include
> the `network` subcommand.  On bionic, the bridge test fails within
> containers, because LXD isn't able to manipulate the host kernel as it
> expects.
> 
> (focal and later do run successfully in containers, but we don't have a
> good way of expressing that presently.)

## Test Steps

`CLOUD_INIT_OS_IMAGE=xenial pytest tests/integration_tests/modules/test_lxd_bridge.py` and `CLOUD_INIT_OS_IMAGE=bionic pytest tests/integration_tests/modules/test_lxd_bridge.py` fail currently, and with this change instead passes (with all skips).

`CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=xenial pytest tests/integration_tests/modules/test_lxd_bridge.py` fails currently, and with this change instead passes (with 1 skip, the bridge test). `CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=bionic pytest tests/integration_tests/modules/test_lxd_bridge.py` fails currently, and with this change instead passes.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
