### PR TITLE
doc: avoid two warnings

### DIFF
--- a/doc/rtd/topics/format.rst
+++ b/doc/rtd/topics/format.rst
@@ -23,9 +23,11 @@ Using a mime-multi part file, the user can specify more than one type of data.
 For example, both a user data script and a cloud-config type could be
 specified.
 
-Supported content-types are listed from the cloud-init subcommand make-mime::
+Supported content-types are listed from the cloud-init subcommand make-mime:
 
-    % cloud-init devel make-mime --list-types
+.. code-block:: shell-session
+
+    $ cloud-init devel make-mime --list-types
     cloud-boothook
     cloud-config
     cloud-config-archive
@@ -47,9 +49,11 @@ The cloud-init subcommand can generate MIME multi-part files: `make-mime`_.
 separated by a colon (e.g. ``config.yaml:cloud-config``) and emits a MIME
 multipart message to stdout.  An example invocation, assuming you have your
 cloud config in ``config.yaml`` and a shell script in ``script.sh`` and want
-to store the multipart message in ``user-data``::
+to store the multipart message in ``user-data``:
 
-    % cloud-init devel make-mime -a config.yaml:cloud-config -a script.sh:x-shellscript > user-data
+.. code-block:: shell-session
+
+    $ cloud-init devel make-mime -a config.yaml:cloud-config -a script.sh:x-shellscript > user-data
 
 .. _make-mime: https://github.com/canonical/cloud-init/blob/master/cloudinit/cmd/devel/make_mime.py
 
@@ -70,7 +74,7 @@ archive.
 Example
 -------
 
-::
+.. code-block:: shell-session
 
   $ cat myscript.sh
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -9,6 +9,7 @@ bipinbachhao
 BirknerAlex
 candlerb
 cawamata
+dankenigsberg
 dermotbradley
 dhensby
 eandersson


### PR DESCRIPTION
Two shell code blocks are not marked as such, confusing rst to consider
them as yaml. Be explicit about their syntax, and use $ prompt to match
elsewhere in the docs.

```
/home/travis/build/canonical/cloud-init/doc/rtd/topics/format.rst:28: WARNING: Could not lex literal_block as "yaml". Highlighting skipped.
/home/travis/build/canonical/cloud-init/doc/rtd/topics/format.rst:52: WARNING: Could not lex literal_block as "yaml". Highlighting skipped.
```

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
