### PR TITLE
Add retries to DataSourceGCE.py when connecting to GCE

### DIFF
--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -29,6 +29,8 @@ class GoogleMetadataFetcher(object):
 
     def __init__(self, metadata_address):
         self.metadata_address = metadata_address
+        self.retries = 5
+        self.sec_between_retries = 1
 
     def get_value(self, path, is_text, is_recursive=False):
         value = None
@@ -36,7 +38,9 @@ class GoogleMetadataFetcher(object):
             url = self.metadata_address + path
             if is_recursive:
                 url += '/?recursive=True'
-            resp = url_helper.readurl(url=url, headers=HEADERS)
+            resp = url_helper.readurl(url=url, headers=HEADERS,
+                                      retries=self.retries,
+                                      sec_between=self.sec_between_retries)
         except url_helper.UrlError as exc:
             msg = "url %s raised exception %s"
             LOG.debug(msg, path, exc)


### PR DESCRIPTION
## Proposed Commit Message
Add retries to DataSourceGCE.py when connecting to GCE
```
summary: 

Add retries to DatasourceGCE when connecting to GCE. Sometimes when the trying to fetch the metadata, the cloud-init fails and the fallback datasource NoCloud is used which is not expected. So adding retries to ensure loading of the data source. 

```

## Additional Context
<!-- If relevant -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
