### PR TITLE
Remove configobj a_to_u calls

### DIFF
--- a/cloudinit/distros/parsers/sys_conf.py
+++ b/cloudinit/distros/parsers/sys_conf.py
@@ -107,7 +107,7 @@ class SysConf(configobj.ConfigObj):
         return "%s%s%s%s%s" % (
             indent_string,
             key,
-            self._a_to_u("="),
+            "=",
             val,
             cmnt,
         )

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -96,6 +96,7 @@ smoser
 sshedi
 sstallion
 stappersg
+stefanor
 steverweber
 t-8ch
 taoyama


### PR DESCRIPTION
## Proposed Commit Message

```
Remove configobj _a_to_u() calls
    
configobj upstream removed it in
https://github.com/DiffSK/configobj/commit/7b07952dc599fb00d2dd2b5a1c1d1ec19d720132
    
In this case it should be a no-op on Python 3

Paving the way to resolve https://bugs.debian.org/1016467
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly