### PR TITLE
sources/azure: consolidate ephemeral DHCP configuration

### DIFF
--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -25,7 +25,6 @@ from cloudinit import (
     version,
 )
 from cloudinit.net import dhcp
-from cloudinit.net.dhcp import EphemeralDHCPv4
 from cloudinit.reporting import events
 from cloudinit.settings import CFG_BUILTIN
 
@@ -215,6 +214,7 @@ def report_diagnostic_event(
     msg: str, *, logger_func=None
 ) -> events.ReportingEvent:
     """Report a diagnostic event"""
+    print(msg)
     if callable(logger_func):
         logger_func(msg)
     evt = events.ReportingEvent(
@@ -1241,23 +1241,6 @@ def dhcp_log_cb(out, err):
     report_diagnostic_event(
         "dhclient error stream: %s" % err, logger_func=LOG.debug
     )
-
-
-class EphemeralDHCPv4WithReporting(EphemeralDHCPv4):
-    def __init__(self, reporter, iface=None):
-        self.reporter = reporter
-
-        super(EphemeralDHCPv4WithReporting, self).__init__(
-            iface=iface, dhcp_log_func=dhcp_log_cb
-        )
-
-    def __enter__(self):
-        with events.ReportEventStack(
-            name="obtain-dhcp-lease",
-            description="obtain dhcp lease",
-            parent=self.reporter,
-        ):
-            return super(EphemeralDHCPv4WithReporting, self).__enter__()
 
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
Introduce:

-  _setup_ephemeral_networking() to bring up networking.
  If no iface is specified, it will use net.find_fallback_nic()
  which is consistent with the previous usage of fallback_interface.
  This method now tracks the encoded address of the wireserver
  with a new property `_wireserver_endpoint`.

- _teardown_ephemeral_networking() to bring down networking.

- _is_ephemeral_networking_up() to check status.

Ephemeral networking is now:

- Brought up prior to checking IMDS.

- Torn down following metadata crawl.

- For Savable PPS, torn down prior to waiting for NIC detach.
  The link must be torn down in advance or we will see errors
  from cleaning up network after the interface is unplugged.

- For Running PPS, torn down after waiting for media switch.
  The link must be up for media switch to be detected.

- For all PPS, after network switch is complete, networking is
  brought back up to poll for reprovision data and report ready.
  It will be torn down after metadata crawl is complete like
  non-PPS paths.

Additionally:

- Remove EphemeralDHCPv4WithReporting variant in favor of directly
using EphemeralDHCPv4.  The reporting was only for __enter__ usage
which is no longer a used path.  Continue to use dhcp_log_cb
callback.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>