### PR TITLE
Add necessary mocks to test_ovf unit tests

### DIFF
--- a/tests/unittests/test_datasource/test_ovf.py
+++ b/tests/unittests/test_datasource/test_ovf.py
@@ -518,10 +518,16 @@ class TestDatasourceOVF(CiTestCase):
                         'vmware (%s/seed/ovf-env.xml)' % self.tdir,
                         ds.subplatform)
 
-    def test_get_data_vmware_guestinfo_with_network_config(self):
+    @mock.patch('cloudinit.subp.subp')
+    @mock.patch('cloudinit.sources.DataSource.persist_instance_data')
+    def test_get_data_vmware_guestinfo_with_network_config(
+        self, m_persist, m_subp
+    ):
         self._test_get_data_with_network_config(guestinfo=False, iso=True)
 
-    def test_get_data_iso9660_with_network_config(self):
+    @mock.patch('cloudinit.subp.subp')
+    @mock.patch('cloudinit.sources.DataSource.persist_instance_data')
+    def test_get_data_iso9660_with_network_config(self, m_persist, m_subp):
         self._test_get_data_with_network_config(guestinfo=True, iso=False)
 
     def _test_get_data_with_network_config(self, guestinfo, iso):


### PR DESCRIPTION
We likely have a test somewhere not cleaning up its mocks causing tests to run after it to not have to mock things that should be mocked. When run in isolation, these tests will fail. We need to find this test and fix it, but for now, fix the lack of mocks. 
