### PR TITLE
typing: Use TypedDict backport in python < 3.8

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -8,12 +8,11 @@ import os
 import re
 import sys
 import textwrap
-import typing
 from collections import defaultdict
 from copy import deepcopy
 from functools import partial
 from itertools import chain
-from typing import List, NamedTuple, Optional, Type, Union, cast
+from typing import TYPE_CHECKING, List, NamedTuple, Optional, Type, Union, cast
 
 import yaml
 
@@ -66,12 +65,14 @@ SCHEMA_EXAMPLES_SPACER_TEMPLATE = "\n    # --- Example{0} ---"
 DEPRECATED_KEY = "deprecated"
 
 
-# annotations add value for development, but don't break old versions
-# pyver: 3.6 -> 3.8
-# pylint: disable=E1101
-if sys.version_info >= (3, 8):
+# type-annotate only if type-checking.
+# Consider to add `type_extensions` as a dependency when Bionic is EOL.
+if TYPE_CHECKING:
+    import typing
 
-    class MetaSchema(typing.TypedDict):
+    from typing_extensions import TypedDict
+
+    class MetaSchema(TypedDict):
         name: str
         id: str
         title: str
@@ -82,7 +83,6 @@ if sys.version_info >= (3, 8):
 
 else:
     MetaSchema = dict
-# pylint: enable=E1101
 
 
 class SchemaDeprecationError(ValidationError):

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ types-oauthlib==3.1.6
 types-PyYAML==6.0.4
 types-requests==2.27.8
 types-setuptools==57.4.9
+typing-extensions==4.1.1
 
 [testenv:flake8]
 deps =
@@ -66,6 +67,7 @@ deps =
     types-pyyaml=={[format_deps]types-PyYAML}
     types-requests=={[format_deps]types-requests}
     types-setuptools=={[format_deps]types-setuptools}
+    typing-extensions=={[format_deps]typing-extensions}
 commands = {envpython} -m mypy cloudinit/ tests/ tools/
 
 [testenv:check_format]
@@ -83,6 +85,7 @@ deps =
     types-pyyaml=={[format_deps]types-PyYAML}
     types-requests=={[format_deps]types-requests}
     types-setuptools=={[format_deps]types-setuptools}
+    typing-extensions=={[format_deps]typing-extensions}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
 commands =


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
typing: Use TypedDict backport in python < 3.8
```

## Additional Context
<!-- If relevant -->
I think it would be nice to make use of `type_extensions` in order to have type-annotation back-ports.

Sadly, in order to use it normally, we need to have it as a dependency, but `python3-typing-extensions` is only available in series >= focal. That's why I imported it only if we are type-checking.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
