### PR TITLE
Ensure system_cfg read before ds net config on Oracle (SC-720)

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -104,9 +104,9 @@ class DataSourceOracle(sources.DataSource):
     vendordata_pure = None
     network_config_sources = (
         sources.NetworkConfigSource.cmdline,
+        sources.NetworkConfigSource.system_cfg,
         sources.NetworkConfigSource.ds,
         sources.NetworkConfigSource.initramfs,
-        sources.NetworkConfigSource.system_cfg,
     )
 
     _network_config = sources.UNSET

--- a/tests/integration_tests/network/test_net_config_load.py
+++ b/tests/integration_tests/network/test_net_config_load.py
@@ -23,6 +23,5 @@ def test_network_disabled_via_etc_cloud(client: IntegrationInstance):
         )
     _customize_envionment(client)
 
-    # assert client.execute("test -f /etc/netplan/50-cloud-init.yaml").failed
     log = client.read_from_file("/var/log/cloud-init.log")
     assert "network config is disabled by system_cfg" in log

--- a/tests/integration_tests/network/test_net_config_load.py
+++ b/tests/integration_tests/network/test_net_config_load.py
@@ -1,0 +1,28 @@
+"""Test loading the network config"""
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+
+
+def _customize_envionment(client: IntegrationInstance):
+    # Insert our "disable_network_config" file here
+    client.write_to_file(
+        "/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg",
+        "network: {config: disabled}\n",
+    )
+    client.execute("cloud-init clean --logs")
+    client.restart()
+
+
+def test_network_disabled_via_etc_cloud(client: IntegrationInstance):
+    """Test that network can be disabled via config file in /etc/cloud"""
+    if client.settings.CLOUD_INIT_SOURCE == "IN_PLACE":
+        pytest.skip(
+            "IN_PLACE not supported as we mount /etc/cloud contents into the "
+            "container"
+        )
+    _customize_envionment(client)
+
+    # assert client.execute("test -f /etc/netplan/50-cloud-init.yaml").failed
+    log = client.read_from_file("/var/log/cloud-init.log")
+    assert "network config is disabled by system_cfg" in log

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -920,12 +920,14 @@ class TestNetworkConfig:
         assert network_config == m_read_initramfs_config.return_value
         assert "Failed to parse secondary network configuration" in caplog.text
 
-    def test_ds_network_cfg_preferred_over_initramfs(self, _m):
-        """Ensure that DS net config is preferred over initramfs config"""
+    def test_ds_network_cfg_order(self, _m):
+        """Ensure that DS net config is preferred over initramfs config
+        but less tahn system config."""
         config_sources = oracle.DataSourceOracle.network_config_sources
+        system_idx = config_sources.index(NetworkConfigSource.system_cfg)
         ds_idx = config_sources.index(NetworkConfigSource.ds)
         initramfs_idx = config_sources.index(NetworkConfigSource.initramfs)
-        assert ds_idx < initramfs_idx
+        assert system_idx < ds_idx < initramfs_idx
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -922,7 +922,7 @@ class TestNetworkConfig:
 
     def test_ds_network_cfg_order(self, _m):
         """Ensure that DS net config is preferred over initramfs config
-        but less tahn system config."""
+        but less than system config."""
         config_sources = oracle.DataSourceOracle.network_config_sources
         system_idx = config_sources.index(NetworkConfigSource.system_cfg)
         ds_idx = config_sources.index(NetworkConfigSource.ds)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Ensure system_cfg read before ds net config on Oracle

In 2c52e6e88b19f5db8d55eb7280ee27703e05d75f, the order of
reading network config was changed for Oracle due to initramfs
needing to take lower precedence than the datasource. However,
this also bumped system_cfg to a lower precedence than ds, which
means that any network configuration specified in /etc/cloud will not
be applied. system_cfg should instead be moved above ds so network
configuration in /etc/cloud takes precedence.

LP: #1956788
```

## Additional Context
https://github.com/canonical/cloud-init/commit/2c52e6e88b19f5db8d55eb7280ee27703e05d75f

## Test Steps
Boot an Oracle instance using the Oracle datasource.
Create /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with contents `network: {config: disabled}`
rm /etc/netplan/50-cloud-init.yaml (or rename it if you need it)
`cloud-init clean --logs && cloud-init init --local`
Without patch, /etc/netplan/50-cloud-init.yaml should get written. With patch, it won't be written and logs should show no network written.

I can also include an Oracle-specific integration test, but wanted to get the PR up sooner rather than later.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
