### PR TITLE
Fix error on upgrade caused by new vendordata2 attributes

### DIFF
--- a/cloudinit/tests/test_upgrade.py
+++ b/cloudinit/tests/test_upgrade.py
@@ -46,3 +46,7 @@ class TestUpgrade:
 
     def test_paths_has_run_dir_attribute(self, previous_obj_pkl):
         assert previous_obj_pkl.paths.run_dir is not None
+
+    def test_vendordata_exists(self, previous_obj_pkl):
+        assert previous_obj_pkl.vendordata2 is None
+        assert previous_obj_pkl.vendordata2_raw is None

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -111,14 +111,14 @@ class IntegrationCloud(ABC):
             # Even if we're using the default key, it may still have a
             # different name in the clouds, so we need to set it separately.
             self.cloud_instance.key_pair.name = settings.KEYPAIR_NAME
-        self._released_image_id = self._get_initial_image()
+        self.released_image_id = self._get_initial_image()
         self.snapshot_id = None
 
     @property
     def image_id(self):
         if self.snapshot_id:
             return self.snapshot_id
-        return self._released_image_id
+        return self.released_image_id
 
     def emit_settings_to_log(self) -> None:
         log.info(

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import pytest
 import time
 from pathlib import Path
@@ -8,6 +9,8 @@ from tests.integration_tests.conftest import (
     get_validated_source,
     session_start_time,
 )
+from tests.integration_tests.instances import CloudInitSource
+
 
 log = logging.getLogger('integration_testing')
 
@@ -93,6 +96,26 @@ def test_upgrade(session_cloud: IntegrationCloud):
         instance.install_new_cloud_init(source, take_snapshot=False)
         instance.execute('hostname something-else')
         _restart(instance)
+        assert instance.execute('cloud-init status --wait --long').ok
         _output_to_compare(instance, after_path, netcfg_path)
 
     log.info('Wrote upgrade test logs to %s and %s', before_path, after_path)
+
+
+@pytest.mark.ci
+@pytest.mark.ubuntu
+def test_upgrade_package(session_cloud: IntegrationCloud):
+    if get_validated_source(session_cloud) != CloudInitSource.DEB_PACKAGE:
+        not_run_message = 'Test only supports upgrading to build deb'
+        if os.environ.get('TRAVIS'):
+            # If this isn't running on CI, we should know
+            pytest.fail(not_run_message)
+        else:
+            pytest.skip(not_run_message)
+
+    launch_kwargs = {'image_id': session_cloud._get_initial_image()}
+
+    with session_cloud.launch(launch_kwargs=launch_kwargs) as instance:
+        instance.install_deb()
+        instance.restart()
+        assert instance.execute('cloud-init status --wait --long').ok

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -66,7 +66,7 @@ def test_upgrade(session_cloud: IntegrationCloud):
         return  # type checking doesn't understand that skip raises
 
     launch_kwargs = {
-        'image_id': session_cloud._get_initial_image(),
+        'image_id': session_cloud.released_image_id,
     }
 
     image = ImageSpecification.from_os_image()
@@ -113,7 +113,7 @@ def test_upgrade_package(session_cloud: IntegrationCloud):
         else:
             pytest.skip(not_run_message)
 
-    launch_kwargs = {'image_id': session_cloud._get_initial_image()}
+    launch_kwargs = {'image_id': session_cloud.released_image_id}
 
     with session_cloud.launch(launch_kwargs=launch_kwargs) as instance:
         instance.install_deb()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix error on upgrade caused by new vendordata2 attributes

In #777, we added 'vendordata2' and 'vendordata2_raw' attributes to
the DataSource class, but didn't use the upgrade framework to deal
with an unpickle after upgrade. This commit adds the necessary
upgrade code.

Additionally, added a smaller-scope upgrade test to our integration
tests that will be run on every CI run so we catch these issues
immediately in the future.

LP: #1922739
```

## Additional Context
We haven't caught this is our current upgrade test because we haven't been checking for error status of `cloud-init status`. I added a check for that in the larger upgrade test as well.

## Test Steps
Since the latest cloud-init version is already in LXD images, it's not as straightforward. You can launch a xenial instance and then upgrade to the latest PPA/deb. For other releases, you can launch an instance, manually downgrade to 20.4.1, run a `cloud-init clean`, then upgrade to latest. I've manually reproduced the bug both ways and manually verified the bug both ways.

I also locally reproduced/verified the new integration test by launching the test against a xenial instance (CI uses focal).
