### PR TITLE
Changelog: correct errant classification of LP issues as GH

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -21,16 +21,15 @@
  - tests: cc_set_passoword update for systemd, non-systemd distros  (#1449)
  - Fix bug in url_helper/dual_stack() logging (#1426)
  - schema: render schema paths from _CustomSafeLoaderWithMarks (#1391)
-   (GH: SC-929)
  - testing: Make integration tests kinetic friendly (#1441)
  - Handle error if SSH service no present. (#1422)
-   [Alberto Contreras] (GH: #1969526)
+   [Alberto Contreras] (LP: #1969526)
  - Fix network-manager activator availability and order (#1438)
  - sources/azure: remove reprovisioning marker (#1414) [Chris Patterson]
  - upstart: drop vestigial support for upstart (#1421)
  - testing: Ensure NoCloud detected in test (#1439)
  - Update .github-cla-signers kallioli [Kevin Allioli]
- - Consistently strip top-level network key (#1417) (GH: #1906187)
+ - Consistently strip top-level network key (#1417) (LP: #1906187)
  - testing: Fix LXD VM metadata test (#1430)
  - testing: Add NoCloud setup for NoCloud test (#1425)
  - Update linters and adapt code for compatibility (#1434) [Paride Legovini]
@@ -43,9 +42,9 @@
  - tests: verify_ordered_items fallback to re.escape if needed (#1420)
  - Misc module cleanup (#1418)
  - docs: Fix doc warnings and enable errors (#1419)
-   [Alberto Contreras] (GH: #1876341)
+   [Alberto Contreras] (LP: #1876341)
  - Refactor cloudinit.sources.NetworkConfigSource to enum (#1413)
-   [Alberto Contreras] (GH: #1874875)
+   [Alberto Contreras] (LP: #1874875)
  - Don't fail if IB and Ethernet devices 'collide' (#1411)
  - Use cc_* module meta defintion over hardcoded vars (SC-888) (#1385)
  - Fix cc_rsyslog.py initialization (#1404) [Alberto Contreras]
@@ -57,13 +56,13 @@
  - Allow growpart to resize encrypted partitions (#1316)
  - Fix typo in integration_test.rst (#1405) [Alberto Contreras]
  - cloudinit.net refactor: apply_network_config_names (#1388)
-   [Alberto Contreras] (GH: #1884602)
+   [Alberto Contreras] (LP: #1884602)
  - tests/azure: add fixtures for hardcoded paths (markers and data_dir)
    (#1399) [Chris Patterson]
  - testing: Add responses workaround for focal/impish (#1403)
  - cc_ssh_import_id: fix is_key_in_nested_dict to avoid early False
  - Fix ds-identify not detecting NoCloud seed in config (#1381)
-   (GH: #1876375)
+   (LP: #1876375)
  - sources/azure: retry dhcp for failed processes (#1401) [Chris Patterson]
  - Move notes about refactorization out of CONTRIBUTING.rst (#1389)
  - Shave ~8ms off generator runtime (#1387)
@@ -78,28 +77,27 @@
  - sources/azure: only wait for primary nic to be attached during restore
    (#1378) [Anh Vo]
  - cc_ntp: migrated legacy schema to cloud-init-schema.json (#1384)
-   (GH: SC-803)
  - Network functions refactor and bugfixes (#1383)
  - schema: add JSON defs for modules cc_users_groups (#1379)
-   (GH: SC-928, SC-846, SC-897, #1858930)
+   (LP: #1858930)
  - Fix doc typo (#1382) [Alberto Contreras]
  - Add support for dual stack IPv6/IPv4 IMDS to Ec2 (#1160)
- - Fix KeyError when rendering sysconfig IPv6 routes (#1380) (GH: #1958506)
+ - Fix KeyError when rendering sysconfig IPv6 routes (#1380) (LP: #1958506)
  - Return a namedtuple from subp() (#1376)
  - Mypy stubs and other tox maintenance (SC-920) (#1374)
  - Distro Compatibility Fixes (#1375)
  - Pull in Gentoo patches (#1372)
  - schema: add json defs for modules U-Z (#1360)
-   (GH: #1858928, #1858929, #1858931, #1858932)
+   (LP: #1858928, #1858929, #1858931, #1858932)
  - util: atomically update sym links to avoid Suppress FileNotFoundError
-   when reading status (#1298) [Adam Collard] (GH: LP:1962150)
+   when reading status (#1298) [Adam Collard] (LP: #1962150)
  - schema: add json defs for modules scripts-timezone (SC-801) (#1365)
  - docs: Add first tutorial (SC-900) (#1368)
  - BUG 1473527: module ssh-authkey-fingerprints fails Input/output error…
-   (#1340) [Andrew Lee] (GH: #1473527)
+   (#1340) [Andrew Lee] (LP: #1473527)
  - add arch hosts template (#1371)
  - ds-identify: detect LXD for VMs launched from host with > 5.10 kernel
-   (#1370) (GH: #1968085)
+   (#1370) (LP: #1968085)
  - Support EC2 tags in instance metadata (#1309) [Eduardo Dobay]
  - schema: add json defs for modules e-install (SC-651) (#1366)
  - Improve "(no_create_home|system): true" test (#1367) [Jeffrey 'jf' Lim]
@@ -122,7 +120,7 @@
  - testing: Add missing is_FreeBSD mock to networking test (#1353)
  - Add --no-update to add-apt-repostory call (SC-880) (#1337)
  - schema: add json defs for modules K-L (#1321)
-   (GH: #1858899, #1858900, #1858901, #1858902)
+   (LP: #1858899, #1858900, #1858901, #1858902)
  - docs: Re-order readthedocs install (#1354)
  - Stop cc_ssh_authkey_fingerprints from ALWAYS creating home (#1343)
    [Jeffrey 'jf' Lim]
@@ -131,14 +129,14 @@
  - sources/azure: move get_ip_from_lease_value out of shim (#1324)
    [Chris Patterson]
  - Fix cloud-init status --wait when no datasource found (#1349)
-   (GH: #1966085)
+   (LP: #1966085)
  - schema: add JSON defs for modules resize-salt (SC-654) (#1341)
  - Add myself as a future contributor (#1345) [Neal Gompa (ニール・ゴンパ)]
  - Update .github-cla-signers (#1342) [Jeffrey 'jf' Lim]
  - add Requires=cloud-init-hotplugd.socket in cloud-init-hotplugd.service
    file (#1335) [yangzz-97]
  - Fix sysconfig render when set-name is missing (#1327)
-   [Andrew Kutz] (GH: #1855945)
+   [Andrew Kutz] (LP: #1855945)
  - Refactoring helper funcs out of NetworkState (#1336) [Andrew Kutz]
  - url_helper: add tuple support for readurl timeout (#1328)
    [Chris Patterson]
@@ -162,7 +160,7 @@
  - Doc cleanups (#1317)
  - docs improvements (#1312)
  - add support for jinja do statements, add unit test (#1314)
-   [Paul Bruno] (GH: #1962759)
+   [Paul Bruno] (LP: #1962759)
  - sources/azure: prevent tight loops for DHCP retries (#1285)
    [Chris Patterson]
  - net/dhcp: surface type of DHCP lease failure to caller (#1276)
@@ -177,7 +175,7 @@
    [Adam Collard]
  - check for existing symlink while force creating symlink (#1281)
    [Shreenidhi Shedi]
- - Do not silently ignore integer uid (#1280) (GH: #1875772)
+ - Do not silently ignore integer uid (#1280) (LP: #1875772)
  - tests: create a IPv4/IPv6 VPC in Ec2 integration tests (#1291)
  - Integration test fix ppa  (#1296)
  - tests: on official EC2. cloud-id actually startswith aws not ec2 (#1289)
@@ -319,8 +317,7 @@
  - sources/azure: remove unnecessary hostname bounce (#1143)
    [Chris Patterson]
  - find_devs/openbsd: accept ISO on disk (#1132)
-   [Gonéri Le Bouder] (GH:
-   https://github.com/ContainerCraft/kmi/issues/12)
+   [Gonéri Le Bouder]
  - Improve error log message when mount failed (#1140) [Ksenija Stanojevic]
  - add KsenijaS as a contributor (#1145) [Ksenija Stanojevic]
  - travis - don't run integration tests if no deb (#1139)
@@ -328,14 +325,14 @@
  - testing: Add deterministic test id (#1138)
  - mock sleep() in azure test (#1137)
  - Add miraclelinux support (#1128) [Haruki TSURUMOTO]
- - docs: Make MACs lowercase in network config (#1135) (GH: #1876941)
+ - docs: Make MACs lowercase in network config (#1135) (LP: #1876941)
  - Add Strict Metaschema Validation (#1101)
  - update dead link (#1133)
  - cloudinit/net: handle two different routes for the same ip (#1124)
    [Emanuele Giuseppe Esposito]
  - docs: pin mistune dependency (#1134)
  - Reorganize unit test locations under tests/unittests (#1126)
- - Fix exception when no activator found (#1129) (GH: #1948681)
+ - Fix exception when no activator found (#1129) (LP: #1948681)
  - jinja: provide and document jinja-safe key aliases in instance-data
    (SC-622) (#1123)
  - testing: Remove date from final_message test (SC-638) (#1127)
@@ -352,7 +349,7 @@
  - lxd: add preference for LXD cloud-init.* config keys over user keys
    (#1108)
  - VMware: source /etc/network/interfaces.d/* on Debian
-   [chengcheng-chcheng] (GH: #1950136)
+   [chengcheng-chcheng] (LP: #1950136)
  - Add cjp256 as contributor (#1109) [Chris Patterson]
  - integration_tests: Ensure log directory exists before symlinking to it
    (#1110)
@@ -362,8 +359,8 @@
  - tests: specialize lxd_discovery test for lxd_vm vendordata (#1106)
  - Add convenience symlink to integration test output (#1105)
  - Fix for set-name bug in networkd renderer (#1100)
-   [Andrew Kutz] (GH: #1949407)
- - Wait for apt lock (#1034) (GH: #1944611)
+   [Andrew Kutz] (LP: #1949407)
+ - Wait for apt lock (#1034) (LP: #1944611)
  - testing: stop chef test from running on openstack (#1102)
  - alpine.py: add options to the apk upgrade command (#1089) [dermotbradley]
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Changelog: correct errant classification of LP issues as GH
```
## Additional Context
log2dch incorrectly represented `Fixes: SC-###` as fixed github issues in changelogs.
https://github.com/canonical/uss-tableflip/pull/89

<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
