### PR TITLE
Better interface handling for Vultr, expect unexpected DHCP servers

### DIFF
--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -28,7 +28,7 @@ def get_metadata(url, timeout, retries, sec_between, agent):
                 iface=iface[0], connectivity_url_data={"url": url}
             ):
                 # Check for the metadata route, skip if not there
-                if not check_route():
+                if not check_route(url):
                     continue
 
                 # Fetch the metadata
@@ -65,7 +65,7 @@ def get_interface_list():
 
 # Check for /32 route that our dhcp servers inject
 # in order to determine if this a customer-run dhcp server
-def check_route():
+def check_route(url):
     # Get routes, confirm entry exists
     routes = netinfo.route_info()
 
@@ -75,7 +75,7 @@ def check_route():
 
     # Parse each route into a more searchable format
     for route in routes["ipv4"]:
-        if "169.254.169.254" in route["destination"]:
+        if route.get("destination", None) in url:
             return True
 
     return False
@@ -168,7 +168,7 @@ def generate_network_config(interfaces):
         interface = interfaces[i]
 
         # Skip interfaces set not to be configured
-        if "unconfigured" in interface and interface["unconfigured"]:
+        if interface.get("unconfigured"):
             continue
 
         private = generate_interface(interface)

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -5,9 +5,11 @@
 import json
 from functools import lru_cache
 
+from requests import exceptions
+
 from cloudinit import dmi
 from cloudinit import log as log
-from cloudinit import net, subp, url_helper, util
+from cloudinit import net, netinfo, subp, url_helper, util
 from cloudinit.net.dhcp import EphemeralDHCPv4, NoDHCPLeaseError
 
 # Get LOG
@@ -20,24 +22,63 @@ def get_metadata(url, timeout, retries, sec_between, agent):
     exception = RuntimeError("Failed to DHCP")
 
     # Seek iface with DHCP
+    for iface in get_interface_list():
+        try:
+            with EphemeralDHCPv4(
+                iface=iface[0], connectivity_url_data={"url": url}
+            ):
+                # Check for the metadata route, skip if not there
+                if not check_route():
+                    continue
+
+                # Fetch the metadata
+                v1 = read_metadata(url, timeout, retries, sec_between, agent)
+
+                return json.loads(v1)
+        except (
+            NoDHCPLeaseError,
+            subp.ProcessExecutionError,
+            RuntimeError,
+            exceptions.RequestException,
+        ) as exc:
+            LOG.error("DHCP Exception: %s", exc)
+            exception = exc
+    raise exception
+
+
+# Get interface list, sort, and clean
+# Should be replaced with find_candidate_nics
+# Dummy and lo will remain to need to be removed
+def get_interface_list():
+    ifaces = []
     for iface in net.get_interfaces():
         # Skip dummy, lo interfaces
         if "dummy" in iface[0]:
             continue
         if "lo" == iface[0]:
             continue
-        try:
-            with EphemeralDHCPv4(
-                iface=iface[0], connectivity_url_data={"url": url}
-            ):
-                # Fetch the metadata
-                v1 = read_metadata(url, timeout, retries, sec_between, agent)
+        ifaces.append(iface)
 
-                return json.loads(v1)
-        except (NoDHCPLeaseError, subp.ProcessExecutionError) as exc:
-            LOG.error("DHCP Exception: %s", exc)
-            exception = exc
-    raise exception
+    # Sort alphabetically
+    return sorted(ifaces, key=lambda i: i[0])
+
+
+# Check for /32 route that our dhcp servers inject
+# in order to determine if this a customer-run dhcp server
+def check_route():
+    # Get routes, confirm entry exists
+    routes = netinfo.route_info()
+
+    # If no tools exist and empty dict is returned
+    if "ipv4" not in routes:
+        return False
+
+    # Parse each route into a more searchable format
+    for route in routes["ipv4"]:
+        if "169.254.169.254" in route["destination"]:
+            return True
+
+    return False
 
 
 # Read the system information from SMBIOS
