### PR TITLE
Revert unnecesary lcase in ds-identify

### DIFF
--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -449,7 +449,7 @@ detect_virt() {
 read_virt() {
     cached "$DI_VIRT" && return 0
     detect_virt
-    DI_VIRT="$(echo "${_RET}" | tr '[:upper:]' '[:lower:]')"
+    DI_VIRT="${_RET}"
 }
 
 is_container() {


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Revert unnecesary lcase in ds-identify

This patch reverts an unnecessary lcase optimization in the
ds-identify script. SystemD documents the values produced by
the systemd-detect-virt command are lower case, and the mapping
table used by the FreeBSD check is also lower-case.

The optimization added two new forked processes, needlessly
causing overhead.
```

## Additional Context
Please see https://github.com/canonical/cloud-init/pull/970#discussion_r688621314 for more information.

cc @smoser 

## Test Steps
```bash
$ make clean_pyc && PYTHONPATH="$(pwd)" python3 -m pytest -v tests/unittests/test_ds_identify.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
