### PR TITLE
tests: create a IPv4/IPv6 VPC in Ec2 integration tests

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -204,6 +204,14 @@ class Ec2Cloud(IntegrationCloud):
     def _get_cloud_instance(self):
         return EC2(tag="ec2-integration-test")
 
+    def _perform_launch(self, launch_kwargs, **kwargs):
+        """Use a dual-stack VPC for cloud-init integration testing."""
+        launch_kwargs["vpc"] = self.cloud_instance.get_or_create_vpc(
+            name="ec2-cloud-init-integration"
+        )
+        pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
+        return pycloudlib_instance
+
 
 class GceCloud(IntegrationCloud):
     datasource = "gce"


### PR DESCRIPTION
## Proposed Commit Message

```
tests: create a IPv4/IPv6 VPC in Ec2 integration tests

Integration tests should create their own VPC in EC2 because
an account's default VPC, subnets, security groups and ACLs
cloud be configured for for limited or unexpected connectivity.
```

<!-- Include a proposed commit message because all PRs are squash merged -->

## Test Steps
```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=ec2  tox -e integration-tests  tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
