### PR TITLE
tox: bump the pinned flake8 and pylint version (SC-422)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,8 +24,9 @@ jobs=4
 # W0631(undefined-loop-variable)
 # W0703(broad-except)
 # W1401(anomalous-backslash-in-string)
+# W1514(unspecified-encoding)
 
-disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401
+disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401, W1514
 
 
 [REPORTS]

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -137,8 +137,8 @@ class HyperVKvpReportingHandler(ReportingHandler):
         self._event_types = event_types
         self.q = queue.Queue()
         self.incarnation_no = self._get_incarnation_no()
-        self.event_key_prefix = u"{0}|{1}".format(self.EVENT_PREFIX,
-                                                  self.incarnation_no)
+        self.event_key_prefix = "{0}|{1}".format(self.EVENT_PREFIX,
+                                                 self.incarnation_no)
         self.publish_thread = threading.Thread(
             target=self._publish_event_routine
         )
@@ -200,9 +200,9 @@ class HyperVKvpReportingHandler(ReportingHandler):
         CLOUD_INIT|<incarnation number>|<event_type>|<event_name>|<uuid>
         [|subevent_index]
         """
-        return u"{0}|{1}|{2}|{3}".format(self.event_key_prefix,
-                                         event.event_type, event.name,
-                                         uuid.uuid4())
+        return "{0}|{1}|{2}|{3}".format(self.event_key_prefix,
+                                        event.event_type, event.name,
+                                        uuid.uuid4())
 
     def _encode_kvp_item(self, key, value):
         data = struct.pack(

--- a/cloudinit/safeyaml.py
+++ b/cloudinit/safeyaml.py
@@ -15,7 +15,7 @@ class _CustomSafeLoader(yaml.SafeLoader):
 
 
 _CustomSafeLoader.add_constructor(
-    u'tag:yaml.org,2002:python/unicode',
+    'tag:yaml.org,2002:python/unicode',
     _CustomSafeLoader.construct_python_unicode)
 
 

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -247,7 +247,7 @@ def _quick_read_instance_id(dirs=None):
         try:
             data = util.pathprefix2dict(d, required=['meta-data'])
             md = util.load_yaml(data['meta-data'])
-            if iid_key in md:
+            if md and iid_key in md:
                 return md[iid_key]
         except ValueError:
             pass

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -36,14 +36,14 @@ from cloudinit import util
 LOG = logging.getLogger(__name__)
 TYPE_MATCHER = re.compile(r"##\s*template:(.*)", re.I)
 BASIC_MATCHER = re.compile(r'\$\{([A-Za-z0-9_.]+)\}|\$([A-Za-z0-9_.]+)')
-MISSING_JINJA_PREFIX = u'CI_MISSING_JINJA_VAR/'
+MISSING_JINJA_PREFIX = 'CI_MISSING_JINJA_VAR/'
 
 
 class UndefinedJinjaVariable(JUndefined):
     """Class used to represent any undefined jinja template variable."""
 
     def __str__(self):
-        return u'%s%s' % (MISSING_JINJA_PREFIX, self._undefined_name)
+        return '%s%s' % (MISSING_JINJA_PREFIX, self._undefined_name)
 
     def __sub__(self, other):
         other = str(other).replace(MISSING_JINJA_PREFIX, '')

--- a/cloudinit/tests/test_subp.py
+++ b/cloudinit/tests/test_subp.py
@@ -91,8 +91,8 @@ class TestSubp(CiTestCase):
         tmp_file = self.tmp_path('test.out')
         cmd = 'echo HI MOM >> {tmp_file}'.format(tmp_file=tmp_file)
         (out, _err) = subp.subp(cmd.encode('utf-8'), shell=True)
-        self.assertEqual(u'', out)
-        self.assertEqual(u'', _err)
+        self.assertEqual('', out)
+        self.assertEqual('', _err)
         self.assertEqual('HI MOM\n', util.load_file(tmp_file))
 
     def test_subp_handles_strings(self):
@@ -100,8 +100,8 @@ class TestSubp(CiTestCase):
         tmp_file = self.tmp_path('test.out')
         cmd = 'echo HI MOM >> {tmp_file}'.format(tmp_file=tmp_file)
         (out, _err) = subp.subp(cmd, shell=True)
-        self.assertEqual(u'', out)
-        self.assertEqual(u'', _err)
+        self.assertEqual('', out)
+        self.assertEqual('', _err)
         self.assertEqual('HI MOM\n', util.load_file(tmp_file))
 
     def test_subp_handles_utf8(self):

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -912,13 +912,13 @@ scbus-1 on xpt0 bus 0
             'PreprovisionedVMType': None,
             'PreprovisionedVm': False,
             'datasource': {'Azure': {'agent_command': 'my_command'}},
-            'system_info': {'default_user': {'name': u'myuser'}}}
+            'system_info': {'default_user': {'name': 'myuser'}}}
         expected_metadata = {
             'azure_data': {
                 'configurationsettype': 'LinuxProvisioningConfiguration'},
             'imds': NETWORK_METADATA,
             'instance-id': EXAMPLE_UUID,
-            'local-hostname': u'myhost',
+            'local-hostname': 'myhost',
             'random_seed': 'wild'}
 
         crawled_metadata = dsrc.crawl_metadata()
@@ -1385,7 +1385,7 @@ scbus-1 on xpt0 bus 0
 
     def test_ovf_can_include_unicode(self):
         xml = construct_valid_ovf_env(data={})
-        xml = u'\ufeff{0}'.format(xml)
+        xml = '\ufeff{0}'.format(xml)
         dsrc = self._get_ds({'ovfcontent': xml})
         dsrc.get_data()
 

--- a/tests/unittests/test_datasource/test_configdrive.py
+++ b/tests/unittests/test_datasource/test_configdrive.py
@@ -15,7 +15,7 @@ from cloudinit import util
 from cloudinit.tests.helpers import CiTestCase, ExitStack, mock, populate_dir
 
 
-PUBKEY = u'ssh-rsa AAAAB3NzaC1....sIkJhq8wdX+4I3A4cYbYP ubuntu@server-460\n'
+PUBKEY = 'ssh-rsa AAAAB3NzaC1....sIkJhq8wdX+4I3A4cYbYP ubuntu@server-460\n'
 EC2_META = {
     'ami-id': 'ami-00000001',
     'ami-launch-index': 0,

--- a/tests/unittests/test_datasource/test_openstack.py
+++ b/tests/unittests/test_datasource/test_openstack.py
@@ -21,7 +21,7 @@ from cloudinit.sources.helpers import openstack
 from cloudinit import util
 
 BASE_URL = "http://169.254.169.254"
-PUBKEY = u'ssh-rsa AAAAB3NzaC1....sIkJhq8wdX+4I3A4cYbYP ubuntu@server-460\n'
+PUBKEY = 'ssh-rsa AAAAB3NzaC1....sIkJhq8wdX+4I3A4cYbYP ubuntu@server-460\n'
 EC2_META = {
     'ami-id': 'ami-00000001',
     'ami-launch-index': '0',

--- a/tests/unittests/test_datasource/test_scaleway.py
+++ b/tests/unittests/test_datasource/test_scaleway.py
@@ -209,9 +209,9 @@ class TestDataSourceScaleway(HttprettyTestCase):
         self.assertEqual(self.datasource.get_instance_id(),
                          MetadataResponses.FAKE_METADATA['id'])
         self.assertEqual(self.datasource.get_public_ssh_keys().sort(), [
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABCCCCC',
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABDDDDD',
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABCCCCC',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABDDDDD',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA',
         ].sort())
         self.assertEqual(self.datasource.get_hostname(),
                          MetadataResponses.FAKE_METADATA['hostname'])
@@ -242,8 +242,8 @@ class TestDataSourceScaleway(HttprettyTestCase):
         ]
         self.datasource.metadata['ssh_public_keys'] = []
         self.assertEqual(self.datasource.get_public_ssh_keys().sort(), [
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABDDDDD',
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABCCCCC',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABDDDDD',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABCCCCC',
         ].sort())
 
     def test_ssh_keys_only_conf(self):
@@ -260,9 +260,9 @@ class TestDataSourceScaleway(HttprettyTestCase):
             'fingerprint': '2048 06:ff:...  login2 (RSA)'
         }]
         self.assertEqual(self.datasource.get_public_ssh_keys().sort(), [
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABCCCCC',
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABDDDDD',
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABCCCCC',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABDDDDD',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA',
         ].sort())
 
     def test_ssh_keys_both(self):
@@ -282,9 +282,9 @@ class TestDataSourceScaleway(HttprettyTestCase):
             'fingerprint': '2048 06:ff:...  login2 (RSA)'
         }]
         self.assertEqual(self.datasource.get_public_ssh_keys().sort(), [
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABCCCCC',
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABDDDDD',
-            u'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABCCCCC',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABDDDDD',
+            'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABA',
         ].sort())
 
     @mock.patch('cloudinit.sources.DataSourceScaleway.EphemeralDHCPv4')

--- a/tests/unittests/test_handler/test_handler_apt_source_v3.py
+++ b/tests/unittests/test_handler/test_handler_apt_source_v3.py
@@ -26,7 +26,7 @@ from cloudinit.sources import DataSourceNone
 
 from cloudinit.tests import helpers as t_help
 
-EXPECTEDKEY = u"""-----BEGIN PGP PUBLIC KEY BLOCK-----
+EXPECTEDKEY = """-----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
 
 mI0ESuZLUgEEAKkqq3idtFP7g9hzOu1a8+v8ImawQN4TrvlygfScMU1TIS1eC7UQ

--- a/tests/unittests/test_handler/test_handler_debug.py
+++ b/tests/unittests/test_handler/test_handler_debug.py
@@ -41,7 +41,7 @@ class TestDebug(FilesystemMockingTestCase):
         m_locale.return_value = 'en_US.UTF-8'
         cfg = {
             'abc': '123',
-            'c': u'\u20a0',
+            'c': '\u20a0',
             'debug': {
                 'verbose': True,
                 # Does not actually write here due to mocking...

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -604,7 +604,7 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
 class TestMessageFromString(helpers.TestCase):
 
     def test_unicode_not_messed_up(self):
-        roundtripped = util.message_from_string(u'\n').as_string()
+        roundtripped = util.message_from_string('\n').as_string()
         self.assertNotIn('\x00', roundtripped)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ passenv=
 [testenv:flake8]
 basepython = python3
 deps =
-    flake8==3.8.2
+    flake8==3.9.2
 commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/ setup.py}
 
 # https://github.com/gabrielfalcao/HTTPretty/issues/223
@@ -23,7 +23,7 @@ setenv =
 basepython = python3
 deps =
     # requirements
-    pylint==2.9.3
+    pylint==2.11.1
     # test-requirements because unit tests are now present in cloudinit tree
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tox: bump the pinned flake8 and pylint version

* pylint: fix W1406 (redundant-u-string-prefix)

The u prefix for strings is no longer necessary in Python >=3.0.

* pylint: disable W1514 (unspecified-encoding)
    
From https://www.python.org/dev/peps/pep-0597/ (Python 3.10):
    
The new warning stems form https://www.python.org/dev/peps/pep-0597,
which says:
    
  Developers using macOS or Linux may forget that the default encoding
  is not always UTF-8. [...] Even Python experts may assume that the
  default encoding is UTF-8. This creates bugs that only happen on Windows.
    
The warning could be fixed by always specifying encoding='utf-8',
however we should be careful to not break environments which are not
utf-8 (or explicitly state that only utf-8 is supported). Let's silence
the warning for now.

* _quick_read_instance_id: cover the case where load_yaml() returns None

Spotted by pylint:
 - E1135 (unsupported-membership-test)
 - E1136 (unsubscriptable-object)

LP: #1944414
```

## Additional Context
<!-- If relevant -->

Spotted by the `cloud-init-style-tip` Jenkins job.

## Test Steps

Reproduce with: `tox -e tip-pylint`. Test this branch by just running `tox` from it.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
