### PR TITLE
Fix lo being used for DHCP, try next on cmd fail

### DIFF
--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -24,7 +24,7 @@ def get_metadata(url, timeout, retries, sec_between, agent):
         # Skip dummy, lo interfaces
         if "dummy" in iface[0]:
             continue
-        if 'lo' == iface[0]:
+        if "lo" == iface[0]:
             continue
         try:
             with EphemeralDHCPv4(

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -22,7 +22,9 @@ def get_metadata(url, timeout, retries, sec_between, agent):
     # Seek iface with DHCP
     for iface in net.get_interfaces():
         # Skip dummy, lo interfaces
-        if iface[0] in ['lo', 'dummy']:
+        if "dummy" in iface[0]:
+            continue
+        if 'lo' == iface[0]:
             continue
         try:
             with EphemeralDHCPv4(

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -21,8 +21,8 @@ def get_metadata(url, timeout, retries, sec_between, agent):
 
     # Seek iface with DHCP
     for iface in net.get_interfaces():
-        # Skip dummy interfaces
-        if "dummy" in iface[0]:
+        # Skip dummy, lo interfaces
+        if iface[0] in ['lo', 'dummy']:
             continue
         try:
             with EphemeralDHCPv4(
@@ -33,7 +33,7 @@ def get_metadata(url, timeout, retries, sec_between, agent):
 
                 # Fetch the metadata
                 v1 = read_metadata(url, timeout, retries, sec_between, agent)
-        except (NoDHCPLeaseError) as exc:
+        except (NoDHCPLeaseError, subp.ProcessExecutionError) as exc:
             LOG.error("DHCP Exception: %s", exc)
             exception = exc
 


### PR DESCRIPTION
## Proposed Commit Message
Fix lo being used for DHCP, try next on cmd fail

```
Arch didn't like the last fix and lo found its way into this list. Checking for this and skipping interfaces that generate subp failures.
```

## Test Steps
Deployed Arch on Vultr

## Checklist:
 - [ X ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ X ] I have updated or added any unit tests accordingly
 - [ X ] I have updated or added any documentation accordingly
