### PR TITLE
Add Puppet contributors to CLA signers

### DIFF
--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -13,6 +13,7 @@ BirknerAlex
 bmhughes
 candlerb
 cawamata
+ciprianbadescu
 dankenigsberg
 ddymko
 dermotbradley
@@ -21,8 +22,10 @@ eandersson
 eb3095
 emmanuelthome
 esposem
+GabrielNagy
 giggsoff
 hamalq
+impl
 irishgordo
 izzyleung
 johnsonshi


### PR DESCRIPTION
This change adds myself and two Puppet employees, @GabrielNagy and @ciprianbadescu, to the approved CLA signers list in support of #960.

## Proposed Commit Message

```
tools: Add Puppet contributors to CLA signers
```
