### PR TITLE
openbsd/net: flush the route table on net restart

### DIFF
--- a/cloudinit/net/openbsd.py
+++ b/cloudinit/net/openbsd.py
@@ -36,6 +36,9 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
         if not self._postcmds:
             LOG.debug("openbsd generate postcmd disabled")
             return
+        subp.subp(['pkill', 'dhclient'], capture=True, rcs=[0, 1])
+        subp.subp(['route', 'del', 'default'], capture=True, rcs=[0, 1])
+        subp.subp(['route', 'flush', 'default'], capture=True, rcs=[0, 1])
         subp.subp(['sh', '/etc/netstart'], capture=True)
 
     def set_route(self, network, netmask, gateway):


### PR DESCRIPTION
Ensure we've got a clean environment before we restart the network.

In some cases, the `sh /etc/netstart` is not enough to restart the
network. A previous default route remains in the route table and
as a result the network is broken.
Also `sh /netstart` does not kill `dhclient`.
The problen happens for instance with OVH OpenStack SBG3.