### PR TITLE
Fix cloud-init status --wait when no datasource found

### DIFF
--- a/systemd/cloud-init-generator.tmpl
+++ b/systemd/cloud-init-generator.tmpl
@@ -9,6 +9,7 @@ LOG_F="/run/cloud-init/cloud-init-generator.log"
 ENABLE="enabled"
 DISABLE="disabled"
 RUN_ENABLED_FILE="$LOG_D/$ENABLE"
+RUN_DISABLED_FILE="$LOG_D/$DISABLE"
 CLOUD_TARGET_NAME="cloud-init.target"
 # lxc sets 'container', but lets make that explicitly a global
 CONTAINER="${container}"
@@ -151,6 +152,10 @@ main() {
                     "ln $CLOUD_SYSTEM_TARGET $link_path"
             fi
         fi
+        if [ -e $RUN_DISABLED_FILE ]; then
+            debug 1 "removing $RUN_DISABLED_FILE and creating $RUN_ENABLED_FILE"
+            rm -f $RUN_DISABLED_FILE
+        fi
         : > "$RUN_ENABLED_FILE"
     elif [ "$result" = "$DISABLE" ]; then
         if [ -f "$link_path" ]; then
@@ -164,8 +169,10 @@ main() {
             debug 1 "already disabled: no change needed [no $link_path]"
         fi
         if [ -e "$RUN_ENABLED_FILE" ]; then
+            debug 1 "removing $RUN_ENABLED_FILE and creating $RUN_DISABLED_FILE"
             rm -f "$RUN_ENABLED_FILE"
         fi
+        : > "$RUN_DISABLED_FILE"
     else
         debug 0 "unexpected result '$result' 'ds=$ds'"
         ret=3

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -5,6 +5,7 @@ import os.path
 import random
 import string
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Optional, Type
 from uuid import UUID
 
@@ -290,7 +291,8 @@ class _LxdIntegrationCloud(IntegrationCloud):
             ).format(**format_variables)
             subp(command.split())
 
-    def _perform_launch(self, launch_kwargs, **kwargs):
+    def _perform_launch(self, original_kwargs, **kwargs):
+        launch_kwargs = deepcopy(original_kwargs)
         launch_kwargs["inst_type"] = launch_kwargs.pop("instance_type", None)
         wait = launch_kwargs.pop("wait", True)
         release = launch_kwargs.pop("image_id")

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -291,14 +291,16 @@ class _LxdIntegrationCloud(IntegrationCloud):
             ).format(**format_variables)
             subp(command.split())
 
-    def _perform_launch(self, original_kwargs, **kwargs):
-        launch_kwargs = deepcopy(original_kwargs)
-        launch_kwargs["inst_type"] = launch_kwargs.pop("instance_type", None)
-        wait = launch_kwargs.pop("wait", True)
-        release = launch_kwargs.pop("image_id")
+    def _perform_launch(self, launch_kwargs, **kwargs):
+        instance_kwargs = deepcopy(launch_kwargs)
+        instance_kwargs["inst_type"] = instance_kwargs.pop(
+            "instance_type", None
+        )
+        wait = instance_kwargs.pop("wait", True)
+        release = instance_kwargs.pop("image_id")
 
         try:
-            profile_list = launch_kwargs["profile_list"]
+            profile_list = instance_kwargs["profile_list"]
         except KeyError:
             profile_list = self._get_or_set_profile_list(release)
 
@@ -307,10 +309,10 @@ class _LxdIntegrationCloud(IntegrationCloud):
             random.choices(string.ascii_lowercase + string.digits, k=8)
         )
         pycloudlib_instance = self.cloud_instance.init(
-            launch_kwargs.pop("name", default_name),
+            instance_kwargs.pop("name", default_name),
             release,
             profile_list=profile_list,
-            **launch_kwargs,
+            **instance_kwargs,
         )
         if self.settings.CLOUD_INIT_SOURCE == "IN_PLACE":
             self._mount_source(pycloudlib_instance)

--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -13,7 +13,7 @@ def _wait_for_cloud_init(client: IntegrationInstance):
     last_exception = None
     for _ in range(30):
         try:
-            result = client.execute("cloud-init status")
+            result = client.execute("cloud-init status --long")
             if result and result.ok:
                 return result
         except Exception as e:
@@ -59,6 +59,7 @@ def test_wait_when_no_datasource(session_cloud: IntegrationCloud, setup_image):
             "impish",
         ]:
             _remove_nocloud_dir_and_reboot(client)
-        status = _wait_for_cloud_init(client)
-        assert status.stdout.strip() == "status: disabled"
+        status_out = _wait_for_cloud_init(client).stdout.strip()
+        assert "status: disabled" in status_out
+        assert "Cloud-init disabled by cloud-init-generator" in status_out
         assert client.execute("cloud-init status --wait").ok

--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -1,0 +1,58 @@
+"""Tests for `cloud-init status`"""
+from time import sleep
+
+import pytest
+
+from tests.integration_tests.clouds import ImageSpecification, IntegrationCloud
+from tests.integration_tests.instances import IntegrationInstance
+
+
+# We're implementing our own here in case cloud-init status --wait
+# isn't working correctly (LP: #1966085)
+def _wait_for_cloud_init(client: IntegrationInstance):
+    last_exception = None
+    for _ in range(30):
+        try:
+            result = client.execute("cloud-init status")
+            if result and result.ok:
+                return result
+        except Exception as e:
+            last_exception = e
+        sleep(1)
+    raise Exception(
+        "cloud-init status did not return successfully."
+    ) from last_exception
+
+
+def _remove_nocloud_dir_and_reboot(client: IntegrationInstance):
+    client.execute("rm -rf /var/lib/cloud/seed/nocloud-net")
+    client.execute("cloud-init clean --logs --reboot")
+
+
+@pytest.mark.ubuntu
+@pytest.mark.lxd_container
+def test_wait_when_no_datasource(session_cloud: IntegrationCloud, setup_image):
+    """Ensure that when no datasource is found, we get status: disabled
+
+    LP: #1966085
+    """
+    with session_cloud.launch(
+        launch_kwargs={
+            "config_dict": {"security.devlxd": False},
+            "wait": False,
+        }
+    ) as client:
+        # We know this will be an LXD instance due to our pytest mark
+        client.instance.execute_via_ssh = False  # type: ignore
+        # No ubuntu user if cloud-init didn't run
+        client.instance.username = "root"
+        # Jammy and above will use LXD datasource by default
+        if ImageSpecification.from_os_image().release in [
+            "bionic",
+            "focal",
+            "impish",
+        ]:
+            _remove_nocloud_dir_and_reboot(client)
+        status = _wait_for_cloud_init(client)
+        assert status.stdout.strip() == "status: disabled"
+        assert client.execute("cloud-init status --wait").ok


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix cloud-init status --wait when no datasource found

In 0de7acb1, we modified status checks to wait until we get an "enabled"
or "disabled" file from our generator. It never outputs a
"disabled" file, so "status --wait" will wait indefinitely if no
datasource is found.

LP: #1966085
```

## Additional Context
See: https://github.com/canonical/cloud-init/pull/1162

## Test Steps
Run tests/integration_tests/cmd/test_status.py

I also manually checked the generator script to verify that enabled and disabled files get created as expected and are mutually exclusive.
