### PR TITLE
Missing IPV6_AUTOCONF=no to render sysconfig dhcp6 stateful on RHEL

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -402,6 +402,7 @@ class Renderer(renderer.Renderer):
                     iface_cfg['BOOTPROTO'] = 'dhcp'
                     iface_cfg['DHCPV6C'] = True
                     iface_cfg['IPV6INIT'] = True
+                    iface_cfg['IPV6_AUTOCONF'] = False
                 else:
                     iface_cfg['IPV6INIT'] = True
                     # Configure network settings using DHCPv6

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1369,6 +1369,7 @@ NETWORK_CONFIGS = {
             DEVICE=iface0
             DHCPV6C=yes
             IPV6INIT=yes
+            IPV6_AUTOCONF=no
             IPV6_FORCE_ACCEPT_RA=yes
             DEVICE=iface0
             NM_CONTROLLED=no


### PR DESCRIPTION
## Proposed Commit Message
IPV6_AUTOCONF needs to be set to 'no' on RHEL so NetworkManager can
properly acquire ipv6 address.

rhbz: #1859695

Signed-off-by: Eduardo Otubo <otubo@redhat.com>

## Additional Context
According to additional tests from the reporter Tom Barron on the Original Bugzilla ([1859695](https://bugzilla.redhat.com/show_bug.cgi?id=1859695)) the option IPV6_AUTOCONF should also be set to `no` on this specific case. Most of the BZ is marked as private, though.

## Test Steps
(as described on the above mentioned BZ)
Steps to Reproduce:

1. Create StorageNFS network with IPv6 CIDR and address range defined
1. Create a Nova instance with 2 NICs, 2nd NIC connected to StorageNFS network
1. Login to VM and examin Eth1 IP address

Actual results:
The Nova assigned IPv6 address was not assigned to device Eth1

Expected results:
Expected the Nova assigned IP address to be assigned to Eth1 interface

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
