### PR TITLE
net_convert: add some missing help text

### DIFF
--- a/cloudinit/cmd/devel/net_convert.py
+++ b/cloudinit/cmd/devel/net_convert.py
@@ -28,11 +28,13 @@ def get_parser(parser=None):
     if not parser:
         parser = argparse.ArgumentParser(prog=NAME, description=__doc__)
     parser.add_argument("-p", "--network-data", type=open,
-                        metavar="PATH", required=True)
+                        metavar="PATH", required=True,
+                        help="The network configuration to read")
     parser.add_argument("-k", "--kind",
                         choices=['eni', 'network_data.json', 'yaml',
                                  'azure-imds', 'vmware-imc'],
-                        required=True)
+                        required=True,
+                        help="The format of the given network config")
     parser.add_argument("-d", "--directory",
                         metavar="PATH",
                         help="directory to place output in",
@@ -50,7 +52,8 @@ def get_parser(parser=None):
                         help='enable debug logging to stderr.')
     parser.add_argument("-O", "--output-kind",
                         choices=['eni', 'netplan', 'sysconfig'],
-                        required=True)
+                        required=True,
+                        help="The network config format to emit")
     return parser
 
 


### PR DESCRIPTION
## Proposed Commit Message
```
net_convert: add some missing help text
```

## Test Steps

You can run this in a local checkout; here's the output diff:

```diff
--- before	2021-01-06 16:23:47.951011650 -0500
+++ after	2021-01-06 16:23:51.771062044 -0500
@@ -7,7 +7,9 @@
 optional arguments:
   -h, --help            show this help message and exit
   -p PATH, --network-data PATH
+                        The network configuration to read
   -k {eni,network_data.json,yaml,azure-imds,vmware-imc}, --kind {eni,network_data.json,yaml,azure-imds,vmware-imc}
+                        The format of the given network config
   -d PATH, --directory PATH
                         directory to place output in
   -D {alpine,arch,debian,ubuntu,freebsd,gentoo,amazon,centos,fedora,rhel,opensuse,sles}, --distro {alpine,arch,debian,ubuntu,freebsd,gentoo,amazon,centos,fedora,rhel,opensuse,sles}
@@ -15,3 +17,4 @@
                         interface name to mac mapping
   --debug               enable debug logging to stderr.
   -O {eni,netplan,sysconfig}, --output-kind {eni,netplan,sysconfig}
+                        The network config format to emit
```

## Checklist:

 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly