### PR TITLE
Add platform restrictions to serial console password test

### DIFF
--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -129,6 +129,7 @@ class Mixin:
         assert "dick:" not in cloud_init_output
         assert "harry:" not in cloud_init_output
 
+    @pytest.mark.lxd_container
     def test_random_passwords_emitted_to_serial_console(self, class_client):
         """We should emit passwords to the serial console. (LP: #1918303)"""
         try:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add platform restrictions to serial console password test
```

## Additional Context
Even on platforms where getting the console text is supported, not all platforms return the full console text. This test will either fail or be skipped on anything other than LXD containers.

