### PR TITLE
schema: add aggregate descriptions in anyOf/oneOf

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -649,7 +649,6 @@
                   "description": "Specifies the partition table type, either ``mbr`` or ``gpt``. Default: ``mbr``."
                 },
                 "layout": {
-                  "type": ["string", "boolean", "array"],
                   "default": false,
                   "oneOf": [
                     {"type": "string", "enum": ["remove"]},
@@ -807,7 +806,7 @@
               "description": "Device to use as target for grub installation. If unspecified, ``grub-probe`` of ``/boot`` will be used to find the device"
             },
             "grub-pc/install_devices_empty": {
-              "description": "Sets values for ``grub-pc/install_devices_empty``. If unspecified, will be set to ``true`` if ``grub-pc/install_devices`` is empty, otherwise ``false``. Using a non-boolean value for this field is deprecated.",
+              "description": "Sets values for ``grub-pc/install_devices_empty``. If unspecified, will be set to ``true`` if ``grub-pc/install_devices`` is empty, otherwise ``false``.",
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1385,7 +1384,7 @@
                     "type": "string",
                     "pattern": "^\\+?[0-9]+$",
                     "deprecated": true,
-                    "description": "Dropped after April 2027. Use ``now`` or integer type."
+                    "description": "Use of string for this value will be dropped after April 2027. Use ``now`` or integer type."
                 },
                 {"enum": ["now"]}
               ]

--- a/tests/unittests/config/test_cc_power_state_change.py
+++ b/tests/unittests/config/test_cc_power_state_change.py
@@ -176,16 +176,18 @@ class TestPowerStateChangeSchema:
             (
                 {"power_state": {"mode": "halt", "delay": "5"}},
                 (
-                    "power_state.delay: DEPRECATED."
-                    " Dropped after April 2027. Use ``now`` or integer type."
+                    "power_state.delay: DEPRECATED:"
+                    " Use of string for this value will be dropped after"
+                    " April 2027. Use ``now`` or integer type."
                 ),
             ),
             ({"power_state": {"mode": "halt", "delay": "now"}}, None),
             (
                 {"power_state": {"mode": "halt", "delay": "+5"}},
                 (
-                    "power_state.delay: DEPRECATED."
-                    " Dropped after April 2027. Use ``now`` or integer type."
+                    "power_state.delay: DEPRECATED:"
+                    " Use of string for this value will be dropped after"
+                    " April 2027. Use ``now`` or integer type."
                 ),
             ),
             ({"power_state": {"mode": "halt", "delay": "+"}}, ""),

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -404,7 +404,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"a-b": "asdf"},
-                "Deprecated cloud-config provided:\na-b: DEPRECATED. <desc>",
+                "Deprecated cloud-config provided:\na-b: DEPRECATED: <desc>",
             ),
             (
                 {
@@ -423,7 +423,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "+5"},
-                "Deprecated cloud-config provided:\nx: DEPRECATED. <desc>",
+                "Deprecated cloud-config provided:\nx: DEPRECATED: <desc>",
             ),
             (
                 {
@@ -441,7 +441,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "5"},
-                "Deprecated cloud-config provided:\nx: DEPRECATED. <desc>",
+                "Deprecated cloud-config provided:\nx: DEPRECATED: <desc>",
             ),
             (
                 {
@@ -460,7 +460,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "5"},
-                "Deprecated cloud-config provided:\nx: DEPRECATED. <desc>",
+                "Deprecated cloud-config provided:\nx: DEPRECATED: <desc>",
             ),
             (
                 {
@@ -474,7 +474,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "+5"},
-                "Deprecated cloud-config provided:\nx: DEPRECATED. <desc>",
+                "Deprecated cloud-config provided:\nx: DEPRECATED: <desc>",
             ),
             (
                 {
@@ -509,7 +509,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "+5"},
-                "Deprecated cloud-config provided:\nx: DEPRECATED. <desc>",
+                "Deprecated cloud-config provided:\nx: DEPRECATED: <desc>",
             ),
             (
                 {
@@ -546,7 +546,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"a-b": "asdf"},
-                "Deprecated cloud-config provided:\na-b: DEPRECATED. <desc>",
+                "Deprecated cloud-config provided:\na-b: DEPRECATED: <desc>",
             ),
             pytest.param(
                 {
@@ -769,7 +769,7 @@ class TestSchemaDocMarkdown:
             **Supported distros:** debian, rhel
 
             **Config schema**:
-                **prop1:** (array of integer) prop-description
+                **prop1:** (array of integer) prop-description.
 
             **Examples**::
 
@@ -822,9 +822,9 @@ class TestSchemaDocMarkdown:
             **Activate only on keys:** ``prop1``, ``prop2``
 
             **Config schema**:
-                **prop1:** (array of string) prop-description
+                **prop1:** (array of string) prop-description.
 
-                **prop2:** (boolean) prop2-description
+                **prop2:** (boolean) prop2-description.
 
             **Examples**::
 
@@ -867,7 +867,7 @@ class TestSchemaDocMarkdown:
                 """\
             **prop1:** (string/object) Objects support the following keys:
 
-                    **<opaque_label>:** (array of string) List of cool strings
+                    **<opaque_label>:** (array of string) List of cool strings.
             """
             )
             in get_meta_doc(self.meta, schema)
@@ -1012,7 +1012,7 @@ class TestSchemaDocMarkdown:
             dedent(
                 """
             **Config schema**:
-                **prop1:** (array of integer) prop-description
+                **prop1:** (array of integer) prop-description.
 
             **Examples**::
 
@@ -1058,7 +1058,7 @@ class TestSchemaDocMarkdown:
                         - option2
                         - option3
 
-                The default value is option1
+                The default value is option1.
 
         """
             )
@@ -1169,7 +1169,7 @@ class TestSchemaDocMarkdown:
                         }
                     }
                 },
