### PR TITLE
Remove legacy eth0 from default interfaces file

### DIFF
--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -113,6 +113,7 @@ class Distro(distros.Distro):
 
     def _write_network_config(self, netconfig):
         _maybe_remove_legacy_eth0()
+        _maybe_remove_legacy_eth0("/etc/network/interfaces")
         return self._supported_write_network_config(netconfig)
 
     def _bring_up_interfaces(self, device_names):


### PR DESCRIPTION
## Proposed Commit Message
Remove legacy eth0 from default interfaces file

```
summary: default dhcp config blocks static IPv6 configuration

The Debian cloud images have dhcp by default for eth0 in
/etc/network/interfaces. The cloud-init script will write additional
config to /etc/network/interfaces.d/50-cloud-init, but the static
config for eth0 for IPv6 will be ignored as long as the dhcp config
exists.

The function to remove the legacy config points to another file
by default, but it should also be called for /etc/network/interfaces.
```

## Test Steps
An updated Debian cloud image should be created with the fix,
and then the behaviour can be tested. I have observed this
on an Openstack cluster.

## Checklist:
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
