### PR TITLE
systemctl location

### DIFF
--- a/cloudinit/analyze/show.py
+++ b/cloudinit/analyze/show.py
@@ -139,7 +139,7 @@ class SystemctlReader(object):
 
     def __init__(self, property, parameter=None):
         self.epoch = None
-        self.args = ["/bin/systemctl", "show"]
+        self.args = [subp.which("systemctl"), "show"]
         if parameter:
             self.args.append(parameter)
         self.args.extend(["-p", property])

--- a/cloudinit/config/cc_puppet.py
+++ b/cloudinit/config/cc_puppet.py
@@ -142,9 +142,9 @@ def _autostart_puppet(log):
             ],
             capture=False,
         )
-    elif os.path.exists("/bin/systemctl"):
+    elif subp.which("systemctl"):
         subp.subp(
-            ["/bin/systemctl", "enable", "puppet.service"], capture=False
+            ["systemctl", "enable", "puppet.service"], capture=False
         )
     elif os.path.exists("/sbin/chkconfig"):
         subp.subp(["/sbin/chkconfig", "puppet", "on"], capture=False)

--- a/cloudinit/config/cc_puppet.py
+++ b/cloudinit/config/cc_puppet.py
@@ -143,9 +143,7 @@ def _autostart_puppet(log):
             capture=False,
         )
     elif subp.which("systemctl"):
-        subp.subp(
-            ["systemctl", "enable", "puppet.service"], capture=False
-        )
+        subp.subp(["systemctl", "enable", "puppet.service"], capture=False)
     elif os.path.exists("/sbin/chkconfig"):
         subp.subp(["/sbin/chkconfig", "puppet", "on"], capture=False)
     else:

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -115,7 +115,7 @@ def get_boot_telemetry():
 
     try:
         out, _ = subp.subp(
-            ["/bin/systemctl", "show", "-p", "UserspaceTimestampMonotonic"],
+            ["systemctl", "show", "-p", "UserspaceTimestampMonotonic"],
             capture=True,
         )
         tsm = None
@@ -140,7 +140,7 @@ def get_boot_telemetry():
     try:
         out, _ = subp.subp(
             [
-                "/bin/systemctl",
+                "systemctl",
                 "show",
                 "cloud-init-local",
                 "-p",

--- a/tests/unittests/config/test_cc_puppet.py
+++ b/tests/unittests/config/test_cc_puppet.py
@@ -9,11 +9,12 @@ from tests.unittests.util import get_cloud
 
 LOG = logging.getLogger(__name__)
 
-
+@mock.patch("cloudinit.config.cc_puppet.subp.which")
 @mock.patch("cloudinit.config.cc_puppet.subp.subp")
 @mock.patch("cloudinit.config.cc_puppet.os")
 class TestAutostartPuppet(CiTestCase):
-    def test_wb_autostart_puppet_updates_puppet_default(self, m_os, m_subp):
+    def test_wb_autostart_puppet_updates_puppet_default(
+            self, m_os, m_subp, m_subpw):
         """Update /etc/default/puppet to autostart if it exists."""
 
         def _fake_exists(path):
@@ -37,10 +38,12 @@ class TestAutostartPuppet(CiTestCase):
             m_subp.call_args_list,
         )
 
-    def test_wb_autostart_pupppet_enables_puppet_systemctl(self, m_os, m_subp):
+    def test_wb_autostart_pupppet_enables_puppet_systemctl(
+            self, m_os, m_subp, m_subpw):
         """If systemctl is present, enable puppet via systemctl."""
 
-        m_subp.which.side_effect = '/usr/bin/systemctl'
+        m_os.path.exists.return_value = False
+        m_subpw.return_value = '/usr/bin/systemctl'
         cc_puppet._autostart_puppet(LOG)
         expected_calls = [
             mock.call(
@@ -49,13 +52,14 @@ class TestAutostartPuppet(CiTestCase):
         ]
         self.assertEqual(expected_calls, m_subp.call_args_list)
 
-    def test_wb_autostart_pupppet_enables_puppet_chkconfig(self, m_os, m_subp):
+    def test_wb_autostart_pupppet_enables_puppet_chkconfig(
+            self, m_os, m_subp, m_subpw):
         """If chkconfig is present, enable puppet via checkcfg."""
 
         def _fake_exists(path):
             return path == "/sbin/chkconfig"
 
-        m_subp.which.side_effect = None
+        m_subpw.return_value = None
         m_os.path.exists.side_effect = _fake_exists
         cc_puppet._autostart_puppet(LOG)
         expected_calls = [

--- a/tests/unittests/config/test_cc_puppet.py
+++ b/tests/unittests/config/test_cc_puppet.py
@@ -9,12 +9,14 @@ from tests.unittests.util import get_cloud
 
 LOG = logging.getLogger(__name__)
 
+
 @mock.patch("cloudinit.config.cc_puppet.subp.which")
 @mock.patch("cloudinit.config.cc_puppet.subp.subp")
 @mock.patch("cloudinit.config.cc_puppet.os")
 class TestAutostartPuppet(CiTestCase):
     def test_wb_autostart_puppet_updates_puppet_default(
-            self, m_os, m_subp, m_subpw):
+        self, m_os, m_subp, m_subpw
+    ):
         """Update /etc/default/puppet to autostart if it exists."""
 
         def _fake_exists(path):
@@ -39,21 +41,21 @@ class TestAutostartPuppet(CiTestCase):
         )
 
     def test_wb_autostart_pupppet_enables_puppet_systemctl(
-            self, m_os, m_subp, m_subpw):
+        self, m_os, m_subp, m_subpw
+    ):
         """If systemctl is present, enable puppet via systemctl."""
 
         m_os.path.exists.return_value = False
