### PR TITLE
Enable OVF environment transport via ISO and guestInfo.ovfEnv in example

### DIFF
--- a/doc/sources/ovf/example/ubuntu-server.ovf
+++ b/doc/sources/ovf/example/ubuntu-server.ovf
@@ -49,7 +49,7 @@
           <Description>If set, the default user's password will be set to this value to allow password based login.  The password will be good for only a single login.  If set to the string 'RANDOM' then a random password will be generated, and written to the console.</Description>
       </Property>
     </ProductSection>
-    <VirtualHardwareSection>
+    <VirtualHardwareSection ovf:transport="iso com.vmware.guestInfo">
       <Info>Virtual hardware requirements</Info>
       <System>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>


### PR DESCRIPTION
This enables the OVF environment transport via ISO and the guestInfo.ovfEnv
variable. This is a useful default, as this behavior is expected by the
user.

Reference:
https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-14A25C25-A6F8-4818-9D0C-C0247C0672FA.html

## Additional Context
The guestInfo.ovfEnv variable handover via RPC.

## Test Steps
* Create a template using the OVF example
* Instantiate a VM from that template
* Check if the content is available using the RPCTool ``vmware-rpctool "info-get guestinfo.ovfEnv"

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly (N/A because it is just an example file)
 - [x] I have updated or added any documentation accordingly (N/A because it is just an example file)
