### PR TITLE
Grab last remaining Gentoo patches (SC-919)

### DIFF
--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -218,23 +218,26 @@ class Distro(distros.Distro):
         distros.set_etc_timezone(tz=tz, tz_file=self._find_tz_file(tz))
 
     def package_command(self, command, args=None, pkgs=None):
-        if pkgs is None:
-            pkgs = []
-
         cmd = list("emerge")
         # Redirect output
         cmd.append("--quiet")
 
-        if args and isinstance(args, str):
-            cmd.append(args)
-        elif args and isinstance(args, list):
-            cmd.extend(args)
+        if command == "upgrade":
+            cmd.extend(["--update", "world"])
+        else:
+            if pkgs is None:
+                pkgs = []
 
-        if command:
-            cmd.append(command)
+            if args and isinstance(args, str):
+                cmd.append(args)
+            elif args and isinstance(args, list):
+                cmd.extend(args)
 
-        pkglist = util.expand_package_list("%s-%s", pkgs)
-        cmd.extend(pkglist)
+            if command:
+                cmd.append(command)
+
+            pkglist = util.expand_package_list("%s-%s", pkgs)
+            cmd.extend(pkglist)
 
         # Allow the output of this to flow outwards (ie not be captured)
         subp.subp(cmd, capture=False)
@@ -243,7 +246,7 @@ class Distro(distros.Distro):
         self._runner.run(
             "update-sources",
             self.package_command,
-            ["-u", "world"],
+            ["--sync"],
             freq=PER_INSTANCE,
         )
 


### PR DESCRIPTION
```
Pull in Gentoo patches.

These patches are issues/features that have been fixed downstream.
Grab the remaining patches.
```

## Additional Context

See the 22.1 patches here:
https://github.com/gentoo/gentoo/tree/master/app-emulation/cloud-init/files

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
