### PR TITLE
Some miscellaneous integration test fixes (SC-606)

### DIFF
--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -19,10 +19,6 @@ apt:
             Fix-Broken "true";
         }
     }
-  proxy: "http://proxy.internal:3128"
-  http_proxy: "http://squid.internal:3128"
-  ftp_proxy: "ftp://squid.internal:3128"
-  https_proxy: "https://squid.internal:3128"
   primary:
     - arches: [default]
       uri: http://badarchive.ubuntu.com/ubuntu
@@ -38,9 +34,9 @@ apt:
     deb-src $SECURITY $RELEASE-security multiverse
   sources:
     test_keyserver:
-        keyid: 72600DB15B8E4C8B1964B868038ACC97C660A937
-        keyserver: keyserver.ubuntu.com
-        source: "deb http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu $RELEASE main"
+      keyid: 110E21D8B0E2A1F0243AF6820856F197B892ACEA
+      keyserver: keyserver.ubuntu.com
+      source: "deb http://ppa.launchpad.net/canonical-kernel-team/ppa/ubuntu $RELEASE main"
     test_ppa:
       keyid: 441614D8
       keyserver: keyserver.ubuntu.com
@@ -95,10 +91,8 @@ EXPECTED_REGEXES = [
     r"deb-src http://badsecurity.ubuntu.com/ubuntu [a-z]+-security multiverse",
 ]
 
-TEST_KEYSERVER_KEY = "7260 0DB1 5B8E 4C8B 1964  B868 038A CC97 C660 A937"
-
+TEST_KEYSERVER_KEY = "110E 21D8 B0E2 A1F0 243A  F682 0856 F197 B892 ACEA"
 TEST_PPA_KEY = "3552 C902 B4DD F7BD 3842  1821 015D 28D7 4416 14D8"
-
 TEST_KEY = "1FF0 D853 5EF7 E719 E5C8  1B9C 083D 06FB E4D3 04DF"
 TEST_SIGNED_BY_KEY = "A2EB 2DEC 0BD7 519B 7B38  BE38 376A 290E C806 8B11"
 
@@ -148,18 +142,6 @@ class TestApt:
         assert 'Assume-Yes "true";' in apt_config
         assert 'Fix-Broken "true";' in apt_config
 
-    def test_apt_proxy(self, class_client: IntegrationInstance):
-        """Test the apt proxy functionality.
-
-        Ported from tests/cloud_tests/testcases/modules/apt_configure_proxy.py
-        """
-        out = class_client.read_from_file(
-            '/etc/apt/apt.conf.d/90cloud-init-aptproxy')
-        assert 'Acquire::http::Proxy "http://proxy.internal:3128";' in out
-        assert 'Acquire::http::Proxy "http://squid.internal:3128";' in out
-        assert 'Acquire::ftp::Proxy "ftp://squid.internal:3128";' in out
-        assert 'Acquire::https::Proxy "https://squid.internal:3128";' in out
-
     def test_ppa_source(self, class_client: IntegrationInstance):
         """Test the apt ppa functionality.
 
@@ -186,7 +168,6 @@ class TestApt:
             "deb [signed-by=/etc/apt/cloud-init.gpg.d/test_signed_by.gpg] "
             "http://ppa.launchpad.net/juju/stable/ubuntu"
             " {} main".format(release))
-        print(class_client.execute('cat /var/log/cloud-init.log'))
         path_contents = class_client.read_from_file(
             '/etc/apt/sources.list.d/test_signed_by.list')
         assert path_contents == source
@@ -230,7 +211,7 @@ class TestApt:
         )
 
         assert (
-            'http://ppa.launchpad.net/cloud-init-raharper/curtin-dev/ubuntu'
+            'http://ppa.launchpad.net/canonical-kernel-team/ppa/ubuntu'
         ) in test_keyserver_contents
 
         assert TEST_KEYSERVER_KEY in self.get_keys(class_client)
@@ -342,3 +323,25 @@ class TestDisabled:
             '/etc/apt/apt.conf.d/90cloud-init-pipelining'
         )
         assert 'Acquire::http::Pipeline-Depth "0";' in conf
+
+
+APT_PROXY_DATA = """\
+#cloud-config
+apt:
+  proxy: "http://proxy.internal:3128"
+  http_proxy: "http://squid.internal:3128"
+  ftp_proxy: "ftp://squid.internal:3128"
+  https_proxy: "https://squid.internal:3128"
+"""
+
+
+@pytest.mark.ubuntu
+@pytest.mark.user_data(APT_PROXY_DATA)
+def test_apt_proxy(client: IntegrationInstance):
+    """Test the apt proxy data gets written correctly."""
+    out = client.read_from_file(
+        '/etc/apt/apt.conf.d/90cloud-init-aptproxy')
+    assert 'Acquire::http::Proxy "http://proxy.internal:3128";' in out
+    assert 'Acquire::http::Proxy "http://squid.internal:3128";' in out
+    assert 'Acquire::ftp::Proxy "ftp://squid.internal:3128";' in out
+    assert 'Acquire::https::Proxy "https://squid.internal:3128";' in out

--- a/tests/integration_tests/modules/test_keys_to_console.py
+++ b/tests/integration_tests/modules/test_keys_to_console.py
@@ -4,6 +4,8 @@
 ``tests/cloud_tests/testcases/modules/keys_to_console.yaml``.)"""
 import pytest
 
