### PR TITLE
Ubuntu/bionic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cloud-init (21.2-3-g899bfaa9-0ubuntu2~18.04.2) UNRELEASED; urgency=medium
+
+  * d/patches/ubuntu-advantage-revert-tip.patch: drop revert patch
+    + ubuntu-advantage-tools completed SRU to bionic. Bionic now
+      compatible with upstream ua python-client CLI behavior.
+  * d/cloud-init.templates: Add comment for Oracle DS ommission on Bionic
+
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 15 Jun 2021 10:37:40 -0600
+
 cloud-init (21.2-3-g899bfaa9-0ubuntu2~18.04.1) bionic; urgency=medium
 
   * d/cloud-init.templates: Add Vultr datasource support

--- a/debian/cloud-init.templates
+++ b/debian/cloud-init.templates
@@ -1,3 +1,4 @@
+# Oracle DS absent to retain orig behavior: Oracle(Bionic) == OpenStack detected
 Template: cloud-init/datasources
 Type: multiselect
 Default: NoCloud, ConfigDrive, OpenNebula, DigitalOcean, Azure, AltCloud, OVF, MAAS, GCE, OpenStack, CloudSigma, SmartOS, Bigstep, Scaleway, AliYun, Ec2, CloudStack, Hetzner, IBMCloud, Exoscale, RbxCloud, UpCloud, Vultr, None

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,4 +1,3 @@
 openstack-no-network-config.patch
-ubuntu-advantage-revert-tip.patch
 ec2-dont-apply-full-imds-network-config.patch
 renderer-do-not-prefer-netplan.patch


### PR DESCRIPTION
Drop UA client reverts from bionic now that upstream UA python-client has been SRU'd to xenial and later.

## Proposed Commit Messages (separate commits merged by author **do not squash merge**)

    - update changelog unreleased
    
    - d/cloud-init.templates: comment about why Oracle DS is absent
    
    - d/patches/-ubuntu-advantage-revert-tip.patch: ua completed SRU to bionic
   

## Additional Context


## Test Steps
```bash
# check patch apply and removal
quilt  push -a
quilt pop -a
git diff # make sure not diff leftover locally

# build package to exercise application of quilt patches
sed -i '0,/UNRELEASED/s//bionic/' debian/changelog
git commit -am 'changelog for bionic build'
build-package
sbuild-it ../out/cloud-init_21.2-3-g899bfaa9-0ubuntu2~18.04.2.dsc

# also make sure upstream/ubuntu/daily/bionic still merges for daily builds
git merge origin/ubuntu/daily/bionic
echo $?
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
