### PR TITLE
Refactor release handing in integration tests

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,6 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
+packaging
 pycloudlib @ git+https://github.com/canonical/pycloudlib.git@5975c7e60be4a1e95814909a35592634cc145938
 pytest

--- a/tests/integration_tests/bugs/test_gh626.py
+++ b/tests/integration_tests/bugs/test_gh626.py
@@ -8,8 +8,8 @@ import pytest
 import yaml
 
 from tests.integration_tests import random_mac_address
-from tests.integration_tests.clouds import ImageSpecification
 from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.releases import Release
 
 
 MAC_ADDRESS = random_mac_address()
@@ -36,7 +36,7 @@ iface eth0 inet dhcp
     "volatile.eth0.hwaddr": MAC_ADDRESS,
 })
 def test_wakeonlan(client: IntegrationInstance):
-    if ImageSpecification.from_os_image().release == 'xenial':
+    if Release.from_os_image().name == 'xenial':
         eni = client.execute('cat /etc/network/interfaces.d/50-cloud-init.cfg')
         assert eni.endswith(EXPECTED_ENI_END)
         return

--- a/tests/integration_tests/bugs/test_lp1835584.py
+++ b/tests/integration_tests/bugs/test_lp1835584.py
@@ -32,10 +32,9 @@ import re
 import pytest
 
 from tests.integration_tests.instances import IntegrationAzureInstance
-from tests.integration_tests.clouds import (
-    ImageSpecification, IntegrationCloud
-)
+from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.conftest import get_validated_source
+from tests.integration_tests.releases import BIONIC
 
 
 IMG_AZURE_UBUNTU_PRO_FIPS_BIONIC = (
@@ -76,16 +75,10 @@ def _check_iid_insensitive_across_kernel_upgrade(
 
 @pytest.mark.azure
 @pytest.mark.sru_next
+@pytest.mark.release(BIONIC)
 def test_azure_kernel_upgrade_case_insensitive_uuid(
     session_cloud: IntegrationCloud
 ):
-    cfg_image_spec = ImageSpecification.from_os_image()
-    if (cfg_image_spec.os, cfg_image_spec.release) != ("ubuntu", "bionic"):
-        pytest.skip(
-            "Test only supports ubuntu:bionic not {0.os}:{0.release}".format(
-                cfg_image_spec
-            )
-        )
     source = get_validated_source(session_cloud)
     if not source.installs_new_version():
         pytest.skip(

--- a/tests/integration_tests/bugs/test_lp1898997.py
+++ b/tests/integration_tests/bugs/test_lp1898997.py
@@ -11,6 +11,7 @@ default gateway.
 """
 import pytest
 from tests.integration_tests import random_mac_address
+from tests.integration_tests.releases import UBUNTU, XENIAL, BIONIC
 
 MAC_ADDRESS = random_mac_address()
 
@@ -40,10 +41,8 @@ version: 2
 })
 @pytest.mark.lxd_vm
 @pytest.mark.lxd_use_exec
-@pytest.mark.not_bionic
-@pytest.mark.not_xenial
+@pytest.mark.release([r for r in UBUNTU if r not in [XENIAL, BIONIC]])
 @pytest.mark.sru_2020_11
-@pytest.mark.ubuntu
 class TestInterfaceListingWithOpenvSwitch:
     def test_ovs_member_interfaces_not_excluded(self, client):
         # We need to install openvswitch for our provided network configuration

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -15,7 +15,7 @@ from pycloudlib import (
 from pycloudlib.lxd.instance import LXDInstance
 
 import cloudinit
-from cloudinit.subp import subp, ProcessExecutionError
+from cloudinit.subp import subp
 from tests.integration_tests import integration_settings
 from tests.integration_tests.instances import (
     IntegrationEc2Instance,
@@ -24,6 +24,7 @@ from tests.integration_tests.instances import (
     IntegrationOciInstance,
     IntegrationLxdInstance,
 )
+from tests.integration_tests.releases import get_image_from_spec, Release
 
 try:
     from typing import Optional
@@ -32,65 +33,6 @@ except ImportError:
 
 
 log = logging.getLogger('integration_testing')
-
-
-def _get_ubuntu_series() -> list:
-    """Use distro-info-data's ubuntu.csv to get a list of Ubuntu series"""
-    out = ""
-    try:
-        out, _err = subp(["ubuntu-distro-info", "-a"])
-    except ProcessExecutionError:
-        log.info(
-            "ubuntu-distro-info (from the distro-info package) must be"
-            " installed to guess Ubuntu os/release"
-        )
-    return out.splitlines()
-
-
-class ImageSpecification:
-    """A specification of an image to launch for testing.
-
-    If either of ``os`` and ``release`` are not specified, an attempt will be
-    made to infer the correct values for these on instantiation.
-
-    :param image_id:
-        The image identifier used by the rest of the codebase to launch this
-        image.
-    :param os:
-        An optional string describing the operating system this image is for
-        (e.g.  "ubuntu", "rhel", "freebsd").
-    :param release:
-        A optional string describing the operating system release (e.g.
-        "focal", "8"; the exact values here will depend on the OS).
-    """
-
-    def __init__(
-        self,
-        image_id: str,
-        os: "Optional[str]" = None,
-        release: "Optional[str]" = None,
-    ):
-        if image_id in _get_ubuntu_series():
-            if os is None:
-                os = "ubuntu"
-            if release is None:
-                release = image_id
-
-        self.image_id = image_id
-        self.os = os
-        self.release = release
-        log.info(
-            "Detected image: image_id=%s os=%s release=%s",
-            self.image_id,
-            self.os,
-            self.release,
-        )
-
-    @classmethod
-    def from_os_image(cls):
-        """Return an ImageSpecification for integration_settings.OS_IMAGE."""
-        parts = integration_settings.OS_IMAGE.split("::", 2)
-        return cls(*parts)
 
 
 class IntegrationCloud(ABC):
@@ -134,11 +76,14 @@ class IntegrationCloud(ABC):
         raise NotImplementedError
 
     def _get_initial_image(self):
-        image = ImageSpecification.from_os_image()
-        try:
-            return self.cloud_instance.released_image(image.image_id)
-        except (ValueError, IndexError):
-            return image.image_id
+        image = get_image_from_spec()
+        if image.id:
+            return image.id
+        else:
+            try:
+                return self.cloud_instance.released_image(image.release)
+            except (ValueError, IndexError):
+                return image.release
 
     def _perform_launch(self, launch_kwargs):
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
@@ -338,14 +283,14 @@ class OpenstackCloud(IntegrationCloud):
         )
 
     def _get_initial_image(self):
-        image = ImageSpecification.from_os_image()
+        image_id = get_image_from_spec().id
         try:
-            UUID(image.image_id)
+            UUID(image_id)
         except ValueError as e:
             raise Exception(
                 'When using Openstack, `OS_IMAGE` MUST be specified with '
                 'a 36-character UUID image ID. Passing in a release name is '
                 'not valid here.\n'
-                'OS image id: {}'.format(image.image_id)
+                'OS image id: {}'.format(image_id)
             ) from e
-        return image.image_id
+        return image_id

--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -1,10 +1,10 @@
 """Series of integration tests covering apt functionality."""
 import re
-from tests.integration_tests.clouds import ImageSpecification
 
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.releases import Release, UBUNTU
 
 
 USER_DATA = """\
@@ -94,7 +94,7 @@ TEST_KEY = "1FF0 D853 5EF7 E719 E5C8  1B9C 083D 06FB E4D3 04DF"
 
 
 @pytest.mark.ci
-@pytest.mark.ubuntu
+@pytest.mark.release(UBUNTU)
 @pytest.mark.user_data(USER_DATA)
 class TestApt:
     def test_sources_list(self, class_client: IntegrationInstance):
@@ -142,10 +142,10 @@ class TestApt:
         Ported from
         tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.py
         """
-        release = ImageSpecification.from_os_image().release
+        release_name = Release.from_os_image().name
         ppa_path_contents = class_client.read_from_file(
             '/etc/apt/sources.list.d/'
-            'simplestreams-dev-ubuntu-trunk-{}.list'.format(release)
+            'simplestreams-dev-ubuntu-trunk-{}.list'.format(release_name)
         )
 
         assert (
@@ -212,7 +212,7 @@ apt:
 """
 
 
-@pytest.mark.ubuntu
+@pytest.mark.release(UBUNTU)
 @pytest.mark.user_data(DEFAULT_DATA)
 class TestDefaults:
     def test_primary(self, class_client: IntegrationInstance):
@@ -251,7 +251,7 @@ apt_pipelining: false
 """
 
 
-@pytest.mark.ubuntu
+@pytest.mark.release(UBUNTU)
 @pytest.mark.user_data(DISABLED_DATA)
 class TestDisabled:
     def test_disable_suites(self, class_client: IntegrationInstance):

--- a/tests/integration_tests/modules/test_ca_certs.py
+++ b/tests/integration_tests/modules/test_ca_certs.py
@@ -10,6 +10,8 @@ import os.path
 
 import pytest
 
+from tests.integration_tests.releases import UBUNTU
+
 
 USER_DATA = """\
 #cloud-config
@@ -55,7 +57,7 @@ ca-certs:
 """
 
 
-@pytest.mark.ubuntu
+@pytest.mark.release(UBUNTU)
 @pytest.mark.user_data(USER_DATA)
 class TestCaCerts:
     def test_certs_updated(self, class_client):

--- a/tests/integration_tests/modules/test_lxd_bridge.py
+++ b/tests/integration_tests/modules/test_lxd_bridge.py
@@ -6,6 +6,8 @@
 import pytest
 import yaml
 
+from tests.integration_tests.releases import UBUNTU, XENIAL
+
 
 USER_DATA = """\
 #cloud-config
@@ -33,7 +35,7 @@ class TestLxdBridge:
         """Check that the expected LXD binaries are installed"""
         assert class_client.execute(["which", binary_name]).ok
 
-    @pytest.mark.not_xenial
+    @pytest.mark.release([r for r in UBUNTU if r != XENIAL])
     @pytest.mark.sru_2020_11
     def test_bridge(self, class_client):
         """Check that the given bridge is configured"""

--- a/tests/integration_tests/modules/test_package_update_upgrade_install.py
+++ b/tests/integration_tests/modules/test_package_update_upgrade_install.py
@@ -15,6 +15,8 @@ NOTE: the testcase for this looks for the command in history.log as
 import re
 import pytest
 
+from tests.integration_tests.releases import UBUNTU
+
 
 USER_DATA = """\
 #cloud-config
@@ -26,7 +28,7 @@ package_upgrade: true
 """
 
 
-@pytest.mark.ubuntu
+@pytest.mark.release(UBUNTU)
 @pytest.mark.user_data(USER_DATA)
 class TestPackageUpdateUpgradeInstall:
 

--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -10,6 +10,7 @@ import pytest
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.log_utils import verify_ordered_items_in_text
+from tests.integration_tests.releases import UBUNTU
 
 USER_DATA = """\
 #cloud-config
@@ -52,7 +53,7 @@ def _can_connect(instance):
 # occasionally some timing issues will crop up.
 @pytest.mark.unstable
 @pytest.mark.sru_2020_11
-@pytest.mark.ubuntu
+@pytest.mark.release(UBUNTU)
 @pytest.mark.lxd_container
 class TestPowerChange:
     @pytest.mark.parametrize('mode,delay,timeout,expected', [

--- a/tests/integration_tests/modules/test_snap.py
+++ b/tests/integration_tests/modules/test_snap.py
@@ -8,6 +8,8 @@ and then checks that if that command was executed during boot.
 
 import pytest
 
+from tests.integration_tests.releases import UBUNTU
+
 
 USER_DATA = """\
 #cloud-config
@@ -20,7 +22,7 @@ snap:
 
 
 @pytest.mark.ci
-@pytest.mark.ubuntu
+@pytest.mark.release(UBUNTU)
 class TestSnap:
 
     @pytest.mark.user_data(USER_DATA)

--- a/tests/integration_tests/modules/test_ssh_import_id.py
+++ b/tests/integration_tests/modules/test_ssh_import_id.py
@@ -12,6 +12,8 @@ TODO:
 
 import pytest
 
+from tests.integration_tests.releases import UBUNTU
+
 
 USER_DATA = """\
 #cloud-config
@@ -22,7 +24,7 @@ ssh_import_id:
 
 
 @pytest.mark.ci
-@pytest.mark.ubuntu
+@pytest.mark.release(UBUNTU)
 class TestSshImportId:
 
     @pytest.mark.user_data(USER_DATA)

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -11,6 +11,8 @@ import re
 
 import pytest
 
+from tests.integration_tests.releases import UBUNTU
+
 
 USER_DATA = """\
 #cloud-config
@@ -45,7 +47,7 @@ AHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
 @pytest.mark.ci
 @pytest.mark.user_data(USER_DATA)
 class TestUsersGroups:
-    @pytest.mark.ubuntu
+    @pytest.mark.release(UBUNTU)
     @pytest.mark.parametrize(
         "getent_args,regex",
         [

--- a/tests/integration_tests/releases.py
+++ b/tests/integration_tests/releases.py
@@ -1,0 +1,90 @@
+import functools
+import logging
+from collections import namedtuple
+
+from packaging import version
+
+from cloudinit.subp import subp, ProcessExecutionError
+from tests.integration_tests import integration_settings
+
+log = logging.getLogger('integration_testing')
+_image_spec = namedtuple('ImageSpec', 'id, os, release')
+
+
+def _get_ubuntu_series() -> list:
+    """Use distro-info-data's ubuntu.csv to get a list of Ubuntu series"""
+    out = ""
+    try:
+        out, _err = subp(["ubuntu-distro-info", "-a"])
+    except ProcessExecutionError:
+        log.info(
+            "ubuntu-distro-info (from the distro-info package) must be"
+            " installed to guess Ubuntu os/release"
+        )
+    return out.splitlines()
+
+
+def get_image_from_spec(
+    os_image: str = integration_settings.OS_IMAGE
+) -> _image_spec:
+    """Get the individual parts from an OS_IMAGE definition.
+
+    Returns a namedtuple containing id, os, and release of the image."""
+    parts = os_image.split('::', 2)
+    image_id = None
+    if len(parts) == 1:
+        os = 'ubuntu'
+        release = parts[0]
+        if release not in _get_ubuntu_series():
+            raise ValueError(
+                'Specified release is not a recognized Ubuntu release')
+    elif len(parts) == 3:
+        image_id, os, release = parts
+    else:
+        raise Exception(
+            'OS_IMAGE must either contain release name or be in the form '
+            'of <image_id>[::<os>[::<release>]]')
+    return _image_spec(id=image_id, os=os, release=release)
+
+
+@functools.total_ordering
+class Release:
+    _all_releases = []
+
+    def __init__(self, os, name, number):
+        self.os = os
+        self.name = name
+        self.number = number
+        Release._all_releases.append(self)
+
+    def __repr__(self):
+        return 'Release({}, {}, {})'.format(self.os, self.name, self.number)
+
+    def __lt__(self, other):
+        return version.parse(self.number) < version.parse(other.number)
+
+    @classmethod
+    def all_releases(cls):
+        return cls._all_releases
+
+    @classmethod
+    def from_os_image(
+        cls, os_image=integration_settings.OS_IMAGE
+    ) -> 'Release':
+        _, os, release_name = get_image_from_spec(os_image)
+        matching_releases = [r for r in cls.all_releases(
+        ) if r.os == os and r.name == release_name]
+        if len(matching_releases) != 1:
+            raise Exception(
+                'Expected to find one matching release. '
+                'Instead found: {}'.format(matching_releases))
+        return matching_releases[0]
+
+
+XENIAL = Release('ubuntu', 'xenial', '16.04')
+BIONIC = Release('ubuntu', 'bionic', '18.04')
+FOCAL = Release('ubuntu', 'focal', '20.04')
+GROOVY = Release('ubuntu', 'groovy', '20.10')
+HIRSUTE = Release('ubuntu', 'hirsuite', '21.04')
+
+UBUNTU = [r for r in Release.all_releases() if r.os == 'ubuntu']

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -3,11 +3,12 @@ import pytest
 import time
 from pathlib import Path
 
-from tests.integration_tests.clouds import ImageSpecification, IntegrationCloud
+from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.conftest import (
     get_validated_source,
     session_start_time,
 )
+from tests.integration_tests.releases import Release
 
 log = logging.getLogger('integration_testing')
 
@@ -66,14 +67,14 @@ def test_upgrade(session_cloud: IntegrationCloud):
         'image_id': session_cloud._get_initial_image(),
     }
 
-    image = ImageSpecification.from_os_image()
+    release = Release.from_os_image()
 
     # Get the paths to write test logs
     output_dir = Path(session_cloud.settings.LOCAL_LOG_PATH)
     output_dir.mkdir(parents=True, exist_ok=True)
     base_filename = 'test_upgrade_{platform}_{os}_{{stage}}_{time}.log'.format(
         platform=session_cloud.settings.PLATFORM,
-        os=image.release,
+        os=release.name,
         time=session_start_time,
     )
     before_path = output_dir / base_filename.format(stage='before')
@@ -81,9 +82,9 @@ def test_upgrade(session_cloud: IntegrationCloud):
 
     # Get the network cfg file
     netcfg_path = '/dev/null'
-    if image.os == 'ubuntu':
+    if release.os == 'ubuntu':
         netcfg_path = '/etc/netplan/50-cloud-init.yaml'
-        if image.release == 'xenial':
+        if release.name == 'xenial':
             netcfg_path = '/etc/network/interfaces.d/50-cloud-init.cfg'
 
     with session_cloud.launch(

--- a/tox.ini
+++ b/tox.ini
@@ -178,13 +178,11 @@ markers =
     lxd_container: test will only run in LXD container
     lxd_use_exec: `execute` will use `lxc exec` instead of SSH
     lxd_vm: test will only run in LXD VM
-    not_xenial: test cannot run on the xenial release
-    not_bionic: test cannot run on the bionic release
     no_container: test cannot run in a container
+    release: specify specific releases required for this test
     user_data: the user data to be passed to the test instance
     instance_name: the name to be used for the test instance
     sru_2020_11: test is part of the 2020/11 SRU verification
     sru_2021_01: test is part of the 2021/01 SRU verification
     sru_next: test is part of the next SRU verification
-    ubuntu: this test should run on Ubuntu
     unstable: skip this test because it is flakey


### PR DESCRIPTION
This looks like a big PR, but most of it is updating call points. The majority of the functionality is in releases.py and clouds.py. I haven't extensively tested this yet. I would like a +1 on the idea first.

One minor change in existing functionality is this now *requires* you to use the `image_id::os::release` semantics if you specify anything other than a known ubuntu release. 

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Refactor release handing in integration tests

There are currently two ways we filter the releases supported by a given
test:
1. Mark the test with a pytest mark for the given release.
2. Check the release at the beginning of the test at skip if appropriate
(1) is problematic because it's quite rigid. There's no easy way to
specify things like "all versions greater than focal", or "only run on
Xenial and Groovy" without adding yet another mark. Having dozens of
marks for each combination of release we may want isn't realistic.
(2) is problematic because by the time we hit the first line of the
test, we've already wasted time launching an instance.

This change allows us to use a single decorator that can take a defined
release or list of defined releases.
```

## Additional Context
<!-- If relevant -->

## Test Steps
Run `pytest tests/integration_tests` as before.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
