### PR TITLE
Azure: eject the provisioning iso before reporting ready

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -467,7 +467,11 @@ class DataSourceAzure(persistence.CloudInitPickleMixin, sources.DataSource):
 
             report_diagnostic_event("Found provisioning metadata in %s" % cdev,
                                     logger_func=LOG.debug)
-            self.iso_dev = cdev
+
+            # save the iso device for ejection before reporting ready
+            if cdev.startswith("/dev"):
+                self.iso_dev = cdev
+
             perform_reprovision = reprovision or self._should_reprovision(ret)
             perform_reprovision_after_nic_attach = (
                 reprovision_after_nic_attach or

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -29,7 +29,6 @@ from cloudinit import subp
 from cloudinit.url_helper import UrlError, readurl, retry_on_url_exc
 from cloudinit import util
 from cloudinit.reporting import events
-from cloudinit import persistence
 
 from cloudinit.sources.helpers.azure import (
     DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE,
@@ -328,7 +327,7 @@ def temporary_hostname(temp_hostname, cfg, hostname_command='hostname'):
         set_hostname(previous_hostname, hostname_command)
 
 
-class DataSourceAzure(persistence.CloudInitPickleMixin, sources.DataSource):
+class DataSourceAzure(sources.DataSource):
 
     dsname = 'Azure'
     _negotiated = False
@@ -352,6 +351,7 @@ class DataSourceAzure(persistence.CloudInitPickleMixin, sources.DataSource):
         self.iso_dev = None
 
     def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
         if "iso_dev" not in self.__dict__:
             self.iso_dev = None
 

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -865,7 +865,19 @@ class WALinuxAgentShim:
         return endpoint_ip_address
 
     @azure_ds_telemetry_reporter
-    def register_with_azure_and_fetch_data(self, pubkey_info=None) -> dict:
+    def eject_iso(self, iso_dev) -> None:
+        try:
+            LOG.debug("Ejecting the provisioning iso")
+            subp.subp(['eject', iso_dev])
+        except Exception as e:
+            report_diagnostic_event(
+                "Failed ejecting the provisioning iso: %s" % e,
+                logger_func=LOG.debug)
+
+    @azure_ds_telemetry_reporter
+    def register_with_azure_and_fetch_data(self,
+                                           pubkey_info=None,
+                                           iso_dev=None) -> dict:
         """Gets the VM's GoalState from Azure, uses the GoalState information
         to report ready/send the ready signal/provisioning complete signal to
         Azure, and then uses pubkey_info to filter and obtain the user's
@@ -891,6 +903,10 @@ class WALinuxAgentShim:
             ssh_keys = self._get_user_pubkeys(goal_state, pubkey_info)
         health_reporter = GoalStateHealthReporter(
             goal_state, self.azure_endpoint_client, self.endpoint)
+
+        if iso_dev is not None:
+            self.eject_iso(iso_dev)
+
         health_reporter.send_ready_signal()
         return {'public-keys': ssh_keys}
 
@@ -1046,11 +1062,12 @@ class WALinuxAgentShim:
 
 @azure_ds_telemetry_reporter
 def get_metadata_from_fabric(fallback_lease_file=None, dhcp_opts=None,
-                             pubkey_info=None):
+                             pubkey_info=None, iso_dev=None):
     shim = WALinuxAgentShim(fallback_lease_file=fallback_lease_file,
                             dhcp_options=dhcp_opts)
     try:
-        return shim.register_with_azure_and_fetch_data(pubkey_info=pubkey_info)
+        return shim.register_with_azure_and_fetch_data(
+            pubkey_info=pubkey_info, iso_dev=iso_dev)
     finally:
         shim.clean_up()
 

--- a/tests/unittests/test_datasource/test_azure_helper.py
+++ b/tests/unittests/test_datasource/test_azure_helper.py
@@ -1009,6 +1009,14 @@ class TestWALinuxAgentShim(CiTestCase):
         self.GoalState.return_value.container_id = self.test_container_id
         self.GoalState.return_value.instance_id = self.test_instance_id
 
+    def test_eject_iso_is_called(self):
+        shim = wa_shim()
+        with mock.patch.object(
+            shim, 'eject_iso', autospec=True
+        ) as m_eject_iso:
+            shim.register_with_azure_and_fetch_data(iso_dev="/dev/sr0")
+            m_eject_iso.assert_called_once_with("/dev/sr0")
+
     def test_http_client_does_not_use_certificate_for_report_ready(self):
         shim = wa_shim()
         shim.register_with_azure_and_fetch_data()
@@ -1283,13 +1291,14 @@ class TestGetMetadataGoalStateXMLAndReportReadyToFabric(CiTestCase):
 
     def test_calls_shim_register_with_azure_and_fetch_data(self):
         m_pubkey_info = mock.MagicMock()
-        azure_helper.get_metadata_from_fabric(pubkey_info=m_pubkey_info)
+        azure_helper.get_metadata_from_fabric(
+            pubkey_info=m_pubkey_info, iso_dev="/dev/sr0")
         self.assertEqual(
             1,
             self.m_shim.return_value
                 .register_with_azure_and_fetch_data.call_count)
         self.assertEqual(
-            mock.call(pubkey_info=m_pubkey_info),
+            mock.call(iso_dev="/dev/sr0", pubkey_info=m_pubkey_info),
             self.m_shim.return_value
                 .register_with_azure_and_fetch_data.call_args)
 


### PR DESCRIPTION
## Proposed Commit Message
Azure: eject the provisioning iso before reporting ready

Due to hyper-v implementations, iso ejection is more efficient if performed 
from within the guest. The code will attempt to perform a best-effort ejection.
Failure during ejection will not prevent reporting ready from happening. If iso
ejection is successful, later iso ejection from the platform will be a no-op.
In the event the iso ejection from the guest fails, iso ejection will still happen at
the platform level.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
