### PR TITLE
typing: Type UrlResponse.contents

### DIFF
--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from errno import ENOENT
 from time import sleep, time
-from typing import List, Optional
+from typing import List, Optional, Union
 from xml.etree import ElementTree
 from xml.sax.saxutils import escape
 
@@ -448,7 +448,7 @@ class InvalidGoalStateXMLException(Exception):
 class GoalState:
     def __init__(
         self,
-        unparsed_xml: str,
+        unparsed_xml: Union[str, bytes],
         azure_endpoint_client: AzureEndpointHttpClient,
         need_certificate: bool = True,
     ) -> None:
@@ -888,7 +888,7 @@ class WALinuxAgentShim:
         )
 
     @azure_ds_telemetry_reporter
-    def _get_raw_goal_state_xml_from_azure(self) -> str:
+    def _get_raw_goal_state_xml_from_azure(self) -> bytes:
         """Fetches the GoalState XML from the Azure endpoint and returns
         the XML as a string.
 
@@ -916,7 +916,9 @@ class WALinuxAgentShim:
 
     @azure_ds_telemetry_reporter
     def _parse_raw_goal_state_xml(
-        self, unparsed_goal_state_xml: str, need_certificate: bool
+        self,
+        unparsed_goal_state_xml: Union[str, bytes],
+        need_certificate: bool,
     ) -> GoalState:
         """Parses a GoalState XML string and returns a GoalState object.
 

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -118,6 +118,8 @@ class UrlResponse(object):
 
     @property
     def contents(self) -> bytes:
+        if self._response.content is None:
+            return b""
         return self._response.content
 
     @property

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -117,7 +117,7 @@ class UrlResponse(object):
         self._response = response
 
     @property
-    def contents(self):
+    def contents(self) -> bytes:
         return self._response.content
 
     @property


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
typing: Type UrlResponse.contents

As requests.Response.contents returns always an instance of bytes,
type UrlResponse.contents accordingly.

This change undercovered an incorrect typing in
sources/helpers/azure, that was hidden because
ElementTree.fromstring accepts str and bytes.
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/1606#discussion_r934791692

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
