### PR TITLE
archlinux: fix package upgrade command handling

### DIFF
--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -152,6 +152,8 @@ class Distro(distros.Distro):
         elif args and isinstance(args, list):
             cmd.extend(args)
 
+        if command == "upgrade":
+            command = "-u"
         if command:
             cmd.append(command)
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -26,6 +26,7 @@ nishigori
 olivierlemasle
 omBratteng
 onitake
+qubidt
 riedel
 slyon
 smoser


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
archlinux: fix package upgrade command handling

pacman uses `-u` instead of `upgrade` to trigger a system upgrade, fix
the command handling so this is properly accounted for. as is, the
resulting command attempts to install a (non-existent) `upgrade` package
```

## Additional Context
<!-- If relevant -->

Pretty straightforward. Arch's pacman uses `-u` instead of `upgrade` (see [`man 8 pacman`](https://man.archlinux.org/man/core/pacman/pacman.8.en#SYNC_OPTIONS_(APPLY_TO_-S))). Without this change I get an error when `package_upgrade: true`:

```
Cloud-init v. 20.4 running 'single' at Tue, 12 Jan 2021 00:37:17 +0000. Up 3995.82 seconds.
:: Synchronizing package databases...
error: target not found: upgrade
 core is up to date
 extra is up to date
 community is up to date
2021-01-12 00:37:17,927 - util.py[WARNING]: Package upgrade failed
2021-01-12 00:37:17,928 - cc_package_update_upgrade_install.py[WARNING]: 1 failed with exceptions, re-raising the last one
2021-01-12 00:37:17,928 - util.py[WARNING]: Running module package-update-upgrade-install (<module 'cloudinit.config.cc_package_update_upgrade_install' from '/usr/lib/python3.9/site-packages/cloudinit/config/cc_package_update_upgrade_install.py'>) failed
2021-01-12 00:37:17,929 - main.py[WARNING]: Ran package-update-upgrade-install but it failed!
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

I think some tests for this would be good to avoid regressions but I'm pretty unfamiliar with cloud-init and moreso with the project's testing setup. Any help would be appreciated 

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly

