### PR TITLE
sources/azure: don't enforce nic ordering

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -2059,9 +2059,7 @@ def generate_network_config_from_instance_network_metadata(
                 )
         if dev_config and has_ip_address:
             mac = normalize_mac_address(intf["macAddress"])
-            dev_config.update(
-                {"match": {"macaddress": mac.lower()}, "set-name": nicname}
-            )
+            dev_config.update({"match": {"macaddress": mac.lower()}})
             driver = determine_device_driver_for_mac(mac)
             if driver:
                 dev_config["match"]["driver"] = driver

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -210,11 +210,11 @@ def get_hv_netvsc_macs_normalized() -> List[str]:
 @azure_ds_telemetry_reporter
 def determine_device_driver_for_mac(mac: str) -> Optional[str]:
     """Determine the device driver to match on, if any."""
-    interfaces = [
-        i for i in net.get_interfaces() if mac == normalize_mac_address(i[1])
+    drivers = [
+        i[2]
+        for i in net.get_interfaces(blacklist_drivers=BLACKLIST_DRIVERS)
+        if mac == normalize_mac_address(i[1])
     ]
-    drivers = [i[2] for i in interfaces if i[2] not in BLACKLIST_DRIVERS]
-
     if "hv_netvsc" in drivers:
         return "hv_netvsc"
 

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -169,15 +169,10 @@ def mock_get_interfaces():
         MOCKPATH + "net.get_interfaces",
         return_value=[
             ("dummy0", "9e:65:d6:19:19:01", None, None),
-            ("enP0", "00:11:22:33:44:00", "mlx4_core", "0x3"),
-            ("enP1", "00:11:22:33:44:01", "mlx5_core", "0x3"),
-            ("enP2", "00:11:22:33:44:02", "mlx5_core", "0x3"),
-            ("enP3", "00:11:22:33:44:03", "unknown_accel", "0x3"),
+            ("enP3", "00:11:22:33:44:02", "unknown_accel", "0x3"),
             ("eth0", "00:11:22:33:44:00", "hv_netvsc", "0x3"),
-            ("eth1", "00:11:22:33:44:01", "hv_netvsc", "0x3"),
-            ("eth2", "00:11:22:33:44:02", "unknown_with_known_vf", "0x3"),
-            ("eth3", "00:11:22:33:44:03", "unknown_with_unknown_vf", "0x3"),
-            ("eth4", "00:11:22:33:44:04", "unknown_without_vf", "0x3"),
+            ("eth2", "00:11:22:33:44:01", "unknown", "0x3"),
+            ("eth3", "00:11:22:33:44:02", "unknown_with_unknown_vf", "0x3"),
             ("lo", "00:00:00:00:00:00", None, None),
         ],
     ) as m:
@@ -549,7 +544,44 @@ class TestGenerateNetworkConfig:
                 },
             ),
             (
-                "unknown with known matching VF",
+                "unknown",
+                {
+                    "interface": [
+                        {
+                            "macAddress": "001122334401",
+                            "ipv6": {"ipAddress": []},
+                            "ipv4": {
+                                "subnet": [
+                                    {"prefix": "24", "address": "10.0.0.0"}
+                                ],
+                                "ipAddress": [
+                                    {
+                                        "privateIpAddress": "10.0.0.4",
+                                        "publicIpAddress": "104.46.124.81",
+                                    }
+                                ],
+                            },
+                        }
+                    ]
+                },
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": False,
+                            "match": {
+                                "macaddress": "00:11:22:33:44:01",
+                                "driver": "unknown",
+                            },
+                            "set-name": "eth0",
+                        }
+                    },
+                    "version": 2,
+                },
+            ),
+            (
+                "unknown with unknown matching VF",
                 {
                     "interface": [
                         {
@@ -577,80 +609,6 @@ class TestGenerateNetworkConfig:
                             "dhcp6": False,
                             "match": {
                                 "macaddress": "00:11:22:33:44:02",
-                                "driver": "unknown_with_known_vf",
-                            },
-                            "set-name": "eth0",
-                        }
-                    },
-                    "version": 2,
-                },
-            ),
-            (
-                "unknown with unknown matching VF",
-                {
-                    "interface": [
-                        {
-                            "macAddress": "001122334403",
-                            "ipv6": {"ipAddress": []},
-                            "ipv4": {
-                                "subnet": [
-                                    {"prefix": "24", "address": "10.0.0.0"}
-                                ],
-                                "ipAddress": [
-                                    {
-                                        "privateIpAddress": "10.0.0.4",
-                                        "publicIpAddress": "104.46.124.81",
-                                    }
-                                ],
-                            },
-                        }
-                    ]
-                },
-                {
-                    "ethernets": {
-                        "eth0": {
-                            "dhcp4": True,
-                            "dhcp4-overrides": {"route-metric": 100},
-                            "dhcp6": False,
-                            "match": {
-                                "macaddress": "00:11:22:33:44:03",
-                            },
-                            "set-name": "eth0",
-                        }
-                    },
-                    "version": 2,
-                },
-            ),
-            (
-                "unknown without matching VF",
-                {
-                    "interface": [
-                        {
-                            "macAddress": "001122334404",
-                            "ipv6": {"ipAddress": []},
-                            "ipv4": {
-                                "subnet": [
-                                    {"prefix": "24", "address": "10.0.0.0"}
-                                ],
-                                "ipAddress": [
-                                    {
-                                        "privateIpAddress": "10.0.0.4",
-                                        "publicIpAddress": "104.46.124.81",
-                                    }
-                                ],
-                            },
-                        }
-                    ]
-                },
-                {
-                    "ethernets": {
-                        "eth0": {
-                            "dhcp4": True,
-                            "dhcp4-overrides": {"route-metric": 100},
-                            "dhcp6": False,
-                            "match": {
-                                "macaddress": "00:11:22:33:44:04",
-                                "driver": "unknown_without_vf",
                             },
                             "set-name": "eth0",
                         }

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -500,7 +500,6 @@ class TestGenerateNetworkConfig:
                             "dhcp4-overrides": {"route-metric": 100},
                             "dhcp6": False,
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
-                            "set-name": "eth0",
                         }
                     },
                     "version": 2,
@@ -537,7 +536,6 @@ class TestGenerateNetworkConfig:
                                 "macaddress": "00:11:22:33:44:00",
                                 "driver": "hv_netvsc",
                             },
