### PR TITLE
cc_salt_minion freebsd fix for rc.conf (SC-782)

### DIFF
--- a/cloudinit/config/cc_salt_minion.py
+++ b/cloudinit/config/cc_salt_minion.py
@@ -61,7 +61,7 @@ class SaltConstants(object):
 
         # constants tailored for FreeBSD
         if util.is_FreeBSD():
-            self.pkg_name = "py36-salt"
+            self.pkg_name = "py-salt"
             self.srv_name = "salt_minion"
             self.conf_dir = "/usr/local/etc/salt"
         # constants for any other OS

--- a/cloudinit/config/cc_salt_minion.py
+++ b/cloudinit/config/cc_salt_minion.py
@@ -46,7 +46,7 @@ specify them with ``pkg_name``, ``service_name`` and ``config_dir``.
 import os
 
 from cloudinit import safeyaml, subp, util
-from cloudinit.distros import rhel_util
+from cloudinit.distros import bsd_utils
 
 # Note: see https://docs.saltstack.com/en/latest/topics/installation/
 # Note: see https://docs.saltstack.com/en/latest/ref/configuration/
@@ -128,9 +128,7 @@ def handle(name, cfg, cloud, log, _args):
     # we need to have the salt minion service enabled in rc in order to be
     # able to start the service. this does only apply on FreeBSD servers.
     if cloud.distro.osfamily == "freebsd":
-        rhel_util.update_sysconfig_file(
-            "/etc/rc.conf", {"salt_minion_enable": "YES"}
-        )
+        bsd_utils.set_rc_config_value("salt_minion_enable", "YES")
 
     # restart salt-minion. 'service' will start even if not started. if it
     # was started, it needs to be restarted for config change.


### PR DESCRIPTION
```
cc_salt_minion freebsd fix for rc.conf

This fixes a bug that prevents the salt module from enabling the salt minion in rc.conf.

For more details:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=254339
```