### PR TITLE
azure: imds publicKeys can contain CRLF characters \r\n

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -652,7 +652,7 @@ class DataSourceAzure(sources.DataSource):
         ssh_keys = []
         try:
             ssh_keys = [
-                public_key['keyData']
+                public_key['keyData'].replace('\r\n', '')
                 for public_key
                 in self.metadata['imds']['compute']['publicKeys']
             ]

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -108,7 +108,7 @@ NETWORK_METADATA = {
         "zone": "",
         "publicKeys": [
             {
-                "keyData": "key1",
+                "keyData": "ssh-rsa key1\r\n23",
                 "path": "path1"
             }
         ]
@@ -1797,7 +1797,7 @@ scbus-1 on xpt0 bus 0
         dsrc.get_data()
         dsrc.setup(True)
         ssh_keys = dsrc.get_public_ssh_keys()
-        self.assertEqual(ssh_keys, ['key1'])
+        self.assertEqual(ssh_keys, ['ssh-rsa key123'])
         self.assertEqual(m_parse_certificates.call_count, 0)
 
     @mock.patch(MOCKPATH + 'get_metadata_from_imds')


### PR DESCRIPTION
azure IMDS publicKeys may contain CRLF characters which cloud-init
copies directly into .ssh/authorize_keys files.

Since authorize_keys expects to see 1 pubkey per line, the content
gets ignored making it impossible to ssh into Azure VMs if using
keys auto-generated by azure platform.

To workaround on 20.4 this one can provide the specific key content
as userdata or --custom-data to the instance at launch time by using
the ssh-rsa pub key reported from your Azure auto-generated pem file
by running:

KEY=`ssh-keygen -f ~/path/to/azure_key.pem`

and providing the following userdata (--custom-data on cli) to launch:

   #cloud-config
   ssh_authorized_keys:
   - <KEY_from_above>

LP: #191085


## Test Steps
Open portal.azure.com and launch an Ubuntu bionic VM:
- select the region "South Central US"
- select to allow azure to auto-generate the ssh key
- on the Advanced tab provide the following cloud-config (or --custom-data your.yaml):
```bash
 #cloud-config
 ssh-import-id: [<your_lp_id>]
```

ssh -i ~/Downloads/your_azure_key.pem ubuntu@<your_vm_ip> # and expect unauthorized SSH access
\# you should be able to still connect with whatever key you specified in ssh-import-id: above


```bash
# ssh to the system and make sure cloud-init read keys from IMDS
$ grep "Successfully retrieved" /var/log/cloud-init.log 
2021-01-09 03:11:12,786 - DataSourceAzure.py[DEBUG]: Successfully retrieved 1 key(s) from IMDS
# check that azure-generated-key can be parse properly from authorized_keys
$ ssh-keygen -lf .ssh/authorized_keys | grep generated-by-azure
3072 SHA256:PQ9EKxTKONJKFC2N56UpL6+Oc/cujfA9HpsF5VW2QDI generated-by-azure (RSA)
```

## Checklist:

 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
