### PR TITLE
Remove wait argument from tests with session_cloud calls

### DIFF
--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -65,7 +65,7 @@ class TestPowerChange:
         with session_cloud.launch(
             user_data=USER_DATA.format(
                 delay=delay, mode=mode, timeout=timeout, condition='true'),
-            wait=False
+            launch_kwargs={'wait': False},
         ) as instance:
             if mode == 'reboot':
                 _detect_reboot(instance)

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -87,7 +87,7 @@ def test_upgrade(session_cloud: IntegrationCloud):
             netcfg_path = '/etc/network/interfaces.d/50-cloud-init.cfg'
 
     with session_cloud.launch(
-        launch_kwargs=launch_kwargs, user_data=USER_DATA, wait=True,
+        launch_kwargs=launch_kwargs, user_data=USER_DATA,
     ) as instance:
         _output_to_compare(instance, before_path, netcfg_path)
         instance.install_new_cloud_init(source, take_snapshot=False)


### PR DESCRIPTION
During #788 , I forgot to update the calls to `session_cloud.launch(...)` to remove the `wait` argument.