### PR TITLE
sources/azure: remove unused metadata captured when parsing ovf

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1901,8 +1901,7 @@ def read_azure_ovf(contents):
     if not lpcs.hasChildNodes():
         raise BrokenAzureDataSource("no child nodes of configuration set")
 
-    md_props = "seedfrom"
-    md: Dict[str, Any] = {"azure_data": {}}
+    md: Dict[str, Any] = {}
     cfg = {}
     ud = ""
     password = None
@@ -1914,13 +1913,11 @@ def read_azure_ovf(contents):
 
         name = child.localName.lower()
 
-        simple = False
         value = ""
         if (
             len(child.childNodes) == 1
             and child.childNodes[0].nodeType == dom.TEXT_NODE
         ):
-            simple = True
             value = child.childNodes[0].wholeText
 
         attrs = dict([(k, v) for k, v in child.attributes.items()])
@@ -1946,11 +1943,6 @@ def read_azure_ovf(contents):
             cfg["_pubkeys"] = load_azure_ovf_pubkeys(child)
         elif name == "disablesshpasswordauthentication":
             cfg["ssh_pwauth"] = util.is_false(value)
-        elif simple:
-            if name in md_props:
-                md[name] = value
-            else:
-                md["azure_data"][name] = value
 
     defuser = {}
     if username:

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1294,9 +1294,6 @@ scbus-1 on xpt0 bus 0
             "system_info": {"default_user": {"name": "myuser"}},
         }
         expected_metadata = {
-            "azure_data": {
-                "configurationsettype": "LinuxProvisioningConfiguration"
-            },
             "imds": NETWORK_METADATA,
             "instance-id": EXAMPLE_UUID,
             "local-hostname": "myhost",


### PR DESCRIPTION
- seedfrom is not used by Azure ovf-env.xml, remove it.

- azure_data is capturing arbitrary keys and we already
  have a redacted ovf-env.xml if we need to inspect any
  (unused) properties.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>