### PR TITLE
setup.py: adjust udev/rules default path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -302,6 +302,11 @@ data_files = [
     ),
 ]
 if not platform.system().endswith("BSD"):
+
+    RULES_PATH = LIB
+    if os.path.isfile("/etc/redhat-release"):
+        RULES_PATH = "/usr/lib"
+
     data_files.extend(
         [
             (
@@ -309,7 +314,7 @@ if not platform.system().endswith("BSD"):
                 ["tools/hook-network-manager"],
             ),
             (ETC + "/dhcp/dhclient-exit-hooks.d/", ["tools/hook-dhclient"]),
-            (LIB + "/udev/rules.d", [f for f in glob("udev/*.rules")]),
+            (RULES_PATH + "/udev/rules.d", [f for f in glob("udev/*.rules")]),
             (
                 ETC + "/systemd/system/sshd-keygen@.service.d/",
                 ["systemd/disable-sshd-keygen-if-cloud-init-active.conf"],


### PR DESCRIPTION
```
RHEL must put cloudinit .rules files in /usr/lib/udev/rules.d
This place is a rhel standard and since it is used by all packages
cannot be modified.

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
