### PR TITLE
sources/azure: always initialize _ephemeral_dhcp_ctx on unpickle

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -518,6 +518,7 @@ class DataSourceAzure(sources.DataSource):
             use_cached_ephemeral = (
                 self.distro.networking.is_up(self.fallback_interface)
                 and self._ephemeral_dhcp_ctx
+                and self._ephemeral_dhcp_ctx.lease
             )
             if use_cached_ephemeral:
                 self._report_ready(lease=self._ephemeral_dhcp_ctx.lease)


### PR DESCRIPTION
Avoid requirement of getattr() and ensure _ephemeral_dhcp_ctx isn't
persisted in the cache.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