@@ -124,7 +165,13 @@ def generate_network_config(interfaces):
 
     # Prepare additional interfaces, private
     for i in range(1, len(interfaces)):
-        private = generate_interface(interfaces[i])
+        interface = interfaces[i]
+
+        # Skip interfaces set not to be configured
+        if "unconfigured" in interface and interface["unconfigured"]:
+            continue
+
+        private = generate_interface(interface)
         network["config"].append(private)
 
     return network

--- a/tests/unittests/sources/test_vultr.py
+++ b/tests/unittests/sources/test_vultr.py
@@ -149,6 +149,18 @@ INTERFACES = [
     ["eth2", "56:00:03:15:c4:03", "drv", "devid3"],
 ]
 
+ORDERED_INTERFACES = [
+    ["eth0", "56:00:03:15:c4:04", "drv", "devid4"],
+    ["eth1", "56:00:03:15:c4:02", "drv", "devid2"],
+    ["eth2", "56:00:03:15:c4:03", "drv", "devid3"],
+]
+
+FILTERED_INTERFACES = [
+    ["eth1", "56:00:03:15:c4:02", "drv", "devid2"],
+    ["eth2", "56:00:03:15:c4:03", "drv", "devid3"],
+    ["eth0", "56:00:03:15:c4:04", "drv", "devid4"],
+]
+
 # Expected generated objects
 
 # Expected config
@@ -224,7 +236,15 @@ INTERFACE_MAP = {
 }
 
 
-EPHERMERAL_USED = ""
+FINAL_INTERFACE_USED = ""
+
+
+# Static override, pylint doesnt like this in
+# classes without self
+def check_route():
+    if FINAL_INTERFACE_USED == "eth0":
+        return True
+    return False
 
 
 class TestDataSourceVultr(CiTestCase):
@@ -297,32 +317,59 @@ class TestDataSourceVultr(CiTestCase):
     @mock.patch("cloudinit.net.get_interfaces_by_mac")
     def test_private_network_config(self, mock_netmap):
         mock_netmap.return_value = INTERFACE_MAP
-        interf = VULTR_V1_2["interfaces"]
+        interf = VULTR_V1_2["interfaces"].copy()
 
+        # Test configuring
         self.assertEqual(
             EXPECTED_VULTR_NETWORK_2, vultr.generate_network_config(interf)
         )
 
+        # Test unconfigured
+        interf[1]["unconfigured"] = True
+        expected = EXPECTED_VULTR_NETWORK_2.copy()
+        expected["config"].pop(2)
+        self.assertEqual(expected, vultr.generate_network_config(interf))
+
+    # Override ephemeral for proper unit testing
     def ephemeral_init(self, iface="", connectivity_url_data=None):
-        global EPHERMERAL_USED
-        EPHERMERAL_USED = iface
+        global FINAL_INTERFACE_USED
+        FINAL_INTERFACE_USED = iface
         if iface == "eth0":
             return
         raise NoDHCPLeaseError("Generic for testing")
 
+    # Override ephemeral for proper unit testing
+    def ephemeral_init_always(self, iface="", connectivity_url_data=None):
+        global FINAL_INTERFACE_USED
+        FINAL_INTERFACE_USED = iface
+
+    # Override ephemeral for proper unit testing
+    def override_enter(self):
+        return
+
+    # Override ephemeral for proper unit testing
+    def override_exit(self, excp_type, excp_value, excp_traceback):
+        return
+
     # Test interface seeking to ensure we are able to find the correct one
     @mock.patch("cloudinit.net.dhcp.EphemeralDHCPv4.__init__", ephemeral_init)
+    @mock.patch("cloudinit.net.dhcp.EphemeralDHCPv4.__enter__", override_enter)
+    @mock.patch("cloudinit.net.dhcp.EphemeralDHCPv4.__exit__", override_exit)
+    @mock.patch("cloudinit.sources.helpers.vultr.check_route")
     @mock.patch("cloudinit.sources.helpers.vultr.is_vultr")
     @mock.patch("cloudinit.sources.helpers.vultr.read_metadata")
