### PR TITLE
Impish: d/control: add python3-responses for unittests

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (22.1-14-g2e17a0d6-0ubuntu1~21.10.4) UNRELEASED; urgency=medium
+
+  * d/control:
+    - add python3-responses for unittests
+    - add Suggests: ssh-import-id
+
+ -- Brett Holman <brett.holman@canonical.com>  Fri, 22 Apr 2022 11:49:39 -0600
+
 cloud-init (22.1-14-g2e17a0d6-0ubuntu1~21.10.1) impish; urgency=medium
 
   * d/patches/retain-apt-partner-pocket.patch:

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,8 @@ Build-Depends: debhelper-compat (= 13),
                python3-requests,
                python3-serial,
                python3-setuptools,
-               python3-yaml
+               python3-yaml,
+               python3-responses
 XS-Python-Version: all
 Vcs-Browser: https://github.com/canonical/cloud-init/tree/ubuntu/devel
 Vcs-Git: https://github.com/canonical/cloud-init -b ubuntu/devel
@@ -42,6 +43,7 @@ Depends: cloud-guest-utils | cloud-utils,
          ${misc:Depends},
          ${python3:Depends}
 Recommends: eatmydata, gdisk, gnupg, software-properties-common
+Suggests: ssh-import-id
 XB-Python-Version: ${python:Versions}
 Description: initialization and customization tool for cloud instances
  Cloud-init is the industry standard multi-distribution method for


### PR DESCRIPTION
## Proposed Commit Message
```
d/control: add python3-responses for unittests
```

## Additional Context
ref: https://github.com/canonical/cloud-init/compare/ubuntu/bionic...holmanb:ubuntu/bionic?expand=1
## Test Steps
```
git checkout upstream/ubuntu/impish
git merge <this_branch>
build-package
sbuild --resolve-alternatives --dist=impish --arch=amd64 ../out/cloud-init*dsc
```