### PR TITLE
Holmanb/completion schema fix

### DIFF
--- a/bash_completion/cloud-init
+++ b/bash_completion/cloud-init
@@ -10,7 +10,7 @@ _cloudinit_complete()
     cur_word="${COMP_WORDS[COMP_CWORD]}"
     prev_word="${COMP_WORDS[COMP_CWORD-1]}"
 
-    subcmds="analyze clean collect-logs devel dhclient-hook features init modules query single status"
+    subcmds="analyze clean collect-logs devel dhclient-hook features init modules query schema single status"
     base_params="--help --file --version --debug --force"
     case ${COMP_CWORD} in
         1)
@@ -28,7 +28,7 @@ _cloudinit_complete()
                     COMPREPLY=($(compgen -W "--help --tarfile --include-userdata" -- $cur_word))
                     ;;
                 devel)
-                    COMPREPLY=($(compgen -W "--help hotplug-hook schema net-convert" -- $cur_word))
+                    COMPREPLY=($(compgen -W "--help hotplug-hook net-convert" -- $cur_word))
                     ;;
                 dhclient-hook)
                     COMPREPLY=($(compgen -W "--help up down" -- $cur_word))


### PR DESCRIPTION
```
completion: update schema command

LP: #1979547
```

## Additional Context
I borked this in [commit 3bcffacb2](https://github.com/canonical/cloud-init/pull/1402). Oops.

## Test Steps
```bash
. bash_completion/cloud-init  # source locally
cloud-init       (Press TAB)
cloud-init sch   (Press TAB)
cloud-init devel (Press twice TAB)
```

## Test Output
```bash
arc~/cloud-init-e(cloud-init-e|✚1…) bash 
holmanb@arc:~/cloud-init-e$ . bash_completion/cloud-init 
holmanb@arc:~/cloud-init-e$ cloud-init 
analyze        collect-logs   devel          features       --force        init           query          single         --version      
clean          --debug        dhclient-hook  --file         --help         modules        schema         status               
holmanb@arc:~/cloud-init-e$ cloud-init schema --
--annotate     --config-file  --docs         --help         --system       
holmanb@arc:~/cloud-init-e$ cloud-init devel 
--help        hotplug-hook  net-convert   
```