### PR TITLE
cc_ssh.py: Change private keyfile mode to 600

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -252,7 +252,7 @@ def handle(_name, cfg, cloud, log, _args):
                     if gid != -1:
                         # perform same "sanitize permissions" as sshd-keygen
                         os.chown(keyfile, -1, gid)
-                        os.chmod(keyfile, 0o640)
+                        os.chmod(keyfile, 0o600)
                         os.chmod(keyfile + ".pub", 0o644)
                 except subp.ProcessExecutionError as e:
                     err = util.decode_binary(e.stderr).lower()


### PR DESCRIPTION
sshd required that private key files are not accessible by others.
Permissions 0640 for keyfile are too open.

One use case is provision one ubuntu 20.04 VM with sshd version
‘OpenSSH_8.2p1 Ubuntu-4ubuntu0.3’. 
ssh.service process is aborted, because ExecStartPre=‘/usr/sbin/sshd -t’ 
run failed. Can’t connect vm using ssh connection anymore. 
So change private key files to 600 mode.

Signed-off-by: Jianlin Lv <lvlin@mail.ustc.edu.cn>

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
I provisioned one Ubuntu 20.04 VM and can't login with ssh.
ssh.service startup failed, because ExecStartPre=‘/usr/sbin/sshd -t’ returns an error.
The root cause is the permissions of private key are too open.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
