### PR TITLE
schema: add json defs for modules U-Z

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -6,11 +6,7 @@ from textwrap import dedent
 
 from cloudinit import log as logging
 from cloudinit import subp, util
-from cloudinit.config.schema import (
-    MetaSchema,
-    get_meta_doc,
-    validate_cloudconfig_schema,
-)
+from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.settings import PER_INSTANCE
 
 UA_URL = "https://ubuntu.com/advantage"
@@ -77,29 +73,7 @@ meta: MetaSchema = {
     "frequency": PER_INSTANCE,
 }
 
-schema = {
-    "type": "object",
-    "properties": {
-        "ubuntu_advantage": {
-            "type": "object",
-            "properties": {
-                "enable": {
-                    "type": "array",
-                    "items": {"type": "string"},
-                },
-                "token": {
-                    "type": "string",
-                    "description": "A contract token obtained from %s."
-                    % UA_URL,
-                },
-            },
-            "required": ["token"],
-            "additionalProperties": False,
-        }
-    },
-}
-
-__doc__ = get_meta_doc(meta, schema)  # Supplement python help()
+__doc__ = get_meta_doc(meta)
 
 LOG = logging.getLogger(__name__)
 
@@ -194,7 +168,6 @@ def handle(name, cfg, cloud, log, args):
             name,
         )
         return
