### PR TITLE
retain commented APT partner pocket in sources list

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,8 @@
 cloud-init (22.1-1-gb3d9acdd-0ubuntu1~18.04.1) bionic; urgency=medium
 
+  * d/patches/retain-apt-partner-pocket.patch:
+    - Jammy dropped commented APT partner pocket. Retain this comment on
+      stable releases.
   * d/apport-launcher.py Fix format
   * d/cloud-init.templates: Move LXD to back of datasource_list
   * refresh patches:
@@ -58,8 +61,6 @@ cloud-init (22.1-1-gb3d9acdd-0ubuntu1~18.04.1) bionic; urgency=medium
     - fix parallel tox execution (#1214)
     - sources/azure: refactor _report_ready_if_needed and _poll_imds (#1222)
       [Chris Patterson]
-    - Do not support setting up archive.canonical.com as a source (#1219)
-      [Steve Langasek]
     - Vultr: Fix lo being used for DHCP, try next on cmd fail (#1208) [eb3095]
     - sources/azure: refactor _should_reprovision[_after_nic_attach]() logic
       (#1206) [Chris Patterson]

--- a/debian/patches/retain-apt-partner-pocket.patch
+++ b/debian/patches/retain-apt-partner-pocket.patch
@@ -1,0 +1,25 @@
+Description: Retain commented APT partner pocket in sources.list template
+Author: chad.smith@canonical.com
+Origin: backport
+Forwarded: not-needed
+Last-Update: 2022-02-22
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Index: cloud-init/templates/sources.list.ubuntu.tmpl
+===================================================================
+--- cloud-init.orig/templates/sources.list.ubuntu.tmpl
++++ cloud-init/templates/sources.list.ubuntu.tmpl
+@@ -43,6 +43,13 @@ deb {{mirror}} {{codename}}-updates mult
+ deb {{mirror}} {{codename}}-backports main restricted universe multiverse
+ # deb-src {{mirror}} {{codename}}-backports main restricted universe multiverse
+ 
++## Uncomment the following two lines to add software from Canonical's
++## 'partner' repository.
++## This software is not part of Ubuntu, but is offered by Canonical and the
++## respective vendors as a service to Ubuntu users.
++# deb http://archive.canonical.com/ubuntu {{codename}} partner
++# deb-src http://archive.canonical.com/ubuntu {{codename}} partner
++
+ deb {{security}} {{codename}}-security main restricted
+ # deb-src {{security}} {{codename}}-security main restricted
+ deb {{security}} {{codename}}-security universe

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 openstack-no-network-config.patch
 ec2-dont-apply-full-imds-network-config.patch
 renderer-do-not-prefer-netplan.patch
+retain-apt-partner-pocket.patch


### PR DESCRIPTION
revert of upstream 0362abcd

We need to revert one minor PR to retain original behavior on impish/focal/bionic for default APT sources templates.

Steps to create this PR:
https://github.com/canonical/uss-tableflip/blob/main/doc/ubuntu_release_process.md#adding-a-quilt-patch-to-debianpatches

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate bug reference or remove
this line entirely if there is no associated bug)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
