### PR TITLE
bsd/net_v1 format: read MTU from interface config

### DIFF
--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -33,7 +33,7 @@ class BSDRenderer(renderer.Renderer):
         self.interface_configurations = {}
         self._postcmds = config.get('postcmds', True)
 
-    def _ifconfig_entries(self, settings, target=None):
+    def _ifconfig_entries(self, settings):
         ifname_by_mac = net.get_interfaces_by_mac()
         for interface in settings.iter_interfaces():
             device_name = interface.get("name")
@@ -76,10 +76,10 @@ class BSDRenderer(renderer.Renderer):
                     self.interface_configurations[device_name] = {
                         'address': subnet.get('address'),
                         'netmask': subnet.get('netmask'),
-                        'mtu': subnet.get('mtu'),
+                        'mtu': subnet.get('mtu') or interface.get('mtu'),
                     }
 
-    def _route_entries(self, settings, target=None):
+    def _route_entries(self, settings):
         routes = list(settings.iter_routes())
         for interface in settings.iter_interfaces():
             subnets = interface.get("subnets", [])
@@ -102,7 +102,7 @@ class BSDRenderer(renderer.Renderer):
             gateway = route.get('gateway')
             self.set_route(network, netmask, gateway)
 
-    def _resolve_conf(self, settings, target=None):
+    def _resolve_conf(self, settings):
         nameservers = settings.dns_nameservers
         searchdomains = settings.dns_searchdomains
         for interface in settings.iter_interfaces():
@@ -115,11 +115,11 @@ class BSDRenderer(renderer.Renderer):
         # fails.
         try:
             resolvconf = ResolvConf(util.load_file(subp.target_path(
-                target, self.resolv_conf_fn)))
+                self.target, self.resolv_conf_fn)))
             resolvconf.parse()
         except IOError:
             util.logexc(LOG, "Failed to parse %s, use new empty file",
-                        subp.target_path(target, self.resolv_conf_fn))
+                        subp.target_path(self.target, self.resolv_conf_fn))
             resolvconf = ResolvConf('')
             resolvconf.parse()
 
@@ -137,10 +137,12 @@ class BSDRenderer(renderer.Renderer):
             except ValueError:
                 util.logexc(LOG, "Failed to add search domain %s", domain)
         util.write_file(
-            subp.target_path(target, self.resolv_conf_fn),
+            subp.target_path(self.target, self.resolv_conf_fn),
             str(resolvconf), 0o644)
 
     def render_network_state(self, network_state, templates=None, target=None):
+        if target:
+            self.target = target
         self._ifconfig_entries(settings=network_state)
         self._route_entries(settings=network_state)
         self._resolve_conf(settings=network_state)

--- a/tests/unittests/test_net_freebsd.py
+++ b/tests/unittests/test_net_freebsd.py
@@ -1,8 +1,24 @@
-from cloudinit import net
+import os
+import yaml
 
-from cloudinit.tests.helpers import (CiTestCase, mock, readResource)
+import cloudinit.net
+import cloudinit.net.network_state
+from cloudinit.tests.helpers import (CiTestCase, mock, readResource, dir2dict)
+
 
 SAMPLE_FREEBSD_IFCONFIG_OUT = readResource("netinfo/freebsd-ifconfig-output")
+V1 = """
+config:
+-   id: eno1
+    mac_address: 08:94:ef:51:ae:e0
+    mtu: 1470
+    name: eno1
+    subnets:
+    -   address: 172.20.80.129/25
+        type: static
+    type: physical
+version: 1
+"""
 
 
 class TestInterfacesByMac(CiTestCase):
@@ -12,8 +28,49 @@ class TestInterfacesByMac(CiTestCase):
     def test_get_interfaces_by_mac(self, mock_is_FreeBSD, mock_subp):
         mock_is_FreeBSD.return_value = True
         mock_subp.return_value = (SAMPLE_FREEBSD_IFCONFIG_OUT, 0)
-        a = net.get_interfaces_by_mac()
+        a = cloudinit.net.get_interfaces_by_mac()
         assert a == {'52:54:00:50:b7:0d': 'vtnet0',
                      '80:00:73:63:5c:48': 're0.33',
                      '02:14:39:0e:25:00': 'bridge0',
                      '02:ff:60:8c:f3:72': 'vnet0:11'}
+
+
+class TestFreeBSDRoundTrip(CiTestCase):
+
+    def _render_and_read(self, network_config=None, state=None,
+                         netplan_path=None, target=None):
+        if target is None:
+            target = self.tmp_dir()
+            os.mkdir("%s/etc" % target)
+            with open("%s/etc/rc.conf" % target, 'a') as fd:
+                fd.write("# dummy rc.conf\n")
+            with open("%s/etc/resolv.conf" % target, 'a') as fd:
+                fd.write("# dummy resolv.conf\n")
+
+        if network_config:
+            ns = cloudinit.net.network_state.parse_net_config_data(
+                network_config)
+        elif state:
+            ns = state
+        else:
+            raise ValueError("Expected data or state, got neither")
+
+        renderer = cloudinit.net.freebsd.Renderer()
+        renderer.render_network_state(ns, target=target)
+        return dir2dict(target)
+
+    @mock.patch('cloudinit.subp.subp')
+    def test_render_output_has_yaml(self, mock_subp):
+
+        entry = {
+            'yaml': V1,
+        }
+        network_config = yaml.load(entry['yaml'])
+        ns = cloudinit.net.network_state.parse_net_config_data(network_config)
+        files = self._render_and_read(state=ns)
+        assert files == {
+            '/etc/resolv.conf': '# dummy resolv.conf\n',
+            '/etc/rc.conf': (
+                "# dummy rc.conf\n"
+                "ifconfig_eno1="
+                "'172.20.80.129 netmask 255.255.255.128 mtu 1470'\n")}


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
bsd/net_v1 format: read MTU from interface config

We read the MTU from the subnet entries. With the v1 format, the MTU can
be set at the root level of the interface entry in the `config` section.

Limitation, we won't set the MTU if the interface use DHCP. This
would require a bit of refactoring.

Also simplify/clarify how we pass the target variable in `cloudinit.net.bsd`.

See: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=256309
Reported-by: Andrey Fesenko
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ x] I have updated or added any unit tests accordingly
 - [ x] I have updated or added any documentation accordingly
