### PR TITLE
UC015.U1.1 clean: allow third party cleanup scripts in /etc/cloud/clean.d

### DIFF
--- a/cloudinit/cmd/clean.py
+++ b/cloudinit/cmd/clean.py
@@ -11,8 +11,9 @@ import glob
 import os
 import sys
 
+from cloudinit import settings
 from cloudinit.stages import Init
-from cloudinit.subp import ProcessExecutionError, subp
+from cloudinit.subp import ProcessExecutionError, runparts, subp
 from cloudinit.util import (
     del_dir,
     del_file,
@@ -94,6 +95,13 @@ def remove_artifacts(remove_logs, remove_seed=False):
         except OSError as e:
             error("Could not remove {0}: {1}".format(path, str(e)))
             return 1
+    try:
+        runparts(settings.CLEAN_RUNPARTS_DIR)
+    except Exception as e:
+        error(
+            f"Failure during run-parts of {settings.CLEAN_RUNPARTS_DIR}: {e}"
+        )
+        return 1
     return 0
 
 

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -14,6 +14,8 @@ CFG_ENV_NAME = "CLOUD_CFG"
 # This is expected to be a yaml formatted file
 CLOUD_CONFIG = "/etc/cloud/cloud.cfg"
 
+CLEAN_RUNPARTS_DIR = "/etc/cloud/clean.d"
+
 RUN_CLOUD_CONFIG = "/run/cloud-init/cloud.cfg"
 
 # What u get if no config is provided

--- a/config/clean.d/README
+++ b/config/clean.d/README
@@ -1,0 +1,18 @@
+-- cloud-init's clean.d run-parts directory --
+
+This directory is provided for third party applications which need
+additional configuration artifact cleanup from the filesystem when
+the command `cloud-init clean` is invoked.
+
+The `cloud-init clean` operation is typically performed by image creators
+when preparing a golden image for clone and redeployment. The clean command
+removes any cloud-init semaphores, allowing cloud-init to treat the next
+boot of this image as the "first boot". When the image is next booted
+cloud-init will performing all initial configuration based on any valid
+datasource meta-data and user-data.
+
+Any executable scripts in this subdirectory will be invoked in lexicographical
+order with run-parts by the command: sudo cloud-init clean.
+
+Typical format of such scripts would be a ##-<some-app> like the following:
+  /etc/cloud/clean.d/99-live-installer

--- a/setup.py
+++ b/setup.py
@@ -276,6 +276,7 @@ if not in_virtualenv():
 
 data_files = [
     (ETC + "/cloud", [render_tmpl("config/cloud.cfg.tmpl")]),
+    (ETC + "/cloud/clean.d", glob("config/clean.d/*")),
     (ETC + "/cloud/cloud.cfg.d", glob("config/cloud.cfg.d/*")),
     (ETC + "/cloud/templates", glob("templates/*")),
     (


### PR DESCRIPTION
cloud-init clean command provides a run-parts /etc/cloud/clean.d
directory to allow third party apps to deliver supplemental cleanup
scripts to aid in golden image creation.

Any executable scripts in /etc/cloud/clean.d will be run in
lexicographical order via subp.runparts.

This aids customers creating golden images, where the typical process
an image creator performs is to reset cloud-init on that system so
the next boot of this cloned image will be treated as first-boot and
perform all early system configuration.

This PR is part of a series of improvements in cloud-init and live-installer interaction:

- [x] THIS PR UC01: cloud-init clean to provide a /etc/cloud/clean.d run-parts directory which allows subiquity to provide scripts which can clean initial install config artifacts to aid in golden image creation from server live-installer.
- [ ]  [UC02.1 cloud-ini add opaque schema validation for a new top-level autoinstall key in cloud-config user-datat](https://github.com/canonical/cloud-init/pull/1572)
- [ ] UC03: bug fix for cloud-init collect-logs to improve configuration artifact collection when cloud-init is disabled and no /run/cloud-init/* files exist.
- [ ]  UC04: live-desktop installer to disable cloud-init by default after installed boot
- [ ]  UC05: cloud-init status to provide machine-readable JSON/YAML format support


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
clean: allow third party cleanup scripts in /etc/cloud/clean.d

cloud-init clean command provides a run-parts /etc/cloud/clean.d
directory to allow third party apps to deliver supplemental cleanup
scripts to aid in golden image creation.

Any executable scripts in /etc/cloud/clean.d will be run in
lexicographical order via subp.runparts.

This aids customers creating golden images, where the typical process
an image creator performs is to reset cloud-init on that system so
the next boot of this cloned image will be treated as first-boot and
perform all early system configuration.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
