### PR TITLE
sources/azure: drop unused case in _report_failure()

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -14,6 +14,7 @@ from collections import namedtuple
 from enum import Enum
 from functools import partial
 from time import sleep, time
+from typing import Optional
 from xml.dom import minidom
 
 import requests
@@ -1310,7 +1311,7 @@ class DataSourceAzure(sources.DataSource):
         return return_val
 
     @azure_ds_telemetry_reporter
-    def _report_failure(self, description=None) -> bool:
+    def _report_failure(self, description: Optional[str] = None) -> bool:
         """Tells the Azure fabric that provisioning has failed.
 
         @param description: A description of the error encountered.
@@ -1356,21 +1357,6 @@ class DataSourceAzure(sources.DataSource):
         except Exception as e:
             report_diagnostic_event(
                 "Failed to report failure using new ephemeral dhcp: %s" % e,
-                logger_func=LOG.debug,
-            )
-
-        try:
-            report_diagnostic_event(
-                "Using fallback lease to report failure to Azure"
-            )
-            report_failure_to_fabric(
-                fallback_lease_file=self.dhclient_lease_file,
-                description=description,
-            )
-            return True
-        except Exception as e:
-            report_diagnostic_event(
-                "Failed to report failure using fallback lease: %s" % e,
                 logger_func=LOG.debug,
             )
 


### PR DESCRIPTION
According to the documentation in the tests:

```
We expect 3 calls to report_failure_to_fabric,
because we try 3 different methods of calling report failure.
The different methods are attempted in the following order:
1. Using cached ephemeral dhcp context to report failure to Azure
2. Using new ephemeral dhcp to report failure to Azure
3. Using fallback lease to report failure to Azure
```

Case 1 and 2 make sense.  If networking is established, use it.
Should failure occur using current network configuration, retry
with fresh DHCP.

Case 3 suggests that we can fall back to a lease file and retry.

Given that:

1. The wireserver address has never changed to date.
2. The wireserver address should be in the DHCP lease.
3. Parsing the lease file does not improve connectivity over the
   prior attempts.

...we can safely remove this case without regression.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>