### PR TITLE
Fix exception when no activator found (SC-540)

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -228,7 +228,12 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         # Now try to bring them up
         if bring_up:
             LOG.debug('Bringing up newly configured network interfaces')
-            network_activator = activators.select_activator()
+            try:
+                network_activator = activators.select_activator()
+            except activators.NoActivatorException:
+                LOG.warning("No network activator found, not bringing up "
+                            "network interfaces")
+                return True
             network_activator.bring_up_all_interfaces(network_state)
         else:
             LOG.debug("Not bringing up newly configured network interfaces")

--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -16,6 +16,10 @@ from cloudinit.net.sysconfig import NM_CFG_FILE
 LOG = logging.getLogger(__name__)
 
 
+class NoActivatorException(Exception):
+    pass
+
+
 def _alter_interface(cmd, device_name) -> bool:
     LOG.debug("Attempting command %s for device %s", cmd, device_name)
     try:
@@ -271,7 +275,7 @@ def select_activator(priority=None, target=None) -> Type[NetworkActivator]:
         tmsg = ""
         if target and target != "/":
             tmsg = " in target=%s" % target
-        raise RuntimeError(
+        raise NoActivatorException(
             "No available network activators found%s. Searched "
             "through list: %s" % (tmsg, priority))
     selected = found[0]

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -12,7 +12,8 @@ from cloudinit.net.activators import (
     IfUpDownActivator,
     NetplanActivator,
     NetworkManagerActivator,
-    NetworkdActivator
+    NetworkdActivator,
+    NoActivatorException,
 )
 from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.safeyaml import load
@@ -99,7 +100,7 @@ class TestSearchAndSelect:
         resp = search_activator()
         assert resp == []
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(NoActivatorException):
             select_activator()
 
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix exception when no activator found

Given that there are additional network management tools that we haven't
yet supported with activators, we should log a warning and continue
without network activation here, especially since this was a no-op for
years.

LP: #1948681
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