-    validate_cloudconfig_schema(cfg, schema)
     if "commands" in ua_section:
         msg = (
             'Deprecated configuration "ubuntu-advantage: commands" provided.'

--- a/cloudinit/config/cc_ubuntu_drivers.py
+++ b/cloudinit/config/cc_ubuntu_drivers.py
@@ -7,17 +7,13 @@ from textwrap import dedent
 
 from cloudinit import log as logging
 from cloudinit import subp, temp_utils, type_utils, util
-from cloudinit.config.schema import (
-    MetaSchema,
-    get_meta_doc,
-    validate_cloudconfig_schema,
-)
+from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.settings import PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
-frequency = PER_INSTANCE
 distros = ["ubuntu"]
+
 meta: MetaSchema = {
     "id": "cc_ubuntu_drivers",
     "name": "Ubuntu Drivers",
@@ -37,46 +33,14 @@ meta: MetaSchema = {
         """
         )
     ],
-    "frequency": frequency,
+    "frequency": PER_INSTANCE,
 }
 
-schema = {
-    "type": "object",
-    "properties": {
-        "drivers": {
-            "type": "object",
-            "additionalProperties": False,
-            "properties": {
-                "nvidia": {
-                    "type": "object",
-                    "additionalProperties": False,
-                    "required": ["license-accepted"],
-                    "properties": {
-                        "license-accepted": {
-                            "type": "boolean",
-                            "description": (
-                                "Do you accept the NVIDIA driver license?"
-                            ),
-                        },
-                        "version": {
-                            "type": "string",
-                            "description": (
-                                "The version of the driver to install (e.g."
-                                ' "390", "410"). Defaults to the latest'
-                                " version."
-                            ),
-                        },
-                    },
-                },
-            },
-        },
-    },
-}
+__doc__ = get_meta_doc(meta)
+
 OLD_UBUNTU_DRIVERS_STDERR_NEEDLE = (
     "ubuntu-drivers: error: argument <command>: invalid choice: 'install'"
 )
-
-__doc__ = get_meta_doc(meta, schema)  # Supplement python help()
 
 
 # Use a debconf template to configure a global debconf variable
@@ -180,5 +144,4 @@ def handle(name, cfg, cloud, log, _args):
         log.debug("Skipping module named %s, no 'drivers' key in config", name)
         return
 
-    validate_cloudconfig_schema(cfg, schema)
     install_drivers(cfg["drivers"], cloud.distro.install_packages)

--- a/cloudinit/config/cc_update_etc_hosts.py
+++ b/cloudinit/config/cc_update_etc_hosts.py
@@ -21,7 +21,7 @@ Management of the hosts file is controlled using ``manage_etc_hosts``. If this
 is set to false, cloud-init will not manage the hosts file at all. This is the
 default behavior.
 
-If set to ``true`` or ``template``, cloud-init will generate the hosts file
+If set to ``true``, cloud-init will generate the hosts file
 using the template located in ``/etc/cloud/templates/hosts.tmpl``. In the
 ``/etc/cloud/templates/hosts.tmpl`` template, the strings ``$hostname`` and
 ``$fqdn`` will be replaced with the hostname and fqdn respectively.

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -6,38 +6,76 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-"""
-Update Hostname
----------------
-**Summary:** update hostname and fqdn
+"""Update Hostname: Update hostname and fqdn"""
 
+import os
+from textwrap import dedent
+
+from cloudinit import util
+from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.settings import PER_ALWAYS
+
+MODULE_DESCRIPTION = """\
 This module will update the system hostname and fqdn. If ``preserve_hostname``
-is set, then the hostname will not be altered.
+is set ``true``, then the hostname will not be altered.
 
 .. note::
     for instructions on specifying hostname and fqdn, see documentation for
     ``cc_set_hostname``
-
-**Internal name:** ``cc_update_hostname``
-
-**Module frequency:** always
-
-**Supported distros:** all
-
-**Config keys**::
-
-    preserve_hostname: <true/false>
-    prefer_fqdn_over_hostname: <true/false>
-    fqdn: <fqdn>
-    hostname: <fqdn/hostname>
 """
 
-import os
+distros = ["all"]
 
-from cloudinit import util
-from cloudinit.settings import PER_ALWAYS
+meta: MetaSchema = {
+    "id": "cc_update_hostname",
+    "name": "Update Hostname",
+    "title": "Update hostname and fqdn",
+    "description": MODULE_DESCRIPTION,
+    "distros": distros,
+    "examples": [
+        dedent(
+            """\
+        # By default: when ``preserve_hostname`` is not specified cloud-init
+        # updates ``/etc/hostname`` per-boot based on the cloud provided
+        # ``local-hostname`` setting. If you manually change ``/etc/hostname``
+        # after boot cloud-init will no longer modify it.
+        #
+        # This default cloud-init behavior is equivalent to this cloud-config:
+        preserve_hostname: false
+        """
+        ),
+        dedent(
+            """\
+        # Prevent cloud-init from updating the system hostname.
+        preseve_hostname: true
+        """
+        ),
+        dedent(
+            """\
+        # Prevent cloud-init from updating ``/etc/hostname``
+        preseve_hostname: true
+        """
+        ),
+        (
+            """\
+        # Set hostname to "external.fqdn.me" instead of "myhost"
+        fqdn: external.fqdn.me
+        hostname: myhost
+        prefer_fqdn_over_hostname: true
+        """
+        ),
+        (
+            """\
+        # Set hostname to "external" instead of "external.fqdn.me" when
+        # cloud metadata provides the ``local-hostname``: "external.fqdn.me".
+        prefer_fqdn_over_hostname: false
+        """
+        ),
+    ],
+    "frequency": PER_ALWAYS,
+}
 
-frequency = PER_ALWAYS
+__doc__ = get_meta_doc(meta)
 
 
 def handle(name, cfg, cloud, log, _args):

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -56,7 +56,7 @@ meta: MetaSchema = {
         preseve_hostname: true
         """
         ),
-        (
+        dedent(
             """\
         # Set hostname to "external.fqdn.me" instead of "myhost"
         fqdn: external.fqdn.me
@@ -64,7 +64,7 @@ meta: MetaSchema = {
         prefer_fqdn_over_hostname: true
         """
         ),
-        (
+        dedent(
             """\
         # Set hostname to "external" instead of "external.fqdn.me" when
         # cloud metadata provides the ``local-hostname``: "external.fqdn.me".

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -12,14 +12,8 @@ from textwrap import dedent
 
 from cloudinit import log as logging
 from cloudinit import util
-from cloudinit.config.schema import (
-    MetaSchema,
-    get_meta_doc,
-    validate_cloudconfig_schema,
-)
+from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.settings import PER_INSTANCE
-
-frequency = PER_INSTANCE
 
 DEFAULT_OWNER = "root:root"
 DEFAULT_PERMS = 0o644
@@ -35,17 +29,6 @@ distros = ["all"]
 # It allows cloud-config to validate and alert users to invalid or ignored
 # configuration options before actually attempting to deploy with said
 # configuration.
-
-supported_encoding_types = [
-    "gz",
-    "gzip",
-    "gz+base64",
-    "gzip+base64",
-    "gz+b64",
-    "gzip+b64",
-    "b64",
-    "base64",
-]
 
 meta: MetaSchema = {
     "id": "cc_write_files",
@@ -132,113 +115,13 @@ meta: MetaSchema = {
         """
         ),
     ],
-    "frequency": frequency,
+    "frequency": PER_INSTANCE,
 }
 
-schema = {
-    "type": "object",
-    "properties": {
-        "write_files": {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": dedent(
-                            """\
-                            Path of the file to which ``content`` is decoded
-                            and written
-                        """
-                        ),
-                    },
-                    "content": {
-                        "type": "string",
-                        "default": "",
-                        "description": dedent(
-                            """\
-                            Optional content to write to the provided ``path``.
-                            When content is present and encoding is not '%s',
-                            decode the content prior to writing. Default:
-                            **''**
-                        """
-                            % UNKNOWN_ENC
-                        ),
-                    },
-                    "owner": {
-                        "type": "string",
-                        "default": DEFAULT_OWNER,
-                        "description": dedent(
-                            """\
-                            Optional owner:group to chown on the file. Default:
-                            **{owner}**
-                        """.format(
-                                owner=DEFAULT_OWNER
-                            )
-                        ),
-                    },
-                    "permissions": {
-                        "type": "string",
-                        "default": oct(DEFAULT_PERMS).replace("o", ""),
-                        "description": dedent(
-                            """\
-                            Optional file permissions to set on ``path``
-                            represented as an octal string '0###'. Default:
-                            **'{perms}'**
-                        """.format(
-                                perms=oct(DEFAULT_PERMS).replace("o", "")
-                            )
-                        ),
-                    },
-                    "encoding": {
-                        "type": "string",
-                        "default": UNKNOWN_ENC,
-                        "enum": supported_encoding_types,
-                        "description": dedent(
-                            """\
-                            Optional encoding type of the content. Default is
-                            **text/plain** and no content decoding is
-                            performed. Supported encoding types are:
-                            %s."""
-                            % ", ".join(supported_encoding_types)
-                        ),
-                    },
-                    "append": {
-                        "type": "boolean",
-                        "default": False,
-                        "description": dedent(
-                            """\
-                            Whether to append ``content`` to existing file if
-                            ``path`` exists. Default: **false**.
-                        """
-                        ),
-                    },
-                    "defer": {
-                        "type": "boolean",
-                        "default": DEFAULT_DEFER,
-                        "description": dedent(
-                            """\
-                            Defer writing the file until 'final' stage, after
-                            users were created, and packages were installed.
-                            Default: **{defer}**.
-                        """.format(
-                                defer=DEFAULT_DEFER
-                            )
-                        ),
-                    },
-                },
-                "required": ["path"],
-                "additionalProperties": False,
-            },
-        }
-    },
-}
-
-__doc__ = get_meta_doc(meta, schema)  # Supplement python help()
+__doc__ = get_meta_doc(meta)
 
 
 def handle(name, cfg, _cloud, log, _args):
-    validate_cloudconfig_schema(cfg, schema)
     file_list = cfg.get("write_files", [])
     filtered_files = [
         f

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -22,14 +22,6 @@ UNKNOWN_ENC = "text/plain"
 
 LOG = logging.getLogger(__name__)
 
-distros = ["all"]
-
-# The schema definition for each cloud-config module is a strict contract for
-# describing supported configuration parameters for each cloud-config section.
-# It allows cloud-config to validate and alert users to invalid or ignored
-# configuration options before actually attempting to deploy with said
-# configuration.
-
 meta: MetaSchema = {
     "id": "cc_write_files",
     "name": "Write Files",
@@ -53,7 +45,7 @@ meta: MetaSchema = {
         the early boot process. Use /run/somedir instead to avoid race
         LP:1707222."""
     ),
-    "distros": distros,
+    "distros": ["all"],
     "examples": [
         dedent(
             """\

--- a/cloudinit/config/cc_write_files_deferred.py
+++ b/cloudinit/config/cc_write_files_deferred.py
@@ -5,10 +5,7 @@
 """Defer writing certain files"""
 
 from cloudinit import util
-from cloudinit.config.cc_write_files import DEFAULT_DEFER
-from cloudinit.config.cc_write_files import schema as write_files_schema
-from cloudinit.config.cc_write_files import write_files
-from cloudinit.config.schema import validate_cloudconfig_schema
+from cloudinit.config.cc_write_files import DEFAULT_DEFER, write_files
 
 # meta is not used in this module, but it remains as code documentation
 #
@@ -28,15 +25,11 @@ from cloudinit.config.schema import validate_cloudconfig_schema
 #    *Please note that his module is not exposed to the user through
 #    its own dedicated top-level directive.*
 
-schema = write_files_schema
-
-
 # Not exposed, because related modules should document this behaviour
 __doc__ = None
 
 
 def handle(name, cfg, _cloud, log, _args):
-    validate_cloudconfig_schema(cfg, schema)
     file_list = cfg.get("write_files", [])
     filtered_files = [
         f

--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -4,38 +4,23 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-"""
-Yum Add Repo
-------------
-**Summary:** add yum repository configuration to the system
-
-Add yum repository configuration to ``/etc/yum.repos.d``. Configuration files
-are named based on the dictionary key under the ``yum_repos`` they are
-specified with. If a config file already exists with the same name as a config
-entry, the config entry will be skipped.
-
-**Internal name:** ``cc_yum_add_repo``
-
-**Module frequency:** always
-
-**Supported distros:** almalinux, centos, cloudlinux, eurolinux, fedora,
-                       miraclelinux, openEuler, photon, rhel, rocky, virtuozzo
-
-**Config keys**::
-
-    yum_repos:
-        <repo-name>:
-            baseurl: <repo url>
-            name: <repo name>
-            enabled: <true/false>
-            # any repository configuration options (see man yum.conf)
-"""
+"Yum Add Repo: Add yum repository configuration to the system"
 
 import io
 import os
 from configparser import ConfigParser
+from textwrap import dedent
 
 from cloudinit import util
+from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.settings import PER_INSTANCE
+
+MODULE_DESCRIPTION = """\
+Add yum repository configuration to ``/etc/yum.repos.d``. Configuration files
+are named based on the opaque dictionary key under the ``yum_repos`` they are
+specified with. If a config file already exists with the same name as a config
+entry, the config entry will be skipped.
+"""
 
 distros = [
     "almalinux",
@@ -49,6 +34,86 @@ distros = [
     "rocky",
     "virtuozzo",
 ]
+
+COPR_BASEURL = (
+    "https://download.copr.fedorainfracloud.org/results/@cloud-init/"
+    "cloud-init-dev/epel-8-$basearch/"
+)
+COPR_GPG_URL = (
+    "https://download.copr.fedorainfracloud.org/results/@cloud-init/"
+    "cloud-init-dev/pubkey.gpg"
+)
+EPEL_TESTING_BASEURL = (
+    "https://download.copr.fedorainfracloud.org/results/@cloud-init/"
+    "cloud-init-dev/pubkey.gpg"
+)
+
+meta: MetaSchema = {
+    "id": "cc_yum_add_repo",
+    "name": "Yum Add Repo",
+    "title": "Add yum repository configuration to the system",
+    "description": MODULE_DESCRIPTION,
+    "distros": distros,
+    "examples": [
+        dedent(
+            """\
+            yum_repos:
+              my_repo:
+                baseurl: http://blah.org/pub/epel/testing/5/$basearch/
+            """
+        ),
+        dedent(
+            f"""\
+            # Enable cloud-init upstream's daily testing repo for EPEL 8 to
+            # install latest cloud-init from tip of `main` for testing.
+            yum_repos:
+              cloud-init-daily:
+                name: Copr repo for cloud-init-dev owned by @cloud-init
+                baseurl: {COPR_BASEURL}
+                type: rpm-md
+                skip_if_unavailable: true
+                gpgcheck: true
+                gpgkey: {COPR_GPG_URL}
+                enabled_metadata: 1
+            """
+        ),
+        dedent(
+            f"""\
+            # Add the file /etc/yum.repos.d/epel_testing.repo which can then
+            # subsequently be used by yum for later operations.
+            yum_repos:
+            # The name of the repository
+             epel-testing:
+               baseurl: {EPEL_TESTING_BASEURL}
+               enabled: false
+               failovermethod: priority
+               gpgcheck: true
+               gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL
+               name: Extra Packages for Enterprise Linux 5 - Testing
+            """
+        ),
+        dedent(
+            """\
+            # Any yum repo configuration can be passed directly into
+            # the repository file created. See: man yum.conf for supported
+            # config keys.
+            #
+            # Write /etc/yum.conf.d/my_package_stream.repo with gpgkey checks
+            # on the repo data of the repositoy enabled.
+            yum_repos:
+              my package stream:
+                baseurl: http://blah.org/pub/epel/testing/5/$basearch/
+                mirrorlist: http://some-url-to-list-of-baseurls
+                repo_gpgcheck: 1
+                enable_gpgcheck: true
+                gpgkey: https://url.to.ascii-armored-gpg-key
+            """
+        ),
+    ],
+    "frequency": PER_INSTANCE,
+}
+
+__doc__ = get_meta_doc(meta)
 
 
 def _canonicalize_id(repo_id):

--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -60,6 +60,7 @@ meta: MetaSchema = {
             yum_repos:
               my_repo:
                 baseurl: http://blah.org/pub/epel/testing/5/$basearch/
+            yum_repo_dir: /store/custom/yum.repos.d
             """
         ),
         dedent(

--- a/cloudinit/config/cc_zypper_add_repo.py
+++ b/cloudinit/config/cc_zypper_add_repo.py
@@ -60,53 +60,7 @@ meta: MetaSchema = {
     "frequency": PER_ALWAYS,
 }
 
-schema = {
-    "type": "object",
-    "properties": {
-        "zypper": {
-            "type": "object",
-            "properties": {
-                "repos": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "id": {
-                                "type": "string",
-                                "description": dedent(
-                                    """\
-                                    The unique id of the repo, used when
-                                     writing
-                                    /etc/zypp/repos.d/<id>.repo."""
-                                ),
-                            },
-                            "baseurl": {
-                                "type": "string",
-                                "format": "uri",  # built-in format type
-                                "description": "The base repositoy URL",
-                            },
-                        },
-                        "required": ["id", "baseurl"],
-                        "additionalProperties": True,
-                    },
-                    "minItems": 1,
-                },
-                "config": {
-                    "type": "object",
-                    "description": dedent(
-                        """\
-                        Any supported zypo.conf key is written to
-                        /etc/zypp/zypp.conf'"""
-                    ),
-                },
-            },
-            "minProperties": 1,  # Either config or repo must be provided
-            "additionalProperties": False,  # only repos and config allowed
-        }
-    },
-}
-
-__doc__ = get_meta_doc(meta, schema)  # Supplement python help()
+__doc__ = get_meta_doc(meta)
 
 LOG = logging.getLogger(__name__)
 

--- a/cloudinit/config/cc_zypper_add_repo.py
+++ b/cloudinit/config/cc_zypper_add_repo.py
@@ -3,7 +3,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-"""zypper_add_repo: Add zyper repositories to the system"""
+"""zypper_add_repo: Add zypper repositories to the system"""
 
 import os
 from textwrap import dedent
@@ -16,22 +16,25 @@ from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.settings import PER_ALWAYS
 
 distros = ["opensuse", "sles"]
+MODULE_DESCRIPTION = """\
+Zypper behavior can be configured using the ``config`` key, which will modify
+``/etc/zypp/zypp.conf``. The configuration writer will only append the
+provided configuration options to the configuration file. Any duplicate
+options will be resolved by the way the zypp.conf INI file is parsed.
 
+.. note::
+    Setting ``configdir`` is not supported and will be skipped.
+
+The ``repos`` key may be used to add repositories to the system. Beyond the
+required ``id`` and ``baseurl`` attributions, no validation is performed
+on the ``repos`` entries. It is assumed the user is familiar with the
+zypper repository file format.
+"""
 meta: MetaSchema = {
     "id": "cc_zypper_add_repo",
-    "name": "ZypperAddRepo",
+    "name": "Zypper Add Repo",
     "title": "Configure zypper behavior and add zypper repositories",
-    "description": dedent(
-        """\
-        Configure zypper behavior by modifying /etc/zypp/zypp.conf. The
-        configuration writer is "dumb" and will simply append the provided
-        configuration options to the configuration file. Option settings
-        that may be duplicate will be resolved by the way the zypp.conf file
-        is parsed. The file is in INI format.
-        Add repositories to the system. No validation is performed on the
-        repository file entries, it is assumed the user is familiar with
-        the zypper repository file format."""
-    ),
+    "description": MODULE_DESCRIPTION,
     "distros": distros,
     "examples": [
         dedent(

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1895,7 +1895,95 @@
           "minItems": 1
         }
       }
-    }
+    },
+    "cc_yum_add_repo": {
+      "type": "object",
+      "properties": {
+        "yum_repo_dir": {
+            "type": "string",
+             "default": "/etc/yum.repos.d",
+             "description": "The repo parts directory where individual yum repo config files will be writting. Default: ``/etc/yum.repos.d``"
+        },
+        "yum_repos": {
+          "type": "object",
+          "minProperties": 1,
+          "patternProperties": {
+            "^[0-9a-zA-Z -_]+$": {
+              "type": "object",
+              "description": "Object keyedon unique yum repo IDs. The key used will be used to write yum repo config files in ``yum_repo_dir``/<repo_key_id>.repo.",
+              "properties": {
+                "baseurl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL to the directory where the yum repository's 'repodata' directory lives"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Optional human-readable name of the yum repo."
+                },
+                "enabled": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Whether to enabled the repo. Default: ``true``."
+                }
+              },
+              "patternProperties": {
+                "^[0-9a-zA-Z_]+$": {
+                    "oneOf": [
+                      {"type": "integer"},
+                      {"type": "boolean"},
+                      {"type": "string"}
+                    ],
+                    "description": "Any supported yum repository configuration options will be written to the yum repo config file. See: man yum.conf"
+                }
+              },
+              "required": ["baseurl"]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "cc_zypper_add_repo": {
+      "type": "object",
+      "properties": {
+        "zypper": {
+          "type": "object",
+          "properties": {
+            "repos": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The unique id of the repo, used when writing /etc/zypp/repos.d/<id>.repo."
+                  },
+                  "baseurl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The base repositoy URL"
+                  }
+                },
+                "required": [
+                  "id",
+                  "baseurl"
+                ],
+                "additionalProperties": true
+              },
+              "minItems": 1
+            },
+            "config": {
+              "type": "object",
+              "description": "Any supported zypo.conf key is written to ``/etc/zypp/zypp.conf``"
+            }
+          },
+          "minProperties": 1,
+          "additionalProperties": false
+        }
+      }
+    },
+>>>>>>> df0b41702... yum
   },
   "allOf": [
     { "$ref": "#/$defs/cc_apk_configure" },
@@ -1945,6 +2033,7 @@
     { "$ref": "#/$defs/cc_ubuntu_drivers"},
     { "$ref": "#/$defs/cc_update_etc_hosts"},
     { "$ref": "#/$defs/cc_update_hostname"},
-    { "$ref": "#/$defs/cc_write_files"}
+    { "$ref": "#/$defs/cc_write_files"},
+    { "$ref": "#/$defs/cc_yum_add_repo"}
   ]
 }

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1783,6 +1783,34 @@
           "additionalProperties": false
         }
       }
+    },
+    "cc_ubuntu_drivers": {
+      "type": "object",
+      "properties": {
+        "drivers": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "nvidia": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "license-accepted"
+              ],
+              "properties": {
+                "license-accepted": {
+                  "type": "boolean",
+                  "description": "Do you accept the NVIDIA driver license?"
+                },
+                "version": {
+                  "type": "string",
+                  "description": "The version of the driver to install (e.g. \"390\", \"410\"). Defaults to the latest version."
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "allOf": [
@@ -1829,6 +1857,7 @@
     { "$ref": "#/$defs/cc_ssh_import_id"},
     { "$ref": "#/$defs/cc_ssh"},
     { "$ref": "#/$defs/cc_timezone"},
-    { "$ref": "#/$defs/cc_ubuntu_advantage"}
+    { "$ref": "#/$defs/cc_ubuntu_advantage"},
+    { "$ref": "#/$defs/cc_ubuntu_drivers"}
   ]
 }

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1812,6 +1812,24 @@
         }
       }
     },
+    "cc_update_etc_hosts": {
+      "type": "object",
+      "properties": {
+        "manage_etc_hosts": {
+          "default": false,
+          "description": "Whether to manage /etc/hosts on the system. When set ``true``, cloud-init will render the hosts file using ``/etc/cloud/templates/hosts.tmpl`` replacing ``$hostname`` and ``$fdqn``. When set ``localhost``, Default: ``false``. DEPRECATED value ``template``will be dropped, use ``true`` instead.",
+          "oneOf": [{"type": "boolean"}, {"enum": ["template", "localhost"]}]
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "Optional fully qualified domain name to use when updating ``/etc/hosts``. Preferred over ``hostname`` if both are provided. In absence of ``hostname`` and ``fqdn`` in cloud-config, the ``local-hostname`` value will be used from datasource metadata."
+        },
+        "hostname": {
+          "type": "string",
+          "description": "Hostname to set when rendering ``/etc/hosts``. If ``fqdn`` is set, the hostname extracted from ``fqdn`` overrides ``hostname``."
+        }
+      }
+    },
     "cc_write_files": {
       "type": "object",
       "properties": {
@@ -1910,6 +1928,7 @@
     { "$ref": "#/$defs/cc_timezone"},
     { "$ref": "#/$defs/cc_ubuntu_advantage"},
     { "$ref": "#/$defs/cc_ubuntu_drivers"},
+    { "$ref": "#/$defs/cc_update_etc_hosts"},
     { "$ref": "#/$defs/cc_write_files"}
   ]
 }

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1762,6 +1762,27 @@
           "description": "The timezone to use as represented in /usr/share/zoneinfo"
         }
       }
