### PR TITLE
CI: drop linters from Travis CI (moved to GH Actions) (SC-1118)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,16 +130,6 @@ matrix:
             TOXENV=lowest-supported
             PYTEST_ADDOPTS=-v  # List all tests run by pytest
           dist: bionic
-        - python: 3.6
-          env: TOXENV=flake8
-        - python: 3.6
-          env: TOXENV=mypy
-        - python: 3.6
-          env: TOXENV=pylint
-        - python: 3.6
-          env: TOXENV=black
-        - python: 3.6
-          env: TOXENV=isort
         - python: 3.7
           env: TOXENV=doc
           install:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
CI: drop linters from Travis CI (moved to GH Actions)
```

## Additional Context
<!-- If relevant -->

Past PR that added a GH Actions workflow for the linters: https://github.com/canonical/cloud-init/pull/1496

Looks reliable.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Check the "checks" list in any recent PR.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
