### PR TITLE
Fix test to pass with older pytest.

### DIFF
--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -112,10 +112,7 @@ class TestRender:
         with mock.patch("sys.stderr", new_callable=StringIO):
             with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
                 assert render.handle_args("anyname", args) == 0
-        assert "Converted jinja variables\n{" in caplog.text
-        # TODO enable after pytest>=3.4
-        # more info: https://docs.pytest.org/en/stable/how-to/logging.html
-        # assert "Converted jinja variables\n{" in m_stderr.getvalue()
+        assert "Converted jinja variables\n" in caplog.text
         assert "rendering: jinja worked" == m_stdout.getvalue()
 
     @skipUnlessJinja()


### PR DESCRIPTION
The test did not work with:
- pytest==4.6.9
- pytest-mock==3.0.0

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix daily focal build.

Fix the test to pass with:
- python3-pytest_4.6.9
- python3-pytest-mock_3.0.0
```

## Additional Context
<!-- If relevant -->
https://launchpad.net/~cloud-init-dev/+archive/ubuntu/daily/+build/23756305

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Reproduce the daily build in focal.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
