### PR TITLE
[examples] config-user-groups expire in the future

### DIFF
--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -19,7 +19,7 @@ users:
     primary_group: foobar
     groups: users
     selinux_user: staff_u
-    expiredate: '2012-09-01'
+    expiredate: '2022-09-01'
     ssh_import_id: foobar
     lock_passwd: false
     passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/


### PR DESCRIPTION
Changed year 2012 into year 2022.
