### PR TITLE
pin doc8

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,4 +1,4 @@
-doc8
+doc8==0.11.2
 m2r2
 sphinx==4.3.0
 sphinx_rtd_theme==1.0.0

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,3 +1,4 @@
+# doc8 1.0.0 depends on docutils 0.18.1 or later which added Node.findall()
 doc8==0.11.2
 m2r2
 sphinx==4.3.0


### PR DESCRIPTION
```
doc: pin doc8 to last passing version

Pinned to 0.11.2 because doc8 1.0.0 depends on docutils >= 0.18.1
```

## Additional Context
[doc8 released](https://pypi.org/project/doc8/1.0.0/) [1.0.0](https://github.com/PyCQA/doc8/releases/tag/v1.0.0) an [hour ago](https://github.com/PyCQA/doc8/releases) and [now CI is failing on travis](https://app.travis-ci.com/github/canonical/cloud-init/jobs/577966903)