### PR TITLE
Return cc_set_hostname to PER_INSTANCE frequency (SC-1222)

### DIFF
--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -14,9 +14,9 @@ from cloudinit import util
 from cloudinit.atomic_helper import write_json
 from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.distros import ALL_DISTROS
-from cloudinit.settings import PER_ALWAYS
+from cloudinit.settings import PER_INSTANCE
 
-frequency = PER_ALWAYS
+frequency = PER_INSTANCE
 MODULE_DESCRIPTION = """\
 This module handles setting the system hostname and fully qualified domain
 name (FQDN). If ``preserve_hostname`` is set, then the hostname will not be


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Return cc_set_hostname to PER_INSTANCE frequency

In 96eb95a the frequency was inadvertently changed to ALWAYS due to
the documentation being incorrect. The code and documentation should
now align to be PER_INSTANCE.

LP: #1983811

```
