### PR TITLE
docs: Align git remotes with uss-tableflip setup

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -72,10 +72,10 @@ Follow these steps to submit your first pull request to cloud-init:
 
   .. code:: sh
 
-    git clone git://github.com/canonical/cloud-init
+    git clone git@github.com:GH_USER/cloud-init.git
     cd cloud-init
-    git remote add GH_USER git@github.com:GH_USER/cloud-init.git
-    git push GH_USER main
+    git remote add upstream git@github.com:canonical/cloud-init.git
+    git push origin main
 
 * Read through the cloud-init `Code Review Process`_, so you understand
   how your changes will end up in cloud-init's codebase.
@@ -144,7 +144,7 @@ Do these things for each feature or bug
 
 * Push your changes to your personal GitHub repository::
 
-    git push -u GH_USER my-topic-branch
+    git push -u origin my-topic-branch
 
 * Use your browser to create a pull request:
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
docs: Align git remotes with uss-tableflip setup

`uss-tableflip/scripts/upstream-release` assumes Canonical remote is 
called `upstream` and your personal remote `origin`.
Fix upstream git URI.
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/uss-tableflip/blob/e8528bcfdc3fdb28cdf0c4f4b434c47f57aec6b6/doc/upstream_release_process.md?plain=1#L5

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
