### PR TITLE
Fix KeyError when rendering sysconfig IPv6 routes (SC-776)

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -959,12 +959,12 @@ def _normalize_net_keys(network, address_keys=()):
             else:
                 # this supports input of 255.255.255.0
                 prefix = ipv4_mask_to_net_prefix(maybe_prefix)
+    elif "prefix" in net:
+        prefix = int(net["prefix"])
     elif netmask and not ipv6:
         prefix = ipv4_mask_to_net_prefix(netmask)
     elif netmask and ipv6:
         prefix = ipv6_mask_to_net_prefix(netmask)
-    elif "prefix" in net:
-        prefix = int(net["prefix"])
     else:
         prefix = 64 if ipv6 else 24
 

--- a/cloudinit/net/renderer.py
+++ b/cloudinit/net/renderer.py
@@ -8,7 +8,7 @@
 import abc
 import io
 
-from cloudinit.net.network_state import parse_net_config_data
+from cloudinit.net.network_state import NetworkState, parse_net_config_data
 from cloudinit.net.udev import generate_udev_rule
 
 
@@ -32,7 +32,7 @@ class Renderer(object):
         pass
 
     @staticmethod
-    def _render_persistent_net(network_state):
+    def _render_persistent_net(network_state: NetworkState):
         """Given state, emit udev rules to map mac to ifname."""
         # TODO(harlowja): this seems shared between eni renderer and
         # this, so move it to a shared location.

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -4,17 +4,18 @@ import copy
 import io
 import os
 import re
+from typing import Mapping
 
 from cloudinit import log as logging
 from cloudinit import subp, util
 from cloudinit.distros.parsers import networkmanager_conf, resolv_conf
 from cloudinit.net import (
     IPV6_DYNAMIC_TYPES,
-    ipv6_mask_to_net_prefix,
     is_ipv6_addr,
     net_prefix_to_ipv4_mask,
     subnet_is_ipv6,
 )
+from cloudinit.net.network_state import NetworkState
 
 from . import renderer
 
@@ -176,7 +177,6 @@ class Route(ConfigMap):
 
             index = key.replace("ADDRESS", "")
             address_value = str(self._conf[key])
-            netmask_value = str(self._conf["NETMASK" + index])
             gateway_value = str(self._conf["GATEWAY" + index])
 
             # only accept combinations:
@@ -186,6 +186,7 @@ class Route(ConfigMap):
             # do not add ipv4 routes if proto is ipv6
             # (this array will contain a mix of ipv4 and ipv6)
             if proto == "ipv4" and not self.is_ipv6_route(address_value):
+                netmask_value = str(self._conf["NETMASK" + index])
                 # increase IPv4 index
                 reindex = reindex + 1
                 buf.write(
@@ -208,7 +209,7 @@ class Route(ConfigMap):
                         % ("METRIC" + str(reindex), _quote_value(metric_value))
                     )
             elif proto == "ipv6" and self.is_ipv6_route(address_value):
-                prefix_value = ipv6_mask_to_net_prefix(netmask_value)
+                prefix_value = str(self._conf[f"PREFIX{index}"])
                 metric_value = (
                     "metric " + str(self._conf["METRIC" + index])
                     if "METRIC" + index in self._conf
@@ -657,21 +658,19 @@ class Renderer(renderer.Renderer):
                         iface_cfg["METRIC"] = route["metric"]
 
                 else:
-                    gw_key = "GATEWAY%s" % route_cfg.last_idx
-                    nm_key = "NETMASK%s" % route_cfg.last_idx
-                    addr_key = "ADDRESS%s" % route_cfg.last_idx
-                    metric_key = "METRIC%s" % route_cfg.last_idx
-                    route_cfg.last_idx += 1
                     # add default routes only to ifcfg files, not
                     # to route-* or route6-*
-                    for (old_key, new_key) in [
-                        ("gateway", gw_key),
-                        ("metric", metric_key),
-                        ("netmask", nm_key),
-                        ("network", addr_key),
+                    for old_key, new_name in [
+                        ("gateway", "GATEWAY"),
+                        ("metric", "METRIC"),
+                        ("prefix", "PREFIX"),
+                        ("netmask", "NETMASK"),
+                        ("network", "ADDRESS"),
                     ]:
                         if old_key in route:
+                            new_key = f"{new_name}{route_cfg.last_idx}"
                             route_cfg[new_key] = route[old_key]
+                    route_cfg.last_idx += 1
 
     @classmethod
     def _render_bonding_opts(cls, iface_cfg, iface, flavor):
@@ -948,7 +947,7 @@ class Renderer(renderer.Renderer):
         """Given state, return /etc/sysconfig files + contents"""
         if not templates:
             templates = cls.templates
-        iface_contents = {}
+        iface_contents: Mapping[str, NetInterface] = {}
         for iface in network_state.iter_interfaces():
             if iface["type"] == "loopback":
                 continue
@@ -981,7 +980,9 @@ class Renderer(renderer.Renderer):
                         contents[cpath] = iface_cfg.routes.to_string(proto)
         return contents
 
-    def render_network_state(self, network_state, templates=None, target=None):
+    def render_network_state(
+        self, network_state: NetworkState, templates=None, target=None
+    ):
         if not templates:
             templates = self.templates
         file_mode = 0o644

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -636,12 +636,9 @@ class Renderer(renderer.Renderer):
                             "Duplicate declaration of default "
                             "route found for interface '%s'" % (iface_cfg.name)
                         )
-                    # NOTE(harlowja): ipv6 and ipv4 default gateways
-                    gw_key = "GATEWAY0"
-                    nm_key = "NETMASK0"
-                    addr_key = "ADDRESS0"
-                    # The owning interface provides the default route.
-                    #
+                    # NOTE that instead of defining the route0 settings,
+                    # the owning interface provides the default route.
+
                     # TODO(harlowja): add validation that no other iface has
                     # also provided the default route?
                     iface_cfg["DEFROUTE"] = True

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5137,6 +5137,108 @@ USERCTL=no
                 expected, self._render_and_read(network_config=v2data)
             )
 
