### PR TITLE
[VMware]:disable network config if no network provided in metadata

### DIFF
--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -172,9 +172,8 @@ class DataSourceOVF(sources.DataSource):
                 if network:
                     self._network_config = network
                 else:
-                    self._network_config = (
-                        self.distro.generate_fallback_config()
-                    )
+                    LOG.debug("Network not found, disable network config.")
+                    self._network_config = {'config': 'disabled'}
 
             except safeyaml.YAMLError as e:
                 _raise_error_status(


### PR DESCRIPTION
summary: disable network config if no network provided in metadata

vmware vSphere users want to re-customize the VM without changing network,
which means the network could be absent in metadata.  In this case,  we need to
set the network config to disabled in datasource.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [X ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
