### PR TITLE
WIP: Resize encrypted partitions

### DIFF
--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -338,7 +338,7 @@ def get_underlying_partition(blockdev):
 
 
 def resize_encrypted(blockdev):
-    subp.subp(['cryptsetup', '--key-file', '<keyfile>', 'resize', blockdev])
+    subp.subp(['cryptsetup', 'resize', blockdev])
 
 
 def resize_devices(resizer, devices):

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -63,7 +63,9 @@ growpart is::
             - "/dev/vdb1"
         ignore_growroot_disabled: <true/false>
 """
+import base64
 import copy
+import json
 import os
 import os.path
 import re
@@ -83,6 +85,8 @@ DEFAULT_CONFIG = {
     'devices': ['/'],
     'ignore_growroot_disabled': False,
 }
+
+KEYDATA_PATH = "/cc_growpart_keydata"
 
 
 class RESIZE(object):
@@ -287,35 +291,31 @@ def devent2dev(devent):
     return dev
 
 
-def is_mapped_device(blockdev) -> bool:
-    """
-    Check if a device is a mapped device.
+def get_mapped_device(blockdev):
+    """Returns underlying block device for a mapped device.
 
-    blockdev should look something like '/dev/mapper/disk1' if True,
-    otherwise something like /dev/vdb1.
+    If blockdev is a symlink pointing to a /dev/dm-* device, return
+    the device pointed to. Otherwise, return None.
     """
-    is_mapped = blockdev.startswith('/dev/mapper/')
-    LOG.debug("%s is %s a mapped device", blockdev, "" if is_mapped else "not")
-    return is_mapped
+    realpath = os.path.realpath(blockdev)
+    if realpath.startswith("/dev/dm-"):
+        LOG.debug("%s is a mapped device pointing to %s", blockdev, realpath)
+        return realpath
+    return None
 
 
 def is_encrypted(blockdev) -> bool:
     """
-    Check if a device is an encrypted device.
-
-    Will work for both mapped and raw devices.
+    Check if a device is an encrypted device. blockdev should have
+    a /dev/dm-* path.
     """
-    is_encrypted = False
-    if not subp.which('cryptsetup'):
-        LOG.debug('cryptsetup not found. Assuming no encrypted partitions')
+    if not subp.which("cryptsetup"):
+        LOG.debug("cryptsetup not found. Assuming no encrypted partitions")
         return False
+    is_encrypted = False
     with suppress(subp.ProcessExecutionError):
-        subp.subp(['cryptsetup', 'status', blockdev])
+        subp.subp(["cryptsetup", "status", blockdev])
         is_encrypted = True
-    if not is_encrypted:
-        with suppress(subp.ProcessExecutionError):
-            subp.subp(['cryptsetup', 'isLuks', blockdev])
-            is_encrypted = True
     LOG.debug(
         "Determined that %s is %s encrypted",
         blockdev,
@@ -325,20 +325,40 @@ def is_encrypted(blockdev) -> bool:
 
 
 def get_underlying_partition(blockdev):
-    command = 'dmsetup deps -o devname {}'.format(blockdev)
-    dep = subp.subp(command.split())[0]
+    command = ["dmsetup", "deps", "--options=devname", blockdev]
+    dep = subp.subp(command)[0]
     try:
         # Returned result should look something like:
         # 1 dependencies : (vdb1)
-        return '/dev/{}'.format(dep.split(': (')[1].split(')')[0])
+        return "/dev/{}".format(dep.split(": (")[1].split(")")[0])
     except IndexError:
         raise Exception(
             "Ran `{}`, but received unexpected stdout: `{}`".format(
                 command, dep))
 
 
-def resize_encrypted(blockdev):
-    subp.subp(['cryptsetup', 'resize', blockdev])
+def resize_encrypted(blockdev, partition):
+    """Use 'cryptsetup resize' to resize LUKS volume.
+
+    The loaded keyfile is json formatted with 'key' and 'slot' keys.
+    key is base64 encoded. Example:
+    {"key":"XFmCwX2FHIQp0LBWaLEMiHIyfxt1SGm16VvUAVledlY=","slot":5}
+    """
+    try:
+        with open(KEYDATA_PATH) as f:
+            keydata = json.load(f)
+        key = keydata["key"]
+        decoded_key = base64.b64decode(key)
+        slot = keydata["slot"]
+    except Exception as e:
+        raise Exception("Could not load encryption key") from e
+    subp.subp(
+        ["cryptsetup", "--key-file", "-", "resize", blockdev],
+        data=decoded_key,
+    )
+    subp.subp([
+        "cryptsetup", "luksKillSlot", "--batch-mode", partition, str(slot)
+    ])
 
 
 def resize_devices(resizer, devices):
@@ -347,9 +367,9 @@ def resize_devices(resizer, devices):
     info = []
 
     while devices:
-        devent = devices.pop(0)  # /mnt  TODO: DELETE ME
+        devent = devices.pop(0)
         try:
-            blockdev = devent2dev(devent)  # /dev/mapper/disk2  TODO: DELETE ME
+            blockdev = devent2dev(devent)
         except ValueError as e:
             info.append((devent, RESIZE.SKIPPED,
                          "unable to convert to device: %s" % e,))
@@ -368,10 +388,9 @@ def resize_devices(resizer, devices):
                          "device '%s' not a block device" % blockdev,))
             continue
 
