### PR TITLE
Scaleway: Fix network configuration for netplan 0.102 and later

### DIFF
--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -254,8 +254,14 @@ class DataSourceScaleway(sources.DataSource):
                 {
                     "type": "static",
                     "address": "%s" % self.metadata["ipv6"]["address"],
-                    "gateway": "%s" % self.metadata["ipv6"]["gateway"],
                     "netmask": "%s" % self.metadata["ipv6"]["netmask"],
+                    "routes": [
+                        {
+                            "network": "::",
+                            "prefix": "0",
+                            "gateway": "%s" % self.metadata["ipv6"]["gateway"],
+                        }
+                    ],
                 }
             ]
         netcfg["subnets"] = subnets

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -444,8 +444,14 @@ class TestDataSourceScaleway(HttprettyTestCase):
                         {
                             "type": "static",
                             "address": "2000:abc:4444:9876::42:999",
-                            "gateway": "2000:abc:4444:9876::42:000",
                             "netmask": "127",
+                            "routes": [
+                                {
+                                    "gateway": "2000:abc:4444:9876::42:000",
+                                    "network": "::",
+                                    "prefix": "0",
+                                }
+                            ],
                         },
                     ],
                 }

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -73,6 +73,7 @@ nishigori
 olivierlemasle
 omBratteng
 onitake
+Oursin
 qubidt
 renanrodrigo
 rhansen


### PR DESCRIPTION
## Proposed Commit Message

```
summary: Scaleway: Fix network configuration for netplan 0.102 and later

Since version 0.102 netplan no longer supports the option `gateway6`.
This commit changes this option to the newer `routes` one.
```

## Additional Context
Cloud init currently fails to run on Scaleway instances with OSes using recent Netplan versions. This PR fixes the issue by updating the generated netplan configuration to stop using deprecated options.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
