### PR TITLE
Azure: Add telemetry for poll IMDS

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -983,6 +983,7 @@ class DataSourceAzure(sources.DataSource):
             if nl_sock:
                 nl_sock.close()
 
+    @azure_ds_telemetry_reporter
     def _poll_imds(self):
         """Poll IMDS for the new provisioning data until we get a valid
         response. Then return the returned JSON object."""


### PR DESCRIPTION
## Proposed Commit Message

```
Azure: Add telemetry for poll IMDS
```

## Additional Context

`_poll_imds` within `DataSourceAzure.py` currently doesn't have the Azure telemetry decorator `@azure_ds_telemetry_reporter`. This decorator enriches telemetry needed for diagnosing issues related to Azure polling of IMDS.

## Test Steps
* Deployed a `Canonical:UbuntuServer:18.04-LTS:latest` VM on Azure.
* Built a `deb` package out of my branch's cloud-init.
* Installed the `deb` in the Azure VM.
* Cleaned the VM and captured it into a generalized custom image.
* Deployed and provisioned a VM from this generalized custom image containing custom cloud-init.
* Verified that everything works.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
