### PR TITLE
DataSourceVMware: fix var use before init

### DIFF
--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -800,7 +800,7 @@ def wait_on_network(metadata):
                 wait_on_ipv6 = util.translate_bool(wait_on_ipv6_val)
 
     # Get information about the host.
-    host_info = None
+    host_info, ipv4_ready, ipv6_ready = None, False, False
     while host_info is None:
         # This loop + sleep results in two logs every second while waiting
         # for either ipv4 or ipv6 up. Do we really need to log each iteration
@@ -845,7 +845,10 @@ def main():
     except Exception:
         pass
     metadata = {
-        "wait-on-network": {"ipv4": True, "ipv6": "false"},
+        WAIT_ON_NETWORK: {
+            WAIT_ON_NETWORK_IPV4: True,
+            WAIT_ON_NETWORK_IPV6: False,
+        },
         "network": {"config": {"dhcp": True}},
     }
     host_info = wait_on_network(metadata)

--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -87,6 +87,8 @@ class TestDataSourceVMware(CiTestCase):
     Test common functionality that is not transport specific.
     """
 
+    with_logs = True
+
     def setUp(self):
         super(TestDataSourceVMware, self).setUp()
         self.tmp = self.tmp_dir()
@@ -140,6 +142,78 @@ class TestDataSourceVMware(CiTestCase):
         self.assertTrue(
             host_info[DataSourceVMware.LOCAL_IPV6] == "2001:db8::::::8888"
         )
+
+    @mock.patch("cloudinit.sources.DataSourceVMware.get_host_info")
+    def test_wait_on_network(self, m_fn):
+        metadata = {
+            DataSourceVMware.WAIT_ON_NETWORK: {
+                DataSourceVMware.WAIT_ON_NETWORK_IPV4: True,
+                DataSourceVMware.WAIT_ON_NETWORK_IPV6: False,
+            },
+        }
+        m_fn.side_effect = [
+            {
+                "hostname": "host.cloudinit.test",
+                "local-hostname": "host.cloudinit.test",
+                "local_hostname": "host.cloudinit.test",
+                "network": {
+                    "interfaces": {
+                        "by-ipv4": {},
+                        "by-ipv6": {},
+                        "by-mac": {
+                            "aa:bb:cc:dd:ee:ff": {"ipv4": [], "ipv6": []}
+                        },
+                    },
+                },
+            },
+            {
+                "hostname": "host.cloudinit.test",
+                "local-hostname": "host.cloudinit.test",
+                "local-ipv4": "10.10.10.1",
+                "local_hostname": "host.cloudinit.test",
+                "network": {
+                    "interfaces": {
+                        "by-ipv4": {
+                            "10.10.10.1": {
+                                "mac": "aa:bb:cc:dd:ee:ff",
+                                "netmask": "255.255.255.0",
+                            }
+                        },
+                        "by-mac": {
+                            "aa:bb:cc:dd:ee:ff": {
+                                "ipv4": [
+                                    {
+                                        "addr": "10.10.10.1",
+                                        "broadcast": "10.10.10.255",
+                                        "netmask": "255.255.255.0",
+                                    }
+                                ],
+                                "ipv6": [],
+                            }
+                        },
+                    },
+                },
+            },
+        ]
+
+        host_info = DataSourceVMware.wait_on_network(metadata)
+
+        logs = self.logs.getvalue()
+        expected_logs = [
+            "DEBUG: waiting on network: wait4=True, "
+            + "ready4=False, wait6=False, ready6=False\n",
+            "DEBUG: waiting on network complete\n",
+        ]
+        for log in expected_logs:
+            self.assertIn(log, logs)
+
+        self.assertTrue(host_info)
+        self.assertTrue(host_info["hostname"])
+        self.assertTrue(host_info["hostname"] == "host.cloudinit.test")
+        self.assertTrue(host_info["local-hostname"])
+        self.assertTrue(host_info["local_hostname"])
+        self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4])
+        self.assertTrue(host_info[DataSourceVMware.LOCAL_IPV4] == "10.10.10.1")
 
 
 class TestDataSourceVMwareEnvVars(FilesystemMockingTestCase):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
DataSourceVMware: fix var use before init

This patch fixes an issue in the DataSourceVMware code where the
variable ipv6_ready was used in a logging statement before it was
initialized. Now the variable is initialized, avoiding the panic.

LP: #1987005
```

## Additional Context
<!-- If relevant -->

## Test Steps
I reproduced the bug by:

* applying the following patch to move the logging statement into a position where it would always be executed:

    ```diff
    diff --git a/cloudinit/sources/DataSourceVMware.py b/cloudinit/sources/DataSourceVMware.py
    index 80a01e89..b2a54d0b 100644
    --- a/cloudinit/sources/DataSourceVMware.py
    +++ b/cloudinit/sources/DataSourceVMware.py
    @@ -822,6 +822,14 @@ def wait_on_network(metadata):
                 if not ipv6_ready:
                     host_info = None
     
    +        LOG.debug(
    +            "waiting on network: wait4=%s, ready4=%s, wait6=%s, ready6=%s",
    +            wait_on_ipv4,
    +            ipv4_ready,
    +            wait_on_ipv6,
    +            ipv6_ready,
    +        )
    +
             if host_info is None:
                 LOG.debug(
                     "waiting on network: wait4=%s, ready4=%s, wait6=%s, ready6=%s",
    ```

* and then running the following command locally:

    ```shell
    $ PYTHONPATH="$(pwd)" python3 cloudinit/sources/DataSourceVMware.py
    Traceback (most recent call last):
      File "cloudinit/sources/DataSourceVMware.py", line 865, in <module>
        main()
      File "cloudinit/sources/DataSourceVMware.py", line 859, in main
        host_info = wait_on_network(metadata)
      File "cloudinit/sources/DataSourceVMware.py", line 830, in wait_on_network
        ipv6_ready,
    UnboundLocalError: local variable 'ipv6_ready' referenced before assignment
    ```

* then I applied the following patch on _top_ of the one in this PR:

    ```diff
    diff --git a/cloudinit/sources/DataSourceVMware.py b/cloudinit/sources/DataSourceVMware.py
    index cf5f9f52..7cef6eaf 100644
    --- a/cloudinit/sources/DataSourceVMware.py
    +++ b/cloudinit/sources/DataSourceVMware.py
    @@ -822,6 +822,14 @@ def wait_on_network(metadata):
                 if not ipv6_ready:
                     host_info = None
     
    +        LOG.debug(
    +            "waiting on network: wait4=%s, ready4=%s, wait6=%s, ready6=%s",
    +            wait_on_ipv4,
    +            ipv4_ready,
    +            wait_on_ipv6,
    +            ipv6_ready,
    +        )
    +
             if host_info is None:
                 LOG.debug(
                     "waiting on network: wait4=%s, ready4=%s, wait6=%s, ready6=%s",
    ```

* and tried to reproduce the issue once more:

    ```shell
    $ PYTHONPATH="$(pwd)" python3 cloudinit/sources/DataSourceVMware.py
    2022-08-19 13:48:51,762 - DataSourceVMware.py[DEBUG]: waiting on network: wait4=True, ready4=True, wait6=False, ready6=None
    2022-08-19 13:48:51,763 - DataSourceVMware.py[DEBUG]: waiting on network complete
    {
     "hostname": "akutz-a03.vmware.com",
     "local-hostname": "akutz-a03.vmware.com",
     "local-ipv4": "192.168.0.188",
     "local-ipv6": "fe80::10ec:eca5:84a2:eb15%en7",
     "local_hostname": "akutz-a03.vmware.com",
     "network": {
      "config": {
       "dhcp": true
      },
      "interfaces": {
       "by-ipv4": {
        "10.25.121.155": {
         "netmask": "255.255.255.255",
         "peer": "10.25.121.155"
        },
        "192.168.0.188": {
         "broadcast": "192.168.0.255",
         "mac": "64:4b:f0:18:9a:21",
         "netmask": "255.255.255.0"
        }
       },
       "by-ipv6": {},
       "by-mac": {
        "64:4b:f0:18:9a:21": {
         "ipv4": [
          {
           "addr": "192.168.0.188",
           "broadcast": "192.168.0.255",
           "netmask": "255.255.255.0"
          }
         ],
         "ipv6": []
        },
        "8a:9f:e4:1b:3c:ac": {
         "ipv6": []
        },
        "8a:9f:e4:1b:3c:ad": {
         "ipv6": []
        },
        "8a:9f:e4:1b:3c:ae": {
         "ipv6": []
        }
       }
      }
     },
     "wait-on-network": {
      "ipv4": true,
      "ipv6": false
     }
    }
    ```

    Everything worked as expected!

I also added a unit test, `tests/unittests/sources/test_vmware.py::TestDataSourceVMware::test_wait_on_network`:

```shell
$ make clean_pyc && \
  PYTHONPATH="$(pwd)" \
  python3 -m pytest -v tests/unittests/sources/test_vmware.py
=================================================================================================================================== test session starts ===================================================================================================================================
platform darwin -- Python 3.8.9, pytest-7.1.2, pluggy-1.0.0 -- /Library/Developer/CommandLineTools/usr/bin/python3
cachedir: .pytest_cache
rootdir: /Users/akutz/Projects/cloud-init, configfile: tox.ini
plugins: mock-3.8.2, cov-3.0.0
collected 26 items                                                                                                                                                                                                                                                                        

tests/unittests/sources/test_vmware.py::TestDataSourceVMware::test_get_host_info_dual PASSED                                                                                                                                                                                        [  3%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMware::test_get_host_info_ipv4 PASSED                                                                                                                                                                                        [  7%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMware::test_get_host_info_ipv6 PASSED                                                                                                                                                                                        [ 11%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMware::test_no_data_access_method PASSED                                                                                                                                                                                     [ 15%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMware::test_wait_on_network PASSED                                                                                                                                                                                           [ 19%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_get_data_metadata_b64 PASSED                                                                                                                                                                              [ 23%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_get_data_metadata_base64 PASSED                                                                                                                                                                           [ 26%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_get_data_metadata_gz_b64 PASSED                                                                                                                                                                           [ 30%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_get_data_metadata_gzip_base64 PASSED                                                                                                                                                                      [ 34%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_get_data_metadata_only PASSED                                                                                                                                                                             [ 38%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_get_data_userdata_only PASSED                                                                                                                                                                             [ 42%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_get_data_vendordata_only PASSED                                                                                                                                                                           [ 46%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_get_subplatform PASSED                                                                                                                                                                                    [ 50%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_metadata_multiple_ssh_keys PASSED                                                                                                                                                                         [ 53%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareEnvVars::test_metadata_single_ssh_key PASSED                                                                                                                                                                            [ 57%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_ds_valid_on_vmware_platform PASSED                                                                                                                                                                      [ 61%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_get_data_metadata_b64 PASSED                                                                                                                                                                            [ 65%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_get_data_metadata_base64 PASSED                                                                                                                                                                         [ 69%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_get_data_metadata_gz_b64 PASSED                                                                                                                                                                         [ 73%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_get_data_metadata_gzip_base64 PASSED                                                                                                                                                                    [ 76%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_get_data_userdata_only PASSED                                                                                                                                                                           [ 80%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_get_data_vendordata_only PASSED                                                                                                                                                                         [ 84%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_get_subplatform PASSED                                                                                                                                                                                  [ 88%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_metadata_multiple_ssh_keys PASSED                                                                                                                                                                       [ 92%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo::test_metadata_single_ssh_key PASSED                                                                                                                                                                          [ 96%]
tests/unittests/sources/test_vmware.py::TestDataSourceVMwareGuestInfo_InvalidPlatform::test_ds_invalid_on_non_vmware_platform PASSED                                                                                                                                                [100%]
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
