### PR TITLE
test: make ansible test work across older versions

### DIFF
--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -31,8 +31,9 @@ write_files:
        WantedBy=cloud-init-local.service
 
        [Service]
-       ExecStart=/usr/bin/env python3 -m http.server \
-         --directory /root/playbooks/.git
+       WorkingDirectory=/root/playbooks/.git
+       ExecStart=/usr/bin/env python3 -m http.server --bind 0.0.0.0 8000
+
 
   - path: /etc/systemd/system/repo_waiter.service
     content: |
@@ -49,7 +50,7 @@ write_files:
        # running and continue once it is up, but this is simple and works
        [Service]
        Type=oneshot
-       ExecStart=sh -c "while \
+       ExecStart=/bin/sh -c "while \
             ! git clone http://0.0.0.0:8000/ $(mktemp -d); do sleep 0.1; done"
 
   - path: /root/playbooks/ubuntu.yml

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -95,6 +95,9 @@ ansible:
 """
 
 SETUP_REPO = f"cd {REPO_D}                                    &&\
+git config --global user.name auto                            &&\
+git config --global user.email autom@tic.io                   &&\
+git config --global init.defaultBranch main                   &&\
 git init {REPO_D}                                             &&\
 git add {REPO_D}/roles/apt/tasks/main.yml {REPO_D}/ubuntu.yml &&\
 git commit -m auto                                            &&\
@@ -102,8 +105,9 @@ git commit -m auto                                            &&\
 
 
 def _test_ansible_pull_from_local_server(my_client):
-
-    assert my_client.execute(SETUP_REPO).ok
+    setup = my_client.execute(SETUP_REPO)
+    assert not setup.stderr
+    assert not setup.return_code
     my_client.execute("cloud-init clean --logs")
     my_client.restart()
     log = my_client.read_from_file("/var/log/cloud-init.log")


### PR DESCRIPTION
```
test: make ansible test compatible with old versions

- python http.server: drop --directory arg
- systemd: use absolute paths with ExecStart=

Additionally make git repo setup more robust and improve output
during error condition.
```

Bionic Output
=============
`man systemd.service`:
```bash
<snip>
           For each of the specified commands, the first argument must be an absolute path to an executable. Optionally, this filename may be prefixed with a number of
           special characters:
<snip>
```

`http.server` has no directory arg (added in 3.7):
```
~# python3 -m http.server --help
usage: server.py [-h] [--cgi] [--bind ADDRESS] [port]

positional arguments:
  port                  Specify alternate port [default: 8000]

optional arguments:
  -h, --help            show this help message and exit
  --cgi                 Run as CGI Server
  --bind ADDRESS, -b ADDRESS
                        Specify alternate bind address [default: all
                        interfaces]
```

Git Repo Setup Failure
======================
```
AssertionError: assert False
 +  where False = 'Initialized empty Git repository in /root/playbooks/.git/'.ok
 +    where 'Initialized empty Git repository in /root/playbooks/.git/' = <bound method IntegrationInstance.execute of <tests.integration_tests.instances.IntegrationInstance object at 0x7fc7545cff10>>('cd /root/playbooks                                    &&git init /root/playbooks                                             &&git add /root/playbooks/roles/apt/tasks/main.yml /root/playbooks/ubuntu.yml &&git commit -m auto                                            &&(cd /root/playbooks/.git; git update-server-info)')
 +      where <bound method IntegrationInstance.execute of <tests.integration_tests.instances.IntegrationInstance object at 0x7fc7545cff10>> = <tests.integration_tests.instances.IntegrationInstance object at 0x7fc7545cff10>.execute
```
I have been unable to reproduce this locally. However, I added some basic config settings that make this more robust[1]. This additionally adds some code that will make failures in jenkins produce useful error messages.

[1] un-configured username/email used to cause `git commit` to fail iirc