### PR TITLE
docs: fix typo and include sudo for report bugs commands

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -17,7 +17,7 @@ keys.
 Authorized Keys
 ^^^^^^^^^^^^^^^
 
-Authorized keys are a list of public SSH keys that are allowed to connect to a
+Authorized keys are a list of public SSH keys that are allowed to connect to
 a user account on a system. They are stored in `.ssh/authorized_keys` in that
 account's home directory. Authorized keys for the default user defined in
 ``users`` can be specified using ``ssh_authorized_keys``. Keys

--- a/doc/rtd/topics/bugs.rst
+++ b/doc/rtd/topics/bugs.rst
@@ -17,7 +17,7 @@ To aid in debugging, please collect the necessary logs. To do so, run the
 
 .. code-block:: shell-session
 
-  $ cloud-init collect-logs
+  $ sudo cloud-init collect-logs
   Wrote /home/ubuntu/cloud-init.tar.gz
 
 If your version of cloud-init does not have the  `collect-logs` subcommand,
@@ -25,7 +25,7 @@ then please manually collect the base log files by doing the following:
 
 .. code-block:: shell-session
 
-  $ dmesg > dmesg.txt
+  $ sudo dmesg > dmesg.txt
   $ sudo journalctl -o short-precise > journal.txt
   $ sudo tar -cvf cloud-init.tar dmesg.txt journal.txt /run/cloud-init \
       /var/log/cloud-init.log /var/log/cloud-init-output.log


### PR DESCRIPTION
Remove a duplicate "a" in the docs, and change the bug reporting documentation to tell users to run the commands with sudo.

LP: #1940236

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
