### PR TITLE
Add an option for rhel to force the use of hostname config

### DIFF
--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -19,7 +19,10 @@ A hostname and fqdn can be provided by specifying a full domain name under the
 key, and the fqdn of the cloud wil be used. If a fqdn specified with the
 ``hostname`` key, it will be handled properly, although it is better to use
 the ``fqdn`` config key. If both ``fqdn`` and ``hostname`` are set,
-it is distro dependent whether ``hostname`` or ``fqdn`` is used.
+it is distro dependent whether ``hostname`` or ``fqdn`` is used,
+unless the ``prefer_fqdn_over_hostname`` option is true and fqdn is set
+it will force the use of FQDN in all distros, and if false then it will
+force the hostname use.
 
 This module will run in the init-local stage before networking is configured
 if the hostname is set by metadata or user data on the local system.
@@ -38,6 +41,7 @@ based on initial hostname.
 **Config keys**::
 
     preserve_hostname: <true/false>
+    prefer_fqdn_over_hostname: <true/false>
     fqdn: <fqdn>
     hostname: <fqdn/hostname>
 """
@@ -62,6 +66,14 @@ def handle(name, cfg, cloud, log, _args):
         log.debug(("Configuration option 'preserve_hostname' is set,"
                    " not setting the hostname in module %s"), name)
         return
+
+    # Set prefer_fqdn_over_hostname value in distro
+    hostname_fqdn = util.get_cfg_option_bool(cfg,
+                                             "prefer_fqdn_over_hostname",
+                                             None)
+    if hostname_fqdn is not None:
+        cloud.distro.set_option('prefer_fqdn_over_hostname', hostname_fqdn)
+
     (hostname, fqdn) = util.get_hostname_fqdn(cfg, cloud)
     # Check for previous successful invocation of set-hostname
 

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -27,6 +27,7 @@ is set, then the hostname will not be altered.
 **Config keys**::
 
     preserve_hostname: <true/false>
+    prefer_fqdn_over_hostname: <true/false>
     fqdn: <fqdn>
     hostname: <fqdn/hostname>
 """

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -45,6 +45,13 @@ def handle(name, cfg, cloud, log, _args):
                    " not updating the hostname in module %s"), name)
         return
 
+    # Set prefer_fqdn_over_hostname value in distro
+    hostname_fqdn = util.get_cfg_option_bool(cfg,
+                                             "prefer_fqdn_over_hostname",
+                                             None)
+    if hostname_fqdn is not None:
+        cloud.distro.set_option('prefer_fqdn_over_hostname', hostname_fqdn)
+
     (hostname, fqdn) = util.get_hostname_fqdn(cfg, cloud)
     try:
         prev_fn = os.path.join(cloud.get_cpath('data'), "previous-hostname")

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -79,6 +79,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     shutdown_options_map = {'halt': '-H', 'poweroff': '-P', 'reboot': '-r'}
 
     _ci_pkl_version = 1
+    prefer_fqdn = False
 
     def __init__(self, name, cfg, paths):
         self._paths = paths
@@ -130,6 +131,9 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
     def get_option(self, opt_name, default=None):
         return self._cfg.get(opt_name, default)
+
+    def set_option(self, opt_name, value=None):
+        self._cfg[opt_name] = value
 
     def set_hostname(self, hostname, fqdn=None):
         writeable_hostname = self._select_hostname(hostname, fqdn)
@@ -259,6 +263,9 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def _select_hostname(self, hostname, fqdn):
         # Prefer the short hostname over the long
         # fully qualified domain name
+        if util.get_cfg_option_bool(self._cfg, "prefer_fqdn_over_hostname",
+                                    self.prefer_fqdn) and fqdn:
+            return fqdn
         if not hostname:
             return fqdn
         return hostname

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -27,12 +27,7 @@ class Distro(cloudinit.distros.bsd.BSD):
     pkg_cmd_remove_prefix = ["pkg", "remove"]
     pkg_cmd_update_prefix = ["pkg", "update"]
     pkg_cmd_upgrade_prefix = ["pkg", "upgrade"]
