### PR TITLE
Refactor cloudinit.sources.NetworkConfigSource to enum

### DIFF
--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -11,8 +11,7 @@ from cloudinit.event import EventScope, EventType
 from cloudinit.net import activators, read_sys_net_safe
 from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.reporting import events
-from cloudinit.sources import DataSource  # noqa: F401
-from cloudinit.sources import DataSourceNotFoundException
+from cloudinit.sources import DataSource, DataSourceNotFoundException
 from cloudinit.stages import Init
 
 LOG = log.getLogger(__name__)
@@ -72,7 +71,7 @@ def get_parser(parser=None):
 class UeventHandler(abc.ABC):
     def __init__(self, id, datasource, devpath, action, success_fn):
         self.id = id
-        self.datasource = datasource  # type: DataSource
+        self.datasource: DataSource = datasource
         self.devpath = devpath
         self.action = action
         self.success_fn = success_fn

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -16,6 +16,7 @@ Notes:
 import base64
 from collections import namedtuple
 from contextlib import suppress as noop
+from typing import Tuple
 
 from cloudinit import dmi
 from cloudinit import log as logging
@@ -102,11 +103,11 @@ class DataSourceOracle(sources.DataSource):
     dsname = "Oracle"
     system_uuid = None
     vendordata_pure = None
