### PR TITLE
Networkd multi-address support/fix

### DIFF
--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -44,10 +44,16 @@ class CfgParser:
         for k, v in sorted(self.conf_dict.items()):
             if not v:
                 continue
-            contents += "[" + k + "]\n"
-            for e in sorted(v):
-                contents += e + "\n"
-            contents += "\n"
+            if k == "Address":
+                for e in sorted(v):
+                    contents += "[" + k + "]\n"
+                    contents += e + "\n"
+                    contents += "\n"
+            else:
+                contents += "[" + k + "]\n"
+                for e in sorted(v):
+                    contents += e + "\n"
+                contents += "\n"
 
         return contents
 

--- a/tests/unittests/net/test_networkd.py
+++ b/tests/unittests/net/test_networkd.py
@@ -12,6 +12,7 @@ network:
     eth0:
       match:
         macaddress: '00:11:22:33:44:55'
+      addresses["172.16.10.2/12" "172.16.10.3/12"]
       nameservers:
         search: [spam.local, eggs.local]
         addresses: [8.8.8.8]
@@ -24,7 +25,13 @@ network:
         addresses: [4.4.4.4]
 """
 
-V2_CONFIG_SET_NAME_RENDERED_ETH0 = """[Match]
+V2_CONFIG_SET_NAME_RENDERED_ETH0 = """[Address]
+Address=172.16.10.2/12
+
+[Address]
+Address=172.16.10.3/12
+
+[Match]
 MACAddress=00:11:22:33:44:55
 Name=eth0
 

--- a/tests/unittests/net/test_networkd.py
+++ b/tests/unittests/net/test_networkd.py
@@ -12,7 +12,7 @@ network:
     eth0:
       match:
         macaddress: '00:11:22:33:44:55'
-      addresses["172.16.10.2/12" "172.16.10.3/12"]
+      addresses: [172.16.10.2/12, 172.16.10.3/12]
       nameservers:
         search: [spam.local, eggs.local]
         addresses: [8.8.8.8]

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1277,6 +1277,7 @@ NETWORK_CONFIGS = {
             DHCP=no
             [Address]
             Address=192.168.14.2/24
+            [Address]
             Address=2001:1::1/64
         """
         ).rstrip(" "),

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -38,6 +38,7 @@ emmanuelthome
 eslerm
 esposem
 GabrielNagy
+garzdin
 giggsoff
 hamalq
 holmanb


### PR DESCRIPTION
Networkd multi-address support/fix

```
Given a cloud-init network config with multiple addresses for an interface the networkd backend outputs an invalid networkd service config. According to the `man` page of `systemd-networkd` only one `Address=` field per `[Address]` section is allowed.
```

## Additional Context
[Ref: https://www.freedesktop.org/software/systemd/man/systemd.network.html#Address=1](https://www.freedesktop.org/software/systemd/man/systemd.network.html#Address=1)
[Ref: https://man.archlinux.org/man/systemd.network.5#%5BADDRESS%5D_SECTION_OPTIONS](https://man.archlinux.org/man/systemd.network.5#%5BADDRESS%5D_SECTION_OPTIONS)

Older versions of `cloud-init` (e.g 19.4) output a valid config.

File location: `/etc/systemd/network/`

The invalid config leads to only one of the IPs being configured for the interface, since the second one is ignored. This can lead to communication issues between systems (e.g Kubernetes).

## Test Steps
Provision two systems that use `systemd-networkd` to configure network interfaces. Install 19.4 on one and 22.3 on the other. In the `cloud-init` network configuration specify 2 IPs for an interface. On the machine provisioned by `cloud-init` 19.4 the interface is correctly configured. On the machine provisioned by `cloud-init` 22.3 the interface only gets assigned the first IP from the `[Address]` section.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
