### PR TITLE
applied patch from falcojr; this was intended for PR #1166, but I mad…

### DIFF
--- a/doc/rtd/topics/format.rst
+++ b/doc/rtd/topics/format.rst
@@ -38,6 +38,9 @@ Supported content-types are listed from the cloud-init subcommand make-mime:
     x-include-once-url
     x-include-url
     x-shellscript
+    x-shellscript-per-boot
+    x-shellscript-per-instance
+    x-shellscript-per-once
 
 
 Helper subcommand to generate mime messages
@@ -47,13 +50,26 @@ The cloud-init subcommand can generate MIME multi-part files: `make-mime`_.
 
 ``make-mime`` subcommand takes pairs of (filename, "text/" mime subtype)
 separated by a colon (e.g. ``config.yaml:cloud-config``) and emits a MIME
-multipart message to stdout.  An example invocation, assuming you have your
-cloud config in ``config.yaml`` and a shell script in ``script.sh`` and want
-to store the multipart message in ``user-data``:
+multipart message to stdout.
+
+Examples
+--------
+Create userdata containing both a cloud-config (``config.yaml``)
+and a shell script (``script.sh``)
 
 .. code-block:: shell-session
 
-    $ cloud-init devel make-mime -a config.yaml:cloud-config -a script.sh:x-shellscript > user-data
+    $ cloud-init devel make-mime -a config.yaml:cloud-config -a script.sh:x-shellscript > userdata
+
+Create userdata containing 3 shell scripts:
+
+- ``always.sh`` - Run every boot
+- ``instance.sh`` - Run once per instance
+- ``once.sh`` - Run once
+
+.. code-block:: shell-session
+
+    $ cloud-init devel make-mime -a always.sh:x-shellscript-per-boot -a instance.sh:x-shellscript-per-instance -a once.sh:x-shellscript-per-once
 
 .. _make-mime: https://github.com/canonical/cloud-init/blob/main/cloudinit/cmd/devel/make_mime.py
 


### PR DESCRIPTION
Docs update - a Followup to PR #1166

Towards the end of the #1166 approval process, @TheRealFalcon provided a patch for a change to a docs file (`doc/rtd/topics/format.rst`) to update the docs to capture the changes made by #1166. I mistakenly applied the patch on main, not the PR branch, and so they were missed in the PR. This PR is intended to correct that mistake.

 - [x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ x] I have updated or added any unit tests accordingly
 - [ x] I have updated or added any documentation accordingly
