### PR TITLE
testing: fix test_ssh_import_id.py (SC-272)

### DIFF
--- a/tests/integration_tests/modules/test_ssh_import_id.py
+++ b/tests/integration_tests/modules/test_ssh_import_id.py
@@ -12,6 +12,7 @@ TODO:
 
 import pytest
 
+from tests.integration_tests.util import retry
 
 USER_DATA = """\
 #cloud-config
@@ -26,6 +27,11 @@ ssh_import_id:
 class TestSshImportId:
 
     @pytest.mark.user_data(USER_DATA)
+    # Retry is needed here because ssh import id is one of the last modules
+    # run, and it fires off a web request, then continues with the rest of
+    # cloud-init. It is possible cloud-init's status is "done" before the
+    # id's have been fully imported.
+    @retry(tries=30, delay=1)
     def test_ssh_import_id(self, client):
         ssh_output = client.read_from_file(
             "/home/ubuntu/.ssh/authorized_keys")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: fix test_ssh_import_id.py

test_ssh_import_id.py occassionally fails because cloud-init finishes
before the keys have been fully imported. A retry has been added to the
test .
```

## Additional Context
<!-- If relevant -->

## Test Steps
pytest tests/integration_tests/modules/test_ssh_import_id.py

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
