### PR TITLE
cc_ssh_import_id: Substitute deprecated warn

### DIFF
--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -57,7 +57,7 @@ def handle(_name, cfg, cloud, log, args):
         )
         return
     elif not subp.which(SSH_IMPORT_ID_BINARY):
-        log.warn(
+        log.warning(
             "ssh-import-id is not installed, but module ssh_import_id is "
             "configured. Skipping module."
         )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ssh_import_id: Substitute deprecated warn
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Run `tox -e py3`. The following warning won't appear:

```
tests/unittests/config/test_cc_ssh_import_id.py::TestHandleSshImportIDs::test_skip_inapplicable_configs[cfg2-ssh-import-id is not installed]
  /home/aciba/canonical/cloud-init/cloudinit/config/cc_ssh_import_id.py:61: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    "ssh-import-id is not installed, but module ssh_import_id is "
``` 

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
