### PR TITLE
3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,6 +150,7 @@ matrix:
             - make check_spelling && tox
         # Test all supported Python versions (but at the end, so we schedule
         # longer-running jobs first)
+        - python: 3.11-dev
         - python: "3.10"
         - python: 3.9
         - python: 3.8


### PR DESCRIPTION
```
ci: add python 3.11 (currently unreleased)
```

I pushed this PR with the intention of grabbing failure logs for a ticket tracking future changes in upstream python, but since this passed maybe we just merge it? I am ambivalent about it - if any objections feel free to close.