### PR TITLE
cc_seed_random: update documentation and fix integration test

### DIFF
--- a/cloudinit/config/cc_seed_random.py
+++ b/cloudinit/config/cc_seed_random.py
@@ -24,15 +24,19 @@ Configuration for this module is under the ``random_seed`` config key. The
 optionally be specified in encoded form, with the encoding specified in
 ``encoding``.
 
+If the cloud provides its own random seed data, it will be appended to ``data``
+before it is written to ``file``.
+
 .. note::
     when using a multiline value for ``data`` or specifying binary data, be
     sure to follow yaml syntax and use the ``|`` and ``!binary`` yaml format
     specifiers when appropriate
 
-Instead of specifying a data string, a command can be run to generate/collect
-the data to be written. The command should be specified as a list of args in
-the ``command`` key. If a command is specified that cannot be run, no error
-will be reported unless ``command_required`` is set to true.
+If the ``command`` key is specified, the given command will be executed.  This
+will happen after ``file`` has been populated.  That command's environment will
+contain the value of the ``file`` key as ``RANDOM_SEED_FILE``. If a command is
+specified that cannot be run, no error will be reported unless
+``command_required`` is set to true.
 
 For example, to use ``pollinate`` to gather data from a
 remote entropy server and write it to ``/dev/urandom``, the following could be

--- a/tests/integration_tests/modules/test_seed_random_data.py
+++ b/tests/integration_tests/modules/test_seed_random_data.py
@@ -25,4 +25,4 @@ class TestSeedRandomData:
     @pytest.mark.user_data(USER_DATA)
     def test_seed_random_data(self, client):
         seed_output = client.read_from_file("/root/seed")
-        assert seed_output.strip() == "MYUb34023nD:LFDK10913jk;dfnk:Df"
+        assert seed_output.startswith("MYUb34023nD:LFDK10913jk;dfnk:Df")


### PR DESCRIPTION
## Proposed Commit Message
```
cc_seed_random: update documentation and fix integration test

The documentation did not mention that the given data may not be the
exact string written: the cloud's random data may be added to it.
Additionally, the documentation of the command key was incorrect.

test_seed_random_data was updated to check that the given data is a
prefix of the written data, to match cloud-init's expected (and, now,
documented) behaviour.

LP: #1911227
```

## Test Steps

Run `CLOUD_INIT_PLATFORM=azure pytest tests/integration_tests/modules/test_seed_random_data.py` and observe a pass (vs. a fail previously).

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
