### PR TITLE
integration_tests: log image serial if available

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -173,6 +173,9 @@ class IntegrationCloud(ABC):
                 'cloud-init version: %s',
                 instance.execute("cloud-init --version")
             )
+            serial = instance.execute("grep serial /etc/cloud/build.info")
+            if serial:
+                log.info('image serial: %s', serial.split()[1])
         return instance
 
     def get_instance(self, cloud_instance, settings=integration_settings):


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: log image serial if available

Ubuntu cloud images ship /etc/cloud/build.info which includes a line
with the build serial used to identify the image:

    serial: 20210108

This is valuable information when verifying Ubuntu issues (to confirm
that testing is happening against the expected image), but is also
useful when debugging test failures: manifests of all packages in (the
base) images can be found at http://cloud-images.ubuntu.com/
```

## Test Steps

Run a test (against Ubuntu) and observe:

```
2021-01-13 17:52:03 INFO      integration_testing:clouds.py:178 image serial: 20210112
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly