### PR TITLE
net: Passthough v2 netconfigs in netplan systems

### DIFF
--- a/cloudinit/cmd/devel/net_convert.py
+++ b/cloudinit/cmd/devel/net_convert.py
@@ -133,13 +133,17 @@ def handle_args(name, args):
         config = ovf.Config(ovf.ConfigFile(args.network_data.name))
         pre_ns = ovf.get_network_config_from_conf(config, False)
 
-    ns = network_state.parse_net_config_data(pre_ns)
+    if args.output_kind == "netplan" and pre_ns.get("version") == 2:
+        if args.debug:
+            sys.stderr.write("Passthrough netplan v2 config")
+        ns = network_state.NetworkState.to_passthrough(pre_ns)
+    else:
+        ns = network_state.parse_net_config_data(pre_ns)
 
     if args.debug:
         sys.stderr.write("\n".join(["", "Internal State", yaml.dump(ns), ""]))
     distro_cls = distros.fetch(args.distro)
     distro = distro_cls(args.distro, {}, None)
-    config = {}
     if args.output_kind == "eni":
         r_cls = eni.Renderer
         config = distro.renderer_configs.get("eni")

--- a/cloudinit/cmd/devel/net_convert.py
+++ b/cloudinit/cmd/devel/net_convert.py
@@ -133,15 +133,6 @@ def handle_args(name, args):
         config = ovf.Config(ovf.ConfigFile(args.network_data.name))
         pre_ns = ovf.get_network_config_from_conf(config, False)
 
-    if args.output_kind == "netplan" and pre_ns.get("version") == 2:
-        if args.debug:
-            sys.stderr.write("Passthrough netplan v2 config")
-        ns = network_state.NetworkState.to_passthrough(pre_ns)
-    else:
-        ns = network_state.parse_net_config_data(pre_ns)
-
-    if args.debug:
-        sys.stderr.write("\n".join(["", "Internal State", yaml.dump(ns), ""]))
     distro_cls = distros.fetch(args.distro)
     distro = distro_cls(args.distro, {}, None)
     if args.output_kind == "eni":
@@ -169,6 +160,11 @@ def handle_args(name, args):
         raise RuntimeError("Invalid output_kind")
 
     r = r_cls(config=config)
