### PR TITLE
cloudinit.sub.py: Return a namedtuple

### DIFF
--- a/cloudinit/gpg.py
+++ b/cloudinit/gpg.py
@@ -41,7 +41,7 @@ def dearmor(key):
 
     note: man gpg(1) makes no mention of an --armour spelling, only --armor
     """
-    return subp.subp(["gpg", "--dearmor"], data=key, decode=False)[0]
+    return subp.subp(["gpg", "--dearmor"], data=key, decode=False).stdout
 
 
 def list(key_file, human_output=False):

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -209,7 +209,7 @@ def get_hv_netvsc_macs_normalized() -> List[str]:
 
 def execute_or_debug(cmd, fail_ret=None) -> str:
     try:
-        return subp.subp(cmd)[0]  # type: ignore
+        return subp.subp(cmd).stdout  # type: ignore
     except subp.ProcessExecutionError:
         LOG.debug("Failed to execute: %s", " ".join(cmd))
         return fail_ret

--- a/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
@@ -141,7 +141,7 @@ def get_tools_config(section, key, defaultVal):
     cmd = ["vmware-toolbox-cmd", "config", "get", section, key]
 
     try:
-        (outText, _) = subp.subp(cmd)
+        out = subp.subp(cmd)
     except subp.ProcessExecutionError as e:
         if e.exit_code == 69:
             logger.debug(
@@ -156,7 +156,7 @@ def get_tools_config(section, key, defaultVal):
         return defaultVal
 
     retValue = defaultVal
-    m = re.match(r"([^=]+)=(.*)", outText)
+    m = re.match(r"([^=]+)=(.*)", out.stdout)
     if m:
         retValue = m.group(2).strip()
         logger.debug("Get tools config: [%s] %s = %s", section, key, retValue)

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -9,7 +9,7 @@ from errno import ENOEXEC
 
 LOG = logging.getLogger(__name__)
 
-PipeOutput = collections.namedtuple('PipeOutput', ['stdout', 'stderr'])
+SubpResult = collections.namedtuple('SubpResult', ['stdout', 'stderr'])
 
 def prepend_base_command(base_command, commands):
     """Ensure user-provided commands start with base_command; warn otherwise.
@@ -169,7 +169,7 @@ def subp(
     update_env=None,
     status_cb=None,
     cwd=None,
-) -> PipeOutput:
+) -> SubpResult:
     """Run a subprocess.
 
     :param args: command to run in a list. [cmd, arg1, arg2...]
@@ -336,7 +336,7 @@ def subp(
         )
     if status_cb:
         status_cb("End run command: exit({code})\n".format(code=rc))
-    return PipeOutput(out, err)
+    return SubpResult(out, err)
 
 
 def target_path(target, path=None):

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -1,15 +1,16 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Common utility functions for interacting with subprocess."""
 
+import collections
 import logging
 import os
 import subprocess
-import collections
 from errno import ENOEXEC
 
 LOG = logging.getLogger(__name__)
 
-SubpResult = collections.namedtuple('SubpResult', ['stdout', 'stderr'])
+SubpResult = collections.namedtuple("SubpResult", ["stdout", "stderr"])
+
 
 def prepend_base_command(base_command, commands):
     """Ensure user-provided commands start with base_command; warn otherwise.
@@ -213,9 +214,9 @@ def subp(
         if not capturing, return is (None, None)
         if capturing, stdout and stderr are returned.
             if decode:
-                entries in tuple will be python2 unicode or python3 string
+                entries in tuple will be string
             if not decode:
-                entries in tuple will be python2 string or python3 bytes
+                entries in tuple will be bytes
     """
 
     # not supported in cloud-init (yet), for now kept in the call signature

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -169,7 +169,7 @@ def subp(
     update_env=None,
     status_cb=None,
     cwd=None,
-):
+) -> PipeOutput:
     """Run a subprocess.
 
     :param args: command to run in a list. [cmd, arg1, arg2...]

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -4,10 +4,12 @@
 import logging
 import os
 import subprocess
+import collections
 from errno import ENOEXEC
 
 LOG = logging.getLogger(__name__)
 
+PipeOutput = collections.namedtuple('PipeOutput', ['stdout', 'stderr'])
 
 def prepend_base_command(base_command, commands):
     """Ensure user-provided commands start with base_command; warn otherwise.
