### PR TITLE
d/control: add python3-debconf to Build-Depends

### DIFF
--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -3,7 +3,8 @@ Source: cloud-init
 Section: admin
 Priority: optional
 Maintainer: Scott Moser <smoser@ubuntu.com>
-Build-Depends: ${build_depends}
+Build-Depends: ${build_depends},
+               python3-debconf
 XS-Python-Version: all
 Standards-Version: 3.9.6
 

--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -3,8 +3,7 @@ Source: cloud-init
 Section: admin
 Priority: optional
 Maintainer: Scott Moser <smoser@ubuntu.com>
-Build-Depends: ${build_depends},
-               python3-debconf
+Build-Depends: ${build_depends}
 XS-Python-Version: all
 Standards-Version: 3.9.6
 

--- a/packages/pkg-deps.json
+++ b/packages/pkg-deps.json
@@ -3,7 +3,8 @@
       "build-requires" : [
          "debhelper",
          "dh-python",
-         "dh-systemd"
+         "dh-systemd",
+         "python3-debconf"
       ],
       "renames" : {
          "pyyaml" : "python3-yaml",


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
d/control: add python3-debconf to Build-Depends
```

## Additional Context
<!-- If relevant -->
Added to be able to run python3-debconf unittests.

SC-1102
https://github.com/canonical/cloud-init/pull/1511/files#r899456743

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`make deb`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
