### PR TITLE
Test Optimization Proposal (SC-736)

### DIFF
--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -10,7 +10,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import argparse
 import collections
 import re
 import sys
@@ -183,65 +182,17 @@ def render_string(content, params):
     return renderer(content, params)
 
 
-def render_cloudcfg(argv):
-    VARIANTS = [
-        "almalinux",
-        "alpine",
-        "amazon",
-        "arch",
-        "centos",
-        "cloudlinux",
-        "debian",
-        "eurolinux",
-        "fedora",
-        "freebsd",
-        "miraclelinux",
-        "netbsd",
-        "openbsd",
-        "openEuler",
-        "photon",
-        "rhel",
-        "suse",
-        "rocky",
-        "ubuntu",
-        "unknown",
-        "virtuozzo",
-    ]
-    parser = argparse.ArgumentParser()
-    platform = util.system_info()
-    parser.add_argument(
-        "--variant",
-        default=platform["variant"],
-        action="store",
-        help="define the variant.",
-        choices=VARIANTS,
-    )
-    parser.add_argument(
-        "template",
-        nargs="?",
-        action="store",
-        default="./config/cloud.cfg.tmpl",
-        help="Path to the cloud.cfg template",
-    )
-    parser.add_argument(
-        "output",
-        nargs="?",
-        action="store",
-        default="-",
-        help="Output file.  Use '-' to write to stdout",
-    )
+def render_cloudcfg(variant, template, output):
 
-    args = parser.parse_args(argv)
-
-    with open(args.template, "r") as fh:
+    with open(template, "r") as fh:
         contents = fh.read()
-    tpl_params = {"variant": args.variant}
+    tpl_params = {"variant": variant}
     contents = (render_string(contents, tpl_params)).rstrip() + "\n"
     util.load_yaml(contents)
-    if args.output == "-":
+    if output == "-":
         sys.stdout.write(contents)
     else:
-        write_file(args.output, contents, omode="w")
+        write_file(output, contents, omode="w")
 
 
 # vi: ts=4 expandtab

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -10,10 +10,10 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import sys
+import argparse
 import collections
 import re
-import argparse
+import sys
 
 try:
     from Cheetah.Template import Template as CTemplate

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-from cloudinit import subp, util
+from cloudinit import subp, util, templater
 from tests.unittests.helpers import cloud_init_project_dir
 
 # TODO(Look to align with tools.render-cloudcfg or cloudinit.distos.OSFAMILIES)
@@ -32,10 +32,52 @@ class TestRenderCloudCfg:
     cmd = [sys.executable, cloud_init_project_dir("tools/render-cloudcfg")]
     tmpl_path = cloud_init_project_dir("config/cloud.cfg.tmpl")
 
+    def test_variant_sets_distro_in_cloud_cfg_subp(self, tmpdir):
+        outfile = tmpdir.join("outcfg").strpath
+
+        subp.subp(self.cmd + ["--variant", "ubuntu", self.tmpl_path, outfile])
+        with open(outfile) as stream:
+            system_cfg = util.load_yaml(stream.read())
+        assert system_cfg["system_info"]["distro"] == "ubuntu"
+
+    def test_variant_sets_default_user_in_cloud_cfg_subp(self, tmpdir):
+        outfile = tmpdir.join("outcfg").strpath
+        templater.render_cloudcfg(
+            ["--variant", "ubuntu", self.tmpl_path, outfile]
+        )
+        with open(outfile) as stream:
+            system_cfg = util.load_yaml(stream.read())
+
+        default_user_exceptions = {
+            "amazon": "ec2-user",
+            "debian": "ubuntu",
+            "unknown": "ubuntu",
+        }
+        default_user = system_cfg["system_info"]["default_user"]["name"]
+        assert default_user == default_user_exceptions.get("ubuntu", "ubuntu")
+
+    def test_variant_sets_network_renderer_priority_in_cloud_cfg_subp(
+        self, tmpdir
+    ):
+        outfile = tmpdir.join("outcfg").strpath
+        templater.render_cloudcfg(
+            ["--variant", "openbsd", self.tmpl_path, outfile]
+        )
+        with open(outfile) as stream:
+            system_cfg = util.load_yaml(stream.read())
+
+        assert ["openbsd"] == system_cfg["system_info"]["network"]["renderers"]
+
     @pytest.mark.parametrize("variant", (DISTRO_VARIANTS))
     def test_variant_sets_distro_in_cloud_cfg(self, variant, tmpdir):
+        """Testing parametrized inputs with imported function saves ~0.5s per
+        call versus calling as subp
+        """
         outfile = tmpdir.join("outcfg").strpath
