### PR TITLE
ssh: Allow keys for user "root" to specify key options

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -166,7 +166,7 @@ class AuthKeyLineParser(object):
             (keytype, base64, comment) = parse_ssh_key(ent)
         except TypeError:
             (keyopts, remain) = self._extract_options(ent)
-            if options is None:
+            if not options:
                 options = keyopts
 
             try:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -2,6 +2,7 @@ ader1990
 ajmyyra
 AlexBaranowski
 Aman306
+an-empty-string
 andrewbogott
 antonyc
 aswinrajamannar


### PR DESCRIPTION
## Proposed Commit Message

```
ssh: Allow keys for user "root" to specify key options

This patch fixes https://bugs.launchpad.net/cloud-init/+bug/1924614  
                                                           
In user data, if "user" is set to "root" and "ssh_authorized_keys" are 
set, any SSH key options are ignored. However, the SSH key options
are respected for other users. This patch allows keys for "root" to
specify options.

LP: #1924614
```

## Additional Context

When the user "root" is specified in user-data along with ssh_authorized_keys, this code path is taken:

- cloudinit.config.cc_ssh:apply_credentials is called
- execution runs through to the last line in the function, where `ssh_util.setup_user_keys` is called with the specified `key_prefix`, which is the empty string now (since disable_root is false)
- setup_user_keys passes the empty string as key options to AuthKeyLineParser.parse, in which the following block is executed:

```python
except TypeError:        
    (keyopts, remain) = self._extract_options(ent)
    if options is None:
        options = keyopts
```

- since `options` is non-None, the key's actual options are ignored and overwritten with the empty string

In my use case, I want to use cloud-init provision an SSH certificate authority that is allowed to sign for root logins while leaving the image default user unconfigured (no password/no keys).

## Test Steps

On a live machine, I tested this this with a minimal `/etc/cloud/cloud.cfg`, specifying only:

```yaml
datasource_list: [ NoCloud ]
cloud_init_modules: [ ssh ]
disable_root: false
```

With the following user-data:

```yaml
#cloud-config
user: root
ssh_authorized_keys:
  - cert-authority,principals="root" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGln82WcPZ4U92MYD+HSaexQLxVO4T10XBu8d1wVqgOK tris@maclane
```

Before the patch, `cloud-init -f /etc/cloud/cloud.cfg init` put this in `/root/.ssh/authorized_keys`:

```
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGln82WcPZ4U92MYD+HSaexQLxVO4T10XBu8d1wVqgOK tris@maclane
```

After the patch, it's instead the expected:

```
cert-authority,principals="root" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGln82WcPZ4U92MYD+HSaexQLxVO4T10XBu8d1wVqgOK tris@maclane
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly -- *happy to write a test for this functionality but not sure where it'd be appropriate to do so*
 - [x] I have updated or added any documentation accordingly
