### PR TITLE
Check for existing symlink while force creating symlink

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1886,7 +1886,7 @@ def is_link(path):
 
 def sym_link(source, link, force=False):
     LOG.debug("Creating symbolic link from %r => %r", link, source)
-    if force and os.path.exists(link):
+    if force and os.path.lexists(link):
         del_file(link)
     os.symlink(source, link)
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -361,6 +361,52 @@ class TestUtil(CiTestCase):
         self.assertEqual(is_rw, False)
 
 
+class TestSymlink(CiTestCase):
+    def test_sym_link_simple(self):
+        tmpd = self.tmp_dir()
+        link = self.tmp_path("link", tmpd)
+        target = self.tmp_path("target", tmpd)
+        util.write_file(target, "hello")
+
+        util.sym_link(target, link)
+        self.assertTrue(os.path.exists(link))
+        self.assertTrue(os.path.islink(link))
+
+    def test_sym_link_source_exists(self):
+        tmpd = self.tmp_dir()
+        link = self.tmp_path("link", tmpd)
+        target = self.tmp_path("target", tmpd)
+        util.write_file(target, "hello")
+
+        util.sym_link(target, link)
+        self.assertTrue(os.path.exists(link))
+
+        util.sym_link(target, link, force=True)
+        self.assertTrue(os.path.exists(link))
+
+    def test_sym_link_dangling_link(self):
+        tmpd = self.tmp_dir()
+        link = self.tmp_path("link", tmpd)
+        target = self.tmp_path("target", tmpd)
+
+        util.sym_link(target, link)
+        self.assertTrue(os.path.islink(link))
+        self.assertFalse(os.path.exists(link))
+
+        util.sym_link(target, link, force=True)
+        self.assertTrue(os.path.islink(link))
+        self.assertFalse(os.path.exists(link))
+
+    def test_sym_link_create_dangling(self):
+        tmpd = self.tmp_dir()
+        link = self.tmp_path("link", tmpd)
+        target = self.tmp_path("target", tmpd)
+
+        util.sym_link(target, link)
+        self.assertTrue(os.path.islink(link))
+        self.assertFalse(os.path.exists(link))
+
+
 class TestUptime(CiTestCase):
     @mock.patch("cloudinit.util.boottime")
     @mock.patch("cloudinit.util.os.path.exists")


### PR DESCRIPTION
If a dead symlink by the same name is present, os.path.exists returns
false.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>
Signed-off-by: Shreenidhi Shedi <yesshedi@vmware.com>

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Check for existing symlink while force creating symlink

If a dead symlink by the same name is present, os.path.exists returns
false.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
