### PR TITLE
travis supports 3.10 now (SC-843)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,7 @@ matrix:
             - tox
         # Test all supported Python versions (but at the end, so we schedule
         # longer-running jobs first)
-        - python: "3.10.1"
+        - python: "3.10"
         - python: 3.9
         - python: 3.8
         - python: 3.7


### PR DESCRIPTION
```
Switch to python 3.10 in Travis CI

Travis 3.10 support previously required pinning to 3.10.1. This restriction
no longer exists.
```