+    },
+    "cc_ubuntu_advantage": {
+      "type": "object",
+      "properties": {
+        "ubuntu_advantage": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "Optional list of ubuntu-advantage services to enable. Any of: cc-eal, cis, esm-infra, fips, fips-updates, livepatch. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled."
+            },
+            "token": {
+              "type": "string",
+              "description": "Required contract token obtained from https://ubuntu.com/advantage to attach."
+            }
+          },
+          "required": ["token"],
+          "additionalProperties": false
+        }
+      }
     }
   },
   "allOf": [
@@ -1807,6 +1828,7 @@
     { "$ref": "#/$defs/cc_ssh_authkey_fingerprints"},
     { "$ref": "#/$defs/cc_ssh_import_id"},
     { "$ref": "#/$defs/cc_ssh"},
-    { "$ref": "#/$defs/cc_timezone"}
+    { "$ref": "#/$defs/cc_timezone"},
+    { "$ref": "#/$defs/cc_ubuntu_advantage"}
   ]
 }

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1830,6 +1830,21 @@
         }
       }
     },
+    "cc_update_hostname": {
+      "type": "object",
+      "properties": {
+        "preserve_hostname": {
+          "type": "boolean",
+          "default": false,
+          "description": "Do not update system hostname when ``true``. Default: ``false``."
+        },
+        "prefer_fqdn_over_hostname": {
+          "type": "boolean",
+          "default": null,
+          "description": "By default, cloud-init will set the hostname to the short hostname instead of the fully qualified domain name even if cloud-config user-data provides an ``fqdn`` or instance metadata or provides an fqdn in its ``local-hostname`` value. When set ``true``, use fully qualified domain name if present as hostname instead of short hostname. When set ``false``, use ``hostname`` config value if present, otherwise fallback to ``fqdn``."
+        }
+      }
+    },
     "cc_write_files": {
       "type": "object",
       "properties": {
@@ -1929,6 +1944,7 @@
     { "$ref": "#/$defs/cc_ubuntu_advantage"},
     { "$ref": "#/$defs/cc_ubuntu_drivers"},
     { "$ref": "#/$defs/cc_update_etc_hosts"},
+    { "$ref": "#/$defs/cc_update_hostname"},
     { "$ref": "#/$defs/cc_write_files"}
   ]
 }

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1817,7 +1817,7 @@
       "properties": {
         "manage_etc_hosts": {
           "default": false,
-          "description": "Whether to manage ``/etc/hosts`` on the system. Set ``true`` to render the hosts file using ``/etc/cloud/templates/hosts.tmpl`` replacing ``$hostname`` and ``$fdqn``. Set ``localhost`` to and cloud-init will append a ``127.0.1.1`` entry that resolves from FQDN and hostname every boot. Default: ``false``. DEPRECATED value ``template`` will be dropped, use ``true`` instead.",
+          "description": "Whether to manage ``/etc/hosts`` on the system. If ``true``, render the hosts file using ``/etc/cloud/templates/hosts.tmpl`` replacing ``$hostname`` and ``$fdqn``. If ``localhost``, append a ``127.0.1.1`` entry that resolves from FQDN and hostname every boot. Default: ``false``. DEPRECATED value ``template`` will be dropped, use ``true`` instead.",
           "enum": [true, false, "template", "localhost"]
         },
         "fqdn": {

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1811,6 +1811,57 @@
           }
         }
       }
