### PR TITLE
Clean up artifacts from pytest, packaging, release with make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,28 @@ clean_pyc:
 	@find . -type f -name "*.pyc" -delete
 	@find . -type d -name __pycache__ -delete
 
-clean: clean_pyc
-	rm -rf doc/rtd_html .tox .coverage
+clean_pytest:
+	rm -rf .cache htmlcov
+
+clean_packaging:
+	rm -rf debian srpm cloud_init.egg-info/ \
+		cloud-init-*.tar.gz \
+		cloud-init-*.tar.gz.asc \
+		cloud-init.dsc \
+		cloud-init_*.build \
+		cloud-init_*.buildinfo \
+		cloud-init_*.changes \
+		cloud-init_*.deb \
+		cloud-init_*.dsc \
+		cloud-init_*.orig.tar.gz \
+		cloud-init_*.tar.xz \
+		cloud-init_*.upload
+
+clean_release:
+	rm -rf new-upstream-changes.txt commit.msg
+
+clean: clean_pyc clean_pytest clean_packaging clean_release
+	rm -rf doc/rtd_html .tox .coverage tags
 
 yaml:
 	@$(PYTHON) $(CWD)/tools/validate-yaml.py $(YAML_FILES)
@@ -122,4 +142,5 @@ fix_spelling:
 
 .PHONY: test flake8 clean rpm srpm deb deb-src yaml
 .PHONY: check_version pip-test-requirements pip-requirements clean_pyc
-.PHONY: unittest style-check doc fix_spelling check_spelling
+.PHONY: unittest style-check doc fix_spelling
+.PHONY: clean_pytest clean_packaging check_spelling clean_release


### PR DESCRIPTION
```
Clean up artifacts from pytest, packaging, release with make clean
```

It looks like my dev directory has acquired some cruft that `make clean` doesn't currently clean. Some is pytest related, some packaging related, some release related. The `.gitignore` file currently masks some of this from git, some it doesn't. Clean it all.

Examples[1]:

```
	cloud-init-21.4-130-gf19ca12d.tar.gz
	cloud-init-21.4-130-gf19ca12d.tar.gz.asc
	cloud-init-22.1.tar.gz
	cloud-init-22.1.tar.gz.asc
	cloud-init.dsc
	cloud-init_22.1-0-gf19ca12d-1~bddeb.debian.tar.xz
	cloud-init_22.1-0-gf19ca12d-1~bddeb.dsc
	cloud-init_22.1-0-gf19ca12d-1~bddeb_source.build
	cloud-init_22.1-0-gf19ca12d-1~bddeb_source.buildinfo
	cloud-init_22.1-0-gf19ca12d-1~bddeb_source.changes
	cloud-init_22.1-0-gf19ca12d-1~bddeb~18.04.1.debian.tar.xz
	cloud-init_22.1-0-gf19ca12d-1~bddeb~18.04.1.dsc
	cloud-init_22.1-0-gf19ca12d-1~bddeb~18.04.1_source.build
	cloud-init_22.1-0-gf19ca12d-1~bddeb~18.04.1_source.buildinfo
	cloud-init_22.1-0-gf19ca12d-1~bddeb~18.04.1_source.changes
	cloud-init_22.1-0-gf19ca12d.orig.tar.gz
	cloud_init.egg-info/
	commit.msg
	debian/
	new-upstream-changes.txt
	srpm/
	tags
```

Note: It appears that `debian/rules` calls `make check`, which does not invoke the `clean` target, so this shouldn't change our packaging. I didn't see any other instances of `make` being called programmatically, so unless I missed something, this should just be a dev tool change.

Tested locally.

[1] list of all "untracked" when .gitignore is deleted 