### PR TITLE
nested ssh import id and jammy lxd test fixes

### DIFF
--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -173,11 +173,13 @@ def is_key_in_nested_dict(config: dict, search_key: str) -> bool:
         if search_key == config_key:
             return True
         if isinstance(config[config_key], dict):
-            return is_key_in_nested_dict(config[config_key], search_key)
+            if is_key_in_nested_dict(config[config_key], search_key):
+                return True
         if isinstance(config[config_key], list):
             # this code could probably be generalized to walking the whole
             # config by iterating lists in search of dictionaries
             for item in config[config_key]:
                 if isinstance(item, dict):
-                    return is_key_in_nested_dict(item, search_key)
+                    if is_key_in_nested_dict(item, search_key):
+                        return True
     return False

--- a/tests/integration_tests/bugs/test_gh570.py
+++ b/tests/integration_tests/bugs/test_gh570.py
@@ -22,6 +22,7 @@ def test_nocloud_seedfrom_vendordata(client: IntegrationInstance):
     seed_dir = "/var/tmp/test_seed_dir"
     result = client.execute(
         "mkdir {seed_dir} && "
+        "mkdir -p /var/lib/cloud/seed/nocloud-net && "
         "touch {seed_dir}/user-data && "
         "touch {seed_dir}/meta-data && "
         "echo 'seedfrom: {seed_dir}/' > "

--- a/tests/integration_tests/bugs/test_gh632.py
+++ b/tests/integration_tests/bugs/test_gh632.py
@@ -15,7 +15,7 @@ from tests.integration_tests.util import verify_clean_log
 def test_datasource_rbx_no_stacktrace(client: IntegrationInstance):
     client.write_to_file(
         "/etc/cloud/cloud.cfg.d/90_dpkg.cfg",
-        "datasource_list: [ RbxCloud, NoCloud ]\n",
+        "datasource_list: [ RbxCloud, NoCloud, LXD ]\n",
     )
     client.write_to_file(
         "/etc/cloud/ds-identify.cfg",

--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -13,9 +13,6 @@ def _customize_envionment(client: IntegrationInstance):
     ds_id_log = client.execute("cat /run/cloud-init/ds-identify.log").stdout
     assert "check for 'LXD' returned found" in ds_id_log
 
-    # At some point Jammy will fail this test. We want to be informed
-    # when Jammy images no longer ship NoCloud template files (LP: #1958460).
-    assert "check for 'NoCloud' returned found" in ds_id_log
     if client.settings.PLATFORM == "lxd_vm":
         # ds-identify runs at systemd generator time before /dev/lxd/sock.
         # Assert we can expected artifact which indicates LXD is viable.
@@ -38,6 +35,14 @@ def _customize_envionment(client: IntegrationInstance):
         "/etc/cloud/cloud.cfg.d/99-detect-lxd-first.cfg",
         "datasource_list: [LXD, NoCloud]\n",
     )
+    if ImageSpecification.from_os_image().release == "jammy":
+        # Add nocloud-net seed files because Jammy no longer delivers NoCloud
+        # (LP: #1958460).
+        client.execute("mkdir -p /var/lib/cloud/seed/nocloud-net")
+        client.write_to_file("/var/lib/cloud/seed/nocloud-net/meta-data", "")
+        client.write_to_file(
+            "/var/lib/cloud/seed/nocloud-net/user-data", "#cloud-config\n{}"
+        )
     client.execute("cloud-init clean --logs")
     client.restart()
 
@@ -104,15 +109,17 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
         yaml.safe_load(ds_cfg["config"]["user.meta-data"])
     )
     assert "#cloud-config\ninstance-id" in ds_cfg["meta-data"]
-    # Assert NoCloud seed data is still present in cloud image metadata
-    # This will start failing if we redact metadata templates from
-    # https://cloud-images.ubuntu.com/daily/server/jammy/current/\
-    #    jammy-server-cloudimg-amd64-lxd.tar.xz
-    nocloud_metadata = yaml.safe_load(
-        client.read_from_file("/var/lib/cloud/seed/nocloud-net/meta-data")
-    )
-    assert client.instance.name == nocloud_metadata["instance-id"]
-    assert (
-        nocloud_metadata["instance-id"] == nocloud_metadata["local-hostname"]
-    )
-    assert v1["public_ssh_keys"][0] == nocloud_metadata["public-keys"]
+
+    # Jammy not longer provides nocloud-net seed files (LP: #1958460)
+    if ImageSpecification.from_os_image().release != "jammy":
+        # Assert NoCloud seed files are still present in non-Jammy images
+        # and that NoCloud seed files provide the same content as LXD socket.
+        nocloud_metadata = yaml.safe_load(
+            client.read_from_file("/var/lib/cloud/seed/nocloud-net/meta-data")
+        )
+        assert client.instance.name == nocloud_metadata["instance-id"]
+        assert (
+            nocloud_metadata["instance-id"]
+            == nocloud_metadata["local-hostname"]
+        )
+        assert v1["public_ssh_keys"][0] == nocloud_metadata["public-keys"]

