### PR TITLE
cloud-final.service.tmpl: run vgimportdevices -a

### DIFF
--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -25,6 +25,7 @@ ExecStartPost=/bin/sh -c 'u=NetworkManager.service; \
  out=$(systemctl show --property=SubState $u) || exit; \
  [ "$out" = "SubState=running" ] || exit 0; \
  systemctl reload-or-try-restart $u'
+ExecStartPost=/usr/sbin/vgimportdevices -a
 {% else %}
 TasksMax=infinity
 {% endif %}


### PR DESCRIPTION
```
On RHEL, lvs, pvs, vgs commands are throwing the following error:
     Devices file sys_wwid naa.600224807870e92594223868a58ec36b PVID 9dRHhFlPYWgaHo3wlfv4ZahXpnSdLYP2 last seen on /dev/sda4 not found.

This happens when copying/cloning VM images without unconfiguring the system-specific
info in /etc/lvm/devices/system.devices.
lvm will only use PVs on disks with wwids matching the wwids listed in system.devices.

The procedure for copying/cloning VM images needs to include removing the old
system.devices file and recreating a new system.devices on the new system
(using vgimportdevices or lvmdevices).

Therefore, add vgimportdevices -a command.

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>
```

For more informations, see BZ 2091017:
https://bugzilla.redhat.com/show_bug.cgi?id=2091017

## Test Steps
How reproducible:
Always 

Steps to Reproduce:
1. Create an RHEL 9 LVM VM on Azure
2. check output of commands:
```
lvs
  Devices file sys_wwid naa.600224807870e92594223868a58ec36b PVID 9dRHhFlPYWgaHo3wlfv4ZahXpnSdLYP2 last seen on /dev/sda4 not found.
[root@rhel9ade-lvm anujmaurya]#
[root@rhel9ade-lvm anujmaurya]# pvs
  Devices file sys_wwid naa.600224807870e92594223868a58ec36b PVID 9dRHhFlPYWgaHo3wlfv4ZahXpnSdLYP2 last seen on /dev/sda4 not found.
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
