### PR TITLE
Rename find_modules() to avoid confusion

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -18,7 +18,7 @@ import yaml
 
 from cloudinit import importer, safeyaml
 from cloudinit.cmd.devel import read_cfg_paths
-from cloudinit.util import error, find_modules, load_file
+from cloudinit.util import error, get_modules_from_dir, load_file
 
 error = partial(error, sys_exit=True)
 LOG = logging.getLogger(__name__)
@@ -635,7 +635,7 @@ def get_meta_doc(meta: MetaSchema, schema: Optional[dict] = None) -> str:
 
 def get_modules() -> dict:
     configs_dir = os.path.dirname(os.path.abspath(__file__))
-    return find_modules(configs_dir)
+    return get_modules_from_dir(configs_dir)
 
 
 def load_doc(requested_modules: list) -> str:

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -576,7 +576,7 @@ class Init(object):
             # Attempts to register any handler modules under the given path.
             if not path or not os.path.isdir(path):
                 return
-            potential_handlers = util.find_modules(path)
+            potential_handlers = util.get_modules_from_dir(path)
             for (fname, mod_name) in potential_handlers.items():
                 try:
                     mod_locs, looked_locs = importer.find_module(

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -368,7 +368,7 @@ def extract_usergroup(ug_pair):
     return (u, g)
 
 
-def find_modules(root_dir) -> dict:
+def get_modules_from_dir(root_dir: str) -> dict:
     entries = dict()
     for fname in glob.glob(os.path.join(root_dir, "*.py")):
         if not os.path.isfile(fname):

--- a/tests/unittests/sources/test_init.py
+++ b/tests/unittests/sources/test_init.py
@@ -761,7 +761,9 @@ class TestDataSource(CiTestCase):
         """Validate get_hostname signature on all subclasses of DataSource."""
         base_args = inspect.getfullargspec(DataSource.get_hostname)
         # Import all DataSource subclasses so we can inspect them.
-        modules = util.find_modules(os.path.dirname(os.path.dirname(__file__)))
+        modules = util.get_modules_from_dir(
+            os.path.dirname(os.path.dirname(__file__))
+        )
         for _loc, name in modules.items():
             mod_locs, _ = importer.find_module(name, ["cloudinit.sources"], [])
             if mod_locs:


### PR DESCRIPTION
```
Rename find_modules() to avoid confusion

Currently find_modules() and find_module() are imported
from cloudinit.util and cloudinit.importer, respectively.
Rename find_module() to something more self-descriptive.
```

Since both functions are intended to be used outside the modules they are defined in, and in some parts of the code they are called right next to each other, disambiguation should improve readability.