### PR TITLE
pylint: silence errors on compat code for old jsonschema

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -118,12 +118,12 @@ def get_jsonschema_validator():
             type_checker=type_checker,
         )
     else:  # jsonschema 2.6 workaround
-        types = Draft4Validator.DEFAULT_TYPES
+        types = Draft4Validator.DEFAULT_TYPES  # pylint: disable=E1101
         # Allow bytes as well as string (and disable a spurious unsupported
         # assignment-operation pylint warning which appears because this
         # code path isn't written against the latest jsonschema).
         types["string"] = (str, bytes)  # pylint: disable=E1137
-        cloudinitValidator = create(
+        cloudinitValidator = create(  # pylint: disable=E1123
             meta_schema=strict_metaschema,
             validators=Draft4Validator.VALIDATORS,
             version="draft4",


### PR DESCRIPTION
## Proposed Commit Message
```
pylint: silence errors on compat code for old jsonschema

Let's silence the errors which are emitted by pylint on
a code path that exists only for backwards compatibility
with older versions of jsonschema. Pylint can't be aware
of the library version check we're doing.
```

## Additional Context
Spotted by Jenkins:
```
************* Module cloudinit.config.schema
cloudinit/config/schema.py:121: [E1101(no-member), get_jsonschema_validator] Class 'Validator' has no 'DEFAULT_TYPES' member
cloudinit/config/schema.py:126: [E1123(unexpected-keyword-arg), get_jsonschema_validator] Unexpected keyword argument 'default_types' in function call
```

## Test Steps
Run `tox -e pylint` on a >= Focal system and verify that pylint emits no errors.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
