### PR TITLE
azure: case-insensitive UUID to avoid new IID during kernel upgrade

### DIFF
--- a/tests/integration_tests/bugs/test_lp1835584.py
+++ b/tests/integration_tests/bugs/test_lp1835584.py
@@ -1,0 +1,104 @@
+""" Integration test for LP #1835584
+
+Upstream linux kernels prior to 4.15 providate DMI product_uuid in uppercase.
+More recent kernels switched to lowercase for DMI product_uuid. Azure
+datasource uses this product_uuid as the instance-id for cloud-init.
+
+The linux-azure-fips kernel installed in PRO FIPs images, that product UUID is
+uppercase whereas the linux-azure cloud-optimized kernel reports the UUID as
+lowercase.
+
+In cases where product_uuid changes case, ensure cloud-init doesn't
+recreate ssh hostkeys across reboot (due to detecting an instance_id change).
+
+This currently only affects linux-azure-fips -> linux-azure on Bionic.
+This test won't run on Xenial because both linux-azure-fips and linux-azure
+report uppercase product_uuids.
+
+The test will launch a specific Bionic Ubuntu PRO FIPS image which has a
+linux-azure-fips kernel known to report product_uuid as uppercase. Then upgrade
+and reboot into linux-azure kernel which is known to report product_uuid as
+lowercase.
+
+Across the reboot, assert that we didn't re-run config_ssh by virtue of
+seeing only one semaphore creation log entry of type:
+
+ Writing to /var/lib/cloud/instances/<UUID>/sem/config_ssh -
+
+https://bugs.launchpad.net/cloud-init/+bug/1835584
+"""
+import re
+
+import pytest
+
+from tests.integration_tests.instances import IntegrationAzureInstance
+from tests.integration_tests.clouds import (
+    ImageSpecification, IntegrationCloud
+)
+from tests.integration_tests.conftest import get_validated_source
+
+
+IMG_AZURE_UBUNTU_PRO_FIPS_BIONIC = (
+    "Canonical:0001-com-ubuntu-pro-bionic-fips:pro-fips-18_04:18.04.202010201"
+)
+
+
+def _check_iid_insensitive_across_kernel_upgrade(
+    instance: IntegrationAzureInstance
+):
+    uuid = instance.read_from_file("/sys/class/dmi/id/product_uuid")
+    assert uuid.isupper(), (
+        "Expected uppercase UUID on Ubuntu FIPS image {}".format(
+            uuid
+        )
+    )
+    orig_kernel = instance.execute("uname -r").strip()
+    assert "azure-fips" in orig_kernel
+    result = instance.execute("apt-get update")
+    # Install a 5.4+ kernel which provides lowercase product_uuid
+    result = instance.execute("apt-get install linux-azure --assume-yes")
+    if not result.ok:
+        pytest.fail("Unable to install linux-azure kernel: {}".format(result))
+    instance.restart()
+    new_kernel = instance.execute("uname -r").strip()
+    assert orig_kernel != new_kernel
+    assert "azure-fips" not in new_kernel
+    assert "azure" in new_kernel
+    new_uuid = instance.read_from_file("/sys/class/dmi/id/product_uuid")
+    assert (
+        uuid.lower() == new_uuid
+    ), "Expected UUID on linux-azure to be lowercase of FIPS: {}".format(uuid)
+    log = instance.read_from_file("/var/log/cloud-init.log")
+    RE_CONFIG_SSH_SEMAPHORE = r"Writing.*sem/config_ssh "
+    ssh_runs = len(re.findall(RE_CONFIG_SSH_SEMAPHORE, log))
+    assert 1 == ssh_runs, "config_ssh ran too many times {}".format(ssh_runs)
+
+
+@pytest.mark.azure
+@pytest.mark.sru_next
+def test_azure_kernel_upgrade_case_insensitive_uuid(
+    session_cloud: IntegrationCloud
+):
+    cfg_image_spec = ImageSpecification.from_os_image()
+    if (cfg_image_spec.os, cfg_image_spec.release) != ("ubuntu", "bionic"):
+        pytest.skip(
+            "Test only supports ubuntu:bionic not {0.os}:{0.release}".format(
+                cfg_image_spec
+            )
+        )
+    source = get_validated_source(session_cloud)
+    if not source.installs_new_version():
+        pytest.skip(
+            "Provide CLOUD_INIT_SOURCE to install expected working cloud-init"
+        )
+    image_id = IMG_AZURE_UBUNTU_PRO_FIPS_BIONIC
+    with session_cloud.launch(
+        launch_kwargs={"image_id": image_id}
+    ) as instance:
+        # We can't use setup_image fixture here because we want to avoid
+        # taking a snapshot or cleaning the booted machine after cloud-init
+        # upgrade.
+        instance.install_new_cloud_init(
+            source, take_snapshot=False, clean=False
+        )
+        _check_iid_insensitive_across_kernel_upgrade(instance)

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -116,7 +116,8 @@ class IntegrationInstance:
     def install_new_cloud_init(
         self,
         source: CloudInitSource,
-        take_snapshot=True
+        take_snapshot=True,
+        clean=True,
     ):
         if source == CloudInitSource.DEB_PACKAGE:
             self.install_deb()
