### PR TITLE
travis - don't run integration tests if no deb (SC-699)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,9 +120,10 @@ matrix:
                 fi
             # Use sudo to get a new shell where we're in the sbuild group
             # Don't run integration tests when build fails
-            - sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc'
-            - ssh-keygen -P "" -q -f ~/.ssh/id_rsa
-            - sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci'
+            - |
+                sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc' &
+                  ssh-keygen -P "" -q -f ~/.ssh/id_rsa                                                         &
+                  sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci'
         - python: 3.5
           env:
               TOXENV=xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,10 +119,10 @@ matrix:
                     sudo tar --sparse --xattrs --xattrs-include=* -cf "$TRAVIS_BUILD_DIR/chroots/xenial-amd64.tar" -C /var/lib/schroot/chroots/xenial-amd64 .
                 fi
             # Use sudo to get a new shell where we're in the sbuild group
-            # Don't run integration tests when build failes
-            - | sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc' &&
-                  ssh-keygen -P "" -q -f ~/.ssh/id_rsa &&
-                  sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci'
+            # Don't run integration tests when build fails
+            - sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc'
+            - ssh-keygen -P "" -q -f ~/.ssh/id_rsa
+            - sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci'
         - python: 3.5
           env:
               TOXENV=xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,9 +119,10 @@ matrix:
                     sudo tar --sparse --xattrs --xattrs-include=* -cf "$TRAVIS_BUILD_DIR/chroots/xenial-amd64.tar" -C /var/lib/schroot/chroots/xenial-amd64 .
                 fi
             # Use sudo to get a new shell where we're in the sbuild group
-            - sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc'
-            - ssh-keygen -P "" -q -f ~/.ssh/id_rsa
-            - sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci'
+            # Don't run integration tests when build failes
+            - | sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc' &&
+                  ssh-keygen -P "" -q -f ~/.ssh/id_rsa &&
+                  sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci'
         - python: 3.5
           env:
               TOXENV=xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,8 +121,8 @@ matrix:
             # Use sudo to get a new shell where we're in the sbuild group
             # Don't run integration tests when build fails
             - |
-                sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc' &
-                  ssh-keygen -P "" -q -f ~/.ssh/id_rsa                                                         &
+                sudo -E su $USER -c 'sbuild --nolog --no-run-lintian --verbose --dist=xenial cloud-init_*.dsc' &&
+                  ssh-keygen -P "" -q -f ~/.ssh/id_rsa                                                         &&
                   sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls *.deb)" tox -e integration-tests-ci'
         - python: 3.5
           env:

--- a/tests/unittests/test_fail.py
+++ b/tests/unittests/test_fail.py
@@ -1,0 +1,2 @@
+def test_fail():
+    assert False

--- a/tests/unittests/test_fail.py
+++ b/tests/unittests/test_fail.py
@@ -1,2 +1,0 @@
-def test_fail():
-    assert False


### PR DESCRIPTION
```
If building the *.deb fails, exit

Currently integration tests will run and fail with a non-obvious
message. This makes it so the last thing in the logs is whatever
caused the build to fail.
```

## Additional Context
Consider the new output for a failed build:
https://app.travis-ci.com/github/canonical/cloud-init/jobs/551267972

