### PR TITLE
tests: focal caplog has whitespace indentation for multi-line logs

### DIFF
--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -234,9 +234,12 @@ class TestValidateCloudConfigSchema:
         """When strict is False validate_cloudconfig_schema emits warnings."""
         schema = {"properties": {"p1": {"type": "string"}}}
         validate_cloudconfig_schema({"p1": -1}, schema, strict=False)
+        [(module, log_level, log_msg)] = caplog.record_tuples
+        assert "cloudinit.config.schema" == module
+        assert logging.WARNING == log_level
         assert (
-            "Invalid cloud-config provided:\np1: -1 is not of type 'string'\n"
-            in (caplog.text)
+            "Invalid cloud-config provided:\np1: -1 is not of type 'string'"
+            == log_msg
         )
 
     @skipUnlessJsonSchema()


### PR DESCRIPTION
Avoid series-specific log formatting in tests by using
caplog.record_tuples.

Added benefit, we can easily check log-level WARNING too.

Fixes unit test failures from Focal Package builds at:
https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily/+build/23076508

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Avoid series-specific log formatting in tests by using
caplog.record_tuples.

Added benefit, we can easily check log-level WARNING too.

Fixes unit test failures from Focal Package builds at:
https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily/\
  +build/23076508
```

## Additional Context
<!-- If relevant -->

## Test Steps
```bash
git checkout upstream/focal
get merge tests-focal-fix-log-whitespace
build-package
sbuild --resolve-alternatives --dist=focal --arch=amd64  --arch-all ../out/cloud-init_21.4-0ubuntu1~20.04.1.dsc
# build should succeed instead of failing in unit tests
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
