### PR TITLE
tests: on AWS proper, cloud-id actually starts with aws not ec2

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -309,10 +309,10 @@ class TestCombined:
         v1_data = data["v1"]
         assert v1_data["cloud_name"] == "aws"
         assert v1_data["platform"] == "ec2"
-        # Different regions will show up as ec2-(gov|china)
-        assert v1_data["cloud_id"].startswith("ec2")
+        # Different regions will show up as aws-(gov|china)
+        assert v1_data["cloud_id"].startswith("aws")
         assert f"{v1_data['cloud_id']}" == client.read_from_file(
-            "/run/cloud-init/cloud-id-ec2"
+            "/run/cloud-init/cloud-id-aws"
         )
         assert v1_data["subplatform"].startswith("metadata")
         assert (


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: on AWS proper, cloud-id actually starts with aws not ec2

Other clouds such as aliyun, brightbox, e24cloud and zstack
which have EC2-like metadata services will not return "aws"
from cloud-id.

Example AWS instance data:
  $ cloud-init query --format '{{platform}} {{cloud_id}}'
  ec2 aws
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=ec2  tox -e integration-tests  tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
