### PR TITLE
find_devs_with_openbsd: ensure we return the last entry

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1211,7 +1211,7 @@ def find_devs_with_openbsd(criteria=None, oformat='device',
                            tag=None, no_cache=False, path=None):
     out, _err = subp.subp(['sysctl', '-n', 'hw.disknames'], rcs=[0])
     devlist = []
-    for entry in out.split(','):
+    for entry in out.rstrip().split(','):
         if not entry.endswith(':'):
             # ffs partition with a serial, not a config-drive
             continue
@@ -1220,12 +1220,6 @@ def find_devs_with_openbsd(criteria=None, oformat='device',
         devlist.append(entry[:-1] + 'a')
         if not entry.startswith('cd'):
             devlist.append(entry[:-1] + 'i')
-    if criteria == "TYPE=iso9660":
-        devlist = [i for i in devlist if i.startswith('cd')]
-    elif criteria in ["LABEL=CONFIG-2", "TYPE=vfat"]:
-        devlist = [i for i in devlist if not i.startswith('cd')]
-    elif criteria:
-        LOG.debug("Unexpected criteria: %s", criteria)
     return ['/dev/' + i for i in devlist]
 
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2336,7 +2336,7 @@ class TestFindDevs:
     def test_find_devs_with_openbsd_with_criteria(self, m_subp):
         m_subp.return_value = ('cd0:,sd0:630d98d32b5d3759,sd1:,fd0:', '')
         devlist = util.find_devs_with_openbsd(criteria="TYPE=iso9660")
-        assert devlist == ['/dev/cd0a']
+        assert devlist == ['/dev/cd0a', '/dev/sd1a', '/dev/sd1i']
 
         # lp: #1841466
         devlist = util.find_devs_with_openbsd(criteria="LABEL_FATBOOT=A_LABEL")


### PR DESCRIPTION
`sysctl -n hw.disknames` returns a trailing `\n`. We need to clean
this up. In addition, the criteria matching system is a source of
problem because:

- we don't have a way to look up the label of the partition
- we've got situation where an ISO image can be exposed through a virtio
  block device.

So we just totally ignore the value of `criteria`. We end-up with a
slightly longer loop of mount-retry. But this way we're sure we don't
miss a configuration disk.

Tested on Kubvirt with the help of Brady Pratt @jbpratt.
