### PR TITLE
tox: Remove entries from default envlist (SC-1176)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
     py3,
-    lowest-supported-dev,
-    hypothesis-slow,
     black,
     flake8,
     isort,


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tox: Remove entries from default envlist

lowest-supported-dev requires running with python 3.6, which few people
will be running locally.

hypothesis-slow is being removed because fuzz testing
shouldn't be a gate for new features.

LP: #1980854
```