### PR TITLE
sources/azure: remove unused encoding support for customdata

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1917,13 +1917,8 @@ def read_azure_ovf(contents):
         ):
             value = child.childNodes[0].wholeText
 
-        attrs = dict([(k, v) for k, v in child.attributes.items()])
-
         if name == "customdata":
-            if attrs.get("encoding") in (None, "base64"):
-                ud = base64.b64decode("".join(value.split()))
-            else:
-                ud = value
+            ud = base64.b64decode("".join(value.split()))
         elif name == "username":
             username = value
         elif name == "userpassword":


### PR DESCRIPTION
It is unused and unsupported in Azure's ovf-env.xml. Remove it.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>