### PR TITLE
integration_tests: set log-cli-level to INFO by default

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -261,3 +261,20 @@ def pytest_assertrepr_compare(op, left, right):
                 '"{}" not in cloud-init.log string; unexpectedly found on'
                 " these lines:".format(left)
             ] + found_lines
+
+
+def pytest_configure(config):
+    """Perform initial configuration, before the test runs start.
+
+    This hook is only called if integration tests are being executed, so we can
+    use it to configure defaults for integration testing that differ from the
+    rest of the tests in the codebase.
+
+    See
+    https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_configure
+    for pytest's documentation.
+    """
+    if "log_cli_level" in config.option and not config.option.log_cli_level:
+        # If log_cli_level is available in this version of pytest and not set
+        # to anything, set it to INFO.
+        config.option.log_cli_level = "INFO"


### PR DESCRIPTION
## Proposed Commit Message
> integration_tests: set log-cli-level to INFO by default
>
> This gives us more detailed integration testing output by default.
> This will make debugging failures reported by users/developers easier to
> debug, as it removes the need for an initial round-trip to get the
> output we need for debugging.  It will also make debugging intermittent
> failures easier: there will definitely be log output from runs which
> exhibit the intermittent failure.

## Test Steps

Run the integration tests without any CLI arguments and observe log output:

```
$ pytest tests/integration_tests/modules/test_ntp_servers.py
...
2020-12-18 15:20:52 INFO      integration_testing:clouds.py:73 Detected image: image_id=focal os=ubuntu release=focal
...
```

Run the unittests without any CLI arguments and observe no log output:

```
$ pytest
...
```

Run the integration tests with a different log level and observe it being honoured:

```
$ pytest --log-cli-level DEBUG tests/integration_tests/modules/test_ntp_servers.py
...
2020-12-18 15:22:18 INFO      integration_testing:clouds.py:73 Detected image: image_id=focal os=ubuntu release=focal
2020-12-18 15:22:18 DEBUG     pycloudlib.cloud:cloud.py:322 finding released Ubuntu image for focal
...
```

Run the integration tests with `CRITICAL` log level and observe no log output:

```
$ pytest --log-cli-level CRITICAL tests/integration_tests/modules/test_ntp_servers.py
...
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly