### PR TITLE
cloudinit.net refactor: apply_network_config_names

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -254,7 +254,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         return False
 
     def apply_network_config_names(self, netconfig):
-        net.apply_network_config_names(netconfig)
+        self.networking.apply_network_config_names(netconfig)
 
     @abc.abstractmethod
     def apply_locale(self, locale, out_fn=None):

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -253,9 +253,6 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             LOG.debug("Not bringing up newly configured network interfaces")
         return False
 
-    def apply_network_config_names(self, netconfig):
-        self.networking.apply_network_config_names(netconfig)
-
     @abc.abstractmethod
     def apply_locale(self, locale, out_fn=None):
         raise NotImplementedError()

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -133,6 +133,3 @@ class BSD(distros.Distro):
 
     def apply_locale(self, locale, out_fn=None):
         LOG.debug("Cannot set the locale.")
-
-    def apply_network_config_names(self, netconfig):
-        LOG.debug("Cannot rename network interface.")

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -13,7 +13,18 @@ from cloudinit import log as logging
 from cloudinit import subp, util
 from cloudinit.settings import PER_INSTANCE
 
+from .networking import BSDNetworking, NetworkConfig
+
 LOG = logging.getLogger(__name__)
+
+
+class FreeBSDNetworking(BSDNetworking):
+    def apply_network_config_names(self, netcfg: NetworkConfig) -> None:
+        # This is handled by the freebsd network renderer. It writes in
+        # /etc/rc.conf a line with the following format:
+        #    ifconfig_OLDNAME_name=NEWNAME
+        # FreeBSD network script will rename the interface automatically.
+        pass
 
 
 class Distro(cloudinit.distros.bsd.BSD):
@@ -23,6 +34,7 @@ class Distro(cloudinit.distros.bsd.BSD):
     (N.B. DragonFlyBSD inherits from this class.)
     """
 
+    networking_cls = FreeBSDNetworking
     usr_lib_exec = "/usr/local/lib"
     login_conf_fn = "/etc/login.conf"
     login_conf_fn_bak = "/etc/login.conf.orig"
@@ -152,13 +164,6 @@ class Distro(cloudinit.distros.bsd.BSD):
                 util.logexc(
                     LOG, "Failed to restore %s backup", self.login_conf_fn
                 )
-
-    def apply_network_config_names(self, netconfig):
-        # This is handled by the freebsd network renderer. It writes in
-        # /etc/rc.conf a line with the following format:
-        #    ifconfig_OLDNAME_name=NEWNAME
-        # FreeBSD network script will rename the interface automatically.
-        pass
 
     def _get_pkg_cmd_environ(self):
         """Return environment vars used in *BSD package_command operations"""

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -13,18 +13,9 @@ from cloudinit import log as logging
 from cloudinit import subp, util
 from cloudinit.settings import PER_INSTANCE
 
-from .networking import BSDNetworking, NetworkConfig
+from .networking import FreeBSDNetworking
 
 LOG = logging.getLogger(__name__)
-
-
-class FreeBSDNetworking(BSDNetworking):
-    def apply_network_config_names(self, netcfg: NetworkConfig) -> None:
-        # This is handled by the freebsd network renderer. It writes in
-        # /etc/rc.conf a line with the following format:
-        #    ifconfig_OLDNAME_name=NEWNAME
-        # FreeBSD network script will rename the interface automatically.
-        pass
 
 
 class Distro(cloudinit.distros.bsd.BSD):

--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -133,9 +133,6 @@ class NetBSD(cloudinit.distros.bsd.BSD):
     def apply_locale(self, locale, out_fn=None):
         LOG.debug("Cannot set the locale.")
 
-    def apply_network_config_names(self, netconfig):
-        LOG.debug("NetBSD cannot rename network interface.")
-
     def _get_pkg_cmd_environ(self):
         """Return env vars used in NetBSD package_command operations"""
         os_release = platform.release()

--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -19,7 +19,7 @@ class Networking(metaclass=abc.ABCMeta):
 
     This is part of an ongoing refactor in the cloud-init codebase, for more
     details see "``cloudinit.net`` -> ``cloudinit.distros.networking``
-    Hierarchy" in HACKING.rst for full details.
+    Hierarchy" in CONTRIBUTING.rst for full details.
     """
 
     def __init__(self):
@@ -32,7 +32,19 @@ class Networking(metaclass=abc.ABCMeta):
         return net._rename_interfaces(renames, current_info=current_info)
 
     def apply_network_config_names(self, netcfg: NetworkConfig) -> None:
-        return net.apply_network_config_names(netcfg)
+        """Read the network config and rename devices accordingly.
+
+        Renames are only attempted for interfaces of type 'physical'.  It is
+        expected that the network system will create other devices with the
+        correct name in place.
+        """
+
+        try:
+            self._rename_interfaces(self.extract_physdevs(netcfg))
+        except RuntimeError as e:
+            raise RuntimeError(
+                "Failed to apply network config names: %s" % e
+            ) from e
 
     def device_devid(self, devname: DeviceName):
         return net.device_devid(devname)

