### PR TITLE
schema: write_files defaults, versions $ref full URL and add vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "redhat.vscode-yaml"
+  ]
+}

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2089,7 +2089,7 @@
               },
               "content": {
                 "type": "string",
-                "default": "",
+                "default": "''",
                 "description": "Optional content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``"
               },
               "owner": {
@@ -2099,7 +2099,7 @@
               },
               "permissions": {
                 "type": "string",
-                "default": "0o644",
+                "default": "'0o644'",
                 "description": "Optional file permissions to set on ``path`` represented as an octal string '0###'. Default: ``0o644``"
               },
               "encoding": {

--- a/cloudinit/config/schemas/versions.schema.cloud-config.json
+++ b/cloudinit/config/schemas/versions.schema.cloud-config.json
@@ -11,7 +11,7 @@
             }
           }
         },
-        {"$ref": "./schema-cloud-config-v1.json"}
+        {"$ref": "https://raw.githubusercontent.com/canonical/cloud-init/main/cloudinit/config/schemas/schema-cloud-config-v1.json"}
       ]
     }
   ]


### PR DESCRIPTION
## Proposed Commit Message
```
schema: write_files defaults, versions $ref full URL and add vscode

* Set write_files.permissions and content defaults the correct "string"
   data type. This aids in vscode auto-completion which injects default
   values for defined cloud-config keys.

* Make the $ref URI a full URL to our schema-cloud-config-v1.json
   JSON schema Draft-04 does not support relative $ref URLs which
   prevents validators like https://www.jsonschemavalidator.net/
   from parsing our versions schema with the error:
      Error when resolving schema reference './schema-cloud...json'.

* Add vscode exstentions for validatating #cloud-config YAML
    Developers using the cloud-init repo are likely to also
    want to create #cloud-config YAML files for development. Provide
    the suggested YAML extension in .vscode/extensions.json.
    
    This YAML extension will prompt vscode developers with the following
    message upon opening the cloud-init repo:
    
      'YAML' extension is recommended for this repository. Do you want
      to install?
    
    This RedHat YAML extension sources public schemas from
    https://schemastore.org and will treat the following file formats as
    as #cloud-config files:

      cloud-init.yaml
      cloudinit.yaml
      *.cloud-init.yaml
      *.cloudinit.yaml
  
    Any filenames matching those formats will get automatic validation
    against cloud-config schema and auto-complete known #cloud-config
    keys.
```

## Additional Context
<!-- If relevant -->

## Test Steps
1. [install vscode](https://code.visualstudio.com/download)
2. Start vscode in the cloud-init directory with this PR
```bash
cd cloud-init
code
```
3. Open the new cloud-init project in vscode
4. See and click "Blue Install button in lower right corner for the recommended YAML extension
5. Use the file navigator to open the cloud-init directory 
6. Create a new file named cloud-config.yaml    
7. Notice that a header link to "schema-cloud-config-v1.json" is rendered at the top you the cloud-config.yaml file
8. start typing any characters and see drop down menus of auto-completion vscode intellisense suggestions for known cloud-config schema.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
