### PR TITLE
docs: add jinja2 pin

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -5,5 +5,6 @@ sphinx_rtd_theme
 pyyaml
 
 # Indirect dependencies
+jinja2<3.1.0  # https://github.com/readthedocs/readthedocs.org/issues/9037
 docutils<0.18
 mistune<2.0.0  # https://github.com/miyakogi/m2r/issues/66


### PR DESCRIPTION
CI docs is currently failing on main due to a new jinja2 release.