### PR TITLE
Fix network-manager activator availability and order (SC-991)

### DIFF
--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -255,8 +255,8 @@ class NetworkdActivator(NetworkActivator):
 # version to encompass both seems overkill at this point
 DEFAULT_PRIORITY = [
     IfUpDownActivator,
-    NetworkManagerActivator,
     NetplanActivator,
+    NetworkManagerActivator,
     NetworkdActivator,
 ]
 

--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -373,7 +373,14 @@ def conn_filename(con_id, target=None):
 def available(target=None):
     config_present = os.path.isfile(subp.target_path(target, path=NM_CFG_FILE))
     nmcli_present = subp.which("nmcli", target=target)
-    return config_present and bool(nmcli_present)
+    service_active = True
+    if subp.which("systemctl"):
+        try:
+            subp.subp(["systemctl", "is-active", "NetworkManager.service"])
+        except subp.ProcessExecutionError:
+            service_active = False
+
+    return config_present and bool(nmcli_present) and service_active
 
 
 # vi: ts=4 expandtab

--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -20,6 +20,7 @@ from . import renderer
 
 NM_RUN_DIR = "/etc/NetworkManager"
 NM_LIB_DIR = "/usr/lib/NetworkManager"
+NM_CFG_FILE = "/etc/NetworkManager/NetworkManager.conf"
 LOG = logging.getLogger(__name__)
 
 
@@ -370,8 +371,9 @@ def conn_filename(con_id, target=None):
 
 
 def available(target=None):
-    target_nm_dir = subp.target_path(target, NM_LIB_DIR)
-    return os.path.exists(target_nm_dir)
+    config_present = os.path.isfile(subp.target_path(target, path=NM_CFG_FILE))
+    nmcli_present = subp.which("nmcli", target=target)
+    return config_present and bool(nmcli_present)
 
 
 # vi: ts=4 expandtab

--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -380,7 +380,7 @@ def available(target=None):
     service_active = True
     if uses_systemd():
         try:
-            subp.subp(["systemctl", "is-active", "NetworkManager.service"])
+            subp.subp(["systemctl", "is-enabled", "NetworkManager.service"])
         except subp.ProcessExecutionError:
             service_active = False
 

--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -371,10 +371,14 @@ def conn_filename(con_id, target=None):
 
 
 def available(target=None):
+    # TODO: Move `uses_systemd` to a more appropriate location
+    # It is imported here to avoid circular import
+    from cloudinit.distros import uses_systemd
+
     config_present = os.path.isfile(subp.target_path(target, path=NM_CFG_FILE))
     nmcli_present = subp.which("nmcli", target=target)
     service_active = True
-    if subp.which("systemctl"):
+    if uses_systemd():
         try:
             subp.subp(["systemctl", "is-active", "NetworkManager.service"])
         except subp.ProcessExecutionError:

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -33,7 +33,6 @@ KNOWN_DISTROS = [
     "suse",
     "virtuozzo",
 ]
