### PR TITLE
cc_update_etc_hosts: Use the distribution-defined path for the hosts file

### DIFF
--- a/cloudinit/config/cc_update_etc_hosts.py
+++ b/cloudinit/config/cc_update_etc_hosts.py
@@ -9,27 +9,28 @@
 """
 Update Etc Hosts
 ----------------
-**Summary:** update ``/etc/hosts``
+**Summary:** update the hosts file (usually ``/etc/hosts``)
 
-This module will update the contents of ``/etc/hosts`` based on the
-hostname/fqdn specified in config. Management of ``/etc/hosts`` is controlled
-using ``manage_etc_hosts``. If this is set to false, cloud-init will not manage
-``/etc/hosts`` at all. This is the default behavior.
+This module will update the contents of the local hosts database (hosts file;
+usually ``/etc/hosts``) based on the hostname/fqdn specified in config.
+Management of the hosts file is controlled using ``manage_etc_hosts``. If this
+is set to false, cloud-init will not manage the hosts file at all. This is the
+default behavior.
 
-If set to ``true`` or ``template``, cloud-init will generate ``/etc/hosts``
+If set to ``true`` or ``template``, cloud-init will generate the hosts file
 using the template located in ``/etc/cloud/templates/hosts.tmpl``. In the
 ``/etc/cloud/templates/hosts.tmpl`` template, the strings ``$hostname`` and
 ``$fqdn`` will be replaced with the hostname and fqdn respectively.
 
 If ``manage_etc_hosts`` is set to ``localhost``, then cloud-init will not
-rewrite ``/etc/hosts`` entirely, but rather will ensure that a entry for the
-fqdn with a distribution dependent ip is present in ``/etc/hosts`` (i.e.
-``ping <hostname>`` will ping ``127.0.0.1`` or ``127.0.1.1`` or other ip).
+rewrite the hosts file entirely, but rather will ensure that a entry for the
+fqdn with a distribution dependent ip is present (i.e. ``ping <hostname>`` will
+ping ``127.0.0.1`` or ``127.0.1.1`` or other ip).
 
 .. note::
     if ``manage_etc_hosts`` is set ``true`` or ``template``, the contents
-    of ``/etc/hosts`` will be updated every boot. to make any changes to
-    ``/etc/hosts`` persistant they must be made in
+    of the hosts file will be updated every boot. To make any changes to
+    the hosts file persistent they must be made in
     ``/etc/cloud/templates/hosts.tmpl``
 
 .. note::
@@ -59,6 +60,9 @@ frequency = PER_ALWAYS
 
 def handle(name, cfg, cloud, log, _args):
     manage_hosts = util.get_cfg_option_str(cfg, "manage_etc_hosts", False)
+
+    hosts_fn = cloud.distro.hosts_fn
+
     if util.translate_bool(manage_hosts, addons=['template']):
         (hostname, fqdn) = util.get_hostname_fqdn(cfg, cloud)
         if not hostname:
@@ -74,7 +78,7 @@ def handle(name, cfg, cloud, log, _args):
                                 " found for distro %s") %
                                (cloud.distro.osfamily))
 
-        templater.render_to_file(tpl_fn_name, '/etc/hosts',
+        templater.render_to_file(tpl_fn_name, hosts_fn,
                                  {'hostname': hostname, 'fqdn': fqdn})
 
     elif manage_hosts == "localhost":
@@ -84,10 +88,10 @@ def handle(name, cfg, cloud, log, _args):
                          " but no hostname was found"))
             return
 
-        log.debug("Managing localhost in /etc/hosts")
+        log.debug("Managing localhost in %s", hosts_fn)
         cloud.distro.update_etc_hosts(hostname, fqdn)
     else:
         log.debug(("Configuration option 'manage_etc_hosts' is not set,"
-                   " not managing /etc/hosts in module %s"), name)
+                   " not managing %s in module %s"), hosts_fn, name)
 
 # vi: ts=4 expandtab

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -14,6 +14,7 @@ bmhughes
 candlerb
 cawamata
 ciprianbadescu
+citrus-it
 dankenigsberg
 ddymko
 dermotbradley


### PR DESCRIPTION
## Proposed Commit Message

```
cc_update_etc_hosts: Use the distribution-defined path for the hosts file

The distribution class has a property that specifies the location of
the system hosts file and this can be overridden in subclasses.
While the property is correctly used in distro.update_etc_hosts(), the
update_etc_hosts module does not use it and just assumes '/etc/hosts'

This fixes the module to use the distribution-specific property.
```

## Additional Context
There are still places in the code where the path is assumed to be `/etc/hosts` but this
fixes the update_etc_hosts module.

## Test Steps
I've been using this patch as part of my work to bring in support for the illumos family of operating systems, where the canonical hosts file is `/etc/inet/hosts`

```
2021-08-17 14:07:05,773 - util.py[DEBUG]: Cloud-init v. 21.2 running 'single' at Tue, 17 Aug 2021 14:07:05 +0000. Up 8903.657099246979 seconds.
2021-08-17 14:07:05,776 - stages.py[DEBUG]: Using distro class <class 'cloudinit.distros.omnios.Distro'>
2021-08-17 14:07:05,776 - stages.py[DEBUG]: Running module update_etc_hosts (<module 'cloudinit.config.cc_update_etc_hosts' from '/data/omnios-build/omniosorg/cloud-init/root/usr/lib/python3.9/site-packages/cloudinit/config/cc_update_etc_hosts.py'>) with frequency always
2021-08-17 14:07:05,777 - helpers.py[DEBUG]: Running config-update_etc_hosts using lock (<cloudinit.helpers.DummyLock object at 0xfffffc7fec541c40>)
2021-08-17 14:07:05,777 - util.py[DEBUG]: Reading from /etc/cloud/templates/hosts.illumos.tmpl (quiet=False)
2021-08-17 14:07:05,777 - util.py[DEBUG]: Read 783 bytes from /etc/cloud/templates/hosts.illumos.tmpl
2021-08-17 14:07:05,778 - templater.py[DEBUG]: Rendering content of '/etc/cloud/templates/hosts.illumos.tmpl' using renderer jinja
2021-08-17 14:07:05,785 - util.py[DEBUG]: Writing to /etc/inet/hosts - wb: [644] 455 bytes
2021-08-17 14:07:05,786 - util.py[DEBUG]: cloud-init mode 'single' took 0.191 seconds (0.15)
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
