### PR TITLE
Network config V2 -> V1 conversion: handle accept-ra

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -771,8 +771,8 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
             subnets.append(subnet)
         if cfg.get('dhcp6'):
             subnet = {'type': 'dhcp6'}
-            if 'accept_ra' in cfg:
-                if cfg.get('accept_ra'):
+            if 'accept-ra' in cfg:
+                if cfg.get('accept-ra'):
                     subnet = {'type': 'ipv6_dhcpv6-stateless'}
                 else:
                     subnet.update({'accept-ra': False})
@@ -793,7 +793,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
                 if 'gateway6' in cfg and gateway6 is None:
                     gateway6 = cfg.get('gateway6')
                     subnet.update({'gateway': gateway6})
-                if cfg.get('accept_ra'):
+                if cfg.get('accept-ra'):
                     subnet.update({'accept-ra': True})
             else:
                 if 'gateway4' in cfg and gateway4 is None:

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -771,6 +771,11 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
             subnets.append(subnet)
         if cfg.get('dhcp6'):
             subnet = {'type': 'dhcp6'}
+            if 'accept_ra' in cfg:
+                if cfg.get('accept_ra'):
+                    subnet = {'type': 'ipv6_dhcpv6-stateless'}
+                else:
+                    subnet.update({'accept-ra': False})
             self.use_ipv6 = True
             _add_dhcp_overrides(cfg.get('dhcp6-overrides', {}), subnet)
             subnets.append(subnet)
@@ -788,11 +793,12 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
                 if 'gateway6' in cfg and gateway6 is None:
                     gateway6 = cfg.get('gateway6')
                     subnet.update({'gateway': gateway6})
+                if cfg.get('accept_ra'):
+                    subnet.update({'accept-ra': True})
             else:
                 if 'gateway4' in cfg and gateway4 is None:
                     gateway4 = cfg.get('gateway4')
                     subnet.update({'gateway': gateway4})
-
             if 'nameservers' in cfg and not nameservers:
                 addresses = cfg.get('nameservers').get('addresses')
                 if addresses:

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -772,10 +772,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
         if cfg.get('dhcp6'):
             subnet = {'type': 'dhcp6'}
             if 'accept-ra' in cfg:
-                if cfg.get('accept-ra'):
-                    subnet = {'type': 'ipv6_dhcpv6-stateless'}
-                else:
-                    subnet.update({'accept-ra': False})
+                subnet.update({'accept-ra': cfg.get('accept-ra')})
             self.use_ipv6 = True
             _add_dhcp_overrides(cfg.get('dhcp6-overrides', {}), subnet)
             subnets.append(subnet)


### PR DESCRIPTION
## Handle accept_ra in network config conversion
Network config V2 -> V1 conversion: handle accept-ra

```
Network config version 2 is converted back to version 1 when rendered with a legacy render (ENI). This conversion is done by the handle functions in net/network_state.py, for example `handle_ethernets` that takes care of the ethernets part in network config v2. Subnet creation happens in function `_v2_to_v1_ipcfg` that is missing the accept-ra functionality available in both network config versions. This PR adds that.

LP: #1912545
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
