### PR TITLE
Only run github actions on pull request (SC-1094)

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -1,6 +1,5 @@
 name: Lint Tests
 on:
-  push:
   pull_request:
 
 concurrency:


### PR DESCRIPTION
Is there a reason we want it enabled for push and not just for PRs?