### PR TITLE
sources/azure: fix and consolidate imds retry logic

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -639,16 +639,29 @@ def oauth_headers(
     return signed_headers
 
 
-def retry_on_url_exc(msg, exc):
-    """readurl exception_cb that will retry on NOT_FOUND and Timeout.
+def retry_on_url_exc(
+    msg,
+    exc,
+    *,
+    retry_codes=(NOT_FOUND,),
+    retry_instances=(
+        requests.Timeout,
+        requests.ConnectionError,
+    )
+):
+    """Configurable retry exception callback for readurl().
 
-    Returns False to raise the exception from readurl, True to retry.
+    :param retry_codes: Codes to retry on. Defaults to 404.
+    :param retry_instances: Exception types to retry on. Defaults to
+      requests.ConnectionError and requests.Timeout.
+
+    :returns: False to raise the exception from readurl(), True to retry.
     """
     if not isinstance(exc, UrlError):
         return False
-    if exc.code == NOT_FOUND:
+    if exc.code in retry_codes:
         return True
-    if exc.cause and isinstance(exc.cause, requests.Timeout):
+    if exc.cause and isinstance(exc.cause, retry_instances):
         return True
     return False
 


### PR DESCRIPTION
Extend retry_on_url_exc with some configurable knobs for error
codes and exception types.  Replace all custom callbacks with
this, replacing the log backoff logic with retry back-off, where
errors are logged between attempts.

Retry for codes:
- code 404 = not found (yet)
- code 410 = gone / unavailable (yet)
- code 429 = rate-limited/throttled
- code 500 = server error

Never retry for:
- code 400 = bad request (unsupported API version or malformed request)

In addition to the consolidation, this should address three issues:

1. get_imds_data_with_api_fallback() will attempt one request with
IMDS_VER_WANT.  If the connection fails due to a timeout or other
connection issue, an empty dictionary will be returned without
attempting the requested number of retries.

2. IMDS_VER_WANT will never be attempted if retries=0, such as when
fetching network metadata with infinite=True.

3. Only 404 error codes were retried in some cases.  Retry for all
above codes.