-                "**prop1:** (string/integer) DEPRECATED. <description>",
+                "**prop1:** (string/integer) DEPRECATED: <description>",
             ),
             (
                 {
@@ -1182,7 +1182,7 @@ class TestSchemaDocMarkdown:
                         },
                     },
                 },
-                "**prop1:** (string/integer) DEPRECATED. <description>",
+                "**prop1:** (string/integer) DEPRECATED: <description>",
             ),
             (
                 {
@@ -1200,7 +1200,7 @@ class TestSchemaDocMarkdown:
                         }
                     },
                 },
-                "**prop1:** (string/integer) DEPRECATED. <description>",
+                "**prop1:** (string/integer) DEPRECATED: <description>",
             ),
             (
                 {
@@ -1220,7 +1220,7 @@ class TestSchemaDocMarkdown:
                         }
                     },
                 },
-                "**prop1:** (string/integer) DEPRECATED. <description>",
+                "**prop1:** (string/integer) DEPRECATED: <description>",
             ),
             (
                 {
@@ -1238,7 +1238,7 @@ class TestSchemaDocMarkdown:
                         },
                     },
                 },
-                "**prop1:** (UNDEFINED) <description>\n",
+                "**prop1:** (UNDEFINED) <description>. DEPRECATED: <deprecat",
             ),
             (
                 {
@@ -1259,7 +1259,8 @@ class TestSchemaDocMarkdown:
                         },
                     },
                 },
-                "**prop1:** (UNDEFINED)\n",
+                "**prop1:** (UNDEFINED) <description>. DEPRECATED:"
+                " <deprecated_description>",
             ),
         ],
     )
@@ -1623,9 +1624,9 @@ class TestHandleSchemaArgs:
                     apt_reboot_if_required: true		# D3
 
                     # Deprecations: -------------
-                    # D1: DEPRECATED. Dropped after April 2027. Use ``package_update``. Default: ``false``
-                    # D2: DEPRECATED. Dropped after April 2027. Use ``package_upgrade``. Default: ``false``
-                    # D3: DEPRECATED. Dropped after April 2027. Use ``package_reboot_if_required``. Default: ``false``
+                    # D1: DEPRECATED: Dropped after April 2027. Use ``package_update``. Default: ``false``
+                    # D2: DEPRECATED: Dropped after April 2027. Use ``package_upgrade``. Default: ``false``
+                    # D3: DEPRECATED: Dropped after April 2027. Use ``package_reboot_if_required``. Default: ``false``
 
 
                     Valid cloud-config: {}
@@ -1637,9 +1638,9 @@ class TestHandleSchemaArgs:
                 dedent(
                     """\
                     Cloud config schema deprecations: \
-apt_reboot_if_required: DEPRECATED. Dropped after April 2027. Use ``package_reboot_if_required``. Default: ``false``, \
-apt_update: DEPRECATED. Dropped after April 2027. Use ``package_update``. Default: ``false``, \
-apt_upgrade: DEPRECATED. Dropped after April 2027. Use ``package_upgrade``. Default: ``false``
+apt_reboot_if_required: DEPRECATED: Dropped after April 2027. Use ``package_reboot_if_required``. Default: ``false``, \
+apt_update: DEPRECATED: Dropped after April 2027. Use ``package_update``. Default: ``false``, \
+apt_upgrade: DEPRECATED: Dropped after April 2027. Use ``package_upgrade``. Default: ``false``
                     Valid cloud-config: {}
                     """  # noqa: E501
                 ),


### PR DESCRIPTION
Order deprecated sub schema property descriptions after
any active descriptions.

Add trailing stop for descriptions in docs is absent.

For readability, preface any deprecated sub-schema properties with
    DEPRECATED:

SC-1175

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Order deprecated sub schema property descriptions after
any active descriptions.

Add trailing stop for descriptions in docs is absent.

For readability, preface any deprecated sub-schema properties with
    DEPRECATED:

SC-1175
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
