### PR TITLE
tools: read-version check GITHUB_REF and git branch --show-current

### DIFF
--- a/tools/read-version
+++ b/tools/read-version
@@ -39,20 +39,20 @@ def which(program):
 
 def is_gitdir(path):
     # Return boolean indicating if path is a git tree.
-    git_meta = os.path.join(path, '.git')
+    git_meta = os.path.join(path, ".git")
     if os.path.isdir(git_meta):
         return True
     if os.path.exists(git_meta):
         # in a git worktree, .git is a file with 'gitdir: x'
         with open(git_meta, "rb") as fp:
-            if b'gitdir:' in fp.read():
+            if b"gitdir:" in fp.read():
                 return True
     return False
 
 
-use_long = '--long' in sys.argv or os.environ.get('CI_RV_LONG')
-use_tags = '--tags' in sys.argv or os.environ.get('CI_RV_TAGS')
-output_json = '--json' in sys.argv
+use_long = "--long" in sys.argv or os.environ.get("CI_RV_LONG")
+use_tags = "--tags" in sys.argv or os.environ.get("CI_RV_TAGS")
+output_json = "--json" in sys.argv
 
 src_version = ci_version.version_string()
 version_long = None
@@ -60,32 +60,46 @@ version_long = None
 # If we're performing CI for a new release branch (which our tooling creates
 # with an "upstream/" prefix), then we don't want to enforce strict version
 # matching because we know it will fail.
-is_release_branch_ci = (
+github_ci_release_br = bool(
+    os.environ.get("GITHUB_HEAD_REF", "").startswith(f"upstream/{src_version}")
+)
+travis_ci_release_br = bool(
     os.environ.get("TRAVIS_PULL_REQUEST_BRANCH", "").startswith("upstream/")
 )
+is_release_branch_ci = bool(github_ci_release_br or travis_ci_release_br)
+
 if is_gitdir(_tdir) and which("git") and not is_release_branch_ci:
-    flags = []
-    if use_tags:
-        flags = ['--tags']
-    cmd = ['git', 'describe', '--abbrev=8', '--match=[0-9]*'] + flags
+    branch_name = tiny_p(["git", "branch", "--show-current"]).strip()
+    if branch_name.startswith(f"upstream/{src_version}"):
+        version = src_version
+        version_long = None
+    else:
 
-    try:
-        version = tiny_p(cmd).strip()
-    except RuntimeError:
-        version = None
+        flags = []
+        if use_tags:
+            flags = ["--tags"]
+        cmd = ["git", "describe", "--abbrev=8", "--match=[0-9]*"] + flags
 
-    if version is None or not version.startswith(src_version):
-        sys.stderr.write("git describe version (%s) differs from "
-                         "cloudinit.version (%s)\n" % (version, src_version))
-        sys.stderr.write(
-            "Please get the latest upstream tags.\n"
-            "As an example, this can be done with the following:\n"
-            "$ git remote add upstream https://git.launchpad.net/cloud-init\n"
-            "$ git fetch upstream --tags\n"
-        )
-        sys.exit(1)
+        try:
+            version = tiny_p(cmd).strip()
+        except RuntimeError:
+            version = None
 
-    version_long = tiny_p(cmd + ["--long"]).strip()
+        if version is None or not version.startswith(src_version):
+            sys.stderr.write(
+                f"git describe version ({version}) differs from "
+                f"cloudinit.version ({src_version})\n"
+            )
+            sys.stderr.write(
+                "Please get the latest upstream tags.\n"
+                "As an example, this can be done with the following:\n"
+                "$ git remote add upstream https://git.launchpad.net/"
+                "cloud-init\n"
+                "$ git fetch upstream --tags\n"
+            )
+            sys.exit(1)
+
+        version_long = tiny_p(cmd + ["--long"]).strip()
 else:
     version = src_version
     version_long = None
@@ -105,13 +119,13 @@ if version_long:
     commit = commit[1:]
 
 data = {
-    'release': release,
-    'version': version,
-    'version_long': version_long,
-    'extra': extra,
-    'commit': commit,
-    'distance': distance,
-    'is_release_branch_ci': is_release_branch_ci,
+    "release": release,
+    "version": version,
+    "version_long": version_long,
+    "extra": extra,
+    "commit": commit,
+    "distance": distance,
+    "is_release_branch_ci": is_release_branch_ci,
 }
 
 if output_json:


### PR DESCRIPTION
## Proposed Commit Message
```
When creating a release branch with uss-tableflip/upstream-release
the branch name created is upstream/XX.YY.

If the current branch name is of that format, we should trust the
version defined in version.py as valid and avoid strict checks.

This branch adapts our branch name check for two cases:
1. We recently migrated CI format tests from Travis to github actions.
   Use GITHUB_REF environment variable instead of TRAVIS_PULL_REQUEST_BRANCH
2. local branches on developer machines will be named upstream/XX.YY.
   Use git branch --show-current to check if we are on such a branch
```

## Additional Context
<!-- If relevant -->
WIP branch proposed faking upstream/22.4 release https://github.com/canonical/cloud-init/pull/1678 which tests these tooling changes to ensure github actions pass on version checks

## Test Steps
```
# run against this branch
$ ./tools/read-version
22.3
# delete upstream tag expect failure message
$ git tag --delete 22.3
$ git describe version (22.2-158-g0431c145) differs from cloudinit.version (22.3)
Please get the latest upstream tags.
As an example, this can be done with the following:
$ git remote add upstream https://git.launchpad.net/cloud-init
$ git fetch upstream --tags

# rename this branch to upstream/22.4 and make sure src_version reflects that
sed -i 's/22.3/22.4/' cloudinit/version.py
git branch -m upstream/22.4
./tools/read-version
22.4
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
