### PR TITLE
Change netifaces dependency to 0.10.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,4 @@ jsonschema
 # and still participate in instance-data by gathering the network in detail at
 # runtime and merge that information into the metadata and repersist that to
 # disk.
-netifaces>=0.10.9
+netifaces>=0.10.4


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Change netifaces dependency to 0.10.4

Currently versions Ubuntu <=20.10 use netifaces 0.10.4 By requiring
netifaces 0.10.9, the VMware datasource omitted itself from cloud-init
on Ubuntu <=20.10.

This patch changes the netifaces dependency to 0.10.4. While it is true
there are patches to netifaces post 0.10.4 that are desirable, testing
against the most common network configuration was performed to verify
the VMware datasource will still function with netifaces 0.10.4.
```

## Additional Context
NA

## Test Steps
To verify this patch, two Dockerfiles were created based on Ubuntu 20.04:

**netifaces 0.10.4**

```Dockerfile
FROM ubuntu:20.04

RUN apt-get -y update && \
    apt-get -y --no-install-recommends install \
      ca-certificates \
      curl \
      git \
      python3 \
      python3-configobj \
      python3-distutils \
      python3-requests \
      python3-yaml

RUN mkdir -p /usr/local/src && \
    git clone https://github.com/canonical/cloud-init.git /usr/local/src/cloud-init

RUN apt-get -y --no-install-recommends install python3-netifaces

WORKDIR /usr/local/src/cloud-init

ENV PYTHONPATH=/usr/local/src/cloud-init

CMD [ "/usr/local/src/cloud-init/cloudinit/sources/DataSourceVMware.py" ]
ENTRYPOINT [ "/usr/bin/python3" ]
```

**netifaces 0.10.9**

```Dockerfile
FROM ubuntu:20.04

RUN apt-get -y update && \
    apt-get -y --no-install-recommends install \
      ca-certificates \
      curl \
      git \
      python3 \
      python3-configobj \
      python3-distutils \
      python3-requests \
      python3-yaml

RUN mkdir -p /usr/local/src && \
    git clone https://github.com/canonical/cloud-init.git /usr/local/src/cloud-init

RUN apt-get -y install python3-pip && pip3 install 'netifaces == 0.10.9'

WORKDIR /usr/local/src/cloud-init

ENV PYTHONPATH=/usr/local/src/cloud-init

CMD [ "/usr/local/src/cloud-init/cloudinit/sources/DataSourceVMware.py" ]
ENTRYPOINT [ "/usr/bin/python3" ]
```

The two Dockerfiles were built with the following commands:

```bash
docker build -t cloud-init-netifaces-0.10.4 \
             -f Dockerfile.Ubuntu-20.04-Netifaces-0.10.4 . && \
docker build -t cloud-init-netifaces-0.10.9 \
             -f Dockerfile.Ubuntu-20.04-Netifaces-0.10.9 .
```

The following command was used to prove there is no distinguishable difference in the output for the datasource using the different versions of netifaces against a single IPv4 address on a single device:

```bash
diff -I '"local-ipv4":' \
     -I '"addr":' \
     -I '"[[:digit:]]\{1,3\}.[[:digit:]]\{1,3\}.[[:digit:]]\{1,3\}.[[:digit:]]\{1,3\}":' \
  <(docker run --rm \
               --hostname netifaces \
               --mac-address 12:34:56:78:9a:bc \
               docker.io/library/cloud-init-netifaces-0.10.4 2>/dev/null) \
  <(docker run --rm \
               --hostname netifaces \
               --mac-address 12:34:56:78:9a:bc \
               docker.io/library/cloud-init-netifaces-0.10.9 2>/dev/null)
```

Finally, the following series of commands validates netifaces 0.10.4 against a container with multiple network interfaces:

```bash
docker network create --subnet=172.19.0.0/16 netifaces

docker create \
  --hostname netifaces \
  --network bridge \
  --name netifaces-0.10.4 \
  docker.io/library/cloud-init-netifaces-0.10.4 && \
docker network connect netifaces netifaces-0.10.4

docker create \
  --hostname netifaces \
  --network bridge \
  --name netifaces-0.10.9 \
  docker.io/library/cloud-init-netifaces-0.10.9 && \
docker network connect netifaces netifaces-0.10.9

diff -I '"local-ipv4":' \
     -I '"addr":' \
     -I '"mac":' \
     -I '"[[:digit:]]\{1,3\}.[[:digit:]]\{1,3\}.[[:digit:]]\{1,3\}.[[:digit:]]\{1,3\}":' \
     -I '"[[:alnum:]]\{2\}:[[:alnum:]]\{2\}:[[:alnum:]]\{2\}:[[:alnum:]]\{2\}:[[:alnum:]]\{2\}:[[:alnum:]]\{2\}":' \
  <(docker start -a netifaces-0.10.4 2>/dev/null) \
  <(docker start -a netifaces-0.10.9 2>/dev/null)

docker stop netifaces-0.10.4 netifaces-0.10.9 && \
docker rm netifaces-0.10.4 netifaces-0.10.9
```

While this is not all of the possible network configurations, they are the most common, and it is better to have the VMware datasource on Ubuntu 20.04 with netifaces 0.10.4 than not have the datasource at all.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
