### PR TITLE
improve runcmd docs

### DIFF
--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -33,10 +33,6 @@ how it is executed:
 * If the item is a list, the items will be executed as if passed to execve(3)
   (with the first arg as the command).
 
-
-Each item is written to ``/var/lib/cloud/instance/runcmd`` to be later
-interpreted using ``sh``.
-
 Note that the ``runcmd`` module only writes the script to be run
 later. The module that actually runs the script is ``scripts-user``
 in the :ref:`topics/boot:Final` boot stage.

--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -24,7 +24,7 @@ from cloudinit.settings import PER_INSTANCE
 
 
 MODULE_DESCRIPTION = """\
-Run arbitrary commands at a rc.local like level with output to the
+Run arbitrary commands at a rc.local like time-frame with output to the
 console. Each item can be either a list or a string. The item type affects
 how it is executed:
 

--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -25,10 +25,17 @@ from cloudinit.settings import PER_INSTANCE
 
 MODULE_DESCRIPTION = """\
 Run arbitrary commands at a rc.local like level with output to the
-console. Each item can be either a list or a string. If the item is a
-list, it will be properly quoted. Each item is written to
-``/var/lib/cloud/instance/runcmd`` to be later interpreted using
-``sh``.
+console. Each item can be either a list or a string. The item type affects
+how it is executed:
+
+
+* If the item is a string, it will be interpreted by ``sh``.
+* If the item is a list, the items will be executed as if passed to execve(3)
+  (with the first arg as the command).
+
+
+Each item is written to ``/var/lib/cloud/instance/runcmd`` to be later
+interpreted using ``sh``.
 
 Note that the ``runcmd`` module only writes the script to be run
 later. The module that actually runs the script is ``scripts-user``


### PR DESCRIPTION
```bash
doc: Add runcmd str vs. list arg behavior to module docs
```

Per discussion [here](https://bugs.launchpad.net/cloud-init/+bug/1977780) I think we should document this better.


Note: The comment about rc.local isn't as relevant as it used to be, but I don't think it should be removed at this time.

The rendering:

![runcmd](https://user-images.githubusercontent.com/16310367/172426894-53948081-7d60-4acc-9e33-d4b754c30d3a.png)