### PR TITLE
Allow braces to appear in dhclient output

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -173,7 +173,7 @@ def parse_dhcp_lease_file(lease_file):
     @raises: InvalidDHCPLeaseFileError on empty of unparseable leasefile
         content.
     """
-    lease_regex = re.compile(r"lease {(?P<lease>[^}]*)}\n")
+    lease_regex = re.compile(r"lease {(?P<lease>.*?)}\n", re.DOTALL)
     dhcp_leases = []
     lease_content = util.load_file(lease_file)
     if len(lease_content) == 0:

--- a/cloudinit/net/tests/test_dhcp.py
+++ b/cloudinit/net/tests/test_dhcp.py
@@ -42,6 +42,7 @@ class TestParseDHCPLeasesFile(CiTestCase):
             lease {
               interface "wlp3s0";
               fixed-address 192.168.2.74;
+              filename "http://192.168.2.50/boot.php?mac=${netX}";
               option subnet-mask 255.255.255.0;
               option routers 192.168.2.1;
               renew 4 2017/07/27 18:02:30;
@@ -50,6 +51,7 @@ class TestParseDHCPLeasesFile(CiTestCase):
             lease {
               interface "wlp3s0";
               fixed-address 192.168.2.74;
+              filename "http://192.168.2.50/boot.php?mac=${netX}";
               option subnet-mask 255.255.255.0;
               option routers 192.168.2.1;
             }
@@ -58,8 +60,10 @@ class TestParseDHCPLeasesFile(CiTestCase):
             {'interface': 'wlp3s0', 'fixed-address': '192.168.2.74',
              'subnet-mask': '255.255.255.0', 'routers': '192.168.2.1',
              'renew': '4 2017/07/27 18:02:30',
-             'expire': '5 2017/07/28 07:08:15'},
+             'expire': '5 2017/07/28 07:08:15',
+             'filename': 'http://192.168.2.50/boot.php?mac=${netX}'},
             {'interface': 'wlp3s0', 'fixed-address': '192.168.2.74',
+             'filename': 'http://192.168.2.50/boot.php?mac=${netX}',
              'subnet-mask': '255.255.255.0', 'routers': '192.168.2.1'}]
         write_file(lease_file, content)
         self.assertCountEqual(expected, parse_dhcp_lease_file(lease_file))


### PR DESCRIPTION
## Proposed Commit Message
Allow braces to appear in dhclient output

```
dhclient output that contains brackets for pxe variables will break the dhclient parsing regex line. This fix retains the current
functionality while fixing this particular issue.
```

Not sure if there are any cases I may be missing that the regex there was intended to resolve, but this line passes the tests and
fixes my particular issue with it. It seems to function exactly as it did before from what I can see.

## Test Steps
This was the following output that broke this line,

```
lease {
  interface "enp1s0f0";
  fixed-address 45.63.17.162;
  filename "http://100.100.100.1/getbootconfig.php?mac=${netX/mac}";
  server-name "100.100.100.1";
  option subnet-mask 255.255.254.0;
  option routers 45.63.16.1;
  option dhcp-lease-time 86400;
  option dhcp-message-type 5;
  option domain-name-servers 108.61.10.10;
  option dhcp-server-identifier 169.254.1.1;
  option dhcp-renewal-time 43200;
  option rfc3442-classless-static-routes 0,45,63,16,1,32,169,254,169,254,45,63,16,1;
  option broadcast-address 45.63.17.255;
  option dhcp-rebinding-time 75600;
  option host-name "blankedout";
  renew 4 2021/05/27 03:29:58;
  rebind 4 2021/05/27 14:17:16;
  expire 4 2021/05/27 17:17:16;
}
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ X ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ X ] I have updated or added any unit tests accordingly
 - [ X ] I have updated or added any documentation accordingly
