### PR TITLE
Fix NoCloud docs:

### DIFF
--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -66,26 +66,31 @@ sufficient disk by following the example below.
 
 ::
 
-    ## create user-data and meta-data files that will be used
+    ## 1) create user-data and meta-data files that will be used
     ## to modify image on first boot
     $ { echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
-
     $ printf "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n" > user-data
 
-    ## create a disk to attach with some user-data and meta-data
+    ## 2a) create a disk to attach with some user-data and meta-data
     $ genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
 
-    ## alternatively, create a vfat filesystem with same files
+    ## 2b) alternatively, create a vfat filesystem with same files
     ## $ truncate --size 2M seed.img
     ## $ mkfs.vfat -n cidata seed.img
+
+    ## 2b) option 1: mount and copy files
     ## $ sudo mount -t vfat /tmp/seed.img /mnt
     ## $ sudo cp user-data meta-data /mnt
     ## $ sudo umount /mnt
 
-    ## create a new qcow image to boot, backed by your original image
+    ## 2b) option 2: the mtools package provides mcopy, which can access vfat
+    filesystems without mounting them
+    ## $ mcopy -oi seed.img user-data meta-data
+
+    ## 3) create a new qcow image to boot, backed by your original image
     $ qemu-img create -f qcow2 -b disk.img -F qcow2 -K qcow2 boot-disk.img
 
-    ## boot the image and login as 'ubuntu' with password 'passw0rd'
+    ## 4) boot the image and login as 'ubuntu' with password 'passw0rd'
     ## note, passw0rd was set as password through the user-data above,
     ## there is no password set on these images.
     $ kvm -m 256 \

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -68,27 +68,27 @@ sufficient disk by following the example below.
 
     ## 1) create user-data and meta-data files that will be used
     ## to modify image on first boot
-    $ { echo instance-id: iid-local01; echo local-hostname: cloudimg; } > meta-data
-    $ printf "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n" > user-data
+    $ echo "instance-id: iid-local01\nlocal-hostname: cloudimg" > meta-data
+    $ echo "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n" > user-data
 
     ## 2a) create a disk to attach with some user-data and meta-data
     $ genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data
 
     ## 2b) alternatively, create a vfat filesystem with same files
-    ## $ truncate --size 2M seed.img
-    ## $ mkfs.vfat -n cidata seed.img
+    ## $ truncate --size 2M seed.iso
+    ## $ mkfs.vfat -n cidata seed.iso
 
     ## 2b) option 1: mount and copy files
-    ## $ sudo mount -t vfat /tmp/seed.img /mnt
+    ## $ sudo mount -t vfat seed.iso /mnt
     ## $ sudo cp user-data meta-data /mnt
     ## $ sudo umount /mnt
 
     ## 2b) option 2: the mtools package provides mcopy, which can access vfat
-    filesystems without mounting them
-    ## $ mcopy -oi seed.img user-data meta-data
+    ## filesystems without mounting them
+    ## $ mcopy -oi seed.iso user-data meta-data
 
     ## 3) create a new qcow image to boot, backed by your original image
-    $ qemu-img create -f qcow2 -b disk.img -F qcow2 -K qcow2 boot-disk.img
+    $ qemu-img create -f qcow2 -b disk.img -F qcow2 boot-disk.img
 
     ## 4) boot the image and login as 'ubuntu' with password 'passw0rd'
     ## note, passw0rd was set as password through the user-data above,

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -61,7 +61,7 @@ You may also optionally provide a vendor-data file in the following format.
 
   /vendor-data
 
-Given a disk ubuntu 12.04 cloud image in 'disk.img', you can create a
+Given a disk ubuntu cloud image in 'disk.img', you can create a
 sufficient disk by following the example below.
 
 ::
@@ -78,10 +78,12 @@ sufficient disk by following the example below.
     ## alternatively, create a vfat filesystem with same files
     ## $ truncate --size 2M seed.img
     ## $ mkfs.vfat -n cidata seed.img
-    ## $ mcopy -oi seed.img user-data meta-data ::
+    ## $ sudo mount -t vfat /tmp/seed.img /mnt
+    ## $ sudo cp user-data meta-data /mnt
+    ## $ sudo umount /mnt
 
     ## create a new qcow image to boot, backed by your original image
-    $ qemu-img create -f qcow2 -b disk.img boot-disk.img
+    $ qemu-img create -f qcow2 -b disk.img -F qcow2 -K qcow2 boot-disk.img
 
     ## boot the image and login as 'ubuntu' with password 'passw0rd'
     ## note, passw0rd was set as password through the user-data above,
@@ -89,7 +91,7 @@ sufficient disk by following the example below.
     $ kvm -m 256 \
        -net nic -net user,hostfwd=tcp::2222-:22 \
        -drive file=boot-disk.img,if=virtio \
-       -drive file=seed.iso,if=virtio
+       -drive driver=raw,file=seed.iso,if=virtio
 
 **Note:** that the instance-id provided (``iid-local01`` above) is what is used
 to determine if this is "first boot".  So if you are making updates to


### PR DESCRIPTION
```
- fix failing example command
- augment "alternative commands" with more common utilities
- drop reference to decade old release
```

qemu-img correctly identifies the format of the backing file, but fails anyways:
```
arc/tmp qemu-img create -f qcow2 -b disk.img boot-disk.img 
qemu-img: boot-disk.img: Backing file specified without backing format
Detected format of qcow2.%                                                                                            arc/tmp echo $?
1
```

Fix by adding `-F qcow2` to invocation.

Additionally, add some context to the `mcopy` command, as well as alternative option with mount/umount/cp

