### PR TITLE
Decrease azure ephemeral resource disk wait time

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1486,7 +1486,7 @@ def address_ephemeral_resize(devpath=RESOURCE_DISK_PATH, maxwait=5,
             report_diagnostic_event(
                 "ephemeral device '%s' did not appear after %d seconds." %
                 (devpath, maxwait),
-                logger_func=LOG.warning)
+                logger_func=LOG.debug)
             return
 
     result = False

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -621,9 +621,21 @@ class DataSourceAzure(sources.DataSource):
 
         # Only merge in default cloud config related to the ephemeral disk
         # if the ephemeral disk exists
-        if os.path.exists(RESOURCE_DISK_PATH):
+        devpath = RESOURCE_DISK_PATH
+        if os.path.exists(devpath):
+            report_diagnostic_event(
+                "Ephemeral resource disk '%s' exists. "
+                "Merging default Azure cloud ephemeral disk configs."
+                % devpath,
+                logger_func=LOG.debug)
             self.cfg = util.mergemanydict(
                 [crawled_data['cfg'], BUILTIN_CLOUD_EPHEMERAL_DISK_CONFIG])
+        else:
+            report_diagnostic_event(
+                "Ephemeral resource disk '%s' does not exist. "
+                "Not merging default Azure cloud ephemeral disk configs."
+                % devpath,
+                logger_func=LOG.debug)
 
         self._metadata_imds = crawled_data['metadata']['imds']
         self.metadata = util.mergemanydict(
@@ -1477,9 +1489,13 @@ def address_ephemeral_resize(devpath=RESOURCE_DISK_PATH,
                              is_new_instance=False, preserve_ntfs=False):
     if not os.path.exists(devpath):
         report_diagnostic_event(
-            "ephemeral resource disk '%s' does not exist." % devpath,
+            "Ephemeral resource disk '%s' does not exist." % devpath,
             logger_func=LOG.debug)
         return
+    else:
+        report_diagnostic_event(
+            "Ephemeral resource disk '%s' exists." % devpath,
+            logger_func=LOG.debug)
 
     result = False
     msg = None

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -636,6 +636,7 @@ class DataSourceAzure(sources.DataSource):
                 "Not merging default Azure cloud ephemeral disk configs."
                 % devpath,
                 logger_func=LOG.debug)
