### PR TITLE
black: bump pinned version to 22.3.0 to avoid click dependency issues

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -178,7 +178,7 @@ def suggested_swapsize(memsize=None, maxsize=None, fsys=None):
     if memsize is None:
         memsize = util.read_meminfo()["total"]
 
-    GB = 2 ** 30
+    GB = 2**30
     sugg_max = 8 * GB
 
     info = {"avail": "na", "max_in": maxsize, "mem": memsize}
@@ -230,7 +230,7 @@ def suggested_swapsize(memsize=None, maxsize=None, fsys=None):
 
     info["size"] = size
 
-    MB = 2 ** 20
+    MB = 2**20
     pinfo = {}
     for k, v in info.items():
         if isinstance(v, int):
@@ -324,7 +324,7 @@ def setup_swapfile(fname, size=None, maxsize=None):
             fsys=swap_dir, maxsize=maxsize, memsize=memsize
         )
 
-    mibsize = str(int(size / (2 ** 20)))
+    mibsize = str(int(size / (2**20)))
     if not size:
         LOG.debug("Not creating swap: suggested size was 0")
         return

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -871,15 +871,12 @@ class Init(object):
             return
 
         def event_enabled_and_metadata_updated(event_type):
-            return (
-                update_event_enabled(
-                    datasource=self.datasource,
-                    cfg=self.cfg,
-                    event_source_type=event_type,
-                    scope=EventScope.NETWORK,
-                )
-                and self.datasource.update_metadata_if_supported([event_type])
-            )
+            return update_event_enabled(
+                datasource=self.datasource,
+                cfg=self.cfg,
+                event_source_type=event_type,
+                scope=EventScope.NETWORK,
+            ) and self.datasource.update_metadata_if_supported([event_type])
 
         def should_run_on_boot_event():
             return (

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2664,7 +2664,7 @@ def pathprefix2dict(base, required=None, optional=None, delim=os.path.sep):
 def read_meminfo(meminfo="/proc/meminfo", raw=False):
     # read a /proc/meminfo style file and return
     # a dict with 'total', 'free', and 'available'
-    mpliers = {"kB": 2 ** 10, "mB": 2 ** 20, "B": 1, "gB": 2 ** 30}
+    mpliers = {"kB": 2**10, "mB": 2**20, "B": 1, "gB": 2**30}
     kmap = {
         "MemTotal:": "total",
         "MemFree:": "free",
@@ -2694,7 +2694,7 @@ def human2bytes(size):
     if size.endswith("B"):
         size = size[:-1]
 
-    mpliers = {"B": 1, "K": 2 ** 10, "M": 2 ** 20, "G": 2 ** 30, "T": 2 ** 40}
+    mpliers = {"B": 1, "K": 2**10, "M": 2**20, "G": 2**30, "T": 2**40}
 
     num = size
     mplier = "B"

--- a/tests/unittests/test_merging.py
+++ b/tests/unittests/test_merging.py
@@ -41,7 +41,7 @@ def _old_mergemanydict(*args):
 
 def _random_str(rand):
     base = ""
-    for _i in range(rand.randint(1, 2 ** 8)):
+    for _i in range(rand.randint(1, 2**8)):
         base += rand.choice(string.ascii_letters + string.digits)
     return base
 
@@ -81,7 +81,7 @@ def _make_dict(current_depth, max_depth, rand):
             if t in [tuple]:
                 base = tuple(base)
     elif t in [int]:
-        base = rand.randint(0, 2 ** 8)
+        base = rand.randint(0, 2**8)
     elif t in [str]:
         base = _random_str(rand)
     return base

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv=
     PYTEST_ADDOPTS
 
 [format_deps]
-black==21.12b0
+black==22.3.0
 flake8==3.9.2
 isort==5.10.1
 mypy==0.931


### PR DESCRIPTION
## Proposed Commit Message

```
Black < 22.3.0 didn't handle a dropped internal attribute _unicodefun
 from in more click package version 8.1.0. Due to issue
    Issue: https://github.com/psf/black/issues/2964

This broke our CI and tox -e do_format targets with
   cannot import name '_unicodefun' from 'click'.

Increment our pinned black to 22.3.0 and apply minor format
change rules.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
