### PR TITLE
Oracle ds changes

### DIFF
--- a/cloudinit/dmi.py
+++ b/cloudinit/dmi.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import os
 from collections import namedtuple
+from typing import Optional
 
 from cloudinit import log as logging
 from cloudinit import subp
@@ -58,7 +59,7 @@ DMIDECODE_TO_KERNEL = {
 }
 
 
-def _read_dmi_syspath(key):
+def _read_dmi_syspath(key: str) -> Optional[str]:
     """
     Reads dmi data from /sys/class/dmi/id
     """
@@ -96,7 +97,7 @@ def _read_dmi_syspath(key):
     return None
 
 
-def _read_kenv(key):
+def _read_kenv(key: str) -> Optional[str]:
     """
     Reads dmi data from FreeBSD's kenv(1)
     """
@@ -114,12 +115,11 @@ def _read_kenv(key):
         return result
     except subp.ProcessExecutionError as e:
         LOG.debug("failed kenv cmd: %s\n%s", cmd, e)
-        return None
 
     return None
 
 
-def _call_dmidecode(key, dmidecode_path):
+def _call_dmidecode(key: str, dmidecode_path: str) -> Optional[str]:
     """
     Calls out to dmidecode to get the data out. This is mostly for supporting
     OS's without /sys/class/dmi/id support.
@@ -137,7 +137,7 @@ def _call_dmidecode(key, dmidecode_path):
         return None
 
 
-def read_dmi_data(key):
+def read_dmi_data(key: str) -> Optional[str]:
     """
     Wrapper for reading DMI data.
 

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -250,7 +250,7 @@ def has_netfail_standby_feature(devname):
     return features[62] == "1"
 
 
-def is_netfail_master(devname, driver=None):
+def is_netfail_master(devname, driver=None) -> bool:
     """A device is a "netfail master" device if:
 
     - The device does NOT have the 'master' sysfs attribute

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -100,7 +100,7 @@ class PPSType(Enum):
 PLATFORM_ENTROPY_SOURCE: Optional[str] = "/sys/firmware/acpi/tables/OEM0"
 
 # List of static scripts and network config artifacts created by
-# stock ubuntu suported images.
+# stock ubuntu supported images.
 UBUNTU_EXTENDED_NETWORK_SCRIPTS = [
     "/etc/netplan/90-hotplug-azure.yaml",
     "/usr/local/sbin/ephemeral_eth.sh",

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -22,6 +22,7 @@ from typing import Iterator, Optional, Tuple, cast
 from cloudinit import dmi
 from cloudinit import log as logging
 from cloudinit import net, sources, util
+from cloudinit.distros.networking import NetworkConfig
 from cloudinit.net import (
     cmdline,
     dhcp,
@@ -59,7 +60,7 @@ class KlibcOracleNetworkConfigSource(cmdline.KlibcNetworkConfigSource):
         return bool(self._files)
 
 
-def _ensure_netfailover_safe(network_config: sources.NetworkConfig) -> None:
+def _ensure_netfailover_safe(network_config: NetworkConfig) -> None:
     """
     Search network config physical interfaces to see if any of them are
     a netfailover master.  If found, we prevent matching by MAC as the other

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -204,7 +204,7 @@ class DataSourceOracle(sources.DataSource):
         """Return whether we are on a iscsi machine."""
         return self._network_config_source.is_applicable()
 
