### PR TITLE
tests: verify_ordered_items fallback to re.escape if needed

### DIFF
--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -24,7 +24,10 @@ def verify_ordered_items_in_text(to_verify: list, text: str):
     """
     index = 0
     for item in to_verify:
-        matched = re.search(item, text[index:])
+        try:
+            matched = re.search(item, text[index:])
+        except re.error:
+            matched = re.search(re.escape(item), text[index:])
         assert matched, "Expected item not found: '{}'".format(item)
         index = matched.start()
 


### PR DESCRIPTION

Failures in Jenkins test runner indicate that the recent changes landed in 
02f213b539395be2f4b90b3b9e6bcd5fbc81c202 didn't account for some search items containing characters which need to be
re.escaped.  

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
tests: verify_ordered_items fallback to re.escape if needed

When re.search fails with an re.error, it is most likely due
to characters which need escape. Fallback to re.escape in
this case to try harder.
```

## Additional Context
[Failing Jenkins job](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_container/15/testReport/tests.integration_tests.bugs/test_lp1813396/test_gpg_no_tty/)

## Test Steps
```
.tox/integration-tests/bin/pytest tests/integration_tests/bugs/test_lp1813396.py::test_gpg_no_tty
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
