### PR TITLE
net: Ensure a tmp with exec permissions for dhcp

### DIFF
--- a/cloudinit/config/cc_chef.py
+++ b/cloudinit/config/cc_chef.py
@@ -14,7 +14,9 @@ import os
 from textwrap import dedent
 
 from cloudinit import subp, temp_utils, templater, url_helper, util
+from cloudinit.cloud import Cloud
 from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.distros import Distro
 from cloudinit.settings import PER_ALWAYS
 
 RUBY_VERSION_DEFAULT = "1.8"
@@ -185,7 +187,7 @@ def get_template_params(iid, chef_cfg, log):
     return params
 
 
-def handle(name, cfg, cloud, log, _args):
+def handle(name: str, cfg: dict, cloud: Cloud, log, _args):
     """Handler method activated by cloud-init."""
 
     # If there isn't a chef key in the configuration don't do anything
@@ -289,7 +291,7 @@ def run_chef(chef_cfg, log):
     subp.subp(cmd, capture=False)
 
 
-def subp_blob_in_tempfile(blob, *args, **kwargs):
+def subp_blob_in_tempfile(blob, distro: Distro, *args, **kwargs):
     """Write blob to a tempfile, and call subp with args, kwargs. Then cleanup.
 
     'basename' as a kwarg allows providing the basename for the file.
@@ -298,23 +300,27 @@ def subp_blob_in_tempfile(blob, *args, **kwargs):
     """
     basename = kwargs.pop("basename", "subp_blob")
 
-    if len(args) == 0 and "args" not in kwargs:
-        args = [tuple()]
+    _args = list(args)
+    if len(_args) == 0 and "args" not in kwargs:
+        _args.append(tuple())
 
     # Use tmpdir over tmpfile to avoid 'text file busy' on execute
-    with temp_utils.tempdir(needs_exe=True) as tmpd:
+    with temp_utils.tempdir(
+        dir=distro.get_tmp_exec_path(), needs_exe=True
+    ) as tmpd:
         tmpf = os.path.join(tmpd, basename)
         if "args" in kwargs:
             kwargs["args"] = [tmpf] + list(kwargs["args"])
         else:
-            args = list(args)
-            args[0] = [tmpf] + args[0]
+            _args[0] = [tmpf] + _args[0]
 
         util.write_file(tmpf, blob, mode=0o700)
-        return subp.subp(*args, **kwargs)
+        return subp.subp(*_args, **kwargs)
 
 
-def install_chef_from_omnibus(url=None, retries=None, omnibus_version=None):
+def install_chef_from_omnibus(
+    distro: Distro, url=None, retries=None, omnibus_version=None
+):
     """Install an omnibus unified package from url.
 
     @param url: URL where blob of chef content may be downloaded. Defaults to
@@ -335,11 +341,15 @@ def install_chef_from_omnibus(url=None, retries=None, omnibus_version=None):
         args = ["-v", omnibus_version]
     content = url_helper.readurl(url=url, retries=retries).contents
     return subp_blob_in_tempfile(
-        blob=content, args=args, basename="chef-omnibus-install", capture=False
+        distro=distro,
+        blob=content,
+        args=args,
+        basename="chef-omnibus-install",
+        capture=False,
     )
 
 
-def install_chef(cloud, chef_cfg, log):
+def install_chef(cloud: Cloud, chef_cfg, log):
     # If chef is not installed, we install chef based on 'install_type'
     install_type = util.get_cfg_option_str(
         chef_cfg, "install_type", "packages"
@@ -361,6 +371,7 @@ def install_chef(cloud, chef_cfg, log):
     elif install_type == "omnibus":
         omnibus_version = util.get_cfg_option_str(chef_cfg, "omnibus_version")
         install_chef_from_omnibus(
+            distro=cloud.distro,
             url=util.get_cfg_option_str(chef_cfg, "omnibus_url"),
             retries=util.get_cfg_option_int(chef_cfg, "omnibus_url_retries"),
             omnibus_version=omnibus_version,

--- a/cloudinit/config/cc_puppet.py
+++ b/cloudinit/config/cc_puppet.py
@@ -16,8 +16,9 @@ from textwrap import dedent
 import yaml
 
 from cloudinit import helpers, subp, temp_utils, url_helper, util
+from cloudinit.cloud import Cloud
 from cloudinit.config.schema import MetaSchema, get_meta_doc
-from cloudinit.distros import ALL_DISTROS
+from cloudinit.distros import ALL_DISTROS, Distro
 from cloudinit.settings import PER_INSTANCE
 
 AIO_INSTALL_URL = "https://raw.githubusercontent.com/puppetlabs/install-puppet/main/install.sh"  # noqa: E501
@@ -148,11 +149,16 @@ def get_config_value(puppet_bin, setting):
 
 
 def install_puppet_aio(
-    url=AIO_INSTALL_URL, version=None, collection=None, cleanup=True
+    distro: Distro,
+    url=AIO_INSTALL_URL,
+    version=None,
+    collection=None,
+    cleanup=True,
 ):
     """Install puppet-agent from the puppetlabs repositories using the one-shot
     shell script
 
+    :param distro: Instance of Distro
     :param url: URL from where to download the install script
     :param version: version to install, blank defaults to latest
     :param collection: collection to install, blank defaults to latest
