### PR TITLE
RFC - tox changes (SC-763)

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,7 +19,7 @@ Before any pull request can be accepted, you must do the following:
   `tools/.github-cla-signers`_
 * Add or update any `unit tests`_ accordingly
 * Add or update any `integration tests`_ (if applicable)
-* Format code (using black and isort) with `tox -e format`
+* Format code (using black and isort) with `tox -e do_format`
 * Ensure unit tests and linting pass using `tox`_
 * Submit a PR against the `main` branch of the `cloud-init` repository
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv =
 passenv=
     PYTEST_ADDOPTS
 
-[version]
+[format_deps]
 flake8==3.9.2
 pylint==2.11.1
 black==21.12b0
@@ -17,43 +17,44 @@ isort==5.10.1
 
 [testenv:flake8]
 deps =
-    flake8=={[version]flake8}
+    flake8=={[format_deps]flake8}
 commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/ setup.py}
 
 [testenv:pylint]
 deps =
-    pylint=={[version]pylint}
+    pylint=={[format_deps]pylint}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
 commands = {envpython} -m pylint {posargs:cloudinit tests tools}
 
 [testenv:black]
 deps =
-    black=={[version]black}
+    black=={[format_deps]black}
 commands = {envpython} -m black . --check
 
 [testenv:isort]
 deps =
-    isort=={[version]isort}
+    isort=={[format_deps]isort}
 commands = {envpython} -m isort . --check-only
 
 [testenv:check_format]
-envlist = flake8, pylint, black, isort
 deps =
-    flake8=={[version]flake8}
-    pylint=={[version]pylint}
-    black=={[version]black}
-    isort=={[version]isort}
+    flake8=={[format_deps]flake8}
+    pylint=={[format_deps]pylint}
+    black=={[format_deps]black}
+    isort=={[format_deps]isort}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
 commands =
-    {envpython} -m isort .
-    {envpython} -m black .
+    {[testenv:black]commands}
+    {[testenv:isort]commands}
+    {[testenv:flake8]commands}
+    {[testenv:pylint]commands}
 
 [testenv:do_format]
 deps =
-    black=={[version]black}
-    isort=={[version]isort}
+    black=={[format_deps]black}
+    isort=={[format_deps]isort}
 commands =
     {envpython} -m isort .
     {envpython} -m black .

--- a/tox.ini
+++ b/tox.ini
@@ -9,39 +9,51 @@ setenv =
 passenv=
     PYTEST_ADDOPTS
 
-[flake_env]
-envdir = {toxworkdir}/.flake_env
-deps =
-    flake8==3.9.2
-    pylint==2.11.1
-    black==21.12b0
-    isort==5.10.1
-    -r{toxinidir}/test-requirements.txt
-    -r{toxinidir}/integration-requirements.txt
+[version]
+flake8==3.9.2
+pylint==2.11.1
+black==21.12b0
+isort==5.10.1
 
 [testenv:flake8]
-envdir = {[flake_env]envdir}
-deps = {[flake_env]deps}
+deps =
+    flake8=={[version]flake8}
 commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/ setup.py}
 
 [testenv:pylint]
-envdir = {[flake_env]envdir}
-deps = {[flake_env]deps}
+deps =
+    pylint=={[version]pylint}
+    -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/integration-requirements.txt
 commands = {envpython} -m pylint {posargs:cloudinit tests tools}
 
 [testenv:black]
-envdir = {[flake_env]envdir}
-deps = {[flake_env]deps}
+deps =
+    black=={[version]black}
 commands = {envpython} -m black . --check
 
 [testenv:isort]
-envdir = {[flake_env]envdir}
-deps = {[flake_env]deps}
+deps =
+    isort=={[version]isort}
 commands = {envpython} -m isort . --check-only
 
-[testenv:format]
-envdir = {[flake_env]envdir}
-deps = {[flake_env]deps}
+[testenv:check_format]
+envlist = flake8, pylint, black, isort
+deps =
+    flake8=={[version]flake8}
+    pylint=={[version]pylint}
+    black=={[version]black}
+    isort=={[version]isort}
+    -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/integration-requirements.txt
+commands =
+    {envpython} -m isort .
+    {envpython} -m black .
+
+[testenv:do_format]
+deps =
+    black=={[version]black}
+    isort=={[version]isort}
 commands =
     {envpython} -m isort .
     {envpython} -m black .


### PR DESCRIPTION
```
fix parallel tox execution
```

Changes:
- tox -p fails due to a shared directory clobbering files - use unique env dirs to avoid this (this does cause a longer initial serial run due to deps getting installed multiple times)
- remove unneeded dependencies for black, flake8, and isort environments (saves some CI cycles by avoiding installing unused deps - since travis doesn't share a cache this should be a net gain)
- add a new environment (for convenience) just for "checking formatting" - this moves current "format" env to "do_format" and adds "check_format". I'm happy to adjust names if others would rather "format" doesn't change or think there is some better naming scheme.