### PR TITLE
cmd: status and cloud-id avoid change in behavior for 'not run'

### DIFF
--- a/cloudinit/cmd/cloud_id.py
+++ b/cloudinit/cmd/cloud_id.py
@@ -63,7 +63,7 @@ def handle_args(name, args):
 
     Print the canonical cloud-id on which the instance is running.
 
-    @return: 0 on success, 1 on error, 2 on disabled, 3 on cloud-init not-run.
+    @return: 0 on success, 1 on error, 2 on disabled, 3 on cloud-init not run.
     """
     status, _status_details, _time = get_status_details()
     if status == UXAppStatus.DISABLED:

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -22,7 +22,7 @@ CLOUDINIT_DISABLED_FILE = "/etc/cloud/cloud-init.disabled"
 class UXAppStatus(enum.Enum):
     """Enum representing user-visible cloud-init application status."""
 
-    NOT_RUN = "not-run"
+    NOT_RUN = "not run"
     RUNNING = "running"
     DONE = "done"
     ERROR = "error"

--- a/doc/man/cloud-id.1
+++ b/doc/man/cloud-id.1
@@ -9,7 +9,7 @@ cloud-id \- Report the canonical cloud-id for this instance
 .SH DESCRIPTION
 cloud-id is the lowercase name of the cloud datasource discovered.
 
-The cloud-id will be 'not-run' when systemd generator has not run yet.
+The cloud-id will be 'not run' when systemd generator has not run yet.
 The cloud-id will be 'disabled' when cloud-init is disabled or when
 ds-identify did not find a valid datasource.
 

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -137,7 +137,7 @@ class TestStatus(CiTestCase):
         )
 
     def test_status_returns_not_run(self):
-        """When status.json does not exist yet, return 'not-run'."""
+        """When status.json does not exist yet, return 'not run'."""
         self.assertFalse(
             os.path.exists(self.status_file), "Unexpected status.json found"
         )
@@ -154,7 +154,7 @@ class TestStatus(CiTestCase):
                 cmdargs,
             )
         self.assertEqual(0, retcode)
-        self.assertEqual("status: not-run\n", m_stdout.getvalue())
+        self.assertEqual("status: not run\n", m_stdout.getvalue())
 
     def test_status_returns_disabled_long_on_presence_of_disable_file(self):
         """When cloudinit is disabled, return disabled reason."""


### PR DESCRIPTION
We don't want to break existing snapd. So, let's leave "not run" value untouched. Also note, if we decide to change cloud-init status exit codes, that also has the potential to break snapd too, so we'd need to float that by that team first and get buyin.


## Proposed Commit Message
```
snapd currrently looks for 'not run' from cloud-init status[1].
Avoid changing this behavior and revert "not-run" value to
"not run".

This avoids having to get snapd to change implementation and
release updates as far back as Bionic to handle a hyphenated
not-run string.

[1]: https://github.com/snapcore/snapd/blob/master/sysconfig/\
     cloudinit.go#L802
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
