### PR TITLE
[cc_set_passwords]: Refactor get_users_by_type

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -95,16 +95,12 @@ PW_SET = "".join([x for x in ascii_letters + digits if x not in "loLOI01"])
 
 
 def get_users_by_type(users_list: list, pw_type: str) -> list:
-    """either password or type: RANDOM is required, user is always required"""
-    return (
-        []
-        if not users_list
-        else [
-            (item["name"], item.get("password", "RANDOM"))
-            for item in users_list
-            if item.get("type", "hash") == pw_type
-        ]
-    )
+    """either password or type: RANDOM is required, users_list is always required"""
+    return [
+        item["name"]
+        for item in users_list
+        if item.get("type", "hash") == pw_type
+    ]
 
 
 def handle_ssh_pwauth(pw_auth, distro: Distro):
@@ -240,12 +236,10 @@ def handle(_name, cfg: dict, cloud: Cloud, log: Logger, args: list):
         # This section is for parsing the data that arrives in the form of
         #   chpasswd:
         #     users:
-        plist_in = get_users_by_type(users_list, "text")
-        users = [user for user, _ in plist_in]
-        hashed_plist_in = get_users_by_type(users_list, "hash")
-        hashed_users = [user for user, _ in hashed_plist_in]
+        users = get_users_by_type(users_list, "text")
+        hashed_users = get_users_by_type(users_list, "hash")
         randlist = []
-        for user, _ in get_users_by_type(users_list, "RANDOM"):
+        for user get_users_by_type(users_list, "RANDOM"):
             password = rand_user_password()
             users.append(user)
             plist_in.append((user, password))


### PR DESCRIPTION
Callers were never using the second part (password) of the tuples
returned by get_users_by_type.

No need to shortcut to an empty list with a list comprehension that
iterates over an empty list.

## Proposed Commit Message

```
cc_set_passwords: refactor get_users_by_type

Callers were never using the second part (password) of the tuples
returned by get_users_by_type.

No need to shortcut to an empty list with a list comprehension that
iterates over an empty list.
```


## Test Steps
Unit tests

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
