### PR TITLE
testing: Fix test_ca_certs integration test

### DIFF
--- a/tests/integration_tests/modules/test_ca_certs.py
+++ b/tests/integration_tests/modules/test_ca_certs.py
@@ -92,10 +92,14 @@ class TestCaCerts:
             in checksum
         )
 
-    def test_clean_logs(self, class_client: IntegrationInstance):
+    def test_clean_log(self, class_client: IntegrationInstance):
+        """Verify no errors, no deprecations and correct inactive modules in
+        log.
+        """
         log = class_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log, ignore_deprecations=False)
-        diff = {
+
+        expected_inactive = {
             "apt-pipelining",
             "bootcmd",
             "chef",
@@ -122,7 +126,21 @@ class TestCaCerts:
             "update_etc_hosts",
             "write-files",
             "write-files-deferred",
-        }.symmetric_difference(get_inactive_modules(log))
+        }
+
+        # Remove modules that run independent from user-data
+        if class_client.settings.PLATFORM == "azure":
+            expected_inactive.discard("disk_setup")
+        elif class_client.settings.PLATFORM == "gce":
+            expected_inactive.discard("ntp")
+        elif class_client.settings.PLATFORM == "lxd_vm":
+            if class_client.settings.OS_IMAGE == "bionic":
+                expected_inactive.discard("write-files")
+                expected_inactive.discard("write-files-deferred")
+
+        diff = expected_inactive.symmetric_difference(
+            get_inactive_modules(log)
+        )
         assert (
             not diff
         ), f"Expected inactive modules do not match, diff: {diff}"


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: Fix test_ca_certs integration test
```

## Additional Context
<!-- If relevant -->
After the inclusion of https://github.com/canonical/cloud-init/pull/1609, some Jenkins' jobs fail:

[cloud-init-integration-bionic-azure/68](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-azure/68/)
[cloud-init-integration-bionic-gce/65](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-gce/65/)
[cloud-init-integration-bionic-lxd_vm/67](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-lxd_vm/67/)
[cloud-init-integration-focal-azure/65](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-azure/65/)
[cloud-init-integration-focal-gce/70](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-gce/70/)
[cloud-init-integration-jammy-gce/68](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-gce/68/)
[cloud-init-integration-kinetic-azure/52](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-azure/52/)
[cloud-init-integration-kinetic-gce/53](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-gce/53/)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
