### PR TITLE
test_gh668: fix failure on LXD VMs

### DIFF
--- a/tests/integration_tests/bugs/test_gh668.py
+++ b/tests/integration_tests/bugs/test_gh668.py
@@ -12,6 +12,7 @@ from tests.integration_tests.instances import IntegrationInstance
 
 DESTINATION_IP = "172.16.0.10"
 GATEWAY_IP = "10.0.0.100"
+MAC_ADDRESS = "de:ad:be:ef:12:34"
 
 NETWORK_CONFIG = """\
 version: 2
@@ -22,7 +23,9 @@ ethernets:
     routes:
     - to: {}/32
       via: {}
-""".format(DESTINATION_IP, GATEWAY_IP)
+    match:
+      macaddress: {}
+""".format(DESTINATION_IP, GATEWAY_IP, MAC_ADDRESS)
 
 EXPECTED_ROUTE = "{} via {}".format(DESTINATION_IP, GATEWAY_IP)
 
@@ -31,6 +34,7 @@ EXPECTED_ROUTE = "{} via {}".format(DESTINATION_IP, GATEWAY_IP)
 @pytest.mark.lxd_vm
 @pytest.mark.lxd_config_dict({
     "user.network-config": NETWORK_CONFIG,
+    "volatile.eth0.hwaddr": MAC_ADDRESS,
 })
 def test_static_route_to_host(client: IntegrationInstance):
     route = client.execute("ip route | grep {}".format(DESTINATION_IP))


### PR DESCRIPTION
## Proposed Commit Message
```
test_gh668: fix failure on LXD VMs

In LXD containers, the default interface is named eth0.  In VMs, it
isn't; it's renamed by systemd (likely to enp5s0, but we can't rely on
that).  This means that, on VMs, the network configuration we specify
for "eth0" doesn't match an interface in the system and so is not
applied.

This modifies the test to set a MAC address in a match clause in the
network configuration and on the eth0 interface (which is the LXD name
in both containers and VMs pre-rename): this ensures that the specified
configuration applies in both cases.
```

## Test Steps

Run the test using a LXD VM.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
