### PR TITLE
integration_tests: log the path we collect logs into

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -174,6 +174,7 @@ def _collect_logs(instance: IntegrationInstance, node_id: str,
     log_dir = Path(
         integration_settings.LOCAL_LOG_PATH
     ) / session_start_time / node_id_path
+    log.info("Writing logs to %s", log_dir)
     if not log_dir.exists():
         log_dir.mkdir(parents=True)
     tarball_path = log_dir / 'cloud-init.tar.gz'


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: log the path we collect logs into
>
> This makes it easier to find the failure logs when you're running a
> bunch of similar tests in parallel.

## Test Steps

Run a test that fails, observe that the path to its logs is emitted to the log.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
