### PR TITLE
integration_tests: add UPGRADE CloudInitSource

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -124,6 +124,8 @@ def get_validated_source(
         return CloudInitSource.PPA
     elif os.path.isfile(str(source)):
         return CloudInitSource.DEB_PACKAGE
+    elif source == "UPGRADE":
+        return CloudInitSource.UPGRADE
     raise ValueError(
         'Invalid value for CLOUD_INIT_SOURCE setting: {}'.format(source))
 

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -39,6 +39,7 @@ class CloudInitSource(Enum):
     PROPOSED = 3
     PPA = 4
     DEB_PACKAGE = 5
+    UPGRADE = 6
 
     def installs_new_version(self):
         if self.name in [self.NONE.name, self.IN_PLACE.name]:
@@ -123,6 +124,8 @@ class IntegrationInstance:
             self.install_ppa()
         elif source == CloudInitSource.PROPOSED:
             self.install_proposed_image()
+        elif source == CloudInitSource.UPGRADE:
+            self.upgrade_cloud_init()
         else:
             raise Exception(
                 "Specified to install {} which isn't supported here".format(
@@ -165,6 +168,11 @@ class IntegrationInstance:
             remote_path=remote_path)
         remote_script = 'dpkg -i {path}'.format(path=remote_path)
         self.execute(remote_script)
+
+    def upgrade_cloud_init(self):
+        log.info('Upgrading cloud-init to latest version in archive')
+        self.execute("apt-get update -q")
+        self.execute("apt-get install -qy cloud-init")
 
     def __enter__(self):
         return self

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -59,6 +59,8 @@ EXISTING_INSTANCE_ID = None
 #   code.
 # PROPOSED
 #   Install from the Ubuntu proposed repo
+# UPGRADE
+#   Upgrade cloud-init to the version in the Ubuntu archive
 # <ppa repo>, e.g., ppa:cloud-init-dev/proposed
 #   Install from a PPA. It MUST start with 'ppa:'
 # <file path>


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: add UPGRADE CloudInitSource

This allows out-of-date images to be brought up-to-date with the
archive, so that tests written against the latest cloud-init release
will pass.
```

## Additional Context

This is particularly handy for OpenStack, as deployments may not get fresh Ubuntu images on a regular cadence.

## Test Steps

Run tests against a stale image with `CLOUD_INIT_CLOUD_INIT_SOURCE=UPGRADE` in your environment.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly