### PR TITLE
sources/azure: don't set cfg["password"] for default user pw

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1836,7 +1836,7 @@ def read_azure_ovf(contents):
     if ovf_env.password:
         defuser["lock_passwd"] = False
         if DEF_PASSWD_REDACTION != ovf_env.password:
-            defuser["passwd"] = encrypt_pass(ovf_env.password)
+            defuser["hashed_passwd"] = encrypt_pass(ovf_env.password)
 
     if defuser:
         cfg["system_info"] = {"default_user": defuser}

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1836,9 +1836,7 @@ def read_azure_ovf(contents):
     if ovf_env.password:
         defuser["lock_passwd"] = False
         if DEF_PASSWD_REDACTION != ovf_env.password:
-            defuser["passwd"] = cfg["password"] = encrypt_pass(
-                ovf_env.password
-            )
+            defuser["passwd"] = encrypt_pass(ovf_env.password)
 
     if defuser:
         cfg["system_info"] = {"default_user": defuser}

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -336,7 +336,7 @@ def http_with_retries(
     headers: dict,
     data: Optional[str] = None,
     retry_sleep: int = 5,
-    timeout_minutes: int = 20
+    timeout_minutes: int = 20,
 ) -> url_helper.UrlResponse:
     """Readurl wrapper for querying wireserver.
 

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1637,10 +1637,10 @@ scbus-1 on xpt0 bus 0
         # passwd is crypt formated string $id$salt$encrypted
         # encrypting plaintext with salt value of everything up to final '$'
         # should equal that after the '$'
-        pos = defuser["passwd"].rfind("$") + 1
+        pos = defuser["hashed_passwd"].rfind("$") + 1
         self.assertEqual(
-            defuser["passwd"],
-            crypt.crypt("mypass", defuser["passwd"][0:pos]),
+            defuser["hashed_passwd"],
+            crypt.crypt("mypass", defuser["hashed_passwd"][0:pos]),
         )
 
         assert dsrc.cfg["ssh_pwauth"] is True

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1643,9 +1643,6 @@ scbus-1 on xpt0 bus 0
             crypt.crypt("mypass", defuser["passwd"][0:pos]),
         )
 
-        # the same hashed value should also be present in cfg['password']
-        self.assertEqual(defuser["passwd"], dsrc.cfg["password"])
-
         assert dsrc.cfg["ssh_pwauth"] is True
 
     def test_password_with_disable_ssh_pw_auth_true(self):


### PR DESCRIPTION
The password is still set for the default (admin) user but isn't
immediately expired as a result of this change:
https://github.com/canonical/cloud-init/pull/1577

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>