### PR TITLE
added ipv4 addresses

### DIFF
--- a/cloudinit/sources/DataSourceHetzner.py
+++ b/cloudinit/sources/DataSourceHetzner.py
@@ -94,6 +94,8 @@ class DataSourceHetzner(sources.DataSource):
         self.metadata["local-hostname"] = md["hostname"]
         self.metadata["network-config"] = md.get("network-config", None)
         self.metadata["public-keys"] = md.get("public-keys", None)
+        self.metadata["public-ipv4"] = md.get("public-ipv4", None)
+        self.metadata["local-ipv4"] = md.get("local-ipv4", None)
         self.vendordata_raw = md.get("vendor_data", None)
 
         # instance-id and serial from SMBIOS should be identical


### PR DESCRIPTION
## Proposed Commit Message
datasource/hetzner: added ipv4 addresses

```
Hetzner cloud-init datasource doesn't return all needed network metadata. Added `public-ipv4` and `local-ipv4` to metadata
```

## Additional Context
Querying Hetzner metadata endpoint
`curl http://169.254.169.254/hetzner/v1/metadata`

Getting this content.
 `network-config` section, which is now used in metadata, doesn't contain enough information:
```availability-zone: fsn1-dc14
hostname: test-server
instance-id: 19633573
local-ipv4: <local-address>
network-config:
  config:
  - mac_address: 96:00:01:37:bc:20
    name: eth0
    subnets:
    - ipv4: true
      type: dhcp
    - address: 2a01:4f8:c010:bc09::1/64
      dns_nameservers:
      - 2a01:4ff:ff00::add:2
      - 2a01:4ff:ff00::add:1
      gateway: fe80::1
      ipv6: true
      type: static
    type: physical
  version: 1
public-ipv4: <public-address>
public-keys:
- <public-key-info>
region: eu-central
vendor_data: <some-vendor-data>
