### PR TITLE
cc_ubuntu_advantage: Implement custom auto-attach behaviors

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -264,21 +264,16 @@ def maybe_install_ua_tools(cloud: Cloud):
         raise
 
 
-def _is_pro(config: dict) -> bool:
+def _is_pro() -> bool:
     try:
         from uaclient.api.u.pro.attach.auto.should_auto_attach.v1 import (
             should_auto_attach,
         )
-        from uaclient.config import UAConfig
     except ImportError as ex:
         LOG.debug("Unable to import `uaclient`: %s", ex)
         return False
-
-    ua_config = UAConfig(
-        **{"cfg": {"ua_config": config}} if config is not None else {}
-    )
     try:
-        result = should_auto_attach(cfg=ua_config)
+        result = should_auto_attach()
     except Exception as ex:
         LOG.debug("Error during `should_auto_attach`: %s", ex)
         LOG.warning(
@@ -292,9 +287,7 @@ def _is_pro(config: dict) -> bool:
 def _attach(ua_section: dict, config: dict):
     token = ua_section.get("token")
     if not token:
-        msg = (
-            "`ubuntu-advantage.token` required in non-Pro Ubuntu" " instances."
-        )
+        msg = "`ubuntu-advantage.token` required in non-Pro Ubuntu instances."
         LOG.error(msg)
         raise RuntimeError(msg)
     configure_ua(
@@ -370,7 +363,7 @@ def handle(
     disable_auto_attach = bool(
         ua_section.get("features", {}).get("disable_auto_attach", False)
     )
-    if not disable_auto_attach and _is_pro(config):
+    if not disable_auto_attach and _is_pro():
         _auto_attach(ua_section, config)
     else:
         _attach(ua_section, config)

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -153,14 +153,6 @@ def validate_schema_features(ua_section: dict):
         LOG.error(msg)
         raise RuntimeError(msg)
 
-    # Validate extra keys under ubuntu_advantage.features
-    extra_keys = set(features.keys()) - {"disable_auto_attach"}
-    if extra_keys:
-        LOG.debug(
-            "Ignoring unknown 'ubuntu_advantage.features': %s",
-            ", ".join(sorted(extra_keys)),
-        )
-
     # Validate ubuntu_advantage.features.disable_auto_attach
     if "disable_auto_attach" not in features:
         return

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -328,7 +328,7 @@ def handle(
 
     # ua-auto-attach.service had noop-ed as ua_section is not empty
     features: dict = ua_section.get("features", {})
-    disable_auto_attach = bool(features.get("disable_auto_attach", True))
+    disable_auto_attach = bool(features.get("disable_auto_attach", False))
     is_pro_cfg = not disable_auto_attach
 
     is_pro = None

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -329,11 +329,11 @@ def _attach(ua_section: dict, config: Optional[dict] = None):
 
 def _auto_attach(ua_section: dict):
     try:
+        from uaclient.api.exceptions import UserFacingError
         from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
             FullAutoAttachOptions,
             full_auto_attach,
         )
-        from uaclient.exceptions import UserFacingError
     except ImportError as ex:
         msg = f"Unable to import `uaclient`: {ex}"
         LOG.error(msg)

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -5,6 +5,7 @@
 import re
 from logging import Logger
 from textwrap import dedent
+from typing import Optional
 from urllib.parse import urlparse
 
 from cloudinit import log as logging
@@ -284,7 +285,7 @@ def _is_pro() -> bool:
     return result.should_auto_attach
 
 
-def _attach(ua_section: dict, config: dict):
+def _attach(ua_section: dict, config: Optional[dict] = None):
     token = ua_section.get("token")
     if not token:
         msg = "`ubuntu-advantage.token` required in non-Pro Ubuntu instances."
@@ -297,9 +298,9 @@ def _attach(ua_section: dict, config: dict):
     )
 
 
-def _auto_attach(ua_section: dict, config: dict):
+def _auto_attach(ua_section: dict, config: Optional[dict] = None):
     try:
-        from uaclient.api.u.pro.attach.auto.full_auto_attach.vi import (
+        from uaclient.api.u.pro.attach.auto.full_auto_attach.v1 import (
             FullAutoAttachOptions,
             full_auto_attach,
         )

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -366,7 +366,7 @@ def handle(
     )
     if not disable_auto_attach and _is_pro():
         _auto_attach(ua_section, config)
-    else:
+    elif not ua_section.keys() <= {"features"}:
         _attach(ua_section, config)
 
 

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -302,6 +302,7 @@ def maybe_install_ua_tools(cloud: Cloud):
 
 def _should_auto_attach() -> bool:
     try:
+        from uaclient.api.exceptions import UserFacingError
         from uaclient.api.u.pro.attach.auto.should_auto_attach.v1 import (
             should_auto_attach,
         )
@@ -311,7 +312,7 @@ def _should_auto_attach() -> bool:
         return False
     try:
         result = should_auto_attach()
-    except Exception as ex:
+    except UserFacingError as ex:
         LOG.debug("Error during `should_auto_attach`: %s", ex)
         LOG.warning(ERROR_MSG_SHOULD_AUTO_ATTACH)
         return False

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -34,6 +34,10 @@ meta: MetaSchema = {
         'enable' list is not present, any named service will supplement
         contract-default enabled services.
 
+        In Ubuntu Pro instances, `token` will be ignored. `enable` and
+        `enable_beta` will fully determine what services will be enabled,
+        ignoring contract defaults.
+
         Note that when enabling FIPS or FIPS updates you will need to schedule
         a reboot to ensure the machine is running the FIPS-compliant kernel.
         See `Power State Change`_ for information on how to configure
@@ -92,6 +96,32 @@ meta: MetaSchema = {
             ua_apt_https_proxy: 'https://10.0.10.10:3128'
           enable:
           - fips
+        """
+        ),
+        dedent(
+            """\
+        # Do not enable any service in Ubuntu Pro instances.
+        ubuntu_advantage:
+          enable: []
+          enable_beta: []
+        """
+        ),
+        dedent(
+            """\
+        # Enable esm and beta realtime-kernel services in Ubuntu Pro instances.
+        ubuntu_advantage:
+          enable:
+          - esm
+          enable_beta:
+          - realtime-kernel
+        """
+        ),
+        dedent(
+            """\
+        # Disable auto-attach in Ubuntu Pro instances.
+        ubuntu_advantage:
+          features:
+            disable_auto_attach: True
         """
         ),
     ],

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2199,7 +2199,6 @@
       "properties": {
         "ubuntu_advantage": {
           "type": "object",
-          "required": ["token"],
           "additionalProperties": false,
           "properties": {
             "enable": {
@@ -2207,9 +2206,34 @@
               "items": {"type": "string"},
               "description": "Optional list of ubuntu-advantage services to enable. Any of: cc-eal, cis, esm-infra, fips, fips-updates, livepatch. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled."
             },
+            "enable_beta": {
+              "type": "array",
+              "items": {"type": "string"},
+              "description": "Optional list of ubuntu-advantage beta services to enable. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled."
+            },
             "token": {
               "type": "string",
-              "description": "Required contract token obtained from https://ubuntu.com/advantage to attach."
+              "description": "Contract token obtained from https://ubuntu.com/advantage to attach (in non-Pro instances)."
+            },
+            "features": {
+              "type": "object",
+              "description": "TODO",
+              "additionalProperties": true,
+              "properties": {
+                "disable_auto_attach": {
+                  "type": "boolean",
+                  "description": "Optional boolean for controlling if auto attach (in Ubuntu Pro instances) will be performed. Default: ``true``",
+                  "default": true
+                },
+                "ignore_enable_by_default": {
+                  "type": "boolean",
+                  "description": "Optional boolean for controlling whether to ignore/install default services found in the given contract"
+                },
+                "allow_beta": {
+                  "type": "boolean",
+                  "description": "Optional boolean for controlling whether to install/ignore default beta services found in the given contract"
+                }
+              }
             },
             "config": {
               "type": "object",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2229,7 +2229,7 @@
             },
             "config": {
               "type": "object",
-              "description": "Configuration settings or override Ubuntu Advantage config",
+              "description": "Configuration settings or override Ubuntu Advantage config. Only used in non Ubuntu Pro instances.",
               "properties": {
                 "http_proxy": {
                   "type": "string",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2204,12 +2204,12 @@
             "enable": {
               "type": "array",
               "items": {"type": "string"},
-              "description": "Optional list of ubuntu-advantage services to enable. Any of: cc-eal, cis, esm-infra, fips, fips-updates, livepatch. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled."
+              "description": "Optional list of ubuntu-advantage services to enable. Any of: cc-eal, cis, esm-infra, fips, fips-updates, livepatch. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled. In Ubuntu Pro instances, if this list is given, then only those services will be enabled, ignoring contract defaults."
             },
             "enable_beta": {
               "type": "array",
               "items": {"type": "string"},
-              "description": "Optional list of ubuntu-advantage beta services to enable. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled."
+              "description": "Optional list of ubuntu-advantage beta services to enable. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled. In Ubuntu Pro instances, if this list is given, then only those services will be enabled, ignoring contract defaults."
             },
             "token": {
               "type": "string",
@@ -2217,21 +2217,13 @@
             },
             "features": {
               "type": "object",
-              "description": "TODO",
-              "additionalProperties": true,
+              "description": "Ubuntu Advantage features.",
+              "additionalProperties": false,
               "properties": {
                 "disable_auto_attach": {
                   "type": "boolean",
                   "description": "Optional boolean for controlling if auto attach (in Ubuntu Pro instances) will be performed. Default: ``false``",
                   "default": false
-                },
-                "ignore_enable_by_default": {
-                  "type": "boolean",
-                  "description": "Optional boolean for controlling whether to ignore/install default services found in the given contract"
-                },
-                "allow_beta": {
-                  "type": "boolean",
-                  "description": "Optional boolean for controlling whether to install/ignore default beta services found in the given contract"
                 }
               }
             },

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2204,7 +2204,7 @@
             "enable": {
               "type": "array",
               "items": {"type": "string"},
-              "description": "Optional list of ubuntu-advantage services to enable. Any of: cc-eal, cis, esm-infra, fips, fips-updates, livepatch. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled. In Ubuntu Pro instances, if this list is given, then only those services will be enabled, ignoring contract defaults."
+              "description": "Optional list of ubuntu-advantage services to enable. Any of: cc-eal, cis, esm-infra, fips, fips-updates, livepatch. By default, a given contract token will automatically enable a number of services, use this list to supplement which services should additionally be enabled. Any service unavailable on a given Ubuntu release or unentitled in a given contract will remain disabled. In Ubuntu Pro instances, if this list is given, then only those services will be enabled, ignoring contract defaults. Passing beta services here will cause an error."
             },
             "enable_beta": {
               "type": "array",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2218,7 +2218,7 @@
             "features": {
               "type": "object",
               "description": "Ubuntu Advantage features.",
-              "additionalProperties": false,
+              "additionalProperties": true,
               "properties": {
                 "disable_auto_attach": {
                   "type": "boolean",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2213,7 +2213,7 @@
             },
             "token": {
               "type": "string",
-              "description": "Contract token obtained from https://ubuntu.com/advantage to attach (in non-Pro instances)."
+              "description": "Contract token obtained from https://ubuntu.com/advantage to attach. Required for non-Pro instances."
             },
             "features": {
               "type": "object",
@@ -2222,7 +2222,7 @@
               "properties": {
                 "disable_auto_attach": {
                   "type": "boolean",
-                  "description": "Optional boolean for controlling if auto attach (in Ubuntu Pro instances) will be performed. Default: ``false``",
+                  "description": "Optional boolean for controlling if ua-auto-attach.service (in Ubuntu Pro instances) will be attempted each boot. Default: ``false``",
                   "default": false
                 }
               }

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2222,8 +2222,8 @@
               "properties": {
                 "disable_auto_attach": {
                   "type": "boolean",
-                  "description": "Optional boolean for controlling if auto attach (in Ubuntu Pro instances) will be performed. Default: ``true``",
-                  "default": true
+                  "description": "Optional boolean for controlling if auto attach (in Ubuntu Pro instances) will be performed. Default: ``false``",
+                  "default": false
                 },
                 "ignore_enable_by_default": {
                   "type": "boolean",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2218,7 +2218,7 @@
             "features": {
               "type": "object",
               "description": "Ubuntu Advantage features.",
-              "additionalProperties": true,
+              "additionalProperties": false,
               "properties": {
                 "disable_auto_attach": {
                   "type": "boolean",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,17 +17,18 @@ exclude=[]
 module = [
   "apport.*",
   "BaseHTTPServer",
-  "configobj",
   "cloudinit.feature_overrides",
+  "configobj",
   "debconf",
-  "httpretty",
   "httplib",
+  "httpretty",
   "jsonpatch",
   "netifaces",
   "paramiko.*",
   "pycloudlib.*",
   "responses",
   "serial",
-  "tests.integration_tests.user_settings"
+  "tests.integration_tests.user_settings",
+  "uaclient.*"
 ]
 ignore_missing_imports = true

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -162,8 +162,9 @@ class IntegrationCloud(ABC):
         }
         launch_kwargs = {**default_launch_kwargs, **launch_kwargs}
         display_launch_kwargs = deepcopy(launch_kwargs)
-        if "token" in display_launch_kwargs["user_data"]:
-            display_launch_kwargs["user_data"] = "REDACTED"
+        if display_launch_kwargs.get("user_data") is not None:
+            if "token" in display_launch_kwargs.get("user_data"):
+                display_launch_kwargs["user_data"] = "REDACTED"
         log.info(
             "Launching instance with launch_kwargs:\n%s",
             "\n".join(

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -163,10 +163,11 @@ class IntegrationCloud(ABC):
         }
         launch_kwargs = {**default_launch_kwargs, **launch_kwargs}
         display_launch_kwargs = deepcopy(launch_kwargs)
-        if "token" in display_launch_kwargs.get("user_data", {}):
-            display_launch_kwargs["user_data"] = re.sub(
-                r"token: .*", "token: REDACTED", launch_kwargs["user_data"]
-            )
+        if display_launch_kwargs.get("user_data") is not None:
+            if "token" in display_launch_kwargs.get("user_data"):
+                display_launch_kwargs["user_data"] = re.sub(
+                    r"token: .*", "token: REDACTED", launch_kwargs["user_data"]
+                )
         log.info(
             "Launching instance with launch_kwargs:\n%s",
             "\n".join(

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -3,6 +3,7 @@ import datetime
 import logging
 import os.path
 import random
+import re
 import string
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -162,9 +163,10 @@ class IntegrationCloud(ABC):
         }
         launch_kwargs = {**default_launch_kwargs, **launch_kwargs}
         display_launch_kwargs = deepcopy(launch_kwargs)
-        if display_launch_kwargs.get("user_data") is not None:
-            if "token" in display_launch_kwargs.get("user_data"):
-                display_launch_kwargs["user_data"] = "REDACTED"
+        if "token" in display_launch_kwargs.get("user_data", {}):
+            display_launch_kwargs["user_data"] = re.sub(
+                r"token: .*", "token: REDACTED", launch_kwargs["user_data"]
+            )
         log.info(
             "Launching instance with launch_kwargs:\n%s",
             "\n".join(

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -161,9 +161,14 @@ class IntegrationCloud(ABC):
             "user_data": user_data,
         }
         launch_kwargs = {**default_launch_kwargs, **launch_kwargs}
+        display_launch_kwargs = deepcopy(launch_kwargs)
+        if "token" in display_launch_kwargs["user_data"]:
+            display_launch_kwargs["user_data"] = "REDACTED"
         log.info(
             "Launching instance with launch_kwargs:\n%s",
-            "\n".join("{}={}".format(*item) for item in launch_kwargs.items()),
+            "\n".join(
+                "{}={}".format(*item) for item in display_launch_kwargs.items()
+            ),
         )
 
         with emit_dots_on_travis():

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -34,7 +34,7 @@ AUTO_ATTACH_CUSTOM_SERVICES = """\
 #cloud-config
 ubuntu_advantage:
   enable:
-  - fips
+  - esm
   enable_beta:
   - realtime-kernel
 """

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -5,7 +5,10 @@ from pycloudlib.cloud import ImageType
 
 from tests.integration_tests.clouds import ImageSpecification, IntegrationCloud
 from tests.integration_tests.conftest import get_validated_source
-from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.instances import (
+    CloudInitSource,
+    IntegrationInstance,
+)
 from tests.integration_tests.util import verify_clean_log
 
 CLOUD_INIT_UA_TOKEN = os.environ.get("CLOUD_INIT_UA_TOKEN")
@@ -34,9 +37,7 @@ AUTO_ATTACH_CUSTOM_SERVICES = """\
 #cloud-config
 ubuntu_advantage:
   enable:
-  - esm
-  enable_beta:
-  - realtime-kernel
+  - livepatch
 """
 
 
@@ -83,10 +84,12 @@ def install_ua_daily(session_cloud: IntegrationCloud):
             )
         },
     ) as client:
+        client.execute("ua detach")
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
         source = get_validated_source(session_cloud)
-        client.install_new_cloud_init(source)
+        if source is not CloudInitSource.NONE:
+            client.install_new_cloud_init(source)
         client.destroy()
 
 

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -1,7 +1,9 @@
 import os
 
 import pytest
+from pycloudlib.cloud import ImageType
 
+from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import verify_clean_log
 
@@ -17,37 +19,60 @@ ubuntu_advantage:
   token: {token}
 """
 
-AUTO_ATTACH_DISABLED = """\
+UA_DAILY = """\
 #cloud-config
 apt:
-  ppa:ua-client/daily
-ubuntu_advantage:
-  disable_auto_attach: true
+  sources:
+    ua-daily:
+      source: 'ppa:ua-client/daily'
+package_update: true
+package_upgrade: true
+packages:
+- ubuntu-advantage-tools
 """
 
 AUTO_ATTACH_CUSTOM_SERVICES = """\
+#cloud-config
 ubuntu_advantage:
-enable:
-- fips
-enable_beta:
-- realtime-kernel
+  enable:
+  - fips
+  enable_beta:
+  - realtime-kernel
 """
 
 
 AUTO_ATTACH_DISABLED_SERVICES = """\
+#cloud-config
 ubuntu_advantage:
-enable: []
-enable_beta: []
+  enable: []
+  enable_beta: []
 """
 
 
-def did_ua_service_noop(client: IntegrationInstance) -> bool:
+def did_ua_service_noop(client: IntegrationInstance):
     """Determine if ua.service did run or not"""
-    raise NotImplementedError("TODO")
+    ua_log = client.read_from_file("/var/log/ubuntu-advantage.log")
+    assert (
+        '"should_auto_attach": true'
+        in client.execute(
+            "pro api u.pro.attach.auto.should_auto_attach.v1"
+        ).stdout
+    )
+    assert (
+        "Skipping auto-attach and deferring to cloud-init to setup and"
+        " configure auto-attach" in ua_log
+    )
+
+
+def is_auto_attached(client: IntegrationInstance):
+    assert (
+        "machine is attached to an Ubuntu Pro subscription."
+        in client.execute("pro status").stdout
+    )
 
 
 @pytest.mark.ubuntu
-@pytest.mark.ci
+@pytest.mark.adhoc
 class TestUbuntuAdvantage:
     @pytest.mark.user_data(ATTACH_FALLBACK.format(token=UA_TOKEN_VALID))
     @pytest.mark.skip(reason="TODO: Add `UA_TOKEN_VALID` as secret")
@@ -68,47 +93,80 @@ class TestUbuntuAdvantage:
         assert "This machine is not attached" in status.stdout
 
 
+@pytest.fixture
+def ua_daily_session_cloud(session_cloud: IntegrationCloud, setup_image):
+    # We install here `ubuntu-advantage-tools` for ppa:ua-client/daily
+    # TODO remove this fixture completely after UA releases a new version
+    # containing the 'uaclient.api.u.pro.attach.auto.full_auto_attach.v1' api
+    # endpoint
+    old_snapshot_id = session_cloud.snapshot_id
+    with session_cloud.launch(user_data=UA_DAILY) as client:
+        log = client.read_from_file("/var/log/cloud-init.log")
+        verify_clean_log(log)
+        old_boot_id = client.instance.get_boot_id()
+        client.execute("cloud-init clean --logs --reboot")
+        client.instance._wait_for_execute(old_boot_id=old_boot_id)
+        session_cloud.snapshot_id = client.snapshot()
+
+    yield session_cloud
+
+    try:
+        session_cloud.delete_snapshot()
+    finally:
+        session_cloud.snapshot_id = old_snapshot_id
+
+
+@pytest.mark.integration_cloud_args(image_type=ImageType.PRO)
 @pytest.mark.azure
 @pytest.mark.ec2
 @pytest.mark.gce
 @pytest.mark.ubuntu
-@pytest.mark.ci
+@pytest.mark.adhoc
 class TestUbuntuAdvantagePro:
-    @pytest.mark.user_data(AUTO_ATTACH_DISABLED)
-    @pytest.mark.skip(reason="TODO")
-    def test_ubuntu_advantage_noop(self, client: IntegrationInstance):
-        log = client.read_from_file("/var/log/cloud-init.log")
-        verify_clean_log(log)
-        assert did_ua_service_noop(client)
-
-    @pytest.mark.skip(reason="TODO")
-    def test_ubuntu_advantage_noop_cloud_cfg(
-        self, client: IntegrationInstance
-    ):
-        client.write_to_file(UA_CLOUD_CONFIG, AUTO_ATTACH_DISABLED)
-        client.execute("cloud-init clean --logs --reboot")
-        log = client.read_from_file("/var/log/cloud-init.log")
-        verify_clean_log(log)
-        assert did_ua_service_noop(client)
-
-    @pytest.mark.user_data(AUTO_ATTACH_CUSTOM_SERVICES)
-    @pytest.mark.skip(reason="TODO")
-    def test_ubuntu_advantage_custom_services(
-        self, client: IntegrationInstance
-    ):
-        log = client.read_from_file("/var/log/cloud-init.log")
-        verify_clean_log(log)
-        assert did_ua_service_noop(client)
-        # TODO check that cc_ubuntu_advantage did auto-attach properly
-        # TODO check only fips and realtime-kernel are enabled
-
-    @pytest.mark.user_data(AUTO_ATTACH_DISABLED_SERVICES)
-    @pytest.mark.skip(reason="TODO")
     def test_ubuntu_advantage_disabled_services(
-        self, client: IntegrationInstance
+        self, ua_daily_session_cloud: IntegrationCloud, setup_image
     ):
-        log = client.read_from_file("/var/log/cloud-init.log")
-        verify_clean_log(log)
-        assert did_ua_service_noop(client)
-        # TODO check that cc_ubuntu_advantage did auto-attach properly
-        # TODO check all services are disabled
+        with ua_daily_session_cloud.launch(
+            user_data=AUTO_ATTACH_DISABLED_SERVICES,
+            launch_kwargs={
+                "image_id": ua_daily_session_cloud.snapshot_id,
+            },
+        ) as client:
+            log = client.read_from_file("/var/log/cloud-init.log")
+            verify_clean_log(log)
+            did_ua_service_noop(client)
+            is_auto_attached(client)
+            # TODO check all services are disabled
+
+    def test_ubuntu_advantage_disabled_services_cloud_cfg(
+        self, ua_daily_session_cloud: IntegrationCloud, setup_image
+    ):
+        with ua_daily_session_cloud.launch(
+            launch_kwargs={
+                "image_id": ua_daily_session_cloud.snapshot_id,
+            },
+        ) as client:
+            client.write_to_file(
+                UA_CLOUD_CONFIG, AUTO_ATTACH_DISABLED_SERVICES
+            )
+            client.execute("cloud-init clean --logs --reboot")
+            log = client.read_from_file("/var/log/cloud-init.log")
+            verify_clean_log(log)
+            did_ua_service_noop(client)
+            is_auto_attached(client)
+            # TODO check all services are disabled
+
+    def test_ubuntu_advantage_custom_services(
+        self, ua_daily_session_cloud: IntegrationCloud, setup_image
+    ):
+        with ua_daily_session_cloud.launch(
+            user_data=AUTO_ATTACH_CUSTOM_SERVICES,
+            launch_kwargs={
+                "image_id": ua_daily_session_cloud.snapshot_id,
+            },
+        ) as client:
+            log = client.read_from_file("/var/log/cloud-init.log")
+            verify_clean_log(log)
+            did_ua_service_noop(client)
+            is_auto_attached(client)
+            # TODO check only fips and realtime-kernel are enabled

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -14,26 +14,26 @@ ubuntu_advantage:
 
 def did_ua_service_noop(client: IntegrationInstance) -> bool:
     """Determine if ua.service did run or not"""
-    raise NotImplementedError
+    raise NotImplementedError("TODO")
 
 
 @pytest.mark.ubuntu
 @pytest.mark.user_data(AUTO_ATTACH_DISABLED)
+@pytest.mark.skip(reason="TODO")
 def test_ubuntu_advantage_noop(client: IntegrationInstance):
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
     assert did_ua_service_noop(client)
-    # TODO check that cc_ubuntu_advantage did noop
 
 
 @pytest.mark.ubuntu
+@pytest.mark.skip(reason="TODO")
 def test_ubuntu_advantage_noop_cloud_cfg(client: IntegrationInstance):
     client.write_to_file(UA_CLOUD_CONFIG, AUTO_ATTACH_DISABLED)
     client.execute("cloud-init clean --logs --reboot")
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
     assert did_ua_service_noop(client)
-    # TODO check that cc_ubuntu_advantage did noop
 
 
 CUSTOM_SERVICES = """\
@@ -53,11 +53,12 @@ ubuntu_advantage:
 @pytest.mark.gce
 @pytest.mark.ubuntu
 @pytest.mark.user_data(CUSTOM_SERVICES)
+@pytest.mark.skip(reason="TODO")
 def test_ubuntu_advantage_custom_services(client: IntegrationInstance):
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
     assert did_ua_service_noop(client)
-    # TODO check that cc_ubuntu_advantage did call auto-attach
+    # TODO check that cc_ubuntu_advantage did auto-attach properly
     # TODO check only fips and realtime-kernel are enabled
 
 
@@ -76,6 +77,7 @@ ubuntu_advantage:
 @pytest.mark.gce
 @pytest.mark.ubuntu
 @pytest.mark.user_data(DISALLOW_BETA)
+@pytest.mark.skip(reason="TODO")
 def test_ubuntu_advantage_disallow_beta(client: IntegrationInstance):
     assert did_ua_service_noop(client)
     # log = client.read_from_file("/var/log/cloud-init.log")

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -3,13 +3,12 @@ import os
 import pytest
 from pycloudlib.cloud import ImageType
 
-from tests.integration_tests.clouds import IntegrationCloud
+from tests.integration_tests.clouds import ImageSpecification, IntegrationCloud
+from tests.integration_tests.conftest import get_validated_source
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import verify_clean_log
 
-UA_CLOUD_CONFIG = "/etc/cloud/cloud.cfg/05-pro.conf"
-
-UA_TOKEN_VALID = os.environ.get("UA_TOKEN_VALID")
+CLOUD_INIT_UA_TOKEN = os.environ.get("CLOUD_INIT_UA_TOKEN")
 
 ATTACH_FALLBACK = """\
 #cloud-config
@@ -41,132 +40,71 @@ ubuntu_advantage:
 """
 
 
-AUTO_ATTACH_DISABLED_SERVICES = """\
-#cloud-config
-ubuntu_advantage:
-  enable: []
-  enable_beta: []
-"""
-
-
-def did_ua_service_noop(client: IntegrationInstance):
-    """Determine if ua.service did run or not"""
+def did_ua_service_noop(client: IntegrationInstance) -> bool:
     ua_log = client.read_from_file("/var/log/ubuntu-advantage.log")
-    assert (
-        '"should_auto_attach": true'
-        in client.execute(
-            "pro api u.pro.attach.auto.should_auto_attach.v1"
-        ).stdout
-    )
-    assert (
+    return (
         "Skipping auto-attach and deferring to cloud-init to setup and"
         " configure auto-attach" in ua_log
     )
 
 
-def is_auto_attached(client: IntegrationInstance):
-    assert (
+def is_auto_attached(client: IntegrationInstance) -> bool:
+    return (
         "machine is attached to an Ubuntu Pro subscription."
         in client.execute("pro status").stdout
     )
 
 
-@pytest.mark.ubuntu
 @pytest.mark.adhoc
+@pytest.mark.ubuntu
 class TestUbuntuAdvantage:
-    @pytest.mark.user_data(ATTACH_FALLBACK.format(token=UA_TOKEN_VALID))
-    @pytest.mark.skip(reason="TODO: Add `UA_TOKEN_VALID` as secret")
+    @pytest.mark.user_data(ATTACH_FALLBACK.format(token=CLOUD_INIT_UA_TOKEN))
     def test_valid_token(self, client: IntegrationInstance):
+        assert CLOUD_INIT_UA_TOKEN, "CLOUD_INIT_UA_TOKEN env var not provided"
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
         status = client.execute("ua status")
         assert status.ok
         assert "This machine is not attached" not in status.stdout
 
-    @pytest.mark.user_data(ATTACH_FALLBACK.format(token="<invalid_token>"))
-    def test_invalid_token(self, client: IntegrationInstance):
-        log = client.read_from_file("/var/log/cloud-init.log")
-        assert "Failure attaching Ubuntu Advantage:" in log
-        assert "Stderr: Invalid token. See https://ubuntu.com/advantage" in log
-        status = client.execute("ua status")
-        assert status.ok
-        assert "This machine is not attached" in status.stdout
 
+def install_ua_daily(session_cloud: IntegrationCloud):
+    """Install `ubuntu-advantage-tools` from ppa:ua-client/daily in an
+    Ubuntu Pro image.
 
-@pytest.fixture
-def ua_daily_session_cloud(session_cloud: IntegrationCloud, setup_image):
-    # We install here `ubuntu-advantage-tools` for ppa:ua-client/daily
-    # TODO remove this fixture completely after UA releases a new version
-    # containing the 'uaclient.api.u.pro.attach.auto.full_auto_attach.v1' api
-    # endpoint
-    old_snapshot_id = session_cloud.snapshot_id
-    with session_cloud.launch(user_data=UA_DAILY) as client:
+    TODO: Remove this after UA releases the next version.
+    """
+    cfg_image_spec = ImageSpecification.from_os_image()
+    with session_cloud.launch(
+        user_data=UA_DAILY,
+        launch_kwargs={
+            "image_id": session_cloud.cloud_instance.daily_image(
+                cfg_image_spec.image_id, image_type=ImageType.PRO
+            )
+        },
+    ) as client:
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
-        old_boot_id = client.instance.get_boot_id()
-        client.execute("cloud-init clean --logs --reboot")
-        client.instance._wait_for_execute(old_boot_id=old_boot_id)
-        session_cloud.snapshot_id = client.snapshot()
-
-    yield session_cloud
-
-    try:
-        session_cloud.delete_snapshot()
-    finally:
-        session_cloud.snapshot_id = old_snapshot_id
+        source = get_validated_source(session_cloud)
+        client.install_new_cloud_init(source)
+        client.destroy()
 
 
-@pytest.mark.integration_cloud_args(image_type=ImageType.PRO)
+@pytest.mark.adhoc
 @pytest.mark.azure
 @pytest.mark.ec2
 @pytest.mark.gce
 @pytest.mark.ubuntu
-@pytest.mark.adhoc
 class TestUbuntuAdvantagePro:
-    def test_ubuntu_advantage_disabled_services(
-        self, ua_daily_session_cloud: IntegrationCloud, setup_image
-    ):
-        with ua_daily_session_cloud.launch(
-            user_data=AUTO_ATTACH_DISABLED_SERVICES,
-            launch_kwargs={
-                "image_id": ua_daily_session_cloud.snapshot_id,
-            },
-        ) as client:
-            log = client.read_from_file("/var/log/cloud-init.log")
-            verify_clean_log(log)
-            did_ua_service_noop(client)
-            is_auto_attached(client)
-            # TODO check all services are disabled
-
-    def test_ubuntu_advantage_disabled_services_cloud_cfg(
-        self, ua_daily_session_cloud: IntegrationCloud, setup_image
-    ):
-        with ua_daily_session_cloud.launch(
-            launch_kwargs={
-                "image_id": ua_daily_session_cloud.snapshot_id,
-            },
-        ) as client:
-            client.write_to_file(
-                UA_CLOUD_CONFIG, AUTO_ATTACH_DISABLED_SERVICES
-            )
-            client.execute("cloud-init clean --logs --reboot")
-            log = client.read_from_file("/var/log/cloud-init.log")
-            verify_clean_log(log)
-            did_ua_service_noop(client)
-            is_auto_attached(client)
-            # TODO check all services are disabled
-
-    def test_ubuntu_advantage_custom_services(
-        self, ua_daily_session_cloud: IntegrationCloud, setup_image
-    ):
-        with ua_daily_session_cloud.launch(
+    def test_custom_services(self, session_cloud: IntegrationCloud):
+        install_ua_daily(session_cloud)
+        with session_cloud.launch(
             user_data=AUTO_ATTACH_CUSTOM_SERVICES,
             launch_kwargs={
-                "image_id": ua_daily_session_cloud.snapshot_id,
+                "image_id": session_cloud.snapshot_id,
             },
         ) as client:
             log = client.read_from_file("/var/log/cloud-init.log")
             verify_clean_log(log)
-            did_ua_service_noop(client)
-            is_auto_attached(client)
-            # TODO check only fips and realtime-kernel are enabled
+            assert did_ua_service_noop(client)
+            assert is_auto_attached(client)

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -72,7 +72,7 @@ def install_ua_daily(session_cloud: IntegrationCloud):
     """Install `ubuntu-advantage-tools` from ppa:ua-client/daily in an
     Ubuntu Pro image.
 
-    TODO: Remove this after UA releases the next version.
+    TODO: Remove this after UA releases v28.0.
     """
     cfg_image_spec = ImageSpecification.from_os_image()
     with session_cloud.launch(

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -1,0 +1,82 @@
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+UA_CLOUD_CONFIG = "/etc/cloud/cloud.cfg/05-pro.conf"
+
+AUTO_ATTACH_DISABLED = """\
+#cloud-config
+ubuntu_advantage:
+  disable_auto_attach: true
+"""
+
+
+def did_ua_service_noop(client: IntegrationInstance) -> bool:
+    """Determine if ua.service did run or not"""
+    raise NotImplementedError
+
+
+@pytest.mark.ubuntu
+@pytest.mark.user_data(AUTO_ATTACH_DISABLED)
+def test_ubuntu_advantage_noop(client: IntegrationInstance):
+    log = client.read_from_file("/var/log/cloud-init.log")
+    verify_clean_log(log)
+    assert did_ua_service_noop(client)
+    # TODO check that cc_ubuntu_advantage did noop
+
+
+@pytest.mark.ubuntu
+def test_ubuntu_advantage_noop_cloud_cfg(client: IntegrationInstance):
+    client.write_to_file(UA_CLOUD_CONFIG, AUTO_ATTACH_DISABLED)
+    client.execute("cloud-init clean --logs --reboot")
+    log = client.read_from_file("/var/log/cloud-init.log")
+    verify_clean_log(log)
+    assert did_ua_service_noop(client)
+    # TODO check that cc_ubuntu_advantage did noop
+
+
+CUSTOM_SERVICES = """\
+ubuntu_advantage:
+  features:
+    ignore_enable_by_default: true
+    allow_beta: true
+  enable:
+  - fips
+  enable_beta:
+  - realtime-kernel
+"""
+
+
+@pytest.mark.azure
+@pytest.mark.ec2
+@pytest.mark.gce
+@pytest.mark.ubuntu
+@pytest.mark.user_data(CUSTOM_SERVICES)
+def test_ubuntu_advantage_custom_services(client: IntegrationInstance):
+    log = client.read_from_file("/var/log/cloud-init.log")
+    verify_clean_log(log)
+    assert did_ua_service_noop(client)
+    # TODO check that cc_ubuntu_advantage did call auto-attach
+    # TODO check only fips and realtime-kernel are enabled
+
+
+DISALLOW_BETA = """\
+ubuntu_advantage:
+  features:
+    ignore_enable_by_default: true
+    allow_beta: false
+  enable:
+  - realtime-kernel
+"""
+
+
+@pytest.mark.azure
+@pytest.mark.ec2
+@pytest.mark.gce
+@pytest.mark.ubuntu
+@pytest.mark.user_data(DISALLOW_BETA)
+def test_ubuntu_advantage_disallow_beta(client: IntegrationInstance):
+    assert did_ua_service_noop(client)
+    # log = client.read_from_file("/var/log/cloud-init.log")
+    # TODO check that cc_ubuntu_advantage did handle ua auto-attach errors

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -1,7 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import logging
 import re
-from copy import deepcopy
 
 import pytest
 
@@ -405,13 +404,6 @@ class TestHandle:
     cloud = get_cloud()
 
     @pytest.mark.parametrize(
-        "with_disable_auto_attach",
-        [
-            pytest.param(False, id="no_disable_auto_attach"),
-            pytest.param(True, id="disable_auto_attach"),
-        ],
-    )
-    @pytest.mark.parametrize(
         [
             "cfg",
             "cloud",
@@ -508,12 +500,10 @@ class TestHandle:
         log_record_tuples,
         maybe_install_call_args_list,
         configure_ua_call_args_list,
-        with_disable_auto_attach,
         caplog,
     ):
-        if with_disable_auto_attach:
-            cfg = deepcopy(cfg)
-            cfg["features"] = {"disable_auto_attach": True}
+        """Non-Pro schemas and instance."""
+        m_auto_attach_short.side_effect = NotAProInstance
         handle("nomatter", cfg=cfg, cloud=cloud, log=None, args=None)
         for record_tuple in log_record_tuples:
             assert record_tuple in caplog.record_tuples
@@ -524,9 +514,6 @@ class TestHandle:
             )
         if configure_ua_call_args_list is not None:
             assert configure_ua_call_args_list == m_configure_ua.call_args_list
-        assert (
-            0 == m_auto_attach_short.call_count
-        ), "Unexpected call to `auto_attach_short`"
         assert (
             0 == m_auto_attach_long.call_count
         ), "Unexpected call to `auto_attach_long`"

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import sys
+from builtins import __import__
 from collections import namedtuple
 
 import pytest
@@ -27,6 +28,17 @@ from tests.unittests.util import get_cloud
 
 # Module path used in mocks
 MPATH = "cloudinit.config.cc_ubuntu_advantage"
+
+
+def decorate__import__with_errors(name_startswith):
+    """Decorates __import__ with errors"""
+
+    def __import__with_error(name, *args, **kwargs):
+        if name.startswith(name_startswith):
+            raise ImportError(f"No module named '{name_startswith}'")
+        return __import__(name, *args, **kwargs)
+
+    return __import__with_error
 
 
 class FakeUserFacingError(Exception):
@@ -838,15 +850,17 @@ class TestHandle:
                 "nomatter",
                 cfg=cfg,
                 log=mock.Mock(),
-                cloud=None,
+                cloud=self.cloud,
                 args=None,
             )
 
 
 class TestShouldAutoAttach:
     def test_uaclient_not_installed(self, caplog, mocker):
-        mocker.patch.dict("sys.modules")
-        sys.modules.pop("uaclient", None)
+        mocker.patch(
+            "builtins.__import__",
+            side_effect=decorate__import__with_errors("uaclient"),
+        )
         assert not _should_auto_attach(ua_section={})
         assert (
             "Unable to import `uaclient`: No module named 'uaclient'"
@@ -862,7 +876,12 @@ class TestShouldAutoAttach:
         sys.modules["uaclient"] = mock.Mock()
         sys.modules["uaclient.api"] = mock.Mock()
         sys.modules["uaclient.api.u.pro.attach.auto"] = mock.Mock()
-        sys.modules.pop("uaclient.api.exceptions", None)
+        mocker.patch(
+            "builtins.__import__",
+            side_effect=decorate__import__with_errors(
+                "uaclient.api.exceptions"
+            ),
+        )
         assert not _should_auto_attach({})
         assert (
             "Unable to import `uaclient`: No module named"
@@ -921,8 +940,10 @@ class TestAutoAttach:
     ua_section: dict = {}
 
     def test_uaclient_not_installed(self, caplog, mocker):
-        mocker.patch.dict("sys.modules")
-        sys.modules.pop("uaclient", None)
+        mocker.patch(
+            "builtins.__import__",
+            side_effect=decorate__import__with_errors("uaclient"),
+        )
         expected_msg = (
             "Unable to import `uaclient`: No module named 'uaclient'"
         )
@@ -936,13 +957,15 @@ class TestAutoAttach:
         sys.modules["uaclient.api"] = mock.Mock()
         sys.modules["uaclient.api.exceptions"] = mock.Mock()
         sys.modules["uaclient.api.u.pro.attach.auto"] = mock.Mock()
-        sys.modules.pop(
-            "uaclient.api.u.pro.attach.auto.full_auto_attach", None
+        mocker.patch(
+            "builtins.__import__",
+            side_effect=decorate__import__with_errors(
+                "uaclient.api.u.pro.attach.auto.full_auto_attach"
+            ),
         )
         expected_msg = (
             "Unable to import `uaclient`: No module named"
-            " 'uaclient.api.u.pro.attach.auto.full_auto_attach';"
-            " 'uaclient.api.u.pro.attach.auto' is not a package"
+            " 'uaclient.api.u.pro.attach.auto.full_auto_attach'"
         )
         with pytest.raises(RuntimeError, match=re.escape(expected_msg)):
             _auto_attach(self.ua_section)

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -607,6 +607,44 @@ class TestHandle:
             assert configure_ua_call_args_list == m_attach.call_args_list
         assert auto_attach_call_args_list == m_auto_attach.call_args_list
 
+    @pytest.mark.parametrize("is_pro", [False, True])
+    @pytest.mark.parametrize(
+        "cfg",
+        [
+            (
+                {
+                    "ubuntu_advantage": {
+                        "features": {"disable_auto_attach": False},
+                    }
+                }
+            ),
+            (
+                {
+                    "ubuntu_advantage": {
+                        "features": {"disable_auto_attach": True},
+                    }
+                }
+            ),
+        ],
+    )
+    @mock.patch(f"{MPATH}._is_pro")
+    @mock.patch(f"{MPATH}._auto_attach")
+    @mock.patch(f"{MPATH}._attach")
+    def test_no_fallback_attach(
+        self,
+        m_attach,
+        m_auto_attach,
+        m_is_pro,
+        cfg,
+        is_pro,
+    ):
+        """Checks that attach is not called in the case we want only to
+        enable or disable ua auto-attach.
+        """
+        m_is_pro.return_value = is_pro
+        handle("nomatter", cfg=cfg, cloud=self.cloud, log=None, args=None)
+        assert not m_attach.call_args_list
+
     @pytest.mark.parametrize(
         "cfg, handle_kwargs, match",
         [

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -39,10 +39,11 @@ def fake_uaclient(mocker):
     sys.modules[
         "uaclient.api.u.pro.attach.auto.full_auto_attach.v1"
     ] = mock.Mock()
+    sys.modules["uaclient.api"] = mock.Mock()
     _exceptions = namedtuple("exceptions", ["UserFacingError"])(
         FakeUserFacingError
     )
-    sys.modules["uaclient.exceptions"] = _exceptions
+    sys.modules["uaclient.api.exceptions"] = _exceptions
 
 
 @mock.patch(f"{MPATH}.subp.subp")
@@ -757,6 +758,9 @@ class TestAutoAttach:
 
     def test_uaclient_old_version(self, caplog, mocker):
         mocker.patch.dict("sys.modules")
+        sys.modules["uaclient"] = mock.Mock()
+        sys.modules["uaclient.api"] = mock.Mock()
+        sys.modules["uaclient.api.exceptions"] = mock.Mock()
         sys.modules["uaclient.api.u.pro.attach.auto"] = mock.Mock()
         sys.modules.pop(
             "uaclient.api.u.pro.attach.auto.full_auto_attach", None

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -414,7 +414,13 @@ class TestUbuntuAdvantageSchema:
                         "token": "<token>",
                     }
                 },
-                does_not_raise(),
+                pytest.raises(
+                    SchemaValidationError,
+                    match=re.escape(
+                        "ubuntu_advantage.features: Additional properties are"
+                        " not allowed ('asdf'"
+                    ),
+                ),
                 id="pro_additional_features",
             ),
         ],
@@ -462,14 +468,6 @@ class TestUbuntuAdvantageSchema:
                 [
                     "'ubuntu_advantage.features.disable_auto_attach' should be"
                     " a bool, not a list\n"
-                ],
-            ),
-            (
-                {"features": {"unknown": True, "foobar": False}},
-                does_not_raise(),
-                [
-                    "Ignoring unknown 'ubuntu_advantage.features': foobar,"
-                    " unknown\n"
                 ],
             ),
         ],

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -363,26 +363,6 @@ class TestUbuntuAdvantageSchema:
             pytest.param(
                 {
                     "ubuntu_advantage": {
-                        "features": {"ignore_enable_by_default": True}
-                    }
-                },
-                does_not_raise(),
-                id="ignore_enable_by_default",
-            ),
-            pytest.param(
-                {
-                    "ubuntu_advantage": {
-                        "features": {"ignore_enable_by_default": True},
-                        "enable": ["fips"],
-                        "enable_beta": ["realtime-kernel"],
-                    }
-                },
-                does_not_raise(),
-                id="custom_ignore_enable_by_default",
-            ),
-            pytest.param(
-                {
-                    "ubuntu_advantage": {
                         "features": {"disable_auto_attach": False},
                         "enable": ["fips"],
                         "enable_beta": ["realtime-kernel"],


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ubuntu_advantage: Implement custom auto-attach behaviors

Previously, ua auto-attach was performed in Ubuntu Pro images
transparently for cloud-init. Offering no configurability options
for cloud-init users.

Extend the `ubuntu_advantage` cloud-cfg section to include
`features.disable_auto_attach` and `enable_beta`.

Integrate new UA apis to detect pro instances and perform 
auto-attach if ua config is given.

The client can configure what non-beta and beta services will be enabled.

This config can be provided via:
- user-data allowing customers to configure auto-attach.
- A conf file under /etc/cloud/cloud.cfg.d allowing resellers to create 
ua-preconfigured golden images.

In the case that the ubuntu-advantage-client version is older than
the one containing the required apis, cc_ubuntu_advantage will fallback
to normal attach.
```

## Additional Context
<!-- If relevant -->
[SC-1145](https://warthogs.atlassian.net/browse/SC-1145)
[SC-1149](https://warthogs.atlassian.net/browse/SC-1149)
https://github.com/canonical/ubuntu-advantage-client/pull/2166
https://github.com/canonical/ubuntu-advantage-client/pull/2171

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```bash
# Run it in gce, azure or ec2 (only clouds providing Pro images)
tox -e integration-test -- tests/integration_tests/modules/test_ubuntu_advantage.py::TestUbuntuAdvantagePro
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
