### PR TITLE
Move GCE metadata fetch to init-local (SC-502)

### DIFF
--- a/tests/unittests/test_datasource/test_common.py
+++ b/tests/unittests/test_datasource/test_common.py
@@ -41,6 +41,7 @@ DEFAULT_LOCAL = [
     CloudSigma.DataSourceCloudSigma,
     ConfigDrive.DataSourceConfigDrive,
     DigitalOcean.DataSourceDigitalOcean,
+    GCE.DataSourceGCELocal,
     Hetzner.DataSourceHetzner,
     IBMCloud.DataSourceIBMCloud,
     LXD.DataSourceLXD,

--- a/tests/unittests/test_datasource/test_gce.py
+++ b/tests/unittests/test_datasource/test_gce.py
@@ -368,19 +368,21 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         "cloudinit.sources.DataSourceGCE.DataSourceGCELocal.fallback_interface"
     )
     def test_local_datasource_uses_ephemeral_dhcp(self, _m_fallback, m_dhcp):
+        _set_mock_metadata()
         ds = DataSourceGCE.DataSourceGCELocal(
             sys_cfg={}, distro=None, paths=None
         )
         ds._get_data()
-        m_dhcp.assert_called_once()
+        assert m_dhcp.call_count == 1
 
     @mock.patch(
         "cloudinit.sources.DataSourceGCE.EphemeralDHCPv4",
         autospec=True,
     )
     def test_datasource_doesnt_use_ephemeral_dhcp(self, m_dhcp):
+        _set_mock_metadata()
         ds = DataSourceGCE.DataSourceGCE(sys_cfg={}, distro=None, paths=None)
         ds._get_data()
-        m_dhcp.assert_not_called()
+        assert m_dhcp.call_count == 0
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_datasource/test_gce.py
+++ b/tests/unittests/test_datasource/test_gce.py
@@ -360,5 +360,27 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         self.ds.publish_host_keys(hostkeys)
         m_readurl.assert_has_calls(readurl_expected_calls, any_order=True)
 
+    @mock.patch(
+        "cloudinit.sources.DataSourceGCE.EphemeralDHCPv4",
+        autospec=True,
+    )
+    @mock.patch(
+        "cloudinit.sources.DataSourceGCE.DataSourceGCELocal.fallback_interface"
+    )
+    def test_local_datasource_uses_ephemeral_dhcp(self, _m_fallback, m_dhcp):
+        ds = DataSourceGCE.DataSourceGCELocal(
+            sys_cfg={}, distro=None, paths=None
+        )
+        ds._get_data()
+        m_dhcp.assert_called_once()
+
+    @mock.patch(
+        "cloudinit.sources.DataSourceGCE.EphemeralDHCPv4",
+        autospec=True,
+    )
+    def test_datasource_doesnt_use_ephemeral_dhcp(self, m_dhcp):
+        ds = DataSourceGCE.DataSourceGCE(sys_cfg={}, distro=None, paths=None)
+        ds._get_data()
+        m_dhcp.assert_not_called()
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Move GCE metadata fetch to init-local

GCE currently fetches metadata after network has come up. There's no
reason we can't fetch at init-local time, so update GCE to fetch at
init-local time to be more consistent with other datasources.
```

## Additional Context
<!-- If relevant -->

## Test Steps
Upload dpkg to GCE instance and install
`cloud-init clean --logs --reboot`
Verify metadata is fetched at init-local time
Verify metadata is NOT fetched at init time

cloud-init.log can be seen at:
https://paste.ubuntu.com/p/tY3RkS9rKY/

Additionally, I ran integration tests on GCE

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
