### PR TITLE
integration_tests: bump pycloudlib dependency

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@5975c7e60be4a1e95814909a35592634cc145938
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@96b146ee1beb99b8e44e36525e18a9a20e00c3f2
 pytest


### PR DESCRIPTION
## Proposed Commit Message
```
integration_tests: bump pycloudlib dependency

The latest pycloudlib now launches official Ubuntu cloud images for
xenial, meaning that `lxc exec` no longer works against them.  This
commit includes handling for tests which are affected by this change;
further details and reasoning in the included comment.
```

## Additional Context

This change will affect our SRU process for xenial. We'll need to perform two test runs for LXD VMs: one with `-m "not lxc_use_exec"` against the default images, and one with `-m lxc_use_exec` against an image with `exec` support. This image could be the known-good `images:` image, or we could consider manually upgrading the kernel in an instance launched from an official image and capturing that as an image which we then pass in. (I considered automating this last step in the test framework: create and snapshot such an image the first time we hit an `lxc_use_exec` test, and then reuse it each time: if we introduce the more general "image catalogue" support we've discussed somewhat in the past, this could be a good candidate for it.)

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly