### PR TITLE
Support ETHx_IP6_GATEWAY, SET_HOSTNAME on OpenNebula

### DIFF
--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -195,7 +195,11 @@ class OpenNebulaNetwork(object):
         return self.get_field(dev, "gateway")
 
     def get_gateway6(self, dev):
-        return self.get_field(dev, "gateway6")
+        # OpenNebula 6.1.80 introduced new context parameter ETHx_IP6_GATEWAY
+        # to replace old ETHx_GATEWAY6. Old ETHx_GATEWAY6 will be removed in
+        # OpenNebula 6.4.0 (https://github.com/OpenNebula/one/issues/5536).
+        return self.get_field(dev, "ip6_gateway",
+                              self.get_field(dev, "gateway6"))
 
     def get_mask(self, dev):
         return self.get_field(dev, "mask", "255.255.255.0")
@@ -440,7 +444,7 @@ def read_context_disk_dir(source_dir, distro, asuser=None):
 
     # custom hostname -- try hostname or leave cloud-init
     # itself create hostname from IP address later
-    for k in ('HOSTNAME', 'PUBLIC_IP', 'IP_PUBLIC', 'ETH0_IP'):
+    for k in ('SET_HOSTNAME', 'HOSTNAME', 'PUBLIC_IP', 'IP_PUBLIC', 'ETH0_IP'):
         if k in context:
             results['metadata']['local-hostname'] = context[k]
             break

--- a/doc/rtd/topics/datasources/opennebula.rst
+++ b/doc/rtd/topics/datasources/opennebula.rst
@@ -69,13 +69,21 @@ Datasource mode configuration override. Values: local, net, disabled.
     ETH<x>_NETWORK
     ETH<x>_MASK
     ETH<x>_GATEWAY
+    ETH<x>_GATEWAY6
     ETH<x>_DOMAIN
     ETH<x>_DNS
+    ETH<x>_SEARCH_DOMAIN
+    ETH<x>_MTU
+    ETH<x>_IP6
+    ETH<x>_IP6_ULA
+    ETH<x>_IP6_PREFIX_LENGTH
+    ETH<x>_IP6_GATEWAY
 
 Static `network configuration`_.
 
 ::
 
+    SET_HOSTNAME
     HOSTNAME
 
 Instance hostname.

--- a/tests/unittests/test_datasource/test_opennebula.py
+++ b/tests/unittests/test_datasource/test_opennebula.py
@@ -211,7 +211,7 @@ class TestOpenNebulaDataSource(CiTestCase):
     def test_hostname(self, m_get_phys_by_mac):
         for dev in ('eth0', 'ens3'):
             m_get_phys_by_mac.return_value = {MACADDR: dev}
-            for k in ('HOSTNAME', 'PUBLIC_IP', 'IP_PUBLIC', 'ETH0_IP'):
+            for k in ('SET_HOSTNAME', 'HOSTNAME', 'PUBLIC_IP', 'IP_PUBLIC', 'ETH0_IP'):
                 my_d = os.path.join(self.tmp, k)
                 populate_context_dir(my_d, {k: PUBLIC_IP})
                 results = ds.read_context_disk_dir(my_d, mock.Mock())
@@ -488,10 +488,11 @@ class TestOpenNebulaNetwork(unittest.TestCase):
         Verify get_gateway6('device') correctly returns IPv6 default gateway
         address.
         """
-        context = {'ETH0_GATEWAY6': IP6_GW}
-        net = ds.OpenNebulaNetwork(context, mock.Mock())
-        val = net.get_gateway6('eth0')
-        self.assertEqual(IP6_GW, val)
+        for k in ('GATEWAY6', 'IP6_GATEWAY'):
+            context = {'ETH0_' + k: IP6_GW}
+            net = ds.OpenNebulaNetwork(context, mock.Mock())
+            val = net.get_gateway6('eth0')
+            self.assertEqual(IP6_GW, val)
 
     def test_get_mask(self):
         """


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Support for ETHx_IP6_GATEWAY and SET_HOSTNAME on OpenNebula

OpenNebula 6.1.80 (current dev. version) is introducing new IPv6 gateway
contextualization variable ETHx_IP6_GATEWAY, which mimics existing
variable ETHx_GATEWAY6. The ETHx_GATEWAY6 used until now will
be depracated in future relase (ET spring 2022).

See:
- new variable - https://github.com/OpenNebula/one/commit/e4d2cc11b9f3c6d01b53774b831f48d9d089c1cc
- deprecation tracking issue - https://github.com/OpenNebula/one/issues/5536

Also, added support for SET_HOSTNAME context variable, which is
currently widely used variable to configure guest VM hostname. See
https://docs.opennebula.io/6.0/management_and_operations/references/template.html#context-section
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
