### PR TITLE
Handle error if SSH service no present.

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -92,12 +92,15 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
         distro.manage_service("status", service)
     except subp.ProcessExecutionError as e:
         LOG.warning(
-            "Ignoring config 'ssh_pwauth: %s'. Service '%s' is not running.",
+            (
+                "Ignoring config 'ssh_pwauth: %s'. SSH deamon service '%s' is "
+                "not running."
+            ),
             pw_auth,
             service,
         )
         LOG.debug(
-            "Service '%s' is not running: %s",
+            "SSH deamon service '%s' is not running: %s",
             service,
             e,
         )

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -112,8 +112,13 @@ def handle_ssh_pwauth(pw_auth, distro):
         LOG.debug("No need to restart SSH service, %s not updated.", cfg_name)
         return
 
-    distro.manage_service("restart", distro.get_option("ssh_svcname", "ssh"))
-    LOG.debug("Restarted the SSH daemon.")
+    service = distro.get_option("ssh_svcname", "ssh")
+    try:
+        distro.manage_service("restart", service)
+    except subp.ProcessExecutionError as e:
+        LOG.warning("Failed to restart the SSH deamon. %s: %s", service, e)
+    else:
+        LOG.debug("Restarted the SSH daemon.")
 
 
 def handle(_name, cfg, cloud, log, args):
@@ -226,7 +231,7 @@ def handle(_name, cfg, cloud, log, args):
     handle_ssh_pwauth(cfg.get("ssh_pwauth"), cloud.distro)
 
     if len(errors):
-        log.debug("%s errors occured, re-raising the last one", len(errors))
+        log.debug("%s errors occurred, re-raising the last one", len(errors))
         raise errors[-1]
 
 

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -850,7 +850,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             args.append(message)
         return args
 
-    def manage_service(self, action, service):
+    def manage_service(self, action: str, service: str):
         """
         Perform the requested action on a service. This handles the common
         'systemctl' and 'service' cases and may be overridden in subclasses
@@ -867,6 +867,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 "restart": ["restart", service],
                 "reload": ["reload-or-restart", service],
                 "try-reload": ["reload-or-try-restart", service],
+                "status": ["status", service],
             }
         else:
             cmds = {
@@ -876,6 +877,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 "restart": [service, "restart"],
                 "reload": [service, "restart"],
                 "try-reload": [service, "restart"],
+                "status": [service, "status"],
             }
         cmd = list(init_cmd) + list(cmds[action])
         return subp.subp(cmd, capture=True)

--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -14,7 +14,7 @@ Depends: ${misc:Depends},
          iproute2,
          isc-dhcp-client
 Recommends: eatmydata, sudo, software-properties-common, gdisk
-Suggests: ssh-import-id
+Suggests: ssh-import-id, openssh-server
 Description: Init scripts for cloud instances
  Cloud instances need special scripts to run during initialisation
  to retrieve and install ssh keys and to let the user run various scripts.

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -101,13 +101,16 @@ class TestHandleSshPwauth(CiTestCase):
         setpass.handle_ssh_pwauth(True, cloud.distro)
         self.assertIn(
             (
-                r"WARNING: Ignoring config 'ssh_pwauth: True'. Service 'ssh' "
-                r"is not running."
+                r"WARNING: Ignoring config 'ssh_pwauth: True'. SSH deamon "
+                r"service 'ssh' is not running."
             ),
             self.logs.getvalue(),
         )
         self.assertIn(
-            rf"DEBUG: Service 'ssh' is not running: {process_error}",
+            (
+                r"DEBUG: SSH deamon service 'ssh' is not running: "
+                rf"{process_error}"
+            ),
             self.logs.getvalue(),
         )
         cloud.distro.manage_service.assert_called_once_with("status", "ssh")


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add pre-fight check to verify if SSH is running

- In negative case then perform an early return with a warning and no 
  modifications
- Handle an exception when user-data provides 'ssh_pwauth: True'
  and the open-ssh service is not available
- Add openssh-server as suggested package for debian-based distros

SC-968
LP: #1969526
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
cat > ssh_needed.yaml << EOF
#cloud-config
ssh_pwauth: true
EOF

lxc launch ubuntu-daily:focal f1 -c user.user-data="$(cat ssh_needed.yaml)"
lxc exec f1 -- cloud-init status --wait
lxc exec f1 apt remove opensssh-server
# reset PasswordAuthentication off again so that cloud-init wants to reset ssh server
lxc exec f1 -- sed -i 's/PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
# force clean reboot so cloud-init reruns
lxc exec f1 -- cloud-init clean --logs --reboot
lxc exec f1 -- cloud-init status --wait --long
```

Expect status Done and a warning in the logs instead of the error.
Warning: `Failed to restart the SSH deamon. ...`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
