### PR TITLE
integration_tests: fix test_gh626 on LXD VMs via SSH

### DIFF
--- a/tests/integration_tests/bugs/test_gh626.py
+++ b/tests/integration_tests/bugs/test_gh626.py
@@ -11,13 +11,16 @@ from tests.integration_tests.clouds import ImageSpecification
 from tests.integration_tests.instances import IntegrationInstance
 
 
+MAC_ADDRESS = "de:ad:be:ef:12:34"
 NETWORK_CONFIG = """\
 version: 2
 ethernets:
   eth0:
     dhcp4: true
     wakeonlan: true
-"""
+    match:
+      macaddress: {}
+""".format(MAC_ADDRESS)
 
 EXPECTED_ENI_END = """\
 iface eth0 inet dhcp
@@ -28,7 +31,8 @@ iface eth0 inet dhcp
 @pytest.mark.lxd_container
 @pytest.mark.lxd_vm
 @pytest.mark.lxd_config_dict({
-    'user.network-config': NETWORK_CONFIG
+    'user.network-config': NETWORK_CONFIG,
+    "volatile.eth0.hwaddr": MAC_ADDRESS,
 })
 def test_wakeonlan(client: IntegrationInstance):
     if ImageSpecification.from_os_image().release == 'xenial':


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: fix test_gh626 on LXD VMs via SSH

Without a MAC address match clause, the test network configuration is
not applied to the primary interface in LXD VMs (which is named enp*s*
rather than eth0). This means that networking does not come up, so
SSH access is not possible.
```

## Test Steps

Run the test on a LXD VM (with either an SSH key configured, or with the new pycloudlib which uses SSH by default) and observe success.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly