### PR TITLE
rpm/copr: ensure RPM represents new clean.d dir artifacts

### DIFF
--- a/packages/redhat/cloud-init.spec.in
+++ b/packages/redhat/cloud-init.spec.in
@@ -192,6 +192,8 @@ fi
 
 # Configs
 %config(noreplace)      %{_sysconfdir}/cloud/cloud.cfg
+%dir                    %{_sysconfdir}/cloud/clean.d
+%config(noreplace)      %{_sysconfdir}/cloud/clean.d/README
 %dir                    %{_sysconfdir}/cloud/cloud.cfg.d
 %config(noreplace)      %{_sysconfdir}/cloud/cloud.cfg.d/*.cfg
 %config(noreplace)      %{_sysconfdir}/cloud/cloud.cfg.d/README

--- a/packages/suse/cloud-init.spec.in
+++ b/packages/suse/cloud-init.spec.in
@@ -114,6 +114,8 @@ version_pys=$(cd "%{buildroot}" && find . -name version.py -type f)
 %doc %{_defaultdocdir}/cloud-init/*
 
 # Configs
+%dir                    %{_sysconfdir}/cloud/clean.d
+%config(noreplace)      %{_sysconfdir}/cloud/clean.d/README
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg
 %dir               %{_sysconfdir}/cloud/cloud.cfg.d
 %config(noreplace) %{_sysconfdir}/cloud/cloud.cfg.d/*.cfg


### PR DESCRIPTION

COPR build failures because cloud-init packages a new /etc/cloud/clean.d directory but didn't list in the spec.

```
RPM build errors:
    Installed (but unpackaged) file(s) found:
   /etc/cloud/clean.d/README
```
[Failed COPR build logs](https://download.copr.fedorainfracloud.org/results/@cloud-init/el-testing/epel-8-x86_64/04750679-cloud-init/builder-live.log.gz)

## Proposed Commit Message

```
rpm/copr: ensure RPM represents new clean.d dir artifacts
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
