### PR TITLE
Suppress FileNotFoundError when reading status

### DIFF
--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -5,7 +5,6 @@
 """Define 'status' utility and handler as part of cloud-init commandline."""
 
 import argparse
-import contextlib
 import enum
 import os
 import sys
@@ -142,8 +141,7 @@ def get_status_details(paths=None):
     if os.path.exists(status_file):
         if not os.path.exists(result_file):
             status = UXAppStatus.RUNNING
-        with contextlib.suppress(FileNotFoundError):
-            status_v1 = load_json(load_file(status_file)).get("v1", {})
+        status_v1 = load_json(load_file(status_file)).get("v1", {})
     errors = []
     latest_event = 0
     for key, value in sorted(status_v1.items()):

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -5,6 +5,7 @@
 """Define 'status' utility and handler as part of cloud-init commandline."""
 
 import argparse
+import contextlib
 import enum
 import os
 import sys
@@ -141,7 +142,8 @@ def get_status_details(paths=None):
     if os.path.exists(status_file):
         if not os.path.exists(result_file):
             status = UXAppStatus.RUNNING
-        status_v1 = load_json(load_file(status_file)).get("v1", {})
+        with contextlib.suppress(FileNotFoundError):
+            status_v1 = load_json(load_file(status_file)).get("v1", {})
     errors = []
     latest_event = 0
     for key, value in sorted(status_v1.items()):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1887,7 +1887,12 @@ def is_link(path):
 def sym_link(source, link, force=False):
     LOG.debug("Creating symbolic link from %r => %r", link, source)
     if force and os.path.lexists(link):
-        del_file(link)
+        # Provide atomic update of symlink to avoid races with status --wait
+        # LP: #1962150
+        tmp_link = os.path.join(os.path.dirname(link), "tmp" + rand_str(8))
+        os.symlink(source, tmp_link)
+        os.replace(tmp_link, link)
+        return
     os.symlink(source, link)
 
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -376,13 +376,16 @@ class TestSymlink(CiTestCase):
         tmpd = self.tmp_dir()
         link = self.tmp_path("link", tmpd)
         target = self.tmp_path("target", tmpd)
+        target2 = self.tmp_path("target2", tmpd)
         util.write_file(target, "hello")
+        util.write_file(target2, "hello2")
 
         util.sym_link(target, link)
         self.assertTrue(os.path.exists(link))
 
-        util.sym_link(target, link, force=True)
+        util.sym_link(target2, link, force=True)
         self.assertTrue(os.path.exists(link))
+        self.assertEqual("hello2", util.load_file(link))
 
     def test_sym_link_dangling_link(self):
         tmpd = self.tmp_dir()


### PR DESCRIPTION
The status file read here is a symlink which is not atomically
updated, since `get_status_details` already copes with not being able
to read the status file, we simply suppress the error reading it.

LP:1962150

## Test Steps
TODO: Needs appropriate testing.

Passes unit tests locally

## Checklist:
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
