### PR TITLE
Adminpass metadata

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -172,6 +172,13 @@ def handle(_name, cfg, cloud, log, args):
         password = util.get_cfg_option_str(cfg, "password", None)
 
     expire = True
+
+    # get_admin_pass() returns either:
+    # (None, True)
+    # or
+    # ("password", False)
+    if not password:
+        password, expire = cloud.datasource.get_admin_pass()
     plist = None
 
     if "chpasswd" in cfg:

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -68,6 +68,12 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
         mstr = "%s [%s,ver=%s]" % (root, self.dsmode, self.version)
         return mstr
 
+    def get_admin_pass(self):
+        if self.metadata and "admin_pass" in self.metadata:
+            password = self.metadata["admin_pass"]
+            expire = False
+        return (password, expire)
+
     def wait_for_metadata_service(self):
         urls = self.ds_cfg.get("metadata_urls", [DEF_MD_URL])
         filtered = [x for x in urls if util.is_resolvable_url(x)]

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -361,6 +361,9 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         if not attr_defaults:
             self._dirty_cache = False
 
+    def get_admin_pass(self):
+        return (None, True)
+
     def get_data(self) -> bool:
         """Datasources implement _get_data to setup metadata and userdata_raw.
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -54,6 +54,7 @@ kallioli
 klausenbusk
 KsenijaS
 landon912
+linitio
 lkundrak
 lucasmoura
 lucendio


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add support to use admin_pass key from metadata server to set password instance. For example in rebuild or rescue process
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
