### PR TITLE
testing: monkeypatch system_info call in unit tests (SC-533)

### DIFF
--- a/cloudinit/analyze/tests/test_boot.py
+++ b/cloudinit/analyze/tests/test_boot.py
@@ -9,12 +9,7 @@ err_code = (FAIL_CODE, -1, -1, -1)
 
 class TestDistroChecker(CiTestCase):
 
-    @mock.patch('cloudinit.util.system_info', return_value={'dist': ('', '',
-                                                                     ''),
-                                                            'system': ''})
-    @mock.patch('cloudinit.util.get_linux_distro', return_value=('', '', ''))
-    @mock.patch('cloudinit.util.is_FreeBSD', return_value=False)
-    def test_blank_distro(self, m_sys_info, m_get_linux_distro, m_free_bsd):
+    def test_blank_distro(self):
         self.assertEqual(err_code, dist_check_timestamp())
 
     @mock.patch('cloudinit.util.system_info', return_value={'dist': ('', '',

--- a/cloudinit/analyze/tests/test_boot.py
+++ b/cloudinit/analyze/tests/test_boot.py
@@ -12,12 +12,8 @@ class TestDistroChecker(CiTestCase):
     def test_blank_distro(self):
         self.assertEqual(err_code, dist_check_timestamp())
 
-    @mock.patch('cloudinit.util.system_info', return_value={'dist': ('', '',
-                                                                     '')})
-    @mock.patch('cloudinit.util.get_linux_distro', return_value=('', '', ''))
     @mock.patch('cloudinit.util.is_FreeBSD', return_value=True)
-    def test_freebsd_gentoo_cant_find(self, m_sys_info,
-                                      m_get_linux_distro, m_is_FreeBSD):
+    def test_freebsd_gentoo_cant_find(self, m_is_FreeBSD):
         self.assertEqual(err_code, dist_check_timestamp())
 
     @mock.patch('cloudinit.subp.subp', return_value=(0, 1))

--- a/cloudinit/config/tests/test_set_passwords.py
+++ b/cloudinit/config/tests/test_set_passwords.py
@@ -121,13 +121,11 @@ class TestSetPasswordsHandle(CiTestCase):
             m_subp.call_args_list)
 
     @mock.patch(MODPATH + "util.multi_log")
-    @mock.patch(MODPATH + "util.is_BSD")
     @mock.patch(MODPATH + "subp.subp")
     def test_handle_on_chpasswd_list_creates_random_passwords(
-        self, m_subp, m_is_bsd, m_multi_log
+        self, m_subp, m_multi_log
     ):
         """handle parses command set random passwords."""
-        m_is_bsd.return_value = False
         cloud = self.tmp_cloud(distro='ubuntu')
         valid_random_pwds = [
             'root:R',

--- a/cloudinit/tests/test_util.py
+++ b/cloudinit/tests/test_util.py
@@ -815,6 +815,44 @@ class TestGetLinuxDistro(CiTestCase):
         self.assertEqual(('foo', '1.1', 'aarch64'), dist)
 
 
+class TestGetVariant:
+    @pytest.mark.parametrize('info, expected_variant', [
+        ({'system': 'Linux', 'dist': ('almalinux',)}, 'almalinux'),
+        ({'system': 'linux', 'dist': ('alpine',)}, 'alpine'),
+        ({'system': 'linux', 'dist': ('arch',)}, 'arch'),
+        ({'system': 'linux', 'dist': ('centos',)}, 'centos'),
+        ({'system': 'linux', 'dist': ('cloudlinux',)}, 'cloudlinux'),
+        ({'system': 'linux', 'dist': ('debian',)}, 'debian'),
+        ({'system': 'linux', 'dist': ('eurolinux',)}, 'eurolinux'),
+        ({'system': 'linux', 'dist': ('fedora',)}, 'fedora'),
+        ({'system': 'linux', 'dist': ('openEuler',)}, 'openeuler'),
+        ({'system': 'linux', 'dist': ('photon',)}, 'photon'),
+        ({'system': 'linux', 'dist': ('rhel',)}, 'rhel'),
+        ({'system': 'linux', 'dist': ('rocky',)}, 'rocky'),
+        ({'system': 'linux', 'dist': ('suse',)}, 'suse'),
+        ({'system': 'linux', 'dist': ('virtuozzo',)}, 'virtuozzo'),
+        ({'system': 'linux', 'dist': ('ubuntu',)}, 'ubuntu'),
+        ({'system': 'linux', 'dist': ('linuxmint',)}, 'ubuntu'),
+        ({'system': 'linux', 'dist': ('mint',)}, 'ubuntu'),
+        ({'system': 'linux', 'dist': ('redhat',)}, 'rhel'),
+        ({'system': 'linux', 'dist': ('opensuse',)}, 'suse'),
+        ({'system': 'linux', 'dist': ('opensuse-tumbleweed',)}, 'suse'),
+        ({'system': 'linux', 'dist': ('opensuse-leap',)}, 'suse'),
+        ({'system': 'linux', 'dist': ('sles',)}, 'suse'),
+        ({'system': 'linux', 'dist': ('sle_hpc',)}, 'suse'),
+        ({'system': 'linux', 'dist': ('my_distro',)}, 'linux'),
+        ({'system': 'Windows', 'dist': ('dontcare',)}, 'windows'),
+        ({'system': 'Darwin', 'dist': ('dontcare',)}, 'darwin'),
+        ({'system': 'Freebsd', 'dist': ('dontcare',)}, 'freebsd'),
+        ({'system': 'Netbsd', 'dist': ('dontcare',)}, 'netbsd'),
+        ({'system': 'Openbsd', 'dist': ('dontcare',)}, 'openbsd'),
+        ({'system': 'Dragonfly', 'dist': ('dontcare',)}, 'dragonfly'),
+    ])
+    def test_get_variant(self, info, expected_variant):
+        """Verify we get the correct variant name"""
+        assert util._get_variant(info) == expected_variant
+
+
 class TestJsonDumps(CiTestCase):
     def test_is_str(self):
         """json_dumps should return a string."""

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -533,6 +533,34 @@ def get_linux_distro():
     return (distro_name, distro_version, flavor)
 
 
+def _get_variant(info):
+    system = info['system'].lower()
+    variant = 'unknown'
+    if system == "linux":
+        linux_dist = info['dist'][0].lower()
+        if linux_dist in (
+                'almalinux', 'alpine', 'arch', 'centos', 'cloudlinux',
+                'debian', 'eurolinux', 'fedora', 'openeuler', 'photon',
+                'rhel', 'rocky', 'suse', 'virtuozzo'):
+            variant = linux_dist
+        elif linux_dist in ('ubuntu', 'linuxmint', 'mint'):
+            variant = 'ubuntu'
+        elif linux_dist == 'redhat':
+            variant = 'rhel'
+        elif linux_dist in (
+                'opensuse', 'opensuse-tumbleweed', 'opensuse-leap',
+                'sles', 'sle_hpc'):
+            variant = 'suse'
+        else:
+            variant = 'linux'
+    elif system in (
+            'windows', 'darwin', "freebsd", "netbsd",
+            "openbsd", "dragonfly"):
+        variant = system
+
+    return variant
+
+
 @lru_cache()
 def system_info():
     info = {
@@ -543,32 +571,7 @@ def system_info():
         'uname': list(platform.uname()),
         'dist': get_linux_distro()
     }
-    system = info['system'].lower()
-    var = 'unknown'
-    if system == "linux":
-        linux_dist = info['dist'][0].lower()
-        if linux_dist in (
-                'almalinux', 'alpine', 'arch', 'centos', 'cloudlinux',
-                'debian', 'eurolinux', 'fedora', 'openEuler', 'photon',
-                'rhel', 'rocky', 'suse', 'virtuozzo'):
-            var = linux_dist
-        elif linux_dist in ('ubuntu', 'linuxmint', 'mint'):
-            var = 'ubuntu'
-        elif linux_dist == 'redhat':
-            var = 'rhel'
-        elif linux_dist in (
-                'opensuse', 'opensuse-tumbleweed', 'opensuse-leap',
-                'sles', 'sle_hpc'):
-            var = 'suse'
-        else:
-            var = 'linux'
-    elif system in (
-            'windows', 'darwin', "freebsd", "netbsd",
-            "openbsd", "dragonfly"):
-        var = system
-
-    info['variant'] = var
-
+    info['variant'] = _get_variant(info)
     return info
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -212,7 +212,7 @@ def monkeypatch_system_info():
             "release": "invalid",
             "python": "invalid",
             "uname": ["invalid"] * 6,
-            "dist": ("invalid",) * 3,
+            "dist": ("Distro", "-1.1", "Codename"),
             "variant": "ubuntu"
         }
 

--- a/conftest.py
+++ b/conftest.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 import pytest
 
-from cloudinit import helpers, subp
+from cloudinit import helpers, subp, util
 
 
 class _FixtureUtils:
@@ -201,3 +201,19 @@ def paths(tmpdir):
         "run_dir": tmpdir.mkdir("run_dir").strpath,
     }
     return helpers.Paths(dirs)
+
+
+@pytest.fixture(autouse=True, scope='session')
+def monkeypatch_system_info():
+    def my_system_info():
+        return {
+            "platform": "invalid",
+            "system": "invalid",
+            "release": "invalid",
+            "python": "invalid",
+            "uname": ["invalid"] * 6,
+            "dist": ("invalid",) * 3,
+            "variant": "ubuntu"
+        }
+
+    util.system_info = my_system_info

--- a/tests/unittests/test_datasource/test_azure.py
+++ b/tests/unittests/test_datasource/test_azure.py
@@ -1789,9 +1789,8 @@ scbus-1 on xpt0 bus 0
             config_driver=True)
 
     @mock.patch(MOCKPATH + 'net.get_interfaces', autospec=True)
