### PR TITLE
ssh_utils.py: ignore when sshd_config options are not key/value pairs

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -484,7 +484,13 @@ def parse_ssh_config_lines(lines):
         try:
             key, val = line.split(None, 1)
         except ValueError:
-            key, val = line.split('=', 1)
+            try:
+                key, val = line.split('=', 1)
+            except ValueError:
+                LOG.debug(
+                    "sshd_config: option \"%s\" has no key/value pair,"
+                    " skipping it", line)
+                continue
         ret.append(SshdConfigLine(line, key, val))
     return ret
 

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -525,6 +525,14 @@ class TestUpdateSshConfigLines(test_helpers.CiTestCase):
         self.assertEqual([self.pwauth], result)
         self.check_line(lines[-1], self.pwauth, "no")
 
+    def test_option_without_value(self):
+        """Implementation only accepts key-value pairs."""
+        extended_exlines = self.exlines.copy()
+        denyusers_opt = "DenyUsers"
+        extended_exlines.append(denyusers_opt)
+        lines = ssh_util.parse_ssh_config_lines(list(extended_exlines))
+        self.assertNotIn(denyusers_opt, str(lines))
+
     def test_single_option_updated(self):
         """A single update should have change made and line updated."""
         opt, val = ("UsePAM", "no")


### PR DESCRIPTION


## Proposed Commit Message
As specified in #LP 1845552,
In cloudinit/ssh_util.py, in parse_ssh_config_lines(), we attempt to
parse each line of sshd_config. This function expects each line to
be one of the following forms:

    # comment
    key value
    key=value

However, options like DenyGroups and DenyUsers are specified to
**optionally** accepts values in sshd_config.
Cloud-init should comply to this and skip the option if a value
is not provided.

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>

LP: #1845552
RHBZ:#1862933

## Test Steps
Add the following line(s) to sshd_config
```
DenyUsers
DenyGroups
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
