### PR TITLE
tests: mock LXD datasource detection in ds-identify on LXD containers

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -92,6 +92,7 @@ MOCK_VIRT_IS_CONTAINER_OTHER = {
     "RET": "container-other",
     "ret": 0,
 }
+MOCK_NOT_LXD_DATASOURCE = {"name": "dscheck_LXD", "ret": 1}
 MOCK_VIRT_IS_KVM = {"name": "detect_virt", "RET": "kvm", "ret": 0}
 MOCK_VIRT_IS_VMWARE = {"name": "detect_virt", "RET": "vmware", "ret": 0}
 # currenty' SmartOS hypervisor "bhyve" is unknown by systemd-detect-virt.
@@ -99,6 +100,8 @@ MOCK_VIRT_IS_VM_OTHER = {"name": "detect_virt", "RET": "vm-other", "ret": 0}
 MOCK_VIRT_IS_XEN = {"name": "detect_virt", "RET": "xen", "ret": 0}
 MOCK_UNAME_IS_PPC64 = {"name": "uname", "out": UNAME_PPC64EL, "ret": 0}
 MOCK_UNAME_IS_FREEBSD = {"name": "uname", "out": UNAME_FREEBSD, "ret": 0}
+
+DEFAULT_MOCKS = [MOCK_NOT_LXD_DATASOURCE]
 
 shell_true = 0
 shell_false = 1
@@ -230,6 +233,13 @@ class DsIdentifyBase(CiTestCase):
                 xwargs[k] = data[k]
             if k in kwargs:
                 xwargs[k] = kwargs[k]
+        if "mocks" not in xwargs:
+            xwargs["mocks"] = DEFAULT_MOCKS
+        else:
+            mocked_funcs = [m["name"] for m in xwargs["mocks"]]
+            for default_mock in DEFAULT_MOCKS:
+                if default_mock["name"] not in mocked_funcs:
+                    xwargs["mocks"].append(default_mock)
 
         return self.call(**xwargs)
 


### PR DESCRIPTION
## Proposed Commit Message
```
On LXD containers /dev/lxd/sock will always exist.

Mock dscheck_LXD to return 1 (NOT_FOUND) to avoid leaking into
test environment and returning LXD as detected.

We have integration tests covering proper LXD datasource detection
so we don't need a Unit test validating the [ -S /dev/lxd/sock] that
is in ds-identify.
```

## Additional Context
<!-- If relevant -->

## Test Steps
```bash
lxc launch ubuntu-daily:bionic dev-b
lxc config device add dev-b rohome disk source="/home/csmith/src/cloud-init" path="/root/cloud-init/"
lxc exec dev-b bash
tox -e py3 tests/unittests/test_ds_identify.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
