### PR TITLE
declare dependency on ssh-import-id (SC-864)

### DIFF
--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -51,7 +51,10 @@ __doc__ = get_meta_doc(meta)
 def handle(_name, cfg, cloud, log, args):
 
     if not is_key_in_nested_dict(cfg, "ssh_import_id"):
-        log.debug("Skipping module named ssh-import-id, no 'ssh_import_id' directives found.")
+        log.debug(
+            "Skipping module named ssh-import-id, no 'ssh_import_id'"
+            " directives found."
+        )
         return
     elif not subp.which(SSH_IMPORT_ID_BINARY):
         log.warn(

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -50,7 +50,9 @@ __doc__ = get_meta_doc(meta)
 
 def handle(_name, cfg, cloud, log, args):
 
-    if is_key_in_nested_dict(cfg, "ssh_import_id") and not subp.which(SSH_IMPORT_ID_BINARY):
+    if is_key_in_nested_dict(cfg, "ssh_import_id") and not subp.which(
+        SSH_IMPORT_ID_BINARY
+    ):
         log.warn(
             "ssh-import-id is not installed, but module ssh_import_id is "
             "configured. Skipping module."

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -50,9 +50,10 @@ __doc__ = get_meta_doc(meta)
 
 def handle(_name, cfg, cloud, log, args):
 
-    if is_key_in_nested_dict(cfg, "ssh_import_id") and not subp.which(
-        SSH_IMPORT_ID_BINARY
-    ):
+    if not is_key_in_nested_dict(cfg, "ssh_import_id"):
+        log.debug("Skipping module named ssh-import-id, no 'ssh_import_id' directives found.")
+        return
+    elif not subp.which(SSH_IMPORT_ID_BINARY):
         log.warn(
             "ssh-import-id is not installed, but module ssh_import_id is "
             "configured. Skipping module."

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -18,7 +18,7 @@ from cloudinit.settings import PER_INSTANCE
 # https://launchpad.net/ssh-import-id
 distros = ["ubuntu", "debian"]
 
-SSH_IMPORT_ID = "ssh-import-id"
+SSH_IMPORT_ID_BINARY = "ssh-import-id"
 MODULE_DESCRIPTION = """\
 This module imports SSH keys from either a public keyserver, usually launchpad
 or github using ``ssh-import-id``. Keys are referenced by the username they are
@@ -50,7 +50,7 @@ __doc__ = get_meta_doc(meta)
 
 def handle(_name, cfg, cloud, log, args):
 
-    if cfg.get("ssh_import_id") and not subp.which(SSH_IMPORT_ID):
+    if cfg.get("ssh_import_id") and not subp.which(SSH_IMPORT_ID_BINARY):
         log.warn(
             "ssh-import-id is not installed, but module ssh_import_id is "
             "configured. Skipping module."
@@ -146,7 +146,7 @@ def import_ssh_ids(ids, user, log):
         "--preserve-env=https_proxy",
         "-Hu",
         user,
-        SSH_IMPORT_ID,
+        SSH_IMPORT_ID_BINARY,
     ] + ids
     log.debug("Importing SSH ids for user %s.", user)
 

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -50,7 +50,7 @@ __doc__ = get_meta_doc(meta)
 
 def handle(_name, cfg, cloud, log, args):
 
-    if cfg.get("ssh_import_id") and subp.which(SSH_IMPORT_ID):
+    if cfg.get("ssh_import_id") and not subp.which(SSH_IMPORT_ID):
         log.warn(
             "ssh-import-id is not installed, but module ssh_import_id is "
             "configured. Skipping module."

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -50,7 +50,7 @@ __doc__ = get_meta_doc(meta)
 
 def handle(_name, cfg, cloud, log, args):
 
-    if cfg.get("ssh_import_id") and not subp.which(SSH_IMPORT_ID_BINARY):
+    if not subp.which(SSH_IMPORT_ID_BINARY):
         log.warn(
             "ssh-import-id is not installed, but module ssh_import_id is "
             "configured. Skipping module."

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -18,6 +18,7 @@ from cloudinit.settings import PER_INSTANCE
 # https://launchpad.net/ssh-import-id
 distros = ["ubuntu", "debian"]
 
+SSH_IMPORT_ID = "ssh-import-id"
 MODULE_DESCRIPTION = """\
 This module imports SSH keys from either a public keyserver, usually launchpad
 or github using ``ssh-import-id``. Keys are referenced by the username they are
@@ -48,6 +49,13 @@ __doc__ = get_meta_doc(meta)
 
 
 def handle(_name, cfg, cloud, log, args):
+
+    if cfg.get("ssh_import_id") and subp.which(SSH_IMPORT_ID):
+        log.warn(
+            "ssh-import-id is not installed, but module ssh_import_id is "
+            "configured. Skipping module."
+        )
+        return
 
     # import for "user: XXXXX"
     if len(args) != 0:
@@ -138,7 +146,7 @@ def import_ssh_ids(ids, user, log):
         "--preserve-env=https_proxy",
         "-Hu",
         user,
-        "ssh-import-id",
+        SSH_IMPORT_ID,
     ] + ids
     log.debug("Importing SSH ids for user %s.", user)
 

--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -14,6 +14,7 @@ Depends: ${misc:Depends},
          iproute2,
          isc-dhcp-client
 Recommends: eatmydata, sudo, software-properties-common, gdisk
+Suggests: ssh-import-id
 Description: Init scripts for cloud instances
  Cloud instances need special scripts to run during initialisation
  to retrieve and install ssh keys and to let the user run various scripts.


### PR DESCRIPTION
```
cc_ssh_import_id: Warn and skip module if missing dep

Add ssh-import-id as a suggested package dependency for debs
```

Context:

We have a module that uses ssh-import-id. Users of ssh-import-id will want this package installed.


