### PR TITLE
Add helper script: tools/build-deb-prepare

### DIFF
--- a/tools/build-deb-prepare
+++ b/tools/build-deb-prepare
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+: "${PACKAGING_BRANCH:=ubuntu/devel}"
+: "${RELEASE:=UNRELEASED}"
+: "${CLOGVER_DEBIAN:=0ubuntu1}"
+: "${DEBFULLNAME:=$(git config user.name)}"
+: "${DEBEMAIL:=$(git config user.email)}"
+
+export DEBFULLNAME DEBEMAIL
+
+fail() { echo "$@" 1>&2; exit 1; }
+
+if [[ "$1" = "-h" || "$1" = "--help" ]]; then
+    cat <<-EOF
+	Usage: ${0##*/}
+	Prepare the source for building a .deb package via e.g. debuild(1).
+	Build a debian/ directory the current git HEAD pulling the debian/
+	directory from branch '$PACKAGING_BRANCH' and updating the changelog,
+	then prepare an .orig tarball matching the new changelog entry.
+	EOF
+    exit
+fi
+
+git clean -f debian || fail "Failed to run git clean."
+
+# This script could work even if a debian/ directory is already existing,
+# but it's a confusing setup that should be avoided.
+[[ ! -e debian ]] || fail "A debian/ directory already exists."
+
+[[ $DEBFULLNAME ]] || fail "Must have DEBFULLNAME or git user.name set."
+[[ $DEBEMAIL ]] || fail "Must have DEBEMAIL or git user.email set."
+
+if [[ $(git status -s) ]]; then
+    cat 1>&2 <<-EOF
+	WARNING: There are uncommitted changes in your working directory.
+	         These changes will not be included in the orig archive.
+	EOF
+fi
+
+# git describe will output something either like '0.1.0' (a tag)
+# or TAG-N-gHASH where N is number of commits since TAG
+uver=$(git describe --abbrev=8) ||
+    fail "Failed to get upstream version with 'git describe'."
+clogver_new="${uver}-${CLOGVER_DEBIAN}"
+
+git fetch "$(git remote)" "$PACKAGING_BRANCH:$PACKAGING_BRANCH" ||
+    fail "Failed to fetch pachaging branch '$PACKAGING_BRANCH'."
+git restore --source="$PACKAGING_BRANCH" debian ||
+    fail "Failed to get debian/ from '$PACKAGING_BRANCH'."
+dch --newversion "$clogver_new" --distribution="$RELEASE" "Upstream build." ||
+    fail "Failed to update d/changelog."
+git deborig --force HEAD ||
+    fail "Failed to generate the orig tarball."


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add helper script: tools/build-deb-prepare
    
The script grabs the debian/ packaging directory from a packaging branch
(default: ubuntu/devel) and generates a suitable d/changelog entry and
an orig tarball. It is suitable for quickly building a deb package from
the current branch via debuild or sbuild.
```

## Additional Context

Will also be useful to run integration testing from Jenkins from a devel branch.

## Test Steps
Assuming that the cloud-init build-deps are installed this should produce a deb package from the current branch using the packaging from `ubuntu/devel`:
```
tools/build-deb-prepare
debuild -us -uc
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