+    },
+    "cc_write_files": {
+      "type": "object",
+      "properties": {
+        "write_files": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path of the file to which ``content`` is decoded and written"
+              },
+              "content": {
+                "type": "string",
+                "default": "",
+                "description": "Optional content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``"
+              },
+              "owner": {
+                "type": "string",
+                "default": "root:root",
+                "description": "Optional owner:group to chown on the file. Default: ``root:root``"
+              },
+              "permissions": {
+                "type": "string",
+                "default": "0o644",
+                "description": "Optional file permissions to set on ``path`` represented as an octal string '0###'. Default: ``0o644``"
+              },
+              "encoding": {
+                "type": "string",
+                "default": "text/plain",
+                "enum": ["gz", "gzip", "gz+base64", "gzip+base64", "gz+b64", "gzip+b64", "b64", "base64"],
+                "description": "Optional encoding type of the content. Default is ``text/plain`` and no content decoding is performed. Supported encoding types are: gz, gzip, gz+base64, gzip+base64, gz+b64, gzip+b64, b64, base64"
+              },
+              "append": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether to append ``content`` to existing file if ``path`` exists. Default: ``false``."
+              },
+              "defer": {
+                "type": "boolean",
+                "default": false,
+                "description": "Defer writing the file until 'final' stage, after users were created, and packages were installed. Default: ``false``."
+              }
+            },
+            "required": ["path"],
+            "additionalProperties": false
+          },
+          "minItems": 1
+        }
+      }
     }
   },
   "allOf": [
@@ -1858,6 +1909,7 @@
     { "$ref": "#/$defs/cc_ssh"},
     { "$ref": "#/$defs/cc_timezone"},
     { "$ref": "#/$defs/cc_ubuntu_advantage"},
-    { "$ref": "#/$defs/cc_ubuntu_drivers"}
+    { "$ref": "#/$defs/cc_ubuntu_drivers"},
+    { "$ref": "#/$defs/cc_write_files"}
   ]
 }

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1817,8 +1817,8 @@
       "properties": {
         "manage_etc_hosts": {
           "default": false,
-          "description": "Whether to manage /etc/hosts on the system. When set ``true``, cloud-init will render the hosts file using ``/etc/cloud/templates/hosts.tmpl`` replacing ``$hostname`` and ``$fdqn``. When set ``localhost``, Default: ``false``. DEPRECATED value ``template``will be dropped, use ``true`` instead.",
-          "oneOf": [{"type": "boolean"}, {"enum": ["template", "localhost"]}]
+          "description": "Whether to manage ``/etc/hosts`` on the system. Set ``true`` to render the hosts file using ``/etc/cloud/templates/hosts.tmpl`` replacing ``$hostname`` and ``$fdqn``. Set ``localhost`` to and cloud-init will append a ``127.0.1.1`` entry that resolves from FQDN and hostname every boot. Default: ``false``. DEPRECATED value ``template`` will be dropped, use ``true`` instead.",
+          "enum": [true, false, "template", "localhost"]
         },
         "fqdn": {
           "type": "string",
@@ -1841,7 +1841,7 @@
         "prefer_fqdn_over_hostname": {
           "type": "boolean",
           "default": null,
-          "description": "By default, cloud-init will set the hostname to the short hostname instead of the fully qualified domain name even if cloud-config user-data provides an ``fqdn`` or instance metadata or provides an fqdn in its ``local-hostname`` value. When set ``true``, use fully qualified domain name if present as hostname instead of short hostname. When set ``false``, use ``hostname`` config value if present, otherwise fallback to ``fqdn``."
+          "description": "By default, it is distro-dependent whether cloud-init uses the short hostname or fully qualified domain name when both ``local-hostname` and ``fqdn`` are both present in instance metadata. When set ``true``, use fully qualified domain name if present as hostname instead of short hostname. When set ``false``, use ``hostname`` config value if present, otherwise fallback to ``fqdn``."
         }
       }
     },
