### PR TITLE
cc_ssh.py: fix private key group owner and permissions

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -240,6 +240,13 @@ def handle(_name, cfg, cloud, log, _args):
                 try:
                     out, err = subp.subp(cmd, capture=True, env=lang_c)
                     sys.stdout.write(util.decode_binary(out))
+
+                    gid = util.get_group_id("ssh_keys")
+                    if gid != -1:
+                        # perform same "sanitize permissions" as sshd-keygen
+                        os.chown(keyfile, -1, gid)
+                        os.chmod(keyfile, 0o640)
+                        os.chmod(keyfile + ".pub", 0o644)
                 except subp.ProcessExecutionError as e:
                     err = util.decode_binary(e.stderr).lower()
                     if (e.exit_code == 1 and

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1880,6 +1880,20 @@ def chmod(path, mode):
             os.chmod(path, real_mode)
 
 
+def get_group_id(grp_name: str) -> int:
+    """
+    Returns the group id of a group name, or -1 if no group exists
+
+    @param grp_name: the name of the group
+    """
+    gid = -1
+    try:
+        gid = grp.getgrnam(grp_name).gr_gid
+    except KeyError:
+        LOG.debug("Group %s is not a valid group name", grp_name)
+    return gid
+
+
 def get_permissions(path: str) -> int:
     """
     Returns the octal permissions of the file/folder pointed by the path,


### PR DESCRIPTION
## Proposed Commit Message
When default host keys are created by sshd-keygen (`/etc/ssh/ssh_host_*_key`)
in RHEL/CentOS/Fedora, `openssh` it performs the following:
```
# create new keys
if ! $KEYGEN -q -t $KEYTYPE -f $KEY -C '' -N '' >&/dev/null; then
        exit 1
fi

# sanitize permissions
/usr/bin/chgrp ssh_keys $KEY
/usr/bin/chmod 640 $KEY
/usr/bin/chmod 644 $KEY.pub
```
Note that the group `ssh_keys` exists only in RHEL/CentOS/Fedora.

Now that we disable sshd-keygen to allow only cloud-init to create
them, we miss the "sanitize permissions" part, where we set the group
owner as ssh_keys and the private key mode to 640.

According to https://bugzilla.redhat.com/show_bug.cgi?id=2013644#c8, failing
to set group ownership and permissions like openssh does makes the RHEL openscap
tool generate an error.

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>

RHBZ: 2013644

## Test Steps
Check permissions after cloud-init has generated ssh host keys:
```
ll /etc/ssh/

-rw-------. 1 root root    545 Oct 14 13:03 ssh_host_ecdsa_key
-rw-r--r--. 1 root root    209 Oct 14 13:03 ssh_host_ecdsa_key.pub
-rw-------. 1 root root    452 Oct 14 13:03 ssh_host_ed25519_key
-rw-r--r--. 1 root root    129 Oct 14 13:03 ssh_host_ed25519_key.pub
-rw-------. 1 root root   2643 Oct 14 13:03 ssh_host_rsa_key
-rw-r--r--. 1 root root    601 Oct 14 13:03 ssh_host_rsa_key.pub
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
