### PR TITLE
testing: Ensure NoCloud detected in test

### DIFF
--- a/tests/integration_tests/modules/test_disk_setup.py
+++ b/tests/integration_tests/modules/test_disk_setup.py
@@ -170,6 +170,13 @@ class TestPartProbeAvailability:
         log = client.read_from_file("/var/log/cloud-init.log")
         self._verify_first_disk_setup(client, log)
 
+        # Ensure NoCloud gets detected on reboot
+        client.execute("mkdir -p /var/lib/cloud/seed/nocloud-net/")
+        client.execute("touch /var/lib/cloud/seed/nocloud-net/meta-data")
+        client.write_to_file(
+            "/etc/cloud/cloud.cfg.d/99_nocloud.cfg",
+            "datasource_list: [ NoCloud ]\n",
+        )
         # Update our userdata and cloud.cfg to mount then perform new disk
         # setup
         client.write_to_file(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: Ensure NoCloud detected in test

test_disk_setup_when_mounted changes userdata during the test run, so
ensure NoCloud datasource is used so new userdata is detected.
```

## Additional Context
This one is simple enough I don't think we need to use the other NoCloud setup.
