### PR TITLE
Systemd and config: align rhel custom files with upstream

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -34,7 +34,11 @@ disable_root: true
 
 {% if variant in ["almalinux", "alpine", "amazon", "centos", "cloudlinux", "eurolinux",
                   "fedora", "miraclelinux", "openEuler", "rhel", "rocky", "virtuozzo"] %}
+{% if variant == "rhel" %}
+mount_default_fields: [~, ~, 'auto', 'defaults,nofail,x-systemd.requires=cloud-init.service,_netdev', '0', '2']
+{% else %}
 mount_default_fields: [~, ~, 'auto', 'defaults,nofail', '0', '2']
+{% endif %}
 {% if variant == "amazon" %}
 resize_rootfs: noblock
 {% endif %}
@@ -64,6 +68,14 @@ datasource_list: ['NoCloud', 'ConfigDrive', 'Azure', 'OpenStack', 'Ec2']
 # Amazon Linux relies on ec2-net-utils for network configuration
 network:
   config: disabled
+{% endif %}
+
+{% if variant == "rhel" %}
+# Default redhat settings:
+ssh_deletekeys:   1
+ssh_genkeytypes:  ['rsa', 'ecdsa', 'ed25519']
+syslog_fix_perms: ~
+disable_vmware_customization: false
 {% endif %}
 
 # The modules that run in the 'init' stage
@@ -107,10 +119,15 @@ cloud_config_modules:
 {% endif %}
 {% if variant not in ["photon"] %}
  - ssh-import-id
- - keyboard
  - locale
+{% if variant not in ["rhel"] %}
+ - keyboard
+{% endif %}
 {% endif %}
  - set-passwords
+{% if variant in ["rhel"] %}
+ - rh_subscription
+{% endif %}
 {% if variant in ["rhel", "fedora", "photon"] %}
 {% if variant not in ["photon"] %}
  - spacewalk
@@ -239,6 +256,10 @@ system_info:
      name: ec2-user
      lock_passwd: True
      gecos: EC2 Default User
+{% elif variant == "rhel" %}
+     name: cloud-user
+     lock_passwd: true
+     gecos: Cloud User
 {% else %}
      name: {{ variant }}
      lock_passwd: True
@@ -254,6 +275,8 @@ system_info:
      groups: [adm, sudo]
 {% elif variant == "arch" %}
      groups: [wheel, users]
+{% elif variant == "rhel" %}
+     groups: [adm, systemd-journal]
 {% else %}
      groups: [wheel, adm, systemd-journal]
 {% endif %}

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -72,7 +72,7 @@ network:
 
 {% if variant == "rhel" %}
 # Default redhat settings:
-ssh_deletekeys:   1
+ssh_deletekeys:   true
 ssh_genkeytypes:  ['rsa', 'ecdsa', 'ed25519']
 syslog_fix_perms: ~
 disable_vmware_customization: false
@@ -119,10 +119,10 @@ cloud_config_modules:
 {% endif %}
 {% if variant not in ["photon"] %}
  - ssh-import-id
- - locale
 {% if variant not in ["rhel"] %}
  - keyboard
 {% endif %}
+ - locale
 {% endif %}
  - set-passwords
 {% if variant in ["rhel"] %}

--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -2,9 +2,7 @@
 [Unit]
 Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
-{% if variant not in ["rhel"] %}
 After=snapd.seeded.service
