### PR TITLE
Azure: Retry dhcp on timeouts when polling reprovisiondata in the nic attach path

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1317,6 +1317,10 @@ class DataSourceAzure(sources.DataSource):
             except UrlError:
                 # Teardown our EphemeralDHCPv4 context on failure as we retry
                 self._ephemeral_dhcp_ctx.clean_network()
+
+                # Also reset this flag which determines if we should do dhcp
+                # during retries.
+                is_ephemeral_ctx_present = False
             finally:
                 if nl_sock:
                     nl_sock.close()


### PR DESCRIPTION

## Proposed Commit Message
Azure: Retry dhcp on timeouts when polling reprovisiondata in the nic attach path

```
In the nic attach path, we skip doing dhcp since we already did it when bringing the interface up.

However when polling for reprovisiondata, it is possible for the request to timeout due to platform issues.

In those cases we still need to do dhcp and try again since we tear down the context. We can only skip the first dhcp attempt.
```

## Test Steps
- Create savable PPS VMs (internal to Azure)
- Reuse the PPS VM to exercise the nic hot attach path
- In rare cases, the first attempt to get reprovisiondata might timeout. Without this fix, cloud-init would tear down the dhcp and all retry attempts since then would fail with network unreachable error. With this fix, dhcp is retried and the polling continues.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
