### PR TITLE
sources/azure: reorganize tests for network config

### DIFF
--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -476,9 +476,200 @@ IMDS_NETWORK_METADATA = {
 EXAMPLE_UUID = "d0df4c54-4ecb-4a4b-9954-5bdf3ed5c3b8"
 
 
-class TestNetworkConfig:
+class TestGenerateNetworkConfig:
+    @pytest.mark.parametrize(
+        "label,metadata,expected",
+        [
+            (
+                "simple interface",
+                NETWORK_METADATA["network"],
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": False,
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "set-name": "eth0",
+                        }
+                    },
+                    "version": 2,
+                },
+            ),
+            (
+                "multiple interfaces with increasing route metric",
+                {
+                    "interface": [
+                        {
+                            "macAddress": "000D3A047598",
+                            "ipv6": {"ipAddress": []},
+                            "ipv4": {
+                                "subnet": [
+                                    {"prefix": "24", "address": "10.0.0.0"}
+                                ],
+                                "ipAddress": [
+                                    {
+                                        "privateIpAddress": "10.0.0.4",
+                                        "publicIpAddress": "104.46.124.81",
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                    * 3
+                },
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": False,
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "set-name": "eth0",
+                        },
+                        "eth1": {
+                            "set-name": "eth1",
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "dhcp6": False,
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 200},
+                        },
+                        "eth2": {
+                            "set-name": "eth2",
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "dhcp6": False,
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 300},
+                        },
+                    },
+                    "version": 2,
+                },
+            ),
+            (
+                "secondary IPv4s are static",
+                {
+                    "interface": [
+                        {
+                            "macAddress": "000D3A047598",
+                            "ipv6": {
+                                "subnet": [
+                                    {
+                                        "prefix": "10",
+                                        "address": "2001:dead:beef::16",
+                                    }
+                                ],
+                                "ipAddress": [
+                                    {"privateIpAddress": "2001:dead:beef::1"}
+                                ],
+                            },
+                            "ipv4": {
+                                "subnet": [
+                                    {"prefix": "24", "address": "10.0.0.0"},
+                                ],
+                                "ipAddress": [
+                                    {
+                                        "privateIpAddress": "10.0.0.4",
+                                        "publicIpAddress": "104.46.124.81",
+                                    },
+                                    {
+                                        "privateIpAddress": "11.0.0.5",
+                                        "publicIpAddress": "104.46.124.82",
+                                    },
+                                    {
+                                        "privateIpAddress": "12.0.0.6",
+                                        "publicIpAddress": "104.46.124.83",
+                                    },
+                                ],
+                            },
+                        }
+                    ]
+                },
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "addresses": ["11.0.0.5/24", "12.0.0.6/24"],
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": True,
+                            "dhcp6-overrides": {"route-metric": 100},
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "set-name": "eth0",
+                        }
+                    },
+                    "version": 2,
+                },
+            ),
+            (
+                "ipv6 secondaries",
+                {
+                    "interface": [
+                        {
+                            "macAddress": "000D3A047598",
+                            "ipv6": {
+                                "subnet": [
+                                    {
+                                        "prefix": "10",
+                                        "address": "2001:dead:beef::16",
+                                    }
+                                ],
+                                "ipAddress": [
+                                    {"privateIpAddress": "2001:dead:beef::1"},
+                                    {"privateIpAddress": "2001:dead:beef::2"},
+                                ],
+                            },
+                        }
+                    ]
+                },
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "addresses": ["2001:dead:beef::2/10"],
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": True,
+                            "dhcp6-overrides": {"route-metric": 100},
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "set-name": "eth0",
+                        }
+                    },
+                    "version": 2,
+                },
+            ),
+        ],
+    )
+    def test_parsing_scenarios(
+        self, label, mock_device_driver, metadata, expected
+    ):
+        assert (
+            dsaz.generate_network_config_from_instance_network_metadata(
+                metadata
+            )
+            == expected
+        )
 
