### PR TITLE
Add Xendatasource which uses xenstore info

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -42,6 +42,7 @@ KNOWN_CLOUD_NAMES = [
     'UpCloud',
     'VMware',
     'Vultr',
+    'Xen',
     'ZStack',
     'Other'
 ]

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -44,6 +44,7 @@ CFG_BUILTIN = {
         'RbxCloud',
         'UpCloud',
         'VMware',
+        'Xen',
         # At the end to act as a 'catch' when none of the above work...
         'None',
     ],

--- a/cloudinit/sources/DataSourceXen.py
+++ b/cloudinit/sources/DataSourceXen.py
@@ -1,0 +1,616 @@
+# Cloud-Init DataSource for Xen
+#
+# Author: Kalpesh Gade <gadekalpesh19@gmail.com>
+#
+
+'''Cloud-Init Datasource for Xen
+
+This module provides cloud-init datasource for Open Source Xen Platform system and fetches data 
+from xenstore
+
+'''
+
+import collections
+import copy
+from distutils.spawn import find_executable
+import ipaddress
+import json
+import os
+import socket
+import time
+
+from cloudinit import dmi, log as logging
+from cloudinit import sources
+from cloudinit import util
+from cloudinit.sources.DataSourceVMware import advertise_local_ip_addrs, load_json_or_yaml, process_metadata, wait_on_network
+from cloudinit.subp import subp, ProcessExecutionError
+
+import netifaces
+
+PRODUCT_UUID_FILE_PATH = "/sys/class/dmi/id/product_uuid"
+LOG = logging.getLogger(__name__)
+NODATA = "xenstore-read: couldn't read path vm-data/"
+
+XENSTORE_READ = find_executable("xenstore-read")
+XENSTORE_WRITE = find_executable("xenstore-write")
+
+
+LOCAL_IPV4 = "local-ipv4"
+LOCAL_IPV6 = "local-ipv6"
+WAIT_ON_NETWORK = "wait-on-network"
+WAIT_ON_NETWORK_IPV4 = "ipv4"
+WAIT_ON_NETWORK_IPV6 = "ipv6"
+
+class DataSourceXen(sources.DataSource):
+
+    """
+    Setting the hostname:
+        The hostname is set by way of the metadata key "local-hostname".
+
+    Setting the instance ID:
+        The instance ID may be set by way of the metadata key "instance-id".
+        However, if this value is absent then the instance ID is read
+        from the file /sys/class/dmi/id/product_uuid.
+
+    Configuring the network:
+        The network is configured by setting the metadata key "network"
+        with a value consistent with Network Config Versions 1 or 2,
+        depending on the Linux distro's version of cloud-init:
+
+            Network Config Version 1 - http://bit.ly/cloudinit-net-conf-v1
+            Network Config Version 2 - http://bit.ly/cloudinit-net-conf-v2
+
+    """
+
+    dsname = "Xen"
+    def __init__(self, sys_cfg, distro: Distro, paths, ud_proc=None):
+        sources.DataSource.__init__(sys_cfg, distro, paths, ud_proc=ud_proc)
+
+        self.data_access_method = None
+        self.xenstore_read = XENSTORE_READ
+        self.xenstore_write = XENSTORE_WRITE
+
+    def _get_data(self):
+        if not self.data_access_method:
+            system_type = dmi.read_dmi_data("system-product-name")
+            if system_type is None:
+                LOG.debug("No system-product-name found")
+                return False
+            if "xen" not in system_type.lower():
+                LOG.debug("Not a Xen platform")
+                return False
+
+        if not self.data_access_method:
+            if self.xenstore_read:
+                metadata = xenstoredata("metadata", self.xenstore_read)
+                userdata = xenstoredata("userdata", self.xenstore_read)
+                vendordata = xenstoredata("vendordata", self.xenstore_read)
+
+                if metadata or userdata or vendordata:
+                    self.data_access_method =  True
+
+        if not self.data_access_method:
+            LOG.error("Failed to find data on xenstore-data")
+            return False
+
+        LOG.info("Using xenstore data for metadata, userdata and vendordata")
+
+        # Access metadata from xenstore vm-data/metadata
+        self.metadata = process_metadata(load_json_or_yaml(metadata))
+
+        # Access Userdata from xenstore vm-data/userdata 
+        self.userdata_raw = userdata
+
+        # Access Vendordata from xenstore vm-data/vendordata
+        self.vendordata_raw = vendordata
+
+        if self.metadata or self.userdata_raw or self.vendordata_raw:
+            return True
+        else:
+            return False
+
+    def setup(self, is_new_instance):
+        """setup(is_new_instance)
+
+        This is called before user-data and vendor-data have been processed.
+
+        Unless the datasource has set mode to 'local', then networking
+        per 'fallback' or per 'network_config' will have been written and
+        brought up the OS at this point.
+        """
+
+
+        host_info = wait_on_network(self.metadata)
+        LOG.info("got host-info: %s", host_info)
+
+        advertise_local_ip_addrs(host_info)
+
+        self.metadata = util.mergemanydict([self.metadata, host_info])
+        self.persist_instance_data()
+
+    def _get_subplatform(self):
+        get_key_name_func = None
+        if self.data_access_method == True:
+            get_key_name_func = get_xenstore_key_name
+        else:
+            return sources.METADATA_UNKNOWN
+        return "%s (%s)" % (
+            self.data_access_method,
+            get_key_name_func("metadata"),
+        )    
+
+    @property
+    def network_config(self):
+        if "network" in self.metadata:
+            LOG.debug("using metadata network config")
+        else:
+            LOG.debug("using failback network config")
+            self.metadata["network"] = {
+                "config": self.distro.generate_fallback_config(),
+            }    
+        return self.metadata["network"]["config"]
+
+    def get_instance_id(self):
+        if self.metadata and "instance-id" in self.metadata:
+            return self.metadata["instance-id"]
+        with open(PRODUCT_UUID_FILE_PATH, "r") as uuid_file:
+            self.metadata["instance-id"] = str(uuid_file.read()).rstrip().lower()
+            return self.metadata["instance-id"]
+
+    def get_public_ssh_keys(self):
+        for key_name in (
+            "public-keys-data",
+            "public_keys_data",
+            "public-keys",
+            "public_keys",
+        ):
+            if key_name in self.metadata:
+                return sources.normalize_pubkey_data(self.metadata[key_name])
+        return []
+
+def decode(key, enc_type, data):
+    LOG.debug("Getting encoded data for key=%s, enc=%s", key, enc_type)
+    raw_data = None
+
+    if enc_type in ["gzip+base64", "gz+b64"]:
+        LOG.debug("Decoding %s type of %s", enc_type, key)
+        raw_data = util.decomp_gzip(util.b64d(data))
+    elif enc_type in ["base64", "b64"]:
+        LOG.debug("Decoding %s type of %s", enc_type, key) 
+        raw_data = util.b64d(data)
+    else:
+        LOG.debug("Plain-text data %s", key)
+        raw_data = data
+    return util.decode_binary(raw_data)
+
+def get_none_if_empty_val(val):
+    val = util.decode_binary(val)
+    val = val.rstrip()
+
+    if len(val) == 0:
+        return None
+    return val
+
+def advertise_local_ip_address(host_info):
+    if not host_info:
+        return
+
+    local_ipv4 = host_info.get(LOCAL_IPV4)
+    if local_ipv4:
+        xenstore_set_value(LOCAL_IPV4, local_ipv4)
+        LOG.info("advertised local ipv4 address %s in xenstore", local_ipv4)
+
+    local_ipv6 = host_info.get(LOCAL_IPV6)
+    if local_ipv6:
+        xenstore_set_value(LOCAL_IPV6, local_ipv6)
+        LOG.info("advertised local ipv6 address %s in xenstore", local_ipv6)
+
+def handled_returned_xenstore_val(key,val):
+    val = get_none_if_empty_val(val)
+    if val:
+        return val
+    LOG.debug("Value not found for key %s", key)
+    return None
+
+def get_xenstore_key_name(key):
+    return key
+
+
+def xenstoredata(key, xenstore_read=XENSTORE_READ):
+    """
+    guestinfo returns the guestinfo value for the provided key, decoding
+    the value when required
+    """
+    val = xenstore_get_value(key, xenstore_read)
+    if not val:
+        return None
+    enc_type = xenstore_get_value(key + "/encoding", xenstore_read)
+    return decode(get_xenstore_key_name(key), enc_type, val)
+
+def xenstore_get_value(key, xenstore_read=XENSTORE_READ):
+    LOG.debug("Getting xenstore value for key %s", key)
+
+    try:
+        (stdout, stderr) = subp(
+            [
+                xenstore_read,
+                "vm-data/" + get_xenstore_key_name(key),
+            ]
+        )
+        if stderr == NODATA:
+            LOG.debug("Couldn't find value for %s in xenstore", key)
+        elif not stdout:
+            LOG.debug("Failed to find value for %s in xenstore", key)
+        return handled_returned_xenstore_val(key, stdout)    
+    except ProcessExecutionError as error:
+        if error.stderr == NODATA:
+            LOG.debug("Couldn't find value for key %s in xenstore", key)
+        else:
+            util.logexc(
+                LOG,
+                "Couldn't find value for %s in xenstore: %s",
+                key,
+                error,
+            )
+    except Exception:
+        util.logexc(
+            LOG,
+            "Unexpected value while trying to get "
+            + "xenstore value for key %s",
+            key,
+        )
+    return None
+
+def xenstore_set_value(key, value, xenstore_write=XENSTORE_WRITE):
+    if value == "":
+        value = " "
+    LOG.debug("Setting xenstore value for key %s to %s", key,value)
+
+    try:
+        subp(
+            [
+                    xenstore_write,
+                    ("vm-data/%s" %(key)),
+                    ("%s" %(value))
+            ]
+        )
+        return True
+
+    except ProcessExecutionError as error:
+        util.logexc(
+            LOG,
+            "Failed to set xenstore value %s for key %s: %s",
+            value,
+            key,
+            error,
+        )
+    except Exception:
+        util.logexc(
+            LOG,
+            "Unexpected error while trying to set "
+            + "xenstore key=%s to value=%s",
+            key,
+            value,
+        )
+    return None
+
+
+def load_json_or_yaml(data):
+    if not data:
+        return {}
+    try:
+        return util.load_json(data)
+    except (json.JSONDecodeError, TypeError):
+        return util.load_yaml(data)
+
+def process_metadata(data):
+    network = None
+    if "network" in data:
+        network = data["network"]
+        del data["network"]
+
+    network_enc = None
+    if "network.encoding" in data:
+        network_enc = data["network.encoding"]
+        del data["network.encoding"]
+
+    if network:
+        if isinstance(network, collections.abc.Mapping):
+            LOG.debug("network data copied to 'config' key")
+            network = {"config": copy.deepcopy(network)}
+        else:
+            LOG.debug("network data to be decoded %s", network)
+            dec_net = decode("metadata.network", network_enc, network)
+            network = {
+                "config": load_json_or_yaml(dec_net),
+            }    
+
+        LOG.debug("network data %s", network)
+        data["network"] = network
+    return data
+
+datasources = [
+    (DataSourceXen, (sources.DEP_FILESYSTEM,)),  # Run at init-local
+    (DataSourceXen, (sources.DEP_FILESYSTEM, sources.DEP_NETWORK)),
+]    
+
+def get_datasource_list(depends):
+    return sources.list_from_depends(depends, datasources)
+
+def get_default_ip_address():
+    gateways = netifaces.gateways()
+    if "default" not in gateways:
+        return None, None
+
+    default_gateway = gateways["default"]
+
+    if (
+        netifaces.AF_INET not in default_gateway
+        and netifaces.AF_INET6 not in default_gateway
+    ):
+        return None, None
+
+    ipv4 = None
+    ipv6 = None
+
+    gateway4 = default_gateway.get(netifaces.AF_INET)
+    if gateway4:
+        _, dev4 = gateway4
+        address4_fams = netifaces.ifaddresses(dev4)
+        if address4_fams:
+            af_inet4 = address4_fams.get(netifaces.AF_INET)
+            if af_inet4:
+                if len(af_inet4) > 1:
+                    LOG.warning(
+                        "device %s has more than one ipv4 address: %s",
+                        dev4,
+                        af_inet4,
+                    )
+                elif "addr" in af_inet4[0]:
+                    ipv4 = af_inet4[0]["addr"]
+
+    gateway6 = default_gateway.get(netifaces.AF_INET6)
+    if gateway6:
+        _, dev6 = gateway6
+        address6_fams = netifaces.ifaddresses(dev6)
+        if address6_fams:
+            af_inet6 = address6_fams.get(netifaces.AF_INET6)
+            if af_inet6:
+                if len(af_inet6) > 1:
+                    LOG.warning(
+                        "device %s has more than one ipv6 address: %s",
+                        dev6,
+                        af_inet6,
+                    )
+                elif "addr" in af_inet6[0]:
+                    ipv6 = af_inet6[0]["addr"]
+
+    if ipv4 and not ipv6:
+        af_inet6 = address4_fams.get(netifaces.AF_INET6)
+        if af_inet6:
+            if len(af_inet6) > 1:
+                LOG.warning(
+                   "device %s has more than one ipv6 address: %s",
+                   dev4,
+                   af_inet6, 
+                )
+            elif "addr" in af_inet6[0]:
+                ipv6 = af_inet6[0]["addr"]
+
+    if not ipv4 and ipv6:
+        af_inet4 = address6_fams.get(netifaces.AF_INET)
+        if af_inet4:
+            if len(af_inet4) > 1:
+                LOG.warning(
+                    "device %s has more than one ipv4 address: %s",
+                    dev6,
+                    af_inet4,
+                )
+            elif "addr" in af_inet4[0]:
+                ipv4 = af_inet4[0]["addr"]
+    
+    return ipv4, ipv6
+
+def getfqdn(name=""):
+    name = name.strip()
+    if not name or name == "0.0.0.0":
+        name = util.get_hostname()
+    try:
+        address = socket.getaddrinfo(
+            name, None, 0, socket.SOCK_DGRAM, 0, socket.AI_CANONNAME
+        )
+    except socket.error:
+        pass
+    else:
+        for addr in address:
+            if addr[3]:
+                name = addr[3]
+                break
+    return name
+
+def is_valid_ip_address(value):
+    """
+    Returns false if the address is loopback, link local or unspecified;
+    otherwise true is returned.
+    """
+    # TODO(extend cloudinit.net.is_ip_addr exclude link_local/loopback etc)
+    # TODO(migrate to use cloudinit.net.is_ip_addr)#
+
+    addr = None
+    try:
+        addr = ipaddress.ip_address(value)
+    except ipaddress.AddressValueError:
+        addr = ipaddress.ip_address(str(value))
+    except Exception:
+        return None
+
+    if addr.is_link_local or addr.is_loopback or addr.is_unspecified:
+        return False
+    return True    
+
+def get_host_info():
+    """
+    Returns host information such as the host name and network interfaces.
+    """
+    # TODO(look to promote netifices use up in cloud-init netinfo funcs)
+    host_info = {
+        "network": {
+            "interfaces": {
+                "by-mac": collections.OrderedDict(),
+                "by-ipv4": collections.OrderedDict(),
+                "by-ipv6": collections.OrderedDict(),
+            },
+        },
+    }
+    hostname = getfqdn(util.get_hostname())
+    if hostname:
+        host_info["hostname"] = hostname
+        host_info["local-hostname"] = hostname
+        host_info["local_hostname"] = hostname
+
+    default_ipv4, default_ipv6 = get_default_ip_address()
+    if default_ipv4:
+        host_info[LOCAL_IPV4] = default_ipv4
+    if default_ipv6:
+        host_info[LOCAL_IPV6] = default_ipv6
+
+    by_mac = host_info["network"]["interfaces"]["by-mac"]
+    by_ipv4 = host_info["network"]["interfaces"]["by-ipv4"]
+    by_ipv6 = host_info["network"]["interfaces"]["by-ipv6"]
+
+    ifaces = netifaces.interfaces()
+    for dev_name in ifaces:
+        address_fams = netifaces.ifaddresses(dev_name)
+        af_link = address_fams.get(netifaces.AF_LINK)
+        af_inet4 = address_fams.get(netifaces.AF_INET)
+        af_inet6 = address_fams.get(netifaces.AF_INET6)
+
+        mac = None
+        if af_link and "addr" in af_link[0]:
+            mac = af_link[0]["addr"]
+
+        # Do not bother recording localhost
+        if mac == "00:00:00:00:00:00":
+            continue
+
+        if mac and (af_inet4 or af_inet6):
+            key = mac
+            val = {}
+            if af_inet4:
+                af_inet4_vals = []
+                for ip_info in af_inet4:
+                    if not is_valid_ip_address(ip_info["addr"]):
+                        continue
+                    af_inet4_vals.append(ip_info)
+                val["ipv4"] = af_inet4_vals
+            if af_inet6:
+                af_inet6_vals = []
+                for ip_info in af_inet6:
+                    if not is_valid_ip_address(ip_info["addr"]):
+                        continue
+                    af_inet6_vals.append(ip_info)
+                val["ipv6"] = af_inet6_vals
+            by_mac[key] = val
+
+        if af_inet4:
+            for ip_info in af_inet4:
+                key = ip_info["addr"]
+                if not is_valid_ip_address(key):
+                    continue
+                val = copy.deepcopy(ip_info)
+                del val["addr"]
+                if mac:
+                    val["mac"] = mac
+                by_ipv4[key] = val
+
+        if af_inet6:
+            for ip_info in af_inet6:
+                key = ip_info["addr"]
+                if not is_valid_ip_address(key):
+                    continue
+                val = copy.deepcopy(ip_info)
+                del val["addr"]
+                if mac:
+                    val["mac"] = mac
+                by_ipv6[key] = val
+
+    return host_info
+
+def wait_on_network(metadata):
+    # Determine whether we need to wait on the network coming online.
+    wait_on_ipv4 = False
+    wait_on_ipv6 = False
+    if WAIT_ON_NETWORK in metadata:
+        wait_on_network = metadata[WAIT_ON_NETWORK]
+        if WAIT_ON_NETWORK_IPV4 in wait_on_network:
+            wait_on_ipv4_val = wait_on_network[WAIT_ON_NETWORK_IPV4]
+            if isinstance(wait_on_ipv4_val, bool):
+                wait_on_ipv4 = wait_on_ipv4_val
+            else:
+                wait_on_ipv4 = util.translate_bool(wait_on_ipv4_val)
+        if WAIT_ON_NETWORK_IPV6 in wait_on_network:
+            wait_on_ipv6_val = wait_on_network[WAIT_ON_NETWORK_IPV6]
+            if isinstance(wait_on_ipv6_val, bool):
+                wait_on_ipv6 = wait_on_ipv6_val
+            else:
+                wait_on_ipv6 = util.translate_bool(wait_on_ipv6_val)
+
+    # Get information about the host.
+    host_info = None
+    while host_info is None:
+        # This loop + sleep results in two logs every second while waiting
+        # for either ipv4 or ipv6 up. Do we really need to log each iteration
+        # or can we log once and log on successful exit?
+        host_info = get_host_info()
+
+        network = host_info.get("network") or {}
+        interfaces = network.get("interfaces") or {}
+        by_ipv4 = interfaces.get("by-ipv4") or {}
+        by_ipv6 = interfaces.get("by-ipv6") or {}
+
+        if wait_on_ipv4:
+            ipv4_ready = len(by_ipv4) > 0 if by_ipv4 else False
+            if not ipv4_ready:
+                host_info = None
+
+        if wait_on_ipv6:
+            ipv6_ready = len(by_ipv6) > 0 if by_ipv6 else False
+            if not ipv6_ready:
+                host_info = None
+
+        if host_info is None:
+            LOG.debug(
+                "waiting on network: wait4=%s, ready4=%s, wait6=%s, ready6=%s",
+                wait_on_ipv4,
+                ipv4_ready,
+                wait_on_ipv6,
+                ipv6_ready,
+            )
+            time.sleep(1)
+
+    LOG.debug("waiting on network complete")
+    return host_info
+
+
+def main():
+    """
+    Executed when this file is used as a program.
+    """
+    try:
+        logging.setupBasicLogging()
+    except Exception:
+        pass
+    metadata = {
+        "wait-on-network": {"ipv4": True, "ipv6": "false"},
+        "network": {"config": {"dhcp": True}},
+    }
+    host_info = wait_on_network(metadata)
+    metadata = util.mergemanydict([metadata, host_info])
+    print(util.json_dumps(metadata))
+
+
+if __name__ == "__main__":
+    main()
+
+
+