@@ -1902,15 +1902,16 @@
         "yum_repo_dir": {
             "type": "string",
              "default": "/etc/yum.repos.d",
-             "description": "The repo parts directory where individual yum repo config files will be writting. Default: ``/etc/yum.repos.d``"
+             "description": "The repo parts directory where individual yum repo config files will be written. Default: ``/etc/yum.repos.d``"
         },
         "yum_repos": {
           "type": "object",
           "minProperties": 1,
           "patternProperties": {
             "^[0-9a-zA-Z -_]+$": {
+              "label": "<repo_name>",
               "type": "object",
-              "description": "Object keyedon unique yum repo IDs. The key used will be used to write yum repo config files in ``yum_repo_dir``/<repo_key_id>.repo.",
+              "description": "Object keyed on unique yum repo IDs. The key used will be used to write yum repo config files in ``yum_repo_dir``/<repo_key_id>.repo.",
               "properties": {
                 "baseurl": {
                     "type": "string",
@@ -1924,11 +1925,12 @@
                 "enabled": {
                   "type": "boolean",
                   "default": true,
-                  "description": "Whether to enabled the repo. Default: ``true``."
+                  "description": "Whether to enable the repo. Default: ``true``."
                 }
               },
               "patternProperties": {
                 "^[0-9a-zA-Z_]+$": {
+                    "label": "<yum_config_option>",
                     "oneOf": [
                       {"type": "integer"},
                       {"type": "boolean"},

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1982,8 +1982,7 @@
           "additionalProperties": false
         }
       }
-    },
->>>>>>> df0b41702... yum
+    }
   },
   "allOf": [
     { "$ref": "#/$defs/cc_apk_configure" },
@@ -2034,6 +2033,7 @@
     { "$ref": "#/$defs/cc_update_etc_hosts"},
     { "$ref": "#/$defs/cc_update_hostname"},
     { "$ref": "#/$defs/cc_write_files"},
-    { "$ref": "#/$defs/cc_yum_add_repo"}
+    { "$ref": "#/$defs/cc_yum_add_repo"},
+    { "$ref": "#/$defs/cc_zypper_add_repo"}
   ]
 }

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -315,7 +315,7 @@ resize_rootfs: True
 #      * Whatever is present at instance boot time will be present after boot.
 #      * User changes will not be overwritten
 #
-#    true or 'template':
+#    true:
 #      on every boot, /etc/hosts will be re-written from
 #      /etc/cloud/templates/hosts.tmpl.
 #      The strings '$hostname' and '$fqdn' are replaced in the template

--- a/doc/rtd/topics/modules.rst
+++ b/doc/rtd/topics/modules.rst
@@ -63,4 +63,5 @@ Modules
 .. automodule:: cloudinit.config.cc_users_groups
 .. automodule:: cloudinit.config.cc_write_files
 .. automodule:: cloudinit.config.cc_yum_add_repo
+.. automodule:: cloudinit.config.cc_zypper_add_repo
 .. vi: textwidth=79

--- a/tests/unittests/config/test_cc_update_etc_hosts.py
+++ b/tests/unittests/config/test_cc_update_etc_hosts.py
@@ -4,8 +4,15 @@ import logging
 import os
 import shutil
 
+import pytest
+
 from cloudinit import cloud, distros, helpers, util
 from cloudinit.config import cc_update_etc_hosts
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
 from tests.unittests import helpers as t_help
 
 LOG = logging.getLogger(__name__)
@@ -66,3 +73,22 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
             self.assertIsNone("No entry for 127.0.1.1 in etc/hosts")
         if "::1 cloud-init.test.us cloud-init" not in contents:
             self.assertIsNone("No entry for 127.0.0.1 in etc/hosts")
+
+
+class TestUpdateEtcHosts:
+    @pytest.mark.parametrize(
+        "config, error_msg",
+        [
+            (
+                {"manage_etc_hosts": "templatey"},
+                "manage_etc_hosts: 'templatey' is not valid",
+            ),
+        ],
+    )
+    @t_help.skipUnlessJsonSchema()
+    def test_schema_validation(self, config, error_msg):
+        if error_msg is None:
+            validate_cloudconfig_schema(config, get_schema(), strict=True)
+        else:
+            with pytest.raises(SchemaValidationError, match=error_msg):
+                validate_cloudconfig_schema(config, get_schema(), strict=True)

--- a/tests/unittests/config/test_cc_update_etc_hosts.py
+++ b/tests/unittests/config/test_cc_update_etc_hosts.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import shutil
 
 import pytest
@@ -81,7 +82,10 @@ class TestUpdateEtcHosts:
         [
             (
                 {"manage_etc_hosts": "templatey"},
-                "manage_etc_hosts: 'templatey' is not valid",
+                re.escape(
+                    "manage_etc_hosts: 'templatey' is not one of"
+                    " [True, False, 'template', 'localhost']"
+                ),
             ),
         ],
     )

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -1,19 +1,25 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import base64
-import copy
 import gzip
 import io
+import re
 import shutil
 import tempfile
+
+import pytest
 
 from cloudinit import log as logging
 from cloudinit import util
 from cloudinit.config.cc_write_files import decode_perms, handle, write_files
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
 from tests.unittests.helpers import (
     CiTestCase,
     FilesystemMockingTestCase,
-    mock,
     skipUnlessJsonSchema,
 )
 
@@ -55,74 +61,6 @@ VALID_SCHEMA = {
     ]
 }
 
