### PR TITLE
Fix bug in url_helper/dual_stack() logging

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -413,6 +413,7 @@ def dual_stack(
             return_exception = future.exception()
             if return_exception:
                 last_exception = return_exception
+                exceptions.append(last_exception)
             else:
                 return_result = future.result()
                 if return_result:
@@ -428,7 +429,7 @@ def dual_stack(
             LOG.warning(
                 "Exception(s) %s during request to %s, "
                 "raising last exception",
-                " ".join(exceptions),
+                " ".join([str(e) for e in exceptions]),
                 returned_address,
             )
             raise last_exception

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -427,10 +427,8 @@ def dual_stack(
         # debugging
         if last_exception:
             LOG.warning(
-                "Exception(s) %s during request to %s, "
-                "raising last exception",
-                " ".join([str(e) for e in exceptions]),
-                returned_address,
+                f"Exception(s) {exceptions} during request to "
+                f"{returned_address}, raising last exception",
             )
             raise last_exception
         else:

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -427,8 +427,10 @@ def dual_stack(
         # debugging
         if last_exception:
             LOG.warning(
-                f"Exception(s) {exceptions} during request to "
-                f"{returned_address}, raising last exception",
+                "Exception(s) %s during request to "
+                "%s, raising last exception",
+                exceptions,
+                returned_address,
             )
             raise last_exception
         else:

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -383,13 +383,13 @@ class TestDualStack:
             ),
             (
                 lambda _a, _b: (_ for _ in ()).throw(
-                    Exception('soap stone is not effective soap')
+                    Exception("soapstone is not effective soap")
                 ),
                 ("are", "ignored"),
                 0,
                 1,
-                "Exception(s) [Exception('soap stone is not effective soap'), "
-                "Exception('soap stone is not effective soap')] during request",
+                "Exception(s) [Exception('soapstone is not effective soap'), "
+                "Exception('soapstone is not effective soap')] during request",
                 Exception,
             ),
         ],

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -419,7 +419,7 @@ class TestDualStack:
         # in a version-independant way for testing, the extra comma on old
         # versions won't hurt anything
         exc_list = str([expected_exc(message) for _ in addresses])
-        expected_msg = f'Exception(s) {exc_list} during request'
+        expected_msg = f"Exception(s) {exc_list} during request"
         gen = partial(
             dual_stack,
             func,


### PR DESCRIPTION
```
Log all exceptions in dual_stack()
```

While debugging something that uses the dual_stack() function, I noticed that exceptions are not being logged as originally intended.

All exceptions thrown from futures in dual_stack() should be logged for debugging purposes. 