### PR TITLE
Fix LXD datasource crawl when BOOT enabled

### DIFF
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -13,7 +13,7 @@ import os
 import socket
 import stat
 from json.decoder import JSONDecodeError
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Union, cast
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -134,8 +134,8 @@ class DataSourceLXD(sources.DataSource):
 
     dsname = "LXD"
 
-    _network_config: Optional[dict] = None
-    _crawled_metadata: Optional[dict] = None
+    _network_config: Union[Dict, str] = sources.UNSET
+    _crawled_metadata: Union[Dict, str] = sources.UNSET
 
     sensitive_metadata_keys = (
         "merged_cfg",
@@ -202,18 +202,18 @@ class DataSourceLXD(sources.DataSource):
 
         If none is present, then we generate fallback configuration.
         """
-        if self._network_config is None:
-            if self._crawled_metadata is None:
+        if self._network_config == sources.UNSET:
+            if self._crawled_metadata == sources.UNSET:
                 self._get_data()
-            if self._crawled_metadata and self._crawled_metadata.get(
-                "network-config"
-            ):
+            if isinstance(
+                self._crawled_metadata, dict
+            ) and self._crawled_metadata.get("network-config"):
                 self._network_config = self._crawled_metadata.get(
-                    "network-config"
+                    "network-config", {}
                 )
-            if self._network_config is None:
+            else:
                 self._network_config = generate_fallback_network_config()
-        return self._network_config
+        return cast(dict, self._network_config)
 
 
 def is_platform_viable() -> bool:

--- a/tests/unittests/sources/test_lxd.py
+++ b/tests/unittests/sources/test_lxd.py
@@ -10,6 +10,7 @@ from unittest import mock
 import pytest
 import yaml
 
+from cloudinit.sources import UNSET
 from cloudinit.sources import DataSourceLXD as lxd
 from cloudinit.sources import InvalidMetaDataException
 
@@ -166,8 +167,8 @@ class TestDataSourceLXD:
 
     def test__get_data(self, lxd_ds):
         """get_data calls read_metadata, setting appropiate instance attrs."""
-        assert None is lxd_ds._crawled_metadata
-        assert None is lxd_ds._network_config
+        assert UNSET == lxd_ds._crawled_metadata
+        assert UNSET == lxd_ds._network_config
         assert None is lxd_ds.userdata_raw
         assert True is lxd_ds._get_data()
         assert LXD_V1_METADATA == lxd_ds._crawled_metadata
@@ -181,14 +182,14 @@ class TestDataSourceLXD:
         """network_config is correctly computed when _network_config and
         _crawled_metadata are unset.
         """
-        assert None is lxd_ds._crawled_metadata
-        assert None is lxd_ds._network_config
+        assert UNSET == lxd_ds._crawled_metadata
+        assert UNSET == lxd_ds._network_config
         assert None is lxd_ds.userdata_raw
         # network-config is dumped from YAML
         assert NETWORK_V1 == lxd_ds.network_config
         assert LXD_V1_METADATA == lxd_ds._crawled_metadata
 
-    def test_network_config_crawled_metadata_no_newtwork_config(
+    def test_network_config_crawled_metadata_no_network_config(
         self, lxd_ds_no_network_config
     ):
         """network_config is correctly computed when _network_config is unset
@@ -197,8 +198,8 @@ class TestDataSourceLXD:
         lxd.generate_fallback_network_config = mock.Mock(
             return_value=NETWORK_V1
         )
-        assert None is lxd_ds_no_network_config._crawled_metadata
-        assert None is lxd_ds_no_network_config._network_config
+        assert UNSET == lxd_ds_no_network_config._crawled_metadata
+        assert UNSET == lxd_ds_no_network_config._network_config
         assert None is lxd_ds_no_network_config.userdata_raw
         # network-config is dumped from YAML
         assert NETWORK_V1 == lxd_ds_no_network_config.network_config


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix LXD datasource crawl when BOOT enabled

In 53a995e2, the network config code was updated to initialize
variables to None rather than using "_unset" in order to simplify the
typing. On subsequent boots with the BOOT event enabled, this resulted
in network config being set to "_unset", causing cloud-init to fail
with traceback.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-lxd_container/47/testReport/tests.integration_tests.modules/test_user_events/test_boot_event_enabled/
