### PR TITLE
pytest: yield_fixture deprecated since pytest 6.2

### DIFF
--- a/cloudinit/distros/tests/test_networking.py
+++ b/cloudinit/distros/tests/test_networking.py
@@ -14,7 +14,7 @@ from cloudinit.distros.networking import (
 from contextlib import ExitStack as does_not_raise
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def generic_networking_cls():
     """Returns a direct Networking subclass which errors on /sys usage.
 
@@ -40,7 +40,7 @@ def generic_networking_cls():
         yield TestNetworking
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def sys_class_net(tmpdir):
     sys_class_net_path = tmpdir.join("sys/class/net")
     sys_class_net_path.ensure_dir()

--- a/cloudinit/sources/tests/test_oracle.py
+++ b/cloudinit/sources/tests/test_oracle.py
@@ -93,7 +93,7 @@ def metadata_version():
     return 2
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def oracle_ds(request, fixture_utils, paths, metadata_version):
     """
     Return an instantiated DataSourceOracle.
@@ -521,7 +521,7 @@ class TestCommon_GetDataBehaviour:
     separate class for that case.)
     """
 
-    @pytest.yield_fixture(params=[True, False])
+    @pytest.fixture(params=[True, False])
     def parameterized_oracle_ds(self, request, oracle_ds):
         """oracle_ds parameterized for iSCSI and non-iSCSI root respectively"""
         is_iscsi_root = request.param

--- a/cloudinit/tests/test_features.py
+++ b/cloudinit/tests/test_features.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import cloudinit
 
 
-@pytest.yield_fixture()
+@pytest.fixture
 def create_override(request):
     """
     Create a feature overrides file and do some module wizardry to make

--- a/cloudinit/tests/test_stages.py
+++ b/cloudinit/tests/test_stages.py
@@ -351,7 +351,7 @@ class TestInit_InitializeFilesystem:
     TODO: Expand these tests to cover all of _initialize_filesystem's behavior.
     """
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def init(self, paths):
         """A fixture which yields a stages.Init instance with paths and cfg set
 

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -714,7 +714,7 @@ class TestMountCb:
     TODO: Test the if/else branch that actually performs the mounting operation
     """
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def already_mounted_device_and_mountdict(self):
         """Mock an already-mounted device, and yield (device, mount dict)"""
         device = "/dev/fake0"

--- a/conftest.py
+++ b/conftest.py
@@ -65,7 +65,7 @@ class _FixtureUtils:
         return result[0]
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def disable_subp_usage(request, fixture_utils):
     """
     Across all (pytest) tests, ensure that subp.subp is not invoked.
@@ -165,7 +165,7 @@ def fixture_utils():
     return _FixtureUtils
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def httpretty():
     """
     Enable HTTPretty for duration of the testcase, resetting before and after.

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -88,7 +88,7 @@ def disable_subp_usage(request):
     pass
 
 
-@pytest.yield_fixture(scope='session')
+@pytest.fixture(scope='session')
 def session_cloud():
     if integration_settings.PLATFORM not in platforms.keys():
         raise ValueError(
@@ -216,21 +216,21 @@ def _client(request, fixture_utils, session_cloud: IntegrationCloud):
         _collect_logs(instance, request.node.nodeid, test_failed)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def client(request, fixture_utils, session_cloud, setup_image):
     """Provide a client that runs for every test."""
     with _client(request, fixture_utils, session_cloud) as client:
         yield client
 
 
-@pytest.yield_fixture(scope='module')
+@pytest.fixture(scope='module')
 def module_client(request, fixture_utils, session_cloud, setup_image):
     """Provide a client that runs once per module."""
     with _client(request, fixture_utils, session_cloud) as client:
         yield client
 
 
-@pytest.yield_fixture(scope='class')
+@pytest.fixture(scope='class')
 def class_client(request, fixture_utils, session_cloud, setup_image):
     """Provide a client that runs once per class."""
     with _client(request, fixture_utils, session_cloud) as client:


### PR DESCRIPTION
## Proposed Commit Message
Avoid warning messages from pytest when 
```bash
conftest.py:68
  /root/cloud-init/conftest.py:68: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(autouse=True)
```


## Test Steps
tox -r -e integration-tests  #without this changset and confirm that pytest==6.2.2 is being pulled in during environment build

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
