### PR TITLE
Resize encrypted partitions (SC-353)

### DIFF
--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -407,7 +407,10 @@ def resize_encrypted(blockdev, partition) -> Tuple[str, str]:
             LOG, "Failed to remove keyfile after resizing encrypted volume"
         )
 
-    return (RESIZE.CHANGED, f"Resized encrypted volume {blockdev}")
+    return (
+        RESIZE.CHANGED,
+        f"Successfully resized encrypted volume '{blockdev}'",
+    )
 
 
 def resize_devices(resizer, devices):

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -331,7 +331,7 @@ def is_encrypted(blockdev) -> bool:
     LOG.debug(
         "Determined that %s is %sencrypted",
         blockdev,
-        "" if is_encrypted else "not",
+        "" if is_encrypted else "not ",
     )
     return is_encrypted
 

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -7,10 +7,15 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Growpart: Grow partitions"""
 
+import base64
+import copy
+import json
 import os
 import os.path
 import re
 import stat
+from contextlib import suppress
+from pathlib import Path
 from textwrap import dedent
 
 from cloudinit import log as logging

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -344,7 +344,7 @@ def get_underlying_partition(blockdev):
 
 
 def resize_encrypted(blockdev):
-    subp.subp(['cryptsetup', '--key-file', '<keyfile>', 'resize', blockdev])
+    subp.subp(['cryptsetup', 'resize', blockdev])
 
 
 def resize_devices(resizer, devices):

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -323,7 +323,7 @@ def is_encrypted(blockdev) -> bool:
     LOG.debug(
         "Determined that %s is %s encrypted",
         blockdev,
-        "" if is_encrypted else "not"
+        "" if is_encrypted else "not",
     )
     return is_encrypted
 
@@ -338,7 +338,9 @@ def get_underlying_partition(blockdev):
     except IndexError:
         raise Exception(
             "Ran `{}`, but received unexpected stdout: `{}`".format(
-                command, dep))
+                command, dep
+            )
+        )
 
 
 def resize_encrypted(blockdev, partition):
@@ -360,9 +362,9 @@ def resize_encrypted(blockdev, partition):
         ["cryptsetup", "--key-file", "-", "resize", blockdev],
         data=decoded_key,
     )
-    subp.subp([
-        "cryptsetup", "luksKillSlot", "--batch-mode", partition, str(slot)
-    ])
+    subp.subp(
+        ["cryptsetup", "luksKillSlot", "--batch-mode", partition, str(slot)]
+    )
 
 
 def resize_devices(resizer, devices):
@@ -424,18 +426,25 @@ def resize_devices(resizer, devices):
                     continue
                 resize_encrypted(blockdev, partition)
             except Exception as e:
-                info.append((
-                    devent,
-                    RESIZE.FAILED,
-                    "Resizing encrypted device ({}) failed: {}".format(
-                        blockdev, e
+                info.append(
+                    (
+                        devent,
+                        RESIZE.FAILED,
+                        "Resizing encrypted device ({}) failed: {}".format(
+                            blockdev, e
+                        ),
                     )
-                ))
+                )
         try:
             (disk, ptnum) = device_part_info(blockdev)
         except (TypeError, ValueError) as e:
-            info.append((devent, RESIZE.SKIPPED,
-                         "device_part_info(%s) failed: %s" % (blockdev, e),))
+            info.append(
+                (
+                    devent,
+                    RESIZE.SKIPPED,
+                    "device_part_info(%s) failed: %s" % (blockdev, e),
+                )
+            )
             continue
 
         try:

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -293,12 +293,69 @@ def devent2dev(devent):
     return dev
 
 
+def is_mapped_device(blockdev) -> bool:
+    """
+    Check if a device is a mapped device.
+
+    blockdev should look something like '/dev/mapper/disk1' if True,
+    otherwise something like /dev/vdb1.
+    """
+    is_mapped = blockdev.startswith('/dev/mapper/')
+    LOG.debug("%s is %s a mapped device", blockdev, "" if is_mapped else "not")
+    return is_mapped
+
+
+def is_encrypted(blockdev) -> bool:
+    """
+    Check if a device is an encrypted device.
+
+    Will work for both mapped and raw devices.
+    """
+    is_encrypted = False
+    if not subp.which('cryptsetup'):
+        LOG.debug('cryptsetup not found. Assuming no encrypted partitions')
+        return False
+    with suppress(subp.ProcessExecutionError):
+        subp.subp(['cryptsetup', 'status', blockdev])
+        is_encrypted = True
+    if not is_encrypted:
+        with suppress(subp.ProcessExecutionError):
+            subp.subp(['cryptsetup', 'isLuks', blockdev])
+            is_encrypted = True
+    LOG.debug(
+        "Determined that %s is %s encrypted",
+        blockdev,
+        "" if is_encrypted else "not"
+    )
+    return is_encrypted
+
+
+def get_underlying_partition(blockdev):
+    command = 'dmsetup deps -o devname {}'.format(blockdev)
+    dep = subp.subp(command.split())[0]
+    try:
+        # Returned result should look something like:
+        # 1 dependencies : (vdb1)
+        return '/dev/{}'.format(dep.split(': (')[1].split(')')[0])
+    except IndexError:
+        raise Exception(
+            "Ran `{}`, but received unexpected stdout: `{}`".format(
+                command, dep))
+
+
+def resize_encrypted(blockdev):
+    subp.subp(['cryptsetup', '--key-file', '<keyfile>', 'resize', blockdev])
+
+
 def resize_devices(resizer, devices):
     # returns a tuple of tuples containing (entry-in-devices, action, message)
+    devices = copy.copy(devices)
     info = []
-    for devent in devices:
+
+    while devices:
+        devent = devices.pop(0)  # /mnt  TODO: DELETE ME
         try:
-            blockdev = devent2dev(devent)
+            blockdev = devent2dev(devent)  # /dev/mapper/disk2  TODO: DELETE ME
         except ValueError as e:
             info.append(
                 (
@@ -336,13 +393,25 @@ def resize_devices(resizer, devices):
         try:
             (disk, ptnum) = device_part_info(blockdev)
         except (TypeError, ValueError) as e:
-            info.append(
-                (
+            if is_mapped_device(blockdev) and is_encrypted(blockdev):
+                # We need to resize the underlying partition first
+                partition = get_underlying_partition(blockdev)
+                if partition not in [x[0] for x in info]:
+                    # We shouldn't attempt to resize this mapped partition
+                    # until the underlying partition is resized, so re-add
+                    # our device to the beginning of the list we're iterating
+                    # over, then add our underlying partition so it can
+                    # get processed first
+                    devices.insert(0, devent)
+                    devices.insert(0, partition)
+                    continue
+                resize_encrypted(blockdev)
+            else:
+                info.append((
                     devent,
                     RESIZE.SKIPPED,
                     "device_part_info(%s) failed: %s" % (blockdev, e),
-                )
-            )
+                ))
             continue
 
         try:

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -4,6 +4,8 @@
 import logging
 import os
 import subprocess
+from typing import Tuple, Any
+
 from errno import ENOEXEC
 
 LOG = logging.getLogger(__name__)
@@ -154,20 +156,11 @@ class ProcessExecutionError(IOError):
 
 
 def subp(
-    args,
-    data=None,
-    rcs=None,
-    env=None,
-    capture=True,
-    combine_capture=False,
-    shell=False,
-    logstring=False,
-    decode="replace",
-    target=None,
-    update_env=None,
-    status_cb=None,
-    cwd=None,
-):
+    args, data=None, rcs=None, env=None, capture=True,
+    combine_capture=False, shell=False,
+    logstring=False, decode="replace", target=None, update_env=None,
+    status_cb=None, cwd=None
+) -> Tuple[Any, Any]:
     """Run a subprocess.
 
     :param args: command to run in a list. [cmd, arg1, arg2...]

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -5,7 +5,6 @@ import logging
 import os
 import subprocess
 from errno import ENOEXEC
