### PR TITLE
stages: sync datasource cache after updating metadata

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -914,6 +914,9 @@ class Init(object):
             self._apply_netcfg_names(netcfg)
             return
 
+        # sync cache after update
+        self._write_to_cache()
+
         # refresh netcfg after update
         netcfg, src = self._find_networking_config()
 


### PR DESCRIPTION
The datasource's caches are set on first boot in init-local.  However,
subsequent boots where metadata is updated for network config, changes
do not persist and the original cache is continued to be used for
applying net names.

Ensure the caches are synced when metadata is refreshed.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>