### PR TITLE
integration_tests: add SSH key selection settings

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -91,6 +91,15 @@ class IntegrationCloud(ABC):
     def __init__(self, settings=integration_settings):
         self.settings = settings
         self.cloud_instance = self._get_cloud_instance()
+        if settings.PUBLIC_SSH_KEY is not None:
+            # If we have a non-default key, use it.
+            self.cloud_instance.use_key(
+                settings.PUBLIC_SSH_KEY, name=settings.KEYPAIR_NAME
+            )
+        elif settings.KEYPAIR_NAME is not None:
+            # Even if we're using the default key, it may still have a
+            # different name in the clouds, so we need to set it separately.
+            self.cloud_instance.key_pair.name = settings.KEYPAIR_NAME
         self._released_image_id = self._get_initial_image()
         self.snapshot_id = None
 

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -76,6 +76,18 @@ COLLECT_LOGS = 'ON_ERROR'
 LOCAL_LOG_PATH = '/tmp/cloud_init_test_logs'
 
 ##################################################################
+# SSH KEY SETTINGS
+##################################################################
+
+# A path to the public SSH key to use for test runs.  (Defaults to pycloudlib's
+# default behaviour, using ~/.ssh/id_rsa.pub.)
+PUBLIC_SSH_KEY = None
+
+# For clouds which use named keypairs for SSH connection, the name that is used
+# for the keypair.  (Defaults to pycloudlib's default behaviour.)
+KEYPAIR_NAME = None
+
+##################################################################
 # GCE SPECIFIC SETTINGS
 ##################################################################
 # Required for GCE


### PR DESCRIPTION
```
integration_tests: add SSH key selection settings

This introduces PUBLIC_SSH_KEY, to configure what public SSH key should
be passed to (and used to access) systems under test, and KEYPAIR_NAME,
to configure the name used in clouds for that SSH key (or the default
SSH key, in PUBLIC_SSH_KEY's absence).
```

## Test Steps

To test both parts together, register a non-default SSH key in EC2 with a key name other than your username, then run:

```
CLOUD_INIT_KEYPAIR_NAME=<EC2 key name> CLOUD_INIT_PUBLIC_SSH_KEY=/path/to/your/created/public/key pytest tests/integration_tests/modules/test_ca_certs.py
```

Verify that the settings have been correctly picked up (by examining the logged output), and then confirm that the test passes.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
