### PR TITLE
integration: do not LXD bind mount /etc/cloud/cloud.cfg.d

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@e52cc257c5467bb16442a8ef943ca1931c4e1757
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@d8c7654dbef1a7daf47417337e50515e6842aed6
 pytest

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -295,7 +295,10 @@ class _LxdIntegrationCloud(IntegrationCloud):
             cloudinit_path, "..", "config", "cloud.cfg.d"
         )
         for src_file in os.listdir(config_dir):
-            command = f"lxc file push {config_dir}/{src_file} {instance.name}/etc/cloud/cloud.cfg.d/"
+            command = (
+                f"lxc file push {config_dir}/{src_file} "
+                f"{instance.name}/etc/cloud/cloud.cfg.d/"
+            )
             subp(command.split())
 
     def _perform_launch(self, launch_kwargs, **kwargs):

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -259,10 +259,6 @@ class _LxdIntegrationCloud(IntegrationCloud):
         mounts = [
             (cloudinit_path, "/usr/lib/python3/dist-packages/cloudinit"),
             (
-                os.path.join(cloudinit_path, "..", "config", "cloud.cfg.d"),
-                "/var/tmp/etc/cloud/cloud.cfg.d",
-            ),
-            (
                 os.path.join(cloudinit_path, "..", "templates"),
                 "/etc/cloud/templates",
             ),

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -134,7 +134,7 @@ class IntegrationCloud(ABC):
         user_data=None,
         launch_kwargs=None,
         settings=integration_settings,
-        **kwargs
+        **kwargs,
     ) -> IntegrationInstance:
         if launch_kwargs is None:
             launch_kwargs = {}
@@ -260,7 +260,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
             (cloudinit_path, "/usr/lib/python3/dist-packages/cloudinit"),
             (
                 os.path.join(cloudinit_path, "..", "config", "cloud.cfg.d"),
-                "/etc/cloud/cloud.cfg.d",
+                "/var/tmp/etc/cloud/cloud.cfg.d",
             ),
             (
                 os.path.join(cloudinit_path, "..", "templates"),
@@ -286,6 +286,18 @@ class _LxdIntegrationCloud(IntegrationCloud):
             ).format(**format_variables)
             subp(command.split())
 
+        # /etc/cloud/cloud.cfg.d is a directory we write to in some
+        # integration tests. We can't use lxc mount in the container
+        # as /etc/cloud/cloud.cfg.d will then be owned nobody:nogroup and be
+        # read-only for root.
+        # Instead copy static files to the instance under test.
+        config_dir = os.path.join(
+            cloudinit_path, "..", "config", "cloud.cfg.d"
+        )
+        for src_file in os.listdir(config_dir):
+            command = f"lxc file push {config_dir}/{src_file} {instance.name}/etc/cloud/cloud.cfg.d/"
+            subp(command.split())
+
     def _perform_launch(self, launch_kwargs, **kwargs):
         launch_kwargs["inst_type"] = launch_kwargs.pop("instance_type", None)
         wait = launch_kwargs.pop("wait", True)
@@ -304,7 +316,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
             launch_kwargs.pop("name", default_name),
             release,
             profile_list=profile_list,
-            **launch_kwargs
+            **launch_kwargs,
         )
         if self.settings.CLOUD_INIT_SOURCE == "IN_PLACE":
             self._mount_source(pycloudlib_instance)

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -81,13 +81,13 @@ class IntegrationInstance:
         # First copy to a temporary directory because of permissions issues
         tmp_path = _get_tmp_path()
         self.instance.execute("cp {} {}".format(str(remote_path), tmp_path))
-        self.instance.pull_file(tmp_path, str(local_path))
+        assert self.instance.pull_file(tmp_path, str(local_path)).ok
 
     def push_file(self, local_path, remote_path):
         # First push to a temporary directory because of permissions issues
         tmp_path = _get_tmp_path()
         self.instance.push_file(str(local_path), tmp_path)
-        self.execute("mv {} {}".format(tmp_path, str(remote_path)))
+        assert self.execute("mv {} {}".format(tmp_path, str(remote_path))).ok
 
     def read_from_file(self, remote_path) -> str:
         result = self.execute("cat {}".format(remote_path))


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
integration: do not LXD bind mount /etc/cloud/cloud.cfg.d
    
Since lxc bind mounts will be read-only as nobody:nogroup
we don't want to bind mount /etc/cloud/cloud.cfg.d into the
instance because some tests add artifacts to /etc/cloud/cloud.cfg.d.

Also make LXD push_file pull_file methods assert that the
file transfer was a success, otherwise we miss the root-cause
for test failures.

This resulted in failed Jenkins runs in test_lxd_discovery with a
symptom of NoCloud being detected instead of LXD datasource.
The root-case was that instance.file_push failed due to permission
errors for root on the bind mounted /etc/cloud/cloud.cfg.d.

Also bump pycloudlib commitish to get Azure Jammy image support.
```

## Additional Context
<!-- If relevant -->

## Test Steps
```bash
cat >/tmp/pycloudlib-lxd.toml <<EOF
[lxd]
EOF
CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_OS_IMAGE=focal CLOUD_INIT_COLLECT_LOGS=ON_ERROR PYCLOUDLIB_CONFIG=/tmp/pycloudlib-lxd.toml CLOUD_INIT_LOCAL_LOG_PATH=/tmp/ci-logs CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests tests/integration_tests/datasources/test_lxd_discovery.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
