### PR TITLE
cloud-id: publish /run/cloud-init/cloud-id-<cloud-type> files

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -413,7 +413,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         )
         cloud_id = instance_data["v1"].get("cloud_id", "none")
         cloud_id_file = os.path.join(self.paths.run_dir, "cloud-id")
-        util.write_file(f"{cloud_id_file}-{cloud_id}", cloud_id)
+        util.write_file(f"{cloud_id_file}-{cloud_id}", f"{cloud_id}\n")
         if os.path.exists(cloud_id_file):
             prev_cloud_id_file = os.path.realpath(cloud_id_file)
         else:

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -260,7 +260,7 @@ class TestCombined:
         assert v1_data["cloud_name"] == "unknown"
         assert v1_data["platform"] == "lxd"
         assert v1_data["cloud_id"] == "lxd"
-        assert f"{v1_data['cloud_id']}\n" == client.read_from_file(
+        assert f"{v1_data['cloud_id']}" == client.read_from_file(
             "/run/cloud-init/cloud-id-lxd"
         )
         assert (
@@ -285,7 +285,7 @@ class TestCombined:
         assert v1_data["cloud_name"] == "unknown"
         assert v1_data["platform"] == "lxd"
         assert v1_data["cloud_id"] == "lxd"
-        assert f"{v1_data['cloud_id']}\n" == client.read_from_file(
+        assert f"{v1_data['cloud_id']}" == client.read_from_file(
             "/run/cloud-init/cloud-id-lxd"
         )
         assert any(
@@ -311,7 +311,7 @@ class TestCombined:
         assert v1_data["platform"] == "ec2"
         # Different regions will show up as ec2-(gov|china)
         assert v1_data["cloud_id"].startswith("ec2")
-        assert f"{v1_data['cloud_id']}\n" == client.read_from_file(
+        assert f"{v1_data['cloud_id']}" == client.read_from_file(
             "/run/cloud-init/cloud-id-ec2"
         )
         assert v1_data["subplatform"].startswith("metadata")
@@ -333,6 +333,9 @@ class TestCombined:
         v1_data = data["v1"]
         assert v1_data["cloud_name"] == "gce"
         assert v1_data["platform"] == "gce"
+        assert f"{v1_data['cloud_id']}" == client.read_from_file(
+            "/run/cloud-init/cloud-id-gce"
+        )
         assert v1_data["subplatform"].startswith("metadata")
         assert v1_data["availability_zone"] == client.instance.zone
         assert v1_data["instance_id"] == client.instance.instance_id

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -222,6 +222,16 @@ class TestCombined:
                 == parsed_datasource
             )
 
+    def test_cloud_id_file_symlink(self, class_client: IntegrationInstance):
+        cloud_id = class_client.execute("cloud-id").stdout
+        expected_link_output = (
+            "'/run/cloud-init/cloud-id' -> "
+            f"'/run/cloud-init/cloud-id-{cloud_id}'"
+        )
+        assert expected_link_output == str(
+            class_client.execute("stat -c %N /run/cloud-init/cloud-id")
+        )
+
     def _check_common_metadata(self, data):
         assert data["base64_encoded_keys"] == []
         assert data["merged_cfg"] == "redacted for non-root user"

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -249,6 +249,10 @@ class TestCombined:
         v1_data = data["v1"]
         assert v1_data["cloud_name"] == "unknown"
         assert v1_data["platform"] == "lxd"
+        assert v1_data["cloud_id"] == "lxd"
+        assert f"{v1_data['cloud_id']}\n" == client.read_from_file(
+            "/run/cloud-init/cloud-id-lxd"
+        )
         assert (
             v1_data["subplatform"]
             == "seed-dir (/var/lib/cloud/seed/nocloud-net)"
@@ -270,6 +274,10 @@ class TestCombined:
         v1_data = data["v1"]
         assert v1_data["cloud_name"] == "unknown"
         assert v1_data["platform"] == "lxd"
+        assert v1_data["cloud_id"] == "lxd"
+        assert f"{v1_data['cloud_id']}\n" == client.read_from_file(
+            "/run/cloud-init/cloud-id-lxd"
+        )
         assert any(
             [
                 "/var/lib/cloud/seed/nocloud-net" in v1_data["subplatform"],
@@ -291,6 +299,11 @@ class TestCombined:
         v1_data = data["v1"]
         assert v1_data["cloud_name"] == "aws"
         assert v1_data["platform"] == "ec2"
+        # Different regions will show up as ec2-(gov|china)
+        assert v1_data["cloud_id"].startswith("ec2")
+        assert f"{v1_data['cloud_id']}\n" == client.read_from_file(
+            "/run/cloud-init/cloud-id-ec2"
+        )
         assert v1_data["subplatform"].startswith("metadata")
         assert (
             v1_data["availability_zone"] == client.instance.availability_zone

--- a/tests/unittests/sources/test_init.py
+++ b/tests/unittests/sources/test_init.py
@@ -693,7 +693,7 @@ class TestDataSource(CiTestCase):
             "cloudinit.sources.canonical_cloud_id", return_value="my-cloud"
         ):
             datasource.get_data()
-        self.assertEqual("my-cloud", util.load_file(cloud_id_link))
+        self.assertEqual("my-cloud\n", util.load_file(cloud_id_link))
         # A symlink with the generic /run/cloud-init/cloud-id link is present
         self.assertTrue(util.is_link(cloud_id_link))
         # When cloud-id changes, symlink and content change
@@ -701,12 +701,12 @@ class TestDataSource(CiTestCase):
             "cloudinit.sources.canonical_cloud_id", return_value="my-cloud2"
         ):
             datasource.persist_instance_data()
-        self.assertEqual("my-cloud2", util.load_file(cloud_id2_file))
+        self.assertEqual("my-cloud2\n", util.load_file(cloud_id2_file))
         # Previous cloud-id-<cloud-type> file removed
         self.assertFalse(os.path.exists(cloud_id_file))
         # Generic link persisted which contains canonical-cloud-id as content
         self.assertTrue(util.is_link(cloud_id_link))
-        self.assertEqual("my-cloud2", util.load_file(cloud_id_link))
+        self.assertEqual("my-cloud2\n", util.load_file(cloud_id_link))
 
     def test_persist_instance_data_writes_network_json_when_set(self):
         """When network_data.json class attribute is set, persist to json."""


### PR DESCRIPTION
Once a valid datasource is detected, publish the following artifacts
to expedite cloud-identification without having to invoke cloud-id from
shell scripts or sheling out from python.

These files can also be relied on in systemd ConditionPathExists
directives to limit execution of services and units to specific
clouds.

/run/cloud-init/cloud-id:
 - A symlink with content that is the canonical cloud-id of the                    datasource detected. This content is the same lower-case value
   as the output of /usr/bin/cloud-id.

/run/cloud-init/cloud-id-\<**canonical-cloud-id**\>:
 - A single file which will contain the canonical cloud-id encoded
   in the filename

## Proposed Commit Message
```
Once a valid datasource is detected, publish the following artifacts
to expedite cloud-identification without having to invoke cloud-id from
shell scripts or sheling out from python.
    
These files can also be relied on in systemd ConditionPathExists
directives to limit execution of services and units to specific
clouds.
    
/run/cloud-init/cloud-id:
 - A symlink with content that is the canonical cloud-id of the
   datasource detected. This content is the same lower-case value
   as the output of /usr/bin/cloud-id.

/run/cloud-init/cloud-id-<canonical-cloud-id>:
 - A single file which will contain the canonical cloud-id encoded
   in the filename
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
