### PR TITLE
factor out function for getting top level directory of cloudinit

### DIFF
--- a/tests/unittests/config/test_cc_chef.py
+++ b/tests/unittests/config/test_cc_chef.py
@@ -9,13 +9,18 @@ from cloudinit.config import cc_chef
 from cloudinit import util
 
 from tests.unittests.helpers import (
-    HttprettyTestCase, FilesystemMockingTestCase, mock, skipIf)
+    HttprettyTestCase,
+    FilesystemMockingTestCase,
+    mock,
+    skipIf,
+    CloudinitDir,
+)
 
 from tests.unittests.util import get_cloud
 
 LOG = logging.getLogger(__name__)
 
-CLIENT_TEMPL = os.path.sep.join(["templates", "chef_client.rb.tmpl"])
+CLIENT_TEMPL = CloudinitDir("templates/chef_client.rb.tmpl")
 
 # This is adjusted to use http because using with https causes issue
 # in some openssl/httpretty combinations.
@@ -138,7 +143,7 @@ class TestChef(FilesystemMockingTestCase):
         Chef::Log::Formatter.show_time = true
         encrypted_data_bag_secret  "/etc/chef/encrypted_data_bag_secret"
         """
-        tpl_file = util.load_file('templates/chef_client.rb.tmpl')
+        tpl_file = util.load_file(CLIENT_TEMPL)
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
 
@@ -200,7 +205,7 @@ class TestChef(FilesystemMockingTestCase):
     @skipIf(not os.path.isfile(CLIENT_TEMPL),
             CLIENT_TEMPL + " is not available")
     def test_template_deletes(self):
-        tpl_file = util.load_file('templates/chef_client.rb.tmpl')
+        tpl_file = util.load_file(CLIENT_TEMPL)
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
 
@@ -222,7 +227,7 @@ class TestChef(FilesystemMockingTestCase):
             CLIENT_TEMPL + " is not available")
     def test_validation_cert_and_validation_key(self):
         # test validation_cert content is written to validation_key path
-        tpl_file = util.load_file('templates/chef_client.rb.tmpl')
+        tpl_file = util.load_file(CLIENT_TEMPL)
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
 
@@ -245,7 +250,7 @@ class TestChef(FilesystemMockingTestCase):
 
     def test_validation_cert_with_system(self):
         # test validation_cert content is not written over system file
-        tpl_file = util.load_file('templates/chef_client.rb.tmpl')
+        tpl_file = util.load_file(CLIENT_TEMPL)
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
 

--- a/tests/unittests/config/test_cc_chef.py
+++ b/tests/unittests/config/test_cc_chef.py
@@ -13,14 +13,14 @@ from tests.unittests.helpers import (
     FilesystemMockingTestCase,
     mock,
     skipIf,
-    CloudinitDir,
+    cloud_init_project_dir,
 )
 
 from tests.unittests.util import get_cloud
 
 LOG = logging.getLogger(__name__)
 
-CLIENT_TEMPL = CloudinitDir("templates/chef_client.rb.tmpl")
+CLIENT_TEMPL = cloud_init_project_dir("templates/chef_client.rb.tmpl")
 
 # This is adjusted to use http because using with https causes issue
 # in some openssl/httpretty combinations.

--- a/tests/unittests/config/test_cc_resolv_conf.py
+++ b/tests/unittests/config/test_cc_resolv_conf.py
@@ -114,7 +114,7 @@ class TestResolvConf(t_help.FilesystemMockingTestCase):
 class TestGenerateResolvConf:
 
     dist = MockDistro()
-    tmpl_fn = "templates/resolv.conf.tmpl"
+    tmpl_fn = t_help.CloudinitDir("templates/resolv.conf.tmpl")
 
     @mock.patch("cloudinit.config.cc_resolv_conf.templater.render_to_file")
     def test_dist_resolv_conf_fn(self, m_render_to_file):

--- a/tests/unittests/config/test_cc_resolv_conf.py
+++ b/tests/unittests/config/test_cc_resolv_conf.py
@@ -114,7 +114,7 @@ class TestResolvConf(t_help.FilesystemMockingTestCase):
 class TestGenerateResolvConf:
 
     dist = MockDistro()
-    tmpl_fn = t_help.CloudinitDir("templates/resolv.conf.tmpl")
+    tmpl_fn = t_help.cloud_init_project_dir("templates/resolv.conf.tmpl")
 
     @mock.patch("cloudinit.config.cc_resolv_conf.templater.render_to_file")
     def test_dist_resolv_conf_fn(self, m_render_to_file):

--- a/tests/unittests/config/test_cc_update_etc_hosts.py
+++ b/tests/unittests/config/test_cc_update_etc_hosts.py
@@ -55,7 +55,10 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
             'manage_etc_hosts': 'template',
             'hostname': 'cloud-init.test.us'
         }
-        shutil.copytree('templates', '%s/etc/cloud/templates' % self.tmp)
+        shutil.copytree(
+            t_help.CloudinitDir('templates'),
+            '%s/etc/cloud/templates' % self.tmp,
+        )
         distro = self._fetch_distro('sles')
         paths = helpers.Paths({})
         paths.template_tpl = '%s' % self.tmp + '/etc/cloud/templates/%s.tmpl'

--- a/tests/unittests/config/test_cc_update_etc_hosts.py
+++ b/tests/unittests/config/test_cc_update_etc_hosts.py
@@ -56,7 +56,7 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
             'hostname': 'cloud-init.test.us'
         }
         shutil.copytree(
-            t_help.CloudinitDir('templates'),
+            t_help.cloud_init_project_dir('templates'),
             '%s/etc/cloud/templates' % self.tmp,
         )
         distro = self._fetch_distro('sles')

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from textwrap import dedent
 from yaml import safe_load
 
-import cloudinit
 from cloudinit.config.schema import (
     CLOUD_CONFIG_HEADER,
     SchemaValidationError,
@@ -27,7 +26,12 @@ from cloudinit.config.schema import (
     MetaSchema,
 )
 from cloudinit.util import write_file
-from tests.unittests.helpers import CiTestCase, mock, skipUnlessJsonSchema
+from tests.unittests.helpers import (
+    CiTestCase,
+    mock,
+    skipUnlessJsonSchema,
+    CloudinitDir,
+)
 
 
 def get_schemas() -> dict:
@@ -616,8 +620,7 @@ class TestMain:
 
 
 def _get_meta_doc_examples():
-    examples_dir = Path(
-        cloudinit.__file__).parent.parent / 'doc' / 'examples'
+    examples_dir = Path(CloudinitDir('doc/examples'))
     assert examples_dir.is_dir()
 
     all_text_files = (f for f in examples_dir.glob('cloud-config*.txt')

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -30,7 +30,7 @@ from tests.unittests.helpers import (
     CiTestCase,
     mock,
     skipUnlessJsonSchema,
-    CloudinitDir,
+    cloud_init_project_dir,
 )
 
 
@@ -54,7 +54,9 @@ def get_module_variable(var_name) -> dict:
     """Inspect modules and get variable from module matching var_name"""
     schemas = {}
 
-    files = list(Path(CloudinitDir("../../cloudinit/config/")).glob("cc_*.py"))
+    files = list(
+        Path(cloud_init_project_dir("../../cloudinit/config/")).glob("cc_*.py")
+    )
 
     modules = [mod.stem for mod in files]
 
@@ -621,7 +623,7 @@ class TestMain:
 
 
 def _get_meta_doc_examples():
-    examples_dir = Path(CloudinitDir('doc/examples'))
+    examples_dir = Path(cloud_init_project_dir('doc/examples'))
     assert examples_dir.is_dir()
 
     all_text_files = (f for f in examples_dir.glob('cloud-config*.txt')

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -54,7 +54,8 @@ def get_module_variable(var_name) -> dict:
     """Inspect modules and get variable from module matching var_name"""
     schemas = {}
 
-    files = list(Path("../../cloudinit/config/").glob("cc_*.py"))
+    files = list(Path(CloudinitDir("../../cloudinit/config/")).glob("cc_*.py"))
+
     modules = [mod.stem for mod in files]
 
     for module in modules:

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -510,7 +510,7 @@ if not hasattr(mock.Mock, 'assert_not_called'):
 def get_top_level_dir() -> Path:
     """Return the path to the top cloudinit project directory
 
