### PR TITLE
stale: fix error in definition

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 name: Mark and close stale pull requests
 
-#on:
+on: workflow_dispatch
 #  schedule:
 #  - cron: "0 0 * * *"  # Daily @ 00:00
 


### PR DESCRIPTION
## Proposed Commit Message
```
stale: fix error in definition

This should fix the error, and also allows us to manually trigger the
workflow.
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
