### PR TITLE
Docs: Replace all freenode references with libera (SC-68)

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -34,7 +34,7 @@ Follow these steps to submit your first pull request to cloud-init:
     "Cloud-Init CLA"
 
   * You also may contact user ``rick_h`` in the ``#cloud-init``
-    channel on the Freenode IRC network.
+    channel on the Libera IRC network.
 
 * Configure git with your email and name for commit messages.
 
@@ -159,7 +159,7 @@ Then, someone in the `Ubuntu Server`_ team will review your changes and
 follow up in the pull request.  Look at the `Code Review Process`_ doc
 to understand the following steps.
 
-Feel free to ping and/or join ``#cloud-init`` on freenode irc if you
+Feel free to ping and/or join ``#cloud-init`` on Libera irc if you
 have any questions.
 
 .. _tox: https://tox.readthedocs.io/en/latest/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you need support, start with the [user documentation](https://cloudinit.readt
 
 If you need additional help consider reaching out with one of the following options:
 
-- Ask a question in the [``#cloud-init`` IRC channel on Freenode](https://webchat.freenode.net/?channel=#cloud-init)
+- Ask a question in the [``#cloud-init`` IRC channel on Libera](https://libera.chat/)
 - Search the cloud-init [mailing list archive](https://lists.launchpad.net/cloud-init/)
 - Better yet, join the [cloud-init mailing list](https://launchpad.net/~cloud-init) and participate
 - Find a bug? [Report bugs on Launchpad](https://bugs.launchpad.net/cloud-init/+filebug)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you need support, start with the [user documentation](https://cloudinit.readt
 
 If you need additional help consider reaching out with one of the following options:
 
-- Ask a question in the [``#cloud-init`` IRC channel on Libera](https://libera.chat/)
+- Ask a question in the [``#cloud-init`` IRC channel on Libera](https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init)
 - Search the cloud-init [mailing list archive](https://lists.launchpad.net/cloud-init/)
 - Better yet, join the [cloud-init mailing list](https://launchpad.net/~cloud-init) and participate
 - Find a bug? [Report bugs on Launchpad](https://bugs.launchpad.net/cloud-init/+filebug)

--- a/doc/rtd/index.rst
+++ b/doc/rtd/index.rst
@@ -27,7 +27,7 @@ Getting help
 Having trouble? We would like to help!
 
 - Try the :ref:`FAQ` – its got answers to some common questions
-- Ask a question in the ``#cloud-init`` IRC channel on Freenode
+- Ask a question in the ``#cloud-init`` IRC channel on Libera
 - Join and ask questions on the `cloud-init mailing list <https://launchpad.net/~cloud-init>`_
 - Find a bug? `Report bugs on Launchpad <https://bugs.launchpad.net/cloud-init/+filebug>`_
 

--- a/doc/rtd/topics/code_review.rst
+++ b/doc/rtd/topics/code_review.rst
@@ -22,7 +22,7 @@ questions about the code review process, or at any point during the
 code review process, these are the available avenues:
 
 * if you have an open Pull Request, comment on that pull request
-* join the ``#cloud-init`` channel on the Freenode IRC network and ask
+* join the ``#cloud-init`` channel on the Libera IRC network and ask
   away
 * send an email to the cloud-init mailing list,
   cloud-init@lists.launchpad.net

--- a/doc/rtd/topics/debugging.rst
+++ b/doc/rtd/topics/debugging.rst
@@ -258,8 +258,9 @@ from **-proposed**
 
    * Create a `new cloud-init bug`_ reporting the version of cloud-init
      affected
-   * Ping upstream cloud-init on Libera's #cloud-init IRC channel
+   * Ping upstream cloud-init on Libera's `#cloud-init IRC channel`_
 
 .. _SRU: https://wiki.ubuntu.com/StableReleaseUpdates
 .. _CloudinitUpdates: https://wiki.ubuntu.com/CloudinitUpdates
 .. _new cloud-init bug: https://bugs.launchpad.net/cloud-init/+filebug
+.. _#cloud-init IRC channel: https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init

--- a/doc/rtd/topics/debugging.rst
+++ b/doc/rtd/topics/debugging.rst
@@ -258,9 +258,8 @@ from **-proposed**
 
    * Create a `new cloud-init bug`_ reporting the version of cloud-init
      affected
-   * Ping upstream cloud-init on Freenode's `#cloud-init IRC channel`_
+   * Ping upstream cloud-init on Libera's #cloud-init IRC channel
 
 .. _SRU: https://wiki.ubuntu.com/StableReleaseUpdates
 .. _CloudinitUpdates: https://wiki.ubuntu.com/CloudinitUpdates
 .. _new cloud-init bug: https://bugs.launchpad.net/cloud-init/+filebug
-.. _#cloud-init IRC channel: https://webchat.freenode.net/?channel=#cloud-init

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -10,7 +10,7 @@ Having trouble? We would like to help!
 
 - First go through this page with answers to common questions
 - Use the search bar at the upper left to search these docs
-- Ask a question in the ``#cloud-init`` IRC channel on Freenode
+- Ask a question in the ``#cloud-init`` IRC channel on Libera
 - Join and ask questions on the `cloud-init mailing list <https://launchpad.net/~cloud-init>`_
 - Find a bug? Check out the :ref:`reporting_bugs` topic for
   how to report one


### PR DESCRIPTION
Libera has no webchat, so removed one link, and replaced another with a link to the main website.