-    def _get_iscsi_config(self) -> Optional[dict]:
+    def _get_iscsi_config(self) -> dict:
         return self._network_config_source.render_config()
 
     @property

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -260,10 +260,12 @@ class DataSourceOracle(sources.DataSource):
         """
         if self._network_config is None:
             self._network_config = {"config": [], "version": 1}
-        yield
-        if self._network_config == {"config": [], "version": 1}:
-            self._network_config = None
-            LOG.warning("Network config is not configured.")
+        try:
+            yield
+        finally:
+            if self._network_config == {"config": [], "version": 1}:
+                self._network_config = None
+                LOG.warning("Network config is not configured.")
 
     def _add_network_config_from_opc_imds(
         self, primary: bool, secondary: bool

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -988,7 +988,9 @@ def list_sources(cfg_list, depends, pkg_list):
     return src_list
 
 
-def instance_id_matches_system_uuid(instance_id, field: str = "system-uuid") -> bool:
+def instance_id_matches_system_uuid(
+    instance_id, field: str = "system-uuid"
+) -> bool:
     # quickly (local check only) if self.instance_id is still valid
     # we check kernel command line or files.
     if not instance_id:

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -28,6 +28,8 @@ from cloudinit.filters import launch_index
 from cloudinit.persistence import CloudInitPickleMixin
 from cloudinit.reporting import events
 
+NetworkConfig = dict
+
 DSMODE_DISABLED = "disabled"
 DSMODE_LOCAL = "local"
 DSMODE_NETWORK = "net"
@@ -361,7 +363,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         if not attr_defaults:
             self._dirty_cache = False
 
-    def get_data(self):
+    def get_data(self) -> bool:
         """Datasources implement _get_data to setup metadata and userdata_raw.
 
         Minimally, the datasource should return a boolean True on success.
@@ -442,7 +444,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         write_json(json_file, redact_sensitive_keys(processed_data))
         return True
 
