### PR TITLE
network-manager: ipv6 connection does not work on Azure and Openstack

### DIFF
--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -69,7 +69,7 @@ class NMConnection:
 
         method_map = {
             "static": "manual",
-            "dhcp6": "dhcp",
+            "dhcp6": "auto",
             "ipv6_slaac": "auto",
             "ipv6_dhcpv6-stateless": "auto",
             "ipv6_dhcpv6-stateful": "auto",
@@ -96,8 +96,6 @@ class NMConnection:
 
         self.config[family]["method"] = method
         self._set_default(family, "may-fail", "false")
-        if family == "ipv6":
-            self._set_default(family, "addr-gen-mode", "stable-privacy")
 
     def _add_numbered(self, section, key_prefix, value):
         """

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1248,9 +1248,8 @@ NETWORK_CONFIGS = {
                 may-fail=false
 
                 [ipv6]
-                method=dhcp
+                method=auto
                 may-fail=false
-                addr-gen-mode=stable-privacy
 
                 """
             ),
@@ -1383,7 +1382,6 @@ NETWORK_CONFIGS = {
                 [ipv6]
                 method=manual
                 may-fail=false
-                addr-gen-mode=stable-privacy
                 address1=2001:1::1/64
 
                 """
@@ -1416,9 +1414,8 @@ NETWORK_CONFIGS = {
                 [ethernet]
 
                 [ipv6]
-                method=dhcp
+                method=auto
                 may-fail=false
-                addr-gen-mode=stable-privacy
 
                 [ipv4]
                 method=auto
@@ -1517,9 +1514,8 @@ NETWORK_CONFIGS = {
                 [ethernet]
 
                 [ipv6]
-                method=dhcp
+                method=auto
                 may-fail=false
-                addr-gen-mode=stable-privacy
 
                 """
             ),
@@ -1750,7 +1746,6 @@ NETWORK_CONFIGS = {
                 [ipv6]
                 method=auto
                 may-fail=false
-                addr-gen-mode=stable-privacy
 
                 """
             ),
@@ -1862,7 +1857,6 @@ NETWORK_CONFIGS = {
                 [ipv6]
                 method=auto
                 may-fail=false
-                addr-gen-mode=stable-privacy
 
                 """
             ),
@@ -2683,7 +2677,6 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 [ipv6]
                 method=manual
                 may-fail=false
-                addr-gen-mode=stable-privacy
                 address1=2001:1::1/64
                 route1=::/0,2001:4800:78ff:1b::1
 
@@ -2736,9 +2729,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 xmit_hash_policy=layer3+4
 
                 [ipv6]
-                method=dhcp
+                method=auto
                 may-fail=false
-                addr-gen-mode=stable-privacy
 
                 """
             ),
@@ -3342,7 +3334,6 @@ iface bond0 inet6 static
                 [ipv6]
                 method=manual
                 may-fail=false
-                addr-gen-mode=stable-privacy
                 address1=2001:1::1/92
                 route1=2001:67c::/32,2001:67c:1562::1
                 route2=3001:67c::/32,3001:67c:15::1
@@ -3463,7 +3454,6 @@ iface bond0 inet6 static
                 [ipv6]
                 method=manual
                 may-fail=false
-                addr-gen-mode=stable-privacy
                 address1=2001:1::bbbb/96
                 route1=::/0,2001:1::1
 
@@ -3641,7 +3631,6 @@ iface bond0 inet6 static
                 [ipv6]
                 method=manual
                 may-fail=false
-                addr-gen-mode=stable-privacy
                 address1=2001:1::100/96
 
                 """
@@ -3666,7 +3655,6 @@ iface bond0 inet6 static
                 [ipv6]
                 method=manual
                 may-fail=false
-                addr-gen-mode=stable-privacy
                 address1=2001:1::101/96
 
                 """


### PR DESCRIPTION
## Proposed Commit Message
```
This problem is found after below bug fix, ipv6 is not workable after launching a new instance.

[Bug 2056964](https://bugzilla.redhat.com/show_bug.cgi?id=2056964) - [RHEL-9]Rebase cloud-init from Fedora so it can configure networking using NM keyfiles

we can see log "Not bringing up newly configured network interfaces" in /var/log/cloud-init.log

2022-06-17 02:15:22,191 - __init__.py[DEBUG]: Selected renderer 'network-manager' from priority list: ['netplan', 'network-manager', 'networkd', 'sysconfig', 'eni']
2022-06-17 02:15:22,192 - util.py[DEBUG]: Writing to /etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection - wb: [600] 376 bytes
2022-06-17 02:15:22,193 - util.py[DEBUG]: Restoring selinux mode for /etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection (recursive=False)
2022-06-17 02:15:22,194 - util.py[DEBUG]: Restoring selinux mode for /etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection (recursive=False)
2022-06-17 02:15:22,194 - __init__.py[DEBUG]: Not bringing up newly configured network interfaces


On Azure, ping6 gets Network is unreachable.

$ ping6 ace:cab:deca::fe -c 1
ping6: connect: Network is unreachable

# ip -6 route
::1 dev lo proto kernel metric 256 pref medium
ace:cab:deca::4 dev eth0 proto kernel metric 100 pref medium
fe80::/64 dev eth0 proto kernel metric 1024 pref medium


cat /etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection
# Generated by cloud-init. Changes will be lost.

[connection]
id=cloud-init eth0
uuid=1dd9a779-d327-56e1-8454-c65e2556c12c
type=ethernet

[user]
org.freedesktop.NetworkManager.origin=cloud-init

[ethernet]
mac-address=00:0D:3A:58:0F:B3

[ipv4]
method=auto
may-fail=false

[ipv6]
method=dhcp
may-fail=false
addr-gen-mode=stable-privacy


On Openstack, ping6 error is a little bit different, but unreachable either.

#  ping6 2620:52:0:88:f816:3eff:fe23:e623 -c 1
PING 2620:52:0:88:f816:3eff:fe23:e623(2620:52:0:88:f816:3eff:fe23:e623) 56 data bytes
From 2620:52:0:88:ef7e:b597:1cc8:32df icmp_seq=1 Destination unreachable: Address unreachable

--- 2620:52:0:88:f816:3eff:fe23:e623 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms


$ ip -6 route
::1 dev lo proto kernel metric 256 pref medium
2620:52:0:88::/64 dev eth0 proto ra metric 100 pref medium
fe80::/64 dev eth0 proto kernel metric 1024 pref medium
default proto static metric 100 pref medium
	nexthop via 2620:52:0:88::3fe dev eth0 weight 1 
	nexthop via fe80::4e16:fc01:d8c:98ed dev eth0 weight 1 
	nexthop via fe80::4e16:fc01:d83:88aa dev eth0 weight 1 

cat /etc/NetworkManager/system-connections/cloud-init-eth0.nmconnection
# Generated by cloud-init. Changes will be lost.

[connection]
id=cloud-init eth0
uuid=1dd9a779-d327-56e1-8454-c65e2556c12c
type=ethernet

[user]
org.freedesktop.NetworkManager.origin=cloud-init

[ethernet]
mtu=1500
mac-address=FA:16:3E:CE:97:C9

[ipv4]
method=auto
may-fail=false

[ipv6]
method=auto
may-fail=false
addr-gen-mode=stable-privacy
route1=::/0,2620:52:0:88::3fe

dhcp6 mode should be "auto" and addr-gen-mode=stable-privacy should be removed.

Signed-off-by: Emanuele Giuseppe Esposito <eesposit@redhat.com>

RHBZ: 2098501
```


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
