### PR TITLE
mock sleep() in azure test

### DIFF
--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2981,7 +2981,8 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
 
         m_is_up.side_effect = is_up_mock
 
-        dsa.wait_for_link_up("eth0")
+        with mock.patch('cloudinit.sources.DataSourceAzure.sleep'):
+            dsa.wait_for_link_up("eth0")
         self.assertEqual(2, m_try_set_link_up.call_count)
         self.assertEqual(2, m_is_up.call_count)
 


### PR DESCRIPTION
It looks like this is patched in other tests, this must have been missed.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
mock sleep() in azure test
```

It looks like this is patched in other tests, this must have been missed.
```
arc~/cloud-init(:cd40789a|…) pytest --durations=1 tests/unittests/sources/test_azure.py
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.9.7, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /home/holmanb/cloud-init, configfile: tox.ini
plugins: cov-3.0.0, xdist-2.2.0, forked-1.3.0
collected 160 items                                                                                                                                                                                        

tests/unittests/sources/test_azure.py .............................................................................................................................................................. [ 98%]
..                                                                                                                                                                                                   [100%]

=========================================================================================== slowest 1 durations ============================================================================================
0.50s call     tests/unittests/sources/test_azure.py::TestPreprovisioningHotAttachNics::test_wait_for_link_up_checks_link_after_sleep
=========================================================================================== 160 passed in 2.61s ============================================================================================



arc~/cloud-init(main↓1↑5|…) pytest --durations=1 tests/unittests/sources/test_azure.py
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.9.7, pytest-6.0.2, py-1.10.0, pluggy-0.13.0
rootdir: /home/holmanb/cloud-init, configfile: tox.ini
plugins: cov-3.0.0, xdist-2.2.0, forked-1.3.0
collected 160 items                                                                                                                                                                                        

tests/unittests/sources/test_azure.py .............................................................................................................................................................. [ 98%]
..                                                                                                                                                                                                   [100%]

=========================================================================================== slowest 1 durations ============================================================================================
0.04s call     tests/unittests/sources/test_azure.py::TestAzureDataSource::test_user_not_locked_if_password_redacted
=========================================================================================== 160 passed in 2.11s ============================================================================================
```