### PR TITLE
Remove 'remove-raise-on-failure' calls from integration_tests

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@39805087affaed07b266d64cf0d883be775b5c0f
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@878981e3c7caaf583a8c7c5494dba9d9447acee8
 pytest

--- a/tests/integration_tests/bugs/test_gh570.py
+++ b/tests/integration_tests/bugs/test_gh570.py
@@ -34,5 +34,6 @@ def test_nocloud_seedfrom_vendordata(client: IntegrationInstance):
         VENDOR_DATA,
     )
     client.execute('cloud-init clean --logs')
-    client.restart(raise_on_cloudinit_failure=True)
+    client.restart()
+    assert client.execute('cloud-init status').ok
     assert 'seeded_vendordata_test_file' in client.execute('ls /var/tmp')

--- a/tests/integration_tests/bugs/test_lp1900837.py
+++ b/tests/integration_tests/bugs/test_lp1900837.py
@@ -22,7 +22,8 @@ class TestLogPermissionsNotResetOnReboot:
         assert "600" == _get_log_perms(client)
 
         # Reboot
-        client.restart(raise_on_cloudinit_failure=True)
+        client.restart()
+        assert client.execute('cloud-init status').ok
 
         # Check that permissions are not reset on reboot
         assert "600" == _get_log_perms(client)

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -135,7 +135,7 @@ class IntegrationCloud(ABC):
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
         return pycloudlib_instance
 
-    def launch(self, user_data=None, launch_kwargs=None, wait=True,
+    def launch(self, user_data=None, launch_kwargs=None,
                settings=integration_settings):
         if launch_kwargs is None:
             launch_kwargs = {}
@@ -147,13 +147,9 @@ class IntegrationCloud(ABC):
                 self.settings.EXISTING_INSTANCE_ID
             )
             return
-        if 'wait' in launch_kwargs:
-            raise Exception("Specify 'wait' directly to launch, "
-                            "not in 'launch_kwargs'")
         kwargs = {
             'image_id': self.image_id,
             'user_data': user_data,
-            'wait': False,
         }
         kwargs.update(launch_kwargs)
         log.info(
@@ -163,11 +159,9 @@ class IntegrationCloud(ABC):
         )
 
         pycloudlib_instance = self._perform_launch(kwargs)
-        if wait:
-            pycloudlib_instance.wait(raise_on_cloudinit_failure=False)
         log.info('Launched instance: %s', pycloudlib_instance)
         instance = self.get_instance(pycloudlib_instance, settings)
-        if wait:
+        if kwargs.get('wait', True):
             # If we aren't waiting, we can't rely on command execution here
             log.info(
                 'cloud-init version: %s',
@@ -277,7 +271,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
 
     def _perform_launch(self, launch_kwargs):
         launch_kwargs['inst_type'] = launch_kwargs.pop('instance_type', None)
-        launch_kwargs.pop('wait')
+        wait = launch_kwargs.pop('wait', True)
         release = launch_kwargs.pop('image_id')
 
         try:
@@ -293,7 +287,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
         )
         if self.settings.CLOUD_INIT_SOURCE == 'IN_PLACE':
             self._mount_source(pycloudlib_instance)
-        pycloudlib_instance.start(wait=False)
+        pycloudlib_instance.start(wait=wait)
         return pycloudlib_instance
 
 

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -59,9 +59,7 @@ class IntegrationInstance:
     def restart(self):
         """Restart this instance (via cloud mechanism) and wait for boot.
 
-        This wraps pycloudlib's `BaseInstance.restart` to pass
-        `raise_on_cloudinit_failure=False` to `BaseInstance.wait`, mirroring
-        our launch behaviour.
+        This wraps pycloudlib's `BaseInstance.restart`
         """
         log.info("Restarting instance and waiting for boot")
         self.instance.restart()

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -56,18 +56,15 @@ class IntegrationInstance:
     def destroy(self):
         self.instance.delete()
 
-    def restart(self, raise_on_cloudinit_failure=False):
+    def restart(self):
         """Restart this instance (via cloud mechanism) and wait for boot.
 
         This wraps pycloudlib's `BaseInstance.restart` to pass
         `raise_on_cloudinit_failure=False` to `BaseInstance.wait`, mirroring
         our launch behaviour.
         """
-        self.instance.restart(wait=False)
-        log.info("Instance restarted; waiting for boot")
-        self.instance.wait(
-            raise_on_cloudinit_failure=raise_on_cloudinit_failure
-        )
+        log.info("Restarting instance and waiting for boot")
+        self.instance.restart()
 
     def execute(self, command, *, use_sudo=True) -> Result:
         if self.instance.username == 'root' and use_sudo is False:

--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -27,13 +27,13 @@ def _detect_reboot(instance: IntegrationInstance):
     # detecting the first boot or second boot, so we also check
     # the logs to ensure we've booted twice. If the logs show we've
     # only booted once, wait until we've booted twice
-    instance.instance.wait(raise_on_cloudinit_failure=False)
+    instance.instance.wait()
     for _ in range(600):
         try:
             log = instance.read_from_file('/var/log/cloud-init.log')
             boot_count = log.count("running 'init-local'")
             if boot_count == 1:
-                instance.instance.wait(raise_on_cloudinit_failure=False)
+                instance.instance.wait()
             elif boot_count > 1:
                 break
         except Exception:

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -43,15 +43,14 @@ def _output_to_compare(instance, file_path, netcfg_path):
 
 def _restart(instance):
     # work around pad.lv/1908287
-    try:
-        instance.restart(raise_on_cloudinit_failure=True)
-    except OSError as e:
+    instance.restart()
+    if not instance.execute('cloud-init status --wait --long').ok:
         for _ in range(10):
             time.sleep(5)
             result = instance.execute('cloud-init status --wait --long')
             if result.ok:
                 return
-        raise e
+        raise Exception("Cloud-init didn't finish starting up")
 
 
 @pytest.mark.sru_2020_11


### PR DESCRIPTION
Pycloudlib no longer raises exceptions when cloud-init fails to start,
and the API has been updated accordingly. Changes have been made to
integration tests accordingly

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Remove 'remove-raise-on-failure' calls from integration_tests

Pycloudlib no longer raises exceptions when cloud-init fails to start,
and the API has been updated accordingly. Changes have been made to
integration tests accordingly
```

## Additional Context
https://github.com/canonical/pycloudlib/pull/93

## Test Steps
> pytest tests/integration_tests

Tested on both lxd containers and lxd vms. Failures were unrelated.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
