### PR TITLE
tests: fix integrate test to expect ansible inactive without user-data

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,5 +1,5 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib @ git+https://github.com/canonical/pycloudlib.git@f9293647e44dff6e98996e6ca83376477139eb5e
+pycloudlib @ git+https://github.com/canonical/pycloudlib.git@68fe052baf6f32415b727d02ba2ba48b7a995bf2
 pytest

--- a/tests/integration_tests/modules/test_ca_certs.py
+++ b/tests/integration_tests/modules/test_ca_certs.py
@@ -101,6 +101,7 @@ class TestCaCerts:
 
         expected_inactive = {
             "apt-pipelining",
+            "ansible",
             "bootcmd",
             "chef",
             "disable-ec2-metadata",


### PR DESCRIPTION
## Proposed Commit Message

```
tests: can run without azure-cli, tests expect inactive ansible

Bump pycloud version to include fixes so Azure tests can run on VMs
without an azure-cli installed.
```

## Additional Context
<!-- If relevant -->
Related jenkins failure https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-ec2/55/testReport/junit/tests.integration_tests.modules.test_ca_certs/TestCaCerts/test_clean_log/

## Test Steps
```bash
CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_OS_IMAGE=kinetic CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests ./tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_clean_log
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
