### PR TITLE
tests: use /var/tmp instead of /tmp to avoid travis failures

### DIFF
--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -76,7 +76,7 @@ CLOUD_INIT_SOURCE = 'NONE'
 #   'ON_ERROR'
 #   'NEVER'
 COLLECT_LOGS = 'ON_ERROR'
-LOCAL_LOG_PATH = '/tmp/cloud_init_test_logs'
+LOCAL_LOG_PATH = '/var/tmp/cloud_init_test_logs'
 
 ##################################################################
 # SSH KEY SETTINGS


### PR DESCRIPTION
## Proposed Commit Message

```
/tmp is not guaranteed to be stable during early system boot.
It is better to use /var/tmp as /tmp may be remounted during
early boot and lead to spurrious build failures. This issue is
related to LP: #1707222.
```

## Additional Context
This could have hit my travis build at https://app.travis-ci.com/github/canonical/cloud-init/jobs/548632221#L8762
where the tmpdir didn't exist anymore.

## Test Steps
PR Integration tests should cover this, could introduce an assert 0 intentionally locally to make sure it creates the right subdir

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
