### PR TITLE
hosts.alpine.tmpl: rearrange the order of short and long hostnames

### DIFF
--- a/templates/hosts.alpine.tmpl
+++ b/templates/hosts.alpine.tmpl
@@ -13,16 +13,13 @@ you need to add the following to config:
 #     /etc/cloud/cloud.cfg or cloud-config from user-data
 #
 # The following lines are desirable for IPv4 capable hosts
-127.0.1.1 {{fqdn}} {{hostname}}
-127.0.0.1 localhost.localdomain localhost
-127.0.0.1 localhost4.localdomain4 localhost4
+127.0.1.1 {{hostname}} {{fqdn}}
+127.0.0.1 localhost localhost.localdomain
+127.0.0.1 localhost4 localhost4.localdomain4
 
 # The following lines are desirable for IPv6 capable hosts
-::1 {{fqdn}} {{hostname}}
-::1 localhost6.localdomain6 localhost6
+::1 {{hostname}} {{fqdn}}
+::1 localhost6 localhost6.localdomain6
 
-fe00::0 ip6-localnet
-ff00::0 ip6-mcastprefix
 ff02::1 ip6-allnodes
 ff02::2 ip6-allrouters
-ff02::3 ip6-allhosts


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
hosts.alpine.tmpl: rearrange the order of short and long hostnames

The Alpine /etc/hosts template results in a file where the long form of
names (including localhost) come before the short form. This means that
when running tools like 'netstat' and 'ss' which convert IP address to
names that their output will show 'localhost.localdomain' rather than
'localhost.' This patch swaps the order of the short and long form names
so such utils will show the short form name.

It also removes several unnecessary IPv6-specific entries.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
