### PR TITLE
d/cloud-init.templates: remove comment (unsupported by debconf)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,7 +3,6 @@ cloud-init (21.2-3-g899bfaa9-0ubuntu2~18.04.2) UNRELEASED; urgency=medium
   * d/patches/ubuntu-advantage-revert-tip.patch: drop revert patch
     + ubuntu-advantage-tools completed SRU to bionic. Bionic now
       compatible with upstream ua python-client CLI behavior.
-  * d/cloud-init.templates: Add comment for Oracle DS ommission on Bionic
 
  -- Chad Smith <chad.smith@canonical.com>  Tue, 15 Jun 2021 10:37:40 -0600
 

--- a/debian/cloud-init.templates
+++ b/debian/cloud-init.templates
@@ -1,4 +1,3 @@
-# Oracle DS absent to retain orig behavior: Oracle(Bionic) == OpenStack detected
 Template: cloud-init/datasources
 Type: multiselect
 Default: NoCloud, ConfigDrive, OpenNebula, DigitalOcean, Azure, AltCloud, OVF, MAAS, GCE, OpenStack, CloudSigma, SmartOS, Bigstep, Scaleway, AliYun, Ec2, CloudStack, Hetzner, IBMCloud, Exoscale, RbxCloud, UpCloud, Vultr, None

--- a/debian/cloud-init.templates.README
+++ b/debian/cloud-init.templates.README
@@ -1,0 +1,2 @@
+Oracle DS absent from d/cloud-init.templates to retain the original behavior:
+Oracle(Bionic) == OpenStack detected.


### PR DESCRIPTION
- Revert "d/cloud-init.templates: comment about why Oracle DS is absent"
- Update d/changelog (UNRELEASED)

## Proposed Commit Message

If it's OK not to squash PRs to packaging branches then maybe this can be merged non-squashed. Otherwise the commit message can be
```
d/cloud-init.templates: remove comment (unsupported by debconf)
```

## Additional Context
<!-- If relevant -->
Spotted by our CI.

## Test Steps

When installing a deb package with the comment this happens:
```
debconf: unable to initialize frontend: Dialog
debconf: (Dialog frontend will not work on a dumb terminal, an emacs shell buffer, or without a controlling terminal.)
debconf: falling back to frontend: Readline
Template parse error near `# Oracle DS absent to retain orig behavior: Oracle(Bionic) == OpenStack detected', in stanza #1 of /var/lib/dpkg/info/cloud-init.templates
dpkg: error processing package cloud-init (--configure):
installed cloud-init package post-installation script subprocess returned error exit status 255
```
The error goes away removing the comment.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
