### PR TITLE
lxd: add preference for LXD cloud-init.* config keys over user keys

### DIFF
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -353,6 +353,11 @@ def read_metadata(
                     # fallback config on old LXD, with new cloud-init images.
                     if CONFIG_KEY_ALIASES[cfg_key] not in md:
                         md[CONFIG_KEY_ALIASES[cfg_key]] = response.text
+                    else:
+                        LOG.warning(
+                            "Ignoring LXD config %s in favor of %s value.",
+                            cfg_key, cfg_key.replace("user", "cloud-init", 1)
+                        )
             else:
                 LOG.debug(
                     "Skipping %s on [HTTP:%d]:%s",

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -43,12 +43,11 @@ LXD_SOCKET_API_VERSION = "1.0"
 CONFIG_KEY_ALIASES = {
     "user.user-data": "user-data",
     "user.network-config": "network-config",
-    "user.network_mode": "network_mode",
     "user.vendor-data": "vendor-data"
 }
 
 
-def generate_fallback_network_config(network_mode: str = "") -> dict:
+def generate_fallback_network_config() -> dict:
     """Return network config V1 dict representing instance network config."""
     network_v1 = {
         "version": 1,
@@ -76,12 +75,6 @@ def generate_fallback_network_config(network_mode: str = "") -> dict:
                 network_v1["config"][0]["name"] = "enc9"
             else:
                 network_v1["config"][0]["name"] = "enp5s0"
-    if network_mode == "link-local":
-        network_v1["config"][0]["subnets"][0]["control"] = "manual"
-    elif network_mode not in ("", "dhcp"):
-        LOG.warning(
-            "Ignoring unexpected value user.network_mode: %s", network_mode
-        )
     return network_v1
 
 
@@ -244,10 +237,7 @@ class DataSourceLXD(sources.DataSource):
                     "network-config"
                 )
             else:
-                network_mode = self._crawled_metadata.get("network_mode", "")
-                self._network_config = generate_fallback_network_config(
-                    network_mode
-                )
+                self._network_config = generate_fallback_network_config()
         return self._network_config
 
 

--- a/cloudinit/sources/tests/test_lxd.py
+++ b/cloudinit/sources/tests/test_lxd.py
@@ -336,6 +336,12 @@ class TestReadMetadata:
                     " http://lxd/1.0/config/cloud-init.user-data",
                     "[GET] [HTTP:200]"
                     " http://lxd/1.0/config/cloud-init.vendor-data",
+                    "Ignoring LXD config user.user-data in favor of"
+                    " cloud-init.user-data value.",
+                    "Ignoring LXD config user.network-config in favor of"
+                    " cloud-init.network-config value.",
+                    "Ignoring LXD config user.vendor-data in favor of"
+                    " cloud-init.vendor-data value.",
                 ],
             ),
         )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
lxd: add preference for LXD cloud-init.* config keys over user keys

LXD now adds cloud-init scoped configuration keys network-config,
user-data and vendor-data. The existing user.user-data,
user.vendor-data, user.network-config and meta-data will be
deprecated in newer LXD.

cloud-init will prefer LXD config keys cloud-init.* keys above
user.* keys even if both are present.

Expectation is that the configuration user.network-config,
user.meta-data, user.user-data and user.vendor-data* keys should
not be present at the same time as the comparable cloud-init.* keys.

Also drop awareness of user.network_mode as this was deprecated
from LXD 2.1.

```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
