### PR TITLE
Replace deprecated collections.Iterable with abc replacement (SC-127)

### DIFF
--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -8,7 +8,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import collections
+import collections.abc
 import io
 import logging
 import logging.config
@@ -78,7 +78,7 @@ def setupLogging(cfg=None):
         for a_cfg in cfg['log_cfgs']:
             if isinstance(a_cfg, str):
                 log_cfgs.append(a_cfg)
-            elif isinstance(a_cfg, (collections.Iterable)):
+            elif isinstance(a_cfg, (collections.abc.Iterable)):
                 cfg_str = [str(c) for c in a_cfg]
                 log_cfgs.append('\n'.join(cfg_str))
             else:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Replace deprecated collections.Iterable with abc replacement

LP: #1932048
```

## Additional Context
> Deprecated since version 3.3, will be removed in version 3.10: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.9.

https://docs.python.org/3.9/library/collections.html

I did a quick search for any other references to something in `collections` that should be coming from `collections.abc` and didn't find anything.

## Test Steps
n/a

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
