### PR TITLE
Fix cc_rsyslog.py initialization

### DIFF
--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -94,9 +94,12 @@ def reload_syslog(distro, command=DEF_RELOAD):
     return subp.subp(command, capture=True)
 
 
-def load_config(cfg):
-    # return an updated config with entries of the correct type
-    # support converting the old top level format into new format
+def load_config(cfg: dict) -> dict:
+    """Return an updated config.
+
+    Support converting the old top level format into new format.
+    Raise a `ValueError` if some top level entry has an incorrect type.
+    """
     mycfg = cfg.get("rsyslog", {})
 
     if isinstance(cfg.get("rsyslog"), list):
@@ -119,8 +122,13 @@ def load_config(cfg):
     )
 
     for key, default, vtypes in fillup:
-        if key not in mycfg or not isinstance(mycfg[key], vtypes):
+        if key not in mycfg:
             mycfg[key] = default
+        elif not isinstance(mycfg[key], vtypes):
+            raise ValueError(
+                f"Invalid type for key `{key}`. Expected type(s): {vtypes}. "
+                f"Current type: {type(mycfg[key])}"
+            )
 
     return mycfg
 


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix cc_rsyslog.py initialization

Raises an error if some top level config value has an invalid type.
Previously, it replaced them with default values.

Fixes: SC-878
```

## Test Steps

Execute `cloud-init` with this config:

```yaml
#cloud-config
rsyslog:
  config_dir: True
```

Expected error:

```txt
"Invalid type for key `config_filename`. Expected type(s): <class 'str'>. Current type: <class 'bool'>"
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