-    @mock.patch("cloudinit.net.get_interfaces")
+    @mock.patch("cloudinit.sources.helpers.vultr.get_interface_list")
     def test_interface_seek(
-        self, mock_get_interfaces, mock_read_metadata, mock_isvultr
+        self,
+        mock_interface_list,
+        mock_read_metadata,
+        mock_isvultr,
+        mock_check_route,
     ):
-        mock_read_metadata.side_effect = NoDHCPLeaseError(
-            "Generic for testing"
-        )
+        mock_read_metadata.return_value = {}
         mock_isvultr.return_value = True
-        mock_get_interfaces.return_value = INTERFACES
+        mock_interface_list.return_value = FILTERED_INTERFACES
+        mock_check_route.return_value = True
 
         source = DataSourceVultr.DataSourceVultr(
             settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
@@ -333,7 +380,41 @@ class TestDataSourceVultr(CiTestCase):
         except Exception:
             pass
 
-        self.assertEqual(EPHERMERAL_USED, INTERFACES[3][0])
+        self.assertEqual(FINAL_INTERFACE_USED, INTERFACES[3][0])
+
+    # Test route checking sucessful DHCPs
+    @mock.patch("cloudinit.sources.helpers.vultr.check_route", check_route)
+    @mock.patch(
+        "cloudinit.net.dhcp.EphemeralDHCPv4.__init__", ephemeral_init_always
+    )
+    @mock.patch("cloudinit.net.dhcp.EphemeralDHCPv4.__enter__", override_enter)
+    @mock.patch("cloudinit.net.dhcp.EphemeralDHCPv4.__exit__", override_exit)
+    @mock.patch("cloudinit.sources.helpers.vultr.get_interface_list")
+    @mock.patch("cloudinit.sources.helpers.vultr.is_vultr")
+    @mock.patch("cloudinit.sources.helpers.vultr.read_metadata")
+    def test_interface_seek_route_check(
+        self, mock_read_metadata, mock_isvultr, mock_interface_list
+    ):
+        mock_read_metadata.return_value = {}
+        mock_interface_list.return_value = FILTERED_INTERFACES
+        mock_isvultr.return_value = True
+
+        source = DataSourceVultr.DataSourceVultr(
+            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+        )
+
+        try:
+            source._get_data()
+        except Exception:
+            pass
+
+        self.assertEqual(FINAL_INTERFACE_USED, INTERFACES[3][0])
+
+    # Test interface list to ensure alphabetical and cleaned
+    @mock.patch("cloudinit.net.get_interfaces")
+    def test_interface_list(self, mock_get_interfaces):
+        mock_get_interfaces.return_value = INTERFACES
+        self.assertEqual(ORDERED_INTERFACES, vultr.get_interface_list())
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/sources/test_vultr.py
+++ b/tests/unittests/sources/test_vultr.py
@@ -241,7 +241,7 @@ FINAL_INTERFACE_USED = ""
 
 # Static override, pylint doesnt like this in
 # classes without self
-def check_route():
+def check_route(url):
     if FINAL_INTERFACE_USED == "eth0":
         return True
     return False


### PR DESCRIPTION
## Proposed Commit Message
Better interface handling for Vultr, expect unexpected DHCP servers

```
If a private interface is configured, has a DHCP server on it, and Cloud-Init runs, the Datasource fails to fail over to the next interface interrupting seeking. Configuring it as such can also lead to delays in deploy time if it did. This sorts the interface list to limit the potential of this occurring. Checks for the metadata route before trying, and now appropriately fails over if those contingencies fails by appropriately continuing to seek on metadata failure as was originally intended. Ideally the upcoming candidate_nic would of been used here to avoid the interface list function.
```

## Additional Context
The complexity here is due to the wild inconsistency on the platform. An image may end up on a vm, or a baremetal server, or not even be made by us. Options to handle this has been limited. New unittests were added to keep this in check as well.

## Test Steps
Deploy a server with a private interface with a dhcp server running on the private network.

## Checklist:
 - [ X ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [ X ] I have updated or added any unit tests accordingly
 - [ X ] I have updated or added any documentation accordingly
