### PR TITLE
doc: Replace remaining references to user-scripts as a config module

### DIFF
--- a/cloudinit/config/cc_rightscale_userdata.py
+++ b/cloudinit/config/cc_rightscale_userdata.py
@@ -44,7 +44,7 @@ user scripts configuration directory, to be run later by ``cc_scripts_user``.
 # - read the blob of data from raw user data, and parse it as key/value
 # - for each key that is found, download the content to
 #   the local instance/scripts directory and set them executable.
-# - the files in that directory will be run by the user-scripts module
+# - the files in that directory will be run by the scripts-user module
 #   Therefore, this must run before that.
 #
 #

--- a/doc/rtd/topics/boot.rst
+++ b/doc/rtd/topics/boot.rst
@@ -150,7 +150,7 @@ Things that run here include
 
  * package installations
  * configuration management plugins (puppet, chef, salt-minion)
- * user-scripts (i.e. shell scripts passed as user-data)
+ * user-defined scripts (i.e. shell scripts passed as user-data)
 
 For scripts external to cloud-init looking to wait until cloud-init is
 finished, the ``cloud-init status`` subcommand can help block external

--- a/doc/rtd/topics/vendordata.rst
+++ b/doc/rtd/topics/vendordata.rst
@@ -47,8 +47,8 @@ way as user-data.
 
 The only differences are:
 
- * user-scripts are stored in a different location than user-scripts (to
-   avoid namespace collision)
+ * vendor-data-defined scripts are stored in a different location than
+   user-data-defined scripts (to avoid namespace collision)
  * user can disable part handlers by cloud-config settings.
    For example, to disable handling of 'part-handlers' in vendor-data,
    the user could provide user-data like this:


### PR DESCRIPTION

## Proposed Commit Message

```
doc: Replace remaining references to user-scripts as a config module

git-grep showed a few more locations where we refer to a "user-scripts"
config module which is really cc_scripts_user module.  Replace these
references with slightly different language so as not to confuse
future me when looking for "user-scripts" vs. "scripts-user"
```

## Test Steps

```
tox -e doc
```

## Checklist:
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
