### PR TITLE
Add Oracle Linux 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cloud-init
 
-[![Build Status](https://travis-ci.com/canonical/cloud-init.svg?branch=main)](https://travis-ci.com/canonical/cloud-init) [![Read the Docs](https://readthedocs.org/projects/cloudinit/badge/?version=latest&style=flat)](https://cloudinit.readthedocs.org)
+[![Build Status](https://app.travis-ci.com/canonical/cloud-init.svg?branch=main)](https://app.travis-ci.com/canonical/cloud-init) [![Read the Docs](https://readthedocs.org/projects/cloudinit/badge/?version=latest&style=flat)](https://cloudinit.readthedocs.org)
 
 Cloud-init is the *industry standard* multi-distribution method for
 cross-platform cloud instance initialization. It is supported across all
@@ -39,7 +39,7 @@ get in contact with that distribution and send them our way!
 
 | Supported OSes | Supported Public Clouds | Supported Private Clouds |
 | --- | --- | --- |
-| Alpine Linux<br />ArchLinux<br />Debian<br />DragonFlyBSD<br />Fedora<br />FreeBSD<br />Gentoo Linux<br />NetBSD<br />OpenBSD<br />openEuler<br />RHEL/CentOS/AlmaLinux/Rocky/PhotonOS/Virtuozzo/EuroLinux/CloudLinux/MIRACLE LINUX<br />SLES/openSUSE<br />Ubuntu<br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /> | Amazon Web Services<br />Microsoft Azure<br />Google Cloud Platform<br />Oracle Cloud Infrastructure<br />Softlayer<br />Rackspace Public Cloud<br />IBM Cloud<br />DigitalOcean<br />Bigstep<br />Hetzner<br />Joyent<br />CloudSigma<br />Alibaba Cloud<br />OVH<br />OpenNebula<br />Exoscale<br />Scaleway<br />CloudStack<br />AltCloud<br />SmartOS<br />HyperOne<br />Vultr<br />Rootbox<br /> | Bare metal installs<br />OpenStack<br />LXD<br />KVM<br />Metal-as-a-Service (MAAS)<br />VMware<br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />|
+| Alpine Linux<br />ArchLinux<br />Debian<br />DragonFlyBSD<br />Fedora<br />FreeBSD<br />Gentoo Linux<br />NetBSD<br />OpenBSD<br />openEuler<br />RHEL/CentOS/AlmaLinux/Rocky/Oracle Linux/PhotonOS/Virtuozzo/EuroLinux/CloudLinux/MIRACLE LINUX<br />SLES/openSUSE<br />Ubuntu<br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /> | Amazon Web Services<br />Microsoft Azure<br />Google Cloud Platform<br />Oracle Cloud Infrastructure<br />Softlayer<br />Rackspace Public Cloud<br />IBM Cloud<br />DigitalOcean<br />Bigstep<br />Hetzner<br />Joyent<br />CloudSigma<br />Alibaba Cloud<br />OVH<br />OpenNebula<br />Exoscale<br />Scaleway<br />CloudStack<br />AltCloud<br />SmartOS<br />HyperOne<br />Vultr<br />Rootbox<br /> | Bare metal installs<br />OpenStack<br />LXD<br />KVM<br />Metal-as-a-Service (MAAS)<br />VMware<br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br /><br />|
 
 ## To start developing cloud-init
 

--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -29,6 +29,7 @@ distros = [
     "eurolinux",
     "fedora",
     "miraclelinux",
+    "ol",
     "openEuler",
     "opensuse",
     "photon",

--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -19,7 +19,7 @@ entry, the config entry will be skipped.
 **Module frequency:** always
 
 **Supported distros:** almalinux, centos, cloudlinux, eurolinux, fedora,
-                       miraclelinux, openEuler, photon, rhel, rocky, virtuozzo
+                       miraclelinux, openEuler, oraclelinux, photon, rhel, rocky, virtuozzo
 
 **Config keys**::
 
@@ -43,6 +43,7 @@ distros = [
     "cloudlinux",
     "eurolinux",
     "fedora",
+    "ol",
     "openEuler",
     "photon",
     "rhel",

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -46,6 +46,7 @@ OSFAMILIES = {
         "eurolinux",
         "fedora",
         "miraclelinux",
+        "ol",
         "openEuler",
         "photon",
         "rhel",

--- a/cloudinit/distros/ol.py
+++ b/cloudinit/distros/ol.py
@@ -1,0 +1,10 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from cloudinit.distros import rhel
+
+
+class Distro(rhel.Distro):
+    pass
+
+
+# vi: ts=4 expandtab

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -27,6 +27,7 @@ KNOWN_DISTROS = [
     "eurolinux",
     "fedora",
     "miraclelinux",
+    "ol",
     "openEuler",
     "rhel",
     "rocky",

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -584,6 +584,7 @@ def _get_variant(info):
             "eurolinux",
             "fedora",
             "miraclelinux",
+            "ol",
             "openeuler",
             "photon",
             "rhel",

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -33,7 +33,7 @@ disable_root: true
 {% endif %}
 
 {% if variant in ["almalinux", "alpine", "amazon", "centos", "cloudlinux", "eurolinux",
-                  "fedora", "miraclelinux", "openEuler", "rhel", "rocky", "virtuozzo"] %}
+                  "fedora", "miraclelinux", "ol", "openEuler", "rhel", "rocky", "virtuozzo"] %}
 mount_default_fields: [~, ~, 'auto', 'defaults,nofail', '0', '2']
 {% if variant == "amazon" %}
 resize_rootfs: noblock
@@ -177,7 +177,7 @@ cloud_final_modules:
 system_info:
    # This will affect which distro class gets used
 {% if variant in ["almalinux", "alpine", "amazon", "arch", "centos", "cloudlinux", "debian",
-                  "eurolinux", "fedora", "freebsd", "gentoo", "netbsd", "miraclelinux", "openbsd", "openEuler",
+                  "eurolinux", "fedora", "freebsd", "gentoo", "netbsd", "miraclelinux", "openbsd", "ol", "openEuler",
                   "photon", "rhel", "rocky", "suse", "ubuntu", "virtuozzo"] %}
    distro: {{ variant }}
 {% elif variant in ["dragonfly"] %}
@@ -232,7 +232,7 @@ system_info:
          security: http://ports.ubuntu.com/ubuntu-ports
    ssh_svcname: ssh
 {% elif variant in ["almalinux", "alpine", "amazon", "arch", "centos", "cloudlinux", "eurolinux",
-                    "fedora", "gentoo", "miraclelinux", "openEuler", "rhel", "rocky", "suse", "virtuozzo"] %}
+                    "fedora", "gentoo", "miraclelinux", "ol", "openEuler", "rhel", "rocky", "suse", "virtuozzo"] %}
    # Default user name + that default users groups (if added/used)
    default_user:
 {% if variant == "amazon" %}

--- a/doc/rtd/topics/availability.rst
+++ b/doc/rtd/topics/availability.rst
@@ -27,7 +27,7 @@ OpenBSD and DragonFlyBSD:
 - NetBSD
 - OpenBSD
 - Photon OS
-- RHEL/CentOS/AlmaLinux/Rocky Linux/EuroLinux
+- RHEL/CentOS/AlmaLinux/Rocky Linux/EuroLinux/OracleLinux
 - SLES/openSUSE
 - Ubuntu
 

--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -71,5 +71,19 @@
          "procps",
          "sudo"
       ]
+   },
+   "ol" : {
+      "build-requires" : [
+         "python3-devel"
+      ],
+      "requires" : [
+         "e2fsprogs",
+         "iproute",
+         "net-tools",
+         "procps",
+         "rsyslog",
+         "shadow-utils",
+         "sudo"
+      ]
    }
 }

--- a/systemd/cloud-init-generator.tmpl
+++ b/systemd/cloud-init-generator.tmpl
@@ -84,7 +84,7 @@ default() {
 check_for_datasource() {
     local ds_rc=""
 {% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora", 
-                  "miraclelinux", "openEuler", "rhel", "rocky", "virtuozzo"] %}
+                  "miraclelinux", "ol", "openEuler", "rhel", "rocky", "virtuozzo"] %}
     local dsidentify="/usr/libexec/cloud-init/ds-identify"
 {% else %}
     local dsidentify="/usr/lib/cloud-init/ds-identify"

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -13,7 +13,7 @@ After=systemd-networkd-wait-online.service
 After=networking.service
 {% endif %}
 {% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora",
-                  "miraclelinux", "openEuler", "rhel", "rocky", "virtuozzo"] %}
+                  "miraclelinux", "ol", "openEuler", "rhel", "rocky", "virtuozzo"] %}
 After=network.service
 After=NetworkManager.service
 {% endif %}

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -257,8 +257,8 @@ class TestCLI(test_helpers.FilesystemMockingTestCase):
                 "**Supported distros:** all",
                 "**Supported distros:** almalinux, alpine, centos, "
                 "cloudlinux, debian, eurolinux, fedora, miraclelinux, "
-                "openEuler, opensuse, photon, rhel, rocky, sles, ubuntu, "
-                "virtuozzo",
+                "ol, openEuler, opensuse, photon, rhel, rocky, sles, "
+                "ubuntu, virtuozzo",
                 "**Config schema**:\n    **resize_rootfs:** "
                 "(true/false/noblock)",
                 "**Examples**::\n\n    runcmd:\n        - [ ls, -l, / ]\n",

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -6217,6 +6217,7 @@ class TestNetRenderers(CiTestCase):
             "eurolinux",
             "fedora",
             "rhel",
+            "ol",
         ]
         for distro_name in variants:
             m_info.return_value = {"variant": distro_name}

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -18,6 +18,7 @@ DISTRO_VARIANTS = [
     "freebsd",
     "gentoo",
     "netbsd",
+    "ol",
     "openbsd",
     "photon",
     "rhel",

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -816,7 +816,7 @@ class TestGetLinuxDistro(CiTestCase):
 
     @mock.patch("cloudinit.util.load_file")
     def test_get_linux_ol_8_rhrelease(self, m_os_release, m_path_exists):
-        """Verify almalinux 8 read from redhat-release."""
+        """Verify Oracle Linux 8 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_OL_8
         m_path_exists.side_effect = TestGetLinuxDistro.redhat_release_exists
         dist = util.get_linux_distro()
@@ -824,7 +824,7 @@ class TestGetLinuxDistro(CiTestCase):
 
     @mock.patch("cloudinit.util.load_file")
     def test_get_linux_ol_8_osrelease(self, m_os_release, m_path_exists):
-        """Verify almalinux 8 read from os-release."""
+        """Verify Oracle Linux 8 read from os-release."""
         m_os_release.return_value = OS_RELEASE_OL_8
         m_path_exists.side_effect = TestGetLinuxDistro.os_release_exists
         dist = util.get_linux_distro()

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -201,6 +201,28 @@ OS_RELEASE_MIRACLELINUX_8 = dedent(
 """
 )
 
