### PR TITLE
archlinux: Use hostnamectl to set the transient hostname

### DIFF
--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -137,6 +137,17 @@ class Distro(distros.Distro):
             return default
         return hostname
 
+    # hostname (inetutils) isn't installed per default on arch, so we use
+    # hostnamectl which is installed per default (systemd).
+    def _apply_hostname(self, hostname):
+        LOG.debug("Non-persistently setting the system hostname to %s",
+                  hostname)
+        try:
+            subp.subp(['hostnamectl', '--transient', 'set-hostname', hostname])
+        except subp.ProcessExecutionError:
+            util.logexc(LOG, "Failed to non-persistently adjust the system "
+                        "hostname to %s", hostname)
+
     def set_timezone(self, tz):
         distros.set_etc_timezone(tz=tz, tz_file=self._find_tz_file(tz))
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -20,6 +20,7 @@ johnsonshi
 jordimassaguerpla
 jqueuniet
 jsf9k
+klausenbusk
 landon912
 lucasmoura
 lungj


### PR DESCRIPTION
## Proposed Commit Message
```
archlinux: Use hostnamectl to set the transient hostname

hostname (inetutils) isn't installed per default on arch, so switch
to hostnamectl which is installed per default (systemd).
```

## Test Steps
This has been tested manually with the Arch Linux [cloud-init package](https://archlinux.org/packages/community/any/cloud-init/) (`arch.py` patched with the changes in this commit) and `inetutils` forcefully removed (`pacman -Rsddn inetutils`).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly