### PR TITLE
Prevent concurrency issue in test_webhook_hander.py

### DIFF
--- a/tests/unittests/reporting/test_webhook_handler.py
+++ b/tests/unittests/reporting/test_webhook_handler.py
@@ -106,13 +106,14 @@ class TestWebHookHandler:
         for all messages to be posted
         """
         responses.add(responses.POST, "http://localhost", status=404)
-        for _ in range(20):
+        for _ in range(10):
             report_start_event("name", "description")
         start_time = time.time()
         while time.time() - start_time < 3:
             with suppress(AssertionError):
-                assert 20 == caplog.text.count("Failed posting event")
+                assert 10 == caplog.text.count("Failed posting event")
                 break
+            time.sleep(0.01)  # Force context switch
         else:
             pytest.fail(
                 "Expected 20 failures, only got "


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Prevent concurrency issue in test_webhook_hander.py

There were very occassionally failures seen in
test_multiple_failures_no_flush, likely due to the background thread not
having enough CPU time. Reduce background thread load and add short
sleep in main loop to fix issue.
```

## Additional Context
I haven't been able to intentionally reproduce this bug, but I have seen it a few times in the past couple of months.

One such error:
```
    @responses.activate
    def test_multiple_failures_no_flush(self, caplog):
        """Test we don't cancel posting if flush hasn't been requested.
    
        Since processing happens in the background, wait in a loop
        for all messages to be posted
        """
        responses.add(responses.POST, "http://localhost", status=404)
        for _ in range(20):
            report_start_event("name", "description")
        start_time = time.time()
        while time.time() - start_time < 3:
            with suppress(AssertionError):
                assert 20 == caplog.text.count("Failed posting event")
                break
        else:
            pytest.fail(
>               "Expected 20 failures, only got "
                f"{caplog.text.count('Failed posting event')}"
            )
E           Failed: Expected 20 failures, only got 18

tests/unittests/reporting/test_webhook_handler.py:118: Failed
```