### PR TITLE
Holmanb/lxd ig test

### DIFF
--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -50,7 +50,7 @@ class TestLxdBridge:
         verify_clean_log(cloud_init_log)
 
         # The bridge should exist
-        assert class_client.execute("ip addr show lxdbr0")
+        assert class_client.execute("ip addr show lxdbr0").ok
 
         raw_network_config = class_client.execute("lxc network show lxdbr0")
         network_config = yaml.safe_load(raw_network_config)
@@ -59,7 +59,6 @@ class TestLxdBridge:
 
 def validate_storage(validate_client, pkg_name, command):
     log = validate_client.read_from_file("/var/log/cloud-init.log")
-    assert re.search(f"apt-get.*install.*{pkg_name}", log) is not None
     verify_clean_log(log, ignore_deprecations=False)
     return log
 


### PR DESCRIPTION
```
test: drop erroneous lxd assertion, ensure that result is ok
```

## Additional Context
```
    def validate_storage(validate_client, pkg_name, command):
        log = validate_client.read_from_file("/var/log/cloud-init.log")
>       assert re.search(f"apt-get.*install.*{pkg_name}", log) is not None
E       assert None is not None
```

Since we dropped the forced install test logic in https://github.com/canonical/cloud-init/commit/92c43874cc35e66a240d41cda7ce63c3b427e898, we should not assert that this was done.

https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-gce/79/testReport/junit/tests.integration_tests.modules/test_lxd/test_storage_lvm/
