### PR TITLE
.travis.yml: add (most) supported Python versions to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,16 +33,18 @@ install:
 script:
     - tox
 
+env:
+  TOXENV=py3
+  PYTEST_ADDOPTS=-v  # List all tests run by pytest
+
 matrix:
     fast_finish: true
     allow_failures:
       - name: "Integration Tests (WIP)"
     include:
         - python: 3.6
-          env:
-              TOXENV=py3
-              PYTEST_ADDOPTS=-v  # List all tests run by pytest
         - if: NOT branch =~ /^ubuntu\//
+          env: {}
           cache:
               - directories:
                   - lxd_images
@@ -123,6 +125,7 @@ matrix:
             - sg lxd -c 'tox -e citest -- run --verbose --preserve-data --data-dir results --os-name xenial --test modules/apt_configure_sources_list.yaml --test modules/ntp_servers --test modules/set_password_list --test modules/user_groups --deb cloud-init_*_all.deb'
         - name: "Integration Tests (WIP)"
           if: NOT branch =~ /^ubuntu\//
+          env: {}
           cache:
               - directories:
                   - lxd_images
@@ -220,3 +223,9 @@ matrix:
           env: TOXENV=pylint
         - python: 3.6
           env: TOXENV=doc
+        # Test all supported Python versions (but at the end, so we schedule
+        # longer-running jobs first)
+        - python: 3.9
+        - python: 3.8
+        - python: 3.7
+        - python: 3.5


### PR DESCRIPTION
## Proposed Commit Message
> .travis.yml: add (most) supported Python versions to CI
>
> This excludes Python 3.4, as there are currently test failures there;
> that will be addressed separately.

## Test Steps

Travis is sufficient.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