+            self.cfg = crawled_data['cfg']
 
         self._metadata_imds = crawled_data['metadata']['imds']
         self.metadata = util.mergemanydict(

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -270,7 +270,7 @@ BUILTIN_DS_CONFIG = {
 }
 # RELEASE_BLOCKER: Xenial and earlier apply_network_config default is False
 
-BUILTIN_CLOUD_CONFIG = {
+BUILTIN_CLOUD_EPHEMERAL_DISK_CONFIG = {
     'disk_setup': {
         'ephemeral0': {'table_type': 'gpt',
                        'layout': [100],
@@ -618,8 +618,13 @@ class DataSourceAzure(sources.DataSource):
             maybe_remove_ubuntu_network_config_scripts()
 
         # Process crawled data and augment with various config defaults
-        self.cfg = util.mergemanydict(
-            [crawled_data['cfg'], BUILTIN_CLOUD_CONFIG])
+
+        # Only merge in default cloud config related to the ephemeral disk
+        # if the ephemeral disk exists
+        if os.path.exists(RESOURCE_DISK_PATH):
+            self.cfg = util.mergemanydict(
+                [crawled_data['cfg'], BUILTIN_CLOUD_EPHEMERAL_DISK_CONFIG])
+
         self._metadata_imds = crawled_data['metadata']['imds']
         self.metadata = util.mergemanydict(
             [crawled_data['metadata'], DEFAULT_METADATA])
@@ -1468,26 +1473,13 @@ def can_dev_be_reformatted(devpath, preserve_ntfs):
 
 
 @azure_ds_telemetry_reporter
-def address_ephemeral_resize(devpath=RESOURCE_DISK_PATH, maxwait=5,
+def address_ephemeral_resize(devpath=RESOURCE_DISK_PATH,
                              is_new_instance=False, preserve_ntfs=False):
-    # wait for ephemeral disk to come up
-    naplen = .2
-    with events.ReportEventStack(
-        name="wait-for-ephemeral-disk",
-        description="wait for ephemeral disk",
-        parent=azure_ds_reporter
-    ):
-        missing = util.wait_for_files([devpath],
-                                      maxwait=maxwait,
-                                      naplen=naplen,
-                                      log_pre="Azure ephemeral disk: ")
-
-        if missing:
-            report_diagnostic_event(
-                "ephemeral device '%s' did not appear after %d seconds." %
-                (devpath, maxwait),
-                logger_func=LOG.debug)
-            return
+    if not os.path.exists(devpath):
+        report_diagnostic_event(
+            "ephemeral resource disk '%s' does not exist." % devpath,
+            logger_func=LOG.debug)
+        return
 
     result = False
     msg = None

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1468,7 +1468,7 @@ def can_dev_be_reformatted(devpath, preserve_ntfs):
 
 
 @azure_ds_telemetry_reporter
-def address_ephemeral_resize(devpath=RESOURCE_DISK_PATH, maxwait=120,
+def address_ephemeral_resize(devpath=RESOURCE_DISK_PATH, maxwait=5,
                              is_new_instance=False, preserve_ntfs=False):
     # wait for ephemeral disk to come up
     naplen = .2

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@3a6c668fed769f00d83d1e6bea7d68953787cc38
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@da8445325875674394ffd85aaefaa3d2d0e0020d
 pytest

--- a/tests/integration_tests/bugs/test_lp1901011.py
+++ b/tests/integration_tests/bugs/test_lp1901011.py
@@ -1,0 +1,36 @@
+"""Integration test for LP: #1901011
+
+Ensure an ephemeral disk exists after boot.
+
+See https://github.com/canonical/cloud-init/pull/800
+"""
+import re
+
+import pytest
+
+from tests.integration_tests.clouds import IntegrationCloud
+
+
+@pytest.mark.azure
+@pytest.mark.parametrize('instance_type,is_ephemeral', [
+    ('Standard_DS1_v2', True),
+    ('Standard_D2s_v4', False),
+])
+def test_ephemeral(instance_type, is_ephemeral,
+                   session_cloud: IntegrationCloud, setup_image):
+    if is_ephemeral:
+        expected_log = (
+            'Ephemeral resource disk .* exists. Merging default Azure cloud '
+            'ephemeral disk configs.'
+        )
+    else:
+        expected_log = (
+            'Ephemeral resource disk .* does not exist. Not merging '
+            'default Azure cloud ephemeral disk configs.'
+        )
+
+    with session_cloud.launch(
+        launch_kwargs={'instance_type': instance_type}
+    ) as client:
+        log = client.read_from_file('/var/log/cloud-init.log')
+        assert re.search(expected_log, log) is not None


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

Azure: Support for VMs without ephemeral resource disks.

Changes:
* Only merge in default Azure cloud ephemeral disk configs
during `DataSourceAzure._get_data()` if the ephemeral disk
exists.
* `DataSourceAzure.address_ephemeral_resize()` (which is
invoked in `DataSourceAzure.activate()` should only set up
the ephemeral disk if the disk exists.

Azure VMs may or may not come with ephemeral resource disks
depending on the VM SKU. For VM SKUs that come with
ephemeral resource disks, the Azure platform guarantees that
the ephemeral resource disk is attached to the VM before
the VM is booted. For VM SKUs that do not come with
ephemeral resource disks, cloud-init currently attempts
to wait and set up a non-existent ephemeral resource
disk, which wastes boot time. It also causes disk setup
modules to fail (due to non-existent references to the
ephemeral resource disk).

`udevadm settle` is invoked by cloud-init very early in boot.
`udevadm settle` is invoked very early, before
`DataSourceAzure`'s `_get_data()` and `activate()` methods.

Within `DataSourceAzure`'s `_get_data()` and `activate()` methods,
the ephemeral resource disk path should exist if the
VM SKU comes with an ephemeral resource disk.
The ephemeral resource disk path should not exist if the
VM SKU does not come with an ephemeral resource disk.

LP: #1901011

## Additional Context
<!-- If relevant -->

#### Problem

For Azure VMs, cloud-init's `DataSourceAzure.py` formats and addresses ephemeral disk resizing. It does this for all Azure VM SKUs. See [code](https://github.com/canonical/cloud-init/blob/54e202a6480e48dbb8a72004f7a5003f7c4edfae/cloudinit/sources/DataSourceAzure.py#L1314-L1316) and [code](https://github.com/canonical/cloud-init/blob/54e202a6480e48dbb8a72004f7a5003f7c4edfae/cloudinit/sources/DataSourceAzure.py#L1453-L1455).

The [code right now waits up to 120 seconds for the ephemeral disk to appear](https://github.com/canonical/cloud-init/blob/54e202a6480e48dbb8a72004f7a5003f7c4edfae/cloudinit/sources/DataSourceAzure.py#L1454-L1473) before either proceeding or giving up. It waits up to 120 secs for the symlink `/dev/disk/cloud/azure_resource` to appear.

For new Azure VM SKUs (such as `Dv4`, `Dsv4`, `Ev4`, `Esv4`) that do not come with ephemeral resource disks, cloud-init would wait up to 120 seconds before giving up. See [LP: #1901011](https://bugs.launchpad.net/cloud-init/+bug/1901011).

For these new Azure VM SKUs without ephemeral resource disks, the `disk_setup` module would also fail later in cloud-init because "builtin Azure ephemeral disk configs" are merged into DataSourceAzure metadata. These builtin configs reference the non-existent ephemeral disk, which causes the module to fail.

#### Why this approach was chosen

As of today, the Azure Instance Metadata Service (Azure IMDS) does not expose VM instance metadata indicating whether an ephemeral resource disk exists for the VM or not.

The Azure host also guarantees that the ephemeral resource disk is attached to the VM before it is booted during VM deployment.

Additionally, the ephemeral resource disk symlink (`/dev/disk/cloud/azure_resource`) that cloud-init waits for is actually created by [a udev rule that comes with cloud-init](https://github.com/canonical/cloud-init/blob/master/udev/66-azure-ephemeral.rules). Additional relevant [code](https://github.com/canonical/cloud-init/blob/54e202a6480e48dbb8a72004f7a5003f7c4edfae/udev/66-azure-ephemeral.rules#L10), [code](https://github.com/canonical/cloud-init/blob/54e202a6480e48dbb8a72004f7a5003f7c4edfae/udev/66-azure-ephemeral.rules#L26), and [code](https://github.com/canonical/cloud-init/blob/54e202a6480e48dbb8a72004f7a5003f7c4edfae/udev/66-azure-ephemeral.rules#L29-L31).

Because:
* the Azure host guarantees that resource disks are attached for VM SKUs that have resource disks, 
* because the symlinks are created by `udev` rules (created as soon as the kernel detects the disk and sends the event to `udev`),
* and because `udevadm settle` is invoked very early in boot by cloud-init (before DataSourceAzure runs),
it is **guaranteed** that the ephemeral resource disk symlink exists by the time DataSourceAzure runs.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

#### No regression for VM SKUs _with_ ephemeral resource disk

* Created a custom image with this branch's cloud-init installed.
* Deployed a `Standard_DS1_V2` VM (has ephemeral resource disk) from this custom image.
* Cloud-init logs here: https://paste.ubuntu.com/p/qdxkfwYKRD/

```
2021-02-03 23:23:31,913 - __init__.py[DEBUG]: Found unstable nic names: ['eth0']; calling udevadm settle
2021-02-03 23:23:31,914 - subp.py[DEBUG]: Running command ['udevadm', 'settle'] with allowed return codes [0] (shell=False, capture=True)
2021-02-03 23:23:31,933 - util.py[DEBUG]: Waiting for udev events to settle took 0.019 seconds
...
2021-02-03 23:23:32,823 - handlers.py[DEBUG]: finish: azure-ds/crawl_metadata: SUCCESS: crawl_metadata
2021-02-03 23:23:32,823 - util.py[DEBUG]: Crawl of metadata service took 1.117 seconds
...
2021-02-03 23:23:32,824 - azure.py[DEBUG]: Ephemeral resource disk '/dev/disk/cloud/azure_resource' exists. Merging default Azure cloud ephemeral disk configs.
...
2021-02-03 23:23:38,563 - handlers.py[DEBUG]: start: azure-ds/activate: activate
2021-02-03 23:23:38,563 - handlers.py[DEBUG]: start: azure-ds/address_ephemeral_resize: address_ephemeral_resize
2021-02-03 23:23:38,564 - azure.py[DEBUG]: Ephemeral resource disk '/dev/disk/cloud/azure_resource' exists.
...
2021-02-03 23:23:38,894 - handlers.py[DEBUG]: finish: azure-ds/address_ephemeral_resize: SUCCESS: address_ephemeral_resize
```

#### Fix for VM SKUs _without_ ephemeral resource disk

* Created a custom image with this branch's cloud-init installed.
* Deployed a `Standard_D2s_v4` VM (_no_ ephemeral resource disk) from this custom image.
* Cloud-init logs here: https://paste.ubuntu.com/p/GmCqBNTQrG/

```
2021-02-03 23:20:53,217 - __init__.py[DEBUG]: Found unstable nic names: ['eth0']; calling udevadm settle
2021-02-03 23:20:53,217 - subp.py[DEBUG]: Running command ['udevadm', 'settle'] with allowed return codes [0] (shell=False, capture=True)
2021-02-03 23:20:53,235 - util.py[DEBUG]: Waiting for udev events to settle took 0.018 seconds
...
2021-02-03 23:20:54,388 - handlers.py[DEBUG]: finish: azure-ds/crawl_metadata: SUCCESS: crawl_metadata
2021-02-03 23:20:54,389 - util.py[DEBUG]: Crawl of metadata service took 1.363 seconds
...
2021-02-03 23:20:54,389 - azure.py[DEBUG]: Ephemeral resource disk '/dev/disk/cloud/azure_resource' does not exist. Not merging default Azure cloud ephemeral disk configs.
...
2021-02-03 23:20:59,846 - handlers.py[DEBUG]: start: azure-ds/activate: activate
2021-02-03 23:20:59,846 - handlers.py[DEBUG]: start: azure-ds/address_ephemeral_resize: address_ephemeral_resize
2021-02-03 23:20:59,847 - azure.py[DEBUG]: Ephemeral resource disk '/dev/disk/cloud/azure_resource' does not exist.
2021-02-03 23:20:59,847 - handlers.py[DEBUG]: finish: azure-ds/address_ephemeral_resize: SUCCESS: address_ephemeral_resize
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
