### PR TITLE
add Requires=cloud-init-hotplugd.socket

### DIFF
--- a/systemd/cloud-init-hotplugd.service
+++ b/systemd/cloud-init-hotplugd.service
@@ -11,6 +11,7 @@
 
 [Unit]
 Description=cloud-init hotplug hook daemon
+After=cloud-init-hotplugd.socket
 Requires=cloud-init-hotplugd.socket
 
 [Service]

--- a/systemd/cloud-init-hotplugd.service
+++ b/systemd/cloud-init-hotplugd.service
@@ -11,7 +11,7 @@
 
 [Unit]
 Description=cloud-init hotplug hook daemon
-After=cloud-init-hotplugd.socket
+Requires=cloud-init-hotplugd.socket
 
 [Service]
 Type=simple


### PR DESCRIPTION

I think if the service depends on socket, it should change After=cloud-init-hotplugd.socket to Requires=cloud-init-hotplugd.socket in the cloud-init-hotplugd.service file.