### PR TITLE
 cloudinit/net: handle two different routes for the same ip

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1157,7 +1157,7 @@ class EphemeralIPv4Network(object):
             if gateway != "0.0.0.0":
                 via_arg = ['via', gateway]
             subp.subp(
-                ['ip', '-4', 'route', 'add', net_address] + via_arg +
+                ['ip', '-4', 'route', 'append', net_address] + via_arg +
                 ['dev', self.interface], capture=True)
             self.cleanup_cmds.insert(
                 0, ['ip', '-4', 'route', 'del', net_address] + via_arg +

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -723,13 +723,13 @@ class TestEphemeralIPV4Network(CiTestCase):
                 ['ip', '-family', 'inet', 'link', 'set', 'dev', 'eth0', 'up'],
                 capture=True),
             mock.call(
-                ['ip', '-4', 'route', 'add', '192.168.2.1/32',
+                ['ip', '-4', 'route', 'append', '192.168.2.1/32',
                  'dev', 'eth0'], capture=True),
             mock.call(
-                ['ip', '-4', 'route', 'add', '169.254.169.254/32',
+                ['ip', '-4', 'route', 'append', '169.254.169.254/32',
                  'via', '192.168.2.1', 'dev', 'eth0'], capture=True),
             mock.call(
-                ['ip', '-4', 'route', 'add', '0.0.0.0/0',
+                ['ip', '-4', 'route', 'append', '0.0.0.0/0',
                  'via', '192.168.2.1', 'dev', 'eth0'], capture=True)]
         expected_teardown_calls = [
             mock.call(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
If we set a dhcp server side like this:
$ cat /var/tmp/cloud-init/cloud-init-dhcp-f0rie5tm/dhcp.leases
lease {
...
option classless-static-routes 31.169.254.169.254 0.0.0.0,31.169.254.169.254
    10.112.143.127,22.10.112.140 0.0.0.0,0 10.112.140.1;
...
}
cloud-init fails to configure the routes via 'ip route add' because to there are
two different routes for 169.254.169.254:

$ ip -4 route add 192.168.1.1/32 via 0.0.0.0 dev eth0
$ ip -4 route add 192.168.1.1/32 via 10.112.140.248 dev eth0

But NetworkManager can handle such scenario successfully as it uses "ip route append".
So change cloud-init to also use "ip route append" to fix the issue:

$ ip -4 route append 192.168.1.1/32 via 0.0.0.0 dev eth0
$ ip -4 route append 192.168.1.1/32 via 10.112.140.248 dev eth0

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>

RHBZ: #2003231
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
