### PR TITLE
prevent cloudinit/config/cc_ssh_authkey_fingerprints.py from creating home when "no_create_home: true", or "system: true"

### DIFF
--- a/cloudinit/config/cc_ssh_authkey_fingerprints.py
+++ b/cloudinit/config/cc_ssh_authkey_fingerprints.py
@@ -119,6 +119,9 @@ def handle(name, cfg, cloud, log, _args):
     hash_meth = util.get_cfg_option_str(cfg, "authkey_hash", "sha256")
     (users, _groups) = ug_util.normalize_users_groups(cfg, cloud.distro)
     for (user_name, _cfg) in users.items():
+        if _cfg.get('no_create_home') or _cfg.get('system'):
+            continue
+
         (key_fn, key_entries) = ssh_util.extract_authorized_keys(user_name)
         _pprint_key_entries(user_name, key_fn, key_entries, hash_meth)
 

--- a/cloudinit/config/cc_ssh_authkey_fingerprints.py
+++ b/cloudinit/config/cc_ssh_authkey_fingerprints.py
@@ -119,7 +119,7 @@ def handle(name, cfg, cloud, log, _args):
     hash_meth = util.get_cfg_option_str(cfg, "authkey_hash", "sha256")
     (users, _groups) = ug_util.normalize_users_groups(cfg, cloud.distro)
     for (user_name, _cfg) in users.items():
-        if _cfg.get('no_create_home') or _cfg.get('system'):
+        if _cfg.get("no_create_home") or _cfg.get("system"):
             continue
 
         (key_fn, key_entries) = ssh_util.extract_authorized_keys(user_name)

--- a/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
+++ b/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
@@ -13,6 +13,7 @@ import re
 import pytest
 
 from tests.integration_tests.util import retry
+from tests.integration_tests.instances import IntegrationInstance
 
 USER_DATA_SSH_AUTHKEY_DISABLE = """\
 #cloud-config

--- a/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
+++ b/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
@@ -12,8 +12,8 @@ import re
 
 import pytest
 
-from tests.integration_tests.util import retry
 from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import retry
 
 USER_DATA_SSH_AUTHKEY_DISABLE = """\
 #cloud-config

--- a/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
+++ b/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
@@ -50,3 +50,25 @@ class TestSshAuthkeyFingerprints:
         assert re.search(r"256 SHA256:.*(ED25519)", syslog_output) is not None
         assert re.search(r"1024 SHA256:.*(DSA)", syslog_output) is None
         assert re.search(r"2048 SHA256:.*(RSA)", syslog_output) is None
+
+
+@pytest.mark.user_data(
+    """\
+#cloud-config
+users:
+ - default
+ - name: nch
+   no_create_home: true
+ - name: system
+   system: true
+"""
+)
+def test_no_home_directory_created(client: IntegrationInstance):
+    """Ensure cc_ssh_authkey_fingerprints doesn't create user directories"""
+    home_output = client.execute("ls /home")
+    assert "nch" not in home_output
+    assert "system" not in home_output
+
+    passwd = client.execute("cat /etc/passwd")
+    assert "nch:" in passwd
+    assert "system:" in passwd


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
prevent cc_ssh_authkey_fingerprints.py from inadvertently creating a home when "no_create_home: true", or "system: true"

```
summary: stop cc_ssh_authkey_fingerprints from ALWAYS creating home

cloudinit/config/cc_ssh_authkey_fingerprints.py unintentionally ends
up creating a home directory for a user even when `no_create_home:
true` or `system: true`. This prevents it.

`cc_ssh_authkey_fingerprints.py` calls `ssh_util.extract_authorized_keys`,
which ends up calling `check_create_path`, which creates the as yet
non-existent home while looking for an `authorized_keys` file to parse.
`cc_ssh_authkey_fingerprints.py` looks like the best place to stop this.

NOTE that I do not handle the situation where (`no_create_home: true`
or `system: true`) *and* yet `ssh_authorized_keys` is provided. In
this case, by virtue of the code `no_create_home: true` / `system:
true` takes precedence
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

sample user data:
```
#cloud-config

system_info:
  default_user:
    name: jf

users:
  - default

  - name: nch
    no_create_home: true

  - name: system
    system: true
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
