### PR TITLE
Make VMWare data source test host independent and expand testing

### DIFF
--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -7,6 +7,7 @@
 import base64
 import gzip
 import os
+from contextlib import ExitStack
 
 import pytest
 
@@ -59,13 +60,26 @@ runcmd:
 
 @pytest.fixture(autouse=True)
 def common_patches():
-    with mock.patch("cloudinit.util.platform.platform", return_value="Linux"):
-        with mock.patch.multiple(
+    mocks = [
+        mock.patch("cloudinit.util.platform.platform", return_value="Linux"),
+        mock.patch.multiple(
             "cloudinit.dmi",
             is_container=mock.Mock(return_value=False),
             is_FreeBSD=mock.Mock(return_value=False),
-        ):
-            yield
+        ),
+        mock.patch(
+            "cloudinit.sources.DataSourceVMware.netifaces.interfaces",
+            return_value=[],
+        ),
+        mock.patch(
+            "cloudinit.sources.DataSourceVMware.getfqdn",
+            return_value="host.cloudinit.test",
+        ),
+    ]
+    with ExitStack() as stack:
+        for some_mock in mocks:
+            stack.enter_context(some_mock)
+        yield
 
 
 class TestDataSourceVMware(CiTestCase):
@@ -83,13 +97,9 @@ class TestDataSourceVMware(CiTestCase):
         ret = ds.get_data()
         self.assertFalse(ret)
 
-    @mock.patch("cloudinit.sources.DataSourceVMware.netifaces.interfaces")
     @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")
-    @mock.patch("cloudinit.sources.DataSourceVMware.getfqdn")
-    def test_get_host_info_ipv4(self, m_fn_fqdn, m_fn_ipaddr, m_fn_ifaces):
-        m_fn_fqdn.return_value = "host.cloudinit.test"
+    def test_get_host_info_ipv4(self, m_fn_ipaddr):
         m_fn_ipaddr.return_value = ("10.10.10.1", None)
-        m_fn_ifaces.return_value = []
         host_info = DataSourceVMware.get_host_info()
         self.assertTrue(host_info)
         self.assertTrue(host_info["hostname"])
@@ -100,13 +110,9 @@ class TestDataSourceVMware(CiTestCase):
         self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4] == "10.10.10.1")
         self.assertFalse(host_info.get(DataSourceVMware.LOCAL_IPV6))
 
-    @mock.patch("cloudinit.sources.DataSourceVMware.netifaces.interfaces")
     @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")
-    @mock.patch("cloudinit.sources.DataSourceVMware.getfqdn")
-    def test_get_host_info_ipv6(self, m_fn_fqdn, m_fn_ipaddr, m_fn_ifaces):
-        m_fn_fqdn.return_value = "host.cloudinit.test"
+    def test_get_host_info_ipv6(self, m_fn_ipaddr):
         m_fn_ipaddr.return_value = (None, "2001:db8::::::8888")
-        m_fn_ifaces.return_value = []
         host_info = DataSourceVMware.get_host_info()
         self.assertTrue(host_info)
         self.assertTrue(host_info["hostname"])
@@ -119,13 +125,9 @@ class TestDataSourceVMware(CiTestCase):
         )
         self.assertFalse(host_info.get(DataSourceVMware.LOCAL_IPV4))
 
-    @mock.patch("cloudinit.sources.DataSourceVMware.netifaces.interfaces")
     @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")
-    @mock.patch("cloudinit.sources.DataSourceVMware.getfqdn")
-    def test_get_host_info_dual(self, m_fn_fqdn, m_fn_ipaddr, m_fn_ifaces):
-        m_fn_fqdn.return_value = "host.cloudinit.test"
+    def test_get_host_info_dual(self, m_fn_ipaddr):
         m_fn_ipaddr.return_value = ("10.10.10.1", "2001:db8::::::8888")
-        m_fn_ifaces.return_value = []
         host_info = DataSourceVMware.get_host_info()
         self.assertTrue(host_info)
         self.assertTrue(host_info["hostname"])

--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -83,82 +83,60 @@ class TestDataSourceVMware(CiTestCase):
         ret = ds.get_data()
         self.assertFalse(ret)
 
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.netifaces.interfaces"
-    )
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.get_default_ip_addrs"
-    )
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.getfqdn"
-    )
+    @mock.patch("cloudinit.sources.DataSourceVMware.netifaces.interfaces")
+    @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")
+    @mock.patch("cloudinit.sources.DataSourceVMware.getfqdn")
     def test_get_host_info_ipv4(self, m_fn_fqdn, m_fn_ipaddr, m_fn_ifaces):