+OS_RELEASE_OL_8 = dedent(
+    """\
+    NAME="Oracle Linux Server"
+    VERSION="8.5"
+    ID="ol"
+    ID_LIKE="fedora"
+    VARIANT="Server"
+    VARIANT_ID="server"
+    VERSION_ID="8.5"
+    PLATFORM_ID="platform:el8"
+    PRETTY_NAME="Oracle Linux Server 8.5"
+    ANSI_COLOR="0;31"
+    CPE_NAME="cpe:/o:oracle:linux:8:5:server"
+    HOME_URL="https://linux.oracle.com/"
+    BUG_REPORT_URL="https://bugzilla.oracle.com/"
+    ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
+    ORACLE_BUGZILLA_PRODUCT_VERSION=8.5
+    ORACLE_SUPPORT_PRODUCT="Oracle Linux"
+    ORACLE_SUPPORT_PRODUCT_VERSION=8.5
+"""
+)
+
 OS_RELEASE_ROCKY_8 = dedent(
     """\
     NAME="Rocky Linux"
@@ -272,6 +294,7 @@ REDHAT_RELEASE_ALMALINUX_8 = "AlmaLinux release 8.3 (Purple Manul)"
 REDHAT_RELEASE_EUROLINUX_7 = "EuroLinux release 7.9 (Minsk)"
 REDHAT_RELEASE_EUROLINUX_8 = "EuroLinux release 8.4 (Vaduz)"
 REDHAT_RELEASE_MIRACLELINUX_8 = "MIRACLE LINUX release 8.4 (Peony)"
+REDHAT_RELEASE_OL_8 = "Oracle Linux release 8.5"
 REDHAT_RELEASE_ROCKY_8 = "Rocky Linux release 8.3 (Green Obsidian)"
 REDHAT_RELEASE_VIRTUOZZO_8 = "Virtuozzo Linux release 8"
 REDHAT_RELEASE_CLOUDLINUX_8 = "CloudLinux release 8.4 (Valery Rozhdestvensky)"
@@ -790,6 +813,22 @@ class TestGetLinuxDistro(CiTestCase):
         m_path_exists.side_effect = TestGetLinuxDistro.os_release_exists
         dist = util.get_linux_distro()
         self.assertEqual(("miraclelinux", "8", "Peony"), dist)
+
+    @mock.patch("cloudinit.util.load_file")
+    def test_get_linux_ol_8_rhrelease(self, m_os_release, m_path_exists):
+        """Verify almalinux 8 read from redhat-release."""
+        m_os_release.return_value = REDHAT_RELEASE_OL_8
+        m_path_exists.side_effect = TestGetLinuxDistro.redhat_release_exists
+        dist = util.get_linux_distro()
+        self.assertEqual(("ol", "8.5", ""), dist)
+
+    @mock.patch("cloudinit.util.load_file")
+    def test_get_linux_ol_8_osrelease(self, m_os_release, m_path_exists):
+        """Verify almalinux 8 read from os-release."""
+        m_os_release.return_value = OS_RELEASE_OL_8
+        m_path_exists.side_effect = TestGetLinuxDistro.os_release_exists
+        dist = util.get_linux_distro()
+        self.assertEqual(("ol", "8.5", ""), dist)
 
     @mock.patch("cloudinit.util.load_file")
     def test_get_linux_rocky8_rhrelease(self, m_os_release, m_path_exists):

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -52,6 +52,7 @@ mal
 mamercad
 manuelisimo
 marlluslustosa
+marthydavid
 matthewruffell
 maxnet
 megian

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -29,6 +29,7 @@ DISTRO_PKG_TYPE_MAP = {
     'redhat': 'redhat',
     'debian': 'debian',
     'ubuntu': 'debian',
+    'ol': 'redhat',
     'opensuse': 'suse',
     'suse': 'suse'
 }
@@ -72,6 +73,7 @@ DRY_DISTRO_INSTALL_PKG_CMD = {
     'centos': ['yum', 'install', '--assumeyes'],
     'eurolinux': ['yum', 'install', '--assumeyes'],
     'miraclelinux': ['yum', 'install', '--assumeyes'],
+    'ol': ['yum', 'install', '--assumeyes'],
     'redhat': ['yum', 'install', '--assumeyes'],
 }
 
@@ -285,10 +287,10 @@ def pkg_install(pkg_list, distro, test_distro=False, dry_run=False):
         cmd = DRY_DISTRO_INSTALL_PKG_CMD[distro]
     install_cmd.extend(cmd)
 
-    if distro in ['centos', 'redhat', 'rocky', 'eurolinux']:
+    if distro in ['centos', 'redhat', 'rocky', 'eurolinux', 'ol']:
         # CentOS and Redhat need epel-release to access oauthlib and jsonschema
         subprocess.check_call(install_cmd + ['epel-release'])
-    if distro in ['suse', 'opensuse', 'redhat', 'rocky', 'centos', 'eurolinux']:
+    if distro in ['suse', 'opensuse', 'redhat', 'rocky', 'centos', 'eurolinux', 'ol']:
         pkg_list.append('rpm-build')
     subprocess.check_call(install_cmd + pkg_list)
 

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -73,7 +73,7 @@ DRY_DISTRO_INSTALL_PKG_CMD = {
     'centos': ['yum', 'install', '--assumeyes'],
     'eurolinux': ['yum', 'install', '--assumeyes'],
     'miraclelinux': ['yum', 'install', '--assumeyes'],
-    'ol': ['yum', 'install', '--assumeyes'],
+    'ol': ['dnf', 'install', '--assumeyes'],
     'redhat': ['yum', 'install', '--assumeyes'],
 }
 

--- a/tools/render-cloudcfg
+++ b/tools/render-cloudcfg
@@ -23,6 +23,7 @@ def main():
         "gentoo",
         "miraclelinux",
         "netbsd",
+        "ol",
         "openbsd",
         "openEuler",
         "photon",


### PR DESCRIPTION
Add Oracle Linux 8 support
This is similar alternative as AlmaLinux or Rocky for RHEL.

## Additional Context
[oracle.com/linux](https://www.oracle.com/linux/)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
