### PR TITLE
cli: status machine-readable output --format yaml/json

### DIFF
--- a/cloudinit/cmd/cloud_id.py
+++ b/cloudinit/cmd/cloud_id.py
@@ -65,12 +65,12 @@ def handle_args(name, args):
 
     @return: 0 on success, 1 on error, 2 on disabled, 3 on cloud-init not run.
     """
-    status, _status_details, _time = get_status_details()
-    if status == UXAppStatus.DISABLED:
-        sys.stdout.write("{0}\n".format(status.value))
+    status_details = get_status_details()
+    if status_details.status == UXAppStatus.DISABLED:
+        sys.stdout.write("{0}\n".format(status_details.status.value))
         return 2
-    elif status == UXAppStatus.NOT_RUN:
-        sys.stdout.write("{0}\n".format(status.value))
+    elif status_details.status == UXAppStatus.NOT_RUN:
+        sys.stdout.write("{0}\n".format(status_details.status.value))
         return 3
 
     try:
@@ -92,6 +92,7 @@ def handle_args(name, args):
         v1.get("platform", METADATA_UNKNOWN),
     )
     if args.json:
+        sys.stderr.write("DEPRECATED: Use: cloud-init query v1\n")
         v1["cloud_id"] = cloud_id
         response = json.dumps(  # Pretty, sorted json
             v1, indent=1, sort_keys=True, separators=(",", ": ")

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -154,7 +154,7 @@ def handle_status_args(name, args) -> int:
     elif args.format == "json":
         print(
             json.dumps(  # Pretty, sorted json
-                details_dict, indent=1, sort_keys=True, separators=(",", ": ")
+                details_dict, indent=2, sort_keys=True, separators=(",", ": ")
             )
         )
     elif args.format == "yaml":
@@ -207,13 +207,12 @@ def get_status_details(paths=None) -> StatusDetails:
     status = UXAppStatus.NOT_RUN
     errors = []
     datasource = ""
-    description = ""
     status_v1 = {}
 
     status_file = os.path.join(paths.run_dir, "status.json")
     result_file = os.path.join(paths.run_dir, "result.json")
 
-    (boot_status_code, description) = get_bootstatus(
+    boot_status_code, description = get_bootstatus(
         CLOUDINIT_DISABLED_FILE, paths
     )
     if boot_status_code in DISABLED_BOOT_CODES:

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -7,12 +7,15 @@
 """Define 'status' utility and handler as part of cloud-init commandline."""
 
 import argparse
+import copy
 import enum
+import json
 import os
 import sys
 from time import gmtime, sleep, strftime
-from typing import Tuple
+from typing import Any, Dict, List, NamedTuple, Tuple, Union
 
+from cloudinit import safeyaml
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.distros import uses_systemd
 from cloudinit.util import get_cmdline, load_file, load_json
@@ -32,6 +35,43 @@ class UXAppStatus(enum.Enum):
     DISABLED = "disabled"
 
 
+@enum.unique
+class UXAppBootStatusCode(enum.Enum):
+    """Enum representing user-visible cloud-init boot status codes."""
+
+    DISABLED_BY_GENERATOR = "disabled-by-generator"
+    DISABLED_BY_KERNEL_CMDLINE = "disabled-by-kernel-cmdline"
+    DISABLED_BY_MARKER_FILE = "disabled-by-marker-file"
+    ENABLED_BY_GENERATOR = "enabled-by-generator"
+    ENABLED_BY_KERNEL_CMDLINE = "enabled-by-kernel-cmdline"
+    ENABLED_BY_SYSVINIT = "enabled-by-sysvinit"
+    UNKNOWN = "unknown"
+
+
+DISABLED_BOOT_CODES = frozenset(
+    [
+        UXAppBootStatusCode.DISABLED_BY_GENERATOR,
+        UXAppBootStatusCode.DISABLED_BY_KERNEL_CMDLINE,
+        UXAppBootStatusCode.DISABLED_BY_MARKER_FILE,
+    ]
+)
+
+
+class StatusDetails(NamedTuple):
+    status: UXAppStatus
+    boot_status_code: UXAppBootStatusCode
+    description: str
+    errors: List[str]
+    last_update: str
+    datasource: str
+
+
+TABULAR_LONG_TMPL = """\
+boot_status_code: {boot_code}
+{last_update}detail:
+{description}"""
+
+
 def get_parser(parser=None):
     """Build or extend an arg parser for status utility.
 
