### PR TITLE
Fix apt default integration test

### DIFF
--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -223,18 +223,10 @@ class TestDefaults:
 
         When no uri is provided.
         """
-        version = class_client.execute(
-            'curl http://169.254.169.254'
-        ).split('\n')[-1]
-        zone = class_client.execute(
-            'curl http://169.254.169.254/{}/meta-data/placement/'
-            'availability-zone'.format(version),
-        )
-
+        zone = class_client.execute('cloud-init query v1.availability_zone')
         sources_list = class_client.read_from_file('/etc/apt/sources.list')
         assert '{}.clouds.archive.ubuntu.com'.format(zone) in sources_list
 
-    @pytest.mark.user_data(DEFAULT_DATA)
     def test_security(self, class_client: IntegrationInstance):
         """Test apt default security sources.
 

--- a/tox.ini
+++ b/tox.ini
@@ -174,6 +174,7 @@ markers =
     gce: test will only run on GCE platform
     azure: test will only run on Azure platform
     oci: test will only run on OCI platform
+    openstack: test will only run on openstack
     lxd_config_dict: set the config_dict passed on LXD instance creation
     lxd_container: test will only run in LXD container
     lxd_use_exec: `execute` will use `lxc exec` instead of SSH


### PR DESCRIPTION
The apt default test wasn't ported over from cloud-tests correctly.
Fix it so it works as it did in the cloud tests.

Also add openstack specific test for apt configuration with no uri.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix apt default integration test

The apt default test wasn't ported over from cloud-tests correctly.
uri should be specified in the test, but it was not, so the test
failed on openstack (and likely other platforms) because without
a specified uri, the default uri will vary by platform. I separated
this uri test out into a separate test function.

Also add openstack specific test for apt configuration with no uri.
Other platform-specific tests should be added here over time.
```

## Additional Context
n/a

## Test Steps
Run integration tests on openstack

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
