### PR TITLE
schema: Resolve user-data if --system given

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -19,7 +19,7 @@ import yaml
 
 from cloudinit import importer, safeyaml
 from cloudinit.stages import Init
-from cloudinit.util import encode_text, error, get_modules_from_dir, load_file
+from cloudinit.util import error, get_modules_from_dir, load_file
 
 try:
     from jsonschema import ValidationError as _ValidationError
@@ -618,16 +618,8 @@ def validate_cloudconfig_file(config_path, schema, annotate=False):
                 " Try using sudo"
             )
         init = Init(ds_deps=[])
-        ds = init.fetch("trust")
-        ud = ds.get_userdata()
-        content = None
-        for part in ud.walk():
-            if part.get_content_type() == "text/cloud-config":
-                content = encode_text(part.get_payload())
-                break
-        if not content:
-            print("No cloud-config userdata found. Skipping verification")
-            return
+        init.consume_data()
+        content = load_file(init.paths.get_ipath("cloud_config"), decode=False)
     else:
         if not os.path.exists(config_path):
             raise RuntimeError(

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -618,6 +618,7 @@ def validate_cloudconfig_file(config_path, schema, annotate=False):
                 " Try using sudo"
             )
         init = Init(ds_deps=[])
+        init.fetch(existing="trust")
         init.consume_data()
         content = load_file(init.paths.get_ipath("cloud_config"), decode=False)
     else:

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -43,13 +43,6 @@ class FakeDistro(object):
         return
 
 
-class FakeDatasource:
-    """Fake Datasource helper object"""
-
-    def __init__(self):
-        self.region = "region"
-
-
 class TestAptSourceConfig(TestCase):
     """TestAptSourceConfig
     Main Class to test apt_source configs

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -45,13 +45,6 @@ MOCK_LSB_RELEASE_DATA = {
 }
 
 
-class FakeDatasource:
-    """Fake Datasource helper object"""
-
-    def __init__(self):
-        self.region = "region"
-
-
 class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
     """TestAptSourceConfig
     Main Class to test apt configs

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -18,7 +18,7 @@ from typing import List, Optional, Sequence, Set
 
 import pytest
 
