### PR TITLE
Drop cc_snap.maybe_install_squashfuse.

### DIFF
--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -182,23 +182,6 @@ def run_commands(commands):
         raise RuntimeError(msg)
 
 
-# RELEASE_BLOCKER: Once LP: #1628289 is released on xenial, drop this function.
-def maybe_install_squashfuse(cloud):
-    """Install squashfuse if we are in a container."""
-    if not util.is_container():
-        return
-    try:
-        cloud.distro.update_package_sources()
-    except Exception:
-        util.logexc(LOG, "Package update failed")
-        raise
-    try:
-        cloud.distro.install_packages(["squashfuse"])
-    except Exception:
-        util.logexc(LOG, "Failed to install squashfuse")
-        raise
-
-
 def handle(name, cfg, cloud, log, args):
     cfgin = cfg.get("snap", {})
     if not cfgin:
@@ -207,8 +190,6 @@ def handle(name, cfg, cloud, log, args):
         )
         return
 
-    if util.is_true(cfgin.get("squashfuse_in_container", False)):
-        maybe_install_squashfuse(cloud)
     add_assertions(cfgin.get("assertions", []))
     run_commands(cfgin.get("commands", []))
 

--- a/cloudinit/config/cloud-init-schema.json
+++ b/cloudinit/config/cloud-init-schema.json
@@ -1819,11 +1819,6 @@
                   {"type": "array", "items": {"type": "string"}}
                 ]
               }
-            },
-            "squashfuse_in_container": {
-              "type": "boolean",
-              "default": false,
-              "description": "DEPRECATED: This key is no longer needed and will be removed in a future version of cloud-init."
             }
           }
         }

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -59,7 +59,6 @@ runcmd:
   - #
   - logger "My test log"
 snap:
-  squashfuse_in_container: true
   commands:
     - snap install hello-world
 ssh_import_id:


### PR DESCRIPTION
cc_snap.maybe_install_squashfuse no longer needed in Bionic++.

squashfuse install no longer required as snapd feature was backported
and released (and Xenial support is no longer available for
cloud-init).

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Drop cc_snap.maybe_install_squashfuse.

cc_snap.maybe_install_squashfuse no longer needed in Bionic++.

squashfuse install no longer required as snapd feature was backported
and released (and Xenial support is no longer available for
cloud-init).
```

## Additional Context
<!-- If relevant -->
SC-903

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
