### PR TITLE
Add _netdev option to mount Azure ephemeral disk

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -392,7 +392,8 @@ def handle(_name, cfg, cloud, log, _args):
     def_mnt_opts = "defaults,nobootwait"
     uses_systemd = cloud.distro.uses_systemd()
     if uses_systemd:
-        def_mnt_opts = "defaults,nofail,x-systemd.requires=cloud-init.service"
+        def_mnt_opts = ("defaults,nofail,x-systemd.requires=cloud-init.service,"
+                        ",_netdev")
 
     defvals = [None, None, "auto", def_mnt_opts, "0", "2"]
     defvals = cfg.get("mount_default_fields", defvals)

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -392,8 +392,8 @@ def handle(_name, cfg, cloud, log, _args):
     def_mnt_opts = "defaults,nobootwait"
     uses_systemd = cloud.distro.uses_systemd()
     if uses_systemd:
-        def_mnt_opts = ("defaults,nofail,x-systemd.requires=cloud-init.service,"
-                        ",_netdev")
+        def_mnt_opts = ("defaults,nofail,"
+                        "x-systemd.requires=cloud-init.service,_netdev")
 
     defvals = [None, None, "auto", def_mnt_opts, "0", "2"]
     defvals = cfg.get("mount_default_fields", defvals)

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -392,8 +392,9 @@ def handle(_name, cfg, cloud, log, _args):
     def_mnt_opts = "defaults,nobootwait"
     uses_systemd = cloud.distro.uses_systemd()
     if uses_systemd:
-        def_mnt_opts = ("defaults,nofail,"
-                        "x-systemd.requires=cloud-init.service,_netdev")
+        def_mnt_opts = (
+            "defaults,nofail," "x-systemd.requires=cloud-init.service,_netdev"
+        )
 
     defvals = [None, None, "auto", def_mnt_opts, "0", "2"]
     defvals = cfg.get("mount_default_fields", defvals)

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -393,7 +393,7 @@ def handle(_name, cfg, cloud, log, _args):
     uses_systemd = cloud.distro.uses_systemd()
     if uses_systemd:
         def_mnt_opts = (
-            "defaults,nofail," "x-systemd.requires=cloud-init.service,_netdev"
+            "defaults,nofail, x-systemd.requires=cloud-init.service, _netdev"
         )
 
     defvals = [None, None, "auto", def_mnt_opts, "0", "2"]


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
The ephemeral disk depends on a functional network to be mounted. Even
though it depends on cloud-init.service, sometimes an ordering cycle is
noticed on the instance. If the option "_netdev" is added the problem is
gone.

rhbz: #1998445

Signed-off-by: Eduardo Otubo <otubo@redhat.com>

## Additional Context
<!-- If relevant -->

## Test Steps
Deploy a RHEL-9/cloud-init-21.1 instance on Azure and observe that sometimes there's an ordering cycle on the logs and there's no network connectivity.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
