### PR TITLE
The devname referenced in your traceback should be the result of get_devicelist(), which should be mocked.

### DIFF
--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -7394,7 +7394,7 @@ class TestNetRenderers(CiTestCase):
 )
 class TestGetInterfaces(CiTestCase):
     _data = {
-        "bonds": ["bond1", "bond0"],
+        "bonds": ["bond1"],
         "bridges": ["bridge1"],
         "vlans": ["bond1.101"],
         "own_macs": [
@@ -7417,7 +7417,6 @@ class TestGetInterfaces(CiTestCase):
             "greptap0": "00:00:00:00:00:00",
             "eth1": "aa:aa:aa:aa:aa:01",
             "tun0": None,
-            "bond0": None,
         },
         "drivers": {
             "enp0s1": "virtio_net",
@@ -7430,7 +7429,6 @@ class TestGetInterfaces(CiTestCase):
             "greptap0": None,
             "eth1": "mlx4_core",
             "tun0": None,
-            "bond0": None,
         },
     }
     data = {}
@@ -7508,11 +7506,11 @@ class TestGetInterfaces(CiTestCase):
             [mock.call("enp0s1"), mock.call("bond1")], any_order=True
         )
         expected = [
-            ("enp0s2", "aa:aa:aa:aa:aa:02", "e1000", "0x6"),
-            ("enp0s1", "aa:aa:aa:aa:aa:01", "virtio_net", "0x5"),
-            ("eth1", "aa:aa:aa:aa:aa:01", "mlx4_core", "0x7"),
-            ("lo", "00:00:00:00:00:00", None, "0x9"),
-            ("bridge1-nic", "aa:aa:aa:aa:aa:03", None, "0x4"),
+            ("enp0s2", "aa:aa:aa:aa:aa:02", "e1000", "0x5"),
+            ("enp0s1", "aa:aa:aa:aa:aa:01", "virtio_net", "0x4"),
+            ("eth1", "aa:aa:aa:aa:aa:01", "mlx4_core", "0x6"),
+            ("lo", "00:00:00:00:00:00", None, "0x8"),
+            ("bridge1-nic", "aa:aa:aa:aa:aa:03", None, "0x3"),
         ]
         self.assertEqual(sorted(expected), sorted(ret))
 

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -7454,6 +7454,12 @@ class TestGetInterfaces(CiTestCase):
     def _se_interface_has_own_mac(self, name):
         return name in self.data["own_macs"]
 
+    def _se_is_bond(self, name):
+        return name in self.data["bonds"]
+
+    def _se_is_netfailover(self, name):
+        return False
+
     def _mock_setup(self):
         self.data = copy.deepcopy(self._data)
         self.data["devices"] = set(list(self.data["macs"].keys()))
@@ -7465,6 +7471,8 @@ class TestGetInterfaces(CiTestCase):
             "is_vlan",
             "device_driver",
             "device_devid",
+            "is_bond",
+            "is_netfailover",
         )
         self.mocks = {}
         for n in mocks:


### PR DESCRIPTION
Hello
I am executing the cloud-init test case and the testcase has occasionally failed.
The failure testcases are:
FAILED tests/unittests/test_net.py::TestGetInterfaces::test_gi_excludes_any_without_mac_address
FAILED tests/unittests/test_net.py::TestGetInterfaces::test_gi_excludes_stolen_macs
FAILED tests/unittests/test_net.py::TestGetInterfaces::test_gi_includes_duplicate_macs

The error log for each failed use case is similar as follows:
```

    def test_gi_excludes_any_without_mac_address(self):
        self._mock_setup()
>       ret = net.get_interfaces()

tests/unittests/test_net.py:5431:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cloudinit/net/__init__.py:941: in get_interfaces
    if is_netfailover(name):
cloudinit/net/__init__.py:204: in is_netfailover
    if is_netfail_primary(devname, driver) or is_netfail_standby(devname,
cloudinit/net/__init__.py:279: in is_netfail_primary
    master_driver = device_driver(master_devname)
/usr/lib64/python3.9/unittest/mock.py:1092: in __call__
    return self._mock_call(*args, **kwargs)
/usr/lib64/python3.9/unittest/mock.py:1096: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
/usr/lib64/python3.9/unittest/mock.py:1157: in _execute_mock_call
    result = effect(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <tests.unittests.test_net.TestGetInterfaces testMethod=test_gi_excludes_any_without_mac_address>
name = 'bond0'

    def _se_device_driver(self, name):
>       return self.data['drivers'][name]
E       KeyError: 'bond0'

tests/unittests/test_net.py:5390: KeyError

Note: The file line number in the preceding log information may not match the latest code.

When the test case fails, the bond0 network adapter exists in my environment. 

According to the error log "KeyError: 'bond0'", I think that the data dictionary defined in the test case does not contain the bond keyword.

SO，I tried to add the bond0 keyword to the data dictionary. The test case was successfully executed.
Please help me to check whether the modification is feasible. Thank you.