-                            "set-name": "eth0",
                         }
                     },
                     "version": 2,
@@ -574,7 +572,6 @@ class TestGenerateNetworkConfig:
                                 "macaddress": "00:11:22:33:44:01",
                                 "driver": "unknown",
                             },
-                            "set-name": "eth0",
                         }
                     },
                     "version": 2,
@@ -610,7 +607,6 @@ class TestGenerateNetworkConfig:
                             "match": {
                                 "macaddress": "00:11:22:33:44:02",
                             },
-                            "set-name": "eth0",
                         }
                     },
                     "version": 2,
@@ -645,17 +641,14 @@ class TestGenerateNetworkConfig:
                             "dhcp4-overrides": {"route-metric": 100},
                             "dhcp6": False,
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
-                            "set-name": "eth0",
                         },
                         "eth1": {
-                            "set-name": "eth1",
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
                             "dhcp6": False,
                             "dhcp4": True,
                             "dhcp4-overrides": {"route-metric": 200},
                         },
                         "eth2": {
-                            "set-name": "eth2",
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
                             "dhcp6": False,
                             "dhcp4": True,
@@ -713,7 +706,6 @@ class TestGenerateNetworkConfig:
                             "dhcp6": True,
                             "dhcp6-overrides": {"route-metric": 100},
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
-                            "set-name": "eth0",
                         }
                     },
                     "version": 2,
@@ -749,7 +741,6 @@ class TestGenerateNetworkConfig:
                             "dhcp6": True,
                             "dhcp6-overrides": {"route-metric": 100},
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
-                            "set-name": "eth0",
                         }
                     },
                     "version": 2,
@@ -793,7 +784,6 @@ class TestNetworkConfig:
                     "dhcp4-overrides": {"route-metric": 100},
                     "dhcp6": False,
                     "match": {"macaddress": "00:0d:3a:04:75:98"},
-                    "set-name": "eth0",
                 }
             },
             "version": 2,
@@ -1618,7 +1608,6 @@ scbus-1 on xpt0 bus 0
         expected_network_config = {
             "ethernets": {
                 "eth0": {
-                    "set-name": "eth0",
                     "match": {"macaddress": "00:0d:3a:04:75:98"},
                     "dhcp6": False,
                     "dhcp4": True,
@@ -1641,21 +1630,18 @@ scbus-1 on xpt0 bus 0
         expected_network_config = {
             "ethernets": {
                 "eth0": {
-                    "set-name": "eth0",
                     "match": {"macaddress": "00:0d:3a:04:75:98"},
                     "dhcp6": False,
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
                 },
                 "eth1": {
-                    "set-name": "eth1",
                     "match": {"macaddress": "22:0d:3a:04:75:98"},
                     "dhcp6": False,
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 200},
                 },
                 "eth2": {
-                    "set-name": "eth2",
                     "match": {"macaddress": "33:0d:3a:04:75:98"},
                     "dhcp6": False,
                     "dhcp4": True,
@@ -1687,7 +1673,6 @@ scbus-1 on xpt0 bus 0
         expected_network_config = {
             "ethernets": {
                 "eth0": {
-                    "set-name": "eth0",
                     "match": {"macaddress": "00:0d:3a:04:75:98"},
                     "dhcp6": False,
                     "dhcp4": True,


### PR DESCRIPTION
The cloud-init generated netplan config persists between boots and the
names are applied early in boot by the netplan generator.  This may
result in the primary NIC being renamed away from "eth0", causing
cloud-init local to fail.

The ordering of NICs provided by IMDS may not match the order
enumerated by kernel, this will cause additional renaming thrashing
which tends to result in different types of failures with networkd
on Ubuntu 18.04, 20.04, and 22.04.

Stop setting device names until we can guarantee that:
(a) we can find the primary NIC regardless if it is eth0
(b) Ubuntu doesn't fail to bring up networking

Without ordering reliability, we cannot rely on checking the interface
device driver as named, so add a helper to reliably identify the most
appropriate matching.

LP #1958280

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>