-from typing import Any, Tuple
 
 LOG = logging.getLogger(__name__)
 
@@ -168,7 +167,7 @@ def subp(
     update_env=None,
     status_cb=None,
     cwd=None,
-) -> Tuple[Any, Any]:
+):
     """Run a subprocess.
 
     :param args: command to run in a list. [cmd, arg1, arg2...]

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -4,9 +4,8 @@
 import logging
 import os
 import subprocess
-from typing import Tuple, Any
-
 from errno import ENOEXEC
+from typing import Any, Tuple
 
 LOG = logging.getLogger(__name__)
 
@@ -156,10 +155,19 @@ class ProcessExecutionError(IOError):
 
 
 def subp(
-    args, data=None, rcs=None, env=None, capture=True,
-    combine_capture=False, shell=False,
-    logstring=False, decode="replace", target=None, update_env=None,
-    status_cb=None, cwd=None
+    args,
+    data=None,
+    rcs=None,
+    env=None,
+    capture=True,
+    combine_capture=False,
+    shell=False,
+    logstring=False,
+    decode="replace",
+    target=None,
+    update_env=None,
+    status_cb=None,
+    cwd=None,
 ) -> Tuple[Any, Any]:
     """Run a subprocess.
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 httpretty>=0.7.1
 pytest
 pytest-cov
+pytest-mock
 
 # Only really needed on older versions of python
 setuptools

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -545,7 +545,7 @@ class TestEncrypted:
                 raise subp.ProcessExecutionError()
             return mock.Mock()
 
