### PR TITLE
Rename the openmandriva user to omv

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -256,6 +256,10 @@ system_info:
      name: cloud-user
      lock_passwd: true
      gecos: Cloud User
+{% elif variant == "openmandriva" %}
+     name: omv
+     lock_passwd: True
+     gecos: OpenMandriva admin
 {% else %}
      name: {{ variant }}
      lock_passwd: True


### PR DESCRIPTION
## Proposed Commit Message
```
User feedback on the initial OpenMandriva support patch was that
it works great, but it's too easy to mistype the overly long
username.

Shorten it to omv -- this is also consistent with what we do
on PinePhone.

Signed-off-by: Bernhard Rosenkränzer <bero@lindev.ch>
```

## Additional Context
Unit tests and documentation aren't affected - so no need to update them as per checklist

## Test Steps
Install OpenMandriva with patched cloud-init, ssh in as user omv, try to ssh in as user openmandriva and make sure that fails.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
