### PR TITLE
jinja: provide and document jinja-safe key aliases in instance-data (SC-622)

### DIFF
--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -96,22 +96,24 @@ def load_userdata(ud_file_path):
         return util.decomp_gzip(bdata, quiet=False, decode=True)
 
 
-def handle_args(name, args):
-    """Handle calls to 'cloud-init query' as a subcommand."""
-    paths = None
-    addLogHandlerCLI(LOG, log.DEBUG if args.debug else log.WARNING)
-    if not any([args.list_keys, args.varname, args.format, args.dump_all]):
-        LOG.error(
-            'Expected one of the options: --all, --format,'
-            ' --list-keys or varname')
-        get_parser().print_help()
-        return 1
+def _read_instance_data(instance_data, user_data, vendor_data) -> dict:
+    """Return a dict of merged instance-data, vendordata and userdata.
 
+    The dict will contain supplemental userdata and vendordata keys sourced
+    from default user-data and vendor-data files.
+
+    Non-root users will have redacted INSTANCE_JSON_FILE content and redacted
+    vendordata and userdata values.
+
+    :raise: IOError/OSError on absence of instance-data.json file or invalid
+        access perms.
+    """
+    paths = None
     uid = os.getuid()
-    if not all([args.instance_data, args.user_data, args.vendor_data]):
+    if not all([instance_data, user_data, vendor_data]):
         paths = read_cfg_paths()
-    if args.instance_data:
-        instance_data_fn = args.instance_data
+    if instance_data:
+        instance_data_fn = instance_data
     else:
         redacted_data_fn = os.path.join(paths.run_dir, INSTANCE_JSON_FILE)
         if uid == 0:
@@ -127,12 +129,12 @@ def handle_args(name, args):
                 instance_data_fn = redacted_data_fn
         else:
             instance_data_fn = redacted_data_fn
-    if args.user_data:
-        user_data_fn = args.user_data
+    if user_data:
+        user_data_fn = user_data
     else:
         user_data_fn = os.path.join(paths.instance_link, 'user-data.txt')
-    if args.vendor_data:
-        vendor_data_fn = args.vendor_data
+    if vendor_data:
+        vendor_data_fn = vendor_data
     else:
         vendor_data_fn = os.path.join(paths.instance_link, 'vendor-data.txt')
 
@@ -143,7 +145,7 @@ def handle_args(name, args):
             LOG.error("No read permission on '%s'. Try sudo", instance_data_fn)
         else:
             LOG.error('Missing instance-data file: %s', instance_data_fn)
-        return 1
+        raise
 
     instance_data = util.load_json(instance_json)
     if uid != 0:
@@ -154,6 +156,65 @@ def handle_args(name, args):
     else:
         instance_data['userdata'] = load_userdata(user_data_fn)
         instance_data['vendordata'] = load_userdata(vendor_data_fn)
+    return instance_data
+
+
+def _find_instance_data_leaf_by_varname_path(
+    jinja_vars_without_aliases: dict, jinja_vars_with_aliases: dict,
+    varname: str, list_keys: bool
+):
+    """Return the value of the dot-delimited varname path in instance-data
+
+    Split a dot-delimited jinja variable name path into components, walk the
+    path components into the instance_data and look up a matching jinja
+    variable name or cloud-init's underscore-delimited key aliases.
+
+    :raises: ValueError when varname represents an invalid key name or path or
+        if list-keys is provided by varname isn't a dict object.
+    """
+    walked_key_path = ""
+    response = jinja_vars_without_aliases
+    for key_path_part in varname.split('.'):
+        try:
+            # Walk key path using complete aliases dict, yet response
+            # should only contain jinja_without_aliases
+            jinja_vars_with_aliases = jinja_vars_with_aliases[key_path_part]
+        except KeyError as e:
+            if walked_key_path:
+                msg = "instance-data '{key_path}' has no '{leaf}'".format(
+                    leaf=key_path_part, key_path=walked_key_path
+                )
+            else:
+                msg = "Undefined instance-data key '{}'".format(varname)
+            raise ValueError(msg) from e
+        if key_path_part in response:
+            response = response[key_path_part]
+        else:  # We are an underscore_delimited key alias
+            for key in response:
+                if get_jinja_variable_alias(key) == key_path_part:
+                    response = response[key]
+                    break
+        if walked_key_path:
+            walked_key_path += "."
+        walked_key_path += key_path_part
+    return response
+
+
+def handle_args(name, args):
+    """Handle calls to 'cloud-init query' as a subcommand."""
+    addLogHandlerCLI(LOG, log.DEBUG if args.debug else log.WARNING)
+    if not any([args.list_keys, args.varname, args.format, args.dump_all]):
+        LOG.error(
+            'Expected one of the options: --all, --format,'
+            ' --list-keys or varname')
+        get_parser().print_help()
+        return 1
+    try:
+        instance_data = _read_instance_data(
+            args.instance_data, args.user_data, args.vendor_data
+        )
+    except (IOError, OSError):
+        return 1
     if args.format:
         payload = '## template: jinja\n{fmt}'.format(fmt=args.format)
         rendered_payload = render_jinja_payload(
@@ -165,48 +226,32 @@ def handle_args(name, args):
             return 0
         return 1
 
-    jinja_without_aliases = convert_jinja_instance_data(instance_data)
-    jinja_aliases = convert_jinja_instance_data(
-        instance_data, include_key_aliases=True
-    )
-    response = jinja_without_aliases
+    # If not rendering a structured format above, query output will be either:
+    #  - JSON dump of all instance-data/jinja variables
+    #  - JSON dump of a value at an dict path into the instance-data dict.
+    #  - a list of keys for a specific dict path into the instance-data dict.
+    response = convert_jinja_instance_data(instance_data)
     if args.varname:
-        walked_key_path = ""
-        for key_path_part in args.varname.split('.'):
-            try:
-                # Walk key path using complete aliases dict, yet response
-                # should only contain jinja_without_aliases
-                jinja_aliases = jinja_aliases[key_path_part]
-            except KeyError:
-                if walked_key_path:
-                    msg = "instance-data '{key_path}' has no '{leaf}'".format(
-                        leaf=key_path_part, key_path=walked_key_path
-                    )
-                else:
-                    msg = "Undefined instance-data key '{}'".format(
-                        args.varname
-                    )
-                LOG.error(msg)
-                return 1
-            if key_path_part in response:
-                response = response[key_path_part]
-            else:  # We are an underscore_delimited key alias
-                for key in response:
-                    if get_jinja_variable_alias(key) == key_path_part:
-                        response = response[key]
-                        break
-            if walked_key_path:
-                walked_key_path += "."
-            walked_key_path += key_path_part
-        if args.list_keys:
-            if not isinstance(response, dict):
-                LOG.error(
-                    "--list-keys provided but '%s' is not a dict",
-                    key_path_part
-                )
-                return 1
-            response = '\n'.join(sorted(response.keys()))
-    elif args.list_keys:
+        jinja_vars_with_aliases = convert_jinja_instance_data(
+            instance_data, include_key_aliases=True
+        )
+        try:
+            response = _find_instance_data_leaf_by_varname_path(
+                jinja_vars_without_aliases=response,
+                jinja_vars_with_aliases=jinja_vars_with_aliases,
+                varname=args.varname,
+                list_keys=args.list_keys
+            )
+        except (KeyError, ValueError) as e:
+            LOG.error(e)
+            return 1
+    if args.list_keys:
+        if not isinstance(response, dict):
+            LOG.error(
+                "--list-keys provided but '%s' is not a dict",
+                args.varname
+            )
+            return 1
         response = '\n'.join(sorted(response.keys()))
     if not isinstance(response, str):
         response = util.json_dumps(response)

--- a/cloudinit/cmd/tests/test_query.py
+++ b/cloudinit/cmd/tests/test_query.py
@@ -193,8 +193,8 @@ class TestQuery:
                 m_getuid.return_value = 0
                 assert 0 == query.handle_args('anyname', args)
         expected = (
-            '{\n "my_var": "it worked",\n "userdata": "ud",\n '
-            '"vendordata": "vd"\n}\n'
+            '{\n "my-var": "it worked",\n "my_var": "it worked",\n '
+            '"userdata": "ud",\n "vendordata": "vd"\n}\n'
         )
         out, _err = capsys.readouterr()
         assert expected == out
@@ -211,7 +211,8 @@ class TestQuery:
             m_getuid.return_value = 100
             assert 0 == query.handle_args('anyname', args)
         expected = (
-            '{\n "my_var": "it worked",\n "userdata": "<%s> file:ud",\n'
+            '{\n "my-var": "it worked",\n "my_var": "it worked",\n'
+            ' "userdata": "<%s> file:ud",\n'
             ' "vendordata": "<%s> file:vd"\n}\n' % (
                 REDACT_SENSITIVE_VALUE, REDACT_SENSITIVE_VALUE
             )

--- a/cloudinit/cmd/tests/test_query.py
+++ b/cloudinit/cmd/tests/test_query.py
@@ -75,6 +75,40 @@ class TestQuery:
         assert 'usage: query' in out
         assert 1 == m_cli_log.call_count
 
+    @pytest.mark.parametrize(
+        "inst_data,varname,expected_error", (
+            (
+                '{"v1": {"key-2": "value-2"}}',
+                'v1.absent_leaf',
+                "instance-data 'v1' has no 'absent_leaf'\n"
+            ),
+            (
+                '{"v1": {"key-2": "value-2"}}',
+                'absent_key',
+                "Undefined instance-data key 'absent_key'\n"
+            ),
+        )
+    )
+    def test_handle_args_error_on_invalid_vaname_paths(
+        self, inst_data, varname, expected_error, caplog, tmpdir
+    ):
+        """Error when varname is not a valid instance-data variable path."""
+        instance_data = tmpdir.join('instance-data')
+        instance_data.write(inst_data)
+        args = self.args(
+            debug=False, dump_all=False, format=None,
+            instance_data=instance_data.strpath,
+            list_keys=False, user_data=None, vendor_data=None, varname=varname
+        )
+        paths, _, _, _ = self._setup_paths(tmpdir)
+        with mock.patch('cloudinit.cmd.query.read_cfg_paths') as m_paths:
+            m_paths.return_value = paths
+            with mock.patch(
+                "cloudinit.cmd.query.addLogHandlerCLI", return_value=""
+            ):
+                assert 1 == query.handle_args('anyname', args)
+        assert expected_error in caplog.text
+
     def test_handle_args_error_on_missing_instance_data(self, caplog, tmpdir):
         """When instance_data file path does not exist, log an error."""
         absent_fn = tmpdir.join('absent')
@@ -166,7 +200,7 @@ class TestQuery:
                 assert 0 == query.handle_args('anyname', args)
         out, _err = capsys.readouterr()
         cmd_output = json.loads(out)
-        assert "it worked" == cmd_output['my_var']
+        assert "it worked" == cmd_output['my-var']
         if ud_expected == "ci-b64:":
             ud_expected = "ci-b64:{}".format(b64e(ud_src))
         if vd_expected == "ci-b64:":
@@ -193,7 +227,7 @@ class TestQuery:
                 m_getuid.return_value = 0
                 assert 0 == query.handle_args('anyname', args)
         expected = (
-            '{\n "my-var": "it worked",\n "my_var": "it worked",\n '
+            '{\n "my-var": "it worked",\n '
             '"userdata": "ud",\n "vendordata": "vd"\n}\n'
         )
         out, _err = capsys.readouterr()
@@ -211,8 +245,7 @@ class TestQuery:
             m_getuid.return_value = 100
             assert 0 == query.handle_args('anyname', args)
         expected = (
-            '{\n "my-var": "it worked",\n "my_var": "it worked",\n'
-            ' "userdata": "<%s> file:ud",\n'
+            '{\n "my-var": "it worked",\n "userdata": "<%s> file:ud",\n'
             ' "vendordata": "<%s> file:vd"\n}\n' % (
                 REDACT_SENSITIVE_VALUE, REDACT_SENSITIVE_VALUE
             )
@@ -234,21 +267,38 @@ class TestQuery:
         out, _err = capsys.readouterr()
         assert 'it worked\n' == out
 
-    def test_handle_args_returns_nested_varname(self, capsys, tmpdir):
+    @pytest.mark.parametrize(
+        'inst_data,varname,expected',
+        (
+            (
+                '{"v1": {"key-2": "value-2"}, "my-var": "it worked"}',
+                'v1.key_2',
+                'value-2\n'
+            ),
+            # Assert no jinja underscore-delimited aliases are reported on CLI
+            (
+                '{"v1": {"something-hyphenated": {"no.underscores":"x",'
+                ' "no-alias": "y"}}, "my-var": "it worked"}',
+                'v1.something_hyphenated',
+                '{\n "no-alias": "y",\n "no.underscores": "x"\n}\n'
+            ),
+        )
+    )
+    def test_handle_args_returns_nested_varname(
+        self, inst_data, varname, expected, capsys, tmpdir
+    ):
         """If user_data file is a jinja template render instance-data vars."""
         instance_data = tmpdir.join('instance-data')
-        instance_data.write(
-            '{"v1": {"key-2": "value-2"}, "my-var": "it worked"}'
-        )
+        instance_data.write(inst_data)
         args = self.args(
             debug=False, dump_all=False, format=None,
             instance_data=instance_data.strpath, user_data='ud',
-            vendor_data='vd', list_keys=False, varname='v1.key_2')
+            vendor_data='vd', list_keys=False, varname=varname)
         with mock.patch('os.getuid') as m_getuid:
             m_getuid.return_value = 100
             assert 0 == query.handle_args('anyname', args)
         out, _err = capsys.readouterr()
-        assert 'value-2\n' == out
+        assert expected == out
 
     def test_handle_args_returns_standardized_vars_to_top_level_aliases(
         self, capsys, tmpdir

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -190,8 +190,8 @@ class DataSourceLXD(sources.DataSource):
         self.metadata = _raw_instance_data_to_dict(
             "meta-data", self._crawled_metadata.get("meta-data")
         )
-        if LXD_SOCKET_API_VERSION in self._crawled_metadata:
-            config = self._crawled_metadata[LXD_SOCKET_API_VERSION].get(
+        if "v" + LXD_SOCKET_API_VERSION in self._crawled_metadata:
+            config = self._crawled_metadata["v" + LXD_SOCKET_API_VERSION].get(
                 "config", {}
             )
             user_metadata = config.get("user.meta-data", {})
@@ -304,7 +304,7 @@ def read_metadata(
         if metadata_only:
             return md  # Skip network-data, vendor-data, user-data
 
-        md[LXD_SOCKET_API_VERSION] = {
+        md["v" + LXD_SOCKET_API_VERSION] = {
             "config": {},
             "meta-data": md["meta-data"]
         }
@@ -345,7 +345,9 @@ def read_metadata(
                 # Leave raw data values/format unchanged to represent it in
                 # instance-data.json for cloud-init query or jinja template
                 # use.
-                md[LXD_SOCKET_API_VERSION]["config"][cfg_key] = response.text
+                md["v" + LXD_SOCKET_API_VERSION]["config"][cfg_key] = (
+                    response.text
+                )
                 # Promote common CONFIG_KEY_ALIASES to top-level keys.
                 if cfg_key in CONFIG_KEY_ALIASES:
                     # Due to sort of config_routes, promote cloud-init.*

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -190,19 +190,16 @@ class DataSourceLXD(sources.DataSource):
         self.metadata = _raw_instance_data_to_dict(
             "meta-data", self._crawled_metadata.get("meta-data")
         )
-        if "v" + LXD_SOCKET_API_VERSION in self._crawled_metadata:
-            config = self._crawled_metadata["v" + LXD_SOCKET_API_VERSION].get(
-                "config", {}
+        config = self._crawled_metadata.get("config", {})
+        user_metadata = config.get("user.meta-data", {})
+        if user_metadata:
+            user_metadata = _raw_instance_data_to_dict(
+                "user.meta-data", user_metadata
             )
-            user_metadata = config.get("user.meta-data", {})
-            if user_metadata:
-                user_metadata = _raw_instance_data_to_dict(
-                    "user.meta-data", user_metadata
-                )
-            if not isinstance(self.metadata, dict):
-                self.metadata = util.mergemanydict(
-                    [util.load_yaml(self.metadata), user_metadata]
-                )
+        if not isinstance(self.metadata, dict):
+            self.metadata = util.mergemanydict(
+                [util.load_yaml(self.metadata), user_metadata]
+            )
         if "user-data" in self._crawled_metadata:
             self.userdata_raw = self._crawled_metadata["user-data"]
         if "network-config" in self._crawled_metadata:
@@ -304,7 +301,8 @@ def read_metadata(
         if metadata_only:
             return md  # Skip network-data, vendor-data, user-data
 
-        md["v" + LXD_SOCKET_API_VERSION] = {
+        md = {
+            "_metadata_api_version": api_version,  # Document API version read
             "config": {},
             "meta-data": md["meta-data"]
         }
@@ -345,9 +343,7 @@ def read_metadata(
                 # Leave raw data values/format unchanged to represent it in
                 # instance-data.json for cloud-init query or jinja template
                 # use.
-                md["v" + LXD_SOCKET_API_VERSION]["config"][cfg_key] = (
-                    response.text
-                )
+                md["config"][cfg_key] = response.text
                 # Promote common CONFIG_KEY_ALIASES to top-level keys.
                 if cfg_key in CONFIG_KEY_ALIASES:
                     # Due to sort of config_routes, promote cloud-init.*

--- a/cloudinit/sources/tests/test_lxd.py
+++ b/cloudinit/sources/tests/test_lxd.py
@@ -187,9 +187,9 @@ class TestReadMetadata:
                     "http://lxd/1.0/meta-data": "local-hostname: md\n",
                     "http://lxd/1.0/config": "[]",
                 },
-                {"_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
-                 "config": {}, "meta-data": "local-hostname: md\n",
-                 "meta-data": "local-hostname: md\n"},
+                {
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {}, "meta-data": "local-hostname: md\n"                },
                 ["[GET] [HTTP:200] http://lxd/1.0/meta-data",
                  "[GET] [HTTP:200] http://lxd/1.0/config"],
             ),

--- a/cloudinit/sources/tests/test_lxd.py
+++ b/cloudinit/sources/tests/test_lxd.py
@@ -42,7 +42,7 @@ LXD_V1_METADATA = {
     "network-config": NETWORK_V1,
     "user-data": "#cloud-config\npackages: [sl]\n",
     "vendor-data": "#cloud-config\nruncmd: ['echo vendor-data']\n",
-    "1.0": {
+    "v1.0": {
         "meta-data": "instance-id: my-lxc\nlocal-hostname: my-lxc\n\n",
         "config": {
             "user.user-data":
@@ -190,7 +190,7 @@ class TestReadMetadata:
                     "http://lxd/1.0/meta-data": "local-hostname: md\n",
                     "http://lxd/1.0/config": "[]",
                 },
-                {"1.0": {"config": {}, "meta-data": "local-hostname: md\n"},
+                {"v1.0": {"config": {}, "meta-data": "local-hostname: md\n"},
                  "meta-data": "local-hostname: md\n"},
                 ["[GET] [HTTP:200] http://lxd/1.0/meta-data",
                  "[GET] [HTTP:200] http://lxd/1.0/config"],
@@ -211,7 +211,7 @@ class TestReadMetadata:
                     "http://lxd/1.0/config/user.vendor-data": "",  # 404
                 },
                 {
-                    "1.0": {
+                    "v1.0": {
                         "config": {
                             "user.custom1": "custom1",   # Not promoted
                             "user.network-config": "net-config",
@@ -250,7 +250,7 @@ class TestReadMetadata:
                     "http://lxd/1.0/config/user.vendor-data": "vendor-data",
                 },
                 {
-                    "1.0": {
+                    "v1.0": {
                         "config": {
                             "user.custom1": "custom1",   # Not promoted
                             "user.meta-data": "meta-data",
@@ -303,7 +303,7 @@ class TestReadMetadata:
                         "cloud-init.vendor-data",
                 },
                 {
-                    "1.0": {
+                    "v1.0": {
                         "config": {
                             "user.meta-data": "user.meta-data",
                             "user.network-config": "user.network-config",

--- a/cloudinit/sources/tests/test_lxd.py
+++ b/cloudinit/sources/tests/test_lxd.py
@@ -42,15 +42,12 @@ LXD_V1_METADATA = {
     "network-config": NETWORK_V1,
     "user-data": "#cloud-config\npackages: [sl]\n",
     "vendor-data": "#cloud-config\nruncmd: ['echo vendor-data']\n",
-    "v1.0": {
-        "meta-data": "instance-id: my-lxc\nlocal-hostname: my-lxc\n\n",
-        "config": {
-            "user.user-data":
-                "instance-id: my-lxc\nlocal-hostname: my-lxc\n\n",
-            "user.vendor-data":
-                "#cloud-config\nruncmd: ['echo vendor-data']\n",
-            "user.network-config": yaml.safe_dump(NETWORK_V1),
-        }
+    "config": {
+        "user.user-data":
+            "instance-id: my-lxc\nlocal-hostname: my-lxc\n\n",
+        "user.vendor-data":
+            "#cloud-config\nruncmd: ['echo vendor-data']\n",
+        "user.network-config": yaml.safe_dump(NETWORK_V1),
     }
 }
 
@@ -190,7 +187,8 @@ class TestReadMetadata:
                     "http://lxd/1.0/meta-data": "local-hostname: md\n",
                     "http://lxd/1.0/config": "[]",
                 },
-                {"v1.0": {"config": {}, "meta-data": "local-hostname: md\n"},
+                {"_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                 "config": {}, "meta-data": "local-hostname: md\n",
                  "meta-data": "local-hostname: md\n"},
                 ["[GET] [HTTP:200] http://lxd/1.0/meta-data",
                  "[GET] [HTTP:200] http://lxd/1.0/config"],
@@ -211,12 +209,10 @@ class TestReadMetadata:
                     "http://lxd/1.0/config/user.vendor-data": "",  # 404
                 },
                 {
-                    "v1.0": {
-                        "config": {
-                            "user.custom1": "custom1",   # Not promoted
-                            "user.network-config": "net-config",
-                        },
-                        "meta-data": "local-hostname: md\n",
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {
+                        "user.custom1": "custom1",   # Not promoted
+                        "user.network-config": "net-config",
                     },
                     "meta-data": "local-hostname: md\n",
                     "network-config": "net-config",
@@ -250,15 +246,13 @@ class TestReadMetadata:
                     "http://lxd/1.0/config/user.vendor-data": "vendor-data",
                 },
                 {
-                    "v1.0": {
-                        "config": {
-                            "user.custom1": "custom1",   # Not promoted
-                            "user.meta-data": "meta-data",
-                            "user.network-config": "net-config",
-                            "user.user-data": "user-data",
-                            "user.vendor-data": "vendor-data",
-                        },
-                        "meta-data": "local-hostname: md\n",
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {
+                        "user.custom1": "custom1",   # Not promoted
+                        "user.meta-data": "meta-data",
+                        "user.network-config": "net-config",
+                        "user.user-data": "user-data",
+                        "user.vendor-data": "vendor-data",
                     },
                     "meta-data": "local-hostname: md\n",
                     "network-config": "net-config",
@@ -303,19 +297,17 @@ class TestReadMetadata:
                         "cloud-init.vendor-data",
                 },
                 {
-                    "v1.0": {
-                        "config": {
-                            "user.meta-data": "user.meta-data",
-                            "user.network-config": "user.network-config",
-                            "user.user-data": "user.user-data",
-                            "user.vendor-data": "user.vendor-data",
-                            "cloud-init.network-config":
-                                "cloud-init.network-config",
-                            "cloud-init.user-data": "cloud-init.user-data",
-                            "cloud-init.vendor-data":
-                                "cloud-init.vendor-data",
-                        },
-                        "meta-data": "local-hostname: md\n",
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {
+                        "user.meta-data": "user.meta-data",
+                        "user.network-config": "user.network-config",
+                        "user.user-data": "user.user-data",
+                        "user.vendor-data": "user.vendor-data",
+                        "cloud-init.network-config":
+                            "cloud-init.network-config",
+                        "cloud-init.user-data": "cloud-init.user-data",
+                        "cloud-init.vendor-data":
+                            "cloud-init.vendor-data",
                     },
                     "meta-data": "local-hostname: md\n",
                     "network-config": "cloud-init.network-config",

--- a/cloudinit/sources/tests/test_lxd.py
+++ b/cloudinit/sources/tests/test_lxd.py
@@ -189,7 +189,8 @@ class TestReadMetadata:
                 },
                 {
                     "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
-                    "config": {}, "meta-data": "local-hostname: md\n"                },
+                    "config": {}, "meta-data": "local-hostname: md\n"
+                },
                 ["[GET] [HTTP:200] http://lxd/1.0/meta-data",
                  "[GET] [HTTP:200] http://lxd/1.0/config"],
             ),

--- a/doc/rtd/topics/instancedata.rst
+++ b/doc/rtd/topics/instancedata.rst
@@ -530,12 +530,18 @@ Both user-data scripts and **#cloud-config** data support jinja template
 rendering.
 When the first line of the provided user-data begins with,
 **## template: jinja** cloud-init will use jinja to render that file.
-Any instance-data-sensitive.json variables are surfaced as dot-delimited
-jinja template variables because cloud-config modules are run as 'root'
-user.
+Any instance-data-sensitive.json variables are surfaced as jinja template
+variables because cloud-config modules are run as 'root' user.
 
+.. note::
+  cloud-init also provides jinja-safe key aliases for any instance-data.json
+  keys which contain jinja operator characters such as +, -, ., /, etc. Any
+  jinja operator will be replaced with underscores in the jinja-safe key
+  alias. This allows for cloud-init templates to use aliased variable
+  references which allow for jinja's dot-notation reference such as
+  ``{{ ds.v1_0.my_safe_key }}`` instead of ``{{ ds["v1.0"]["my/safe-key"] }}``.
 
-Below are some examples of providing these types of user-data:
+Below are some other examples of using jinja templates in user-data:
 
 * Cloud config calling home with the ec2 public hostname and availability-zone
 

--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -53,7 +53,9 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
     assert "lxd" == v1["platform"]
     assert "LXD socket API v. 1.0 (/dev/lxd/sock)" == v1["subplatform"]
     ds_cfg = json.loads(client.execute('cloud-init query ds').stdout)
-    assert ["config", "meta_data"] == sorted(list(ds_cfg["1.0"].keys()))
+    assert ["_doc", "_metadata_api_version", "config", "meta-data"] == sorted(
+        list(ds_cfg.keys())
+    )
     if (
         client.settings.PLATFORM == "lxd_vm" and
         ImageSpecification.from_os_image().release in ("xenial", "bionic")
@@ -62,15 +64,18 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
         # to start the lxd-agent.
         # https://github.com/canonical/pycloudlib/blob/main/pycloudlib/\
         #    lxd/defaults.py#L13-L27
-        lxd_config_keys = ["user.meta_data", "user.vendor_data"]
+        # Underscore-delimited aliases exist for any keys containing hyphens or
+        # dots.
+        lxd_config_keys = ["user.meta-data", "user.vendor-data"]
     else:
-        lxd_config_keys = ["user.meta_data"]
-    assert lxd_config_keys == list(ds_cfg["1.0"]["config"].keys())
+        lxd_config_keys = ["user.meta-data"]
+    assert "1.0" == ds_cfg["_metadata_api_version"]
+    assert lxd_config_keys == list(ds_cfg["config"].keys())
     assert {"public-keys": v1["public_ssh_keys"][0]} == (
-        yaml.safe_load(ds_cfg["1.0"]["config"]["user.meta_data"])
+        yaml.safe_load(ds_cfg["config"]["user.meta-data"])
     )
     assert (
-        "#cloud-config\ninstance-id" in ds_cfg["1.0"]["meta_data"]
+        "#cloud-config\ninstance-id" in ds_cfg["meta-data"]
     )
     # Assert NoCloud seed data is still present in cloud image metadata
     # This will start failing if we redact metadata templates from

--- a/tests/integration_tests/modules/test_jinja_templating.py
+++ b/tests/integration_tests/modules/test_jinja_templating.py
@@ -19,9 +19,9 @@ runcmd:
 def test_runcmd_with_variable_substitution(client: IntegrationInstance):
     """Test jinja substitution.
 
-    Ensure we can also substitute variables from instance-data-sensitive
-    LP: #1931392 and that underscore-delimited aliases exist for hyphenated
-    keys.
+    Ensure underscore-delimited aliases exist for hyphenated key and
+    we can also substitute variables from instance-data-sensitive
+    LP: #1931392.
     """
     hostname = client.execute('hostname').stdout.strip()
     expected = [

--- a/tests/integration_tests/modules/test_jinja_templating.py
+++ b/tests/integration_tests/modules/test_jinja_templating.py
@@ -11,6 +11,7 @@ USER_DATA = """\
 runcmd:
   - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
   - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+  - echo {{v1['local-hostname']}} >> /var/tmp/runcmd_output
 """
 
 
@@ -19,12 +20,15 @@ def test_runcmd_with_variable_substitution(client: IntegrationInstance):
     """Test jinja substitution.
 
     Ensure we can also substitute variables from instance-data-sensitive
-    LP: #1931392
+    LP: #1931392 and that underscore-delimited aliases exist for hyphenated
+    keys.
     """
+    hostname = client.execute('hostname').stdout.strip()
     expected = [
-        client.execute('hostname').stdout.strip(),
+        hostname,
         ('Merged cloud-init system config from /etc/cloud/cloud.cfg and '
-            '/etc/cloud/cloud.cfg.d/')
+            '/etc/cloud/cloud.cfg.d/'),
+        hostname
     ]
     output = client.read_from_file('/var/tmp/runcmd_output')
     verify_ordered_items_in_text(expected, output)

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -316,7 +316,7 @@ class TestConvertJinjaInstanceData:
     def test_convert_instance_data_operators_to_underscores(
         self, include_key_aliases, data, expected
     ):
-        """Replace Jinja operatiors keys with underscores in instance-data."""
+        """Replace Jinja operators keys with underscores in instance-data."""
         assert expected == convert_jinja_instance_data(
             data=data, include_key_aliases=include_key_aliases
         )

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -287,7 +287,8 @@ class TestConvertJinjaInstanceData(CiTestCase):
         """Replace hyphenated keys with underscores in instance-data."""
         data = {'hyphenated-key': 'hyphenated-val',
                 'underscore_delim_key': 'underscore_delimited_val'}
-        expected_data = {'hyphenated_key': 'hyphenated-val',
+        expected_data = {'hyphenated-key': 'hyphenated-val',
+                         'hyphenated_key': 'hyphenated-val',
                          'underscore_delim_key': 'underscore_delimited_val'}
         self.assertEqual(
             expected_data,
@@ -355,6 +356,7 @@ class TestRenderJinjaPayload(CiTestCase):
             DEBUG: Converted jinja variables
             {
              "hostname": "foo",
+             "instance-id": "iid",
              "instance_id": "iid",
              "v1": {
               "hostname": "foo"


### PR DESCRIPTION
## Proposed Commit Message
```
Allow #cloud-config and cloud-init query to use underscore-delimited
"jinja-safe" key aliases for any instance-data.json keys
containing jinja operator characters.

This provides a means to use Jinja's dot-notation instead of square brackets
and quoting to reference "unsafe" obtain attribute names.

Support for these aliased keys is available to both #cloud-config user-data and
`cloud-init query`.

For example #cloud-config alias access can look like:
  {{ ds.config.user_network_config }}

  - instead of -
  - 
  {{ ds.config["user.network-config"] }}
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```bash
 tox -e integration-tests tests/integration_tests/datasources/test_lxd_discovery.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
