### PR TITLE
Revert "ssh_util: handle non-default AuthorizedKeysFile config (#586)"

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -262,13 +262,13 @@ def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
 
         except (IOError, OSError):
             # Give up and use a default key filename
-            auth_key_fns.append(default_authorizedkeys_file)
+            auth_key_fns[0] = default_authorizedkeys_file
             util.logexc(LOG, "Failed extracting 'AuthorizedKeysFile' in SSH "
                         "config from %r, using 'AuthorizedKeysFile' file "
                         "%r instead", DEF_SSHD_CFG, auth_key_fns[0])
 
-    # always store all the keys in the first file configured on sshd_config
-    return (auth_key_fns[0], parse_authorized_keys(auth_key_fns))
+    # always store all the keys in the user's private file
+    return (default_authorizedkeys_file, parse_authorized_keys(auth_key_fns))
 
 
 def setup_user_keys(keys, username, options=None):

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -593,7 +593,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
             fpw.pw_name, sshd_config)
         content = ssh_util.update_authorized_keys(auth_key_entries, [])
 
-        self.assertEqual(authorized_keys, auth_key_fn)
+        self.assertEqual("%s/.ssh/authorized_keys" % fpw.pw_dir, auth_key_fn)
         self.assertTrue(VALID_CONTENT['rsa'] in content)
         self.assertTrue(VALID_CONTENT['dsa'] in content)
 
@@ -610,7 +610,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         sshd_config = self.tmp_path('sshd_config')
         util.write_file(
             sshd_config,
-            "AuthorizedKeysFile %s %s" % (user_keys, authorized_keys)
+            "AuthorizedKeysFile %s %s" % (authorized_keys, user_keys)
         )
 
         (auth_key_fn, auth_key_entries) = ssh_util.extract_authorized_keys(
@@ -618,7 +618,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         )
         content = ssh_util.update_authorized_keys(auth_key_entries, [])
 
-        self.assertEqual(user_keys, auth_key_fn)
+        self.assertEqual("%s/.ssh/authorized_keys" % fpw.pw_dir, auth_key_fn)
         self.assertTrue(VALID_CONTENT['rsa'] in content)
         self.assertTrue(VALID_CONTENT['dsa'] in content)
 


### PR DESCRIPTION
## Proposed Commit Message
```
Revert "ssh_util: handle non-default AuthorizedKeysFile config (#586)"

This reverts commit b0e73814db4027dba0b7dc0282e295b7f653325c.

LP: #1911680
```

## Additional Context

This is the same fix used in the 20.4.1 hotfix release, now being included upstream.

## Test Steps

The following integration test can be used to validate this:

```py
ABSOLUTE_AUTH_KEYS_PATH = "/etc/ssh/authorized_keys"
BACKDOOR_KEYS = "/etc/backdoor_keys"
USER_DATA_TMPL = """\
#cloud-config
bootcmd:
- sed -i "s,#AuthorizedKeysFile.*,AuthorizedKeysFile {0} {1}," /etc/ssh/sshd_config
runcmd:
- |
    cat << EOF > {1}
    {{}}
    EOF
""".format(ABSOLUTE_AUTH_KEYS_PATH, BACKDOOR_KEYS)


# This test checks that we do not write keys into an absolute
# AuthorizedKeysFile by default, because doing so presents a security issue.
#
# Because we're intentionally testing that we do not write authorized keys to
# the location configured for sshd, we cannot SSH into the system using keys in
# that path.  We use runcmd to populate a second configured path to grant us
# access; runcmd will install the key after all the SSH key determination has
# been completed, therefore not affecting it.


def test_test(session_cloud, setup_image):
    # We shouldn't write out absolute files until we've figured out how to do
    # it right
    user_data = USER_DATA_TMPL.format(
        session_cloud.cloud_instance.key_pair.public_key_content
    )
    with session_cloud.launch(user_data=user_data) as client:
        assert client.execute(
            "test -f {}".format(ABSOLUTE_AUTH_KEYS_PATH)
        ).failed
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly