### PR TITLE
Update Debian security suite for bullseye

### DIFF
--- a/templates/sources.list.debian.tmpl
+++ b/templates/sources.list.debian.tmpl
@@ -15,8 +15,8 @@ deb-src {{mirror}} {{codename}} main
 
 ## Major bug fix updates produced after the final release of the
 ## distribution.
-deb {{security}} {{codename}}-security main
-deb-src {{security}} {{codename}}-security main
+deb {{security}} {{codename}}{% if codename in ('buster', 'stretch') %}/updates{% else %}-security{% endif %} main
+deb-src {{security}} {{codename}}{% if codename in ('buster', 'stretch') %}/updates{% else %}-security{% endif %} main
 deb {{mirror}} {{codename}}-updates main
 deb-src {{mirror}} {{codename}}-updates main
 


### PR DESCRIPTION
## Proposed Commit Message
Update Debian security suite for bullseye

Debian Bullseye is using a new suite for security updates, `bullseye-security` instead of `bullseye/updates`. This PR ensures the template is not trigerring any error when running on this release of Debian.

## Test Steps

1. Start a VM with APT sources configured
2. APT complains the security repository does not have a valid Release file

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
