### PR TITLE
Ubuntu/devel (SC-984)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,8 @@ cloud-init (22.1-63-gd8f39d79-0ubuntu1~22.04.1) UNRELEASED; urgency=medium
     - add python3-responses for unittests
     - add python3-pytest-mock for unittests
     - add Suggests: ssh-import-id
+  * d/cloud-init.postinst:
+    - remove deprecated emit_upstart from cloud.cfg on upgrade
   * New upstream snapshot.
     - testing: add additional mocks to test_net tests (#1356) [yangzz-97]
     - schema: add JSON schema for mcollective, migrator and mounts modules

--- a/debian/changelog
+++ b/debian/changelog
@@ -74,6 +74,41 @@ cloud-init (22.1-63-gd8f39d79-0ubuntu1~22.04.1) UNRELEASED; urgency=medium
 
  -- Chad Smith <chad.smith@canonical.com>  Thu, 31 Mar 2022 14:54:00 -0600
 
+cloud-init (22.1-14-g2e17a0d6-0ubuntu1~22.04.5) jammy; urgency=medium
+
+  * d/p/cpick-be9389c6-Work-around-bug-in-LXD-VM-detection-1325:
+    cherry-pick be9389c6: Work around bug in LXD VM detection (#1325)
+  * d/p/cpick-30ccd51a-ds-identify-also-discover-LXD-by-presence-from-DMI:
+    cherry-pick 30ccd51a: ds-identify: also discover LXD by presence
+    from DMI
+  * d/p/pick-e3307e4d-ds-identify-detect-LXD-for-VMs-launched-from-host-with:
+    cherry-pick e3307e4d: ds-identify: detect LXD for VMs launched from
+    host with > 5.10 kernel (LP: #1968085)
+
+ -- James Falcon <james.falcon@canonical.com>  Wed, 06 Apr 2022 16:48:16 -0500
+
+cloud-init (22.1-14-g2e17a0d6-0ubuntu1~22.04.4) jammy; urgency=medium
+
+  * d/p/cpick-eee60329-Fix-cloud-init-status-wait-when-no-datasource-found:
+    cherry-pick eee60329: Fix cloud-init status --wait when no datasource
+    found (#1349)
+
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 23 Mar 2022 20:10:41 -0600
+
+cloud-init (22.1-14-g2e17a0d6-0ubuntu1~22.04.3) jammy; urgency=medium
+
+  * d/patches: include the missing quilt patch from v. 22.04.2 upload
+    - cpick-5e347d25-Revert-Ensure-system_cfg-read-before-ds-net-config-on
+
+ -- James Falcon <james.falcon@canonical.com>  Fri, 11 Mar 2022 15:19:52 -0600
+
+cloud-init (22.1-14-g2e17a0d6-0ubuntu1~22.04.2) jammy; urgency=medium
+
+  * cherry-pick 156b927e: Revert "Ensure system_cfg read before ds
+    net config on Oracle (#1174)" (#1326)
+
+ -- James Falcon <james.falcon@canonical.com>  Fri, 11 Mar 2022 11:55:37 -0600
+
 cloud-init (22.1-14-g2e17a0d6-0ubuntu1~22.04.1) jammy; urgency=medium
 
   * debian/apport-launcher.py: Fix string and whitespace formatting

--- a/debian/cloud-init.postinst
+++ b/debian/cloud-init.postinst
@@ -208,6 +208,22 @@ cleanup_lp1552999() {
         "$edir/cloud-init-local.service" "$edir/cloud-init.service"
 }
 
+remove_deprecated_cloud_config_modules() {
+    local oldver="$1" last_bad_ver="22.1-14-g2e17a0d6-0ubuntu1~22.04.5"
+    if dpkg --compare-versions "$oldver" le "$last_bad_ver"; then
+      if grep -q emit_upstart /etc/cloud/cloud.cfg; then
+         # Redact emit_upstart if present in locally modified cloud.cfg:
+         # 1. "- emit_upstart" on a single line as defined in upstream
+         # 2. upstart_dir config which is no longer used
+         sed -i -e '/- emit_upstart/d' -e '/upstart_dir/d' /etc/cloud/cloud.cfg || true
+         if grep -q emit_upstart /etc/cloud/cloud.cfg; then
+             echo "DEPRECATION: unable to remove emit_upstart from /etc/cloud/cloud.cfg."
+             echo "This module is deprecated, you may remove it to eliminate warnings in cloud-init logs."
+         fi
+      fi
+    fi
+}
+
 disable_network_config_on_upgrade() {
     local oldver="$1" last_without_net="0.7.7~bzr1182-0ubuntu1"
     if [ ! -f /var/lib/cloud/instance/obj.pkl ]; then
@@ -369,6 +385,8 @@ EOF
 
    # make upgrades disable network changes by cloud-init
    disable_network_config_on_upgrade "$2"
+
+   remove_deprecated_cloud_config_modules "$2"
 
    fix_azure_upgrade_1611074 "$2"
 


### PR DESCRIPTION
## Do not squash merge through github UI

Support people who want to keep their modified /etc/cloud/cloud.cfg instead of package maintainer's version
by redacting deprecated emit_upstart config module from /etc/cloud/cloud.cfg if present.


In the event that a someone modified their /etc/cloud/cloud.cfg and opted to
keep their modified version instead of upstream maintainers version across up
cloud-init will remove the emit_upstart and upstart_dir references to avoid having a warning
in cloud-init logs about a missing emit_upstart config module.

Also in this branch is a sync of the released d/changelog entries from our devel-22.1-hotfix branch to prepare for a new-upstream-snapshot in ubuntu/devel which will follow after #1421 lands

## Proposed Commit Message
```
  -  changelog
  
  -  d/postinst: remove deprecated emit_upstart from cloud.cfg on upgrade

  - changelog
  
  -  changelog: sync released changelog entries from hotfix branch
```

## Additional Context

After #1421 lands, I'll follow up this branch with a new-upstream-snapshot for kinetic which will also reference the "d/patches: dropped cherry-picks" 
<!-- If relevant -->

## Test Steps

```
sed -i -e "1s/UNRELEASED/kinetic/" debian/changelog
git commit -am 'wip changelog for building'
debuild -b
lxc launch images:ubuntu/kinetic dev-k
lxc file push ../cloud-init*deb dev-k/
lxc exec dev-k apt update
lxc exec dev-k apt install cloud-init
lxc exec dev-k bash
$ vi /etc/cloud/cloud.cfg     # add some comments or changes to the file
$ dpkg -i /cloud-init*deb
$ grep upstart /etc/cloud/cloud.cfg
```


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