-from cloudinit import sources, stages
+from cloudinit import stages
 from cloudinit.config.schema import (
     CLOUD_CONFIG_HEADER,
     VERSIONED_USERDATA_SCHEMA_FILE,
@@ -51,19 +51,9 @@ from tests.unittests.helpers import (
     skipUnlessHypothesisJsonSchema,
     skipUnlessJsonSchema,
 )
+from tests.unittests.util import FakeDataSource
 
 M_PATH = "cloudinit.config.schema."
-
-INSTANCE_ID = "i-testing"
-
-
-class FakeDataSource(sources.DataSource):
-    def __init__(self, userdata=None, vendordata=None, vendordata2=None):
-        sources.DataSource.__init__(self, {}, None, None)
-        self.metadata = {"instance-id": INSTANCE_ID}
-        self.userdata_raw = userdata
-        self.vendordata_raw = vendordata
-        self.vendordata2_raw = vendordata2
 
 
 def get_schemas() -> dict:

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -16,23 +16,13 @@ import httpretty
 
 from cloudinit import handlers
 from cloudinit import helpers as c_helpers
-from cloudinit import log, safeyaml, sources, stages
+from cloudinit import log, safeyaml, stages
 from cloudinit import user_data as ud
 from cloudinit import util
 from cloudinit.config.modules import Modules
 from cloudinit.settings import PER_INSTANCE
 from tests.unittests import helpers
-
-INSTANCE_ID = "i-testing"
-
-
-class FakeDataSource(sources.DataSource):
-    def __init__(self, userdata=None, vendordata=None, vendordata2=None):
-        sources.DataSource.__init__(self, {}, None, None)
-        self.metadata = {"instance-id": INSTANCE_ID}
-        self.userdata_raw = userdata
-        self.vendordata_raw = vendordata
-        self.vendordata2_raw = vendordata2
+from tests.unittests.util import FakeDataSource
 
 
 def count_messages(root):

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -11,29 +11,9 @@ from cloudinit.event import EventScope, EventType
 from cloudinit.sources import NetworkConfigSource
 from cloudinit.util import write_file
 from tests.unittests.helpers import mock
+from tests.unittests.util import TEST_INSTANCE_ID, FakeDataSource
 
-TEST_INSTANCE_ID = "i-testing"
 M_PATH = "cloudinit.stages."
-
-
-class FakeDataSource(sources.DataSource):
-    def __init__(
-        self, paths=None, userdata=None, vendordata=None, network_config=""
-    ):
-        super(FakeDataSource, self).__init__({}, None, paths=paths)
-        self.metadata = {"instance-id": TEST_INSTANCE_ID}
-        self.userdata_raw = userdata
-        self.vendordata_raw = vendordata
-        self._network_config = None
-        if network_config:  # Permit for None value to setup attribute
-            self._network_config = network_config
-
-    @property
-    def network_config(self):
-        return self._network_config
-
-    def _get_data(self):
-        return True
 
 
 class TestInit:

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -2,7 +2,7 @@
 from unittest import mock
 
 from cloudinit import cloud, distros, helpers
-from cloudinit.sources import DataSourceHostname
+from cloudinit.sources import DataSource, DataSourceHostname
 from cloudinit.sources.DataSourceNone import DataSourceNone
 
 
@@ -147,3 +147,32 @@ class MockDistro(distros.Distro):
 
     def update_package_sources(self):
         return (True, "yay")
+
+
+TEST_INSTANCE_ID = "i-testing"
+
+
+class FakeDataSource(DataSource):
+    def __init__(
+        self,
+        userdata=None,
+        vendordata=None,
+        vendordata2=None,
+        network_config="",
+        paths=None,
+    ):
+        DataSource.__init__(self, {}, None, paths=paths)
+        self.metadata = {"instance-id": TEST_INSTANCE_ID}
+        self.userdata_raw = userdata
+        self.vendordata_raw = vendordata
+        self.vendordata2_raw = vendordata2
+        self._network_config = None
+        if network_config:  # Permit for None value to setup attribute
+            self._network_config = network_config
+
+    @property
+    def network_config(self):
+        return self._network_config
+
+    def _get_data(self):
+        return True


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
schema: Resolve user-data if --system given

Validated the processed/rendered userdata instead of "userdata_raw"
so that `sudo cloud-init schema --system` provides a concise
error about what the procesed invalid user-data is.

LP: #1983306
```

## Additional Context
<!-- If relevant -->
SC-1215

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```bash
mkdir -p /tmp/instance-data

cat > /tmp/instance-data/user-data <<EOF
#cloud-config
runcmd:
- touch /root/hello.txt
EOF

cat > /tmp/instance-data/script.sh <<EOF
#!/bin/sh

touch /root/bye.txt
EOF
python -m cloudinit.cmd.main devel make-mime -a /tmp/instance-data/user-data:cloud-config -a /tmp/instance-data/script.sh:x-shellscript > /tmp/instance-data/userdata
gzip -f /tmp/instance-data/userdata
cd /tmp/instance-data && python3 -m http.server &

cat > /tmp/include.yaml <<EOF
#include http://0.0.0.0:8000/userdata.gz
EOF

lxc init ubuntu-daily:kinetic include-k -c user.user-data="$(cat /tmp/include.yaml)"
lxc config device add include-k hostbind proxy listen=tcp:0.0.0.0:8000 connect=tcp:0.0.0.0:8000 bind=instance
lxc config device add include-k host-cloud-init disk source="/home/aciba/canonical/cloud-init/cloudinit" path=/usr/lib/python3/dist-packages/cloudinit
lxc start include-k

lxc exec include-k -- cloud-init status --wait

# See raw userdata (this is ok/desired)
$ lxc exec include-k -- cloud-init query userdata
include http://0.0.0.0:8000/userdata.gz

# verify cloud-init schema --system alias for rendered user-data (not correct)
$ lxc exec include-k -- cloud-init schema --system --annotate
Valid cloud-config: system userdata

$ lxc exec include-k -- ls /root/*.txt
bye.txt  hello.txt
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
