### PR TITLE
Debian: tell apt-get not to check dates

### DIFF
--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -24,6 +24,7 @@ APT_GET_COMMAND = (
     "apt-get",
     "--option=Dpkg::Options::=--force-confold",
     "--option=Dpkg::options::=--force-unsafe-io",
+    "--option=Acquire::Check-Date=false",
     "--assume-yes",
     "--quiet",
 )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Debian: tell apt-get not to check dates

* Date and time may not always be set correctly, especially on systems without RTC.
* "apt-get update" fails if current time is not set correctly, and the 
  Releases file mentions a Date in the future.
* Ideally, we would order systemd units to wait for NTP synchronization to be complete 
  before using any "apt" function. 
  However there may still be a chicken and the egg problem here if we
  do that, if NTP client is not installed yet in image, 
  and the cc_ntp module wants to use apt-get to install it...

So just tell apt-get not to perform date/time checks.

LP: #1951639 
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly

(Note, I am currently not in .github-cla-signers yet, but there is another PR that takes care of that).