### PR TITLE
integration_tests: fix IN_PLACE CLOUD_INIT_SOURCE

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -108,6 +108,7 @@ def session_cloud():
 
 
 def get_validated_source(
+    session_cloud: IntegrationCloud,
     source=integration_settings.CLOUD_INIT_SOURCE
 ) -> CloudInitSource:
     if source == 'NONE':
@@ -134,7 +135,7 @@ def setup_image(session_cloud: IntegrationCloud):
     So we can launch instances / run tests with the correct image
     """
 
-    source = get_validated_source()
+    source = get_validated_source(session_cloud)
     if not source.installs_new_version():
         return
     log.info('Setting up environment for %s', session_cloud.datasource)

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -56,7 +56,7 @@ def _restart(instance):
 
 @pytest.mark.sru_2020_11
 def test_upgrade(session_cloud: IntegrationCloud):
-    source = get_validated_source()
+    source = get_validated_source(session_cloud)
     if not source.installs_new_version():
         pytest.skip("Install method '{}' not supported for this test".format(
             source


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: fix IN_PLACE CLOUD_INIT_SOURCE
>
> This fixes up an issue introduced in
> 54e202a6480e48dbb8a72004f7a5003f7c4edfae.

## Test Steps

Run the tests using `CLOUD_INIT_SOURCE=IN_PLACE`: it fails in master, and passes with this PR.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
