### PR TITLE
stale: re-enable post holidays

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,8 +1,8 @@
 name: Mark and close stale pull requests
 
-on: workflow_dispatch
-#  schedule:
-#  - cron: "0 0 * * *"  # Daily @ 00:00
+on:
+  schedule:
+  - cron: "0 0 * * *"  # Daily @ 00:00
 
 jobs:
   stale:


### PR DESCRIPTION
## Proposed Commit Message
```
stale: re-enable post holidays

This reverts commits fad919aa2c894abaa3af88aed1e064c1220937fe ("stale:
disable check for holiday break (#735)") and
e4f2d6139a802e659c571f581763eddeee715e2f ("stale: fix error in
definition (#740)").
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
