### PR TITLE
archlinux: Fix broken locale logic

### DIFF
--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -20,6 +20,7 @@ johnsonshi
 jordimassaguerpla
 jqueuniet
 jsf9k
+klausenbusk
 landon912
 lucasmoura
 lungj


### PR DESCRIPTION
## Proposed Commit Message
```
archlinux: Fix broken locale logic

The locale wasn't persisted correct nor set.

LP: https://bugs.launchpad.net/cloud-init/+bug/1402406
```

## Additional Context
See LP bug: https://bugs.launchpad.net/cloud-init/+bug/1402406

## Test Steps
This has been tested manually and `/etc/locale.gen` is in the expected format now and the locale is written to `/etc/locale.conf`.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
