### PR TITLE
tox: integration-tests-jenkins: softfail if only some test failed (SC-1117)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -200,7 +200,10 @@ setenv =
     PYTEST_ADDOPTS="-m ci and not adhoc"
 
 [testenv:integration-tests-jenkins]
-commands = {[testenv:integration-tests]commands}
+# Pytest's RC=1 means "Tests were collected and run but some of the tests failed".
+# Do not fail in this case, but let Jenkins handle it using the junit report.
+allowlist_externals = sh
+commands = sh -c "{envpython} -m pytest --log-cli-level=INFO -vv {posargs:tests/integration_tests/none} || [ $? -eq 1 ]"
 deps = {[testenv:integration-tests]deps}
 passenv = *_proxy CLOUD_INIT_* PYCLOUDLIB_* SSH_AUTH_SOCK OS_* GOOGLE_* GCP_*
 setenv =


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tox: integration-tests-jenkins: softfail if only some test failed

Prior to this change a single test failure when running the
integration-tests-jenkins tox environment caused Jenkins jobs to fully
fail (status FAILURE).

With this change the pytest's "some tests failed" return code [1] is
ignored, and the status of the Jenkins jobs is determined using the
junit report that pytest generates. Most of the time this will result
in UNSTABLE (yellow) jobs when some tests failed.

If the junit report is missing (or only reports failures) the job
will still be marked as FAILURE (red).

[1] https://docs.pytest.org/en/7.1.x/reference/exit-codes.html
```

## Additional Context
<!-- If relevant -->

See the internal Jenkins `cloud-init` view.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

1. Sabotage a test and run the `integration-tests-jenkins` on a subset
of tests containing it. Verify that tox logs the failure but returns 0.
2. Pass a test directory that doesn't exist to the environment via posargs.
Verify that tox returns nonzero (should return 4 iirc).

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