-        try:
-            (disk, ptnum) = device_part_info(blockdev)
-        except (TypeError, ValueError) as e:
-            if is_mapped_device(blockdev) and is_encrypted(blockdev):
+        underlying_blockdev = get_mapped_device(blockdev)
+        if underlying_blockdev and is_encrypted(underlying_blockdev):
+            try:
                 # We need to resize the underlying partition first
                 partition = get_underlying_partition(blockdev)
                 if partition not in [x[0] for x in info]:
@@ -383,13 +402,20 @@ def resize_devices(resizer, devices):
                     devices.insert(0, devent)
                     devices.insert(0, partition)
                     continue
-                resize_encrypted(blockdev)
-            else:
+                resize_encrypted(blockdev, partition)
+            except Exception as e:
                 info.append((
                     devent,
-                    RESIZE.SKIPPED,
-                    "device_part_info(%s) failed: %s" % (blockdev, e),
+                    RESIZE.FAILED,
+                    "Resizing encrypted device ({}) failed: {}".format(
+                        blockdev, e
+                    )
                 ))
+        try:
+            (disk, ptnum) = device_part_info(blockdev)
+        except (TypeError, ValueError) as e:
+            info.append((devent, RESIZE.SKIPPED,
+                         "device_part_info(%s) failed: %s" % (blockdev, e),))
             continue
 
         try:

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -4,6 +4,7 @@
 import logging
 import os
 import subprocess
+from typing import Tuple, Any
 
 from errno import ENOEXEC
 
@@ -141,10 +142,12 @@ class ProcessExecutionError(IOError):
         return text.rstrip(cr).replace(cr, cr + indent)
 
 
-def subp(args, data=None, rcs=None, env=None, capture=True,
-         combine_capture=False, shell=False,
-         logstring=False, decode="replace", target=None, update_env=None,
-         status_cb=None, cwd=None):
+def subp(
+    args, data=None, rcs=None, env=None, capture=True,
+    combine_capture=False, shell=False,
+    logstring=False, decode="replace", target=None, update_env=None,
+    status_cb=None, cwd=None
+) -> Tuple[Any, Any]:
     """Run a subprocess.
 
     :param args: command to run in a list. [cmd, arg1, arg2...]


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
TODO...
```

## Additional Context
<!-- If relevant -->

## Test Steps
Can't test on a fully encrypted system yet, but approximated what we're trying to achieve on openstack with ephemeral drives.

Using this cloud-config:
```
#cloud-config
growpart:
  mode: auto
  devices: ["/", "/dev/mapper/disk2", "/dev/vdc1"]  # or /mnt instead of /dev/mapper/disk2
```

Launch an instance with:
```
openstack server create --flavor m1.small --image  827195be-5e47-40f1-8f40-32c30b4965b7 --key-name newt --nic net-id=falcojr_admin_net test-growpart --ephemeral size=1 --ephemeral size=1 --wait --user-data /home/james/my-user-data
```
add floating ip here
upload cloud-init deb and install it

Run:
```
echo '{"key":"XFmCwX2FHIQp0LBWaLEMiHIyfxt1SGm16VvUAVledlY=","slot":5}' > /cc_growpart_keydata  # write to /cc_growpart_keydata
umount /mnt
parted --script /dev/vdb mklabel gpt mkpart primary ext4 100 1000
parted --script /dev/vdc mklabel gpt mkpart primary ext4 100 1000
```

lsblk should show a /dev/vdb1 and /dev/vdc1 with 859M size of partition.
possibly reboot here because jbd2 won't let go of vdb and rerun parted

After reboot, run:
```
echo 'XFmCwX2FHIQp0LBWaLEMiHIyfxt1SGm16VvUAVledlY=' | base64 --decode | cryptsetup -y -v luksFormat /dev/vdb1 --key-file - --key-slot 5
echo 'XFmCwX2FHIQp0LBWaLEMiHIyfxt1SGm16VvUAVledlY=' | base64 --decode | cryptsetup luksOpen --key-file - /dev/vdb1 disk2
mkfs.ext4 /dev/mapper/disk2
mount /dev/mapper/disk2 /mnt
cloud-init clean --logs; cloud-init init --local; cloud-init init; cloud-init modules --mode=config; cloud-init modules --mode=final; cloud-init status --wait --long
```

lsblk should show a resized sizes for both encrypted and unencrypted device with no errors in `/var/log/cloud-init.log`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
