### PR TITLE
Fix unit test broken by pyyaml upgrade (SC-510)

### DIFF
--- a/tests/unittests/test_net_freebsd.py
+++ b/tests/unittests/test_net_freebsd.py
@@ -1,8 +1,8 @@
 import os
-import yaml
 
 import cloudinit.net
 import cloudinit.net.network_state
+from cloudinit import safeyaml
 from cloudinit.tests.helpers import (CiTestCase, mock, readResource, dir2dict)
 
 
@@ -65,7 +65,7 @@ class TestFreeBSDRoundTrip(CiTestCase):
         entry = {
             'yaml': V1,
         }
-        network_config = yaml.load(entry['yaml'])
+        network_config = safeyaml.load(entry['yaml'])
         ns = cloudinit.net.network_state.parse_net_config_data(network_config)
         files = self._render_and_read(state=ns)
         assert files == {


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix unit test broken by pyyaml upgrade

PyYAML upgraded from 5.4.1 to 6.0.0. 6.0.0 always requires a  `Loader`
arg to `yaml.load()`
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
