### PR TITLE
cc_ssh.py: Add configuration for controlling ssh-keygen output

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -89,6 +89,10 @@ optionally, ``<key type>_certificate``, e.g. ``rsa_private: <key>``,
 key types. Not all key types have to be specified, ones left unspecified will
 not be used. If this config option is used, then no keys will be generated.
 
+When host keys are generated the output of the ssh-keygen command(s) can be
+displayed on the console using the ``ssh_quiet_keygen`` configuration key.
+This settings defaults to False which displays the keygen output.
+
 .. note::
     when specifying private host keys in cloud-config, care should be taken to
     ensure that the communication between the data source and the instance is
@@ -151,6 +155,7 @@ config flags are:
     ssh_publish_hostkeys:
         enabled: <true/false> (Defaults to true)
         blacklist: <list of key types> (Defaults to [dsa])
+    ssh_quiet_keygen: <true/false>
 """
 
 import glob
@@ -239,7 +244,9 @@ def handle(_name, cfg, cloud, log, _args):
             with util.SeLinuxGuard("/etc/ssh", recursive=True):
                 try:
                     out, err = subp.subp(cmd, capture=True, env=lang_c)
-                    sys.stdout.write(util.decode_binary(out))
+                    if not util.get_cfg_option_bool(cfg, 'ssh_quiet_keygen',
+                                                    False):
+                        sys.stdout.write(util.decode_binary(out))
 
                     gid = util.get_group_id("ssh_keys")
                     if gid != -1:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ssh.py: Add configuration for controlling ssh-keygen output

When ssh host keys are generated during initial boot the full output of
ssh-keygen, including the randomart for the key, is displayed on the
console for each of the generated key types, which takes up a large
amount of screen output (17 lines per key type).

With this change ssh-keygen output is still displayed by default.

Setting ssh_quiet_keygen to True will prevent ssh-keygen output from
appearing. If only the fingerprints of the host keys should be
displayed then this can be achieved using the existing
emit_keys_to_console and/or ssh_fp_console_blacklist settings.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
