### PR TITLE
Fix comment typo regarding use of `packages:` and relationship to `package_update:`

### DIFF
--- a/doc/examples/cloud-config-apt.txt
+++ b/doc/examples/cloud-config-apt.txt
@@ -35,7 +35,7 @@ apt_pipelining: False
 #
 # Default: none
 #
-# if packages are specified, this package_update will be set to true
+# if packages are specified, then package_update will be set to true
 
 packages: ['pastebinit']
 

--- a/doc/examples/cloud-config-install-packages.txt
+++ b/doc/examples/cloud-config-install-packages.txt
@@ -4,7 +4,7 @@
 #
 # Default: none
 #
-# if packages are specified, this package_update will be set to true
+# if packages are specified, then package_update will be set to true
 #
 # packages may be supplied as a single package name or as a list
 # with the format [<package>, <version>] wherein the specific

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -5,9 +5,9 @@ akutz
 AlexBaranowski
 Aman306
 andgein
+andrew-lee-metaswitch
 andrewbogott
 andrewlukoshko
-andrew-lee-metaswitch
 antonyc
 aswinrajamannar
 beantaxi
@@ -62,6 +62,7 @@ lkundrak
 lucasmoura
 lucendio
 lungj
+magnetikonline
 mal
 mamercad
 manuelisimo
@@ -93,8 +94,8 @@ sshedi
 stappersg
 steverweber
 t-8ch
-TheRealFalcon
 taoyama
+TheRealFalcon
 thetoolsmith
 timothegenzmer
 tnt-dev


### PR DESCRIPTION
## Proposed Commit Message

Fix comment typo regarding use of `packages:` and relationship to `package_update:`

```
Found a small typo in the online documentation.
```

## Additional Context

N/A

## Test Steps

N/A

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
