### PR TITLE
sources/azure: drop debug print

### DIFF
--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -214,7 +214,6 @@ def report_diagnostic_event(
     msg: str, *, logger_func=None
 ) -> events.ReportingEvent:
     """Report a diagnostic event"""
-    print(msg)
     if callable(logger_func):
         logger_func(msg)
     evt = events.ReportingEvent(


### PR DESCRIPTION
Remove debug print that snuck in on a previous fixup.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
