### PR TITLE
Add support for gentoo templates and cloud.cfg

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -176,7 +176,7 @@ cloud_final_modules:
 system_info:
    # This will affect which distro class gets used
 {% if variant in ["almalinux", "alpine", "amazon", "arch", "centos", "cloudlinux", "debian",
-                  "eurolinux", "fedora", "freebsd", "netbsd", "miraclelinux", "openbsd", "openEuler",
+                  "eurolinux", "fedora", "freebsd", "gentoo", "netbsd", "miraclelinux", "openbsd", "openEuler",
                   "photon", "rhel", "rocky", "suse", "ubuntu", "virtuozzo"] %}
    distro: {{ variant }}
 {% elif variant in ["dragonfly"] %}
@@ -231,7 +231,7 @@ system_info:
          security: http://ports.ubuntu.com/ubuntu-ports
    ssh_svcname: ssh
 {% elif variant in ["almalinux", "alpine", "amazon", "arch", "centos", "cloudlinux", "eurolinux",
-                    "fedora", "miraclelinux", "openEuler", "rhel", "rocky", "suse", "virtuozzo"] %}
+                    "fedora", "gentoo", "miraclelinux", "openEuler", "rhel", "rocky", "suse", "virtuozzo"] %}
    # Default user name + that default users groups (if added/used)
    default_user:
 {% if variant == "amazon" %}
@@ -245,6 +245,10 @@ system_info:
 {% endif %}
 {% if variant == "suse" %}
      groups: [cdrom, users]
+{% if variant == "gentoo" %}
+     groups: [users, wheel]
+     primary_group: users
+     no_user_group: true
 {% elif variant == "alpine" %}
      groups: [adm, sudo]
 {% elif variant == "arch" %}

--- a/templates/hosts.gentoo.tmpl
+++ b/templates/hosts.gentoo.tmpl
@@ -1,0 +1,23 @@
+## template:jinja
+{#
+This file /etc/cloud/templates/hosts.gentoo.tmpl is only utilized
+if enabled in cloud-config.  Specifically, in order to enable it
+you need to add the following to config:
+  manage_etc_hosts: True
+-#}
+# Your system has configured 'manage_etc_hosts' as True.
+# As a result, if you wish for changes to this file to persist
+# then you will need to either
+# a.) make changes to the master file in /etc/cloud/templates/hosts.gentoo.tmpl
+# b.) change or remove the value of 'manage_etc_hosts' in
+#     /etc/cloud/cloud.cfg or cloud-config from user-data
+#
+# The following lines are desirable for IPv4 capable hosts
+127.0.0.1 {{fqdn}} {{hostname}}
+127.0.0.1 localhost.localdomain localhost
+127.0.0.1 localhost4.localdomain4 localhost4
+
+# The following lines are desirable for IPv6 capable hosts
+::1 {{fqdn}} {{hostname}}
+::1 localhost.localdomain localhost
+::1 localhost6.localdomain6 localhost6

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -16,6 +16,7 @@ DISTRO_VARIANTS = [
     "eurolinux",
     "fedora",
     "freebsd",
+    "gentoo",
     "netbsd",
     "openbsd",
     "photon",

--- a/tools/render-cloudcfg
+++ b/tools/render-cloudcfg
@@ -5,7 +5,7 @@ import os
 import sys
 
 VARIANTS = ["almalinux", "alpine", "amazon", "arch", "centos", "cloudlinux", "debian",
-            "eurolinux", "fedora", "freebsd", "miraclelinux", "netbsd", "openbsd", "openEuler", "photon",
+            "eurolinux", "fedora", "freebsd", "gentoo", "miraclelinux", "netbsd", "openbsd", "openEuler", "photon",
             "rhel", "suse","rocky", "ubuntu", "unknown", "virtuozzo"]
 
 


### PR DESCRIPTION
## Add support for gentoo in cloud.cfg and templates
<!-- Include a proposed commit message because all PRs are squash merged -->

```

Add support for gentoo in cloud.cfg and templates.
This is an already existing patch in gentoo upstream https://gitweb.gentoo.org/repo/gentoo.git/tree/app-emulation/cloud-init/files/cloud-init-20.4-gentoo-support-upstream-templates.patch.
Cherry-picking the patch to the upstream cloud-init.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
