### PR TITLE
Improve Ubuntu Advantage module's idempotency

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -24,9 +24,10 @@ meta: MetaSchema = {
         Attach machine to an existing Ubuntu Advantage support contract and
         enable or disable support services such as Livepatch, ESM,
         FIPS and FIPS Updates. When attaching a machine to Ubuntu Advantage,
-        one can also specify services to enable.  When the 'enable'
-        list is present, any named service will supplement the contract-default
-        enabled services.
+        one can also specify services to enable. When the 'enable'
+        list is present, only named services will be activated. Whereas
+        'enable' list is not present, any named service will supplement
+        contract-default enabled services.
 
         Note that when enabling FIPS or FIPS updates you will need to schedule
         a reboot to ensure the machine is running the FIPS-compliant kernel.
@@ -233,7 +234,7 @@ def configure_ua(token=None, enable=None, config=None):
             msg = 'Service "{service}" already enabled:\n{warning}'.format(
                 service=service, warning=str(warning)
             )
-            util.logexc(LOG, msg)
+            LOG.warning(msg)
 
     if enable_errors:
         for service, error in enable_errors:

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -82,7 +82,8 @@ class TestConfigureUA:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Attaching to Ubuntu Advantage. ua attach --no-auto-enable SomeToken",
+                        "Attaching to Ubuntu Advantage. ua attach"
+                        " --no-auto-enable SomeToken",
                     )
                 ],
                 id="with_specific_services",
