### PR TITLE
Fill entry['gateway'] for IPv6 routes

### DIFF
--- a/cloudinit/netinfo.py
+++ b/cloudinit/netinfo.py
@@ -300,6 +300,7 @@ def _netdev_route_info_iproute(iproute_data):
             toks = line.split()
             if toks[0] == "default":
                 entry['destination'] = "::/0"
+                entry['gateway'] = "::"
                 entry['flags'] = "UG"
             else:
                 entry['destination'] = toks[0]


### PR DESCRIPTION
## Fill entry['gateway'] for IPv6 routes

Otherwise this code (https://github.com/canonical/cloud-init/blob/main/cloudinit/netinfo.py#L478) fails with

```
failed run of stage init                                                                                     
------------------------------------------------------------                         
Traceback (most recent call last):                                                                           
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 652, in status_wrapper
    ret = functor(name, args)                                                                                
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 283, in main_init                        
    sys.stderr.write("%s\n" % (netinfo.debug_info()))                                                                                                                                                                      
  File "/usr/lib/python3/dist-packages/cloudinit/netinfo.py", line 496, in debug_info                        
    route_lines = route_pformat().splitlines()                                                               
  File "/usr/lib/python3/dist-packages/cloudinit/netinfo.py", line 480, in route_pformat                     
    r['gateway'], r['iface'], r['flags']])                                                                   
KeyError: 'gateway'                                                                                                                                                                                                        
------------------------------------------------------------   
```


## Test Steps

1. Create machine with custom default IPv6 route, i.e.
```
root@host:~# ip -o -6 route list table all
...                   
default dev eth1 proto static metric 50 pref medium 
...
```
2. Run `cloud-init init`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
