### PR TITLE
testing: make fake cloud-init wait actually wait

### DIFF
--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -13,7 +13,7 @@ def _wait_for_cloud_init(client: IntegrationInstance):
     last_exception = None
     for _ in range(30):
         try:
-            result = client.execute("cloud-init status --long")
+            result = client.execute("cloud-init status")
             if (
                 result
                 and result.ok


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: make fake cloud-init wait actually wait
```

Fixes: https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-impish-lxd_container/21/testReport/junit/tests.integration_tests.cmd/test_status/test_wait_when_no_datasource/