### PR TITLE
cloudinit/dmi.py: Change warning to debug to prevent console display

### DIFF
--- a/cloudinit/dmi.py
+++ b/cloudinit/dmi.py
@@ -156,8 +156,8 @@ def read_dmi_data(key):
     if dmidecode_path:
         return _call_dmidecode(key, dmidecode_path)
 
-    LOG.warning("did not find either path %s or dmidecode command",
-                DMI_SYS_PATH)
+    LOG.debug("did not find either path %s or dmidecode command",
+              DMI_SYS_PATH)
     return None
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cloudinit/dmi.py: Change warning to debug to prevent console display

Change DMI warning to a debug message to prevent it appearing on
console during boot of machines, such as Raspberry Pi, that do
not support DMI.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
