### PR TITLE
docs: Re-order readthedocs install (SC-884)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,6 +3,6 @@ version: 2
 formats: all
 
 python:
-    install:
-        - requirements: doc-requirements.txt
-        - path: .
+  install:
+    - path: .
+    - requirements: doc-requirements.txt


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
docs: Re-order readthedocs install

Order building cloud-init before building doc-requirements.txt.
Building '.' invokes a 'pip install --upgrade .' which happens to also
re-install the latest versions of some previously pinned 
docs dependencies

Also updated the yaml to 2-space indents.
```