-        m_subpw.return_value = '/usr/bin/systemctl'
+        m_subpw.return_value = "/usr/bin/systemctl"
         cc_puppet._autostart_puppet(LOG)
         expected_calls = [
-            mock.call(
-                ["systemctl", "enable", "puppet.service"], capture=False
-            )
+            mock.call(["systemctl", "enable", "puppet.service"], capture=False)
         ]
         self.assertEqual(expected_calls, m_subp.call_args_list)
 
     def test_wb_autostart_pupppet_enables_puppet_chkconfig(
-            self, m_os, m_subp, m_subpw):
+        self, m_os, m_subp, m_subpw
+    ):
         """If chkconfig is present, enable puppet via checkcfg."""
 
         def _fake_exists(path):

--- a/tests/unittests/config/test_cc_puppet.py
+++ b/tests/unittests/config/test_cc_puppet.py
@@ -40,14 +40,11 @@ class TestAutostartPuppet(CiTestCase):
     def test_wb_autostart_pupppet_enables_puppet_systemctl(self, m_os, m_subp):
         """If systemctl is present, enable puppet via systemctl."""
 
-        def _fake_exists(path):
-            return path == "/bin/systemctl"
-
-        m_os.path.exists.side_effect = _fake_exists
+        m_subp.which.side_effect = '/usr/bin/systemctl'
         cc_puppet._autostart_puppet(LOG)
         expected_calls = [
             mock.call(
-                ["/bin/systemctl", "enable", "puppet.service"], capture=False
+                ["systemctl", "enable", "puppet.service"], capture=False
             )
         ]
         self.assertEqual(expected_calls, m_subp.call_args_list)
@@ -58,6 +55,7 @@ class TestAutostartPuppet(CiTestCase):
         def _fake_exists(path):
             return path == "/sbin/chkconfig"
 
+        m_subp.which.side_effect = None
         m_os.path.exists.side_effect = _fake_exists
         cc_puppet._autostart_puppet(LOG)
         expected_calls = [


### PR DESCRIPTION
## Proposed Commit Message
It is reasonable to expect that "systemctl" is found in one of the locations in the PATH
  + Using the '/bin' prefix is very distribution specific. A number of
    distributions are moving all executables from '/' to '/usr'.

```
systemctl may bot be in `/bin`

```

## Additional Context
<!-- If relevant -->

## Test Steps
cloud-init on a distribution where systmctl is in `/usr/bin` produces an error
Command: ['/bin/systemctl', 'show', '-p', 'UserspaceTimestampMonotonic']
[   37.366919] cloud-init[882]: Exit code: -
[   37.369468] cloud-init[882]: Reason: [Errno 2] No such file or directory:

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