--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -198,6 +198,15 @@ class BSDNetworking(Networking):
         raise NotImplementedError()
 
 
+class FreeBSDNetworking(BSDNetworking):
+    def apply_network_config_names(self, netcfg: NetworkConfig) -> None:
+        # This is handled by the freebsd network renderer. It writes in
+        # /etc/rc.conf a line with the following format:
+        #    ifconfig_OLDNAME_name=NEWNAME
+        # FreeBSD network script will rename the interface automatically.
+        pass
+
+
 class LinuxNetworking(Networking):
     """Implementation of networking functionality common to Linux distros."""
 

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -660,24 +660,6 @@ def extract_physdevs(netcfg):
     raise RuntimeError("Unknown network config version: %s" % version)
 
 
-def apply_network_config_names(netcfg, strict_present=True, strict_busy=True):
-    """read the network config and rename devices accordingly.
-    if strict_present is false, then do not raise exception if no devices
-    match.  if strict_busy is false, then do not raise exception if the
-    device cannot be renamed because it is currently configured.
-
-    renames are only attempted for interfaces of type 'physical'.  It is
-    expected that the network system will create other devices with the
-    correct name in place."""
-
-    try:
-        _rename_interfaces(extract_physdevs(netcfg))
-    except RuntimeError as e:
-        raise RuntimeError(
-            "Failed to apply network config names: %s" % e
-        ) from e
-
-
 def interface_has_own_mac(ifname, strict=False):
     """return True if the provided interface has its own address.
 

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -852,7 +852,7 @@ class Init(object):
     def _apply_netcfg_names(self, netcfg):
         try:
             LOG.debug("applying net config names for %s", netcfg)
-            self.distro.apply_network_config_names(netcfg)
+            self.distro.networking.apply_network_config_names(netcfg)
         except Exception as e:
             LOG.warning("Failed to rename devices: %s", e)
 

--- a/tests/unittests/distros/test_networking.py
+++ b/tests/unittests/distros/test_networking.py
@@ -332,7 +332,9 @@ class TestLinuxNetworkingApplyNetworkCfgNames:
             pytest.param("V2_CONFIG_NO_MAC", id="without_mac"),
         ],
     )
-    def test_apply_v2_renames_skips_without_setname(self, config_attr: str):
+    def test_apply_v2_renames_skips_without_setname_or_mac(
+        self, config_attr: str
+    ):
         networking = LinuxNetworking()
         netcfg = yaml.load(getattr(self, config_attr))
         with mock.patch.object(

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -4,7 +4,6 @@ import copy
 import errno
 import ipaddress
 import os
-import textwrap
 from pathlib import Path
 from typing import Optional
 from unittest import mock
@@ -14,7 +13,6 @@ import pytest
 import requests
 
 import cloudinit.net as net
-from cloudinit import safeyaml as yaml
 from cloudinit.subp import ProcessExecutionError
 from cloudinit.util import ensure_file, write_file
 from tests.unittests.helpers import CiTestCase, HttprettyTestCase
@@ -1194,105 +1192,6 @@ class TestEphemeralIPV4Network(CiTestCase):
         with net.EphemeralIPv4Network(**params):
             self.assertEqual(expected_setup_calls, m_subp.call_args_list)
         m_subp.assert_has_calls(expected_setup_calls + expected_teardown_calls)
-
-
-class TestApplyNetworkCfgNames(CiTestCase):
-    V1_CONFIG = textwrap.dedent(
-        """\
-        version: 1
-        config:
-            - type: physical
-              name: interface0
-              mac_address: "52:54:00:12:34:00"
-              subnets:
-                  - type: static
-                    address: 10.0.2.15
-                    netmask: 255.255.255.0
-                    gateway: 10.0.2.2
-    """
-    )
-    V2_CONFIG = textwrap.dedent(
-        """\
-      version: 2
-      ethernets:
-          interface0:
-            match:
-              macaddress: "52:54:00:12:34:00"
-            addresses:
-              - 10.0.2.15/24
-            gateway4: 10.0.2.2
-            set-name: interface0
-    """
-    )
-
-    V2_CONFIG_NO_SETNAME = textwrap.dedent(
-        """\
-      version: 2
-      ethernets:
-          interface0:
-            match:
-              macaddress: "52:54:00:12:34:00"
-            addresses:
-              - 10.0.2.15/24
-            gateway4: 10.0.2.2
-    """
-    )
-
-    V2_CONFIG_NO_MAC = textwrap.dedent(
-        """\
-      version: 2
-      ethernets:
-          interface0:
-            match:
-              driver: virtio-net
-            addresses:
-              - 10.0.2.15/24
-            gateway4: 10.0.2.2
-            set-name: interface0
-    """
-    )
-
-    @mock.patch("cloudinit.net.device_devid")
-    @mock.patch("cloudinit.net.device_driver")
-    @mock.patch("cloudinit.net._rename_interfaces")
-    def test_apply_v1_renames(
-        self, m_rename_interfaces, m_device_driver, m_device_devid
-    ):
-        m_device_driver.return_value = "virtio_net"
-        m_device_devid.return_value = "0x15d8"
-
-        net.apply_network_config_names(yaml.load(self.V1_CONFIG))
-
-        call = ["52:54:00:12:34:00", "interface0", "virtio_net", "0x15d8"]
-        m_rename_interfaces.assert_called_with([call])
-
-    @mock.patch("cloudinit.net.device_devid")
-    @mock.patch("cloudinit.net.device_driver")
-    @mock.patch("cloudinit.net._rename_interfaces")
-    def test_apply_v2_renames(
-        self, m_rename_interfaces, m_device_driver, m_device_devid
-    ):
-        m_device_driver.return_value = "virtio_net"
-        m_device_devid.return_value = "0x15d8"
-
-        net.apply_network_config_names(yaml.load(self.V2_CONFIG))
-
-        call = ["52:54:00:12:34:00", "interface0", "virtio_net", "0x15d8"]
-        m_rename_interfaces.assert_called_with([call])
-
-    @mock.patch("cloudinit.net._rename_interfaces")
-    def test_apply_v2_renames_skips_without_setname(self, m_rename_interfaces):
-        net.apply_network_config_names(yaml.load(self.V2_CONFIG_NO_SETNAME))
-        m_rename_interfaces.assert_called_with([])
-
-    @mock.patch("cloudinit.net._rename_interfaces")
-    def test_apply_v2_renames_skips_without_mac(self, m_rename_interfaces):
-        net.apply_network_config_names(yaml.load(self.V2_CONFIG_NO_MAC))
-        m_rename_interfaces.assert_called_with([])
-
-    def test_apply_v2_renames_raises_runtime_error_on_unknown_version(self):
-        with self.assertRaises(RuntimeError):
-            net.apply_network_config_names(yaml.load("version: 3"))
 
 
 class TestHasURLConnectivity(HttprettyTestCase):

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -360,14 +360,16 @@ class TestInit(CiTestCase):
         self.init._find_networking_config = fake_network_config
 
         self.init.apply_network_config(True)
-        self.init.distro.apply_network_config_names.assert_called_with(net_cfg)
+        networking = self.init.distro.networking
+        networking.apply_network_config_names.assert_called_with(net_cfg)
         self.init.distro.apply_network_config.assert_called_with(
             net_cfg, bring_up=True
         )
 
     @mock.patch("cloudinit.distros.ubuntu.Distro")
     def test_apply_network_on_same_instance_id(self, m_ubuntu):
-        """Only call distro.apply_network_config_names on same instance id."""
+        """Only call distro.networking.apply_network_config_names on same
+        instance id."""
         self.init.is_new_instance = self._real_is_new_instance
         old_instance_id = os.path.join(
             self.init.paths.get_cpath("data"), "instance-id"
@@ -391,7 +393,8 @@ class TestInit(CiTestCase):
         self.init._find_networking_config = fake_network_config
 
         self.init.apply_network_config(True)
-        self.init.distro.apply_network_config_names.assert_called_with(net_cfg)
+        networking = self.init.distro.networking
+        networking.apply_network_config_names.assert_called_with(net_cfg)
         self.init.distro.apply_network_config.assert_not_called()
         assert (
             "No network config applied. Neither a new instance nor datasource "
@@ -439,9 +442,10 @@ class TestInit(CiTestCase):
         net_cfg = self._apply_network_setup(m_macs)
 
         self.init.apply_network_config(True)
+        networking = self.init.distro.networking
         assert (
             mock.call(net_cfg)
-            == self.init.distro.apply_network_config_names.call_args_list[-1]
+            == networking.apply_network_config_names.call_args_list[-1]
         )
         assert (
             mock.call(net_cfg, bring_up=True)
@@ -479,7 +483,8 @@ class TestInit(CiTestCase):
         net_cfg = self._apply_network_setup(m_macs)
         self.init._cfg = {"updates": {"network": {"when": ["boot"]}}}
         self.init.apply_network_config(True)
-        self.init.distro.apply_network_config_names.assert_called_with(net_cfg)
+        networking = self.init.distro.networking
+        networking.apply_network_config_names.assert_called_with(net_cfg)
         self.init.distro.apply_network_config.assert_called_with(
             net_cfg, bring_up=True
         )

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -84,9 +84,6 @@ class MockDistro(distros.Distro):
     def apply_network_config(self, netconfig, bring_up=False) -> bool:
         return False
 
-    def apply_network_config_names(self, netconfig):
-        pass
-
     def apply_locale(self, locale, out_fn=None):
         pass
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cloudinit.net refactor: apply_network_config_names

- Remove `apply_network_config_names` from `cloudinit.net` and `Distro` classes so it is only accessible via the networking attribute.

LP: #1884602
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
