### PR TITLE
Stop storing system keys in user's authorized keys file

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -283,8 +283,10 @@ def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
             "AuthorizedKeysFile has an user-specific authorized_keys, "
             "using %s", user_authorizedkeys_file)
 
-    # always store all the keys in the user's private file
-    return (user_authorizedkeys_file, parse_authorized_keys(auth_key_fns))
+    return (
+        user_authorizedkeys_file,
+        parse_authorized_keys([user_authorizedkeys_file])
+    )
 
 
 def setup_user_keys(keys, username, options=None):


### PR DESCRIPTION
In #60, one of the changes added system-wide authorized keys into user-specific authorized keys files.

After #937, this could lead to some unintended consequences.

Given this cloud-config:
```
#cloud-config
bootcmd:
 - sed -i 's;#AuthorizedKeysFile.*;AuthorizedKeysFile /etc/ssh/authorized_keys /home/test_user/.ssh/authorized_keys;' /etc/ssh/sshd_config
users:
- default
- name: test_user
  ssh_authorized_keys:
    - <key2>
- name: test_user2
  ssh_authorized_keys:
    - <key3>
```
we would see `test_user`'s key info getting written into `test_user2`'s authorized keys file.

I understand that this sort of configuration seems very unlikely, but given this, plus the fact that we already have the global authorized keys file, I don't see a benefit to copying system-wide keys into a user-specific key file.

@otubo , you initially made this change, and @esposem , you changed this code most recently. Does it make sense to stop copying all system-wide keys into each user's authorizedkeys? Is there a use case this addresses that I'm missing?

Note that this PR is WIP because we'd still need to update tests. I'm just looking for validation of the idea at the moment.