### PR TITLE
Add 2021-07-15 EC2 instance meta version (Adds support for instance tags)

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -62,7 +62,7 @@ class DataSourceEc2(sources.DataSource):
 
     # Priority ordered list of additional metadata versions which will be tried
     # for extended metadata content. IPv6 support comes in 2016-09-02
-    extended_metadata_versions = ["2018-09-24", "2016-09-02"]
+    extended_metadata_versions = ["2021-07-15", "2018-09-24", "2016-09-02"]
 
     # Setup read_url parameters per get_url_params.
     url_max_wait = 120

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -670,7 +670,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
         logs_with_redacted = [log for log in all_logs if REDACT_TOK in log]
         logs_with_token = [log for log in all_logs if "API-TOKEN" in log]
         self.assertEqual(1, len(logs_with_redacted_ttl))
-        self.assertEqual(81, len(logs_with_redacted))
+        self.assertEqual(83, len(logs_with_redacted))
         self.assertEqual(0, len(logs_with_token))
 
     @mock.patch("cloudinit.net.dhcp.maybe_perform_dhcp_discovery")

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -73,6 +73,7 @@ renanrodrigo
 rhansen
 riedel
 sarahwzadara
+seanhood
 slingamn
 slyon
 smoser


### PR DESCRIPTION
By updating to the latest EC2 instance metadata version, EC2 instance tags are then available from within cloud-init.

Ref: https://aws.amazon.com/about-aws/whats-new/2022/01/instance-tags-amazon-ec2-instance-metadata-service/

This feels like a rather big change without added tests, however I didn't see any other tests which checked for arbitrary keys within the metadata. In a separate commit I've added a sample of the 2021-07-15 metadata.

https://github.com/SeanHood/cloud-init/commit/51fc6ea86fa76a931536a092465575992a61fa02

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Add 2021-07-15 EC2 instance meta version

By updating to the latest EC2 instance metadata version, EC2 instance tags are then available from within cloud-init.

Ref: https://aws.amazon.com/about-aws/whats-new/2022/01/instance-tags-amazon-ec2-instance-metadata-service/
```


## Test Steps
1. Create EC2 instance with some tags and enable "Allow tags in instance metadata"

2. With this patch there should now be tags populated in the cloud-init metadata.
    ```
    $ jq '.ds."meta-data".tags.instance' /run/cloud-init/instance-data.json
    {
      "Env": "Dev",
      "Name": "Test-instance"
    }
    ```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