-    def _get_data(self):
+    def _get_data(self) -> bool:
         """Walk metadata sources, process crawled data and save attributes."""
         raise NotImplementedError(
             "Subclasses of DataSource must implement _get_data which"
@@ -986,7 +988,7 @@ def list_sources(cfg_list, depends, pkg_list):
     return src_list
 
 
-def instance_id_matches_system_uuid(instance_id, field="system-uuid"):
+def instance_id_matches_system_uuid(instance_id, field: str = "system-uuid") -> bool:
     # quickly (local check only) if self.instance_id is still valid
     # we check kernel command line or files.
     if not instance_id:

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -28,8 +28,6 @@ from cloudinit.filters import launch_index
 from cloudinit.persistence import CloudInitPickleMixin
 from cloudinit.reporting import events
 
-NetworkConfig = dict
-
 DSMODE_DISABLED = "disabled"
 DSMODE_LOCAL = "local"
 DSMODE_NETWORK = "net"

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@2eba2592d598562425016867a119f7675a85f42c
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@ba29161a1bb494576ea7ed3e2c69f6f9dd4c7985
 pytest

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@ba29161a1bb494576ea7ed3e2c69f6f9dd4c7985
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@c42341990cb35460946ee04e2623d0f9fffe2b3c
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ module = [
   "httplib",
   "jsonpatch",
   "netifaces",
+  "oci",
   "paramiko.*",
   "pycloudlib.*",
   "responses",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ module = [
   "httplib",
   "jsonpatch",
   "netifaces",
-  "oci",
   "paramiko.*",
   "pycloudlib.*",
   "responses",

--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -8,7 +8,7 @@ from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import verify_clean_log
 
 
-def _customize_envionment(client: IntegrationInstance):
+def _customize_environment(client: IntegrationInstance):
     # Assert our platform can detect LXD during systemd generator timeframe.
     ds_id_log = client.execute("cat /run/cloud-init/ds-identify.log").stdout
     assert "check for 'LXD' returned found" in ds_id_log
@@ -54,7 +54,7 @@ def _customize_envionment(client: IntegrationInstance):
 def test_lxd_datasource_discovery(client: IntegrationInstance):
     """Test that DataSourceLXD is detected instead of NoCloud."""
 
-    _customize_envionment(client)
+    _customize_environment(client)
     result = client.execute("cloud-init status --wait --long")
     if not result.ok:
         raise AssertionError("cloud-init failed:\n%s", result.stderr)

--- a/tests/integration_tests/datasources/test_network_dependency.py
+++ b/tests/integration_tests/datasources/test_network_dependency.py
@@ -3,7 +3,7 @@ import pytest
 from tests.integration_tests.instances import IntegrationInstance
 
 
-def _customize_envionment(client: IntegrationInstance):
+def _customize_environment(client: IntegrationInstance):
     # Insert our "disable_network_activation" file here
     client.write_to_file(
         "/etc/cloud/cloud.cfg.d/99-disable-network-activation.cfg",
@@ -19,7 +19,7 @@ def _customize_envionment(client: IntegrationInstance):
 @pytest.mark.ubuntu  # Because netplan
 def test_network_activation_disabled(client: IntegrationInstance):
     """Test that the network is not activated during init mode."""
-    _customize_envionment(client)
+    _customize_environment(client)
     result = client.execute("systemctl status google-guest-agent.service")
     if not result.ok:
         raise AssertionError(

--- a/tests/integration_tests/datasources/test_oci_networking.py
+++ b/tests/integration_tests/datasources/test_oci_networking.py
@@ -50,8 +50,6 @@ def test_oci_networking_iscsi_instance(client: IntegrationInstance):
     assert result_net_files.ok, "No net files found under /run"
 
     log = client.read_from_file("/var/log/cloud-init.log")
-    with open("oci.log", "w") as f:
-        f.write(log)
     verify_clean_log(log)
 
     assert (
@@ -132,8 +130,6 @@ def test_oci_networking_iscsi_instance_secondary_vnics(
     _customize_environment(client, iscsi=True)
 
     log = client.read_from_file("/var/log/cloud-init.log")
-    with open("oci.log", "w") as f:
-        f.write(log)
     verify_clean_log(log)
 
     assert "opc/v2/vnics/" in log, f"vnics data not fetched in {log}"

--- a/tests/integration_tests/datasources/test_oci_networking.py
+++ b/tests/integration_tests/datasources/test_oci_networking.py
@@ -1,5 +1,5 @@
 import re
-from typing import Set
+from typing import Iterator, Set
 
 import oci
 import pytest
@@ -93,8 +93,10 @@ def test_oci_networking_iscsi_instance(client: IntegrationInstance, tmpdir):
 
 
 @pytest.fixture(scope="function")
-def client_with_secondary_vnic(session_cloud: IntegrationCloud):
-    """Attach a temporary vnic to the created instance
+def client_with_secondary_vnic(
+    session_cloud: IntegrationCloud,
+) -> Iterator[IntegrationInstance]:
+    """Create an instance client and attach a temporary vnic.
 
     Note: It assumes the associated compartment has at least one subnet and
     creates the vnic in the first encountered subnet.
@@ -134,7 +136,7 @@ def client_with_secondary_vnic(session_cloud: IntegrationCloud):
 
 @pytest.mark.oci
 def test_oci_networking_iscsi_instance_secondary_vnics(
-    client_with_secondary_vnic, tmpdir
+    client_with_secondary_vnic: IntegrationInstance, tmpdir
 ):
     client = client_with_secondary_vnic
     _customize_environment(

--- a/tests/integration_tests/datasources/test_oci_networking.py
+++ b/tests/integration_tests/datasources/test_oci_networking.py
@@ -11,7 +11,6 @@ from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import verify_clean_log
 
 DS_CFG = """\
-#cloud-config
 datasource:
   Oracle:
     configure_secondary_nics: {configure_secondary_nics}
@@ -23,12 +22,6 @@ def customize_environment(
     tmpdir,
     configure_secondary_nics: bool = False,
 ):
-    assert client.execute("rm -f /run/initramfs/open-iscsi.interface").ok
-    # Force network config
-    assert client.execute(
-        "rm -f /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
-    ).ok
-
     cfg = tmpdir.join("01_oracle_datasource.cfg")
     with open(cfg, "w") as f:
         f.write(
@@ -63,7 +56,7 @@ def test_oci_networking_iscsi_instance(client: IntegrationInstance, tmpdir):
 
     assert (
         "opc/v2/vnics/" not in log
-    ), "vnic data was fetched and it should no have been"
+    ), "vnic data was fetched and it should not have been"
 
     netplan_yaml = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
     netplan_cfg = yaml.safe_load(netplan_yaml)

--- a/tests/integration_tests/datasources/test_oci_networking.py
+++ b/tests/integration_tests/datasources/test_oci_networking.py
@@ -7,7 +7,6 @@ import yaml
 from pycloudlib.oci.utils import wait_till_ready
 
 from tests.integration_tests.clouds import IntegrationCloud
-from tests.integration_tests.conftest import get_validated_source
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import verify_clean_log
 

--- a/tests/integration_tests/datasources/test_oci_networking.py
+++ b/tests/integration_tests/datasources/test_oci_networking.py
@@ -18,16 +18,12 @@ datasource:
 """
 
 
-def _customize_environment(
+def customize_environment(
     client: IntegrationInstance,
     tmpdir,
     configure_secondary_nics: bool = False,
-    iscsi: bool = True,
 ):
     assert client.execute("rm -f /run/initramfs/open-iscsi.interface").ok
-    if not iscsi:
-        assert client.execute("rm -f /run/net-*.conf").ok
-
     # Force network config
     assert client.execute(
         "rm -f /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
@@ -58,9 +54,7 @@ def extract_interface_names(network_config: dict) -> Set[str]:
 
 @pytest.mark.oci
 def test_oci_networking_iscsi_instance(client: IntegrationInstance, tmpdir):
-    _customize_environment(
-        client, tmpdir, configure_secondary_nics=False, iscsi=True
-    )
+    customize_environment(client, tmpdir, configure_secondary_nics=False)
     result_net_files = client.execute("ls /run/net-*.conf")
     assert result_net_files.ok, "No net files found under /run"
 
@@ -74,22 +68,26 @@ def test_oci_networking_iscsi_instance(client: IntegrationInstance, tmpdir):
     netplan_yaml = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
     netplan_cfg = yaml.safe_load(netplan_yaml)
     configured_interfaces = extract_interface_names(netplan_cfg["network"])
+    assert 1 <= len(
+        configured_interfaces
+    ), "Expected at least 1 primary network configuration."
 
-    expeceted_interfaces = set(
+    expected_interfaces = set(
         re.findall(r"/run/net-(.+)\.conf", result_net_files.stdout)
     )
-    for expected_interface in expeceted_interfaces:
+    for expected_interface in expected_interfaces:
         assert (
             f"Reading from /run/net-{expected_interface}.conf" in log
         ), "Expected {expected_interface} not found in: {log}"
 
-    not_found_interfaces = expeceted_interfaces.difference(
+    not_found_interfaces = expected_interfaces.difference(
         configured_interfaces
     )
     assert not not_found_interfaces, (
         f"Interfaces, {not_found_interfaces}, expected to be configured in"
         f" {netplan_cfg['network']}"
     )
+    assert client.execute("ping -c 2 canonical.com").ok
 
 
 @pytest.fixture(scope="function")
@@ -139,9 +137,7 @@ def test_oci_networking_iscsi_instance_secondary_vnics(
     client_with_secondary_vnic: IntegrationInstance, tmpdir
 ):
     client = client_with_secondary_vnic
-    _customize_environment(
-        client, tmpdir, configure_secondary_nics=True, iscsi=True
-    )
+    customize_environment(client, tmpdir, configure_secondary_nics=True)
 
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
@@ -150,26 +146,13 @@ def test_oci_networking_iscsi_instance_secondary_vnics(
     netplan_yaml = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
     netplan_cfg = yaml.safe_load(netplan_yaml)
     configured_interfaces = extract_interface_names(netplan_cfg["network"])
-    assert 2 == len(configured_interfaces)
+    assert 2 <= len(
+        configured_interfaces
+    ), "Expected at least 1 primary and 1 secondary network configurations"
 
-
-@pytest.mark.skip(
-    reason="Figure out how to configure a non iscsi network instance in oci"
-)
-@pytest.mark.oci
-def test_oci_networking_non_iscsi_instance(
-    session_cloud: IntegrationCloud, tmpdir
-):
-    launch_options = oci.core.models.LaunchOptions(
-        boot_volume_type=oci.core.models.LaunchOptions.BOOT_VOLUME_TYPE_VFIO,
-        network_type=oci.core.models.LaunchOptions.NETWORK_TYPE_VFIO,
+    result_net_files = client.execute("ls /run/net-*.conf")
+    expected_interfaces = set(
+        re.findall(r"/run/net-(.+)\.conf", result_net_files.stdout)
     )
-    with session_cloud.launch(
-        launch_kwargs={"launch_options": launch_options}
-    ) as client:
-        _customize_environment(
-            client, tmpdir, configure_secondary_nics=False, iscsi=False
-        )
-        log = client.read_from_file("/var/log/cloud-init.log")
-        verify_clean_log(log)
-        assert "opc/v2/vnics/" in log, f"vnics data not fetched in {log}"
+    assert len(expected_interfaces) + 1 == len(configured_interfaces)
+    assert client.execute("ping -c 2 canonical.com").ok

--- a/tests/integration_tests/datasources/test_oci_networking.py
+++ b/tests/integration_tests/datasources/test_oci_networking.py
@@ -1,0 +1,162 @@
+import re
+from typing import Set
+
+import oci
+import pytest
+import yaml
+from pycloudlib.oci.utils import wait_till_ready
+
+from tests.integration_tests.clouds import IntegrationCloud
+from tests.integration_tests.conftest import get_validated_source
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+DS_CFG = """\
+#cloud-config
+datasource:
+  Oracle:
+    configure_secondary_nics: True
+"""
+
+
+def _customize_environment(client: IntegrationInstance, iscsi: bool = True):
+    assert client.execute("rm -f /run/initramfs/open-iscsi.interface").ok
+    if not iscsi:
+        assert client.execute("rm -f /run/net-*.conf").ok
+
+    # Force network config
+    assert client.execute(
+        "rm -f /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
+    ).ok
+    client.execute("cloud-init clean --logs")
+    client.restart()
+
+
+def extract_interface_names(network_config: dict) -> Set[str]:
+    if network_config["version"] == 1:
+        interfaces = map(lambda conf: conf["name"], network_config["config"])
+    elif network_config["version"] == 2:
+        interfaces = network_config["ethernets"].keys()
+    else:
+        raise NotImplementedError(
+            f'Implement me for version={network_config["version"]}'
+        )
+    return set(interfaces)
+
+
+@pytest.mark.oci
+def test_oci_networking_iscsi_instance(client: IntegrationInstance):
+    _customize_environment(client, iscsi=True)
+    result_net_files = client.execute("ls /run/net-*.conf")
+    assert result_net_files.ok, "No net files found under /run"
+
+    log = client.read_from_file("/var/log/cloud-init.log")
+    with open("oci.log", "w") as f:
+        f.write(log)
+    verify_clean_log(log)
+
+    assert (
+        "opc/v2/vnics/" not in log
+    ), "vnic data was fetched and it should no have been"
+
+    netplan_yaml = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
+    netplan_cfg = yaml.safe_load(netplan_yaml)
+    configured_interfaces = extract_interface_names(netplan_cfg["network"])
+
+    expeceted_interfaces = set(
+        re.findall(r"/run/net-(.+)\.conf", result_net_files.stdout)
+    )
+    for expected_interface in expeceted_interfaces:
+        assert (
+            f"Reading from /run/net-{expected_interface}.conf" in log
+        ), "Expected {expected_interface} not found in: {log}"
+
+    not_found_interfaces = expeceted_interfaces.difference(
+        configured_interfaces
+    )
+    assert not not_found_interfaces, (
+        f"Interfaces, {not_found_interfaces}, expected to be configured in"
+        f" {netplan_cfg['network']}"
+    )
+
+
+@pytest.fixture(scope="function")
+def client_with_secondary_vnic(session_cloud: IntegrationCloud):
+    """Attach a temporary vnic to the created instance
+
+    Note: It assumes the associated compartment has at least one subnet and
+    creates the vnic in the first encountered subnet.
+    """
+    with session_cloud.launch(launch_kwargs={}) as client:
+        compute_client = session_cloud.cloud_instance.compute_client
+
+        subnet_id = (
+            client.instance.network_client.list_subnets(
+                client.instance.compartment_id, limit=1
+            )
+            .data[0]
+            .id
+        )
+        create_vnic_details = oci.core.models.CreateVnicDetails(
+            assign_private_dns_record=False,
+            assign_public_ip=False,
+            subnet_id=subnet_id,
+        )
+        attach_vnic_details = oci.core.models.AttachVnicDetails(
+            create_vnic_details=create_vnic_details,
+            instance_id=client.instance.instance_id,
+        )
+        vnic_data = compute_client.attach_vnic(attach_vnic_details).data
+
+        wait_till_ready(
+            func=compute_client.get_vnic_attachment,
+            current_data=vnic_data,
+            desired_state=vnic_data.LIFECYCLE_STATE_ATTACHED,
+        )
+        yield client
+        response = compute_client.detach_vnic(vnic_data.id)
+        assert (
+            response.status == 204
+        ), f"Attached vnic not deleted: {vnic_data.id}"
+
+
+@pytest.mark.oci
+def test_oci_networking_iscsi_instance_secondary_vnics(
+    client_with_secondary_vnic, tmpdir
+):
+    client = client_with_secondary_vnic
+
+    cfg = tmpdir.join("01_oracle_datasource.cfg")
+    with open(cfg, "w") as f:
+        f.write(DS_CFG)
+    client.push_file(cfg, "/etc/cloud/cloud.cfg.d/01_oracle_datasource.cfg")
+    _customize_environment(client, iscsi=True)
+
+    log = client.read_from_file("/var/log/cloud-init.log")
+    with open("oci.log", "w") as f:
+        f.write(log)
+    verify_clean_log(log)
+
+    assert "opc/v2/vnics/" in log, f"vnics data not fetched in {log}"
+    netplan_yaml = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
+    netplan_cfg = yaml.safe_load(netplan_yaml)
+    configured_interfaces = extract_interface_names(netplan_cfg["network"])
+    assert 2 == len(configured_interfaces)
+
+
+@pytest.mark.skip(
+    reason="Figure out how to configure a non iscsi network instance in oci"
+)
+@pytest.mark.oci
+def test_oci_networking_non_iscsi_instance(session_cloud: IntegrationCloud):
+    launch_options = oci.core.models.LaunchOptions(
+        boot_volume_type=oci.core.models.LaunchOptions.BOOT_VOLUME_TYPE_VFIO,
+        network_type=oci.core.models.LaunchOptions.NETWORK_TYPE_VFIO,
+    )
+    with session_cloud.launch(
+        launch_kwargs={"launch_options": launch_options}
+    ) as client:
+        _customize_environment(client, iscsi=False)
+        log = client.read_from_file("/var/log/cloud-init.log")
+        verify_clean_log(log)
+        assert "opc/v2/vnics/" in log, f"vnics data not fetched in {log}"

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -1,5 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import os
+from typing import Optional
 
 from cloudinit.util import is_false, is_true
 
@@ -26,7 +27,7 @@ PLATFORM = "lxd_container"
 
 # The cloud-specific instance type to run. E.g., a1.medium on AWS
 # If the pycloudlib instance provides a default, this can be left None
-INSTANCE_TYPE = None
+INSTANCE_TYPE: Optional[str] = None
 
 # Determines the base image to use or generate new images from.
 #
@@ -38,7 +39,7 @@ OS_IMAGE = "focal"
 
 # Populate if you want to use a pre-launched instance instead of
 # creating a new one. The exact contents will be platform dependent
-EXISTING_INSTANCE_ID = None
+EXISTING_INSTANCE_ID: Optional[str] = None
 
 ##################################################################
 # IMAGE GENERATION SETTINGS

--- a/tests/unittests/distros/test_networking.py
+++ b/tests/unittests/distros/test_networking.py
@@ -2,7 +2,6 @@
 # /parametrize.html#parametrizing-conditional-raising
 
 import textwrap
-from contextlib import ExitStack as does_not_raise
 from unittest import mock
 
 import pytest
@@ -14,6 +13,7 @@ from cloudinit.distros.networking import (
     LinuxNetworking,
     Networking,
 )
+from tests.unittests.helpers import does_not_raise
 
 
 @pytest.fixture

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -72,6 +72,13 @@ def retarget_many_wrapper(new_base, am, old_func):
     return wrapper
 
 
+def random_string(length=8):
+    """return a random lowercase string with default length of 8"""
+    return "".join(
+        random.choice(string.ascii_lowercase) for _ in range(length)
+    )
+
+
 class TestCase(unittest.TestCase):
     def reset_global_state(self):
         """Reset any global state to its original settings.
@@ -86,9 +93,13 @@ class TestCase(unittest.TestCase):
         In the future this should really be done with some registry that
         can then be cleaned in a more obvious way.
         """
-        util.PROC_CMDLINE = None
+        assert getattr(util, "PROC_CMDLINE", None) is None, getattr(
+            util, "PROC_CMDLINE", None
+        )
         util._DNS_REDIRECT_IP = None
-        util._LSB_RELEASE = {}
+        assert not getattr(util, "_LSB_RELEASE", None), getattr(
+            util, "_LSB_RELEASE", None
+        )
 
     def setUp(self):
         super(TestCase, self).setUp()
@@ -227,10 +238,7 @@ class CiTestCase(TestCase):
 
     @classmethod
     def random_string(cls, length=8):
-        """return a random lowercase string with default length of 8"""
-        return "".join(
-            random.choice(string.ascii_lowercase) for _ in range(length)
-        )
+        return random_string(length)
 
 
 class ResourceUsingTestCase(CiTestCase):

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -93,13 +93,7 @@ class TestCase(unittest.TestCase):
         In the future this should really be done with some registry that
         can then be cleaned in a more obvious way.
         """
-        assert getattr(util, "PROC_CMDLINE", None) is None, getattr(
-            util, "PROC_CMDLINE", None
-        )
         util._DNS_REDIRECT_IP = None
-        assert not getattr(util, "_LSB_RELEASE", None), getattr(
-            util, "_LSB_RELEASE", None
-        )
 
     def setUp(self):
         super(TestCase, self).setUp()

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -18,6 +18,7 @@ from unittest import mock
 from unittest.util import strclass
 
 import httpretty
+import pytest
 
 import cloudinit
 from cloudinit import cloud, distros
@@ -552,6 +553,34 @@ def cloud_init_project_dir(sub_path: str) -> str:
     Example: cloud_init_project_dir("my/path") -> "/path/to/cloud-init/my/path"
     """
     return str(get_top_level_dir() / sub_path)
+
+
+@contextmanager
+def does_not_raise():
+    """Context manager to parametrize tests raising and not raising exceptions
+
+    Note: In python-3.7+, this can be substituted by contextlib.nullcontext
+    More info:
+    https://docs.pytest.org/en/6.2.x/example/parametrize.html?highlight=does_not_raise#parametrizing-conditional-raising
+
+    Example:
+    --------
+    >>> @pytest.mark.parametrize(
+    >>>     "example_input,expectation",
+    >>>     [
+    >>>         (1, does_not_raise()),
+    >>>         (0, pytest.raises(ZeroDivisionError)),
+    >>>     ],
+    >>> )
+    >>> def test_division(example_input, expectation):
+    >>>     with expectation:
+    >>>         assert (0 / example_input) is not None
+
+    """
+    try:
+        yield
+    except Exception as ex:
+        raise pytest.fail("DID RAISE {0}".format(ex))
 
 
 # vi: ts=4 expandtab

--- a/tox.ini
+++ b/tox.ini
@@ -242,3 +242,4 @@ markers =
     ubuntu: this test should run on Ubuntu
     unstable: skip this test because it is flakey
     adhoc: only run on adhoc basis, not in any CI environment (travis or jenkins)
+    is_iscsi: whether is an instance has iscsi net cfg or not


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

iSCSI-based config is limited to older images in Oracle. 
cloud-init need to prefer network content from vNIC IMDS crawl.

1. Use /run/net-* files if they exist. Currently if /run/initramfs/open-iscsi.interface does not exist, we do not use them.
2. If we cannot obtain networking information from /run/net-* files, use IMDS to configure the primary interface. Currently IMDS is ONLY used for secondary interfaces, and if the iSCSI files don’t exist, we use the fallback “best guess” method as our primary interface.

```
DS Oracle network changes

For primary network config:
- Use `iSCSI` config if some `/run/net*` file exists, even if 
  `/run/initramfs/open-iscsi.interface` does not.
- If the instance is not an `iSCSI` one, then crawl the network
  config from `IMDS` instead of falling back to "best guess".

- Remove unnecessary conditional use of dhcp.EphemeralDHCPv4
  and use it always to crawl `IMDS`.
- Migrate tests to pytest.
- Extend unit test coverage.
- Add some types for mypy.

LP: #1967942
```

## Additional Context
<!-- If relevant -->
SC-907
LP: #1967942

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Instantiate a normal and a BM instance with an Ubuntu cloud image containing this `cloud-init` version.
ssh into it and  execute: 

```sh
$ cloud-init status
status: done
$ cat /var/log/cloud-init.log | grep -iE "warning|error"
$ ping -c 2 canonical.com
PING canonical.com (185.125.190.20) 56(84) bytes of data.
64 bytes from website-content-cache-1.canonical.com (185.125.190.20): icmp_seq=1 ttl=56 time=97.9 ms
64 bytes from website-content-cache-1.canonical.com (185.125.190.20): icmp_seq=2 ttl=56 time=121 ms

--- canonical.com ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 97.943/109.233/120.524/11.290 ms
```

### Deeper inspection

#### ISCSI instance

Instantiate an Ubuntu BM instance and ssh into it.

```sh
git clone --branch oracle_ds_changes https://github.com/aciba90/cloud-init.git
cd cloud-init
sudo PYTHONPATH=. python3
```

Manual test network config:

```py
>>> from cloudinit.cmd.main import *
>>> from cloudinit.sources.DataSourceOracle import DataSourceOracle
>>> init = stages.Init()
>>> init.read_cfg()
>>> init.initialize()
>>> ds = DataSourceOracle({}, init.distro, init.paths)
>>> ds._is_iscsi_root()  # iscsi instance
True
>>> ds._get_iscsi_config()
{'config': [{'type': 'physical', 'name': 'ens2f0', 'subnets': [{'type': 'dhcp', 'control': 'manual', 'netmask': '255.255.255.0', 'broadcast': '20.0.0.255', 'gateway': '20.0.0.1', 'dns_nameservers': ['169.254.169.254'], 'dns_search': ['vcn04151407.oraclevcn.com']}], 'mac_address': '90:e2:ba:ac:fe:1c'}], 'version': 1}
>>> ds._network_config
>>> ds._get_data()
True
>>> ds._vnics_data
>>> ds._network_config
>>> ds.network_config
{'config': [{'type': 'physical', 'name': 'ens2f0', 'subnets': [{'type': 'dhcp', 'control': 'manual', 'netmask': '255.255.255.0', 'broadcast': '20.0.0.255', 'gateway': '20.0.0.1', 'dns_nameservers': ['169.254.169.254'], 'dns_search': ['vcn04151407.oraclevcn.com']}], 'mac_address': '90:e2:ba:ac:fe:1c'}], 'version': 1}
```

#### Non-ISCSI instance

Ssh into an instance.

```sh
git clone --branch oracle_ds_changes https://github.com/aciba90/cloud-init.git
cd cloud-init
sudo rm -rf /run/net-*.conf  # Ensure the instance is not detected as iscsi
sudo PYTHONPATH=. python3
```

Manual test network config:

```py
>>> from cloudinit.cmd.main import *
>>> from cloudinit.sources.DataSourceOracle import DataSourceOracle
>>> init = stages.Init()
>>> init.read_cfg()
>>> init.initialize()
>>> ds = DataSourceOracle({}, init.distro, init.paths)
>>> ds._is_iscsi_root()  # non-iscsi instance
False
>>> ds._get_iscsi_config()
>>> ds._network_config
>>> ds._get_data()
True
>>> ds._vnics_data
[{'vnicId': 'ocid1.vnic.oc1.phx.abyhqljttvu5zfaqmd6i3tarkdflmoviy6wv5slk7m5432y3bmfr3zhlwviq', 'privateIp': '20.0.0.132', 'vlanTag': 388, 'macAddr': '00:00:17:02:B8:C1', 'virtualRouterIp': '20.0.0.1', 'subnetCidrBlock': '20.0.0.0/24'}]
>>> ds._network_config
>>> ds.network_config
{'config': [{'name': 'ens3', 'type': 'physical', 'mac_address': '00:00:17:02:b8:c1', 'mtu': 9000, 'subnets': [{'type': 'static', 'address': '20.0.0.132'}]}], 'version': 1}
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
