### PR TITLE
spell check docs with spellintian (SC-770)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,6 +140,13 @@ matrix:
           env: TOXENV=isort
         - python: 3.7
           env: TOXENV=doc
+          install:
+            - git fetch --unshallow
+            - sudo apt-get install lintian
+            - pip install tox
+          script:
+            - make check_spelling
+            - tox
         # Test all supported Python versions (but at the end, so we schedule
         # longer-running jobs first)
         - python: "3.10.1"

--- a/Makefile
+++ b/Makefile
@@ -122,4 +122,4 @@ fix_spelling:
 
 .PHONY: test flake8 clean rpm srpm deb deb-src yaml
 .PHONY: check_version pip-test-requirements pip-requirements clean_pyc
-.PHONY: unittest style-check doc fix_spelling check_spelling _check_spelling
+.PHONY: unittest style-check doc fix_spelling check_spelling

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,43 @@ deb-src:
 doc:
 	tox -e doc
 
+# Spell check && filter false positives
+_CHECK_SPELLING := find doc -type f -exec spellintian {} + | \
+       grep -v -e 'doc/rtd/topics/cli.rst: modules modules' \
+               -e 'doc/examples/cloud-config-mcollective.txt: WARNING WARNING' \
+               -e 'doc/examples/cloud-config-power-state.txt: Bye Bye' \
+               -e 'doc/examples/cloud-config.txt: Bye Bye'
+
+
+# For CI we require a failing return code when spellintian finds spelling errors
+check_spelling:
+	@! $(_CHECK_SPELLING)
+
+# Manipulate the output of spellintian into a valid "sed" command which is run
+# to fix the error
+#
+# Example spellintian output:
+#
+# doc/examples/kernel-cmdline.txt: everthing -> everything
+#
+# The "fix_spelling" target manipulates the above output into the following command
+# and runs that command.
+#
+# sed -i "s/everthing/everything/g" doc/examples/kernel-cmdline.txt
+#
+# awk notes:
+#
+# -F ': | -> ' means use the strings ": " or " -> " as field delimeters
+# \046 is octal for double quote
+# $$2 will contain the second field, ($ must be escaped because this is in a Makefile)
+#
+# Limitation: duplicate words with newline between them are not automatically fixed
+fix_spelling:
+	@$(_CHECK_SPELLING) | \
+		sed 's/ (duplicate word)//g' | \
+		awk -F ': | -> ' '{printf "sed -i \047s/%s/%s/g\047 %s\n", $$2, $$3, $$1}' | \
+		sh
+
 .PHONY: test flake8 clean rpm srpm deb deb-src yaml
 .PHONY: check_version pip-test-requirements pip-requirements clean_pyc
-.PHONY: unittest style-check doc
+.PHONY: unittest style-check doc fix_spelling check_spelling _check_spelling

--- a/doc/examples/cloud-config-disk-setup.txt
+++ b/doc/examples/cloud-config-disk-setup.txt
@@ -207,7 +207,7 @@ fs_setup:
 #     as a partition value. However, ephermalX.0 is the _same_ as ephemeralX.
 #
 #   <PART_VALUE>:
-#     Partition definitions are overwriten if you use the '<DEVICE>.Y' notation.
+#     Partition definitions are overwritten if you use the '<DEVICE>.Y' notation.
 #
 #     The valid options are:
 #     "auto|any": tell cloud-init not to care whether there is a partition
@@ -243,7 +243,7 @@ fs_setup:
 #
 #         In general, if you have a specific partition configuration in mind,
 #         you should define either the device or the partition number. 'auto'
-#         and 'any' are specifically intended for formating ephemeral storage or
+#         and 'any' are specifically intended for formatting ephemeral storage or
 #         for simple schemes.
 #
 #       "none": Put the file system directly on the device.

--- a/doc/examples/cloud-config-install-packages.txt
+++ b/doc/examples/cloud-config-install-packages.txt
@@ -7,7 +7,7 @@
 # if packages are specified, this apt_update will be set to true
 #
 # packages may be supplied as a single package name or as a list
-# with the format [<package>, <version>] wherein the specifc
+# with the format [<package>, <version>] wherein the specific
 # package version will be installed.
 packages:
  - pwgen

--- a/doc/examples/cloud-config-landscape.txt
+++ b/doc/examples/cloud-config-landscape.txt
@@ -2,7 +2,7 @@
 # Landscape-client configuration
 #
 # Anything under the top 'landscape: client' entry
