### PR TITLE
Update linters and adapt code for compatibility (SC-986)

### DIFF
--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -209,6 +209,7 @@ def handle_hotplug(hotplug_init: Init, devpath, subsystem, udevaction):
         success_fn=hotplug_init._write_to_cache,
     )  # type: UeventHandler
     wait_times = [1, 3, 5, 10, 30]
+    last_exception = Exception("Bug while processing hotplug event.")
     for attempt, wait in enumerate(wait_times):
         LOG.debug(
             "subsystem=%s update attempt %s/%s",
@@ -231,7 +232,7 @@ def handle_hotplug(hotplug_init: Init, devpath, subsystem, udevaction):
             time.sleep(wait)
             last_exception = e
     else:
-        raise last_exception  # type: ignore
+        raise last_exception
 
 
 def handle_args(name, args):

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,12 @@ import setuptools
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
+# pylint: disable=W0402
 try:
     from setuptools.errors import DistutilsError
 except ImportError:
     from distutils.errors import DistutilsArgError as DistutilsError
+# pylint: enable=W0402
 
 RENDERED_TMPD_PREFIX = "RENDERED_TEMPD"
 VARIANT = None

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -320,8 +320,8 @@ class TestResize(unittest.TestCase):
                 raise e
             return real_stat(path)
 
+        opinfo = cc_growpart.device_part_info
         try:
-            opinfo = cc_growpart.device_part_info
             cc_growpart.device_part_info = simple_device_part_info
             os.stat = mystat
 

--- a/tests/unittests/sources/test_configdrive.py
+++ b/tests/unittests/sources/test_configdrive.py
@@ -603,11 +603,10 @@ class TestConfigDriveDataSource(CiTestCase):
         def my_is_partition(dev):
             return dev[-1] in "0123456789" and not dev.startswith("sr")
 
+        orig_find_devs_with = util.find_devs_with
+        orig_is_partition = util.is_partition
         try:
-            orig_find_devs_with = util.find_devs_with
             util.find_devs_with = my_devs_with
-
-            orig_is_partition = util.is_partition
             util.is_partition = my_is_partition
 
             devs_with_answers = {

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -164,7 +164,7 @@ class DsIdentifyBase(CiTestCase):
         def write_mock(data):
             ddata = {"out": None, "err": None, "ret": 0, "RET": None}
             ddata.update(data)
-            for k in ddata:
+            for k in ddata.keys():
                 if ddata[k] is None:
                     ddata[k] = unset
             return SHELL_MOCK_TMPL % ddata

--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,11 @@ passenv=
 
 [format_deps]
 black==22.3.0
-flake8==3.9.2
+flake8==4.0.1
 isort==5.10.1
-mypy==0.931
-pylint==2.11.1
-pytest==7.0.0
+mypy==0.950
+pylint==2.13.8
+pytest==7.0.1
 types-jsonschema==4.4.2
 types-oauthlib==3.1.6
 types-PyYAML==6.0.4


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Update linters and adapt code for compatibility

Changes:
- pylint 2.13.8: fix E0601(used-before-assignment)
- pylint 2.13.8: fix E4702(modified-iterating-dict)
- pylint 2.13.8: silence W0402(deprecated-module) on distutils.errors
- tox: bump linters versions
```

## Additional Context
<!-- If relevant -->
This should make the `cloud-init-style-tip` green.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
tox -e py3,black,flake8,isort,mypy,pylint,tip-flake8,tip-mypy,tip-pylint
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
