### PR TITLE
add Requires=cloud-init-hotplugd.socket in cloud-init-hotplugd.servic…

### DIFF
--- a/systemd/cloud-init-hotplugd.service
+++ b/systemd/cloud-init-hotplugd.service
@@ -12,6 +12,7 @@
 [Unit]
 Description=cloud-init hotplug hook daemon
 After=cloud-init-hotplugd.socket
+Requires=cloud-init-hotplugd.socket
 
 [Service]
 Type=simple

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -92,4 +92,5 @@ Vultaire
 WebSpider
 xiachen-rh
 xnox
+yangzz-97
 zhuzaifangxuele


### PR DESCRIPTION
If we start the service directly, it should pull up the socket through Requires
https://github.com/canonical/cloud-init/pull/1331#issuecomment-1067186646