-NM_CFG_FILE = "/etc/NetworkManager/NetworkManager.conf"
 
 
 def _make_header(sep="#"):

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -44,7 +44,9 @@ NETPLAN_CALL_LIST = [
 def available_mocks():
     mocks = namedtuple("Mocks", "m_which, m_file, m_exists")
     with ExitStack() as mocks_context:
-        mocks_context.enter_context(patch("cloudinit.subp.subp"))
+        mocks_context.enter_context(
+            patch("cloudinit.distros.uses_systemd", return_value=False)
+        )
         m_which = mocks_context.enter_context(
             patch("cloudinit.subp.which", return_value=True)
         )
@@ -61,7 +63,9 @@ def available_mocks():
 def unavailable_mocks():
     mocks = namedtuple("Mocks", "m_which, m_file, m_exists")
     with ExitStack() as mocks_context:
-        mocks_context.enter_context(patch("cloudinit.subp.subp"))
+        mocks_context.enter_context(
+            patch("cloudinit.distros.uses_systemd", return_value=False)
+        )
         m_which = mocks_context.enter_context(
             patch("cloudinit.subp.which", return_value=False)
         )

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from contextlib import ExitStack
 from unittest.mock import patch
 
 import pytest
@@ -42,19 +43,35 @@ NETPLAN_CALL_LIST = [
 @pytest.fixture
 def available_mocks():
     mocks = namedtuple("Mocks", "m_which, m_file, m_exists")
-    with patch("cloudinit.subp.which", return_value=True) as m_which:
-        with patch("os.path.isfile", return_value=True) as m_file:
-            with patch("os.path.exists", return_value=True) as m_exists:
-                yield mocks(m_which, m_file, m_exists)
+    with ExitStack() as mocks_context:
+        mocks_context.enter_context(patch("cloudinit.subp.subp"))
+        m_which = mocks_context.enter_context(
+            patch("cloudinit.subp.which", return_value=True)
+        )
+        m_file = mocks_context.enter_context(
+            patch("os.path.isfile", return_value=True)
+        )
+        m_exists = mocks_context.enter_context(
+            patch("os.path.exists", return_value=True)
+        )
+        yield mocks(m_which, m_file, m_exists)
 
 
 @pytest.fixture
 def unavailable_mocks():
     mocks = namedtuple("Mocks", "m_which, m_file, m_exists")
-    with patch("cloudinit.subp.which", return_value=False) as m_which:
-        with patch("os.path.isfile", return_value=False) as m_file:
-            with patch("os.path.exists", return_value=False) as m_exists:
-                yield mocks(m_which, m_file, m_exists)
+    with ExitStack() as mocks_context:
+        mocks_context.enter_context(patch("cloudinit.subp.subp"))
+        m_which = mocks_context.enter_context(
+            patch("cloudinit.subp.which", return_value=False)
+        )
+        m_file = mocks_context.enter_context(
+            patch("os.path.isfile", return_value=False)
+        )
+        m_exists = mocks_context.enter_context(
+            patch("os.path.exists", return_value=False)
+        )
+        yield mocks(m_which, m_file, m_exists)
 
 
 class TestSearchAndSelect:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix network-manager activator availability and order

The current network-manager activator availability check is too broad.
It triggers as available if chrony is installed. Its priority is also
higher than netplan, which means it can activate even if netplan config
has been rendered. This commit reverts the network-manager check to its
previous state and orders netplan above network-manager in priority.
```

## Additional Context
Currently the check for network-manager only checks if '/usr/lib/NetworkManager' exists ([here](https://github.com/canonical/cloud-init/blob/main/cloudinit/net/network_manager.py#L372) and [here](https://github.com/canonical/cloud-init/blob/main/cloudinit/net/network_manager.py#L22))

On an Azure instance, after upgrade (tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package) I can see the following in the logs:
```
2022-05-05 18:10:14,595 - __init__.py[DEBUG]: Selected renderer 'netplan' from priority list: ['netplan', 'eni', 'sysconfig']
2022-05-05 18:10:14,595 - netplan.py[DEBUG]: V2 to V2 passthrough
2022-05-05 18:10:14,596 - util.py[DEBUG]: Writing to /etc/netplan/50-cloud-init.yaml - wb: [644] 481 bytes
2022-05-05 18:10:14,596 - subp.py[DEBUG]: Running command ['netplan', 'generate'] with allowed return codes [0] (shell=False, capture=True)
2022-05-05 18:10:14,686 - subp.py[DEBUG]: Running command ['udevadm', 'test-builtin', 'net_setup_link', '/sys/class/net/lo'] with allowed return codes [0] (shell=False, capture=True)
2022-05-05 18:10:14,690 - subp.py[DEBUG]: Running command ['udevadm', 'test-builtin', 'net_setup_link', '/sys/class/net/eth0'] with allowed return codes [0] (shell=False, capture=True)
2022-05-05 18:10:14,695 - __init__.py[DEBUG]: Bringing up newly configured network interfaces
2022-05-05 18:10:14,695 - activators.py[DEBUG]: Using selected activator: <class 'cloudinit.net.activators.NetworkManagerActivator'>
2022-05-05 18:10:14,695 - activators.py[DEBUG]: Attempting command ['nmcli', 'connection', 'load', '/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection'] for device eth0
2022-05-05 18:10:14,695 - subp.py[DEBUG]: Running command ['nmcli', 'connection', 'load', '/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection'] with allowed return codes [0]
(shell=False, capture=True)
2022-05-05 18:10:14,697 - util.py[WARNING]: Running interface command ['nmcli', 'connection', 'load', '/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection'] failed
2022-05-05 18:10:14,697 - util.py[DEBUG]: Running interface command ['nmcli', 'connection', 'load', '/etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection'] failed
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 291, in subp
    sp = subprocess.Popen(
  File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: b'nmcli'
```

network-manager is not installed, but the chrony package is creating the directory we use to check if network-manager is installed:
```
ubuntu@SRU-worked:~$ dpkg -L chrony | grep "/usr/lib/NetworkManager"
/usr/lib/NetworkManager
/usr/lib/NetworkManager/dispatcher.d
/usr/lib/NetworkManager/dispatcher.d/20-chrony-dhcp
/usr/lib/NetworkManager/dispatcher.d/20-chrony-onoffline
```

Because of this, I reverted the check back to checking for `/etc/NetworkManager/NetworkManager.conf` and the existance of `nmcli`.

@lkundrak and @Conan-Kudo , does this seem reasonable to you?

## Test Steps
```
DEB_BUILD_OPTIONS=nocheck packages/bddeb -d
CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_all.deb CLOUD_INIT_PLATFORM=azure CLOUD_INIT_OS_IMAGE=impish pytest tests/integration_tests/test_upgrade.py::test_clean_boot_of_upgraded_package
```