### PR TITLE
draft: github.workflow: perform format validation on only the local PR chang…

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -28,6 +28,7 @@ jobs:
         run: |
           git fetch --unshallow
           git remote add upstream https://git.launchpad.net/cloud-init
+          echo "CHANGED_PY_FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }} | grep py$)" >> $GITHUB_ENV
 
       - name: Dependencies
         run: |
@@ -48,4 +49,6 @@ jobs:
         continue-on-error: true
         env:
           TOXENV: tip-${{ matrix.env }}
-        run: tox
+
+        run: |
+            tox $CHANGED_PY_FILES

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git fetch --unshallow
           git remote add upstream https://git.launchpad.net/cloud-init
-          echo "CHANGED_PY_FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.event.after }} | grep py$)" >> $GITHUB_ENV
+          echo "CHANGED_PY_FILES=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep .ts$ | xargs) >> $GITHUB_ENV
 
       - name: Dependencies
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands = {envpython} -m pylint {posargs:cloudinit/ tests/ tools/ conftest.py s
 [testenv:black]
 deps =
     black=={[format_deps]black}
-commands = {envpython} -m black . --check
+commands = {envpython} -m black --check {posargs:.}
 
 [testenv:isort]
 deps =


### PR DESCRIPTION
…ed files

# Draft for discussion: Trying to see if there is a magic only format changed files in github workflow

<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate bug reference or remove
this line entirely if there is no associated bug)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
