### PR TITLE
schema: Enable deprecations in cc_set_passwords

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1828,9 +1828,13 @@
         "ssh_pwauth": {
           "oneOf": [
             {"type": "boolean"},
-            {"type": "string"}
+            {
+              "type": "string",
+              "description": "Use of non-boolean values for this field is DEPRECATED and will result in an error in a future version of cloud-init.",
+              "deprecated": true
+            }
           ],
-          "description": "Sets whether or not to accept password authentication. ``true`` will enable password auth. ``false`` will disable. Default is to leave the value unchanged. Use of non-boolean values for this field is DEPRECATED and will result in an error in a future version of cloud-init."
+          "description": "Sets whether or not to accept password authentication. ``true`` will enable password auth. ``false`` will disable. Default is to leave the value unchanged."
         },
         "chpasswd": {
           "type": "object",

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -699,8 +699,31 @@ class TestSetPasswordsSchema:
         [
             # Test both formats still work
             ({"ssh_pwauth": True}, does_not_raise()),
-            ({"ssh_pwauth": "yes"}, does_not_raise()),
-            ({"ssh_pwauth": "unchanged"}, does_not_raise()),
+            ({"ssh_pwauth": False}, does_not_raise()),
+            (
+                {"ssh_pwauth": "yes"},
+                pytest.raises(
+                    SchemaValidationError,
+                    match=(
+                        "deprecations: ssh_pwauth: DEPRECATED. Use of"
+                        " non-boolean values for this field is DEPRECATED and"
+                        " will result in an error in a future version of"
+                        " cloud-init."
+                    ),
+                ),
+            ),
+            (
+                {"ssh_pwauth": "unchanged"},
+                pytest.raises(
+                    SchemaValidationError,
+                    match=(
+                        "deprecations: ssh_pwauth: DEPRECATED. Use of"
+                        " non-boolean values for this field is DEPRECATED and"
+                        " will result in an error in a future version of"
+                        " cloud-init."
+                    ),
+                ),
+            ),
             (
                 {"chpasswd": {"list": "blah"}},
                 pytest.raises(SchemaValidationError, match="DEPRECATED"),


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
schema: Enable deprecations in cc_set_passwords
```

## Additional Context
<!-- If relevant -->
SC-1173

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
