### PR TITLE
Stop linting cloud_tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -123,13 +123,12 @@ commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/}
 deps = flake8
 
 [testenv:tip-pylint]
-commands = {envpython} -m pylint {posargs:cloudinit tests tools}
+commands = {envpython} -m pylint {posargs:cloudinit tests --ignore=cloud_tests tools}
 deps =
     # requirements
     pylint
     # test-requirements
     -r{toxinidir}/test-requirements.txt
-    -r{toxinidir}/cloud-tests-requirements.txt
     -r{toxinidir}/integration-requirements.txt
 
 [testenv:citest]

--- a/tox.ini
+++ b/tox.ini
@@ -26,9 +26,9 @@ deps =
     pylint==2.6.0
     # test-requirements because unit tests are now present in cloudinit tree
     -r{toxinidir}/test-requirements.txt
-    -r{toxinidir}/cloud-tests-requirements.txt
     -r{toxinidir}/integration-requirements.txt
-commands = {envpython} -m pylint {posargs:cloudinit tests tools}
+commands = {envpython} -m pylint {posargs:cloudinit tests --ignore=cloud_tests tools}
+
 
 [testenv:py3]
 basepython = python3


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Stop linting cloud_tests

The tox pylint command was failing because of competing dependencies in
the multiple requirements files. Given that we plan on no longer
updating cloud_tests, we also no longer need to lint them.
```

## Additional Context
n/a

## Test Steps
`tox -e pylint` in a bionic container
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
