### PR TITLE
Fix mis-detecting network configuration in initramfs cmdline

### DIFF
--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -73,7 +73,7 @@ class KlibcNetworkConfigSource(InitramfsNetworkConfigSource):
                 (ii) an open-iscsi interface file is present in the system
         """
         if self._files:
-            if re.search(r'(^|\s)ip[6]*=', self._cmdline):
+            if re.search(r'(^|\s)ip6?=', self._cmdline):
                 return True
             if os.path.exists(_OPEN_ISCSI_INTERFACE_FILE):
                 # iBft can configure networking without ip=

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -12,7 +12,7 @@ import gzip
 import io
 import logging
 import os
-import re
+import shlex
 
 from cloudinit import util
 
@@ -73,8 +73,9 @@ class KlibcNetworkConfigSource(InitramfsNetworkConfigSource):
                 (ii) an open-iscsi interface file is present in the system
         """
         if self._files:
-            if re.search(r'(^|\s)ip6?=', self._cmdline):
-                return True
+            for item in shlex.split(self._cmdline):
+                if item.startswith('ip=') or item.startswith('ip6='):
+                    return True
             if os.path.exists(_OPEN_ISCSI_INTERFACE_FILE):
                 # iBft can configure networking without ip=
                 return True

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -12,6 +12,7 @@ import gzip
 import io
 import logging
 import os
+import re
 
 from cloudinit import util
 
@@ -72,7 +73,7 @@ class KlibcNetworkConfigSource(InitramfsNetworkConfigSource):
                 (ii) an open-iscsi interface file is present in the system
         """
         if self._files:
-            if 'ip=' in self._cmdline or 'ip6=' in self._cmdline:
+            if re.search(r'(^|\s)ip[6]*=', self._cmdline):
                 return True
             if os.path.exists(_OPEN_ISCSI_INTERFACE_FILE):
                 # iBft can configure networking without ip=

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4387,6 +4387,16 @@ class TestCmdlineKlibcNetworkConfigSource(FilesystemMockingTestCase):
         )
         self.assertFalse(src.is_applicable())
 
+    def test_with_faux_ip(self):
+        content = {'net6-eno1.conf': DHCP6_CONTENT_1}
+        files = sorted(populate_dir(self.tmp_dir(), content))
+        src = cmdline.KlibcNetworkConfigSource(
+            _files=files,
+            _cmdline='foo iscsi_target_ip=root=/dev/sda',
+            _mac_addrs=self.macs,
+        )
+        self.assertFalse(src.is_applicable())
+
     def test_with_both_ip_ip6(self):
         content = {
             '/run/net-eth0.conf': DHCP_CONTENT_1,

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4397,6 +4397,36 @@ class TestCmdlineKlibcNetworkConfigSource(FilesystemMockingTestCase):
         )
         self.assertFalse(src.is_applicable())
 
+    def test_empty_cmdline(self):
+        content = {'net6-eno1.conf': DHCP6_CONTENT_1}
+        files = sorted(populate_dir(self.tmp_dir(), content))
+        src = cmdline.KlibcNetworkConfigSource(
+            _files=files,
+            _cmdline='',
+            _mac_addrs=self.macs,
+        )
+        self.assertFalse(src.is_applicable())
+
+    def test_whitespace_cmdline(self):
+        content = {'net6-eno1.conf': DHCP6_CONTENT_1}
+        files = sorted(populate_dir(self.tmp_dir(), content))
+        src = cmdline.KlibcNetworkConfigSource(
+            _files=files,
+            _cmdline='          ',
+            _mac_addrs=self.macs,
+        )
+        self.assertFalse(src.is_applicable())
+
+    def test_cmdline_no_lhand(self):
+        content = {'net6-eno1.conf': DHCP6_CONTENT_1}
+        files = sorted(populate_dir(self.tmp_dir(), content))
+        src = cmdline.KlibcNetworkConfigSource(
+            _files=files,
+            _cmdline='=wut',
+            _mac_addrs=self.macs,
+        )
+        self.assertFalse(src.is_applicable())
+
     def test_with_both_ip_ip6(self):
         content = {
             '/run/net-eth0.conf': DHCP_CONTENT_1,

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4427,6 +4427,16 @@ class TestCmdlineKlibcNetworkConfigSource(FilesystemMockingTestCase):
         )
         self.assertFalse(src.is_applicable())
 
+    def test_cmdline_embedded_ip(self):
+        content = {'net6-eno1.conf': DHCP6_CONTENT_1}
+        files = sorted(populate_dir(self.tmp_dir(), content))
+        src = cmdline.KlibcNetworkConfigSource(
+            _files=files,
+            _cmdline='opt="some things and ip=foo"',
+            _mac_addrs=self.macs,
+        )
+        self.assertFalse(src.is_applicable())
+
     def test_with_both_ip_ip6(self):
         content = {
             '/run/net-eth0.conf': DHCP_CONTENT_1,


### PR DESCRIPTION
**Integration test still needs to be written**

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix mis-detecting network configuration in initramfs cmdline

klibc initramfs in debian allows the 'iscsi_target_ip=' cmdline
parameter to specify an iscsi device attachment. This can
cause cloud-init to mis-detect the cmdline paramter as a
networking config.

LP: #1919188
```

## Additional Context
https://bugs.launchpad.net/cloud-init/+bug/1919188

## Test Steps
**Integration test still needs to be written**

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
