### PR TITLE
Fix unit tests breaking from new httpretty version

### DIFF
--- a/cloudinit/tests/helpers.py
+++ b/cloudinit/tests/helpers.py
@@ -171,7 +171,7 @@ class CiTestCase(TestCase):
         if self.with_logs:
             # Remove the handler we setup
             logging.getLogger().handlers = self.old_handlers
-            logging.getLogger().level = None
+            logging.getLogger().setLevel(logging.NOTSET)
         subp.subp = _real_subp
         super(CiTestCase, self).tearDown()
 
@@ -360,6 +360,9 @@ class HttprettyTestCase(CiTestCase):
         httpretty.HTTPretty.allow_net_connect = False
         httpretty.reset()
         httpretty.enable()
+        # Stop the logging from HttpPretty so our logs don't get mixed
+        # up with its logs
+        logging.getLogger('httpretty.core').setLevel(logging.CRITICAL)
 
     def tearDown(self):
         httpretty.disable()

--- a/cloudinit/tests/test_url_helper.py
+++ b/cloudinit/tests/test_url_helper.py
@@ -8,6 +8,7 @@ from cloudinit import util
 from cloudinit import version
 
 import httpretty
+import logging
 import requests
 
 
@@ -81,6 +82,9 @@ class TestReadFileOrUrl(CiTestCase):
         url = 'http://hostname/path'
         headers = {'sensitive': 'sekret', 'server': 'blah'}
         httpretty.register_uri(httpretty.GET, url)
+        # By default, httpretty will log our request along with the header,
+        # so if we don't change this the secret will show up in the logs
+        logging.getLogger('httpretty.core').setLevel(logging.CRITICAL)
 
         read_file_or_url(url, headers=headers, headers_redact=['sensitive'])
         logs = self.logs.getvalue()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix unit tests breaking from new httpretty version

Httpretty now logs all requests by default which gets mixed up with our
logging tests. Also we were incorrectly setting a logging level to
'None', which now also causes issues with the new httpretty version.
See https://github.com/gabrielfalcao/HTTPretty/pull/419
```

## Additional Context
<!-- If relevant -->

## Test Steps
Run pytest

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