-        subp.subp(self.cmd + ["--variant", variant, self.tmpl_path, outfile])
+
+        templater.render_cloudcfg(
+            ["--variant", variant, self.tmpl_path, outfile]
+        )
         with open(outfile) as stream:
             system_cfg = util.load_yaml(stream.read())
         if variant == "unknown":
@@ -44,8 +86,13 @@ class TestRenderCloudCfg:
 
     @pytest.mark.parametrize("variant", (DISTRO_VARIANTS))
     def test_variant_sets_default_user_in_cloud_cfg(self, variant, tmpdir):
+        """Testing parametrized inputs with imported function saves ~0.5s per
+        call versus calling as subp
+        """
         outfile = tmpdir.join("outcfg").strpath
-        subp.subp(self.cmd + ["--variant", variant, self.tmpl_path, outfile])
+        templater.render_cloudcfg(
+            ["--variant", variant, self.tmpl_path, outfile]
+        )
         with open(outfile) as stream:
             system_cfg = util.load_yaml(stream.read())
 
@@ -69,8 +116,13 @@ class TestRenderCloudCfg:
     def test_variant_sets_network_renderer_priority_in_cloud_cfg(
         self, variant, renderers, tmpdir
     ):
+        """Testing parametrized inputs with imported function saves ~0.5s per
+        call versus calling as subp
+        """
         outfile = tmpdir.join("outcfg").strpath
-        subp.subp(self.cmd + ["--variant", variant, self.tmpl_path, outfile])
+        templater.render_cloudcfg(
+            ["--variant", variant, self.tmpl_path, outfile]
+        )
         with open(outfile) as stream:
             system_cfg = util.load_yaml(stream.read())
 

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -47,9 +47,7 @@ class TestRenderCloudCfg:
         """
         outfile = tmpdir.join("outcfg").strpath
 
-        templater.render_cloudcfg(
-            ["--variant", variant, self.tmpl_path, outfile]
-        )
+        templater.render_cloudcfg(variant, self.tmpl_path, outfile)
         with open(outfile) as stream:
             system_cfg = util.load_yaml(stream.read())
         if variant == "unknown":
@@ -62,9 +60,7 @@ class TestRenderCloudCfg:
         call versus calling as subp
         """
         outfile = tmpdir.join("outcfg").strpath
-        templater.render_cloudcfg(
-            ["--variant", variant, self.tmpl_path, outfile]
-        )
+        templater.render_cloudcfg(variant, self.tmpl_path, outfile)
         with open(outfile) as stream:
             system_cfg = util.load_yaml(stream.read())
 
@@ -92,9 +88,7 @@ class TestRenderCloudCfg:
         call versus calling as subp
         """
         outfile = tmpdir.join("outcfg").strpath
-        templater.render_cloudcfg(
-            ["--variant", variant, self.tmpl_path, outfile]
-        )
+        templater.render_cloudcfg(variant, self.tmpl_path, outfile)
         with open(outfile) as stream:
             system_cfg = util.load_yaml(stream.read())
 

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -4,7 +4,7 @@ import sys
 
 import pytest
 
-from cloudinit import subp, util, templater
+from cloudinit import subp, templater, util
 from tests.unittests.helpers import cloud_init_project_dir
 
 # TODO(Look to align with tools.render-cloudcfg or cloudinit.distos.OSFAMILIES)

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -40,34 +40,6 @@ class TestRenderCloudCfg:
             system_cfg = util.load_yaml(stream.read())
         assert system_cfg["system_info"]["distro"] == "ubuntu"
 
-    def test_variant_sets_default_user_in_cloud_cfg_subp(self, tmpdir):
-        outfile = tmpdir.join("outcfg").strpath
-        templater.render_cloudcfg(
-            ["--variant", "ubuntu", self.tmpl_path, outfile]
-        )
-        with open(outfile) as stream:
-            system_cfg = util.load_yaml(stream.read())
-
-        default_user_exceptions = {
-            "amazon": "ec2-user",
-            "debian": "ubuntu",
-            "unknown": "ubuntu",
-        }
-        default_user = system_cfg["system_info"]["default_user"]["name"]
-        assert default_user == default_user_exceptions.get("ubuntu", "ubuntu")
-
-    def test_variant_sets_network_renderer_priority_in_cloud_cfg_subp(
-        self, tmpdir
-    ):
-        outfile = tmpdir.join("outcfg").strpath
-        templater.render_cloudcfg(
-            ["--variant", "openbsd", self.tmpl_path, outfile]
-        )
-        with open(outfile) as stream:
-            system_cfg = util.load_yaml(stream.read())
-
-        assert ["openbsd"] == system_cfg["system_info"]["network"]["renderers"]
-
     @pytest.mark.parametrize("variant", (DISTRO_VARIANTS))
     def test_variant_sets_distro_in_cloud_cfg(self, variant, tmpdir):
         """Testing parametrized inputs with imported function saves ~0.5s per