-# will be basically rendered into a ConfigObj formated file
+# will be basically rendered into a ConfigObj formatted file
 # under the '[client]' section of /etc/landscape/client.conf
 # 
 # Note: 'tags' should be specified as a comma delimited string

--- a/doc/examples/cloud-config-mount-points.txt
+++ b/doc/examples/cloud-config-mount-points.txt
@@ -19,7 +19,7 @@
 #
 # - if a device does not exist at the time, an entry will still be
 #   written to /etc/fstab.
-# - '/dev' can be ommitted for device names that begin with: xvd, sd, hd, vd
+# - '/dev' can be omitted for device names that begin with: xvd, sd, hd, vd
 # - if an entry does not have all 6 fields, they will be filled in
 #   with values from 'mount_default_fields' below.
 #

--- a/doc/examples/cloud-config-power-state.txt
+++ b/doc/examples/cloud-config-power-state.txt
@@ -4,7 +4,7 @@
 # default: none
 #
 # power_state can be used to make the system shutdown, reboot or
-# halt after boot is finished.  This same thing can be acheived by
+# halt after boot is finished.  This same thing can be achieved by
 # user-data scripts or by runcmd by simply invoking 'shutdown'.
 # 
 # Doing it this way ensures that cloud-init is entirely finished with

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -118,7 +118,7 @@ users:
 #             command available on Ubuntu systems.  If the user has an account
 #             on the Ubuntu SSO, specifying the email will allow snap to
 #             request a username and any public ssh keys and will import
-#             these into the system with username specifed by SSO account.
+#             these into the system with username specified by SSO account.
 #             If 'username' is not set in SSO, then username will be the
 #             shortname before the email domain.
 #

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -42,7 +42,7 @@ packages:
 #
 # - if a device does not exist at the time, an entry will still be
 #   written to /etc/fstab.
-# - '/dev' can be ommitted for device names that begin with: xvd, sd, hd, vd
+# - '/dev' can be omitted for device names that begin with: xvd, sd, hd, vd
 # - if an entry does not have all 6 fields, they will be filled in
 #   with values from 'mount_default_fields' below.
 #
@@ -258,7 +258,7 @@ locale: en_US.UTF-8
 locale_configfile: /etc/default/locale
 
 # add entries to rsyslog configuration
-# The first occurance of a given filename will truncate. 
+# The first occurrence of a given filename will truncate. 
 # subsequent entries will append.
 # if value is a scalar, its content is assumed to be 'content', and the
 # default filename is used.
@@ -272,7 +272,7 @@ rsyslog:
  - filename: 01-examplecom.conf
    content: "*.*   @@syslogd.example.com"
 
-# resize_rootfs should the / filesytem be resized on first boot
+# resize_rootfs should the / filesystem be resized on first boot
 # this allows you to launch an instance with a larger disk / partition
 # and have the instance automatically grow / to accomoddate it
 # set to 'False' to disable
@@ -339,7 +339,7 @@ resize_rootfs: True
 #      /etc/cloud/templates/hosts.tmpl.
 #      The strings '$hostname' and '$fqdn' are replaced in the template
 #      with the appropriate values.
-#      To make modifications persistant across a reboot, you must make 
+#      To make modifications persistent across a reboot, you must make 
 #      modificatoins to /etc/cloud/templates/hosts.tmpl
 #
 #    localhost:
@@ -509,7 +509,7 @@ manual_cache_clean: False
 # default: none
 #
 # power_state can be used to make the system shutdown, reboot or
-# halt after boot is finished.  This same thing can be acheived by
+# halt after boot is finished.  This same thing can be achieved by
 # user-data scripts or by runcmd by simply invoking 'shutdown'.
 #
 # Doing it this way ensures that cloud-init is entirely finished with

--- a/doc/examples/kernel-cmdline.txt
+++ b/doc/examples/kernel-cmdline.txt
@@ -7,7 +7,7 @@ The format is:
 
 cloud-config will consider any content after 'cc:' to be cloud-config
 data.  If an 'end_cc' string is present, then it will stop reading there.
-otherwise it considers everthing after 'cc:' to be cloud-config content.
+otherwise it considers everything after 'cc:' to be cloud-config content.
 
 In order to allow carriage returns, you must enter '\\n', literally,
 on the command line two backslashes followed by a letter 'n'.

