### PR TITLE
schema: render schema paths from _CustomSafeLoaderWithMarks

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -360,7 +360,7 @@ def validate_cloudconfig_file(config_path, schema, annotate=False):
         if annotate:
             print(
                 annotated_cloudconfig_file(
-                    {}, content, error.schema_errors, marks
+                    {}, content, error.schema_errors, {}
                 )
             )
         raise error from e

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -14,7 +14,7 @@ from functools import partial
 
 import yaml
 
-from cloudinit import importer
+from cloudinit import importer, safeyaml
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.util import error, find_modules, load_file
 
@@ -236,7 +236,9 @@ def validate_cloudconfig_schema(
             )
 
 
-def annotated_cloudconfig_file(cloudconfig, original_content, schema_errors):
+def annotated_cloudconfig_file(
+    cloudconfig, original_content, schema_errors, schemamarks
+):
     """Return contents of the cloud-config file annotated with schema errors.
 
     @param cloudconfig: YAML-loaded dict from the original_content or empty
@@ -247,7 +249,6 @@ def annotated_cloudconfig_file(cloudconfig, original_content, schema_errors):
     """
     if not schema_errors:
         return original_content
-    schemapaths = {}
     errors_by_line = defaultdict(list)
     error_footer = []
     error_header = "# Errors: -------------\n{0}\n\n"
@@ -259,10 +260,6 @@ def annotated_cloudconfig_file(cloudconfig, original_content, schema_errors):
             lines
             + [error_header.format("# E1: Cloud-config is not a YAML dict.")]
         )
-    if cloudconfig:
-        schemapaths = _schemapath_for_cloudconfig(
-            cloudconfig, original_content
-        )
     for path, msg in schema_errors:
         match = re.match(r"format-l(?P<line>\d+)\.c(?P<col>\d+).*", path)
         if match:
@@ -270,7 +267,7 @@ def annotated_cloudconfig_file(cloudconfig, original_content, schema_errors):
             errors_by_line[int(line)].append(msg)
         else:
             col = None
-            errors_by_line[schemapaths[path]].append(msg)
+            errors_by_line[schemamarks[path]].append(msg)
         if col is not None:
             msg = "Line {line} column {col}: {msg}".format(
                 line=line, col=col, msg=msg
@@ -331,10 +328,18 @@ def validate_cloudconfig_file(config_path, schema, annotate=False):
         )
         error = SchemaValidationError(errors)
         if annotate:
-            print(annotated_cloudconfig_file({}, content, error.schema_errors))
+            print(
+                annotated_cloudconfig_file(
+                    {}, content, error.schema_errors, {}
+                )
+            )
         raise error
     try:
-        cloudconfig = yaml.safe_load(content)
+        if annotate:
+            cloudconfig, marks = safeyaml.load_with_marks(content)
+        else:
+            cloudconfig = safeyaml.load(content)
+            marks = {}
     except (yaml.YAMLError) as e:
         line = column = 1
         mark = None
@@ -353,7 +358,11 @@ def validate_cloudconfig_file(config_path, schema, annotate=False):
         )
         error = SchemaValidationError(errors)
         if annotate:
-            print(annotated_cloudconfig_file({}, content, error.schema_errors))
+            print(
+                annotated_cloudconfig_file(
+                    {}, content, error.schema_errors, marks
+                )
+            )
         raise error from e
     if not isinstance(cloudconfig, dict):
         # Return a meaningful message on empty cloud-config
@@ -365,74 +374,10 @@ def validate_cloudconfig_file(config_path, schema, annotate=False):
         if annotate:
             print(
                 annotated_cloudconfig_file(
-                    cloudconfig, content, e.schema_errors
+                    cloudconfig, content, e.schema_errors, marks
                 )
             )
         raise
