### PR TITLE
test_ppa_source: accept both http and https URLs (SC-825)

### DIFF
--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -154,7 +154,7 @@ class TestApt:
         )
         host = "launchpad" if release == "jammy" else "launchpadcontent"
         assert (
-            f"http://ppa.{host}.net/simplestreams-dev/trunk/ubuntu"
+            f"://ppa.{host}.net/simplestreams-dev/trunk/ubuntu"
             in ppa_path_contents
         )
 


### PR DESCRIPTION
software-properties 0.99.18 now adds PPAs with HTTPS URLs in
sources.list when using add-apt-repository. This change only
affects Jammy.

We could use a regexp to match both, but it's simpler to just remove
the protocol from the search string.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
test_ppa_source: accept both http and https URLs

software-properties 0.99.18 (>= Jammy) adds PPAs with
HTTPS URLs in sources.list when using add-apt-repository.
Older versions still add plain HTTP URLs.

We could use a regexp to match both, but it's simpler to just
remove the protocol from the search string.
```

## Additional Context
<!-- If relevant -->

Spotted by Jenkins.

```
 AssertionError: assert 'http://ppa.launchpad.net/simplestreams-dev/trunk/ubuntu' in 'deb https://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu/ jammy main\n# deb-src https://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu/ jammy main'
 ```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Run the test against on Jammy.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
