### PR TITLE
make: drop broken targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ YAML_FILES=$(shell find cloudinit tests tools -name "*.yaml" -type f )
 YAML_FILES+=$(shell find doc/examples -name "cloud-config*.txt" -type f )
 
 PYTHON = python3
-PIP_INSTALL := pip3 install
 
 NUM_ITER ?= 100
 
@@ -55,14 +54,6 @@ ci-deps-ubuntu:
 
 ci-deps-centos:
 	@$(PYTHON) $(CWD)/tools/read-dependencies --distro centos --test-distro
-
-pip-requirements:
-	@echo "Installing cloud-init dependencies..."
-	$(PIP_INSTALL) -r "$@.txt" -q
-
-pip-test-requirements:
-	@echo "Installing cloud-init test dependencies..."
-	$(PIP_INSTALL) -r "$@.txt" -q
 
 test: unittest
 
@@ -174,6 +165,6 @@ fix_spelling:
 		sh
 
 .PHONY: all check test flake8 clean rpm srpm deb deb-src yaml
-.PHONY: check_version pip-test-requirements pip-requirements clean_pyc
+.PHONY: check_version clean_pyc
 .PHONY: unittest style-check fix_spelling render-template benchmark-generator
 .PHONY: clean_pytest clean_packaging check_spelling clean_release doc


### PR DESCRIPTION
```
make: drop broken targets
```

## Additional Context
These targets appear to be unneeded:
```bash
isa~/cloud-init-c(holmanb/drop-broken-make-targets|…) rg pip-requirements
isa~/cloud-init-c(holmanb/drop-broken-make-targets|…) rg pip-test-requirements
isa~/cloud-init-c(holmanb/drop-broken-make-targets|…) grep PIP_INSTALL Makefile    
isa~/cloud-init-c(holmanb/drop-broken-make-targets|…)  
```

## Test Steps
These targets were broken when they were originally added in https://github.com/canonical/cloud-init/commit/b2ebae64a7b9738db6c6408cee4adc2bf2f17:
```bash
isa~/cloud-init-c(holmanb/drop-broken-make-targets|…) git checkout b2ebae64a7b9738db6c6408cee4adc2bf2f17 
Note: switching to 'b2ebae64a7b9738db6c6408cee4adc2bf2f17'.
<snip>

isa~/cloud-init-c(:b2ebae64|…) make pip-test-requirements
Installing cloud-init test dependencies...
pip install -r "pip-test-requirements.txt" -q
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'pip-test-requirements.txt'
make: *** [Makefile:34: pip-test-requirements] Error 1

isa~/cloud-init-c(:b2ebae64|…) make pip-requirements     
Installing cloud-init dependencies...
pip install -r "pip-requirements.txt" -q
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'pip-requirements.txt'
make: *** [Makefile:30: pip-requirements] Error 1
```