-    network_config_sources = (
-        sources.NetworkConfigSource.cmdline,
-        sources.NetworkConfigSource.ds,
-        sources.NetworkConfigSource.initramfs,
-        sources.NetworkConfigSource.system_cfg,
+    network_config_sources: Tuple[sources.NetworkConfigSource, ...] = (
+        sources.NetworkConfigSource.CMD_LINE,
+        sources.NetworkConfigSource.DS,
+        sources.NetworkConfigSource.INITRAMFS,
+        sources.NetworkConfigSource.SYSTEM_CFG,
     )
 
     _network_config = sources.UNSET

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -14,7 +14,7 @@ import json
 import os
 from collections import namedtuple
 from enum import Enum, unique
-from typing import Dict, List, Tuple  # noqa: F401
+from typing import Dict, List, Tuple
 
 from cloudinit import dmi, importer
 from cloudinit import log as logging

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -807,15 +807,15 @@ class Init(object):
             return (None, disable_file)
 
         available_cfgs = {
-            NetworkConfigSource.cmdline: cmdline.read_kernel_cmdline_config(),
-            NetworkConfigSource.initramfs: cmdline.read_initramfs_config(),
-            NetworkConfigSource.ds: None,
-            NetworkConfigSource.system_cfg: self.cfg.get("network"),
+            NetworkConfigSource.CMD_LINE: cmdline.read_kernel_cmdline_config(),
+            NetworkConfigSource.INITRAMFS: cmdline.read_initramfs_config(),
+            NetworkConfigSource.DS: None,
+            NetworkConfigSource.SYSTEM_CFG: self.cfg.get("network"),
         }
 
         if self.datasource and hasattr(self.datasource, "network_config"):
             available_cfgs[
-                NetworkConfigSource.ds
+                NetworkConfigSource.DS
             ] = self.datasource.network_config
 
         if self.datasource:
@@ -823,7 +823,7 @@ class Init(object):
         else:
             order = sources.DataSource.network_config_sources
         for cfg_source in order:
-            if not hasattr(NetworkConfigSource, cfg_source):
+            if not isinstance(cfg_source, NetworkConfigSource):
                 LOG.warning(
                     "data source specifies an invalid network cfg_source: %s",
                     cfg_source,
@@ -844,7 +844,7 @@ class Init(object):
                 return (ncfg, cfg_source)
         return (
             self.distro.generate_fallback_config(),
-            NetworkConfigSource.fallback,
+            NetworkConfigSource.FALLBACK,
         )
 
     def _apply_netcfg_names(self, netcfg):

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -9,7 +9,7 @@ import os
 import pickle
 import sys
 from collections import namedtuple
-from typing import Dict, List, Optional, Set  # noqa: F401
+from typing import Dict, List, Optional, Set
 
 from cloudinit import cloud, distros, handlers, helpers, importer
 from cloudinit import log as logging

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -106,7 +106,7 @@ class TestDataSourceInvariants(test_helpers.TestCase):
                     " {}".format(str(ds), cfg_src)
                 )
                 self.assertTrue(
-                    hasattr(sources.NetworkConfigSource, cfg_src), fail_msg
+                    isinstance(cfg_src, sources.NetworkConfigSource), fail_msg
                 )
 
     def test_expected_dsname_defined(self):

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -923,8 +923,8 @@ class TestNetworkConfig:
     def test_ds_network_cfg_preferred_over_initramfs(self, _m):
         """Ensure that DS net config is preferred over initramfs config"""
         config_sources = oracle.DataSourceOracle.network_config_sources
-        ds_idx = config_sources.index(NetworkConfigSource.ds)
-        initramfs_idx = config_sources.index(NetworkConfigSource.initramfs)
+        ds_idx = config_sources.index(NetworkConfigSource.DS)
+        initramfs_idx = config_sources.index(NetworkConfigSource.INITRAMFS)
         assert ds_idx < initramfs_idx
 
 

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -73,7 +73,7 @@ class TestInit(CiTestCase):
         m_cmdline.return_value = {"config": "disabled"}
         m_initramfs.return_value = {"config": ["fake_initrd"]}
         self.assertEqual(
-            (None, NetworkConfigSource.cmdline),
+            (None, NetworkConfigSource.CMD_LINE),
             self.init._find_networking_config(),
         )
         self.assertEqual(
@@ -89,7 +89,7 @@ class TestInit(CiTestCase):
         m_cmdline.return_value = {}
         m_initramfs.return_value = {"config": "disabled"}
         self.assertEqual(
-            (None, NetworkConfigSource.initramfs),
+            (None, NetworkConfigSource.INITRAMFS),
             self.init._find_networking_config(),
         )
         self.assertEqual(
@@ -114,7 +114,7 @@ class TestInit(CiTestCase):
             network_config={"config": "disabled"}
         )
         self.assertEqual(
-            (None, NetworkConfigSource.ds), self.init._find_networking_config()
+            (None, NetworkConfigSource.DS), self.init._find_networking_config()
         )
         self.assertEqual(
             "DEBUG: network config disabled by ds\n", self.logs.getvalue()
@@ -133,7 +133,7 @@ class TestInit(CiTestCase):
             "network": {"config": "disabled"},
         }
         self.assertEqual(
-            (None, NetworkConfigSource.system_cfg),
+            (None, NetworkConfigSource.SYSTEM_CFG),
             self.init._find_networking_config(),
         )
         self.assertEqual(
@@ -156,14 +156,14 @@ class TestInit(CiTestCase):
         ds_net_cfg = {"config": {"needle": True}}
         self.init.datasource = FakeDataSource(network_config=ds_net_cfg)
         self.init.datasource.network_config_sources = [
-            NetworkConfigSource.ds,
-            NetworkConfigSource.system_cfg,
-            NetworkConfigSource.cmdline,
-            NetworkConfigSource.initramfs,
+            NetworkConfigSource.DS,
+            NetworkConfigSource.SYSTEM_CFG,
+            NetworkConfigSource.CMD_LINE,
+            NetworkConfigSource.INITRAMFS,
         ]
 
         self.assertEqual(
-            (ds_net_cfg, NetworkConfigSource.ds),
+            (ds_net_cfg, NetworkConfigSource.DS),
             self.init._find_networking_config(),
         )
 
@@ -177,11 +177,11 @@ class TestInit(CiTestCase):
         self.init.datasource = FakeDataSource(network_config=ds_net_cfg)
         self.init.datasource.network_config_sources = [
             "invalid_src",
-            NetworkConfigSource.ds,
+            NetworkConfigSource.DS,
         ]
 
         self.assertEqual(
-            (ds_net_cfg, NetworkConfigSource.ds),
+            (ds_net_cfg, NetworkConfigSource.DS),
             self.init._find_networking_config(),
         )
         self.assertIn(
@@ -199,12 +199,12 @@ class TestInit(CiTestCase):
         ds_net_cfg = {"config": {"needle": True}}
         self.init.datasource = FakeDataSource(network_config=ds_net_cfg)
         self.init.datasource.network_config_sources = [
-            NetworkConfigSource.fallback,
-            NetworkConfigSource.ds,
+            NetworkConfigSource.FALLBACK,
+            NetworkConfigSource.DS,
         ]
 
         self.assertEqual(
-            (ds_net_cfg, NetworkConfigSource.ds),
+            (ds_net_cfg, NetworkConfigSource.DS),
             self.init._find_networking_config(),
         )
         self.assertIn(
@@ -230,7 +230,7 @@ class TestInit(CiTestCase):
             network_config={"config": ["fakedatasource"]}
         )
         self.assertEqual(
-            (expected_cfg, NetworkConfigSource.cmdline),
+            (expected_cfg, NetworkConfigSource.CMD_LINE),
             self.init._find_networking_config(),
         )
 
@@ -251,7 +251,7 @@ class TestInit(CiTestCase):
             network_config={"config": ["fakedatasource"]}
         )
         self.assertEqual(
-            (expected_cfg, NetworkConfigSource.initramfs),
+            (expected_cfg, NetworkConfigSource.INITRAMFS),
             self.init._find_networking_config(),
         )
 
@@ -272,7 +272,7 @@ class TestInit(CiTestCase):
             network_config={"config": ["fakedatasource"]}
         )
         self.assertEqual(
-            (expected_cfg, NetworkConfigSource.system_cfg),
+            (expected_cfg, NetworkConfigSource.SYSTEM_CFG),
             self.init._find_networking_config(),
         )
 
@@ -288,7 +288,7 @@ class TestInit(CiTestCase):
         expected_cfg = {"config": ["fakedatasource"]}
         self.init.datasource = FakeDataSource(network_config=expected_cfg)
         self.assertEqual(
-            (expected_cfg, NetworkConfigSource.ds),
+            (expected_cfg, NetworkConfigSource.DS),
             self.init._find_networking_config(),
         )
 
@@ -314,7 +314,7 @@ class TestInit(CiTestCase):
         distro = self.init.distro
         distro.generate_fallback_config = fake_generate_fallback
         self.assertEqual(
-            (fake_cfg, NetworkConfigSource.fallback),
+            (fake_cfg, NetworkConfigSource.FALLBACK),
             self.init._find_networking_config(),
         )
         self.assertNotIn("network config disabled", self.logs.getvalue())
@@ -353,7 +353,7 @@ class TestInit(CiTestCase):
         }
 
         def fake_network_config():
-            return net_cfg, NetworkConfigSource.fallback
+            return net_cfg, NetworkConfigSource.FALLBACK
 
         m_macs.return_value = {"42:42:42:42:42:42": "eth9"}
 
@@ -388,7 +388,7 @@ class TestInit(CiTestCase):
         }
 
         def fake_network_config():
-            return net_cfg, NetworkConfigSource.fallback
+            return net_cfg, NetworkConfigSource.FALLBACK
 
         self.init._find_networking_config = fake_network_config
 
@@ -422,7 +422,7 @@ class TestInit(CiTestCase):
         }
 
         def fake_network_config():
-            return net_cfg, NetworkConfigSource.fallback
+            return net_cfg, NetworkConfigSource.FALLBACK
 
         m_macs.return_value = {"42:42:42:42:42:42": "eth9"}
 


### PR DESCRIPTION
From nametuple to enum.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Refactor cloudinit.sources.NetworkConfigSource to enum

It was implemented as a namedtuple, because it was written
when the codebase supported Python 2 (where using an enum would have
introduced a new dependency). As enum is in the stdlib in all our
supported Python releases, we can now use it without that constraint.

LP: #1874875
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