@@ -334,7 +336,7 @@ def subp(
         )
     if status_cb:
         status_cb("End run command: exit({code})\n".format(code=rc))
-    return (out, err)
+    return PipeOutput(out, err)
 
 
 def target_path(target, path=None):

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -170,7 +170,7 @@ def subp(
     update_env=None,
     status_cb=None,
     cwd=None,
-) -> SubpResult:
+):
     """Run a subprocess.
 
     :param args: command to run in a list. [cmd, arg1, arg2...]

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -91,9 +91,7 @@ def lsb_release(target=None):
 
     data = {}
     try:
-        out = subp.subp(
-            ["lsb_release", "--all"], capture=True, target=target
-        )
+        out = subp.subp(["lsb_release", "--all"], capture=True, target=target)
         for line in out.stdout.splitlines():
             fname, _, val = line.partition(":")
             if fname in fmap:

--- a/tests/unittests/config/test_apt_key.py
+++ b/tests/unittests/config/test_apt_key.py
@@ -2,6 +2,7 @@ import os
 from unittest import mock
 
 from cloudinit import subp, util
+from cloudinit.subp import PipeOutput
 from cloudinit.config import cc_apt_configure
 
 TEST_KEY_HUMAN = """
@@ -38,7 +39,7 @@ class TestAptKey:
     Class to test apt-key commands
     """
 
-    @mock.patch.object(subp, "subp", return_value=("fakekey", ""))
+    @mock.patch.object(subp, "subp", return_value=PipeOutput("fakekey", ""))
     @mock.patch.object(util, "write_file")
     def _apt_key_add_success_helper(self, directory, *args, hardened=False):
         file = cc_apt_configure.apt_key(

--- a/tests/unittests/config/test_apt_key.py
+++ b/tests/unittests/config/test_apt_key.py
@@ -2,8 +2,8 @@ import os
 from unittest import mock
 
 from cloudinit import subp, util
-from cloudinit.subp import SubpResult
 from cloudinit.config import cc_apt_configure
+from cloudinit.subp import SubpResult
 
 TEST_KEY_HUMAN = """
 /etc/apt/cloud-init.gpg.d/my_key.gpg

--- a/tests/unittests/config/test_apt_key.py
+++ b/tests/unittests/config/test_apt_key.py
@@ -2,7 +2,7 @@ import os
 from unittest import mock
 
 from cloudinit import subp, util
-from cloudinit.subp import PipeOutput
+from cloudinit.subp import SubpResult
 from cloudinit.config import cc_apt_configure
 
 TEST_KEY_HUMAN = """
@@ -39,7 +39,7 @@ class TestAptKey:
     Class to test apt-key commands
     """
 