--- a/tools/render-cloudcfg
+++ b/tools/render-cloudcfg
@@ -2,14 +2,63 @@
 
 import os
 import sys
+import argparse
 
 
 def main():
     _tdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
     sys.path.insert(0, _tdir)
-    from cloudinit import templater  # pylint: disable=E0401
+    from cloudinit import templater, util  # pylint: disable=E0401
 
-    templater.render_cloudcfg(sys.argv[1:])
+    VARIANTS = [
+        "almalinux",
+        "alpine",
+        "amazon",
+        "arch",
+        "centos",
+        "cloudlinux",
+        "debian",
+        "eurolinux",
+        "fedora",
+        "freebsd",
+        "miraclelinux",
+        "netbsd",
+        "openbsd",
+        "openEuler",
+        "photon",
+        "rhel",
+        "suse",
+        "rocky",
+        "ubuntu",
+        "unknown",
+        "virtuozzo",
+    ]
+    parser = argparse.ArgumentParser()
+    platform = util.system_info()
+    parser.add_argument(
+        "--variant",
+        default=platform["variant"],
+        action="store",
+        help="define the variant.",
+        choices=VARIANTS,
+    )
+    parser.add_argument(
+        "template",
+        nargs="?",
+        action="store",
+        default="./config/cloud.cfg.tmpl",
+        help="Path to the cloud.cfg template",
+    )
+    parser.add_argument(
+        "output",
+        nargs="?",
+        action="store",
+        default="-",
+        help="Output file.  Use '-' to write to stdout",
+    )
+
+    args = parser.parse_args(sys.argv[1:])
+    templater.render_cloudcfg(args.variant, args.template, args.output)
 
 
 if __name__ == "__main__":

--- a/tools/render-cloudcfg
+++ b/tools/render-cloudcfg
@@ -5,12 +5,11 @@ import sys
 
 
 def main():
-    if "avoid-pep8-E402-import-not-top-of-file":
-        _tdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-        sys.path.insert(0, _tdir)
-        from cloudinit import templater
+    _tdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    sys.path.insert(0, _tdir)
+    from cloudinit import templater  # pylint: disable=E0401
 
-        templater.render_cloudcfg(sys.argv[1:])
+    templater.render_cloudcfg(sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/tools/render-cloudcfg
+++ b/tools/render-cloudcfg
@@ -1,47 +1,17 @@
 #!/usr/bin/env python3
 
-import argparse
 import os
 import sys
 
-VARIANTS = ["almalinux", "alpine", "amazon", "arch", "centos", "cloudlinux", "debian",
-            "eurolinux", "fedora", "freebsd", "miraclelinux", "netbsd", "openbsd", "openEuler", "photon",
-            "rhel", "suse","rocky", "ubuntu", "unknown", "virtuozzo"]
-
-
-if "avoid-pep8-E402-import-not-top-of-file":
-    _tdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-    sys.path.insert(0, _tdir)
-    from cloudinit import templater
-    from cloudinit import util
-    from cloudinit.atomic_helper import write_file
-
 
 def main():
-    parser = argparse.ArgumentParser()
-    platform = util.system_info()
-    parser.add_argument(
-        "--variant", default=platform['variant'], action="store",
-        help="define the variant.", choices=VARIANTS)
-    parser.add_argument(
-        "template", nargs="?", action="store",
-        default='./config/cloud.cfg.tmpl',
-        help="Path to the cloud.cfg template")
-    parser.add_argument(
-        "output", nargs="?", action="store", default="-",
-        help="Output file.  Use '-' to write to stdout")
+    if "avoid-pep8-E402-import-not-top-of-file":
+        _tdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        sys.path.insert(0, _tdir)
+        from cloudinit import templater
 
-    args = parser.parse_args()
+        templater.render_cloudcfg(sys.argv[1:])
 
-    with open(args.template, 'r') as fh:
-        contents = fh.read()
-    tpl_params = {'variant': args.variant}
-    contents = (templater.render_string(contents, tpl_params)).rstrip() + "\n"
-    util.load_yaml(contents)
-    if args.output == "-":
-        sys.stdout.write(contents)
-    else:
-        write_file(args.output, contents, omode="w")
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
```
Reduce template rendering test runtime
```

## Additional Context
Pytest consistently shows the parametrized template rendering tests as the most time-consuming in the unit test suite (0.5s per test). Profile analysis shows that nearly all of the time spent is in one-time setup tasks (importing modules). Currently each test invokes a subprocess to execute the test.

This change should be non-functional. It simply moves the rendering code into the `templater` module and uses function calls in place of spawning a new process per parametrized test (function calls share the setup cost of module import). A single test that calls the tool as a subprocess was added to maintain test coverage.

This saves ~7s on my machine (which is 13% of the total unittest runtime).