### PR TITLE
Wait for apt lock

### DIFF
--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -208,7 +208,7 @@ class Distro(distros.Distro):
                     func=subp.subp,
                     kwargs=subp_kwargs,
                 )
-            except subp.ProcessExecutionError as e:
+            except subp.ProcessExecutionError:
                 # Even though we have already waited for the apt lock to be
                 # available, it is possible that the lock was acquired by
                 # another process since the check. Since apt doesn't provide
@@ -220,7 +220,7 @@ class Distro(distros.Distro):
                 # raced us when we tried to acquire it, so raise the apt
                 # error received. If the lock is unavailable, just keep waiting
                 if self._apt_lock_available():
-                    raise e
+                    raise
                 LOG.debug('Another process holds apt lock. Waiting...')
                 time.sleep(1)
         raise TimeoutError('Could not get apt lock')

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -177,7 +177,7 @@ class Distro(distros.Distro):
             with open(lock, 'w') as handle:
                 try:
                     fcntl.lockf(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                except IOError:
+                except OSError:
                     return False
         return True
 

--- a/tests/unittests/test_distros/test_debian.py
+++ b/tests/unittests/test_distros/test_debian.py
@@ -132,7 +132,7 @@ class TestPackageCommand:
                 side_effect=[False, False, True])
     @mock.patch("cloudinit.distros.debian.time.sleep")
     def test_wait_for_lock(self, m_sleep, m_apt_avail, m_subp, m_which):
-        self.distro._wait_for_apt_install("stub", {"args": "stub2"})
+        self.distro._wait_for_apt_command("stub", {"args": "stub2"})
         assert m_sleep.call_args_list == [mock.call(1), mock.call(1)]
         assert m_subp.call_args_list == [mock.call(args='stub2')]
 
@@ -144,7 +144,7 @@ class TestPackageCommand:
         self, m_time, m_sleep, m_apt_avail, m_subp, m_which
     ):
         with pytest.raises(TimeoutError):
-            self.distro._wait_for_apt_install("stub", "stub2", timeout=5)
+            self.distro._wait_for_apt_command("stub", "stub2", timeout=5)
         assert m_subp.call_args_list == []
 
     @mock.patch("cloudinit.distros.debian.Distro._is_apt_lock_available",
@@ -155,7 +155,7 @@ class TestPackageCommand:
             exit_code=100, stderr="Could not get apt lock"
         )
         m_subp.side_effect = [exception, exception, "return_thing"]
-        ret = self.distro._wait_for_apt_install("stub", {"args": "stub2"})
+        ret = self.distro._wait_for_apt_command("stub", {"args": "stub2"})
         assert ret == "return_thing"
 
     @mock.patch("cloudinit.distros.debian.Distro._is_apt_lock_available",
@@ -169,6 +169,6 @@ class TestPackageCommand:
             exit_code=100, stderr="Could not get apt lock"
         )
         with pytest.raises(TimeoutError):
-            self.distro._wait_for_apt_install(
+            self.distro._wait_for_apt_command(
                 "stub", {"args": "stub2"}, timeout=5
             )

--- a/tests/unittests/test_handler/test_handler_landscape.py
+++ b/tests/unittests/test_handler/test_handler_landscape.py
@@ -22,6 +22,10 @@ class TestLandscape(FilesystemMockingTestCase):
         self.conf = self.tmp_path('client.conf', self.new_root)
         self.default_file = self.tmp_path('default_landscape', self.new_root)
         self.patchUtils(self.new_root)
+        self.add_patch(
+            'cloudinit.distros.ubuntu.Distro.install_packages',
+            'm_install_packages'
+        )
 
     def test_handler_skips_empty_landscape_cloudconfig(self):
         """Empty landscape cloud-config section does no work."""


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Wait for apt lock

Currently any attempt to run an apt command while another process holds
an apt lock will fail. We should instead wait to acquire the apt lock.

LP: #1944611
```

## Additional Context
See https://bugs.launchpad.net/cloud-init/+bug/1944611 . I have also seen this intermittently while testing.

## Test Steps
Beyond the unit tests, start an instance with the following cloud-config
```
#cloud-config
bootcmd:
  - python3 -c "import fcntl; from time import sleep; x = open('/var/lib/dpkg/lock', 'w'); fcntl.lockf(x, fcntl.LOCK_EX | fcntl.LOCK_NB); sleep(50000)" &
drivers:
  nvidia:
    license-accepted: true
```
Old behavior is to fail immediately. With this PR it will wait 30 seconds and then fail. Decrease the sleep an appropriate amount of time if you'd like to see it wait and then proceed when the lock is cleared.


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
