### PR TITLE
testing: Wait for changed boot-id in test_status.py (SC-1146)

### DIFF
--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -32,7 +32,9 @@ def _remove_nocloud_dir_and_reboot(client: IntegrationInstance):
     # On Impish and below, NoCloud will be detected on an LXD container.
     # If we remove this directory, it will no longer be detected.
     client.execute("rm -rf /var/lib/cloud/seed/nocloud-net")
+    old_boot_id = client.instance.get_boot_id()
     client.execute("cloud-init clean --logs --reboot")
+    client.instance._wait_for_execute(old_boot_id=old_boot_id)
 
 
 @pytest.mark.ubuntu


### PR DESCRIPTION
We occasionally get [jenkins failures](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-impish-lxd_container/47/testReport/tests.integration_tests.cmd/test_status/test_wait_when_no_datasource/) that I believe are caused by the post-reboot code running on an instance that hasn't even gone down yet.
