### PR TITLE
raise ValueError when "no_create_home" or "system" is set and ssh_authorized_keys is also provided

### DIFF
--- a/cloudinit/config/cc_ssh_authkey_fingerprints.py
+++ b/cloudinit/config/cc_ssh_authkey_fingerprints.py
@@ -123,6 +123,10 @@ def handle(name, cfg, cloud, log, _args):
     (users, _groups) = ug_util.normalize_users_groups(cfg, cloud.distro)
     for (user_name, _cfg) in users.items():
         if _cfg.get("no_create_home") or _cfg.get("system"):
+            log.debug(
+                "Skipping printing of ssh fingerprints for user '%s' because no home directory is created",
+                user_name,
+            )
             continue
 
         (key_fn, key_entries) = ssh_util.extract_authorized_keys(user_name)

--- a/cloudinit/config/cc_ssh_authkey_fingerprints.py
+++ b/cloudinit/config/cc_ssh_authkey_fingerprints.py
@@ -124,7 +124,8 @@ def handle(name, cfg, cloud, log, _args):
     for (user_name, _cfg) in users.items():
         if _cfg.get("no_create_home") or _cfg.get("system"):
             log.debug(
-                "Skipping printing of ssh fingerprints for user '%s' because no home directory is created",
+                "Skipping printing of ssh fingerprints for user '%s' because "
+                "no home directory is created",
                 user_name,
             )
             continue

--- a/cloudinit/config/cc_users_groups.py
+++ b/cloudinit/config/cc_users_groups.py
@@ -171,8 +171,8 @@ def handle(name, cfg, cloud, _log, _args):
         need_home = [key for key in NEED_HOME if config.get(key)]
         if no_home and need_home:
             raise ValueError(
-                f"Not creating user {user}. Key(s) {need_home.join(',')}"
-                f" cannot be provided with {no_home.join(',')}"
+                f"Not creating user {user}. Key(s) {', '.join(need_home)}"
+                f" cannot be provided with {', '.join(no_home)}"
             )
 
         ssh_redirect_user = config.pop("ssh_redirect_user", False)

--- a/cloudinit/config/cc_users_groups.py
+++ b/cloudinit/config/cc_users_groups.py
@@ -162,8 +162,6 @@ def handle(name, cfg, cloud, _log, _args):
     (default_user, _user_config) = ug_util.extract_default(users)
     cloud_keys = cloud.get_public_ssh_keys() or []
 
-    no_homedir_options = ("no_create_home", "system")
-
     for (name, members) in groups.items():
         cloud.distro.create_group(name, members)
 

--- a/cloudinit/config/cc_users_groups.py
+++ b/cloudinit/config/cc_users_groups.py
@@ -186,6 +186,15 @@ def handle(name, cfg, cloud, _log, _args):
             else:
                 config["ssh_redirect_user"] = default_user
                 config["cloud_public_ssh_keys"] = cloud_keys
+
+        if (
+            config.get("no_create_home") or config.get("system")
+        ) and config.get("ssh_authorized_keys"):
+            raise ValueError(
+                "Not creating user %s. ssh_authorized_keys cannot be"
+                " provided with no_create_home: true or system: true" % user
+            )
+
         cloud.distro.create_user(user, **config)
 
 

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -87,6 +87,8 @@ users:
 #   no_log_init: When set to true, do not initialize lastlog and faillog database.
 #   ssh_import_id: Optional. Import SSH ids
 #   ssh_authorized_keys: Optional. [list] Add keys to user's authorized keys file
+#                        An error will be raised if no_create_home or system is
+#                        also set.
 #   ssh_redirect_user: Optional. [bool] Set true to block ssh logins for cloud
 #       ssh public keys and emit a message redirecting logins to
 #       use <default_username> instead. This option only disables cloud

--- a/tests/unittests/config/test_cc_users_groups.py
+++ b/tests/unittests/config/test_cc_users_groups.py
@@ -192,6 +192,27 @@ class TestHandleUsersGroups(CiTestCase):
         )
         m_group.assert_not_called()
 
+    def test_users_without_home_cannot_import_ssh_keys(self, m_user, m_group):
+        cfg = {
+            "users": [
+                "default",
+                {
+                    "name": "me2",
+                    "ssh_import_id": ["snowflake"],
+                    "no_create_home": True,
+                },
+            ]
+        }
+        cloud = self.tmp_cloud(distro="ubuntu", sys_cfg={}, metadata={})
+        with self.assertRaises(ValueError) as context_manager:
+            cc_users_groups.handle("modulename", cfg, cloud, None, None)
+        m_group.assert_not_called()
+        self.assertEqual(
+            "Not creating user me2. Key(s) ssh_import_id cannot be provided"
+            " with no_create_home",
+            str(context_manager.exception),
+        )
+
     def test_users_with_ssh_redirect_user_non_default(self, m_user, m_group):
         """Warn when ssh_redirect_user is not 'default'."""
         cfg = {


### PR DESCRIPTION
## Proposed Commit Message

```
summary: raise error when home should not be created AND ssh keys are provided

An invalid user config would be if no_create_home or system is set to
True, AND (ssh_authorized_keys or ssh_import_id or ssh_redirect_user)
is also provided. Right now, cloud-init proceeds to create the keys
(which would obviously create home for the user).

This change will cause an error to be raised instead for this invalid
config.

```

## Additional Context
<!-- If relevant -->

## Test Steps

sample user data:
```
#cloud-config

system_info:
  default_user:
    name: jf

users:
  - default

  - name: nch
    no_create_home: true
    ssh_authorized_keys:
      - list
      - of
      - keys

  - name: system
    system: true
    ssh_authorized_keys:
      - list
      - of
      - keys
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
