### PR TITLE
tune azure ds telemetry annotation

### DIFF
--- a/cloudinit/analyze/show.py
+++ b/cloudinit/analyze/show.py
@@ -134,6 +134,7 @@ class SystemctlReader(object):
     '''
     Class for dealing with all systemctl subp calls in a consistent manner.
     '''
+
     def __init__(self, property, parameter=None):
         self.epoch = None
         self.args = ['/bin/systemctl', 'show']
@@ -310,9 +311,9 @@ def generate_records(events, blame_sort=False,
 
     unprocessed = []
     for e in range(0, len(sorted_events)):
-        event = events[e]
+        event = sorted_events[e]
         try:
-            next_evt = events[e + 1]
+            next_evt = sorted_events[e + 1]
         except IndexError:
             next_evt = None
 

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -2197,7 +2197,6 @@ def _generate_network_config_from_imds_metadata(imds_metadata) -> dict:
     return netconfig
 
 
-@azure_ds_telemetry_reporter
 def _generate_network_config_from_fallback_config() -> dict:
     """Generate fallback network config excluding blacklisted devices.
 

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -256,7 +256,6 @@ def push_log_to_kvp(file_name=CFG_BUILTIN['def_log_file']):
             logger_func=LOG.warning)
 
 
-@azure_ds_telemetry_reporter
 def get_last_log_byte_pushed_to_kvp_index():
     try:
         with open(LOG_PUSHED_TO_KVP_INDEX_FILE, "r") as f:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -57,3 +57,4 @@ Vultaire
 WebSpider
 xiachen-rh
 xnox
+haitch


### PR DESCRIPTION
## Proposed Commit Message
```
summary: tune azure ds telemetry annotation

remove unnecessary azure telemetry, to avoid **cloud-init analyze** generate multiple boot record for a single boot. 

the reason is generate_records in /cloudinit/analyze/show.py have a bug, if a DS event is start and this DS has been seen, it will generate a new boot record.

        if event_type(event) == 'start':
            if event.get('name') in stages_seen:

LP: #1930956 (replace with the appropriate bug reference or remove
this line entirely if there is no associated bug)
```

## Additional Context
bug filed at: https://bugs.launchpad.net/cloud-init/+bug/1930956
this PR is not real fix for ```cloud-init analyze```,  it's a easy workaround we can take.

## Test Steps
manually tested

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
