### PR TITLE
Enable OVF environment transport via ISO in example

### DIFF
--- a/doc/sources/ovf/example/ubuntu-server.ovf
+++ b/doc/sources/ovf/example/ubuntu-server.ovf
@@ -53,7 +53,7 @@
           <Description>This field is optional. The value for network-config has to be base64 encoded.</Description>
       </Property>
     </ProductSection>
-    <VirtualHardwareSection>
+    <VirtualHardwareSection ovf:transport="iso">
       <Info>Virtual hardware requirements</Info>
       <System>
         <vssd:ElementName>Virtual Hardware Family</vssd:ElementName>


### PR DESCRIPTION
This enables the OVF enviroment transport via ISO variable as defined
in the Open Virtualization Format Specification Version: 2.1.1.

8.1 VirtualHardwareSection
11.1 Transport media

Reference:
https://www.dmtf.org/sites/default/files/standards/documents/DSP0243_2.1.1.pdf

## Test Steps
* Create a template using the OVF example
* Instantiate a VM from that template
* Check if the content is available via ISO transport

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly (N/A because it is just an example file)
 - [x] I have updated or added any documentation accordingly (N/A because it is just an example file)