### PR TITLE
fqdn should be used as hostname

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -257,9 +257,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                         "hostname to %s", hostname)
 
     def _select_hostname(self, hostname, fqdn):
-        # Prefer the short hostname over the long
-        # fully qualified domain name
-        if not hostname:
+        # If both fqdn and hostname are set, fqdn will be used.
+        if fqdn:
             return fqdn
         return hostname
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -37,6 +37,7 @@ slyon
 smoser
 sshedi
 TheRealFalcon
+taoyama
 tnt-dev
 tomponline
 tsanghan


### PR DESCRIPTION
## Proposed Commit Message
_Set Hostname_ Document say:
[If both ``fqdn`` and ``hostname`` are set, ``fqdn`` will be used.](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#:~:text=If%20both%20fqdn%20and%20hostname%20are%20set%2C%20fqdn%20will%20be%20used.)

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
