### PR TITLE
Minor Documentation Improvements

### DIFF
--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -95,7 +95,6 @@ users:
 #       provided public-keys. An error will be raised if ssh_authorized_keys
 #       or ssh_import_id is provided for the same user.
 #
-#       ssh_authorized_keys.
 #   sudo: Defaults to none. Accepts a sudo rule string, a list of sudo rule
 #         strings or False to explicitly deny sudo usage. Examples:
 #
@@ -125,7 +124,7 @@ users:
 
 # Default user creation:
 #
-# Unless you define users, you will get a 'ubuntu' user on ubuntu systems with the
+# Unless you define users, you will get a 'ubuntu' user on Ubuntu systems with the
 # legacy permission (no password sudo, locked user, etc). If however, you want
 # to have the 'ubuntu' user in addition to other users, you need to instruct
 # cloud-init that you also want the default user. To do this use the following

--- a/doc/examples/cloud-config-write-files.txt
+++ b/doc/examples/cloud-config-write-files.txt
@@ -2,7 +2,7 @@
 # vim: syntax=yaml
 #
 # This is the configuration syntax that the write_files module
-# will know how to understand. encoding can be given b64 or gzip or (gz+b64).
+# will know how to understand. Encoding can be given b64 or gzip or (gz+b64).
 # The content will be decoded accordingly and then written to the path that is
 # provided. 
 #

--- a/doc/rtd/topics/boot.rst
+++ b/doc/rtd/topics/boot.rst
@@ -65,10 +65,10 @@ If this is an instance's first boot, then the selected network configuration
 is rendered.  This includes clearing of all previous (stale) configuration
 including persistent device naming with old mac addresses.
 
-This stage must block network bring-up or any stale configuration might
-already have been applied.  That could have negative effects such as DHCP
-hooks or broadcast of an old hostname.  It would also put the system in
-an odd state to recover from as it may then have to restart network
+This stage must block network bring-up or any stale configuration that might
+have already been applied.  Otherwise, that could have negative effects such
+as DHCP hooks or broadcast of an old hostname.  It would also put the system
+in an odd state to recover from, as it may then have to restart network
 devices.
 
 Cloud-init then exits and expects for the continued boot of the operating
@@ -93,7 +93,7 @@ Network
 +---------+--------+----------------------------------------------------------+
 
 This stage requires all configured networking to be online, as it will fully
-process any user-data that is found.  Here, processing means:
+process any user-data that is found.  Here processing means:
 
  * retrieve any ``#include`` or ``#include-once`` (recursively) including http
  * decompress any compressed content
@@ -106,7 +106,7 @@ from sources only available via network.  For example, a user may have
 provided user-data in a network resource that describes how local mounts
 should be done.
 
-On some clouds such as Azure, this stage will create filesystems to be
+On some clouds, such as Azure, this stage will create filesystems to be
 mounted, including ones that have stale (previous instance) references in
 ``/etc/fstab``. As such, entries ``/etc/fstab`` other than those necessary for
 cloud-init to run should not be done until after this stage.
@@ -146,7 +146,7 @@ Final
 
 This stage runs as late in boot as possible.  Any scripts that a user is
 accustomed to running after logging into a system should run correctly here.
-Things that run here include
+Things that run here include:
 
  * package installations
  * configuration management plugins (puppet, chef, salt-minion)

--- a/doc/rtd/topics/cli.rst
+++ b/doc/rtd/topics/cli.rst
@@ -17,10 +17,10 @@ option. This can be used against cloud-init itself or any of its subcommands.
     -h, --help            show this help message and exit
     --version, -v         show program's version number and exit
     --file FILES, -f FILES
-                            additional yaml configuration files to use
+                          additional yaml configuration files to use
     --debug, -d           show additional pre-action logging (default: False)
     --force               force running even if no datasource is found (use at
-                            your own risk)
+                          your own risk)
 
     Subcommands:
     {init,modules,single,query,dhclient-hook,features,analyze,devel,collect-logs,clean,status}
@@ -115,7 +115,7 @@ Current subcommands:
    containing  the jinja template header ``## template: jinja`` and renders
    that content with any instance-data.json variables present.
  * ``schema``: a **#cloud-config** format and schema