-
-
-def _schemapath_for_cloudconfig(config, original_content):
-    """Return a dictionary mapping schemapath to original_content line number.
-
-    @param config: The yaml.loaded config dictionary of a cloud-config file.
-    @param original_content: The simple file content of the cloud-config file
-    """
-    # TODO( handle multi-line lists or multi-line strings, inline dicts)
-    content_lines = original_content.decode().split("\n")
-    schema_line_numbers = {}
-    list_index = 0
-    RE_YAML_INDENT = r"^(\s*)"
-    scopes = []
-    if not config:
-        return {}  # No YAML config dict, no schemapaths to annotate
-    for line_number, line in enumerate(content_lines, 1):
-        indent_depth = len(re.match(RE_YAML_INDENT, line).groups()[0])
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if scopes:
-            previous_depth, path_prefix = scopes[-1]
-        else:
-            previous_depth = -1
-            path_prefix = ""
-        if line.startswith("- "):
-            # Process list items adding a list_index to the path prefix
-            previous_list_idx = ".%d" % (list_index - 1)
-            if path_prefix and path_prefix.endswith(previous_list_idx):
-                path_prefix = path_prefix[: -len(previous_list_idx)]
-            key = str(list_index)
-            item_indent = len(re.match(RE_YAML_INDENT, line[1:]).groups()[0])
-            item_indent += 1  # For the leading '-' character
-            previous_depth = indent_depth
-            indent_depth += item_indent
-            line = line[item_indent:]  # Strip leading list item + whitespace
-            list_index += 1
-        else:
-            # Process non-list lines setting value if present
-            list_index = 0
-            key, value = line.split(":", 1)
-        if path_prefix and indent_depth > previous_depth:
-            # Append any existing path_prefix for a fully-pathed key
-            key = path_prefix + "." + key
-        while indent_depth <= previous_depth:
-            if scopes:
-                previous_depth, path_prefix = scopes.pop()
-                if list_index > 0 and indent_depth == previous_depth:
-                    path_prefix = ".".join(path_prefix.split(".")[:-1])
-                    break
-            else:
-                previous_depth = -1
-                path_prefix = ""
-        scopes.append((indent_depth, key))
-        if value:
-            value = value.strip()
-            if value.startswith("["):
-                scopes.append((indent_depth + 2, key + ".0"))
-                for inner_list_index in range(0, len(yaml.safe_load(value))):
-                    list_key = key + "." + str(inner_list_index)
-                    schema_line_numbers[list_key] = line_number
-        schema_line_numbers[key] = line_number
-    return schema_line_numbers
 
 
 def _sort_property_order(value):

--- a/cloudinit/safeyaml.py
+++ b/cloudinit/safeyaml.py
@@ -135,7 +135,7 @@ def dumps(obj, explicit_start=True, explicit_end=True, noalias=False):
         explicit_start=explicit_start,
         explicit_end=explicit_end,
         default_flow_style=False,
-        Dumper=(NoAliasSafeDumper if noalias else yaml.dumper.Dumper),
+        Dumper=(NoAliasSafeDumper if noalias else yaml.dumper.SafeDumper),
     )
 
 

--- a/cloudinit/safeyaml.py
+++ b/cloudinit/safeyaml.py
@@ -23,7 +23,7 @@ class _CustomSafeLoader(yaml.SafeLoader):
 
 
 class _CustomSafeLoaderWithMarks(yaml.SafeLoader):
-    """A loader which catalogs line and column coordination for objects."""
+    """A loader preserving line and column start and end  marks for objects."""
 
     def __init__(self, stream):
         super().__init__(stream)

--- a/cloudinit/safeyaml.py
+++ b/cloudinit/safeyaml.py
@@ -32,7 +32,7 @@ class _CustomSafeLoaderWithMarks(yaml.SafeLoader):
     def _get_nested_path_prefix(self, node):
         if node.start_mark.line in self.schemamarks_by_line:
             return f"{self.schemamarks_by_line[node.start_mark.line][0][0]}."
