### PR TITLE
Update IPv6 entries in /etc/hosts

### DIFF
--- a/templates/hosts.debian.tmpl
+++ b/templates/hosts.debian.tmpl
@@ -17,10 +17,7 @@ you need to add the following to config:
 127.0.0.1 localhost
 
 # The following lines are desirable for IPv6 capable hosts
-::1 ip6-localhost ip6-loopback
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
+::1 localhost ip6-localhost ip6-loopback
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
-ff02::3 ip6-allhosts
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -53,6 +53,7 @@ omBratteng
 onitake
 qubidt
 renanrodrigo
+rhansen
 riedel
 sarahwzadara
 slyon


### PR DESCRIPTION
## Proposed Commit Message

```
Update IPv6 entries in /etc/hosts

Add IPv6 localhost (::1) entry. See:
https://salsa.debian.org/installer-team/netcfg/-/blob/1767c9264e04652b9150ffc7b25568e4ea6b2bdd/netcfg.h#L42
https://salsa.debian.org/md/netbase/-/blob/9de8afcad482418cc4956dc09bbf6a2e8624d574/debian/netbase.postinst#L8

Also remove ip6-localnet, ip6-mcastprefix, and ip6-allhosts. See:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=499800
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=688090

LP: #1943798
```

## Test Steps

`pytest-3`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly

cc @dseomn