-    maxDiff = None
+    def test_match_hv_netvsc(self, mock_device_driver):
+        mock_device_driver.return_value = "hv_netvsc"
+
+        assert dsaz.generate_network_config_from_instance_network_metadata(
+            NETWORK_METADATA["network"]
+        ) == {
+            "ethernets": {
+                "eth0": {
+                    "dhcp4": True,
+                    "dhcp4-overrides": {"route-metric": 100},
+                    "dhcp6": False,
+                    "match": {
+                        "macaddress": "00:0d:3a:04:75:98",
+                        "driver": "hv_netvsc",
+                    },
+                    "set-name": "eth0",
+                }
+            },
+            "version": 2,
+        }
+
+
+class TestNetworkConfig:
     fallback_config = {
         "version": 1,
         "config": [
@@ -501,133 +692,6 @@ class TestNetworkConfig:
                     "dhcp4-overrides": {"route-metric": 100},
                     "dhcp6": False,
                     "match": {"macaddress": "00:0d:3a:04:75:98"},
-                    "set-name": "eth0",
-                }
-            },
-            "version": 2,
-        }
-        azure_ds._metadata_imds = NETWORK_METADATA
-
-        assert azure_ds.network_config == expected
-
-    def test_increases_route_metric_for_non_primary_nics(
-        self, azure_ds, mock_device_driver
-    ):
-        """Network config increases route-metric for each nic"""
-        expected = {
-            "ethernets": {
-                "eth0": {
-                    "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": False,
-                    "match": {"macaddress": "00:0d:3a:04:75:98"},
-                    "set-name": "eth0",
-                },
-                "eth1": {
-                    "set-name": "eth1",
-                    "match": {"macaddress": "22:0d:3a:04:75:98"},
-                    "dhcp6": False,
-                    "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 200},
-                },
-                "eth2": {
-                    "set-name": "eth2",
-                    "match": {"macaddress": "33:0d:3a:04:75:98"},
-                    "dhcp6": False,
-                    "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 300},
-                },
-            },
-            "version": 2,
-        }
-        imds_data = copy.deepcopy(NETWORK_METADATA)
-        imds_data["network"]["interface"].append(SECONDARY_INTERFACE)
-        third_intf = copy.deepcopy(SECONDARY_INTERFACE)
-        third_intf["macAddress"] = third_intf["macAddress"].replace("22", "33")
-        third_intf["ipv4"]["subnet"][0]["address"] = "10.0.2.0"
-        third_intf["ipv4"]["ipAddress"][0]["privateIpAddress"] = "10.0.2.6"
-        imds_data["network"]["interface"].append(third_intf)
-        azure_ds._metadata_imds = imds_data
-
-        assert azure_ds.network_config == expected
-
-    def test_ipv4_secondary_ips_will_be_static_addrs(
-        self, azure_ds, mock_device_driver
-    ):
-        """Network config emits primary ipv4 as dhcp others are static"""
-        expected = {
-            "ethernets": {
-                "eth0": {
-                    "addresses": ["10.0.0.5/24"],
-                    "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": True,
-                    "dhcp6-overrides": {"route-metric": 100},
-                    "match": {"macaddress": "00:0d:3a:04:75:98"},
-                    "set-name": "eth0",
-                }
-            },
-            "version": 2,
-        }
-        imds_data = copy.deepcopy(NETWORK_METADATA)
-        nic1 = imds_data["network"]["interface"][0]
-        nic1["ipv4"]["ipAddress"].append({"privateIpAddress": "10.0.0.5"})
-
-        nic1["ipv6"] = {
-            "subnet": [{"prefix": "10", "address": "2001:dead:beef::16"}],
-            "ipAddress": [{"privateIpAddress": "2001:dead:beef::1"}],
-        }
-        azure_ds._metadata_imds = imds_data
-
-        assert azure_ds.network_config == expected
-
-    def test_ipv6_secondary_ips_will_be_static_cidrs(
-        self, azure_ds, mock_device_driver
-    ):
-        """Network config emits primary ipv6 as dhcp others are static"""
-        expected = {
-            "ethernets": {
-                "eth0": {
-                    "addresses": ["10.0.0.5/24", "2001:dead:beef::2/10"],
-                    "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": True,
-                    "dhcp6-overrides": {"route-metric": 100},
-                    "match": {"macaddress": "00:0d:3a:04:75:98"},
-                    "set-name": "eth0",
-                }
-            },
-            "version": 2,
-        }
-        imds_data = copy.deepcopy(NETWORK_METADATA)
-        nic1 = imds_data["network"]["interface"][0]
-        nic1["ipv4"]["ipAddress"].append({"privateIpAddress": "10.0.0.5"})
-
-        # Secondary ipv6 addresses currently ignored/unconfigured
-        nic1["ipv6"] = {
-            "subnet": [{"prefix": "10", "address": "2001:dead:beef::16"}],
-            "ipAddress": [
-                {"privateIpAddress": "2001:dead:beef::1"},
-                {"privateIpAddress": "2001:dead:beef::2"},
-            ],
-        }
-        azure_ds._metadata_imds = imds_data
-
-        assert azure_ds.network_config == expected
-
-    def test_match_driver_for_netvsc(self, azure_ds, mock_device_driver):
-        """Network config emits driver when using netvsc."""
-        mock_device_driver.return_value = "hv_netvsc"
-        expected = {
-            "ethernets": {
-                "eth0": {
-                    "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": False,
-                    "match": {
-                        "macaddress": "00:0d:3a:04:75:98",
-                        "driver": "hv_netvsc",
-                    },
                     "set-name": "eth0",
                 }
             },


### PR DESCRIPTION
Split tests for parsing/converting network config from network_config.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>