### PR TITLE
Fix test gh-632 test to only run on NoCloud

### DIFF
--- a/tests/integration_tests/bugs/test_gh632.py
+++ b/tests/integration_tests/bugs/test_gh632.py
@@ -9,6 +9,9 @@ import pytest
 from tests.integration_tests.instances import IntegrationInstance
 
 
+# With some datasource hacking, we can run this on a NoCloud instance
+@pytest.mark.lxd_container
+@pytest.mark.lxd_vm
 @pytest.mark.sru_2020_11
 def test_datasource_rbx_no_stacktrace(client: IntegrationInstance):
     client.write_to_file(


### PR DESCRIPTION
## Proposed Commit Message
Fix test gh-632 test to only run on NoCloud

## Additional Context
This test was attempting to run and failing on Azure

## Test Steps
pytest -s tests/integration_tests/bugs/test_gh632.py
will now skip on anything other than LXD.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
