### PR TITLE
Schema example doc fixes

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -49,7 +49,7 @@ meta: MetaSchema = {
         # only fips and esm services. Services will only be enabled if
         # the environment supports said service. Otherwise warnings will
         # be logged for incompatible services specified.
-        ubuntu-advantage:
+        ubuntu_advantage:
           token: <ua_contract_token>
           enable:
           - fips
@@ -63,7 +63,7 @@ meta: MetaSchema = {
         # completed.
         power_state:
           mode: reboot
-        ubuntu-advantage:
+        ubuntu_advantage:
           token: <ua_contract_token>
           enable:
           - fips

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -47,13 +47,13 @@ meta: MetaSchema = {
         dedent(
             """\
         # Prevent cloud-init from updating the system hostname.
-        preseve_hostname: true
+        preserve_hostname: true
         """
         ),
         dedent(
             """\
         # Prevent cloud-init from updating ``/etc/hostname``
-        preseve_hostname: true
+        preserve_hostname: true
         """
         ),
         dedent(

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1688,7 +1688,7 @@
     "cc_seed_random": {
       "type": "object",
       "properties": {
-        "seed_random": {
+        "random_seed": {
           "type": "object",
           "additionalProperties": false,
           "properties": {

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -230,20 +230,20 @@ class TestSeedRandomSchema:
         "config, error_msg",
         [
             (
-                {"seed_random": {"encoding": "bad"}},
+                {"random_seed": {"encoding": "bad"}},
                 "'bad' is not one of "
                 r"\['raw', 'base64', 'b64', 'gzip', 'gz'\]",
             ),
             (
-                {"seed_random": {"command": "foo"}},
+                {"random_seed": {"command": "foo"}},
                 "'foo' is not of type 'array'",
             ),
             (
-                {"seed_random": {"command_required": "true"}},
+                {"random_seed": {"command_required": "true"}},
                 "'true' is not of type 'boolean'",
             ),
             (
-                {"seed_random": {"bad": "key"}},
+                {"random_seed": {"bad": "key"}},
                 "Additional properties are not allowed",
             ),
         ],


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
    tests: make module example tests very strict to specific schema
    
    Followup to c2bfd5. Schema module examples should be strictly
    validated against the specific schema. Given that
    cloud-init-schema.json defines a permissive 'allOf' set of schemas
    top-level additionalParoperties that are undefined in schema are
    permitted.
    
    This allowed for multiple typos to get through schema
    unittest validation.

     Also fix invalid schema definition in cc_seed_random which should define
     `random_seed` property instead of `seed_random`.
```

## Additional Context
<!-- If relevant -->

## Test Steps
Unit tests should now strictly validate and fail and specific example typos:
```
tox -e py3  tests/unittests/config/test_schema.py -vv
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