@@ -170,13 +176,15 @@ def install_puppet_aio(
     content = url_helper.readurl(url=url, retries=5).contents
 
     # Use tmpdir over tmpfile to avoid 'text file busy' on execute
-    with temp_utils.tempdir(needs_exe=True) as tmpd:
+    with temp_utils.tempdir(
+        dir=distro.get_tmp_exec_path(), needs_exe=True
+    ) as tmpd:
         tmpf = os.path.join(tmpd, "puppet-install")
         util.write_file(tmpf, content, mode=0o700)
         return subp.subp([tmpf] + args, capture=False)
 
 
-def handle(name, cfg, cloud, log, _args):
+def handle(name: str, cfg: dict, cloud: Cloud, log, _args):
     # If there isn't a puppet key in the configuration don't do anything
     if "puppet" not in cfg:
         log.debug(
@@ -228,7 +236,9 @@ def handle(name, cfg, cloud, log, _args):
         if install_type == "packages":
             cloud.distro.install_packages((package_name, version))
         elif install_type == "aio":
-            install_puppet_aio(aio_install_url, version, collection, cleanup)
+            install_puppet_aio(
+                cloud.distro, aio_install_url, version, collection, cleanup
+            )
         else:
             log.warning("Unknown puppet install type '%s'", install_type)
             run = False

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -20,7 +20,15 @@ from typing import Any, Mapping, Optional, Type
 
 from cloudinit import importer
 from cloudinit import log as logging
-from cloudinit import net, persistence, ssh_util, subp, type_utils, util
+from cloudinit import (
+    net,
+    persistence,
+    ssh_util,
+    subp,
+    temp_utils,
+    type_utils,
+    util,
+)
 from cloudinit.distros.parsers import hosts
 from cloudinit.features import ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES
 from cloudinit.net import activators, eni, network_state, renderers
@@ -942,7 +950,10 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         else:
             raise NotImplementedError()
 
-    def _get_tmp_exec_path(self) -> str:
+    def get_tmp_exec_path(self) -> str:
+        tmp_dir = temp_utils.get_tmp_ancestor(needs_exe=True)
+        if not util.has_mount_opt(tmp_dir, "noexec"):
+            return tmp_dir
         return os.path.join(self.usr_lib_exec, "cloud-init", "clouddir")
 
 

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -942,6 +942,9 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         else:
             raise NotImplementedError()
 
+    def _get_tmp_exec_path(self) -> str:
+        return os.path.join(self.usr_lib_exec, "cloud-init", "clouddir")
+
 
 def _apply_hostname_transformations_to_url(url: str, transformations: list):
     """

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -41,9 +41,7 @@ class NoDHCPLeaseMissingDhclientError(NoDHCPLeaseError):
     """Raised when unable to find dhclient."""
 
 
-def maybe_perform_dhcp_discovery(
-    nic=None, dhcp_log_func=None, alt_exe_dir=None
-):
+def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None, tmp_dir=None):
     """Perform dhcp discovery if nic valid and dhclient command exists.
 
     If the nic is invalid or undiscoverable or dhclient command is not found,
@@ -52,7 +50,7 @@ def maybe_perform_dhcp_discovery(
     @param nic: Name of the network interface we want to run dhclient on.
     @param dhcp_log_func: A callable accepting the dhclient output and error
         streams.
-    @param alt_exe_dir: Alternative dir with exec permissions.
+    @param tmp_dir: Tmp dir with exec permissions.
     @return: A list of dicts representing dhcp options for each lease obtained
         from the dhclient discovery if run, otherwise an empty list is
         returned.
@@ -75,7 +73,7 @@ def maybe_perform_dhcp_discovery(
         rmtree_ignore_errors=True,
         prefix="cloud-init-dhcp-",
         needs_exe=True,
-        alt_exe_dir=alt_exe_dir,
+        dir=tmp_dir,
     ) as tdir:
         # Use /var/tmp because /run/cloud-init/tmp is mounted noexec
         return dhcp_discovery(dhclient_path, nic, tdir, dhcp_log_func)

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -41,7 +41,9 @@ class NoDHCPLeaseMissingDhclientError(NoDHCPLeaseError):
     """Raised when unable to find dhclient."""
 
 
-def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None):
+def maybe_perform_dhcp_discovery(
+    nic=None, dhcp_log_func=None, alt_exe_dir=None
+):
     """Perform dhcp discovery if nic valid and dhclient command exists.
 
     If the nic is invalid or undiscoverable or dhclient command is not found,
@@ -50,6 +52,7 @@ def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None):
     @param nic: Name of the network interface we want to run dhclient on.
     @param dhcp_log_func: A callable accepting the dhclient output and error
         streams.
+    @param alt_exe_dir: Alternative dir with exec permissions.
     @return: A list of dicts representing dhcp options for each lease obtained
         from the dhclient discovery if run, otherwise an empty list is
         returned.
@@ -69,7 +72,10 @@ def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None):
         LOG.debug("Skip dhclient configuration: No dhclient command found.")
         raise NoDHCPLeaseMissingDhclientError()
     with temp_utils.tempdir(
-        rmtree_ignore_errors=True, prefix="cloud-init-dhcp-", needs_exe=True
+        rmtree_ignore_errors=True,
+        prefix="cloud-init-dhcp-",
+        needs_exe=True,
+        alt_exe_dir=alt_exe_dir,
     ) as tdir:
         # Use /var/tmp because /run/cloud-init/tmp is mounted noexec
         return dhcp_discovery(dhclient_path, nic, tdir, dhcp_log_func)

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -315,14 +315,14 @@ class EphemeralDHCPv4(object):
         iface=None,
         connectivity_url_data: Dict[str, Any] = None,
         dhcp_log_func=None,
-        alt_tmp_dir=None,
+        tmp_dir=None,
     ):
         self.iface = iface
         self._ephipv4 = None
         self.lease = None
         self.dhcp_log_func = dhcp_log_func
         self.connectivity_url_data = connectivity_url_data
-        self.alt_tmp_dir = alt_tmp_dir
+        self.tmp_dir = tmp_dir
 
     def __enter__(self):
         """Setup sandboxed dhcp context, unless connectivity_url can already be
@@ -361,7 +361,7 @@ class EphemeralDHCPv4(object):
         if self.lease:
             return self.lease
         leases = maybe_perform_dhcp_discovery(
-            self.iface, self.dhcp_log_func, self.alt_tmp_dir
+            self.iface, self.dhcp_log_func, self.tmp_dir
         )
         if not leases:
             raise NoDHCPLeaseError()
@@ -426,14 +426,14 @@ class EphemeralIPNetwork:
         interface,
         ipv6: bool = False,
         ipv4: bool = True,
-        alt_tmp_dir=None,
+        tmp_dir=None,
     ):
         self.interface = interface
         self.ipv4 = ipv4
         self.ipv6 = ipv6
         self.stack = contextlib.ExitStack()
         self.state_msg: str = ""
-        self.alt_tmp_dir = alt_tmp_dir
+        self.tmp_dir = tmp_dir
 
     def __enter__(self):
         # ipv6 dualstack might succeed when dhcp4 fails
@@ -441,9 +441,7 @@ class EphemeralIPNetwork:
         try:
             if self.ipv4:
                 self.stack.enter_context(
-                    EphemeralDHCPv4(
-                        self.interface, alt_tmp_dir=self.alt_tmp_dir
-                    )
+                    EphemeralDHCPv4(self.interface, tmp_dir=self.tmp_dir)
                 )
             if self.ipv6:
                 self.stack.enter_context(EphemeralIPv6Network(self.interface))

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -315,12 +315,14 @@ class EphemeralDHCPv4(object):
         iface=None,
         connectivity_url_data: Dict[str, Any] = None,
         dhcp_log_func=None,
+        alt_tmp_dir=None,
     ):
         self.iface = iface
         self._ephipv4 = None
         self.lease = None
         self.dhcp_log_func = dhcp_log_func
         self.connectivity_url_data = connectivity_url_data
+        self.alt_tmp_dir = alt_tmp_dir
 
     def __enter__(self):
         """Setup sandboxed dhcp context, unless connectivity_url can already be
@@ -358,7 +360,9 @@ class EphemeralDHCPv4(object):
         """
         if self.lease:
             return self.lease
-        leases = maybe_perform_dhcp_discovery(self.iface, self.dhcp_log_func)
+        leases = maybe_perform_dhcp_discovery(
+            self.iface, self.dhcp_log_func, self.alt_tmp_dir
+        )
         if not leases:
             raise NoDHCPLeaseError()
         self.lease = leases[-1]
@@ -417,19 +421,30 @@ class EphemeralDHCPv4(object):
 class EphemeralIPNetwork:
     """Marries together IPv4 and IPv6 ephemeral context managers"""
 
-    def __init__(self, interface, ipv6: bool = False, ipv4: bool = True):
+    def __init__(
+        self,
+        interface,
+        ipv6: bool = False,
+        ipv4: bool = True,
+        alt_tmp_dir=None,
+    ):
         self.interface = interface
         self.ipv4 = ipv4
         self.ipv6 = ipv6
         self.stack = contextlib.ExitStack()
         self.state_msg: str = ""
