### PR TITLE
Github is deprecating the 18.04 runner starting 12.1

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         env: [flake8, mypy, pylint, black, isort]
         lint-with:
-          - {tip-versions: false, os: ubuntu-18.04}
+          - {tip-versions: false, os: ubuntu-20.04}
           - {tip-versions: true, os: ubuntu-latest}
     name: Check ${{ matrix.lint-with.tip-versions && 'tip-' || '' }}${{ matrix.env }}
     runs-on: ${{ matrix.lint-with.os }}


### PR DESCRIPTION
```
ci: Bump format tests runner to focal

https://github.com/actions/runner-images/issues/6002
```

you may have noticed the following deprecation warning in CI:
```
Lint Tests: .github#L1
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead. For more details see https://github.com/actions/virtual-environments/issues/6002
```

see https://github.com/actions/runner-images/issues/6002