### PR TITLE
Fix integration test client creation

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -20,7 +20,7 @@ from pycloudlib import (
 )
 from pycloudlib.cloud import BaseCloud
 from pycloudlib.lxd.cloud import _BaseLXD
-from pycloudlib.lxd.instance import LXDInstance
+from pycloudlib.lxd.instance import BaseInstance, LXDInstance
 
 import cloudinit
 from cloudinit.subp import ProcessExecutionError, subp
@@ -126,7 +126,7 @@ class IntegrationCloud(ABC):
         except (ValueError, IndexError):
             return image.image_id
 
-    def _perform_launch(self, launch_kwargs, **kwargs):
+    def _perform_launch(self, launch_kwargs, **kwargs) -> BaseInstance:
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
         return pycloudlib_instance
 
@@ -145,10 +145,11 @@ class IntegrationCloud(ABC):
                 "Instance id: %s",
                 self.settings.EXISTING_INSTANCE_ID,
             )
-            self.instance = self.cloud_instance.get_instance(
+            pycloudlib_instance = self.cloud_instance.get_instance(
                 self.settings.EXISTING_INSTANCE_ID
             )
-            return self.instance
+            instance = self.get_instance(pycloudlib_instance, settings)
+            return instance
         default_launch_kwargs = {
             "image_id": self.image_id,
             "user_data": user_data,
@@ -174,7 +175,9 @@ class IntegrationCloud(ABC):
                 log.info("image serial: %s", serial.split()[1])
         return instance
 
-    def get_instance(self, cloud_instance, settings=integration_settings):
+    def get_instance(
+        self, cloud_instance, settings=integration_settings
+    ) -> IntegrationInstance:
         return IntegrationInstance(self, cloud_instance, settings)
 
     def destroy(self):


### PR DESCRIPTION
In the case of pre-launched instances, the IntegrationInstance
client creation did return a pycloudlib.BaseInstance instead of
an IntegrationInstance.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix integration test client creation

In the case of pre-launched instances, the IntegrationInstance
client creation did return a pycloudlib.BaseInstance instead of
an IntegrationInstance.
```

## Additional Context
<!-- If relevant -->
SC-1091

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

1. Create manually a cloud Instance.
2. Configure the instance_id in `tests/integration_tests/integration_settings.py::EXISTING_INSTANCE_ID`.
3. Execute an integration hitting the configured cloud.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
