### PR TITLE
mounts: fix suggested_swapsize for > 64GB hosts

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -9,6 +9,7 @@
 """Mounts: Configure mount points and swap files"""
 
 import logging
+import math
 import os
 import re
 from string import whitespace
@@ -110,6 +111,8 @@ NETWORK_NAME_RE = re.compile(NETWORK_NAME_FILTER)
 WS = re.compile("[%s]+" % (whitespace))
 FSTAB_PATH = "/etc/fstab"
 MNT_COMMENT = "comment=cloudconfig"
+MB = 2**20
+GB = 2**30
 
 LOG = logging.getLogger(__name__)
 
@@ -210,13 +213,12 @@ def suggested_swapsize(memsize=None, maxsize=None, fsys=None):
     if memsize is None:
         memsize = util.read_meminfo()["total"]
 
-    GB = 2**30
-    sugg_max = 8 * GB
+    sugg_max = memsize * 2
 
     info = {"avail": "na", "max_in": maxsize, "mem": memsize}
 
     if fsys is None and maxsize is None:
-        # set max to 8GB default if no filesystem given
+        # set max to default if no filesystem given
         maxsize = sugg_max
     elif fsys:
         statvfs = os.statvfs(fsys)
@@ -234,35 +236,17 @@ def suggested_swapsize(memsize=None, maxsize=None, fsys=None):
 
     info["max"] = maxsize
 
-    formulas = [
-        # < 1G: swap = double memory
-        (1 * GB, lambda x: x * 2),
-        # < 2G: swap = 2G
-        (2 * GB, lambda x: 2 * GB),
-        # < 4G: swap = memory
-        (4 * GB, lambda x: x),
-        # < 16G: 4G
-        (16 * GB, lambda x: 4 * GB),
-        # < 64G: 1/2 M up to max
-        (64 * GB, lambda x: x / 2),
-    ]
+    if memsize < 4 * GB:
+        minsize = memsize
+    elif memsize < 16 * GB:
+        minsize = 4 * GB
+    else:
+        minsize = round(math.sqrt(memsize / GB)) * GB
 
-    size = None
-    for top, func in formulas:
-        if memsize <= top:
-            size = min(func(memsize), maxsize)
-            # if less than 1/2 memory and not much, return 0
-            if size < (memsize / 2) and size < 4 * GB:
-                size = 0
-                break
-            break
-
-    if size is not None:
-        size = maxsize
+    size = min(minsize, maxsize)
 
     info["size"] = size
 
-    MB = 2**20
     pinfo = {}
     for k, v in info.items():
         if isinstance(v, int):

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -89,6 +89,7 @@ slingamn
 slyon
 smoser
 sshedi
+sstallion
 stappersg
 steverweber
 t-8ch


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
mounts: fix suggested_swapsize for > 64GB hosts
```

## Additional Context
If provisioning hosts with more than 64GB of memory, swap will not be created and the following error messages will be logged by cloud-init:
```
2022-07-07 23:45:13,257 - cc_mounts.py[DEBUG]: suggest None swap for 257675.54296875 MB memory with '958841.80859375 MB' disk given max=16384.0 MB [max=16384.0 MB]'
2022-07-07 23:45:13,257 - cc_mounts.py[WARNING]: failed to setup swap: unsupported operand type(s) for /: 'NoneType' and 'int'
```
Upon inspection, this appears to be a bug in `suggested_swapsize`; I could not see a case where the existing conditional would be correct behavior, but I would like to hear from upstream in case I missed something obvious.

## Test Steps
Attempt to provision a system with more than 64GB of RAM with the following config snippet; no swap file will be created, and the above error messages should be present in `/var/log/cloud-init.log`.
```
swap:
  filename: /swap.img
  size: auto
  maxsize: 16G
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
