### PR TITLE
CI: Fix GH pinned-format jobs

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -18,7 +18,7 @@ jobs:
         lint-with:
           - {tip-versions: false, os: ubuntu-18.04}
           - {tip-versions: true, os: ubuntu-latest}
-    name: ${{ matrix.lint-with.tip-versions && 'Check format (tip)' || 'Check format (pinned)' }}
+    name: Check ${{ matrix.lint-with.tip-versions && 'tip-' || '' }}${{ matrix.env }}
     runs-on: ${{ matrix.lint-with.os }}
     steps:
       - name: "Checkout #1"

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -38,7 +38,7 @@ jobs:
         run: python3 --version
 
       - name: Test
-        if: matrix.lint-with.tip-versions
+        if: ${{ !matrix.lint-with.tip-versions }}
         env:
           # matrix env: not to be confused w/environment variables or testenv
           TOXENV: ${{ matrix.env }}

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2017 Canonical Ltd.
 #
-# This file is part of cloud-init. See LICENSE file for license information.
+# This file is part of cloud-init. See LICENSE file for license information.asdfasdf
 
 """Cloud-init apport interface"""
 from cloudinit.cmd.devel import read_cfg_paths

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -1,6 +1,6 @@
 # Copyright (C) 2017 Canonical Ltd.
 #
-# This file is part of cloud-init. See LICENSE file for license information.asdfasdf
+# This file is part of cloud-init. See LICENSE file for license information.
 
 """Cloud-init apport interface"""
 from cloudinit.cmd.devel import read_cfg_paths


### PR DESCRIPTION
We can see that `Lint Tests / Check format (pinned)` jobs do not run: [runs/2595343023](https://github.com/canonical/cloud-init/actions/runs/2595343023)

Fixed here: [actions/runs/2595516299](https://github.com/canonical/cloud-init/actions/runs/2595516299)

I have also improved the job names.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
CI: Fix GH pinned-format jobs
```

## Additional Context
<!-- If relevant -->
https://warthogs.atlassian.net/browse/SC-1150

It is expected that jobs with `continue-on-error: true` finish as green in the UI but they are shown as red in the Action summary. More context on this: https://github.com/github-community/community/discussions/15452

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
