### PR TITLE
Add user/group '-' deprecation warning (SC-1095)

### DIFF
--- a/cloudinit/distros/ug_util.py
+++ b/cloudinit/distros/ug_util.py
@@ -110,9 +110,17 @@ def _normalize_users(u_cfg, def_user_cfg=None):
         for uname, uconfig in users.items():
             c_uconfig = {}
             for k, v in uconfig.items():
-                k = k.replace("-", "_").strip()
-                if k:
-                    c_uconfig[k] = v
+                new_k = k.replace("-", "_").strip()
+                if k != new_k:
+                    LOG.warning(
+                        "User/Group key '%s' is deprecated and will be "
+                        "removed in a future version of cloud-init. Use '%s' "
+                        "instead.",
+                        k,
+                        new_k,
+                    )
+                if new_k:
+                    c_uconfig[new_k] = v
             c_users[uname] = c_uconfig
         users = c_users
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add user/group '-' deprecation warning

Any user/group userdata key that has an '_' can also be used
with '-' instead. Add a deprecation warning if '-' is specified.

LP: #1977818
```

## Additional Context
See https://superuser.com/questions/1725127/invalid-config-for-cloud-init-but-apparently-still-works-how-do-i-remove-the/

Using the userdata in that post, I now see this in the logs:
```
2022-06-07 12:54:44,954 - ug_util.py[WARNING]: User/Group key 'ssh-authorized-keys' is deprecated and will be removed in a future version of cloud-init. Use 'ssh_authorized_keys' instead.
```
