### PR TITLE
stale.yml: don't ask submitters to reopen PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,5 +20,5 @@ jobs:
 
           If you are waiting for code review and you are seeing this message, apologies!  Please reply, tagging mitechie, and he will ensure that someone takes a look soon.
 
-          (If the pull request is closed, please do feel free to reopen it if you wish to continue working on it.)
+          (If the pull request is closed and you would like to continue working on it, please do tag mitechie to reopen it.)
         stale-pr-label: 'stale-pr'


### PR DESCRIPTION
## Proposed Commit Message
```
stale.yml: don't ask submitters to reopen PRs

Because they don't have the permissions to do it.  Instead, reword the
message to ask people to ping mitechie, in line with the rest of the
message.
```

## Additional Context

The lack of permissions was pointed out in https://github.com/canonical/cloud-init/pull/745.

## Test Steps

No particularly good way of testing this; we'll have to observe it in action.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly