### PR TITLE
integration tests: Ensure one image for all tests

### DIFF
--- a/tests/integration_tests/bugs/test_lp1835584.py
+++ b/tests/integration_tests/bugs/test_lp1835584.py
@@ -84,7 +84,13 @@ def test_azure_kernel_upgrade_case_insensitive_uuid(
         pytest.skip(
             "Provide CLOUD_INIT_SOURCE to install expected working cloud-init"
         )
-    with session_cloud.launch() as instance:
+    with session_cloud.launch(
+        launch_kwargs={
+            "image_id": session_cloud.cloud_instance.daily_image(
+                cfg_image_spec.image_id, image_type=ImageType.PRO_FIPS
+            )
+        }
+    ) as instance:
         # We can't use setup_image fixture here because we want to avoid
         # taking a snapshot or cleaning the booted machine after cloud-init
         # upgrade.


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
integration tests: Ensure one image for all tests

In bccf9a5, integration test setup was inadvertently changed to force
image setup for every test. Revert that behavior back.

```

Haven't fully tested things yet, but wanted to get it available sooner rather than later.