### PR TITLE
network: add system_info network activator cloud.cfg overrides

### DIFF
--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -10,7 +10,7 @@ import time
 
 from cloudinit import log, reporting, stages
 from cloudinit.event import EventScope, EventType
-from cloudinit.net import activators, read_sys_net_safe
+from cloudinit.net import read_sys_net_safe
 from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.reporting import events
 from cloudinit.sources import DataSource, DataSourceNotFoundException
@@ -132,7 +132,7 @@ class NetHandler(UeventHandler):
             bring_up=False,
         )
         interface_name = os.path.basename(self.devpath)
-        activator = activators.select_activator()
+        activator = self.datasource.distro.network_activator()
         if self.action == "add":
             if not activator.bring_up_interface(interface_name):
                 raise RuntimeError(

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -16,7 +16,7 @@ import stat
 import string
 import urllib.parse
 from io import StringIO
-from typing import Any, Mapping, Type
+from typing import Any, Mapping, Optional, Type
 
 from cloudinit import importer
 from cloudinit import log as logging
@@ -117,6 +117,17 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             "Legacy function '_write_network' was called in distro '%s'.\n"
             "_write_network_config needs implementation.\n" % self.name
         )
+
+    @property
+    def network_activator(self) -> Optional[Type[activators.NetworkActivator]]:
+        """Return the configured network activator for this environment."""
+        priority = util.get_cfg_by_path(
+            self._cfg, ("network", "activators"), None
+        )
+        try:
+            return activators.select_activator(priority=priority)
+        except activators.NoActivatorException:
+            return None
 
     def _write_network_state(self, network_state):
         priority = util.get_cfg_by_path(
@@ -242,14 +253,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         # Now try to bring them up
         if bring_up:
             LOG.debug("Bringing up newly configured network interfaces")
-            priority = util.get_cfg_by_path(
-                self._cfg, ("network", "activators"), None
-            )
-            try:
-                network_activator = activators.select_activator(
-                    priority=priority
-                )
-            except activators.NoActivatorException:
+            network_activator = self.network_activator
+            if not network_activator:
                 LOG.warning(
                     "No network activator found, not bringing up "
                     "network interfaces"

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -242,8 +242,13 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         # Now try to bring them up
         if bring_up:
             LOG.debug("Bringing up newly configured network interfaces")
+            priority = util.get_cfg_by_path(
+                self._cfg, ("network", "activators"), None
+            )
             try:
-                network_activator = activators.select_activator()
+                network_activator = activators.select_activator(
+                    priority=priority
+                )
             except activators.NoActivatorException:
                 LOG.warning(
                     "No network activator found, not bringing up "

--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import logging
 from abc import ABC, abstractmethod
-from typing import Dict, Iterable, List, Type
+from typing import Dict, Iterable, List, Optional, Type, Union
 
 from cloudinit import subp, util
 from cloudinit.net.eni import available as eni_available
@@ -32,7 +32,7 @@ def _alter_interface(cmd, device_name) -> bool:
 class NetworkActivator(ABC):
     @staticmethod
     @abstractmethod
-    def available(target: str = None) -> bool:
+    def available(target: Optional[str] = None) -> bool:
         """Return True if activator is available, otherwise return False."""
         raise NotImplementedError()
 
@@ -269,11 +269,8 @@ NAME_TO_ACTIVATOR: Dict[str, Type[NetworkActivator]] = {
 
 
 def search_activator(
-    priority: List[str] = None, target: str = None
+    priority: List[str], target: Union[str, None]
 ) -> List[Type[NetworkActivator]]:
-    if priority is None:
-        priority = DEFAULT_PRIORITY
-
     unknown = [i for i in priority if i not in DEFAULT_PRIORITY]
     if unknown:
         raise ValueError(
@@ -287,10 +284,12 @@ def search_activator(
     ]
 
 
-def select_activator(priority=None, target=None) -> Type[NetworkActivator]:
-    found = search_activator(priority, target)
+def select_activator(
+    priority: Optional[List[str]] = None, target: Optional[str] = None
+) -> Type[NetworkActivator]:
     if priority is None:
         priority = DEFAULT_PRIORITY
+    found = search_activator(priority, target)
     if not found:
         tmsg = ""
         if target and target != "/":

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -215,6 +215,7 @@ system_info:
 {# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
    network:
      renderers: ['netplan', 'eni', 'sysconfig']
+     activators: ['netplan', 'eni', 'network-manager', 'networkd']
    # Automatically discover the best ntp_client
    ntp_client: auto
    # Other config here will be given to the distro class and/or path classes

--- a/tests/unittests/cmd/devel/test_hotplug_hook.py
+++ b/tests/unittests/cmd/devel/test_hotplug_hook.py
@@ -19,7 +19,9 @@ FAKE_MAC = "11:22:33:44:55:66"
 @pytest.fixture
 def mocks():
     m_init = mock.MagicMock(spec=Init)
+    m_activator = mock.MagicMock(spec=NetworkActivator)
     m_distro = mock.MagicMock(spec=Distro)
+    m_distro.network_activator = mock.PropertyMock(return_value=m_activator)
     m_datasource = mock.MagicMock(spec=DataSource)
     m_datasource.distro = m_distro
     m_init.datasource = m_datasource
@@ -41,18 +43,11 @@ def mocks():
         return_value=m_network_state,
     )
 
-    m_activator = mock.MagicMock(spec=NetworkActivator)
-    select_activator = mock.patch(
-        "cloudinit.cmd.devel.hotplug_hook.activators.select_activator",
-        return_value=m_activator,
-    )
-
     sleep = mock.patch("time.sleep")
 
     read_sys_net.start()
     update_event_enabled.start()
     parse_net.start()
-    select_activator.start()
     m_sleep = sleep.start()
 
     yield namedtuple("mocks", "m_init m_network_state m_activator m_sleep")(
@@ -65,7 +60,6 @@ def mocks():
     read_sys_net.stop()
     update_event_enabled.stop()
     parse_net.stop()
-    select_activator.stop()
     sleep.stop()
 
 

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -252,12 +252,17 @@ class TestNetCfgDistroBase(FilesystemMockingTestCase):
         super(TestNetCfgDistroBase, self).setUp()
         self.add_patch("cloudinit.util.system_is_snappy", "m_snappy")
 
-    def _get_distro(self, dname, renderers=None):
+    def _get_distro(self, dname, renderers=None, activators=None):
         cls = distros.fetch(dname)
         cfg = settings.CFG_BUILTIN
         cfg["system_info"]["distro"] = dname
+        system_info_network_cfg = {}
         if renderers:
-            cfg["system_info"]["network"] = {"renderers": renderers}
+            system_info_network_cfg["renderers"] = renderers
+        if activators:
+            system_info_network_cfg["activators"] = activators
+        if system_info_network_cfg:
+            cfg["system_info"]["network"] = system_info_network_cfg
         paths = helpers.Paths({})
         return cls(dname, cfg.get("system_info"), paths)
 
@@ -371,7 +376,9 @@ ifconfig_eth1=DHCP
 class TestNetCfgDistroUbuntuEni(TestNetCfgDistroBase):
     def setUp(self):
         super(TestNetCfgDistroUbuntuEni, self).setUp()
-        self.distro = self._get_distro("ubuntu", renderers=["eni"])
+        self.distro = self._get_distro(
+            "ubuntu", renderers=["eni"], activators=["eni"]
+        )
 
     def eni_path(self):
         return "/etc/network/interfaces.d/50-cloud-init.cfg"
@@ -397,6 +404,45 @@ class TestNetCfgDistroUbuntuEni(TestNetCfgDistroBase):
             print("----------")
             self.assertEqual(expected, results[cfgpath])
             self.assertEqual(0o644, get_mode(cfgpath, tmpd))
+
+    def test_apply_network_config_and_bringup_filters_priority_eni_ub(self):
+        """Network activator search priority can be overridden from config."""
+        expected_cfgs = {
+            self.eni_path(): V1_NET_CFG_OUTPUT,
+        }
+        # ub_distro.apply_network_config(V1_NET_CFG, False)
+        with mock.patch(
+            "cloudinit.net.activators.select_activator"
+        ) as select_activator:
+            self._apply_and_verify_eni(
+                self.distro.apply_network_config,
+                V1_NET_CFG,
+                expected_cfgs=expected_cfgs.copy(),
+                bringup=True,
+            )
+        self.assertEqual(
+            [mock.call(priority=["eni"])], select_activator.call_args_list
+        )
+
+    def test_apply_network_config_and_bringup_activator_defaults_ub(self):
+        """Network activator search priority defaults when unspecified."""
+        expected_cfgs = {
+            self.eni_path(): V1_NET_CFG_OUTPUT,
+        }
+        # Don't set activators to see DEFAULT_PRIORITY
+        self.distro = self._get_distro("ubuntu", renderers=["eni"])
+        with mock.patch(
+            "cloudinit.net.activators.select_activator"
+        ) as select_activator:
+            self._apply_and_verify_eni(
+                self.distro.apply_network_config,
+                V1_NET_CFG,
+                expected_cfgs=expected_cfgs.copy(),
+                bringup=True,
+            )
+        self.assertEqual(
+            [mock.call(priority=None)], select_activator.call_args_list
+        )
 
     def test_apply_network_config_eni_ub(self):
         expected_cfgs = {

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 from cloudinit import distros, helpers, safeyaml, settings, subp, util
 from cloudinit.distros.parsers.sys_conf import SysConf
+from cloudinit.net.activators import IfUpDownActivator
 from tests.unittests.helpers import FilesystemMockingTestCase, dir2dict
 
 BASE_NET_CFG = """
@@ -414,14 +415,17 @@ class TestNetCfgDistroUbuntuEni(TestNetCfgDistroBase):
         with mock.patch(
             "cloudinit.net.activators.select_activator"
         ) as select_activator:
+            select_activator.return_value = IfUpDownActivator
             self._apply_and_verify_eni(
                 self.distro.apply_network_config,
                 V1_NET_CFG,
                 expected_cfgs=expected_cfgs.copy(),
                 bringup=True,
             )
+            # 2nd call to select_activator via distro.network_activator prop
+            assert IfUpDownActivator == self.distro.network_activator
         self.assertEqual(
-            [mock.call(priority=["eni"])], select_activator.call_args_list
+            [mock.call(priority=["eni"])] * 2, select_activator.call_args_list
         )
 
     def test_apply_network_config_and_bringup_activator_defaults_ub(self):
@@ -434,14 +438,17 @@ class TestNetCfgDistroUbuntuEni(TestNetCfgDistroBase):
         with mock.patch(
             "cloudinit.net.activators.select_activator"
         ) as select_activator:
+            select_activator.return_value = IfUpDownActivator
             self._apply_and_verify_eni(
                 self.distro.apply_network_config,
                 V1_NET_CFG,
                 expected_cfgs=expected_cfgs.copy(),
                 bringup=True,
             )
+            # 2nd call to select_activator via distro.network_activator prop
+            assert IfUpDownActivator == self.distro.network_activator
         self.assertEqual(
-            [mock.call(priority=None)], select_activator.call_args_list
+            [mock.call(priority=None)] * 2, select_activator.call_args_list
         )
 
     def test_apply_network_config_eni_ub(self):

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -6,6 +6,7 @@ import pytest
 
 from cloudinit.net.activators import (
     DEFAULT_PRIORITY,
+    NAME_TO_ACTIVATOR,
     IfUpDownActivator,
     NetplanActivator,
     NetworkdActivator,
@@ -81,18 +82,18 @@ def unavailable_mocks():
 class TestSearchAndSelect:
     def test_defaults(self, available_mocks):
         resp = search_activator()
-        assert resp == DEFAULT_PRIORITY
+        assert resp == [NAME_TO_ACTIVATOR[name] for name in DEFAULT_PRIORITY]
 
         activator = select_activator()
-        assert activator == DEFAULT_PRIORITY[0]
+        assert activator == NAME_TO_ACTIVATOR[DEFAULT_PRIORITY[0]]
 
     def test_priority(self, available_mocks):
-        new_order = [NetplanActivator, NetworkManagerActivator]
+        new_order = ["netplan", "network-manager"]
         resp = search_activator(priority=new_order)
-        assert resp == new_order
+        assert resp == [NAME_TO_ACTIVATOR[name] for name in new_order]
 
         activator = select_activator(priority=new_order)
-        assert activator == new_order[0]
+        assert activator == NAME_TO_ACTIVATOR[new_order[0]]
 
     def test_target(self, available_mocks):
         search_activator(target="/tmp")
@@ -107,10 +108,12 @@ class TestSearchAndSelect:
     )
     def test_first_not_available(self, m_available, available_mocks):
         resp = search_activator()
-        assert resp == DEFAULT_PRIORITY[1:]
+        assert resp == [
+            NAME_TO_ACTIVATOR[activator] for activator in DEFAULT_PRIORITY[1:]
+        ]
 
         resp = select_activator()
-        assert resp == DEFAULT_PRIORITY[1]
+        assert resp == NAME_TO_ACTIVATOR[DEFAULT_PRIORITY[1]]
 
     def test_priority_not_exist(self, available_mocks):
         with pytest.raises(ValueError):

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -80,8 +80,8 @@ def unavailable_mocks():
 
 
 class TestSearchAndSelect:
-    def test_defaults(self, available_mocks):
-        resp = search_activator()
+    def test_empty_list(self, available_mocks):
+        resp = search_activator(priority=DEFAULT_PRIORITY, target=None)
         assert resp == [NAME_TO_ACTIVATOR[name] for name in DEFAULT_PRIORITY]
 
         activator = select_activator()
@@ -89,14 +89,14 @@ class TestSearchAndSelect:
 
     def test_priority(self, available_mocks):
         new_order = ["netplan", "network-manager"]
-        resp = search_activator(priority=new_order)
+        resp = search_activator(priority=new_order, target=None)
         assert resp == [NAME_TO_ACTIVATOR[name] for name in new_order]
 
         activator = select_activator(priority=new_order)
         assert activator == NAME_TO_ACTIVATOR[new_order[0]]
 
     def test_target(self, available_mocks):
-        search_activator(target="/tmp")
+        search_activator(priority=DEFAULT_PRIORITY, target="/tmp")
         assert "/tmp" == available_mocks.m_which.call_args[1]["target"]
 
         select_activator(target="/tmp")
@@ -107,7 +107,7 @@ class TestSearchAndSelect:
         return_value=False,
     )
     def test_first_not_available(self, m_available, available_mocks):
-        resp = search_activator()
+        resp = search_activator(priority=DEFAULT_PRIORITY, target=None)
         assert resp == [
             NAME_TO_ACTIVATOR[activator] for activator in DEFAULT_PRIORITY[1:]
         ]
@@ -117,12 +117,12 @@ class TestSearchAndSelect:
 
     def test_priority_not_exist(self, available_mocks):
         with pytest.raises(ValueError):
-            search_activator(priority=["spam", "eggs"])
+            search_activator(priority=["spam", "eggs"], target=None)
         with pytest.raises(ValueError):
             select_activator(priority=["spam", "eggs"])
 
     def test_none_available(self, unavailable_mocks):
-        resp = search_activator()
+        resp = search_activator(priority=DEFAULT_PRIORITY, target=None)
         assert resp == []
 
         with pytest.raises(NoActivatorException):


### PR DESCRIPTION
## Proposed Commit Message

```
Support overriding network activators in cloud.cfg system_info
on disk.

Default cloud-init activators are used either during hot-plug or
for datasources that are detected during init-network stage when
basic networking has already been setup by the OS.a

Activators are discovered in the following priority order and
determined based on the presence of related network tools:

system_info:
  network:
    activators: [eni, netplan, network-manager, networkd]

On some systems where multiple network config tools are installed
it is necessary to override the priority order of detection to ensure
one activator is chosen over the other. This is done by providing
the a custom cloud config snippet in a /etc/cloud/cloud.cfg.d/*cfg.

LP: #1958377
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Addtional context
Also related to ubuntu-desktop-installer [LP #1982855](https://bugs.launchpad.net/livecd-rootfs/+bug/1982855)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
