### PR TITLE
bonding sysconfig: use bonding_module_opts instead of bonding_opts

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -637,14 +637,15 @@ class Renderer(renderer.Renderer):
                     break
         if bond_opts:
             if flavor == 'suse':
-                # suse uses the sysconfig support which requires BONDING_MODULE_OPTS
-                # see https://www.kernel.org/doc/Documentation/networking/bonding.txt
-                # 3.1 Configuration with Sysconfig Support            
+                # suse uses the sysconfig support which requires
+                # BONDING_MODULE_OPTS see
+                # https://www.kernel.org/doc/Documentation/networking/bonding.txt
+                # 3.1 Configuration with Sysconfig Support
                 iface_cfg['BONDING_MODULE_OPTS'] = " ".join(bond_opts)
             else:
                 # rhel uses initscript support and thus requires BONDING_OPTS
-                # this is also the old default
-                # see https://www.kernel.org/doc/Documentation/networking/bonding.txt
+                # this is also the old default see
+                # https://www.kernel.org/doc/Documentation/networking/bonding.txt
                 #  3.2 Configuration with Initscripts Support
                 iface_cfg['BONDING_OPTS'] = " ".join(bond_opts)
 

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -635,18 +635,17 @@ class Renderer(renderer.Renderer):
                         bond_value = " ".join(bond_value)
                     bond_opts.append(value_tpl % (bond_value))
                     break
-        # suse uses the sysconfig support which requires BONDING_MODULE_OPTS
-        # see https://www.kernel.org/doc/Documentation/networking/bonding.txt
-        # 3.1 Configuration with Sysconfig Support
-        if flavor == 'suse':
-            if bond_opts:
+        if bond_opts:
+            if flavor == 'suse':
+                # suse uses the sysconfig support which requires BONDING_MODULE_OPTS
+                # see https://www.kernel.org/doc/Documentation/networking/bonding.txt
+                # 3.1 Configuration with Sysconfig Support            
                 iface_cfg['BONDING_MODULE_OPTS'] = " ".join(bond_opts)
-        # rhel uses initscript support and thus requires BONDING_OPTS
-        # this is also the old default
-        # see https://www.kernel.org/doc/Documentation/networking/bonding.txt
-        #  3.2 Configuration with Initscripts Support
-        else:
-            if bond_opts:
+            else:
+                # rhel uses initscript support and thus requires BONDING_OPTS
+                # this is also the old default
+                # see https://www.kernel.org/doc/Documentation/networking/bonding.txt
+                #  3.2 Configuration with Initscripts Support
                 iface_cfg['BONDING_OPTS'] = " ".join(bond_opts)
 
     @classmethod

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -313,7 +313,8 @@ class Renderer(renderer.Renderer):
     }
 
     # If these keys exist, then their values will be used to form
-    # a BONDING_OPTS grouping; otherwise no grouping will be set.
+    # a BONDING_OPTS / BONDING_MODULE_OPTS grouping; otherwise no
+    # grouping will be set.
     bond_tpl_opts = tuple([
         ('bond_mode', "mode=%s"),
         ('bond_xmit_hash_policy', "xmit_hash_policy=%s"),
@@ -622,7 +623,7 @@ class Renderer(renderer.Renderer):
                             route_cfg[new_key] = route[old_key]
 
     @classmethod
-    def _render_bonding_opts(cls, iface_cfg, iface):
+    def _render_bonding_opts(cls, iface_cfg, iface, flavor):
         bond_opts = []
         for (bond_key, value_tpl) in cls.bond_tpl_opts:
             # Seems like either dash or underscore is possible?
@@ -634,8 +635,19 @@ class Renderer(renderer.Renderer):
                         bond_value = " ".join(bond_value)
                     bond_opts.append(value_tpl % (bond_value))
                     break
-        if bond_opts:
-            iface_cfg['BONDING_OPTS'] = " ".join(bond_opts)
+        # suse uses the sysconfig support which requires BONDING_MODULE_OPTS
+        # see https://www.kernel.org/doc/Documentation/networking/bonding.txt
+        # 3.1 Configuration with Sysconfig Support
+        if flavor == 'suse':
+            if bond_opts:
+                iface_cfg['BONDING_MODULE_OPTS'] = " ".join(bond_opts)
+        # rhel uses initscript support and thus requires BONDING_OPTS
+        # this is also the old default
+        # see https://www.kernel.org/doc/Documentation/networking/bonding.txt
+        #  3.2 Configuration with Initscripts Support
+        else:
+            if bond_opts:
+                iface_cfg['BONDING_OPTS'] = " ".join(bond_opts)
 
     @classmethod
     def _render_physical_interfaces(
@@ -663,7 +675,7 @@ class Renderer(renderer.Renderer):
         for iface in network_state.iter_interfaces(bond_filter):
             iface_name = iface['name']
             iface_cfg = iface_contents[iface_name]
-            cls._render_bonding_opts(iface_cfg, iface)
+            cls._render_bonding_opts(iface_cfg, iface, flavor)
 
             # Ensure that the master interface (and any of its children)
             # are actually marked as being bond types...

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1654,7 +1654,7 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
         'expected_sysconfig_opensuse': {
             'ifcfg-bond0': textwrap.dedent("""\
                 BONDING_MASTER=yes
-                BONDING_OPTS="mode=active-backup """
+                BONDING_MODULE_OPTS="mode=active-backup """
                                            """xmit_hash_policy=layer3+4 """
                                            """miimon=100"
                 BONDING_SLAVE_0=eth1
@@ -2240,7 +2240,7 @@ iface bond0 inet6 static
         'expected_sysconfig_opensuse': {
             'ifcfg-bond0': textwrap.dedent("""\
         BONDING_MASTER=yes
-        BONDING_OPTS="mode=active-backup xmit_hash_policy=layer3+4 """
+        BONDING_MODULE_OPTS="mode=active-backup xmit_hash_policy=layer3+4 """
                                            """miimon=100 num_grat_arp=5 """
                                            """downdelay=10 updelay=20 """
                                            """fail_over_mac=active """


### PR DESCRIPTION
Current documentation[1][2] recommends to use BONDING_MODULE_OPTS
instead of BONDING_OPTS. SLES/wicked even ignores BONDING_OPTS
except for the bonding mode and requires BONDING_MODULE_OPTS.

[1] https://wiki.linuxfoundation.org/networking/bonding
[2] https://www.kernel.org/doc/Documentation/networking/bonding.txt

I also changed the name of the render function so that there is no difference between function_name and what it does.

## Additional Context
Currently bonding on SLES (I only tested 15sp2 but it's probably true for prior versions as well as even SLES9 docu only mentions BONDING_MODULE_OPTS) via Configdrive on OpenStack fails because cloud-init sets BONDING_OPTS but SLES ignores the BONDING_OPTS. SLES also requires that the miimon option is set. (SLES [config example](https://documentation.suse.com/sles/15-SP2/single-html/SLES-admin/#sec-network-iface-bonding-hotplug) ) Even if this is set in OpenStack and cloud-init writes it as part of the BONDING_OPTS, SLES ignores it. From what I can tell current best practice seems to be to use BONDING_MODULE_OPTS instead of BONDING_OPTS

## Test Steps
Deploy a SLES 15SP2 on OpenStack ironic that is using port-groups. The ifcfg-bond0 file gets generated  with BONDING_OPTS but SLES will ignore it with a `bonding validation, insufficient monitoring settings` error.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly

I found no corresponding documentation to change and I it seems the `tools/net-convert.py` mentioned in `doc/rtd/topics/network-config.rst` is not present any longer.

Requires #828 before it can be merged