+        self.alt_tmp_dir = alt_tmp_dir
 
     def __enter__(self):
         # ipv6 dualstack might succeed when dhcp4 fails
         # therefore catch exception unless only v4 is used
         try:
             if self.ipv4:
-                self.stack.enter_context(EphemeralDHCPv4(self.interface))
+                self.stack.enter_context(
+                    EphemeralDHCPv4(
+                        self.interface, alt_tmp_dir=self.alt_tmp_dir
+                    )
+                )
             if self.ipv6:
                 self.stack.enter_context(EphemeralIPv6Network(self.interface))
         # v6 link local might be usable

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -401,7 +401,7 @@ class DataSourceAzure(sources.DataSource):
         self._ephemeral_dhcp_ctx = EphemeralDHCPv4(
             iface=iface,
             dhcp_log_func=dhcp_log_cb,
-            alt_tmp_dir=self.distro._get_tmp_exec_path(),
+            tmp_dir=self.distro.get_tmp_exec_path(),
         )
 
         lease = None

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -399,7 +399,9 @@ class DataSourceAzure(sources.DataSource):
 
         LOG.debug("Requested ephemeral networking (iface=%s)", iface)
         self._ephemeral_dhcp_ctx = EphemeralDHCPv4(
-            iface=iface, dhcp_log_func=dhcp_log_cb
+            iface=iface,
+            dhcp_log_func=dhcp_log_cb,
+            alt_tmp_dir=self.distro._get_tmp_exec_path(),
         )
 
         lease = None

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -130,7 +130,7 @@ class DataSourceEc2(sources.DataSource):
                     self.fallback_interface,
                     ipv4=True,
                     ipv6=True,
