### PR TITLE
cc_keys_to_console.py: Add documentation for recently added config key

### DIFF
--- a/cloudinit/config/cc_keys_to_console.py
+++ b/cloudinit/config/cc_keys_to_console.py
@@ -9,14 +9,17 @@
 """
 Keys to Console
 ---------------
-**Summary:** control which SSH keys may be written to console
+**Summary:** control which SSH host keys may be written to console
 
-For security reasons it may be desirable not to write SSH fingerprints and keys
-to the console. To avoid the fingerprint of types of SSH keys being written to
-console the ``ssh_fp_console_blacklist`` config key can be used. By default all
-types of keys will have their fingerprints written to console. To avoid keys
-of a key type being written to console the ``ssh_key_console_blacklist`` config
-key can be used. By default ``ssh-dss`` keys are not written to console.
+For security reasons it may be desirable not to write SSH host keys and their
+fingerprints to the console. To avoid either being written to the console the
+``emit_keys_to_console`` config key under the main ``ssh`` config key can be
+used. To avoid the fingerprint of types of SSH host keys being written to
+console the ``ssh_fp_console_blacklist`` config key can be used. By default
+all types of keys will have their fingerprints written to console. To avoid
+host keys of a key type being written to console the
+``ssh_key_console_blacklist`` config key can be used. By default ``ssh-dss``
+host keys are not written to console.
 
 **Internal name:** ``cc_keys_to_console``
 
@@ -25,6 +28,9 @@ key can be used. By default ``ssh-dss`` keys are not written to console.
 **Supported distros:** all
 
 **Config keys**::
+
+    ssh:
+      emit_keys_to_console: false
 
     ssh_fp_console_blacklist: <list of key types>
     ssh_key_console_blacklist: <list of key types>


### PR DESCRIPTION
PR #811 added a new config key, emit_keys_to_console, but didn't update the
documentation for mention it.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