@@ -45,6 +85,13 @@ def get_parser(parser=None):
         parser = argparse.ArgumentParser(
             prog="status", description="Report run status of cloud init"
         )
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=["json", "tabular", "yaml"],
+        default="tabular",
+        help="Specify output format for cloud-id (default: tabular)",
+    )
     parser.add_argument(
         "-l",
         "--long",
@@ -69,54 +116,87 @@ def handle_status_args(name, args) -> int:
     """Handle calls to 'cloud-init status' as a subcommand."""
     # Read configured paths
     paths = read_cfg_paths()
-    status, status_detail, time = get_status_details(paths)
+    details = get_status_details(paths)
     if args.wait:
-        while status in (UXAppStatus.NOT_RUN, UXAppStatus.RUNNING):
-            sys.stdout.write(".")
-            sys.stdout.flush()
-            status, status_detail, time = get_status_details(paths)
+        while details.status in (UXAppStatus.NOT_RUN, UXAppStatus.RUNNING):
+            if args.format == "tabular":
+                sys.stdout.write(".")
+                sys.stdout.flush()
+            details = get_status_details(paths)
             sleep(0.25)
-        sys.stdout.write("\n")
-    print("status: {0}".format(status.value))
-    if args.long:
-        if time:
-            print("time: {0}".format(time))
-        print("detail:\n{0}".format(status_detail))
-    return 1 if status == UXAppStatus.ERROR else 0
+    details_dict: Dict[str, Union[str, List[str], Dict[str, Any]]] = {
+        "datasource": details.datasource,
+        "boot_status_code": details.boot_status_code.value,
+        "status": details.status.value,
+        "detail": details.description,
+        "errors": details.errors,
+        "last_update": details.last_update,
+    }
+    details_dict["schemas"] = {"1": copy.deepcopy(details_dict)}
+    details_dict["_schema_version"] = "1"
+
+    if args.format == "tabular":
+        prefix = "\n" if args.wait else ""
+        print(f"{prefix}status: {details.status.value}")
+        if args.long:
+            if details.last_update:
+                last_update = f"last_update: {details.last_update}\n"
+            else:
+                last_update = ""
+            print(
+                TABULAR_LONG_TMPL.format(
+                    prefix=prefix,
+                    boot_code=details.boot_status_code.value,
+                    description=details.description,
+                    last_update=last_update,
+                )
+            )
+    elif args.format == "json":
+        print(
+            json.dumps(  # Pretty, sorted json
+                details_dict, indent=1, sort_keys=True, separators=(",", ": ")
+            )
+        )
+    elif args.format == "yaml":
+        print(safeyaml.dumps(details_dict))
+    return 1 if details.status == UXAppStatus.ERROR else 0
 
 
-def _is_cloudinit_disabled(disable_file, paths):
-    """Report whether cloud-init is disabled.
+def get_bootstatus(disable_file, paths) -> Tuple[UXAppBootStatusCode, str]:
+    """Report whether cloud-init current boot status
 
     @param disable_file: The path to the cloud-init disable file.
     @param paths: An initialized cloudinit.helpers.Paths object.
-    @returns: A tuple containing (bool, reason) about cloud-init's status and
+    @returns: A tuple containing (code, reason) about cloud-init's status and
     why.
     """
-    is_disabled = False
     cmdline_parts = get_cmdline().split()
     if not uses_systemd():
+        bootstatus_code = UXAppBootStatusCode.ENABLED_BY_SYSVINIT
         reason = "Cloud-init enabled on sysvinit"
     elif "cloud-init=enabled" in cmdline_parts:
+        bootstatus_code = UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE
         reason = "Cloud-init enabled by kernel command line cloud-init=enabled"
     elif os.path.exists(disable_file):
-        is_disabled = True
+        bootstatus_code = UXAppBootStatusCode.DISABLED_BY_MARKER_FILE
         reason = "Cloud-init disabled by {0}".format(disable_file)
     elif "cloud-init=disabled" in cmdline_parts:
-        is_disabled = True
+        bootstatus_code = UXAppBootStatusCode.DISABLED_BY_KERNEL_CMDLINE
         reason = "Cloud-init disabled by kernel parameter cloud-init=disabled"
     elif os.path.exists(os.path.join(paths.run_dir, "disabled")):
-        is_disabled = True
+        bootstatus_code = UXAppBootStatusCode.DISABLED_BY_GENERATOR
         reason = "Cloud-init disabled by cloud-init-generator"
     elif os.path.exists(os.path.join(paths.run_dir, "enabled")):
+        bootstatus_code = UXAppBootStatusCode.ENABLED_BY_GENERATOR
         reason = "Cloud-init enabled by systemd cloud-init-generator"
     else:
+        bootstatus_code = UXAppBootStatusCode.UNKNOWN
         reason = "Systemd generator may not have run yet."
-    return (is_disabled, reason)
+    return (bootstatus_code, reason)
 
 
-def get_status_details(paths=None) -> Tuple[UXAppStatus, str, str]:
-    """Return a 3-tuple of status, status_details and time of last event.
+def get_status_details(paths=None) -> StatusDetails:
+    """Return a dict with status, details and errors.
 
     @param paths: An initialized cloudinit.helpers.paths object.
 
@@ -125,31 +205,33 @@ def get_status_details(paths=None) -> Tuple[UXAppStatus, str, str]:
     paths = paths or read_cfg_paths()
 
     status = UXAppStatus.NOT_RUN
-    status_detail = ""
+    errors = []
+    datasource = ""
+    description = ""
     status_v1 = {}
 
     status_file = os.path.join(paths.run_dir, "status.json")
     result_file = os.path.join(paths.run_dir, "result.json")
 
-    (is_disabled, reason) = _is_cloudinit_disabled(
+    (boot_status_code, description) = get_bootstatus(
         CLOUDINIT_DISABLED_FILE, paths
     )
-    if is_disabled:
+    if boot_status_code in DISABLED_BOOT_CODES:
         status = UXAppStatus.DISABLED
-        status_detail = reason
     if os.path.exists(status_file):
         if not os.path.exists(result_file):
             status = UXAppStatus.RUNNING
         status_v1 = load_json(load_file(status_file)).get("v1", {})
-    errors = []
     latest_event = 0
     for key, value in sorted(status_v1.items()):
         if key == "stage":
             if value:
                 status = UXAppStatus.RUNNING
-                status_detail = "Running in stage: {0}".format(value)
+                description = "Running in stage: {0}".format(value)
         elif key == "datasource":
-            status_detail = value
+            description = value
+            datasource, _, _ = value.partition(" ")
+            datasource = datasource.lower().replace("datasource", "")
         elif isinstance(value, dict):
             errors.extend(value.get("errors", []))
             start = value.get("start") or 0
@@ -161,14 +243,17 @@ def get_status_details(paths=None) -> Tuple[UXAppStatus, str, str]:
                 latest_event = event_time
     if errors:
         status = UXAppStatus.ERROR
-        status_detail = "\n".join(errors)
+        description = "\n".join(errors)
     elif status == UXAppStatus.NOT_RUN and latest_event > 0:
         status = UXAppStatus.DONE
-    if latest_event:
-        time = strftime("%a, %d %b %Y %H:%M:%S %z", gmtime(latest_event))
-    else:
-        time = ""
-    return status, status_detail, time
+    last_update = (
+        strftime("%a, %d %b %Y %H:%M:%S %z", gmtime(latest_event))
+        if latest_event
+        else ""
+    )
+    return StatusDetails(
+        status, boot_status_code, description, errors, last_update, datasource
+    )
 
 
 def main():

--- a/doc/rtd/topics/boot.rst
+++ b/doc/rtd/topics/boot.rst
@@ -153,7 +153,7 @@ Things that run here include:
  * user-defined scripts (i.e. shell scripts passed as user-data)
 
 For scripts external to cloud-init looking to wait until cloud-init is
-finished, the ``cloud-init status`` subcommand can help block external
+finished, the ``cloud-init status --wait`` subcommand can help block external
 scripts until cloud-init is done without having to write your own systemd
 units dependency chains. See :ref:`cli_status` for more info.
 

--- a/doc/rtd/topics/cli.rst
+++ b/doc/rtd/topics/cli.rst
@@ -303,6 +303,8 @@ non-zero if an error is detected in cloud-init.
 
 * ``--long``: detailed status information
 * ``--wait``: block until cloud-init completes
+* ``--format [yaml|json|tabular]``: machine-readable JSON or YAML detailed
+                                    output
 
 Below are examples of output when cloud-init is running, showing status and
 the currently running modules, as well as when it is done.
@@ -323,8 +325,19 @@ the currently running modules, as well as when it is done.
 
   $ cloud-init status --long
   status: done
-  time: Wed, 17 Jan 2018 20:41:59 +0000
+  boot_status_code: enabled-by-generator
+  last_update: Tue, 16 Aug 2022 19:12:58 +0000
   detail:
   DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]
+
+  $ cloud-init status --format=json
+  {
+   "boot_status_code": "enabled-by-generator",
+   "datasource": "nocloud",
+   "detail": "DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]",
+   "errors": [],
+   "last_update": "Tue, 16 Aug 2022 19:12:58 +0000",
+   "status": "done"
+  }
 
 .. _More details on machine-id: https://www.freedesktop.org/software/systemd/man/machine-id.html

--- a/doc/rtd/topics/cli.rst
+++ b/doc/rtd/topics/cli.rst
@@ -304,7 +304,7 @@ non-zero if an error is detected in cloud-init.
 * ``--long``: detailed status information
 * ``--wait``: block until cloud-init completes
 * ``--format [yaml|json|tabular]``: machine-readable JSON or YAML detailed
-                                    output
+  output
 
 Below are examples of output when cloud-init is running, showing status and
 the currently running modules, as well as when it is done.

--- a/tests/unittests/cmd/test_cloud_id.py
+++ b/tests/unittests/cmd/test_cloud_id.py
@@ -5,10 +5,51 @@
 import pytest
 
 from cloudinit import util
-from cloudinit.cmd import cloud_id
+from cloudinit.cmd import cloud_id, status
+from cloudinit.helpers import Paths
 from tests.unittests.helpers import mock
 
 M_PATH = "cloudinit.cmd.cloud_id."
+
+STATUS_DETAILS_DONE = status.StatusDetails(
+    status.UXAppStatus.DONE,
+    status.UXAppBootStatusCode.UNKNOWN,
+    "DataSourceNoCloud somedetail",
+    [],
+    "",
+    "nocloud",
+)
+STATUS_DETAILS_DISABLED = status.StatusDetails(
+    status.UXAppStatus.DISABLED,
+    status.UXAppBootStatusCode.DISABLED_BY_GENERATOR,
+    "DataSourceNoCloud somedetail",
+    [],
+    "",
+    "",
+)
+STATUS_DETAILS_NOT_RUN = status.StatusDetails(
+    status.UXAppStatus.NOT_RUN,
+    status.UXAppBootStatusCode.UNKNOWN,
+    "",
+    [],
+    "",
+    "",
+)
+STATUS_DETAILS_RUNNING = status.StatusDetails(
+    status.UXAppStatus.RUNNING,
+    status.UXAppBootStatusCode.UNKNOWN,
+    "",
+    [],
+    "",
+    "",
+)
+
+
+@pytest.fixture(autouse=True)
+def setup_mocks(mocker):
+    mocker.patch(
+        "cloudinit.cmd.cloud_id.read_cfg_paths", return_value=Paths({})
+    )
 
 
 class TestCloudId:
@@ -43,7 +84,7 @@ class TestCloudId:
         self, get_status_details, tmpdir, capsys
     ):
         """Exit error when the provided instance-data.json does not exist."""
-        get_status_details.return_value = cloud_id.UXAppStatus.DONE, "n/a", ""
+        get_status_details.return_value = STATUS_DETAILS_DONE
         instance_data = tmpdir.join("instance-data.json")
         cmd = ["cloud-id", "--instance-data", instance_data.strpath]
         with mock.patch("sys.argv", cmd):
@@ -58,7 +99,7 @@ class TestCloudId:
         self, get_status_details, tmpdir, capsys
     ):
         """Exit error when the provided instance-data.json is not json."""
-        get_status_details.return_value = cloud_id.UXAppStatus.DONE, "n/a", ""
+        get_status_details.return_value = STATUS_DETAILS_DONE
         instance_data = tmpdir.join("instance-data.json")
         cmd = ["cloud-id", "--instance-data", instance_data.strpath]
         instance_data.write("{")
@@ -78,7 +119,7 @@ class TestCloudId:
     ):
         """Report canonical cloud-id from cloud_name in instance-data."""
         instance_data = tmpdir.join("instance-data.json")
-        get_status_details.return_value = cloud_id.UXAppStatus.DONE, "n/a", ""
+        get_status_details.return_value = STATUS_DETAILS_DONE
         instance_data.write(
             '{"v1": {"cloud_name": "mycloud", "region": "somereg"}}',
         )
@@ -95,7 +136,7 @@ class TestCloudId:
         self, get_status_details, tmpdir, capsys
     ):
         """Report long cloud-id format from cloud_name and region."""
-        get_status_details.return_value = cloud_id.UXAppStatus.DONE, "n/a", ""
+        get_status_details.return_value = STATUS_DETAILS_DONE
         instance_data = tmpdir.join("instance-data.json")
         instance_data.write(
             '{"v1": {"cloud_name": "mycloud", "region": "somereg"}}',
@@ -113,7 +154,7 @@ class TestCloudId:
         self, get_status_details, tmpdir, capsys
     ):
         """Report discovered canonical cloud_id when region lookup matches."""
-        get_status_details.return_value = cloud_id.UXAppStatus.DONE, "n/a", ""
+        get_status_details.return_value = STATUS_DETAILS_DONE
         instance_data = tmpdir.join("instance-data.json")
         instance_data.write(
             '{"v1": {"cloud_name": "aws", "region": "cn-north-1",'
@@ -132,7 +173,7 @@ class TestCloudId:
         self, get_status_details, tmpdir, capsys
     ):
         """Report v1 instance-data content with cloud_id when --json set."""
-        get_status_details.return_value = cloud_id.UXAppStatus.DONE, "n/a", ""
+        get_status_details.return_value = STATUS_DETAILS_DONE
         instance_data = tmpdir.join("instance-data.json")
         instance_data.write(
             '{"v1": {"cloud_name": "unknown", "region": "dfw",'
@@ -151,26 +192,27 @@ class TestCloudId:
         with mock.patch("sys.argv", cmd):
             with pytest.raises(SystemExit) as context_manager:
                 cloud_id.main()
-        out, _err = capsys.readouterr()
+        out, err = capsys.readouterr()
+        assert "DEPRECATED: Use: cloud-init query v1\n" == err
         assert 0 == context_manager.value.code
         assert expected + "\n" == out
 
     @pytest.mark.parametrize(
-        "status, exit_code",
+        "details, exit_code",
         (
-            (cloud_id.UXAppStatus.DISABLED, 2),
-            (cloud_id.UXAppStatus.NOT_RUN, 3),
-            (cloud_id.UXAppStatus.RUNNING, 0),
+            (STATUS_DETAILS_DISABLED, 2),
+            (STATUS_DETAILS_NOT_RUN, 3),
+            (STATUS_DETAILS_RUNNING, 0),
         ),
     )
     @mock.patch(M_PATH + "get_status_details")
     def test_cloud_id_unique_exit_codes_for_status(
-        self, get_status_details, status, exit_code, tmpdir, capsys
+        self, get_status_details, details, exit_code, tmpdir, capsys
     ):
         """cloud-id returns unique exit codes for status."""
-        get_status_details.return_value = status, "n/a", ""
+        get_status_details.return_value = details
         instance_data = tmpdir.join("instance-data.json")
-        if status == cloud_id.UXAppStatus.RUNNING:
+        if details.status == cloud_id.UXAppStatus.RUNNING:
             instance_data.write("{}")
         cmd = ["cloud-id", "--instance-data", instance_data.strpath, "--json"]
         with mock.patch("sys.argv", cmd):

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -1,8 +1,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import json
 import os
 from collections import namedtuple
-from io import StringIO
 from textwrap import dedent
 from typing import Callable, Dict, Optional, Union
 from unittest import mock
@@ -18,7 +18,7 @@ M_NAME = "cloudinit.cmd.status"
 M_PATH = f"{M_NAME}."
 
 MyPaths = namedtuple("MyPaths", "run_dir")
-MyArgs = namedtuple("MyArgs", "long wait")
+MyArgs = namedtuple("MyArgs", "long wait format")
 Config = namedtuple(
     "Config", "new_root, status_file, disable_file, result_file, paths"
 )
@@ -36,13 +36,15 @@ def config(tmpdir):
 
 
 class TestStatus:
+    maxDiff = None
+
     @pytest.mark.parametrize(
         [
             "ensured_file",
             "uses_systemd",
             "get_cmdline",
-            "expected_is_disabled",
-            "is_disabled_msg",
+            "expected_bootstatus",
+            "failure_msg",
             "expected_reason",
         ],
         [
@@ -51,7 +53,7 @@ class TestStatus:
                 lambda config: config.disable_file,
                 False,
                 "root=/dev/my-root not-important",
-                False,
+                status.UXAppBootStatusCode.ENABLED_BY_SYSVINIT,
                 "expected enabled cloud-init on sysvinit",
                 "Cloud-init enabled on sysvinit",
                 id="false_on_sysvinit",
@@ -61,7 +63,7 @@ class TestStatus:
                 lambda config: config.disable_file,
                 True,
                 "root=/dev/my-root not-important",
-                True,
+                status.UXAppBootStatusCode.DISABLED_BY_MARKER_FILE,
                 "expected disabled cloud-init",
                 lambda config: f"Cloud-init disabled by {config.disable_file}",
                 id="true_on_disable_file",
@@ -71,7 +73,7 @@ class TestStatus:
                 lambda config: config.disable_file,
                 True,
                 "something cloud-init=enabled else",
-                False,
+                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
                 "expected enabled cloud-init",
                 "Cloud-init enabled by kernel command line cloud-init=enabled",
                 id="false_on_kernel_cmdline_enable",
@@ -81,7 +83,7 @@ class TestStatus:
                 None,
                 True,
                 "something cloud-init=disabled else",
-                True,
+                status.UXAppBootStatusCode.DISABLED_BY_KERNEL_CMDLINE,
                 "expected disabled cloud-init",
                 "Cloud-init disabled by kernel parameter cloud-init=disabled",
                 id="true_on_kernel_cmdline",
@@ -91,7 +93,7 @@ class TestStatus:
                 lambda config: os.path.join(config.paths.run_dir, "disabled"),
                 True,
                 "something",
-                True,
+                status.UXAppBootStatusCode.DISABLED_BY_GENERATOR,
                 "expected disabled cloud-init",
                 "Cloud-init disabled by cloud-init-generator",
                 id="true_when_generator_disables",
@@ -101,63 +103,65 @@ class TestStatus:
                 lambda config: os.path.join(config.paths.run_dir, "enabled"),
                 True,
                 "something ignored",
-                False,
+                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
                 "expected enabled cloud-init",
                 "Cloud-init enabled by systemd cloud-init-generator",
                 id="false_when_enabled_in_systemd",
             ),
         ],
     )
-    def test__is_cloudinit_disabled(
+    def test_get_bootstatus(
         self,
         ensured_file: Optional[Callable],
         uses_systemd: bool,
         get_cmdline: str,
-        expected_is_disabled: bool,
-        is_disabled_msg: str,
+        expected_bootstatus: bool,
+        failure_msg: str,
         expected_reason: Union[str, Callable],
         config: Config,
     ):
         if ensured_file is not None:
             ensure_file(ensured_file(config))
-        (is_disabled, reason) = wrap_and_call(
+        (code, reason) = wrap_and_call(
             M_NAME,
             {
                 "uses_systemd": uses_systemd,
                 "get_cmdline": get_cmdline,
             },
-            status._is_cloudinit_disabled,
+            status.get_bootstatus,
             config.disable_file,
             config.paths,
         )
-        assert is_disabled == expected_is_disabled, is_disabled_msg
+        assert code == expected_bootstatus, failure_msg
         if isinstance(expected_reason, str):
             assert reason == expected_reason
         else:
             assert reason == expected_reason(config)
 
     @mock.patch(M_PATH + "read_cfg_paths")
-    def test_status_returns_not_run(self, m_read_cfg_paths, config: Config):
+    def test_status_returns_not_run(
+        self, m_read_cfg_paths, config: Config, capsys
+    ):
         """When status.json does not exist yet, return 'not run'."""
         m_read_cfg_paths.return_value = config.paths
         assert not os.path.exists(
             config.status_file
         ), "Unexpected status.json found"
-        cmdargs = MyArgs(long=False, wait=False)
-        with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
-            retcode = wrap_and_call(
-                M_NAME,
-                {"_is_cloudinit_disabled": (False, "")},
-                status.handle_status_args,
-                "ignored",
-                cmdargs,
-            )
+        cmdargs = MyArgs(long=False, wait=False, format="tabular")
+        retcode = wrap_and_call(
+            M_NAME,
+            {"get_bootstatus": (status.UXAppBootStatusCode.UNKNOWN, "")},
+            status.handle_status_args,
+            "ignored",
+            cmdargs,
+        )
         assert retcode == 0
-        assert m_stdout.getvalue() == "status: not run\n"
+        out, _err = capsys.readouterr()
+        assert out == "status: not run\n"
 
     @mock.patch(M_PATH + "read_cfg_paths")
     def test_status_returns_disabled_long_on_presence_of_disable_file(
-        self, m_read_cfg_paths, config: Config
+        self, m_read_cfg_paths, config: Config, capsys
     ):
         """When cloudinit is disabled, return disabled reason."""
         m_read_cfg_paths.return_value = config.paths
@@ -168,21 +172,20 @@ class TestStatus:
             status_file = os.path.join(config.paths.run_dir, "status.json")
             return bool(not filepath == status_file)
 
-        cmdargs = MyArgs(long=True, wait=False)
-        with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
-            retcode = wrap_and_call(
-                M_NAME,
-                {
-                    "os.path.exists": {"side_effect": fakeexists},
-                    "_is_cloudinit_disabled": (
-                        True,
-                        "disabled for some reason",
-                    ),
-                },
-                status.handle_status_args,
-                "ignored",
-                cmdargs,
-            )
+        cmdargs = MyArgs(long=True, wait=False, format="tabular")
+        retcode = wrap_and_call(
+            M_NAME,
+            {
+                "os.path.exists": {"side_effect": fakeexists},
+                "get_bootstatus": (
+                    status.UXAppBootStatusCode.DISABLED_BY_KERNEL_CMDLINE,
+                    "disabled for some reason",
+                ),
+            },
+            status.handle_status_args,
+            "ignored",
+            cmdargs,
+        )
         assert retcode == 0
         assert checked_files == [
             os.path.join(config.paths.run_dir, "status.json")
@@ -190,15 +193,18 @@ class TestStatus:
         expected = dedent(
             """\
             status: disabled
+            boot_status_code: disabled-by-kernel-cmdline
             detail:
             disabled for some reason
         """
         )
-        assert m_stdout.getvalue() == expected
+        out, _err = capsys.readouterr()
+        assert out == expected
 
     @pytest.mark.parametrize(
         [
             "ensured_file",
+            "bootstatus",
             "status_content",
             "assert_file",
             "cmdargs",
@@ -209,9 +215,10 @@ class TestStatus:
             # Report running when status.json exists but result.json does not.
             pytest.param(
                 None,
+                status.UXAppBootStatusCode.UNKNOWN,
                 {},
                 lambda config: config.result_file,
-                MyArgs(long=False, wait=False),
+                MyArgs(long=False, wait=False, format="tabular"),
                 0,
                 "status: running\n",
                 id="running_on_no_results_json",
@@ -219,9 +226,10 @@ class TestStatus:
             # Report running when status exists with an unfinished stage.
             pytest.param(
                 lambda config: config.result_file,
+                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
                 {"v1": {"init": {"start": 1, "finished": None}}},
                 None,
-                MyArgs(long=False, wait=False),
+                MyArgs(long=False, wait=False, format="tabular"),
                 0,
                 "status: running\n",
                 id="running",
@@ -229,6 +237,7 @@ class TestStatus:
             # Report done results.json exists no stages are unfinished.
             pytest.param(
                 lambda config: config.result_file,
+                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
                 {
                     "v1": {
                         "stage": None,  # No current stage running
@@ -247,7 +256,7 @@ class TestStatus:
                     }
                 },
                 None,
-                MyArgs(long=False, wait=False),
+                MyArgs(long=False, wait=False, format="tabular"),
                 0,
                 "status: done\n",
                 id="done",
@@ -255,6 +264,7 @@ class TestStatus:
             # Long format of done status includes datasource info.
             pytest.param(
                 lambda config: config.result_file,
+                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
                 {
                     "v1": {
                         "stage": None,
@@ -268,12 +278,13 @@ class TestStatus:
                     }
                 },
                 None,
-                MyArgs(long=True, wait=False),
+                MyArgs(long=True, wait=False, format="tabular"),
                 0,
                 dedent(
                     """\
                     status: done
-                    time: Thu, 01 Jan 1970 00:02:05 +0000
+                    boot_status_code: enabled-by-generator
+                    last_update: Thu, 01 Jan 1970 00:02:05 +0000
                     detail:
                     DataSourceNoCloud [seed=/var/.../seed/nocloud-net]\
 [dsmode=net]
@@ -284,6 +295,7 @@ class TestStatus:
             # Reports error when any stage has errors.
             pytest.param(
                 None,
+                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
                 {
                     "v1": {
                         "stage": None,
@@ -297,7 +309,7 @@ class TestStatus:
                     }
                 },
                 None,
-                MyArgs(long=False, wait=False),
+                MyArgs(long=False, wait=False, format="tabular"),
                 1,
                 "status: error\n",
                 id="on_errors",
@@ -305,6 +317,7 @@ class TestStatus:
             # Long format of error status includes all error messages.
             pytest.param(
                 None,
+                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
                 {
                     "v1": {
                         "stage": None,
@@ -326,12 +339,13 @@ class TestStatus:
                     }
                 },
                 None,
-                MyArgs(long=True, wait=False),
+                MyArgs(long=True, wait=False, format="tabular"),
                 1,
                 dedent(
                     """\
                     status: error
-                    time: Thu, 01 Jan 1970 00:02:05 +0000
+                    boot_status_code: enabled-by-kernel-cmdline
+                    last_update: Thu, 01 Jan 1970 00:02:05 +0000
                     detail:
                     error1
                     error2
@@ -343,6 +357,7 @@ class TestStatus:
             # Long format reports the stage in which we are running.
             pytest.param(
                 None,
+                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
                 {
                     "v1": {
                         "stage": "init",
@@ -351,17 +366,89 @@ class TestStatus:
                     }
                 },
                 None,
-                MyArgs(long=True, wait=False),
+                MyArgs(long=True, wait=False, format="tabular"),
                 0,
                 dedent(
                     """\
                     status: running
-                    time: Thu, 01 Jan 1970 00:02:04 +0000
+                    boot_status_code: enabled-by-kernel-cmdline
+                    last_update: Thu, 01 Jan 1970 00:02:04 +0000
                     detail:
                     Running in stage: init
                     """
                 ),
                 id="running_long_format",
+            ),
+            pytest.param(
+                None,
+                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                {
+                    "v1": {
+                        "stage": "init",
+                        "init": {"start": 124.456, "finished": None},
+                        "init-local": {"start": 123.45, "finished": 123.46},
+                    }
+                },
+                None,
+                MyArgs(long=False, wait=False, format="yaml"),
+                0,
+                dedent(
+                    """\
+                   ---
+                   _schema_version: '1'
+                   boot_status_code: enabled-by-kernel-cmdline
+                   datasource: ''
+                   detail: 'Running in stage: init'
+                   errors: []
+                   last_update: Thu, 01 Jan 1970 00:02:04 +0000
+                   schemas:
+                       '1':
+                           boot_status_code: enabled-by-kernel-cmdline
+                           datasource: ''
+                           detail: 'Running in stage: init'
+                           errors: []
+                           last_update: Thu, 01 Jan 1970 00:02:04 +0000
+                           status: running
+                   status: running
+                   ...
+
+                   """
+                ),
+                id="running_yaml_format",
+            ),
+            pytest.param(
+                None,
+                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                {
+                    "v1": {
+                        "stage": "init",
+                        "init": {"start": 124.456, "finished": None},
+                        "init-local": {"start": 123.45, "finished": 123.46},
+                    }
+                },
+                None,
+                MyArgs(long=False, wait=False, format="json"),
+                0,
+                {
+                    "_schema_version": "1",
+                    "boot_status_code": "enabled-by-kernel-cmdline",
+                    "datasource": "",
+                    "detail": "Running in stage: init",
+                    "errors": [],
+                    "last_update": "Thu, 01 Jan 1970 00:02:04 +0000",
+                    "schemas": {
+                        "1": {
+                            "boot_status_code": "enabled-by-kernel-cmdline",
+                            "datasource": "",
+                            "detail": "Running in stage: init",
+                            "errors": [],
+                            "last_update": "Thu, 01 Jan 1970 00:02:04 +0000",
+                            "status": "running",
+                        }
+                    },
+                    "status": "running",
+                },
+                id="running_json_format",
             ),
         ],
     )
@@ -370,12 +457,14 @@ class TestStatus:
         self,
         m_read_cfg_paths,
         ensured_file: Optional[Callable],
+        bootstatus: status.UXAppBootStatusCode,
         status_content: Dict,
         assert_file,
         cmdargs: MyArgs,
         expected_retcode: int,
         expected_status: str,
         config: Config,
+        capsys,
     ):
         m_read_cfg_paths.return_value = config.paths
         if ensured_file:
@@ -388,20 +477,23 @@ class TestStatus:
             assert not os.path.exists(
                 config.result_file
             ), f"Unexpected {config.result_file} found"
-        with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
-            retcode = wrap_and_call(
-                M_NAME,
-                {"_is_cloudinit_disabled": (False, "")},
-                status.handle_status_args,
-                "ignored",
-                cmdargs,
-            )
+        retcode = wrap_and_call(
+            M_NAME,
+            {"get_bootstatus": (bootstatus, "")},
+            status.handle_status_args,
+            "ignored",
+            cmdargs,
+        )
         assert retcode == expected_retcode
-        assert m_stdout.getvalue() == expected_status
+        out, _err = capsys.readouterr()
+        if isinstance(expected_status, dict):
+            assert json.loads(out) == expected_status
+        else:
+            assert out == expected_status
 
     @mock.patch(M_PATH + "read_cfg_paths")
     def test_status_wait_blocks_until_done(
-        self, m_read_cfg_paths, config: Config
+        self, m_read_cfg_paths, config: Config, capsys
     ):
         """Specifying wait will poll every 1/4 second until done state."""
         m_read_cfg_paths.return_value = config.paths
@@ -433,25 +525,25 @@ class TestStatus:
                 result_file = config.result_file
                 ensure_file(result_file)
 
-        cmdargs = MyArgs(long=False, wait=True)
-        with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
-            retcode = wrap_and_call(
-                M_NAME,
-                {
-                    "sleep": {"side_effect": fake_sleep},
-                    "_is_cloudinit_disabled": (False, ""),
-                },
-                status.handle_status_args,
-                "ignored",
-                cmdargs,
-            )
+        cmdargs = MyArgs(long=False, wait=True, format="tabular")
+        retcode = wrap_and_call(
+            M_NAME,
+            {
+                "sleep": {"side_effect": fake_sleep},
+                "get_bootstatus": (status.UXAppBootStatusCode.UNKNOWN, ""),
+            },
+            status.handle_status_args,
+            "ignored",
+            cmdargs,
+        )
         assert retcode == 0
         assert sleep_calls == 4
-        assert m_stdout.getvalue() == "....\nstatus: done\n"
+        out, _err = capsys.readouterr()
+        assert out == "....\nstatus: done\n"
 
     @mock.patch(M_PATH + "read_cfg_paths")
     def test_status_wait_blocks_until_error(
-        self, m_read_cfg_paths, config: Config
+        self, m_read_cfg_paths, config: Config, capsys
     ):
         """Specifying wait will poll every 1/4 second until error state."""
         m_read_cfg_paths.return_value = config.paths
@@ -485,24 +577,24 @@ class TestStatus:
             elif sleep_calls == 3:
                 write_json(config.status_file, error_json)
 
-        cmdargs = MyArgs(long=False, wait=True)
-        with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
-            retcode = wrap_and_call(
-                M_NAME,
-                {
-                    "sleep": {"side_effect": fake_sleep},
-                    "_is_cloudinit_disabled": (False, ""),
-                },
-                status.handle_status_args,
-                "ignored",
-                cmdargs,
-            )
+        cmdargs = MyArgs(long=False, wait=True, format="tabular")
+        retcode = wrap_and_call(
+            M_NAME,
+            {
+                "sleep": {"side_effect": fake_sleep},
+                "get_bootstatus": (status.UXAppBootStatusCode.UNKNOWN, ""),
+            },
+            status.handle_status_args,
+            "ignored",
+            cmdargs,
+        )
         assert retcode == 1
         assert sleep_calls == 4
-        assert m_stdout.getvalue() == "....\nstatus: error\n"
+        out, _err = capsys.readouterr()
+        assert out == "....\nstatus: error\n"
 
     @mock.patch(M_PATH + "read_cfg_paths")
-    def test_status_main(self, m_read_cfg_paths, config: Config):
+    def test_status_main(self, m_read_cfg_paths, config: Config, capsys):
         """status.main can be run as a standalone script."""
         m_read_cfg_paths.return_value = config.paths
         write_json(
@@ -510,17 +602,17 @@ class TestStatus:
             {"v1": {"init": {"start": 1, "finished": None}}},
         )
         with pytest.raises(SystemExit) as e:
-            with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
-                wrap_and_call(
-                    M_NAME,
-                    {
-                        "sys.argv": {"new": ["status"]},
-                        "_is_cloudinit_disabled": (False, ""),
-                    },
-                    status.main,
-                )
+            wrap_and_call(
+                M_NAME,
+                {
+                    "sys.argv": {"new": ["status"]},
+                    "get_bootstatus": (status.UXAppBootStatusCode.UNKNOWN, ""),
+                },
+                status.main,
+            )
         assert e.value.code == 0
-        assert m_stdout.getvalue() == "status: running\n"
+        out, _err = capsys.readouterr()
+        assert out == "status: running\n"
 
 
 # vi: ts=4 expandtab syntax=python


### PR DESCRIPTION
## Proposed Commit Message

```
    cli: status machine-readable output --format yaml/json
    
    Provide --format option for cloud-init status and cloud-id to
    surface machine-readable output and detailed boot_status_codes.
    Add a `_schema_version` key to the JSON status output to represent
    whether a schema version has been incremented due to incompatibility.
    
    Preserve a static `schemas`:`1` key which contains a copy of status
    version 1 output which will be preserved even if the default
    `_schema_version` is incremented.
    
    Provide new boot_code_code values in json/yaml output
    which will surface unique codes for the current disabled
    status reasons which gives visibility to whether cloud-init
    may become active on next boot or later in the current boot.
    
    The boot-status-code can be:
     - 'unknown': systemd generators and ds-identify haven't run yet to
                  determine if cloud-init should be run during this boot
     - 'disabled-by-marker-file': /etc/cloud/cloud-init.disabled exists
                  which prevents cloud-init from ever running
     - 'disabled-by-generator': systemd generator ran ds-identify and
                  determined no applicable cloud-init datasources
     - 'disabled-by-kernel-cmdline': kernel cmdline contained
                  cloud-init=disabled
     - 'enabled-by-kernel-cmdline': kernel cmdline contained
                  cloud-init=enabled
     - 'enabled-by-generator': ds-identify detected possible cloud-init
                  datasources
     - 'enabled-by-sysvinit': enabled by default in SysV init environment

    Also deprecate `cloud-id --json` in favor of `cloud-init query v1`.
    
    LP: #1883122
```

## Additional Context
General improvements to machine-readable output to aid in ubuntu live installer (subiquity) and snappy /cloud-init  integration

Expect a separate PR to follow this which will standardize how errors are represented in status JSON output

## Test Steps
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