--- a/doc/examples/seed/README
+++ b/doc/examples/seed/README
@@ -15,7 +15,7 @@ The directory must have both files.
   This is the user data, as would be consumed from ec2's metadata service
   see examples in doc/examples.
 - meta-data:
-  This file is yaml formated data similar to what is in the ec2 metadata
+  This file is yaml formatted data similar to what is in the ec2 metadata
   service under meta-data/.  See the example, or, on an ec2 instance,
   run:
      python -c 'import boto.utils, yaml; print(

--- a/doc/examples/seed/meta-data
+++ b/doc/examples/seed/meta-data
@@ -1,4 +1,4 @@
-# this is yaml formated data
+# this is yaml formatted data
 # it is expected to be roughly what you would get from running the following
 # on an ec2 instance:
 # python -c 'import boto.utils, yaml; print(yaml.dump(boto.utils.get_instance_metadata()))'

--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath("./"))
 sys.path.insert(0, os.path.abspath("."))
 
 
-# Supress warnings for docs that aren't used yet
+# Suppress warnings for docs that aren't used yet
 # unused_docs = [
 # ]
 

--- a/doc/rtd/topics/datasources.rst
+++ b/doc/rtd/topics/datasources.rst
@@ -99,7 +99,7 @@ need to take care of the following items:
   your datasource module name to the end of the ``datasource_list``
   entry in ``cloudinit/settings.py``.
 
-* **Add your your cloud platform to apport collection prompts:** Update the
+* **Add your cloud platform to apport collection prompts:** Update the
   list of cloud platforms in ``cloudinit/apport.py``.  This list will be
   provided to the user who invokes ``ubuntu-bug cloud-init``.
 

--- a/doc/rtd/topics/datasources/smartos.rst
+++ b/doc/rtd/topics/datasources/smartos.rst
@@ -13,7 +13,7 @@ SmartOS Platform
 The SmartOS virtualization platform uses meta-data to the instance via the
 second serial console. On Linux, this is /dev/ttyS1. The data is a provided
 via a simple protocol: something queries for the data, the console responds
-responds with the status and if "SUCCESS" returns until a single ".\n".
+with the status and if "SUCCESS" returns until a single ".\n".
 
 New versions of the SmartOS tooling will include support for base64 encoded
 data.

--- a/doc/rtd/topics/datasources/vmware.rst
+++ b/doc/rtd/topics/datasources/vmware.rst
@@ -333,7 +333,7 @@ Setting the instance ID
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 The instance ID may be set by way of the metadata key ``instance-id``. However,
-if this value is absent then then the instance ID is read from the file
+if this value is absent then the instance ID is read from the file
 ``/sys/class/dmi/id/product_uuid``.
 
 Providing public SSH keys

--- a/doc/rtd/topics/datasources/vultr.rst
+++ b/doc/rtd/topics/datasources/vultr.rst
@@ -21,7 +21,7 @@ Vultr's datasource can be configured as follows:
       timeout: 2
       wait: 2
 
-- *url*: The URL used to aquire the metadata configuration from
+- *url*: The URL used to acquire the metadata configuration from
 - *retries*: Determines the number of times to attempt to connect to the
   metadata service
 - *timeout*: Determines the timeout in seconds to wait for a response from the

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -56,7 +56,7 @@ instance
 --------
 
 The `/var/lib/cloud/instance` directory is a symbolic link that points
-to the most recenlty used instance-id directory. This folder contains the
+to the most recently used instance-id directory. This folder contains the
 information cloud-init received from datasources, including vendor and user
 data. This can be helpful to review to ensure the correct data was passed.
 
@@ -74,9 +74,9 @@ previous boot:
 * `instance-id`: id of the instance as discovered by cloud-init. Changing
   this file has no effect.
 * `result.json`: json file will show both the datasource used to setup
-  the instance, and if any errors occured
+  the instance, and if any errors occurred
 * `status.json`: json file shows the datasource used and a break down
-  of all four modules if any errors occured and the start and stop times.
+  of all four modules if any errors occurred and the start and stop times.
 
 What datasource am I using?
 ===========================

--- a/doc/rtd/topics/instancedata.rst
+++ b/doc/rtd/topics/instancedata.rst
@@ -30,7 +30,7 @@ deployed with cloud-init:
 
 * simple static object to query to obtain a instance's metadata
 * speed: avoid costly network transactions for metadata that is already cached
