### PR TITLE
HACKING.rst: add clarifying note to LP CLA process section

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -98,6 +98,11 @@ The cloud-init team will review the two merge proposals and verify that
 the CLA has been signed for the Launchpad user and record the
 associated GitHub account.
 
+.. note::
+   If you are a first time contributor, you will not need to touch
+   Launchpad to contribute to cloud-init: all new CLA signatures are
+   handled as part of the GitHub pull request process described above.
+
 Do these things for each feature or bug
 =======================================
 


### PR DESCRIPTION
## Proposed Commit Message
```
HACKING.rst: add clarifying note to LP CLA process section

We've had some first time contributors still end up trying to submit via
Launchpad: this commit underlines that this is not necessary.
```

## Test Steps

Build the docs and observe:

![cla-note](https://user-images.githubusercontent.com/62736/105869068-d9f6f000-5fc4-11eb-88fa-40dca60437dd.png)

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly