### PR TITLE
Ubuntu/bionic: refresh bionic patches to fix daily recipe build

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ cloud-init (22.2-0ubuntu1~18.04.2) UNRELEASED; urgency=medium
   * d/control: add python3-debconf to Depends and Build-Depends
   * d/cloud-init.postinst: lintian fixes:
     + Fix command-with-path-in-maintainer-script for grub-install
+  * d/patches/renderer-do-not-prefer-netplan refresh to activators change
   * d/source/lintian-overrides: lintian fixes:
     + silence binary-nmu-debian-revision-in-source bug:
       https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1014584

--- a/debian/patches/renderer-do-not-prefer-netplan.patch
+++ b/debian/patches/renderer-do-not-prefer-netplan.patch
@@ -5,19 +5,24 @@ Author: Chad Smith <chad.smith@canonical.com>
 Origin: backport
 Forwarded: not-needed
 Last-Update: 2020-06-01
+Index: cloud-init/config/cloud.cfg.tmpl
+===================================================================
 --- a/config/cloud.cfg.tmpl
 +++ b/config/cloud.cfg.tmpl
-@@ -209,9 +209,7 @@ system_info:
+@@ -212,10 +212,7 @@ system_info:
       groups: [adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video]
       sudo: ["ALL=(ALL) NOPASSWD:ALL"]
       shell: /bin/bash
 -{# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
 -   network:
 -     renderers: ['netplan', 'eni', 'sysconfig']
+-     activators: ['netplan', 'eni', 'network-manager', 'networkd']
 +{# SRU_UPSTREAM_COMMIT: 4fb6fd8a. Do not ship network renderers #}
     # Automatically discover the best ntp_client
     ntp_client: auto
     # Other config here will be given to the distro class and/or path classes
+Index: cloud-init/tests/unittests/test_render_cloudcfg.py
+===================================================================
 --- a/tests/unittests/test_render_cloudcfg.py
 +++ b/tests/unittests/test_render_cloudcfg.py
 @@ -80,7 +80,6 @@ class TestRenderCloudCfg:


### PR DESCRIPTION
Daily recipe builds for bionic broke due to `quilt push -a` not being able to apply any more due drift in tip of main introduced by commit 6e498773bf153f7b2f5e995a2f2fe24774dd3cab

Performed steps documented here https://github.com/canonical/uss-tableflip/blob/main/doc/ubuntu_release_process.md#when-the-daily-recipe-build-fails

# Do not  squash merge


## Proposed Commit Message
* update changelog
* d/patches/renderer-do-not-prefer-netplan refresh to activators change

## Additional Context
<!-- If relevant -->

## Test Steps

```
git clone git@github.com:canonical/cloud-init.git -r upstream
cd cloud-init
git merge origin/ubuntu/bionic
quilt push -a # ensure no failure applying patches
tox -e py3   # ensure no failure in unit tests
quilt pop -a
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