-    @mock.patch(MOCKPATH + 'util.is_FreeBSD')
     def test_blacklist_through_distro(
-            self, m_is_freebsd, m_net_get_interfaces):
+            self, m_net_get_interfaces):
         """Verify Azure DS updates blacklist drivers in the distro's
            networking object."""
         odata = {'HostName': "myhost", 'UserName': "myuser"}
@@ -1805,7 +1804,6 @@ scbus-1 on xpt0 bus 0
         self.assertEqual(distro.networking.blacklist_drivers,
                          dsaz.BLACKLIST_DRIVERS)
 
-        m_is_freebsd.return_value = False
         distro.networking.get_interfaces_by_mac()
         m_net_get_interfaces.assert_called_with(
             blacklist_drivers=dsaz.BLACKLIST_DRIVERS)
@@ -3219,7 +3217,6 @@ class TestPreprovisioningPollIMDS(CiTestCase):
 @mock.patch(MOCKPATH + 'DataSourceAzure._report_ready', mock.MagicMock())
 @mock.patch(MOCKPATH + 'subp.subp', mock.MagicMock())
 @mock.patch(MOCKPATH + 'util.write_file', mock.MagicMock())
-@mock.patch(MOCKPATH + 'util.is_FreeBSD')
 @mock.patch('cloudinit.sources.helpers.netlink.'
             'wait_for_media_disconnect_connect')
 @mock.patch('cloudinit.net.dhcp.EphemeralIPv4Network', autospec=True)
