### PR TITLE
cc_modules: set default meta frequency value when no config available

### DIFF
--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -172,7 +172,8 @@ class Modules(object):
                     raw_name,
                     freq,
                 )
-                # Reset it so when ran it will get set to a known value
+                # Misconfigured in /etc/cloud/cloud.cfg. Reset so cc_* module
+                # default meta attribute "frequency" value is used.
                 freq = None
             mod_locs, looked_locs = importer.find_module(
                 mod_name, ["", type_utils.obj_name(config)], ["handle"]
@@ -186,6 +187,9 @@ class Modules(object):
                 continue
             mod = importer.import_module(mod_locs[0])
             validate_module(mod, raw_name)
+            if freq is None:
+                # Use cc_* module default setting since no cloud.cfg overrides
+                freq = mod.meta["frequency"]
             mostly_mods.append(
                 ModuleDetails(
                     module=mod,

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -245,6 +245,7 @@ class TestCombined:
         assert (
             found_count > 10
         ), "Not enough modules found in log. Did the log message change?"
+        assert "with frequency None" not in log
 
     def _check_common_metadata(self, data):
         assert data["base64_encoded_keys"] == []

--- a/tests/integration_tests/modules/test_frequency_override.py
+++ b/tests/integration_tests/modules/test_frequency_override.py
@@ -1,0 +1,33 @@
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+
+USER_DATA = """\
+#cloud-config
+runcmd:
+ - echo "hi" >> /var/tmp/hi
+"""
+
+
+@pytest.mark.user_data(USER_DATA)
+def test_frequency_override(client: IntegrationInstance):
+    # Some pre-checks
+    assert (
+        "running config-scripts-user with frequency once-per-instance"
+        in client.read_from_file("/var/log/cloud-init.log")
+    )
+    assert client.read_from_file("/var/tmp/hi").strip().count("hi") == 1
+
+    # Change frequency of scripts-user to always
+    config = client.read_from_file("/etc/cloud/cloud.cfg")
+    new_config = config.replace("- scripts-user", "- [ scripts-user, always ]")
+    client.write_to_file("/etc/cloud/cloud.cfg", new_config)
+
+    client.restart()
+
+    # Ensure the script was run again
+    assert (
+        "running config-scripts-user with frequency always"
+        in client.read_from_file("/var/log/cloud-init.log")
+    )
+    assert client.read_from_file("/var/tmp/hi").strip().count("hi") == 2

--- a/tests/integration_tests/modules/test_write_files.py
+++ b/tests/integration_tests/modules/test_write_files.py
@@ -50,6 +50,7 @@ write_files:
     defer: true
     owner: 'myuser'
     permissions: '0644'
+    append: true
 """.format(
     B64_CONTENT.decode("ascii")
 )
@@ -91,3 +92,8 @@ class TestWriteFiles:
             class_client.execute('stat -c "%U %a" /home/testuser/my-file')
             == "myuser 644"
         )
+        # Assert write_files per-instance is honored and run only once.
+        # Given append: true multiple runs across would append new content.
+        class_client.restart()
+        out = class_client.read_from_file("/home/testuser/my-file")
+        assert "echo 'hello world!'" == out


### PR DESCRIPTION
## Proposed Commit Message
```
Each cloud-config module defines meta["frequency"] module attribute.
This frequency will be preferred unless overrides are given in
/etc/cloud/cloud.cfg module definitions.
```
## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
