### PR TITLE
find_devs/openbsd: accept ISO on disk

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1217,8 +1217,9 @@ def find_devs_with_openbsd(criteria=None, oformat='device',
             continue
         if entry == 'fd0:':
             continue
-        part_id = 'a' if entry.startswith('cd') else 'i'
-        devlist.append(entry[:-1] + part_id)
+        devlist.append(entry[:-1] + 'a')
+        if not entry.startswith('cd'):
+            devlist.append(entry[:-1] + 'i')
     if criteria == "TYPE=iso9660":
         devlist = [i for i in devlist if i.startswith('cd')]
     elif criteria in ["LABEL=CONFIG-2", "TYPE=vfat"]:

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2330,7 +2330,7 @@ class TestFindDevs:
     def test_find_devs_with_openbsd(self, m_subp):
         m_subp.return_value = ('cd0:,sd0:630d98d32b5d3759,sd1:,fd0:', '')
         devlist = util.find_devs_with_openbsd()
-        assert devlist == ['/dev/cd0a', '/dev/sd1i']
+        assert devlist == ['/dev/cd0a', '/dev/sd1a', '/dev/sd1i']
 
     @mock.patch('cloudinit.subp.subp')
     def test_find_devs_with_openbsd_with_criteria(self, m_subp):
@@ -2340,7 +2340,7 @@ class TestFindDevs:
 
         # lp: #1841466
         devlist = util.find_devs_with_openbsd(criteria="LABEL_FATBOOT=A_LABEL")
-        assert devlist == ['/dev/cd0a', '/dev/sd1i']
+        assert devlist == ['/dev/cd0a', '/dev/sd1a', '/dev/sd1i']
 
     @pytest.mark.parametrize(
         'criteria,expected_devlist',


### PR DESCRIPTION
When the metadata is an ISO image and is exposed through a disk,
the device is called `/dev/sd?a` internally. For instance `/dev/sd1a`.

It can then be mounted with `mount_cd9660 /dev/sd1a /mnt`.

Metadata in the FAT32 format are exposed as `/dev/sd?i`.

With this change, we try to mount `/dev/sd?a` in addition to `/dev/sd?i`.

Closes: https://github.com/ContainerCraft/kmi/issues/12
