### PR TITLE
run-container: add support for LXD VMs (stable-19.4)

### DIFF
--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -12,6 +12,7 @@ from time import time
 
 import contextlib
 import os
+import six
 
 from six import StringIO
 from six.moves.configparser import (
@@ -25,6 +26,10 @@ from cloudinit import type_utils
 from cloudinit import util
 
 LOG = logging.getLogger(__name__)
+
+if six.PY2:
+    class PermissionError(OSError):
+        pass
 
 
 class LockFailure(Exception):

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -34,6 +34,13 @@ MAYBE_RELIABLE_YUM_INSTALL = [
     'sh', '-c',
     """
     error() { echo "$@" 1>&2; }
+    configure_repos_for_proxy_use() {
+        grep -q "^proxy=" /etc/yum.conf || return 0
+        error ":: http proxy in use => forcing the use of fixed URLs in /etc/yum.repos.d/*.repo"
+        sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo
+        sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo
+    }
+    configure_repos_for_proxy_use
     n=0; max=10;
     bcmd="yum install --downloadonly --assumeyes --setopt=keepcache=1"
     while n=$(($n+1)); do
@@ -48,6 +55,7 @@ MAYBE_RELIABLE_YUM_INSTALL = [
     done
     error ":: running yum install --cacheonly --assumeyes $*"
     yum install --cacheonly --assumeyes "$@"
+    configure_repos_for_proxy_use
     """,
     'reliable-yum-install']
 

--- a/tools/run-container
+++ b/tools/run-container
@@ -41,6 +41,7 @@ Usage: ${0##*/} [ options ] [images:]image-ref
       -p | --package         build a binary package (.deb or .rpm)
       -s | --source-package  build source package (debuild -S or srpm)
       -u | --unittest        run unit tests
+           --vm              use a VM instead of a container
 
     Example:
       * ${0##*/} --package --source-package --unittest centos/6
@@ -53,7 +54,7 @@ cleanup() {
         if [ "$KEEP" = "true" ]; then
             error "not deleting container '$CONTAINER' due to --keep"
         else
-            delete_container "$CONTAINER"
+            delete_instance "$CONTAINER"
         fi
     fi
 }
@@ -360,6 +361,12 @@ wait_inside() {
 wait_for_boot() {
     local name="$1"
     local out="" ret="" wtime=$DEFAULT_WAIT_MAX
+    local system_up=false
+    for i in {0..30}; do
+        [ "$i" -gt 1 ] && sleep 5
+        inside "$name" true 2>/dev/null && system_up=true && break
+    done
+    [ $system_up == true ] || { errorrc "exec command inside $name failed."; return; }
     get_os_info_in "$name"
     [ "$OS_NAME" = "debian" ] && wtime=300 &&
         debug 1 "on debian we wait for ${wtime}s"
@@ -379,10 +386,12 @@ wait_for_boot() {
     fi
 }
 
-start_container() {
-    local src="$1" name="$2"
+start_instance() {
+    local src="$1" name="$2" use_vm="$3"
     debug 1 "starting container $name from '$src'"
-    lxc launch "$src" "$name" || {
+    launch_flags=()
+    [ "$use_vm" == true ] && launch_flags+=(--vm)
+    lxc launch "$src" "$name" "${launch_flags[@]}" || {
         errorrc "Failed to start container '$name' from '$src'";
         return
     }
@@ -390,7 +399,7 @@ start_container() {
     wait_for_boot "$name"
 }
 
-delete_container() {
+delete_instance() {
     debug 1 "removing container $1 [--keep to keep]"
     lxc delete --force "$1"
 }
@@ -410,7 +419,7 @@ run_self_inside_as_cd() {
 
 main() {
     local short_opts="a:hknpsuv"
-    local long_opts="artifacts:,dirty,help,keep,name:,pyexe:,package,source-package,unittest,verbose"
+    local long_opts="artifacts:,dirty,help,keep,name:,pyexe:,package,source-package,unittest,verbose,vm"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
@@ -420,6 +429,7 @@ main() {
     local cur="" next=""
     local package=false srcpackage=false unittest="" name=""
     local dirty=false pyexe="auto" artifact_d="."
+    local use_vm=false
 
     while [ $# -ne 0 ]; do
         cur="${1:-}"; next="${2:-}";
@@ -434,6 +444,7 @@ main() {
             -s|--source-package) srcpackage=true;;
             -u|--unittest) unittest=1;;
             -v|--verbose) VERBOSITY=$((VERBOSITY+1));;
+               --vm) use_vm=true;;
             --) shift; break;;
         esac
         shift;
@@ -463,7 +474,7 @@ main() {
 
     trap cleanup EXIT
 
-    start_container "$img_ref" "$name" ||
+    start_instance "$img_ref" "$name" "$use_vm" ||
         { errorrc "Failed to start container for $img_ref"; return; }
 
     get_os_info_in "$name" ||

--- a/tools/run-container
+++ b/tools/run-container
@@ -371,9 +371,8 @@ wait_for_boot() {
         if [ "$OS_NAME" = "centos" ]; then
             debug 1 "configuring proxy ${http_proxy}"
             inside "$name" sh -c "echo proxy=$http_proxy >> /etc/yum.conf"
-            inside "$name" sed -i s/enabled=1/enabled=0/ \
-                /etc/yum/pluginconf.d/fastestmirror.conf
-            inside "$name" sh -c "sed -i '/^#baseurl=/s/#// ; s/^mirrorlist/#mirrorlist/' /etc/yum.repos.d/*.repo"
+            inside "$name" sh -c "sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo"
+            inside "$name" sh -c "sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo"
         else
             debug 1 "do not know how to configure proxy on $OS_NAME"
         fi


### PR DESCRIPTION
run-container: add support for LXD VMs

Backport of d1149988323bb88 to stable-19.4.

Images of older releases (e.g. CentOS 7) can't run as containers on
newer Ubuntu releases because they need a CGroupV1 host system. They
can however run as VMs.
