### PR TITLE
Add flexibility to IMDS api-version

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -2125,6 +2125,7 @@ def _get_metadata_from_imds(
         api_version=IMDS_VER_MIN):
     url = "{}?api-version={}".format(md_type.value, api_version)
     headers = {"Metadata": "true"}
+    LOG.info("IMDS url: %s", url)
     try:
         response = readurl(
             url, timeout=IMDS_TIMEOUT_IN_SECONDS, headers=headers,

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1018,7 +1018,7 @@ class DataSourceAzure(sources.DataSource):
     def _poll_imds(self):
         """Poll IMDS for the new provisioning data until we get a valid
         response. Then return the returned JSON object."""
-        url = metadata_type.reprovisiondata.value
+        url = "{}?api-version={}".format(metadata_type.reprovisiondata.value, IMDS_VER_MIN)
         headers = {"Metadata": "true"}
         nl_sock = None
         report_ready = bool(not os.path.isfile(REPORTED_READY_MARKER_FILE))

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -635,7 +635,11 @@ class DataSourceAzure(sources.DataSource):
         return True
 
     @azure_ds_telemetry_reporter
-    def get_imds_data(self, fallback_nic, retries, md_type=metadata_type.compute):
+    def get_imds_data(
+                self,
+                fallback_nic,
+                retries,
+                md_type=metadata_type.compute):
         LOG.info("Using IMDS api-version: {}".format(self.api_version))
         if self.failed_desired_api_version:
             return get_metadata_from_imds(
@@ -654,7 +658,10 @@ class DataSourceAzure(sources.DataSource):
                     self.api_version
                 )
             except UrlError as err:
-                LOG.info("UrlError with IMDS api-version: {}".format(self.api_version))
+                LOG.info(
+                    "UrlError with IMDS api-version: {}".format(
+                        self.api_version
+                ))
                 if err.code == 400:
                     self.api_version = IMDS_VER_MIN
                     self.failed_desired_api_version = True
@@ -1020,7 +1027,10 @@ class DataSourceAzure(sources.DataSource):
     def _poll_imds(self):
         """Poll IMDS for the new provisioning data until we get a valid
         response. Then return the returned JSON object."""
-        url = "{}?api-version={}".format(metadata_type.reprovisiondata.value, IMDS_VER_MIN)
+        url = "{}?api-version={}".format(
+            metadata_type.reprovisiondata.value,
+            IMDS_VER_MIN
+        )
         headers = {"Metadata": "true"}
         nl_sock = None
         report_ready = bool(not os.path.isfile(REPORTED_READY_MARKER_FILE))
@@ -2088,7 +2098,8 @@ def get_metadata_from_imds(fallback_nic,
     """
     kwargs = {'logfunc': LOG.debug,
               'msg': 'Crawl of Azure Instance Metadata Service (IMDS)',
-              'func': _get_metadata_from_imds, 'args': (retries, md_type, api_version,)}
+              'func': _get_metadata_from_imds,
+              'args': (retries, md_type, api_version,)}
     if net.is_up(fallback_nic):
         return util.log_time(**kwargs)
     else:
@@ -2104,8 +2115,10 @@ def get_metadata_from_imds(fallback_nic,
 
 
 @azure_ds_telemetry_reporter
-def _get_metadata_from_imds(retries, md_type=metadata_type.compute, api_version=IMDS_VER_MIN):
-
+def _get_metadata_from_imds(
+        retries,
+        md_type=metadata_type.compute,
+        api_version=IMDS_VER_MIN):
     url = "{}?api-version={}".format(md_type.value, api_version)
     headers = {"Metadata": "true"}
     try:

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -2125,7 +2125,6 @@ def _get_metadata_from_imds(
         api_version=IMDS_VER_MIN):
     url = "{}?api-version={}".format(md_type.value, api_version)
     headers = {"Metadata": "true"}
-    LOG.info("IMDS url: %s", url)
     try:
         response = readurl(
             url, timeout=IMDS_TIMEOUT_IN_SECONDS, headers=headers,

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -636,10 +636,10 @@ class DataSourceAzure(sources.DataSource):
 
     @azure_ds_telemetry_reporter
     def get_imds_data(
-                self,
-                fallback_nic,
-                retries,
-                md_type=metadata_type.compute):
+            self,
+            fallback_nic,
+            retries,
+            md_type=metadata_type.compute):
         LOG.info("Attempting IMDS api-version: %s", self.api_version)
         if self.failed_desired_api_version:
             return get_metadata_from_imds(
@@ -2133,6 +2133,7 @@ def _get_metadata_from_imds(
             url, timeout=IMDS_TIMEOUT_IN_SECONDS, headers=headers,
             retries=retries, exception_cb=retry_on_url_exc)
     except Exception as e:
+        # pylint:disable=no-member
         if isinstance(e, UrlError) and e.code == 400:
             raise
         else:

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -643,19 +643,19 @@ class DataSourceAzure(sources.DataSource):
         LOG.info("Using IMDS api-version: %s", self.api_version)
         if self.failed_desired_api_version:
             return get_metadata_from_imds(
-                fallback_nic,
-                retries,
-                md_type,
-                self.api_version
+                fallback_nic=fallback_nic,
+                retries=retries,
+                md_type=md_type,
+                api_version=self.api_version
             )
 
         try:
             try:
                 return get_metadata_from_imds(
-                    fallback_nic,
-                    1,
-                    md_type,
-                    self.api_version
+                    fallback_nic=fallback_nic,
+                    retries=1,
+                    md_type=md_type,
+                    api_version=self.api_version
                 )
             except UrlError as err:
                 LOG.info(

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -640,7 +640,7 @@ class DataSourceAzure(sources.DataSource):
                 fallback_nic,
                 retries,
                 md_type=metadata_type.compute):
-        LOG.info("Using IMDS api-version: {}".format(self.api_version))
+        LOG.info("Using IMDS api-version: %s", self.api_version)
         if self.failed_desired_api_version:
             return get_metadata_from_imds(
                 fallback_nic,
@@ -659,9 +659,9 @@ class DataSourceAzure(sources.DataSource):
                 )
             except UrlError as err:
                 LOG.info(
-                    "UrlError with IMDS api-version: {}".format(
-                        self.api_version
-                ))
+                    "UrlError with IMDS api-version: %s",
+                    self.api_version
+                )
                 if err.code == 400:
                     self.api_version = IMDS_VER_MIN
                     self.failed_desired_api_version = True

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -2070,7 +2070,7 @@ def _generate_network_config_from_fallback_config() -> dict:
 def get_metadata_from_imds(fallback_nic,
                            retries,
                            md_type=metadata_type.compute,
-                           api_version):
+                           api_version=IMDS_VER_MIN):
     """Query Azure's instance metadata service, returning a dictionary.
 
     If network is not up, setup ephemeral dhcp on fallback_nic to talk to the
@@ -2102,7 +2102,7 @@ def get_metadata_from_imds(fallback_nic,
 
 
 @azure_ds_telemetry_reporter
-def _get_metadata_from_imds(retries, md_type=metadata_type.compute, api_version):
+def _get_metadata_from_imds(retries, md_type=metadata_type.compute, api_version=IMDS_VER_MIN):
 
     url = "{}?api-version={}".format(md_type.value, api_version)
     headers = {"Metadata": "true"}

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -647,7 +647,7 @@ class DataSourceAzure(sources.DataSource):
 
         try:
             try:
-                get_metadata_from_imds(
+                return get_metadata_from_imds(
                     fallback_nic,
                     1,
                     md_type,

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -2130,14 +2130,15 @@ def _get_metadata_from_imds(
         response = readurl(
             url, timeout=IMDS_TIMEOUT_IN_SECONDS, headers=headers,
             retries=retries, exception_cb=retry_on_url_exc)
-    except UrlError:
-        raise
     except Exception as e:
-        report_diagnostic_event(
-            'Ignoring IMDS instance metadata. '
-            'Get metadata from IMDS failed: %s' % e,
-            logger_func=LOG.warning)
-        return {}
+        if isinstance(e, UrlError) and e.code == 400:
+            raise
+        else:
+            report_diagnostic_event(
+                'Ignoring IMDS instance metadata. '
+                'Get metadata from IMDS failed: %s' % e,
+                logger_func=LOG.warning)
+            return {}
     try:
         from json.decoder import JSONDecodeError
         json_decode_error = JSONDecodeError

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -640,7 +640,7 @@ class DataSourceAzure(sources.DataSource):
                 fallback_nic,
                 retries,
                 md_type=metadata_type.compute):
-        LOG.info("Using IMDS api-version: %s", self.api_version)
+        LOG.info("Attempting IMDS api-version: %s", self.api_version)
         if self.failed_desired_api_version:
             return get_metadata_from_imds(
                 fallback_nic=fallback_nic,
@@ -664,6 +664,10 @@ class DataSourceAzure(sources.DataSource):
                 )
                 if err.code == 400:
                     self.api_version = IMDS_VER_MIN
+                    LOG.info(
+                        "Falling back to IMDS api-version: %s",
+                        self.api_version
+                    )
                     self.failed_desired_api_version = True
                 raise
         except Exception:

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -664,9 +664,12 @@ class DataSourceAzure(sources.DataSource):
                 )
                 if err.code == 400:
                     self.api_version = IMDS_VER_MIN
-                    LOG.info(
-                        "Falling back to IMDS api-version: %s",
+                    log_msg = "Falling back to IMDS api-version: {}".format(
                         self.api_version
+                    )
+                    report_diagnostic_event(
+                        log_msg,
+                        logger_func=LOG.info
                     )
                     self.failed_desired_api_version = True
                 raise

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -2130,6 +2130,8 @@ def _get_metadata_from_imds(
         response = readurl(
             url, timeout=IMDS_TIMEOUT_IN_SECONDS, headers=headers,
             retries=retries, exception_cb=retry_on_url_exc)
+    except UrlError:
+        raise
     except Exception as e:
         report_diagnostic_event(
             'Ignoring IMDS instance metadata. '

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -637,6 +637,7 @@ class DataSourceAzure(sources.DataSource):
 
     @azure_ds_telemetry_reporter
     def get_imds_data(self, fallback_nic, retries, md_type=metadata_type.compute):
+        LOG.info("Using IMDS api-version: {}".format(self.api_version))
         if self.failed_desired_api_version:
             return get_metadata_from_imds(
                 fallback_nic,
@@ -654,6 +655,7 @@ class DataSourceAzure(sources.DataSource):
                     self.api_version
                 )
             except UrlError as err:
+                LOG.info("UrlError with IMDS api-version: {}".format(self.api_version))
                 if err.code == 400:
                     self.api_version = IMDS_VER_MIN
                     self.failed_desired_api_version = True

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -521,8 +521,7 @@ class DataSourceAzure(sources.DataSource):
                     self._wait_for_all_nics_ready()
                 ret = self._reprovision()
 
-            imds_md = get_metadata_from_imds(
-                self.fallback_interface, retries=10)
+            imds_md = self.get_imds_data(self.fallback_interface, retries=10)
             (md, userdata_raw, cfg, files) = ret
             self.seed = cdev
             crawled_data.update({
@@ -883,10 +882,11 @@ class DataSourceAzure(sources.DataSource):
         # primary nic is being attached first helps here. Otherwise each nic
         # could add several seconds of delay.
         try:
-            imds_md = get_metadata_from_imds(
+            imds_md = self.get_imds_data(
                 ifname,
                 5,
-                metadata_type.network)
+                metadata_type.network
+            )
         except Exception as e:
             LOG.warning(
                 "Failed to get network metadata using nic %s. Attempt to "

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -659,7 +659,7 @@ class DataSourceAzure(sources.DataSource):
                     )
                     return get_metadata_from_imds(
                         fallback_nic=fallback_nic,
-                        retries=retries,
+                        retries=0,
                         md_type=md_type,
                         api_version=IMDS_VER_WANT
                     )

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -1840,6 +1840,19 @@ scbus-1 on xpt0 bus 0
         self.assertIsNotNone(dsrc.metadata)
         self.assertEqual(dsrc.api_version, dsaz.IMDS_VER_MIN)
 
+    @mock.patch(MOCKPATH + 'get_metadata_from_imds', return_value=NETWORK_METADATA)
+    def test_imds_api_version_wanted_exists(self, m_get_metadata_from_imds):
+        sys_cfg = {'datasource': {'Azure': {'apply_network_config': True}}}
+        odata = {'HostName': "myhost", 'UserName': "myuser"}
+        data = {
+            'ovfcontent': construct_valid_ovf_env(data=odata),
+            'sys_cfg': sys_cfg
+        }
+        dsrc = self._get_ds(data)
+        dsrc.get_data()
+        self.assertIsNotNone(dsrc.metadata)
+        self.assertEqual(dsrc.api_version, dsaz.IMDS_VER_WANT)
+
 
 class TestAzureBounce(CiTestCase):
 

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -407,7 +407,9 @@ class TestGetMetadataFromIMDS(HttprettyTestCase):
 
     def setUp(self):
         super(TestGetMetadataFromIMDS, self).setUp()
-        self.network_md_url = dsaz.IMDS_URL + "/instance?api-version=2019-06-01"
+        self.network_md_url = "{}/instance?api-version=2019-06-01".format(
+            dsaz.IMDS_URL
+        )
 
     @mock.patch(MOCKPATH + 'readurl')
     @mock.patch(MOCKPATH + 'EphemeralDHCPv4', autospec=True)

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -1823,12 +1823,14 @@ scbus-1 on xpt0 bus 0
         self.assertEqual(ssh_keys, ['key2'])
 
     @mock.patch(MOCKPATH + 'get_metadata_from_imds')
-    def test_imds_api_version_wanted_nonexistent(self, m_get_metadata_from_imds):
-        def get_metadata_from_imds_side_effect(*args, **kwargs):
+    def test_imds_api_version_wanted_nonexistent(
+            self,
+            m_get_metadata_from_imds):
+        def get_metadata_from_imds_side_eff(*args, **kwargs):
             if kwargs['api_version'] == dsaz.IMDS_VER_WANT:
                 raise url_helper.UrlError("No IMDS version", code=400)
             return NETWORK_METADATA
-        m_get_metadata_from_imds.side_effect = get_metadata_from_imds_side_effect
+        m_get_metadata_from_imds.side_effect = get_metadata_from_imds_side_eff
         sys_cfg = {'datasource': {'Azure': {'apply_network_config': True}}}
         odata = {'HostName': "myhost", 'UserName': "myuser"}
         data = {
@@ -1840,7 +1842,8 @@ scbus-1 on xpt0 bus 0
         self.assertIsNotNone(dsrc.metadata)
         self.assertEqual(dsrc.api_version, dsaz.IMDS_VER_MIN)
 
-    @mock.patch(MOCKPATH + 'get_metadata_from_imds', return_value=NETWORK_METADATA)
+    @mock.patch(
+        MOCKPATH + 'get_metadata_from_imds', return_value=NETWORK_METADATA)
     def test_imds_api_version_wanted_exists(self, m_get_metadata_from_imds):
         sys_cfg = {'datasource': {'Azure': {'apply_network_config': True}}}
         odata = {'HostName': "myhost", 'UserName': "myuser"}

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -2600,7 +2600,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
     @mock.patch(MOCKPATH + 'DataSourceAzure.wait_for_link_up')
     @mock.patch('cloudinit.sources.helpers.netlink.wait_for_nic_attach_event')
     @mock.patch('cloudinit.sources.net.find_fallback_nic')
-    @mock.patch(MOCKPATH + 'get_metadata_from_imds')
+    @mock.patch(MOCKPATH + 'DataSourceAzure.get_imds_data')
     @mock.patch(MOCKPATH + 'EphemeralDHCPv4')
     @mock.patch(MOCKPATH + 'DataSourceAzure._wait_for_nic_detach')
     @mock.patch('os.path.isfile')

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -407,7 +407,7 @@ class TestGetMetadataFromIMDS(HttprettyTestCase):
 
     def setUp(self):
         super(TestGetMetadataFromIMDS, self).setUp()
-        self.network_md_url = dsaz.IMDS_URL + "instance?api-version=2019-06-01"
+        self.network_md_url = dsaz.IMDS_URL + "/instance?api-version=2019-06-01"
 
     @mock.patch(MOCKPATH + 'readurl')
     @mock.patch(MOCKPATH + 'EphemeralDHCPv4', autospec=True)
@@ -517,7 +517,7 @@ class TestGetMetadataFromIMDS(HttprettyTestCase):
         """Return empty dict when IMDS network metadata is absent."""
         httpretty.register_uri(
             httpretty.GET,
-            dsaz.IMDS_URL + 'instance?api-version=2017-12-01',
+            dsaz.IMDS_URL + '/instance?api-version=2017-12-01',
             body={}, status=404)
 
         m_net_is_up.return_value = True  # skips dhcp

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -1840,7 +1840,7 @@ scbus-1 on xpt0 bus 0
         dsrc = self._get_ds(data)
         dsrc.get_data()
         self.assertIsNotNone(dsrc.metadata)
-        self.assertEqual(dsrc.api_version, dsaz.IMDS_VER_MIN)
+        self.assertTrue(dsrc.failed_desired_api_version)
 
     @mock.patch(
         MOCKPATH + 'get_metadata_from_imds', return_value=NETWORK_METADATA)
@@ -1854,7 +1854,7 @@ scbus-1 on xpt0 bus 0
         dsrc = self._get_ds(data)
         dsrc.get_data()
         self.assertIsNotNone(dsrc.metadata)
-        self.assertEqual(dsrc.api_version, dsaz.IMDS_VER_WANT)
+        self.assertFalse(dsrc.failed_desired_api_version)
 
 
 class TestAzureBounce(CiTestCase):
@@ -2636,7 +2636,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
     @mock.patch(MOCKPATH + 'DataSourceAzure.wait_for_link_up')
     @mock.patch('cloudinit.sources.helpers.netlink.wait_for_nic_attach_event')
     @mock.patch('cloudinit.sources.net.find_fallback_nic')
-    @mock.patch(MOCKPATH + 'DataSourceAzure.get_imds_data')
+    @mock.patch(MOCKPATH + 'DataSourceAzure.get_imds_data_with_api_fallback')
     @mock.patch(MOCKPATH + 'EphemeralDHCPv4')
     @mock.patch(MOCKPATH + 'DataSourceAzure._wait_for_nic_detach')
     @mock.patch('os.path.isfile')


### PR DESCRIPTION
## Proposed Commit Message

Add flexibility to IMDS api-version by having both a desired IMDS api-version and a minimum api-version. The desired api-version will be used first, and if that fails it will fall back to the minimum api-version.

## Additional Context

This PR will allow us to rollout features in cloud-init to take advantage of newer features in IMDS.

## Test Steps

The following shell script was used to validate this end-to-end both using an existing desired IMDS api-version and then using an impossible (future) api-version, forcing a fallback to the minimum version. This script relies on [helper functions from my az-cli-helpers repo](https://github.com/trstringer/az-cli-helpers).

```bash
#!/bin/bash -i

# First create a VM and install the updated cloud-init from my build. Ensure
# that we are able to utilize the "desired" IMDS api version 2020-09-01.
RESOURCE_NAME=$(resource_name)
echo "$(date) - Using resource name $RESOURCE_NAME"
az_vm_create_default
az_vm_deb_install "$RESOURCE_NAME" ~/dev/cloud-init/cloud-init_all.deb
OLD_RESOURCE_NAME=$RESOURCE_NAME
RESOURCE_NAME=$(resource_name)
az_vm_create_from_vm "$OLD_RESOURCE_NAME"

if az_vm_ssh "$RESOURCE_NAME" "grep 'Falling back to IMDS api-version' /var/log/cloud-init.log"; then
    echo "$(date) Failed: api-version not found"
    exit 1
else
    echo "$(date) api-version found successfully"
fi

if az_vm_ssh "$RESOURCE_NAME" "grep 'UrlError' /var/log/cloud-init.log"; then
    echo "$(date) Failed: found UrlError"
    exit 1
else
    echo "$(date) no UrlError in logs"
fi

# For the second test, modify the source code directly so that the desired
# IMDS api-version is impossible to be used (a future date). This test
# should verify that we fall back to the minimum api-version for IMDS.
echo "$(date) Modifying to impossible IMDS version for wanted"
az_vm_ssh "$RESOURCE_NAME" "sudo sed -i 's/2020-09-01/2022-09-01/g' /usr/lib/python3/dist-packages/cloudinit/sources/DataSourceAzure.py"
az_vm_ssh "$RESOURCE_NAME" "sudo cloud-init clean --logs"
OLD_RESOURCE_NAME=$RESOURCE_NAME
RESOURCE_NAME=$(resource_name)
az_vm_create_from_vm "$OLD_RESOURCE_NAME"

if ! az_vm_ssh "$RESOURCE_NAME" "grep 'Falling back to IMDS api-version' /var/log/cloud-init.log"; then
    echo "$(date) Failed: no fall back for IMDS version"
    exit 1
else
    echo "$(date) Success for fall back IMDS version"
fi

echo "$(date) - All tests succeded"
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
