### PR TITLE
docs: Add more details to runcmd docs

### DIFF
--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -37,7 +37,8 @@ meta = {
         ``sh``.
 
         Note that the ``runcmd`` module only writes the script to be run
-        later. The module that actually runs the script is ``scripts-user``.
+        later. The module that actually runs the script is ``scripts-user``
+        in the ref:`Final` boot stage.
 
         .. note::
 

--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -38,7 +38,7 @@ meta = {
 
         Note that the ``runcmd`` module only writes the script to be run
         later. The module that actually runs the script is ``scripts-user``
-        in the ref:`Final` boot stage.
+        in the :ref:`Final` boot stage.
 
         .. note::
 

--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -32,10 +32,12 @@ meta = {
         """\
         Run arbitrary commands at a rc.local like level with output to the
         console. Each item can be either a list or a string. If the item is a
-        list, it will be properly executed as if passed to ``execve()`` (with
-        the first arg as the command). If the item is a string, it will be
-        written to a file and interpreted
-        using ``sh``.
+        list, it will be properly quoted. Each item is written to
+        ``/var/lib/cloud/instance/runcmd`` to be later interpreted using
+        ``sh``.
+
+        Note that the ``runcmd`` module only writes the script to be run
+        later. The module that actually runs the script is ``scripts-user``.
 
         .. note::
 


### PR DESCRIPTION
Multiple times I have seen confusion over runcmd and how to know what it's running. It'd help to know that runcmd isn't actually executing the script and what module is.