### PR TITLE
bringup_static_routes: fix gateway check

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1135,7 +1135,7 @@ class EphemeralIPv4Network(object):
         #                  ("0.0.0.0/0", "130.56.240.1")]
         for net_address, gateway in self.static_routes:
             via_arg = []
-            if gateway != "0.0.0.0/0":
+            if gateway != "0.0.0.0":
                 via_arg = ['via', gateway]
             subp.subp(
                 ['ip', '-4', 'route', 'add', net_address] + via_arg +

--- a/cloudinit/net/tests/test_dhcp.py
+++ b/cloudinit/net/tests/test_dhcp.py
@@ -194,6 +194,11 @@ class TestDHCPParseStaticRoutes(CiTestCase):
         self.assertEqual([('0.0.0.0/0', '130.56.240.1')],
                          parse_static_routes(rfc3442))
 
+    def test_unspecified_gateway(self):
+        rfc3442 = "32,169,254,169,254,0,0,0,0"
+        self.assertEqual([('169.254.169.254/32', '0.0.0.0')],
+                         parse_static_routes(rfc3442))
+
     def test_parse_static_routes_class_c_b_a(self):
         class_c = "24,192,168,74,192,168,0,4"
         class_b = "16,172,16,172,16,0,4"

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -16,6 +16,7 @@ dhensby
 eandersson
 eb3095
 emmanuelthome
+giggsoff
 izzyleung
 johnsonshi
 jordimassaguerpla


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Inside gateway field we has ip address not in CIDR notation. We must check it because of different ip route behavior for gatewayed and direct routes.
```

## Test Steps
Try to run cloud-init with classless-static-routes with direct-connection of networks give me errors https://github.com/lf-edge/eve/pull/1982#issuecomment-802983262.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
