### PR TITLE
testing: Remove date from final_message test (SC-638)

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -74,23 +74,16 @@ class TestCombined:
         """Test that final_message module works as expected.
 
         Also tests LP 1511485: final_message is silent.
-
-        It's possible that if this test is run within a minute or so of
-        midnight that we'll see a failure because the day in the logs
-        is different from the day specified in the test definition.
         """
         client = class_client
         log = client.read_from_file('/var/log/cloud-init.log')
-        # Get date on host rather than locally as our host could be in a
-        # wildly different timezone (or more likely recording UTC)
-        today = client.execute('date "+%a, %d %b %Y"')
         expected = (
             'This is my final message!\n'
             r'\d+\.\d+.*\n'
-            '{}.*\n'
+            '.*\n'  # Checking date is too error prone due to timezone
             'DataSource.*\n'
             r'\d+\.\d+'
-        ).format(today)
+        )
 
         assert re.search(expected, log)
 

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -78,11 +78,11 @@ class TestCombined:
         client = class_client
         log = client.read_from_file('/var/log/cloud-init.log')
         expected = (
-            'This is my final message!\n'
-            r'\d+\.\d+.*\n'
-            '.*\n'  # Checking date is too error prone due to timezone
-            'DataSource.*\n'
-            r'\d+\.\d+'
+            "This is my final message!\n"
+            r"\d+\.\d+.*\n"
+            r"\w{3}, \d{2} \w{3} \d{4} \d{2}:\d{2}:\d{2} \+\d{4}\n"  # Datetime
+            "DataSource.*\n"
+            r"\d+\.\d+"
         )
 
         assert re.search(expected, log)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: Remove date from final_message test
```

## Additional Context
We've seen a number of failures due to timezones that it's silly to keep this check around, especially for this module.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
