### PR TITLE
Revert "Add support to resize rootfs if using LVM (#721)"

### DIFF
--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -68,9 +68,7 @@ import os
 import os.path
 import re
 import stat
-import platform
 
-from functools import lru_cache
 from cloudinit import log as logging
 from cloudinit.settings import PER_ALWAYS
 from cloudinit import subp
@@ -93,58 +91,6 @@ class RESIZE(object):
 
 
 LOG = logging.getLogger(__name__)
-
-
-@lru_cache()
-def is_lvm_lv(devpath):
-    if util.is_Linux():
-        # all lvm lvs will have a realpath as a 'dm-*' name.
-        rpath = os.path.realpath(devpath)
-        if not os.path.basename(rpath).startswith("dm-"):
-            return False
-        out, _ = subp.subp("udevadm", "info", devpath)
-        # lvs should have DM_LV_NAME=<lvmuuid> and also DM_VG_NAME
-        return 'DM_LV_NAME=' in out
-    else:
-        LOG.info("Not an LVM Logical Volume partition")
-        return False
-
-
-@lru_cache()
-def get_pvs_for_lv(devpath):
-    myenv = {'LANG': 'C'}
-
-    if not util.is_Linux():
-        LOG.info("No support for LVM on %s", platform.system())
-        return None
-    if not subp.which('lvm'):
-        LOG.info("No 'lvm' command present")
-        return None
-
-    try:
-        (out, _err) = subp.subp(["lvm", "lvs", devpath, "--options=vgname",
-                                 "--noheadings"], update_env=myenv)
-        vgname = out.strip()
-    except subp.ProcessExecutionError as e:
-        if e.exit_code != 0:
-            util.logexc(LOG, "Failed: can't get Volume Group information "
-                        "from %s", devpath)
-            raise ResizeFailedException(e) from e
-
-    try:
-        (out, _err) = subp.subp(["lvm", "vgs", vgname, "--options=pvname",
-                                 "--noheadings"], update_env=myenv)
-        pvs = [p.strip() for p in out.splitlines()]
-        if len(pvs) > 1:
-            LOG.info("Do not know how to resize multiple Physical"
-                     " Volumes")
-        else:
-            return pvs[0]
-    except subp.ProcessExecutionError as e:
-        if e.exit_code != 0:
-            util.logexc(LOG, "Failed: can't get Physical Volume "
-                        "information from Volume Group %s", vgname)
-            raise ResizeFailedException(e) from e
 
 
 def resizer_factory(mode):
@@ -262,17 +208,12 @@ def get_size(filename):
         os.close(fd)
 
 
-def device_part_info(devpath, is_lvm):
+def device_part_info(devpath):
     # convert an entry in /dev/ to parent disk and partition number
 
     # input of /dev/vdb or /dev/disk/by-label/foo
     # rpath is hopefully a real-ish path in /dev (vda, sdb..)
     rpath = os.path.realpath(devpath)
-
-    # first check if this is an LVM and get its PVs
-    lvm_rpath = get_pvs_for_lv(devpath)
-    if is_lvm and lvm_rpath:
-        rpath = lvm_rpath
 
     bname = os.path.basename(rpath)
     syspath = "/sys/class/block/%s" % bname
@@ -303,7 +244,7 @@ def device_part_info(devpath, is_lvm):
 
     # diskdevpath has something like 253:0
     # and udev has put links in /dev/block/253:0 to the device name in /dev/
-    return diskdevpath, ptnum
+    return (diskdevpath, ptnum)
 
 
 def devent2dev(devent):
@@ -353,9 +294,8 @@ def resize_devices(resizer, devices):
                          "device '%s' not a block device" % blockdev,))
             continue
 
-        is_lvm = is_lvm_lv(blockdev)
         try:
-            disk, ptnum = device_part_info(blockdev, is_lvm)
+            (disk, ptnum) = device_part_info(blockdev)
         except (TypeError, ValueError) as e:
             info.append((devent, RESIZE.SKIPPED,
                          "device_part_info(%s) failed: %s" % (blockdev, e),))
@@ -375,23 +315,6 @@ def resize_devices(resizer, devices):
             info.append((devent, RESIZE.FAILED,
                          "failed to resize: disk=%s, ptnum=%s: %s" %
                          (disk, ptnum, e),))
-
-        if is_lvm and isinstance(resizer, ResizeGrowPart):
-            try:
-                if len(devices) == 1:
-                    (_out, _err) = subp.subp(
-                        ["lvm", "lvextend", "--extents=100%FREE", blockdev],
-                        update_env={'LANG': 'C'})
-                    info.append((devent, RESIZE.CHANGED,
-                                 "Logical Volume %s extended" % devices[0],))
-                else:
-                    LOG.info("Exactly one device should be configured to be "
-                             "resized when using LVM. More than one configured"
-                             ": %s", devices)
-            except (subp.ProcessExecutionError, ValueError) as e:
-                info.append((devent, RESIZE.NOCHANGE,
-                             "Logical Volume %s resize failed: %s" %
-                             (blockdev, e),))
 
     return info
 

--- a/doc/examples/cloud-config-growpart.txt
+++ b/doc/examples/cloud-config-growpart.txt
@@ -13,8 +13,6 @@
 #
 # devices:
 #   a list of things to resize.
-#   if the devices are under LVM, the list should be a single entry,
-#   cloud-init will then extend the single entry, otherwise it will fail.
 #   items can be filesystem paths or devices (in /dev)
 #   examples:
 #     devices: [/, /dev/vdb1]


### PR DESCRIPTION
## Proposed Commit Message
```
Revert "Add support to resize rootfs if using LVM (#721)"

This reverts commit 74fa008bfcd3263eb691cc0b3f7a055b17569f8b.

During pre-release testing, we discovered two issues with this commit.
Firstly, there's a typo in the udevadm command that causes a TypeError
for _all_ growpart executions.  Secondly, the LVM resizing does not
appear to successfully resize everything up to the LV, though some
things do get resized.

We certainly want this change, so we'll be happy to review and land it
alongside an integration test which confirms that it is working as
expected.

LP: #1922742
```

## Additional Context

I'm working on an integration test to cover this LVM case, as it's a fairly complex use of our test framework. A rough draft can be seen in https://paste.ubuntu.com/p/y6zG3fdTZv/

## Test Steps

LXD containers do not perform disk setup (as they don't have any disks), so CI does not exercise this. LXD VM testing does trip over this issue, so I'm currently performing a full VM test run locally.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly