### PR TITLE
Mypy stubs and other tox maintenance (SC-920)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,11 +113,13 @@ def render_tmpl(template, mode=None):
                 VARIANT,
                 template,
                 fpath,
-            ]
+            ],
+            check=True,
         )
     else:
         subprocess.run(
-            [sys.executable, "./tools/render-cloudcfg", template, fpath]
+            [sys.executable, "./tools/render-cloudcfg", template, fpath],
+            check=True,
         )
     if mode:
         os.chmod(fpath, mode)
@@ -202,7 +204,7 @@ class MyEggInfo(egg_info):
     """This makes sure to not include the rendered files in SOURCES.txt."""
 
     def find_sources(self):
-        ret = egg_info.find_sources(self)
+        egg_info.find_sources(self)
         # update the self.filelist.
         self.filelist.exclude_pattern(
             RENDERED_TMPD_PREFIX + ".*", is_regex=True
@@ -216,7 +218,6 @@ class MyEggInfo(egg_info):
                 ]
             with open(mfname, "w") as fp:
                 fp.write("".join(files))
-        return ret
 
 
 # TODO: Is there a better way to do this??

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ isort==5.10.1
 mypy==0.931
 pylint==2.11.1
 pytest==7.0.0
-types-Jinja2==2.11.9
 types-jsonschema==4.4.2
 types-oauthlib==3.1.6
 types-PyYAML==6.0.4
@@ -48,7 +47,6 @@ commands = {envpython} -m isort . --check-only
 [testenv:mypy]
 deps =
     mypy=={[format_deps]mypy}
-    types-Jinja2=={[format_deps]types-Jinja2}
     types-jsonschema=={[format_deps]types-jsonschema}
     types-oauthlib=={[format_deps]types-oauthlib}
     types-pyyaml=={[format_deps]types-PyYAML}
@@ -65,7 +63,6 @@ deps =
     mypy=={[format_deps]mypy}
     pylint=={[format_deps]pylint}
     pytest=={[format_deps]pytest}
-    types-Jinja2=={[format_deps]types-Jinja2}
     types-jsonschema=={[format_deps]types-jsonschema}
     types-oauthlib=={[format_deps]types-oauthlib}
     types-pyyaml=={[format_deps]types-PyYAML}
@@ -156,7 +153,6 @@ commands = {envpython} -m mypy --install-types --non-interactive cloudinit/ test
 deps =
     mypy
     pytest
-    types-Jinja2
     types-jsonschema
     types-oauthlib
     types-PyYAML

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,9 @@ isort==5.10.1
 mypy==0.931
 pylint==2.11.1
 pytest==7.0.0
+types-Jinja2==2.11.9
+types-jsonschema==4.4.2
+types-oauthlib==3.1.6
 types-PyYAML==6.0.4
 types-requests==2.27.8
 types-setuptools==57.4.9
@@ -23,14 +26,14 @@ types-setuptools==57.4.9
 [testenv:flake8]
 deps =
     flake8=={[format_deps]flake8}
-commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/ setup.py}
+commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/ conftest.py setup.py}
 
 [testenv:pylint]
 deps =
     pylint=={[format_deps]pylint}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
-commands = {envpython} -m pylint {posargs:cloudinit tests tools}
+commands = {envpython} -m pylint {posargs:cloudinit/ tests/ tools/ conftest.py setup.py}
 
 [testenv:black]
 deps =
@@ -45,11 +48,14 @@ commands = {envpython} -m isort . --check-only
 [testenv:mypy]
 deps =
     mypy=={[format_deps]mypy}
+    types-Jinja2=={[format_deps]types-Jinja2}
+    types-jsonschema=={[format_deps]types-jsonschema}
+    types-oauthlib=={[format_deps]types-oauthlib}
     types-pyyaml=={[format_deps]types-PyYAML}
     types-requests=={[format_deps]types-requests}
     types-setuptools=={[format_deps]types-setuptools}
     pytest=={[format_deps]pytest}
-commands = {envpython} -m mypy .
+commands = {envpython} -m mypy cloudinit/ tests/ tools/
 
 [testenv:check_format]
 deps =
@@ -59,6 +65,9 @@ deps =
     mypy=={[format_deps]mypy}
     pylint=={[format_deps]pylint}
     pytest=={[format_deps]pytest}
+    types-Jinja2=={[format_deps]types-Jinja2}
+    types-jsonschema=={[format_deps]types-jsonschema}
+    types-oauthlib=={[format_deps]types-oauthlib}
     types-pyyaml=={[format_deps]types-PyYAML}
     types-requests=={[format_deps]types-requests}
     types-setuptools=={[format_deps]types-setuptools}
@@ -139,20 +148,23 @@ commands =
     doc8 doc/rtd
 
 [testenv:tip-flake8]
-commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/ setup.py}
+commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/ conftest.py setup.py}
 deps = flake8
 
 [testenv:tip-mypy]
-commands = {envpython} -m mypy --install-types --non-interactive .
+commands = {envpython} -m mypy --install-types --non-interactive cloudinit/ tests/ tools/
 deps =
     mypy
     pytest
+    types-Jinja2
+    types-jsonschema
+    types-oauthlib
     types-PyYAML
     types-requests
     types-setuptools
 
 [testenv:tip-pylint]
-commands = {envpython} -m pylint {posargs:cloudinit tests tools}
+commands = {envpython} -m pylint {posargs:cloudinit/ tests/ tools/ conftest.py setup.py}
 deps =
     # requirements
     pylint


### PR DESCRIPTION
```
Mypy stubs and other tox maintenance

 - add type stubs for mypy: jinja, jsonschema, oauthlib
 - specify mypy directories to avoid env/ false positive
 - add conftest.py and setup.py
 - make setup.py pass pylint:
   - check ./tools/render-cloudcfg return code in setup.py
   - find_sources() has no return code, don't check for one
```

find_sources has never had a return code: https://github.com/pypa/setuptools/commit/873ebe91a8de43df836c873d9106e5af31c302e4