-   validator. It accepts a cloud-config yaml file and annotates potential
+   validator. It accepts a cloud-config YAML file and annotates potential
    schema errors locally without the need for deployment. Schema
    validation is work in progress and supports a subset of cloud-config
    modules.

--- a/doc/rtd/topics/contributing.rst
+++ b/doc/rtd/topics/contributing.rst
@@ -1,2 +1,2 @@
 .. include:: ../../../CONTRIBUTING.rst
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources.rst
+++ b/doc/rtd/topics/datasources.rst
@@ -4,9 +4,9 @@ Datasources
 ***********
 
 Datasources are sources of configuration data for cloud-init that typically
-come from the user (e.g. userdata) or come from the cloud that created the
-configuration drive (e.g. metadata). Typical userdata would include files,
-yaml, and shell scripts while typical metadata would include server name,
+come from the user (i.e. userdata) or come from the cloud that created the
+configuration drive (i.e. metadata). Typical userdata would include files,
+YAML, and shell scripts while typical metadata would include server name,
 instance id, display name and other cloud specific details.
 
 Since there are multiple ways to provide this data (each cloud solution seems
@@ -29,13 +29,13 @@ The following is a list of documents for each supported datasource:
 
    datasources/aliyun.rst
    datasources/altcloud.rst
+   datasources/ec2.rst
    datasources/azure.rst
    datasources/cloudsigma.rst
    datasources/cloudstack.rst
    datasources/configdrive.rst
    datasources/digitalocean.rst
    datasources/e24cloud.rst
-   datasources/ec2.rst
    datasources/exoscale.rst
    datasources/fallback.rst
    datasources/gce.rst
@@ -49,9 +49,9 @@ The following is a list of documents for each supported datasource:
    datasources/rbxcloud.rst
    datasources/smartos.rst
    datasources/upcloud.rst
-   datasources/zstack.rst
-   datasources/vultr.rst
    datasources/vmware.rst
+   datasources/vultr.rst
+   datasources/zstack.rst
 
 Creation
 ========

--- a/doc/rtd/topics/datasources/aliyun.rst
+++ b/doc/rtd/topics/datasources/aliyun.rst
@@ -86,4 +86,4 @@ If no user-data is provided, this will return a 404.
     #!/bin/sh
     echo "Hello World."
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/altcloud.rst
+++ b/doc/rtd/topics/datasources/altcloud.rst
@@ -91,4 +91,4 @@ For more information on Delta Cloud see: http://deltacloud.apache.org
 
 .. _RHEVm: https://www.redhat.com/virtualization/rhev/desktop/rhevm/
 .. _vSphere: https://www.vmware.com/products/datacenter-virtualization/vsphere/overview.html
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/azure.rst
+++ b/doc/rtd/topics/datasources/azure.rst
@@ -139,4 +139,4 @@ this by setting the hostname in the DataSource's 'get_data' method via
 behavior can be configured or disabled in the datasource config.  See
 'Configuration' above.
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/cloudsigma.rst
+++ b/doc/rtd/topics/datasources/cloudsigma.rst
@@ -39,4 +39,4 @@ value.  If this field does not exist the default value is "net".
 .. _server context: http://cloudsigma-docs.readthedocs.org/en/latest/server_context.html
 .. _meta field: http://cloudsigma-docs.readthedocs.org/en/latest/meta.html
 .. _config formats: http://cloudinit.readthedocs.org/en/latest/topics/format.html
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/cloudstack.rst
+++ b/doc/rtd/topics/datasources/cloudstack.rst
@@ -51,4 +51,4 @@ An example configuration with the default values is provided below:
 .. _Apache CloudStack: http://cloudstack.apache.org/
 .. _CloudStack Administrator Guide: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/latest/virtual_machines.html#user-data-and-meta-data
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/configdrive.rst
+++ b/doc/rtd/topics/datasources/configdrive.rst
@@ -128,4 +128,4 @@ what all can be present here.
 .. _iso9660: https://en.wikipedia.org/wiki/ISO_9660
 .. _vfat: https://en.wikipedia.org/wiki/File_Allocation_Table
 .. _the config drive extension: https://docs.openstack.org/nova/latest/admin/config-drive.html
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/digitalocean.rst
+++ b/doc/rtd/topics/datasources/digitalocean.rst
@@ -29,4 +29,4 @@ DigitalOcean's datasource can be configured as follows:
 .. _metadata service: https://developers.digitalocean.com/metadata/
 .. _Full documentation: https://developers.digitalocean.com/metadata/
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/e24cloud.rst
+++ b/doc/rtd/topics/datasources/e24cloud.rst
@@ -2,8 +2,8 @@
 
 E24Cloud
 ========
-`E24Cloud <https://www.e24cloud.com/en/>` platform provides an AWS Ec2 metadata
+`E24Cloud <https://www.e24cloud.com/en/>`_ platform provides an AWS Ec2 metadata
 service clone.  It identifies itself to guests using the dmi
 system-manufacturer (/sys/class/dmi/id/sys_vendor).
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -121,4 +121,4 @@ Notes
    For example: the primary NIC will have a DHCP route-metric of 100,
    the next NIC will be 200.
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/fallback.rst
+++ b/doc/rtd/topics/datasources/fallback.rst
@@ -15,4 +15,4 @@ will be so that the user is not left with an inaccessible instance.
 **Note:** the instance id that this datasource provides is
 ``iid-datasource-none``.
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/gce.rst
+++ b/doc/rtd/topics/datasources/gce.rst
@@ -39,4 +39,4 @@ An example configuration with the default values is provided below:
 
 .. _GCE metadata docs: https://cloud.google.com/compute/docs/storing-retrieving-metadata#querying
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/lxd.rst
+++ b/doc/rtd/topics/datasources/lxd.rst
@@ -62,4 +62,4 @@ datasource for LXD instances with a more direct support for LXD APIs instead
 of static NoCloud seed files.
 
 .. _LXD socket device: https://linuxcontainers.org/lxd/docs/master/dev-lxd
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -52,7 +52,7 @@ These user-data and meta-data files are expected to be in the following format.
 
 Both files are required to be present for it to be considered a valid seed ISO.
 
-Basically, user-data is simply user-data and meta-data is a yaml formatted file
+Basically, user-data is simply user-data and meta-data is a YAML formatted file
 representing what you'd find in the EC2 metadata service.
 
 You may also optionally provide a vendor-data file in the following format.
@@ -115,7 +115,7 @@ Example metadata:
 
 Network configuration can also be provided to cloud-init in either
 :ref:`network_config_v1` or :ref:`network_config_v2` by providing that
-yaml formatted data in a file named ``network-config``.  If found,
+YAML formatted data in a file named ``network-config``.  If found,
 this file will override a ``network-interfaces`` file.
 
 See an example below.  Note specifically that this file does not
@@ -151,4 +151,4 @@ be network configuration based on the filename.
 
 .. _iso9660: https://en.wikipedia.org/wiki/ISO_9660
 .. _vfat: https://en.wikipedia.org/wiki/File_Allocation_Table
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/opennebula.rst
+++ b/doc/rtd/topics/datasources/opennebula.rst
@@ -153,4 +153,4 @@ Example VM's context section
 .. _contextualizing VMs: http://opennebula.org/documentation:documentation:cong
 .. _network configuration: http://opennebula.org/documentation:documentation:cong#network_configuration
 .. _iso9660: https://en.wikipedia.org/wiki/ISO_9660
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/openstack.rst
+++ b/doc/rtd/topics/datasources/openstack.rst
@@ -12,10 +12,10 @@ Discovery
 To determine whether a platform looks like it may be OpenStack, cloud-init
 checks the following environment attributes as a potential OpenStack platform:
 
- * Maybe OpenStack if
+ * Maybe OpenStack if:
 
    * **non-x86 cpu architecture**: because DMI data is buggy on some arches
- * Is OpenStack **if x86 architecture and ANY** of the following
+ * Is OpenStack **if x86 architecture and ANY** of the following:
 
    * **/proc/1/environ**: Nova-lxd contains *product_name=OpenStack Nova*
    * **DMI product_name**: Either *Openstack Nova* or *OpenStack Compute*
@@ -32,7 +32,7 @@ The settings that may be configured are:
 
  * **metadata_urls**: This list of urls will be searched for an OpenStack
    metadata service. The first entry that successfully returns a 200 response
-   for <url>/openstack will be selected. (default: ['http://169.254.169.254']).
+   for <url>/openstack will be selected. (default: ['http://169.254.169.254'])
  * **max_wait**:  the maximum amount of clock time in seconds that should be
    spent searching metadata_urls.  A value less than zero will result in only
    one request being made, to the first in the list. (default: -1)
@@ -90,4 +90,4 @@ Cloud-init will look for a ``cloud-init`` at the vendor_data2 path; if found,
 settings are applied after (and, hence, overriding) the settings from static
 vendor data. Both sets of vendor data can be overridden by user data.
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/oracle.rst
+++ b/doc/rtd/topics/datasources/oracle.rst
@@ -46,4 +46,4 @@ An example configuration with the default values is provided below:
     configure_secondary_nics: false
 
 .. _Oracle Compute Infrastructure: https://cloud.oracle.com/
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/ovf.rst
+++ b/doc/rtd/topics/datasources/ovf.rst
@@ -41,6 +41,6 @@ The following VMTools configuration options affect cloud-init's behavior on a bo
 
 VMWare admin can refer to (https://github.com/canonical/cloud-init/blob/main/cloudinit/sources/helpers/vmware/imc/config.py) and set the customization specification settings.
 
-For more information, see [VMware vSphere Product Documentation](https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-9A5093A5-C54F-4502-941B-3F9C0F573A39.html) and specific VMTools parameters consumed.
+For more information, see `VMware vSphere Product Documentation <https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-9A5093A5-C54F-4502-941B-3F9C0F573A39.html>`_ and specific VMTools parameters consumed.
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/rbxcloud.rst
+++ b/doc/rtd/topics/datasources/rbxcloud.rst
@@ -22,4 +22,4 @@ is restarted, if the partition exists. For more information see
 .. _HyperOne Virtual Machine docs: http://www.hyperone.com/
 .. _FAT: https://en.wikipedia.org/wiki/File_Allocation_Table
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/smartos.rst
+++ b/doc/rtd/topics/datasources/smartos.rst
@@ -165,4 +165,4 @@ You can control the disk_setup then in 2 ways:
 
 See doc/examples/cloud-config-disk-setup.txt for information on disk_setup.
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/upcloud.rst
+++ b/doc/rtd/topics/datasources/upcloud.rst
@@ -21,4 +21,4 @@ immutable during server's lifetime and can be removed by deleting the server.
 .. _UpCloud: https://upcloud.com/
 .. _metadata service: https://upcloud.com/community/tutorials/upcloud-metadata-service/
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/vmware.rst
+++ b/doc/rtd/topics/datasources/vmware.rst
@@ -18,7 +18,7 @@ GuestInfo Keys
 ^^^^^^^^^^^^^^
 
 One method of providing meta, user, and vendor data is by setting the following
-key/value pairs on a VM's ``extraConfig`` `property <https://vdc-repo.vmware.com/vmwb-repository/dcr-public/723e7f8b-4f21-448b-a830-5f22fd931b01/5a8257bd-7f41-4423-9a73-03307535bd42/doc/vim.vm.ConfigInfo.html>`_ :
+key/value pairs on a VM's ``extraConfig`` `property <https://vdc-repo.vmware.com/vmwb-repository/dcr-public/723e7f8b-4f21-448b-a830-5f22fd931b01/5a8257bd-7f41-4423-9a73-03307535bd42/doc/vim.vm.ConfigInfo.html>`_:
 
 .. list-table::
    :header-rows: 1

--- a/doc/rtd/topics/datasources/vultr.rst
+++ b/doc/rtd/topics/datasources/vultr.rst
@@ -5,7 +5,7 @@ Vultr
 
 The `Vultr`_ datasource retrieves basic configuration values from the locally
 accessible `metadata service`_. All data is served over HTTP from the address
-169.254.169.254. The endpoints are documented in,
+169.254.169.254. The endpoints are documented in
 `https://www.vultr.com/metadata/
 <https://www.vultr.com/metadata/>`_
 
@@ -32,4 +32,4 @@ Vultr's datasource can be configured as follows:
 .. _Vultr: https://www.vultr.com/
 .. _metadata service: https://www.vultr.com/metadata/
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/datasources/zstack.rst
+++ b/doc/rtd/topics/datasources/zstack.rst
@@ -34,4 +34,4 @@ Same as EC2, instance userdata can be queried at
     user_data
     password
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/dir_layout.rst
+++ b/doc/rtd/topics/dir_layout.rst
@@ -84,4 +84,4 @@ application::
   semaphore `files` which are only supposed to run `per-once` (not tied to the
   instance id).
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/events.rst
+++ b/doc/rtd/topics/events.rst
@@ -92,4 +92,4 @@ On every boot, apply network configuration found in the datasource.
 
 .. _Cloud-init: https://launchpad.net/cloud-init
 .. _on Launchpad: https://bugs.launchpad.net/cloud-init/+bug/1936229
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/examples.rst
+++ b/doc/rtd/topics/examples.rst
@@ -179,4 +179,4 @@ Grow partitions
 
 .. _chef: http://www.chef.io/chef/
 .. _puppet: http://puppetlabs.com/
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/format.rst
+++ b/doc/rtd/topics/format.rst
@@ -89,7 +89,7 @@ Include File
 This content is a ``include`` file.
 
 The file contains a list of urls, one per line. Each of the URLs will be read,
-and their content will be passed through this same set of rules. Ie, the
+and their content will be passed through this same set of rules. I.e., the
 content read from the URL can be gzipped, mime-multi-part, or plain text. If
 an error occurs reading a file the remaining files will not be read.
 
@@ -112,7 +112,7 @@ These things include:
 - *and many more...*
 
 .. note::
-   This file must be valid yaml syntax.
+   This file must be valid YAML syntax.
 
 See the :ref:`yaml_examples` section for a commented set of examples of
 supported cloud config formats.
@@ -209,4 +209,4 @@ cloud-init from processing user-data.
 .. [#] See your cloud provider for applicable user-data size limitations...
 .. _blog: http://foss-boss.blogspot.com/2011/01/advanced-cloud-init-custom-handlers.html
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/instancedata.rst
+++ b/doc/rtd/topics/instancedata.rst
@@ -655,4 +655,4 @@ see only redacted values.
   instance booted on your favorite cloud. See :ref:`cli_devel` for more
   information.
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/integration_tests.rst
+++ b/doc/rtd/topics/integration_tests.rst
@@ -91,7 +91,7 @@ tests against the image in question.  If it's a RHEL8 image, then we
 would expect Ubuntu-specific tests to fail (and vice versa).
 
 To address this, a full image specification can be given.  This is of
-the form: ``<image_id>[::<os>[::<release]]`` where ``image_id`` is a
+the form: ``<image_id>[::<os>[::<release>]]`` where ``image_id`` is a
 cloud's image ID, ``os`` is the OS name, and ``release`` is the OS
 release name.  So, for example, Ubuntu 18.04 (Bionic Beaver) on LXD is
 ``ubuntu:bionic::ubuntu::bionic`` or RHEL 8 on Amazon is

--- a/doc/rtd/topics/logging.rst
+++ b/doc/rtd/topics/logging.rst
@@ -52,9 +52,9 @@ module using the standard python fileConfig format. Cloud-init looks for
 config for the logging module under the ``logcfg`` key.
 
 .. note::
-    the logging configuration is not yaml, it is python ``fileConfig`` format,
+    the logging configuration is not YAML, it is python ``fileConfig`` format,
     and is passed through directly to the python logging module. please use the
-    correct syntax for a multi-line string in yaml.
+    correct syntax for a multi-line string in YAML.
 
 By default, cloud-init uses the logging configuration provided in
 ``/etc/cloud/cloud.cfg.d/05_logging.cfg``. The default python logging
@@ -173,4 +173,4 @@ For more information on rsyslog configuration, see :ref:`cc_rsyslog`.
 .. _python logging config: https://docs.python.org/3/library/logging.config.html#configuration-file-format
 .. _python logging handlers: https://docs.python.org/3/library/logging.handlers.html
 .. _python logging formatters: https://docs.python.org/3/library/logging.html#formatter-objects
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/merging.rst
+++ b/doc/rtd/topics/merging.rst
@@ -6,8 +6,8 @@ Overview
 ========
 
 This was implemented because it has been a common feature request that there be
-a way to specify how cloud-config yaml "dictionaries" provided as user-data are
-merged together when there are multiple yaml files to merge together (say when
+a way to specify how cloud-config YAML "dictionaries" provided as user-data are
+merged together when there are multiple YAML files to merge together (say when
 performing an #include).
 
 Since previously the merging algorithm was very simple and would only overwrite
@@ -236,7 +236,7 @@ Other uses
 ==========
 
 In addition to being used for merging user-data sections, the default merging
-algorithm for merging 'conf.d' yaml files (which form an initial yaml config
+algorithm for merging 'conf.d' YAML files (which form an initial YAML config
 for cloud-init) was also changed to use this mechanism so its full
 benefits (and customization) can also be used there as well. Other places that
 used the previous merging are also, similarly, now extensible (metadata
@@ -285,4 +285,4 @@ The second config
      - bash4
 
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/modules.rst
+++ b/doc/rtd/topics/modules.rst
@@ -64,4 +64,4 @@ Modules
 .. automodule:: cloudinit.config.cc_users_groups
 .. automodule:: cloudinit.config.cc_write_files
 .. automodule:: cloudinit.config.cc_yum_add_repo
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/network-config-format-eni.rst
+++ b/doc/rtd/topics/network-config-format-eni.rst
@@ -17,4 +17,4 @@ Please reference existing `documentation`_ for the
 
 .. _Cloud-init: https://launchpad.net/cloud-init
 .. _documentation: http://manpages.ubuntu.com/manpages/trusty/en/man5/interfaces.5.html
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/network-config-format-v1.rst
+++ b/doc/rtd/topics/network-config-format-v1.rst
@@ -621,4 +621,4 @@ Some more examples to explore the various options available.
 
 .. _SLAAC: https://tools.ietf.org/html/rfc4862
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/network-config-format-v2.rst
+++ b/doc/rtd/topics/network-config-format-v2.rst
@@ -527,4 +527,4 @@ This is a complex example which shows most available features: ::
         dhcp4: yes
 
 .. _netplan: https://netplan.io
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/network-config.rst
+++ b/doc/rtd/topics/network-config.rst
@@ -286,4 +286,4 @@ Example output converting V2 to sysconfig:
 .. _UpCloud JSON metadata: https://developers.upcloud.com/1.3/8-servers/#metadata-service
 .. _Vultr JSON metadata: https://www.vultr.com/metadata/
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/security.rst
+++ b/doc/rtd/topics/security.rst
@@ -2,4 +2,4 @@
 
 .. mdinclude:: ../../../SECURITY.md
 
-.. vi: textwidth=78
+.. vi: textwidth=79

--- a/doc/rtd/topics/vendordata.rst
+++ b/doc/rtd/topics/vendordata.rst
@@ -68,4 +68,4 @@ of input files.  That data can then be given to an instance.
 
 See 'write-mime-multipart --help' for usage.
 
-.. vi: textwidth=78
+.. vi: textwidth=79


### PR DESCRIPTION
## Proposed Commit Message

Minor Documentation Improvements

## Summary: Minor Documentation Improvements

Primarily improved grammar for clarity.

A few Sphinx/RST syntax fixes.

Set text width to 79 characters per [footer documnentaiton](https://cloudinit.readthedocs.io/en/latest/topics/docs.html#footer) where needed.

Changed "yaml" to "YAML" when used in sentences.

## Test Steps

Checked with `tox -e doc` and verified Sphinx/RST syntax fixes in
generated HTML files manually.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