-INVALID_SCHEMA = {  # Dropped required path key
-    "write_files": [
-        {
-            "append": False,
-            "content": "a",
-            "encoding": "gzip",
-            "owner": "jeff",
-            "permissions": "0777",
-        }
-    ]
-}
-
-
-@skipUnlessJsonSchema()
-@mock.patch("cloudinit.config.cc_write_files.write_files")
-class TestWriteFilesSchema(CiTestCase):
-
-    with_logs = True
-
-    def test_schema_validation_warns_missing_path(self, m_write_files):
-        """The only required file item property is 'path'."""
-        cc = self.tmp_cloud("ubuntu")
-        valid_config = {"write_files": [{"path": "/some/path"}]}
-        handle("cc_write_file", valid_config, cc, LOG, [])
-        self.assertNotIn(
-            "Invalid cloud-config provided:", self.logs.getvalue()
-        )
-        handle("cc_write_file", INVALID_SCHEMA, cc, LOG, [])
-        self.assertIn("Invalid cloud-config provided:", self.logs.getvalue())
-        self.assertIn("'path' is a required property", self.logs.getvalue())
-
-    def test_schema_validation_warns_non_string_type_for_files(
-        self, m_write_files
-    ):
-        """Schema validation warns of non-string values for each file item."""
-        cc = self.tmp_cloud("ubuntu")
-        for key in VALID_SCHEMA["write_files"][0].keys():
-            if key == "append":
-                key_type = "boolean"
-            else:
-                key_type = "string"
-            invalid_config = copy.deepcopy(VALID_SCHEMA)
-            invalid_config["write_files"][0][key] = 1
-            handle("cc_write_file", invalid_config, cc, LOG, [])
-            self.assertIn(
-                mock.call("cc_write_file", invalid_config["write_files"]),
-                m_write_files.call_args_list,
-            )
-            self.assertIn(
-                "write_files.0.%s: 1 is not of type '%s'" % (key, key_type),
-                self.logs.getvalue(),
-            )
-        self.assertIn("Invalid cloud-config provided:", self.logs.getvalue())
-
-    def test_schema_validation_warns_on_additional_undefined_propertes(
-        self, m_write_files
-    ):
-        """Schema validation warns on additional undefined file properties."""
-        cc = self.tmp_cloud("ubuntu")
-        invalid_config = copy.deepcopy(VALID_SCHEMA)
-        invalid_config["write_files"][0]["bogus"] = "value"
-        handle("cc_write_file", invalid_config, cc, LOG, [])
-        self.assertIn(
-            "Invalid cloud-config provided:\nwrite_files.0: Additional"
-            " properties are not allowed ('bogus' was unexpected)",
-            self.logs.getvalue(),
-        )
-
 
 class TestWriteFiles(FilesystemMockingTestCase):
 
@@ -132,19 +70,6 @@ class TestWriteFiles(FilesystemMockingTestCase):
         super(TestWriteFiles, self).setUp()
         self.tmp = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tmp)
-
-    @skipUnlessJsonSchema()
-    def test_handler_schema_validation_warns_non_array_type(self):
-        """Schema validation warns of non-array value."""
-        invalid_config = {"write_files": 1}
-        cc = self.tmp_cloud("ubuntu")
-        with self.assertRaises(TypeError):
-            handle("cc_write_file", invalid_config, cc, LOG, [])
-        self.assertIn(
-            "Invalid cloud-config provided:\nwrite_files: 1 is not of type"
-            " 'array'",
-            self.logs.getvalue(),
-        )
 
     def test_simple(self):
         self.patchUtils(self.tmp)
@@ -262,6 +187,38 @@ def _gzip_bytes(data):
     finally:
         if fp:
             fp.close()
+
+
+class TestWriteFilesSchema:
+    @pytest.mark.parametrize(
+        "config, error_msg",
+        [
+            # Top-level write_files type validation
+            ({"write_files": 1}, "write_files: 1 is not of type 'array'"),
+            ({"write_files": []}, re.escape("write_files: [] is too short")),
+            (
+                {"write_files": [{}]},
+                "write_files.0: 'path' is a required property",
+            ),
+            (
+                {"write_files": [{"path": "/some", "bogus": True}]},
+                re.escape(
+                    "write_files.0: Additional properties are not allowed"
+                    " ('bogus'"
+                ),
+            ),
+            (  # Strict encoding choices
+                {"write_files": [{"path": "/some", "encoding": "g"}]},
+                re.escape(
+                    "write_files.0.encoding: 'g' is not one of ['gz', 'gzip',"
+                ),
+            ),
+        ],
+    )
+    @skipUnlessJsonSchema()
+    def test_schema_validation(self, config, error_msg):
+        with pytest.raises(SchemaValidationError, match=error_msg):
+            validate_cloudconfig_schema(config, get_schema(), strict=True)
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/config/test_cc_write_files_deferred.py
+++ b/tests/unittests/config/test_cc_write_files_deferred.py
@@ -3,54 +3,22 @@
 import shutil
 import tempfile
 
+import pytest
+
 from cloudinit import log as logging
 from cloudinit import util
 from cloudinit.config.cc_write_files_deferred import handle
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
 from tests.unittests.helpers import (
-    CiTestCase,
     FilesystemMockingTestCase,
-    mock,
     skipUnlessJsonSchema,
 )
 
-from .test_cc_write_files import VALID_SCHEMA
-
 LOG = logging.getLogger(__name__)
-
-
-@skipUnlessJsonSchema()
-@mock.patch("cloudinit.config.cc_write_files_deferred.write_files")
-class TestWriteFilesDeferredSchema(CiTestCase):
-
-    with_logs = True
-
-    def test_schema_validation_warns_invalid_value(
-        self, m_write_files_deferred
-    ):
-        """If 'defer' is defined, it must be of type 'bool'."""
-
-        valid_config = {
-            "write_files": [
-                {**VALID_SCHEMA.get("write_files")[0], "defer": True}
-            ]
-        }
-
-        invalid_config = {
-            "write_files": [
-                {**VALID_SCHEMA.get("write_files")[0], "defer": str("no")}
-            ]
-        }
-
-        cc = self.tmp_cloud("ubuntu")
-        handle("cc_write_files_deferred", valid_config, cc, LOG, [])
-        self.assertNotIn(
-            "Invalid cloud-config provided:", self.logs.getvalue()
-        )
-        handle("cc_write_files_deferred", invalid_config, cc, LOG, [])
-        self.assertIn("Invalid cloud-config provided:", self.logs.getvalue())
-        self.assertIn(
-            "defer: 'no' is not of type 'boolean'", self.logs.getvalue()
-        )
 
 
 class TestWriteFilesDeferred(FilesystemMockingTestCase):
