### PR TITLE
Add --no-update to add-apt-repostory call (SC-880)

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -571,7 +571,10 @@ def add_apt_sources(
 
         if aa_repo_match(source):
             try:
-                subp.subp(["add-apt-repository", source], target=target)
+                subp.subp(
+                    ["add-apt-repository", "--no-update", source],
+                    target=target,
+                )
             except subp.ProcessExecutionError:
                 LOG.exception("add-apt-repository failed.")
                 raise

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -663,7 +663,12 @@ class TestAptSourceConfig(TestCase):
         with mock.patch.object(subp, "subp") as mockobj:
             cc_apt_configure.handle("test", cfg, self.fakecloud, None, None)
         mockobj.assert_called_once_with(
-            ["add-apt-repository", "ppa:smoser/cloud-init-test"], target=None
+            [
+                "add-apt-repository",
+                "--no-update",
+                "ppa:smoser/cloud-init-test",
+            ],
+            target=None,
         )
 
         # adding ppa should ignore filename (uses add-apt-repository)
@@ -689,15 +694,27 @@ class TestAptSourceConfig(TestCase):
             cc_apt_configure.handle("test", cfg, self.fakecloud, None, None)
         calls = [
             call(
-                ["add-apt-repository", "ppa:smoser/cloud-init-test"],
+                [
+                    "add-apt-repository",
+                    "--no-update",
+                    "ppa:smoser/cloud-init-test",
+                ],
                 target=None,
             ),
             call(
-                ["add-apt-repository", "ppa:smoser/cloud-init-test2"],
+                [
+                    "add-apt-repository",
+                    "--no-update",
+                    "ppa:smoser/cloud-init-test2",
+                ],
                 target=None,
             ),
             call(
-                ["add-apt-repository", "ppa:smoser/cloud-init-test3"],
+                [
+                    "add-apt-repository",
+                    "--no-update",
+                    "ppa:smoser/cloud-init-test3",
+                ],
                 target=None,
             ),
         ]

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -601,7 +601,12 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
                 cfg, TARGET, template_params=params, aa_repo_match=self.matcher
             )
         mockobj.assert_any_call(
-            ["add-apt-repository", "ppa:smoser/cloud-init-test"], target=TARGET
+            [
+                "add-apt-repository",
+                "--no-update",
+                "ppa:smoser/cloud-init-test",
+            ],
+            target=TARGET,
         )
 
         # adding ppa should ignore filename (uses add-apt-repository)
@@ -622,15 +627,27 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
             )
         calls = [
             call(
-                ["add-apt-repository", "ppa:smoser/cloud-init-test"],
+                [
+                    "add-apt-repository",
+                    "--no-update",
+                    "ppa:smoser/cloud-init-test",
+                ],
                 target=TARGET,
             ),
             call(
-                ["add-apt-repository", "ppa:smoser/cloud-init-test2"],
+                [
+                    "add-apt-repository",
+                    "--no-update",
+                    "ppa:smoser/cloud-init-test2",
+                ],
                 target=TARGET,
             ),
             call(
-                ["add-apt-repository", "ppa:smoser/cloud-init-test3"],
+                [
+                    "add-apt-repository",
+                    "--no-update",
+                    "ppa:smoser/cloud-init-test3",
+                ],
                 target=TARGET,
             ),
         ]


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add --no-update to add-apt-repostory call

In cc_apt_configure, "add-apt-repository" is called a few lines before
we make a call to update packages, so the additional update that
happens in "add-apt-repository" is redundant and a waste of time.
Additionally, the update in add-apt-repository can fail on
obtaining apt lock and cause the module to raise an exception.
```
