### PR TITLE
net: fix interface matching support

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -928,10 +928,11 @@ def get_interfaces_by_mac(blacklist_drivers=None) -> dict:
         )
 
 
-def get_interface_from_mac(mac: str):
+def find_interface_name_from_mac(mac: str) -> Optional[str]:
     for interface_mac, interface_name in get_interfaces_by_mac().items():
-        if mac == interface_mac.lower():
+        if mac.lower() == interface_mac.lower():
             return interface_name
+    return None
 
 
 def get_interfaces_by_mac_on_freebsd(blacklist_drivers=None) -> dict:

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -928,6 +928,12 @@ def get_interfaces_by_mac(blacklist_drivers=None) -> dict:
         )
 
 
+def get_interface_from_mac(mac: str):
+    for interface_mac, interface_name in get_interfaces_by_mac().items():
+        if mac == interface_mac.lower():
+            return interface_name
+
+
 def get_interfaces_by_mac_on_freebsd(blacklist_drivers=None) -> dict:
     (out, _) = subp.subp(["ifconfig", "-a", "ether"])
 

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -11,8 +11,8 @@ from typing import Any, Dict
 
 from cloudinit import safeyaml, util
 from cloudinit.net import (
+    find_interface_name_from_mac,
     get_interfaces_by_mac,
-    get_interface_from_mac,
     ipv4_mask_to_net_prefix,
     ipv6_mask_to_net_prefix,
     is_ip_network,
@@ -706,7 +706,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
                 name = set_name
             elif mac_address and ifaces_by_mac:
                 lcase_mac_address = mac_address.lower()
-                mac = get_interface_from_mac(lcase_mac_address)
+                mac = find_interface_name_from_mac(lcase_mac_address)
                 if mac:
                     name = mac
             phy_cmd["name"] = name
@@ -782,7 +782,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
                 self.handle_nameserver(name_cmd)
 
                 mac_address = dev_cfg.get("match", {}).get("macaddress")
-                real_if_name = get_interface_from_mac(mac_address)
+                real_if_name = find_interface_name_from_mac(mac_address)
                 if real_if_name:
                     iface = real_if_name
 


### PR DESCRIPTION
```
net: fix interface matching support

- broken in bf94945fb855c40c5188cef5fb
- factor out a reusable helper function
- stylistic change for match keyword

LP: #1979877
```

TODO: Find a better name than `get_interface_from_mac()`

## Test Steps

Adapted from the test proposed [here](https://bugs.launchpad.net/cloud-init/+bug/1979877)
```
diff --git a/tests/unittests/test_net.py b/tests/unittests/test_net.py
index bfc13734..3b185509 100644
--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -13,6 +13,7 @@ import pytest
 from yaml.serializer import Serializer
 
 from cloudinit import distros, net
+from cloudinit import safeyaml
 from cloudinit import safeyaml as yaml
 from cloudinit import subp, temp_utils, util
 from cloudinit.net import (
@@ -8276,4 +8277,24 @@ class TestNetworkState(CiTestCase):
         )
 
 
-# vi: ts=4 expandtab
+class TestNetDns:
+    @mock.patch("cloudinit.net.network_state.get_interfaces_by_mac")
+    @mock.patch("cloudinit.net.get_interfaces_by_mac")
+    def test_networkd_render_x(self, by_mac_state, by_mac_init):
+        by_mac_state.return_value = {"00:11:22:33:44:55": "foobar"}
+        by_mac_init.return_value = {"00:11:22:33:44:55": "foobar"}
+        network_state.parse_net_config_data(
+            safeyaml.load(
+                """\
+version: 2
+ethernets:
+  eth:
+    match:
+      macaddress: '00:11:22:33:44:55'
+    addresses: [10.0.0.2/24]
+    gateway4: 10.0.0.1
+    nameservers:
+      addresses: [10.0.0.1]
+"""
+            )
+        )
```
