### PR TITLE
cc_yum_add_repo: Fix repo id canonicalization

### DIFF
--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -99,8 +99,8 @@ meta: MetaSchema = {
             # the repository file created. See: man yum.conf for supported
             # config keys.
             #
-            # Write /etc/yum.conf.d/my_package_stream.repo with gpgkey checks
-            # on the repo data of the repositoy enabled.
+            # Write /etc/yum.conf.d/my-package-stream.repo with gpgkey checks
+            # on the repo data of the repository enabled.
             yum_repos:
               my package stream:
                 baseurl: http://blah.org/pub/epel/testing/5/$basearch/
@@ -117,10 +117,17 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def _canonicalize_id(repo_id):
-    repo_id = repo_id.lower().replace("-", "_")
-    repo_id = repo_id.replace(" ", "_")
-    return repo_id
+def _canonicalize_id(repo_id: str) -> str:
+    """Canonicalize repo id.
+
+    The sole name convention for repo ids is to not contain namespaces,
+    and typically the separator used is `-`. More info:
+    https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sec-setting_repository_options
+
+    :param repo_id: Repo id to convert.
+    :return: Canonical repo id.
+    """
+    return repo_id.replace(" ", "-")
 
 
 def _format_repo_value(val):

--- a/tests/unittests/config/test_cc_yum_add_repo.py
+++ b/tests/unittests/config/test_cc_yum_add_repo.py
@@ -61,11 +61,11 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         }
         self.patchUtils(self.tmp)
         cc_yum_add_repo.handle("yum_add_repo", cfg, None, LOG, [])
-        contents = util.load_file("/etc/yum.repos.d/epel_testing.repo")
+        contents = util.load_file("/etc/yum.repos.d/epel-testing.repo")
         parser = configparser.ConfigParser()
         parser.read_string(contents)
         expected = {
-            "epel_testing": {
+            "epel-testing": {
                 "name": "Extra Packages for Enterprise Linux 5 - Testing",
                 "failovermethod": "priority",
                 "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL",
@@ -101,11 +101,11 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         }
         self.patchUtils(self.tmp)
         cc_yum_add_repo.handle("yum_add_repo", cfg, None, LOG, [])
-        contents = util.load_file("/etc/yum.repos.d/puppetlabs_products.repo")
+        contents = util.load_file("/etc/yum.repos.d/puppetlabs-products.repo")
         parser = configparser.ConfigParser()
         parser.read_string(contents)
         expected = {
-            "puppetlabs_products": {
+            "puppetlabs-products": {
                 "name": "Puppet Labs Products El 6 - $basearch",
                 "baseurl": "http://yum.puppetlabs.com/el/6/products/$basearch",
                 "gpgkey": (


### PR DESCRIPTION
Prefer "-" as repo id separator.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_yum_add_repo: Fix repo id canonicalization

Prefer "-" as repo id separator.

LP: #1975818
```

## Additional Context
<!-- If relevant -->
SC-1086
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/sec-setting_repository_options

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```sh
cat <<EOT > /tmp/user-data.yaml
#cloud-config
yum_repos:
  rhel-8.5-appstream-mycloud:
    baseurl: <url>
    name: "repo name"
    enabled: True
EOT

lxc launch images:fedora/36/cloud fedora --config=user.user-data="$(cat /tmp/user-data.yaml)"
lxc exec fedora -- cloud-init status --wait

$ lxc exec fedora -- cat /etc/yum.repos.d/rhel-8.5-appstream-mycloud.repo
[rhel-8.5-appstream-mycloud]
baseurl = ...
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
