### PR TITLE
Fix apparent typos in disk names

### DIFF
--- a/doc/examples/cloud-config-disk-setup.txt
+++ b/doc/examples/cloud-config-disk-setup.txt
@@ -7,7 +7,7 @@
 # (Not implemented yet, but provided for future documentation)
 
 disk_setup:
-  ephmeral0:
+  ephemeral0:
     table_type: 'mbr'
     layout: True
     overwrite: False
@@ -78,7 +78,7 @@ fs_setup:
 # The disk_setup directive instructs Cloud-init to partition a disk. The format is:
 
 disk_setup:
-  ephmeral0:
+  ephemeral0:
     table_type: 'mbr'
     layout: true
   /dev/xvdh:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix typos in disk names

The name `ephmeral0` appears in two places in this file, but based 
on the fact that `ephemeral0` is used elsewhere in the file, it is 
very likely that `ephmeral0` is actually a typo.
```

## Additional Context

First spotted while reading the formatted docs at https://cloudinit.readthedocs.io/en/latest/topics/examples.html

## Test Steps

This is a file of examples and (I think) not something that can be tested directly.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
