### PR TITLE
[WIP] Fix/gh721 regression

### DIFF
--- a/tests/integration_tests/bugs/test_lp1922742.py
+++ b/tests/integration_tests/bugs/test_lp1922742.py
@@ -1,0 +1,23 @@
+"""Integration test for LP: #1922742
+
+cloud-init fails to resize and fails on any non-LVM root partitions in KVM.
+
+This test checks that cloud-init doesn't fail to resize partitions on KVM for
+non-LVM root partitions.
+TODO: It should also setup an lvm partition and verify that lvm resizing works.
+"""
+import pytest
+
+
+@pytest.mark.lxd_vm
+@pytest.mark.lxd_use_exec
+@pytest.mark.ubuntu
+class TestLVMResize:
+    def test_sucess_resize2fs_and_no_errors_from_growpart_on_non_lvm(
+        self, client
+    ):
+        assert client.execute('cloud-init status --wait --long').ok is True
+        log = client.read_from_file('/var/log/cloud-init.log')
+        assert "SUCCESS: config-growpart ran successfully" in log
+        assert "Running command ('resize2fs', '/dev/sda1')" in log
+        assert "'/' resized" in log


### PR DESCRIPTION
WIP branch for discussion/handoff if necessary. A cut at an integration test which should pass on lxd vms. I'll probably need a bit of a hand setting up the positive lvm case (the integration test only asserts we avoid failures on non-lvm deployments)

## Proposed Commit Message
growpart: avoid root resizing regression on non-lvm devices
    
Commit b17569f8b regressed root resize on non-lvm devices due
to calls to "lvm lvs" on non-lvm devices.

First check is_lvm_lv on a block device before making calls to
get_pvs_for_lv.

LP: #1922742


```

## Additional Context

## Test Steps
```bash
See failure on daily 
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=lxd_vm tox -e integration-tests tests/integration_tests/bugs/test_lp1922742.py
CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_PLATFORM=lxd_vm tox -e integration-tests tests/integration_tests/bugs/test_lp1922742.py
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
 - [x] I have updated or added any integration tests accordingly