### PR TITLE
Centos copr builds udev

### DIFF
--- a/packages/redhat/cloud-init.spec.in
+++ b/packages/redhat/cloud-init.spec.in
@@ -166,7 +166,7 @@ fi
 
 %files
 
-/lib/udev/rules.d/66-azure-ephemeral.rules
+%{_udevrulesdir}/66-azure-ephemeral.rules
 
 %if "%{init_system}" == "systemd"
 /usr/lib/systemd/system-generators/cloud-init-generator


### PR DESCRIPTION
Update spec file per change landed in PR: #1513 


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
redhat spec: udev/rules.d lives under /usr/lib on rhel-based systems

Cloud-init now delivers udev rules to /usr/lib/udv/rules.d on
rhel-based systems as of commit 7071512.

Update spec template to unblock COPR builds of CentOS/8-Stream which
fail on RPM build errors like:
File not found: /build.../lib/udev/rules.d/66-azure-ephemeral.rules

Use spec macro %{_udevrulesdir} instead of hard-coding rules dir.
```

## Additional Context

COPR build log failure on CentOS/8:
https://download.copr.fedorainfracloud.org/results/@cloud-init/cloud-init-dev/epel-8-x86_64/04547217-cloud-init/builder-live.log.gz

## Test Steps
```
# ensure we can build the RPM and exec unittests
./tools/run-container centos/8-Stream --vm --name ci-c8 --source-package --package --artifacts=.
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
