### PR TITLE
add support for jinja do statements, add unit test

### DIFF
--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -104,7 +104,10 @@ def detect_template(text):
         add = "\n" if content.endswith("\n") else ""
         return (
             JTemplate(
-                content, undefined=UndefinedJinjaVariable, trim_blocks=True
+                content,
+                undefined=UndefinedJinjaVariable,
+                trim_blocks=True,
+                extensions=["jinja2.ext.do"],
             ).render(**params)
             + add
         )

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -184,5 +184,19 @@ $a,$b"""
             self.logs.getvalue(),
         )
 
+    def test_jinja_do_extension_render_to_string(self):
+        """Test jinja render_to_string using do extension."""
+        expected_result = "[1, 2, 3]"
+        jinja_template = (
+            "{% set r = [] %} {% set input = [1,2,3] %} "
+            "{% for i in input %} {% do r.append(i) %} {% endfor %} {{r}}"
+        )
+        self.assertEqual(
+            templater.render_string(
+                self.add_header("jinja", jinja_template), {}
+            ).strip(),
+            expected_result,
+        )
+
 
 # vi: ts=4 expandtab

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -79,6 +79,7 @@ steverweber
 t-8ch
 TheRealFalcon
 taoyama
+thetoolsmith
 timothegenzmer
 tnt-dev
 tomponline


### PR DESCRIPTION
## Proposed Commit Message
Adding support for jinja do statements in template rendering.
```
summary: adding support for jinja 'do' statements in jinja templating

Support for jinja do statements will prevent having to workaround the following exception:
jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'do'.

LP: #1962759
```

## Additional Context

## Test Steps
When processing the following example, the jinja exception is thrown.

{% set data_result = [] %}
{% set data_input = [1,2,3] %}
{% for i in data_input %}
  {% do data_result.append(i) %}
{% endfor %}
{{data_result}}

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
