### PR TITLE
Add .python-version to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 __pycache__
 .tox
 .coverage
+.python-version
 doc/rtd_html
 parts
 prime


### PR DESCRIPTION
```
Add pyenv version file to .gitignore

This file is an artifact of the `pyenv local` command, which is helpful for
setting a project-specific python version for testing.
```