### PR TITLE
sources/azure: unpack ret tuple in crawl_metadata()

### DIFF
--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2803,9 +2803,7 @@ class TestPreprovisioningShouldReprovision(CiTestCase):
         isfile.return_value = False
         dsa = dsaz.DataSourceAzure({}, distro=mock.Mock(), paths=self.paths)
         self.assertTrue(
-            dsa._should_reprovision(
-                (None, None, {"PreprovisionedVm": True}, None)
-            )
+            dsa._should_reprovision({"PreprovisionedVm": True}, None)
         )
 
     def test__should_reprovision_with_file_existing(self, isfile):
@@ -2814,9 +2812,7 @@ class TestPreprovisioningShouldReprovision(CiTestCase):
         isfile.return_value = True
         dsa = dsaz.DataSourceAzure({}, distro=mock.Mock(), paths=self.paths)
         self.assertTrue(
-            dsa._should_reprovision(
-                (None, None, {"preprovisionedvm": False}, None)
-            )
+            dsa._should_reprovision({"preprovisionedvm": False}, None)
         )
 
     def test__should_reprovision_returns_false(self, isfile):
@@ -2824,7 +2820,7 @@ class TestPreprovisioningShouldReprovision(CiTestCase):
         if config and sentinal are not present."""
         isfile.return_value = False
         dsa = dsaz.DataSourceAzure({}, distro=mock.Mock(), paths=self.paths)
-        self.assertFalse(dsa._should_reprovision((None, None, {}, None)))
+        self.assertFalse(dsa._should_reprovision({}))
 
     @mock.patch(MOCKPATH + "util.write_file", autospec=True)
     def test__should_reprovision_uses_imds_md(self, write_file, isfile):
@@ -2834,14 +2830,14 @@ class TestPreprovisioningShouldReprovision(CiTestCase):
         dsa = dsaz.DataSourceAzure({}, distro=mock.Mock(), paths=self.paths)
         self.assertTrue(
             dsa._should_reprovision(
-                (None, None, {}, None),
+                {},
                 {"extended": {"compute": {"ppsType": "Running"}}},
             )
         )
-        self.assertFalse(dsa._should_reprovision((None, None, {}, None), {}))
+        self.assertFalse(dsa._should_reprovision({}, {}))
         self.assertFalse(
             dsa._should_reprovision(
-                (None, None, {}, None),
+                {},
                 {"extended": {"compute": {"hasCustomData": False}}},
             )
         )


### PR DESCRIPTION
load_azure_ds_dir() always returns a tuple.  Instead of saving this
tuple as ret, expand it immediately as md, userdata_raw, cfg, files.

This allows for more fine-grained passing of data before getting
expanded later.

- Update _should_reprovision methods to use cfg instead of tuple.

- Update _should_reprovision methods to remove the ovf_md guard.
 This should be a safe refactor as the OVF is not required, and the
 config is initialized to an empty dict.  In practice, a mount failure
 would have initalized ret anyways if the OVF was not found. If a
 mount failure wasn't seen and ret was None, this guard could be
 causing other failures by ignoring the PPS state that should be
 available from IMDS metadata.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>