### PR TITLE
test: use fake filesystem to avoid file removal

### DIFF
--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -57,6 +57,7 @@ def _replace_options(user: Optional[str] = None) -> str:
     return options
 
 
+@pytest.mark.usefixtures("fake_filesystem")
 @mock.patch(MODPATH + "ssh_util.setup_user_keys")
 class TestHandleSsh:
     """Test cc_ssh handling of ssh config."""

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -1,0 +1,57 @@
+import builtins
+import glob
+import os
+
+import pytest
+
+from cloudinit import atomic_helper, util
+from tests.unittests.helpers import retarget_many_wrapper
+
+FS_FUNCS = {
+    os.path: [
+        ("isfile", 1),
+        ("exists", 1),
+        ("islink", 1),
+        ("isdir", 1),
+        ("lexists", 1),
+        ("relpath", 1),
+    ],
+    os: [
+        ("listdir", 1),
+        ("mkdir", 1),
+        ("lstat", 1),
+        ("symlink", 2),
+        ("stat", 1),
+        ("scandir", 1),
+    ],
+    util: [
+        ("write_file", 1),
+        ("append_file", 1),
+        ("load_file", 1),
+        ("ensure_dir", 1),
+        ("chmod", 1),
+        ("delete_dir_contents", 1),
+        ("del_file", 1),
+        ("sym_link", -1),
+        ("copy", -1),
+    ],
+    glob: [
+        ("glob", 1),
+    ],
+    builtins: [
+        ("open", 1),
+    ],
+    atomic_helper: [
+        ("write_file", 1),
+    ],
+}
+
+
+@pytest.fixture
+def fake_filesystem(mocker, tmpdir):
+    """Mocks fs functions to operate under `tmpdir`"""
+    for (mod, funcs) in FS_FUNCS.items():
+        for f, nargs in funcs:
+            func = getattr(mod, f)
+            trap_func = retarget_many_wrapper(str(tmpdir), nargs, func)
+            mocker.patch.object(mod, f, trap_func)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
test: use fake filesystem to avoid file removal
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/1646

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
sudo touch /etc/ssh/ssh_host_a_key_b
sudo chown root:root /etc/ssh/ssh_host_a_key_b
sudo chmod 700 /etc/ssh/ssh_host_a_key_b

tox -e py3
# This should without complaining about not able to delete /etc/ssh/ssh_host_a_key_b

./package/bddeb -d
# This should build
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
