### PR TITLE
tests: python 3.10 is showing up in cloudimages

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -228,7 +228,7 @@ class TestCombined:
         assert v1_data["distro"] == image_spec.os
         assert v1_data["distro_release"] == image_spec.release
         assert v1_data["machine"] == "x86_64"
-        assert re.match(r"3.\d\.\d", v1_data["python_version"])
+        assert re.match(r"3.\d+\.\d+", v1_data["python_version"])
 
     @pytest.mark.lxd_container
     def test_instance_json_lxd(self, class_client: IntegrationInstance):


### PR DESCRIPTION
## Additional Context
Fixes failures like:
```
>       assert re.match(r"3.\d\.\d", v1_data["python_version"])
E       AssertionError: assert None
E        +  where None = <function match at 0x7f1206b7bc80>('3.\\d\\.\\d', '3.10.3')
```
https://jenkins.ubuntu.com/server/view/cloud-init/job/cloud-init-integration-jammy-gce/2/testReport/tests.integration_tests.modules.test_combined/TestCombined/test_instance_json_gce/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
