### PR TITLE
Add python3-deconf dependency

### DIFF
--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -12,7 +12,8 @@ Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
          iproute2,
-         isc-dhcp-client
+         isc-dhcp-client,
+         python3-debconf
 Recommends: eatmydata, sudo, software-properties-common, gdisk
 Suggests: ssh-import-id, openssh-server
 Description: Init scripts for cloud instances


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add python3-deconf dependency
```

## Additional Context
<!-- If relevant -->
SC-1102
In [#1472](https://github.com/canonical/cloud-init/pull/1472#discussion_r883089701) we started to make use of `python3-debconf` in `cc_ubuntu_drivers`.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`make deb`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