--- a/doc/rtd/topics/datasources/xen.rst
+++ b/doc/rtd/topics/datasources/xen.rst
@@ -1,0 +1,313 @@
+.. _datasource_xen:
+
+Xen
+======
+
+This datasource is for the use with XCP-ng/ Xen platforms reads vendor, metadata and user data from
+Xenstore
+
+
+Configuration
+-------------
+
+The configuration method is dependent upon the transport:
+
+Xenstore Keys
+^^^^^^^^^^^^^^
+
+One method of providing meta, user, and vendor data is by setting the following
+key/value pairs on a VM's Xenstore:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - ``vm-data/metadata``
+     - A YAML or JSON document containing the cloud-init metadata.
+   * - ``vm-data/metadata/encoding``
+     - The encoding type for ``vm-data/metadata``.
+   * - ``vm-data/userdata``
+     - A YAML document containing the cloud-init user data.
+   * - ``vm-data/userdata/encoding``
+     - The encoding type for ``vm-data/userdata``.
+   * - ``vm-data/vendordata``
+     - A YAML document containing the cloud-init vendor data.
+   * - ``vm-data/vendordata/encoding``
+     - The encoding type for ``vm-data/vendordata``.
+
+
+All ``vm-data/*/encoding`` values may be set to ``base64`` or
+``gzip+base64``.
+
+Features
+--------
+
+This section reviews several features available in this datasource, regardless
+of how the meta, user, and vendor data was discovered.
+
+Instance data and lazy networks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+One of the hallmarks of cloud-init is `its use of instance-data and JINJA
+queries <../instancedata.html#using-instance-data>`_
+-- the ability to write queries in user and vendor data that reference runtime
+information present in ``/run/cloud-init/instance-data.json``. This works well
+when the metadata provides all of the information up front, such as the network
+configuration. For systems that rely on DHCP, however, this information may not
+be available when the metadata is persisted to disk.
+
+This datasource ensures that even if the instance is using DHCP to configure
+networking, the same details about the configured network are available in
+``/run/cloud-init/instance-data.json`` as if static networking was used. This
+information collected at runtime is easy to demonstrate by executing the
+datasource on the command line. From the root of this repository, run the
+following command:
+
+.. code-block:: bash
+
+   PYTHONPATH="$(pwd)" python3 cloudinit/sources/DataSourceVMware.py
+
+The above command will result in output similar to the below JSON:
+
+.. code-block:: json
+
+   {
+       "hostname": "kalpesh.localhost",
+       "local-hostname": "kalpesh.localhost",
+       "local-ipv4": "10.10.8.15",
+       "local_hostname": "kalpesh.localhost",
+       "network": {
+           "config": {
+               "dhcp": true
+           },
+           "interfaces": {
+               "by-ipv4": {
+                   "172.0.0.2": {
+                       "netmask": "255.255.255.255",
+                       "peer": "172.0.0.2"
+                   },
+                   "192.168.0.188": {
+                       "broadcast": "192.168.0.255",
+                       "mac": "64:4b:f0:18:9a:21",
+                       "netmask": "255.255.255.0"
+                   }
+               },
+               "by-ipv6": {
+                   "fd8e:d25e:c5b6:1:1f5:b2fd:8973:22f2": {
+                       "flags": 208,
+                       "mac": "64:4b:f0:18:9a:21",
+                       "netmask": "ffff:ffff:ffff:ffff::/64"
+                   }
+               },
+               "by-mac": {
+                   "64:4b:f0:18:9a:21": {
+                       "ipv4": [
+                           {
+                               "addr": "192.168.0.188",
+                               "broadcast": "192.168.0.255",
+                               "netmask": "255.255.255.0"
+                           }
+                       ],
+                       "ipv6": [
+                           {
+                               "addr": "fd8e:d25e:c5b6:1:1f5:b2fd:8973:22f2",
+                               "flags": 208,
+                               "netmask": "ffff:ffff:ffff:ffff::/64"
+                           }
+                       ]
+                   },
+                   "ac:de:48:00:11:22": {
+                       "ipv6": []
+                   }
+               }
+           }
+       },
+       "wait-on-network": {
+           "ipv4": true,
+           "ipv6": "false"
+       }
+   }
+
+Reading the local IP addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This datasource automatically discovers the local IPv4 and IPv6 addresses for
+a guest operating system based on the default routes. However, when inspecting
+a VM externally, it's not possible to know what the *default* IP address is for
+the guest OS. That's why this datasource sets the discovered, local IPv4 and
+IPv6 addresses back in the guestinfo namespace as the following keys:
+
+
+* ``vm-data/local-ipv4``
+* ``vm-data/local-ipv6``
+
+It is possible that a host may not have any default, local IP addresses. It's
+also possible the reported, local addresses are link-local addresses. But these
+two keys may be used to discover what this datasource determined were the local
+IPv4 and IPv6 addresses for a host.
+
+Waiting on the network
+^^^^^^^^^^^^^^^^^^^^^^
+
+Sometimes cloud-init may bring up the network, but it will not finish coming
+online before the datasource's ``setup`` function is called, resulting in an
+``/var/run/cloud-init/instance-data.json`` file that does not have the correct
+network information. It is possible to instruct the datasource to wait until an
+IPv4 or IPv6 address is available before writing the instance data with the
+following metadata properties:
+
+.. code-block:: yaml
+
+   wait-on-network:
+     ipv4: true
+     ipv6: true
+
+If either of the above values are true, then the datasource will sleep for a
+second, check the network status, and repeat until one or both addresses from
+the specified families are available.
+
+Walkthrough
+-----------
+
+The following series of steps is a demonstration on how to configure a VM with
+this datasource:
+
+
+#. Create the metadata file for the VM. Save the following YAML to a file named
+   ``metadata.yaml``\ :
+
+   .. code-block:: yaml
+
+        instance-id: {VM_Name}
+        local-hostname: "vmsvc-cloudinit-0"
+        network:
+        version: 2
+        ethernets:
+            ens192:
+            addresses: [10.12.6.181/24]
+            gateway4: 10.12.6.1
+            dhcp6: false
+            nameservers:
+                addresses:
+                - 8.8.8.8
+                search:
+                - search.local
+            dhcp4: false
+            optional: true
+
+
+#. Create the userdata file ``userdata.yaml``\ :
+
+   .. code-block:: yaml
+
+        #cloud-config
+        #This is example configuration. We can create according to need
+        users:
+        - default
+        
+        - name: kalpesh
+            gecos: Kalpesh Gade
+            #To disable password login (It allows only SSH key based login )
+            lock_passwd: false
+            hashed_passwd: <SHA512 encoded passwd with rounds 4096>
+            #To copy SSH keys to ~/.ssh/authorized_keys
+            ssh_authorized_keys:
+                - ssh-rsa <SSH KEYS>
+            #Unrestricted Sudo access
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            #To allow SSH Password Authentication
+            ssh_pwauth: True
+
+
+#. Please note this step requires that the VM be powered off. 
+
+     xe vm-export -h hostname -u root -pw password vm=vm_name \
+    filename=pathname_of_file
+
+#. Power off the VM:
+
+   .. raw:: html
+
+      <hr />
+
+      &#x26a0;&#xfe0f; <strong>First Boot Mode</strong>
+
+   To ensure the next power-on operation results in a first-boot scenario for
+   cloud-init, it may be necessary to run the following command just before
+   powering off the VM:
+
+   .. code-block:: bash
+
+      cloud-init clean
+
+   Otherwise cloud-init may not run in first-boot mode. For more information
+   on how the boot mode is determined, please see the
+   `First Boot Documentation <../boot.html#first-boot-determination>`_.
+   .. code-block:: bash
+
+      xe vm-shutdown uuid=<UUID of VM> force=true    
+
+
+#.
+   Export the environment variables that contain the cloud-init metadata and
+   userdata:
+
+   .. code-block:: shell
+
+      export METADATA=$(gzip -c9 <metadata.yaml | { base64 -w0 2>/dev/null || base64; }) \
+           USERDATA=$(gzip -c9 <userdata.yaml | { base64 -w0 2>/dev/null || base64; })
+
+#.
+   Assign the metadata and userdata to the VM:
+
+   .. code-block:: shell
+
+        xe vm-param-set uuid=<new-vm-uuid> xenstore-data:vm-data/userdata=<userdata>
+        xe vm-param-set uuid=<new-vm-uuid> xenstore-data:vm-data/metadata=<metadata>
+        xe vm-param-set uuid=<new-vm-uuid> xenstore-data:vm-data/metadata/encoding=<enc_type>
+        xe vm-param-set uuid=<new-vm-uuid> xenstore-data:vm-data/userdata/encoding=<enc_type>
+
+   Please note the above commands include specifying the encoding for the
+   properties. This is important as it informs the datasource how to decode
+   the data for cloud-init. Valid values for ``metadata/encoding`` and
+   ``userdata/encoding`` include:
+
+
+   * ``base64``
+   * ``gzip+base64``
+
+
+
+If all went according to plan, the CentOS box is:
+
+* Locked down, allowing SSH access only for the user in the userdata
+* Configured for a dynamic IP address via DHCP
+* Has a hostname of ``cloud-vm``
+
+Examples
+--------
+
+This section reviews common configurations:
+
+Setting the hostname
+^^^^^^^^^^^^^^^^^^^^
+
+The hostname is set by way of the metadata key ``local-hostname``.
+
+Setting the instance ID
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The instance ID may be set by way of the metadata key ``instance-id``. However,
+if this value is absent then then the instance ID is read from the file
+``/sys/class/dmi/id/product_uuid``.
+
+Providing public SSH keys
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The public SSH keys may be set by way of the metadata key ``public-keys-data``.
+Each newline-terminated string will be interpreted as a separate SSH public
+key, which will be placed in distro's default user's
+``~/.ssh/authorized_keys``. If the value is empty or absent, then nothing will
+be written to ``~/.ssh/authorized_keys``.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ jsonpatch
 # For validating cloud-config sections per schema definitions
 jsonschema
 
-# Used by DataSourceVMware to inspect the host's network configuration during
+# Used by DataSourceVMware and DataSourceXen to inspect the host's network configuration during
 # the "setup()" function.
 #
 # This allows a host that uses DHCP to bring up the network during BootLocal

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -26,6 +26,7 @@ eb3095
 emmanuelthome
 esposem
 GabrielNagy
+gadekalp
 giggsoff
 hamalq
 holmanb
@@ -77,4 +78,4 @@ WebSpider
 xiachen-rh
 xnox
 zhuzaifangxuele
-gadekalp
+

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -77,3 +77,4 @@ WebSpider
 xiachen-rh
 xnox
 zhuzaifangxuele
+gadekalp

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1451,6 +1451,40 @@ dscheck_VMware() {
     return "${DS_NOT_FOUND}"
 }
 
+dscheck_Xen() {
+    if ! xen_xenstore_read; then
+        return "${DS_NOT_FOUND}"
+    fi
+
+    if { xenstore_read_xenstore_metadata || \
+         xenstore_read_xenstore_userdata || \
+         xenstore_read_xenstore_vendordata; } >/dev/null 2>&1; then    
+        return "${DS_FOUND}"
+    fi
+
+    return "${DS_NOT_FOUND}"    
+}
+
+xen_xenstore_read() {
+    command -v xenstore-read >/dev/null 2>&1
+}
+
+xenstore_read() {
+    xenstore-read "vm-data/${1}" 2>/dev/null | grep "[[:alnum:]]"
+}
+
+xenstore_read_xenstore_metadata() {
+    xenstore_read "metadata"
+}
+
+xenstore_read_xenstore_userdata() {
+    xenstore_read "userdata"
+}
+
+xenstore_read_xenstore_vendordata() {
+    xenstore_read "vendordata"
+}
+
 collect_info() {
     read_uname_info
     read_virt


### PR DESCRIPTION
## Proposed Commit Message
Add Xendatasource which uses xenstore info to configure VM
```

As cloud-init doesn't support Xen datasource so we tried to implement it using xenstore-data from which this script will make use of endpoints vm-data/metadata, vm-data/userdata and vm-data/vendordata and their encoding at points vm-data/*/encoding.
 
## Test Steps

1. Create cloud-init OS template for xen
2. Create VM from template created at step 1 (Keep VM turned off)
3. Send data to VM using xe utility
   -  xe vm-param-set uuid=<new-vm-uuid> xenstore-data:vm-data/userdata=<userdata>
   -  xe vm-param-set uuid=<new-vm-uuid> xenstore-data:vm-data/metadata=<metadata>
   -  xe vm-param-set uuid=<new-vm-uuid> xenstore-data:vm-data/metadata/encoding=<enc_type>
   -  xe vm-param-set uuid=<new-vm-uuid> xenstore-data:vm-data/userdata/encoding=<enc_type>
4. Start the VM

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
