### PR TITLE
ds-identify: detect LXD for VMs launched from host with > 5.10 kernel

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -351,7 +351,8 @@ class TestDsIdentify(DsIdentifyBase):
 
         Assert ds-identify can match systemd-detect-virt="qemu" and
         /sys/class/dmi/id/board_name = LXD.
-        Once systemd 251 is available, the virtualized CPUID will be                    represented properly as "kvm"
+        Once systemd 251 is available on a target distro, the virtualized
+        CPUID will be represented properly as "kvm"
         """
         self._test_ds_found("LXD-kvm-qemu-kernel-gt-5.10")
 

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -95,6 +95,10 @@ MOCK_VIRT_IS_CONTAINER_OTHER = {
 }
 MOCK_NOT_LXD_DATASOURCE = {"name": "dscheck_LXD", "ret": 1}
 MOCK_VIRT_IS_KVM = {"name": "detect_virt", "RET": "kvm", "ret": 0}
+# qemu support for LXD is only for host systems > 5.10 kernel as lxd
+# passed `hv_passthrough` which causes systemd < v.251 to misinterpret CPU
+# as "qemu" instead of "kvm"
+MOCK_VIRT_IS_KVM_QEMU = {"name": "detect_virt", "RET": "qemu", "ret": 0}
 MOCK_VIRT_IS_VMWARE = {"name": "detect_virt", "RET": "vmware", "ret": 0}
 # currenty' SmartOS hypervisor "bhyve" is unknown by systemd-detect-virt.
 MOCK_VIRT_IS_VM_OTHER = {"name": "detect_virt", "RET": "vm-other", "ret": 0}
@@ -337,6 +341,19 @@ class TestDsIdentify(DsIdentifyBase):
     def test_lxd_kvm(self):
         """LXD KVM has race on absent /dev/lxd/socket. Use DMI board_name."""
         self._test_ds_found("LXD-kvm")
+
+    def test_lxd_kvm_jammy(self):
+        """LXD KVM on host systems with a kernel > 5.10 need to match "qemu".
+        LXD provides `hv_passthrough` when launching kvm instances when host
+        kernel is > 5.10. This results in systemd being unable to detect the
+        virtualized CPUID="Linux KVM Hv" as type "kvm" and results in
+        systemd-detect-virt returning "qemu" in this case.
+
+        Assert ds-identify can match systemd-detect-virt="qemu" and
+        /sys/class/dmi/id/board_name = LXD.
+        Once systemd 251 is available, the virtualized CPUID will be                    represented properly as "kvm"
+        """
+        self._test_ds_found("LXD-kvm-qemu-kernel-gt-5.10")
 
     def test_lxd_containers(self):
         """LXD containers will have /dev/lxd/socket at generator time."""
@@ -1029,6 +1046,13 @@ VALID_CFG = {
         "files": {P_BOARD_NAME: "LXD\n"},
         # /dev/lxd/sock does not exist and KVM virt-type
         "mocks": [{"name": "is_socket_file", "ret": 1}, MOCK_VIRT_IS_KVM],
+        "no_mocks": ["dscheck_LXD"],  # Don't default mock dscheck_LXD
+    },
+    "LXD-kvm-qemu-kernel-gt-5.10": {  # LXD host > 5.10 kvm launch virt==qemu
+        "ds": "LXD",
+        "files": {P_BOARD_NAME: "LXD\n"},
+        # /dev/lxd/sock does not exist and KVM virt-type
+        "mocks": [{"name": "is_socket_file", "ret": 1}, MOCK_VIRT_IS_KVM_QEMU],
         "no_mocks": ["dscheck_LXD"],  # Don't default mock dscheck_LXD
     },
     "LXD": {

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -823,7 +823,11 @@ dscheck_LXD() {
     # On LXD KVM instances, /dev/lxd/sock is not yet setup by
     # lxd-agent-loader's systemd lxd-agent.service.
     # Rely on DMI product information that is present on all LXD images.
-    if [ "${DI_VIRT}" = "kvm" ]; then
+    # Note "qemu" is returned on kvm instances launched from a host kernel
+    # kernels >=5.10, due to `hv_passthrough` option.
+    # systemd v. 251 should properly return "kvm" in this scenario
+    # https://github.com/systemd/systemd/issues/22709
+    if [ "${DI_VIRT}" = "kvm" -o "${DI_VIRT}" = "qemu" ]; then
         [ "${DI_DMI_BOARD_NAME}" = "LXD" ] && return ${DS_FOUND}
     fi
     return ${DS_NOT_FOUND}


### PR DESCRIPTION
## Proposed Commit Message
```
Launching KVM instances from a host system with > 5.10 kernel results
in LXC passing `hv_passthrough` to the kvm instance being launched.
Systemd < 251 will incorrectly detect the CPU in this case as
"qemu" instead of "kvm".

ds-identify needs to properly interpret systems with
sytemd-detect-virt="qemu"  and /sys/class/dmi/id/board_name="LXD"

This functionality can be dropped once systemd 251 support is
available on all supported distributions.

LP: #1968085
```

<!-- Include a proposed commit message because all PRs are squash merged -->

## Additional Context
https://github.com/systemd/systemd/issues/22709

## Test Steps
From a jammy host:
```
$ lxc profile show jammy-vm
config: {}
description: Default LXD profile for jammy VMs
devices:
  eth0:
    name: eth0
    network: lxdbr0
    type: nic
  root:
    path: /
    pool: default
    type: disk
name: jammy-vm

$ lxc launch ubuntu-daily:jammy --vm --profile jammy-vm test-jammy
$ lxc exec test-jammy -- systemd-detect-virt
qemu
$ lxc stop test-jammy
$ lxc config set test-jammy security.devlxd=false
$ lxc start test-jammy
$ lxc exec test-jammy -- DEBUG_LEVEL=2 DI_LOG=stderr /usr/lib/cloud-init/ds-identify --force
# Ensure "no datasource detected"
$ lxc exec test-jammy -- add-apt-repository ppa:cloud-init-dev/daily
$ lxc exec test-jammy -- apt install cloud-init
$ lxc exec test-jammy -- DEBUG_LEVEL=2 DI_LOG=stderr /usr/lib/cloud-init/ds-identify --force
"Found single datasource: LXD"
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
