### PR TITLE
Rongz609 pr2976717

### DIFF
--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -50,6 +50,9 @@ CONFGROUPNAME_GUESTCUSTOMIZATION = "deployPkg"
 GUESTCUSTOMIZATION_ENABLE_CUST_SCRIPTS = "enable-custom-scripts"
 VMWARE_IMC_DIR = "/var/run/vmware-imc"
 
+class GuestCustScriptDisabledException(Exception):
+    """Specifies explicit exception for GUESTCUST_ERROR_SCRIPT_DISABLED"""
+    pass
 
 class DataSourceOVF(sources.DataSource):
 
@@ -270,11 +273,19 @@ class DataSourceOVF(sources.DataSource):
                             GuestCustStateEnum.GUESTCUST_STATE_RUNNING,
                             GuestCustErrorEnum.GUESTCUST_ERROR_SCRIPT_DISABLED,
                         )
-                        raise RuntimeError(msg)
+                        raise GuestCustScriptDisabledException(msg)
 
                 ccScriptsDir = os.path.join(
                     self.paths.get_cpath("scripts"), "per-instance"
                 )
+            except GuestCustScriptDisabledException as e:
+                LOG.debug("GuestCustScriptDisabledException")
+                _raise_error_status(
+                    "Error parsing the customization Config File",
+                    e,
+                    GuestCustErrorEnum.GUESTCUST_ERROR_SCRIPT_DISABLED,
+                    vmwareImcConfigFilePath,
+                    self._vmware_cust_conf)
             except Exception as e:
                 _raise_error_status(
                     "Error parsing the customization Config File",

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -50,9 +50,10 @@ CONFGROUPNAME_GUESTCUSTOMIZATION = "deployPkg"
 GUESTCUSTOMIZATION_ENABLE_CUST_SCRIPTS = "enable-custom-scripts"
 VMWARE_IMC_DIR = "/var/run/vmware-imc"
 
-class GuestCustScriptDisabledException(Exception):
-    """Specifies explicit exception for GUESTCUST_ERROR_SCRIPT_DISABLED"""
+
+class GuestCustScriptDisabled(Exception):
     pass
+
 
 class DataSourceOVF(sources.DataSource):
 
@@ -273,19 +274,20 @@ class DataSourceOVF(sources.DataSource):
                             GuestCustStateEnum.GUESTCUST_STATE_RUNNING,
                             GuestCustErrorEnum.GUESTCUST_ERROR_SCRIPT_DISABLED,
                         )
-                        raise GuestCustScriptDisabledException(msg)
+                        raise GuestCustScriptDisabled(msg)
 
                 ccScriptsDir = os.path.join(
                     self.paths.get_cpath("scripts"), "per-instance"
                 )
-            except GuestCustScriptDisabledException as e:
-                LOG.debug("GuestCustScriptDisabledException")
+            except GuestCustScriptDisabled as e:
+                LOG.debug("GuestCustScriptDisabled")
                 _raise_error_status(
                     "Error parsing the customization Config File",
                     e,
                     GuestCustErrorEnum.GUESTCUST_ERROR_SCRIPT_DISABLED,
                     vmwareImcConfigFilePath,
-                    self._vmware_cust_conf)
+                    self._vmware_cust_conf,
+                )
             except Exception as e:
                 _raise_error_status(
                     "Error parsing the customization Config File",

--- a/tests/unittests/sources/test_ovf.py
+++ b/tests/unittests/sources/test_ovf.py
@@ -13,6 +13,7 @@ from cloudinit import subp, util
 from cloudinit.helpers import Paths
 from cloudinit.safeyaml import YAMLError
 from cloudinit.sources import DataSourceOVF as dsovf
+from cloudinit.sources.DataSourceOVF import GuestCustScriptDisabled
 from cloudinit.sources.helpers.vmware.imc.config_custom_script import (
     CustomScriptNotFound,
 )
@@ -447,7 +448,7 @@ class TestDatasourceOVF(CiTestCase):
             with mock.patch(
                 MPATH + "set_customization_status", return_value=("msg", b"")
             ):
-                with self.assertRaises(RuntimeError) as context:
+                with self.assertRaises(GuestCustScriptDisabled) as context:
                     wrap_and_call(
                         "cloudinit.sources.DataSourceOVF",
                         {


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: 
Change the second error code reporting for GUESTCUST_ERROR_SCRIPT_DISABLED from (4, 100) to (4, 6)
```

## Additional Context
<!-- If relevant -->
In GUESTCUST_ERROR_SCRIPT_DISABLED failure, cloud-init reports customization state (and error code) twice, which are used to be (4, 6) and (4, 100). The interval of the two reporting is short. 
Sometimes the first reporting (4, 6) can be inhibited, which may make users confused about the customization failure reason.
This update changes the second reporting from (4, 100) to (4, 6). 
And this change is compatible with the VMware traditional guest OS customization behavior. 
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run unit test
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
