### PR TITLE
run-container: fixup the centos repos baseurls when using http_proxy

### DIFF
--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -40,6 +40,7 @@ MAYBE_RELIABLE_YUM_INSTALL = [
         error ":: http proxy in use => forcing the use of fixed URLs in /etc/yum.repos.d/*.repo"
         sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo
         sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo
+        sed -i 's/download\.example/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo
     }
     configure_repos_for_proxy_use
     n=0; max=10;

--- a/tools/run-container
+++ b/tools/run-container
@@ -353,6 +353,7 @@ wait_for_boot() {
             inside "$name" sh -c "echo proxy=$http_proxy >> /etc/yum.conf"
             inside "$name" sh -c "sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo"
             inside "$name" sh -c "sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo"
+            inside "$name" sh -c "sed -i 's/download\.example/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo"
         else
             debug 1 "do not know how to configure proxy on $OS_NAME"
         fi


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
run-container: fixup the centos repos baseurls when using http_proxy

The EPEL repo file used to have download.fedoraproject.org as its
baseurl. That has now been replaced by `download.example`, which we need
to replace with dl.fedoraproject.org, the actual mirror we want to
download from.

We can't use download.fedoraproject.org or the mirrorlist (which is the
default way for finding mirrors) because of our internal proxy rules.

This change only applies if http_proxy is set, otherwise the mirrors are
reached in the default way.

```

## Additional Context
<!-- If relevant -->
Should fix our `cloud-init-copr-build` job.

## Test Steps

Follow what Jenkins does step by step:

https://github.com/canonical/server-jenkins-jobs/blob/main/jenkins-jobs/cloud-init/centos.yaml#L60

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
