### PR TITLE
clear fallback interface before reprovisioning

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -498,6 +498,11 @@ class DataSourceAzure(sources.DataSource):
             self.fallback_interface,
             retries=10
         )
+
+        # reset _fallback_interface so that if the code enters reprovisioning
+        # flow, it will force re-evaluation of new fallback nic.
+        self._fallback_interface = None
+
         if not imds_md and not ovf_is_accessible:
             msg = 'No OVF or IMDS available'
             report_diagnostic_event(msg)


### PR DESCRIPTION
## Proposed Commit Message
Azure: fallback nic needs to be reevaluated during reprovisioning

```
During reprovisioning, VM network will change. fallback nic
should be cleared after use so that it can be re-evaluated after
reprovisioning
```


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
