### PR TITLE
sources/azure: fix provisioning dhcp timeout to 20 minutes

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -530,7 +530,7 @@ class DataSourceAzure(sources.DataSource):
         # If we require IMDS metadata, try harder to obtain networking, waiting
         # for at least 20 minutes.  Otherwise only wait 5 minutes.
         requires_imds_metadata = bool(self._iso_dev) or not ovf_is_accessible
-        timeout_minutes = 5 if requires_imds_metadata else 20
+        timeout_minutes = 20 if requires_imds_metadata else 5
         try:
             self._setup_ephemeral_networking(timeout_minutes=timeout_minutes)
         except NoDHCPLeaseError:


### PR DESCRIPTION
While this was a previously intended change, the actual logic was
backwards.  Try for 20 minutes during provisioning, only 5 minutes
otherwise.

Add test coverage to verify the timeout for provisioning scenarios.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>