### PR TITLE
net/dhcp: surface type of DHCP lease failure to caller

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -28,7 +28,11 @@ LOG = logging.getLogger(__name__)
 NETWORKD_LEASES_DIR = "/run/systemd/netif/leases"
 
 
-class InvalidDHCPLeaseFileError(Exception):
+class NoDHCPLeaseError(Exception):
+    """Raised when unable to get a DHCP lease."""
+
+
+class InvalidDHCPLeaseFileError(NoDHCPLeaseError):
     """Raised when parsing an empty or invalid dhcp.leases file.
 
     Current uses are DataSourceAzure and DataSourceEc2 during ephemeral
@@ -36,8 +40,12 @@ class InvalidDHCPLeaseFileError(Exception):
     """
 
 
-class NoDHCPLeaseError(Exception):
-    """Raised when unable to get a DHCP lease."""
+class NoDHCPLeaseInterfaceError(NoDHCPLeaseError):
+    """Raised when unable to find a viable interface for DHCP."""
+
+
+class NoDHCPLeaseMissingDhclientError(NoDHCPLeaseError):
+    """Raised when unable to find dhclient."""
 
 
 class EphemeralDHCPv4(object):
@@ -89,12 +97,7 @@ class EphemeralDHCPv4(object):
         """
         if self.lease:
             return self.lease
-        try:
-            leases = maybe_perform_dhcp_discovery(
-                self.iface, self.dhcp_log_func
-            )
-        except InvalidDHCPLeaseFileError as e:
-            raise NoDHCPLeaseError() from e
+        leases = maybe_perform_dhcp_discovery(self.iface, self.dhcp_log_func)
         if not leases:
             raise NoDHCPLeaseError()
         self.lease = leases[-1]
@@ -165,16 +168,16 @@ def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None):
         nic = find_fallback_nic()
         if nic is None:
             LOG.debug("Skip dhcp_discovery: Unable to find fallback nic.")
-            return []
+            raise NoDHCPLeaseInterfaceError()
     elif nic not in get_devicelist():
         LOG.debug(
             "Skip dhcp_discovery: nic %s not found in get_devicelist.", nic
         )
-        return []
+        raise NoDHCPLeaseInterfaceError()
     dhclient_path = subp.which("dhclient")
     if not dhclient_path:
         LOG.debug("Skip dhclient configuration: No dhclient command found.")
-        return []
+        raise NoDHCPLeaseMissingDhclientError()
     with temp_utils.tempdir(
         rmtree_ignore_errors=True, prefix="cloud-init-dhcp-", needs_exe=True
     ) as tdir:


### PR DESCRIPTION
When performing DHCP, it is useful for the caller to have context
on the type of failure.  This can be done with some new exceptions
types, subclassing NoDHCPLeaseError so the caller's current
contract remains.

- Add the following errors:

  - NoDHCPLeaseInterfaceError if there are problems finding
  the (possibly specified) interface.

  - NoDHCPLeaseMissingDhclientError for missing dhclient.

- Update InvalidDHCPLeaseFileError to subclass NoDHCPLeaseError.

- Pass through these errors rather than catching it in obtain_lease().

Tests:

- Add missing mock for test_provided_nic_does_not_exist().

- Add new test coverage for EphemeralDHCPv4 errors.

- Update existing tests for maybe_perform_dhcp_discovery() to match
  new behavior.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
