### PR TITLE
sources/azure: set ovf_is_accessible when OVF is read successfully

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -337,7 +337,7 @@ class DataSourceAzure(sources.DataSource):
         # the candidate list determines the path to take in order to get the
         # metadata we need.
         reprovision = False
-        ovf_is_accessible = True
+        ovf_is_accessible = False
         reprovision_after_nic_attach = False
         metadata_source = None
         ret = None
@@ -370,9 +370,9 @@ class DataSourceAzure(sources.DataSource):
                             ret = util.mount_cb(src, load_azure_ds_dir)
                         # save the device for ejection later
                         self.iso_dev = src
-                        ovf_is_accessible = True
                     else:
                         ret = load_azure_ds_dir(src)
+                    ovf_is_accessible = True
                     metadata_source = src
                     break
                 except NonAzureDataSource:
@@ -385,7 +385,6 @@ class DataSourceAzure(sources.DataSource):
                     report_diagnostic_event(
                         "%s was not mountable" % src, logger_func=LOG.debug
                     )
-                    ovf_is_accessible = False
                     empty_md = {"local-hostname": ""}
                     empty_cfg = dict(
                         system_info=dict(default_user=dict(name=""))

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -775,7 +775,13 @@ scbus-1 on xpt0 bus 0
         return dsaz
 
     def _get_ds(
-        self, data, distro="ubuntu", apply_network=None, instance_id=None
+        self,
+        data,
+        distro="ubuntu",
+        apply_network=None,
+        instance_id=None,
+        write_ovf_to_data_dir: bool = False,
+        write_ovf_to_seed_dir: bool = True,
     ):
         def _wait_for_files(flist, _maxwait=None, _naplen=None):
             data["waited"] = flist
@@ -789,8 +795,11 @@ scbus-1 on xpt0 bus 0
                 yield cache_dir
 
         seed_dir = os.path.join(self.paths.seed_dir, "azure")
-        if data.get("ovfcontent") is not None:
+        if write_ovf_to_seed_dir and data.get("ovfcontent") is not None:
             populate_dir(seed_dir, {"ovf-env.xml": data["ovfcontent"]})
+
+        if write_ovf_to_data_dir and data.get("ovfcontent") is not None:
+            populate_dir(self.waagent_d, {"ovf-env.xml": data["ovfcontent"]})
 
         dsaz.BUILTIN_DS_CONFIG["data_dir"] = self.waagent_d
 
@@ -1004,6 +1013,34 @@ scbus-1 on xpt0 bus 0
         self.assertEqual(
             "seed-dir (%s/seed/azure)" % self.tmp, dsrc.subplatform
         )
+
+    def test_data_dir_without_imds_data(self):
+        odata = {"HostName": "myhost", "UserName": "myuser"}
+        data = {
+            "ovfcontent": construct_valid_ovf_env(data=odata),
+            "sys_cfg": {},
+        }
+        dsrc = self._get_ds(
+            data, write_ovf_to_data_dir=True, write_ovf_to_seed_dir=False
+        )
+
+        self.m_get_metadata_from_imds.return_value = {}
+        with mock.patch(MOCKPATH + "util.mount_cb") as m_mount_cb:
+            m_mount_cb.side_effect = [
+                MountFailedError("fail"),
+                ({"local-hostname": "me"}, "ud", {"cfg": ""}, {}),
+            ]
+            ret = dsrc.get_data()
+
+        self.assertTrue(ret)
+        self.assertEqual(dsrc.userdata_raw, "")
+        self.assertEqual(dsrc.metadata["local-hostname"], odata["HostName"])
+        self.assertTrue(
+            os.path.isfile(os.path.join(self.waagent_d, "ovf-env.xml"))
+        )
+        self.assertEqual("azure", dsrc.cloud_name)
+        self.assertEqual("azure", dsrc.platform_type)
+        self.assertEqual("seed-dir (%s)" % self.waagent_d, dsrc.subplatform)
 
     def test_basic_dev_file(self):
         """When a device path is used, present that in subplatform."""


### PR DESCRIPTION
The if-statement set ovf_is_accessible to True if the OVF is read
from /dev/sr0, but not from other data sources.  It defaults to
True, but may get flipped to False while processing an invalid
source, and never get set back to True when reading from the data
directory.

Instead, default ovf_is_accessible to False, and only set it to
True once we've read an OVF successfully (and end the search).

This fixes an error when OVF is read from data_dir and IMDS
data is unavailable (failing with "No OVF or IMDS available").

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
