### PR TITLE
Fix format for tests in ubuntu/devel

### DIFF
--- a/debian/apport-launcher.py
+++ b/debian/apport-launcher.py
@@ -1,6 +1,7 @@
-'''Wrapper for cloudinit apport interface'''
+"""Wrapper for cloudinit apport interface"""
 
 from cloudinit.apport import add_info as cloudinit_add_info
+
 
 def add_info(report, ui):
     return cloudinit_add_info(report, ui)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloud-init (22.1-1-gb3d9acdd-0ubuntu1~22.04.2) UNRELEASED; urgency=medium
+
+  * debian/apport-launcher.py: Fix string and whitespace formatting
+
+ -- Brett Holman <brett.holman@canonical.com>  Thu, 17 Feb 2022 11:57:57 -0700
+
 cloud-init (22.1-1-gb3d9acdd-0ubuntu1~22.04.1) jammy; urgency=medium
 
   * New upstream snapshot.


### PR DESCRIPTION
```
debian/apport-launcher.py: Fix string and whitespace formatting
```