### PR TITLE
ssh_util: Handle sshd_config.d folder

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -544,11 +544,27 @@ def parse_ssh_config_map(fname):
     return ret
 
 
+def _includes_dconf(fname: str) -> bool:
+    if not os.path.isfile(fname):
+        return False
+    with open(fname, "r") as f:
+        for line in f:
+            if f"Include {fname}.d/*.conf" in line:
+                return True
+    return False
+
+
 def update_ssh_config(updates, fname=DEF_SSHD_CFG):
     """Read fname, and update if changes are necessary.
 
     @param updates: dictionary of desired values {Option: value}
     @return: boolean indicating if an update was done."""
+    if _includes_dconf(fname):
+        if not os.path.isdir(f"{fname}.d"):
+            util.ensure_dir(f"{fname}.d", mode=0o755)
+        fname = os.path.join(f"{fname}.d", "99-cloud-init.conf")
+        if not os.path.isfile(fname):
+            util.ensure_file(fname, 0o644)
     lines = parse_ssh_config(fname)
     changed = update_ssh_config_lines(lines=lines, updates=updates)
     if changed:

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -549,7 +549,7 @@ def _includes_dconf(fname: str) -> bool:
         return False
     with open(fname, "r") as f:
         for line in f:
-            if f"Include {fname}.d/*.conf" in line:
+            if line.startswith(f"Include {fname}.d/*.conf"):
                 return True
     return False
 

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -562,9 +562,10 @@ def update_ssh_config(updates, fname=DEF_SSHD_CFG):
     if _includes_dconf(fname):
         if not os.path.isdir(f"{fname}.d"):
             util.ensure_dir(f"{fname}.d", mode=0o755)
-        fname = os.path.join(f"{fname}.d", "00-cloud-init.conf")
+        fname = os.path.join(f"{fname}.d", "50-cloud-init.conf")
         if not os.path.isfile(fname):
-            util.ensure_file(fname, 0o644)
+            # Ensure root read-only:
+            util.ensure_file(fname, 0o600)
     lines = parse_ssh_config(fname)
     changed = update_ssh_config_lines(lines=lines, updates=updates)
     if changed:

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -562,7 +562,7 @@ def update_ssh_config(updates, fname=DEF_SSHD_CFG):
     if _includes_dconf(fname):
         if not os.path.isdir(f"{fname}.d"):
             util.ensure_dir(f"{fname}.d", mode=0o755)
-        fname = os.path.join(f"{fname}.d", "99-cloud-init.conf")
+        fname = os.path.join(f"{fname}.d", "00-cloud-init.conf")
         if not os.path.isfile(fname):
             util.ensure_file(fname, 0o644)
     lines = parse_ssh_config(fname)

--- a/packages/debian/cloud-init.postrm
+++ b/packages/debian/cloud-init.postrm
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+cleanup_sshd_config() {
+  rm -f "/etc/ssh/sshd_config.d/99-cloud-init.conf"
+}
+
+if [ "$1" = "purge" ]; then
+  cleanup_sshd_config
+fi

--- a/packages/debian/cloud-init.postrm
+++ b/packages/debian/cloud-init.postrm
@@ -3,7 +3,7 @@
 set -e
 
 cleanup_sshd_config() {
-  rm -f "/etc/ssh/sshd_config.d/00-cloud-init.conf"
+  rm -f "/etc/ssh/sshd_config.d/50-cloud-init.conf"
 }
 
 if [ "$1" = "purge" ]; then

--- a/packages/debian/cloud-init.postrm
+++ b/packages/debian/cloud-init.postrm
@@ -3,7 +3,7 @@
 set -e
 
 cleanup_sshd_config() {
-  rm -f "/etc/ssh/sshd_config.d/99-cloud-init.conf"
+  rm -f "/etc/ssh/sshd_config.d/00-cloud-init.conf"
 }
 
 if [ "$1" = "purge" ]; then

--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -181,21 +181,8 @@ class Mixin:
 
     def test_sshd_config(self, class_client):
         """Test that SSH password auth is enabled."""
-        if class_client.execute("ls /etc/ssh/sshd_config.d").ok:
-            assert class_client.execute(
-                "ls /etc/ssh/sshd_config.d/00-cloud-init.conf"
-            ).ok
-            sshd_config = class_client.read_from_file(
-                "/etc/ssh/sshd_config.d/00-cloud-init.conf"
-            )
-        else:
-            sshd_config = class_client.read_from_file("/etc/ssh/sshd_config")
-        # We look for the exact line match, to avoid a commented line matching
-        assert "PasswordAuthentication yes" in sshd_config.splitlines()
-        assert (
-            "passwordauthentication yes"
-            in class_client.execute("sshd -T").stdout
-        )
+        sshd_config = class_client.execute("sshd -T").stdout
+        assert "passwordauthentication yes" in sshd_config
 
 
 @pytest.mark.user_data(LIST_USER_DATA)