-                    alt_tmp_dir=self.distro._get_tmp_exec_path(),
+                    tmp_dir=self.distro.get_tmp_exec_path(),
                 ) as netw:
                     state_msg = f" {netw.state_msg}" if netw.state_msg else ""
                     self._crawled_metadata = util.log_time(

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -127,7 +127,10 @@ class DataSourceEc2(sources.DataSource):
                 return False
             try:
                 with EphemeralIPNetwork(
-                    self.fallback_interface, ipv6=True
+                    self.fallback_interface,
+                    ipv4=True,
+                    ipv6=True,
+                    alt_tmp_dir=self.distro._get_tmp_exec_path(),
                 ) as netw:
                     state_msg = f" {netw.state_msg}" if netw.state_msg else ""
                     self._crawled_metadata = util.log_time(

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -85,7 +85,7 @@ class DataSourceGCE(sources.DataSource):
         if self.perform_dhcp_setup:
             network_context = EphemeralDHCPv4(
                 self.fallback_interface,
-                alt_tmp_dir=self.distro._get_tmp_exec_path(),
+                tmp_dir=self.distro.get_tmp_exec_path(),
             )
         with network_context:
             ret = util.log_time(

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -83,7 +83,10 @@ class DataSourceGCE(sources.DataSource):
         url_params = self.get_url_params()
         network_context = noop()
         if self.perform_dhcp_setup:
-            network_context = EphemeralDHCPv4(self.fallback_interface)
+            network_context = EphemeralDHCPv4(
+                self.fallback_interface,
+                alt_tmp_dir=self.distro._get_tmp_exec_path(),
+            )
         with network_context:
             ret = util.log_time(
                 LOG.debug,

--- a/cloudinit/sources/DataSourceHetzner.py
+++ b/cloudinit/sources/DataSourceHetzner.py
@@ -61,7 +61,7 @@ class DataSourceHetzner(sources.DataSource):
                 connectivity_url_data={
                     "url": BASE_URL_V1 + "/metadata/instance-id",
                 },
-                alt_tmp_dir=self.distro._get_tmp_exec_path(),
+                tmp_dir=self.distro.get_tmp_exec_path(),
             ):
                 md = hc_helper.read_metadata(
                     self.metadata_address,

--- a/cloudinit/sources/DataSourceHetzner.py
+++ b/cloudinit/sources/DataSourceHetzner.py
@@ -61,6 +61,7 @@ class DataSourceHetzner(sources.DataSource):
                 connectivity_url_data={
                     "url": BASE_URL_V1 + "/metadata/instance-id",
                 },
+                alt_tmp_dir=self.distro._get_tmp_exec_path(),
             ):
                 md = hc_helper.read_metadata(
                     self.metadata_address,

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -150,7 +150,10 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
 
         if self.perform_dhcp_setup:  # Setup networking in init-local stage.
             try:
-                with EphemeralDHCPv4(self.fallback_interface):
+                with EphemeralDHCPv4(
+                    self.fallback_interface,
+                    alt_tmp_dir=self.distro._get_tmp_exec_path(),
+                ):
                     results = util.log_time(
                         logfunc=LOG.debug,
                         msg="Crawl of metadata service",

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -152,7 +152,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             try:
                 with EphemeralDHCPv4(
                     self.fallback_interface,
-                    alt_tmp_dir=self.distro._get_tmp_exec_path(),
+                    tmp_dir=self.distro.get_tmp_exec_path(),
                 ):
                     results = util.log_time(
                         logfunc=LOG.debug,

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -155,7 +155,7 @@ class DataSourceOracle(sources.DataSource):
                 "url": METADATA_PATTERN.format(version=2, path="instance"),
                 "headers": V2_HEADERS,
             },
-            alt_tmp_dir=self.distro._get_tmp_exec_path(),
+            tmp_dir=self.distro.get_tmp_exec_path(),
         )
         fetch_primary_nic = not self._is_iscsi_root()
         fetch_secondary_nics = self.ds_cfg.get(

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -155,6 +155,7 @@ class DataSourceOracle(sources.DataSource):
                 "url": METADATA_PATTERN.format(version=2, path="instance"),
                 "headers": V2_HEADERS,
             },
+            alt_tmp_dir=self.distro._get_tmp_exec_path(),
         )
         fetch_primary_nic = not self._is_iscsi_root()
         fetch_secondary_nics = self.ds_cfg.get(

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -212,7 +212,7 @@ class DataSourceScaleway(sources.DataSource):
         try:
             with EphemeralDHCPv4(
                 self._fallback_interface,
-                alt_tmp_dir=self.distro._get_tmp_exec_path(),
+                tmp_dir=self.distro.get_tmp_exec_path(),
             ):
                 util.log_time(
                     logfunc=LOG.debug,

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -210,7 +210,10 @@ class DataSourceScaleway(sources.DataSource):
         if self._fallback_interface is None:
             self._fallback_interface = net.find_fallback_nic()
         try:
-            with EphemeralDHCPv4(self._fallback_interface):
+            with EphemeralDHCPv4(
+                self._fallback_interface,
+                alt_tmp_dir=self.distro._get_tmp_exec_path(),
+            ):
                 util.log_time(
                     logfunc=LOG.debug,
                     msg="Crawl of metadata service",

--- a/cloudinit/sources/DataSourceUpCloud.py
+++ b/cloudinit/sources/DataSourceUpCloud.py
@@ -71,7 +71,9 @@ class DataSourceUpCloud(sources.DataSource):
                 LOG.debug("Finding a fallback NIC")
                 nic = cloudnet.find_fallback_nic()
                 LOG.debug("Discovering metadata via DHCP interface %s", nic)
-                with EphemeralDHCPv4(nic):
+                with EphemeralDHCPv4(
+                    nic, alt_tmp_dir=self.distro._get_tmp_exec_path()
+                ):
                     md = util.log_time(
                         logfunc=LOG.debug,
                         msg="Reading from metadata service",

--- a/cloudinit/sources/DataSourceUpCloud.py
+++ b/cloudinit/sources/DataSourceUpCloud.py
@@ -72,7 +72,7 @@ class DataSourceUpCloud(sources.DataSource):
                 nic = cloudnet.find_fallback_nic()
                 LOG.debug("Discovering metadata via DHCP interface %s", nic)
                 with EphemeralDHCPv4(
-                    nic, alt_tmp_dir=self.distro._get_tmp_exec_path()
+                    nic, tmp_dir=self.distro.get_tmp_exec_path()
                 ):
                     md = util.log_time(
                         logfunc=LOG.debug,

--- a/cloudinit/sources/DataSourceVultr.py
+++ b/cloudinit/sources/DataSourceVultr.py
@@ -99,6 +99,7 @@ class DataSourceVultr(sources.DataSource):
             self.ds_cfg["retries"],
             self.ds_cfg["wait"],
             self.ds_cfg["user-agent"],
+            alt_tmp_dir=self.distro._get_tmp_exec_path(),
         )
 
     # Compare subid as instance id

--- a/cloudinit/sources/DataSourceVultr.py
+++ b/cloudinit/sources/DataSourceVultr.py
@@ -99,7 +99,7 @@ class DataSourceVultr(sources.DataSource):
             self.ds_cfg["retries"],
             self.ds_cfg["wait"],
             self.ds_cfg["user-agent"],
-            alt_tmp_dir=self.distro._get_tmp_exec_path(),
+            tmp_dir=self.distro.get_tmp_exec_path(),
         )
 
     # Compare subid as instance id

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -18,7 +18,7 @@ LOG = log.getLogger(__name__)
 
 
 @lru_cache()
-def get_metadata(url, timeout, retries, sec_between, agent):
+def get_metadata(url, timeout, retries, sec_between, agent, alt_tmp_dir=None):
     # Bring up interface (and try untill one works)
     exception = RuntimeError("Failed to DHCP")
 
@@ -26,7 +26,9 @@ def get_metadata(url, timeout, retries, sec_between, agent):
     for iface in get_interface_list():
         try:
             with EphemeralDHCPv4(
-                iface=iface, connectivity_url_data={"url": url}
+                iface=iface,
+                connectivity_url_data={"url": url},
+                alt_tmp_dir=alt_tmp_dir,
             ):
                 # Check for the metadata route, skip if not there
                 if not check_route(url):

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -18,7 +18,7 @@ LOG = log.getLogger(__name__)
 
 
 @lru_cache()
-def get_metadata(url, timeout, retries, sec_between, agent, alt_tmp_dir=None):
+def get_metadata(url, timeout, retries, sec_between, agent, tmp_dir=None):
     # Bring up interface (and try untill one works)
     exception = RuntimeError("Failed to DHCP")
 
@@ -28,7 +28,7 @@ def get_metadata(url, timeout, retries, sec_between, agent, alt_tmp_dir=None):
             with EphemeralDHCPv4(
                 iface=iface,
                 connectivity_url_data={"url": url},
-                alt_tmp_dir=alt_tmp_dir,
+                tmp_dir=tmp_dir,
             ):
                 # Check for the metadata route, skip if not there
                 if not check_route(url):

--- a/cloudinit/temp_utils.py
+++ b/cloudinit/temp_utils.py
@@ -15,11 +15,6 @@ _ROOT_TMPDIR = "/run/cloud-init/tmp"
 _EXE_ROOT_TMPDIR = "/var/tmp/cloud-init"
 
 
-def _is_noexec_mount(path) -> bool:
-    *_, mnt_opts = util.get_mount_info(path, get_mnt_opts=True)
-    return "noexec" in mnt_opts
-
-
 def get_tmp_ancestor(odir=None, needs_exe: bool = False):
     if odir is not None:
         return odir

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2592,6 +2592,11 @@ def get_mount_info(path, log=LOG, get_mnt_opts=False):
         return parse_mount(path)
 
 
+def has_mount_opt(path, opt: str) -> bool:
+    *_, mnt_opts = get_mount_info(path, get_mnt_opts=True)
+    return opt in mnt_opts.split(",")
+
+
 T = TypeVar("T")
 
 

--- a/tests/integration_tests/datasources/test_tmp_noexec.py
+++ b/tests/integration_tests/datasources/test_tmp_noexec.py
@@ -21,6 +21,9 @@ def customize_client(client: IntegrationInstance):
 @pytest.mark.openstack
 def test_dhcp_tmp_noexec(client: IntegrationInstance):
     customize_client(client)
+    assert (
+        "noexec" in client.execute('grep "/var/tmp" /proc/mounts').stdout
+    ), "Precondition error: /var/tmp is not mounted as noexec"
     log = client.read_from_file("/var/log/cloud-init.log")
     assert (
         "dhclient did not produce expected files: dhcp.leases, dhclient.pid"

--- a/tests/integration_tests/datasources/test_tmp_noexec.py
+++ b/tests/integration_tests/datasources/test_tmp_noexec.py
@@ -1,0 +1,29 @@
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+
+def customize_client(client: IntegrationInstance):
+    assert client.execute(
+        "echo '/tmp /var/tmp none rw,noexec,nosuid,nodev,bind 0 0'"
+        " | sudo tee -a /etc/fstab"
+    ).ok
+    client.execute("cloud-init clean --logs")
+    client.restart()
+
+
+@pytest.mark.adhoc
+@pytest.mark.azure
+@pytest.mark.ec2
+@pytest.mark.gce
+@pytest.mark.oci
+@pytest.mark.openstack
+def test_dhcp_tmp_noexec(client: IntegrationInstance):
+    customize_client(client)
+    log = client.read_from_file("/var/log/cloud-init.log")
+    assert (
+        "dhclient did not produce expected files: dhcp.leases, dhclient.pid"
+        not in log
+    )
+    verify_clean_log(log)

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -101,7 +101,7 @@ class TestDisabled(unittest.TestCase):
     def setUp(self):
         super(TestDisabled, self).setUp()
         self.name = "growpart"
-        self.cloud_init = None
+        self.cloud = None
         self.log = logging.getLogger("TestDisabled")
         self.args = []
 
@@ -114,9 +114,7 @@ class TestDisabled(unittest.TestCase):
         config = {"growpart": {"mode": "off"}}
 
         with mock.patch.object(cc_growpart, "resizer_factory") as mockobj:
-            self.handle(
-                self.name, config, self.cloud_init, self.log, self.args
-            )
+            self.handle(self.name, config, self.cloud, self.log, self.args)
             self.assertEqual(mockobj.call_count, 0)
 
 
@@ -130,7 +128,6 @@ class TestConfig(TestCase):
         self.log = logging.getLogger("TestConfig")
         self.args = []
 
-        self.cloud_init = self.cloud
         self.handle = cc_growpart.handle
         self.tmppath = "/tmp/cloudinit-test-file"
         self.tmpdir = os.scandir("/tmp")
@@ -147,9 +144,7 @@ class TestConfig(TestCase):
         ) as mockobj:
 
             config = {"growpart": {"mode": "auto"}}
-            self.handle(
-                self.name, config, self.cloud_init, self.log, self.args
-            )
+            self.handle(self.name, config, self.cloud, self.log, self.args)
 
             mockobj.assert_has_calls(
                 [
@@ -171,7 +166,7 @@ class TestConfig(TestCase):
                 self.handle,
                 self.name,
                 config,
-                self.cloud_init,
+                self.cloud,
                 self.log,
                 self.args,
             )
@@ -276,7 +271,7 @@ class TestConfig(TestCase):
                 )
             )
 
-            self.handle(self.name, {}, self.cloud_init, self.log, self.args)
+            self.handle(self.name, {}, self.cloud, self.log, self.args)
 
             factory.assert_called_once_with("auto", self.distro)
             rsdevs.assert_called_once_with(myresizer, ["/"])

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -125,11 +125,12 @@ class TestConfig(TestCase):
         super(TestConfig, self).setUp()
         self.name = "growpart"
         self.paths = None
-        self.cloud = cloud.Cloud(None, self.paths, None, None, None)
+        self.distro = mock.Mock()
+        self.cloud = cloud.Cloud(None, self.paths, None, self.distro, None)
         self.log = logging.getLogger("TestConfig")
         self.args = []
 
-        self.cloud_init = None
+        self.cloud_init = self.cloud
         self.handle = cc_growpart.handle
         self.tmppath = "/tmp/cloudinit-test-file"
         self.tmpdir = os.scandir("/tmp")
@@ -184,7 +185,7 @@ class TestConfig(TestCase):
         with mock.patch.object(
             subp, "subp", return_value=(HELP_GROWPART_RESIZE, "")
         ) as mockobj:
-            ret = cc_growpart.resizer_factory(mode="auto")
+            ret = cc_growpart.resizer_factory(mode="auto", distro=mock.Mock())
             self.assertIsInstance(ret, cc_growpart.ResizeGrowPart)
 
             mockobj.assert_called_once_with(
@@ -210,7 +211,7 @@ class TestConfig(TestCase):
             subp, "subp", return_value=(HELP_GROWPART_RESIZE, "")
         ) as mockobj:
 
-            ret = cc_growpart.resizer_factory(mode="auto")
+            ret = cc_growpart.resizer_factory(mode="auto", distro=mock.Mock())
             self.assertIsInstance(ret, cc_growpart.ResizeGrowPart)
             diskdev = "/dev/sdb"
             partnum = 1
@@ -234,7 +235,7 @@ class TestConfig(TestCase):
         with mock.patch.object(
             subp, "subp", return_value=("", HELP_GPART)
         ) as mockobj:
-            ret = cc_growpart.resizer_factory(mode="auto")
+            ret = cc_growpart.resizer_factory(mode="auto", distro=mock.Mock())
             self.assertIsInstance(ret, cc_growpart.ResizeGpart)
 
             mockobj.assert_has_calls(
@@ -277,7 +278,7 @@ class TestConfig(TestCase):
 
             self.handle(self.name, {}, self.cloud_init, self.log, self.args)
 
-            factory.assert_called_once_with("auto")
+            factory.assert_called_once_with("auto", self.distro)
             rsdevs.assert_called_once_with(myresizer, ["/"])
 
 

--- a/tests/unittests/config/test_cc_ubuntu_drivers.py
+++ b/tests/unittests/config/test_cc_ubuntu_drivers.py
@@ -218,8 +218,11 @@ class TestUbuntuDrivers:
         debconf_file = tmpdir.join("nvidia.template")
         m_tmp.return_value = tdir
         pkg_install = mock.MagicMock()
+        distro = mock.Mock()
         drivers.install_drivers(
-            cfg_accepted["drivers"], pkg_install_func=pkg_install
+            cfg_accepted["drivers"],
+            pkg_install_func=pkg_install,
+            distro=distro,
         )
         assert 0 == pkg_install.call_count
         assert [mock.call("ubuntu-drivers")] == m_which.call_args_list
@@ -233,8 +236,11 @@ class TestUbuntuDrivers:
     ):
         """install_drivers should raise TypeError if not given a config dict"""
         pkg_install = mock.MagicMock()
+        distro = mock.Mock()
         with pytest.raises(TypeError, match=".*expected dict.*"):
-            drivers.install_drivers("mystring", pkg_install_func=pkg_install)
+            drivers.install_drivers(
+                "mystring", pkg_install_func=pkg_install, distro=distro
+            )
         assert 0 == pkg_install.call_count
 
     @mock.patch(M_TMP_PATH)

--- a/tests/unittests/net/test_ephemeral.py
+++ b/tests/unittests/net/test_ephemeral.py
@@ -22,16 +22,22 @@ class TestEphemeralIPNetwork:
         m_exit_stack,
         ipv4,
         ipv6,
+        tmpdir,
     ):
         interface = object()
-        with EphemeralIPNetwork(interface, ipv4=ipv4, ipv6=ipv6):
+        tmp_dir = str(tmpdir)
+        with EphemeralIPNetwork(
+            interface, ipv4=ipv4, ipv6=ipv6, tmp_dir=tmp_dir
+        ):
             pass
         expected_call_args_list = []
         if ipv4:
             expected_call_args_list.append(
                 mock.call(m_ephemeral_dhcp_v4.return_value)
             )
-            assert [mock.call(interface)] == m_ephemeral_dhcp_v4.call_args_list
+            assert [
+                mock.call(interface, tmp_dir=tmp_dir)
+            ] == m_ephemeral_dhcp_v4.call_args_list
         else:
             assert [] == m_ephemeral_dhcp_v4.call_args_list
         if ipv6:

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3005,7 +3005,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
         """Wait for nic attach if we do not have a fallback interface.
         Skip waiting for additional nics after we have found primary"""
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         lease = {
             "interface": "eth9",
@@ -3069,7 +3069,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
         """Retry polling for network metadata on all failures except timeout
         and network unreachable errors"""
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         lease = {
             "interface": "eth9",
@@ -3288,7 +3288,7 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         report_file = self.tmp_path("report_marker", self.tmp)
         m_isfile.return_value = True
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         with mock.patch.object(
             dsa, "_reported_ready_marker_file", report_file
@@ -3354,7 +3354,7 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         ]
         m_media_switch.return_value = None
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         self.assertFalse(os.path.exists(report_file))
         with mock.patch.object(
@@ -3388,7 +3388,7 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         m_media_switch.return_value = None
         m_report_ready.side_effect = [Exception("fail")]
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         self.assertFalse(os.path.exists(report_file))
         with mock.patch.object(
@@ -3650,7 +3650,7 @@ class TestEphemeralNetworking:
             mock.call(
                 iface=iface,
                 dhcp_log_func=dsaz.dhcp_log_cb,
-                alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+                tmp_dir=azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call().obtain_lease(),
         ]
@@ -3677,7 +3677,7 @@ class TestEphemeralNetworking:
             mock.call(
                 iface=iface,
                 dhcp_log_func=dsaz.dhcp_log_cb,
-                alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+                tmp_dir=azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call().obtain_lease(),
         ]
@@ -3720,7 +3720,7 @@ class TestEphemeralNetworking:
             mock.call(
                 iface=None,
                 dhcp_log_func=dsaz.dhcp_log_cb,
-                alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+                tmp_dir=azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call().obtain_lease(),
             mock.call().obtain_lease(),
@@ -3755,7 +3755,7 @@ class TestEphemeralNetworking:
             mock.call(
                 iface=None,
                 dhcp_log_func=dsaz.dhcp_log_cb,
-                alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+                tmp_dir=azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call().obtain_lease(),
             mock.call().obtain_lease(),
@@ -3794,7 +3794,7 @@ class TestEphemeralNetworking:
                 mock.call(
                     iface=None,
                     dhcp_log_func=dsaz.dhcp_log_cb,
-                    alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+                    tmp_dir=azure_ds.distro.get_tmp_exec_path(),
                 ),
             ]
             + [mock.call().obtain_lease()] * 11
@@ -4132,7 +4132,7 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             )
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
@@ -4213,12 +4213,12 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
@@ -4325,12 +4325,12 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call(
                 "ethAttached1",
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
@@ -4473,12 +4473,12 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call(
                 "ethAttached1",
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
@@ -4569,7 +4569,7 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             ),
         ]
 
@@ -4633,7 +4633,7 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro._get_tmp_exec_path(),
+                self.azure_ds.distro.get_tmp_exec_path(),
             )
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3004,7 +3004,9 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
     ):
         """Wait for nic attach if we do not have a fallback interface.
         Skip waiting for additional nics after we have found primary"""
-        dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
+        dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         lease = {
             "interface": "eth9",
             "fixed-address": "192.168.2.9",
@@ -3050,7 +3052,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
         m_attach.side_effect = ["eth0", "eth1"]
         m_imds.reset_mock()
         m_imds.side_effect = [{}, md]
-        dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
+        dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         dsa._wait_for_all_nics_ready()
         self.assertEqual(1, m_detach.call_count)
         self.assertEqual(2, m_attach.call_count)
@@ -3066,7 +3068,9 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
     ):
         """Retry polling for network metadata on all failures except timeout
         and network unreachable errors"""
-        dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
+        dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         lease = {
             "interface": "eth9",
             "fixed-address": "192.168.2.9",
@@ -3102,7 +3106,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
             requests.Timeout("Fake connection timeout")
         ] * 6 + [requests.ConnectionError("Fake Network Unreachable")] * 6
 
-        dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
+        dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
 
         is_primary, expected_nic_count = dsa._check_if_nic_is_primary("eth1")
         self.assertEqual(False, is_primary)
@@ -3283,7 +3287,9 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         m_request.side_effect = fake_timeout_once
         report_file = self.tmp_path("report_marker", self.tmp)
         m_isfile.return_value = True
-        dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
+        dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         with mock.patch.object(
             dsa, "_reported_ready_marker_file", report_file
         ), mock.patch.object(dsa, "_ephemeral_dhcp_ctx") as m_dhcp_ctx:
@@ -3347,7 +3353,9 @@ class TestPreprovisioningPollIMDS(CiTestCase):
             }
         ]
         m_media_switch.return_value = None
-        dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
+        dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         self.assertFalse(os.path.exists(report_file))
         with mock.patch.object(
             dsa, "_reported_ready_marker_file", report_file
@@ -3379,7 +3387,9 @@ class TestPreprovisioningPollIMDS(CiTestCase):
         ]
         m_media_switch.return_value = None
         m_report_ready.side_effect = [Exception("fail")]
-        dsa = dsaz.DataSourceAzure({}, distro=None, paths=self.paths)
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
+        dsa = dsaz.DataSourceAzure({}, distro=distro, paths=self.paths)
         self.assertFalse(os.path.exists(report_file))
         with mock.patch.object(
             dsa, "_reported_ready_marker_file", report_file
@@ -3637,7 +3647,11 @@ class TestEphemeralNetworking:
         azure_ds._setup_ephemeral_networking(iface=iface)
 
         assert mock_ephemeral_dhcp_v4.mock_calls == [
-            mock.call(iface=iface, dhcp_log_func=dsaz.dhcp_log_cb),
+            mock.call(
+                iface=iface,
+                dhcp_log_func=dsaz.dhcp_log_cb,
+                alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+            ),
             mock.call().obtain_lease(),
         ]
         assert mock_sleep.mock_calls == []
@@ -3660,7 +3674,11 @@ class TestEphemeralNetworking:
         azure_ds._setup_ephemeral_networking(iface=iface)
 
         assert mock_ephemeral_dhcp_v4.mock_calls == [
-            mock.call(iface=iface, dhcp_log_func=dsaz.dhcp_log_cb),
+            mock.call(
+                iface=iface,
+                dhcp_log_func=dsaz.dhcp_log_cb,
+                alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+            ),
             mock.call().obtain_lease(),
         ]
         assert mock_sleep.mock_calls == []
@@ -3699,7 +3717,11 @@ class TestEphemeralNetworking:
         azure_ds._setup_ephemeral_networking()
 
         assert mock_ephemeral_dhcp_v4.mock_calls == [
-            mock.call(iface=None, dhcp_log_func=dsaz.dhcp_log_cb),
+            mock.call(
+                iface=None,
+                dhcp_log_func=dsaz.dhcp_log_cb,
+                alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+            ),
             mock.call().obtain_lease(),
             mock.call().obtain_lease(),
         ]
@@ -3730,7 +3752,11 @@ class TestEphemeralNetworking:
         azure_ds._setup_ephemeral_networking()
 
         assert mock_ephemeral_dhcp_v4.mock_calls == [
-            mock.call(iface=None, dhcp_log_func=dsaz.dhcp_log_cb),
+            mock.call(
+                iface=None,
+                dhcp_log_func=dsaz.dhcp_log_cb,
+                alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+            ),
             mock.call().obtain_lease(),
             mock.call().obtain_lease(),
         ]
@@ -3765,7 +3791,11 @@ class TestEphemeralNetworking:
         assert (
             mock_ephemeral_dhcp_v4.mock_calls
             == [
-                mock.call(iface=None, dhcp_log_func=dsaz.dhcp_log_cb),
+                mock.call(
+                    iface=None,
+                    dhcp_log_func=dsaz.dhcp_log_cb,
+                    alt_tmp_dir=azure_ds.distro._get_tmp_exec_path(),
+                ),
             ]
             + [mock.call().obtain_lease()] * 11
         )
@@ -4099,7 +4129,11 @@ class TestProvisioning:
             mock.call(timeout_minutes=20)
         ]
         assert self.mock_net_dhcp_maybe_perform_dhcp_discovery.mock_calls == [
-            mock.call(None, dsaz.dhcp_log_cb)
+            mock.call(
+                None,
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            )
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
         assert self.azure_ds._is_ephemeral_networking_up() is False
@@ -4176,8 +4210,16 @@ class TestProvisioning:
             mock.call(timeout_minutes=5),
         ]
         assert self.mock_net_dhcp_maybe_perform_dhcp_discovery.mock_calls == [
-            mock.call(None, dsaz.dhcp_log_cb),
-            mock.call(None, dsaz.dhcp_log_cb),
+            mock.call(
+                None,
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            ),
+            mock.call(
+                None,
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
         assert self.azure_ds._is_ephemeral_networking_up() is False
@@ -4280,8 +4322,16 @@ class TestProvisioning:
             mock.call(iface="ethAttached1", timeout_minutes=20),
         ]
         assert self.mock_net_dhcp_maybe_perform_dhcp_discovery.mock_calls == [
-            mock.call(None, dsaz.dhcp_log_cb),
-            mock.call("ethAttached1", dsaz.dhcp_log_cb),
+            mock.call(
+                None,
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            ),
+            mock.call(
+                "ethAttached1",
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
         assert self.azure_ds._is_ephemeral_networking_up() is False
@@ -4420,8 +4470,16 @@ class TestProvisioning:
             mock.call(iface="ethAttached1", timeout_minutes=20),
         ]
         assert self.mock_net_dhcp_maybe_perform_dhcp_discovery.mock_calls == [
-            mock.call(None, dsaz.dhcp_log_cb),
-            mock.call("ethAttached1", dsaz.dhcp_log_cb),
+            mock.call(
+                None,
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            ),
+            mock.call(
+                "ethAttached1",
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
         assert self.azure_ds._is_ephemeral_networking_up() is False
@@ -4508,7 +4566,11 @@ class TestProvisioning:
             mock.call(timeout_minutes=20),
         ]
         assert self.mock_net_dhcp_maybe_perform_dhcp_discovery.mock_calls == [
-            mock.call(None, dsaz.dhcp_log_cb),
+            mock.call(
+                None,
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            ),
         ]
 
         # Verify IMDS metadata.
@@ -4568,7 +4630,11 @@ class TestProvisioning:
             mock.call(timeout_minutes=20)
         ]
         assert self.mock_net_dhcp_maybe_perform_dhcp_discovery.mock_calls == [
-            mock.call(None, dsaz.dhcp_log_cb)
+            mock.call(
+                None,
+                dsaz.dhcp_log_cb,
+                self.azure_ds.distro._get_tmp_exec_path(),
+            )
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
         assert self.azure_ds._is_ephemeral_networking_up() is False

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -337,7 +337,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
     def _setup_ds(self, sys_cfg, platform_data, md, md_version=None):
         self.uris = []
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         paths = helpers.Paths({"run_dir": self.tmp})
         if sys_cfg is None:
             sys_cfg = {}

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -336,7 +336,8 @@ class TestEc2(test_helpers.HttprettyTestCase):
 
     def _setup_ds(self, sys_cfg, platform_data, md, md_version=None):
         self.uris = []
-        distro = {}
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
         paths = helpers.Paths({"run_dir": self.tmp})
         if sys_cfg is None:
             sys_cfg = {}
@@ -873,7 +874,7 @@ class TestEc2(test_helpers.HttprettyTestCase):
 
         ret = ds.get_data()
         self.assertTrue(ret)
-        m_dhcp.assert_called_once_with("eth9", None)
+        m_dhcp.assert_called_once_with("eth9", None, mock.ANY)
         m_net4.assert_called_once_with(
             broadcast="192.168.2.255",
             interface="eth9",

--- a/tests/unittests/sources/test_gce.py
+++ b/tests/unittests/sources/test_gce.py
@@ -396,8 +396,10 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
     )
     def test_local_datasource_uses_ephemeral_dhcp(self, _m_fallback, m_dhcp):
         _set_mock_metadata()
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
         ds = DataSourceGCE.DataSourceGCELocal(
-            sys_cfg={}, distro=None, paths=None
+            sys_cfg={}, distro=distro, paths=None
         )
         ds._get_data()
         assert m_dhcp.call_count == 1

--- a/tests/unittests/sources/test_gce.py
+++ b/tests/unittests/sources/test_gce.py
@@ -397,7 +397,7 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
     def test_local_datasource_uses_ephemeral_dhcp(self, _m_fallback, m_dhcp):
         _set_mock_metadata()
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         ds = DataSourceGCE.DataSourceGCELocal(
             sys_cfg={}, distro=distro, paths=None
         )

--- a/tests/unittests/sources/test_hetzner.py
+++ b/tests/unittests/sources/test_hetzner.py
@@ -66,8 +66,10 @@ class TestDataSourceHetzner(CiTestCase):
         self.tmp = self.tmp_dir()
 
     def get_ds(self):
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
         ds = DataSourceHetzner.DataSourceHetzner(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         return ds
 
@@ -112,6 +114,7 @@ class TestDataSourceHetzner(CiTestCase):
             connectivity_url_data={
                 "url": "http://169.254.169.254/hetzner/v1/metadata/instance-id"
             },
+            alt_tmp_dir=mock.ANY,
         )
 
         self.assertTrue(m_readmd.called)

--- a/tests/unittests/sources/test_hetzner.py
+++ b/tests/unittests/sources/test_hetzner.py
@@ -67,7 +67,7 @@ class TestDataSourceHetzner(CiTestCase):
 
     def get_ds(self):
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         ds = DataSourceHetzner.DataSourceHetzner(
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
@@ -114,7 +114,7 @@ class TestDataSourceHetzner(CiTestCase):
             connectivity_url_data={
                 "url": "http://169.254.169.254/hetzner/v1/metadata/instance-id"
             },
-            alt_tmp_dir=mock.ANY,
+            tmp_dir=mock.ANY,
         )
 
         self.assertTrue(m_readmd.called)

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -293,7 +293,7 @@ class TestOpenStackDataSource(test_helpers.HttprettyTestCase):
         """OpenStackLocal calls EphemeralDHCPNetwork and gets instance data."""
         _register_uris(self.VERSION, EC2_FILES, EC2_META, OS_FILES)
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         ds_os_local = ds.DataSourceOpenStackLocal(
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -18,6 +18,7 @@ from cloudinit.sources import DataSourceOpenStack as ds
 from cloudinit.sources import convert_vendordata
 from cloudinit.sources.helpers import openstack
 from tests.unittests import helpers as test_helpers
+from tests.unittests.helpers import mock
 
 BASE_URL = "http://169.254.169.254"
 PUBKEY = "ssh-rsa AAAAB3NzaC1....sIkJhq8wdX+4I3A4cYbYP ubuntu@server-460\n"
@@ -291,8 +292,10 @@ class TestOpenStackDataSource(test_helpers.HttprettyTestCase):
     def test_local_datasource(self, m_dhcp, m_net):
         """OpenStackLocal calls EphemeralDHCPNetwork and gets instance data."""
         _register_uris(self.VERSION, EC2_FILES, EC2_META, OS_FILES)
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
         ds_os_local = ds.DataSourceOpenStackLocal(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         ds_os_local._fallback_interface = "eth9"  # Monkey patch for dhcp
         m_dhcp.return_value = [
@@ -322,7 +325,7 @@ class TestOpenStackDataSource(test_helpers.HttprettyTestCase):
         self.assertEqual(VENDOR_DATA, ds_os_local.vendordata_pure)
         self.assertEqual(VENDOR_DATA2, ds_os_local.vendordata2_pure)
         self.assertIsNone(ds_os_local.vendordata_raw)
-        m_dhcp.assert_called_with("eth9", None)
+        m_dhcp.assert_called_with("eth9", None, mock.ANY)
 
     def test_bad_datasource_meta(self):
         os_files = copy.deepcopy(OS_FILES)

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -929,7 +929,7 @@ class TestNonIscsiRoot_GetDataBehaviour:
                     "headers": {"Authorization": "Bearer Oracle"},
                     "url": "http://169.254.169.254/opc/v2/instance/",
                 },
-                alt_tmp_dir=oracle_ds.distro._get_tmp_exec_path(),
+                tmp_dir=oracle_ds.distro.get_tmp_exec_path(),
             )
         ] == m_EphemeralDHCPv4.call_args_list
 
@@ -972,7 +972,7 @@ class TestNonIscsiRoot_GetDataBehaviour:
                     "headers": {"Authorization": "Bearer Oracle"},
                     "url": "http://169.254.169.254/opc/v2/instance/",
                 },
-                alt_tmp_dir=oracle_ds.distro._get_tmp_exec_path(),
+                tmp_dir=oracle_ds.distro.get_tmp_exec_path(),
             )
         ] == m_EphemeralDHCPv4.call_args_list
 

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -929,6 +929,7 @@ class TestNonIscsiRoot_GetDataBehaviour:
                     "headers": {"Authorization": "Bearer Oracle"},
                     "url": "http://169.254.169.254/opc/v2/instance/",
                 },
+                alt_tmp_dir=oracle_ds.distro._get_tmp_exec_path(),
             )
         ] == m_EphemeralDHCPv4.call_args_list
 
@@ -971,6 +972,7 @@ class TestNonIscsiRoot_GetDataBehaviour:
                     "headers": {"Authorization": "Bearer Oracle"},
                     "url": "http://169.254.169.254/opc/v2/instance/",
                 },
