### PR TITLE
cc_ssh: handle race between cloud-init and sshd-keygen

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -241,10 +241,15 @@ def handle(_name, cfg, cloud, log, _args):
                     out, err = subp.subp(cmd, capture=True, env=lang_c)
                     sys.stdout.write(util.decode_binary(out))
                 except subp.ProcessExecutionError as e:
+                    out = util.decode_binary(e.stdout).lower()
                     err = util.decode_binary(e.stderr).lower()
                     if (e.exit_code == 1 and
                             err.lower().startswith("unknown key")):
                         log.debug("ssh-keygen: unknown key type '%s'", keytype)
+                    elif (e.exit_code == 1 and
+                            ("%s already exists." % keyfile) in out):
+                        log.debug("ssh-keygen: key concurrently created by "
+                                  "sshd-keygen.service. Ignoring key.")
                     else:
                         util.logexc(log, "Failed generating key type %s to "
                                     "file %s", keytype, keyfile)


### PR DESCRIPTION


## Proposed Commit Message
It looks like that at least in AWS RHEL 9 images there is
a race between cloud-init and sshd-keygen.
In particular, they both create `/etc/ssh/ssh_host_*key*`
at first boot, causing sometimes warning in cloud-init:
```
cloudinit.subp.ProcessExecutionError: Unexpected error while running command.
Command: ['ssh-keygen', '-t', 'rsa', '-N', '', '-f', '/etc/ssh/ssh_host_rsa_key']
Exit code: 1
Reason: -
Stdout: Generating public/private rsa key pair.
        /etc/ssh/ssh_host_rsa_key already exists.
        Overwrite (y/n)?
Stderr:
```

This is not a critical issue, as a new key is created anyways, either by cloud-init or by sshd.

What happens is:
1) cloud-init checks if /etc/ssh/ssh_host_rsa_key exist
2) it does not exist, so it continues the logic in cc_ssh line 234
3) sshd-keygen in the meanwhile creates /etc/ssh/ssh_host_rsa_key
4) cloud-init issues `ssh-keygen -t rsa -N '' -f /etc/ssh/ssh_host_rsa_key`,
   failing

Masking the service with `systemctl mask sshd-keygen.target` fixes
the bug, but it is not the right solution.

The solution proposed here is to just analyze the error and
avoid throwing a warning if the file has been created in the meanwhile.

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>
RHBZ: 2002492



## Test Steps
```
# rm -rf /etc/ssh/ssh_host_rsa_key*
# cloud-init clean
# reboot
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