--- a/tests/integration_tests/modules/test_persistence.py
+++ b/tests/integration_tests/modules/test_persistence.py
@@ -26,7 +26,7 @@ def test_log_message_on_missing_version_file(client: IntegrationInstance):
             "attribute 'policy'. Ignoring current cache.",
             "no cache found",
             "Searching for local data source",
-            "SUCCESS: found local data from DataSourceNoCloud",
+            r"SUCCESS: found local data from DataSource(NoCloud|LXD)",
         ],
         log,
     )

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -2,6 +2,7 @@ import functools
 import logging
 import multiprocessing
 import os
+import re
 import time
 from collections import namedtuple
 from contextlib import contextmanager
@@ -23,8 +24,9 @@ def verify_ordered_items_in_text(to_verify: list, text: str):
     """
     index = 0
     for item in to_verify:
-        index = text[index:].find(item)
-        assert index > -1, "Expected item not found: '{}'".format(item)
+        matched = re.search(item, text[index:])
+        assert matched, "Expected item not found: '{}'".format(item)
+        index = matched.start()
 
 
 def verify_clean_log(log):

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -1,0 +1,78 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import logging
+from unittest import mock
+
+import pytest
+
+from cloudinit.config import cc_ssh_import_id
+from tests.unittests.util import get_cloud
+
+LOG = logging.getLogger(__name__)
+
+MODPATH = "cloudinit.config.cc_ssh_import_ids."
+
+
+class TestIsKeyInNestedDict:
+    @pytest.mark.parametrize(
+        "cfg,expected",
+        (
+            ({}, False),
+            ({"users": [{"name": "bob"}]}, False),
+            ({"ssh_import_id": ["yep"]}, True),
+            ({"ssh_import_id": ["yep"], "users": [{"name": "bob"}]}, True),
+            (
+                {
+                    "apt": {"preserve_sources_list": True},
+                    "ssh_import_id": ["yep"],
+                    "users": [{"name": "bob"}],
+                },
+                True,
+            ),
+            (
+                {
+                    "apt": [{}],
+                    "ssh_import_id": ["yep"],
+                    "users": [{"name": "bob"}],
+                },
+                True,
+            ),
+            (
+                {
+                    "apt": {"preserve_sources_list": True},
+                    "users": [
+                        {"name": "bob"},
+                        {"name": "judy", "ssh_import_id": ["yep"]},
+                    ],
+                },
+                True,
+            ),
+        ),
+    )
+    def test_find_ssh_import_id_directives(self, cfg, expected):
+        assert expected is cc_ssh_import_id.is_key_in_nested_dict(
+            cfg, "ssh_import_id"
+        )
+
+
+class TestHandleSshImportIDs:
+    """Test cc_ssh_import_id handling of config."""
+
+    @pytest.mark.parametrize(
+        "cfg,log",
+        (
+            ({}, "no 'ssh_import_id' directives found"),
+            (
+                {"users": [{"name": "bob"}]},
+                "no 'ssh_import_id' directives found",
+            ),
+            ({"ssh_import_id": ["bobkey"]}, "ssh-import-id is not installed"),
+        ),
+    )
+    @mock.patch("cloudinit.subp.which")
+    def test_skip_inapplicable_configs(self, m_which, cfg, log, caplog):
+        """Skip config without ssh_import_id"""
+        m_which.return_value = None
+        cloud = get_cloud("ubuntu")
+        cc_ssh_import_id.handle("name", cfg, cloud, LOG, [])
+        assert log in caplog.text


### PR DESCRIPTION
## Proposed Commit Message
```
cc_ssh_import_id: fix is_key_in_nested_dict avoid early return False

In 437cb0a we added recursive is_key_in_nested_dict.
This function should early returning only in the event of finding
an ssh_import_id directive.

Test updates:
- test_combined LXD datasource expectation for Jammy
- Jammy LXD no longer supplies /var/lib/cloud/seed/nocloud-net/
- Jammy has neither NoCloud nor /var/lib/cloud/seed/nocloud-net
- verify_ordered_items_in_text accept regex LXD|NoCloud
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
make deb
CLOUD_INIT_PLATFORM=lxd_container  CLOUD_INIT_OS_IMAGE=jammy::ubuntu::jammy CLOUD_INIT_CLOUD_INIT_SOURCE=/path/to/cloud-init*.deb tox -e integration-tests tests/integration_tests/modules/test_combined.py
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
