### PR TITLE
Holmanb/integration test fix ppa

### DIFF
--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -155,6 +155,8 @@ class TestApt:
 
         assert (
             "http://ppa.launchpad.net/simplestreams-dev/trunk/ubuntu"
+            in ppa_path_contents or
+            "https://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu/"
             in ppa_path_contents
         )
 

--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -155,8 +155,8 @@ class TestApt:
 
         assert (
             "http://ppa.launchpad.net/simplestreams-dev/trunk/ubuntu"
-            in ppa_path_contents or
-            "https://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu/"
+            in ppa_path_contents
+            or "https://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu/"
             in ppa_path_contents
         )
 

--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -152,11 +152,9 @@ class TestApt:
             "/etc/apt/sources.list.d/"
             "simplestreams-dev-ubuntu-trunk-{}.list".format(release)
         )
-
+        host = "launchpad" if release == "jammy" else "launchpadcontent"
         assert (
-            "http://ppa.launchpad.net/simplestreams-dev/trunk/ubuntu"
-            in ppa_path_contents
-            or "https://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu/"
+            f"http://ppa.{host}.net/simplestreams-dev/trunk/ubuntu"
             in ppa_path_contents
         )
 


### PR DESCRIPTION
```
Update apt test for new ppa url in jammy
```

## Additional Context
Looks like [we're not the only ones](https://www.mail-archive.com/ubuntu-bugs@lists.ubuntu.com/msg5999672.html) affected by this behavior change. 

Test failures look like this:
```
07:51:15 ___________________________ TestApt.test_ppa_source ____________________________
07:51:15 
07:51:15 self = <test_apt.TestApt object at 0x7f7b6878fda0>
07:51:15 class_client = <tests.integration_tests.instances.IntegrationInstance object at 0x7f7b6554c940>
07:51:15 
07:51:15     def test_ppa_source(self, class_client: IntegrationInstance):
07:51:15         """Test the apt ppa functionality.
07:51:15     
07:51:15         Ported from
07:51:15         tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.py
07:51:15         """
07:51:15         release = ImageSpecification.from_os_image().release
07:51:15         ppa_path_contents = class_client.read_from_file(
07:51:15             "/etc/apt/sources.list.d/"
07:51:15             "simplestreams-dev-ubuntu-trunk-{}.list".format(release)
07:51:15         )
07:51:15     
07:51:15 >       assert (
07:51:15             "http://ppa.launchpad.net/simplestreams-dev/trunk/ubuntu"
07:51:15             in ppa_path_contents
07:51:15         )
07:51:15 E       AssertionError: assert 'http://ppa.launchpad.net/simplestreams-dev/trunk/ubuntu' in 'deb https://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu/ jammy main\n# deb-src https://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu/ jammy main'
07:51:15 
```