### PR TITLE
Remove pin in dependencies for jsonschema (SC-508)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ requests
 jsonpatch
 
 # For validating cloud-config sections per schema definitions
-jsonschema==3.2.0
+jsonschema
 
 # Used by DataSourceVMware to inspect the host's network configuration during
 # the "setup()" function.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,4 +5,4 @@ pytest-cov
 
 # Only really needed on older versions of python
 setuptools
-jsonschema==3.2.0
+jsonschema

--- a/tests/unittests/test_handler/test_schema.py
+++ b/tests/unittests/test_handler/test_schema.py
@@ -108,11 +108,11 @@ class ValidateCloudConfigSchemaTest(CiTestCase):
     def test_validateconfig_schema_honors_formats(self):
         """With strict True, validate_cloudconfig_schema errors on format."""
         schema = {
-            'properties': {'p1': {'type': 'string', 'format': 'hostname'}}}
+            'properties': {'p1': {'type': 'string', 'format': 'email'}}}
         with self.assertRaises(SchemaValidationError) as context_mgr:
             validate_cloudconfig_schema({'p1': '-1'}, schema, strict=True)
         self.assertEqual(
-            "Cloud config schema errors: p1: '-1' is not a 'hostname'",
+            "Cloud config schema errors: p1: '-1' is not a 'email'",
             str(context_mgr.exception))
 
 
@@ -189,12 +189,12 @@ class ValidateCloudConfigFileTest(CiTestCase):
     def test_validateconfig_file_sctrictly_validates_schema(self):
         """validate_cloudconfig_file raises errors on invalid schema."""
         schema = {
-            'properties': {'p1': {'type': 'string', 'format': 'hostname'}}}
-        write_file(self.config_file, '#cloud-config\np1: "-1"')
+            'properties': {'p1': {'type': 'string', 'format': 'string'}}}
+        write_file(self.config_file, '#cloud-config\np1: -1')
         with self.assertRaises(SchemaValidationError) as context_mgr:
             validate_cloudconfig_file(self.config_file, schema)
         self.assertEqual(
-            "Cloud config schema errors: p1: '-1' is not a 'hostname'",
+            "Cloud config schema errors: p1: -1 is not of type 'string'",
             str(context_mgr.exception))
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ deps =
     pyserial==3.0.1
     configobj==5.0.6
     requests==2.9.1
-    jsonschema==3.2.0
+    jsonschema
     # test-requirements
     pytest-catchlog==1.2.1
 


### PR DESCRIPTION
```
Remove pin in dependencies for jsonschema

In jsonschema 4, hostname validation was changed to have an optional
dependency on the fqdn package. Since we don't have this dependency
in cloud-init, attempting this validation will no longer fail for
a string that isn't a valid hostname.
```

## Additional Context
This is to fix two failing unit tests.

Are we ok with this validation being disabled? It is currently in use in cc_ntp.py. Nothing is broken by it not being there, it will just validate it as a string rather than as a hostname.
