### PR TITLE
tests: lsblk --json output changes mountpoint key to mountpoinst []

### DIFF
--- a/tests/integration_tests/modules/test_disk_setup.py
+++ b/tests/integration_tests/modules/test_disk_setup.py
@@ -70,9 +70,13 @@ class TestDeviceAliases:
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]
         assert len(sdb["children"]) == 2
         assert sdb["children"][0]["name"] == "sdb1"
-        assert sdb["children"][0]["mountpoint"] == "/mnt1"
         assert sdb["children"][1]["name"] == "sdb2"
-        assert sdb["children"][1]["mountpoint"] == "/mnt2"
+        if "mountpoint" in sdb["children"][0]:
+            assert sdb["children"][0]["mountpoint"] == "/mnt1"
+            assert sdb["children"][1]["mountpoint"] == "/mnt2"
+        else:
+            assert sdb["children"][0]["mountpoints"] == ["/mnt1"]
+            assert sdb["children"][1]["mountpoints"] == ["/mnt2"]
         result = client.execute("mount -a")
         assert result.return_code == 0
         assert result.stdout.strip() == ""
@@ -137,9 +141,13 @@ class TestPartProbeAvailability:
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]
         assert len(sdb["children"]) == 2
         assert sdb["children"][0]["name"] == "sdb1"
-        assert sdb["children"][0]["mountpoint"] == "/mnt1"
         assert sdb["children"][1]["name"] == "sdb2"
-        assert sdb["children"][1]["mountpoint"] == "/mnt2"
+        if "mountpoint" in sdb["children"][0]:
+            assert sdb["children"][0]["mountpoint"] == "/mnt1"
+            assert sdb["children"][1]["mountpoint"] == "/mnt2"
+        else:
+            assert sdb["children"][0]["mountpoints"] == ["/mnt1"]
+            assert sdb["children"][1]["mountpoints"] == ["/mnt2"]
 
     # Not bionic because the LXD agent gets in the way of us
     # changing the userdata
@@ -183,7 +191,10 @@ class TestPartProbeAvailability:
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]
         assert len(sdb["children"]) == 1
         assert sdb["children"][0]["name"] == "sdb1"
-        assert sdb["children"][0]["mountpoint"] == "/mnt3"
+        if "mountpoint" in sdb["children"][0]:
+            assert sdb["children"][0]["mountpoint"] == "/mnt3"
+        else:
+            assert sdb["children"][0]["mountpoints"] == ["/mnt3"]
 
     def test_disk_setup_no_partprobe(
         self, create_disk, client: IntegrationInstance


### PR DESCRIPTION
## Proposed Commit Message
Ubuntu Jammy output from lsblk --json now contains
'mountpoints': [...] instead of 'mountpoint' for children devs.

Let our integration test handle either case.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
 CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_KEEP_INSTANCE=true CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_OS_IMAGE=bionic::ubuntu::bionic  .tox/integration-tests/bin/pytest tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases

-- or Jammy --
 CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_KEEP_INSTANCE=true CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_OS_IMAGE=jammy::ubuntu::jammy .tox/integration-tests/bin/pytest tests/integration_tests/modules/test_disk_setup.py::TestDeviceAliases

```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
