### PR TITLE
d/cloud-init.manpages: include upstream manpages in package.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloud-init (20.4-0ubuntu2) hirsute; urgency=medium
+
+  * d/cloud-init.manpages: include upstream manpages in package (LP: #1908548)
+
+ -- Daniel Watkins <oddbloke@ubuntu.com>  Mon, 04 Jan 2021 10:44:13 -0500
+
 cloud-init (20.4-0ubuntu1) hirsute; urgency=medium
 
   * d/control: add gnupg to Recommends as cc_apt_configure requires it to be

--- a/debian/cloud-init.manpages
+++ b/debian/cloud-init.manpages
@@ -1,0 +1,3 @@
+doc/man/cloud-id.1
+doc/man/cloud-init-per.1
+doc/man/cloud-init.1


### PR DESCRIPTION
## Proposed Commit Message
```
d/cloud-init.manpages: include upstream manpages in package.
```

## Test Steps

I've built the package locally, installed it into a hirsute container and confirmed that `man cloud-init`, `man cloud-init-per` and `man cloud-id` work as expected.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