+    def test_from_v2_routes(self):
+        """verify routes (including IPv6) get rendered using v2 config.
+
+        LP: #1958506
+        """
+        v2_data = {
+            "version": 2,
+            "ethernets": {
+                "eth0": {
+                    "addresses": [
+                        "10.54.2.19/21",
+                        "2a00:1730:fff9:100::52/128",
+                    ],
+                    "gateway4": "10.54.0.1",
+                    "gateway6": "2a00:1730:fff9:100::1",
+                    "match": {"macaddress": "52:54:00:3f:fc:f7"},
+                    "mtu": 1400,
+                    "nameservers": {
+                        "addresses": [
+                            "10.52.1.1",
+                            "10.52.1.71",
+                            "2001:4860:4860::8888",
+                            "2001:4860:4860::8844",
+                        ]
+                    },
+                    "routes": [
+                        {
+                            "scope": "link",
+                            "to": "10.54.0.1/32",
+                            "via": "0.0.0.0",
+                        },
+                        {
+                            "scope": "link",
+                            "to": "0.0.0.0/0",
+                            "via": "10.54.0.1",
+                        },
+                        {
+                            "scope": "link",
+                            "to": "2a00:1730:fff9:100::1/128",
+                            "via": "::0",
+                        },
+                        {
+                            "scope": "link",
+                            "to": "::0/0",
+                            "via": "2a00:1730:fff9:100::1",
+                        },
+                    ],
+                    "set-name": "eth0",
+                }
+            },
+        }
+
+        expected = {
+            "ifcfg-eth0": textwrap.dedent(
+                """\
+                # Created by cloud-init on instance boot automatically, do not edit.
+                #
+                BOOTPROTO=none
+                DEFROUTE=yes
+                DEVICE=eth0
+                DNS1=10.52.1.1
+                DNS2=10.52.1.71
+                DNS3=2001:4860:4860::8888
+                GATEWAY=10.54.0.1
+                HWADDR=52:54:00:3f:fc:f7
+                IPADDR=10.54.2.19
+                IPV6ADDR=2a00:1730:fff9:100::52/128
+                IPV6INIT=yes
+                IPV6_AUTOCONF=no
+                IPV6_DEFAULTGW=2a00:1730:fff9:100::1
+                IPV6_FORCE_ACCEPT_RA=no
+                MTU=1400
+                NETMASK=255.255.248.0
+                NM_CONTROLLED=no
+                ONBOOT=yes
+                TYPE=Ethernet
+                USERCTL=no
+                """
+            ),
+            "route-eth0": textwrap.dedent(
+                """\
+                # Created by cloud-init on instance boot automatically, do not edit.
+                #
+                ADDRESS0=10.54.0.1
+                GATEWAY0=0.0.0.0
+                NETMASK0=255.255.255.255
+                """
+            ),
+            "route6-eth0": textwrap.dedent(
+                """\
+                # Created by cloud-init on instance boot automatically, do not edit.
+                #
+                2a00:1730:fff9:100::1/128 via ::0  dev eth0
+                ::0/64 via 2a00:1730:fff9:100::1  dev eth0
+                """
+            ),
+        }
+
+        found = self._render_and_read(network_config=v2_data)
+        self._compare_files_to_expected(expected, found)
+        self._assert_headers(found)
+
     @mock.patch("cloudinit.net.sys_dev_path")
     @mock.patch("cloudinit.net.read_sys_net")
     @mock.patch("cloudinit.net.get_devicelist")

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5214,7 +5214,7 @@ USERCTL=no
                 ONBOOT=yes
                 TYPE=Ethernet
                 USERCTL=no
-                """
+                """  # noqa: E501
             ),
             "route-eth0": textwrap.dedent(
                 """\
@@ -5223,7 +5223,7 @@ USERCTL=no
                 ADDRESS0=10.54.0.1
                 GATEWAY0=0.0.0.0
                 NETMASK0=255.255.255.255
-                """
+                """  # noqa: E501
             ),
             "route6-eth0": textwrap.dedent(
                 """\
@@ -5231,7 +5231,7 @@ USERCTL=no
                 #
                 2a00:1730:fff9:100::1/128 via ::0  dev eth0
                 ::0/64 via 2a00:1730:fff9:100::1  dev eth0
-                """
+                """  # noqa: E501
             ),
         }
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix KeyError when rendering sysconfig IPv6 routes

Route rendering code was expecting a netmask rather than using the
prefix. A prefix is provided to the renderer, but was being hidden
from the route rendering code. This commit exposes the prefix and
prefers it for IPv6, given how uncommon netmasks are for IPv6.

LP: #1958506
```

## Additional Context
See https://bugs.launchpad.net/cloud-init/+bug/1958506