### PR TITLE
Allow libexec for hotplug (SC-532)

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -196,6 +196,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         EventType.BOOT_NEW_INSTANCE,
         EventType.BOOT,
         EventType.BOOT_LEGACY,
+        EventType.HOTPLUG,
     }}
     default_update_events = {EventScope.NETWORK: {
         EventType.BOOT_NEW_INSTANCE,

--- a/packages/redhat/cloud-init.spec.in
+++ b/packages/redhat/cloud-init.spec.in
@@ -119,12 +119,6 @@ version_pys=$(cd "$RPM_BUILD_ROOT" && find . -name version.py -type f)
 ( cd "$RPM_BUILD_ROOT" &&
   sed -i "s,@@PACKAGED_VERSION@@,%{version}-%{release}," $version_pys )
 
-# patch hotplug /usr/libexec script path
-hotplug_file=$(cd "$RPM_BUILD_ROOT" && find . -name 10-cloud-init-hook-hotplug.rules -type f)
-
-( cd "$RPM_BUILD_ROOT" &&
-  sed -i "s,/usr/lib,%{_libexecdir}," $hotplug_file )
-
 %clean
 rm -rf $RPM_BUILD_ROOT
 
@@ -178,7 +172,6 @@ fi
 %files
 
 /lib/udev/rules.d/66-azure-ephemeral.rules
-/lib/udev/rules.d/10-cloud-init-hook-hotplug.rules
 
 %if "%{init_system}" == "systemd"
 /usr/lib/systemd/system-generators/cloud-init-generator

--- a/tests/unittests/test_datasource/test_ovf.py
+++ b/tests/unittests/test_datasource/test_ovf.py
@@ -518,10 +518,16 @@ class TestDatasourceOVF(CiTestCase):
                         'vmware (%s/seed/ovf-env.xml)' % self.tdir,
                         ds.subplatform)
 
-    def test_get_data_vmware_guestinfo_with_network_config(self):
+    @mock.patch('cloudinit.subp.subp')
+    @mock.patch('cloudinit.sources.DataSource.persist_instance_data')
+    def test_get_data_vmware_guestinfo_with_network_config(
+        self, m_persist, m_subp
+    ):
         self._test_get_data_with_network_config(guestinfo=False, iso=True)
 
-    def test_get_data_iso9660_with_network_config(self):
+    @mock.patch('cloudinit.subp.subp')
+    @mock.patch('cloudinit.sources.DataSource.persist_instance_data')
+    def test_get_data_iso9660_with_network_config(self, m_persist, m_subp):
         self._test_get_data_with_network_config(guestinfo=True, iso=False)
 
     def _test_get_data_with_network_config(self, guestinfo, iso):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Allow libexec for hotplug

When we added the install hotplug module, we forgot to update the
redhet/cloud-init.spec.in file and allow for execution on /usr/libexec.
This PR adds that functionality
```

## Additional Context
<!-- If relevant -->

## Test Steps
Verified rpm package builds, `/etc/udev/rules.d/10-cloud-init-hook-hotplug.rules` gets written and references `/usr/libexec/cloud-init/hoook-hotplug` and `/usr/libexec/cloud-init/hook-hotplug` exists. Also tested that integration test still passes on ubuntu.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
