### PR TITLE
cloud.cfg.tmpl: add a key to manage fallback network config

### DIFF
--- a/cloudinit/distros/photon.py
+++ b/cloudinit/distros/photon.py
@@ -5,6 +5,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from cloudinit import net
 from cloudinit import util
 from cloudinit import subp
 from cloudinit import distros
@@ -53,6 +54,20 @@ class Distro(distros.Distro):
         except subp.ProcessExecutionError:
             util.logexc(LOG, 'Command %s failed', cmd)
             return False, None, None
+
+    def generate_fallback_config(self):
+        key = 'disable_fallback_netcfg'
+        disable_fallback_netcfg = self._cfg.get(key, True)
+        LOG.debug('%s value is: %s', key, disable_fallback_netcfg)
+
+        if not disable_fallback_netcfg:
+            return net.generate_fallback_config()
+
+        LOG.info(
+            'Skipping generate_fallback_config. Rely on PhotonOS default '
+            'network config'
+        )
+        return None
 
     def apply_locale(self, locale, out_fn=None):
         # This has a dependancy on glibc-i18n, user need to manually install it

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -18,9 +18,10 @@ users:
    - default
 {% endif %}
 
-# VMware guest customization.
 {% if variant in ["photon"] %}
+# VMware guest customization.
 disable_vmware_customization: true
+manage_etc_hosts: false
 {% endif %}
 
 # If this is set, 'root' will not be able to ssh in and they
@@ -306,10 +307,15 @@ system_info:
    paths:
       cloud_dir: /var/lib/cloud/
       templates_dir: /etc/cloud/templates/
+   network:
+      renderers: ['networkd']
 
    ssh_svcname: sshd
 
-#manage_etc_hosts: true
+   # If set to true, cloud-init will not use fallback network config.
+   # In Photon, we have default network settings, hence if network settings are
+   # not explicitly given in metadata, don't use fallback network config.
+   disable_fallback_netcfg: true
 {% endif %}
 {% if variant in ["freebsd", "netbsd", "openbsd"] %}
    network:

--- a/doc/rtd/topics/availability.rst
+++ b/doc/rtd/topics/availability.rst
@@ -26,6 +26,7 @@ OpenBSD and DragonFlyBSD:
 - Gentoo Linux
 - NetBSD
 - OpenBSD
+- Photon OS
 - RHEL/CentOS
 - SLES/openSUSE
 - Ubuntu

--- a/doc/rtd/topics/network-config.rst
+++ b/doc/rtd/topics/network-config.rst
@@ -104,6 +104,13 @@ interface given the information it has available.
 Finally after selecting the "right" interface, a configuration is
 generated and applied to the system.
 
+.. note::
+
+   PhotonOS disables fallback networking configuration by default leaving
+   network unrendered when no other network config is provided.
+   If fallback config is still desired on PhotonOS, it can be enabled by
+   providing `disable_fallback_netcfg: false` in
+   `/etc/cloud/cloud.cfg:sys_config` settings.
 
 Network Configuration Sources
 =============================

--- a/tests/unittests/test_distros/test_photon.py
+++ b/tests/unittests/test_distros/test_photon.py
@@ -1,0 +1,51 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from . import _get_distro
+from cloudinit import util
+from cloudinit.tests.helpers import mock
+from cloudinit.tests.helpers import CiTestCase
+
+SYSTEM_INFO = {
+    'paths': {
+        'cloud_dir': '/var/lib/cloud/',
+        'templates_dir': '/etc/cloud/templates/',
+    },
+    'network': {'renderers': 'networkd'},
+}
+
+
+class TestPhoton(CiTestCase):
+    with_logs = True
+    distro = _get_distro('photon', SYSTEM_INFO)
+    expected_log_line = 'Rely on PhotonOS default network config'
+
+    def test_network_renderer(self):
+        self.assertEqual(self.distro._cfg['network']['renderers'], 'networkd')
+
+    def test_get_distro(self):
+        self.assertEqual(self.distro.osfamily, 'photon')
+
+    def test_write_hostname(self):
+        hostname = 'myhostname'
+        hostfile = self.tmp_path('hostfile')
+        self.distro._write_hostname(hostname, hostfile)
+        self.assertEqual(hostname + '\n', util.load_file(hostfile))
+
+    @mock.patch('cloudinit.net.generate_fallback_config')
+    def test_fallback_netcfg(self, m_fallback_cfg):
+
+        key = 'disable_fallback_netcfg'
+        # Don't use fallback if no setting given
+        self.logs.truncate(0)
+        assert(self.distro.generate_fallback_config() is None)
+        self.assertIn(self.expected_log_line, self.logs.getvalue())
+
+        self.logs.truncate(0)
+        self.distro._cfg[key] = True
+        assert(self.distro.generate_fallback_config() is None)
+        self.assertIn(self.expected_log_line, self.logs.getvalue())
+
+        self.logs.truncate(0)
+        self.distro._cfg[key] = False
+        assert(self.distro.generate_fallback_config() is not None)
+        self.assertNotIn(self.expected_log_line, self.logs.getvalue())


### PR DESCRIPTION
Currently cloud-init generates fallback network config on various
scenarios.

For example:
1. When no DS found
2. There is no 'network' info given in DS metadata.
3. If a DS gives a network config once and upon reboot if DS doesn't
   give any network info, previously set network data will be
   overridden.

This newly introduced key can be used to control this behaviour.

Also, if OS comes with a set of default network files(configs), like in
PhotonOS, cloud-init should not overwrite them by default.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>

## Proposed Commit Message
cloud.cfg.tmpl: add a key to manage fallback network config

```
Currently cloud-init generates fallback network config on various
scenarios.

For example:
1. When no DS found
2. There is no 'network' info given in DS metadata and so on.
3. If a DS gives a network config once and upon reboot if DS doesn't
   give any network info, previously set network data will be
   overridden.

This newly introduced key can be used to control this behaviour.

Also, if OS comes with a set of default network files(configs), like in
PhotonOS, cloud-init should not overwrite them by default.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