+    ns = network_state.parse_net_config_data(pre_ns, renderer=r)
+
+    if args.debug:
+        sys.stderr.write("\n".join(["", "Internal State", yaml.dump(ns), ""]))
+
     sys.stderr.write(
         "".join(
             [

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -24,8 +24,7 @@ from cloudinit import net, persistence, ssh_util, subp, type_utils, util
 from cloudinit.distros.parsers import hosts
 from cloudinit.features import ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES
 from cloudinit.net import activators, eni, network_state, renderers
-from cloudinit.net.netplan import Renderer as NetplanRenderer
-from cloudinit.net.network_state import NetworkState, parse_net_config_data
+from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.net.renderer import Renderer
 
 from .networking import LinuxNetworking, Networking
@@ -254,14 +253,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 netconfig, bring_up=bring_up
             )
 
-        if (
-            isinstance(renderer, NetplanRenderer)
-            and netconfig.get("version") == 2
-        ):
-            LOG.debug("Passthrough netplan v2 config")
-            network_state = NetworkState.to_passthrough(netconfig)
-        else:
-            network_state = parse_net_config_data(netconfig)
+        network_state = parse_net_config_data(netconfig, renderer=renderer)
         self._write_network_state(network_state, renderer)
 
         # Now try to bring them up

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -11,6 +11,7 @@ from cloudinit import log as logging
 from cloudinit import subp, util
 from cloudinit.distros import net_util
 from cloudinit.distros.parsers.hostname import HostnameConf
+from cloudinit.net.renderer import Renderer
 from cloudinit.net.renderers import RendererNotFoundError
 from cloudinit.settings import PER_INSTANCE
 
@@ -61,9 +62,9 @@ class Distro(distros.Distro):
         self.update_package_sources()
         self.package_command("", pkgs=pkglist)
 
-    def _write_network_state(self, network_state):
+    def _get_renderer(self) -> Renderer:
         try:
-            super()._write_network_state(network_state)
+            return super()._get_renderer()
         except RendererNotFoundError as e:
             # Fall back to old _write_network
             raise NotImplementedError from e

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -137,9 +137,9 @@ class Distro(distros.Distro):
         self.update_package_sources()
         self.package_command("install", pkgs=pkglist)
 
-    def _write_network_state(self, network_state):
+    def _write_network_state(self, *args, **kwargs):
         _maybe_remove_legacy_eth0()
-        return super()._write_network_state(network_state)
+        return super()._write_network_state(*args, **kwargs)
 
     def _write_hostname(self, hostname, filename):
         conf = None

--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -1,11 +1,13 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import re
+from typing import Optional
 
 from cloudinit import log as logging
 from cloudinit import net, subp, util
 from cloudinit.distros import bsd_utils
 from cloudinit.distros.parsers.resolv_conf import ResolvConf
+from cloudinit.net.network_state import NetworkState
 
 from . import renderer
 
@@ -156,7 +158,12 @@ class BSDRenderer(renderer.Renderer):
             0o644,
         )
 
-    def render_network_state(self, network_state, templates=None, target=None):
+    def render_network_state(
+        self,
+        network_state: NetworkState,
+        templates: Optional[dict] = None,
+        target=None,
+    ) -> None:
         if target:
             self.target = target
         self._ifconfig_entries(settings=network_state)

--- a/cloudinit/net/eni.py
+++ b/cloudinit/net/eni.py
@@ -4,10 +4,12 @@ import copy
 import glob
 import os
 import re
+from typing import Optional
 
 from cloudinit import log as logging
 from cloudinit import subp, util
 from cloudinit.net import subnet_is_ipv6
+from cloudinit.net.network_state import NetworkState
 
 from . import ParserError, renderer
 
@@ -561,7 +563,12 @@ class Renderer(renderer.Renderer):
 
         return "\n\n".join(["\n".join(s) for s in sections]) + "\n"
 
-    def render_network_state(self, network_state, templates=None, target=None):
+    def render_network_state(
+        self,
+        network_state: NetworkState,
+        templates: Optional[dict] = None,
+        target=None,
+    ) -> None:
         fpeni = subp.target_path(target, self.eni_path)
         util.ensure_dir(os.path.dirname(fpeni))
         header = self.eni_header if self.eni_header else ""

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -3,7 +3,7 @@
 import copy
 import os
 import textwrap
-from typing import cast
+from typing import Optional, cast
 
 from cloudinit import log as logging
 from cloudinit import safeyaml, subp, util
@@ -240,7 +240,12 @@ class Renderer(renderer.Renderer):
                 LOG.debug("Failed to list features from netplan info: %s", e)
         return self._features
 
-    def render_network_state(self, network_state, templates=None, target=None):
+    def render_network_state(
+        self,
+        network_state: NetworkState,
+        templates: Optional[dict] = None,
+        target=None,
+    ) -> None:
         # check network state for version
         # if v2, then extract network_state.config
         # else render_v2_from_state

--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -11,10 +11,12 @@ import io
 import itertools
 import os
 import uuid
+from typing import Optional
 
 from cloudinit import log as logging
 from cloudinit import subp, util
 from cloudinit.net import is_ipv6_address, subnet_is_ipv6
+from cloudinit.net.network_state import NetworkState
 
 from . import renderer
 
@@ -344,7 +346,12 @@ class Renderer(renderer.Renderer):
             # Well, what can we do...
             return con_id
 
-    def render_network_state(self, network_state, templates=None, target=None):
+    def render_network_state(
+        self,
+        network_state: NetworkState,
+        templates: Optional[dict] = None,
+        target=None,
+    ) -> None:
         # First pass makes sure there's NMConnections for all known
         # interfaces that have UUIDs that can be linked to from related
         # interfaces

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -136,14 +136,16 @@ class CommandHandlerMeta(type):
 
 
 class NetworkState(object):
-    def __init__(self, network_state, version=NETWORK_STATE_VERSION):
+    def __init__(
+        self, network_state: dict, version: int = NETWORK_STATE_VERSION
+    ):
         self._network_state = copy.deepcopy(network_state)
         self._version = version
         self.use_ipv6 = network_state.get("use_ipv6", False)
         self._has_default_route = None
 
     @property
-    def config(self):
+    def config(self) -> dict:
         return self._network_state["config"]
 
     @property
@@ -203,6 +205,20 @@ class NetworkState(object):
         return (
             route.get("prefix") == 0 and route.get("network") in default_nets
         )
+
+    @classmethod
+    def to_passthrough(cls, network_state: dict) -> "NetworkState":
+        """Instantiates a `NetworkState` without interpreting its data.
+
+        That means only `config` and `version` are copied.
+
+        :param network_state: Network state data.
+        :return: Instance of `NetworkState`.
+        """
+        kwargs = {}
+        if "version" in network_state:
+            kwargs["version"] = network_state["version"]
+        return cls({"config": network_state}, **kwargs)
 
 
 class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
@@ -268,7 +284,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
     def as_dict(self):
         return {"version": self._version, "config": self._config}
 
-    def get_network_state(self):
+    def get_network_state(self) -> NetworkState:
         ns = self.network_state
         return ns
 
@@ -1044,7 +1060,9 @@ def _normalize_subnets(subnets):
     return [_normalize_subnet(s) for s in subnets]
 
 
-def parse_net_config_data(net_config, skip_broken=True) -> NetworkState:
+def parse_net_config_data(
+    net_config: dict, skip_broken: bool = True
+) -> NetworkState:
     """Parses the config, returns NetworkState object
 
     :param net_config: curtin network config dict

--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -8,9 +8,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 from collections import OrderedDict
+from typing import Optional
 
 from cloudinit import log as logging
 from cloudinit import subp, util
+from cloudinit.net.network_state import NetworkState
 
 from . import renderer
 
@@ -217,7 +219,12 @@ class Renderer(renderer.Renderer):
         util.write_file(net_fn, conf)
         util.chownbyname(net_fn, net_fn_owner, net_fn_owner)
 
-    def render_network_state(self, network_state, templates=None, target=None):
+    def render_network_state(
+        self,
+        network_state: NetworkState,
+        templates: Optional[dict] = None,
+        target=None,
+    ) -> None:
         network_dir = self.network_conf_dir
         if target:
             network_dir = subp.target_path(target) + network_dir

--- a/cloudinit/net/renderer.py
+++ b/cloudinit/net/renderer.py
@@ -7,6 +7,7 @@
 
 import abc
 import io
+from typing import Optional
 
 from cloudinit.net.network_state import NetworkState, parse_net_config_data
 from cloudinit.net.udev import generate_udev_rule
@@ -49,11 +50,19 @@ class Renderer(object):
         return content.getvalue()
 
     @abc.abstractmethod
-    def render_network_state(self, network_state, templates=None, target=None):
+    def render_network_state(
+        self,
+        network_state: NetworkState,
+        templates: Optional[dict] = None,
+        target=None,
+    ) -> None:
         """Render network state."""
 
     def render_network_config(
-        self, network_config, templates=None, target=None
+        self,
+        network_config: dict,
+        templates: Optional[dict] = None,
+        target=None,
     ):
         return self.render_network_state(
             network_state=parse_net_config_data(network_config),

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -4,7 +4,7 @@ import copy
 import io
 import os
 import re
-from typing import Mapping
+from typing import Mapping, Optional
 
 from cloudinit import log as logging
 from cloudinit import subp, util
@@ -980,8 +980,11 @@ class Renderer(renderer.Renderer):
         return contents
 
     def render_network_state(
-        self, network_state: NetworkState, templates=None, target=None
-    ):
+        self,
+        network_state: NetworkState,
+        templates: Optional[dict] = None,
+        target=None,
+    ) -> None:
         if not templates:
             templates = self.templates
         file_mode = 0o644

--- a/tests/unittests/cmd/devel/test_net_convert.py
+++ b/tests/unittests/cmd/devel/test_net_convert.py
@@ -227,7 +227,6 @@ class TestNetConvert:
         if debug:
             _out, err = capsys.readouterr()
             assert "Passthrough netplan v2 config" in err
-            assert "V2 to V2 passthrough" in err
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/cmd/devel/test_net_convert.py
+++ b/tests/unittests/cmd/devel/test_net_convert.py
@@ -185,7 +185,7 @@ class TestNetConvert:
                 ] == chown.call_args_list
 
     @pytest.mark.parametrize("debug", (False, True))
-    def test_convert_netplan_passthrough(self, debug, capsys, tmpdir):
+    def test_convert_netplan_passthrough(self, debug, tmpdir):
         """Assert that if the network config's version is 2 and the renderer is
         Netplan, then the config is passed through as-is.
         """
@@ -224,9 +224,6 @@ class TestNetConvert:
             net_convert.handle_args("somename", args)
         outfile = tmpdir.join("etc/netplan/50-cloud-init.yaml")
         assert yaml.load(content) == yaml.load(outfile.read())
-        if debug:
-            _out, err = capsys.readouterr()
-            assert "Passthrough netplan v2 config" in err
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/cmd/devel/test_net_convert.py
+++ b/tests/unittests/cmd/devel/test_net_convert.py
@@ -4,6 +4,7 @@ import itertools
 
 import pytest
 
+from cloudinit import safeyaml as yaml
 from cloudinit.cmd.devel import net_convert
 from cloudinit.distros.debian import NETWORK_FILE_HEADER
 from tests.unittests.helpers import mock
@@ -182,6 +183,51 @@ class TestNetConvert:
                         outfile.strpath, "systemd-network", "systemd-network"
                     )
                 ] == chown.call_args_list
+
+    @pytest.mark.parametrize("debug", (False, True))
+    def test_convert_netplan_passthrough(self, debug, capsys, tmpdir):
+        """Assert that if the network config's version is 2 and the renderer is
+        Netplan, then the config is passed through as-is.
+        """
+        network_data = tmpdir.join("network_data")
+        # `default` as a route supported by Netplan but not by cloud-init
+        content = """\
+        network:
+          version: 2
+          ethernets:
+            enp0s3:
+              dhcp4: false
+              addresses: [10.0.4.10/24]
+              nameservers:
+                addresses: [10.0.4.1]
+              routes:
+              - to: default
+                via: 10.0.4.1
+                metric: 100
+        """
+        network_data.write(content)
+        args = [
+            "-m",
+            "enp0s3,AA",
+            f"--directory={tmpdir.strpath}",
+            f"--network-data={network_data.strpath}",
+            "--distro=ubuntu",
+            "--kind=yaml",
+            "--output-kind=netplan",
+        ]
+        if debug:
+            args.append("--debug")
+        params = self._replace_path_args(args, tmpdir)
+        with mock.patch("sys.argv", ["net-convert"] + params):
+            args = net_convert.get_parser().parse_args()
+        with mock.patch("cloudinit.util.chownbyname"):
+            net_convert.handle_args("somename", args)
+        outfile = tmpdir.join("etc/netplan/50-cloud-init.yaml")
+        assert yaml.load(content) == yaml.load(outfile.read())
+        if debug:
+            _out, err = capsys.readouterr()
+            assert "Passthrough netplan v2 config" in err
+            assert "V2 to V2 passthrough" in err
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/net/test_network_state.py
+++ b/tests/unittests/net/test_network_state.py
@@ -79,7 +79,8 @@ class TestNetworkStateParseConfig(CiTestCase):
         ncfg = {"version": 2, "otherconfig": {}, "somemore": [1, 2, 3]}
         network_state.parse_net_config_data(ncfg)
         self.assertEqual(
-            [mock.call(version=2, config=ncfg)], self.m_nsi.call_args_list
+            [mock.call(version=2, config=ncfg, renderer=None)],
+            self.m_nsi.call_args_list,
         )
 
     def test_valid_config_gets_network_state(self):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
net: Passthough v2 raw net_conf in netplan systems

Adhere to Netplan Passthrough documented behavior,
not limiting v2 netplan configs to the subset of
props that cloud-init supports.

LP: #1978543
```

## Additional Context
<!-- If relevant -->
SC-1120
https://bugs.launchpad.net/cloud-init/+bug/1978543
[Netplan Passthrough](https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html#netplan-passthrough)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
cat > /tmp/lp1978543.yaml <<EOF
network:
  version: 2
  ethernets:
    enp0s3:
      dhcp4: false
      addresses: [10.0.4.10/24]
      nameservers:
        addresses: [10.0.4.1]
      routes:
      - to: default
        via: 10.0.4.1
        metric: 100
EOF

lxc init ubuntu-daily:jammy lp1978543
lxc file push /tmp/lp1978543.yaml lp1978543/etc/cloud/cloud.cfg.d/custom-networking.cfg
lxc file push /tmp/lp1978543.yaml lp1978543/root/
lxc start lp1978543
lxc exec lp1978543 -- cloud-init status --wait

lxc exec lp1978543 -- grep -in valueerror /var/log/cloud-init.log
# No errors found
$ lxc exec lp1978543 -- cat /etc/netplan/50-cloud-init.yaml
...
network:
    ethernets:
        enp0s3:
            addresses:
            - 10.0.4.10/24
            dhcp4: false
            nameservers:
                addresses:
                - 10.0.4.1
            routes:
            -   metric: 100
                to: default
                via: 10.0.4.1
    version: 2

lxc exec lp1978543 -- python3 -m cloudinit.cmd.main devel net-convert -m enp0s3,AA -O netplan --k yaml -p lp1978543.yaml -D ubuntu -d out
# No errors found

$ lxc exec lp1978543 -- cat out/etc/netplan/50-cloud-init.yaml
...
network:
    ethernets:
        enp0s3:
            addresses:
            - 10.0.4.10/24
            dhcp4: false
            nameservers:
                addresses:
                - 10.0.4.1
            routes:
            -   metric: 100
                to: default
                via: 10.0.4.1
    version: 2
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
