### PR TITLE
cloud-config: honor cloud_dir setting

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -3,8 +3,10 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 """Cloud-init apport interface"""
+from cloudinit.cmd.devel import read_cfg_paths
 
 try:
+
     from apport.hookutils import (
         attach_file,
         attach_root_command_outputs,
@@ -53,7 +55,11 @@ KNOWN_CLOUD_NAMES = [
 # Potentially clear text collected logs
 CLOUDINIT_LOG = "/var/log/cloud-init.log"
 CLOUDINIT_OUTPUT_LOG = "/var/log/cloud-init-output.log"
-USER_DATA_FILE = "/var/lib/cloud/instance/user-data.txt"  # Optional
+
+
+def _get_user_data_file() -> str:
+    paths = read_cfg_paths()
+    return paths.get_ipath_cur("userdata_raw")
 
 
 def attach_cloud_init_logs(report, ui=None):
@@ -106,18 +112,19 @@ def attach_cloud_info(report, ui=None):
 def attach_user_data(report, ui=None):
     """Optionally provide user-data if desired."""
     if ui:
+        user_data_file = _get_user_data_file()
         prompt = (
             "Your user-data or cloud-config file can optionally be provided"
             " from {0} and could be useful to developers when addressing this"
             " bug. Do you wish to attach user-data to this bug?".format(
-                USER_DATA_FILE
+                user_data_file
             )
         )
         response = ui.yesno(prompt)
         if response is None:
             raise StopIteration  # User cancelled
         if response:
-            attach_file(report, USER_DATA_FILE, "user_data.txt")
+            attach_file(report, user_data_file, "user_data.txt")
 
 
 def add_bug_tags(report):

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -6,7 +6,6 @@
 from cloudinit.cmd.devel import read_cfg_paths
 
 try:
-
     from apport.hookutils import (
         attach_file,
         attach_root_command_outputs,

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -12,6 +12,7 @@ import shutil
 import sys
 from datetime import datetime
 
+from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.sources import INSTANCE_JSON_SENSITIVE_FILE
 from cloudinit.subp import ProcessExecutionError, subp
 from cloudinit.temp_utils import tempdir
@@ -19,7 +20,11 @@ from cloudinit.util import chdir, copy, ensure_dir, write_file
 
 CLOUDINIT_LOGS = ["/var/log/cloud-init.log", "/var/log/cloud-init-output.log"]
 CLOUDINIT_RUN_DIR = "/run/cloud-init"
-USER_DATA_FILE = "/var/lib/cloud/instance/user-data.txt"  # Optional
+
+
+def _get_user_data_file() -> str:
+    paths = read_cfg_paths()
+    return paths.get_ipath("userdata_raw")
 
 
 def get_parser(parser=None):
@@ -53,6 +58,7 @@ def get_parser(parser=None):
             " Default: cloud-init.tar.gz"
         ),
     )
+    user_data_file = _get_user_data_file()
     parser.add_argument(
         "--include-userdata",
         "-u",
@@ -61,7 +67,7 @@ def get_parser(parser=None):
         dest="userdata",
         help=(
             "Optionally include user-data from {0} which could contain"
-            " sensitive information.".format(USER_DATA_FILE)
+            " sensitive information.".format(user_data_file)
         ),
     )
     return parser
@@ -104,7 +110,7 @@ def _collect_file(path, out_dir, verbosity):
         _debug("file %s did not exist\n" % path, 2, verbosity)
 
 
-def collect_logs(tarfile, include_userdata, verbosity=0):
+def collect_logs(tarfile, include_userdata: bool, verbosity=0):
     """Collect all cloud-init logs and tar them up into the provided tarfile.
 
     @param tarfile: The path of the tar-gzipped file to create.
@@ -152,7 +158,8 @@ def collect_logs(tarfile, include_userdata, verbosity=0):
         for log in CLOUDINIT_LOGS:
             _collect_file(log, log_dir, verbosity)
         if include_userdata:
-            _collect_file(USER_DATA_FILE, log_dir, verbosity)
+            user_data_file = _get_user_data_file()
+            _collect_file(user_data_file, log_dir, verbosity)
         run_dir = os.path.join(log_dir, "run")
         ensure_dir(run_dir)
         if os.path.exists(CLOUDINIT_RUN_DIR):

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -24,7 +24,7 @@ CLOUDINIT_RUN_DIR = "/run/cloud-init"
 
 def _get_user_data_file() -> str:
     paths = read_cfg_paths()
-    return paths.get_ipath("userdata_raw")
+    return paths.get_ipath_cur("userdata_raw")
 
 
 def get_parser(parser=None):

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -661,7 +661,9 @@ def main_single(name, args):
 
 def status_wrapper(name, args, data_d=None, link_d=None):
     if data_d is None:
-        data_d = os.path.normpath("/var/lib/cloud/data")
+        init = stages.Init(ds_deps=[], reporter=None)
+        init.read_cfg(extract_fns(args))
+        data_d = init.paths.get_cpath("data")
     if link_d is None:
         link_d = os.path.normpath("/run/cloud-init")
 

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -47,6 +47,7 @@ from cloudinit import atomic_helper
 
 from cloudinit.config import cc_set_hostname
 from cloudinit import dhclient_hook
+from cloudinit.cmd.devel import read_cfg_paths
 
 
 # Welcome message template
@@ -661,9 +662,8 @@ def main_single(name, args):
 
 def status_wrapper(name, args, data_d=None, link_d=None):
     if data_d is None:
-        init = stages.Init(ds_deps=[], reporter=None)
-        init.read_cfg(extract_fns(args))
-        data_d = init.paths.get_cpath("data")
+        paths = read_cfg_paths()
+        data_d = paths.get_cpath("data")
     if link_d is None:
         link_d = os.path.normpath("/run/cloud-init")
 

--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -113,7 +113,6 @@ __doc__ = get_meta_doc(meta)
 SNAP_CMD = "snap"
 
 
-
 def add_assertions(assertions, assertions_file):
     """Import list of assertions.
 

--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -4,6 +4,7 @@
 
 """Snap: Install, configure and manage snapd and snap packages."""
 
+import os
 import sys
 from textwrap import dedent
 
@@ -110,10 +111,10 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 SNAP_CMD = "snap"
-ASSERTIONS_FILE = "/var/lib/cloud/instance/snapd.assertions"
 
 
-def add_assertions(assertions):
+
+def add_assertions(assertions, assertions_file):
     """Import list of assertions.
 
     Import assertions by concatenating each assertion into a
@@ -133,14 +134,14 @@ def add_assertions(assertions):
             )
         )
 
-    snap_cmd = [SNAP_CMD, "ack"]
+    snap_cmd = [SNAP_CMD, "ack", assertions_file]
     combined = "\n".join(assertions)
 
     for asrt in assertions:
         LOG.debug("Snap acking: %s", asrt.split("\n")[0:2])
 
-    util.write_file(ASSERTIONS_FILE, combined.encode("utf-8"))
-    subp.subp(snap_cmd + [ASSERTIONS_FILE], capture=True)
+    util.write_file(assertions_file, combined.encode("utf-8"))
+    subp.subp(snap_cmd, capture=True)
 
 
 def run_commands(commands):
@@ -190,7 +191,10 @@ def handle(name, cfg, cloud, log, args):
         )
         return
 
-    add_assertions(cfgin.get("assertions", []))
+    add_assertions(
+        cfgin.get("assertions", []),
+        os.path.join(cloud.paths.get_ipath_cur(), "snapd.assertions"),
+    )
     run_commands(cfgin.get("commands", []))
 
 

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1064,7 +1064,7 @@ def _get_arch_package_mirror_info(package_mirrors, arch):
     return default
 
 
-def fetch(name) -> Type[Distro]:
+def fetch(name: str) -> Type[Distro]:
     locs, looked_locs = importer.find_module(name, ["", __name__], ["Distro"])
     if not locs:
         raise ImportError(

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -330,7 +330,7 @@ class ContentHandlers(object):
 class Paths(persistence.CloudInitPickleMixin):
     _ci_pkl_version = 1
 
-    def __init__(self, path_cfgs, ds=None):
+    def __init__(self, path_cfgs: dict, ds=None):
         self.cfgs = path_cfgs
         # Populate all the initial paths
         self.cloud_dir = path_cfgs.get("cloud_dir", "/var/lib/cloud")

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1445,8 +1445,10 @@ class DataSourceAzure(sources.DataSource):
 
     @azure_ds_telemetry_reporter
     def activate(self, cfg, is_new_instance):
+        instance_dir = self.paths.get_ipath_cur()
         try:
             address_ephemeral_resize(
+                instance_dir,
                 is_new_instance=is_new_instance,
                 preserve_ntfs=self.ds_cfg.get(DS_CFG_KEY_PRESERVE_NTFS, False),
             )
@@ -1730,7 +1732,10 @@ def can_dev_be_reformatted(devpath, preserve_ntfs):
 
 @azure_ds_telemetry_reporter
 def address_ephemeral_resize(
-    devpath=RESOURCE_DISK_PATH, is_new_instance=False, preserve_ntfs=False
+    instance_dir: str,
+    devpath: str = RESOURCE_DISK_PATH,
+    is_new_instance: bool = False,
+    preserve_ntfs: bool = False,
 ):
     if not os.path.exists(devpath):
         report_diagnostic_event(
@@ -1756,7 +1761,7 @@ def address_ephemeral_resize(
         return
 
     for mod in ["disk_setup", "mounts"]:
-        sempath = "/var/lib/cloud/instance/sem/config_" + mod
+        sempath = os.path.join(instance_dir, "sem", "config_" + mod)
         bmsg = 'Marker "%s" for module "%s"' % (sempath, mod)
         if os.path.exists(sempath):
             try:

--- a/cloudinit/sources/DataSourceBigstep.py
+++ b/cloudinit/sources/DataSourceBigstep.py
@@ -7,7 +7,6 @@
 import errno
 import json
 import os
-from functools import lru_cache
 
 from cloudinit import sources, url_helper, util
 
@@ -37,7 +36,6 @@ class DataSourceBigstep(sources.DataSource):
         """Return the subplatform metadata source details."""
         return f"metadata ({self._get_url_from_file()})"
 
-    @lru_cache(maxsize=1, typed=False)
     def _get_url_from_file(self):
         url_file = os.path.join(
             self.paths.cloud_dir, "data", "seed", "bigstep", "url"

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -866,17 +866,16 @@ def read_optional_seed(fill, base="", ext="", timeout=5):
 def fetch_ssl_details(paths=None):
     ssl_details = {}
     # Lookup in these locations for ssl key/cert files
-    ssl_cert_paths = [
-        "/var/lib/cloud/data/ssl",
-        "/var/lib/cloud/instance/data/ssl",
-    ]
-    if paths:
-        ssl_cert_paths.extend(
-            [
-                os.path.join(paths.get_ipath_cur("data"), "ssl"),
-                os.path.join(paths.get_cpath("data"), "ssl"),
-            ]
-        )
+    if not paths:
+        ssl_cert_paths = [
+            "/var/lib/cloud/data/ssl",
+            "/var/lib/cloud/instance/data/ssl",
+        ]
+    else:
+        ssl_cert_paths = [
+            os.path.join(paths.get_ipath_cur("data"), "ssl"),
+            os.path.join(paths.get_cpath("data"), "ssl"),
+        ]
     ssl_cert_paths = uniq_merge(ssl_cert_paths)
     ssl_cert_paths = [d for d in ssl_cert_paths if d and os.path.isdir(d)]
     cert_file = None

--- a/tests/integration_tests/bugs/test_lp1976564.py
+++ b/tests/integration_tests/bugs/test_lp1976564.py
@@ -36,6 +36,7 @@ def custom_client(
 
 @pytest.mark.lxd_container
 @pytest.mark.lxd_vm
+@pytest.mark.azure
 class TestLp1976564:
     def verify_log_and_files(self, custom_client):
         log_content = custom_client.read_from_file("/var/log/cloud-init.log")

--- a/tests/integration_tests/bugs/test_lp1976564.py
+++ b/tests/integration_tests/bugs/test_lp1976564.py
@@ -1,0 +1,62 @@
+"""Integration test for LP: #1976564
+
+cloud-init must honor the cloud-dir configured in /etc/cloud/cloud.cfg.d
+"""
+import re
+from typing import Iterator
+
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+DEFAULT_CLOUD_DIR = "/var/lib/cloud"
+NEW_CLOUD_DIR = "/new-cloud-dir"
+CUSTOM_CLOUD_DIR = f"""\
+system_info:
+  paths:
+    cloud_dir: {NEW_CLOUD_DIR}
+"""
+CUSTOM_CLOUD_DIR_FN = "95-custom-cloud-dir.cfg"
+
+
+@pytest.fixture
+def custom_client(
+    client: IntegrationInstance, tmpdir
+) -> Iterator[IntegrationInstance]:
+    cfg = tmpdir.join(CUSTOM_CLOUD_DIR_FN)
+    with open(cfg, "w") as f:
+        f.write(CUSTOM_CLOUD_DIR)
+    client.push_file(cfg, f"/etc/cloud/cloud.cfg.d/{CUSTOM_CLOUD_DIR_FN}")
+    client.execute(f"rm -rf {DEFAULT_CLOUD_DIR}")  # Remove previous cloud_dir
+    client.execute("cloud-init clean --logs")
+    client.restart()
+    yield client
+
+
+@pytest.mark.lxd_container
+@pytest.mark.lxd_vm
+class TestLp1976564:
+    def verify_log_and_files(self, custom_client):
+        log_content = custom_client.read_from_file("/var/log/cloud-init.log")
+        verify_clean_log(log_content)
+        assert NEW_CLOUD_DIR in log_content
+        assert DEFAULT_CLOUD_DIR not in log_content
+        assert custom_client.execute(f"test ! -d {DEFAULT_CLOUD_DIR}").ok
+
+    def collect_logs(self, custom_client: IntegrationInstance):
+        help_result = custom_client.execute("cloud-init collect-logs -h")
+        assert help_result.ok, help_result.stderr
+        assert f"{NEW_CLOUD_DIR}/instance/user-data.txt" in re.sub(
+            r"\s+", "", help_result.stdout
+        ), "user-data file not correctly render in collect-logs -h"
+        collect_logs_result = custom_client.execute(
+            "cloud-init collect-logs --include-userdata"
+        )
+        assert (
+            collect_logs_result.ok
+        ), f"collect-logs error: {collect_logs_result.stderr}"
+
+    def test_lp1976564(self, custom_client: IntegrationInstance):
+        self.verify_log_and_files(custom_client)
+        self.collect_logs(custom_client)

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -1,55 +1,52 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import os
+import re
 from datetime import datetime
 from io import StringIO
 
 from cloudinit.cmd.devel import logs
 from cloudinit.sources import INSTANCE_JSON_SENSITIVE_FILE
 from cloudinit.subp import subp
-from cloudinit.util import ensure_dir, load_file, write_file
-from tests.unittests.helpers import (
-    FilesystemMockingTestCase,
-    mock,
-    wrap_and_call,
-)
+from cloudinit.util import load_file, write_file
+from tests.unittests.helpers import mock
+
+M_PATH = "cloudinit.cmd.devel.logs."
 
 
 @mock.patch("cloudinit.cmd.devel.logs.os.getuid")
-class TestCollectLogs(FilesystemMockingTestCase):
-    def setUp(self):
-        super(TestCollectLogs, self).setUp()
-        self.new_root = self.tmp_dir()
-        self.run_dir = self.tmp_path("run", self.new_root)
-
-    def test_collect_logs_with_userdata_requires_root_user(self, m_getuid):
+class TestCollectLogs:
+    def test_collect_logs_with_userdata_requires_root_user(
+        self, m_getuid, tmpdir
+    ):
         """collect-logs errors when non-root user collects userdata ."""
         m_getuid.return_value = 100  # non-root
-        output_tarfile = self.tmp_path("logs.tgz")
+        output_tarfile = tmpdir.join("logs.tgz")
         with mock.patch("sys.stderr", new_callable=StringIO) as m_stderr:
-            self.assertEqual(
-                1, logs.collect_logs(output_tarfile, include_userdata=True)
+            assert 1 == logs.collect_logs(
+                output_tarfile, include_userdata=True
             )
-        self.assertEqual(
+        assert (
             "To include userdata, root user is required."
-            " Try sudo cloud-init collect-logs\n",
-            m_stderr.getvalue(),
+            " Try sudo cloud-init collect-logs\n" == m_stderr.getvalue()
         )
 
-    def test_collect_logs_creates_tarfile(self, m_getuid):
+    def test_collect_logs_creates_tarfile(self, m_getuid, mocker, tmpdir):
         """collect-logs creates a tarfile with all related cloud-init info."""
         m_getuid.return_value = 100
-        log1 = self.tmp_path("cloud-init.log", self.new_root)
+        log1 = tmpdir.join("cloud-init.log")
         write_file(log1, "cloud-init-log")
-        log2 = self.tmp_path("cloud-init-output.log", self.new_root)
+        log2 = tmpdir.join("cloud-init-output.log")
         write_file(log2, "cloud-init-output-log")
-        ensure_dir(self.run_dir)
-        write_file(self.tmp_path("results.json", self.run_dir), "results")
+        run_dir = tmpdir.join("run")
+        write_file(run_dir.join("results.json"), "results")
         write_file(
-            self.tmp_path(INSTANCE_JSON_SENSITIVE_FILE, self.run_dir),
+            run_dir.join(
+                INSTANCE_JSON_SENSITIVE_FILE,
+            ),
             "sensitive",
         )
-        output_tarfile = self.tmp_path("logs.tgz")
+        output_tarfile = str(tmpdir.join("logs.tgz"))
 
         date = datetime.utcnow().date().strftime("%Y-%m-%d")
         date_logdir = "cloud-init-logs-{0}".format(date)
@@ -80,76 +77,63 @@ class TestCollectLogs(FilesystemMockingTestCase):
 
         fake_stderr = mock.MagicMock()
 
-        wrap_and_call(
-            "cloudinit.cmd.devel.logs",
-            {
-                "subp": {"side_effect": fake_subp},
-                "sys.stderr": {"new": fake_stderr},
-                "CLOUDINIT_LOGS": {"new": [log1, log2]},
-                "CLOUDINIT_RUN_DIR": {"new": self.run_dir},
-            },
-            logs.collect_logs,
-            output_tarfile,
-            include_userdata=False,
-        )
+        mocker.patch(M_PATH + "subp", side_effect=fake_subp)
+        mocker.patch(M_PATH + "sys.stderr", fake_stderr)
+        mocker.patch(M_PATH + "CLOUDINIT_LOGS", [log1, log2])
+        mocker.patch(M_PATH + "CLOUDINIT_RUN_DIR", run_dir)
+        logs.collect_logs(output_tarfile, include_userdata=False)
         # unpack the tarfile and check file contents
-        subp(["tar", "zxvf", output_tarfile, "-C", self.new_root])
-        out_logdir = self.tmp_path(date_logdir, self.new_root)
-        self.assertFalse(
-            os.path.exists(
-                os.path.join(
-                    out_logdir,
-                    "run",
-                    "cloud-init",
-                    INSTANCE_JSON_SENSITIVE_FILE,
-                )
-            ),
-            "Unexpected file found: %s" % INSTANCE_JSON_SENSITIVE_FILE,
+        subp(["tar", "zxvf", output_tarfile, "-C", str(tmpdir)])
+        out_logdir = tmpdir.join(date_logdir)
+        assert not os.path.exists(
+            os.path.join(
+                out_logdir,
+                "run",
+                "cloud-init",
+                INSTANCE_JSON_SENSITIVE_FILE,
+            )
+        ), (
+            "Unexpected file found: %s" % INSTANCE_JSON_SENSITIVE_FILE
         )
-        self.assertEqual(
-            "0.7fake\n", load_file(os.path.join(out_logdir, "dpkg-version"))
+        assert "0.7fake\n" == load_file(
+            os.path.join(out_logdir, "dpkg-version")
         )
-        self.assertEqual(
-            version_out, load_file(os.path.join(out_logdir, "version"))
+        assert version_out == load_file(os.path.join(out_logdir, "version"))
+        assert "cloud-init-log" == load_file(
+            os.path.join(out_logdir, "cloud-init.log")
         )
-        self.assertEqual(
-            "cloud-init-log",
-            load_file(os.path.join(out_logdir, "cloud-init.log")),
+        assert "cloud-init-output-log" == load_file(
+            os.path.join(out_logdir, "cloud-init-output.log")
         )
-        self.assertEqual(
-            "cloud-init-output-log",
-            load_file(os.path.join(out_logdir, "cloud-init-output.log")),
+        assert "dmesg-out\n" == load_file(
+            os.path.join(out_logdir, "dmesg.txt")
         )
-        self.assertEqual(
-            "dmesg-out\n", load_file(os.path.join(out_logdir, "dmesg.txt"))
+        assert "journal-out\n" == load_file(
+            os.path.join(out_logdir, "journal.txt")
         )
-        self.assertEqual(
-            "journal-out\n", load_file(os.path.join(out_logdir, "journal.txt"))
-        )
-        self.assertEqual(
-            "results",
-            load_file(
-                os.path.join(out_logdir, "run", "cloud-init", "results.json")
-            ),
+        assert "results" == load_file(
+            os.path.join(out_logdir, "run", "cloud-init", "results.json")
         )
         fake_stderr.write.assert_any_call("Wrote %s\n" % output_tarfile)
 
-    def test_collect_logs_includes_optional_userdata(self, m_getuid):
+    def test_collect_logs_includes_optional_userdata(
+        self, m_getuid, mocker, tmpdir
+    ):
         """collect-logs include userdata when --include-userdata is set."""
         m_getuid.return_value = 0
-        log1 = self.tmp_path("cloud-init.log", self.new_root)
+        log1 = tmpdir.join("cloud-init.log")
         write_file(log1, "cloud-init-log")
-        log2 = self.tmp_path("cloud-init-output.log", self.new_root)
+        log2 = tmpdir.join("cloud-init-output.log")
         write_file(log2, "cloud-init-output-log")
-        userdata = self.tmp_path("user-data.txt", self.new_root)
+        userdata = tmpdir.join("user-data.txt")
         write_file(userdata, "user-data")
-        ensure_dir(self.run_dir)
-        write_file(self.tmp_path("results.json", self.run_dir), "results")
+        run_dir = tmpdir.join("run")
+        write_file(run_dir.join("results.json"), "results")
         write_file(
-            self.tmp_path(INSTANCE_JSON_SENSITIVE_FILE, self.run_dir),
+            run_dir.join(INSTANCE_JSON_SENSITIVE_FILE),
             "sensitive",
         )
-        output_tarfile = self.tmp_path("logs.tgz")
+        output_tarfile = str(tmpdir.join("logs.tgz"))
 
         date = datetime.utcnow().date().strftime("%Y-%m-%d")
         date_logdir = "cloud-init-logs-{0}".format(date)
@@ -180,34 +164,31 @@ class TestCollectLogs(FilesystemMockingTestCase):
 
         fake_stderr = mock.MagicMock()
 
-        wrap_and_call(
-            "cloudinit.cmd.devel.logs",
-            {
-                "subp": {"side_effect": fake_subp},
-                "sys.stderr": {"new": fake_stderr},
-                "CLOUDINIT_LOGS": {"new": [log1, log2]},
-                "CLOUDINIT_RUN_DIR": {"new": self.run_dir},
-                "USER_DATA_FILE": {"new": userdata},
-            },
-            logs.collect_logs,
-            output_tarfile,
-            include_userdata=True,
-        )
+        mocker.patch(M_PATH + "subp", side_effect=fake_subp)
+        mocker.patch(M_PATH + "sys.stderr", fake_stderr)
+        mocker.patch(M_PATH + "CLOUDINIT_LOGS", [log1, log2])
+        mocker.patch(M_PATH + "CLOUDINIT_RUN_DIR", run_dir)
+        mocker.patch(M_PATH + "_get_user_data_file", return_value=userdata)
+        logs.collect_logs(output_tarfile, include_userdata=True)
         # unpack the tarfile and check file contents
-        subp(["tar", "zxvf", output_tarfile, "-C", self.new_root])
-        out_logdir = self.tmp_path(date_logdir, self.new_root)
-        self.assertEqual(
-            "user-data", load_file(os.path.join(out_logdir, "user-data.txt"))
+        subp(["tar", "zxvf", output_tarfile, "-C", str(tmpdir)])
+        out_logdir = tmpdir.join(date_logdir)
+        assert "user-data" == load_file(
+            os.path.join(out_logdir, "user-data.txt")
         )
-        self.assertEqual(
-            "sensitive",
-            load_file(
-                os.path.join(
-                    out_logdir,
-                    "run",
-                    "cloud-init",
-                    INSTANCE_JSON_SENSITIVE_FILE,
-                )
-            ),
+        assert "sensitive" == load_file(
+            os.path.join(
+                out_logdir,
+                "run",
+                "cloud-init",
+                INSTANCE_JSON_SENSITIVE_FILE,
+            )
         )
         fake_stderr.write.assert_any_call("Wrote %s\n" % output_tarfile)
+
+
+class TestParser:
+    def test_parser_help_has_userdata_file(self, mocker, tmpdir):
+        userdata = str(tmpdir.join("user-data.txt"))
+        mocker.patch(M_PATH + "_get_user_data_file", return_value=userdata)
+        assert userdata in re.sub(r"\s+", "", logs.get_parser().format_help())

--- a/tests/unittests/config/test_cc_snap.py
+++ b/tests/unittests/config/test_cc_snap.py
@@ -1,27 +1,20 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import logging
+import os
 import re
 from io import StringIO
-import os
+
 import pytest
-import logging
+
 from cloudinit import helpers, util
-from cloudinit.config.cc_snap import (
-    add_assertions,
-    handle,
-    run_commands,
-)
+from cloudinit.config.cc_snap import add_assertions, handle, run_commands
 from cloudinit.config.schema import (
     SchemaValidationError,
     get_schema,
     validate_cloudconfig_schema,
 )
-from tests.unittests.helpers import (
-    CiTestCase,
-    mock,
-    skipUnlessJsonSchema,
-    wrap_and_call,
-)
+from tests.unittests.helpers import CiTestCase, mock, skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
 
 M_PATH = "cloudinit.config.cc_snap."
@@ -98,10 +91,9 @@ oG3Ie3WOHrVjCLXIdYslpL1O4nadqR6Xv58pHj6k"""
 def fake_cloud(tmpdir):
     paths = helpers.Paths(
         {
-            "cloud_dir": tmpdir.join("cloud"), 
-            "run_dir": tmpdir.join("cloud-init"), 
-            "templates_dir": tmpdir.join("templates"), 
-            
+            "cloud_dir": tmpdir.join("cloud"),
+            "run_dir": tmpdir.join("cloud-init"),
+            "templates_dir": tmpdir.join("templates"),
         }
     )
     cloud = get_cloud(paths=paths)
@@ -109,7 +101,6 @@ def fake_cloud(tmpdir):
 
 
 class TestAddAssertions:
-
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
     def test_add_assertions_on_empty_list(self, m_subp, caplog, tmpdir):
         """When provided with an empty list, add_assertions does nothing."""
@@ -122,40 +113,51 @@ class TestAddAssertions:
         """When provided an invalid type, add_assertions raises an error."""
         assert_file = tmpdir.join("snapd.assertions")
         with pytest.raises(
-            TypeError, 
-            match="assertion parameter was not a list or dict: I'm Not Valid"
+            TypeError,
+            match="assertion parameter was not a list or dict: I'm Not Valid",
         ):
             add_assertions("I'm Not Valid", assert_file)
 
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_add_assertions_adds_assertions_as_list(self, m_subp, caplog, tmpdir):
+    def test_add_assertions_adds_assertions_as_list(
+        self, m_subp, caplog, tmpdir
+    ):
         """When provided with a list, add_assertions adds all assertions."""
         assert_file = tmpdir.join("snapd.assertions")
         assertions = [SYSTEM_USER_ASSERTION, ACCOUNT_ASSERTION]
         add_assertions(assertions, assert_file)
         assert "Importing user-provided snap assertions" in caplog.text
         assert "sertions" in caplog.text
-        assert (
-            [mock.call(["snap", "ack", assert_file], capture=True)] ==
-            m_subp.call_args_list
-        )
+        assert [
+            mock.call(["snap", "ack", assert_file], capture=True)
+        ] == m_subp.call_args_list
         compare_file = tmpdir.join("comparison")
         util.write_file(compare_file, "\n".join(assertions).encode("utf-8"))
         assert util.load_file(compare_file) == util.load_file(assert_file)
 
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_add_assertions_adds_assertions_as_dict(self, m_subp, caplog, tmpdir):
+    def test_add_assertions_adds_assertions_as_dict(
+        self, m_subp, caplog, tmpdir
+    ):
         """When provided with a dict, add_assertions adds all assertions."""
         assert_file = tmpdir.join("snapd.assertions")
         assertions = {"00": SYSTEM_USER_ASSERTION, "01": ACCOUNT_ASSERTION}
         add_assertions(assertions, assert_file)
         assert "Importing user-provided snap assertions" in caplog.text
-        assert (M_PATH[:-1], logging.DEBUG, "Snap acking: ['type: system-user', 'authority-id: LqvZQdfyfGlYvtep4W6Oj6pFXP9t1Ksp']") in caplog.record_tuples
-        assert (M_PATH[:-1], logging.DEBUG, "Snap acking: ['type: account-key', 'authority-id: canonical']") in caplog.record_tuples
         assert (
-            [mock.call(["snap", "ack", assert_file], capture=True)] ==
-            m_subp.call_args_list
-        )
+            M_PATH[:-1],
+            logging.DEBUG,
+            "Snap acking: ['type: system-user', 'authority-id: "
+            "LqvZQdfyfGlYvtep4W6Oj6pFXP9t1Ksp']",
+        ) in caplog.record_tuples
+        assert (
+            M_PATH[:-1],
+            logging.DEBUG,
+            "Snap acking: ['type: account-key', 'authority-id: canonical']",
+        ) in caplog.record_tuples
+        assert [
+            mock.call(["snap", "ack", assert_file], capture=True)
+        ] == m_subp.call_args_list
         compare_file = tmpdir.join("comparison")
         combined = "\n".join(assertions.values())
         util.write_file(compare_file, combined.encode("utf-8"))
@@ -317,22 +319,17 @@ class TestSnapSchema:
 
 
 class TestHandle:
-
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
     def test_handle_adds_assertions(self, m_subp, fake_cloud, tmpdir):
         """Any configured snap assertions are provided to add_assertions."""
-        assert_file = os.path.join(fake_cloud.paths.get_ipath_cur(), "snapd.assertions")
+        assert_file = os.path.join(
+            fake_cloud.paths.get_ipath_cur(), "snapd.assertions"
+        )
         compare_file = tmpdir.join("comparison")
         cfg = {
             "snap": {"assertions": [SYSTEM_USER_ASSERTION, ACCOUNT_ASSERTION]}
         }
-        handle(
-            "snap",
-            cfg=cfg,
-            cloud=fake_cloud,
-            log=mock.Mock(),
-            args=None
-        )
+        handle("snap", cfg=cfg, cloud=fake_cloud, log=mock.Mock(), args=None)
         content = "\n".join(cfg["snap"]["assertions"])
         util.write_file(compare_file, content.encode("utf-8"))
         assert util.load_file(compare_file) == util.load_file(assert_file)

--- a/tests/unittests/config/test_cc_snap.py
+++ b/tests/unittests/config/test_cc_snap.py
@@ -2,12 +2,11 @@
 
 import re
 from io import StringIO
-
+import os
 import pytest
-
-from cloudinit import util
+import logging
+from cloudinit import helpers, util
 from cloudinit.config.cc_snap import (
-    ASSERTIONS_FILE,
     add_assertions,
     handle,
     run_commands,
@@ -23,6 +22,10 @@ from tests.unittests.helpers import (
     skipUnlessJsonSchema,
     wrap_and_call,
 )
+from tests.unittests.util import get_cloud
+
+M_PATH = "cloudinit.config.cc_snap."
+ASSERTIONS_FILE = "/var/lib/cloud/instance/snapd.assertions"
 
 SYSTEM_USER_ASSERTION = """\
 type: system-user
@@ -91,98 +94,72 @@ IQsRTONp+iVS8YxSmoYZjDlCgRMWUmawez/Fv5b9Fb/XkO5Eq4e+KfrpUujXItaipb+tV8h5v3t
 oG3Ie3WOHrVjCLXIdYslpL1O4nadqR6Xv58pHj6k"""
 
 
-class FakeCloud(object):
-    def __init__(self, distro):
-        self.distro = distro
+@pytest.fixture()
+def fake_cloud(tmpdir):
+    paths = helpers.Paths(
+        {
+            "cloud_dir": tmpdir.join("cloud"), 
+            "run_dir": tmpdir.join("cloud-init"), 
+            "templates_dir": tmpdir.join("templates"), 
+            
+        }
+    )
+    cloud = get_cloud(paths=paths)
+    yield cloud
 
 
-class TestAddAssertions(CiTestCase):
-
-    with_logs = True
-
-    def setUp(self):
-        super(TestAddAssertions, self).setUp()
-        self.tmp = self.tmp_dir()
+class TestAddAssertions:
 
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_add_assertions_on_empty_list(self, m_subp):
+    def test_add_assertions_on_empty_list(self, m_subp, caplog, tmpdir):
         """When provided with an empty list, add_assertions does nothing."""
-        add_assertions([])
-        self.assertEqual("", self.logs.getvalue())
-        m_subp.assert_not_called()
+        assert_file = tmpdir.join("snapd.assertions")
+        add_assertions([], assert_file)
+        assert not caplog.text
+        assert 0 == m_subp.call_count
 
-    def test_add_assertions_on_non_list_or_dict(self):
+    def test_add_assertions_on_non_list_or_dict(self, tmpdir):
         """When provided an invalid type, add_assertions raises an error."""
-        with self.assertRaises(TypeError) as context_manager:
-            add_assertions(assertions="I'm Not Valid")
-        self.assertEqual(
-            "assertion parameter was not a list or dict: I'm Not Valid",
-            str(context_manager.exception),
-        )
+        assert_file = tmpdir.join("snapd.assertions")
+        with pytest.raises(
+            TypeError, 
+            match="assertion parameter was not a list or dict: I'm Not Valid"
+        ):
+            add_assertions("I'm Not Valid", assert_file)
 
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_add_assertions_adds_assertions_as_list(self, m_subp):
+    def test_add_assertions_adds_assertions_as_list(self, m_subp, caplog, tmpdir):
         """When provided with a list, add_assertions adds all assertions."""
-        self.assertEqual(
-            ASSERTIONS_FILE, "/var/lib/cloud/instance/snapd.assertions"
-        )
-        assert_file = self.tmp_path("snapd.assertions", dir=self.tmp)
+        assert_file = tmpdir.join("snapd.assertions")
         assertions = [SYSTEM_USER_ASSERTION, ACCOUNT_ASSERTION]
-        wrap_and_call(
-            "cloudinit.config.cc_snap",
-            {"ASSERTIONS_FILE": {"new": assert_file}},
-            add_assertions,
-            assertions,
+        add_assertions(assertions, assert_file)
+        assert "Importing user-provided snap assertions" in caplog.text
+        assert "sertions" in caplog.text
+        assert (
+            [mock.call(["snap", "ack", assert_file], capture=True)] ==
+            m_subp.call_args_list
         )
-        self.assertIn(
-            "Importing user-provided snap assertions", self.logs.getvalue()
-        )
-        self.assertIn("sertions", self.logs.getvalue())
-        self.assertEqual(
-            [mock.call(["snap", "ack", assert_file], capture=True)],
-            m_subp.call_args_list,
-        )
-        compare_file = self.tmp_path("comparison", dir=self.tmp)
+        compare_file = tmpdir.join("comparison")
         util.write_file(compare_file, "\n".join(assertions).encode("utf-8"))
-        self.assertEqual(
-            util.load_file(compare_file), util.load_file(assert_file)
-        )
+        assert util.load_file(compare_file) == util.load_file(assert_file)
 
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_add_assertions_adds_assertions_as_dict(self, m_subp):
+    def test_add_assertions_adds_assertions_as_dict(self, m_subp, caplog, tmpdir):
         """When provided with a dict, add_assertions adds all assertions."""
-        self.assertEqual(
-            ASSERTIONS_FILE, "/var/lib/cloud/instance/snapd.assertions"
-        )
-        assert_file = self.tmp_path("snapd.assertions", dir=self.tmp)
+        assert_file = tmpdir.join("snapd.assertions")
         assertions = {"00": SYSTEM_USER_ASSERTION, "01": ACCOUNT_ASSERTION}
-        wrap_and_call(
-            "cloudinit.config.cc_snap",
-            {"ASSERTIONS_FILE": {"new": assert_file}},
-            add_assertions,
-            assertions,
+        add_assertions(assertions, assert_file)
+        assert "Importing user-provided snap assertions" in caplog.text
+        assert (M_PATH[:-1], logging.DEBUG, "Snap acking: ['type: system-user', 'authority-id: LqvZQdfyfGlYvtep4W6Oj6pFXP9t1Ksp']") in caplog.record_tuples
+        assert (M_PATH[:-1], logging.DEBUG, "Snap acking: ['type: account-key', 'authority-id: canonical']") in caplog.record_tuples
+        assert (
+            [mock.call(["snap", "ack", assert_file], capture=True)] ==
+            m_subp.call_args_list
         )
-        self.assertIn(
-            "Importing user-provided snap assertions", self.logs.getvalue()
-        )
-        self.assertIn(
-            "DEBUG: Snap acking: ['type: system-user', 'authority-id: Lqv",
-            self.logs.getvalue(),
-        )
-        self.assertIn(
-            "DEBUG: Snap acking: ['type: account-key', 'authority-id: canonic",
-            self.logs.getvalue(),
-        )
-        self.assertEqual(
-            [mock.call(["snap", "ack", assert_file], capture=True)],
-            m_subp.call_args_list,
-        )
-        compare_file = self.tmp_path("comparison", dir=self.tmp)
+        compare_file = tmpdir.join("comparison")
         combined = "\n".join(assertions.values())
         util.write_file(compare_file, combined.encode("utf-8"))
-        self.assertEqual(
-            util.load_file(compare_file), util.load_file(assert_file)
-        )
+        assert util.load_file(compare_file) == util.load_file(assert_file)
 
 
 class TestRunCommands(CiTestCase):
@@ -339,37 +316,26 @@ class TestSnapSchema:
                 validate_cloudconfig_schema(config, get_schema(), strict=True)
 
 
-class TestHandle(CiTestCase):
-
-    with_logs = True
-
-    def setUp(self):
-        super(TestHandle, self).setUp()
-        self.tmp = self.tmp_dir()
+class TestHandle:
 
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_handle_adds_assertions(self, m_subp):
+    def test_handle_adds_assertions(self, m_subp, fake_cloud, tmpdir):
         """Any configured snap assertions are provided to add_assertions."""
-        assert_file = self.tmp_path("snapd.assertions", dir=self.tmp)
-        compare_file = self.tmp_path("comparison", dir=self.tmp)
+        assert_file = os.path.join(fake_cloud.paths.get_ipath_cur(), "snapd.assertions")
+        compare_file = tmpdir.join("comparison")
         cfg = {
             "snap": {"assertions": [SYSTEM_USER_ASSERTION, ACCOUNT_ASSERTION]}
         }
-        wrap_and_call(
-            "cloudinit.config.cc_snap",
-            {"ASSERTIONS_FILE": {"new": assert_file}},
-            handle,
+        handle(
             "snap",
             cfg=cfg,
-            cloud=None,
-            log=self.logger,
-            args=None,
+            cloud=fake_cloud,
+            log=mock.Mock(),
+            args=None
         )
         content = "\n".join(cfg["snap"]["assertions"])
         util.write_file(compare_file, content.encode("utf-8"))
-        self.assertEqual(
-            util.load_file(compare_file), util.load_file(assert_file)
-        )
+        assert util.load_file(compare_file) == util.load_file(assert_file)
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -296,10 +296,10 @@ def patched_markers_dir_path(tmpdir):
 
 
 @pytest.fixture
-def patched_reported_ready_marker_path(patched_markers_dir_path):
+def patched_reported_ready_marker_path(azure_ds, patched_markers_dir_path):
     reported_ready_marker = patched_markers_dir_path / "reported_ready"
-    with mock.patch(
-        MOCKPATH + "REPORTED_READY_MARKER_FILE", str(reported_ready_marker)
+    with mock.patch.object(
+        azure_ds, "_reported_ready_marker_file", str(reported_ready_marker)
     ):
         yield reported_ready_marker
 
@@ -2773,7 +2773,7 @@ class TestDeterminePPSTypeScenarios:
             == dsaz.PPSType.UNKNOWN
         )
         assert is_file.mock_calls == [
-            mock.call(dsaz.REPORTED_READY_MARKER_FILE)
+            mock.call(azure_ds._reported_ready_marker_file)
         ]
 
 
@@ -2826,7 +2826,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
         self.assertEqual(1, m_detach.call_count)
         self.assertEqual(1, m_writefile.call_count)
         m_writefile.assert_called_with(
-            dsaz.REPORTED_READY_MARKER_FILE, mock.ANY
+            dsa._reported_ready_marker_file, mock.ANY
         )
 
     @mock.patch(MOCKPATH + "util.write_file", autospec=True)
@@ -3061,7 +3061,9 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         m_request.side_effect = fake_timeout_once
 
         dsa = dsaz.DataSourceAzure({}, distro=mock.Mock(), paths=self.paths)
-        with mock.patch(MOCKPATH + "REPORTED_READY_MARKER_FILE", report_file):
+        with mock.patch.object(
+            dsa, "_reported_ready_marker_file", report_file
+        ):
             dsa._poll_imds()
 
         assert m_report_ready.mock_calls == [mock.call()]
@@ -3089,7 +3091,9 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         m_isfile.return_value = True
         dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
         dsa._ephemeral_dhcp_ctx = mock.Mock(lease={})
-        with mock.patch(MOCKPATH + "REPORTED_READY_MARKER_FILE", report_file):
+        with mock.patch.object(
+            dsa, "_reported_ready_marker_file", report_file
+        ):
             dsa._poll_imds()
         self.assertEqual(0, m_dhcp.call_count)
         self.assertEqual(0, m_media_switch.call_count)
@@ -3126,8 +3130,8 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         report_file = self.tmp_path("report_marker", self.tmp)
         m_isfile.return_value = True
         dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
-        with mock.patch(
-            MOCKPATH + "REPORTED_READY_MARKER_FILE", report_file
+        with mock.patch.object(
+            dsa, "_reported_ready_marker_file", report_file
         ), mock.patch.object(dsa, "_ephemeral_dhcp_ctx") as m_dhcp_ctx:
             m_dhcp_ctx.obtain_lease.return_value = "Dummy lease"
             dsa._ephemeral_dhcp_ctx = m_dhcp_ctx
@@ -3161,7 +3165,9 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         ]
         m_media_switch.return_value = None
         dsa = dsaz.DataSourceAzure({}, distro=mock.Mock(), paths=self.paths)
-        with mock.patch(MOCKPATH + "REPORTED_READY_MARKER_FILE", report_file):
+        with mock.patch.object(
+            dsa, "_reported_ready_marker_file", report_file
+        ):
             dsa._poll_imds()
         self.assertEqual(m_report_ready.call_count, 0)
 
@@ -3189,7 +3195,9 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         m_media_switch.return_value = None
         dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
         self.assertFalse(os.path.exists(report_file))
-        with mock.patch(MOCKPATH + "REPORTED_READY_MARKER_FILE", report_file):
+        with mock.patch.object(
+            dsa, "_reported_ready_marker_file", report_file
+        ):
             dsa._poll_imds()
         self.assertEqual(m_report_ready.call_count, 1)
         self.assertTrue(os.path.exists(report_file))
@@ -3219,7 +3227,9 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         m_report_ready.side_effect = [Exception("fail")]
         dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
         self.assertFalse(os.path.exists(report_file))
-        with mock.patch(MOCKPATH + "REPORTED_READY_MARKER_FILE", report_file):
+        with mock.patch.object(
+            dsa, "_reported_ready_marker_file", report_file
+        ):
             self.assertRaises(InvalidMetaDataException, dsa._poll_imds)
         self.assertEqual(m_report_ready.call_count, 1)
         self.assertFalse(os.path.exists(report_file))

--- a/tests/unittests/sources/test_bigstep.py
+++ b/tests/unittests/sources/test_bigstep.py
@@ -1,0 +1,48 @@
+import json
+import os
+
+import httpretty
+import pytest
+
+from cloudinit import helpers
+from cloudinit.sources import DataSourceBigstep as bigstep
+from tests.unittests.helpers import mock
+
+M_PATH = "cloudinit.sources.DataSourceBigstep."
+
+IMDS_URL = "http://bigstep.com"
+METADATA_BODY = json.dumps(
+    {
+        "metadata": "metadata",
+        "vendordata_raw": "vendordata_raw",
+        "userdata_raw": "userdata_raw",
+    }
+)
+
+
+class TestBigstep:
+    @httpretty.activate
+    @pytest.mark.parametrize("custom_paths", [False, True])
+    @mock.patch(M_PATH + "util.load_file", return_value=IMDS_URL)
+    def test_get_data_honor_cloud_dir(
+        self, m_load_file, custom_paths, tmpdir
+    ):
+        httpretty.register_uri(httpretty.GET, IMDS_URL, body=METADATA_BODY)
+
+        paths = {}
+        url_file = "/var/lib/cloud/data/seed/bigstep/url"
+        if custom_paths:
+            paths = {
+                "cloud_dir": tmpdir.join("cloud"),
+                "run_dir": tmpdir,
+                "templates_dir": tmpdir,
+            }
+            url_file = os.path.join(
+                paths["cloud_dir"], "data", "seed", "bigstep", "url"
+            )
+
+        ds = bigstep.DataSourceBigstep(
+            sys_cfg={}, distro=mock.Mock(), paths=helpers.Paths(paths)
+        )
+        assert ds._get_data()
+        assert [mock.call(url_file)] == m_load_file.call_args_list

--- a/tests/unittests/sources/test_bigstep.py
+++ b/tests/unittests/sources/test_bigstep.py
@@ -24,9 +24,7 @@ class TestBigstep:
     @httpretty.activate
     @pytest.mark.parametrize("custom_paths", [False, True])
     @mock.patch(M_PATH + "util.load_file", return_value=IMDS_URL)
-    def test_get_data_honor_cloud_dir(
-        self, m_load_file, custom_paths, tmpdir
-    ):
+    def test_get_data_honor_cloud_dir(self, m_load_file, custom_paths, tmpdir):
         httpretty.register_uri(httpretty.GET, IMDS_URL, body=METADATA_BODY)
 
         paths = {}

--- a/tests/unittests/test_apport.py
+++ b/tests/unittests/test_apport.py
@@ -1,0 +1,23 @@
+from tests.unittests.helpers import mock
+
+M_PATH = "cloudinit.apport."
+
+
+class TestApport:
+    def test_attach_user_data(self, mocker, tmpdir):
+        m_hookutils = mock.Mock()
+        mocker.patch.dict("sys.modules", {"apport.hookutils": m_hookutils})
+        user_data_file = tmpdir.join("instance", "user-data.txt")
+        mocker.patch(
+            M_PATH + "_get_user_data_file", return_value=user_data_file
+        )
+
+        from cloudinit import apport
+
+        ui = mock.Mock()
+        ui.yesno.return_value = True
+        report = object()
+        apport.attach_user_data(report, ui)
+        assert [
+            mock.call(report, user_data_file, "user_data.txt")
+        ] == m_hookutils.attach_file.call_args_list

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -5,22 +5,27 @@ import io
 import os
 from collections import namedtuple
 
+import pytest
+
+from cloudinit import helpers
 from cloudinit.cmd import main as cli
 from cloudinit.util import load_file, load_json
 from tests.unittests import helpers as test_helpers
 
 mock = test_helpers.mock
 
+M_PATH = "cloudinit.cmd.main."
 
-class TestCLI(test_helpers.FilesystemMockingTestCase):
 
-    with_logs = True
+@pytest.fixture(autouse=False)
+def mock_get_user_data_file(mocker, tmpdir):
+    yield mocker.patch(
+        "cloudinit.cmd.devel.logs._get_user_data_file",
+        return_value=tmpdir.join("cloud"),
+    )
 
-    def setUp(self):
-        super(TestCLI, self).setUp()
-        self.stderr = io.StringIO()
-        self.patchStdoutAndStderr(stderr=self.stderr)
 
+class TestCLI:
     def _call_main(self, sysv_args=None):
         if not sysv_args:
             sysv_args = ["cloud-init"]
@@ -29,57 +34,48 @@ class TestCLI(test_helpers.FilesystemMockingTestCase):
         except SystemExit as e:
             return e.code
 
-    def test_status_wrapper_errors_on_invalid_name(self):
-        """status_wrapper will error when the name parameter is not valid.
-
-        Valid name values are only init and modules.
-        """
-        tmpd = self.tmp_dir()
-        data_d = self.tmp_path("data", tmpd)
-        link_d = self.tmp_path("link", tmpd)
+    @pytest.mark.parametrize(
+        "action,name,match",
+        [
+            pytest.param(
+                "doesnotmatter",
+                "init1",
+                "^unknown name: init1$",
+                id="invalid_name",
+            ),
+            pytest.param(
+                "modules_name",
+                "modules",
+                "^Invalid cloud init mode specified 'modules-bogusmode'$",
+                id="invalid_modes",
+            ),
+        ],
+    )
+    def test_status_wrapper_errors(self, action, name, match, caplog, tmpdir):
+        data_d = tmpdir.join("data")
+        link_d = tmpdir.join("link")
         FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
 
         def myaction():
             raise Exception("Should not call myaction")
 
-        myargs = FakeArgs(("doesnotmatter", myaction), False, "bogusmode")
-        with self.assertRaises(ValueError) as cm:
-            cli.status_wrapper("init1", myargs, data_d, link_d)
-        self.assertEqual("unknown name: init1", str(cm.exception))
-        self.assertNotIn("Should not call myaction", self.logs.getvalue())
+        myargs = FakeArgs((action, myaction), False, "bogusmode")
+        with pytest.raises(ValueError, match=match):
+            cli.status_wrapper(name, myargs, data_d, link_d)
+        assert "Should not call myaction" not in caplog.text
 
-    def test_status_wrapper_errors_on_invalid_modes(self):
-        """status_wrapper will error if a parameter combination is invalid."""
-        tmpd = self.tmp_dir()
-        data_d = self.tmp_path("data", tmpd)
-        link_d = self.tmp_path("link", tmpd)
-        FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
-
-        def myaction():
-            raise Exception("Should not call myaction")
-
-        myargs = FakeArgs(("modules_name", myaction), False, "bogusmode")
-        with self.assertRaises(ValueError) as cm:
-            cli.status_wrapper("modules", myargs, data_d, link_d)
-        self.assertEqual(
-            "Invalid cloud init mode specified 'modules-bogusmode'",
-            str(cm.exception),
-        )
-        self.assertNotIn("Should not call myaction", self.logs.getvalue())
-
-    def test_status_wrapper_init_local_writes_fresh_status_info(self):
+    def test_status_wrapper_init_local_writes_fresh_status_info(self, tmpdir):
         """When running in init-local mode, status_wrapper writes status.json.
 
         Old status and results artifacts are also removed.
         """
-        tmpd = self.tmp_dir()
-        data_d = self.tmp_path("data", tmpd)
-        link_d = self.tmp_path("link", tmpd)
-        status_link = self.tmp_path("status.json", link_d)
+        data_d = tmpdir.join("data")
+        link_d = tmpdir.join("link")
+        status_link = link_d.join("status.json")
         # Write old artifacts which will be removed or updated.
         for _dir in data_d, link_d:
             test_helpers.populate_dir(
-                _dir, {"status.json": "old", "result.json": "old"}
+                str(_dir), {"status.json": "old", "result.json": "old"}
             )
 
         FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
@@ -92,39 +88,63 @@ class TestCLI(test_helpers.FilesystemMockingTestCase):
         cli.status_wrapper("init", myargs, data_d, link_d)
         # No errors reported in status
         status_v1 = load_json(load_file(status_link))["v1"]
-        self.assertEqual(["an error"], status_v1["init-local"]["errors"])
-        self.assertEqual("SomeDatasource", status_v1["datasource"])
-        self.assertFalse(
-            os.path.exists(self.tmp_path("result.json", data_d)),
-            "unexpected result.json found",
-        )
-        self.assertFalse(
-            os.path.exists(self.tmp_path("result.json", link_d)),
-            "unexpected result.json link found",
-        )
+        assert ["an error"] == status_v1["init-local"]["errors"]
+        assert "SomeDatasource" == status_v1["datasource"]
+        assert False is os.path.exists(
+            data_d.join("result.json")
+        ), "unexpected result.json found"
+        assert False is os.path.exists(
+            link_d.join("result.json")
+        ), "unexpected result.json link found"
 
-    def test_no_arguments_shows_usage(self):
+    def test_status_wrapper_init_local_honor_cloud_dir(self, mocker, tmpdir):
+        """When running in init-local mode, status_wrapper honors cloud_dir."""
+        cloud_dir = tmpdir.join("cloud")
+        paths = helpers.Paths({"cloud_dir": str(cloud_dir)})
+        mocker.patch(M_PATH + "read_cfg_paths", return_value=paths)
+        data_d = cloud_dir.join("data")
+        link_d = tmpdir.join("link")
+
+        FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
+
+        def myaction(name, args):
+            # Return an error to watch status capture them
+            return "SomeDatasource", ["an_error"]
+
+        myargs = FakeArgs(("ignored_name", myaction), True, "bogusmode")
+        cli.status_wrapper("init", myargs, link_d=link_d)  # No explicit data_d
+        # Access cloud_dir directly
+        status_v1 = load_json(load_file(data_d.join("status.json")))["v1"]
+        assert ["an_error"] == status_v1["init-local"]["errors"]
+        assert "SomeDatasource" == status_v1["datasource"]
+        assert False is os.path.exists(
+            data_d.join("result.json")
+        ), "unexpected result.json found"
+        assert False is os.path.exists(
+            link_d.join("result.json")
+        ), "unexpected result.json link found"
+
+    def test_no_arguments_shows_usage(self, capsys):
         exit_code = self._call_main()
-        self.assertIn("usage: cloud-init", self.stderr.getvalue())
-        self.assertEqual(2, exit_code)
+        _out, err = capsys.readouterr()
+        assert "usage: cloud-init" in err
+        assert 2 == exit_code
 
-    def test_no_arguments_shows_error_message(self):
+    def test_no_arguments_shows_error_message(self, capsys):
         exit_code = self._call_main()
         missing_subcommand_message = (
             "the following arguments are required: subcommand"
         )
-        error = self.stderr.getvalue()
-        self.assertIn(
-            missing_subcommand_message,
-            error,
-            "Did not find error message for missing subcommand",
-        )
-        self.assertEqual(2, exit_code)
+        _out, err = capsys.readouterr()
+        assert (
+            missing_subcommand_message in err
+        ), "Did not find error message for missing subcommand"
+        assert 2 == exit_code
 
-    def test_all_subcommands_represented_in_help(self):
+    def test_all_subcommands_represented_in_help(self, capsys):
         """All known subparsers are represented in the cloud-int help doc."""
         self._call_main()
-        error = self.stderr.getvalue()
+        _out, err = capsys.readouterr()
         expected_subcommands = [
             "analyze",
             "clean",
@@ -137,241 +157,188 @@ class TestCLI(test_helpers.FilesystemMockingTestCase):
             "schema",
         ]
         for subcommand in expected_subcommands:
-            self.assertIn(subcommand, error)
+            assert subcommand in err
 
+    @pytest.mark.parametrize("subcommand", ["init", "modules"])
     @mock.patch("cloudinit.cmd.main.status_wrapper")
-    def test_init_subcommand_parser(self, m_status_wrapper):
-        """The subcommand 'init' calls status_wrapper passing init."""
-        self._call_main(["cloud-init", "init"])
+    def test_modules_subcommand_parser(self, m_status_wrapper, subcommand):
+        """The subcommand 'subcommand' calls status_wrapper passing modules."""
+        self._call_main(["cloud-init", subcommand])
         (name, parseargs) = m_status_wrapper.call_args_list[0][0]
-        self.assertEqual("init", name)
-        self.assertEqual("init", parseargs.subcommand)
-        self.assertEqual("init", parseargs.action[0])
-        self.assertEqual("main_init", parseargs.action[1].__name__)
+        assert subcommand == name
+        assert subcommand == parseargs.subcommand
+        assert subcommand == parseargs.action[0]
+        assert f"main_{subcommand}" == parseargs.action[1].__name__
 
-    @mock.patch("cloudinit.cmd.main.status_wrapper")
-    def test_modules_subcommand_parser(self, m_status_wrapper):
-        """The subcommand 'modules' calls status_wrapper passing modules."""
-        self._call_main(["cloud-init", "modules"])
-        (name, parseargs) = m_status_wrapper.call_args_list[0][0]
-        self.assertEqual("modules", name)
-        self.assertEqual("modules", parseargs.subcommand)
-        self.assertEqual("modules", parseargs.action[0])
-        self.assertEqual("main_modules", parseargs.action[1].__name__)
-
-    def test_conditional_subcommands_from_entry_point_sys_argv(self):
-        """Subcommands from entry-point are properly parsed from sys.argv."""
-        stdout = io.StringIO()
-        self.patchStdoutAndStderr(stdout=stdout)
-
-        expected_errors = [
-            "usage: cloud-init analyze",
-            "usage: cloud-init clean",
-            "usage: cloud-init collect-logs",
-            "usage: cloud-init devel",
-            "usage: cloud-init status",
-            "usage: cloud-init schema",
-        ]
-        conditional_subcommands = [
+    @pytest.mark.parametrize(
+        "subcommand",
+        [
             "analyze",
             "clean",
             "collect-logs",
             "devel",
             "status",
             "schema",
-        ]
+        ],
+    )
+    def test_conditional_subcommands_from_entry_point_sys_argv(
+        self, subcommand, capsys, mock_get_user_data_file, tmpdir
+    ):
+        """Subcommands from entry-point are properly parsed from sys.argv."""
+        expected_error = f"usage: cloud-init {subcommand}"
         # The cloud-init entrypoint calls main without passing sys_argv
-        for subcommand in conditional_subcommands:
-            with mock.patch("sys.argv", ["cloud-init", subcommand, "-h"]):
-                try:
-                    cli.main()
-                except SystemExit as e:
-                    self.assertEqual(0, e.code)  # exit 2 on proper -h usage
-        for error_message in expected_errors:
-            self.assertIn(error_message, stdout.getvalue())
+        with mock.patch("sys.argv", ["cloud-init", subcommand, "-h"]):
+            try:
+                cli.main()
+            except SystemExit as e:
+                assert 0 == e.code  # exit 2 on proper -h usage
+        out, _err = capsys.readouterr()
+        assert expected_error in out
 
-    def test_analyze_subcommand_parser(self):
-        """The subcommand cloud-init analyze calls the correct subparser."""
-        self._call_main(["cloud-init", "analyze"])
-        # These subcommands only valid for cloud-init analyze script
-        expected_subcommands = ["blame", "show", "dump"]
-        error = self.stderr.getvalue()
-        for subcommand in expected_subcommands:
-            self.assertIn(subcommand, error)
+    @pytest.mark.parametrize(
+        "subcommand",
+        [
+            "clean",
+            "collect-logs",
+            "status",
+        ],
+    )
+    def test_subcommand_parser(self, subcommand, mock_get_user_data_file):
+        """cloud-init `subcommand` calls its subparser."""
+        # Provide -h param to `subcommand` to avoid having to mock behavior.
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self._call_main(["cloud-init", subcommand, "-h"])
+        assert f"usage: cloud-init {subcommand}" in out.getvalue()
 
-    def test_collect_logs_subcommand_parser(self):
-        """The subcommand cloud-init collect-logs calls the subparser."""
-        # Provide -h param to collect-logs to avoid having to mock behavior.
-        stdout = io.StringIO()
-        self.patchStdoutAndStderr(stdout=stdout)
-        self._call_main(["cloud-init", "collect-logs", "-h"])
-        self.assertIn("usage: cloud-init collect-log", stdout.getvalue())
-
-    def test_clean_subcommand_parser(self):
-        """The subcommand cloud-init clean calls the subparser."""
-        # Provide -h param to clean to avoid having to mock behavior.
-        stdout = io.StringIO()
-        self.patchStdoutAndStderr(stdout=stdout)
-        self._call_main(["cloud-init", "clean", "-h"])
-        self.assertIn("usage: cloud-init clean", stdout.getvalue())
-
-    def test_status_subcommand_parser(self):
-        """The subcommand cloud-init status calls the subparser."""
-        # Provide -h param to clean to avoid having to mock behavior.
-        stdout = io.StringIO()
-        self.patchStdoutAndStderr(stdout=stdout)
-        self._call_main(["cloud-init", "status", "-h"])
-        self.assertIn("usage: cloud-init status", stdout.getvalue())
-
-    def test_subcommand_parser(self):
+    @pytest.mark.parametrize(
+        "args,expected_subcommands",
+        [
+            ([], ["schema"]),
+            (["analyze"], ["blame", "show", "dump"]),
+        ],
+    )
+    def test_subcommand_parser_multi_arg(
+        self, args, expected_subcommands, capsys
+    ):
         """The subcommand cloud-init schema calls the correct subparser."""
-        self._call_main(["cloud-init"])
-        # These subcommands only valid for cloud-init schema script
-        expected_subcommands = ["schema"]
-        error = self.stderr.getvalue()
+        self._call_main(["cloud-init"] + args)
+        _out, err = capsys.readouterr()
         for subcommand in expected_subcommands:
-            self.assertIn(subcommand, error)
+            assert subcommand in err
 
-    def test_wb_schema_subcommand_parser(self):
+    def test_wb_schema_subcommand_parser(self, capsys):
         """The subcommand cloud-init schema calls the correct subparser."""
         exit_code = self._call_main(["cloud-init", "schema"])
-        self.assertEqual(1, exit_code)
+        _out, err = capsys.readouterr()
+        assert 1 == exit_code
         # Known whitebox output from schema subcommand
-        self.assertEqual(
+        assert (
             "Error:\n"
-            "Expected one of --config-file, --system or --docs arguments\n",
-            self.stderr.getvalue(),
+            "Expected one of --config-file, --system or --docs arguments\n"
+            == err
         )
 
-    def test_wb_schema_subcommand_doc_all_spot_check(self):
-        """Validate that doc content has correct values from known examples.
-
-        Ensure that schema doc is returned
-        """
-
-        # Note: patchStdoutAndStderr() is convenient for reducing boilerplate,
-        # but inspecting the code for debugging is not ideal
-        # contextlib.redirect_stdout() provides similar behavior as a context
-        # manager
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            self._call_main(["cloud-init", "schema", "--docs", "all"])
-            expected_doc_sections = [
-                "**Supported distros:** all",
-                "**Supported distros:** almalinux, alpine, centos, "
-                "cloudlinux, debian, eurolinux, fedora, miraclelinux, "
-                "openEuler, openmandriva, opensuse, photon, rhel, rocky, "
-                "sles, ubuntu, virtuozzo",
-                "**Config schema**:\n    **resize_rootfs:** "
-                "(``true``/``false``/``noblock``)",
-                "**Examples**::\n\n    runcmd:\n        - [ ls, -l, / ]\n",
-            ]
-        stdout = stdout.getvalue()
-        for expected in expected_doc_sections:
-            self.assertIn(expected, stdout)
-
-    def test_wb_schema_subcommand_single_spot_check(self):
-        """Validate that doc content has correct values from known example.
-
-        Validate 'all' arg
-        """
-
-        # Note: patchStdoutAndStderr() is convenient for reducing boilerplate,
-        # but inspecting the code for debugging is not ideal
-        # contextlib.redirect_stdout() provides similar behavior as a context
-        # manager
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            self._call_main(["cloud-init", "schema", "--docs", "cc_runcmd"])
-            expected_doc_sections = [
-                "Runcmd\n------\n**Summary:** Run arbitrary commands"
-            ]
-        stdout = stdout.getvalue()
-        for expected in expected_doc_sections:
-            self.assertIn(expected, stdout)
-
-    def test_wb_schema_subcommand_multiple_spot_check(self):
-        """Validate that doc content has correct values from known example.
-
-        Validate single arg
-        """
-
-        stdout = io.StringIO()
-        with contextlib.redirect_stdout(stdout):
-            self._call_main(
+    @pytest.mark.parametrize(
+        "args,expected_doc_sections,is_error",
+        [
+            pytest.param(
+                ["all"],
                 [
-                    "cloud-init",
-                    "schema",
-                    "--docs",
+                    "**Supported distros:** all",
+                    "**Supported distros:** almalinux, alpine, centos, "
+                    "cloudlinux, debian, eurolinux, fedora, miraclelinux, "
+                    "openEuler, openmandriva, opensuse, photon, rhel, rocky, "
+                    "sles, ubuntu, virtuozzo",
+                    "**Config schema**:\n    **resize_rootfs:** "
+                    "(``true``/``false``/``noblock``)",
+                    "**Examples**::\n\n    runcmd:\n        - [ ls, -l, / ]\n",
+                ],
+                False,
+                id="all_spot_check",
+            ),
+            pytest.param(
+                ["cc_runcmd"],
+                ["Runcmd\n------\n**Summary:** Run arbitrary commands"],
+                False,
+                id="single_spot_check",
+            ),
+            pytest.param(
+                [
                     "cc_runcmd",
                     "cc_resizefs",
-                ]
-            )
-            expected_doc_sections = [
-                "Runcmd\n------\n**Summary:** Run arbitrary commands",
-                "Resizefs\n--------\n**Summary:** Resize filesystem",
-            ]
-        stdout = stdout.getvalue()
-        for expected in expected_doc_sections:
-            self.assertIn(expected, stdout)
-
-    def test_wb_schema_subcommand_bad_arg_fails(self):
-        """Validate that doc content has correct values from known example.
-
-        Validate multiple args
-        """
+                ],
+                [
+                    "Runcmd\n------\n**Summary:** Run arbitrary commands",
+                    "Resizefs\n--------\n**Summary:** Resize filesystem",
+                ],
+                False,
+                id="multiple_spot_check",
+            ),
+            pytest.param(
+                ["garbage_value"],
+                ["Invalid --docs value"],
+                True,
+                id="bad_arg_fails",
+            ),
+        ],
+    )
+    def test_wb_schema_subcommand(self, args, expected_doc_sections, is_error):
+        """Validate that doc content has correct values."""
 
         # Note: patchStdoutAndStderr() is convenient for reducing boilerplate,
         # but inspecting the code for debugging is not ideal
         # contextlib.redirect_stdout() provides similar behavior as a context
         # manager
-        stderr = io.StringIO()
-        with contextlib.redirect_stderr(stderr):
-            self._call_main(
-                ["cloud-init", "schema", "--docs", "garbage_value"]
-            )
-            expected_doc_sections = ["Invalid --docs value"]
-        stderr = stderr.getvalue()
+        out_or_err = io.StringIO()
+        redirecter = (
+            contextlib.redirect_stderr
+            if is_error
+            else contextlib.redirect_stdout
+        )
+        with redirecter(out_or_err):
+            self._call_main(["cloud-init", "schema", "--docs"] + args)
+        out_or_err = out_or_err.getvalue()
         for expected in expected_doc_sections:
-            self.assertIn(expected, stderr)
+            assert expected in out_or_err
 
     @mock.patch("cloudinit.cmd.main.main_single")
     def test_single_subcommand(self, m_main_single):
         """The subcommand 'single' calls main_single with valid args."""
         self._call_main(["cloud-init", "single", "--name", "cc_ntp"])
         (name, parseargs) = m_main_single.call_args_list[0][0]
-        self.assertEqual("single", name)
-        self.assertEqual("single", parseargs.subcommand)
-        self.assertEqual("single", parseargs.action[0])
-        self.assertFalse(parseargs.debug)
-        self.assertFalse(parseargs.force)
-        self.assertIsNone(parseargs.frequency)
-        self.assertEqual("cc_ntp", parseargs.name)
-        self.assertFalse(parseargs.report)
+        assert "single" == name
+        assert "single" == parseargs.subcommand
+        assert "single" == parseargs.action[0]
+        assert False is parseargs.debug
+        assert False is parseargs.force
+        assert None is parseargs.frequency
+        assert "cc_ntp" == parseargs.name
+        assert False is parseargs.report
 
     @mock.patch("cloudinit.cmd.main.dhclient_hook.handle_args")
     def test_dhclient_hook_subcommand(self, m_handle_args):
         """The subcommand 'dhclient-hook' calls dhclient_hook with args."""
         self._call_main(["cloud-init", "dhclient-hook", "up", "eth0"])
         (name, parseargs) = m_handle_args.call_args_list[0][0]
-        self.assertEqual("dhclient-hook", name)
-        self.assertEqual("dhclient-hook", parseargs.subcommand)
-        self.assertEqual("dhclient-hook", parseargs.action[0])
-        self.assertFalse(parseargs.debug)
-        self.assertFalse(parseargs.force)
-        self.assertEqual("up", parseargs.event)
-        self.assertEqual("eth0", parseargs.interface)
+        assert "dhclient-hook" == name
+        assert "dhclient-hook" == parseargs.subcommand
+        assert "dhclient-hook" == parseargs.action[0]
+        assert False is parseargs.debug
+        assert False is parseargs.force
+        assert "up" == parseargs.event
+        assert "eth0" == parseargs.interface
 
     @mock.patch("cloudinit.cmd.main.main_features")
     def test_features_hook_subcommand(self, m_features):
         """The subcommand 'features' calls main_features with args."""
         self._call_main(["cloud-init", "features"])
         (name, parseargs) = m_features.call_args_list[0][0]
-        self.assertEqual("features", name)
-        self.assertEqual("features", parseargs.subcommand)
-        self.assertEqual("features", parseargs.action[0])
-        self.assertFalse(parseargs.debug)
-        self.assertFalse(parseargs.force)
+        assert "features" == name
+        assert "features" == parseargs.subcommand
+        assert "features" == parseargs.action[0]
+        assert False is parseargs.debug
+        assert False is parseargs.force
 
 
 # : ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cloud-config: honor cloud_dir setting

- Modules affected: cmd.main, apport, devel.logs (collect-logs),
cc_snap, sources.DataSourceAzure, sources.DataSourceBigstep,
util:fetch_ssl_details.
- testing: Extend and port to pytest unit tests, add integration test.

LP: #1976564
```

## Additional Context
<!-- If relevant -->
https://bugs.launchpad.net/cloud-init/+bug/1976564
https://warthogs.atlassian.net/browse/SC-1085

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```sh
cat > /tmp/95-custom-cloud-dir.cfg <<EOF
system_info:
  paths:
    cloud_dir: /new-cloud-dir
EOF

CONTAINER_NAME=dev-k
lxc launch ubuntu-daily:kinetic $CONTAINER_NAME
lxc file push /tmp/95-custom-cloud-dir.cfg $CONTAINER_NAME/etc/cloud/cloud.cfg.d/
lxc exec $CONTAINER_NAME -- rm -rf /var/lib/cloud
lxc exec $CONTAINER_NAME -- cloud-init clean --logs --reboot
lxc exec $CONTAINER_NAME -- cloud-init status --wait --long

# Expect no logs referencing use of /var/lib/cloud
lxc exec $CONTAINER_NAME -- grep /var/lib /var/log/cloud-init.log

# Expect logs referencing use of new cloud-dir
lxc exec $CONTAINER_NAME -- grep /new-cloud-dir var/log/cloud-init.log

# Expect to find no files in /var/lib/cloud
lxc exec $CONTAINER_NAME find /var/lib/cloud

# Expect user-data file pointing to the correct cloud-dir
lxc exec $CONTAINER_NAME -- cloud-init collect-logs -h
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
