### PR TITLE
Use more cloud defaults in integration tests

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@72e800b8e99c5b735348c4778f19f92cf6c63de0
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@39805087affaed07b266d64cf0d883be775b5c0f
 pytest

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -216,9 +216,6 @@ class GceCloud(IntegrationCloud):
     def _get_cloud_instance(self):
         return GCE(
             tag='gce-integration-test',
-            project=self.settings.GCE_PROJECT,
-            region=self.settings.GCE_REGION,
-            zone=self.settings.GCE_ZONE,
         )
 
 
@@ -246,8 +243,7 @@ class OciCloud(IntegrationCloud):
 
     def _get_cloud_instance(self):
         return OCI(
-            tag='oci-integration-test',
-            compartment_id=self.settings.OCI_COMPARTMENT_ID
+            tag='oci-integration-test'
         )
 
 

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -88,24 +88,6 @@ PUBLIC_SSH_KEY = None
 KEYPAIR_NAME = None
 
 ##################################################################
-# GCE SPECIFIC SETTINGS
-##################################################################
-# Required for GCE
-GCE_PROJECT = None
-
-# You probably want to override these
-GCE_REGION = 'us-central1'
-GCE_ZONE = 'a'
-
-##################################################################
-# OCI SPECIFIC SETTINGS
-##################################################################
-# Compartment-id found at
-# https://console.us-phoenix-1.oraclecloud.com/a/identity/compartments
-# Required for Oracle
-OCI_COMPARTMENT_ID = None
-
-##################################################################
 # USER SETTINGS OVERRIDES
 ##################################################################
 # Bring in any user-file defined settings


### PR DESCRIPTION
## Proposed Commit Message
```
Use more cloud defaults in integration tests

Stop requiring compartment_id for OCI and project_id for GCE since they
can now be inferred in pycloudlib.
```

## Additional Context
n/a

## Test Steps
Remove: GCE_PROJECT, GCE_REGION, GCE_ZONE, and OCI_COMPARTMENT_ID from user_settings.py if they exist there.
Run any integration test using GCE or OCI and it should pass.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
