### PR TITLE
integration tests: If KEEP_INSTANCE = True, log IP (SC-1077)

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -3,7 +3,6 @@ import logging
 import os
 import uuid
 from enum import Enum
-from functools import cached_property
 from tempfile import NamedTemporaryFile
 
 from pycloudlib.instance import BaseInstance
@@ -61,6 +60,7 @@ class IntegrationInstance:
         self.cloud = cloud
         self.instance = instance
         self.settings = settings
+        self._ip = ""
 
     def destroy(self):
         self.instance.delete()
@@ -194,10 +194,12 @@ class IntegrationInstance:
         assert self.execute("apt-get update -q").ok
         assert self.execute("apt-get install -qy cloud-init").ok
 
-    @cached_property
     def ip(self) -> str:
+        if self._ip:
+            return self._ip
         try:
-            return self.instance.ip
+            self._ip = self.instance.ip
+            return self._ip
         except NotImplementedError:
             return "Unknown"
 

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -199,9 +199,9 @@ class IntegrationInstance:
             return self._ip
         try:
             self._ip = self.instance.ip
-            return self._ip
         except NotImplementedError:
-            return "Unknown"
+            self._ip = "Unknown"
+        return self._ip
 
     def __enter__(self):
         return self

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -3,6 +3,7 @@ import logging
 import os
 import uuid
 from enum import Enum
+from functools import cached_property
 from tempfile import NamedTemporaryFile
 
 from pycloudlib.instance import BaseInstance
@@ -193,9 +194,18 @@ class IntegrationInstance:
         assert self.execute("apt-get update -q").ok
         assert self.execute("apt-get install -qy cloud-init").ok
 
+    @cached_property
+    def ip(self) -> str:
+        try:
+            return self.instance.ip
+        except NotImplementedError:
+            return "Unknown"
+
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         if not self.settings.KEEP_INSTANCE:
             self.destroy()
+        else:
+            log.info("Keeping Instance, public ip: %s", self.ip)


### PR DESCRIPTION
```
integration tests: Log ip when `KEEP_INSTANCE = True`
```
Typically when I use this setting I expect manual debugging. Showing the IP at teardown is a small convenience for this workflow.

Thoughts?

Example:
```
-------------------------------------------------------------------------------------------- live log teardown --------------------------------------------------------------------------------------------
2022-05-24 04:21:27 INFO      pycloudlib.instance:instance.py:183 executing: sudo -- sh -c 'cloud-init collect-logs -u -t /var/tmp/cloud-init.tar.gz'
2022-05-24 04:21:28 INFO      integration_testing:conftest.py:197 Writing logs to /tmp/cloud_init_test_logs/220523221536/tests/integration_tests/datasources/test_ec2_ipv6/test_dual_stack
2022-05-24 04:21:28 INFO      pycloudlib.instance:instance.py:183 executing: sh -c 'cp /var/tmp/cloud-init.tar.gz /var/tmp/63c25fb8-f836-4f51-bbb1-338e80329930.tmp'
2022-05-24 04:21:28 INFO      paramiko.transport.sftp:sftp.py:158 [chan 26] Opened sftp connection (server version 3)
2022-05-24 04:21:29 INFO      integration_testing:instances.py:211 Keeping Instance, public ip: 3.141.22.101
2022-05-24 04:21:29 INFO      integration_testing:clouds.py:195 Deleting snapshot image created for this testrun: ami-04cbb2d130b638f79
2022-05-24 04:21:30 INFO      paramiko.transport.sftp:sftp.py:158 [chan 9] sftp session closed.
------------------------------------------------------------------------------------------- live log logreport --------------------------------------------------------------------------------------------
2022-05-24 04:21:30 INFO      paramiko.transport.sftp:sftp.py:158 [chan 26] sftp session closed.
```