### PR TITLE
Refactor instance json files to use Paths (SC-1238)

### DIFF
--- a/cloudinit/cmd/cloud_id.py
+++ b/cloudinit/cmd/cloud_id.py
@@ -8,15 +8,10 @@ import argparse
 import json
 import sys
 
+from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.cmd.status import UXAppStatus, get_status_details
-from cloudinit.sources import (
-    INSTANCE_JSON_FILE,
-    METADATA_UNKNOWN,
-    canonical_cloud_id,
-)
+from cloudinit.sources import METADATA_UNKNOWN, canonical_cloud_id
 from cloudinit.util import error
-
-DEFAULT_INSTANCE_JSON = "/run/cloud-init/%s" % INSTANCE_JSON_FILE
 
 NAME = "cloud-id"
 
@@ -30,6 +25,7 @@ def get_parser(parser=None):
 
     @returns: ArgumentParser with proper argument configuration.
     """
+    default_instance_json = read_cfg_paths().get_runpath("instance_data")
     if not parser:
         parser = argparse.ArgumentParser(
             prog=NAME,
@@ -53,9 +49,11 @@ def get_parser(parser=None):
         "-i",
         "--instance-data",
         type=str,
-        default=DEFAULT_INSTANCE_JSON,
-        help="Path to instance-data.json file. Default is %s"
-        % DEFAULT_INSTANCE_JSON,
+        default=default_instance_json,
+        help=(
+            "Path to instance-data.json file. "
+            f"Default is {default_instance_json}"
+        ),
     )
     return parser
 

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -13,7 +13,7 @@ import sys
 from datetime import datetime
 
 from cloudinit.cmd.devel import read_cfg_paths
-from cloudinit.sources import INSTANCE_JSON_SENSITIVE_FILE
+from cloudinit.helpers import Paths
 from cloudinit.subp import ProcessExecutionError, subp
 from cloudinit.temp_utils import tempdir
 from cloudinit.util import chdir, copy, ensure_dir, write_file
@@ -80,7 +80,7 @@ def _copytree_rundir_ignore_files(curdir, files):
     ]
     if os.getuid() != 0:
         # Ignore root-permissioned files
-        ignored_files.append(INSTANCE_JSON_SENSITIVE_FILE)
+        ignored_files.append(Paths({}).lookups["instance_data_sensitive"])
     return ignored_files
 
 

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -10,7 +10,6 @@ import sys
 
 from cloudinit import log
 from cloudinit.handlers.jinja_template import render_jinja_payload_from_file
-from cloudinit.sources import INSTANCE_JSON_FILE, INSTANCE_JSON_SENSITIVE_FILE
 
 from . import addLogHandlerCLI, read_cfg_paths
 
@@ -65,11 +64,9 @@ def handle_args(name, args):
     else:
         paths = read_cfg_paths()
         uid = os.getuid()
-        redacted_data_fn = os.path.join(paths.run_dir, INSTANCE_JSON_FILE)
+        redacted_data_fn = paths.get_runpath("instance_data")
         if uid == 0:
-            instance_data_fn = os.path.join(
-                paths.run_dir, INSTANCE_JSON_SENSITIVE_FILE
-            )
+            instance_data_fn = paths.get_runpath("instance_data_sensitive")
             if not os.path.exists(instance_data_fn):
                 LOG.warning(
                     "Missing root-readable %s. Using redacted %s instead.",

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -802,12 +802,10 @@ def status_wrapper(name, args, data_d=None, link_d=None):
     return len(v1[mode]["errors"])
 
 
-def _maybe_persist_instance_data(init):
+def _maybe_persist_instance_data(init: stages.Init):
     """Write instance-data.json file if absent and datasource is restored."""
-    if init.ds_restored:
-        instance_data_file = os.path.join(
-            init.paths.run_dir, sources.INSTANCE_JSON_FILE
-        )
+    if init.datasource and init.ds_restored:
+        instance_data_file = init.paths.get_runpath("instance_data")
         if not os.path.exists(instance_data_file):
             init.datasource.persist_instance_data(write_cache=False)
 

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -8,8 +8,8 @@ from typing import Optional, Type
 
 from cloudinit import handlers
 from cloudinit import log as logging
+from cloudinit.helpers import Paths
 from cloudinit.settings import PER_ALWAYS
-from cloudinit.sources import INSTANCE_JSON_SENSITIVE_FILE
 from cloudinit.templater import MISSING_JINJA_PREFIX, render_string
 from cloudinit.util import b64d, json_dumps, load_file, load_json
 
@@ -29,7 +29,7 @@ class JinjaTemplatePartHandler(handlers.Handler):
 
     prefixes = ["## template: jinja"]
 
-    def __init__(self, paths, **_kwargs):
+    def __init__(self, paths: Paths, **_kwargs):
         handlers.Handler.__init__(self, PER_ALWAYS, version=3)
         self.paths = paths
         self.sub_handlers = {}
@@ -40,9 +40,7 @@ class JinjaTemplatePartHandler(handlers.Handler):
     def handle_part(self, data, ctype, filename, payload, frequency, headers):
         if ctype in handlers.CONTENT_SIGNALS:
             return
-        jinja_json_file = os.path.join(
-            self.paths.run_dir, INSTANCE_JSON_SENSITIVE_FILE
-        )
+        jinja_json_file = self.paths.get_runpath("instance_data_sensitive")
         rendered_payload = render_jinja_payload_from_file(
             payload, filename, jinja_json_file
         )

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -382,6 +382,12 @@ class Paths(persistence.CloudInitPickleMixin):
             self.run_dir = Paths(
                 path_cfgs=self.cfgs, ds=self.datasource
             ).run_dir
+        if "instance_data" not in self.lookups:
+            self.lookups["instance_data"] = "instance-data.json"
+        if "instance_data_sensitive" not in self.lookups:
+            self.lookups[
+                "instance_data_sensitive"
+            ] = "instance-data-sensitive.json"
 
     # get_ipath_cur: get the current instance path for an item
     def get_ipath_cur(self, name=None):

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -350,7 +350,12 @@ class Paths(persistence.CloudInitPickleMixin):
             "cloud_config": "cloud-config.txt",
             "data": "data",
             "handlers": "handlers",
+            # File in which public available instance meta-data is written
+            # security-sensitive key values are redacted from this
+            # world-readable file
             "instance_data": "instance-data.json",
+            # security-sensitive key values are present in this root-readable
+            # file
             "instance_data_sensitive": "instance-data-sensitive.json",
             "instance_id": ".instance-id",
             "manual_clean_marker": "manual-clean",

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -333,33 +333,39 @@ class Paths(persistence.CloudInitPickleMixin):
     def __init__(self, path_cfgs: dict, ds=None):
         self.cfgs = path_cfgs
         # Populate all the initial paths
-        self.cloud_dir = path_cfgs.get("cloud_dir", "/var/lib/cloud")
-        self.run_dir = path_cfgs.get("run_dir", "/run/cloud-init")
-        self.instance_link = os.path.join(self.cloud_dir, "instance")
-        self.boot_finished = os.path.join(self.instance_link, "boot-finished")
-        self.seed_dir = os.path.join(self.cloud_dir, "seed")
+        self.cloud_dir: str = path_cfgs.get("cloud_dir", "/var/lib/cloud")
+        self.run_dir: str = path_cfgs.get("run_dir", "/run/cloud-init")
+        self.instance_link: str = os.path.join(self.cloud_dir, "instance")
+        self.boot_finished: str = os.path.join(
+            self.instance_link, "boot-finished"
+        )
+        self.seed_dir: str = os.path.join(self.cloud_dir, "seed")
         # This one isn't joined, since it should just be read-only
-        template_dir = path_cfgs.get("templates_dir", "/etc/cloud/templates/")
-        self.template_tpl = os.path.join(template_dir, "%s.tmpl")
+        template_dir: str = path_cfgs.get(
+            "templates_dir", "/etc/cloud/templates/"
+        )
+        self.template_tpl: str = os.path.join(template_dir, "%s.tmpl")
         self.lookups = {
-            "handlers": "handlers",
-            "scripts": "scripts",
-            "vendor_scripts": "scripts/vendor",
-            "sem": "sem",
             "boothooks": "boothooks",
-            "userdata_raw": "user-data.txt",
-            "userdata": "user-data.txt.i",
-            "obj_pkl": "obj.pkl",
             "cloud_config": "cloud-config.txt",
-            "vendor_cloud_config": "vendor-cloud-config.txt",
-            "vendor2_cloud_config": "vendor2-cloud-config.txt",
             "data": "data",
-            "vendordata_raw": "vendor-data.txt",
-            "vendordata2_raw": "vendor-data2.txt",
-            "vendordata": "vendor-data.txt.i",
-            "vendordata2": "vendor-data2.txt.i",
+            "handlers": "handlers",
+            "instance_data": "instance-data.json",
+            "instance_data_sensitive": "instance-data-sensitive.json",
             "instance_id": ".instance-id",
             "manual_clean_marker": "manual-clean",
+            "obj_pkl": "obj.pkl",
+            "scripts": "scripts",
+            "sem": "sem",
+            "userdata": "user-data.txt.i",
+            "userdata_raw": "user-data.txt",
+            "vendordata": "vendor-data.txt.i",
+            "vendordata2": "vendor-data2.txt.i",
+            "vendordata2_raw": "vendor-data2.txt",
+            "vendordata_raw": "vendor-data.txt",
+            "vendor2_cloud_config": "vendor2-cloud-config.txt",
+            "vendor_cloud_config": "vendor-cloud-config.txt",
+            "vendor_scripts": "scripts/vendor",
             "warnings": "warnings",
         }
         # Set when a datasource becomes active
@@ -415,7 +421,7 @@ class Paths(persistence.CloudInitPickleMixin):
         else:
             return ipath
 
-    def _get_path(self, base, name=None):
+    def _get_path(self, base: str, name=None):
         if name is None:
             return base
         return os.path.join(base, self.lookups[name])

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -26,6 +26,7 @@ from cloudinit.atomic_helper import write_json
 from cloudinit.distros import Distro
 from cloudinit.event import EventScope, EventType
 from cloudinit.filters import launch_index
+from cloudinit.helpers import Paths
 from cloudinit.persistence import CloudInitPickleMixin
 from cloudinit.reporting import events
 
@@ -46,11 +47,6 @@ EXPERIMENTAL_TEXT = (
 )
 
 
-# File in which public available instance meta-data is written
-# security-sensitive key values are redacted from this world-readable file
-INSTANCE_JSON_FILE = "instance-data.json"
-# security-sensitive key values are present in this root-readable file
-INSTANCE_JSON_SENSITIVE_FILE = "instance-data-sensitive.json"
 REDACT_SENSITIVE_VALUE = "redacted for non-root user"
 
 # Key which can be provide a cloud's official product name to cloud-init
@@ -257,7 +253,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
     _ci_pkl_version = 1
 
-    def __init__(self, sys_cfg, distro: Distro, paths, ud_proc=None):
+    def __init__(self, sys_cfg, distro: Distro, paths: Paths, ud_proc=None):
         self.sys_cfg = sys_cfg
         self.distro = distro
         self.paths = paths
@@ -429,9 +425,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         except UnicodeDecodeError as e:
             LOG.warning("Error persisting instance-data.json: %s", str(e))
             return False
-        json_sensitive_file = os.path.join(
-            self.paths.run_dir, INSTANCE_JSON_SENSITIVE_FILE
-        )
+        json_sensitive_file = self.paths.get_runpath("instance_data_sensitive")
         cloud_id = instance_data["v1"].get("cloud_id", "none")
         cloud_id_file = os.path.join(self.paths.run_dir, "cloud-id")
         util.write_file(f"{cloud_id_file}-{cloud_id}", f"{cloud_id}\n")
@@ -443,7 +437,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         if prev_cloud_id_file != cloud_id_file:
             util.del_file(prev_cloud_id_file)
         write_json(json_sensitive_file, processed_data, mode=0o600)
-        json_file = os.path.join(self.paths.run_dir, INSTANCE_JSON_FILE)
+        json_file = self.paths.get_runpath("instance_data")
         # World readable
         write_json(json_file, redact_sensitive_keys(processed_data))
         return True

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -6,12 +6,12 @@ from datetime import datetime
 from io import StringIO
 
 from cloudinit.cmd.devel import logs
-from cloudinit.sources import INSTANCE_JSON_SENSITIVE_FILE
 from cloudinit.subp import subp
 from cloudinit.util import load_file, write_file
 from tests.unittests.helpers import mock
 
 M_PATH = "cloudinit.cmd.devel.logs."
+INSTANCE_JSON_SENSITIVE_FILE = "instance-data-sensitive.json"
 
 
 @mock.patch("cloudinit.cmd.devel.logs.os.getuid")


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Refactor instance json files to use Paths

We have multiple areas of the codebase where we fetch the rundir path
and join it with the filename for instance-data.json or
instance-data-sensitive.json. This commit refactors those calls to use a
'Paths' lookup instead.
```

## Additional Context
In a separate task I was adding a call to instance-data-sensitive.json and decided to refactor this first.


