### PR TITLE
tox: add types-* packages to check_format env (SC-898)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,9 @@ deps =
     mypy=={[format_deps]mypy}
     pylint=={[format_deps]pylint}
     pytest=={[format_deps]pytest}
+    types-pyyaml=={[format_deps]types-PyYAML}
+    types-requests=={[format_deps]types-requests}
+    types-setuptools=={[format_deps]types-setuptools}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
 commands =


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tox: add types-* packages to check_format env
```

## Test Steps
`tox -e check_format` 
Fails on mypy because the type stubs aren't installed.
