### PR TITLE
Azure helper: sleep between retries for http handler

### DIFF
--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -303,6 +303,7 @@ def http_with_retries(url, **kwargs) -> str:
 
     max_readurl_attempts = 240
     default_readurl_timeout = 5
+    sleep_duration_between_retries = 5
     periodic_logging_attempts = 12
 
     if 'timeout' not in kwargs:
@@ -338,6 +339,7 @@ def http_with_retries(url, **kwargs) -> str:
                     'attempt %d with exception: %s' %
                     (url, attempt, e),
                     logger_func=LOG.debug)
+            time.sleep(sleep_duration_between_retries)
 
     raise exc
 


### PR DESCRIPTION
## Proposed commit message

```
Azure helper: sleep between retries for http handler

Ensure that the Azure helper's http
handler sleeps a fixed duration
between retry failure attempts.
The http handler will sleep a
fixed duration between failed
attempts regardless of whether
the attempt failed due to
(1) request timing out or
(2) instant failure (no timeout).

Due to certain platform issues,
the http request to the Azure
endpoint may instantly fail
without reaching the http
timeout duration.

Without sleeping a fixed duration
in between retry attempts, the
http handler will loop through
the max retry attempts quickly.

This causes the communication
between cloud-init and the
Azure platform to be less
resilient due to the
short total duration
if there is no sleep in
between retries.
```

## Test Steps
* Created a cloud-init package from this branch.
* Installed the package to an Azure VM.
* Created a custom generalized VM image out of the Azure VM.
* Deployed an Azure VM.
* Ensured (by inspecting logs) that `azure_helper`'s http requests with the Azure endpoint do not have issues.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
