### PR TITLE
docs: fix stale links rename master branch to main

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -55,7 +55,7 @@ Follow these steps to submit your first pull request to cloud-init:
     git clone git://github.com/canonical/cloud-init
     cd cloud-init
     git remote add GH_USER git@github.com:GH_USER/cloud-init.git
-    git push GH_USER master
+    git push GH_USER main
 
 * Read through the cloud-init `Code Review Process`_, so you understand
   how your changes will end up in cloud-init's codebase.
@@ -78,7 +78,7 @@ Follow these steps to submit your first pull request to cloud-init:
 .. _repository: https://github.com/canonical/cloud-init
 .. _contributor license agreement: https://ubuntu.com/legal/contributors
 .. _contributor-agreement-canonical: https://launchpad.net/%7Econtributor-agreement-canonical/+members
-.. _tools/.github-cla-signers: https://github.com/canonical/cloud-init/blob/master/tools/.github-cla-signers
+.. _tools/.github-cla-signers: https://github.com/canonical/cloud-init/blob/main/tools/.github-cla-signers
 .. _PR #344: https://github.com/canonical/cloud-init/pull/344
 .. _PR #345: https://github.com/canonical/cloud-init/pull/345
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cloud-init
 
-[![Build Status](https://travis-ci.com/canonical/cloud-init.svg?branch=master)](https://travis-ci.com/canonical/cloud-init) [![Read the Docs](https://readthedocs.org/projects/cloudinit/badge/?version=latest&style=flat)](https://cloudinit.readthedocs.org)
+[![Build Status](https://travis-ci.com/canonical/cloud-init.svg?branch=main)](https://travis-ci.com/canonical/cloud-init) [![Read the Docs](https://readthedocs.org/projects/cloudinit/badge/?version=latest&style=flat)](https://cloudinit.readthedocs.org)
 
 Cloud-init is the *industry standard* multi-distribution method for
 cross-platform cloud instance initialization. It is supported across all

--- a/doc/rtd/topics/code_review.rst
+++ b/doc/rtd/topics/code_review.rst
@@ -58,12 +58,12 @@ Reviewer
 
 Committer
    A cloud-init core developer (i.e. a person who has permission to
-   merge PRs into master).
+   merge PRs into **main**).
 
 Prerequisites For Landing Pull Requests
 =======================================
 
-Before a PR can be landed into master, the following conditions *must*
+Before a PR can be landed into **main**, the following conditions *must*
 be met:
 
 * the CLA has been signed by the **Proposer** (or is covered by an
@@ -148,7 +148,7 @@ temporarily closed.  (The first two are covered in this section; see
 
 (In the below, when the verbs "merge" or "squash merge" are used, they
 should be understood to mean "squash merged using the GitHub UI", which
-is the only way that changes can land in cloud-init's master branch.)
+is the only way that changes can land in cloud-init's **main** branch.)
 
 These are the steps that comprise the review phase:
 

--- a/doc/rtd/topics/datasources/ovf.rst
+++ b/doc/rtd/topics/datasources/ovf.rst
@@ -35,7 +35,7 @@ The following VMTools configuration options affect cloud-init's behavior on a bo
       change this default behavior (for example: enabled by default) via
       customization specification settings.
 
-VMWare admin can refer to (https://github.com/canonical/cloud-init/blob/master/cloudinit/sources/helpers/vmware/imc/config.py) and set the customization specification settings.
+VMWare admin can refer to (https://github.com/canonical/cloud-init/blob/main/cloudinit/sources/helpers/vmware/imc/config.py) and set the customization specification settings.
 
 For more information, see [VMware vSphere Product Documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-9A5093A5-C54F-4502-941B-3F9C0F573A39.html) and specific VMTools parameters consumed.
 

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -139,7 +139,7 @@ cloud-config is:
 To verify your YAML, we do have a short script called `validate-yaml.py`_
 that can validate your user data offline.
 
-.. _validate-yaml.py: https://github.com/canonical/cloud-init/blob/master/tools/validate-yaml.py
+.. _validate-yaml.py: https://github.com/canonical/cloud-init/blob/main/tools/validate-yaml.py
 
 Another option is to run the following on an instance to debug userdata
 provided to the system:

--- a/doc/rtd/topics/format.rst
+++ b/doc/rtd/topics/format.rst
@@ -55,7 +55,7 @@ to store the multipart message in ``user-data``:
 
     $ cloud-init devel make-mime -a config.yaml:cloud-config -a script.sh:x-shellscript > user-data
 
-.. _make-mime: https://github.com/canonical/cloud-init/blob/master/cloudinit/cmd/devel/make_mime.py
+.. _make-mime: https://github.com/canonical/cloud-init/blob/main/cloudinit/cmd/devel/make_mime.py
 
 
 User-Data Script

--- a/doc/rtd/topics/testing.rst
+++ b/doc/rtd/topics/testing.rst
@@ -166,8 +166,8 @@ Test Argument Ordering
 .. _pytest: https://docs.pytest.org/
 .. _pytest fixtures: https://docs.pytest.org/en/latest/fixture.html
 .. _TestGetPackageMirrorInfo: https://github.com/canonical/cloud-init/blob/42f69f410ab8850c02b1f53dd67c132aa8ef64f5/cloudinit/distros/tests/test_init.py\#L15
-.. _TestPrependBaseCommands: https://github.com/canonical/cloud-init/blob/master/cloudinit/tests/test_subp.py#L9
+.. _TestPrependBaseCommands: https://github.com/canonical/cloud-init/blob/fbcb224bc12495ba200ab107246349d802c5d8e6/cloudinit/tests/test_subp.py#L20
 .. _assertion introspection: https://docs.pytest.org/en/latest/assert.html
 .. _pytest 3.0: https://docs.pytest.org/en/latest/changelog.html#id1093
-.. _pytest.param: https://docs.pytest.org/en/latest/reference.html#pytest-param
+.. _pytest.param: https://docs.pytest.org/en/6.2.x/reference.html#pytest-param
 .. _autospecced: https://docs.python.org/3.8/library/unittest.mock.html#autospeccing


### PR DESCRIPTION
## Proposed Commit Message
```
Update doc references to 'main' default branch due to rename.
Also some links have eroded:
-  for doc links directly to a line num link to a
   blob/<commit>/file/path#L10 instead of blob/<branch_name>.
- pytest.param link to a specific version doc as latest has dropped
  the link
```

## Additional Context
<!-- If relevant -->

## Test Steps
tox -e doc
open browser to doc/rtd_html/index,html

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
