### PR TITLE
freebsd: Don't assume that root user is in root group

### DIFF
--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -12,10 +12,10 @@ from textwrap import dedent
 
 from cloudinit import log as logging
 from cloudinit import util
+from cloudinit.cloud import Cloud
 from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.settings import PER_INSTANCE
 
-DEFAULT_OWNER = "root:root"
 DEFAULT_PERMS = 0o644
 DEFAULT_DEFER = False
 TEXT_PLAIN_ENC = "text/plain"
@@ -113,7 +113,7 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(name, cfg, _cloud, log, _args):
+def handle(name, cfg, cloud: Cloud, log, _args):
     file_list = cfg.get("write_files", [])
     filtered_files = [
         f
@@ -127,7 +127,7 @@ def handle(name, cfg, _cloud, log, _args):
             name,
         )
         return
-    write_files(name, filtered_files)
+    write_files(name, filtered_files, cloud.distro.default_owner)
 
 
 def canonicalize_extraction(encoding_type):
@@ -155,7 +155,7 @@ def canonicalize_extraction(encoding_type):
     return [TEXT_PLAIN_ENC]
 
 
-def write_files(name, files):
+def write_files(name, files, owner: str):
     if not files:
         return
 
@@ -171,7 +171,7 @@ def write_files(name, files):
         path = os.path.abspath(path)
         extractions = canonicalize_extraction(f_info.get("encoding"))
         contents = extract_contents(f_info.get("content", ""), extractions)
-        (u, g) = util.extract_usergroup(f_info.get("owner", DEFAULT_OWNER))
+        (u, g) = util.extract_usergroup(f_info.get("owner", owner))
         perms = decode_perms(f_info.get("permissions"), DEFAULT_PERMS)
         omode = "ab" if util.get_cfg_option_bool(f_info, "append") else "wb"
         util.write_file(path, contents, omode=omode, mode=perms)

--- a/cloudinit/config/cc_write_files_deferred.py
+++ b/cloudinit/config/cc_write_files_deferred.py
@@ -5,6 +5,7 @@
 """Write Files Deferred: Defer writing certain files"""
 
 from cloudinit import util
+from cloudinit.cloud import Cloud
 from cloudinit.config.cc_write_files import DEFAULT_DEFER, write_files
 from cloudinit.config.schema import MetaSchema
 from cloudinit.distros import ALL_DISTROS
@@ -33,7 +34,7 @@ meta: MetaSchema = {
 __doc__ = ""
 
 
-def handle(name, cfg, _cloud, log, _args):
+def handle(name, cfg, cloud: Cloud, log, _args):
     file_list = cfg.get("write_files", [])
     filtered_files = [
         f
@@ -47,4 +48,4 @@ def handle(name, cfg, _cloud, log, _args):
             name,
         )
         return
-    write_files(name, filtered_files)
+    write_files(name, filtered_files, cloud.distro.default_owner)

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -76,6 +76,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     ci_sudoers_fn = "/etc/sudoers.d/90-cloud-init-users"
     hostname_conf_fn = "/etc/hostname"
     tz_zone_dir = "/usr/share/zoneinfo"
+    default_owner = "root:root"
     init_cmd = ["service"]  # systemctl, service etc
     renderer_configs: Mapping[str, Mapping[str, Any]] = {}
     _preferred_ntp_clients = None

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -15,6 +15,7 @@ class BSD(distros.Distro):
     networking_cls = BSDNetworking
     hostname_conf_fn = "/etc/rc.conf"
     rc_conf_fn = "/etc/rc.conf"
+    default_owner = "root:wheel"
 
     # This differs from the parent Distro class, which has -P for
     # poweroff.

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -26,6 +26,7 @@ class Distro(cloudinit.distros.bsd.BSD):
     """
 
     networking_cls = FreeBSDNetworking
+    default_owner = "root:wheel"
     usr_lib_exec = "/usr/local/lib"
     login_conf_fn = "/etc/login.conf"
     login_conf_fn_bak = "/etc/login.conf.orig"

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -26,7 +26,6 @@ class Distro(cloudinit.distros.bsd.BSD):
     """
 
     networking_cls = FreeBSDNetworking
-    default_owner = "root:wheel"
     usr_lib_exec = "/usr/local/lib"
     login_conf_fn = "/etc/login.conf"
     login_conf_fn_bak = "/etc/login.conf.orig"

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -65,6 +65,7 @@ VALID_SCHEMA = {
 class TestWriteFiles(FilesystemMockingTestCase):
 
     with_logs = True
+    owner = "root:root"
 
     def setUp(self):
         super(TestWriteFiles, self).setUp()
@@ -75,7 +76,11 @@ class TestWriteFiles(FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         expected = "hello world\n"
         filename = "/tmp/my.file"
-        write_files("test_simple", [{"content": expected, "path": filename}])
+        write_files(
+            "test_simple",
+            [{"content": expected, "path": filename}],
+            self.owner,
+        )
         self.assertEqual(util.load_file(filename), expected)
 
     def test_append(self):
@@ -88,13 +93,14 @@ class TestWriteFiles(FilesystemMockingTestCase):
         write_files(
             "test_append",
             [{"content": added, "path": filename, "append": "true"}],
+            self.owner,
         )
         self.assertEqual(util.load_file(filename), expected)
 
     def test_yaml_binary(self):
         self.patchUtils(self.tmp)
         data = util.load_yaml(YAML_TEXT)
-        write_files("testname", data["write_files"])
+        write_files("testname", data["write_files"], self.owner)
         for path, content in YAML_CONTENT_EXPECTED.items():
             self.assertEqual(util.load_file(path), content)
 
@@ -128,7 +134,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
                     files.append(cur)
                     expected.append((cur["path"], data))
 
-        write_files("test_decoding", files)
+        write_files("test_decoding", files, self.owner)
 
         for path, content in expected:
             self.assertEqual(util.load_file(path, decode=False), content)


### PR DESCRIPTION
```
Don't assume root user is in root group

BSD's root user has group name "wheel" for GID 0

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=265177
```

Rather than assuming that "root:root" is default user:group everywhere, move this value into the distro definitions as the default, and override this to "root:wheel" for ~~freebsd~~ BSDs.

I also added some type annotations along the way, which help us catch/prevent bugs thanks to mypy and friends.
