### PR TITLE
Fix CI test.

### DIFF
--- a/tests/unittests/sources/test_ovf.py
+++ b/tests/unittests/sources/test_ovf.py
@@ -1022,11 +1022,15 @@ class TestDatasourceOVF(CiTestCase):
 class TestTransportIso9660(CiTestCase):
     def setUp(self):
         super(TestTransportIso9660, self).setUp()
-        self.add_patch("cloudinit.util.find_devs_with", "m_find_devs_with")
-        self.add_patch("cloudinit.util.mounts", "m_mounts")
-        self.add_patch("cloudinit.util.mount_cb", "m_mount_cb")
         self.add_patch(
-            "cloudinit.sources.DataSourceOVF.get_ovf_env", "m_get_ovf_env"
+            "cloudinit.util.find_devs_with", "m_find_devs_with", autospec=False
+        )
+        self.add_patch("cloudinit.util.mounts", "m_mounts", autospec=False)
+        self.add_patch("cloudinit.util.mount_cb", "m_mount_cb", autospec=False)
+        self.add_patch(
+            "cloudinit.sources.DataSourceOVF.get_ovf_env",
+            "m_get_ovf_env",
+            autospec=False,
         )
         self.m_get_ovf_env.return_value = ("myfile", "mycontent")
 


### PR DESCRIPTION
This tests class tried to autospec multiple times same things
which pytest did not like.
As the autospec is not needed in this case, it was disabled.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix CI test.

This tests class tried to autospec multiple times same things
which pytest did not like.
As the autospec is not needed in this case, it was disabled.
```

## Additional Context
<!-- If relevant -->
https://app.travis-ci.com/github/canonical/cloud-init/jobs/570350390

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
