### PR TITLE
tests: mock dns lookup that causes long timeouts

### DIFF
--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -40,6 +40,11 @@ class TestCloudStackPasswordFetching(CiTestCase):
                 get_networkd_server_address,
             )
         )
+        get_data_server = mock.MagicMock(return_value=None)
+        self.patches.enter_context(
+            mock.patch(mod_name + ".get_data_server", get_data_server)
+        )
+
         self.tmp = self.tmp_dir()
 
     def _set_password_server_response(self, response_string):


### PR DESCRIPTION
```
tests: mock dns resolution that may cause long timeouts
```

This PR turns this (inconsistent):
```
19.72s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_saved_password_doesnt_create_config
19.14s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_password_not_saved_if_bad_request
18.94s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_empty_password_doesnt_create_config
14.21s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_password_not_saved_if_empty
14.15s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_valid_response_means_password_marked_as_saved
14.07s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_password_not_saved_if_already_saved
14.05s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_password_sets_password
2.18s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_bad_request_doesnt_stop_ds_from_working
```
into this:
```
0.01s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_password_not_saved_if_bad_request
0.01s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_valid_response_means_password_marked_as_saved
0.01s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_bad_request_doesnt_stop_ds_from_working
0.01s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_password_not_saved_if_already_saved
0.01s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_password_sets_password
0.01s call     tests/unittests/sources/test_cloudstack.py::TestCloudStackPasswordFetching::test_password_not_saved_if_empty
```
