### PR TITLE
Fix link in CLA check to point to contribution guide.

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,8 +18,8 @@ jobs:
           In order for us to merge this pull request, you need
           to have signed the Contributor License Agreement (CLA).
           Please sign the CLA by following our
-          hacking guide at:
-            https://cloudinit.readthedocs.io/en/latest/topics/hacking.html
+          contribution guide at:
+            https://cloudinit.readthedocs.io/en/latest/topics/contributing.html
 
           Thanks,
           Your friendly cloud-init upstream


### PR DESCRIPTION
Fix link in CLA check to point to contribution guide

The CLA check should point users to the contribution guide, the hacking guide is a 404.

## Test Steps
See CLA results from a recent PR and verify it points to the contribution guide

Verify that the URL mentioned is 200 OK

## Checklist:
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
