### PR TITLE
Add DatasourceOVF network-config propery to Ubuntu OVF example

### DIFF
--- a/doc/sources/ovf/example/ubuntu-server.ovf
+++ b/doc/sources/ovf/example/ubuntu-server.ovf
@@ -48,6 +48,10 @@
           <Label>Default User's password</Label>
           <Description>If set, the default user's password will be set to this value to allow password based login.  The password will be good for only a single login.  If set to the string 'RANDOM' then a random password will be generated, and written to the console.</Description>
       </Property>
+      <Property ovf:key="network-config" ovf:type="string" ovf:userConfigurable="true">
+          <Label>Encoded network-config</Label>
+          <Description>This field is optional. It will be taken if no network configuration is set in user-data. The value for network-config has to be base64 encoded.</Description>
+      </Property>
     </ProductSection>
     <VirtualHardwareSection>
       <Info>Virtual hardware requirements</Info>

--- a/doc/sources/ovf/example/ubuntu-server.ovf
+++ b/doc/sources/ovf/example/ubuntu-server.ovf
@@ -50,7 +50,7 @@
       </Property>
       <Property ovf:key="network-config" ovf:type="string" ovf:userConfigurable="true">
           <Label>Encoded network-config</Label>
-          <Description>This field is optional. It will be taken if no network configuration is set in user-data. The value for network-config has to be base64 encoded.</Description>
+          <Description>This field is optional. The value for network-config has to be base64 encoded.</Description>
       </Property>
     </ProductSection>
     <VirtualHardwareSection>

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -53,6 +53,7 @@ manuelisimo
 marlluslustosa
 matthewruffell
 maxnet
+megian
 mitechie
 nazunalika
 nicolasbock


### PR DESCRIPTION
Cloud-init includes the capability to take the network-config from a
separate key. This removes the need to merge the network config in
the user-data and make it more transparent in some cases.

Reference:
https://github.com/canonical/cloud-init/blob/42b938e8ff4c50833ff7b8f5acc1d9ab3f43ab18/cloudinit/sources/DataSourceOVF.py#L557

## Test Steps
- Create a template using the OVF example
* Instantiate a VM from that template
- Set the property key network-config to
```
bmV0d29yazoKICB2ZXJzaW9uOiAyCiAgZXRoZXJuZXRzOgogICAgaW50ZXJmYWNlMDoKICAgICAgbWF0Y2g6CiAgICAgICAgbmFtZTogZW5zMTkyCiAgICAgIGFkZHJlc3NlczoKICAgICAgICAtIDE5Mi4xNjguMTAwLjEwMC8yNAogICAgICBnYXRld2F5NDogMTkyLjE2OC4xMDAuMQogICAgICBuYW1lc2VydmVyczoKICAgICAgICBzZWFyY2g6CiAgICAgICAgIC0gZm9vLmxvY2FsCiAgICAgICAgIC0gYmFyLmxvY2FsCiAgICAgICAgYWRkcmVzc2VzOgogICAgICAgICAtIDEuMS4xLjEK
```
- Check that if the content has been written to /etc/netplan/50-cloud-init.yaml inside the VM operating system

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly (N/A because it is just an example file)
 - [x] I have updated or added any documentation accordingly (N/A because it is just an example file)