@@ -80,6 +48,23 @@ class TestWriteFilesDeferred(FilesystemMockingTestCase):
         self.assertEqual(util.load_file("/tmp/deferred.file"), expected)
         with self.assertRaises(FileNotFoundError):
             util.load_file("/tmp/not_deferred.file")
+
+
+class TestWriteFilesDeferredSchema:
+    @pytest.mark.parametrize(
+        "config, error_msg",
+        [
+            # Allow undocumented keys client keys without error
+            (
+                {"write_files": [{"defer": "no"}]},
+                "write_files.0.defer: 'no' is not of type 'boolean'",
+            ),
+        ],
+    )
+    @skipUnlessJsonSchema()
+    def test_schema_validation(self, config, error_msg):
+        with pytest.raises(SchemaValidationError, match=error_msg):
+            validate_cloudconfig_schema(config, get_schema(), strict=True)
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -208,6 +208,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_update_hostname"},
             {"$ref": "#/$defs/cc_write_files"},
             {"$ref": "#/$defs/cc_yum_add_repo"},
+            {"$ref": "#/$defs/cc_zypper_add_repo"},
         ]
         found_subschema_defs = []
         legacy_schema_keys = []
@@ -221,7 +222,6 @@ class TestGetSchema:
         # This list will dwindle as we move legacy schema to new $defs
         assert [
             "ntp",
-            "zypper",
         ] == sorted(legacy_schema_keys)
 
 
@@ -234,7 +234,7 @@ class TestLoadDoc:
         "module_name",
         (
             "cc_apt_pipelining",  # new style composite schema file
-            "cc_zypper_add_repo",  # legacy sub-schema defined in module
+            "cc_install_hotplug",  # legacy sub-schema defined in module
         ),
     )
     def test_report_docs_for_legacy_and_consolidated_schema(self, module_name):

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -200,6 +200,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_ssh"},
             {"$ref": "#/$defs/cc_timezone"},
             {"$ref": "#/$defs/cc_ubuntu_advantage"},
+            {"$ref": "#/$defs/cc_ubuntu_drivers"},
         ]
         found_subschema_defs = []
         legacy_schema_keys = []
@@ -212,7 +213,6 @@ class TestGetSchema:
         assert expected_subschema_defs == found_subschema_defs
         # This list will dwindle as we move legacy schema to new $defs
         assert [
-            "drivers",
             "ntp",
             "write_files",
             "write_files",

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -199,6 +199,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_ssh_import_id"},
             {"$ref": "#/$defs/cc_ssh"},
             {"$ref": "#/$defs/cc_timezone"},
+            {"$ref": "#/$defs/cc_ubuntu_advantage"},
         ]
         found_subschema_defs = []
         legacy_schema_keys = []
@@ -213,7 +214,6 @@ class TestGetSchema:
         assert [
             "drivers",
             "ntp",
-            "ubuntu_advantage",
             "write_files",
             "write_files",
             "zypper",

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -149,6 +149,7 @@ class TestGetSchema:
                 "cc_update_etc_hosts",
                 "cc_update_hostname",
                 "cc_write_files",
+                "cc_yum_add_repo",
                 "cc_zypper_add_repo",
             ]
         ) == sorted(
@@ -206,6 +207,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_update_etc_hosts"},
             {"$ref": "#/$defs/cc_update_hostname"},
             {"$ref": "#/$defs/cc_write_files"},
+            {"$ref": "#/$defs/cc_yum_add_repo"},
         ]
         found_subschema_defs = []
         legacy_schema_keys = []

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -215,7 +215,6 @@ class TestGetSchema:
         assert [
             "ntp",
             "write_files",
-            "write_files",
             "zypper",
         ] == sorted(legacy_schema_keys)
 

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -146,6 +146,7 @@ class TestGetSchema:
                 "cc_timezone",
                 "cc_ubuntu_advantage",
                 "cc_ubuntu_drivers",
+                "cc_update_etc_hosts",
                 "cc_write_files",
                 "cc_zypper_add_repo",
             ]
@@ -201,6 +202,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_timezone"},
             {"$ref": "#/$defs/cc_ubuntu_advantage"},
             {"$ref": "#/$defs/cc_ubuntu_drivers"},
+            {"$ref": "#/$defs/cc_update_etc_hosts"},
             {"$ref": "#/$defs/cc_write_files"},
         ]
         found_subschema_defs = []

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -147,6 +147,7 @@ class TestGetSchema:
                 "cc_ubuntu_advantage",
                 "cc_ubuntu_drivers",
                 "cc_update_etc_hosts",
+                "cc_update_hostname",
                 "cc_write_files",
                 "cc_zypper_add_repo",
             ]
@@ -203,6 +204,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_ubuntu_advantage"},
             {"$ref": "#/$defs/cc_ubuntu_drivers"},
             {"$ref": "#/$defs/cc_update_etc_hosts"},
+            {"$ref": "#/$defs/cc_update_hostname"},
             {"$ref": "#/$defs/cc_write_files"},
         ]
         found_subschema_defs = []

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -201,6 +201,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_timezone"},
             {"$ref": "#/$defs/cc_ubuntu_advantage"},
             {"$ref": "#/$defs/cc_ubuntu_drivers"},
+            {"$ref": "#/$defs/cc_write_files"},
         ]
         found_subschema_defs = []
         legacy_schema_keys = []
@@ -214,7 +215,6 @@ class TestGetSchema:
         # This list will dwindle as we move legacy schema to new $defs
         assert [
             "ntp",
-            "write_files",
             "zypper",
         ] == sorted(legacy_schema_keys)
 


### PR DESCRIPTION
## Proposed Commit Message
```
Migrate legacy schema to cloud-init-schema.json:
    - cc_ubuntu_advantage
    - cc_ubuntu_drivers
    - cc_write_files: added minItems: 1 to list to catch potential YAML typos
    - cc_write_files_deferred
    - cc_zypper_add_repo

Defined JSON schema for the following modules:
- cc_update_hostname
- cc_update_etc_hosts: Add DEPRECATED log for manage_etc_hosts: "template" as 
      it is non-intuitive alias of True value
- cc_yum_add_repo:  docstring incorrectly status PER_ALWAYS, but no module
  frequency attribute was defined, so cloud-init defaults to PER_INSTANCE.
  Set it PER_INSTANCE explicitly to avoid change in behavior.
```


## Additional Context
Does not contain cc_user_groups as that's a fairly big module schema to sort, so I'd like to keep that module separate for
ease of review.

## Test Steps
```
tox -re doc; xdg-open doc/rtd_html/topics/modules.html
PYTHONPATH=. python3 -m cloudinit.cmd.main devel schema --docs cc_update_hostname ....
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly