### PR TITLE
sources/azure: remove dscfg parsing from ovf-env.xml

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -747,9 +747,6 @@ class DataSourceAzure(sources.DataSource):
         )
         self.userdata_raw = crawled_data["userdata_raw"]
 
-        user_ds_cfg = util.get_cfg_by_path(self.cfg, DS_CFG_PATH, {})
-        self.ds_cfg = util.mergemanydict([user_ds_cfg, self.ds_cfg])
-
         # walinux agent writes files world readable, but expects
         # the directory to be protected.
         write_files(
@@ -1936,12 +1933,6 @@ def read_azure_ovf(contents):
             password = value
         elif name == "hostname":
             md["local-hostname"] = value
-        elif name == "dscfg":
-            if attrs.get("encoding") in (None, "base64"):
-                dscfg = base64.b64decode("".join(value.split()))
-            else:
-                dscfg = value
-            cfg["datasource"] = {DS_NAME: util.load_yaml(dscfg, default={})}
         elif name == "ssh":
             cfg["_pubkeys"] = load_azure_ovf_pubkeys(child)
         elif name == "disablesshpasswordauthentication":

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import httpretty
 import pytest
 import requests
-import yaml
 
 from cloudinit import distros, helpers, subp, url_helper
 from cloudinit.net import dhcp
@@ -1275,12 +1274,10 @@ scbus-1 on xpt0 bus 0
 
     def test_crawl_metadata_returns_structured_data_and_caches_nothing(self):
         """Return all structured metadata and cache no class attributes."""
-        yaml_cfg = ""
         odata = {
             "HostName": "myhost",
             "UserName": "myuser",
             "CustomData": {"text": "FOOBAR", "encoding": "plain"},
-            "dscfg": {"text": yaml_cfg, "encoding": "plain"},
         }
         data = {
             "ovfcontent": construct_valid_ovf_env(data=odata),
@@ -1290,7 +1287,6 @@ scbus-1 on xpt0 bus 0
         expected_cfg = {
             "PreprovisionedVMType": None,
             "PreprovisionedVm": False,
-            "datasource": {"Azure": {}},
             "system_info": {"default_user": {"name": "myuser"}},
         }
         expected_metadata = {
@@ -1750,31 +1746,6 @@ scbus-1 on xpt0 bus 0
 
             assert "disk_setup" not in cfg
             assert "fs_setup" not in cfg
-
-    def test_provide_disk_aliases(self):
-        # Make sure that user can affect disk aliases
-        dscfg = {"disk_aliases": {"ephemeral0": "/dev/sdc"}}
-        odata = {
-            "HostName": "myhost",
-            "UserName": "myuser",
-            "dscfg": {"text": b64e(yaml.dump(dscfg)), "encoding": "base64"},
-        }
-        usercfg = {
-            "disk_setup": {
-                "/dev/sdc": {"something": "..."},
-                "ephemeral0": False,
-            }
-        }
-        userdata = "#cloud-config" + yaml.dump(usercfg) + "\n"
-
-        ovfcontent = construct_valid_ovf_env(data=odata, userdata=userdata)
-        data = {"ovfcontent": ovfcontent, "sys_cfg": {}}
-
-        dsrc = self._get_ds(data)
-        ret = dsrc.get_data()
-        self.assertTrue(ret)
-        cfg = dsrc.get_config_obj()
-        self.assertTrue(cfg)
 
     def test_userdata_arrives(self):
         userdata = "This is my user-data"


### PR DESCRIPTION
This property is not found in Azure's ovf-env.xml.

Remove relevant code merging it into datasource config
and unit tests.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>