### PR TITLE
Fix Silently Ignored UID (SC-817)

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -529,6 +529,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 if not util.is_group(group):
                     self.create_group(group)
                     LOG.debug("created group '%s' for user '%s'", group, name)
+        if "uid" in kwargs.keys():
+            kwargs["uid"] = str(kwargs["uid"])
 
         # Check the values and create the command
         for key, val in sorted(kwargs.items()):

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -38,6 +38,10 @@ AHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
     gecos: Magic Cloud App Daemon User
     inactive: true
     system: true
+  - name: eric
+    uid: 1742
+  - name: archivist
+    uid: '1743'
 """
 
 
@@ -75,6 +79,10 @@ class TestUsersGroups:
             ),
             # Test the cloudy user
             (["passwd", "cloudy"], r"cloudy:x:[0-9]{3,4}:"),
+            # Test str uid
+            (["passwd", "eric"], r"eric:x:1742:"),
+            # Test int uid
+            (["passwd", "archivist"], r"archivist:x:1743:"),
         ],
     )
     def test_users_groups(self, regex, getent_args, class_client):


### PR DESCRIPTION
```
Do not silently ignore integer uid

The docs do not make it obvious that uid is supposed to be of type string.
Current behavior is to silently ignore integer uid.

LP: #1875772
```
## Context
Since the docs aren't clear about what type it should be, support both string and integer types. It is reasonable for the user to assume integer. Currently planned jsonschema work would have allowed a warning message when providing an "incorrect type", but in the absence of clear documentation for this key, supporting string and integer types here is more user friendly.

## Test Steps
Drop the second commit and watch the new integration test fail

Alternatively:

Verify the following userdata produces users with the correct UID.
```
#cloud-config
# Add groups to the system
groups:
  - secret: [root]
  - cloud-users

# Add users to the system. Users are added after groups are added.
users:
  - default
  - name: foobar
    gecos: Foo B. Bar
    primary_group: foobar
    groups: users
    expiredate: 2038-01-19
    lock_passwd: false
    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
  - name: barfoo
    gecos: Bar B. Foo
    sudo: ALL=(ALL) NOPASSWD:ALL
    groups: [cloud-users, secret]
    lock_passwd: true
  - name: cloudy
    gecos: Magic Cloud App Daemon User
    inactive: true
    system: true
  - name: eric
    uid: 1742
  - name: archivist
    uid: '1743'
```