### PR TITLE
Fix extra ipv6 issues, code reduction and simplification

### DIFF
--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -165,19 +165,18 @@ def generate_network_config(interfaces):
 
     # Prepare interface 0, public
     if len(interfaces) > 0:
-        public = generate_public_network_interface(interfaces[0])
+        public = generate_interface(interfaces[0], primary=True)
         network["config"].append(public)
 
     # Prepare additional interfaces, private
     for i in range(1, len(interfaces)):
-        private = generate_private_network_interface(interfaces[i])
+        private = generate_interface(interfaces[i])
         network["config"].append(private)
 
     return network
 
 
-# Input Metadata and generate public network config part
-def generate_public_network_interface(interface):
+def generate_interface(interface, primary=False):
     interface_name = get_interface_name(interface["mac"])
     if not interface_name:
         raise RuntimeError(
@@ -188,13 +187,33 @@ def generate_public_network_interface(interface):
         "name": interface_name,
         "type": "physical",
         "mac_address": interface["mac"],
-        "accept-ra": 1,
-        "subnets": [
-            {"type": "dhcp", "control": "auto"},
-            {"type": "ipv6_slaac", "control": "auto"},
-        ],
     }
 
+    if primary:
+        netcfg["accept-ra"] = 1
+        netcfg["subnets"] = [
+            {"type": "dhcp", "control": "auto"},
+            {"type": "ipv6_slaac", "control": "auto"},
+        ]
+
+    if not primary:
+        netcfg["subnets"] = [
+            {
+                "type": "static",
+                "control": "auto",
+                "address": interface["ipv4"]["address"],
+                "netmask": interface["ipv4"]["netmask"],
+            }
+        ]
+
+    generate_interface_routes(interface, netcfg)
+    generate_interface_additional_addresses(interface, netcfg)
+
+    # Add config to template
+    return netcfg
+
+
+def generate_interface_routes(interface, netcfg):
     # Options that may or may not be used
     if "mtu" in interface:
         netcfg["mtu"] = interface["mtu"]
@@ -205,6 +224,8 @@ def generate_public_network_interface(interface):
     if "routes" in interface:
         netcfg["subnets"][0]["routes"] = interface["routes"]
 
+
+def generate_interface_additional_addresses(interface, netcfg):
     # Check for additional IP's
     additional_count = len(interface["ipv4"]["additional"])
     if "ipv4" in interface and additional_count > 0:
@@ -228,52 +249,14 @@ def generate_public_network_interface(interface):
             add = {
                 "type": "static6",
                 "control": "auto",
-                "address": additional["address"],
-                "netmask": additional["netmask"],
+                "address": "%s/%s"
+                % (additional["network"], additional["prefix"]),
             }
 
             if "routes" in additional:
                 add["routes"] = additional["routes"]
 
             netcfg["subnets"].append(add)
-
-    # Add config to template
-    return netcfg
-
-
-# Input Metadata and generate private network config part
-def generate_private_network_interface(interface):
-    interface_name = get_interface_name(interface["mac"])
-    if not interface_name:
-        raise RuntimeError(
-            "Interface: %s could not be found on the system" % interface["mac"]
-        )
-
-    netcfg = {
-        "name": interface_name,
-        "type": "physical",
-        "mac_address": interface["mac"],
-        "subnets": [
-            {
-                "type": "static",
-                "control": "auto",
-                "address": interface["ipv4"]["address"],
-                "netmask": interface["ipv4"]["netmask"],
-            }
-        ],
-    }
-
-    # Options that may or may not be used
-    if "mtu" in interface:
-        netcfg["mtu"] = interface["mtu"]
-
-    if "accept-ra" in interface:
-        netcfg["accept-ra"] = interface["accept-ra"]
-
-    if "routes" in interface:
-        netcfg["subnets"][0]["routes"] = interface["routes"]
-
-    return netcfg
 
 
 # Make required adjustments to the network configs provided

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -30,9 +30,6 @@ def get_metadata(url, timeout, retries, sec_between, agent):
             with EphemeralDHCPv4(
                 iface=iface[0], connectivity_url_data={"url": url}
             ):
-                # Set metadata route
-                set_route(iface[0])
-
                 # Fetch the metadata
                 v1 = read_metadata(url, timeout, retries, sec_between, agent)
 
@@ -41,12 +38,6 @@ def get_metadata(url, timeout, retries, sec_between, agent):
             LOG.error("DHCP Exception: %s", exc)
             exception = exc
     raise exception
-
-
-# Set route for metadata
-def set_route(iface):
-    if subp.which("route"):
-        subp.subp(["route", "add", "169.254.169.254/32", iface])
 
 
 # Read the system information from SMBIOS


### PR DESCRIPTION
## Proposed Commit Message
Fix extra ipv6 issues, code reduction and simplification

```
I eliminated the duplicate code and now run the entire configuration routine against both public and private interfaces. I also addressed an inconsistency from our metadata api for ipv6 address configuration.
```

## Test Steps
Start a Vultr vm with additional IPv6's added to the instance.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ X ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ X ] I have updated or added any unit tests accordingly
 - [ X ] I have updated or added any documentation accordingly
