### PR TITLE
redhat: Depend on "hostname" package

### DIFF
--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -52,7 +52,8 @@
          "procps",
          "rsyslog",
          "shadow-utils",
-         "sudo"
+         "sudo",
+         "hostname"
       ]
    },
    "suse" : {


### PR DESCRIPTION
The hostname command, that cloud-init uses to apply a hostname change,
is in a package that is typically around, but not guarranteed to be.

Include it in package dependencies.

---

My CLA signature: https://github.com/canonical/cloud-init/pull/1286