### PR TITLE
Replace broken httpretty tests with mock (SC-324)

### DIFF
--- a/tests/unittests/test_handler/test_handler_puppet.py
+++ b/tests/unittests/test_handler/test_handler_puppet.py
@@ -5,7 +5,6 @@ from cloudinit.sources import DataSourceNone
 from cloudinit import (distros, helpers, cloud, util)
 from cloudinit.tests.helpers import CiTestCase, HttprettyTestCase, mock
 
-import httpretty
 import logging
 import textwrap
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Replace broken httpretty tests with mock

Certain versions of python/httpretty don't work correctly using https
URIs. #960 recently added httpretty tests using https. This commit
replaces the httpretty tests that were failing on https with mocks of
readurl instead.

```

## Additional Context
This was found by running `packages/bddeb` on main.

The [root cause](https://github.com/gabrielfalcao/HTTPretty/issues/242) has been open for 6 years now (and has affected other parts of the code base), so we may want to migrate to [responses](https://github.com/getsentry/responses) at some point in the future.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
