### PR TITLE
Fix fs label documentation and ds-identify (SC-854)

### DIFF
--- a/doc/rtd/topics/datasources/configdrive.rst
+++ b/doc/rtd/topics/datasources/configdrive.rst
@@ -58,7 +58,7 @@ Version 2
 The following criteria are required to as a config drive:
 
 1. Must be formatted with `vfat`_ or `iso9660`_ filesystem
-   or have a *filesystem* label of **config-2**
+   or have a *filesystem* label of **config-2** or **CONFIG-2**
 2. The files that will typically be present in the config drive are:
 
 ::

--- a/doc/rtd/topics/datasources/rbxcloud.rst
+++ b/doc/rtd/topics/datasources/rbxcloud.rst
@@ -12,14 +12,12 @@ user accounts and user metadata.
 Metadata drive
 --------------
 
-Drive metadata is a `FAT`_-formatted partition with the ```CLOUDMD``` label on
-the system disk. Its contents are refreshed each time the virtual machine
-is restarted, if the partition exists. For more information see
-`HyperOne Virtual Machine docs`_.
+Drive metadata is a `FAT`_-formatted partition with the ```CLOUDMD```  or
+```cloudmd``` label on the system disk. Its contents are refreshed each time
+the virtual machine is restarted, if the partition exists. For more information
+see `HyperOne Virtual Machine docs`_.
 
 .. _HyperOne: http://www.hyperone.com/
 .. _Rootbox: https://rootbox.com/
 .. _HyperOne Virtual Machine docs: http://www.hyperone.com/
 .. _FAT: https://en.wikipedia.org/wiki/File_Allocation_Table
-
-.. vi: textwidth=79

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -884,7 +884,7 @@ dscheck_DigitalOcean() {
 
 dscheck_OpenNebula() {
     check_seed_dir opennebula && return ${DS_FOUND}
-    has_fs_with_label "CONTEXT" && return ${DS_FOUND}
+    has_fs_with_label "CONTEXT" "CDROM" && return ${DS_FOUND}
     return ${DS_NOT_FOUND}
 }
 


### PR DESCRIPTION
```
Make fs labels match for ds-identify and docs

- ConfigDrive datasource works with CONFIG-2, document it
- RbxCloud datasource works with cloudmd, document it
- OpenNebula datasource supports CDROM, but ds-identify doesn't check it
```