-  on the filesytem
+  on the filesystem
 * reduce need to recrawl metadata services for static metadata that is already
   cached
 * leverage cloud-init's best practices for crawling cloud-metadata services
@@ -180,7 +180,7 @@ Example output:
 
 v1.platform
 -------------
-An attempt to identify the cloud platfrom instance that the system is running
+An attempt to identify the cloud platform instance that the system is running
 on.
 
 Examples output:

--- a/doc/rtd/topics/network-config-format-v1.rst
+++ b/doc/rtd/topics/network-config-format-v1.rst
@@ -48,7 +48,7 @@ the key ``subnets``.
 Physical
 ~~~~~~~~
 The ``physical`` type configuration represents a "physical" network device,
-typically Ethernet-based.  At least one of of these entries is required for
+typically Ethernet-based.  At least one of these entries is required for
 external network connectivity.  Type ``physical`` requires only one key:
 ``name``.  A ``physical`` device may contain some or all of the following
 keys:
@@ -335,7 +335,7 @@ Users can specify a ``nameserver`` type.  Nameserver dictionaries include
 the following keys:
 
 - ``address``: List of IPv4 or IPv6 address of nameservers.
-- ``search``: List of of hostnames to include in the resolv.conf search path.
+- ``search``: List of hostnames to include in the resolv.conf search path.
 - ``interface``: Optional. Ties the nameserver definition to the specified
   interface. The value specified here must match the `name` of an interface
   defined in this config. If unspecified, this nameserver will be considered

--- a/doc/sources/kernel-cmdline.txt
+++ b/doc/sources/kernel-cmdline.txt
@@ -9,7 +9,7 @@ as it requires knowing in advance the correct command line or modifying
 the boot loader to append data.
 
 For example, when 'cloud-init start' runs, it will check to
-see if if one of 'cloud-config-url' or 'url' appear in key/value fashion
+see if one of 'cloud-config-url' or 'url' appear in key/value fashion
 in the kernel command line as in:
    root=/dev/sda ro url=http://foo.bar.zee/abcde
 

--- a/doc/sources/ovf/README
+++ b/doc/sources/ovf/README
@@ -53,7 +53,7 @@ box, follow the steps below.
   You can change that at the grub prompt if you'd like by editing the
   kernel entry.  Otherwise, to see progress you'll need to switch
   to the serial console.  In kvm graphic mode, you do that by clicking
-  in the window and then pressing pressing 'ctrl-alt-3'.  For information
+  in the window and then pressing 'ctrl-alt-3'.  For information
   on how to do that in virtualbox or kvm curses, see the relevant
   documentation.
 

--- a/doc/sources/ovf/make-iso
+++ b/doc/sources/ovf/make-iso
@@ -28,7 +28,7 @@ Usage() {
 	cat <<EOF
 Usage: ${0##*/} ovf-env.xml.tmpl [user-data-file]
 
-   create an an ovf transport iso with ovf-env.xml.tmpl
+   create an ovf transport iso with ovf-env.xml.tmpl
    as ovf-env.xml on the iso.
 
    if user-data-file is given, the file's contents will be base64 encoded

--- a/doc/userdata.txt
+++ b/doc/userdata.txt
@@ -1,7 +1,7 @@
 === Overview ===
 Userdata is data provided by the entity that launches an instance.
 The cloud provider makes this data available to the instance via in one
-way or anohter.  
+way or another.  
 
 In EC2, the data is provided by the user via the '--user-data' or
 'user-data-file' argument to ec2-run-instances.  The EC2 cloud makes the


### PR DESCRIPTION
```
Fix spelling errors

- Add Makefile target that checks for spelling errors
- Add Makefile target that fixes spelling errors
- Add spelling check to travis doc tests
- Fix various spelling errors in the docs 
```


## Test Steps
revert the bug fixes in the second commit to test the new makefile target functionality
```
git reset --hard HEAD^
make check_spelling
echo $?
make fix_spelling
make check_spelling # note the one error fix_spelling couldn't automagically fix
# manually fix doc/rtd/topics/datasources/smartos.rst
make fix_spelling
echo $?
```

Note that this [build](https://app.travis-ci.com/github/canonical/cloud-init/jobs/557796208) fails (before the spelling fixes) and this [build](https://app.travis-ci.com/github/canonical/cloud-init/jobs/557796695) succeeds (after the fixes).