### PR TITLE
PULL_REQUEST_TEMPLATE.md: use backticks around commit message

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,19 @@
 ## Proposed Commit Message
 <!-- Include a proposed commit message because all PRs are squash merged -->
 
-> summary: no more than 70 characters
->
-> A description of what the change being made is and why it is being
-> made, if the summary line is insufficient.  The blank line above is
-> required. This should be wrapped at 72 characters, but otherwise has
-> no particular length requirements.
->
-> If you need to write multiple paragraphs, feel free.
->
-> LP: #NNNNNNN (replace with the appropriate bug reference or remove
-> this line entirely if there is no associated bug)
+```
+summary: no more than 70 characters
+
+A description of what the change being made is and why it is being
+made, if the summary line is insufficient.  The blank line above is
+required. This should be wrapped at 72 characters, but otherwise has
+no particular length requirements.
+
+If you need to write multiple paragraphs, feel free.
+
+LP: #NNNNNNN (replace with the appropriate bug reference or remove
+this line entirely if there is no associated bug)
+```
 
 ## Additional Context
 <!-- If relevant -->


### PR DESCRIPTION
## Proposed Commit Message
> PULL_REQUEST_TEMPLATE.md: use backticks around commit message
>
> This makes it easier to copy/paste commit messages prepared elsewhere
> into the GitHub UI (and also means that the formatting in the GH UI more
> closely matches how the commit message will be consumed elsewhere).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly