### PR TITLE
tox: Fix tip-flake8 and tip-mypy

### DIFF
--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -49,7 +49,7 @@ EXPECTED_CONVERTED_CONTENT = """## Note, this file is written by cloud-init on f
 deb http://archive.ubuntu.com/ubuntu/ fakerelease main restricted
 deb-src http://archive.ubuntu.com/ubuntu/ fakerelease main restricted
 # FIND_SOMETHING_SPECIAL
-"""
+"""  # noqa: E501
 
 
 class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -234,6 +234,8 @@ commands = {[testenv:flake8]commands}
 
 [testenv:tip-mypy]
 deps =
+    hypothesis
+    hypothesis_jsonschema
     mypy
     pytest
     types-jsonschema


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tox: Fix tip-flake8 and tip-mypy
```

## Additional Context
<!-- If relevant -->
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-style-tip/113/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```bash
tox -e tip-flake8,tip-mypy
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
