### PR TITLE
Set Azure to only update metadata on BOOT_NEW_INSTANCE (SC-386)

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -339,13 +339,6 @@ def temporary_hostname(temp_hostname, cfg, hostname_command='hostname'):
 class DataSourceAzure(sources.DataSource):
 
     dsname = 'Azure'
-    # Regenerate network config new_instance boot and every boot
-    default_update_events = {EventScope.NETWORK: {
-        EventType.BOOT_NEW_INSTANCE,
-        EventType.BOOT,
-        EventType.BOOT_LEGACY
-    }}
-
     _negotiated = False
     _metadata_imds = sources.UNSET
     _ci_pkl_version = 1

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -22,7 +22,7 @@ import requests
 from cloudinit import dmi
 from cloudinit import log as logging
 from cloudinit import net
-from cloudinit.event import EventScope, EventType
+from cloudinit.event import EventType
 from cloudinit.net import device_driver
 from cloudinit.net.dhcp import EphemeralDHCPv4
 from cloudinit import sources


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Set Azure to only update metadata on BOOT_NEW_INSTANCE

In #834, we refactored the handling of events for fetching new metadata.
Previously, in Azure's __init__, the BOOT event was added to the
update_events, so it was assumed that Azure required the standard BOOT
behavior, which is to apply metadata twice every boot: once during
local-init, then again during standard init phase.
https://github.com/canonical/cloud-init/blob/21.2/cloudinit/sources/DataSourceAzure.py#L356

However, this line was effectively meaningless. After the metadata was
fetched in local-init, it was then pickled out to disk. Because
"update_events" was a class variable, the EventType.BOOT was not
persisted into the pickle. When the pickle was then unpickled in the
init phase, metadata did not get re-fetched because EventType.BOOT was
not present, so Azure is effectely only BOOT_NEW_INSTANCE.

Fetching metadata twice during boot causes some issue for
pre-provisioning on Azure because updating metadata during
re-provisioning will cause cloud-init to poll for reprovisiondata again
in DataSourceAzure, which will infinitely return 404(reprovisiondata
is deleted from IMDS after health signal was sent by cloud-init during
init-local). This makes cloud-init stuck in 'init'
```

## Additional Context
Note that the default update events are defined [in the base class](https://github.com/canonical/cloud-init/blob/main/cloudinit/sources/__init__.py#L198), so Azure doesn't need a separate definition here.

Found by Azure during SRU testing.

## Test Steps
Run the updated integration test.

Additionally, manually verified with:
```
DEB_BUILD_OPTIONS=nocheck packages/bddeb -d
scp cloud-init_all.deb <launched_azure_instance>:/tmp/cloud-init.deb
ssh ubuntu@<azure_instance>
sudo dpkg -i /tmp/cloud-init.deb
cloud-init clean --reboot --logs
ssh ubuntu@<azure_instance>
```
Examine `/var/log/cloud-init.log` and verify `Applying network configuration` appears exactly once, then later we see:
```
Event Denied: scopes=['network'] EventType=boot-legacy
No network config applied. Neither a new instance nor datasource network update allowed
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
