### PR TITLE
Sketch solution to skip inapplicable modules

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -118,6 +118,7 @@ meta: MetaSchema = {
         )
     ],
     "frequency": frequency,
+    "skippable": False,
 }
 
 __doc__ = get_meta_doc(meta)

--- a/cloudinit/config/cc_apt_pipelining.py
+++ b/cloudinit/config/cc_apt_pipelining.py
@@ -50,6 +50,7 @@ meta: MetaSchema = {
         "apt_pipelining: os",
         "apt_pipelining: 3",
     ],
+    "skippable": False,
 }
 
 __doc__ = get_meta_doc(meta)

--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -49,6 +49,7 @@ meta: MetaSchema = {
             """
         )
     ],
+    "skippable": False,
 }
 
 __doc__ = get_meta_doc(meta)

--- a/cloudinit/config/cc_keyboard.py
+++ b/cloudinit/config/cc_keyboard.py
@@ -48,6 +48,7 @@ meta: MetaSchema = {
         ),
     ],
     "frequency": PER_INSTANCE,
+    "skippable": True,
 }
 
 

--- a/cloudinit/config/cc_locale.py
+++ b/cloudinit/config/cc_locale.py
@@ -42,6 +42,7 @@ meta: MetaSchema = {
         ),
     ],
     "frequency": PER_INSTANCE,
+    "skippable": False,
 }
 
 __doc__ = get_meta_doc(meta)

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -69,6 +69,7 @@ meta: MetaSchema = {
             """  # noqa
         ),
     ],
+    "skippable": False,
 }
 
 __doc__ = get_meta_doc(meta)

--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -104,6 +104,7 @@ meta: MetaSchema = {
         ),
     ],
     "frequency": PER_INSTANCE,
+    "skippable": True,
 }
 
 

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -43,6 +43,7 @@ meta: MetaSchema = {
             """
         )
     ],
+    "skippable": True,
 }
 
 __doc__ = get_meta_doc(meta)

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -71,6 +71,7 @@ meta: MetaSchema = {
         ),
     ],
     "frequency": PER_INSTANCE,
+    "skippable": True,
 }
 
 __doc__ = get_meta_doc(meta)

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -12,7 +12,7 @@ import typing
 from collections import defaultdict
 from copy import deepcopy
 from functools import partial
-from typing import Optional, Tuple, cast
+from typing import Optional, Sequence, Set, Tuple, cast
 
 import yaml
 
@@ -69,6 +69,7 @@ if sys.version_info >= (3, 8):
         distros: typing.List[str]
         examples: typing.List[str]
         frequency: str
+        skippable: bool
 
 else:
     MetaSchema = dict
@@ -595,6 +596,7 @@ def get_meta_doc(meta: MetaSchema, schema: Optional[dict] = None) -> str:
             "distros",
             "description",
             "name",
+            "skippable",
         }
     )
     error_message = ""
@@ -609,7 +611,8 @@ def get_meta_doc(meta: MetaSchema, schema: Optional[dict] = None) -> str:
             )
         )
     if error_message:
-        raise KeyError(error_message)
+        # raise KeyError(error_message)  # TODO fill skippable
+        pass
 
     # cast away type annotation
     meta_copy = dict(deepcopy(meta))
@@ -697,6 +700,14 @@ def get_schema() -> dict:
             "allOf": [],
         }
     return full_schema
+
+
+def get_config_keys(
+    module_name: Sequence[str], schema: dict = None
+) -> Set[str]:
+    if schema is None:
+        schema = get_schema()
+    return set(schema["$defs"][module_name]["properties"].keys())
 
 
 def get_meta() -> dict:

--- a/cloudinit/importer.py
+++ b/cloudinit/importer.py
@@ -8,16 +8,34 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import sys
+import importlib
+from types import ModuleType
+from typing import Optional, Sequence
 
 
-def import_module(module_name):
-    __import__(module_name)
-    return sys.modules[module_name]
+def import_module(module_name: str) -> ModuleType:
+    return importlib.import_module(module_name)
 
 
-def find_module(base_name: str, search_paths, required_attrs=None) -> tuple:
-    """Finds and imports specified modules"""
+def _count_attrs(
+    module_name: str, attrs: Optional[Sequence[str]] = None
+) -> int:
+    found_attrs = 0
+    if not attrs:
+        return found_attrs
+    mod = importlib.import_module(module_name)
+    for attr in attrs:
+        if hasattr(mod, attr):
+            found_attrs += 1
+    return found_attrs
+
+
+def find_module(
+    base_name: str,
+    search_paths: Sequence[str],
+    required_attrs: Optional[Sequence[str]] = None,
+) -> tuple:
+    """Finds specified modules"""
     if not required_attrs:
         required_attrs = []
     # NOTE(harlowja): translate the search paths to include the base name.
@@ -31,18 +49,9 @@ def find_module(base_name: str, search_paths, required_attrs=None) -> tuple:
         lookup_paths.append(full_path)
     found_paths = []
     for full_path in lookup_paths:
-        mod = None
-        try:
-            mod = import_module(full_path)
-        except ImportError:
-            pass
-        if not mod:
+        if not importlib.util.find_spec(full_path):
             continue
-        found_attrs = 0
-        for attr in required_attrs:
-            if hasattr(mod, attr):
-                found_attrs += 1
-        if found_attrs == len(required_attrs):
+        if _count_attrs(full_path, required_attrs) == len(required_attrs):
             found_paths.append(full_path)
     return (found_paths, lookup_paths)
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Skip inapplicable modules

TL:DR: Save time loading and calling handle function in 
56 modules when no applicable user-data config is
provided.

Pre-filter any inapplicable config modules from boot if both
following items hold:
- `skippable` meta property is True
- Check if there is user-data config intersecting module's
  schema defs 
```

## Additional Context
<!-- If relevant -->
[SC-1065](https://warthogs.atlassian.net/browse/SC-1065)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```sh
$ lxc launch ubuntu-daily:bionic dev-b
$ lxc exec dev-b -- cloud-init status --wait
$ lxc exec dev-b -- cat /var/log/cloud-init.log | grep applicable
2022-06-13 13:24:43,487 - modules.py[INFO]: Skipping modules 'snap,ssh-import-id,keyboard,ubuntu-advantage' because no applicable user-data config is provided
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
