### PR TITLE
tox.ini: pass OS_* environment variables to integration tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -147,13 +147,13 @@ deps =
 [testenv:integration-tests]
 basepython = python3
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
-passenv = CLOUD_INIT_* SSH_AUTH_SOCK
+passenv = CLOUD_INIT_* SSH_AUTH_SOCK OS_*
 deps =
     -r{toxinidir}/integration-requirements.txt
 
 [testenv:integration-tests-ci]
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
-passenv = CLOUD_INIT_* SSH_AUTH_SOCK
+passenv = CLOUD_INIT_* SSH_AUTH_SOCK OS_*
 deps =
     -r{toxinidir}/integration-requirements.txt
 setenv =


### PR DESCRIPTION
## Proposed Commit Message
```
tox.ini: pass OS_* environment variables to integration tests

This allows source'd OpenStack credentials to be used for tox tests.
```

## Test Steps

This fails without the change, and passes with it:

```
. /path/to/novarc
CLOUD_INIT_OS_IMAGE="..." CLOUD_INIT_PLATFORM=openstack tox -e integration-tests-ci
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly