### PR TITLE
Expose https_proxy env variable to ssh-import-id cmd

### DIFF
--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -100,7 +100,7 @@ def import_ssh_ids(ids, user, log):
     except KeyError as exc:
         raise exc
 
-    cmd = ["sudo", "-Hu", user, "ssh-import-id"] + ids
+    cmd = ["sudo", "--preserve-env=https_proxy -Hu", user, "ssh-import-id"] + ids
     log.debug("Importing SSH ids for user %s.", user)
 
     try:

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -100,7 +100,38 @@ def import_ssh_ids(ids, user, log):
     except KeyError as exc:
         raise exc
 
-    cmd = ["sudo", "--preserve-env=https_proxy -Hu", user, "ssh-import-id"] + ids
+    # TODO: We have a use case that involes setting a proxy value earlier
+    # in boot and the user wants this env used when using ssh-import-id.
+    # E.g.,:
+    # bootcmd:
+    #   - mkdir -p /etc/systemd/system/cloud-config.service.d
+    #   - mkdir -p /etc/systemd/system/cloud-final.service.d
+    # write_files:
+    #   - content: |
+    #       http_proxy=http://192.168.1.2:3128/
+    #       https_proxy=http://192.168.1.2:3128/
+    #     path: /etc/cloud/env
+    #   - content: |
+    #       [Service]
+    #       EnvironmentFile=/etc/cloud/env
+    #       PassEnvironment=https_proxy http_proxy
+    #     path: /etc/systemd/system/cloud-config.service.d/override.conf
+    #   - content: |
+    #       [Service]
+    #       EnvironmentFile=/etc/cloud/env
+    #       PassEnvironment=https_proxy http_proxy
+    #     path: /etc/systemd/system/cloud-final.service.d/override.conf
+    #
+    # I'm including the `--preserve-env` here as a one-off, but we should
+    # have a better way of setting env earlier in boot and using it later.
+    # Perhaps a 'set_env' module?
+    cmd = [
+        "sudo",
+        "--preserve-env=https_proxy",
+        "-Hu",
+        user,
+        "ssh-import-id",
+    ] + ids
     log.debug("Importing SSH ids for user %s.", user)
 
     try:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -59,6 +59,7 @@ marlluslustosa
 matthewruffell
 maxnet
 megian
+michaelrommel
 mitechie
 nazunalika
 nicolasbock


### PR DESCRIPTION
The import of ssh keys for users does not work in corporate networks
behind proxies.

The ssh-import-id command does not support cmd line arguments or other
configurations for specifying a proxy. The sudo command in the module
executes the ssh-import-id command directly, so any proxy settings of
shells will not work. The only option would be either to specify the
proxy setting on the command line, but this wouldn't be easily user
editable.

So the only solution is to selectively forward any already set
https_proxy variable to the executed command. Since only one env
variable is used and forwarded, the security impact should be
acceptable.

 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
