### PR TITLE
testing: Fix wrong path in dual stack test

### DIFF
--- a/tests/integration_tests/datasources/test_ec2_ipv6.py
+++ b/tests/integration_tests/datasources/test_ec2_ipv6.py
@@ -42,7 +42,8 @@ def test_dual_stack(client: IntegrationInstance):
 
     # Force NoDHCPLeaseError (by removing dhclient) and assert ipv6 still works
     # Destructive test goes last
-    assert client.execute("rm /usr/sbin/dhclient").ok
+    # dhclient is at /sbin/dhclient on bionic but /usr/sbin/dhclient elseware
+    assert client.execute("rm $(which dhclient)").ok
     client.restart()
     log = client.read_from_file("/var/log/cloud-init.log")
     assert "Crawl of metadata service using link-local ipv6 took" in log


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: Fix wrong path in dual stack test

Test removes /usr/sbin/dhclient, but on bionic, that path is
/sbin/dhclient
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-ec2/45/testReport/tests.integration_tests.datasources/test_ec2_ipv6/test_dual_stack/