### PR TITLE
Resource leak cleanup

### DIFF
--- a/cloudinit/analyze/__main__.py
+++ b/cloudinit/analyze/__main__.py
@@ -6,7 +6,7 @@ import argparse
 import re
 import sys
 from datetime import datetime
-from typing import List, IO
+from typing import IO
 
 from cloudinit.util import json_dumps
 

--- a/cloudinit/analyze/__main__.py
+++ b/cloudinit/analyze/__main__.py
@@ -6,6 +6,7 @@ import argparse
 import re
 import sys
 from datetime import datetime
+from typing import List, IO
 
 from cloudinit.util import json_dumps
 
@@ -192,10 +193,7 @@ def analyze_boot(name, args):
     }
 
     outfh.write(status_map[status_code].format(**kwargs))
-    if outfh != sys.stdout:
-        outfh.close()
-    if infh != sys.stdin:
-        infh.close()
+    clean_io(infh, outfh)
     return status_code
 
 
@@ -222,6 +220,7 @@ def analyze_blame(name, args):
         outfh.write("\n".join(srecs) + "\n")
         outfh.write("\n")
     outfh.write("%d boot records analyzed\n" % (idx + 1))
+    clean_io(infh, outfh)
 
 
 def analyze_show(name, args):
@@ -258,12 +257,14 @@ def analyze_show(name, args):
         )
         outfh.write("\n".join(record) + "\n")
     outfh.write("%d boot records analyzed\n" % (idx + 1))
+    clean_io(infh, outfh)
 
 
 def analyze_dump(name, args):
     """Dump cloud-init events in json format"""
     (infh, outfh) = configure_io(args)
     outfh.write(json_dumps(_get_events(infh)) + "\n")
+    clean_io(infh, outfh)
 
 
 def _get_events(infile):
@@ -295,6 +296,14 @@ def configure_io(args):
             sys.exit(1)
 
     return (infh, outfh)
+
+
+def clean_io(*file_handles: IO) -> None:
+    """close filehandles"""
+    for file_handle in file_handles:
+        if file_handle in (sys.stdin, sys.stdout):
+            continue
+        file_handle.close()
 
 
 if __name__ == "__main__":

--- a/cloudinit/analyze/__main__.py
+++ b/cloudinit/analyze/__main__.py
@@ -192,6 +192,10 @@ def analyze_boot(name, args):
     }
 
     outfh.write(status_map[status_code].format(**kwargs))
+    if outfh != sys.stdout:
+        outfh.close()
+    if infh != sys.stdin:
+        infh.close()
     return status_code
 
 

--- a/cloudinit/cmd/cloud_id.py
+++ b/cloudinit/cmd/cloud_id.py
@@ -76,7 +76,8 @@ def handle_args(name, args):
         return 3
 
     try:
-        instance_data = json.load(open(args.instance_data))
+        with open(args.instance_data) as file:
+            instance_data = json.load(file)
     except IOError:
         return error(
             "File not found '%s'. Provide a path to instance data json file"

--- a/tests/unittests/analyze/test_boot.py
+++ b/tests/unittests/analyze/test_boot.py
@@ -112,19 +112,19 @@ class TestAnalyzeBoot(CiTestCase):
         analyze_boot(name_default, args)
         # now args have been tested, go into outfile and make sure error
         # message is in the outfile
-        outfh = open(args.outfile, "r")
-        data = outfh.read()
-        err_string = (
-            "Your Linux distro or container does not support this "
-            "functionality.\nYou must be running a Kernel "
-            "Telemetry supported distro.\nPlease check "
-            "https://cloudinit.readthedocs.io/en/latest/topics"
-            "/analyze.html for more information on supported "
-            "distros.\n"
-        )
+        with open(args.outfile, "r") as outfh:
+            data = outfh.read()
+            err_string = (
+                "Your Linux distro or container does not support this "
+                "functionality.\nYou must be running a Kernel "
+                "Telemetry supported distro.\nPlease check "
+                "https://cloudinit.readthedocs.io/en/latest/topics"
+                "/analyze.html for more information on supported "
+                "distros.\n"
+            )
 
-        self.remove_dummy_file(path, log_path)
-        self.assertEqual(err_string, data)
+            self.remove_dummy_file(path, log_path)
+            self.assertEqual(err_string, data)
 
     @mock.patch("cloudinit.util.is_container", return_value=True)
     @mock.patch("cloudinit.subp.subp", return_value=("U=1000000", None))

--- a/tests/unittests/analyze/test_dump.py
+++ b/tests/unittests/analyze/test_dump.py
@@ -216,8 +216,8 @@ class TestDumpEvents(CiTestCase):
         tmpfile = self.tmp_path("logfile")
         write_file(tmpfile, SAMPLE_LOGS)
         m_parse_from_date.return_value = 1472594005.972
-
-        events, data = dump_events(cisource=open(tmpfile))
+        with open(tmpfile) as file:
+            events, data = dump_events(cisource=file)
         year = datetime.now().year
         dt1 = datetime.strptime(
             "Nov 03 06:51:06.074410 %d" % year, "%b %d %H:%M:%S.%f %Y"

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2088,7 +2088,8 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
         self._createConsole(self.root)
         logged_string = "something very important"
         util.multi_log(logged_string)
-        self.assertEqual(logged_string, open("/dev/console").read())
+        with open("/dev/console") as f:
+            self.assertEqual(logged_string, f.read())
 
     def test_logs_dont_go_to_stdout_if_console_exists(self):
         self._createConsole(self.root)

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,15 @@ commands = {envpython} -m pytest \
             {posargs:--cov=cloudinit --cov-branch \
             tests/unittests}
 
+#commands = {envpython} -X tracemalloc=40 -Werror::ResourceWarning:cloudinit -m pytest \
+[testenv:py3-leak]
+deps = {[testenv:py3]deps}
+commands = {envpython} -X tracemalloc=40 -Wall -m pytest \
+            --durations 10 \
+            {posargs:--cov=cloudinit --cov-branch \
+            tests/unittests}
+
+
 [lowest-supported-deps]
 # Tox is going to install requirements from pip. This is fine for
 # testing python version compatibility, but when we build cloud-init, we are


### PR DESCRIPTION
```
add tox target for tracing for resource leaks, fix some leaks
```

## Additional Context
I cleaned up a few leaks, but I'm loosing steam on this and would like to merge it as is. My original intent was to clean up all leaks which would make this more useful as a ci / jenkins job, but I have spent too much time on this already and need to move on to other things.

[resource-leak.txt](https://github.com/canonical/cloud-init/files/9023208/resource-leak.txt)


## Test Steps
run the added tox env
