### PR TITLE
cloud-init.service: replace sshd-keygen dependencies for RHEL

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -3,7 +3,11 @@
 Description=Initial cloud-init job (metadata service crawler)
 DefaultDependencies=no
 Wants=cloud-init-local.service
+{% if variant in ["centos", "fedora", "rhel"] %}
+Wants=sshd-keygen.target
+{% else %}
 Wants=sshd-keygen.service
+{% endif %}
 Wants=sshd.service
 After=cloud-init-local.service
 After=systemd-networkd-wait-online.service
@@ -21,7 +25,13 @@ After=wicked.service
 After=dbus.service
 {% endif %}
 Before=network-online.target
+{% if variant in ["centos", "fedora", "rhel"] %}
+Before=sshd-keygen@rsa.service
+Before=sshd-keygen@ed25519.service
+Before=sshd-keygen@ecdsa.service
+{% else %}
 Before=sshd-keygen.service
+{% endif %}
 Before=sshd.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 Before=sysinit.target


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
sshd-keygen.service does not exist anymore in rhel.
Use instead sshd-keygen@.service

rhbz: #1957532

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>
```

## Additional Context
`sshd-keygen.service` does not exist on RHEL 
```
$ systemctl status sshd-keygen.service
     Unit sshd-keygen.service could not be found.
```
As described in the bug, this produces the effect that "If an instance is lunched and a backup AMI and an instance is created from that AMI cloud-init no longer displays the ssh key fingerprints on the serial console".

Using instead the dependencies`sshd-keygen@rsa, sshd-keygen@ed25519
and sshd-keygen@ecdsa` solves the problem.

## Test Steps
(as described in the bz)
How reproducible:
repeatedly

Steps to Reproduce:

1) Launch an EC2 instance with RHEL 8.3 AMI latest AMI (ami-03d64741867e7bb94) 

2) Login & observe /var/log/messages for SSH hostkey fingerprints pushed via cloud-init's 'ssh_authorized_fingerpints' module. They are generated normally and look like this:
```
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: #############################################################
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: -----BEGIN SSH HOST KEY FINGERPRINTS-----
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: 256 SHA256:xxxxxxxxx no comment (ECDSA)
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: 256 SHA256:xxxxxxxxx no comment (ED25519)
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: 3072 SHA256:xxxxxxxx no comment (RSA)
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: -----END SSH HOST KEY FINGERPRINTS-----
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: #############################################################
```
3) Also have a look at the time required to initialize cloud-init during the boot process (first boot):
```
[root@ip-172-31-7-81 ~]# systemd-analyze blame
         54.120s cloud-init-local.service <------ Expected time
         22.260s kdump.service
          2.423s initrd-switch-root.service
          2.371s dnf-makecache.service
          2.126s cloud-init.service
          1.531s sysroot.mount
          1.430s cloud-config.service
          1.398s rh-cloud-firstboot.service
          1.369s sssd.service
          1.243s systemd-logind.service
          1.103s ldconfig.service
          1.058s tuned.service
           832ms dracut-initqueue.service
           745ms cloud-final.service
           718ms systemd-hwdb-update.service
           691ms systemd-journald.service
(...)
```
4) Now create an image (AMI) from the existing instance and launch another EC2 instance.

5) Now login to the new instance and again observe /var/log/messages for SSH hostkey fingerprints pushed via cloud-init's 'ssh_authorized_fingerpints' module. They are not getting printed and look like this:
```
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]:
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]: #############################################################
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]: -----BEGIN SSH HOST KEY FINGERPRINTS-----
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]: -----END SSH HOST KEY FINGERPRINTS-----
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]: #############################################################
Feb 27 06:37:59 ip-172-31-36-36 cloud-init[1052]: Cloud-init v. 19.4 running 'modules:final' at Sat, 27 Feb 2021 06:37:59 +0000. Up 24.68 seconds.
Feb 27 06:37:59 ip-172-31-36-36 cloud-init[1052]: Cloud-init v. 19.4 finished at Sat, 27 Feb 2021 06:37:59 +0000. Datasource DataSourceEc2Local.  Up 24.81 seconds
```
6) Have a look at the time required to initialize cloud-init during the boot process (subsequent boot from image/template):
```
[root@ip-172-31-36-36 ~]# systemd-analyze blame
          5.249s cloud-init-local.service <--------- Early wrap up
          3.980s cloud-init.service
          3.432s kdump.service
          3.381s initrd-switch-root.service
          3.007s dnf-makecache.service
          2.245s sysroot.mount
          1.514s tuned.service
          5.249s cloud-init-local.service
          3.980s cloud-init.service
          3.432s kdump.service
          3.381s initrd-switch-root.service
          3.007s dnf-makecache.service
          2.245s sysroot.mount
          1.514s tuned.service
          1.324s cloud-config.service
          1.045s cloud-final.service
           908ms sssd.service
```
Actual results:
```
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]: #############################################################
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]: -----BEGIN SSH HOST KEY FINGERPRINTS-----
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]: -----END SSH HOST KEY FINGERPRINTS-----
Feb 27 06:37:59 ip-172-31-36-36 ec2[1100]: #############################################################
```

Expected results:
```
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: #############################################################
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: -----BEGIN SSH HOST KEY FINGERPRINTS-----
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: 256 SHA256:xxxxxxxxx no comment (ECDSA)
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: 256 SHA256:xxxxxxxxx no comment (ED25519)
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: 3072 SHA256:xxxxxxxx no comment (RSA)
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: -----END SSH HOST KEY FINGERPRINTS-----
Feb 27 06:28:58 ip-172-31-7-81 ec2[1302]: ###########################################################
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
