### PR TITLE
build-on-netbsd: don't pine a specific py3 version

### DIFF
--- a/tools/build-on-netbsd
+++ b/tools/build-on-netbsd
@@ -2,17 +2,24 @@
 
 fail() { echo "FAILED:" "$@" 1>&2; exit 1; }
 
+PYTHON="${PYTHON:-python3}"
+if [ ! $(which ${PYTHON}) ]; then
+    echo "Please install python first."
+    exit 1
+fi
+py_prefix=$(${PYTHON} -c 'import sys; print("py%d%d" % (sys.version_info.major, sys.version_info.minor))')
+
 # Check dependencies:
 depschecked=/tmp/c-i.dependencieschecked
 pkgs="
    bash
    dmidecode
-   py37-configobj
-   py37-jinja2
-   py37-oauthlib
-   py37-requests
-   py37-setuptools
-   py37-yaml
+   ${py_prefix}-configobj
+   ${py_prefix}-jinja2
+   ${py_prefix}-oauthlib
+   ${py_prefix}-requests
+   ${py_prefix}-setuptools
+   ${py_prefix}-yaml
    sudo
 "
 [ -f "$depschecked" ] || pkg_add ${pkgs} || fail "install packages"
@@ -20,8 +27,8 @@ pkgs="
 touch $depschecked
 
 # Build the code and install in /usr/pkg/:
-python3.7 setup.py build
-python3.7 setup.py install -O1 --distro netbsd --skip-build --init-system sysvinit_netbsd
+${PYTHON} setup.py build
+${PYTHON} setup.py install -O1 --distro netbsd --skip-build --init-system sysvinit_netbsd
 mv -v /usr/local/etc/rc.d/cloud* /etc/rc.d
 
 # Enable cloud-init in /etc/rc.conf:


### PR DESCRIPTION
Reuse the FreeBSD logic to be able to switch between Python3 versions
easily.