-    @return Path('top-cloudinit-dir>')
+    @return Path('<top-cloudinit-dir>')
     """
     return Path(cloudinit.__file__).parent.parent.resolve()
 

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -507,12 +507,12 @@ if not hasattr(mock.Mock, 'assert_not_called'):
     mock.Mock.assert_not_called = __mock_assert_not_called
 
 
-def get_top_level_dir():
+def get_top_level_dir() -> Path:
     """Return the path to the top cloudinit project directory
 
     @return Path('top-cloudinit-dir>')
     """
-    return Path(cloudinit.__file__).parent.parent
+    return Path(cloudinit.__file__).parent.parent.resolve()
 
 
 def CloudinitDir(sub_path: str) -> str:

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -464,7 +464,7 @@ def wrap_and_call(prefix, mocks, func, *args, **kwargs):
 
 
 def resourceLocation(subname=None):
-    path = CloudinitDir('tests/data')
+    path = cloud_init_project_dir('tests/data')
     if not subname:
         return path
     return os.path.join(path, subname)
@@ -515,12 +515,12 @@ def get_top_level_dir() -> Path:
     return Path(cloudinit.__file__).parent.parent.resolve()
 
 
-def CloudinitDir(sub_path: str) -> str:
+def cloud_init_project_dir(sub_path: str) -> str:
     """Get a path within the cloudinit project directory
 
     @return str of the combined path
 
-    Example: CloudinitDir("my/path") -> "/path/to/cloud-init/my/path"
+    Example: cloud_init_project_dir("my/path") -> "/path/to/cloud-init/my/path"
     """
     return str(get_top_level_dir() / sub_path)
 

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -508,7 +508,7 @@ if not hasattr(mock.Mock, 'assert_not_called'):
 
 
 def get_top_level_dir() -> Path:
-    """Return the path to the top cloudinit project directory
+    """Return the absolute path to the top cloudinit project directory
 
     @return Path('<top-cloudinit-dir>')
     """
@@ -516,8 +516,12 @@ def get_top_level_dir() -> Path:
 
 
 def CloudinitDir(sub_path: str) -> str:
-    """Return path within cloudinit project directory"""
-    return str(get_top_level_dir() / sub_path)
+    """Get a path within the cloudinit project directory
 
+    @return str of the combined path
+
+    Example: CloudinitDir("my/path") -> "/path/to/cloud-init/my/path"
+    """
+    return str(get_top_level_dir() / sub_path)
 
 # vi: ts=4 expandtab

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -12,10 +12,12 @@ import sys
 import tempfile
 import time
 import unittest
+from pathlib import Path
 from contextlib import ExitStack, contextmanager
 from unittest import mock
 from unittest.util import strclass
 
+import cloudinit
 from cloudinit.config.schema import (
     SchemaValidationError, validate_cloudconfig_schema)
 from cloudinit import cloud
@@ -462,7 +464,7 @@ def wrap_and_call(prefix, mocks, func, *args, **kwargs):
 
 
 def resourceLocation(subname=None):
-    path = os.path.join('tests', 'data')
+    path = CloudinitDir('tests/data')
     if not subname:
         return path
     return os.path.join(path, subname)
@@ -503,5 +505,19 @@ if not hasattr(mock.Mock, 'assert_not_called'):
                    (mmock._mock_name or 'mock', mmock.call_count))
             raise AssertionError(msg)
     mock.Mock.assert_not_called = __mock_assert_not_called
+
+
+def get_top_level_dir():
+    """Return the path to the top cloudinit project directory
+
+    @return Path('top-cloudinit-dir>')
+    """
+    return Path(cloudinit.__file__).parent.parent
+
+
+def CloudinitDir(sub_path: str) -> str:
+    """Return path within cloudinit project directory"""
+    return str(get_top_level_dir() / sub_path)
+
 
 # vi: ts=4 expandtab

