### PR TITLE
schema: Use additionalProperties by default.

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -19,7 +19,7 @@
           {"required": ["name"]},
           {"required": ["snapuser"]}
       ],
-      "properties": {
+      "additionalProperties": {
         "name": {
           "description": "The user's login name. Required otherwise user creation will be skipped for this user.",
           "type": "string"
@@ -130,8 +130,7 @@
           "description": "The user's ID. Default is next available value.",
           "type": "integer"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "apt_configure.mirror": {
       "type": "array",


### PR DESCRIPTION
This suggestion/discussion item is that our current idiom:
```json
  "properties": {
    "number": { "type": "number" },
    ...
  },
  "additionalProperties": false
```
can largely be replaced by:
```json
  "additionalProperties": {
    "number": { "type": "number" },
    ...
  },
```

Currently cloud-init uses `additionalProperties` as a boolean, where we usually manually set `additionalProperties: False` to force `properties` and `patternProperties` to match or cause a validation failure. This works, but can be error prone to write and audit, especially with a multi-thousand-line json file. All it takes is one missing `additionalProperties: false` in an object definition to disable validation of all subschemas, hence this suggestion.

Per [the docs](https://json-schema.org/understanding-json-schema/reference/object.html#additional-properties):

> The additionalProperties keyword is used to control the handling of extra stuff, that is, properties whose names are not listed in the properties keyword or match any of the regular expressions in the patternProperties keyword. By default any additional properties are allowed.
> The value of the additionalProperties keyword is a schema that will be used to validate any properties in the instance that are not matched by properties or patternProperties. Setting the additionalProperties schema to false means no additional properties will be allowed.

Of course we would want to keep `properties` (with `additionalProperties` set to its default value) in places where we truly wish to allow passthrough of arbitrary data without validation.

I don't believe that this extends to `patternProperties`, so that will still require manually disabling `additionalProperties`.

I'll see if I can grab some examples of where validation is incorrect due to this issue. At a quick glance in my editor I think I see one or more examples of missing `additionalProperties: false` definitions, but I need to test to confirm.