### PR TITLE
mounts: fix mount opts string for ephemeral disk

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -393,7 +393,7 @@ def handle(_name, cfg, cloud, log, _args):
     uses_systemd = cloud.distro.uses_systemd()
     if uses_systemd:
         def_mnt_opts = (
-            "defaults,nofail, x-systemd.requires=cloud-init.service, _netdev"
+            "defaults,nofail,x-systemd.requires=cloud-init.service,_netdev"
         )
 
     defvals = [None, None, "auto", def_mnt_opts, "0", "2"]

--- a/tests/integration_tests/modules/test_disk_setup.py
+++ b/tests/integration_tests/modules/test_disk_setup.py
@@ -73,6 +73,14 @@ class TestDeviceAliases:
         assert sdb["children"][0]["mountpoint"] == "/mnt1"
         assert sdb["children"][1]["name"] == "sdb2"
         assert sdb["children"][1]["mountpoint"] == "/mnt2"
+        result = client.execute("mount -a")
+        assert result.return_code == 0
+        assert result.stdout.strip() == ""
+        assert result.stderr.strip() == ""
+        result = client.execute("findmnt -J /mnt1")
+        assert result.return_code == 0
+        result = client.execute("findmnt -J /mnt2")
+        assert result.return_code == 0
 
 
 PARTPROBE_USERDATA = """\


### PR DESCRIPTION
Fixes the spaces introduced in #1213 