### PR TITLE
cloud_tests: fix the Impish release name

### DIFF
--- a/tests/cloud_tests/releases.yaml
+++ b/tests/cloud_tests/releases.yaml
@@ -137,7 +137,7 @@ releases:
         # EOL: July 2022
         default:
             enabled: true
-            release: hirsute
+            release: impish
             version: "21.10"
             os: ubuntu
             feature_groups:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cloud_tests: fix the Impish release name

Commit f5a2449 introduced Impish but left the release name set to
'hirsute'.
```

## Additional Context
<!-- If relevant -->
Spotted by our CI. 

## Test Steps
On `main`:
```
$ tox -e citest -- run "--os-name=impish" \
  --platform=nocloud-kvm --preserve-data --data-dir=results \
  --verbose "--deb=DAILY_DEB.deb"

# Verbose output, then test failures like:

AssertionError: 'impish' != 'hirsute'
- impish
+ hirsute
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
