### PR TITLE
testing: add support for pycloudlib's pro images

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@6eee33c9c4f630bc9c13b6e48f9ab36e7fb79ca6
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@1e946fa46e2ebd707800d94f5945be901d454753
 pytest

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@1e946fa46e2ebd707800d94f5945be901d454753
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@f9293647e44dff6e98996e6ca83376477139eb5e
 pytest

--- a/tests/integration_tests/bugs/test_lp1835584.py
+++ b/tests/integration_tests/bugs/test_lp1835584.py
@@ -28,14 +28,11 @@ https://bugs.launchpad.net/cloud-init/+bug/1835584
 import re
 
 import pytest
+from pycloudlib.cloud import ImageType
 
 from tests.integration_tests.clouds import ImageSpecification, IntegrationCloud
 from tests.integration_tests.conftest import get_validated_source
 from tests.integration_tests.instances import IntegrationInstance
-
-IMG_AZURE_UBUNTU_PRO_FIPS_BIONIC = (
-    "Canonical:0001-com-ubuntu-pro-bionic-fips:pro-fips-18_04:18.04.202010201"
-)
 
 
 def _check_iid_insensitive_across_kernel_upgrade(
@@ -71,6 +68,8 @@ def _check_iid_insensitive_across_kernel_upgrade(
 
 
 @pytest.mark.azure
+@pytest.mark.lxd_container
+@pytest.mark.integration_cloud_args(image_type=ImageType.PRO_FIPS)
 def test_azure_kernel_upgrade_case_insensitive_uuid(
     session_cloud: IntegrationCloud,
 ):
@@ -86,10 +85,7 @@ def test_azure_kernel_upgrade_case_insensitive_uuid(
         pytest.skip(
             "Provide CLOUD_INIT_SOURCE to install expected working cloud-init"
         )
-    image_id = IMG_AZURE_UBUNTU_PRO_FIPS_BIONIC
-    with session_cloud.launch(
-        launch_kwargs={"image_id": image_id}
-    ) as instance:
+    with session_cloud.launch() as instance:
         # We can't use setup_image fixture here because we want to avoid
         # taking a snapshot or cleaning the booted machine after cloud-init
         # upgrade.

--- a/tests/integration_tests/bugs/test_lp1835584.py
+++ b/tests/integration_tests/bugs/test_lp1835584.py
@@ -68,7 +68,6 @@ def _check_iid_insensitive_across_kernel_upgrade(
 
 
 @pytest.mark.azure
-@pytest.mark.lxd_container
 @pytest.mark.integration_cloud_args(image_type=ImageType.PRO_FIPS)
 def test_azure_kernel_upgrade_case_insensitive_uuid(
     session_cloud: IntegrationCloud,

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -94,7 +94,12 @@ class IntegrationCloud(ABC):
     datasource: str
     cloud_instance: BaseCloud
 
-    def __init__(self, settings=integration_settings):
+    def __init__(
+        self,
+        image_type: ImageType = ImageType.GENERIC,
+        settings=integration_settings,
+    ):
+        self._image_type = image_type
         self.settings = settings
         self.cloud_instance: BaseCloud = self._get_cloud_instance()
         self.initial_image_id = self._get_initial_image()
@@ -219,12 +224,10 @@ class Ec2Cloud(IntegrationCloud):
     def _get_cloud_instance(self):
         return EC2(tag="ec2-integration-test")
 
-    # Remove pylint disable of false positive when we reach pylint>=2.14.3:
-    # https://github.com/PyCQA/pylint/issues/2270#issuecomment-766184062
-    def _get_initial_image(  # pylint: disable=W0235
-        self, *, image_type: ImageType = ImageType.GENERIC, **kwargs
-    ) -> str:
-        return super()._get_initial_image(image_type=image_type, **kwargs)
+    def _get_initial_image(self, **kwargs) -> str:
+        return super()._get_initial_image(
+            image_type=self._image_type, **kwargs
+        )
 
     def _perform_launch(self, launch_kwargs, **kwargs):
         """Use a dual-stack VPC for cloud-init integration testing."""
@@ -252,12 +255,10 @@ class GceCloud(IntegrationCloud):
             tag="gce-integration-test",
         )
 
-    # Remove pylint disable of false positive when we reach pylint>=2.14.3:
-    # https://github.com/PyCQA/pylint/issues/2270#issuecomment-766184062
-    def _get_initial_image(  # pylint: disable=W0235
-        self, *, image_type: ImageType = ImageType.GENERIC, **kwargs
-    ) -> str:
-        return super()._get_initial_image(image_type=image_type, **kwargs)
+    def _get_initial_image(self, **kwargs) -> str:
+        return super()._get_initial_image(
+            image_type=self._image_type, **kwargs
+        )
 
 
 class AzureCloud(IntegrationCloud):
@@ -267,12 +268,10 @@ class AzureCloud(IntegrationCloud):
     def _get_cloud_instance(self):
         return Azure(tag="azure-integration-test")
 
-    # Remove pylint disable of false positive when we reach pylint>=2.14.3:
-    # https://github.com/PyCQA/pylint/issues/2270#issuecomment-766184062
-    def _get_initial_image(  # pylint: disable=W0235
-        self, *, image_type: ImageType = ImageType.GENERIC, **kwargs
-    ) -> str:
-        return super()._get_initial_image(image_type=image_type, **kwargs)
+    def _get_initial_image(self, **kwargs) -> str:
+        return super()._get_initial_image(
+            image_type=self._image_type, **kwargs
+        )
 
     def destroy(self):
         if self.settings.KEEP_INSTANCE:

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -207,16 +207,6 @@ class IntegrationCloud(ABC):
                 )
                 self.cloud_instance.delete_image(self.snapshot_id)
 
-    def _ignore_image_type(self, **kwargs) -> dict:
-        if "image_type" in kwargs:
-            log.warning(
-                "Ignoring `image_type=%s` for %s._get_initial_image",
-                kwargs["image_type"],
-                self.__class__.__name__,
-            )
-            kwargs.pop("image_type")
-        return kwargs
-
 
 class Ec2Cloud(IntegrationCloud):
     datasource = "ec2"
@@ -292,10 +282,6 @@ class OciCloud(IntegrationCloud):
             tag="oci-integration-test",
         )
 
-    def _get_initial_image(self, **kwargs) -> str:
-        kwargs = self._ignore_image_type(**kwargs)
-        return super()._get_initial_image(**kwargs)
-
 
 class _LxdIntegrationCloud(IntegrationCloud):
     pycloudlib_instance_cls: Type[_BaseLXD]
@@ -304,10 +290,6 @@ class _LxdIntegrationCloud(IntegrationCloud):
 
     def _get_cloud_instance(self):
         return self.pycloudlib_instance_cls(tag=self.instance_tag)
-
-    def _get_initial_image(self, **kwargs) -> str:
-        kwargs = self._ignore_image_type(**kwargs)
-        return super()._get_initial_image(**kwargs)
 
     @staticmethod
     def _get_or_set_profile_list(release):
@@ -406,7 +388,6 @@ class OpenstackCloud(IntegrationCloud):
         )
 
     def _get_initial_image(self, **kwargs):
-        kwargs = self._ignore_image_type(**kwargs)
         image = ImageSpecification.from_os_image()
         try:
             UUID(image.image_id)

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -94,17 +94,10 @@ class IntegrationCloud(ABC):
     datasource: str
     cloud_instance: BaseCloud
 
-    def __init__(
-        self,
-        image_type: ImageType = ImageType.GENERIC,
-        settings=integration_settings,
-    ):
-        self.image_type = image_type
+    def __init__(self, settings=integration_settings):
         self.settings = settings
         self.cloud_instance: BaseCloud = self._get_cloud_instance()
-        self.initial_image_id = self._get_initial_image(
-            image_type=self.image_type
-        )
+        self.initial_image_id = self._get_initial_image()
         self.snapshot_id = None
 
     @property
@@ -209,7 +202,7 @@ class IntegrationCloud(ABC):
                 )
                 self.cloud_instance.delete_image(self.snapshot_id)
 
-    def _ignore_image_type(self, **kwargs):
+    def _ignore_image_type(self, **kwargs) -> dict:
         if "image_type" in kwargs:
             log.warning(
                 "Ignoring `image_type=%s` for %s._get_initial_image",
@@ -217,6 +210,7 @@ class IntegrationCloud(ABC):
                 self.__class__.__name__,
             )
             kwargs.pop("image_type")
+        return kwargs
 
 
 class Ec2Cloud(IntegrationCloud):
@@ -224,6 +218,13 @@ class Ec2Cloud(IntegrationCloud):
 
     def _get_cloud_instance(self):
         return EC2(tag="ec2-integration-test")
+
+    # Remove pylint disable of false positive when we reach pylint>=2.14.3:
+    # https://github.com/PyCQA/pylint/issues/2270#issuecomment-766184062
+    def _get_initial_image(  # pylint: disable=W0235
+        self, *, image_type: ImageType = ImageType.GENERIC, **kwargs
+    ) -> str:
+        return super()._get_initial_image(image_type=image_type, **kwargs)
 
     def _perform_launch(self, launch_kwargs, **kwargs):
         """Use a dual-stack VPC for cloud-init integration testing."""
@@ -251,6 +252,13 @@ class GceCloud(IntegrationCloud):
             tag="gce-integration-test",
         )
 
