### PR TITLE
Remove Unused Init Local Artifact

### DIFF
--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -19,7 +19,6 @@ RequiresMountsFor=/var/lib/cloud
 [Service]
 Type=oneshot
 ExecStart=/usr/bin/cloud-init init --local
-ExecStart=/bin/touch /run/cloud-init/network-config-ready
 RemainAfterExit=yes
 TimeoutSec=0
 


### PR DESCRIPTION
```
Remove unused init local artifact
```
This isn't used in cloud-init and systemd provides commands to show that `cloud-init-local.service` has been reached. It seems like a debugging artifact that shouldn't be needed.