@@ -3236,10 +3233,8 @@ class TestAzureDataSourcePreprovisioning(CiTestCase):
 
     def test_poll_imds_returns_ovf_env(self, m_request,
                                        m_dhcp, m_net,
-                                       m_media_switch,
-                                       m_is_bsd):
+                                       m_media_switch):
         """The _poll_imds method should return the ovf_env.xml."""
-        m_is_bsd.return_value = False
         m_media_switch.return_value = None
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',
@@ -3268,10 +3263,8 @@ class TestAzureDataSourcePreprovisioning(CiTestCase):
 
     def test__reprovision_calls__poll_imds(self, m_request,
                                            m_dhcp, m_net,
-                                           m_media_switch,
-                                           m_is_bsd):
+                                           m_media_switch):
         """The _reprovision method should call poll IMDS."""
-        m_is_bsd.return_value = False
         m_media_switch.return_value = None
         m_dhcp.return_value = [{
             'interface': 'eth9', 'fixed-address': '192.168.2.9',

--- a/tests/unittests/test_datasource/test_azure_helper.py
+++ b/tests/unittests/test_datasource/test_azure_helper.py
@@ -129,9 +129,7 @@ class TestFindEndpoint(CiTestCase):
         self.dhcp_options.return_value = {"eth0": {"unknown_245": "5:4:3:2"}}
         self.assertEqual('5.4.3.2', wa_shim.find_endpoint(None))
 
-    @mock.patch('cloudinit.sources.helpers.azure.util.is_FreeBSD')
-    def test_latest_lease_used(self, m_is_freebsd):
-        m_is_freebsd.return_value = False  # To avoid hitting load_file
+    def test_latest_lease_used(self):
         encoded_addresses = ['5:4:3:2', '4:3:2:1']
         file_content = '\n'.join([self._build_lease_content(encoded_address)
                                   for encoded_address in encoded_addresses])

--- a/tests/unittests/test_datasource/test_configdrive.py
+++ b/tests/unittests/test_datasource/test_configdrive.py
@@ -486,11 +486,10 @@ class TestConfigDriveDataSource(CiTestCase):
                                           None,
                                           helpers.Paths({}))
         with mock.patch(M_PATH + 'find_candidate_devs') as m_find_devs:
-            with mock.patch(M_PATH + 'util.is_FreeBSD', return_value=False):
-                with mock.patch(M_PATH + 'util.mount_cb'):
-                    with mock.patch(M_PATH + 'on_first_boot'):
-                        m_find_devs.return_value = ['/dev/anything']
-                        self.assertEqual(True, cfg_ds.get_data())
+            with mock.patch(M_PATH + 'util.mount_cb'):
+                with mock.patch(M_PATH + 'on_first_boot'):
+                    m_find_devs.return_value = ['/dev/anything']
+                    self.assertEqual(True, cfg_ds.get_data())
         self.assertEqual('config-disk (/dev/anything)', cfg_ds.subplatform)
 
 

--- a/tests/unittests/test_distros/test_netconfig.py
+++ b/tests/unittests/test_distros/test_netconfig.py
@@ -783,7 +783,10 @@ class TestNetCfgDistroArch(TestNetCfgDistroBase):
                 """),
         }
 
-        with mock.patch('cloudinit.util.is_FreeBSD', return_value=False):
+        with mock.patch(
+            'cloudinit.net.netplan.get_devicelist',
+            return_value=[]
+        ):
             self._apply_and_verify(self.distro.apply_network_config,
                                    V1_NET_CFG,
                                    expected_cfgs=expected_cfgs.copy(),

--- a/tests/unittests/test_distros/test_netconfig.py
+++ b/tests/unittests/test_distros/test_netconfig.py
@@ -241,8 +241,6 @@ class TestNetCfgDistroBase(FilesystemMockingTestCase):
     def setUp(self):
         super(TestNetCfgDistroBase, self).setUp()
         self.add_patch('cloudinit.util.system_is_snappy', 'm_snappy')
-        self.add_patch('cloudinit.util.system_info', 'm_sysinfo')
-        self.m_sysinfo.return_value = {'dist': ('Distro', '99.1', 'Codename')}
 
     def _get_distro(self, dname, renderers=None):
         cls = distros.fetch(dname)

--- a/tests/unittests/test_distros/test_user_data_normalize.py
+++ b/tests/unittests/test_distros/test_user_data_normalize.py
@@ -26,8 +26,6 @@ class TestUGNormalize(TestCase):
     def setUp(self):
         super(TestUGNormalize, self).setUp()
         self.add_patch('cloudinit.util.system_is_snappy', 'm_snappy')
-        self.add_patch('cloudinit.util.system_info', 'm_sysinfo')
-        self.m_sysinfo.return_value = {'dist': ('Distro', '99.1', 'Codename')}
 
     def _make_distro(self, dtype, def_user=None):
         cfg = dict(settings.CFG_BUILTIN)

--- a/tests/unittests/test_handler/test_handler_ntp.py
+++ b/tests/unittests/test_handler/test_handler_ntp.py
@@ -512,24 +512,25 @@ class TestNtp(FilesystemMockingTestCase):
     def test_opensuse_picks_chrony(self, m_sysinfo):
         """Test opensuse picks chrony or ntp on certain distro versions"""
         #  < 15.0  => ntp
-        m_sysinfo.return_value = {'dist':
-                                       ('openSUSE', '13.2', 'Harlequin')}
+        m_sysinfo.return_value = {
+            'dist': ('openSUSE', '13.2', 'Harlequin')
+        }
         mycloud = self._get_cloud('opensuse')
         expected_client = mycloud.distro.preferred_ntp_clients[0]
         self.assertEqual('ntp', expected_client)
 
         #  >= 15.0 and  not openSUSE => chrony
-        m_sysinfo.return_value = {'dist':
-                                       ('SLES', '15.0',
-                                        'SUSE Linux Enterprise Server 15')}
+        m_sysinfo.return_value = {
+            'dist': ('SLES', '15.0', 'SUSE Linux Enterprise Server 15')
+        }
         mycloud = self._get_cloud('sles')
         expected_client = mycloud.distro.preferred_ntp_clients[0]
         self.assertEqual('chrony', expected_client)
 
         #  >= 15.0 and  openSUSE and ver != 42  => chrony
-        m_sysinfo.return_value = {'dist': ('openSUSE Tumbleweed',
-                                                '20180326',
-                                                'timbleweed')}
+        m_sysinfo.return_value = {
+            'dist': ('openSUSE Tumbleweed', '20180326', 'timbleweed')
+        }
         mycloud = self._get_cloud('opensuse')
         expected_client = mycloud.distro.preferred_ntp_clients[0]
         self.assertEqual('chrony', expected_client)

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5373,21 +5373,20 @@ class TestNetRenderers(CiTestCase):
                           priority=['sysconfig', 'eni'])
 
     @mock.patch("cloudinit.net.sysconfig.available_sysconfig")
-    @mock.patch("cloudinit.util.get_linux_distro")
-    def test_sysconfig_available_uses_variant_mapping(self, m_distro, m_avail):
+    @mock.patch("cloudinit.util.system_info")
+    def test_sysconfig_available_uses_variant_mapping(self, m_info, m_avail):
         m_avail.return_value = True
-        distro_values = [
-            ('opensuse', '', ''),
-            ('opensuse-leap', '', ''),
-            ('opensuse-tumbleweed', '', ''),
-            ('sles', '', ''),
-            ('centos', '', ''),
-            ('eurolinux', '', ''),
-            ('fedora', '', ''),
-            ('redhat', '', ''),
+        variants = [
+            'suse',
+            'centos',
+            'eurolinux',
+            'fedora',
+            'rhel',
         ]
-        for (distro_name, distro_version, flavor) in distro_values:
-            m_distro.return_value = (distro_name, distro_version, flavor)
+        for distro_name in variants:
+            m_info.return_value = {
+                "variant": distro_name
+            }
             if hasattr(util.system_info, "cache_clear"):
                 util.system_info.cache_clear()
             result = sysconfig.available()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: monkeypatch system_info call in unit tests

system_info can make calls that read or write from the filesystem, which
should require special mocking. It is also decorated with 'lru_cache',
which means test authors often don't realize they need to be mocking.
Also, we don't actually want the results from the user's local
machine, so monkeypatching it across all tests should be reasonable.

Additionally, moved some of 'system_info` into a helper function to
reduce the surface area of the monkeypatch, added tests for the new
function (and fixed a bug as a result), and removed related mocks that
should be no longer needed.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
