### PR TITLE
Fix ds-identify not detecting NoCloud seed in config (SC-542)

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -1162,11 +1162,11 @@ def read_runtime_config():
 def fetch_base_config():
     return util.mergemanydict(
         [
-            # builtin config
+            # builtin config, hardcoded in settings.py.
             util.get_builtin_cfg(),
             # Anything in your conf.d or 'default' cloud.cfg location.
             util.read_conf_with_confd(CLOUD_CONFIG),
-            # runtime config
+            # runtime config. I.e., /run/cloud-init/cloud.cfg
             read_runtime_config(),
             # Kernel/cmdline parameters override system config
             util.read_conf_from_cmdline(),

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -3,6 +3,7 @@
 import copy
 import os
 from collections import namedtuple
+from textwrap import dedent
 from uuid import uuid4
 
 from cloudinit import safeyaml, subp, util
@@ -732,6 +733,10 @@ class TestDsIdentify(DsIdentifyBase):
         """NoCloud is found with uppercase filesystem label."""
         self._test_ds_found("NoCloudUpper")
 
+    def test_nocloud_seed_in_cfg(self):
+        """NoCloud seed definition can go in /etc/cloud/cloud.cfg[.d]"""
+        self._test_ds_found("NoCloud-cfg")
+
     def test_nocloud_fatboot(self):
         """NoCloud fatboot label - LP: #184166."""
         self._test_ds_found("NoCloud-fatboot")
@@ -1083,6 +1088,26 @@ VALID_CFG = {
         ],
         "files": {
             "dev/vdb": "pretend iso content for cidata\n",
+        },
+    },
+    "NoCloud-cfg": {
+        "ds": "NoCloud",
+        "files": {
+            # Also include a datasource list of more than just
+            # [NoCloud, None], because that would automatically select
+            # NoCloud without checking
+            "/etc/cloud/cloud.cfg": dedent(
+                """\
+                datasource_list: [ Azure, Openstack, NoCloud, None ]
+                datasource:
+                  NoCloud:
+                    user-data: |
+                      #cloud-config
+                      hostname: footbar
+                    meta-data: |
+                      instance_id: cloud-image
+                """
+            )
         },
     },
     "NoCloud-fbsd": {

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -851,6 +851,11 @@ dscheck_NoCloud() {
         return ${DS_FOUND}
     fi
 
+    # This is a bit hacky, but a NoCloud false positive isn't the end of the world
+    if check_config "NoCloud" && check_config "user-data" && check_config "meta-data"; then
+        return ${DS_FOUND}
+    fi
+
     return ${DS_NOT_FOUND}
 }
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix ds-identify not detecting NoCloud seed in config

NoCloud seed config can be defined in /etc/cloud/cloud.cfg[.d].
However, ds-identify had no means of detecting this config and reported
NOT FOUND. This commit allows ds-identify to detect and report it
properly.

LP: #1876375
```

## Additional Context
LP: #1876375 notes that if you specify the datasource list in a cfg file, it works, but if you don't it doesn't. It has nothing to do with the reading of the config files. If the datasource list only contains one entry (or one + None), ds-identify skips datasource detection entirely and just uses the specified datasource. https://github.com/canonical/cloud-init/blob/main/tools/ds-identify#L1793-L1798 . The problem is that ds-identify just had no means of detecting this use case.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
