### PR TITLE
Distro Compatibility Fixes (SC-921)

### DIFF
--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -398,7 +398,9 @@ class TestNtp(FilesystemMockingTestCase):
 
         Schema validation is not strict, so ntp config is still be rendered.
         """
-        invalid_config = {"ntp": {"pools": [123], "servers": ["valid", None]}}
+        invalid_config = {
+            "ntp": {"pools": [123], "servers": ["www.example.com", None]}
+        }
         for distro in cc_ntp.distros:
             mycloud = self._get_cloud(distro)
             ntpconfig = self._mock_ntp_client_config(distro=distro)
@@ -411,7 +413,7 @@ class TestNtp(FilesystemMockingTestCase):
                 self.logs.getvalue(),
             )
             self.assertEqual(
-                "servers ['valid', None]\npools [123]\n",
+                "servers ['www.example.com', None]\npools [123]\n",
                 util.load_file(confpath),
             )
 

--- a/tests/unittests/test_sshutil.py
+++ b/tests/unittests/test_sshutil.py
@@ -6,6 +6,7 @@ from functools import partial
 from unittest.mock import patch
 
 from cloudinit import ssh_util, util
+from cloudinit.temp_utils import mkdtemp
 from tests.unittests import helpers as test_helpers
 
 # https://stackoverflow.com/questions/11351032/
@@ -691,6 +692,8 @@ class TestBasicAuthorizedKeyParse(test_helpers.CiTestCase):
 
 
 class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
+    tmp_d = mkdtemp()
+
     def create_fake_users(
         self,
         names,
@@ -703,12 +706,12 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
     ):
         homes = []
 
-        root = "/tmp/root"
+        root = self.tmp_d + "/root"
         fpw = FakePwEnt(pw_name="root", pw_dir=root)
         users["root"] = fpw
 
         for name in names:
-            home = "/tmp/home/" + name
+            home = self.tmp_d + "/home/" + name
             fpw = FakePwEnt(pw_name=name, pw_dir=home)
             users[name] = fpw
             homes.append(home)
@@ -730,13 +733,13 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         return authorized_keys
 
     def create_global_authorized_file(self, filename, content_key, keys):
-        authorized_keys = self.tmp_path(filename, dir="/tmp")
+        authorized_keys = self.tmp_path(filename, dir=self.tmp_d)
         util.write_file(authorized_keys, VALID_CONTENT[content_key])
         keys[authorized_keys] = content_key
         return authorized_keys
 
     def create_sshd_config(self, authorized_keys_files):
-        sshd_config = self.tmp_path("sshd_config", dir="/tmp")
+        sshd_config = self.tmp_path("sshd_config", dir=self.tmp_d)
         util.write_file(
             sshd_config, "AuthorizedKeysFile " + authorized_keys_files
         )
@@ -757,8 +760,8 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
             else:
                 self.assertFalse(VALID_CONTENT[key] in content)
 
-        if delete_keys and os.path.isdir("/tmp/home/"):
-            util.delete_dir_contents("/tmp/home/")
+        if delete_keys and os.path.isdir(self.tmp_d + "/home/"):
+            util.delete_dir_contents(self.tmp_d + "/home/")
 
     @patch("cloudinit.ssh_util.pwd.getpwnam")
     @patch("cloudinit.util.get_permissions")
@@ -771,10 +774,12 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/user_keys": ("bobby", "bobby", 0o600),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/user_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
         }
 
         homes = self.create_fake_users(
@@ -815,10 +820,12 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/user_keys": ("bobby", "bobby", 0o600),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/user_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
         }
 
         homes = self.create_fake_users(
@@ -859,10 +866,12 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/user_keys": ("bobby", "bobby", 0o600),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/user_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
         }
 
         homes = self.create_fake_users(
@@ -910,10 +919,12 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/user_keys3": ("bobby", "bobby", 0o600),
-            "/tmp/home/bobby/.ssh/authorized_keys2": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/user_keys3": ("bobby", "bobby", 0o600),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys2": ("bobby", "bobby", 0o600),
         }
 
         homes = self.create_fake_users(
@@ -961,9 +972,10 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
         }
 
         homes = self.create_fake_users(
@@ -998,12 +1010,14 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
-            "/tmp/home/suzie": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh/authorized_keys": ("suzie", "suzie", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/suzie": ("suzie", "suzie", 0o700),
+            self.tmp_d + "/home/suzie/.ssh": ("suzie", "suzie", 0o700),
+            self.tmp_d
+            + "/home/suzie/.ssh/authorized_keys": ("suzie", "suzie", 0o600),
         }
 
         user_bobby = "bobby"
@@ -1048,12 +1062,14 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys2": ("bobby", "bobby", 0o600),
-            "/tmp/home/suzie": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh/authorized_keys2": ("suzie", "suzie", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys2": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/suzie": ("suzie", "suzie", 0o700),
+            self.tmp_d + "/home/suzie/.ssh": ("suzie", "suzie", 0o700),
+            self.tmp_d
+            + "/home/suzie/.ssh/authorized_keys2": ("suzie", "suzie", 0o600),
         }
 
         user_bobby = "bobby"
@@ -1098,14 +1114,18 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys2": ("bobby", "bobby", 0o600),
-            "/tmp/home/bobby/.ssh/user_keys3": ("bobby", "bobby", 0o600),
-            "/tmp/home/suzie": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh/authorized_keys2": ("suzie", "suzie", 0o600),
-            "/tmp/home/suzie/.ssh/user_keys3": ("suzie", "suzie", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys2": ("bobby", "bobby", 0o600),
+            self.tmp_d
+            + "/home/bobby/.ssh/user_keys3": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/suzie": ("suzie", "suzie", 0o700),
+            self.tmp_d + "/home/suzie/.ssh": ("suzie", "suzie", 0o700),
+            self.tmp_d
+            + "/home/suzie/.ssh/authorized_keys2": ("suzie", "suzie", 0o600),
+            self.tmp_d
+            + "/home/suzie/.ssh/user_keys3": ("suzie", "suzie", 0o600),
         }
 
         user_bobby = "bobby"
@@ -1168,13 +1188,15 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys2": ("bobby", "bobby", 0o600),
-            "/tmp/home/bobby/.ssh/user_keys3": ("bobby", "bobby", 0o600),
-            "/tmp/home/badguy": ("root", "root", 0o755),
-            "/tmp/home/badguy/home": ("root", "root", 0o755),
-            "/tmp/home/badguy/home/bobby": ("root", "root", 0o655),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys2": ("bobby", "bobby", 0o600),
+            self.tmp_d
+            + "/home/bobby/.ssh/user_keys3": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/badguy": ("root", "root", 0o755),
+            self.tmp_d + "/home/badguy/home": ("root", "root", 0o755),
+            self.tmp_d + "/home/badguy/home/bobby": ("root", "root", 0o655),
         }
 
         user_bobby = "bobby"
@@ -1200,7 +1222,9 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         )
 
         # /tmp/home/badguy/home/bobby = ""
-        authorized_keys2 = self.tmp_path("home/bobby", dir="/tmp/home/badguy")
+        authorized_keys2 = self.tmp_path(
+            "home/bobby", dir=self.tmp_d + "/home/badguy"
+        )
         util.write_file(authorized_keys2, "")
 
         # /tmp/etc/ssh/authorized_keys = ecdsa
@@ -1239,17 +1263,20 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
-            "/tmp/etc": ("root", "root", 0o755),
-            "/tmp/etc/ssh": ("root", "root", 0o755),
-            "/tmp/etc/ssh/userkeys": ("root", "root", 0o700),
-            "/tmp/etc/ssh/userkeys/bobby": ("bobby", "bobby", 0o600),
-            "/tmp/etc/ssh/userkeys/badguy": ("badguy", "badguy", 0o600),
-            "/tmp/home/badguy": ("badguy", "badguy", 0o700),
-            "/tmp/home/badguy/.ssh": ("badguy", "badguy", 0o700),
-            "/tmp/home/badguy/.ssh/authorized_keys": (
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/etc": ("root", "root", 0o755),
+            self.tmp_d + "/etc/ssh": ("root", "root", 0o755),
+            self.tmp_d + "/etc/ssh/userkeys": ("root", "root", 0o700),
+            self.tmp_d + "/etc/ssh/userkeys/bobby": ("bobby", "bobby", 0o600),
+            self.tmp_d
+            + "/etc/ssh/userkeys/badguy": ("badguy", "badguy", 0o600),
+            self.tmp_d + "/home/badguy": ("badguy", "badguy", 0o700),
+            self.tmp_d + "/home/badguy/.ssh": ("badguy", "badguy", 0o700),
+            self.tmp_d
+            + "/home/badguy/.ssh/authorized_keys": (
                 "badguy",
                 "badguy",
                 0o600,
@@ -1292,7 +1319,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         )
 
         # /tmp/sshd_config
-        options = "/tmp/etc/ssh/userkeys/%u .ssh/authorized_keys"
+        options = self.tmp_d + "/etc/ssh/userkeys/%u .ssh/authorized_keys"
         sshd_config = self.create_sshd_config(options)
 
         self.execute_and_check(
@@ -1318,17 +1345,20 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
-            "/tmp/etc": ("root", "root", 0o755),
-            "/tmp/etc/ssh": ("root", "root", 0o755),
-            "/tmp/etc/ssh/userkeys": ("root", "root", 0o755),
-            "/tmp/etc/ssh/userkeys/bobby": ("bobby", "bobby", 0o600),
-            "/tmp/etc/ssh/userkeys/badguy": ("badguy", "badguy", 0o600),
-            "/tmp/home/badguy": ("badguy", "badguy", 0o700),
-            "/tmp/home/badguy/.ssh": ("badguy", "badguy", 0o700),
-            "/tmp/home/badguy/.ssh/authorized_keys": (
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/etc": ("root", "root", 0o755),
+            self.tmp_d + "/etc/ssh": ("root", "root", 0o755),
+            self.tmp_d + "/etc/ssh/userkeys": ("root", "root", 0o755),
+            self.tmp_d + "/etc/ssh/userkeys/bobby": ("bobby", "bobby", 0o600),
+            self.tmp_d
+            + "/etc/ssh/userkeys/badguy": ("badguy", "badguy", 0o600),
+            self.tmp_d + "/home/badguy": ("badguy", "badguy", 0o700),
+            self.tmp_d + "/home/badguy/.ssh": ("badguy", "badguy", 0o700),
+            self.tmp_d
+            + "/home/badguy/.ssh/authorized_keys": (
                 "badguy",
                 "badguy",
                 0o600,
@@ -1371,7 +1401,7 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         )
 
         # /tmp/sshd_config
-        options = "/tmp/etc/ssh/userkeys/%u .ssh/authorized_keys"
+        options = self.tmp_d + "/etc/ssh/userkeys/%u .ssh/authorized_keys"
         sshd_config = self.create_sshd_config(options)
 
         self.execute_and_check(
@@ -1397,12 +1427,14 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
-            "/tmp/home/suzie": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh/authorized_keys": ("suzie", "suzie", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/suzie": ("suzie", "suzie", 0o700),
+            self.tmp_d + "/home/suzie/.ssh": ("suzie", "suzie", 0o700),
+            self.tmp_d
+            + "/home/suzie/.ssh/authorized_keys": ("suzie", "suzie", 0o600),
         }
 
         user_bobby = "bobby"
@@ -1456,12 +1488,14 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
-            "/tmp/home/suzie": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh/authorized_keys": ("suzie", "suzie", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/suzie": ("suzie", "suzie", 0o700),
+            self.tmp_d + "/home/suzie/.ssh": ("suzie", "suzie", 0o700),
+            self.tmp_d
+            + "/home/suzie/.ssh/authorized_keys": ("suzie", "suzie", 0o600),
         }
 
         user_bobby = "bobby"
@@ -1515,12 +1549,14 @@ class TestMultipleSshAuthorizedKeysFile(test_helpers.CiTestCase):
         keys = {}
         users = {}
         mock_permissions = {
-            "/tmp/home/bobby": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh": ("bobby", "bobby", 0o700),
-            "/tmp/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
-            "/tmp/home/suzie": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh": ("suzie", "suzie", 0o700),
-            "/tmp/home/suzie/.ssh/authorized_keys": ("suzie", "suzie", 0o600),
+            self.tmp_d + "/home/bobby": ("bobby", "bobby", 0o700),
+            self.tmp_d + "/home/bobby/.ssh": ("bobby", "bobby", 0o700),
+            self.tmp_d
+            + "/home/bobby/.ssh/authorized_keys": ("bobby", "bobby", 0o600),
+            self.tmp_d + "/home/suzie": ("suzie", "suzie", 0o700),
+            self.tmp_d + "/home/suzie/.ssh": ("suzie", "suzie", 0o700),
+            self.tmp_d
+            + "/home/suzie/.ssh/authorized_keys": ("suzie", "suzie", 0o600),
         }
 
         user_bobby = "bobby"

--- a/tests/unittests/test_temp_utils.py
+++ b/tests/unittests/test_temp_utils.py
@@ -3,12 +3,15 @@
 """Tests for cloudinit.temp_utils"""
 
 import os
+from tempfile import gettempdir
 
 from cloudinit.temp_utils import mkdtemp, mkstemp, tempdir
 from tests.unittests.helpers import CiTestCase, wrap_and_call
 
 
 class TestTempUtils(CiTestCase):
+    prefix = gettempdir()
+
     def test_mkdtemp_default_non_root(self):
         """mkdtemp creates a dir under /tmp for the unprivileged."""
         calls = []
@@ -28,7 +31,7 @@ class TestTempUtils(CiTestCase):
             mkdtemp,
         )
         self.assertEqual("/fake/return/path", retval)
-        self.assertEqual([{"dir": "/tmp"}], calls)
+        self.assertEqual([{"dir": self.prefix}], calls)
 
     def test_mkdtemp_default_non_root_needs_exe(self):
         """mkdtemp creates a dir under /var/tmp/cloud-init when needs_exe."""
@@ -92,7 +95,7 @@ class TestTempUtils(CiTestCase):
             mkstemp,
         )
         self.assertEqual("/fake/return/path", retval)
-        self.assertEqual([{"dir": "/tmp"}], calls)
+        self.assertEqual([{"dir": self.prefix}], calls)
 
     def test_mkstemp_default_root(self):
         """mkstemp creates a secure tempfile in /run/cloud-init for root."""


### PR DESCRIPTION


```
Distro compatibility fixes:

- Don't assume python's tempdir location
- Fix hostname jsonschema test 
```

## Additional Context

- Gentoo's build system uses an environment variable[1] to specify Python's temporary directories. Our tempfiles tests assume `/tmp/` is the only possible location, which is not always true. Python uses `gettempdir()` to define tempfile locations, so should we.
[gentoo-tempfail.txt](https://github.com/canonical/cloud-init/files/8459928/gentoo-tempfail.txt) 

- jsonschema validation doesn't think that `valid` is a valid hostname on Gentoo. I don't know why this differs (see references in commit message), but the fix is straightforward. Need to investigate to ensure this test isn't getting skipped on Ubuntu.
[gentoo-hostnamefail.txt](https://github.com/canonical/cloud-init/files/8459929/gentoo-hostnamefail.txt)

- some tests assume that /tmp/ is usable directly as a temp directory. If permissions are not as expected, tests fail. Use mkdtemp() instead.
[test-tmp-failure.txt](https://github.com/canonical/cloud-init/files/8460138/test-tmp-failure.txt)

## Test Steps
Make sure the system is up to date, something like this:
```
emaint -a sync
emerge -av --deep --update @world
```

Make sure cloud-init has the `test` USE flag set:
```
$ cat /etc/portage/package.use/cloud-init 
app-emulation/cloud-init test
```

Emerge with tests enabled:
```
FEATURES=test emerge app-emulation/cloud-init
```

Note the failures:
[gentoo-cloud-init-test-install-fail.txt](https://github.com/canonical/cloud-init/files/8459932/gentoo-cloud-init-test-install-fail.txt) (note: this log is actually from the tip of main branch on my github repo)


To validate successes on Gentoo, [setup a local ebuild repo](https://wiki.gentoo.org/wiki/Creating_an_ebuild_repository) using 
[this custom ebuild that is updated to point to this branch cloud-init-9999.ebuild](https://github.com/canonical/cloud-init/files/8459938/cloud-init-9999.ebuild.txt)

Ebuild diff:
```
13,14c13
< 	EGIT_REPO_URI="https://github.com/holmanb/cloud-init.git"
< 	EGIT_BRANCH=holmanb/do-not-manually-use-tmp
---
> 	EGIT_REPO_URI="https://git.launchpad.net/cloud-init"
```


Test and see the success:
```
FEATURES=test emerge app-emulation/cloud-init
```

Successful Test Log:

[gentoo-cloud-init-test-install-success.txt](https://github.com/canonical/cloud-init/files/8459930/gentoo-cloud-init-test-install-success.txt)

[1] Note the `T` variable here: https://devmanual.gentoo.org/ebuild-writing/variables/index.html
