### PR TITLE
BUG 1473527: module ssh-authkey-fingerprints fails Input/output error…

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2078,7 +2078,7 @@ def write_file(
     omode="wb",
     preserve_mode=False,
     *,
-    ensure_dir_exists=True
+    ensure_dir_exists=True,
 ):
     """
     Writes a file with the given content and sets the file mode as specified.

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -401,12 +401,15 @@ def multi_log(
                     wfh.flush()
                 writing_to_console_worked = True
             except OSError:
-                pass
+                console_error = "Failed to write to /dev/console"
+                sys.stdout.write(console_error)
+                if log:
+                    log.log(logging.WARNING, console_error)
 
         if fallback_to_stdout and not writing_to_console_worked:
             # A container may lack /dev/console (arguably a container bug).
             # Additionally, /dev/console may not be writable to on a VM (again
-            # likely a VM bug).
+            # likely a VM bug or virtualization bug).
             #
             # If either of these is the case, then write output to stdout.
             # This will result in duplicate stderr and stdout messages if

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -381,6 +381,12 @@ def find_modules(root_dir) -> dict:
     return entries
 
 
+def write_to_console(conpath, text):
+    with open(conpath, "w") as wfh:
+        wfh.write(text)
+        wfh.flush()
+
+
 def multi_log(
     text,
     console=True,
@@ -396,9 +402,7 @@ def multi_log(
         writing_to_console_worked = False
         if os.path.exists(conpath):
             try:
-                with open(conpath, "w") as wfh:
-                    wfh.write(text)
-                    wfh.flush()
+                write_to_console(conpath, text)
                 writing_to_console_worked = True
             except OSError:
                 console_error = "Failed to write to /dev/console"

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -406,7 +406,7 @@ def multi_log(
                 writing_to_console_worked = True
             except OSError:
                 console_error = "Failed to write to /dev/console"
-                sys.stdout.write(console_error)
+                sys.stdout.write(f"{console_error}\n")
                 if log:
                     log.log(logging.WARNING, console_error)
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -29,7 +29,7 @@ import socket
 import stat
 import string
 import subprocess
-import 
+import sys
 import time
 from base64 import b64decode, b64encode
 from errno import ENOENT
@@ -393,16 +393,17 @@ def multi_log(
         sys.stderr.write(text)
     if console:
         conpath = "/dev/console"
-        writing_to_console_failed = False
+        writing_to_console_worked = False
         if os.path.exists(conpath):
             try:
                 with open(conpath, "w") as wfh:
                     wfh.write(text)
                     wfh.flush()
+                writing_to_console_worked = True
             except OSError:
-                writing_to_console_failed = True
-    
-        if fallback_to_stdout or writing_to_console_failed:
+                pass
+
+        if fallback_to_stdout and not writing_to_console_worked:
             # A container may lack /dev/console (arguably a container bug).
             # Additionally, /dev/console may not be writable to on a VM (again
             # likely a VM bug).

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1986,7 +1986,9 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
         "cloudinit.util.write_to_console",
         mock.Mock(side_effect=OSError("Failed to write to console")),
     )
-    def test_logs_do_go_to_stdout_if_writing_to_console_fails_and_fallback_true(self):
+    def test_logs_do_go_to_stdout_if_writing_to_console_fails_and_fallback_true(
+        self,
+    ):
         self._createConsole(self.root)
         util.multi_log("something", fallback_to_stdout=True)
         self.assertEqual(

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1986,7 +1986,7 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
         "cloudinit.util.write_to_console",
         mock.Mock(side_effect=OSError("Failed to write to console")),
     )
-    def test_logs_do_go_to_stdout_if_writing_to_console_fails_and_fallback_true(
+    def test_logs_go_to_stdout_if_writing_to_console_fails_and_fallback_true(
         self,
     ):
         self._createConsole(self.root)

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1982,6 +1982,30 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
         util.multi_log("something", fallback_to_stdout=False)
         self.assertEqual("", self.stdout.getvalue())
 
+    @mock.patch(
+        "cloudinit.util.write_to_console",
+        mock.Mock(side_effect=OSError("Failed to write to console")),
+    )
+    def test_logs_do_go_to_stdout_if_writing_to_console_fails_and_fallback_true(self):
+        self._createConsole(self.root)
+        util.multi_log("something", fallback_to_stdout=True)
+        self.assertEqual(
+            "Failed to write to /dev/consolesomething", self.stdout.getvalue()
+        )
+
+    @mock.patch(
+        "cloudinit.util.write_to_console",
+        mock.Mock(side_effect=OSError("Failed to write to console")),
+    )
+    def test_logs_go_nowhere_if_writing_to_console_fails_and_fallback_false(
+        self,
+    ):
+        self._createConsole(self.root)
+        util.multi_log("something", fallback_to_stdout=False)
+        self.assertEqual(
+            "Failed to write to /dev/console", self.stdout.getvalue()
+        )
+
     def test_logs_go_to_log_if_given(self):
         log = mock.MagicMock()
         logged_string = "something very important"

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1992,7 +1992,8 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
         self._createConsole(self.root)
         util.multi_log("something", fallback_to_stdout=True)
         self.assertEqual(
-            "Failed to write to /dev/consolesomething", self.stdout.getvalue()
+            "Failed to write to /dev/console\nsomething",
+            self.stdout.getvalue(),
         )
 
     @mock.patch(
@@ -2005,7 +2006,7 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
         self._createConsole(self.root)
         util.multi_log("something", fallback_to_stdout=False)
         self.assertEqual(
-            "Failed to write to /dev/console", self.stdout.getvalue()
+            "Failed to write to /dev/console\n", self.stdout.getvalue()
         )
 
     def test_logs_go_to_log_if_given(self):

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -6,6 +6,7 @@ Aman306
 andgein
 andrewbogott
 andrewlukoshko
+andrew-lee-metaswitch
 antonyc
 aswinrajamannar
 beantaxi


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1473527?comments=all


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Don't error if we cannot log to /dev/console

We've seen instances on VMware of serial consoles not being set up
correctly by the kernel, making /dev/ttyS0 not set up correctly, and 
hence /dev/console not writeable to.

In such circumstances, cloud-init should not fail, instead it should 
gracefully fall back to logging to stdout.

The only time cloud-init tries to write to `/dev/console` is in the
`multi_log` command- which is called by the
ssh-authkey-fingerprints module

LP: #1473527
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
