### PR TITLE
tests: do not assert instance.pull_file().ok()

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -81,7 +81,7 @@ class IntegrationInstance:
         # First copy to a temporary directory because of permissions issues
         tmp_path = _get_tmp_path()
         self.instance.execute("cp {} {}".format(str(remote_path), tmp_path))
-        assert self.instance.pull_file(tmp_path, str(local_path)).ok
+        self.instance.pull_file(tmp_path, str(local_path))
 
     def push_file(self, local_path, remote_path):
         # First push to a temporary directory because of permissions issues


### PR DESCRIPTION
Test pycloudlib's [BaseInstance.pull_file](https://github.com/canonical/pycloudlib/blob/main/pycloudlib/instance.py#L228) doesn't return a Result
object. So we can't call ok() on the None response in integration tests.

When an integration test failes, this error results in _collect_logs incorrectly reporting that a pull_file has failed 
leaving an uncompressed tarfile which was correctly downloaded.

Leave the try/except handling as pull_file will raise an
IOError if there is an error connecting via paramiko's sftp.get.

## Proposed Commit Message
```
Test pycloudlib's BaseInstance.pull_file doesn't return a Result
object. So we can't call ok() on the response in integration tests.

Leave the try/except handling as pull_file will raise an
IOError if there is an error connecting via paramiko's sftp.get.
```
## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Run the following failing test locally on main and notice that the generated logs in /tmp/cloud_init_test_logs/ are still compressed and that we receive an ERROR logged to the console incorrectly saying 
`2022-02-04 21:47:56 ERROR     integration_testing:conftest.py:212 Failed to pull logs: 'NoneType' object has no attribute 'ok'
`

```
# create a failing integration test
$ sed -i 's/X11/XBOGUS/' tests/integration_tests/modules/test_keyboard.py
$ CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_KEEP_INSTANCE=false CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_OS_IMAGE=jammy .tox/integration-tests/bin/pytest tests/integration_tests/modules/test_keyboard.py

# Before this fix: Expect "Failed to pull logs: 'NoneType' object has no attribute 'ok'"  ERROR log to console
#  and expect compressed cloud-init.tar.gz 
$ find /tmp/cloud_init_test_logs/last/
/tmp/cloud_init_test_logs/last/
/tmp/cloud_init_test_logs/last/test_keyboard
/tmp/cloud_init_test_logs/last/test_keyboard/cloud-init.tar.gz

# After fix: no "Failed to pull logs" and uncompressed log results
$ find /tmp/cloud_init_test_logs/last/ | wc -l
25

```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
