### PR TITLE
cc_mounts: exclude netdev mounts from mount -a 

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -534,7 +534,7 @@ def handle(_name, cfg, cloud, log, _args):
         need_mount_all = True
 
     if need_mount_all:
-        activate_cmds.append(["mount", "-a"])
+        activate_cmds.append(["mount", "-a", "-O", "no_netdev"])
         if uses_systemd:
             activate_cmds.append(["systemctl", "daemon-reload"])
 

--- a/tests/unittests/test_handler/test_handler_mounts.py
+++ b/tests/unittests/test_handler/test_handler_mounts.py
@@ -391,7 +391,7 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
             self.assertEqual(fstab_expected_content, fstab_new_content)
         cc_mounts.handle(None, cc, self.mock_cloud, self.mock_log, [])
         self.m_subp_subp.assert_has_calls([
-            mock.call(['mount', '-a']),
+            mock.call(['mount', '-a', '-O', 'no_netdev']),
             mock.call(['systemctl', 'daemon-reload'])])
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
Exclude netdev mounts from mount -a 

```
mounts typically runs in 'init' phase, which is before 
network-online. In many distros, NFS mounts can't be 
mounted too early due to dependencies on rpc-statd, 
which typically runs after network-online. Excluding mounts
annotated with netdev in /etc/fstab from the mount -a
command will avoid boot issue caused by this cyclic dependency.
```

## Additional Context
https://bugzilla.redhat.com/show_bug.cgi?id=1858930

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
