### PR TITLE
doc: add reporting suggestion to docs (SC-1236)

### DIFF
--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -166,21 +166,6 @@ To wait for clous-init to complete, run:
 
         $ cloud-init status --wait
 
-Failing to Complete on Systemd:
--------------------------------
-
-Cloud-init consists of multiple services on systemd. If a service
-that cloud-init depends on stalls, cloud-init will not continue.
-If reporting a bug related to cloud-init failing to complete on
-systemd, please make sure to include the following logs.
-
-.. code-block:: shell-session
-
-        $ systemd-analyze critical-chain cloud-init.target
-        $ journalctl --boot=-1
-        $ systemctl --failed
-
-
 There are a number of reasons that cloud-init might never complete. This list
 is not exhaustive, but attempts to enumerate potential causes:
 
@@ -196,6 +181,21 @@ Internal reasons:
   `cloud-init status --wait` will wait forever on itself and never complete)
 - nonstandard configurations that disable timeouts or set extremely high
   values ("never" is used in a loose sense here)
+
+Failing to Complete on Systemd:
+-------------------------------
+
+Cloud-init consists of multiple services on systemd. If a service
+that cloud-init depends on stalls, cloud-init will not continue.
+If reporting a bug related to cloud-init failing to complete on
+systemd, please make sure to include the following logs.
+
+.. code-block:: shell-session
+
+        $ systemd-analyze critical-chain cloud-init.target
+        $ journalctl --boot=-1
+        $ systemctl --failed
+
 
 How can I make a module run on every boot?
 ==========================================

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -178,7 +178,6 @@ systemd, please make sure to include the following logs.
 
         $ systemd-analyze critical-chain cloud-init.target
         $ journalctl --boot=-1
-
         $ systemctl --failed
 
 

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -177,6 +177,7 @@ systemd, please make sure to include the following logs.
 .. code-block:: shell-session
 
         $ systemd-analyze critical-chain cloud-init.target
+        $ journalctl --boot=-1
 
         $ systemctl --failed
 

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -166,12 +166,27 @@ To wait for clous-init to complete, run:
 
         $ cloud-init status --wait
 
+Failing to Complete on Systemd:
+-------------------------------
+
+Cloud-init consists of multiple services on systemd. If a service
+that cloud-init depends on stalls, cloud-init will not continue.
+If reporting a bug related to cloud-init failing to complete on
+systemd, please make sure to include the following logs.
+
+.. code-block:: shell-session
+
+        $ systemd-analyze critical-chain cloud-init.target
+
+        $ systemctl --failed
+
+
 There are a number of reasons that cloud-init might never complete. This list
 is not exhaustive, but attempts to enumerate potential causes:
 
 External reasons:
 -----------------
-- failed dependant services in the boot
+- failed dependent services in the boot
 - bugs in the kernel or drivers
 - bugs in external userspace tools that are called by cloud-init
 


### PR DESCRIPTION
```
doc: add reporting suggestion to docs
```

## Additional Context
External scripts waiting on cloud-init leads to bug reports that relate to cloud-init only symptomatically. Lets document how users can make better reports in the faq.

(open to suggestions if we want to list more commands to report on)
