### PR TITLE
tools/write-ssh-key-fingerprints: do not display empty header/footer

### DIFF
--- a/tests/integration_tests/modules/test_keys_to_console.py
+++ b/tests/integration_tests/modules/test_keys_to_console.py
@@ -10,6 +10,11 @@ ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
 ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
 """
 
+BLACKLIST_ALL_KEYS_USER_DATA = """\
+#cloud-config
+ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+"""  # noqa: E501
+
 DISABLED_USER_DATA = """\
 #cloud-config
 ssh:
@@ -29,6 +34,20 @@ class TestKeysToConsoleBlacklist:
     def test_included_keys(self, class_client, key_type):
         syslog = class_client.read_from_file("/var/log/syslog")
         assert "({})".format(key_type) in syslog
+
+
+@pytest.mark.user_data(BLACKLIST_ALL_KEYS_USER_DATA)
+class TestAllKeysToConsoleBlacklist:
+    """Test that when key blacklist contains all key types that
+    no header/footer are output.
+    """
+    def test_header_excluded(self, class_client):
+        syslog = class_client.read_from_file("/var/log/syslog")
+        assert "BEGIN SSH HOST KEY FINGERPRINTS" not in syslog
+
+    def test_footer_excluded(self, class_client):
+        syslog = class_client.read_from_file("/var/log/syslog")
+        assert "END SSH HOST KEY FINGERPRINTS" not in syslog
 
 
 @pytest.mark.user_data(DISABLED_USER_DATA)

--- a/tools/write-ssh-key-fingerprints
+++ b/tools/write-ssh-key-fingerprints
@@ -1,39 +1,61 @@
 #!/bin/sh
 # This file is part of cloud-init. See LICENSE file for license information.
 
-logger_opts="-p user.info -t ec2"
 
-# rhels' version of logger_opts does not support long
-# for of -s (--stderr), so use short form.
-logger_opts="$logger_opts -s"
+do_syslog() {
+    log_message=$1
+
+    # rhels' version of logger_opts does not support long
+    # form of -s (--stderr), so use short form.
+    logger_opts="-s"
+
+    # Need to end the options list with "--" to ensure that any minus symbols
+    # in the text passed to logger are not interpreted as logger options.
+    logger_opts="$logger_opts -p user.info -t cloud-init --"
+
+    # shellcheck disable=SC2086  # logger give error if $logger_opts quoted
+    logger $logger_opts "$log_message"
+}
+
 
 # Redirect stderr to stdout
 exec 2>&1
 
 fp_blist=",${1},"
 key_blist=",${2},"
-{
-echo
-echo "#############################################################"
-echo "-----BEGIN SSH HOST KEY FINGERPRINTS-----"
+
+fingerprint_header_shown=0
 for f in /etc/ssh/ssh_host_*key.pub; do
     [ -f "$f" ] || continue
-    read ktype line < "$f"
+    # shellcheck disable=SC2034  # Unused "line" required for word splitting
+    read -r ktype line < "$f"
     # skip the key if its type is in the blacklist
     [ "${fp_blist#*,$ktype,}" = "${fp_blist}" ] || continue
-    ssh-keygen -l -f "$f"
+    if [ $fingerprint_header_shown -eq 0 ]; then
+        do_syslog "#############################################################"
+        do_syslog "-----BEGIN SSH HOST KEY FINGERPRINTS-----"
+        fingerprint_header_shown=1
+    fi
+    do_syslog "$(ssh-keygen -l -f "$f")"
 done
-echo "-----END SSH HOST KEY FINGERPRINTS-----"
-echo "#############################################################"
+if [ $fingerprint_header_shown -eq 1 ]; then
+    do_syslog "-----END SSH HOST KEY FINGERPRINTS-----"
+    do_syslog "#############################################################"
+fi
 
-} | logger $logger_opts
-
-echo "-----BEGIN SSH HOST KEY KEYS-----"
+key_header_shown=0
 for f in /etc/ssh/ssh_host_*key.pub; do
     [ -f "$f" ] || continue
-    read ktype line < "$f"
+    # shellcheck disable=SC2034  # Unused "line" required for word splitting
+    read -r ktype line < "$f"
     # skip the key if its type is in the blacklist
     [ "${key_blist#*,$ktype,}" = "${key_blist}" ] || continue
-    cat $f
+    if [ $key_header_shown -eq 0 ]; then
+        echo "-----BEGIN SSH HOST KEY KEYS-----"
+        key_header_shown=1
+    fi
+    cat "$f"
 done
-echo "-----END SSH HOST KEY KEYS-----"
+if [ $key_header_shown -eq 1 ]; then
+    echo "-----END SSH HOST KEY KEYS-----"
+fi


### PR DESCRIPTION
When console output of SSH info is disabled show no headers/footers.

Prevent risk of message text being interpreted as "logger" option by
appending "--" to logger options.

Correct syslog output that was tagged with "ec2" regardless of DataSource
in use. Now use "cloud-init" tag instead.

Various "shellcheck" corrections.

Add testcase for disabled output of SSH host keys.

LP: #1915460

Provides alternative solution to #811.

## Test Steps

In user-data config add either, or both, of the following lines:

```
ssh_fp_console_blacklist: [ 'ssh-dsa', 'ssh-dss', 'ssh-rsa', 'ssh-ed25519' ]
ssh_key_console_blacklist: [ 'ssh-dsa', 'ssh-dss', 'ssh-rsa', 'ssh-ed25519' ]
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
