### PR TITLE
Update test characters in substitution unit test

### DIFF
--- a/cloudinit/distros/tests/test_init.py
+++ b/cloudinit/distros/tests/test_init.py
@@ -11,10 +11,15 @@ import pytest
 
 from cloudinit.distros import _get_package_mirror_info, LDH_ASCII_CHARS
 
+# In newer versions of python, these characters won't be substituted
+# because of security concerns.
+# See https://bugs.python.org/issue43882
+SECURITY_URL_CHARS = '\n\r\t'
 
 # Define a set of characters we would expect to be replaced
 INVALID_URL_CHARS = [
-    chr(x) for x in range(127) if chr(x) not in LDH_ASCII_CHARS
+    chr(x) for x in range(127)
+    if chr(x) not in LDH_ASCII_CHARS + SECURITY_URL_CHARS
 ]
 for separator in [":", ".", "/", "#", "?", "@", "[", "]"]:
     # Remove from the set characters that either separate hostname parts (":",


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Update test characters in substitution unit test

In newer versions of python, when using urllib.parse, lines containing
newline or tab characters now get sanitized. This caused a unit test to
fail.

See https://bugs.python.org/issue43882
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
