### PR TITLE
mypy: disable missing imports warning for httpretty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ exclude=[
   '^tests/unittests/net/test_dhcp\.py$',
   '^tests/unittests/net/test_init\.py$',
   '^tests/unittests/sources/test_aliyun\.py$',
-  '^tests/unittests/sources/test_azure\.py$',
   '^tests/unittests/sources/test_ec2\.py$',
   '^tests/unittests/sources/test_exoscale\.py$',
   '^tests/unittests/sources/test_gce\.py$',
@@ -100,3 +99,7 @@ exclude=[
   '^tests/unittests/test_util\.py$',
   '^tools/mock-meta\.py$',
 ]
+
+[[tool.mypy.overrides]]
+module = [ "httpretty" ]
+ignore_missing_imports = true


### PR DESCRIPTION
httpretty does not appear to support mypy stubs. Add configuration
to for mypy to ignore this import.

With this we can add checking for test_azure.py.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>