### PR TITLE
write passwords only to serial console, lock down cloud-init-output.log

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -78,7 +78,6 @@ password.
 """
 
 import re
-import sys
 
 from cloudinit.distros import ug_util
 from cloudinit import log as logging
@@ -214,7 +213,9 @@ def handle(_name, cfg, cloud, log, args):
         if len(randlist):
             blurb = ("Set the following 'random' passwords\n",
                      '\n'.join(randlist))
-            sys.stderr.write("%s\n%s\n" % blurb)
+            util.multi_log(
+                "%s\n%s\n" % blurb, stderr=False, fallback_to_stdout=False
+            )
 
         if expire:
             expired_users = []

--- a/tests/integration_tests/test_logging.py
+++ b/tests/integration_tests/test_logging.py
@@ -1,0 +1,22 @@
+"""Integration tests relating to cloud-init's logging."""
+
+
+class TestVarLogCloudInitOutput:
+    """Integration tests relating to /var/log/cloud-init-output.log."""
+
+    def test_var_log_cloud_init_output_not_world_readable(self, client):
+        """
+        The log can contain sensitive data, it shouldn't be world-readable.
+
+        LP: #1918303
+        """
+        # Check the file exists
+        assert client.execute("test -f /var/log/cloud-init-output.log").ok
+
+        # Check its permissions are as we expect
+        perms, user, group = client.execute(
+            "stat -c %a:%U:%G /var/log/cloud-init-output.log"
+        ).split(":")
+        assert "640" == perms
+        assert "root" == user
+        assert "adm" == group

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -572,6 +572,10 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
         util.multi_log(logged_string)
         self.assertEqual(logged_string, self.stdout.getvalue())
 
+    def test_logs_dont_go_to_stdout_if_fallback_to_stdout_is_false(self):
+        util.multi_log('something', fallback_to_stdout=False)
+        self.assertEqual('', self.stdout.getvalue())
+
     def test_logs_go_to_log_if_given(self):
         log = mock.MagicMock()
         logged_string = 'something very important'


### PR DESCRIPTION
## Proposed Commit Message
```
write passwords only to serial console, lock down cloud-init-output.log

Prior to this commit, when a user specified configuration which would
generate random passwords for users, cloud-init would cause those
passwords to be written to the serial console by emitting them on
stderr.  In the default configuration, any stdout or stderr emitted by
cloud-init is also written to `/var/log/cloud-init-output.log`.  This
file is world-readable, meaning that those randomly-generated passwords
were available to be read by any user with access to the system.  This
presents an obvious security issue.

This commit responds to this issue in two ways:

* We address the direct issue by moving from writing the passwords to
  sys.stderr to writing them directly to /dev/console (via
  util.multi_log); this means that the passwords will never end up in
  cloud-init-output.log
* To avoid future issues like this, we also modify the logging code so
  that any files created in a log sink subprocess will only be
  owner/group readable and, if it exists, will be owned by the adm
  group.  This results in `/var/log/cloud-init-output.log` no longer
  being world-readable, meaning that if there are other parts of the
  codebase that are emitting sensitive data intended for the serial
  console, that data is no longer available to all users of the system.

LP: #1918303
```

## Test Steps

See the included integration tests.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly