### PR TITLE
test: reduce number of network dependencies in flaky test

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -67,8 +67,8 @@ snap:
   commands:
     - snap install hello-world
 ssh_import_id:
-  - gh:powersj
   - lp:smoser
+
 timezone: US/Aleutian
 """
 


### PR DESCRIPTION
```
test: reduce number of required http endpoints in flaky test

This should help with Github rate limiting.
```

## Additional Context
This test has always been flaky for reasons outside of our control. Maybe long term it doesn't deserve ci coverage? Current theory is we are getting rate limited by Github (local testing git hit by rate limiting pretty quickly).
```
E           assert ['(\'ssh-import-id\', ProcessExecutionError("Unexpected error while running '\n "command.\\nCommand: ['sudo', '--preserve-env=https_proxy', '-Hu', 'ubuntu', "\n "'ssh-import-id', 'gh:powersj', 'lp:smoser']\\nExit code: 1\\nReason: "\n '-\\nStdout: -\\nStderr: -"))'] == []
E             Left contains one more item: '(\'ssh-import-id\', ProcessExecutionError("Unexpected error while running command.\\nCommand: [\'sudo\', \'--preserve...', \'ubuntu\', \'ssh-import-id\', \'gh:powersj\', \'lp:smoser\']\\nExit code: 1\\nReason: -\\nStdout: -\\nStderr: -"))'
E             Full diff:
E               [
E             -  ,
E             +  '(\'ssh-import-id\', ProcessExecutionError("Unexpected error while running '
E             +  "command.\\nCommand: ['sudo', '--preserve-env=https_proxy', '-Hu', 'ubuntu', "
E             +  "'ssh-import-id', 'gh:powersj', 'lp:smoser']\\nExit code: 1\\nReason: "
E             +  '-\\nStdout: -\\nStderr: -"))',
E               ]
```