### PR TITLE
integration_tests: log cloud-init version in SUT

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -166,7 +166,14 @@ class IntegrationCloud(ABC):
         if wait:
             pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         log.info('Launched instance: %s', pycloudlib_instance)
-        return self.get_instance(pycloudlib_instance, settings)
+        instance = self.get_instance(pycloudlib_instance, settings)
+        if wait:
+            # If we aren't waiting, we can't rely on command execution here
+            log.info(
+                'cloud-init version: %s',
+                instance.execute("cloud-init --version")
+            )
+        return instance
 
     def get_instance(self, cloud_instance, settings=integration_settings):
         return self.integration_instance_cls(self, cloud_instance, settings)


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: log cloud-init version in SUT
```

## Test Steps

Run a test and see a log line like this:

```
2021-01-08 16:46:48 INFO      integration_testing:clouds.py:172 cloud-init version: /usr/bin/cloud-init 20.4-0ubuntu1~16.04.1
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
