### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Automatically apply to git blame with `git config blame.ignorerevsfile .git-blame-ignore-revs`
+
+# Apply black and isort formatting
+bae9b11da9ed7dd0b16fe5adeaf4774b7cc628cf


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add .git-blame-ignore-revs

So git doesn't use formatting changes for git blame
```

So I don't get blamed for everything :wink: 