### PR TITLE
3.10 Test Coverage (SC-719)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ matrix:
           env: TOXENV=doc
         # Test all supported Python versions (but at the end, so we schedule
         # longer-running jobs first)
-        - python: "3.10"
+        - python: "3.10.1"
         - python: 3.9
         - python: 3.8
         - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,6 +141,7 @@ matrix:
           env: TOXENV=doc
         # Test all supported Python versions (but at the end, so we schedule
         # longer-running jobs first)
+        - python: "3.10"
         - python: 3.9
         - python: 3.8
         - python: 3.7


### PR DESCRIPTION
```
Add 3.10 support to test matrix

Multiple supported distros (arch/fedora) have changed their default
python version to 3.10. We should include it in the test matrix.
```
Context: https://travis-ci.community/t/add-python-3-10/12220/12