### PR TITLE
Set Azure to apply networking config every BOOT

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -22,7 +22,7 @@ import requests
 from cloudinit import dmi
 from cloudinit import log as logging
 from cloudinit import net
-from cloudinit.event import EventType
+from cloudinit.event import EventScope, EventType
 from cloudinit.net import device_driver
 from cloudinit.net.dhcp import EphemeralDHCPv4
 from cloudinit import sources
@@ -339,6 +339,10 @@ def temporary_hostname(temp_hostname, cfg, hostname_command='hostname'):
 class DataSourceAzure(sources.DataSource):
 
     dsname = 'Azure'
+    default_update_events = {EventScope.NETWORK: {
+        EventType.BOOT_NEW_INSTANCE,
+        EventType.BOOT,
+    }}
     _negotiated = False
     _metadata_imds = sources.UNSET
     _ci_pkl_version = 1

--- a/tests/integration_tests/modules/test_user_events.py
+++ b/tests/integration_tests/modules/test_user_events.py
@@ -31,8 +31,6 @@ def _add_dummy_bridge_to_netplan(client: IntegrationInstance):
 @pytest.mark.gce
 @pytest.mark.oci
 @pytest.mark.openstack
-@pytest.mark.azure
-@pytest.mark.not_xenial
 def test_boot_event_disabled_by_default(client: IntegrationInstance):
     log = client.read_from_file('/var/log/cloud-init.log')
     if 'network config is disabled' in log:
@@ -77,7 +75,7 @@ def _test_network_config_applied_on_reboot(client: IntegrationInstance):
     assert 'dummy0' not in client.execute('ls /sys/class/net')
 
     _add_dummy_bridge_to_netplan(client)
-    client.execute('rm /var/log/cloud-init.log')
+    client.execute('echo "" > /var/log/cloud-init.log')
     client.restart()
 
     log = client.read_from_file('/var/log/cloud-init.log')
@@ -92,6 +90,11 @@ def _test_network_config_applied_on_reboot(client: IntegrationInstance):
     assert 'dummy0' not in client.execute('ls /sys/class/net')
 
 
+@pytest.mark.azure
+def test_boot_event_enabled_by_default(client: IntegrationInstance):
+    _test_network_config_applied_on_reboot(client)
+
+
 USER_DATA = """\
 #cloud-config
 updates:
@@ -100,7 +103,6 @@ updates:
 """
 
 
-@pytest.mark.not_xenial
 @pytest.mark.user_data(USER_DATA)
 def test_boot_event_enabled(client: IntegrationInstance):
     _test_network_config_applied_on_reboot(client)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Set Azure to apply networking config every BOOT

In #1006, we set Azure to apply networking config every
BOOT_NEW_INSTANCE because the BOOT_LEGACY option was causing problems
applying networking the second time per boot. However,
BOOT_NEW_INSTANCE is also wrong as Azure needs to apply networking
once per boot, during init-local phase.
```

## Additional Context
<!-- If relevant -->

## Test Steps
Run integration test

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