--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -183,15 +183,19 @@ class Mixin:
         """Test that SSH password auth is enabled."""
         if class_client.execute("ls /etc/ssh/sshd_config.d").ok:
             assert class_client.execute(
-                "ls /etc/ssh/sshd_config.d/99-cloud-init.conf"
+                "ls /etc/ssh/sshd_config.d/00-cloud-init.conf"
             ).ok
             sshd_config = class_client.read_from_file(
-                "/etc/ssh/sshd_config.d/99-cloud-init.conf"
+                "/etc/ssh/sshd_config.d/00-cloud-init.conf"
             )
         else:
             sshd_config = class_client.read_from_file("/etc/ssh/sshd_config")
         # We look for the exact line match, to avoid a commented line matching
         assert "PasswordAuthentication yes" in sshd_config.splitlines()
+        assert (
+            "passwordauthentication yes"
+            in class_client.execute("sshd -T").stdout
+        )
 
 
 @pytest.mark.user_data(LIST_USER_DATA)

--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -181,7 +181,15 @@ class Mixin:
 
     def test_sshd_config(self, class_client):
         """Test that SSH password auth is enabled."""
-        sshd_config = class_client.read_from_file("/etc/ssh/sshd_config")
+        if class_client.execute("ls /etc/ssh/sshd_config.d").ok:
+            assert class_client.execute(
+                "ls /etc/ssh/sshd_config.d/99-cloud-init.conf"
+            ).ok
+            sshd_config = class_client.read_from_file(
+                "/etc/ssh/sshd_config.d/99-cloud-init.conf"
+            )
+        else:
+            sshd_config = class_client.read_from_file("/etc/ssh/sshd_config")
         # We look for the exact line match, to avoid a commented line matching
         assert "PasswordAuthentication yes" in sshd_config.splitlines()
 

--- a/tests/integration_tests/modules/test_ssh_keys_provided.py
+++ b/tests/integration_tests/modules/test_ssh_keys_provided.py
@@ -136,18 +136,8 @@ class TestSshKeysProvided:
         assert expected_out in out
 
     @pytest.mark.parametrize(
-        "expected_out", ("HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub")
+        "expected_out", ("hostcertificate /etc/ssh/ssh_host_rsa_key-cert.pub")
     )
     def test_sshd_config(self, expected_out, class_client):
-        if class_client.execute("ls /etc/ssh/sshd_config.d").ok:
-            assert class_client.execute(
-                "ls /etc/ssh/sshd_config.d/00-cloud-init.conf"
-            ).ok
-            out = class_client.read_from_file(
-                "/etc/ssh/sshd_config.d/00-cloud-init.conf"
-            )
-        else:
-            out = class_client.read_from_file("/etc/ssh/sshd_config")
-
-        out = out.strip()
-        assert expected_out in out
+        sshd_config = class_client.execute("sshd -T").stdout
+        assert expected_out in sshd_config

--- a/tests/integration_tests/modules/test_ssh_keys_provided.py
+++ b/tests/integration_tests/modules/test_ssh_keys_provided.py
@@ -141,10 +141,10 @@ class TestSshKeysProvided:
     def test_sshd_config(self, expected_out, class_client):
         if class_client.execute("ls /etc/ssh/sshd_config.d").ok:
             assert class_client.execute(
-                "ls /etc/ssh/sshd_config.d/99-cloud-init.conf"
+                "ls /etc/ssh/sshd_config.d/00-cloud-init.conf"
             ).ok
             out = class_client.read_from_file(
-                "/etc/ssh/sshd_config.d/99-cloud-init.conf"
+                "/etc/ssh/sshd_config.d/00-cloud-init.conf"
             )
         else:
             out = class_client.read_from_file("/etc/ssh/sshd_config")

--- a/tests/integration_tests/modules/test_ssh_keys_provided.py
+++ b/tests/integration_tests/modules/test_ssh_keys_provided.py
@@ -110,10 +110,6 @@ class TestSshKeysProvided:
                 "BP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAAD",
             ),
             (
-                "/etc/ssh/sshd_config",
-                "HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub",
-            ),
-            (
                 "/etc/ssh/ssh_host_ecdsa_key.pub",
                 "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAAB"
                 "BBFsS5Tvky/IC/dXhE/afxxU",
@@ -137,4 +133,21 @@ class TestSshKeysProvided:
     )
     def test_ssh_provided_keys(self, config_path, expected_out, class_client):
         out = class_client.read_from_file(config_path).strip()
