### PR TITLE
Use proper spelling for Red Hat

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -528,7 +528,7 @@
  - docs: add additional details to per-instance/once [Joshua Powers]
  - Update doc-requirements.txt [Joshua Powers]
  - doc-requirements: add missing dep [Joshua Powers]
- - dhcp: Support RedHat dhcp rfc3442 lease format for option 121 (#76)
+ - dhcp: Support Red Hat dhcp rfc3442 lease format for option 121 (#76)
    [Eric Lafontaine] (LP: #1850642)
  - network_state: handle empty v1 config (#45) (LP: #1852496)
  - docs: Add document on how to report bugs [Joshua Powers]

--- a/cloudinit/config/cc_resolv_conf.py
+++ b/cloudinit/config/cc_resolv_conf.py
@@ -14,12 +14,12 @@ Resolv Conf
 This module is intended to manage resolv.conf in environments where early
 configuration of resolv.conf is necessary for further bootstrapping and/or
 where configuration management such as puppet or chef own dns configuration.
-As Debian/Ubuntu will, by default, utilize resolvconf, and similarly RedHat
+As Debian/Ubuntu will, by default, utilize resolvconf, and similarly Red Hat
 will use sysconfig, this module is likely to be of little use unless those
 are configured correctly.
 
 .. note::
-    For RedHat with sysconfig, be sure to set PEERDNS=no for all DHCP
+    For Red Hat with sysconfig, be sure to set PEERDNS=no for all DHCP
     enabled NICs.
 
 .. note::

--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -5,15 +5,15 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 """
-RedHat Subscription
--------------------
+Red Hat Subscription
+--------------------
 **Summary:** register red hat enterprise linux based system
 
-Register a RedHat system either by username and password *or* activation and
+Register a Red Hat system either by username and password *or* activation and
 org. Following a sucessful registration, you can auto-attach subscriptions, set
 the service level, add subscriptions based on pool id, enable/disable yum
 repositories based on repo id, and alter the rhsm_baseurl and server-hostname
-in ``/etc/rhsm/rhs.conf``. For more details, see the ``Register RedHat
+in ``/etc/rhsm/rhs.conf``. For more details, see the ``Register Red Hat
 Subscription`` example config.
 
 **Internal name:** ``cc_rh_subscription``

--- a/doc/rtd/topics/examples.rst
+++ b/doc/rtd/topics/examples.rst
@@ -149,8 +149,8 @@ Disk setup
     :language: yaml
     :linenos:
 
-Register RedHat Subscription
-============================
+Register Red Hat Subscription
+=============================
 
 .. literalinclude:: ../../examples/cloud-config-rh_subscription.txt
     :language: yaml

--- a/tests/cloud_tests/testcases/examples/TODO.md
+++ b/tests/cloud_tests/testcases/examples/TODO.md
@@ -6,7 +6,7 @@ Below lists each of the issing examples and why it is not currently added.
  - Puppet (takes > 60 seconds to run)
  - Manage resolve.conf (lxd backend overrides changes)
  - Adding a yum repository (need centos system)
- - Register RedHat Subscription (need centos system + subscription)
+ - Register Red Hat Subscription (need centos system + subscription)
  - Adjust mount points mounted (need multiple disks)
  - Call a url when finished (need end point)
  - Reboot/poweroff when finished (how to test)


### PR DESCRIPTION
The company name has two district words.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
