### PR TITLE
 Update dscheck_VMware's rpctool check

### DIFF
--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -141,6 +141,7 @@ error() {
     debug 0 "$@"
     stderr "$@"
 }
+
 warn() {
     set -- "WARN:" "$@"
     debug 0 "$@"
@@ -344,7 +345,6 @@ geom_label_status_as() {
     return $ret
 }
 
-
 read_fs_info_freebsd() {
     local oifs="$IFS" line="" delim=","
     local ret=0 labels="" dev="" label="" ftype="" isodevs=""
@@ -404,7 +404,6 @@ cached() {
     [ -n "$1" ] && _RET="$1" && return || return 1
 }
 
-
 detect_virt() {
     local virt="${UNAVAILABLE}" r="" out=""
     if [ -d /run/systemd ]; then
@@ -450,7 +449,7 @@ detect_virt() {
 read_virt() {
     cached "$DI_VIRT" && return 0
     detect_virt
-    DI_VIRT=${_RET}
+    DI_VIRT="$(echo "${_RET}" | tr '[:upper:]' '[:lower:]')"
 }
 
 is_container() {
@@ -1384,16 +1383,20 @@ vmware_has_rpctool() {
     command -v vmware-rpctool >/dev/null 2>&1
 }
 
+vmware_rpctool_guestinfo() {
+    vmware-rpctool "info-get guestinfo.${1}" 2>/dev/null | grep "[[:alnum:]]"
+}
+
 vmware_rpctool_guestinfo_metadata() {
-    vmware-rpctool "info-get guestinfo.metadata"
+    vmware_rpctool_guestinfo "metadata"
 }
 
 vmware_rpctool_guestinfo_userdata() {
-    vmware-rpctool "info-get guestinfo.userdata"
+    vmware_rpctool_guestinfo "userdata"
 }
 
 vmware_rpctool_guestinfo_vendordata() {
-    vmware-rpctool "info-get guestinfo.vendordata"
+    vmware_rpctool_guestinfo "vendordata"
 }
 
 dscheck_VMware() {


### PR DESCRIPTION
Other minor tweaks.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>

## Proposed Commit Message
Update dscheck_VMware's rpctool check

```
Update dscheck_VMware's rpctool check

This patch updates the dscheck_VMware function's use of "vmware-rpctool".

When checking to see if a "guestinfo" property is set.
Because a successful exit code can occur even if there is an empty
string returned, it is possible that the VMware datasource will be
loaded as a false-positive. This patch ensures that in addition to
validating the exit code, the emitted output is also examined to ensure
a non-empty value is returned by rpctool before returning "${DS_FOUND}"
from "dscheck_VMware()".

Other minor tweaks in ds-identify script.
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
