### PR TITLE
Make wording for module frequency consistent

### DIFF
--- a/cloudinit/config/cc_disable_ec2_metadata.py
+++ b/cloudinit/config/cc_disable_ec2_metadata.py
@@ -17,7 +17,7 @@ by default.
 
 **Internal name:** ``cc_disable_ec2_metadata``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** all
 

--- a/cloudinit/config/cc_emit_upstart.py
+++ b/cloudinit/config/cc_emit_upstart.py
@@ -16,7 +16,7 @@ user configuration should be required.
 
 **Internal name:** ``cc_emit_upstart``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** ubuntu, debian
 """

--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -21,7 +21,7 @@ specified as a jinja template with the following variables set:
 
 **Internal name:** ``cc_final_message``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** all
 

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -50,7 +50,7 @@ growpart is::
 
 **Internal name:** ``cc_growpart``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** all
 

--- a/cloudinit/config/cc_migrator.py
+++ b/cloudinit/config/cc_migrator.py
@@ -17,7 +17,7 @@ false`` in config.
 
 **Internal name:** ``cc_migrator``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** all
 

--- a/cloudinit/config/cc_refresh_rmc_and_interface.py
+++ b/cloudinit/config/cc_refresh_rmc_and_interface.py
@@ -28,7 +28,7 @@ This module handles
 
 **Internal name:** ``cc_refresh_rmc_and_interface``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** RHEL
 

--- a/cloudinit/config/cc_scripts_per_boot.py
+++ b/cloudinit/config/cc_scripts_per_boot.py
@@ -17,7 +17,7 @@ module does not accept any config keys.
 
 **Internal name:** ``cc_scripts_per_boot``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** all
 """

--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -34,7 +34,7 @@ based on initial hostname.
 
 **Internal name:** ``cc_set_hostname``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** all
 

--- a/cloudinit/config/cc_update_etc_hosts.py
+++ b/cloudinit/config/cc_update_etc_hosts.py
@@ -39,7 +39,7 @@ ping ``127.0.0.1`` or ``127.0.1.1`` or other ip).
 
 **Internal name:** ``cc_update_etc_hosts``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** all
 

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -20,7 +20,7 @@ is set, then the hostname will not be altered.
 
 **Internal name:** ``cc_update_hostname``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** all
 

--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -16,7 +16,7 @@ entry, the config entry will be skipped.
 
 **Internal name:** ``cc_yum_add_repo``
 
-**Module frequency:** per always
+**Module frequency:** always
 
 **Supported distros:** almalinux, centos, cloudlinux, eurolinux, fedora,
                        openEuler, photon, rhel, rocky, virtuozzo


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Some modules' frequency are documented as `always` while others as
`per always`. The difference in wording can be confusing. This change
updates all such modules to use `always`.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
