### PR TITLE
testing: Fix ssh keys integration test

### DIFF
--- a/tests/integration_tests/modules/test_ssh_keysfile.py
+++ b/tests/integration_tests/modules/test_ssh_keysfile.py
@@ -3,6 +3,7 @@ import pytest
 from io import StringIO
 from paramiko.ssh_exception import SSHException
 
+from tests.integration_tests.clouds import ImageSpecification
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import get_test_rsa_keypair
 
@@ -86,9 +87,9 @@ def common_verify(client, expected_keys):
         if user == 'root':
             home_dir = '/root'
             home_perms = '700'
-        client.execute(
+        assert '{} {}'.format(user, home_perms) == client.execute(
             'stat -c "%U %a" {}'.format(home_dir)
-        ).startswith('{} {}'.format(user, home_perms))
+        )
         if client.execute("test -d {}/.ssh".format(home_dir)).ok:
             assert '{} 700'.format(user) == client.execute(
                 'stat -c "%U %a" {}/.ssh'.format(home_dir)

--- a/tests/integration_tests/modules/test_ssh_keysfile.py
+++ b/tests/integration_tests/modules/test_ssh_keysfile.py
@@ -77,13 +77,15 @@ def common_verify(client, expected_keys):
         # Ensure we haven't messed with any /home permissions
         # See LP: #1940233
         home_dir = '/home/{}'.format(user)
-        home_perms = '755'
+        # Home permissions aren't consistent between releases. On ubuntu
+        # this can change to 750 once focal is unsupported.
+        home_perms = '75'
         if user == 'root':
             home_dir = '/root'
             home_perms = '700'
-        assert '{} {}'.format(user, home_perms) == client.execute(
+        client.execute(
             'stat -c "%U %a" {}'.format(home_dir)
-        )
+        ).startswith('{} {}'.format(user, home_perms))
         if client.execute("test -d {}/.ssh".format(home_dir)).ok:
             assert '{} 700'.format(user) == client.execute(
                 'stat -c "%U %a" {}/.ssh'.format(home_dir)

--- a/tests/integration_tests/modules/test_ssh_keysfile.py
+++ b/tests/integration_tests/modules/test_ssh_keysfile.py
@@ -79,7 +79,10 @@ def common_verify(client, expected_keys):
         home_dir = '/home/{}'.format(user)
         # Home permissions aren't consistent between releases. On ubuntu
         # this can change to 750 once focal is unsupported.
-        home_perms = '75'
+        if ImageSpecification.from_os_image().release in ("bionic", "focal"):
+            home_perms = '755'
+        else:
+            home_perms = '750'
         if user == 'root':
             home_dir = '/root'
             home_perms = '700'


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: Fix ssh keys integration test

Home directory permissions changed in hirsute. The integration test
assumed permissions from earlier releases. Test was fixed to take both
permissions into account
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