+                alt_tmp_dir=oracle_ds.distro._get_tmp_exec_path(),
             )
         ] == m_EphemeralDHCPv4.call_args_list
 

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -173,7 +173,7 @@ class TestDataSourceScaleway(HttprettyTestCase):
     def setUp(self):
         tmp = self.tmp_dir()
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         self.datasource = DataSourceScaleway.DataSourceScaleway(
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": tmp})
         )

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -172,8 +172,10 @@ def get_source_address_adapter(*args, **kwargs):
 class TestDataSourceScaleway(HttprettyTestCase):
     def setUp(self):
         tmp = self.tmp_dir()
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
         self.datasource = DataSourceScaleway.DataSourceScaleway(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": tmp})
         )
         super(TestDataSourceScaleway, self).setUp()
 

--- a/tests/unittests/sources/test_upcloud.py
+++ b/tests/unittests/sources/test_upcloud.py
@@ -208,7 +208,7 @@ class TestUpCloudNetworkSetup(CiTestCase):
 
     def get_ds(self, get_sysinfo=_mock_dmi):
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         ds = DataSourceUpCloudLocal(
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )

--- a/tests/unittests/sources/test_upcloud.py
+++ b/tests/unittests/sources/test_upcloud.py
@@ -207,8 +207,10 @@ class TestUpCloudNetworkSetup(CiTestCase):
         self.tmp = self.tmp_dir()
 
     def get_ds(self, get_sysinfo=_mock_dmi):
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
         ds = DataSourceUpCloudLocal(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         if get_sysinfo:
             ds._get_sysinfo = get_sysinfo
@@ -240,7 +242,7 @@ class TestUpCloudNetworkSetup(CiTestCase):
         self.assertTrue(ret)
 
         self.assertTrue(m_dhcp.called)
-        m_dhcp.assert_called_with("eth1", None)
+        m_dhcp.assert_called_with("eth1", None, mock.ANY)
 
         m_net.assert_called_once_with(
             broadcast="10.6.3.255",

--- a/tests/unittests/sources/test_vultr.py
+++ b/tests/unittests/sources/test_vultr.py
@@ -262,8 +262,10 @@ class TestDataSourceVultr(CiTestCase):
         mock_isvultr.return_value = True
         mock_netmap.return_value = INTERFACE_MAP
 
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
         source = DataSourceVultr.DataSourceVultr(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
 
         # Test for failure
@@ -323,7 +325,9 @@ class TestDataSourceVultr(CiTestCase):
         self.assertEqual(expected, vultr.generate_network_config(interf))
 
     # Override ephemeral for proper unit testing
-    def ephemeral_init(self, iface="", connectivity_url_data=None):
+    def ephemeral_init(
+        self, iface="", connectivity_url_data=None, alt_tmp_dir=None
+    ):
         global FINAL_INTERFACE_USED
         FINAL_INTERFACE_USED = iface
         if iface == "eth0":
@@ -331,7 +335,9 @@ class TestDataSourceVultr(CiTestCase):
         raise NoDHCPLeaseError("Generic for testing")
 
     # Override ephemeral for proper unit testing
-    def ephemeral_init_always(self, iface="", connectivity_url_data=None):
+    def ephemeral_init_always(
+        self, iface="", connectivity_url_data=None, alt_tmp_dir=None
+    ):
         global FINAL_INTERFACE_USED
         FINAL_INTERFACE_USED = iface
 
@@ -369,8 +375,10 @@ class TestDataSourceVultr(CiTestCase):
         mock_interface_list.return_value = FILTERED_INTERFACES
         mock_check_route.return_value = True
 
+        distro = mock.MagicMock()
+        distro._get_tmp_exec_path = self.tmp_dir
         source = DataSourceVultr.DataSourceVultr(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
 
         try:

--- a/tests/unittests/sources/test_vultr.py
+++ b/tests/unittests/sources/test_vultr.py
@@ -263,7 +263,7 @@ class TestDataSourceVultr(CiTestCase):
         mock_netmap.return_value = INTERFACE_MAP
 
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         source = DataSourceVultr.DataSourceVultr(
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
@@ -326,7 +326,7 @@ class TestDataSourceVultr(CiTestCase):
 
     # Override ephemeral for proper unit testing
     def ephemeral_init(
-        self, iface="", connectivity_url_data=None, alt_tmp_dir=None
+        self, iface="", connectivity_url_data=None, tmp_dir=None
     ):
         global FINAL_INTERFACE_USED
         FINAL_INTERFACE_USED = iface
@@ -336,7 +336,7 @@ class TestDataSourceVultr(CiTestCase):
 
     # Override ephemeral for proper unit testing
     def ephemeral_init_always(
-        self, iface="", connectivity_url_data=None, alt_tmp_dir=None
+        self, iface="", connectivity_url_data=None, tmp_dir=None
     ):
         global FINAL_INTERFACE_USED
         FINAL_INTERFACE_USED = iface
@@ -376,7 +376,7 @@ class TestDataSourceVultr(CiTestCase):
         mock_check_route.return_value = True
 
         distro = mock.MagicMock()
-        distro._get_tmp_exec_path = self.tmp_dir
+        distro.get_tmp_exec_path = self.tmp_dir
         source = DataSourceVultr.DataSourceVultr(
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
net: Ensure a tmp with exec permissions for dhcp

In the case cloudinit.temp_utils points to a fs mounted as noexec
and needs_exe=True, fallback to use
os.join.path(Distro.usr_lib_exec, "cloud-init/clouddir) that
will be mounted with exec perms.

LP: #1962343
```

## Additional Context
<!-- If relevant -->
https://bugs.launchpad.net/cloud-init/+bug/1962343
https://warthogs.atlassian.net/browse/SC-958

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Execute `tests/integration_tests/datasources/test_tmp_noexec.py`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
