### PR TITLE
Fix regression by forcing no IMDS ssh keys

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -654,6 +654,7 @@ class DataSourceAzure(sources.DataSource):
             raise KeyError(
                 "Not using public SSH keys from IMDS"
             )
+            # pylint:disable=unreachable
             ssh_keys = [
                 public_key['keyData']
                 for public_key
@@ -1278,6 +1279,7 @@ class DataSourceAzure(sources.DataSource):
                 raise KeyError(
                     "Not using public SSH keys from IMDS"
                 )
+                # pylint:disable=unreachable
                 public_keys = self.metadata['imds']['compute']['publicKeys']
                 LOG.debug(
                     'Successfully retrieved %s key(s) from IMDS',

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -651,6 +651,9 @@ class DataSourceAzure(sources.DataSource):
         LOG.debug('Retrieving public SSH keys')
         ssh_keys = []
         try:
+            raise KeyError(
+                "Not using public SSH keys from IMDS"
+            )
             ssh_keys = [
                 public_key['keyData']
                 for public_key
@@ -1272,6 +1275,9 @@ class DataSourceAzure(sources.DataSource):
 
             pubkey_info = None
             try:
+                raise KeyError(
+                    "Not using public SSH keys from IMDS"
+                )
                 public_keys = self.metadata['imds']['compute']['publicKeys']
                 LOG.debug(
                     'Successfully retrieved %s key(s) from IMDS',

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -1797,7 +1797,9 @@ scbus-1 on xpt0 bus 0
         dsrc.get_data()
         dsrc.setup(True)
         ssh_keys = dsrc.get_public_ssh_keys()
-        self.assertEqual(ssh_keys, ['key1'])
+        # Temporarily alter this test so that SSH public keys
+        # from IMDS are *not* going to be in use to fix a regression.
+        self.assertEqual(ssh_keys, [])
         self.assertEqual(m_parse_certificates.call_count, 0)
 
     @mock.patch(MOCKPATH + 'get_metadata_from_imds')


### PR DESCRIPTION
## Proposed Commit Message

Fix regression with handling of IMDS ssh keys.

```
With the changes for ssh public keys to be retrieved from IMDS as a first option, when a key is passed through not in the raw ssh public key format it causes an issue and the key is not added to the user's authorized_keys file.

This PR will temporarily disable this behavior until a permanent fix is put in place.
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
