### PR TITLE
integration_tests: fix use of SSH agent within tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -147,13 +147,13 @@ deps =
 [testenv:integration-tests]
 basepython = python3
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
-passenv = CLOUD_INIT_*
+passenv = CLOUD_INIT_* SSH_AUTH_SOCK
 deps =
     -r{toxinidir}/integration-requirements.txt
 
 [testenv:integration-tests-ci]
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
-passenv = CLOUD_INIT_*
+passenv = CLOUD_INIT_* SSH_AUTH_SOCK
 deps =
     -r{toxinidir}/integration-requirements.txt
 setenv =


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: fix use of SSH agent within tox

We need to allow the SSH_AUTH_SOCK environment variable through for
paramiko to be able to find the agent.
```

## Test Steps

Run the tests in tox with an SSH key that requires a passphrase and observe that they pass.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly