### PR TITLE
Fix for set-name bug in networkd renderer

### DIFF
--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -41,11 +41,11 @@ class CfgParser:
 
     def get_final_conf(self):
         contents = ''
-        for k, v in self.conf_dict.items():
+        for k, v in sorted(self.conf_dict.items()):
             if not v:
                 continue
             contents += '['+k+']\n'
-            for e in v:
+            for e in sorted(v):
                 contents += e + '\n'
             contents += '\n'
 
@@ -242,6 +242,19 @@ class Renderer(renderer.Renderer):
                 name = iface['name']
                 # network state doesn't give dhcp domain info
                 # using ns.config as a workaround here
+
+                # Check to see if this interface matches against an interface
+                # from the network state that specified a set-name directive.
+                # If there is a device with a set-name directive and it has
+                # set-name value that matches the current name, then update the
+                # current name to the device's name. That will be the value in
+                # the ns.config['ethernets'] dict below.
+                for dev_name, dev_cfg in ns.config['ethernets'].items():
+                    if 'set-name' in dev_cfg:
+                        if dev_cfg.get('set-name') == name:
+                            name = dev_name
+                            break
+
                 self.dhcp_domain(ns.config['ethernets'][name], cfg)
 
             ret_dict.update({link: cfg.get_final_conf()})

--- a/cloudinit/net/tests/test_networkd.py
+++ b/cloudinit/net/tests/test_networkd.py
@@ -1,0 +1,64 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from cloudinit import safeyaml
+from cloudinit.net import networkd, network_state
+
+V2_CONFIG_SET_NAME = """\
+network:
+  version: 2
+  ethernets:
+    eth0:
+      match:
+        macaddress: '00:11:22:33:44:55'
+      nameservers:
+        search: [spam.local, eggs.local]
+        addresses: [8.8.8.8]
+    eth1:
+      match:
+        macaddress: '66:77:88:99:00:11'
+      set-name: "ens92"
+      nameservers:
+        search: [foo.local, bar.local]
+        addresses: [4.4.4.4]
+"""
+
+V2_CONFIG_SET_NAME_RENDERED_ETH0 = """[Match]
+MACAddress=00:11:22:33:44:55
+Name=eth0
+
+[Network]
+DHCP=no
+DNS=8.8.8.8
+Domains=spam.local eggs.local
+
+"""
+
+V2_CONFIG_SET_NAME_RENDERED_ETH1 = """[Match]
+MACAddress=66:77:88:99:00:11
+Name=ens92
+
+[Network]
+DHCP=no
+DNS=4.4.4.4
+Domains=foo.local bar.local
+
+"""
+
+
+class TestNetworkdRenderState:
+    def _parse_network_state_from_config(self, config):
+        yaml = safeyaml.load(config)
+        return network_state.parse_net_config_data(yaml["network"])
+
+    def test_networkd_render_with_set_name(self):
+        ns = self._parse_network_state_from_config(V2_CONFIG_SET_NAME)
+        renderer = networkd.Renderer()
+        rendered_content = renderer._render_content(ns)
+
+        assert "eth0" in rendered_content
+        assert rendered_content["eth0"] == V2_CONFIG_SET_NAME_RENDERED_ETH0
+        assert "ens92" in rendered_content
+        assert rendered_content["ens92"] == V2_CONFIG_SET_NAME_RENDERED_ETH1
+
+
+# vi: ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix for set-name bug in networkd renderer

This patch address an issue where the use of the "set-name"
directive caused the networkd renderer to fail.

LP: #1949407
```

## Additional Context
Please note this was root caused by @pradipd at https://github.com/pradipd/cloud-init/commit/756742a05dacbd812da5c10c0f3ae592156679ca, and this PR is merely an optimization on their existing fix as well as the addition of a unit test to validate the fix.

Fixes Kubernetes image builder bug described in this comment - https://github.com/kubernetes-sigs/image-builder/issues/712#issuecomment-954140935

CC @MaxRink @zawachte-msft @kkeshavamurthy @randomvariable @codenrhoden 

## Test Steps
The following command and output demonstrates the patch works as intended:

```bash
$ make clean_pyc && PYTHONPATH="$(pwd)" python3 -m pytest -v --log-level=DEBUG cloudinit/net/tests/test_networkd.py
====================================================================== test session starts ======================================================================
platform darwin -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/local/opt/python@3.9/bin/python3.9
cachedir: .pytest_cache
rootdir: /Users/akutz/Projects/cloud-init, configfile: tox.ini
collected 1 item                                                                                                                                                

cloudinit/net/tests/test_networkd.py::TestNetworkdRenderState::test_networkd_render_with_set_name PASSED                                                  [100%]

