### PR TITLE
network-config-format-v2.rst: add Netplan Passthrough section

### DIFF
--- a/doc/rtd/topics/network-config-format-v2.rst
+++ b/doc/rtd/topics/network-config-format-v2.rst
@@ -8,6 +8,22 @@ version 2 format defined for the `netplan`_ tool.  Cloud-init supports
 both reading and writing of Version 2; the latter support requires a
 distro with `netplan`_ present.
 
+Netplan Passthrough
+-------------------
+
+On a system with netplan present, cloud-init will pass Version 2 configuration
+through to netplan without modification.  On such systems, you do not need to
+limit yourself to the below subset of netplan's configuration format.
+
+.. warning::
+   If you are writing or generating network configuration that may be used on
+   non-netplan systems, you **must** limit yourself to the subset described in
+   this document, or you will see network configuration failures on
+   non-netplan systems.
+
+Version 2 Configuration Format
+------------------------------
+
 The ``network`` key has at least two required elements.  First
 it must include ``version: 2``  and one or more of possible device
 ``types``.

--- a/doc/rtd/topics/network-config-format-v2.rst
+++ b/doc/rtd/topics/network-config-format-v2.rst
@@ -10,7 +10,7 @@ distro with `netplan`_ present.
 
 The ``network`` key has at least two required elements.  First
 it must include ``version: 2``  and one or more of possible device
-``types``..
+``types``.
 
 Cloud-init will read this format from system config.
 For example the following could be present in
@@ -33,9 +33,6 @@ Supported device ``types`` values are as follows:
 Each type block contains device definitions as a map where the keys (called
 "configuration IDs"). Each entry under the ``types`` may include IP and/or
 device configuration.
-
-Cloud-init does not current support ``wifis`` type that is present in native
-`netplan`_.
 
 
 Device configuration IDs


### PR DESCRIPTION
## Proposed Commit Message
```
network-config-format-v2.rst: add Netplan Passthrough section

We don't currently document our passthrough behaviour, which has lead to
some user confusion about what they can rely upon on Ubuntu systems.
This clarifies our support.
```

## Additional Context

https://bugs.launchpad.net/cloud-init/+bug/1909138 is an example of a user not understanding our support.

## Test Steps

Build the docs and see:

![doc](https://user-images.githubusercontent.com/62736/103672233-09788680-4f4a-11eb-8f4e-544d76c86f5c.png)

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
