### PR TITLE
CI: add non-blocking run against the linters tip versions (SC-1119)

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -15,7 +15,10 @@ jobs:
       fail-fast: false
       matrix:
         env: [flake8, mypy, pylint, black, isort]
-    runs-on: ubuntu-18.04
+        lint-with:
+          - {tip-versions: false, os: ubuntu-18.04}
+          - {tip-versions: true, os: ubuntu-latest}
+    runs-on: ${{ matrix.lint-with.os }}
     steps:
       - name: "Checkout #1"
         uses: actions/checkout@v3.0.0
@@ -34,7 +37,14 @@ jobs:
         run: python3 --version
 
       - name: Test
+        if: matrix.lint-with.tip-versions
         env:
           # matrix env: not to be confused w/environment variables or testenv
           TOXENV: ${{ matrix.env }}
+        run: tox
+      - name: Test (tip versions)
+        if: matrix.lint-with.tip-versions
+        continue-on-error: true
+        env:
+          TOXENV: tip-${{ matrix.env }}
         run: tox

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -18,6 +18,7 @@ jobs:
         lint-with:
           - {tip-versions: false, os: ubuntu-18.04}
           - {tip-versions: true, os: ubuntu-latest}
+    name: ${{ matrix.lint-with.tip-versions && 'Check format (tip)' || 'Check format (pinned)' }}
     runs-on: ${{ matrix.lint-with.os }}
     steps:
       - name: "Checkout #1"

--- a/.pylintrc
+++ b/.pylintrc
@@ -25,8 +25,9 @@ jobs=4
 # W0703(broad-except)
 # W1401(anomalous-backslash-in-string)
 # W1514(unspecified-encoding)
+# E0012(bad-option-value)
 
-disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401, W1514
+disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401, W1514, E0012
 
 
 [REPORTS]

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -213,9 +213,7 @@ def handle(_name, cfg, cloud: Cloud, log: Logger, _args):
                     reason = "unsupported"
                 else:
                     reason = "unrecognized"
-                log.warning(
-                    'Skipping %s ssh_keys entry: "%s"', reason, key
-                )
+                log.warning('Skipping %s ssh_keys entry: "%s"', reason, key)
                 continue
             tgt_fn = CONFIG_KEY_TO_FILE[key][0]
             tgt_perms = CONFIG_KEY_TO_FILE[key][1]

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -213,7 +213,9 @@ def handle(_name, cfg, cloud: Cloud, log: Logger, _args):
                     reason = "unsupported"
                 else:
                     reason = "unrecognized"
-                log.warning("Skipping %s ssh_keys" ' entry: "%s"', reason, key)
+                log.warning(
+                    "Skipping %s ssh_keys" + ' entry: "%s"', reason, key
+                )
                 continue
             tgt_fn = CONFIG_KEY_TO_FILE[key][0]
             tgt_perms = CONFIG_KEY_TO_FILE[key][1]

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -214,7 +214,7 @@ def handle(_name, cfg, cloud: Cloud, log: Logger, _args):
                 else:
                     reason = "unrecognized"
                 log.warning(
-                    "Skipping %s ssh_keys" + ' entry: "%s"', reason, key
+                    'Skipping %s ssh_keys entry: "%s"', reason, key
                 )
                 continue
             tgt_fn = CONFIG_KEY_TO_FILE[key][0]

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -282,7 +282,7 @@ class TestDualStack:
     """
 
     @pytest.mark.parametrize(
-        "func," "addresses," "stagger_delay," "timeout," "expected_val,",
+        ["func", "addresses", "stagger_delay", "timeout", "expected_val"],
         [
             # Assert order based on timeout
             (lambda x, _: x, ("one", "two"), 1, 1, "one"),
@@ -346,12 +346,14 @@ class TestDualStack:
         event.set()
 
     @pytest.mark.parametrize(
-        "func,"
-        "addresses,"
-        "stagger_delay,"
-        "timeout,"
-        "message,"
-        "expected_exc",
+        [
+            "func",
+            "addresses",
+            "stagger_delay",
+            "timeout",
+            "message",
+            "expected_exc",
+        ],
         [
             (
                 lambda _a, _b: 1 / 0,
@@ -370,7 +372,7 @@ class TestDualStack:
                 ZeroDivisionError,
             ),
             (
-                lambda _a, _b: [][0],
+                lambda _a, _b: [][0],  # pylint: disable=E0643
                 ("matter", "these"),
                 0,
                 1,
@@ -479,7 +481,7 @@ class TestUrlHelper:
         return (200, {"request-id": "0"}, cls.success)
 
     @pytest.mark.parametrize(
-        "addresses," "expected_address_index," "response,",
+        ["addresses", "expected_address_index", "response"],
         [
             # Use timeout to test ordering happens as expected
             ((ADDR1, SLEEP1), 0, "SUCCESS"),

--- a/tox.ini
+++ b/tox.ini
@@ -163,11 +163,10 @@ commands =
     {envpython} -m sphinx {posargs:-b linkcheck doc/rtd doc/rtd_html}
 
 [testenv:tip-flake8]
-commands = {envpython} -m flake8 {posargs:cloudinit/ tests/ tools/ conftest.py setup.py}
 deps = flake8
+commands = {[testenv:flake8]commands}
 
 [testenv:tip-mypy]
-commands = {envpython} -m mypy --install-types --non-interactive cloudinit/ tests/ tools/
 deps =
     mypy
     pytest
@@ -176,23 +175,24 @@ deps =
     types-PyYAML
     types-requests
     types-setuptools
+commands = {[testenv:mypy]commands}
 
 [testenv:tip-pylint]
-commands = {envpython} -m pylint {posargs:cloudinit/ tests/ tools/ conftest.py setup.py}
 deps =
     # requirements
     pylint
     # test-requirements
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
+commands = {[testenv:pylint]commands}
 
 [testenv:tip-black]
 deps = black
-commands = {envpython} -m black . --check
+commands = {[testenv:black]commands}
 
 [testenv:tip-isort]
 deps = isort
-commands = {envpython} -m isort . --check-only
+commands = {[testenv:isort]commands}
 
 [testenv:integration-tests]
 commands = {envpython} -m pytest --log-cli-level=INFO -vv {posargs:tests/integration_tests}

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ black==22.3.0
 flake8==4.0.1
 isort==5.10.1
 mypy==0.950
-pylint==2.13.8
+pylint==2.13.9
 pytest==7.0.1
 types-jsonschema==4.4.2
 types-oauthlib==3.1.6
@@ -185,6 +185,14 @@ deps =
     # test-requirements
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
+
+[testenv:tip-black]
+deps = black
+commands = {envpython} -m black . --check
+
+[testenv:tip-isort]
+deps = isort
+commands = {envpython} -m isort . --check-only
 
 [testenv:integration-tests]
 commands = {envpython} -m pytest --log-cli-level=INFO -vv {posargs:tests/integration_tests}


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
CI: add non-blocking run against the linters tip versions

Changes:
 * Tox: the tip-black and tip-isort environments.
 * Tox: reuse the non-tip commands in the tip- environments.
 * Add non-blocking (continue-on-error: true) step in the test
   test matrix to run the tip- linters on ubuntu-latest.
 * Code fixups to make tip-pylint pass.
 * Bump the pinned pylint version to 2.13.9 (last version
   supporting Python 3.6).
```

## Additional Context
<!-- If relevant -->

Spotted by Jenkins job `cloud-init-style-tip`.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