@@ -133,7 +134,8 @@ class IntegrationInstance:
             )
         version = self.execute('cloud-init -v').split()[-1]
         log.info('Installed cloud-init version: %s', version)
-        self.instance.clean()
+        if clean:
+            self.instance.clean()
         if take_snapshot:
             snapshot_id = self.snapshot()
             self.cloud.snapshot_id = snapshot_id

--- a/tox.ini
+++ b/tox.ini
@@ -184,5 +184,6 @@ markers =
     instance_name: the name to be used for the test instance
     sru_2020_11: test is part of the 2020/11 SRU verification
     sru_2021_01: test is part of the 2021/01 SRU verification
+    sru_next: test is part of the next SRU verification
     ubuntu: this test should run on Ubuntu
     unstable: skip this test because it is flakey


### PR DESCRIPTION
## Proposed Commit Message
Kernel's newer than 4.15 present /sys/dmi/id/product_uuid as a
lowercase value. Previously UUID was uppercase.

Azure datasource reads the product_uuid directly as their platform's
instance-id. This presents a problem if a kernel is either
upgraded or downgraded across the 4.15 kernel version boundary because
the case of the UUID will change, resulting in cloud-init seeing a
"new" instance id and re-running all modules.

Re-running cc_ssh in cloud-init deletes and regenerates ssh_host keys
on a system which can cause concern on long-running instances that 
somethingnefarious has happened.

Also add:
 - An integration test for this for Azure Bionic Ubuntu FIPS upgrading from
   a FIPS kernel with uppercase UUID to a lowercase UUID in linux-azure
 - A new pytest.mark.sru_next to collect all integration tests related to our
   next SRU
                                                             
LP: #1835584

## Additional Context
Integration test will add a 4.14 generic kernel, add grub config to prefer the "generic" flavor of that kernel across reboot.
This triggers the uppercase product_uuid which on current cloud-init would generate new ssh host keys.
New cloud-init will not trigger this ssh host key creation.

## Test Steps
```bash
# create a passwordless ssh pub/private keypair
ssh-keygen 


 CLOUD_INIT_PUBLIC_SSH_KEY=/root/.ssh/id_rsa_az.pub CLOUD_INIT_PLATFORM=azure  .tox/integration-tests/bin/py.test -v tests/integration_tests/bugs/test_lp1835584.py
# Expect failure running against current cloud-init: 
# E       AssertionError: config_ssh ran too many times 2
# E       assert 1 == 2
# E         +1
# E         -2

make deb
# Expect success running using CLOUD_INIT_CLOUD_INIT_SOURCE=<deb_from_this_pr>
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [n/a] I have updated or added any documentation accordingly  
