### PR TITLE
Silence jsonschema pylint errors

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -118,12 +118,12 @@ def get_jsonschema_validator():
             type_checker=type_checker,
         )
     else:  # jsonschema 2.6 workaround
-        types = Draft4Validator.DEFAULT_TYPES
+        types = Draft4Validator.DEFAULT_TYPES  # pylint: disable=E1101
         # Allow bytes as well as string (and disable a spurious unsupported
         # assignment-operation pylint warning which appears because this
         # code path isn't written against the latest jsonschema).
         types["string"] = (str, bytes)  # pylint: disable=E1137
-        cloudinitValidator = create(
+        cloudinitValidator = create(  #pylint: disable=E1123
             meta_schema=strict_metaschema,
             validators=Draft4Validator.VALIDATORS,
             version="draft4",


### PR DESCRIPTION
```
Silence unwanted pylint errors for jsonschema

There is some compatibility code for old jsonschema versions that pylint
throws errors on. Pylint is unaware of the jsonschema version, and
therefore thinks it is not valid.
```
