### PR TITLE
.travis.yml: generate an SSH key before running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,6 +120,7 @@ matrix:
                 fi
             # Use sudo to get a new shell where we're in the sbuild group
             - sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc'
+            - ssh-keygen -P "" -q -f ~/.ssh/id_rsa
             - sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci' &
             - |
               SECONDS=0


### PR DESCRIPTION
## Proposed Commit Message
```
.travis.yml: generate an SSH key before running tests
```

## Test Steps

The Travis run should run successfully; note that we currently have a bug where it always goes green: the log will need to be examined.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly