### PR TITLE
WIP: don't write keys to global AuthorizedKeysFiles

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -238,6 +238,13 @@ def render_authorizedkeysfile_paths(value, homedir, username):
     macros = (("%h", homedir), ("%u", username), ("%%", "%"))
     if not value:
         value = "%h/.ssh/authorized_keys"
+    if "%h" not in value or "%u" not in value:
+        msg = (
+            "Absolute/global AuthorizedKeysFile configured (%s); cloud-init"
+            " does not handle these."
+        )
+        LOG.warning(msg, value)
+        raise OSError(msg % (value,))
     paths = value.split()
     rendered = []
     for path in paths:
@@ -264,7 +271,7 @@ def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
             # Give up and use a default key filename
             auth_key_fns.append(default_authorizedkeys_file)
             util.logexc(LOG, "Failed extracting 'AuthorizedKeysFile' in SSH "
-                        "config from %r, using 'AuthorizedKeysFile' file "
+                        "config from %r, using fallback file "
                         "%r instead", DEF_SSHD_CFG, auth_key_fns[0])
 
     # always store all the keys in the first file configured on sshd_config


### PR DESCRIPTION
In https://bugs.launchpad.net/cloud-init/+bug/1911680, it was reported that cloud-init 20.4 has started honouring global SSH AuthorizedKeyFile settings but will only ever write the keys of the last user processed to that file. In the default configuration, we process the default user then root: this means that the snippet used to disable _root_ login is written to the _global_ AuthorizedKeysFile, denying SSH access for _all_ users (even those configured via non-cloud-init means).

I'd recommend reading through the bug: it's an excellent report, and I've broken down the above in a bit more detail in the comments. TL;DR, I believe that we need to carefully think about how global AuthorizedKeyFiles should be treated, so the appropriate first step is to address the regression by restoring cloud-init's previous behaviour: don't write keys to a global AuthorizedKeyFile at all. (This PR also reverts to writing keys to `~/.ssh/authorized_keys` as a fallback: arguably it shouldn't do this.)

This PR is a rough sketch of how we might approach it: it has a couple of problems. The biggest problem is that both `cc_ssh` and `cc_keys_to_console` use the modified codepath: this means that when `cc_keys_to_console` reads the SSH keys from the system, it (of course) uses the fallback path, finds keys and writes them to the console. The problem with that: those SSH keys are written to files which are not configured in `sshd_config`, so the keys being written to the console cannot be used to access the system. (This is a change in behaviour from 20.3, which would correctly report no configured keys.)

The second problem is comparatively minor, the log message is repeated multiple times, twice for each user (one of those in a traceback):

```
2021-01-14 15:56:42,846 - util.py[DEBUG]: Read 2540 bytes from /etc/ssh/sshd_config
2021-01-14 15:56:42,846 - ssh_util.py[WARNING]: Absolute/global AuthorizedKeysFile configured (/etc/ssh/authorized_keys); cloud-init does not handle these.
2021-01-14 15:56:42,847 - util.py[WARNING]: Failed extracting 'AuthorizedKeysFile' in SSH config from '/etc/ssh/sshd_config', using fallback file '/home/ubuntu/.ssh/authorized_keys' instead
2021-01-14 15:56:42,847 - util.py[DEBUG]: Failed extracting 'AuthorizedKeysFile' in SSH config from '/etc/ssh/sshd_config', using fallback file '/home/ubuntu/.ssh/authorized_keys' instead
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/ssh_util.py", line 268, in extract_authorized_keys
    pw_ent.pw_dir, username)
  File "/usr/lib/python3/dist-packages/cloudinit/ssh_util.py", line 247, in render_authorizedkeysfile_paths
    raise OSError(msg % (value,))
OSError: Absolute/global AuthorizedKeysFile configured (/etc/ssh/authorized_keys); cloud-init does not handle these.
2021-01-14 15:56:42,848 - util.py[DEBUG]: Writing to /home/ubuntu/.ssh/authorized_keys - wb: [600] 391 bytes
2021-01-14 15:56:42,848 - util.py[DEBUG]: Changing the ownership of /home/ubuntu/.ssh/authorized_keys to 1000:1000
2021-01-14 15:56:42,849 - util.py[DEBUG]: Changing the ownership of /root/.ssh to 0:0
2021-01-14 15:56:42,849 - util.py[DEBUG]: Reading from /etc/ssh/sshd_config (quiet=False)
2021-01-14 15:56:42,849 - util.py[DEBUG]: Read 2540 bytes from /etc/ssh/sshd_config
2021-01-14 15:56:42,849 - ssh_util.py[WARNING]: Absolute/global AuthorizedKeysFile configured (/etc/ssh/authorized_keys); cloud-init does not handle these.
2021-01-14 15:56:42,849 - util.py[WARNING]: Failed extracting 'AuthorizedKeysFile' in SSH config from '/etc/ssh/sshd_config', using fallback file '/root/.ssh/authorized_keys' instead
2021-01-14 15:56:42,849 - util.py[DEBUG]: Failed extracting 'AuthorizedKeysFile' in SSH config from '/etc/ssh/sshd_config', using fallback file '/root/.ssh/authorized_keys' instead
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/ssh_util.py", line 268, in extract_authorized_keys
    pw_ent.pw_dir, username)
  File "/usr/lib/python3/dist-packages/cloudinit/ssh_util.py", line 247, in render_authorizedkeysfile_paths
    raise OSError(msg % (value,))
OSError: Absolute/global AuthorizedKeysFile configured (/etc/ssh/authorized_keys); cloud-init does not handle these.
2021-01-14 15:56:42,850 - util.py[DEBUG]: Writing to /root/.ssh/authorized_keys - wb: [600] 555 bytes
```