### PR TITLE
integration_tests: use unique MAC addresses for tests

### DIFF
--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -1,0 +1,12 @@
+import random
+
+
+def random_mac_address() -> str:
+    """Generate a random MAC address.
+
+    The MAC address will have a 1 in its least significant bit, indicating it
+    to be a locally administered address.
+    """
+    return "02:00:00:%02x:%02x:%02x" % (random.randint(0, 255),
+                                        random.randint(0, 255),
+                                        random.randint(0, 255))

--- a/tests/integration_tests/bugs/test_gh626.py
+++ b/tests/integration_tests/bugs/test_gh626.py
@@ -7,11 +7,12 @@ in the /etc/network/interfaces or netplan config.
 import pytest
 import yaml
 
+from tests.integration_tests import random_mac_address
 from tests.integration_tests.clouds import ImageSpecification
 from tests.integration_tests.instances import IntegrationInstance
 
 
-MAC_ADDRESS = "de:ad:be:ef:12:34"
+MAC_ADDRESS = random_mac_address()
 NETWORK_CONFIG = """\
 version: 2
 ethernets:

--- a/tests/integration_tests/bugs/test_gh668.py
+++ b/tests/integration_tests/bugs/test_gh668.py
@@ -7,12 +7,13 @@ for all network configuration outputs.
 
 import pytest
 
+from tests.integration_tests import random_mac_address
 from tests.integration_tests.instances import IntegrationInstance
 
 
 DESTINATION_IP = "172.16.0.10"
 GATEWAY_IP = "10.0.0.100"
-MAC_ADDRESS = "de:ad:be:ef:12:34"
+MAC_ADDRESS = random_mac_address()
 
 NETWORK_CONFIG = """\
 version: 2

--- a/tests/integration_tests/bugs/test_lp1898997.py
+++ b/tests/integration_tests/bugs/test_lp1898997.py
@@ -10,8 +10,9 @@ network configuration, and confirms that the bridge can be used to ping the
 default gateway.
 """
 import pytest
+from tests.integration_tests import random_mac_address
 
-MAC_ADDRESS = "de:ad:be:ef:12:34"
+MAC_ADDRESS = random_mac_address()
 
 
 NETWORK_CONFIG = """\

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -153,9 +153,8 @@ class IntegrationCloud(ABC):
         }
         kwargs.update(launch_kwargs)
         log.info(
-            "Launching instance with launch_kwargs:\n{}".format(
-                "\n".join("{}={}".format(*item) for item in kwargs.items())
-            )
+            "Launching instance with launch_kwargs:\n%s",
+            "\n".join("{}={}".format(*item) for item in kwargs.items())
         )
 
         pycloudlib_instance = self._perform_launch(kwargs)
@@ -245,6 +244,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
     integration_instance_cls = IntegrationLxdInstance
 
     def _get_cloud_instance(self):
+        # pylint: disable=no-member
         return self.pycloudlib_instance_cls(tag=self.instance_tag)
 
     @staticmethod
@@ -260,8 +260,10 @@ class _LxdIntegrationCloud(IntegrationCloud):
             'container_path': target_path,
         }
         log.info(
-            'Mounting source {source_path} directly onto LXD container/vm '
-            'named {name} at {container_path}'.format(**format_variables))
+            'Mounting source %(source_path)s directly onto LXD container/vm '
+            'named %(name)s at %(container_path)s',
+            format_variables
+        )
         command = (
             'lxc config device add {name} host-cloud-init disk '
             'source={source_path} '

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -92,6 +92,7 @@ KEYPAIR_NAME = None
 ##################################################################
 # Bring in any user-file defined settings
 try:
+    # pylint: disable=wildcard-import,unused-wildcard-import
     from tests.integration_tests.user_settings import *  # noqa
 except ImportError:
     pass


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: use unique MAC addresses for tests

Using the same MAC address results in strange test behaviour if more
than one such instance is up: traffic gets routed to an arbitrary
interface with the given MAC address.  This can happen if running tests
in parallel, or on a system which retains test instances from previous
runs.

The introduction of tests/integration_tests/__init__.py means that
pylint now checks the integration tests: this commit also addresses
those failures.
```

## Additional Info

This introduces `tests/integration_tests/__init__.py` as a holding place for the utility function this introduces; I didn't want to introduce a `util`, but it also didn't feel like it fit well in anything we currently had.

## Test Steps

Run the affected tests in parallel a few times and observe a lack of collisions.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly