### PR TITLE
Remove non deterministic test param

### DIFF
--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -976,7 +976,7 @@ class TestReadCcFromCmdline:
         "cmdline,expected_cfg",
         [
             # Return None if cmdline has no cc:<YAML>end_cc content.
-            ('cmdline has no cc content', None),
+            pytest.param(CiTestCase.random_string(), None, id="random_string"),
             # Return None if YAML content is empty string.
             ('foo cc: end_cc bar', None),
             # Return expected dictionary without trailing end_cc marker.

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -976,7 +976,7 @@ class TestReadCcFromCmdline:
         "cmdline,expected_cfg",
         [
             # Return None if cmdline has no cc:<YAML>end_cc content.
-            (CiTestCase.random_string(), None),
+            ('cmdline has no cc content', None),
             # Return None if YAML content is empty string.
             ('foo cc: end_cc bar', None),
             # Return expected dictionary without trailing end_cc marker.

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -976,7 +976,7 @@ class TestReadCcFromCmdline:
         random_string = pytest.param(
             CiTestCase.random_string(), None, id="random_string")
     else:
-        random_string = (CiTestCase.random_string(), None),
+        random_string = (CiTestCase.random_string(), None)
 
     @pytest.mark.parametrize(
         "cmdline,expected_cfg",

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -972,11 +972,17 @@ class TestIsLXD(CiTestCase):
 
 
 class TestReadCcFromCmdline:
+    if hasattr(pytest, "param"):
+        random_string = pytest.param(
+            CiTestCase.random_string(), None, id="random_string")
+    else:
+        random_string = (CiTestCase.random_string(), None),
+
     @pytest.mark.parametrize(
         "cmdline,expected_cfg",
         [
             # Return None if cmdline has no cc:<YAML>end_cc content.
-            pytest.param(CiTestCase.random_string(), None, id="random_string"),
+            random_string,
             # Return None if YAML content is empty string.
             ('foo cc: end_cc bar', None),
             # Return expected dictionary without trailing end_cc marker.


### PR DESCRIPTION
```
Remove non-deterministic test parameter
    
Non-deterministic test parameters have multiple downsides:
 - potentially non-deterministic tests results
 - breaks parallel test execution via xdist.
```

## Additional Context
There are other things in our unittests that cause intermittent failures during parallel test execution, but this one will cause failures every time. The random input here is frankly unnecessary. With this change I can (usually) run `pytest tests/unittests -n2` locally in ~25 seconds, rather than the normal >40s to complete.