### PR TITLE
Fix Vultr timeout and wait values

### DIFF
--- a/cloudinit/sources/DataSourceVultr.py
+++ b/cloudinit/sources/DataSourceVultr.py
@@ -16,8 +16,8 @@ LOG = log.getLogger(__name__)
 BUILTIN_DS_CONFIG = {
     'url': 'http://169.254.169.254',
     'retries': 30,
-    'timeout': 2,
-    'wait': 2,
+    'timeout': 10,
+    'wait': 5,
     'user-agent': 'Cloud-Init/%s - OS: %s Variant: %s' %
                   (version.version_string(),
                    util.system_info()['system'],


### PR DESCRIPTION
## Proposed Commit Message
Fix Vultr timeout and wait values

```
Some Vultr Datacenters can experience latency in the connection due to the location of one of the dependant api's. The timouts need to be adjusted so this isn't a failure in the future.
```

## Test Steps
Deploy in Singapore, run curl command to API with various wait/timeouts

## Checklist:
 - [ X ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ X ] I have updated or added any unit tests accordingly
 - [ X ] I have updated or added any documentation accordingly
