### PR TITLE
test_apt_security: azure platform has specific security URL overrides

### DIFF
--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -267,10 +267,14 @@ class TestDefaults:
         sources_list = class_client.read_from_file("/etc/apt/sources.list")
 
         # 3 lines from main, universe, and multiverse
-        assert 3 == sources_list.count("deb http://security.ubuntu.com/ubuntu")
-        assert 3 == sources_list.count(
-            "# deb-src http://security.ubuntu.com/ubuntu"
-        )
+        sec_url = "deb http://security.ubuntu.com/ubuntu"
+        if class_client.settings.PLATFORM == "azure":
+            sec_url = (
+                "deb http://azure.archive.ubuntu.com/ubuntu/ jammy-security"
+            )
+        sec_src_url = sec_url.replace("deb ", "# deb-src ")
+        assert 3 == sources_list.count(sec_url)
+        assert 3 == sources_list.count(sec_src_url)
 
 
 DEFAULT_DATA_WITH_URI = _DEFAULT_DATA.format(


### PR DESCRIPTION
Yet another integration test fix, Azure has custom/local APT security URLs instead of security.ubuntu.com

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
test_apt_security: azure platform has specific security URL overrides

Delivered in /etc/cloud/cloud.cfg.d/90-azure.cfg
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
