### PR TITLE
cmd/status: Check for proper file for stats from cloud-init-generator

### DIFF
--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -103,7 +103,7 @@ def _is_cloudinit_disabled(disable_file, paths):
     elif "cloud-init=disabled" in cmdline_parts:
         is_disabled = True
         reason = "Cloud-init disabled by kernel parameter cloud-init=disabled"
-    elif os.path.exists(os.path.join(paths.run_dir, "disabled")):
+    elif not os.path.exists(os.path.join(paths.run_dir, "enabled")):
         is_disabled = True
         reason = "Cloud-init disabled by cloud-init-generator"
     elif os.path.exists(os.path.join(paths.run_dir, "enabled")):


### PR DESCRIPTION
cloud-init-generator creates `<rundir>/enabled` when it enables
cloud-init and removes it when it disables. Nothing creates
`<rundir>/disabled`.  So the status should check for the non existance
of `<rundir>/enabled` instead of the existance of `<rundir>/disabled`
to check that cloud-init-generator has disabled it.