### PR TITLE
Remove invalid ssh_import_id from examples

### DIFF
--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -20,14 +20,18 @@ users:
     groups: users
     selinux_user: staff_u
     expiredate: '2032-09-01'
-    ssh_import_id: <Launchpad/Github id>
+    ssh_import_id:
+      - lp:falcojr
+      - gh:TheRealFalcon
     lock_passwd: false
     passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
   - name: barfoo
     gecos: Bar B. Foo
     sudo: ALL=(ALL) NOPASSWD:ALL
     groups: users, admin
-    ssh_import_id: <Launchdpad/Github id>
+    ssh_import_id:
+      - lp:falcojr
+      - gh:TheRealFalcon
     lock_passwd: true
     ssh_authorized_keys:
       - <ssh pub key 1>

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -20,14 +20,14 @@ users:
     groups: users
     selinux_user: staff_u
     expiredate: '2032-09-01'
-    ssh_import_id: foobar
+    ssh_import_id: <Launchpad/Github id>
     lock_passwd: false
     passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
   - name: barfoo
     gecos: Bar B. Foo
     sudo: ALL=(ALL) NOPASSWD:ALL
     groups: users, admin
-    ssh_import_id: None
+    ssh_import_id: <Launchdpad/Github id>
     lock_passwd: true
     ssh_authorized_keys:
       - <ssh pub key 1>

--- a/doc/rtd/topics/datasources/vmware.rst
+++ b/doc/rtd/topics/datasources/vmware.rst
@@ -236,7 +236,6 @@ this datasource:
            primary_group: akutz
            sudo: ALL=(ALL) NOPASSWD:ALL
            groups: sudo, wheel
-           ssh_import_id: None
            lock_passwd: true
            ssh_authorized_keys:
            - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDE0c5FczvcGSh/tG4iw+Fhfi/O5/EvUM/96js65tly4++YTXK1d9jcznPS5ruDlbIZ30oveCBd3kT8LLVFwzh6hepYTf0YmCTpF4eDunyqmpCXDvVscQYRXyasEm5olGmVe05RrCJSeSShAeptv4ueIn40kZKOghinGWLDSZG4+FFfgrmcMCpx5YSCtX2gvnEYZJr0czt4rxOZuuP7PkJKgC/mt2PcPjooeX00vAj81jjU2f3XKrjjz2u2+KIt9eba+vOQ6HiC8c2IzRkUAJ5i1atLy8RIbejo23+0P4N2jjk17QySFOVHwPBDTYb0/0M/4ideeU74EN/CgVsvO6JrLsPBR4dojkV5qNbMNxIVv5cUwIy2ThlLgqpNCeFIDLCWNZEFKlEuNeSQ2mPtIO7ETxEL2Cz5y/7AIuildzYMc6wi2bofRC8HmQ7rMXRWdwLKWsR0L7SKjHblIwarxOGqLnUI+k2E71YoP7SZSlxaKi17pqkr0OMCF+kKqvcvHAQuwGqyumTEWOlH6TCx1dSPrW+pVCZSHSJtSTfDW2uzL6y8k10MT06+pVunSrWo5LHAXcS91htHV1M1UrH/tZKSpjYtjMb5+RonfhaFRNzvj7cCE1f3Kp8UVqAdcGBTtReoE8eRUT63qIxjw03a7VwAyB2w+9cu1R9/vAo8SBeRqw== sakutz@gmail.com


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Remove invalid ssh_import_id from examples
```

## Additional Context
`None` could be taken to mean, "this is valid but do nothing", but actually specifying None will give an error in the logs.
@akutz requested I remove the VMWare references as well.

We use `<ssh pub key 1>` in the examples, so I figure using a non-real `<Launchpad/Github id>` is fine.

