### PR TITLE
Test case for parsing static dns when device is present on system

### DIFF
--- a/tests/unittests/net/test_dns.py
+++ b/tests/unittests/net/test_dns.py
@@ -1,0 +1,28 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from unittest import mock
+
+from cloudinit import safeyaml
+from cloudinit.net import network_state
+
+
+class TestNetDns:
+    @mock.patch("cloudinit.net.network_state.get_interfaces_by_mac")
+    def test_system_mac_address_does_not_break_dns_parsing(self, by_mac):
+        by_mac.return_value = {"00:11:22:33:44:55": "foobar"}
+        state = network_state.parse_net_config_data(
+            safeyaml.load(
+                """\
+version: 2
+ethernets:
+  eth:
+    match:
+      macaddress: '00:11:22:33:44:55'
+    addresses: [10.0.0.2/24]
+    gateway4: 10.0.0.1
+    nameservers: 
+      addresses: [10.0.0.3]
+"""
+            )
+        )
+        assert "10.0.0.3" in state.dns_nameservers

--- a/tests/unittests/net/test_dns.py
+++ b/tests/unittests/net/test_dns.py
@@ -8,8 +8,10 @@ from cloudinit.net import network_state
 
 class TestNetDns:
     @mock.patch("cloudinit.net.network_state.get_interfaces_by_mac")
-    def test_system_mac_address_does_not_break_dns_parsing(self, by_mac):
-        by_mac.return_value = {"00:11:22:33:44:55": "foobar"}
+    @mock.patch("cloudinit.net.get_interfaces_by_mac")
+    def test_system_mac_address_does_not_break_dns_parsing(self, by_mac_state, by_mac_init):
+        by_mac_state.return_value = {"00:11:22:33:44:55": "foobar"}
+        by_mac_init.return_value = {"00:11:22:33:44:55": "foobar"}
         state = network_state.parse_net_config_data(
             safeyaml.load(
                 """\
@@ -20,7 +22,7 @@ ethernets:
       macaddress: '00:11:22:33:44:55'
     addresses: [10.0.0.2/24]
     gateway4: 10.0.0.1
-    nameservers: 
+    nameservers:
       addresses: [10.0.0.3]
 """
             )

--- a/tests/unittests/net/test_dns.py
+++ b/tests/unittests/net/test_dns.py
@@ -10,7 +10,7 @@ class TestNetDns:
     @mock.patch("cloudinit.net.network_state.get_interfaces_by_mac")
     @mock.patch("cloudinit.net.get_interfaces_by_mac")
     def test_system_mac_address_does_not_break_dns_parsing(
-            self, by_mac_state, by_mac_init
+        self, by_mac_state, by_mac_init
     ):
         by_mac_state.return_value = {"00:11:22:33:44:55": "foobar"}
         by_mac_init.return_value = {"00:11:22:33:44:55": "foobar"}

--- a/tests/unittests/net/test_dns.py
+++ b/tests/unittests/net/test_dns.py
@@ -9,7 +9,9 @@ from cloudinit.net import network_state
 class TestNetDns:
     @mock.patch("cloudinit.net.network_state.get_interfaces_by_mac")
     @mock.patch("cloudinit.net.get_interfaces_by_mac")
-    def test_system_mac_address_does_not_break_dns_parsing(self, by_mac_state, by_mac_init):
+    def test_system_mac_address_does_not_break_dns_parsing(
+            self, by_mac_state, by_mac_init
+    ):
         by_mac_state.return_value = {"00:11:22:33:44:55": "foobar"}
         by_mac_init.return_value = {"00:11:22:33:44:55": "foobar"}
         state = network_state.parse_net_config_data(

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -108,4 +108,5 @@ wschoot
 xiachen-rh
 xnox
 yangzz-97
+yawkat
 zhuzaifangxuele


### PR DESCRIPTION
This patch adds a test case for the launchpad bug below. When parsing a network configuration where a device on the system has the same mac address as given in the `match` section of the config, but with the real device name not matching the config name, parsing of a static nameserver entry fails with a `KeyError`.

LP: #1979877