-        mocker.patch(
+        self.m_subp = mocker.patch(
             "cloudinit.config.cc_growpart.subp.subp",
             side_effect=_subp_side_effect,
         )
@@ -559,12 +559,12 @@ class TestEncrypted:
         assert (
             "Resizing encrypted device (/dev/mapper/fake) failed" in info[1][2]
         )
-        # Assert no cleanup
+        # Assert we still cleanup
         all_subp_args = list(
             chain(*[args[0][0] for args in self.m_subp.call_args_list])
         )
-        assert "luksKillSlot" not in all_subp_args
-        self.m_unlink.assert_not_called()
+        assert "luksKillSlot" in all_subp_args
+        self.m_unlink.assert_called_once()
 
     def test_resize_skipped(self, common_mocks, mocker, caplog):
         mocker.patch("pathlib.Path.exists", return_value=False)

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -437,6 +437,7 @@ class TestEncrypted:
                 '"slot":5}'
             ),
         )
+        mocker.patch("pathlib.Path.exists", return_value=True)
         self.m_unlink = mocker.patch("pathlib.Path.unlink", autospec=True)
 
         self.resizer = mock.Mock()
@@ -564,6 +565,16 @@ class TestEncrypted:
         )
         assert "luksKillSlot" not in all_subp_args
         self.m_unlink.assert_not_called()
+
+    def test_resize_skipped(self, common_mocks, mocker, caplog):
+        mocker.patch("pathlib.Path.exists", return_value=False)
+        info = cc_growpart.resize_devices(self.resizer, ["/fake_encrypted"])
+        assert len(info) == 2
+        assert info[1] == (
+            "/fake_encrypted",
+            "SKIPPED",
+            "No encryption keyfile found",
+        )
 
 
 def simple_device_part_info(devpath):

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -475,8 +475,9 @@ class TestEncrypted:
             return_value=None,
         )
         info = cc_growpart.resize_devices(self.resizer, ["/fake_encrypted"])
+
         assert len(info) == 1
-        assert "encrypted" not in info[0][2]
+        assert "skipped as it is not encrypted" in info[0][2]
         assert "cryptsetup not found" in caplog.text
         self.assert_no_resize_or_cleanup()
 

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -8,7 +8,6 @@ import shutil
 import stat
 import unittest
 from contextlib import ExitStack
-from copy import deepcopy
 from itertools import chain
 from unittest import mock
 

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -8,6 +8,8 @@ import shutil
 import stat
 import unittest
 from contextlib import ExitStack
+from copy import deepcopy
+from itertools import chain
 from unittest import mock
 
 import pytest
@@ -347,6 +349,221 @@ class TestResize(unittest.TestCase):
         finally:
             cc_growpart.device_part_info = opinfo
             os.stat = real_stat
+
+
+class TestEncrypted:
+    """Attempt end-to-end scenarios using encrypted devices.
+
+    Things are mocked such that:
+     - "/fake_encrypted" is mounted onto "/dev/mapper/fake"
+     - "/dev/mapper/fake" is a LUKS device and symlinked to /dev/dm-1
+     - The partition backing "/dev/mapper/fake" is "/dev/vdx1"
+     - "/" is not encrypted and mounted onto "/dev/vdz1"
+
+    Note that we don't (yet) support non-encrypted mapped drives, such
+    as LVM volumes. If our mount point is /dev/mapper/*, then we will
+    not resize it if it is not encrypted.
+    """
+
+    def _subp_side_effect(self, value, good=True, **kwargs):
+        if value[0] == "dmsetup":
+            return ("1 dependencies : (vdx1)",)
+        return mock.Mock()
+
+    def _device_part_info_side_effect(self, value):
+        if value.startswith("/dev/mapper/"):
+            raise TypeError(f"{value} not a partition")
+        return (1024, 1024)
+
+    def _devent2dev_side_effect(self, value):
+        if value == "/fake_encrypted":
+            return "/dev/mapper/fake"
+        elif value == "/":
+            return "/dev/vdz"
+        elif value.startswith("/dev"):
+            return value
+        raise Exception(f"unexpected value {value}")
+
+    def _realpath_side_effect(self, value):
+        return "/dev/dm-1" if value.startswith("/dev/mapper") else value
+
+    def assert_resize_and_cleanup(self):
+        all_subp_args = list(
+            chain(*[args[0][0] for args in self.m_subp.call_args_list])
+        )
+        assert "resize" in all_subp_args
+        assert "luksKillSlot" in all_subp_args
+        self.m_unlink.assert_called_once()
+
+    def assert_no_resize_or_cleanup(self):
+        all_subp_args = list(
+            chain(*[args[0][0] for args in self.m_subp.call_args_list])
+        )
+        assert "resize" not in all_subp_args
+        assert "luksKillSlot" not in all_subp_args
+        self.m_unlink.assert_not_called()
+
+    @pytest.fixture
+    def common_mocks(self, mocker):
+        # These are all "happy path" mocks which will get overridden
+        # when needed
+        mocker.patch(
+            "cloudinit.config.cc_growpart.device_part_info",
+            side_effect=self._device_part_info_side_effect,
+        )
+        mocker.patch("os.stat")
+        mocker.patch("stat.S_ISBLK")
+        mocker.patch("stat.S_ISCHR")
+        mocker.patch(
+            "cloudinit.config.cc_growpart.devent2dev",
+            side_effect=self._devent2dev_side_effect,
+        )
+        mocker.patch(
+            "os.path.realpath", side_effect=self._realpath_side_effect
+        )
+        # Only place subp.which is used in cc_growpart is for cryptsetup
+        mocker.patch(
+            "cloudinit.config.cc_growpart.subp.which",
+            return_value="/usr/sbin/cryptsetup",
+        )
+        self.m_subp = mocker.patch(
+            "cloudinit.config.cc_growpart.subp.subp",
+            side_effect=self._subp_side_effect,
+        )
+        mocker.patch(
+            "pathlib.Path.open",
+            new_callable=mock.mock_open,
+            read_data=(
+                '{"key":"XFmCwX2FHIQp0LBWaLEMiHIyfxt1SGm16VvUAVledlY=",'
+                '"slot":5}'
+            ),
+        )
+        self.m_unlink = mocker.patch("pathlib.Path.unlink", autospec=True)
+
+        self.resizer = mock.Mock()
+        self.resizer.resize = mock.Mock(return_value=(1024, 1024))
+
+    def test_resize_when_encrypted(self, common_mocks, caplog):
+        info = cc_growpart.resize_devices(self.resizer, ["/fake_encrypted"])
+        assert len(info) == 2
+        assert info[0][0] == "/dev/vdx1"
+        assert info[0][2].startswith("no change necessary")
+        assert info[1][0] == "/fake_encrypted"
+        assert (
+            info[1][2]
+            == "Successfully resized encrypted volume '/dev/mapper/fake'"
+        )
+        assert (
+            "/dev/mapper/fake is a mapped device pointing to /dev/dm-1"
+            in caplog.text
+        )
+        assert "Determined that /dev/dm-1 is encrypted" in caplog.text
+
+        self.assert_resize_and_cleanup()
+
+    def test_resize_when_unencrypted(self, common_mocks):
+        info = cc_growpart.resize_devices(self.resizer, ["/"])
+        assert len(info) == 1
+        assert info[0][0] == "/"
+        assert "encrypted" not in info[0][2]
+        self.assert_no_resize_or_cleanup()
+
+    def test_encrypted_but_cryptsetup_not_found(
+        self, common_mocks, mocker, caplog
+    ):
+        mocker.patch(
+            "cloudinit.config.cc_growpart.subp.which",
+            return_value=None,
+        )
+        info = cc_growpart.resize_devices(self.resizer, ["/fake_encrypted"])
+        assert len(info) == 1
+        assert "encrypted" not in info[0][2]
+        assert "cryptsetup not found" in caplog.text
+        self.assert_no_resize_or_cleanup()
+
+    def test_dmsetup_not_found(self, common_mocks, mocker, caplog):
+        def _subp_side_effect(value, **kwargs):
+            if value[0] == "dmsetup":
+                raise subp.ProcessExecutionError()
+
+        mocker.patch(
+            "cloudinit.config.cc_growpart.subp.subp",
+            side_effect=_subp_side_effect,
+        )
+        info = cc_growpart.resize_devices(self.resizer, ["/fake_encrypted"])
+        assert len(info) == 1
+        assert info[0][0] == "/fake_encrypted"
+        assert info[0][1] == "FAILED"
+        assert (
+            "Resizing encrypted device (/dev/mapper/fake) failed" in info[0][2]
+        )
+        self.assert_no_resize_or_cleanup()
+
+    def test_unparsable_dmsetup(self, common_mocks, mocker, caplog):
+        def _subp_side_effect(value, **kwargs):
+            if value[0] == "dmsetup":
+                return ("2 dependencies",)
+            return mock.Mock()
+
+        mocker.patch(
+            "cloudinit.config.cc_growpart.subp.subp",
+            side_effect=_subp_side_effect,
+        )
+        info = cc_growpart.resize_devices(self.resizer, ["/fake_encrypted"])
+        assert len(info) == 1
+        assert info[0][0] == "/fake_encrypted"
+        assert info[0][1] == "FAILED"
+        assert (
+            "Resizing encrypted device (/dev/mapper/fake) failed" in info[0][2]
+        )
+        self.assert_no_resize_or_cleanup()
+
+    def test_missing_keydata(self, common_mocks, mocker, caplog):
+        # Note that this will be standard behavior after first boot
+        # on a system with an encrypted root partition
+        mocker.patch("pathlib.Path.open", side_effect=FileNotFoundError())
+        info = cc_growpart.resize_devices(self.resizer, ["/fake_encrypted"])
+        assert len(info) == 2
+        assert info[0][0] == "/dev/vdx1"
+        assert info[0][2].startswith("no change necessary")
+        assert info[1][0] == "/fake_encrypted"
+        assert info[1][1] == "FAILED"
+        assert (
+            info[1][2]
+            == "Resizing encrypted device (/dev/mapper/fake) failed: Could "
+            "not load encryption key. This is expected if the volume has "
+            "been previously resized."
+        )
+        self.assert_no_resize_or_cleanup()
+
+    def test_resize_failed(self, common_mocks, mocker, caplog):
+        def _subp_side_effect(value, **kwargs):
+            if value[0] == "dmsetup":
+                return ("1 dependencies : (vdx1)",)
+            elif value[0] == "cryptsetup" and "resize" in value:
+                raise subp.ProcessExecutionError()
+            return mock.Mock()
+
+        mocker.patch(
+            "cloudinit.config.cc_growpart.subp.subp",
+            side_effect=_subp_side_effect,
+        )
+
+        info = cc_growpart.resize_devices(self.resizer, ["/fake_encrypted"])
+        assert len(info) == 2
+        assert info[0][0] == "/dev/vdx1"
+        assert info[0][2].startswith("no change necessary")
+        assert info[1][0] == "/fake_encrypted"
+        assert info[1][1] == "FAILED"
+        assert (
+            "Resizing encrypted device (/dev/mapper/fake) failed" in info[1][2]
+        )
+        # Assert no cleanup
+        all_subp_args = list(
+            chain(*[args[0][0] for args in self.m_subp.call_args_list])
+        )
+        assert "luksKillSlot" not in all_subp_args
+        self.m_unlink.assert_not_called()
 
 
 def simple_device_part_info(devpath):

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,7 @@ deps =
     # test-requirements
     pytest==3.3.2
     pytest-cov==2.5.1
+    pytest-mock==1.7.1
     # Needed by pytest and default causes failures
     attrs==17.4.0
 


### PR DESCRIPTION
Take 2 of #1032

# Proposed commit message
```
Allow growpart to resize encrypted partitions

Adds the ability for growpart to resize a LUKS formatted partition.
This involves resizing the underlying partition as well as the
filesystem. 'cryptsetup' is used for resizing.

This relies on a file present at /cc_growpart_keydata containing
json formatted 'key' and 'slot' keys, with the key being
base64 encoded. If resizing is successful, cloud-init will destroy
the luks slot used for resizing and remove the key file.
```

# Testing
I tried to structure the unit tests such that they act more end-to-end, rather than testing individual functions at a time. This involved some additional mocking setup, but I think it's overall worth it.

As of right now, an in-tree integration test is impractical.

Following a [Canonical internal guide](http://cpc-sites.internal/docs/clouds/azure/confidential_vm.html), I setup an encrypted VM and manually verified the behavior. You can see parts of the logs and commands here:
```
# Normal VM with no encryption
2022-03-28 20:48:17,949 - stages.py[DEBUG]: Running module growpart (<module 'cloudinit.config.cc_growpart' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_growpart.py'>) with frequency always
2022-03-28 20:48:17,949 - handlers.py[DEBUG]: start: init-network/config-growpart: running config-growpart with frequency always
2022-03-28 20:48:17,949 - helpers.py[DEBUG]: Running config-growpart using lock (<cloudinit.helpers.DummyLock object at 0x7f1c6220e5e0>)
2022-03-28 20:48:17,949 - cc_growpart.py[DEBUG]: No 'growpart' entry in cfg.  Using default: {'mode': 'auto', 'devices': ['/'], 'ignore_growroot_disabled': False}
2022-03-28 20:48:17,949 - subp.py[DEBUG]: Running command ['growpart', '--help'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 20:48:17,961 - util.py[DEBUG]: Reading from /proc/535/mountinfo (quiet=False)
2022-03-28 20:48:17,961 - util.py[DEBUG]: Read 3688 bytes from /proc/535/mountinfo
2022-03-28 20:48:17,961 - util.py[DEBUG]: Reading from /sys/class/block/sda1/partition (quiet=False)
2022-03-28 20:48:17,961 - util.py[DEBUG]: Read 2 bytes from /sys/class/block/sda1/partition
2022-03-28 20:48:17,961 - util.py[DEBUG]: Reading from /sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/virtio6/host0/target0:0:0/0:0:0:1/block/sda/dev (quiet=False)
2022-03-28 20:48:17,961 - util.py[DEBUG]: Read 4 bytes from /sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/virtio6/host0/target0:0:0/0:0:0:1/block/sda/dev
2022-03-28 20:48:17,962 - subp.py[DEBUG]: Running command ['growpart', '--dry-run', '/dev/sda', '1'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 20:48:17,985 - subp.py[DEBUG]: Running command ['growpart', '/dev/sda', '1'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 20:48:18,340 - util.py[DEBUG]: resize_devices took 0.379 seconds
2022-03-28 20:48:18,340 - cc_growpart.py[INFO]: '/' resized: changed (/dev/sda, 1) from 2244984320 to 10621009408
2022-03-28 20:48:18,340 - handlers.py[DEBUG]: finish: init-network/config-growpart: SUCCESS: config-growpart ran successfully


# First boot of encrypted VM WITHOUT updated cloud-init
2022-03-28 21:13:57,891 - stages.py[DEBUG]: Running module growpart (<module 'cloudinit.config.cc_growpart' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_growpart.py'>) with frequency always
2022-03-28 21:13:57,891 - handlers.py[WARNING]: failed posting events to kvp, [Errno 2] No such file or directory: '/var/lib/hyperv/.kvp_pool_1'
2022-03-28 21:13:57,893 - handlers.py[DEBUG]: start: init-network/config-growpart: running config-growpart with frequency always
2022-03-28 21:13:57,894 - helpers.py[DEBUG]: Running config-growpart using lock (<cloudinit.helpers.DummyLock object at 0x7f9bf96c4e20>)
2022-03-28 21:13:57,894 - handlers.py[WARNING]: failed posting events to kvp, [Errno 2] No such file or directory: '/var/lib/hyperv/.kvp_pool_1'
2022-03-28 21:13:57,896 - cc_growpart.py[DEBUG]: No 'growpart' entry in cfg.  Using default: {'mode': 'auto', 'devices': ['/'], 'ignore_growroot_disabled': False}
2022-03-28 21:13:57,896 - subp.py[DEBUG]: Running command ['growpart', '--help'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:13:57,900 - util.py[DEBUG]: Reading from /proc/600/mountinfo (quiet=False)
2022-03-28 21:13:57,900 - util.py[DEBUG]: Read 3693 bytes from /proc/600/mountinfo
2022-03-28 21:13:57,900 - util.py[DEBUG]: resize_devices took 0.001 seconds
2022-03-28 21:13:57,900 - cc_growpart.py[DEBUG]: '/' SKIPPED: device_part_info(/dev/mapper/cloudimg-rootfs-91c13bcb-ec6c-4e27-a84c-364921d7dad6) failed: /dev/mapper/cloudimg-rootfs-91c13bcb-ec6c-4e27-a84c-364921d7dad6 not a partition
2022-03-28 21:13:57,901 - handlers.py[DEBUG]: finish: init-network/config-growpart: SUCCESS: config-growpart ran successfully

$ ls /
bin  boot  cc_growpart_keydata  dev  etc  home  lib  lib32  lib64  libx32  lost+found  media  mnt  opt  proc  root  run  sbin  snap  srv  sys  tmp  usr  var

$ blkid
/dev/loop0: TYPE="squashfs"
/dev/loop1: TYPE="squashfs"
/dev/loop2: TYPE="squashfs"
/dev/vda1: UUID="75e523a1-a78f-47fc-8947-e1271e1dc27e" LABEL="cloudimg-rootfs-enc" TYPE="crypto_LUKS" PARTUUID="fbfa67c7-6028-48c4-a76b-ed2e2503bdc0"
/dev/vda15: LABEL_FATBOOT="UEFI" LABEL="UEFI" UUID="5ABB-40A9" TYPE="vfat" PARTUUID="006c3e55-1fc2-41da-ad93-ae9f6278f6c8"
/dev/vdb: UUID="2022-03-28-16-13-19-00" LABEL="cidata" TYPE="iso9660"
/dev/mapper/cloudimg-rootfs-91c13bcb-ec6c-4e27-a84c-364921d7dad6: LABEL="cloudimg-rootfs" UUID="870790f6-4b16-4b58-ac30-4d0c36540bd0" TYPE="ext4"

$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        956M     0  956M   0% /dev
tmpfs           974M     0  974M   0% /dev/shm
tmpfs           195M  3.5M  192M   2% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           974M     0  974M   0% /sys/fs/cgroup
/dev/dm-0       1.9G  1.4G  559M  71% /
/dev/loop0       62M   62M     0 100% /snap/core20/1328
/dev/loop1       68M   68M     0 100% /snap/lxd/21835
/dev/loop2       44M   44M     0 100% /snap/snapd/14978
/dev/vda15     1022M   81M  942M   8% /boot/efi
tmpfs           195M     0  195M   0% /run/user/1000

# Then installed deb and did a cloud-init clean --logs --reboot

# First boot of encrypted VM WITH updated cloud-init
2022-03-28 21:19:20,800 - stages.py[DEBUG]: Running module growpart (<module 'cloudinit.config.cc_growpart' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_growpart.py'>) with frequency always
2022-03-28 21:19:20,800 - handlers.py[WARNING]: failed posting events to kvp, [Errno 2] No such file or directory: '/var/lib/hyperv/.kvp_pool_1'
2022-03-28 21:19:20,800 - handlers.py[DEBUG]: start: init-network/config-growpart: running config-growpart with frequency always
2022-03-28 21:19:20,801 - helpers.py[DEBUG]: Running config-growpart using lock (<cloudinit.helpers.DummyLock object at 0x7fa509cacd00>)
2022-03-28 21:19:20,801 - handlers.py[WARNING]: failed posting events to kvp, [Errno 2] No such file or directory: '/var/lib/hyperv/.kvp_pool_1'
2022-03-28 21:19:20,801 - cc_growpart.py[DEBUG]: No 'growpart' entry in cfg.  Using default: {'mode': 'auto', 'devices': ['/'], 'ignore_growroot_disabled': False}
2022-03-28 21:19:20,801 - subp.py[DEBUG]: Running command ['growpart', '--help'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:20,809 - util.py[DEBUG]: Reading from /proc/610/mountinfo (quiet=False)
2022-03-28 21:19:20,810 - util.py[DEBUG]: Read 3693 bytes from /proc/610/mountinfo
2022-03-28 21:19:20,810 - cc_growpart.py[DEBUG]: /dev/mapper/cloudimg-rootfs-c3ac9cfb-1f50-4dbc-ac42-0d2fb0c637a1 is a mapped device pointing to /dev/dm-0
2022-03-28 21:19:20,810 - subp.py[DEBUG]: Running command ['cryptsetup', 'status', '/dev/dm-0'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:20,823 - cc_growpart.py[DEBUG]: Determined that /dev/dm-0 is encrypted
2022-03-28 21:19:20,823 - subp.py[DEBUG]: Running command ['dmsetup', 'deps', '--options=devname', '/dev/mapper/cloudimg-rootfs-c3ac9cfb-1f50-4dbc-ac42-0d2fb0c637a1'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:20,827 - util.py[DEBUG]: Reading from /sys/class/block/vda1/partition (quiet=False)
2022-03-28 21:19:20,827 - util.py[DEBUG]: Read 2 bytes from /sys/class/block/vda1/partition
2022-03-28 21:19:20,827 - util.py[DEBUG]: Reading from /sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda/dev (quiet=False)
2022-03-28 21:19:20,828 - util.py[DEBUG]: Read 6 bytes from /sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda/dev
2022-03-28 21:19:20,828 - subp.py[DEBUG]: Running command ['growpart', '--dry-run', '/dev/vda', '1'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:20,849 - subp.py[DEBUG]: Running command ['growpart', '/dev/vda', '1'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:21,150 - util.py[DEBUG]: Reading from /proc/610/mountinfo (quiet=False)
2022-03-28 21:19:21,150 - util.py[DEBUG]: Read 3693 bytes from /proc/610/mountinfo
2022-03-28 21:19:21,150 - cc_growpart.py[DEBUG]: /dev/mapper/cloudimg-rootfs-c3ac9cfb-1f50-4dbc-ac42-0d2fb0c637a1 is a mapped device pointing to /dev/dm-0
2022-03-28 21:19:21,151 - subp.py[DEBUG]: Running command ['cryptsetup', 'status', '/dev/dm-0'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:21,159 - cc_growpart.py[DEBUG]: Determined that /dev/dm-0 is encrypted
2022-03-28 21:19:21,159 - subp.py[DEBUG]: Running command ['dmsetup', 'deps', '--options=devname', '/dev/mapper/cloudimg-rootfs-c3ac9cfb-1f50-4dbc-ac42-0d2fb0c637a1'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:21,162 - subp.py[DEBUG]: Running command ['cryptsetup', '--key-file', '-', 'resize', '/dev/mapper/cloudimg-rootfs-c3ac9cfb-1f50-4dbc-ac42-0d2fb0c637a1'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:21,511 - subp.py[DEBUG]: Running command ['cryptsetup', 'luksKillSlot', '--batch-mode', '/dev/vda1', '10'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:19:21,588 - util.py[DEBUG]: resize_devices took 0.779 seconds
2022-03-28 21:19:21,589 - cc_growpart.py[INFO]: '/dev/vda1' resized: changed (/dev/vda, 1) from 2142223872 to 31134302208
2022-03-28 21:19:21,589 - cc_growpart.py[INFO]: '/' resized: Successfully resized encrypted volume '/dev/mapper/cloudimg-rootfs-c3ac9cfb-1f50-4dbc-ac42-0d2fb0c637a1'
2022-03-28 21:19:21,589 - handlers.py[DEBUG]: finish: init-network/config-growpart: SUCCESS: config-growpart ran successfully

$ ls /
bin  boot  dev  etc  home  lib  lib32  lib64  libx32  lost+found  media  mnt  opt  proc  root  run  sbin  snap  srv  sys  tmp  usr  var


$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        956M     0  956M   0% /dev
tmpfs           974M     0  974M   0% /dev/shm
tmpfs           195M  3.5M  192M   2% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
tmpfs           974M     0  974M   0% /sys/fs/cgroup
/dev/dm-0        29G  1.4G   27G   5% /
/dev/loop0       68M   68M     0 100% /snap/lxd/21835
/dev/loop1       44M   44M     0 100% /snap/snapd/14978
/dev/loop2       62M   62M     0 100% /snap/core20/1328
/dev/vda15     1022M   81M  942M   8% /boot/efi
tmpfs           195M     0  195M   0% /run/user/1000

# Subsequent boot of encrypted VM WITH updated cloud-init
2022-03-28 21:22:55,132 - stages.py[DEBUG]: Running module growpart (<module 'cloudinit.config.cc_growpart' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_growpart.py'>) with frequency always
2022-03-28 21:22:55,132 - handlers.py[WARNING]: failed posting events to kvp, [Errno 2] No such file or directory: '/var/lib/hyperv/.kvp_pool_1'
2022-03-28 21:22:55,133 - handlers.py[DEBUG]: start: init-network/config-growpart: running config-growpart with frequency always
2022-03-28 21:22:55,133 - helpers.py[DEBUG]: Running config-growpart using lock (<cloudinit.helpers.DummyLock object at 0x7fa8a098bbb0>)
2022-03-28 21:22:55,133 - handlers.py[WARNING]: failed posting events to kvp, [Errno 2] No such file or directory: '/var/lib/hyperv/.kvp_pool_1'
2022-03-28 21:22:55,134 - cc_growpart.py[DEBUG]: No 'growpart' entry in cfg.  Using default: {'mode': 'auto', 'devices': ['/'], 'ignore_growroot_disabled': False}
2022-03-28 21:22:55,134 - subp.py[DEBUG]: Running command ['growpart', '--help'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:22:55,141 - util.py[DEBUG]: Reading from /proc/585/mountinfo (quiet=False)
2022-03-28 21:22:55,141 - util.py[DEBUG]: Read 3534 bytes from /proc/585/mountinfo
2022-03-28 21:22:55,141 - cc_growpart.py[DEBUG]: /dev/mapper/cloudimg-rootfs-03de45d2-f355-457e-b8e8-87c48127d0a8 is a mapped device pointing to /dev/dm-0
2022-03-28 21:22:55,141 - subp.py[DEBUG]: Running command ['cryptsetup', 'status', '/dev/dm-0'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:22:55,155 - cc_growpart.py[DEBUG]: Determined that /dev/dm-0 is encrypted
2022-03-28 21:22:55,155 - subp.py[DEBUG]: Running command ['dmsetup', 'deps', '--options=devname', '/dev/mapper/cloudimg-rootfs-03de45d2-f355-457e-b8e8-87c48127d0a8'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:22:55,158 - util.py[DEBUG]: Reading from /sys/class/block/vda1/partition (quiet=False)
2022-03-28 21:22:55,158 - util.py[DEBUG]: Read 2 bytes from /sys/class/block/vda1/partition
2022-03-28 21:22:55,158 - util.py[DEBUG]: Reading from /sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda/dev (quiet=False)
2022-03-28 21:22:55,158 - util.py[DEBUG]: Read 6 bytes from /sys/devices/pci0000:00/0000:00:03.0/virtio1/block/vda/dev
2022-03-28 21:22:55,159 - subp.py[DEBUG]: Running command ['growpart', '--dry-run', '/dev/vda', '1'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:22:55,192 - util.py[DEBUG]: Reading from /proc/585/mountinfo (quiet=False)
2022-03-28 21:22:55,193 - util.py[DEBUG]: Read 3534 bytes from /proc/585/mountinfo
2022-03-28 21:22:55,193 - cc_growpart.py[DEBUG]: /dev/mapper/cloudimg-rootfs-03de45d2-f355-457e-b8e8-87c48127d0a8 is a mapped device pointing to /dev/dm-0
2022-03-28 21:22:55,193 - subp.py[DEBUG]: Running command ['cryptsetup', 'status', '/dev/dm-0'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:22:55,199 - cc_growpart.py[DEBUG]: Determined that /dev/dm-0 is encrypted
2022-03-28 21:22:55,199 - subp.py[DEBUG]: Running command ['dmsetup', 'deps', '--options=devname', '/dev/mapper/cloudimg-rootfs-03de45d2-f355-457e-b8e8-87c48127d0a8'] with allowed return codes [0] (shell=False, capture=True)
2022-03-28 21:22:55,202 - util.py[DEBUG]: resize_devices took 0.061 seconds
2022-03-28 21:22:55,202 - cc_growpart.py[DEBUG]: '/dev/vda1' NOCHANGE: no change necessary (/dev/vda, 1)
2022-03-28 21:22:55,202 - cc_growpart.py[DEBUG]: '/' FAILED: Resizing encrypted device (/dev/mapper/cloudimg-rootfs-03de45d2-f355-457e-b8e8-87c48127d0a8) failed: Could not load encryption key. This is expected if the volume has been previously resized.
2022-03-28 21:22:55,202 - handlers.py[DEBUG]: finish: init-network/config-growpart: SUCCESS: config-growpart ran successfully
```