### PR TITLE
init: azure observe excluded_drivers when copying a distro in init

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -344,6 +344,7 @@ class DataSourceAzure(sources.DataSource):
         EventType.BOOT,
         EventType.BOOT_LEGACY
     }}
+    excluded_drivers = BLACKLIST_DRIVERS  # Drivers excluded from network cfg
 
     _negotiated = False
     _metadata_imds = sources.UNSET
@@ -626,7 +627,7 @@ class DataSourceAzure(sources.DataSource):
         except Exception as e:
             LOG.warning("Failed to get system information: %s", e)
 
-        self.distro.networking.blacklist_drivers = BLACKLIST_DRIVERS
+        self.distro.networking.blacklist_drivers = self.excluded_drivers
 
         try:
             crawled_data = util.log_time(

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -92,6 +92,15 @@ class Init(object):
             # said datasource and move its distro/system config
             # from whatever it was to a new set...
             if self.datasource is not NULL_DATA_SOURCE:
+                if hasattr(self.datasource, "excluded_drivers"):
+                    # Certain datasources exclude network devices based
+                    # on the corresponding driver (Azure SRIOV).
+                    # When copying in a new distro, set the
+                    # distro.networking.excluded_drivers for networking config
+                    # generation.
+                    self._distro.networking.blacklist_drivers = getattr(
+                        self.datasource, "excluded_drivers"
+                    )
                 self.datasource.distro = self._distro
                 self.datasource.sys_cfg = self.cfg
         return self._distro


### PR DESCRIPTION
In Stages, the init.distro property will reconstitute the discovered
distro when considering the fully merged system config.

Since distro class now carries a networking instance, cloudinit needs
to ensure any datasource.excluded_drivers are preserved in the newly
fetched distro.networking.blacklist_drivers.

This allows any datasource (currently just AzureDataSource) to
prescribe the types of network devices which will be ignored when
attempting to render full network on all viable network devices
via a call to distros.networking.Network.get_interfaces_by_mac()

LP: #1927124

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
# WIP so I can write a better integration test for this.
```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate bug reference or remove
this line entirely if there is no associated bug)
```

## Additional Context
<!-- If relevant -->

## Test Steps
* launch azure xenial vm with advanced networking
* obtain UA token from https://ubuntu.com/advantage
* ua attach <token>
* ua enable fips
* sudo cloud-init clean --reboot --logs
* Expect system to never come back 

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
