### PR TITLE
Bugfix/ua assume yes 1954842

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -137,7 +137,7 @@ def configure_ua(token=None, enable=None):
     enable_errors = []
     for service in enable:
         try:
-            cmd = ["ua", "enable", service]
+            cmd = ["ua", "enable", "--assume-yes", service]
             subp.subp(cmd, capture=True)
         except subp.ProcessExecutionError as e:
             enable_errors.append((service, e))

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -63,7 +63,9 @@ class TestConfigureUA(CiTestCase):
         """all services should be enabled and then any failures raised"""
 
         def fake_subp(cmd, capture=None):
-            fail_cmds = [["ua", "enable", svc] for svc in ["esm", "cc"]]
+            fail_cmds = [
+                ["ua", "enable", "--assume-yes", svc] for svc in ["esm", "cc"]
+            ]
             if cmd in fail_cmds and capture:
                 svc = cmd[-1]
                 raise subp.ProcessExecutionError(
@@ -78,9 +80,15 @@ class TestConfigureUA(CiTestCase):
             m_subp.call_args_list,
             [
                 mock.call(["ua", "attach", "SomeToken"]),
-                mock.call(["ua", "enable", "esm"], capture=True),
-                mock.call(["ua", "enable", "cc"], capture=True),
-                mock.call(["ua", "enable", "fips"], capture=True),
+                mock.call(
+                    ["ua", "enable", "--assume-yes", "esm"], capture=True
+                ),
+                mock.call(
+                    ["ua", "enable", "--assume-yes", "cc"], capture=True
+                ),
+                mock.call(
+                    ["ua", "enable", "--assume-yes", "fips"], capture=True
+                ),
             ],
         )
         self.assertIn(
@@ -118,7 +126,9 @@ class TestConfigureUA(CiTestCase):
             m_subp.call_args_list,
             [
                 mock.call(["ua", "attach", "SomeToken"]),
-                mock.call(["ua", "enable", "fips"], capture=True),
+                mock.call(
+                    ["ua", "enable", "--assume-yes", "fips"], capture=True
+                ),
             ],
         )
         self.assertEqual(
@@ -135,7 +145,9 @@ class TestConfigureUA(CiTestCase):
             m_subp.call_args_list,
             [
                 mock.call(["ua", "attach", "SomeToken"]),
-                mock.call(["ua", "enable", "fips"], capture=True),
+                mock.call(
+                    ["ua", "enable", "--assume-yes", "fips"], capture=True
+                ),
             ],
         )
         self.assertEqual(

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -33,6 +33,7 @@ holmanb
 impl
 irishgordo
 izzyleung
+j5awry
 Jille
 JohnKepplers
 johnsonshi


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
   Update cc_ubuntu_advantage calls to assume-yes
    
   cloud-init currently makes calls to ubuntu_advantage without assume-yes.
   some ua enable commands, such as ua enable fips, have prompts. In an
   automated environment, calling ua enable without --assume-yes will
   result in errors and not applying the change. This sets --assume-yes by
   default for all enable commands. This capability was added two years ago
   in ua commit 576e605ceb5f so should be safe for use in all systems at
   this time.

   LP: #1954842
```

## Additional Context
This was raised by a Canonical Public Cloud partner as a possible bug when suggested to an end-user as a possible way of running FIPS enablement automatically in their cloud.

## Test Steps
cloud-init snippet that needs added for a test:

```
ubuntu-advantage:
  token: <ua_contract_token>
  enable:
  - fips
```
This will require a valid token. 

Old behaviour -- cloud-init should fail as `ua enable fips` will raise a prompt and no interaction will happen. 

New behaviour -- cloud-init will finish and fips will be enabled on the image. _note_ because `ua enable fips` requires a restart to take affect, the image itself may not be in fips mode until a restart. However this PR only addresses the failure caused by raising an interactive prompt in a non-interactive setting.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
   - As a bugfix, there is no documentation to change. It's documented as working already :)