-        for line_num, schema_marks in sorted(
+        for _line_num, schema_marks in sorted(
             self.schemamarks_by_line.items(), reverse=True
         ):
             for mark in schema_marks[::-1]:

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -20,7 +20,6 @@ from cloudinit.config.schema import (
     CLOUD_CONFIG_HEADER,
     MetaSchema,
     SchemaValidationError,
-    _schemapath_for_cloudconfig,
     annotated_cloudconfig_file,
     get_jsonschema_validator,
     get_meta_doc,
@@ -811,14 +810,12 @@ class TestSchemaDocMarkdown:
         assert ".*" not in meta_doc
 
 
-class AnnotatedCloudconfigFileTest(CiTestCase):
-    maxDiff = None
-
+class AnnotatedCloudconfigFileTest:
     def test_annotated_cloudconfig_file_no_schema_errors(self):
         """With no schema_errors, print the original content."""
         content = b"ntp:\n  pools: [ntp1.pools.com]\n"
-        self.assertEqual(
-            content, annotated_cloudconfig_file({}, content, schema_errors=[])
+        assert content == annotated_cloudconfig_file(
+            {}, content, schema_errors=[], schemamarks={}
         )
 
     def test_annotated_cloudconfig_file_with_non_dict_cloud_config(self):
@@ -837,13 +834,11 @@ class AnnotatedCloudconfigFileTest(CiTestCase):
                 "# E1: Cloud-config is not a YAML dict.\n\n",
             ]
         )
-        self.assertEqual(
-            expected,
-            annotated_cloudconfig_file(
-                None,
-                content,
-                schema_errors=[("", "None is not of type 'object'")],
-            ),
+        assert expected == annotated_cloudconfig_file(
+            None,
+            content,
+            schema_errors=[("", "None is not of type 'object'")],
+            schemamarks={},
         )
 
     def test_annotated_cloudconfig_file_schema_annotates_and_adds_footer(self):
@@ -876,9 +871,8 @@ class AnnotatedCloudconfigFileTest(CiTestCase):
             ("ntp.pools.0", "-99 is not a string"),
             ("ntp.pools.1", "75 is not a string"),
         ]
-        self.assertEqual(
-            expected,
-            annotated_cloudconfig_file(parsed_config, content, schema_errors),
+        assert expected == annotated_cloudconfig_file(
+            parsed_config, content, schema_errors
         )
 
     def test_annotated_cloudconfig_file_annotates_separate_line_items(self):
@@ -906,9 +900,8 @@ class AnnotatedCloudconfigFileTest(CiTestCase):
             ("ntp.pools.0", "-99 is not a string"),
             ("ntp.pools.1", "75 is not a string"),
         ]
-        self.assertIn(
-            expected,
-            annotated_cloudconfig_file(parsed_config, content, schema_errors),
+        assert expected in annotated_cloudconfig_file(
+            parsed_config, content, schema_errors
         )
 
 

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -193,31 +193,6 @@ class TestLoadDoc:
         assert self.docs[module_name] == doc
 
 
-class Test_SchemapathForCloudconfig:
-    """Coverage tests for supported YAML formats."""
-
-    @pytest.mark.parametrize(
-        "source_content, expected",
-        (
-            (b"{}", {}),  # assert empty config handled
-            # Multiple keys account for comments and whitespace lines
-            (b"#\na: va\n  \nb: vb\n#\nc: vc", {"a": 2, "b": 4, "c": 6}),
-            # List items represented on correct line number
-            (b"a:\n - a1\n\n - a2\n", {"a": 1, "a.0": 2, "a.1": 4}),
-            # Nested dicts represented on correct line number
-            (b"a:\n a1:\n\n  aa1: aa1v\n", {"a": 1, "a.a1": 2, "a.a1.aa1": 4}),
-        ),
-    )
-    def test_schemapaths_representative_of_source_yaml(
-        self, source_content, expected
-    ):
-        """Validate schemapaths dict accurately represents source YAML line."""
-        cfg = yaml.safe_load(source_content)
-        assert expected == _schemapath_for_cloudconfig(
-            config=cfg, original_content=source_content
-        )
-
-
 class SchemaValidationErrorTest(CiTestCase):
     """Test validate_cloudconfig_schema"""
 
@@ -353,7 +328,7 @@ class TestCloudConfigExamples:
         according to the unified schema of all config modules
         """
         schema = get_schema()
-        config_load = safe_load(example)
+        config_load = load(example)
         # cloud-init-schema is permissive of additionalProperties at the
         # top-level.
         # To validate specific schemas against known documented examples

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -13,7 +13,6 @@ from types import ModuleType
 from typing import List
 
 import pytest
-import yaml
 from yaml import safe_load
 
 from cloudinit.config.schema import (

--- a/tests/unittests/test_safeyaml.py
+++ b/tests/unittests/test_safeyaml.py
@@ -1,0 +1,60 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+"""Tests for cloudinit.safeyaml."""
+
+import pytest
+
+from cloudinit.safeyaml import load_with_marks
+
+
+class TestLoadWithMarks:
+    @pytest.mark.parametrize(
+        "source_yaml,loaded_yaml,schemamarks",
+        (
+            # Invalid cloud-config, non-dict types don't cause an error
+            (b"scalar", "scalar", {}),
+            # Multiple keys account for comments and whitespace lines
+            (
+                b"#\na: va\n  \nb: vb\n#\nc: vc",
+                {"a": "va", "b": "vb", "c": "vc"},
+                {"a": 2, "b": 4, "c": 6}
+            ),
+            # List items represented on correct line number
+            (
+                b"a:\n - a1\n\n - a2\n",
+                {"a": ["a1", "a2"]},
+                {"a": 1, "a.0": 2, "a.1": 4}
+            ),
+            # Nested dicts represented on correct line number
+            (
+                b"a:\n a1:\n\n  aa1: aa1v\n",
+               {"a": {"a1": {"aa1": "aa1v"}}},
+               {"a": 1, "a.a1": 2, "a.a1.aa1": 4}
+            ),
+            (b"[list, of, scalar]", ["list", "of", "scalar"], {}),
+            (
+                b"{a: [a1, a2], b: [b3]}",
+                {"a": ["a1", "a2"], "b": ["b3"]},
+                {"a": 1, "a.0": 1, "a.1": 1, "b": 1},
+            ),
+            (
+                b"a: [a1, a2]\nb: [b3]",
+                {"a": ["a1", "a2"], "b": ["b3"]},
+                {"a": 1, "a.0": 1, "a.1": 1, "b": 2, "b.0": 2},
+            ),
+            (
+                b"a:\n- a1\n- a2\nb: [b3]",
+                {"a": ["a1", "a2"], "b": ["b3"]},
+                {"a": 1, "a.0": 2, "a.1": 3, "b": 4, "b.0": 4},
+            ),
+            (
+                b"a:\n- a1\n- a2\nb:\n- b3",
+                {"a": ["a1", "a2"], "b": ["b3"]},
+                {"a": 1, "a.0": 2, "a.1": 3, "b": 4, "b.0": 5},
+            ),
+        ),
+    )
+    def test_schema_marks_preserved(
+        self, source_yaml, loaded_yaml, schemamarks
+    ):
+        assert (loaded_yaml, schemamarks) == load_with_marks(source_yaml)

--- a/tests/unittests/test_safeyaml.py
+++ b/tests/unittests/test_safeyaml.py
@@ -17,19 +17,19 @@ class TestLoadWithMarks:
             (
                 b"#\na: va\n  \nb: vb\n#\nc: vc",
                 {"a": "va", "b": "vb", "c": "vc"},
-                {"a": 2, "b": 4, "c": 6}
+                {"a": 2, "b": 4, "c": 6},
             ),
             # List items represented on correct line number
             (
                 b"a:\n - a1\n\n - a2\n",
                 {"a": ["a1", "a2"]},
-                {"a": 1, "a.0": 2, "a.1": 4}
+                {"a": 1, "a.0": 2, "a.1": 4},
             ),
             # Nested dicts represented on correct line number
             (
                 b"a:\n a1:\n\n  aa1: aa1v\n",
-               {"a": {"a1": {"aa1": "aa1v"}}},
-               {"a": 1, "a.a1": 2, "a.a1.aa1": 4}
+                {"a": {"a1": {"aa1": "aa1v"}}},
+                {"a": 1, "a.a1": 2, "a.a1.aa1": 4},
             ),
             (b"[list, of, scalar]", ["list", "of", "scalar"], {}),
             (


### PR DESCRIPTION
## Proposed Commit Message
```
Use a custom yaml.SafeLoader to track SchemaMarks to define
start and end row/column values of each object within the
original cloud-config content.

Fixes KeyError from cloud-init devel schema --annotate when
encountering invalid nested list values under a dict key.

Drop _CustomSafeLoaderWithMarks replaces the need for
_schemapath_for_cloudconfig logic.

Fixes: SC-929
```

## Additional Context
<!-- If relevant -->

## Test Steps
```bash
$ cat <baduser.txt  >>EOF
#cloud-config
users:
- default                                                                       
- name: ok
  sudo: false
- name: user2
  sudo: 2
EOF
 PYTHONPATH=. python3 -m cloudinit.cmd.main devel schema -c baduser.txt --annotate

# expect valid `E1` failure annotations on the correct line of the original content
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
