### PR TITLE
Support EC2 tags in instance metadata

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -61,8 +61,9 @@ class DataSourceEc2(sources.DataSource):
     min_metadata_version = "2009-04-04"
 
     # Priority ordered list of additional metadata versions which will be tried
-    # for extended metadata content. IPv6 support comes in 2016-09-02
-    extended_metadata_versions = ["2018-09-24", "2016-09-02"]
+    # for extended metadata content. IPv6 support comes in 2016-09-02.
+    # Tags support comes in 2021-03-23.
+    extended_metadata_versions = ["2021-03-23", "2018-09-24", "2016-09-02"]
 
     # Setup read_url parameters per get_url_params.
     url_max_wait = 120

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -38,15 +38,26 @@ Userdata is accessible via the following URL:
     GET http://169.254.169.254/2009-04-04/user-data
     1234,fred,reboot,true | 4512,jimbo, | 173,,,
 
-Note that there are multiple versions of this data provided, cloud-init
-by default uses **2009-04-04** but newer versions can be supported with
-relative ease (newer versions have more data exposed, while maintaining
-backward compatibility with the previous versions).
-Version **2016-09-02** is required for secondary IP address support.
+Note that there are multiple EC2 Metadata versions of this data provided
+to instances. cloud-init will attempt to use the most recent API version it
+supports in order to get latest API features and instance-data. If a given
+API version is not exposed to the instance, those API features will be
+unavailable to the instance.
 
-For instance tags support, version **2021-03-23** is required, and the feature
-must be enabled individually on each instance — more information on the `EC2
-user guide <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS>`_.
+
++----------------+----------------------------------------------------------+
++ EC2 version    | supported instance-data/feature                          |
++================+==========================================================+
++ **2021-03-23** | Required for Instance tag support. This feature must be  |
+|                | enabled individually on each instance.  See the          |
+|                | `EC2 tags user guide`_.                                  |
++----------------+----------------------------------------------------------+
+| **2016-09-02** | Required for secondary IP address support.               |
++----------------+----------------------------------------------------------+
+| **2009-04-04** | Minimum supports EC2 API version for meta-data and       |
+|                | user-data.                                               |
++----------------+----------------------------------------------------------+
+
 
 To see which versions are supported from your cloud provider use the following
 URL:
@@ -75,7 +86,7 @@ configuration (in `/etc/cloud/cloud.cfg` or `/etc/cloud/cloud.cfg.d/`).
 
 The settings that may be configured are:
 
- * **metadata_urls**: This list of urls will be searched for an Ec2
+ * **metadata_urls**: This list of urls will be searched for an EC2
    metadata service. The first entry that successfully returns a 200 response
    for <url>/<version>/meta-data/instance-id will be selected.
    (default: ['http://169.254.169.254', 'http://instance-data:8773']).
@@ -125,4 +136,5 @@ Notes
    For example: the primary NIC will have a DHCP route-metric of 100,
    the next NIC will be 200.
 
+.. _EC2 tags user guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS
 .. vi: textwidth=79

--- a/doc/rtd/topics/datasources/ec2.rst
+++ b/doc/rtd/topics/datasources/ec2.rst
@@ -44,6 +44,10 @@ relative ease (newer versions have more data exposed, while maintaining
 backward compatibility with the previous versions).
 Version **2016-09-02** is required for secondary IP address support.
 
+For instance tags support, version **2021-03-23** is required, and the feature
+must be enabled individually on each instance — more information on the `EC2
+user guide <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS>`_.
+
 To see which versions are supported from your cloud provider use the following
 URL:
 

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -212,7 +212,13 @@ M_PATH_NET = "cloudinit.sources.DataSourceEc2.net."
 
 TAGS_METADATA_2021_03_23 = {
     **DEFAULT_METADATA,
-    "tags": {"instance": {"Environment": "production", "Application": "test"}},
+    "tags": {
+        "instance": {
+            "Environment": "production",
+            "Application": "test",
+            "TagWithoutValue": "",
+        }
+    },
 }
 
 

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -210,6 +210,11 @@ SECONDARY_IP_METADATA_2018_09_24 = {
 
 M_PATH_NET = "cloudinit.sources.DataSourceEc2.net."
 
+TAGS_METADATA_2021_03_23 = {
+    **DEFAULT_METADATA,
+    "tags": {"instance": {"Environment": "production", "Application": "test"}},
+}
+
 
 def _register_ssh_keys(rfunc, base_url, keys_data):
     """handle ssh key inconsistencies.
@@ -670,7 +675,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
         logs_with_redacted = [log for log in all_logs if REDACT_TOK in log]
         logs_with_token = [log for log in all_logs if "API-TOKEN" in log]
         self.assertEqual(1, len(logs_with_redacted_ttl))
-        self.assertEqual(81, len(logs_with_redacted))
+        self.assertEqual(83, len(logs_with_redacted))
         self.assertEqual(0, len(logs_with_token))
 
     @mock.patch("cloudinit.net.dhcp.maybe_perform_dhcp_discovery")
@@ -810,6 +815,19 @@ class TestEc2(test_helpers.HttprettyTestCase):
             static_routes=None,
         )
         self.assertIn("Crawl of metadata service took", self.logs.getvalue())
+
+    def test_get_instance_tags(self):
+        ds = self._setup_ds(
+            platform_data=self.valid_platform_data,
+            sys_cfg={"datasource": {"Ec2": {"strict_id": False}}},
+            md={"md": TAGS_METADATA_2021_03_23},
+        )
+        self.assertTrue(ds.get_data())
+        self.assertIn("tags", ds.metadata)
+        self.assertIn("instance", ds.metadata["tags"])
+        instance_tags = ds.metadata["tags"]["instance"]
+        self.assertEqual(instance_tags["Application"], "test")
+        self.assertEqual(instance_tags["Environment"], "production")
 
 
 class TestGetSecondaryAddresses(test_helpers.CiTestCase):

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -28,6 +28,7 @@ dermotbradley
 dhensby
 eandersson
 eb3095
+edudobay
 emmanuelthome
 eslerm
 esposem


### PR DESCRIPTION
## Proposed Commit Message

```
Support EC2 tags in instance metadata

Add support for newer EC2 metadata versions (up to 2021-03-23), so that
tags can be retrieved from the `ds.meta_data.tags` field, as well as
with any new fields that might have been added since the 2018-09-24
version.
```

## Additional Context
I'm not sure about:
* whether I should have used the latest available metadata version as of today (`2021-07-15`, that is one release after the one I wrote). I ended up using the minimum version that supported tags.
    * Maybe the commit message should be modified to reflect other changes (beyond `tags`) that come with that upgrade?
* whether I chose a good testing strategy. My tests would actually pass without the changes I did, so I would appreciate some guidance on how to test something more useful.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
* Enable tags on metadata for the EC2 instance. On the CLI: `aws ec2 modify-instance-metadata-options --instance-id i-008d165d6a0f08d9d --instance-metadata-tags enabled`
* Install the updated `cloud-init` on the instance
* Reboot it and verify that tags are available: `cloud-init query ds.meta_data.tags`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