--- a/tests/unittests/sources/vmware/test_vmware_config_file.py
+++ b/tests/unittests/sources/vmware/test_vmware_config_file.py
@@ -16,13 +16,19 @@ from cloudinit.sources.DataSourceOVF import get_network_config_from_conf
 from cloudinit.sources.DataSourceOVF import read_vmware_imc
 from cloudinit.sources.helpers.vmware.imc.boot_proto import BootProtoEnum
 from cloudinit.sources.helpers.vmware.imc.config import Config
-from cloudinit.sources.helpers.vmware.imc.config_file import ConfigFile
+from cloudinit.sources.helpers.vmware.imc.config_file import (
+    ConfigFile as WrappedConfigFile,
+)
 from cloudinit.sources.helpers.vmware.imc.config_nic import gen_subnet
 from cloudinit.sources.helpers.vmware.imc.config_nic import NicConfigurator
-from tests.unittests.helpers import CiTestCase
+from tests.unittests.helpers import CiTestCase, CloudinitDir
 
 logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 logger = logging.getLogger(__name__)
+
+
+def ConfigFile(path: str):
+    return WrappedConfigFile(CloudinitDir(path))
 
 
 class TestVmwareConfigFile(CiTestCase):

--- a/tests/unittests/sources/vmware/test_vmware_config_file.py
+++ b/tests/unittests/sources/vmware/test_vmware_config_file.py
@@ -21,14 +21,14 @@ from cloudinit.sources.helpers.vmware.imc.config_file import (
 )
 from cloudinit.sources.helpers.vmware.imc.config_nic import gen_subnet
 from cloudinit.sources.helpers.vmware.imc.config_nic import NicConfigurator
-from tests.unittests.helpers import CiTestCase, CloudinitDir
+from tests.unittests.helpers import CiTestCase, cloud_init_project_dir
 
 logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)
 logger = logging.getLogger(__name__)
 
 
 def ConfigFile(path: str):
-    return WrappedConfigFile(CloudinitDir(path))
+    return WrappedConfigFile(cloud_init_project_dir(path))
 
 
 class TestVmwareConfigFile(CiTestCase):

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -11,6 +11,7 @@ from cloudinit import util
 from tests.unittests.helpers import (
     CiTestCase, dir2dict, populate_dir, populate_dir_with_ts)
 
+from tests.unittests.helpers import CloudinitDir
 from cloudinit.sources import DataSourceIBMCloud as ds_ibm
 from cloudinit.sources import DataSourceSmartOS as ds_smartos
 from cloudinit.sources import DataSourceOracle as ds_oracle
@@ -92,7 +93,7 @@ CallReturn = namedtuple('CallReturn',
 
 
 class DsIdentifyBase(CiTestCase):
-    dsid_path = os.path.realpath('tools/ds-identify')
+    dsid_path = CloudinitDir('tools/ds-identify')
     allowed_subp = ['sh']
 
     def call(self, rootd=None, mocks=None, func="main", args=None, files=None,

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -9,9 +9,12 @@ from cloudinit import safeyaml
 from cloudinit import subp
 from cloudinit import util
 from tests.unittests.helpers import (
-    CiTestCase, dir2dict, populate_dir, populate_dir_with_ts)
-
-from tests.unittests.helpers import CloudinitDir
+    CiTestCase,
+    dir2dict,
+    populate_dir,
+    populate_dir_with_ts,
+    CloudinitDir,
+)
 from cloudinit.sources import DataSourceIBMCloud as ds_ibm
 from cloudinit.sources import DataSourceSmartOS as ds_smartos
 from cloudinit.sources import DataSourceOracle as ds_oracle

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -13,7 +13,7 @@ from tests.unittests.helpers import (
     dir2dict,
     populate_dir,
     populate_dir_with_ts,
-    CloudinitDir,
+    cloud_init_project_dir,
 )
 from cloudinit.sources import DataSourceIBMCloud as ds_ibm
 from cloudinit.sources import DataSourceSmartOS as ds_smartos
@@ -96,7 +96,7 @@ CallReturn = namedtuple('CallReturn',
 
 
 class DsIdentifyBase(CiTestCase):
-    dsid_path = CloudinitDir('tools/ds-identify')
+    dsid_path = cloud_init_project_dir('tools/ds-identify')
     allowed_subp = ['sh']
 
     def call(self, rootd=None, mocks=None, func="main", args=None, files=None,

--- a/tests/unittests/test_helpers.py
+++ b/tests/unittests/test_helpers.py
@@ -6,6 +6,7 @@ import os
 from os.path import abspath
 from pathlib import Path
 
+import pytest
 from tests.unittests import helpers as test_helpers
 
 from cloudinit import sources
@@ -46,7 +47,9 @@ class TestCloudinitDir:
 
     @staticmethod
     def _get_top_level_dir_alt_implementation():
-        """Recursively walk until .git/ is found, return parent dir"""
+        """Recursively walk until .git/ is found, return parent dir
+
+        """
 
         def get_git_dir(path):
             if os.path.isdir(str(Path(path, ".git"))):
@@ -59,7 +62,10 @@ class TestCloudinitDir:
 
         return get_git_dir(Path("."))
 
+    @pytest.mark.unittest_only
     def test_top_level_dir(self):
+        """.git/ is pruned during package build, don't run in integration test
+        """
         assert cmp_abspath(
             test_helpers.get_top_level_dir(),
             self._get_top_level_dir_alt_implementation(),

--- a/tests/unittests/test_helpers.py
+++ b/tests/unittests/test_helpers.py
@@ -45,17 +45,22 @@ class TestCloudinitDir:
         return out
 
     def test_top_level_dir(self):
-        """Assert the location of the top project directory is correct
-        """
-        assert 1 == len(set((
-            self.top_dir,
-            self._get_top_level_dir_alt_implementation(),
-        )))
+        """Assert the location of the top project directory is correct"""
+        assert 1 == len(
+            set(
+                (
+                    self.top_dir,
+                    self._get_top_level_dir_alt_implementation(),
+                )
+            )
+        )
 
     def test_CloudinitDir(self):
-        assert (str(Path(self.top_dir, "test")) ==
-                test_helpers.CloudinitDir("test") ==
-                str(Path(self._get_top_level_dir_alt_implementation(), "test"))
-                )
+        assert (
+            str(Path(self.top_dir, "test"))
+            == test_helpers.CloudinitDir("test")
+            == str(Path(self._get_top_level_dir_alt_implementation(), "test"))
+        )
+
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_helpers.py
+++ b/tests/unittests/test_helpers.py
@@ -52,14 +52,8 @@ class Testcloud_init_project_dir:
 
     def test_top_level_dir(self):
         """Assert the location of the top project directory is correct"""
-        assert 1 == len(
-            set(
-                (
-                    self.top_dir,
-                    self._get_top_level_dir_alt_implementation(),
-                )
-            )
-        )
+        assert (self.top_dir ==
+                self._get_top_level_dir_alt_implementation())
 
     def test_cloud_init_project_dir(self):
         """Assert cloud_init_project_dir produces an expected location

--- a/tests/unittests/test_helpers.py
+++ b/tests/unittests/test_helpers.py
@@ -41,6 +41,12 @@ class TestCloudinitDir:
 
     @staticmethod
     def _get_top_level_dir_alt_implementation():
+        """Alternative implementation for comparing against.
+
+        Note: Recursively searching for .git/ fails during build tests due to
+        .git not existing. This implementation assumes that ../../../ is the
+        relative path to the cloud-init project directory form this file.
+        """
         out = Path(__file__).parent.parent.parent.resolve()
         return out
 
@@ -56,6 +62,10 @@ class TestCloudinitDir:
         )
 
     def test_CloudinitDir(self):
+        """Assert CloudinitDir produces an expected location
+
+        Compare the returned value to an alternate (naive) implementation
+        """
         assert (
             str(Path(self.top_dir, "test"))
             == test_helpers.CloudinitDir("test")

--- a/tests/unittests/test_helpers.py
+++ b/tests/unittests/test_helpers.py
@@ -38,37 +38,26 @@ class TestPaths(test_helpers.ResourceUsingTestCase):
         self.assertIsNone(mypaths.get_ipath())
 
 
-def cmp_abspath(*args):
-    """Ensure arguments have the same abspath"""
-    return 1 == len(set(map(abspath, map(str, args))))
-
-
 class TestCloudinitDir:
+    top_dir = test_helpers.get_top_level_dir()
 
     @staticmethod
     def _get_top_level_dir_alt_implementation():
-        """Recursively walk until .git/ is found, return parent dir
+        out = Path(__file__).parent.parent.parent.resolve()
+        return out
 
-        """
-
-        def get_git_dir(path):
-            if os.path.isdir(str(Path(path, ".git"))):
-                return Path(path, ".git").parent
-            # found root dir, not going to find a .git/
-            elif cmp_abspath('/', path):
-                return False
-
-            return get_git_dir(path / "..")
-
-        return get_git_dir(Path("."))
-
-    @pytest.mark.unittest_only
     def test_top_level_dir(self):
-        """.git/ is pruned during package build, don't run in integration test
+        """Assert the location of the top project directory is correct
         """
-        assert cmp_abspath(
-            test_helpers.get_top_level_dir(),
+        assert 1 == len(set((
+            self.top_dir,
             self._get_top_level_dir_alt_implementation(),
-        )
+        )))
+
+    def test_CloudinitDir(self):
+        assert (str(Path(self.top_dir, "test")) ==
+                test_helpers.CloudinitDir("test") ==
+                str(Path(self._get_top_level_dir_alt_implementation(), "test"))
+                )
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_helpers.py
+++ b/tests/unittests/test_helpers.py
@@ -3,10 +3,8 @@
 """Tests of the built-in user data handlers."""
 
 import os
-from os.path import abspath
 from pathlib import Path
 
-import pytest
 from tests.unittests import helpers as test_helpers
 
 from cloudinit import sources

--- a/tests/unittests/test_helpers.py
+++ b/tests/unittests/test_helpers.py
@@ -36,7 +36,7 @@ class TestPaths(test_helpers.ResourceUsingTestCase):
         self.assertIsNone(mypaths.get_ipath())
 
 
-class TestCloudinitDir:
+class Testcloud_init_project_dir:
     top_dir = test_helpers.get_top_level_dir()
 
     @staticmethod
@@ -61,14 +61,14 @@ class TestCloudinitDir:
             )
         )
 
-    def test_CloudinitDir(self):
-        """Assert CloudinitDir produces an expected location
+    def test_cloud_init_project_dir(self):
+        """Assert cloud_init_project_dir produces an expected location
 
         Compare the returned value to an alternate (naive) implementation
         """
         assert (
             str(Path(self.top_dir, "test"))
-            == test_helpers.CloudinitDir("test")
+            == test_helpers.cloud_init_project_dir("test")
             == str(Path(self._get_top_level_dir_alt_implementation(), "test"))
         )
 

--- a/tests/unittests/test_helpers.py
+++ b/tests/unittests/test_helpers.py
@@ -3,6 +3,8 @@
 """Tests of the built-in user data handlers."""
 
 import os
+from os.path import abspath
+from pathlib import Path
 
 from tests.unittests import helpers as test_helpers
 
@@ -33,5 +35,34 @@ class TestPaths(test_helpers.ResourceUsingTestCase):
         mypaths = self.getCloudPaths(myds)
 
         self.assertIsNone(mypaths.get_ipath())
+
+
+def cmp_abspath(*args):
+    """Ensure arguments have the same abspath"""
+    return 1 == len(set(map(abspath, map(str, args))))
+
+
+class TestCloudinitDir:
+
+    @staticmethod
+    def _get_top_level_dir_alt_implementation():
+        """Recursively walk until .git/ is found, return parent dir"""
+
+        def get_git_dir(path):
+            if os.path.isdir(str(Path(path, ".git"))):
+                return Path(path, ".git").parent
+            # found root dir, not going to find a .git/
+            elif cmp_abspath('/', path):
+                return False
+
+            return get_git_dir(path / "..")
+
+        return get_git_dir(Path("."))
+
+    def test_top_level_dir(self):
+        assert cmp_abspath(
+            test_helpers.get_top_level_dir(),
+            self._get_top_level_dir_alt_implementation(),
+        )
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -1,12 +1,12 @@
 """Tests for tools/render-cloudcfg"""
 
-import os
 import sys
 
 import pytest
 
 from cloudinit import subp
 from cloudinit import util
+from tests.unittests.helpers import CloudinitDir
 
 # TODO(Look to align with tools.render-cloudcfg or cloudinit.distos.OSFAMILIES)
 DISTRO_VARIANTS = ["amazon", "arch", "centos", "debian", "eurolinux", "fedora",
@@ -17,8 +17,8 @@ DISTRO_VARIANTS = ["amazon", "arch", "centos", "debian", "eurolinux", "fedora",
 @pytest.mark.allow_subp_for(sys.executable)
 class TestRenderCloudCfg:
 
-    cmd = [sys.executable, os.path.realpath('tools/render-cloudcfg')]
-    tmpl_path = os.path.realpath('config/cloud.cfg.tmpl')
+    cmd = [sys.executable, CloudinitDir('tools/render-cloudcfg')]
+    tmpl_path = CloudinitDir('config/cloud.cfg.tmpl')
 
     @pytest.mark.parametrize('variant', (DISTRO_VARIANTS))
     def test_variant_sets_distro_in_cloud_cfg(self, variant, tmpdir):

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -6,7 +6,7 @@ import pytest
 
 from cloudinit import subp
 from cloudinit import util
-from tests.unittests.helpers import CloudinitDir
+from tests.unittests.helpers import cloud_init_project_dir
 
 # TODO(Look to align with tools.render-cloudcfg or cloudinit.distos.OSFAMILIES)
 DISTRO_VARIANTS = ["amazon", "arch", "centos", "debian", "eurolinux", "fedora",
@@ -17,8 +17,8 @@ DISTRO_VARIANTS = ["amazon", "arch", "centos", "debian", "eurolinux", "fedora",
 @pytest.mark.allow_subp_for(sys.executable)
 class TestRenderCloudCfg:
 
-    cmd = [sys.executable, CloudinitDir('tools/render-cloudcfg')]
-    tmpl_path = CloudinitDir('config/cloud.cfg.tmpl')
+    cmd = [sys.executable, cloud_init_project_dir('tools/render-cloudcfg')]
+    tmpl_path = cloud_init_project_dir('config/cloud.cfg.tmpl')
 
     @pytest.mark.parametrize('variant', (DISTRO_VARIANTS))
     def test_variant_sets_distro_in_cloud_cfg(self, variant, tmpdir):

--- a/tests/unittests/test_subp.py
+++ b/tests/unittests/test_subp.py
@@ -10,7 +10,7 @@ import stat
 from unittest import mock
 
 from cloudinit import subp, util
-from tests.unittests.helpers import CiTestCase
+from tests.unittests.helpers import CiTestCase, get_top_level_dir
 
 
 BASH = subp.which('bash')
@@ -232,13 +232,17 @@ class TestSubp(CiTestCase):
         the default encoding will be set to ascii.  In such an environment
         Popen(['command', 'non-ascii-arg']) would cause a UnicodeDecodeError.
         """
-        python_prog = '\n'.join([
-            'import json, sys',
-            'from cloudinit.subp import subp',
-            'data = sys.stdin.read()',
-            'cmd = json.loads(data)',
-            'subp(cmd, capture=False)',
-            ''])
+        python_prog = '\n'.join(
+            [
+                'import json, sys',
+                'sys.path.append("{}")'.format(get_top_level_dir()),
+                'from cloudinit.subp import subp',
+                'data = sys.stdin.read()',
+                'cmd = json.loads(data)',
+                'subp(cmd, capture=False)',
+                '',
+            ]
+        )
         cmd = [BASH, '-c', 'echo -n "$@"', '--',
                self.utf8_valid.decode("utf-8")]
         python_subp = [sys.executable, '-c', python_prog]

--- a/tests/unittests/test_subp.py
+++ b/tests/unittests/test_subp.py
@@ -235,7 +235,7 @@ class TestSubp(CiTestCase):
         python_prog = '\n'.join(
             [
                 'import json, sys',
-                'sys.path.append("{}")'.format(get_top_level_dir()),
+                'sys.path.insert(0, "{}")'.format(get_top_level_dir()),
                 'from cloudinit.subp import subp',
                 'data = sys.stdin.read()',
                 'cmd = json.loads(data)',

--- a/tox.ini
+++ b/tox.ini
@@ -144,8 +144,6 @@ commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration
 passenv = CLOUD_INIT_* SSH_AUTH_SOCK OS_*
 deps =
     -r{toxinidir}/integration-requirements.txt
-setenv =
-    PYTEST_ADDOPTS="-m not unittest_only"
 
 [testenv:integration-tests-ci]
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
@@ -153,7 +151,7 @@ passenv = CLOUD_INIT_* SSH_AUTH_SOCK OS_* TRAVIS
 deps =
     -r{toxinidir}/integration-requirements.txt
 setenv =
-    PYTEST_ADDOPTS="-m ci and not adhoc and not unittest_only"
+    PYTEST_ADDOPTS="-m ci and not adhoc"
 
 [testenv:integration-tests-jenkins]
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
@@ -161,7 +159,7 @@ passenv = *_proxy CLOUD_INIT_* SSH_AUTH_SOCK OS_* GOOGLE_* GCP_*
 deps =
     -r{toxinidir}/integration-requirements.txt
 setenv =
-    PYTEST_ADDOPTS="-m not adhoc and not unittest_only"
+    PYTEST_ADDOPTS="-m not adhoc"
 
 [pytest]
 # TODO: s/--strict/--strict-markers/ once xenial support is dropped
@@ -170,7 +168,6 @@ addopts = --strict
 log_format = %(asctime)s %(levelname)-9s %(name)s:%(filename)s:%(lineno)d %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 markers =
-    unittest_only: exclude tests from integration test environment
     allow_subp_for: allow subp usage for the given commands (disable_subp_usage)
     allow_all_subp: allow all subp usage (disable_subp_usage)
     ci: run this integration test as part of CI test runs

--- a/tox.ini
+++ b/tox.ini
@@ -144,6 +144,8 @@ commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration
 passenv = CLOUD_INIT_* SSH_AUTH_SOCK OS_*
 deps =
     -r{toxinidir}/integration-requirements.txt
+setenv =
+    PYTEST_ADDOPTS="-m not unittest_only"
 
 [testenv:integration-tests-ci]
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
@@ -151,7 +153,7 @@ passenv = CLOUD_INIT_* SSH_AUTH_SOCK OS_* TRAVIS
 deps =
     -r{toxinidir}/integration-requirements.txt
 setenv =
-    PYTEST_ADDOPTS="-m ci and not adhoc"
+    PYTEST_ADDOPTS="-m ci and not adhoc and not unittest_only"
 
 [testenv:integration-tests-jenkins]
 commands = {envpython} -m pytest --log-cli-level=INFO {posargs:tests/integration_tests}
@@ -159,7 +161,7 @@ passenv = *_proxy CLOUD_INIT_* SSH_AUTH_SOCK OS_* GOOGLE_* GCP_*
 deps =
     -r{toxinidir}/integration-requirements.txt
 setenv =
-    PYTEST_ADDOPTS="-m not adhoc"
+    PYTEST_ADDOPTS="-m not adhoc and not unittest_only"
 
 [pytest]
 # TODO: s/--strict/--strict-markers/ once xenial support is dropped
@@ -168,6 +170,7 @@ addopts = --strict
 log_format = %(asctime)s %(levelname)-9s %(name)s:%(filename)s:%(lineno)d %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 markers =
+    unittest_only: exclude tests from integration test environment
     allow_subp_for: allow subp usage for the given commands (disable_subp_usage)
     allow_all_subp: allow all subp usage (disable_subp_usage)
     ci: run this integration test as part of CI test runs


### PR DESCRIPTION
```
Add a test helper to get top level directory

Many tests need to get the location of files & dirs within the cloud-init
project directory.

Tests implement this in various different ways, and often those ways
depend on the current working directory of the pytest invocation.
Create helper functions (and tests) that gets the path of the top
directory or any sub directory under the top directory. This function
does not depend on the environment.
```

## Additional Context
- This is not a very high value refactor, but not being able to run pytest wherever I please has been bugging me.
- It should also makes a common task less slightly less error prone and tedious.
- I'm sure that I missed tests.
- The tests I converted were unittests that fail when running pytest in a subdirectory.