+from tests.integration_tests.util import retry
+
 BLACKLIST_USER_DATA = """\
 #cloud-config
 ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
@@ -30,6 +32,9 @@ class TestKeysToConsoleBlacklist:
         syslog = class_client.read_from_file("/var/log/syslog")
         assert "({})".format(key_type) not in syslog
 
+    # retry decorator here because it can take some time to be reflected
+    # in syslog
+    @retry(tries=30, delay=1)
     @pytest.mark.parametrize("key_type", ["ED25519", "RSA"])
     def test_included_keys(self, class_client, key_type):
         syslog = class_client.read_from_file("/var/log/syslog")

--- a/tests/integration_tests/modules/test_puppet.py
+++ b/tests/integration_tests/modules/test_puppet.py
@@ -13,7 +13,7 @@ puppet:
 
 
 @pytest.mark.user_data(SERVICE_DATA)
-def test_pupet_service(client: IntegrationInstance):
+def test_puppet_service(client: IntegrationInstance):
     """Basic test that puppet gets installed and runs."""
     log = client.read_from_file('/var/log/cloud-init.log')
     verify_clean_log(log)

--- a/tests/integration_tests/modules/test_puppet.py
+++ b/tests/integration_tests/modules/test_puppet.py
@@ -1,0 +1,39 @@
+"""Test installation configuration of puppet module."""
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+SERVICE_DATA = """\
+#cloud-config
+puppet:
+  install: true
+  install_type: packages
+"""
+
+
+@pytest.mark.user_data(SERVICE_DATA)
+def test_pupet_service(client: IntegrationInstance):
+    """Basic test that puppet gets installed and runs."""
+    log = client.read_from_file('/var/log/cloud-init.log')
+    verify_clean_log(log)
+    assert client.execute('systemctl is-active puppet').ok
+    assert "Running command ['puppet', 'agent'" not in log
+
+
+EXEC_DATA = """\
+#cloud-config
+puppet:
+  install: true
+  install_type: packages
+  exec: true
+  exec_args: ['--noop']
+"""
+
+
+@pytest.mark.user_data
+@pytest.mark.user_data(EXEC_DATA)
+def test_pupet_exec(client: IntegrationInstance):
+    """Basic test that puppet gets installed and runs."""
+    log = client.read_from_file('/var/log/cloud-init.log')
+    assert "Running command ['puppet', 'agent', '--noop']" in log

--- a/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
+++ b/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
@@ -12,6 +12,8 @@ import re
 
 import pytest
 
+from tests.integration_tests.util import retry
+
 
 USER_DATA_SSH_AUTHKEY_DISABLE = """\
 #cloud-config
@@ -38,6 +40,9 @@ class TestSshAuthkeyFingerprints:
             "Skipping module named ssh-authkey-fingerprints, "
             "logging of SSH fingerprints disabled") in cloudinit_output
 
+    # retry decorator here because it can take some time to be reflected
+    # in syslog
+    @retry(tries=30, delay=1)
     @pytest.mark.user_data(USER_DATA_SSH_AUTHKEY_ENABLE)
     def test_ssh_authkey_fingerprints_enable(self, client):
         syslog_output = client.read_from_file("/var/log/syslog")

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -52,6 +52,15 @@ def verify_clean_log(log):
             'http://169.254.169.254/latest/meta-data/')
         warning_texts.append(fetch_error_text)
         traceback_texts.append(fetch_error_text)
+        # Oracle has a file in /etc/cloud/cloud.cfg.d that contains
+        # users:
+        # - default
+        # - name: opc
+        #   ssh_redirect_user: true
+        # This can trigger a warning about opc having no public key
+        warning_texts.append(
+            'Unable to disable SSH logins for opc given ssh_redirect_user'
+        )
 
     for warning_text in warning_texts:
         expected_warnings += log.count(warning_text)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Some miscellaneous integration test fixes

- Added to list of expected warnings on Oracle when opc user has
  no ssh key
- Added retries to tests that read from syslog as that can sometimes
  take time to reflect in the log
- Updated test_apt.py to remove proxy info into its own test as that
  can cause failures in updating, which will immediately traceback
  out of the module and prevent us from running further class tests
- Updated test_apt.py to use a more updated ppa in the test_keyserver
- Added basic rsyslog test to test_combined.py
- Added basic puppet test as test_puppet.py
```


