### PR TITLE
Change groups within the users schema to support lists and strings

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -34,8 +34,10 @@
           "type": "string"
         },
         "groups": {
-          "description": "Optional comma-separated string of groups to add the user to.",
-          "type": "string"
+          "description": "Optional comma-separated string or list of groups to add the user to.",
+          "type": ["string", "array"],
+          "items": {"type": "string"},
+          "minItems": 1
         },
         "homedir": {
           "description": "Optional home dir for user. Default: ``/home/<username>``",

--- a/tests/unittests/config/test_cc_users_groups.py
+++ b/tests/unittests/config/test_cc_users_groups.py
@@ -318,6 +318,10 @@ class TestUsersGroupsSchema:
             ({"users": ["default", ["aaa", "bbb"]]}, None),
             ({"users": ["foobar"]}, None),  # no default user creation
             ({"users": [{"name": "bbsw"}]}, None),
+            (
+                {"users": [{"name": "bbsw", "groups": ["anygrp"]}]},
+                None,
+            ),  # user with a list of groups
             ({"groups": [{"yep": ["user1"]}]}, None),
             (
                 {"user": ["no_list_allowed"]},

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -78,6 +78,7 @@ omBratteng
 onitake
 Oursin
 qubidt
+redkrieg
 renanrodrigo
 rhansen
 riedel

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -78,7 +78,7 @@ omBratteng
 onitake
 Oursin
 qubidt
-redkrieg
+RedKrieg
 renanrodrigo
 rhansen
 riedel


### PR DESCRIPTION
## Proposed Commit Message

```
Change groups within the users schema to support lists and strings.

The `groups` section of `users` has traditionally supported arrays.
This change returns support for groups as a list instead of comma
separated string, as found in the documentation.
```

## Test Steps
Attempt to validate a cloud-config yaml file with a list of groups.

## Checklist:
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
