### PR TITLE
sources/azure: handle network unreachable errors for savable PPS

### DIFF
--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -363,8 +363,16 @@ def http_with_retries(
                 % (url, attempt, e, e.code, e.headers),
                 logger_func=LOG.debug,
             )
-            # Raise exception if we're out of time.
-            if time() + retry_sleep >= timeout:
+            # Raise exception if we're out of time or network is unreachable.
+            # If network is unreachable:
+            # - retries will not resolve the situation
+            # - for reporting ready for PPS, this generally means VM was put
+            #   to sleep or network interface was unplugged before we see
+            #   the call complete successfully.
+            if (
+                time() + retry_sleep >= timeout
+                or "Network is unreachable" in str(e)
+            ):
                 raise
 
         sleep(retry_sleep)


### PR DESCRIPTION
Upon reporting ready for Savable PPS, the VM may be suspended before
we see the http request complete.  When the VM resumes,
http_with_retries will keep retrying even though it sees
"Network is unreachable" errors due to the unplugged NIC (and
perhaps a new unconfigured one) or "Read timed out" raised.

- Do not retry when "Network is unreachable", this will not
  resolve itself in any case.

- Ignore all url errors for Savable PPS.  Worst case scenario is
we failed to report ready anyways (for whatever reason) and the
source PPS VM will soon be discarded.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>