### PR TITLE
Integration test fix ppa 

### DIFF
--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -152,9 +152,10 @@ class TestApt:
             "/etc/apt/sources.list.d/"
             "simplestreams-dev-ubuntu-trunk-{}.list".format(release)
         )
-        host = "launchpadcontent" if release == "jammy" else "launchpad"
         assert (
-            f"://ppa.{host}.net/simplestreams-dev/trunk/ubuntu"
+            "://ppa.launchpad.net/simplestreams-dev/trunk/ubuntu"
+            in ppa_path_contents
+            or "://ppa.launchpadcontent.net/simplestreams-dev/trunk/ubuntu"
             in ppa_path_contents
         )
 

--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -152,7 +152,7 @@ class TestApt:
             "/etc/apt/sources.list.d/"
             "simplestreams-dev-ubuntu-trunk-{}.list".format(release)
         )
-        host = "launchpad" if release == "jammy" else "launchpadcontent"
+        host = "launchpadcontent" if release == "jammy" else "launchpad"
         assert (
             f"://ppa.{host}.net/simplestreams-dev/trunk/ubuntu"
             in ppa_path_contents


### PR DESCRIPTION
```
Fix integration test ppa url
```

Per https://github.com/canonical/cloud-init/pull/1287/files/a677b2486f8a945d35c0f9a5d295063aa9b69209#r812973166, the url conditional is backwards.