======================================================================= warnings summary ========================================================================
../../../../usr/local/lib/python3.9/site-packages/_pytest/config/__init__.py:1183
  /usr/local/lib/python3.9/site-packages/_pytest/config/__init__.py:1183: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(

conftest.py:68
  /Users/akutz/Projects/cloud-init/conftest.py:68: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(autouse=True)

conftest.py:169
  /Users/akutz/Projects/cloud-init/conftest.py:169: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    def httpretty():

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================= 1 passed, 3 warnings in 0.05s =================================================================
```

However, if the patch to the file is removed and the test is executed again, the original error occurs:

```diff
diff --git a/cloudinit/net/networkd.py b/cloudinit/net/networkd.py
index 62ee3bcc..c97aaa68 100644
--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -243,19 +243,6 @@ class Renderer(renderer.Renderer):
                 # network state doesn't give dhcp domain info
                 # using ns.config as a workaround here
 
-                # Check to see if this interface matches against an interface
-                # from the network state that specified a set-name directive.
-                # If there is a device with a set-name directive and it has
-                # set-name value that matches the current name, then update the
-                # current name to the device's name. That will be the valeu in
-                # the ns.config['ethernets'] dict below.
-                for dev_name, dev_cfg in ns.config['ethernets'].items():
-                    if 'set-name' in dev_cfg:
-                        set_name_iface = dev_cfg.get('set-name')
-                        if set_name_iface:
-                            if set_name_iface == name:
-                                name = dev_name
-                                break
                 self.dhcp_domain(ns.config['ethernets'][name], cfg)
 
             ret_dict.update({link: cfg.get_final_conf()})
```

```bash
$ make clean_pyc && PYTHONPATH="$(pwd)" python3 -m pytest -v --log-level=DEBUG cloudinit/net/tests/test_networkd.py
====================================================================== test session starts ======================================================================
platform darwin -- Python 3.9.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /usr/local/opt/python@3.9/bin/python3.9
cachedir: .pytest_cache
rootdir: /Users/akutz/Projects/cloud-init, configfile: tox.ini
collected 1 item                                                                                                                                                

cloudinit/net/tests/test_networkd.py::TestNetworkdRenderState::test_networkd_render_with_set_name FAILED                                                  [100%]

=========================================================================== FAILURES ============================================================================
__________________________________________________ TestNetworkdRenderState.test_networkd_render_with_set_name ___________________________________________________

self = <cloudinit.net.tests.test_networkd.TestNetworkdRenderState object at 0x1023966d0>

    def test_networkd_render_with_set_name(self):
        ns = self._parse_network_state_from_config(V2_CONFIG_NAMESERVERS)
        renderer = networkd.Renderer()
>       rendered_content = renderer._render_content(ns)

cloudinit/net/tests/test_networkd.py:39: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <cloudinit.net.networkd.Renderer object at 0x10230dd30>, ns = <cloudinit.net.network_state.NetworkState object at 0x102396b50>

    def _render_content(self, ns):
        ret_dict = {}
        for iface in ns.iter_interfaces():
            cfg = CfgParser()
    
            link = self.generate_match_section(iface, cfg)
            self.generate_link_section(iface, cfg)
            self.parse_subnets(iface, cfg)
            self.parse_dns(iface, cfg, ns)
    
            for route in ns.iter_routes():
                self.parse_routes(route, cfg)
    
            if ns.version == 2:
                name = iface['name']
                # network state doesn't give dhcp domain info
                # using ns.config as a workaround here
    
>               self.dhcp_domain(ns.config['ethernets'][name], cfg)
E               KeyError: 'ens92'

cloudinit/net/networkd.py:246: KeyError
----------------------------------------------------------------------- Captured log call -----------------------------------------------------------------------
2021-11-04 18:23:55 DEBUG     cloudinit.net.network_state:network_state.py:670 v2(ethernets) -> v1(physical):
{'type': 'physical', 'name': 'eth0', 'mac_address': '00:11:22:33:44:55', 'match': {'macaddress': '00:11:22:33:44:55'}}
2021-11-04 18:23:55 DEBUG     cloudinit.net.network_state:network_state.py:670 v2(ethernets) -> v1(physical):
{'type': 'physical', 'name': 'ens92', 'mac_address': '66:77:88:99:00:11', 'match': {'macaddress': '66:77:88:99:00:11'}}
2021-11-04 18:23:55 DEBUG     cloudinit.net.network_state:network_state.py:711 v2_common: handling config:
{'eth0': {'match': {'macaddress': '00:11:22:33:44:55'}, 'nameservers': {'search': ['spam.local', 'eggs.local'], 'addresses': ['8.8.8.8']}}, 'eth1': {'match': {'macaddress': '66:77:88:99:00:11'}, 'set-name': 'ens92', 'nameservers': {'search': ['foo.local', 'bar.local'], 'addresses': ['4.4.4.4']}}}
======================================================================= warnings summary ========================================================================
../../../../usr/local/lib/python3.9/site-packages/_pytest/config/__init__.py:1183
  /usr/local/lib/python3.9/site-packages/_pytest/config/__init__.py:1183: PytestDeprecationWarning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(

conftest.py:68
  /Users/akutz/Projects/cloud-init/conftest.py:68: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    @pytest.yield_fixture(autouse=True)

conftest.py:169
  /Users/akutz/Projects/cloud-init/conftest.py:169: PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.
    def httpretty():

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================================================================== short test summary info ====================================================================
FAILED cloudinit/net/tests/test_networkd.py::TestNetworkdRenderState::test_networkd_render_with_set_name - KeyError: 'ens92'
================================================================= 1 failed, 3 warnings in 0.18s =================================================================
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
