### PR TITLE
LXD Add MTU Support

### DIFF
--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -56,6 +56,7 @@ meta: MetaSchema = {
                 storage_create_loop: 10
               bridge:
                 mode: new
+                mtu: 1500
                 name: lxdbr0
                 ipv4_address: 10.0.8.1
                 ipv4_netmask: 24

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -292,6 +292,12 @@ def bridge_to_cmd(bridge_cfg):
     if bridge_cfg.get("domain"):
         cmd_create.append("dns.domain=%s" % bridge_cfg.get("domain"))
 
+    # if the default schema value is passed (-1) don't pass arguments
+    # to LXD. Use LXD defaults unless user manually sets a number
+    mtu = bridge_cfg.get("mtu", -1)
+    if mtu != -1:
+        cmd_create.append(f"bridge.mtu={mtu}")
+
     return cmd_create, cmd_attach
 
 

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1052,6 +1052,12 @@
                   "description": "Name of the LXD network bridge to attach or create. Default: ``lxdbr0``.",
                   "default": "lxdbr0"
                 },
+                "mtu": {
+                  "type": "integer",
+                  "description": "Bridge MTU, defaults to LXD's default value",
+                  "default": -1,
+                  "minimum": -1
+                },
                 "ipv4_address": {
                   "type": "string",
                   "description": "IPv4 address for the bridge. If set, ``ipv4_netmask`` key required."

--- a/tests/integration_tests/modules/test_lxd_bridge.py
+++ b/tests/integration_tests/modules/test_lxd_bridge.py
@@ -23,6 +23,7 @@ lxd:
     ipv4_dhcp_last: 10.100.100.200
     ipv4_nat: true
     domain: lxd
+    mtu: 9000
 """
 
 

--- a/tests/unittests/config/test_cc_lxd.py
+++ b/tests/unittests/config/test_cc_lxd.py
@@ -333,6 +333,8 @@ class TestLXDSchema:
             ({"lxd": {}}, "does not have enough properties"),
             # Require bridge.mode
             ({"lxd": {"bridge": {"mode": "new", "mtu": 9000}}}, None),
+            # LXD's default value
+            ({"lxd": {"bridge": {"mode": "new", "mtu": -1}}}, None),
             # No additionalProperties
             (
                 {"lxd": {"init": {"invalid": None}}},

--- a/tests/unittests/config/test_cc_lxd.py
+++ b/tests/unittests/config/test_cc_lxd.py
@@ -207,6 +207,7 @@ class TestLxd(t_help.CiTestCase):
             "ipv6_netmask": "64",
             "ipv6_nat": "true",
             "domain": "lxd",
+            "mtu": 9000,
         }
         self.assertEqual(
             cc_lxd.bridge_to_cmd(data),
@@ -221,6 +222,7 @@ class TestLxd(t_help.CiTestCase):
                     "ipv6.address=fd98:9e0:3744::1/64",
                     "ipv6.nat=true",
                     "dns.domain=lxd",
+                    "bridge.mtu=9000",
                 ],
                 ["network", "attach-profile", "testbr0", "default", "eth0"],
             ),
@@ -232,6 +234,7 @@ class TestLxd(t_help.CiTestCase):
             "ipv6_address": "fd98:9e0:3744::1",
             "ipv6_netmask": "64",
             "ipv6_nat": "true",
+            "mtu": -1,
         }
         self.assertEqual(
             cc_lxd.bridge_to_cmd(data),
@@ -328,6 +331,8 @@ class TestLXDSchema:
             ({"lxd": {"bridge": {}}}, "bridge: 'mode' is a required property"),
             # Require init or bridge keys
             ({"lxd": {}}, "does not have enough properties"),
+            # Require bridge.mode
+            ({"lxd": {"bridge": {"mode": "new", "mtu": 9000}}}, None),
             # No additionalProperties
             (
                 {"lxd": {"init": {"invalid": None}}},


### PR DESCRIPTION
```
lxd: enable MTU configuration in cloud-init

This option exists in LXD already. Plumb the options
without changing default behavior.
```

## Additional Context
depends on https://github.com/canonical/cloud-init/pull/1621