### PR TITLE
Fix chef module run failure when chef_license is set

### DIFF
--- a/cloudinit/config/cc_chef.py
+++ b/cloudinit/config/cc_chef.py
@@ -70,7 +70,6 @@ CHEF_RB_TPL_PATH_KEYS = frozenset([
     'json_attribs',
     'pid_file',
     'encrypted_data_bag_secret',
-    'chef_license',
 ])
 CHEF_RB_TPL_KEYS = list(CHEF_RB_TPL_DEFAULTS.keys())
 CHEF_RB_TPL_KEYS.extend(CHEF_RB_TPL_BOOL_KEYS)
@@ -80,6 +79,7 @@ CHEF_RB_TPL_KEYS.extend([
     'node_name',
     'environment',
     'validation_name',
+    'chef_license',
 ])
 CHEF_RB_TPL_KEYS = frozenset(CHEF_RB_TPL_KEYS)
 CHEF_RB_PATH = '/etc/chef/client.rb'

--- a/templates/chef_client.rb.tmpl
+++ b/templates/chef_client.rb.tmpl
@@ -15,7 +15,7 @@ The reason these are not in quotes is because they are ruby
 symbols that will be placed inside here, and not actual strings...
 #}
 {% if chef_license %}
-chef_license          "{{chef_license}}"
+chef_license           "{{chef_license}}"
 {% endif%}
 {% if log_level %}
 log_level              {{log_level}}

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -50,3 +50,4 @@ WebSpider
 xiachen-rh
 xnox
 hamalq
+bmhughes


### PR DESCRIPTION
## Commit Message

Move `chef_license` from TPL_PATH_KEYS to TPL_KEYS as the chef license setting is not a path but must be added to the client config template. Fixes file or folder not found exception raised from `ensure_dirs`.

## Test Steps

Perform a cloud-init run with chef bootstrap configuration and chef_license set.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
