### PR TITLE
Improve cc_set_passwords.

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -93,25 +93,7 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
         distro.manage_service("status", service)
     except subp.ProcessExecutionError as e:
         uses_systemd = distro.uses_systemd()
-        if uses_systemd and e.exit_code == 3:
-            # Service is not running. Write ssh config.
-            LOG.debug(
-                "Writing config 'ssh_pwauth: %s'. SSH service '%s'"
-                " will not be restarted because it is stopped.",
-                pw_auth,
-                service,
-            )
-            restart_ssh = False
-        elif uses_systemd and e.exit_code == 4:
-            # Service status is unknown
-            LOG.warning(
-                "Ignoring config 'ssh_pwauth: %s'."
-                " SSH service '%s' is not installed.",
-                pw_auth,
-                service,
-            )
-            return
-        elif not uses_systemd:
+        if not uses_systemd:
             LOG.debug(
                 "Writing config 'ssh_pwauth: %s'. SSH service '%s'"
                 " will not be restarted because it is not running or not"
@@ -120,6 +102,24 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
                 service,
             )
             restart_ssh = False
+        elif e.exit_code == 3:
+            # Service is not running. Write ssh config.
+            LOG.debug(
+                "Writing config 'ssh_pwauth: %s'. SSH service '%s'"
+                " will not be restarted because it is stopped.",
+                pw_auth,
+                service,
+            )
+            restart_ssh = False
+        elif e.exit_code == 4:
+            # Service status is unknown
+            LOG.warning(
+                "Ignoring config 'ssh_pwauth: %s'."
+                " SSH service '%s' is not installed.",
+                pw_auth,
+                service,
+            )
+            return
         else:
             LOG.warning(
                 "Ignoring config 'ssh_pwauth: %s'."

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -95,7 +95,7 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
         uses_systemd = distro.uses_systemd()
         if uses_systemd and e.exit_code == 3:
             # Service is not running. Write ssh config.
-            LOG.warning(
+            LOG.debug(
                 "Writing config 'ssh_pwauth: %s'. SSH service '%s'"
                 " will not be restarted because it is stopped.",
                 pw_auth,
@@ -111,6 +111,15 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
                 service,
             )
             return
+        elif not uses_systemd:
+            LOG.debug(
+                "Writing config 'ssh_pwauth: %s'. SSH service '%s'"
+                " will not be restarted because it is not running or not"
+                " available.",
+                pw_auth,
+                service,
+            )
+            restart_ssh = False
         else:
             LOG.warning(
                 "Ignoring config 'ssh_pwauth: %s'."

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -132,7 +132,7 @@ class TestHandleSSHPwauth:
             "uses_systemd",
             "raised_error",
             "warning_log",
-            "debug_log",
+            "debug_logs",
             "update_ssh_call_count",
         ],
         (
@@ -141,9 +141,12 @@ class TestHandleSSHPwauth:
                 subp.ProcessExecutionError(
                     stderr="Service is not running.", exit_code=3
                 ),
-                "Writing config 'ssh_pwauth: True'. SSH service"
-                " 'ssh' will not be restarted because it is stopped.",
-                "Not restarting SSH service: service is stopped.",
+                None,
+                [
+                    "Writing config 'ssh_pwauth: True'. SSH service"
+                    " 'ssh' will not be restarted because it is stopped.",
+                    "Not restarting SSH service: service is stopped.",
+                ],
                 1,
             ),
             (
@@ -153,7 +156,7 @@ class TestHandleSSHPwauth:
                 ),
                 "Ignoring config 'ssh_pwauth: True'. SSH service 'ssh' is"
                 " not installed.",
-                None,
+                [],
                 0,
             ),
             (
@@ -163,7 +166,7 @@ class TestHandleSSHPwauth:
                 ),
                 "Ignoring config 'ssh_pwauth: True'. SSH service 'ssh'"
                 " is not available. Error: ",
-                None,
+                [],
                 0,
             ),
             (
@@ -171,30 +174,42 @@ class TestHandleSSHPwauth:
                 subp.ProcessExecutionError(
                     stderr="Service is not available.", exit_code=25
                 ),
-                "Ignoring config 'ssh_pwauth: True'. SSH service 'ssh'"
-                " is not available. Error: ",
                 None,
-                0,
+                [
+                    "Writing config 'ssh_pwauth: True'. SSH service"
+                    " 'ssh' will not be restarted because it is not running"
+                    " or not available.",
+                    "Not restarting SSH service: service is stopped.",
+                ],
+                1,
             ),
             (
                 False,
                 subp.ProcessExecutionError(
                     stderr="Service is not available.", exit_code=3
                 ),
-                "Ignoring config 'ssh_pwauth: True'. SSH service 'ssh'"
-                " is not available. Error: ",
                 None,
-                0,
+                [
+                    "Writing config 'ssh_pwauth: True'. SSH service"
+                    " 'ssh' will not be restarted because it is not running"
+                    " or not available.",
+                    "Not restarting SSH service: service is stopped.",
+                ],
+                1,
             ),
             (
                 False,
                 subp.ProcessExecutionError(
                     stderr="Service is not available.", exit_code=4
                 ),
-                "Ignoring config 'ssh_pwauth: True'. SSH service 'ssh'"
-                " is not available. Error: ",
                 None,
-                0,
+                [
+                    "Writing config 'ssh_pwauth: True'. SSH service"
+                    " 'ssh' will not be restarted because it is not running"
+                    " or not available.",
+                    "Not restarting SSH service: service is stopped.",
+                ],
+                1,
             ),
         ),
     )
@@ -207,7 +222,7 @@ class TestHandleSSHPwauth:
         uses_systemd,
         raised_error,
         warning_log,
-        debug_log,
+        debug_logs,
         update_ssh_call_count,
         caplog,
     ):
@@ -220,8 +235,11 @@ class TestHandleSSHPwauth:
         logs_by_level = {logging.WARNING: [], logging.DEBUG: []}
         for _, level, msg in caplog.record_tuples:
             logs_by_level[level].append(msg)
-        assert warning_log in "\n".join(logs_by_level[logging.WARNING])
-        if debug_log:
+        if warning_log:
+            assert warning_log in "\n".join(
+                logs_by_level[logging.WARNING]
+            ), logs_by_level
+        for debug_log in debug_logs:
             assert debug_log in logs_by_level[logging.DEBUG]
         assert [
             mock.call("status", "ssh")


### PR DESCRIPTION
- If the system doesn't use systemd and the status of the ssh
service is not 0, then apply the pw_auth config. As distros as
Alpine could start the ssh service later in the boot sequence.

- Change log level from warning to debug when ssh_pwauth is
written but the ssh service is not restarted.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
Improve cc_set_passwords.

- If the system doesn't use systemd and the status of the ssh
service is not 0, then apply the pw_auth config. As distros as
Alpine could start the ssh service later in the boot sequence.

- Change log level from warning to debug when ssh_pwauth is
written but the ssh service is not restarted.
```

## Additional Context
<!-- If relevant -->
SC-968
https://github.com/canonical/cloud-init/pull/1450#issuecomment-1127138478

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
