### PR TITLE
bsd/resolv.d/ avoid duplicated entries

### DIFF
--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -138,14 +138,14 @@ class BSDRenderer(renderer.Renderer):
             resolvconf.parse()
 
         # Add some nameservers
-        for server in nameservers:
+        for server in set(nameservers):
             try:
                 resolvconf.add_nameserver(server)
             except ValueError:
                 util.logexc(LOG, "Failed to add nameserver %s", server)
 
         # And add any searchdomains.
-        for domain in searchdomains:
+        for domain in set(searchdomains):
             try:
                 resolvconf.add_search_domain(domain)
             except ValueError:


### PR DESCRIPTION
Ensure we don't add duplicated nameserver or searchdomains.
This can happen on OpenBSD because of dhcpleased.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate bug reference or remove
this line entirely if there is no associated bug)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
