### PR TITLE
- Create the log file with 640 permissions

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -156,7 +156,7 @@ class Init(object):
         util.ensure_dirs(self._initial_subdirs())
         log_file = util.get_cfg_option_str(self.cfg, 'def_log_file')
         if log_file:
-            util.ensure_file(log_file, preserve_mode=True)
+            util.ensure_file(log_file, mode=0o640, preserve_mode=True)
             perms = self.cfg.get('syslog_fix_perms')
             if not perms:
                 perms = {}


### PR DESCRIPTION
  + Security scanners are often simple minded and complain on arbitrary
    settings such as file permissions. For /var/log/* having world read is
    one of these cases.

## Proposed Commit Message
Appease some simple minded "security" scanners

```
summary: Change log file to 640 permissions

Security scanners are often simple minded and complain on arbitrary
settings such as file permissions. For /var/log/* having world read is
one of these cases.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
