### PR TITLE
Fix Gentoo Locales (SC-748)

### DIFF
--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 
 class Distro(distros.Distro):
     locale_conf_fn = "/etc/env.d/02locale"
-    locale_gen_file = "/etc/locale.gen"
+    locale_gen_fn = "/etc/locale.gen"
     network_conf_fn = "/etc/conf.d/net"
     hostname_conf_fn = "/etc/conf.d/hostname"
     init_cmd = ["rc-service"]  # init scripts
@@ -46,9 +46,7 @@ class Distro(distros.Distro):
         Locales need to be added to /etc/locale.gen and generated prior
         to selection. Default to en_US.UTF-8 for simplicity.
         """
-        util.write_file(
-            self.locale_gen_file, "\n".join(self.locales), mode=644
-        )
+        util.write_file(self.locale_gen_fn, "\n".join(self.locales), mode=644)
 
         # generate locales
         subp.subp(["locale-gen"], capture=False)

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -44,7 +44,9 @@ class Distro(distros.Distro):
         Locales need to be added to /etc/locale.gen and generated prior
         to selection. Default to en_US.UTF-8 for simplicity.
         """
-        util.write_file(self.locale_gen_file, "\n".join(self.locales), mode=644)
+        util.write_file(
+            self.locale_gen_file, "\n".join(self.locales), mode=644
+        )
 
         # generate locales
         subp.subp(["locale-gen"], capture=False)
@@ -59,7 +61,7 @@ class Distro(distros.Distro):
             'LANG="%s"' % self.default_locale,
             "",
         ]
-        util.write_file(out_fn, "\n".join(lines))
+        util.write_file(self.locale_conf_fn, "\n".join(lines))
 
     def install_packages(self, pkglist):
         self.update_package_sources()

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -37,6 +37,8 @@ class Distro(distros.Distro):
         self.osfamily = "gentoo"
         # Fix sshd restarts
         cfg["ssh_svcname"] = "/etc/init.d/sshd"
+        if distros.uses_systemd():
+            LOG.error("Cloud-init does not support systemd with gentoo")
 
     def apply_locale(self, _, out_fn=None):
         """rc-only - not compatible with systemd

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -18,7 +18,7 @@ LOG = logging.getLogger(__name__)
 
 class Distro(distros.Distro):
     locale_conf_fn = "/etc/env.d/02locale"
-    locale_gen = "/etc/locale.gen"
+    locale_gen_file = "/etc/locale.gen"
     network_conf_fn = "/etc/conf.d/net"
     hostname_conf_fn = "/etc/conf.d/hostname"
     init_cmd = ["rc-service"]  # init scripts
@@ -26,7 +26,7 @@ class Distro(distros.Distro):
 
     # C.UTF8 makes sense to generate, but is not selected
     # Add /etc/locale.gen entries to this list to support more locales
-    locale_gen = ["C.UTF8 UTF-8", "en_US.UTF-8 UTF-8"]
+    locales = ["C.UTF8 UTF-8", "en_US.UTF-8 UTF-8"]
 
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
@@ -44,7 +44,7 @@ class Distro(distros.Distro):
         Locales need to be added to /etc/locale.gen and generated prior
         to selection. Default to en_US.UTF-8 for simplicity.
         """
-        util.write_file(self.locale_gen, "\n".join(self.locale_gen), mode=644)
+        util.write_file(self.locale_gen_file, "\n".join(self.locales), mode=644)
 
         # generate locales
         subp.subp(["locale-gen"], capture=False)

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -57,13 +57,6 @@ class Distro(distros.Distro):
         subp.subp(
             ["eselect", "locale", "set", self.default_locale], capture=False
         )
-        # "" provides trailing newline during join
-        lines = [
-            util.make_header(),
-            'LANG="%s"' % self.default_locale,
-            "",
-        ]
-        util.write_file(self.locale_conf_fn, "\n".join(lines))
 
     def install_packages(self, pkglist):
         self.update_package_sources()


### PR DESCRIPTION
```
Fix Gentoo locales
```

## Additional Context
Tracking down a stack trace in gentoo cloud LXD images pointed out an issue with localization on gentoo. It's possible that this code once "succeeded" with a different image build. Fix the trace and actually set a locale. 

https://wiki.gentoo.org/wiki/Localization/Guide/en

Stack Trace:
```
2022-01-24 20:04:10,553 - util.py[DEBUG]: Running module locale (<module 'cloudinit.config.cc_locale' from '/usr/lib/python3.9/site-packages/cloudinit/config/cc_locale.py'>) failed
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/cloudinit/stages.py", line 884, in _run_modules
    ran, _r = cc.run(run_name, mod.handle, func_args,
  File "/usr/lib/python3.9/site-packages/cloudinit/cloud.py", line 54, in run
    return self._runners.run(name, functor, args, freq, clear_on_fail)
  File "/usr/lib/python3.9/site-packages/cloudinit/helpers.py", line 186, in run
    results = functor(*args)
  File "/usr/lib/python3.9/site-packages/cloudinit/config/cc_locale.py", line 78, in handle
    cloud.distro.apply_locale(locale, locale_cfgfile)
  File "/usr/lib/python3.9/site-packages/cloudinit/distros/gentoo.py", line 43, in apply_locale
    subp.subp(['locale-gen', '-G', locale], capture=False)
  File "/usr/lib/python3.9/site-packages/cloudinit/subp.py", line 293, in subp
    raise ProcessExecutionError(stdout=out, stderr=err,
cloudinit.subp.ProcessExecutionError: Unexpected error while running command.
Command: ['locale-gen', '-G', 'en_US.UTF-8']
Exit code: 4
Reason: -
Stdout: -
Stderr: -
```

## Test Steps
1. Start gentoo cloud container (images:gentoo/cloud), note the above stack trace
2. Mount this cloud-init branch locally into container and check for error:
```
# Define BASE_DIR, NAME, and MY_CLOUD_CONFIG to appropriate values first
IMAGE_ID=images:gentoo/cloud
lxc init $IMAGE_ID $NAME -c user.user-data="$(cat $MY_CLOUD_CONFIG)"

# Gentoo currently uses 3.9 as system default 
lxc config device add $NAME host-cloud-init disk source=$BASE_DIR/cloudinit path=/usr/lib/python3.9/site-packages/cloudinit/
lxc start $NAME
lxc shell me 
```