+        assert expected_out in out
+
+    @pytest.mark.parametrize(
+        "expected_out", ("HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub")
+    )
+    def test_sshd_config(self, expected_out, class_client):
+        if class_client.execute("ls /etc/ssh/sshd_config.d").ok:
+            assert class_client.execute(
+                "ls /etc/ssh/sshd_config.d/99-cloud-init.conf"
+            ).ok
+            out = class_client.read_from_file(
+                "/etc/ssh/sshd_config.d/99-cloud-init.conf"
+            )
+        else:
+            out = class_client.read_from_file("/etc/ssh/sshd_config")
+
+        out = out.strip()
         assert expected_out in out

--- a/tests/integration_tests/modules/test_ssh_keys_provided.py
+++ b/tests/integration_tests/modules/test_ssh_keys_provided.py
@@ -9,6 +9,8 @@ system.
 
 import pytest
 
+from tests.integration_tests.clouds import ImageSpecification
+
 USER_DATA = """\
 #cloud-config
 disable_root: false
@@ -136,8 +138,12 @@ class TestSshKeysProvided:
         assert expected_out in out
 
     @pytest.mark.parametrize(
-        "expected_out", ("hostcertificate /etc/ssh/ssh_host_rsa_key-cert.pub")
+        "expected_out", ("HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub")
     )
     def test_sshd_config(self, expected_out, class_client):
-        sshd_config = class_client.execute("sshd -T").stdout
+        if ImageSpecification.from_os_image().release in {"bionic"}:
+            sshd_config_path = "/etc/ssh/sshd_config"
+        else:
+            sshd_config_path = "/etc/ssh/sshd_config.d/50-cloud-init.conf"
+        sshd_config = class_client.read_from_file(sshd_config_path).strip()
         assert expected_out in sshd_config

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -283,9 +283,12 @@ class TestHandleSsh:
             expected_calls == cloud.datasource.publish_host_keys.call_args_list
         )
 
+    @mock.patch(MODPATH + "ssh_util._includes_dconf", return_value=False)
     @mock.patch(MODPATH + "ug_util.normalize_users_groups")
     @mock.patch(MODPATH + "util.write_file")
-    def test_handle_ssh_keys_in_cfg(self, m_write_file, m_nug, m_setup_keys):
+    def test_handle_ssh_keys_in_cfg(
+        self, m_write_file, m_nug, m_includes_dconf, m_setup_keys
+    ):
         """Test handle with ssh keys and certificate."""
         # Populate a config dictionary to pass to handle() as well
         # as the expected file-writing calls.

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -283,15 +283,30 @@ class TestHandleSsh:
             expected_calls == cloud.datasource.publish_host_keys.call_args_list
         )
 
-    @mock.patch(MODPATH + "ssh_util._includes_dconf", return_value=False)
+    @pytest.mark.parametrize("with_sshd_dconf", [False, True])
+    @mock.patch(MODPATH + "util.ensure_dir")
     @mock.patch(MODPATH + "ug_util.normalize_users_groups")
     @mock.patch(MODPATH + "util.write_file")
     def test_handle_ssh_keys_in_cfg(
-        self, m_write_file, m_nug, m_includes_dconf, m_setup_keys
+        self,
+        m_write_file,
+        m_nug,
+        m_ensure_dir,
+        m_setup_keys,
+        with_sshd_dconf,
+        mocker,
     ):
         """Test handle with ssh keys and certificate."""
         # Populate a config dictionary to pass to handle() as well
         # as the expected file-writing calls.
+        mocker.patch(
+            MODPATH + "ssh_util._includes_dconf", return_value=with_sshd_dconf
+        )
+        if with_sshd_dconf:
+            sshd_conf_fname = "/etc/ssh/sshd_config.d/99-cloud-init.conf"
+        else:
+            sshd_conf_fname = "/etc/ssh/sshd_config"
+
         cfg = {"ssh_keys": {}}
 
         expected_calls = []
@@ -327,7 +342,7 @@ class TestHandleSsh:
                         384,
                     ),
                     mock.call(
-                        "/etc/ssh/sshd_config",
+                        sshd_conf_fname,
                         "HostCertificate /etc/ssh/ssh_host_{}_key-cert.pub"
                         "\n".format(key_type),
                         preserve_mode=True,
@@ -345,6 +360,14 @@ class TestHandleSsh:
         # Check that all expected output has been done.
         for call_ in expected_calls:
             assert call_ in m_write_file.call_args_list
+
+        if with_sshd_dconf:
+            assert (
+                mock.call("/etc/ssh/sshd_config.d", mode=0o755)
+                in m_ensure_dir.call_args_list
+            )
+        else:
+            assert [] == m_ensure_dir.call_args_list
 
     @pytest.mark.parametrize(
         "key_type,reason",

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -303,7 +303,7 @@ class TestHandleSsh:
             MODPATH + "ssh_util._includes_dconf", return_value=with_sshd_dconf
         )
         if with_sshd_dconf:
-            sshd_conf_fname = "/etc/ssh/sshd_config.d/00-cloud-init.conf"
+            sshd_conf_fname = "/etc/ssh/sshd_config.d/50-cloud-init.conf"
         else:
             sshd_conf_fname = "/etc/ssh/sshd_config"
 

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -303,7 +303,7 @@ class TestHandleSsh:
             MODPATH + "ssh_util._includes_dconf", return_value=with_sshd_dconf
         )
         if with_sshd_dconf:
-            sshd_conf_fname = "/etc/ssh/sshd_config.d/99-cloud-init.conf"
+            sshd_conf_fname = "/etc/ssh/sshd_config.d/00-cloud-init.conf"
         else:
             sshd_conf_fname = "/etc/ssh/sshd_config"
 

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -619,7 +619,7 @@ class TestUpdateSshConfig:
         assert f"{cfg}\nkey value\n" == util.load_file(mycfg)
         expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
-        assert not os.path.isfile(f"other_{mycfg}.d/00-cloud-init.conf")
+        assert not os.path.isfile(f"other_{mycfg}.d/50-cloud-init.conf")
 
 
 class TestBasicAuthorizedKeyParse:

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -579,6 +579,24 @@ class TestUpdateSshConfig:
         assert self.cfgdata == util.load_file(mycfg)
         m_write_file.assert_not_called()
 
+    def test_without_include(self, tmpdir):
+        mycfg = tmpdir.join("sshd_config")
+        cfg = "X Y"
+        util.write_file(mycfg, cfg)
+        assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
+        assert "X Y\nkey value\n" == util.load_file(mycfg)
+        expected_conf_file = f"{mycfg}.d/99-cloud-init.conf"
+        assert not os.path.isfile(expected_conf_file)
+
+    def test_with_include(self, tmpdir):
+        mycfg = tmpdir.join("sshd_config")
+        cfg = f"Include {mycfg}.d/*.conf"
+        util.write_file(mycfg, cfg)
+        assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
+        expected_conf_file = f"{mycfg}.d/99-cloud-init.conf"
+        assert os.path.isfile(expected_conf_file)
+        assert "key value\n" == util.load_file(expected_conf_file)
+
 
 class TestBasicAuthorizedKeyParse:
     @pytest.mark.parametrize(

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import os
+import stat
 from functools import partial
 from typing import NamedTuple
 from unittest import mock
@@ -585,7 +586,7 @@ class TestUpdateSshConfig:
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
         assert "X Y\nkey value\n" == util.load_file(mycfg)
-        expected_conf_file = f"{mycfg}.d/00-cloud-init.conf"
+        expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
 
     @pytest.mark.parametrize(
@@ -596,8 +597,9 @@ class TestUpdateSshConfig:
         mycfg = tmpdir.join("sshd_config")
         util.write_file(mycfg, cfg.format(mycfg=mycfg))
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
-        expected_conf_file = f"{mycfg}.d/00-cloud-init.conf"
+        expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert os.path.isfile(expected_conf_file)
+        assert 0o600 == stat.S_IMODE(os.stat(expected_conf_file).st_mode)
         assert "key value\n" == util.load_file(expected_conf_file)
 
     def test_with_commented_include(self, tmpdir):
@@ -606,7 +608,7 @@ class TestUpdateSshConfig:
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
         assert f"{cfg}\nkey value\n" == util.load_file(mycfg)
-        expected_conf_file = f"{mycfg}.d/00-cloud-init.conf"
+        expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
 
     def test_with_other_include(self, tmpdir):
@@ -615,7 +617,7 @@ class TestUpdateSshConfig:
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
         assert f"{cfg}\nkey value\n" == util.load_file(mycfg)
-        expected_conf_file = f"{mycfg}.d/00-cloud-init.conf"
+        expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
         assert not os.path.isfile(f"other_{mycfg}.d/00-cloud-init.conf")
 

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -585,7 +585,7 @@ class TestUpdateSshConfig:
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
         assert "X Y\nkey value\n" == util.load_file(mycfg)
-        expected_conf_file = f"{mycfg}.d/99-cloud-init.conf"
+        expected_conf_file = f"{mycfg}.d/00-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
 
     @pytest.mark.parametrize(
@@ -596,7 +596,7 @@ class TestUpdateSshConfig:
         mycfg = tmpdir.join("sshd_config")
         util.write_file(mycfg, cfg.format(mycfg=mycfg))
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
-        expected_conf_file = f"{mycfg}.d/99-cloud-init.conf"
+        expected_conf_file = f"{mycfg}.d/00-cloud-init.conf"
         assert os.path.isfile(expected_conf_file)
         assert "key value\n" == util.load_file(expected_conf_file)
 
@@ -606,7 +606,7 @@ class TestUpdateSshConfig:
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
         assert f"{cfg}\nkey value\n" == util.load_file(mycfg)
-        expected_conf_file = f"{mycfg}.d/99-cloud-init.conf"
+        expected_conf_file = f"{mycfg}.d/00-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
 
     def test_with_other_include(self, tmpdir):
@@ -615,9 +615,9 @@ class TestUpdateSshConfig:
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
         assert f"{cfg}\nkey value\n" == util.load_file(mycfg)
-        expected_conf_file = f"{mycfg}.d/99-cloud-init.conf"
+        expected_conf_file = f"{mycfg}.d/00-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
-        assert not os.path.isfile(f"other_{mycfg}.d/99-cloud-init.conf")
+        assert not os.path.isfile(f"other_{mycfg}.d/00-cloud-init.conf")
 
 
 class TestBasicAuthorizedKeyParse:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
ssh_util: Handle sshd_config.d folder

Write sshd config to /etc/ssh/sshd_config.d/00-cloud-init.conf
if the sshd_config sources sshd_config.d

LP: #1968873
```

## Additional Context
<!-- If relevant -->
SC-1172
LP: #1968873

In order to ease upgrading `openssh-server`, write out sshd_config
into a separated `cloud-init` conf file with high priority under
`/etc/ssh/sshd_config.d/00-cloud-init.conf`.

This fixes #1968873 in `main` and will be SRUed to `focal`, `impish`
and `focal`.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```sh
cat <<EOF > /tmp/user-data
#cloud-config
ssh_pwauth: true
password: asdf
EOF

lxc launch ubuntu:focal ff --config=user.user-data="$(cat /tmp/user-data)"
lxc exec ff -- cloud-init status --wait

$ lxc exec ff -- grep -rn 'PasswordAuthentication ' /etc/ssh/sshd_config /etc/ssh/sshd_config.d
/etc/ssh/sshd_config:58:PasswordAuthentication no
/etc/ssh/sshd_config.d/00-cloud-init.conf:1:PasswordAuthentication yes

# Previously
# /etc/ssh/sshd_config:58:PasswordAuthentication yes

$ lxc exec ff -- grep -ri 'Writing to /etc/ssh/sshd_config - wb' /var/log/cloud-init.log
# Expect no output

# Previously:
# 2022-07-26 10:04:33,269 - util.py[DEBUG]: Writing to /etc/ssh/sshd_config - wb: [644] 3288 bytes

$ lxc exec ff -- grep -ri 'Writing to /etc/ssh/sshd_config.d' /var/log/cloud-init.log
2022-07-26 09:51:10,076 - util.py[DEBUG]: Writing to /etc/ssh/sshd_config.d/00-cloud-init.conf - ab: [644] 0 bytes
2022-07-26 09:51:10,076 - util.py[DEBUG]: Writing to /etc/ssh/sshd_config.d/00-cloud-init.conf - wb: [644] 27 bytes


lxc exec ff -- apt-get udpate
lxc exec ff -- apt-get upgrade -y
$ lxc exec ff -- do-release-upgrade -d
# A prompt does appear:

# A new version (/tmp/tmp.dAvrCWldyw) of configuration file /etc/ssh/sshd_config is available, but the version installed currently has been locally modified.
#
# What do you want to do about modified configuration file sshd_config?
# ...

# click on show diff
# the diff must not contain a diff with `PasswordAuthentication`

# Note: `/etc/ssh/sshd_config` still has modifications but not made by `cloud-init`.

lxc exec ff -- apt-get purge -y cloud-init
$ lxc exec ff -- ls /etc/ssh/sshd_config.d/00-cloud-init.conf 
ls: cannot access '/etc/ssh/sshd_config.d/00-cloud-init.conf': No such file or directory
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
