### PR TITLE
net: Prefer Netplan and NetworkManager renderers by default

### DIFF
--- a/cloudinit/net/renderers.py
+++ b/cloudinit/net/renderers.py
@@ -27,10 +27,10 @@ NAME_TO_RENDERER = {
 }
 
 DEFAULT_PRIORITY = [
-    "eni",
-    "sysconfig",
     "netplan",
     "network-manager",
+    "eni",
+    "sysconfig",
     "freebsd",
     "netbsd",
     "openbsd",

--- a/doc/rtd/topics/network-config.rst
+++ b/doc/rtd/topics/network-config.rst
@@ -188,6 +188,15 @@ generated configuration into an internal network configuration state. From
 this state `Cloud-init`_ delegates rendering of the configuration to Distro
 supported formats.  The following ``renderers`` are supported in cloud-init:
 
+- **NetworkManager**
+
+`NetworkManager <https://networkmanager.dev>`_ is the standard Linux network
+configuration tool suite. It supports a wide range of networking setups.
+Configuration is typically stored in ``/etc/NetworkManager``.
+
+It is the default for a number of Linux distributions, notably Fedora;
+CentOS/RHEL; and derivatives.
+
 - **ENI**
 
 /etc/network/interfaces or ``ENI`` is supported by the ``ifupdown`` package
@@ -212,9 +221,10 @@ Network Output Policy
 The default policy for selecting a network ``renderer`` in order of preference
 is as follows:
 
+- Netplan
+- NetworkManager
 - ENI
 - Sysconfig
-- Netplan
 
 When applying the policy, `Cloud-init`_ checks if the current instance has the
 correct binaries and paths to support the renderer.  The first renderer that
@@ -223,7 +233,7 @@ supplying an updated configuration in cloud-config. ::
 
   system_info:
     network:
-      renderers: ['netplan', 'eni', 'sysconfig', 'freebsd', 'netbsd', 'openbsd']
+      renderers: ['netplan', 'network-manager', 'sysconfig', 'eni', 'freebsd', 'netbsd', 'openbsd']
 
 
 Network Configuration Tools

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -7366,16 +7366,14 @@ class TestRenderersSelect:
             ),
             # -netplan +ifupdown -sys -nm -networkd selects eni
             ("eni", False, True, False, False, False),
-            # +netplan +ifupdown -sys -nm -networkd selects eni
-            ("eni", True, True, False, False, False),
-            # +netplan -ifupdown -sys -nm -networkd selects netplan
-            ("netplan", True, False, False, False, False),
+            # +netplan +ifupdown -sys -nm -networkd selects netplan
+            ("netplan", True, True, False, False, False),
             # +netplan -ifupdown -sys -nm -networkd selects netplan
             ("netplan", True, False, False, False, False),
             # -netplan -ifupdown +sys -nm -networkd selects sysconfig
             ("sysconfig", False, False, True, False, False),
-            # -netplan -ifupdown +sys +nm -networkd selects sysconfig
-            ("sysconfig", False, False, True, True, False),
+            # -netplan -ifupdown +sys +nm -networkd selects network-manager
+            ("network-manager", False, False, True, True, False),
             # -netplan -ifupdown -sys +nm -networkd selects nm
             ("network-manager", False, False, False, True, False),
             # -netplan -ifupdown -sys +nm +networkd selects nm


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
net: Prefer Netplan and NetworkManager renderers by default

NetworkManager is used by default on a variety of Linux distributions,
and exists as a cross-distribution network management service.

Additionally, add information about the NetworkManager renderer to
the cloud-init documentation.

Because Netplan can be explicitly used to manage NetworkManager,
it needs to be preferred before NetworkManager.

As part of this	change, delete a duplicate test case for network
configuration renderers.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>
```

## Additional Context
This change is a follow-up to #1224, which added the native NetworkManager renderer. This patch has been deployed on Fedora's cloud-init package throughout the development of Fedora Linux 36 to verify that it works.

This should also make it tremendously easier for Linux distributions to use cloud-init because now a standard configuration is supported by default.

## Test Steps
This change is deployed in Fedora Cloud images for Fedora Linux 36, so you can see it in action there.

Otherwise, building an image with a package that has _this_ change and also NetworkManager installed in the image and booting it should result in NetworkManager being used by default instead of any of the legacy ones.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