-
-    def _select_hostname(self, hostname, fqdn):
-        # Should be FQDN if available. See rc.conf(5) in FreeBSD
-        if fqdn:
-            return fqdn
-        return hostname
+    prefer_fqdn = True  # See rc.conf(5) in FreeBSD
 
     def _get_add_member_to_group_cmd(self, member_name, group_name):
         return ['pw', 'usermod', '-n', member_name, '-G', group_name]

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -50,6 +50,10 @@ class Distro(distros.Distro):
         }
     }
 
+    # Should be fqdn if we can use it
+    # See: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/5/html/deployment_guide/ch-sysconfig  # noqa: E501
+    prefer_fqdn = True
+
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
@@ -90,13 +94,6 @@ class Distro(distros.Distro):
                 'HOSTNAME': hostname,
             }
             rhel_util.update_sysconfig_file(out_fn, host_cfg)
-
-    def _select_hostname(self, hostname, fqdn):
-        # Should be fqdn if we can use it
-        # See: https://www.centos.org/docs/5/html/Deployment_Guide-en-US/ch-sysconfig.html#s2-sysconfig-network # noqa
-        if fqdn:
-            return fqdn
-        return hostname
 
     def _read_system_hostname(self):
         if self.uses_systemd():

--- a/tests/integration_tests/modules/test_set_hostname.py
+++ b/tests/integration_tests/modules/test_set_hostname.py
@@ -24,6 +24,13 @@ hostname: cloudinit1
 fqdn: cloudinit2.i9n.cloud-init.io
 """
 
+USER_DATA_PREFER_FQDN = """\
+#cloud-config
+prefer_fqdn_over_hostname: true
+hostname: cloudinit1
+fqdn: cloudinit2.test.io
+"""
+
 
 @pytest.mark.ci
 class TestHostname:
@@ -32,6 +39,11 @@ class TestHostname:
     def test_hostname(self, client):
         hostname_output = client.execute("hostname")
         assert "cloudinit2" in hostname_output.strip()
+
+    @pytest.mark.user_data(USER_DATA_PREFER_FQDN)
+    def test_prefer_fqdn(self, client):
+        hostname_output = client.execute("hostname")
+        assert "cloudinit2.test.io" in hostname_output.strip()
 
     @pytest.mark.user_data(USER_DATA_FQDN)
     def test_hostname_and_fqdn(self, client):

--- a/tests/integration_tests/modules/test_set_hostname.py
+++ b/tests/integration_tests/modules/test_set_hostname.py
@@ -26,7 +26,7 @@ fqdn: cloudinit2.i9n.cloud-init.io
 
 USER_DATA_PREFER_FQDN = """\
 #cloud-config
-prefer_fqdn_over_hostname: true
+prefer_fqdn_over_hostname: {}
 hostname: cloudinit1
 fqdn: cloudinit2.test.io
 """
@@ -40,10 +40,15 @@ class TestHostname:
         hostname_output = client.execute("hostname")
         assert "cloudinit2" in hostname_output.strip()
 
-    @pytest.mark.user_data(USER_DATA_PREFER_FQDN)
+    @pytest.mark.user_data(USER_DATA_PREFER_FQDN.format(True))
     def test_prefer_fqdn(self, client):
         hostname_output = client.execute("hostname")
         assert "cloudinit2.test.io" in hostname_output.strip()
+
+    @pytest.mark.user_data(USER_DATA_PREFER_FQDN.format(False))
+    def test_prefer_short_hostname(self, client):
+        hostname_output = client.execute("hostname")
+        assert "cloudinit1" in hostname_output.strip()
 
     @pytest.mark.user_data(USER_DATA_FQDN)
     def test_hostname_and_fqdn(self, client):


### PR DESCRIPTION
    add prefer_fqdn_over_hostname config option
    
    the above option allow the user to control the
    behavior of a distro hostname selection
    so if the user send hostname, FQDN Configs
    if prefer_fqdn_over_hostname is true the
    The FQDN will be selected as hostname
    if false the hostname will be selected

LP: #859 

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate bug reference or remove
this line entirely if there is no associated bug)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
