### PR TITLE
Pin jsonschema to 3.2.0 (SC-466)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ requests
 jsonpatch
 
 # For validating cloud-config sections per schema definitions
-jsonschema
+jsonschema==3.2.0
 
 # Used by DataSourceVMware to inspect the host's network configuration during
 # the "setup()" function.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ pytest-cov
 
 # Only really needed on older versions of python
 setuptools
+jsonschema==3.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -77,6 +77,7 @@ deps =
     pyserial==3.0.1
     configobj==5.0.6
     requests==2.9.1
+    jsonschema==3.2.0
     # test-requirements
     pytest-catchlog==1.2.1
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
Pin jsonschema to 3.2.0

On unit tests, tox is attempting to install 4.0, which fails two of
the unit tests, and fails python 3.5 as it is not compatible.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