-        m_fn_fqdn.return_value = 'host.cloudinit.test'
-        m_fn_ipaddr.return_value = ('10.10.10.1', None)
+        m_fn_fqdn.return_value = "host.cloudinit.test"
+        m_fn_ipaddr.return_value = ("10.10.10.1", None)
         m_fn_ifaces.return_value = []
         host_info = DataSourceVMware.get_host_info()
         self.assertTrue(host_info)
         self.assertTrue(host_info["hostname"])
-        self.assertTrue(host_info["hostname"] == 'host.cloudinit.test')
+        self.assertTrue(host_info["hostname"] == "host.cloudinit.test")
         self.assertTrue(host_info["local-hostname"])
         self.assertTrue(host_info["local_hostname"])
         self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4])
-        self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4] == '10.10.10.1')
+        self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4] == "10.10.10.1")
         self.assertFalse(host_info.get(DataSourceVMware.LOCAL_IPV6))
 
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.netifaces.interfaces"
-    )
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.get_default_ip_addrs"
-    )
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.getfqdn"
-    )
+    @mock.patch("cloudinit.sources.DataSourceVMware.netifaces.interfaces")
+    @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")
+    @mock.patch("cloudinit.sources.DataSourceVMware.getfqdn")
     def test_get_host_info_ipv6(self, m_fn_fqdn, m_fn_ipaddr, m_fn_ifaces):
-        m_fn_fqdn.return_value = 'host.cloudinit.test'
-        m_fn_ipaddr.return_value = (
-            None, '2001:db8::::::8888'
-        )
+        m_fn_fqdn.return_value = "host.cloudinit.test"
+        m_fn_ipaddr.return_value = (None, "2001:db8::::::8888")
         m_fn_ifaces.return_value = []
         host_info = DataSourceVMware.get_host_info()
         self.assertTrue(host_info)
         self.assertTrue(host_info["hostname"])
-        self.assertTrue(host_info["hostname"] == 'host.cloudinit.test')
+        self.assertTrue(host_info["hostname"] == "host.cloudinit.test")
         self.assertTrue(host_info["local-hostname"])
         self.assertTrue(host_info["local_hostname"])
         self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV6])
         self.assertTrue(
-            host_info[DataSourceVMware.LOCAL_IPV6] == '2001:db8::::::8888'
+            host_info[DataSourceVMware.LOCAL_IPV6] == "2001:db8::::::8888"
         )
         self.assertFalse(host_info.get(DataSourceVMware.LOCAL_IPV4))
 
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.netifaces.interfaces"
-    )
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.get_default_ip_addrs"
-    )
-    @mock.patch(
-        "cloudinit.sources.DataSourceVMware.getfqdn"
-    )
+    @mock.patch("cloudinit.sources.DataSourceVMware.netifaces.interfaces")
+    @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")
+    @mock.patch("cloudinit.sources.DataSourceVMware.getfqdn")
     def test_get_host_info_dual(self, m_fn_fqdn, m_fn_ipaddr, m_fn_ifaces):
-        m_fn_fqdn.return_value = 'host.cloudinit.test'
-        m_fn_ipaddr.return_value = (
-            '10.10.10.1', '2001:db8::::::8888'
-        )
+        m_fn_fqdn.return_value = "host.cloudinit.test"
+        m_fn_ipaddr.return_value = ("10.10.10.1", "2001:db8::::::8888")
         m_fn_ifaces.return_value = []
         host_info = DataSourceVMware.get_host_info()
         self.assertTrue(host_info)
         self.assertTrue(host_info["hostname"])
-        self.assertTrue(host_info["hostname"] == 'host.cloudinit.test')
+        self.assertTrue(host_info["hostname"] == "host.cloudinit.test")
         self.assertTrue(host_info["local-hostname"])
         self.assertTrue(host_info["local_hostname"])
         self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4])
-        self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4] == '10.10.10.1')
+        self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4] == "10.10.10.1")
         self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV6])
         self.assertTrue(
-            host_info[DataSourceVMware.LOCAL_IPV6] == '2001:db8::::::8888'
+            host_info[DataSourceVMware.LOCAL_IPV6] == "2001:db8::::::8888"
         )
 
 


### PR DESCRIPTION

## Proposed Commit Message
Make VMWare data source test host independent and expand testing

```
summary: no more than 70 characters
At present the test to get the host info is dependent on the network
of the host on which the test is run. If there is no network the test will
fail. Make the test host independent by applying appropriate mocks and
expand the test to cover ipv4, ipv6, and dual stack setups.

```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
