### PR TITLE
Only invoke hotplug socket when functionality is enabled (SC-251)

### DIFF
--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -3,6 +3,7 @@
 import abc
 import argparse
 import os
+import sys
 import time
 
 from cloudinit import log
@@ -12,7 +13,7 @@ from cloudinit.net import activators, read_sys_net_safe
 from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.reporting import events
 from cloudinit.stages import Init
-from cloudinit.sources import DataSource
+from cloudinit.sources import DataSource, DataSourceNotFoundException
 
 
 LOG = log.getLogger(__name__)
@@ -236,7 +237,13 @@ def handle_args(name, args):
     with hotplug_reporter:
         try:
             if args.hotplug_action == 'query':
-                hotplug_init.fetch(existing="trust")
+                try:
+                    hotplug_init.fetch(existing="trust")
+                except DataSourceNotFoundException:
+                    print(
+                        "Unable to determine hotplug state. No datasource "
+                        "detected")
+                    sys.exit(1)
                 enabled = is_enabled(hotplug_init, args.subsystem)
                 print('enabled' if enabled else 'disabled')
             else:

--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -173,6 +173,10 @@ def initialize_datasource(hotplug_init, subsystem):
     LOG.debug('Fetching datasource')
     datasource = hotplug_init.fetch(existing="trust")
 
+    if not datasource.get_supported_events([EventType.HOTPLUG]):
+        LOG.debug('hotplug not supported for event of type %s', subsystem)
+        return
+
     if not is_enabled(hotplug_init, subsystem):
         LOG.debug('hotplug not enabled for event of type %s', subsystem)
         return

--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -38,6 +38,7 @@ def get_parser(parser=None):
     )
 
     subparsers = parser.add_subparsers(dest='hotplug_action')
+    subparsers.required = True
 
     subparsers.add_parser(
         'query',

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -48,7 +48,7 @@ def test_hotplug_add_remove(client: IntegrationInstance):
 
     # Add new NIC
     added_ip = client.instance.add_network_interface()
-    _wait_till_hotplug_complete(client)
+    _wait_till_hotplug_complete(client, expected_runs=2)
     ips_after_add = _get_ip_addr(client)
     new_addition = [ip for ip in ips_after_add if ip.ip4 == added_ip][0]
 
@@ -63,7 +63,7 @@ def test_hotplug_add_remove(client: IntegrationInstance):
 
     # Remove new NIC
     client.instance.remove_network_interface(added_ip)
-    _wait_till_hotplug_complete(client, expected_runs=2)
+    _wait_till_hotplug_complete(client, expected_runs=4)
     ips_after_remove = _get_ip_addr(client)
     assert len(ips_after_remove) == len(ips_before)
     assert added_ip not in [ip.ip4 for ip in ips_after_remove]
@@ -71,6 +71,10 @@ def test_hotplug_add_remove(client: IntegrationInstance):
     netplan_cfg = client.read_from_file('/etc/netplan/50-cloud-init.yaml')
     config = yaml.safe_load(netplan_cfg)
     assert new_addition.interface not in config['network']['ethernets']
+
+    assert 'enabled' == client.execute(
+        'cloud-init devel hotplug-hook -s net query'
+    )
 
 
 @pytest.mark.openstack
@@ -83,7 +87,7 @@ def test_no_hotplug_in_userdata(client: IntegrationInstance):
     client.instance.add_network_interface()
     _wait_till_hotplug_complete(client)
     log = client.read_from_file('/var/log/cloud-init.log')
-    assert 'hotplug not enabled for event of type network' in log
+    assert "Event Denied: scopes=['network'] EventType=hotplug" in log
 
     ips_after_add = _get_ip_addr(client)
     if len(ips_after_add) == len(ips_before) + 1:
@@ -92,3 +96,7 @@ def test_no_hotplug_in_userdata(client: IntegrationInstance):
         assert new_ip.state == 'DOWN'
     else:
         assert len(ips_after_add) == len(ips_before)
+
+    assert 'disabled' == client.execute(
+        'cloud-init devel hotplug-hook -s net query'
+    )

--- a/tools/hook-hotplug
+++ b/tools/hook-hotplug
@@ -8,12 +8,17 @@ is_finished() {
     [ -e /run/cloud-init/result.json ]
 }
 
-if is_finished; then
+hotplug_enabled() {
+    [ "$(cloud-init devel hotplug-hook -s "${SUBSYSTEM}" query)" == "enabled" ]
+}
+
+if is_finished && hotplug_enabled; then
     # open cloud-init's hotplug-hook fifo rw
     exec 3<>/run/cloud-init/hook-hotplug-cmd
     env_params=(
-        --devpath="${DEVPATH}"
         --subsystem="${SUBSYSTEM}"
+        handle
+        --devpath="${DEVPATH}"
         --udevaction="${ACTION}"
     )
     # write params to cloud-init's hotplug-hook fifo


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Only invoke hotplug socket when functionality is enabled

Alter's hotplug hook to have a query mechanism checking if the
functionality is enabled. This allows us to avoid using the hotplug
socket and service when hotplug is disabled.

`cloud-init devel hotplug-hook -s net query` will return 'enabled' or
'disabled' depending on hotplug availability.
```

## Additional Context
n/a

## Test Steps
see integration test

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