@@ -91,7 +92,9 @@ class TestConfigureUA:
             pytest.param(
                 {"token": "SomeToken", "enable": "fips"},
                 [
-                    mock.call(["ua", "attach", "SomeToken"]),
+                    mock.call(
+                        ["ua", "attach", "--no-auto-enable", "SomeToken"]
+                    ),
                     mock.call(
                         ["ua", "enable", "--assume-yes", "fips"], capture=True
                     ),
@@ -100,7 +103,8 @@ class TestConfigureUA:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Attaching to Ubuntu Advantage. ua attach SomeToken",
+                        "Attaching to Ubuntu Advantage. ua attach"
+                        " --no-auto-enable SomeToken",
                     ),
                     (
                         MPATH,

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -71,7 +71,9 @@ class TestConfigureUA:
             pytest.param(
                 {"token": "SomeToken", "enable": ["fips"]},
                 [
-                    mock.call(["ua", "attach", "SomeToken"]),
+                    mock.call(
+                        ["ua", "attach", "--no-auto-enable", "SomeToken"]
+                    ),
                     mock.call(
                         ["ua", "enable", "--assume-yes", "fips"], capture=True
                     ),
@@ -80,7 +82,7 @@ class TestConfigureUA:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Attaching to Ubuntu Advantage. ua attach SomeToken",
+                        "Attaching to Ubuntu Advantage. ua attach --no-auto-enable SomeToken",
                     )
                 ],
                 id="with_specific_services",
@@ -162,7 +164,7 @@ class TestConfigureUA:
         ):
             configure_ua(token="SomeToken", enable=["esm", "cc", "fips"])
         assert m_subp.call_args_list == [
-            mock.call(["ua", "attach", "SomeToken"]),
+            mock.call(["ua", "attach", "--no-auto-enable", "SomeToken"]),
             mock.call(["ua", "enable", "--assume-yes", "esm"], capture=True),
             mock.call(["ua", "enable", "--assume-yes", "cc"], capture=True),
             mock.call(["ua", "enable", "--assume-yes", "fips"], capture=True),

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -44,7 +44,7 @@ class TestConfigureUA:
             # When token is provided, attach the machine to ua using the token.
             pytest.param(
                 {"token": "SomeToken"},
-                [mock.call(["ua", "attach", "SomeToken"])],
+                [mock.call(["ua", "attach", "SomeToken"], rcs={0, 2})],
                 [
                     (
                         MPATH,
@@ -57,7 +57,7 @@ class TestConfigureUA:
             # When services is an empty list, do not auto-enable attach.
             pytest.param(
                 {"token": "SomeToken", "enable": []},
-                [mock.call(["ua", "attach", "SomeToken"])],
+                [mock.call(["ua", "attach", "SomeToken"], rcs={0, 2})],
                 [
                     (
                         MPATH,
@@ -72,7 +72,8 @@ class TestConfigureUA:
                 {"token": "SomeToken", "enable": ["fips"]},
                 [
                     mock.call(
-                        ["ua", "attach", "--no-auto-enable", "SomeToken"]
+                        ["ua", "attach", "--no-auto-enable", "SomeToken"],
+                        rcs={0, 2},
                     ),
                     mock.call(
                         ["ua", "enable", "--assume-yes", "fips"], capture=True
@@ -93,7 +94,8 @@ class TestConfigureUA:
                 {"token": "SomeToken", "enable": "fips"},
                 [
                     mock.call(
-                        ["ua", "attach", "--no-auto-enable", "SomeToken"]
+                        ["ua", "attach", "--no-auto-enable", "SomeToken"],
+                        rcs={0, 2},
                     ),
                     mock.call(
                         ["ua", "enable", "--assume-yes", "fips"], capture=True
@@ -118,7 +120,7 @@ class TestConfigureUA:
             # When services not string or list, warn but still attach
             pytest.param(
                 {"token": "SomeToken", "enable": {"deffo": "wont work"}},
-                [mock.call(["ua", "attach", "SomeToken"])],
+                [mock.call(["ua", "attach", "SomeToken"], rcs={0, 2})],
                 [
                     (
                         MPATH,
@@ -145,10 +147,53 @@ class TestConfigureUA:
         for record_tuple in log_record_tuples:
             assert record_tuple in caplog.record_tuples
 
+    def test_configure_ua_already_attached(self, m_subp, caplog):
+        """ua is already attached to an subscription"""
+        m_subp.rcs = 2
+        configure_ua(token="SomeToken")
+        assert m_subp.call_args_list == [
+            mock.call(["ua", "attach", "SomeToken"], rcs={0, 2})
+        ]
+        assert (
+            MPATH,
+            logging.DEBUG,
+            "Attaching to Ubuntu Advantage. ua attach SomeToken",
+        ) in caplog.record_tuples
+
+    def test_configure_ua_attach_on_service_enabled(self, m_subp, caplog):
+        """retry enabling an already enabled service"""
+
+        def fake_subp(cmd, capture=None, rcs=None):
+            fail_cmds = [
+                ["ua", "enable", "--assume-yes", svc] for svc in ["livepatch"]
+            ]
+            if cmd in fail_cmds and capture:
+                svc = cmd[-1]
+                raise subp.ProcessExecutionError(
+                    'Service "{}" is already enabled.'.format(svc)
+                )
+
+        m_subp.side_effect = fake_subp
+
+        configure_ua(token="SomeToken", enable=["livepatch"])
+        assert m_subp.call_args_list == [
+            mock.call(
+                ["ua", "attach", "--no-auto-enable", "SomeToken"], rcs={0, 2}
+            ),
+            mock.call(
+                ["ua", "enable", "--assume-yes", "livepatch"], capture=True
+            ),
+        ]
+        assert (
+            MPATH,
+            logging.DEBUG,
+            'Service "livepatch" already enabled.',
+        ) in caplog.record_tuples
+
     def test_configure_ua_attach_on_service_error(self, m_subp, caplog):
         """all services should be enabled and then any failures raised"""
 
-        def fake_subp(cmd, capture=None):
+        def fake_subp(cmd, capture=None, rcs=None):
             fail_cmds = [
                 ["ua", "enable", "--assume-yes", svc] for svc in ["esm", "cc"]
             ]
@@ -168,7 +213,9 @@ class TestConfigureUA:
         ):
             configure_ua(token="SomeToken", enable=["esm", "cc", "fips"])
         assert m_subp.call_args_list == [
-            mock.call(["ua", "attach", "--no-auto-enable", "SomeToken"]),
+            mock.call(
+                ["ua", "attach", "--no-auto-enable", "SomeToken"], rcs={0, 2}
+            ),
             mock.call(["ua", "enable", "--assume-yes", "esm"], capture=True),
             mock.call(["ua", "enable", "--assume-yes", "cc"], capture=True),
             mock.call(["ua", "enable", "--assume-yes", "fips"], capture=True),
@@ -195,7 +242,7 @@ class TestConfigureUA:
             token="SomeToken", config=["http_proxy=http://some-proxy.net:3128"]
         )
         assert [
-            mock.call(["ua", "attach", "SomeToken"])
+            mock.call(["ua", "attach", "SomeToken"], rcs={0, 2})
         ] == m_subp.call_args_list
         assert (
             MPATH,


### PR DESCRIPTION
## Proposed Commit Message

```
Ubuntu Advantage: Improved idempotency

Ubuntu Advantage module is now capable of detecting already
activated subscriptions or/and enabled services. Furthermore,
when "enable" parameter is set, no "default" services
will be enabled anymore.
```

## Additional Context
If `instance-id` changes due to updated user or meta-data, cloud-init
will run again and UA causes an error when a machine has an already
attached subscription and/or service.

Ubuntu Advantage is now capable of ignoring the following messages:

```
Stderr: This machine is already attached to 'X'
        To use a different subscription first run: sudo ua detach.

Stdout: One moment, checking your subscription first
        <Service> is already enabled.
        See: sudo ua status
```
        
The module won't set cloud-init status to error when 
detecting those messages. Nevertheless, it will print error
messages in cloud-init log for easier troubleshooting.

Furthermore, when "enable" parameter is set, the module
only activates the list of services given rather than 
activating default services + list of enabled.

## Test Steps
Tested with the following user-data:

1. user-data with no "enable":
```
ubuntu_advantage:
  token: "{{ ds.meta_data.ua_token }}"
```

3. cloud-init clean --logs --reboot

4. cloud-init status should not state "error" and "default services" should be enabled:
```
root@test:/home/ubuntu# cloud-init status -l
status: done
time: Fri, 19 Aug 2022 06:49:50 +0000
detail:
DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud,/dev/sdc][dsmode=net]

SERVICE          ENTITLED  STATUS    DESCRIPTION
cc-eal           yes       n/a       Common Criteria EAL2 Provisioning Packages
esm-infra        yes       enabled   UA Infra: Extended Security Maintenance (ESM)
fips             yes       disabled  NIST-certified core packages
fips-updates     yes       disabled  NIST-certified core packages with priority security updates
livepatch        yes       enabled   Canonical Livepatch service
usg              yes       disabled  Security compliance and audit tools
```

5. ua detach

6. user-data with "enable":
```
ubuntu_advantage:
  token: "{{ ds.meta_data.ua_token }}"
  enable:
    - livepatch
```

7. cloud-init clean --logs --reboot

8. cloud-init status should not state "error" and only "livepatch" service should be enabled:
```
root@test:/home/ubuntu# cloud-init status -l
status: done
time: Fri, 19 Aug 2022 06:49:50 +0000
detail:
DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud,/dev/sdc][dsmode=net]
```

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
