### PR TITLE
Fix attempting to decode binary data in test_seed_random_data test

### DIFF
--- a/tests/integration_tests/modules/test_seed_random_data.py
+++ b/tests/integration_tests/modules/test_seed_random_data.py
@@ -24,5 +24,7 @@ class TestSeedRandomData:
 
     @pytest.mark.user_data(USER_DATA)
     def test_seed_random_data(self, client):
-        seed_output = client.read_from_file("/root/seed")
-        assert seed_output.startswith("MYUb34023nD:LFDK10913jk;dfnk:Df")
+        # Only read the first 31 characters, because the rest could be
+        # binary data
+        result = client.execute("head -c 31 < /root/seed")
+        assert result.startswith("MYUb34023nD:LFDK10913jk;dfnk:Df")


### PR DESCRIPTION
## Proposed Commit Message
Fix attempting to decode binary data in test_seed_random_data test

`test_seed_random_data.py` was failing on openstack as openstack
provides additional binary seed data to the end of the specified file.
The test has been changed to only read the ascii porition of
seed file.

## Additional Context
n/a

## Test Steps
Using openstack as the testing platform (requires branch #804 if branch isn't merged yet):
`pytest tests/integration_tests/modules/test_seed_random_data.py`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
