### PR TITLE
add google while checking the pname

### DIFF
--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -257,7 +257,7 @@ def read_md(address=None, url_params=None, platform_check=True):
 
 def platform_reports_gce():
     pname = dmi.read_dmi_data('system-product-name') or "N/A"
-    if pname == "Google Compute Engine":
+    if pname == "Google Compute Engine" or pname == "Google":
         return True
 
     # system-product-name is not always guaranteed (LP: #1674861)


### PR DESCRIPTION
## Proposed Commit Message
Add google while checking the pname
```
In some of the cases, the system-product-name is just google.
This is useful incase of nocloud where we use the disk to load the datasource
```

## Test Steps
- Tested on the product in which the pname returns "Google"
- Validating in a mock environment.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
