### PR TITLE
testing: Fix console_log tests (SC-992)

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@db36ef2dfc0a8d916c0e2c1794d7228d49de9192
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@a8584c9da7ef7648cd8702d96a5696de6a6de0e3
 pytest

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@a8584c9da7ef7648cd8702d96a5696de6a6de0e3
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@675dffdc14224a03f8f0ba7212ecb3ca2a8a7083
 pytest

--- a/tests/integration_tests/decorators.py
+++ b/tests/integration_tests/decorators.py
@@ -1,0 +1,34 @@
+import functools
+import time
+
+
+def retry(*, tries: int = 30, delay: int = 1):
+    """Decorator for retries.
+
+    Retry a function until code no longer raises an exception or
+    max tries is reached.
+
+    Example:
+      @retry(tries=5, delay=1)
+      def try_something_that_may_not_be_ready():
+          ...
+    """
+
+    def _retry(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            last_error = None
+            for _ in range(tries):
+                try:
+                    func(*args, **kwargs)
+                    break
+                except Exception as e:
+                    last_error = e
+                    time.sleep(delay)
+            else:
+                if last_error:
+                    raise last_error
+
+        return wrapper
+
+    return _retry

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -9,7 +9,7 @@ from pycloudlib.instance import BaseInstance
 from pycloudlib.result import Result
 
 from tests.integration_tests import integration_settings
-from tests.integration_tests.util import retry
+from tests.integration_tests.decorators import retry
 
 try:
     from typing import TYPE_CHECKING

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -12,9 +12,9 @@ import uuid
 import pytest
 
 from tests.integration_tests.clouds import ImageSpecification
+from tests.integration_tests.decorators import retry
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import (
-    retry,
     verify_clean_log,
     verify_ordered_items_in_text,
 )

--- a/tests/integration_tests/modules/test_keys_to_console.py
+++ b/tests/integration_tests/modules/test_keys_to_console.py
@@ -88,6 +88,11 @@ class TestKeysToConsoleDisabled:
 
 @pytest.mark.user_data(ENABLE_KEYS_TO_CONSOLE_USER_DATA)
 @retry(tries=30, delay=1)
+@pytest.mark.ec2
+@pytest.mark.lxd_container
+@pytest.mark.oci
+@pytest.mark.openstack
+# No Azure because no console log on Azure
 def test_duplicate_messaging_console_log(client: IntegrationInstance):
     """Test that output can be enabled disabled."""
     assert (

--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -11,7 +11,8 @@ only specify one user-data per instance.
 import pytest
 import yaml
 
-from tests.integration_tests.util import retry
+from tests.integration_tests.decorators import retry
+from tests.integration_tests.util import get_console_log
 
 COMMON_USER_DATA = """\
 #cloud-config
@@ -137,21 +138,7 @@ class Mixin:
     @retry(tries=30, delay=1)
     def test_random_passwords_emitted_to_serial_console(self, class_client):
         """We should emit passwords to the serial console. (LP: #1918303)"""
-        try:
-            console_log = class_client.instance.console_log()
-        except NotImplementedError:
-            # Assume that an exception here means that we can't use the console
-            # log
-            pytest.skip("NotImplementedError when requesting console log")
-            return
-        if console_log.lower() == "no console output":
-            # This test retries because we might not have the full console log
-            # on the first fetch. However, if we have no console output
-            # at all, we don't want to keep retrying as that would trigger
-            # another 5 minute wait on the pycloudlib side, which could
-            # leave us waiting for a couple hours
-            pytest.fail("no console output")
-            return
+        console_log = get_console_log(class_client)
         assert "dick:" in console_log
         assert "harry:" in console_log
 

--- a/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
+++ b/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
@@ -12,8 +12,8 @@ import re
 
 import pytest
 
+from tests.integration_tests.decorators import retry
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import retry
 
 USER_DATA_SSH_AUTHKEY_DISABLE = """\
 #cloud-config


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: Fix console_log tests

Bring in the pycloudlib change effecting the console_log on ec2.
Additionally, provide a helper function for retrieving the console log
to reduce duplication.

Moved the retry decorator into a new file to avoid cyclic dependency
and had to update call sites accordingly.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-ec2/15/testReport/tests.integration_tests.modules.test_keys_to_console/TestKeysToConsoleEnabled/test_duplicate_messaging_console_log/