-{% endif %}
 Wants=network-online.target cloud-config.target
 {% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled

--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -2,8 +2,14 @@
 [Unit]
 Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
+{% if variant not in ["rhel"] %}
 After=snapd.seeded.service
+{% endif %}
 Wants=network-online.target cloud-config.target
+{% if variant == "rhel" %}
+ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ConditionKernelCommandLine=!cloud-init=disabled
+{% endif %}
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -7,6 +7,10 @@ After=multi-user.target
 Before=apt-daily.service
 {% endif %}
 Wants=network-online.target cloud-config.service
+{% if variant == "rhel" %}
+ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ConditionKernelCommandLine=!cloud-init=disabled
+{% endif %}
 
 
 [Service]
@@ -15,7 +19,16 @@ ExecStart=/usr/bin/cloud-init modules --mode=final
 RemainAfterExit=yes
 TimeoutSec=0
 KillMode=process
+{% if variant == "rhel" %}
+# Restart NetworkManager if it is present and running.
+ExecStartPost=/bin/sh -c 'u=NetworkManager.service; \
+ out=$(systemctl show --property=SubState $u) || exit; \
+ [ "$out" = "SubState=running" ] || exit 0; \
+ systemctl reload-or-try-restart $u'
+{% else %}
 TasksMax=infinity
+{% endif %}
+
 
 # Output needs to appear in instance console output
 StandardOutput=journal+console

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -5,9 +5,7 @@ Description=Initial cloud-init job (pre-networking)
 DefaultDependencies=no
 {% endif %}
 Wants=network-pre.target
-{% if variant not in ["rhel"] %}
 After=hv_kvp_daemon.service
-{% endif %}
 After=systemd-remount-fs.service
 {% if variant == "rhel" %}
 Requires=dbus.socket

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -1,23 +1,45 @@
 ## template:jinja
 [Unit]
 Description=Initial cloud-init job (pre-networking)
-{% if variant in ["ubuntu", "unknown", "debian"] %}
+{% if variant in ["ubuntu", "unknown", "debian", "rhel" ] %}
 DefaultDependencies=no
 {% endif %}
 Wants=network-pre.target
+{% if variant not in ["rhel"] %}
 After=hv_kvp_daemon.service
+{% endif %}
 After=systemd-remount-fs.service
+{% if variant == "rhel" %}
+Requires=dbus.socket
+After=dbus.socket
+{% endif %}
 Before=NetworkManager.service
+{% if variant == "rhel" %}
+Before=network.service
+{% endif %}
 Before=network-pre.target
 Before=shutdown.target
+{% if variant == "rhel" %}
+Before=firewalld.target
+Conflicts=shutdown.target
+{% endif %}
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 Before=sysinit.target
 Conflicts=shutdown.target
 {% endif %}
 RequiresMountsFor=/var/lib/cloud
+{% if variant == "rhel" %}
+ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ConditionKernelCommandLine=!cloud-init=disabled
+{% endif %}
 
 [Service]
 Type=oneshot
+{% if variant == "rhel" %}
+ExecStartPre=/bin/mkdir -p /run/cloud-init
+ExecStartPre=/sbin/restorecon /run/cloud-init
+ExecStartPre=/usr/bin/touch /run/cloud-init/enabled
+{% endif %}
 ExecStart=/usr/bin/cloud-init init --local
 RemainAfterExit=yes
 TimeoutSec=0

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -1,7 +1,7 @@
 ## template:jinja
 [Unit]
 Description=Initial cloud-init job (metadata service crawler)
-{% if variant not in ["photon"] %}
+{% if variant not in ["photon", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
 Wants=cloud-init-local.service
@@ -36,6 +36,10 @@ Before=shutdown.target
 Conflicts=shutdown.target
 {% endif %}
 Before=systemd-user-sessions.service
+{% if variant == "rhel" %}
+ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ConditionKernelCommandLine=!cloud-init=disabled
+{% endif %}
 
 [Service]
 Type=oneshot

--- a/tests/unittests/test_render_cloudcfg.py
+++ b/tests/unittests/test_render_cloudcfg.py
@@ -68,6 +68,7 @@ class TestRenderCloudCfg:
         default_user_exceptions = {
             "amazon": "ec2-user",
             "debian": "ubuntu",
+            "rhel": "cloud-user",
             "unknown": "ubuntu",
         }
         default_user = system_cfg["system_info"]["default_user"]["name"]


### PR DESCRIPTION
## Proposed Commit Message
```
So far RHEL had its own custom .service and cloud.cfg files,
that diverged from upstream. We always replaced the generated files
with the ones we had.

This caused only confusion and made it harder to rebase and backport
patches targeting these files.
Hopefully this brings some alignment with upstream.
At the same time, we are going to delete our custom downstream-only files
and use the ones generated by .tmpl.

The mapping is
config/cloud.cfg.tmpl -> rhel/cloud.cfg
systemd/* -> rhel/systemd/*

Such rhel-specific files are open and available in the Centos repo:
https://gitlab.com/redhat/centos-stream/src/cloud-init

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>
```

RHBZ 2082071

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
