### PR TITLE
VMware: Fix default route configuration when no primary NIC exists

### DIFF
--- a/tests/unittests/test_vmware_config_file.py
+++ b/tests/unittests/test_vmware_config_file.py
@@ -17,7 +17,6 @@ from cloudinit.sources.DataSourceOVF import read_vmware_imc
 from cloudinit.sources.helpers.vmware.imc.boot_proto import BootProtoEnum
 from cloudinit.sources.helpers.vmware.imc.config import Config
 from cloudinit.sources.helpers.vmware.imc.config_file import ConfigFile
-from cloudinit.sources.helpers.vmware.imc.config_nic import gen_subnet
 from cloudinit.sources.helpers.vmware.imc.config_nic import NicConfigurator
 from cloudinit.tests.helpers import CiTestCase
 
@@ -173,16 +172,6 @@ class TestVmwareConfigFile(CiTestCase):
         self.assertEqual(['eng.vmware.com', 'proxy.vmware.com'],
                          dns_suffixes,
                          "suffixes")
-
-    def test_gen_subnet(self):
-        """Tests if gen_subnet properly calculates network subnet from
-           IPv4 address and netmask"""
-        ip_subnet_list = [['10.20.87.253', '255.255.252.0', '10.20.84.0'],
-                          ['10.20.92.105', '255.255.252.0', '10.20.92.0'],
-                          ['192.168.0.10', '255.255.0.0', '192.168.0.0']]
-        for entry in ip_subnet_list:
-            self.assertEqual(entry[2], gen_subnet(entry[0], entry[1]),
-                             "Subnet for a specified ip and netmask")
 
     def test_get_config_dns_suffixes(self):
         """Tests if get_network_config_from_conf properly
@@ -447,7 +436,7 @@ class TestVmwareNetConfig(CiTestCase):
                   {'control': 'auto', 'type': 'static',
                    'address': '10.20.87.154', 'netmask': '255.255.252.0',
                    'routes':
-                       [{'type': 'route', 'destination': '10.20.84.0/22',
+                       [{'type': 'route', 'destination': '0.0.0.0/0',
                          'gateway': '10.20.87.253', 'metric': 10000}]}]}],
             nc.generate())
 
@@ -489,7 +478,7 @@ class TestVmwareNetConfig(CiTestCase):
                   {'control': 'auto', 'type': 'static',
                    'address': '100.115.223.75', 'netmask': '255.255.255.0',
                    'routes':
-                       [{'type': 'route', 'destination': '100.115.223.0/24',
+                       [{'type': 'route', 'destination': '0.0.0.0/0',
                          'gateway': '100.115.223.254', 'metric': 10000}]}]}],
             nc.generate())
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -24,6 +24,7 @@ manuelisimo
 marlluslustosa
 matthewruffell
 nishigori
+ntoofu
 olivierlemasle
 omBratteng
 onitake


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
VMware: Fix default route configuration when no primary NIC exists

Because a subnet which gateway belongs to is usually treated
as a "directly connected" on the host, adding a route for the subnet has
no effect.

Therefore, `0.0.0.0/0` should be used as destinations of routes
associated with gateways of non-primary NICs instead.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

I verified in this way:

1. Deploy Ubuntu 20.04 virtual machine
2. Add `disable_vmware_customization: false` to `cloud.cfg` in the VM
3. Clone the VM with VMware guest customization by using [Ansible module](https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_module.html)
4. Check the route table in a cloned VM

### Playbook used in step 3

```
- hosts: all
  gather_facts: no
  tasks:
  - community.vmware.vmware_guest:
      hostname: "{{ vcenter_hostname }}"
      username: "{{ vcenter_username }}"
      password: "{{ vcenter_password }}"
      validate_certs: no
      datacenter: Datacenter
      folder: /test
      name: testvm
      state: poweredon
      template: ubuntu-20.04-template
      disk:
      - type: thin
        datastore: datastore
        size_gb: 30
      hardware:
        memory_mb: 1024
        num_cpus: 2
        num_cpu_cores_per_socket: 1
        scsi: paravirtual
      networks:
      - name: VM Network
        ip: 192.168.0.11
        netmask: 255.255.255.0
        gateway: 192.168.0.1
        wait_for_ip_address: true
    delegate_to: localhost
```

### Network settings generated without this patch

```
root@testvm:~# ip addr show
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: ens160: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:50:56:ba:86:41 brd ff:ff:ff:ff:ff:ff
    inet 192.168.0.11/24 brd 192.168.0.255 scope global ens160
       valid_lft forever preferred_lft forever
    inet6 fe80::250:56ff:feba:8641/64 scope link
       valid_lft forever preferred_lft forever

root@testvm:~# ip route show
192.168.0.0/24 dev ens160 proto kernel scope link src 192.168.0.11
192.168.0.0/24 via 192.168.0.1 dev ens160 proto static metric 10000
```

No default route is generated.

### Network settings generated with this patch

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: ens160: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:50:56:ba:db:32 brd ff:ff:ff:ff:ff:ff
    inet 192.168.0.11/24 brd 192.168.0.255 scope global ens160
       valid_lft forever preferred_lft forever
    inet6 fe80::250:56ff:feba:db32/64 scope link
       valid_lft forever preferred_lft forever

root@testvm:~# ip route show
default via 192.168.0.1 dev ens160 proto static metric 10000
192.168.0.0/24 dev ens160 proto kernel scope link src 192.168.0.11
```

A default route is generated as expected.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
