### PR TITLE
integration_tests: introduce lxd_use_exec mark

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@878981e3c7caaf583a8c7c5494dba9d9447acee8
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@3a6c668fed769f00d83d1e6bea7d68953787cc38
 pytest

--- a/tests/integration_tests/bugs/test_gh668.py
+++ b/tests/integration_tests/bugs/test_gh668.py
@@ -37,6 +37,7 @@ EXPECTED_ROUTE = "{} via {}".format(DESTINATION_IP, GATEWAY_IP)
     "user.network-config": NETWORK_CONFIG,
     "volatile.eth0.hwaddr": MAC_ADDRESS,
 })
+@pytest.mark.lxd_use_exec
 def test_static_route_to_host(client: IntegrationInstance):
     route = client.execute("ip route | grep {}".format(DESTINATION_IP))
     assert route.startswith(EXPECTED_ROUTE)

--- a/tests/integration_tests/bugs/test_lp1898997.py
+++ b/tests/integration_tests/bugs/test_lp1898997.py
@@ -39,6 +39,7 @@ version: 2
     "volatile.eth0.hwaddr": MAC_ADDRESS,
 })
 @pytest.mark.lxd_vm
+@pytest.mark.lxd_use_exec
 @pytest.mark.not_bionic
 @pytest.mark.not_xenial
 @pytest.mark.sru_2020_11

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -198,6 +198,9 @@ def _client(request, fixture_utils, session_cloud: IntegrationCloud):
     user_data = getter('user_data')
     name = getter('instance_name')
     lxd_config_dict = getter('lxd_config_dict')
+    lxd_use_exec = fixture_utils.closest_marker_args_or(
+        request, 'lxd_use_exec', None
+    )
 
     launch_kwargs = {}
     if name is not None:
@@ -206,10 +209,18 @@ def _client(request, fixture_utils, session_cloud: IntegrationCloud):
         if not isinstance(session_cloud, _LxdIntegrationCloud):
             pytest.skip("lxd_config_dict requires LXD")
         launch_kwargs["config_dict"] = lxd_config_dict
+    if lxd_use_exec is not None:
+        if not isinstance(session_cloud, _LxdIntegrationCloud):
+            pytest.skip("lxd_use_exec requires LXD")
+        launch_kwargs["execute_via_ssh"] = False
 
     with session_cloud.launch(
         user_data=user_data, launch_kwargs=launch_kwargs
     ) as instance:
+        if lxd_use_exec is not None:
+            # Existing instances are not affected by the launch kwargs, so
+            # ensure it here; we still need the launch kwarg so waiting works
+            instance.execute_via_ssh = False
         previous_failures = request.session.testsfailed
         yield instance
         test_failed = request.session.testsfailed - previous_failures > 0

--- a/tox.ini
+++ b/tox.ini
@@ -176,6 +176,7 @@ markers =
     oci: test will only run on OCI platform
     lxd_config_dict: set the config_dict passed on LXD instance creation
     lxd_container: test will only run in LXD container
+    lxd_use_exec: `execute` will use `lxc exec` instead of SSH
     lxd_vm: test will only run in LXD VM
     not_xenial: test cannot run on the xenial release
     not_bionic: test cannot run on the bionic release


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: introduce lxd_use_exec mark

pycloudlib has modified the way LXD executes tests
(https://github.com/canonical/pycloudlib/pull/114): it will always use
SSH to access them by default, instead of using `lxc exec`.  This
behaviour is transparent for the majority of cloud-init's integration
tests, but some currently depend on using `lxc exec` to access instances
with (intentionally) broken networking: obviously these are not
accessible via SSH.

pycloudlib retains support for switching an instance to use `lxc exec`.
This commit introduces the `lxd_use_exec` mark, which tests can use to
indicate to the integration testing framework that they should be so
switched, and applies it to all applicable tests.
```

## Additional Context

See https://github.com/canonical/pycloudlib/pull/114

## Test Steps

CI tests will indicate that LXD containers work, a manual run is required for LXD VMs.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly