### PR TITLE
cloud-init clean --machine-id

### DIFF
--- a/cloudinit/cmd/clean.py
+++ b/cloudinit/cmd/clean.py
@@ -22,6 +22,8 @@ from cloudinit.util import (
     is_link,
 )
 
+ETC_MACHINE_ID = "/etc/machine-id"
+
 
 def get_parser(parser=None):
     """Build or extend an arg parser for clean utility.
@@ -47,6 +49,15 @@ def get_parser(parser=None):
         default=False,
         dest="remove_logs",
         help="Remove cloud-init logs.",
+    )
+    parser.add_argument(
+        "--machine-id",
+        action="store_true",
+        default=False,
+        help=(
+            "Remove /etc/machine-id for golden image creation."
+            " Next boot generates a new machine-id."
+        ),
     )
     parser.add_argument(
         "-r",
@@ -108,6 +119,8 @@ def remove_artifacts(remove_logs, remove_seed=False):
 def handle_clean_args(name, args):
     """Handle calls to 'cloud-init clean' as a subcommand."""
     exit_code = remove_artifacts(args.remove_logs, args.remove_seed)
+    if args.machine_id:
+        del_file(ETC_MACHINE_ID)
     if exit_code == 0 and args.reboot:
         cmd = ["shutdown", "-r", "now"]
         try:

--- a/doc/rtd/topics/cli.rst
+++ b/doc/rtd/topics/cli.rst
@@ -69,7 +69,7 @@ instance. On reboot, cloud-init will re-run all stages as it did on first boot.
 * ``--reboot``: reboot the system after removing artifacts
 * ``--machine-id``: Remove ``/etc/machine-id`` on this image. Best practice
   when cloning a golden image to ensure that the next boot of that image
-  auto-generates an unique machine ID.
+  auto-generates an unique machine ID. `More details on machine-id`_.
 
 
 .. _cli_collect_logs:
@@ -326,3 +326,5 @@ the currently running modules, as well as when it is done.
   time: Wed, 17 Jan 2018 20:41:59 +0000
   detail:
   DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
+
+.. _More details on machine-id: https://www.freedesktop.org/software/systemd/man/machine-id.html

--- a/doc/rtd/topics/cli.rst
+++ b/doc/rtd/topics/cli.rst
@@ -67,6 +67,9 @@ instance. On reboot, cloud-init will re-run all stages as it did on first boot.
 
 * ``--logs``: optionally remove all cloud-init log files in ``/var/log/``
 * ``--reboot``: reboot the system after removing artifacts
+* ``--machine-id``: Remove ``/etc/machine-id`` on this image. Best practice
+  when cloning a golden image to ensure that the next boot of that image
+  auto-generates an unique machine ID.
 
 
 .. _cli_collect_logs:

--- a/doc/rtd/topics/datasources/vmware.rst
+++ b/doc/rtd/topics/datasources/vmware.rst
@@ -263,7 +263,7 @@ this datasource:
 
    .. code-block:: bash
 
-      cloud-init clean
+      cloud-init clean --logs --machine-id
 
    Otherwise cloud-init may not run in first-boot mode. For more information
    on how the boot mode is determined, please see the

--- a/tests/unittests/cmd/test_clean.py
+++ b/tests/unittests/cmd/test_clean.py
@@ -2,198 +2,215 @@
 
 import os
 from collections import namedtuple
-from io import StringIO
+
+import pytest
 
 import cloudinit.settings
 from cloudinit.cmd import clean
-from cloudinit.util import ensure_dir, sym_link, write_file
-from tests.unittests.helpers import CiTestCase, mock, wrap_and_call
+from cloudinit.util import ensure_dir, sym_link
+from tests.unittests.helpers import mock, wrap_and_call
 
 MyPaths = namedtuple("MyPaths", "cloud_dir")
+CleanPaths = namedtuple(
+    "CleanPaths", ["tmpdir", "cloud_dir", "clean_dir", "log", "output_log"]
+)
 
 
-class TestClean(CiTestCase):
-    def setUp(self):
-        super(TestClean, self).setUp()
-        self.new_root = self.tmp_dir()
-        self.artifact_dir = self.tmp_path("artifacts", self.new_root)
-        self.log1 = self.tmp_path("cloud-init.log", self.new_root)
-        self.log2 = self.tmp_path("cloud-init-output.log", self.new_root)
+@pytest.fixture(scope="function")
+def clean_paths(tmpdir):
+    return CleanPaths(
+        tmpdir=tmpdir,
+        cloud_dir=tmpdir.join("varlibcloud"),
+        clean_dir=tmpdir.join("clean.d"),
+        log=tmpdir.join("cloud-init.log"),
+        output_log=tmpdir.join("cloud-init-output.log"),
+    )
 
-        class FakeInit(object):
-            cfg = {
-                "def_log_file": self.log1,
-                "output": {"all": "|tee -a {0}".format(self.log2)},
-            }
-            # Ensure cloud_dir has a trailing slash, to match real behaviour
-            paths = MyPaths(cloud_dir="{}/".format(self.artifact_dir))
 
-            def __init__(self, ds_deps):
-                pass
+@pytest.fixture(scope="function")
+def init_class(clean_paths):
+    class FakeInit(object):
+        cfg = {
+            "def_log_file": clean_paths.log,
+            "output": {"all": f"|tee -a {clean_paths.output_log}"},
+        }
+        # Ensure cloud_dir has a trailing slash, to match real behaviour
+        paths = MyPaths(cloud_dir=f"{clean_paths.cloud_dir}/")
 
-            def read_cfg(self):
-                pass
+        def __init__(self, ds_deps):
+            pass
 
-        self.init_class = FakeInit
+        def read_cfg(self):
+            pass
 
-    def test_remove_artifacts_removes_logs(self):
+    return FakeInit
+
+
+class TestClean:
+    def test_remove_artifacts_removes_logs(self, clean_paths, init_class):
         """remove_artifacts removes logs when remove_logs is True."""
-        write_file(self.log1, "cloud-init-log")
-        write_file(self.log2, "cloud-init-output-log")
+        clean_paths.log.write("cloud-init-log")
+        clean_paths.output_log.write("cloud-init-output-log")
 
-        self.assertFalse(
-            os.path.exists(self.artifact_dir), "Unexpected artifacts dir"
-        )
+        assert (
+            os.path.exists(clean_paths.cloud_dir) is False
+        ), "Unexpected cloud_dir"
         retcode = wrap_and_call(
             "cloudinit.cmd.clean",
-            {"Init": {"side_effect": self.init_class}},
+            {"Init": {"side_effect": init_class}},
             clean.remove_artifacts,
             remove_logs=True,
         )
-        self.assertFalse(os.path.exists(self.log1), "Unexpected file")
-        self.assertFalse(os.path.exists(self.log2), "Unexpected file")
-        self.assertEqual(0, retcode)
+        assert (
+            clean_paths.log.exists() is False
+        ), f"Unexpected file {clean_paths.log}"
+        assert (
+            clean_paths.output_log.exists() is False
+        ), f"Unexpected file {clean_paths.output_log}"
+        assert 0 == retcode
 
-    def test_remove_artifacts_runparts_clean_d(self):
+    @pytest.mark.allow_all_subp
+    def test_remove_artifacts_runparts_clean_d(self, clean_paths, init_class):
         """remove_artifacts performs runparts on CLEAN_RUNPARTS_DIR"""
-        self.allowed_subp = True
-        ensure_dir(self.artifact_dir)
-        artifact_file = self.tmp_path("didit", self.new_root)
-        clean_dir = self.tmp_path("clean.d", self.new_root)
-        ensure_dir(clean_dir)
-        self.assertFalse(os.path.exists(artifact_file), "Unexpected file")
-        write_file(
-            self.tmp_path("1.sh", clean_dir),
-            f"#!/bin/bash\ntouch {artifact_file}\n",
-            mode=0o755,
-        )
+        ensure_dir(clean_paths.cloud_dir)
+        artifact_file = clean_paths.tmpdir.join("didit")
+        ensure_dir(clean_paths.clean_dir)
+        assert artifact_file.exists() is False, f"Unexpected {artifact_file}"
+        clean_script = clean_paths.clean_dir.join("1.sh")
+        clean_script.write(f"#!/bin/bash\ntouch {artifact_file}\n")
+        clean_script.chmod(mode=0o755)
         with mock.patch.object(
-            cloudinit.settings, "CLEAN_RUNPARTS_DIR", clean_dir
+            cloudinit.settings, "CLEAN_RUNPARTS_DIR", clean_paths.clean_dir
         ):
             retcode = wrap_and_call(
                 "cloudinit.cmd.clean",
                 {
-                    "Init": {"side_effect": self.init_class},
+                    "Init": {"side_effect": init_class},
                 },
                 clean.remove_artifacts,
                 remove_logs=False,
             )
-        self.assertTrue(os.path.exists(artifact_file), "Missing expected file")
-        self.assertEqual(0, retcode)
+        assert (
+            artifact_file.exists() is True
+        ), f"Missing expected {artifact_file}"
+        assert 0 == retcode
 
-    def test_remove_artifacts_preserves_logs(self):
+    def test_remove_artifacts_preserves_logs(self, clean_paths, init_class):
         """remove_artifacts leaves logs when remove_logs is False."""
-        write_file(self.log1, "cloud-init-log")
-        write_file(self.log2, "cloud-init-output-log")
+        clean_paths.log.write("cloud-init-log")
+        clean_paths.output_log.write("cloud-init-output-log")
 
         retcode = wrap_and_call(
             "cloudinit.cmd.clean",
-            {"Init": {"side_effect": self.init_class}},
+            {"Init": {"side_effect": init_class}},
             clean.remove_artifacts,
             remove_logs=False,
         )
-        self.assertTrue(os.path.exists(self.log1), "Missing expected file")
-        self.assertTrue(os.path.exists(self.log2), "Missing expected file")
-        self.assertEqual(0, retcode)
+        assert 0 == retcode
+        assert (
+            clean_paths.log.exists() is True
+        ), f"Missing expected file {clean_paths.log}"
+        assert (
+            clean_paths.output_log.exists()
+        ), f"Missing expected file {clean_paths.output_log}"
 
-    def test_remove_artifacts_removes_unlinks_symlinks(self):
+    def test_remove_artifacts_removes_unlinks_symlinks(
+        self, clean_paths, init_class
+    ):
         """remove_artifacts cleans artifacts dir unlinking any symlinks."""
-        dir1 = os.path.join(self.artifact_dir, "dir1")
+        dir1 = clean_paths.cloud_dir.join("dir1")
         ensure_dir(dir1)
-        symlink = os.path.join(self.artifact_dir, "mylink")
-        sym_link(dir1, symlink)
+        symlink = clean_paths.cloud_dir.join("mylink")
+        sym_link(dir1.strpath, symlink.strpath)
 
         retcode = wrap_and_call(
             "cloudinit.cmd.clean",
-            {"Init": {"side_effect": self.init_class}},
+            {"Init": {"side_effect": init_class}},
             clean.remove_artifacts,
             remove_logs=False,
         )
-        self.assertEqual(0, retcode)
+        assert 0 == retcode
         for path in (dir1, symlink):
-            self.assertFalse(
-                os.path.exists(path), "Unexpected {0} dir".format(path)
-            )
+            assert path.exists() is False, f"Unexpected {path} found"
 
-    def test_remove_artifacts_removes_artifacts_skipping_seed(self):
+    def test_remove_artifacts_removes_artifacts_skipping_seed(
+        self, clean_paths, init_class
+    ):
         """remove_artifacts cleans artifacts dir with exception of seed dir."""
         dirs = [
-            self.artifact_dir,
-            os.path.join(self.artifact_dir, "seed"),
-            os.path.join(self.artifact_dir, "dir1"),
-            os.path.join(self.artifact_dir, "dir2"),
+            clean_paths.cloud_dir,
+            clean_paths.cloud_dir.join("seed"),
+            clean_paths.cloud_dir.join("dir1"),
+            clean_paths.cloud_dir.join("dir2"),
         ]
         for _dir in dirs:
             ensure_dir(_dir)
 
         retcode = wrap_and_call(
             "cloudinit.cmd.clean",
-            {"Init": {"side_effect": self.init_class}},
+            {"Init": {"side_effect": init_class}},
             clean.remove_artifacts,
             remove_logs=False,
         )
-        self.assertEqual(0, retcode)
+        assert 0 == retcode
         for expected_dir in dirs[:2]:
-            self.assertTrue(
-                os.path.exists(expected_dir),
-                "Missing {0} dir".format(expected_dir),
-            )
+            assert expected_dir.exists() is True, f"Missing {expected_dir}"
         for deleted_dir in dirs[2:]:
-            self.assertFalse(
-                os.path.exists(deleted_dir),
-                "Unexpected {0} dir".format(deleted_dir),
-            )
+            assert deleted_dir.exists() is False, f"Unexpected {deleted_dir}"
 
-    def test_remove_artifacts_removes_artifacts_removes_seed(self):
+    def test_remove_artifacts_removes_artifacts_removes_seed(
+        self, clean_paths, init_class
+    ):
         """remove_artifacts removes seed dir when remove_seed is True."""
         dirs = [
-            self.artifact_dir,
-            os.path.join(self.artifact_dir, "seed"),
-            os.path.join(self.artifact_dir, "dir1"),
-            os.path.join(self.artifact_dir, "dir2"),
+            clean_paths.cloud_dir,
+            clean_paths.cloud_dir.join("seed"),
+            clean_paths.cloud_dir.join("dir1"),
+            clean_paths.cloud_dir.join("dir2"),
         ]
         for _dir in dirs:
             ensure_dir(_dir)
 
         retcode = wrap_and_call(
             "cloudinit.cmd.clean",
-            {"Init": {"side_effect": self.init_class}},
+            {"Init": {"side_effect": init_class}},
             clean.remove_artifacts,
             remove_logs=False,
             remove_seed=True,
         )
-        self.assertEqual(0, retcode)
-        self.assertTrue(
-            os.path.exists(self.artifact_dir), "Missing artifact dir"
-        )
+        assert 0 == retcode
+        assert (
+            clean_paths.cloud_dir.exists() is True
+        ), f"Missing dir {clean_paths.cloud_dir}"
         for deleted_dir in dirs[1:]:
-            self.assertFalse(
-                os.path.exists(deleted_dir),
-                "Unexpected {0} dir".format(deleted_dir),
-            )
+            assert (
+                deleted_dir.exists() is False
+            ), f"Unexpected {deleted_dir} dir"
 
-    def test_remove_artifacts_returns_one_on_errors(self):
+    def test_remove_artifacts_returns_one_on_errors(
+        self, clean_paths, init_class, capsys
+    ):
         """remove_artifacts returns non-zero on failure and prints an error."""
-        ensure_dir(self.artifact_dir)
-        ensure_dir(os.path.join(self.artifact_dir, "dir1"))
+        ensure_dir(clean_paths.cloud_dir)
+        ensure_dir(clean_paths.cloud_dir.join("dir1"))
 
-        with mock.patch("sys.stderr", new_callable=StringIO) as m_stderr:
-            retcode = wrap_and_call(
-                "cloudinit.cmd.clean",
-                {
-                    "del_dir": {"side_effect": OSError("oops")},
-                    "Init": {"side_effect": self.init_class},
-                },
-                clean.remove_artifacts,
-                remove_logs=False,
-            )
-        self.assertEqual(1, retcode)
-        self.assertEqual(
-            "Error:\nCould not remove %s/dir1: oops\n" % self.artifact_dir,
-            m_stderr.getvalue(),
+        retcode = wrap_and_call(
+            "cloudinit.cmd.clean",
+            {
+                "del_dir": {"side_effect": OSError("oops")},
+                "Init": {"side_effect": init_class},
+            },
+            clean.remove_artifacts,
+            remove_logs=False,
+        )
+        assert 1 == retcode
+        _out, err = capsys.readouterr()
+        assert (
+            f"Error:\nCould not remove {clean_paths.cloud_dir}/dir1: oops\n"
+            == err
         )
 
-    def test_handle_clean_args_reboots(self):
+    def test_handle_clean_args_reboots(self, init_class):
         """handle_clean_args_reboots when reboot arg is provided."""
 
         called_cmds = []
@@ -202,38 +219,41 @@ class TestClean(CiTestCase):
             called_cmds.append((cmd, capture))
             return "", ""
 
-        myargs = namedtuple("MyArgs", "remove_logs remove_seed reboot")
-        cmdargs = myargs(remove_logs=False, remove_seed=False, reboot=True)
+        myargs = namedtuple(
+            "MyArgs", "remove_logs remove_seed reboot machine_id"
+        )
+        cmdargs = myargs(
+            remove_logs=False, remove_seed=False, reboot=True, machine_id=False
+        )
         retcode = wrap_and_call(
             "cloudinit.cmd.clean",
             {
                 "subp": {"side_effect": fake_subp},
-                "Init": {"side_effect": self.init_class},
+                "Init": {"side_effect": init_class},
             },
             clean.handle_clean_args,
             name="does not matter",
             args=cmdargs,
         )
-        self.assertEqual(0, retcode)
-        self.assertEqual([(["shutdown", "-r", "now"], False)], called_cmds)
+        assert 0 == retcode
+        assert [(["shutdown", "-r", "now"], False)] == called_cmds
 
-    def test_status_main(self):
+    def test_status_main(self, clean_paths, init_class):
         """clean.main can be run as a standalone script."""
-        write_file(self.log1, "cloud-init-log")
-        with self.assertRaises(SystemExit) as context_manager:
+        clean_paths.log.write("cloud-init-log")
+        with pytest.raises(SystemExit) as context_manager:
             wrap_and_call(
                 "cloudinit.cmd.clean",
                 {
-                    "Init": {"side_effect": self.init_class},
+                    "Init": {"side_effect": init_class},
                     "sys.argv": {"new": ["clean", "--logs"]},
                 },
                 clean.main,
             )
-
-        self.assertEqual(0, context_manager.exception.code)
-        self.assertFalse(
-            os.path.exists(self.log1), "Unexpected log {0}".format(self.log1)
-        )
+        assert 0 == context_manager.value.code
+        assert (
+            clean_paths.log.exists() is False
+        ), f"Unexpected log {clean_paths.log}"
 
 
 # vi: ts=4 expandtab syntax=python


### PR DESCRIPTION
## Proposed Commit Message
```
clean: add param to remove /etc/machine-id for golden image creation

Typically when a cloud-image boots /etc/machine-id should be
auto-generated if /etc/machine-id does not exist. Some cloud images
appropriately generate /etc/machine-id if the image is recognized
as a clone, in most other cases it is a best practice to remove
/etc/machine-id and let DBUS or systemd do the work of generating
a new UUID on next boot so the cloned VMs are represented
uniquely to any monitoring/management software.
```

## Additional Context
US015.UC01.2: subiquity/cloud-init spec, golden image support: ability to clean machine-id from golden image

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
