### PR TITLE
tests: fix ipv6 test dhclient lives in either /sbin or /usr/sbin

### DIFF
--- a/tests/integration_tests/datasources/test_ec2_ipv6.py
+++ b/tests/integration_tests/datasources/test_ec2_ipv6.py
@@ -42,7 +42,12 @@ def test_dual_stack(client: IntegrationInstance):
 
     # Force NoDHCPLeaseError (by removing dhclient) and assert ipv6 still works
     # Destructive test goes last
-    assert client.execute("rm /usr/sbin/dhclient").ok
+    dhclient_path = client.execute("which dhclient")
+    result = client.execute(f"rm {dhclient_path.stdout.strip()}")
+    assert result.ok, (
+        f"Unable to remove {dhclient_path} stdout: {result.stdout},"
+        f" stderr: {result.stderr} [exit {result.return_code}]"
+    )
     client.restart()
     log = client.read_from_file("/var/log/cloud-init.log")
     assert "Crawl of metadata service using link-local ipv6 took" in log


### PR DESCRIPTION
## Proposed Commit Message
```
tests: fix ipv6 test dhclient lives in either /sbin or /usr/sbin 

Bionic has /sbin/dhclient install path so use which to sort the
target distro path.
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
pull-ppa-debs --no-conf --ppa=ppa:cloud-init-dev/daily cloud-init bionic
mv cloud-init*deb /tmp/cloud-init-bionic.deb
CLOUD_INIT_PLATFORM=ec2 CLOUD_INIT_OS_IMAGE=bionic CLOUD_INIT_CLOUD_INIT_SOURCE=/tmp/cloud-init-bionic.deb tox -e integration-tests tests/integration_tests/datasources/test_ec2_ipv6.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