+    # Remove pylint disable of false positive when we reach pylint>=2.14.3:
+    # https://github.com/PyCQA/pylint/issues/2270#issuecomment-766184062
+    def _get_initial_image(  # pylint: disable=W0235
+        self, *, image_type: ImageType = ImageType.GENERIC, **kwargs
+    ) -> str:
+        return super()._get_initial_image(image_type=image_type, **kwargs)
+
 
 class AzureCloud(IntegrationCloud):
     datasource = "azure"
@@ -258,6 +266,13 @@ class AzureCloud(IntegrationCloud):
 
     def _get_cloud_instance(self):
         return Azure(tag="azure-integration-test")
+
+    # Remove pylint disable of false positive when we reach pylint>=2.14.3:
+    # https://github.com/PyCQA/pylint/issues/2270#issuecomment-766184062
+    def _get_initial_image(  # pylint: disable=W0235
+        self, *, image_type: ImageType = ImageType.GENERIC, **kwargs
+    ) -> str:
+        return super()._get_initial_image(image_type=image_type, **kwargs)
 
     def destroy(self):
         if self.settings.KEEP_INSTANCE:
@@ -279,7 +294,7 @@ class OciCloud(IntegrationCloud):
         )
 
     def _get_initial_image(self, **kwargs) -> str:
-        self._ignore_image_type(**kwargs)
+        kwargs = self._ignore_image_type(**kwargs)
         return super()._get_initial_image(**kwargs)
 
 
@@ -292,7 +307,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
         return self.pycloudlib_instance_cls(tag=self.instance_tag)
 
     def _get_initial_image(self, **kwargs) -> str:
-        self._ignore_image_type(**kwargs)
+        kwargs = self._ignore_image_type(**kwargs)
         return super()._get_initial_image(**kwargs)
 
     @staticmethod
@@ -392,7 +407,7 @@ class OpenstackCloud(IntegrationCloud):
         )
 
     def _get_initial_image(self, **kwargs):
-        self._ignore_image_type(**kwargs)
+        kwargs = self._ignore_image_type(**kwargs)
         image = ImageSpecification.from_os_image()
         try:
             UUID(image.image_id)

--- a/tox.ini
+++ b/tox.ini
@@ -308,6 +308,7 @@ markers =
     gce: test will only run on GCE platform
     hypothesis_slow: hypothesis test too slow to run as unit test
     instance_name: the name to be used for the test instance
+    integration_cloud_args: args for IntegrationCloud customization
     is_iscsi: whether is an instance has iscsi net cfg or not
     lxd_config_dict: set the config_dict passed on LXD instance creation
     lxd_container: test will only run in LXD container


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: add support for pycloudlib's pro images

Added new pytest marker to define IntegrationCloud customizations.
Migrate test_lp1835584 to use this functionality.
Bump pycloudlib version.
```

## Additional Context
<!-- If relevant -->
SC-1148

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
# Configure integration settings to run on Azure and run:
$ tox -e integration-tests -- tests/integration_test/bugs/test_lp1835584.py::test_azure_kernel_upgrade_case_insensitive_uuid
...
image_id=Canonical:0001-com-ubuntu-pro-bionic-fips:pro-fips-18_04
...
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
