### PR TITLE
remove unnecessary EOF string in disable-sshd-keygen-if-cloud-init-active.conf

### DIFF
--- a/systemd/disable-sshd-keygen-if-cloud-init-active.conf
+++ b/systemd/disable-sshd-keygen-if-cloud-init-active.conf
@@ -5,4 +5,3 @@
 #
 [Unit]
 ConditionPathExists=!/run/systemd/generator.early/multi-user.target.wants/cloud-init.target
-EOF


### PR DESCRIPTION
## Proposed Commit Message
Running `systemd-analyze verify cloud-init-local.service`
triggers the following warning:

`disable-sshhd-keygen-if-cloud-init-active.conf:8: Missing '=', ignoring line.`

The string "EOF" (at line 8) is probably a typo, so remove it.

RHBZ: 2016305


## Test Steps
run `systemd-analyze verify cloud-init-local.service`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
