### PR TITLE
sources/azure: rename metadata_type -> MetadataType

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -75,10 +75,10 @@ IMDS_EXTENDED_VER_MIN = "2021-03-01"
 SSHKeys = namedtuple("SSHKeys", ("keys_from_imds", "ssh_keys"))
 
 
-class metadata_type(Enum):
-    all = "{}/instance".format(IMDS_URL)
-    network = "{}/instance/network".format(IMDS_URL)
-    reprovisiondata = "{}/reprovisiondata".format(IMDS_URL)
+class MetadataType(Enum):
+    ALL = "{}/instance".format(IMDS_URL)
+    NETWORK = "{}/instance/network".format(IMDS_URL)
+    REPROVISION_DATA = "{}/reprovisiondata".format(IMDS_URL)
 
 
 PLATFORM_ENTROPY_SOURCE = "/sys/firmware/acpi/tables/OEM0"
@@ -633,7 +633,7 @@ class DataSourceAzure(sources.DataSource):
         self,
         fallback_nic,
         retries,
-        md_type=metadata_type.all,
+        md_type=MetadataType.ALL,
         exc_cb=retry_on_url_exc,
         infinite=False,
     ):
@@ -1015,7 +1015,7 @@ class DataSourceAzure(sources.DataSource):
         # could add several seconds of delay.
         try:
             imds_md = self.get_imds_data_with_api_fallback(
-                ifname, 0, metadata_type.network, network_metadata_exc_cb, True
+                ifname, 0, MetadataType.NETWORK, network_metadata_exc_cb, True
             )
         except Exception as e:
             LOG.warning(
@@ -1167,7 +1167,7 @@ class DataSourceAzure(sources.DataSource):
         """Poll IMDS for the new provisioning data until we get a valid
         response. Then return the returned JSON object."""
         url = "{}?api-version={}".format(
-            metadata_type.reprovisiondata.value, IMDS_VER_MIN
+            MetadataType.REPROVISION_DATA.value, IMDS_VER_MIN
         )
         headers = {"Metadata": "true"}
         nl_sock = None
@@ -2287,7 +2287,7 @@ def _generate_network_config_from_fallback_config() -> dict:
 def get_metadata_from_imds(
     fallback_nic,
     retries,
-    md_type=metadata_type.all,
+    md_type=MetadataType.ALL,
     api_version=IMDS_VER_MIN,
     exc_cb=retry_on_url_exc,
     infinite=False,
@@ -2331,7 +2331,7 @@ def get_metadata_from_imds(
 def _get_metadata_from_imds(
     retries,
     exc_cb,
-    md_type=metadata_type.all,
+    md_type=MetadataType.ALL,
     api_version=IMDS_VER_MIN,
     infinite=False,
 ):
@@ -2339,7 +2339,7 @@ def _get_metadata_from_imds(
     headers = {"Metadata": "true"}
 
     # support for extended metadata begins with 2021-03-01
-    if api_version >= IMDS_EXTENDED_VER_MIN and md_type == metadata_type.all:
+    if api_version >= IMDS_EXTENDED_VER_MIN and md_type == MetadataType.ALL:
         url = url + "&extended=true"
 
     try:

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -500,7 +500,7 @@ class TestGetMetadataFromIMDS(HttprettyTestCase):
         )
 
         dsaz.get_metadata_from_imds(
-            "eth0", retries=3, md_type=dsaz.metadata_type.all
+            "eth0", retries=3, md_type=dsaz.MetadataType.ALL
         )
         m_readurl.assert_called_with(
             "http://169.254.169.254/metadata/instance?api-version=2019-06-01",
@@ -525,7 +525,7 @@ class TestGetMetadataFromIMDS(HttprettyTestCase):
         )
 
         dsaz.get_metadata_from_imds(
-            "eth0", retries=3, md_type=dsaz.metadata_type.network
+            "eth0", retries=3, md_type=dsaz.MetadataType.NETWORK
         )
         m_readurl.assert_called_with(
             "http://169.254.169.254/metadata/instance/network?api-version="
@@ -576,7 +576,7 @@ class TestGetMetadataFromIMDS(HttprettyTestCase):
         dsaz.get_metadata_from_imds(
             "eth0",
             retries=3,
-            md_type=dsaz.metadata_type.all,
+            md_type=dsaz.MetadataType.ALL,
             api_version="2021-08-01",
         )
         m_readurl.assert_called_with(
@@ -2154,14 +2154,14 @@ scbus-1 on xpt0 bus 0
             mock.call(
                 fallback_nic="eth9",
                 retries=0,
-                md_type=dsaz.metadata_type.all,
+                md_type=dsaz.MetadataType.ALL,
                 api_version="2021-08-01",
                 exc_cb=mock.ANY,
             ),
             mock.call(
                 fallback_nic="eth9",
                 retries=10,
-                md_type=dsaz.metadata_type.all,
+                md_type=dsaz.MetadataType.ALL,
                 api_version="2019-06-01",
                 exc_cb=mock.ANY,
                 infinite=False,
@@ -2186,7 +2186,7 @@ scbus-1 on xpt0 bus 0
             mock.call(
                 fallback_nic="eth9",
                 retries=0,
-                md_type=dsaz.metadata_type.all,
+                md_type=dsaz.MetadataType.ALL,
                 api_version="2021-08-01",
                 exc_cb=mock.ANY,
             )


### PR DESCRIPTION
Format tweak to match naming conventions for classes & enums.

No functional changes.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
