### PR TITLE
Add convenience symlink to integration test output

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -190,6 +190,15 @@ def _collect_logs(instance: IntegrationInstance, node_id: str,
         integration_settings.LOCAL_LOG_PATH
     ) / session_start_time / node_id_path
     log.info("Writing logs to %s", log_dir)
+
+    # Add a symlink to the latest log output directory
+    last_symlink = Path(integration_settings.LOCAL_LOG_PATH) / 'last'
+    if os.path.islink(last_symlink):
+        os.unlink(last_symlink)
+    os.symlink(
+        Path(integration_settings.LOCAL_LOG_PATH) / session_start_time,
+        last_symlink)
+
     if not log_dir.exists():
         log_dir.mkdir(parents=True)
     tarball_path = log_dir / 'cloud-init.tar.gz'


### PR DESCRIPTION
## Context:

Cloud-init allows automatic log collection from integration tests, however the UX isn't very friendly if tests are being ran repeatedly. Selecting "which directory" is not fun. Consider:
```
holmanb@arc:~ > ls /tmp/cloud_init_test_logs -l
total 36
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 10:52 211110105102
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 11:32 211110113108
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 11:38 211110113715
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:37 211110143557
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:39 211110143852
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:41 211110144125
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:47 211110144700
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:48 211110144823
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 15:22 211110152216
```
How to choose? (obviously a mix of tab completion and `ls -1` output makes it not-horrible, but it could certainly be better) 

The most common use case is "look at the last run". This change makes that convenient.

```
holmanb@arc:~ > ls /tmp/cloud_init_test_logs -l
total 36
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 10:52 211110105102
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 11:32 211110113108
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 11:38 211110113715
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:37 211110143557
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:39 211110143852
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:41 211110144125
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:47 211110144700
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:48 211110144823
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 15:22 211110152216
lrwxrwxrwx 1 holmanb holmanb   38 Nov 10 15:22 last -> /tmp/cloud_init_test_logs/211110152216

holmanb@arc:~ > ls /tmp/cloud_init_test_logs -l  
total 40
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 10:52 211110105102
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 11:32 211110113108
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 11:38 211110113715
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:37 211110143557
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:39 211110143852
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:41 211110144125
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:47 211110144700
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 14:48 211110144823
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 15:22 211110152216
drwxrwxr-x 3 holmanb holmanb 4096 Nov 10 15:23 211110152312
lrwxrwxrwx 1 holmanb holmanb   38 Nov 10 15:23 last -> /tmp/cloud_init_test_logs/211110152312
```
Now there is no choice to make for the common use case. `/tmp/cloud_init_test_logs/last/` is *the* answer.

Commit message:
```
Add convenience symlink to integration test output

Integration test runs get unique log directories at
/tmp/cloud_init_test_logs/$DATE_TIME. Make
/tmp/cloud_init_test_logs/last always point to the most recent
integration test directory.
```

## Test:
Run any integration test, watch `/tmp/cloud_init_test_logs/last/` appear as a symlink to latest test.
Run the test again, watch the symlink update.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
