### PR TITLE
config: Support APT automated mirror selection

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -402,6 +402,11 @@
               "default": false,
               "description": "By default, cloud-init will generate a new sources list in ``/etc/apt/sources.list.d`` based on any changes specified in cloud config. To disable this behavior and preserve the sources list from the pristine image, set ``preserve_sources_list`` to ``true``.\n\nThe ``preserve_sources_list`` option overrides all other config keys that would alter ``sources.list`` or ``sources.list.d``, **except** for additional sources to be added to ``sources.list.d``."
             },
+            "generate_mirrorlists": {
+              "type": "boolean",
+              "default": false,
+              "description": "Write lists for APT automated mirror selection (``apt-transport-mirror(1)``). It will write separate lists for both the PRIMARY and SECURITY mirror into ``/etc/apt/mirrors/${DIST}.list`` and ``/etc/apt/mirrors/${DIST}-security.list``.  Those can then be used in the APT source.list as ``mirror+file:///etc/apt/mirrors/${DIST}.list``. No ``/etc/apt/sources.list`` will be writte in this case."
+            },
             "disable_suites": {
               "type": "array",
               "items": {"type": "string"},

--- a/tests/unittests/config/test_apt_configure_mirrorlists_v3.py
+++ b/tests/unittests/config/test_apt_configure_mirrorlists_v3.py
@@ -1,0 +1,68 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+""" test_apt_custom_mirrorlists
+Test creation of mirrorlists
+"""
+import logging
+import shutil
+import tempfile
+from contextlib import ExitStack
+from unittest import mock
+from unittest.mock import call
+
+from cloudinit import subp, util
+from cloudinit.config import cc_apt_configure
+from tests.unittests import helpers as t_help
+from tests.unittests.util import get_cloud
+
+LOG = logging.getLogger(__name__)
+
+
+class TestAptSourceConfigMirrorlists(t_help.FilesystemMockingTestCase):
+    """TestAptSourceConfigMirrorlists - Class to test mirrorlists rendering"""
+
+    def setUp(self):
+        super().setUp()
+        self.subp = subp.subp
+        self.new_root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.new_root)
+
+        rpatcher = mock.patch("cloudinit.util.lsb_release")
+        get_rel = rpatcher.start()
+        get_rel.return_value = {"codename": "fakerel"}
+        self.addCleanup(rpatcher.stop)
+        apatcher = mock.patch("cloudinit.util.get_dpkg_architecture")
+        get_arch = apatcher.start()
+        get_arch.return_value = "amd64"
+        self.addCleanup(apatcher.stop)
+
+    def test_apt_v3_mirrors_list(self):
+        """test_apt_v3_mirrors_list"""
+        cfg = {"apt": {"generate_mirrorlists": True}}
+
+        mycloud = get_cloud("ubuntu")
+
+        with ExitStack() as stack:
+            mock_writefile = stack.enter_context(
+                mock.patch.object(util, "write_file")
+            )
+            stack.enter_context(mock.patch.object(util, "ensure_dir"))
+            cc_apt_configure.handle("test", cfg, mycloud, LOG, None)
+
+        mock_writefile.assert_has_calls(
+            [
+                call(
+                    "/etc/apt/mirrors/ubuntu.list",
+                    "http://archive.ubuntu.com/ubuntu/\n",
+                    mode=0o644,
+                ),
+                call(
+                    "/etc/apt/mirrors/ubuntu-security.list",
+                    "http://security.ubuntu.com/ubuntu/\n",
+                    mode=0o644,
+                ),
+            ]
+        )
+
+
+# vi: ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
```
config: Support APT automated mirror selection

The automated mirror selection supported by APT for some time now allows
to separate most info in sources.list from the mirror URL itself.  A new
config option asks cloud-init to write one mirror file for primary and
one for security mirror.

To write just the mirrors lists, cloud-init does not longer need to know 
about the dists to enable/disable and what the release is to begin with.
On Debian those information is not readily available in all cases.
```

## Additional Context
This will be used in addition https://salsa.debian.org/cloud-team/debian-cloud-images/-/merge_requests/279 to allow mirror selection by cloud-init

## Test Steps

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
