### PR TITLE
alpine.py: add options to the apk upgrade command

### DIFF
--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -128,6 +128,9 @@ class Distro(distros.Distro):
         if command:
             cmd.append(command)
 
+        if command == 'upgrade':
+            cmd.extend(["--update-cache", "--available"])
+
         pkglist = util.expand_package_list('%s-%s', pkgs)
         cmd.extend(pkglist)
 


### PR DESCRIPTION
## Proposed Commit Message

```
alpine.py: add options to the apk upgrade command

Whenever "apk upgrade" is triggered also use the "--available" and
"--update-cache" options to ensure that an up-to-date packages list
is used.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
