### PR TITLE
Log generic warning on non-systemd systems.

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -92,7 +92,8 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
     try:
         distro.manage_service("status", service)
     except subp.ProcessExecutionError as e:
-        if e.exit_code == 3:
+        uses_systemd = distro.uses_systemd()
+        if uses_systemd and e.exit_code == 3:
             # Service is not running. Write ssh config.
             LOG.warning(
                 "Writing config 'ssh_pwauth: %s'. SSH service '%s'"
@@ -101,7 +102,7 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
                 service,
             )
             restart_ssh = False
-        elif e.exit_code == 4:
+        elif uses_systemd and e.exit_code == 4:
             # Service status is unknown
             LOG.warning(
                 "Ignoring config 'ssh_pwauth: %s'."

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -188,6 +188,105 @@ class TestHandleSSHPwauth:
         assert m_update_ssh_config.call_count == update_ssh_call_count
         m_subp.assert_not_called()
 
+    @mock.patch("cloudinit.distros.Distro.uses_systemd", return_value=False)
+    @mock.patch(MODPATH + "update_ssh_config", return_value=True)
+    @mock.patch("cloudinit.distros.subp.subp")
+    def test_failed_ssh_non_systemd_service_is_not_available_exit_code_25(
+        self, m_subp, m_update_ssh_config, m_uses_systemd
+    ):
+        """If the ssh service is not available in a system without systemd,
+        then no updates config, no restart and a generic message is logged.
+        """
+        cloud = self.tmp_cloud(distro="ubuntu")
+        cloud.distro.init_cmd = ["service"]
+        process_error = "Service is not available."
+        cloud.distro.manage_service = mock.Mock(
+            side_effect=subp.ProcessExecutionError(
+                stderr=process_error, exit_code=25
+            )
+        )
+
+        setpass.handle_ssh_pwauth(True, cloud.distro)
+        self.assertIn(
+            r"WARNING: Ignoring config 'ssh_pwauth: True'."
+            r" SSH service 'ssh' is not available. Error: ",
+            self.logs.getvalue(),
+        )
+        self.assertIn(process_error, self.logs.getvalue())
+        self.assertEqual(
+            [mock.call("status", "ssh")],
+            cloud.distro.manage_service.call_args_list,
+        )
+        self.assertEqual(m_update_ssh_config.call_count, 0)
+        self.assertEqual(m_subp.call_count, 0)
+        self.assertEqual(m_uses_systemd.call_count, 1)
+
+    @mock.patch("cloudinit.distros.Distro.uses_systemd", return_value=False)
+    @mock.patch(MODPATH + "update_ssh_config", return_value=True)
+    @mock.patch("cloudinit.distros.subp.subp")
+    def test_failed_ssh_non_systemd_service_is_not_available_exit_code_3(
+        self, m_subp, m_update_ssh_config, m_uses_systemd
+    ):
+        """If the ssh service is not available in a system without systemd,
+        then no updates config, no restart and a generic message is logged.
+        """
+        cloud = self.tmp_cloud(distro="ubuntu")
+        cloud.distro.init_cmd = ["service"]
+        process_error = "Service is not available."
+        cloud.distro.manage_service = mock.Mock(
+            side_effect=subp.ProcessExecutionError(
+                stderr=process_error, exit_code=3
+            )
+        )
+
+        setpass.handle_ssh_pwauth(True, cloud.distro)
+        self.assertIn(
+            r"WARNING: Ignoring config 'ssh_pwauth: True'."
+            r" SSH service 'ssh' is not available. Error: ",
+            self.logs.getvalue(),
+        )
+        self.assertIn(process_error, self.logs.getvalue())
+        self.assertEqual(
+            [mock.call("status", "ssh")],
+            cloud.distro.manage_service.call_args_list,
+        )
+        self.assertEqual(m_update_ssh_config.call_count, 0)
+        self.assertEqual(m_subp.call_count, 0)
+        self.assertEqual(m_uses_systemd.call_count, 1)
+
+    @mock.patch("cloudinit.distros.Distro.uses_systemd", return_value=False)
+    @mock.patch(MODPATH + "update_ssh_config", return_value=True)
+    @mock.patch("cloudinit.distros.subp.subp")
+    def test_failed_ssh_non_systemd_service_is_not_available_exit_code_4(
+        self, m_subp, m_update_ssh_config, m_uses_systemd
+    ):
+        """If the ssh service is not available in a system without systemd,
+        then no updates config, no restart and a generic message is logged.
+        """
+        cloud = self.tmp_cloud(distro="ubuntu")
+        cloud.distro.init_cmd = ["service"]
+        process_error = "Service is not available."
+        cloud.distro.manage_service = mock.Mock(
+            side_effect=subp.ProcessExecutionError(
+                stderr=process_error, exit_code=4
+            )
+        )
+
+        setpass.handle_ssh_pwauth(True, cloud.distro)
+        self.assertIn(
+            r"WARNING: Ignoring config 'ssh_pwauth: True'."
+            r" SSH service 'ssh' is not available. Error: ",
+            self.logs.getvalue(),
+        )
+        self.assertIn(process_error, self.logs.getvalue())
+        self.assertEqual(
+            [mock.call("status", "ssh")],
+            cloud.distro.manage_service.call_args_list,
+        )
+        self.assertEqual(m_update_ssh_config.call_count, 0)
+        self.assertEqual(m_subp.call_count, 0)
+        self.assertEqual(m_uses_systemd.call_count, 1)
+
 
 @pytest.mark.usefixtures("mock_uses_systemd")
 class TestSetPasswordsHandle(CiTestCase):


### PR DESCRIPTION
If the SSH status is checked in a non-systemd system, do not
distinguish between service statuses and log a generic warning
as we cannot expect status exit codes fulfilling any convention.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Log generic warning on non-systemd systems.

If the SSH status is checked in a non-systemd system, do not
distinguish between service statuses and log a generic warning
as we cannot expect status exit codes fulfilling any convention.
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/1422#issuecomment-1124936382

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