-    @mock.patch.object(subp, "subp", return_value=PipeOutput("fakekey", ""))
+    @mock.patch.object(subp, "subp", return_value=SubpResult("fakekey", ""))
     @mock.patch.object(util, "write_file")
     def _apt_key_add_success_helper(self, directory, *args, hardened=False):
         file = cc_apt_configure.apt_key(

--- a/tests/unittests/sources/vmware/test_guestcust_util.py
+++ b/tests/unittests/sources/vmware/test_guestcust_util.py
@@ -12,6 +12,7 @@ from cloudinit.sources.helpers.vmware.imc.guestcust_util import (
     get_tools_config,
     set_gc_status,
 )
+from cloudinit.subp import SubpResult
 from tests.unittests.helpers import CiTestCase, mock
 
 
@@ -35,7 +36,7 @@ class TestGuestCustUtil(CiTestCase):
             with mock.patch.object(
                 subp,
                 "subp",
-                return_value=("key=value", b""),
+                return_value=SubpResult("key=value", b""),
                 side_effect=subp.ProcessExecutionError(
                     "subp failed", exit_code=99
                 ),
@@ -54,19 +55,21 @@ class TestGuestCustUtil(CiTestCase):
         with mock.patch.object(subp, "which", return_value="/dummy/path"):
             # value is not blank
             with mock.patch.object(
-                subp, "subp", return_value=("key =   value  ", b"")
+                subp, "subp", return_value=SubpResult("key =   value  ", b"")
             ):
                 self.assertEqual(
                     get_tools_config("section", "key", "defaultVal"), "value"
                 )
             # value is blank
-            with mock.patch.object(subp, "subp", return_value=("key = ", b"")):
+            with mock.patch.object(
+                subp, "subp", return_value=SubpResult("key = ", b"")
+            ):
                 self.assertEqual(
                     get_tools_config("section", "key", "defaultVal"), ""
                 )
             # value contains =
             with mock.patch.object(
-                subp, "subp", return_value=("key=Bar=Wark", b"")
+                subp, "subp", return_value=SubpResult("key=Bar=Wark", b"")
             ):
                 self.assertEqual(
                     get_tools_config("section", "key", "defaultVal"),
@@ -75,7 +78,7 @@ class TestGuestCustUtil(CiTestCase):
 
             # value contains specific characters
             with mock.patch.object(
-                subp, "subp", return_value=("[a] b.c_d=e-f", b"")
+                subp, "subp", return_value=SubpResult("[a] b.c_d=e-f", b"")
             ):
                 self.assertEqual(
                     get_tools_config("section", "key", "defaultVal"), "e-f"
@@ -97,7 +100,7 @@ class TestGuestCustUtil(CiTestCase):
         cf._insertKey("MISC|POST-GC-STATUS", "YES")
         conf = Config(cf)
         with mock.patch.object(
-            subp, "subp", return_value=("ok", b"")
+            subp, "subp", return_value=SubpResult("ok", b"")
         ) as mockobj:
             self.assertEqual(set_gc_status(conf, "Successful"), ("ok", b""))
             mockobj.assert_called_once_with(

--- a/tests/unittests/test_gpg.py
+++ b/tests/unittests/test_gpg.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from cloudinit import gpg, subp
+from cloudinit.subp import PipeOutput
 from tests.unittests.helpers import CiTestCase
 
 TEST_KEY_HUMAN = """
@@ -64,7 +65,7 @@ class TestGPGCommands:
             "--with-colons",
             "key",
         ]
-        with mock.patch.object(subp, "subp", return_value=("", "")) as m_subp:
+        with mock.patch.object(subp, "subp", return_value=PipeOutput("", "")) as m_subp:
             gpg.list("key")
             assert mock.call(colons, capture=True) == m_subp.call_args
 
@@ -74,7 +75,7 @@ class TestGPGCommands:
 
     def test_gpg_dearmor_args(self):
         """Verify correct command gets called to dearmor keys"""
-        with mock.patch.object(subp, "subp", return_value=("", "")) as m_subp:
+        with mock.patch.object(subp, "subp", return_value=PipeOutput("", "")) as m_subp:
             gpg.dearmor("key")
             test_call = mock.call(
                 ["gpg", "--dearmor"], data="key", decode=False

--- a/tests/unittests/test_gpg.py
+++ b/tests/unittests/test_gpg.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from cloudinit import gpg, subp
-from cloudinit.subp import PipeOutput
+from cloudinit.subp import SubpResult
 from tests.unittests.helpers import CiTestCase
 
 TEST_KEY_HUMAN = """
@@ -65,7 +65,7 @@ class TestGPGCommands:
             "--with-colons",
             "key",
         ]
-        with mock.patch.object(subp, "subp", return_value=PipeOutput("", "")) as m_subp:
+        with mock.patch.object(subp, "subp", return_value=SubpResult("", "")) as m_subp:
             gpg.list("key")
             assert mock.call(colons, capture=True) == m_subp.call_args
 
@@ -75,7 +75,7 @@ class TestGPGCommands:
 
     def test_gpg_dearmor_args(self):
         """Verify correct command gets called to dearmor keys"""
-        with mock.patch.object(subp, "subp", return_value=PipeOutput("", "")) as m_subp:
+        with mock.patch.object(subp, "subp", return_value=SubpResult("", "")) as m_subp:
             gpg.dearmor("key")
             test_call = mock.call(
                 ["gpg", "--dearmor"], data="key", decode=False

--- a/tests/unittests/test_gpg.py
+++ b/tests/unittests/test_gpg.py
@@ -65,7 +65,9 @@ class TestGPGCommands:
             "--with-colons",
             "key",
         ]
-        with mock.patch.object(subp, "subp", return_value=SubpResult("", "")) as m_subp:
+        with mock.patch.object(
+            subp, "subp", return_value=SubpResult("", "")
+        ) as m_subp:
             gpg.list("key")
             assert mock.call(colons, capture=True) == m_subp.call_args
 
@@ -75,7 +77,9 @@ class TestGPGCommands:
 
     def test_gpg_dearmor_args(self):
         """Verify correct command gets called to dearmor keys"""
-        with mock.patch.object(subp, "subp", return_value=SubpResult("", "")) as m_subp:
+        with mock.patch.object(
+            subp, "subp", return_value=SubpResult("", "")
+        ) as m_subp:
             gpg.dearmor("key")
             test_call = mock.call(
                 ["gpg", "--dearmor"], data="key", decode=False

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2389,13 +2389,17 @@ class TestFindDevs:
 
     @mock.patch("cloudinit.subp.subp")
     def test_find_devs_with_openbsd(self, m_subp):
-        m_subp.return_value = SubpResult("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
+        m_subp.return_value = SubpResult(
+            "cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", ""
+        )
         devlist = util.find_devs_with_openbsd()
         assert devlist == ["/dev/cd0a", "/dev/sd1a", "/dev/sd1i"]
 
     @mock.patch("cloudinit.subp.subp")
     def test_find_devs_with_openbsd_with_criteria(self, m_subp):
-        m_subp.return_value = SubpResult("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
+        m_subp.return_value = SubpResult(
+            "cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", ""
+        )
         devlist = util.find_devs_with_openbsd(criteria="TYPE=iso9660")
         assert devlist == ["/dev/cd0a", "/dev/sd1a", "/dev/sd1i"]
 
@@ -2493,7 +2497,9 @@ class TestFindDevs:
     def test_find_devs_with_dragonflybsd(
         self, m_subp, criteria, expected_devlist
     ):
-        m_subp.return_value = SubpResult("md2 md1 cd0 vbd0 acd0 vn3 vn2 vn1 vn0 md0", "")
+        m_subp.return_value = SubpResult(
+            "md2 md1 cd0 vbd0 acd0 vn3 vn2 vn1 vn0 md0", ""
+        )
         devlist = util.find_devs_with_dragonflybsd(criteria=criteria)
         assert devlist == expected_devlist
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -19,7 +19,7 @@ import pytest
 import yaml
 
 from cloudinit import importer, subp, util
-from cloudinit.subp import PipeOutput
+from cloudinit.subp import SubpResult
 from tests.unittests import helpers
 from tests.unittests.helpers import CiTestCase
 
@@ -594,7 +594,7 @@ class TestBlkid(CiTestCase):
 
     @mock.patch("cloudinit.subp.subp")
     def test_functional_blkid(self, m_subp):
-        m_subp.return_value = PipeOutput(self.blkid_out.format(**self.ids), "")
+        m_subp.return_value = SubpResult(self.blkid_out.format(**self.ids), "")
         self.assertEqual(self._get_expected(), util.blkid())
         m_subp.assert_called_with(
             ["blkid", "-o", "full"], capture=True, decode="replace"
@@ -603,7 +603,7 @@ class TestBlkid(CiTestCase):
     @mock.patch("cloudinit.subp.subp")
     def test_blkid_no_cache_uses_no_cache(self, m_subp):
         """blkid should turn off cache if disable_cache is true."""
-        m_subp.return_value = PipeOutput(self.blkid_out.format(**self.ids), "")
+        m_subp.return_value = SubpResult(self.blkid_out.format(**self.ids), "")
         self.assertEqual(self._get_expected(), util.blkid(disable_cache=True))
         m_subp.assert_called_with(
             ["blkid", "-o", "full", "-c", "/dev/null"],
@@ -2389,13 +2389,13 @@ class TestFindDevs:
 
     @mock.patch("cloudinit.subp.subp")
     def test_find_devs_with_openbsd(self, m_subp):
-        m_subp.return_value = PipeOutput("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
+        m_subp.return_value = SubpResult("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
         devlist = util.find_devs_with_openbsd()
         assert devlist == ["/dev/cd0a", "/dev/sd1a", "/dev/sd1i"]
 
     @mock.patch("cloudinit.subp.subp")
     def test_find_devs_with_openbsd_with_criteria(self, m_subp):
-        m_subp.return_value = PipeOutput("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
+        m_subp.return_value = SubpResult("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
         devlist = util.find_devs_with_openbsd(criteria="TYPE=iso9660")
         assert devlist == ["/dev/cd0a", "/dev/sd1a", "/dev/sd1i"]
 
@@ -2443,29 +2443,29 @@ class TestFindDevs:
     @mock.patch("cloudinit.subp.subp")
     def test_find_devs_with_netbsd(self, m_subp, criteria, expected_devlist):
         side_effect_values = [
-            PipeOutput("ld0 dk0 dk1 cd0", ""),
-            PipeOutput(
+            SubpResult("ld0 dk0 dk1 cd0", ""),
+            SubpResult(
                 "mscdlabel: CDIOREADTOCHEADER: "
                 "Inappropriate ioctl for device\n"
                 "track (ctl=4) at sector 0\n"
                 "disklabel not written\n",
                 "",
             ),
-            PipeOutput(
+            SubpResult(
                 "mscdlabel: CDIOREADTOCHEADER: "
                 "Inappropriate ioctl for device\n"
                 "track (ctl=4) at sector 0\n"
                 "disklabel not written\n",
                 "",
             ),
-            PipeOutput(
+            SubpResult(
                 "mscdlabel: CDIOREADTOCHEADER: "
                 "Inappropriate ioctl for device\n"
                 "track (ctl=4) at sector 0\n"
                 "disklabel not written\n",
                 "",
             ),
-            PipeOutput(
+            SubpResult(
                 "track (ctl=4) at sector 0\n"
                 'ISO filesystem, label "config-2", '
                 "creation time: 2020/03/31 17:29\n"
@@ -2493,7 +2493,7 @@ class TestFindDevs:
     def test_find_devs_with_dragonflybsd(
         self, m_subp, criteria, expected_devlist
     ):
-        m_subp.return_value = PipeOutput("md2 md1 cd0 vbd0 acd0 vn3 vn2 vn1 vn0 md0", "")
+        m_subp.return_value = SubpResult("md2 md1 cd0 vbd0 acd0 vn3 vn2 vn1 vn0 md0", "")
         devlist = util.find_devs_with_dragonflybsd(criteria=criteria)
         assert devlist == expected_devlist
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -19,6 +19,7 @@ import pytest
 import yaml
 
 from cloudinit import importer, subp, util
+from cloudinit.subp import PipeOutput
 from tests.unittests import helpers
 from tests.unittests.helpers import CiTestCase
 
@@ -593,7 +594,7 @@ class TestBlkid(CiTestCase):
 
     @mock.patch("cloudinit.subp.subp")
     def test_functional_blkid(self, m_subp):
-        m_subp.return_value = (self.blkid_out.format(**self.ids), "")
+        m_subp.return_value = PipeOutput(self.blkid_out.format(**self.ids), "")
         self.assertEqual(self._get_expected(), util.blkid())
         m_subp.assert_called_with(
             ["blkid", "-o", "full"], capture=True, decode="replace"
@@ -602,7 +603,7 @@ class TestBlkid(CiTestCase):
     @mock.patch("cloudinit.subp.subp")
     def test_blkid_no_cache_uses_no_cache(self, m_subp):
         """blkid should turn off cache if disable_cache is true."""
-        m_subp.return_value = (self.blkid_out.format(**self.ids), "")
+        m_subp.return_value = PipeOutput(self.blkid_out.format(**self.ids), "")
         self.assertEqual(self._get_expected(), util.blkid(disable_cache=True))
         m_subp.assert_called_with(
             ["blkid", "-o", "full", "-c", "/dev/null"],
@@ -2388,13 +2389,13 @@ class TestFindDevs:
 
     @mock.patch("cloudinit.subp.subp")
     def test_find_devs_with_openbsd(self, m_subp):
-        m_subp.return_value = ("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
+        m_subp.return_value = PipeOutput("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
         devlist = util.find_devs_with_openbsd()
         assert devlist == ["/dev/cd0a", "/dev/sd1a", "/dev/sd1i"]
 
     @mock.patch("cloudinit.subp.subp")
     def test_find_devs_with_openbsd_with_criteria(self, m_subp):
-        m_subp.return_value = ("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
+        m_subp.return_value = PipeOutput("cd0:,sd0:630d98d32b5d3759,sd1:,fd0:", "")
         devlist = util.find_devs_with_openbsd(criteria="TYPE=iso9660")
         assert devlist == ["/dev/cd0a", "/dev/sd1a", "/dev/sd1i"]
 
@@ -2442,29 +2443,29 @@ class TestFindDevs:
     @mock.patch("cloudinit.subp.subp")
     def test_find_devs_with_netbsd(self, m_subp, criteria, expected_devlist):
         side_effect_values = [
-            ("ld0 dk0 dk1 cd0", ""),
-            (
+            PipeOutput("ld0 dk0 dk1 cd0", ""),
+            PipeOutput(
                 "mscdlabel: CDIOREADTOCHEADER: "
                 "Inappropriate ioctl for device\n"
                 "track (ctl=4) at sector 0\n"
                 "disklabel not written\n",
                 "",
             ),
-            (
+            PipeOutput(
                 "mscdlabel: CDIOREADTOCHEADER: "
                 "Inappropriate ioctl for device\n"
                 "track (ctl=4) at sector 0\n"
                 "disklabel not written\n",
                 "",
             ),
-            (
+            PipeOutput(
                 "mscdlabel: CDIOREADTOCHEADER: "
                 "Inappropriate ioctl for device\n"
                 "track (ctl=4) at sector 0\n"
                 "disklabel not written\n",
                 "",
             ),
-            (
+            PipeOutput(
                 "track (ctl=4) at sector 0\n"
                 'ISO filesystem, label "config-2", '
                 "creation time: 2020/03/31 17:29\n"
@@ -2492,7 +2493,7 @@ class TestFindDevs:
     def test_find_devs_with_dragonflybsd(
         self, m_subp, criteria, expected_devlist
     ):
-        m_subp.return_value = ("md2 md1 cd0 vbd0 acd0 vn3 vn2 vn1 vn0 md0", "")
+        m_subp.return_value = PipeOutput("md2 md1 cd0 vbd0 acd0 vn3 vn2 vn1 vn0 md0", "")
         devlist = util.find_devs_with_dragonflybsd(criteria=criteria)
         assert devlist == expected_devlist
 


### PR DESCRIPTION
```
Return a namedtuple from subp()

This provides a minor readability improvement.

 subp.subp(cmd)[0] -> subp.subp(cmd).stdout
 subp.subp(cmd)[1] -> subp.subp(cmd).stderr
```

## Additional Context
Named tuples are an "easy win" in terms of readability. I'm open to suggestions if someone would rather a different name than `PipeOutput`.
