### PR TITLE
support dhcp{4,6}-overrides in networkd renderer

### DIFF
--- a/doc/rtd/topics/network-config-format-v2.rst
+++ b/doc/rtd/topics/network-config-format-v2.rst
@@ -8,6 +8,8 @@ version 2 format defined for the `netplan`_ tool.  Cloud-init supports
 both reading and writing of Version 2; the latter support requires a
 distro with `netplan`_ present.
 
+.. _Netplan Passthrough:
+
 Netplan Passthrough
 -------------------
 
@@ -176,6 +178,48 @@ Enable DHCP for IPv4. Off by default.
 **dhcp6**: *<(bool)>*
 
 Enable DHCP for IPv6. Off by default.
+
+**dhcp4-overrides** and **dhcp6-overrides**: *<(mapping)>*
+
+DHCP behavior overrides. Overrides will only have an effect if
+the corresponding DHCP type is enabled. Refer to `netplan#dhcp-overrides`_
+for more documentation.
+
+.. note::
+
+  These properties are only consumed on ``netplan`` and ``networkd``
+  renderers.
+
+The ``netplan`` renderer :ref:`passes through <Netplan Passthrough>`
+everything and the ``networkd`` renderer consumes the following sub-properties:
+
+* ``hostname`` *
+* ``route-metric`` *
+* ``send-hostname`` *
+* ``use-dns``
+* ``use-domains``
+* ``use-hostname``
+* ``use-mtu`` *
+* ``use-ntp``
+* ``use-routes`` *
+
+.. note::
+
+   Sub-properties marked with a ``*`` are unsupported for ``dhcp6-overrides``
+   when used with the ``networkd`` renderer.
+
+Example: ::
+
+  dhcp4-overrides:
+    hostname: hal
+    route-metric: 1100
+    send-hostname: false
+    use-dns: false
+    use-domains: false
+    use-hostname: false
+    use-mtu: false
+    use-ntp: false
+    use-routes: false
 
 **addresses**: *<(sequence of scalars)>*
 
@@ -527,4 +571,5 @@ This is a complex example which shows most available features: ::
         dhcp4: yes
 
 .. _netplan: https://netplan.io
+.. _netplan#dhcp-overrides: https://netplan.io/reference#dhcp-overrides
 .. vi: textwidth=79

--- a/tests/unittests/net/test_networkd.py
+++ b/tests/unittests/net/test_networkd.py
@@ -1,6 +1,9 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from string import Template
 from unittest import mock
+
+import pytest
 
 from cloudinit import safeyaml
 from cloudinit.net import network_state, networkd
@@ -53,6 +56,105 @@ Domains=foo.local bar.local
 
 """
 
+V2_CONFIG_DHCP_YES_OVERRIDES = """\
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+      dhcp4-overrides:
+        hostname: hal
+        route-metric: 1100
+        send-hostname: false
+        use-dns: false
+        use-domains: false
+        use-hostname: false
+        use-mtu: false
+        use-ntp: false
+        use-routes: false
+      dhcp6: true
+      dhcp6-overrides:
+        use-dns: false
+        use-domains: false
+        use-hostname: false
+        use-ntp: false
+      match:
+        macaddress: "00:11:22:33:44:55"
+      nameservers:
+        addresses: ["8.8.8.8", "2001:4860:4860::8888"]
+"""
+
+V2_CONFIG_DHCP_YES_OVERRIDES_RENDERED = """[DHCPv4]
+Hostname=hal
+RouteMetric=1100
+SendHostname=False
+UseDNS=False
+UseDomains=False
+UseHostname=False
+UseMTU=False
+UseNTP=False
+UseRoutes=False
+
+[DHCPv6]
+UseDNS=False
+UseDomains=False
+UseHostname=False
+UseNTP=False
+
+[Match]
+MACAddress=00:11:22:33:44:55
+Name=eth0
+
+[Network]
+DHCP=yes
+DNS=8.8.8.8 2001:4860:4860::8888
+
+"""
+
+V2_CONFIG_DHCP_DOMAIN_VS_OVERRIDE = Template(
+    """\
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp${dhcp_version}domain: true
+      dhcp${dhcp_version}: true
+      dhcp${dhcp_version}-overrides:
+        use-domains: route
+"""
+)
+
+V2_CONFIG_DHCP_OVERRIDES = Template(
+    """\
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp${dhcp_version}: true
+      dhcp${dhcp_version}-overrides:
+        ${key}: ${value}
+      match:
+        macaddress: "00:11:22:33:44:55"
+      nameservers:
+        addresses: ["8.8.8.8", "2001:4860:4860::8888"]
+"""
+)
+
+V2_CONFIG_DHCP_OVERRIDES_RENDERED = Template(
+    """[DHCPv${dhcp_version}]
+${key}=${value}
+
+[Match]
+MACAddress=00:11:22:33:44:55
+Name=eth0
+
+[Network]
+DHCP=ipv${dhcp_version}
+DNS=8.8.8.8 2001:4860:4860::8888
+
+"""
+)
+
 
 class TestNetworkdRenderState:
     def _parse_network_state_from_config(self, config):
@@ -70,6 +172,82 @@ class TestNetworkdRenderState:
         assert rendered_content["eth0"] == V2_CONFIG_SET_NAME_RENDERED_ETH0
         assert "ens92" in rendered_content
         assert rendered_content["ens92"] == V2_CONFIG_SET_NAME_RENDERED_ETH1
+
+    def test_networkd_render_dhcp_yes_with_dhcp_overrides(self):
+        with mock.patch("cloudinit.net.get_interfaces_by_mac"):
+            ns = self._parse_network_state_from_config(
+                V2_CONFIG_DHCP_YES_OVERRIDES
+            )
+            renderer = networkd.Renderer()
+            rendered_content = renderer._render_content(ns)
+
+        assert (
+            rendered_content["eth0"] == V2_CONFIG_DHCP_YES_OVERRIDES_RENDERED
+        )
+
+    @pytest.mark.parametrize("dhcp_version", [("4"), ("6")])
+    def test_networkd_render_dhcp_domains_vs_overrides(self, dhcp_version):
+        expected_exception = (
+            f"eth0 has both dhcp{dhcp_version}domain and"
+            f" dhcp{dhcp_version}-overrides.use-domains configured. Use one"
+        )
+        with pytest.raises(Exception, match=expected_exception):
+            with mock.patch("cloudinit.net.get_interfaces_by_mac"):
+                config = V2_CONFIG_DHCP_DOMAIN_VS_OVERRIDE.substitute(
+                    dhcp_version=dhcp_version
+                )
+                ns = self._parse_network_state_from_config(config)
+                renderer = networkd.Renderer()
+                renderer._render_content(ns)
+
+    @pytest.mark.parametrize(
+        "dhcp_version,spec_key,spec_value,rendered_key,rendered_value",
+        [
+            ("4", "use-dns", "false", "UseDNS", "False"),
+            ("4", "use-dns", "true", "UseDNS", "True"),
+            ("4", "use-ntp", "false", "UseNTP", "False"),
+            ("4", "use-ntp", "true", "UseNTP", "True"),
+            ("4", "send-hostname", "false", "SendHostname", "False"),
+            ("4", "send-hostname", "true", "SendHostname", "True"),
+            ("4", "use-hostname", "false", "UseHostname", "False"),
+            ("4", "use-hostname", "true", "UseHostname", "True"),
+            ("4", "hostname", "olivaw", "Hostname", "olivaw"),
+            ("4", "route-metric", "12345", "RouteMetric", "12345"),
+            ("4", "use-domains", "false", "UseDomains", "False"),
+            ("4", "use-domains", "true", "UseDomains", "True"),
+            ("4", "use-domains", "route", "UseDomains", "route"),
+            ("4", "use-mtu", "false", "UseMTU", "False"),
+            ("4", "use-mtu", "true", "UseMTU", "True"),
+            ("4", "use-routes", "false", "UseRoutes", "False"),
+            ("4", "use-routes", "true", "UseRoutes", "True"),
+            ("6", "use-dns", "false", "UseDNS", "False"),
+            ("6", "use-dns", "true", "UseDNS", "True"),
+            ("6", "use-ntp", "false", "UseNTP", "False"),
+            ("6", "use-ntp", "true", "UseNTP", "True"),
+            ("6", "use-hostname", "false", "UseHostname", "False"),
+            ("6", "use-hostname", "true", "UseHostname", "True"),
+            ("6", "use-domains", "false", "UseDomains", "False"),
+            ("6", "use-domains", "true", "UseDomains", "True"),
+            ("6", "use-domains", "route", "UseDomains", "route"),
+        ],
+    )
+    def test_networkd_render_dhcp_overrides(
+        self, dhcp_version, spec_key, spec_value, rendered_key, rendered_value
+    ):
+        with mock.patch("cloudinit.net.get_interfaces_by_mac"):
+            ns = self._parse_network_state_from_config(
+                V2_CONFIG_DHCP_OVERRIDES.substitute(
+                    dhcp_version=dhcp_version, key=spec_key, value=spec_value
+                )
+            )
+            renderer = networkd.Renderer()
+            rendered_content = renderer._render_content(ns)
+
+        assert rendered_content[
+            "eth0"
+        ] == V2_CONFIG_DHCP_OVERRIDES_RENDERED.substitute(
+            dhcp_version=dhcp_version, key=rendered_key, value=rendered_value
+        )
 
 
 # vi: ts=4 expandtab

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -1,5 +1,6 @@
 aciba90
 ader1990
+adobley
 ajmyyra
 akutz
 AlexBaranowski
@@ -109,6 +110,7 @@ tnt-dev
 tomponline
 tsanghan
 tSU-RooT
+tylerschultz
 vorlonofportland
 vteratipally
 Vultaire


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
support dhcp{4,6}-overrides in networkd renderer
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Create the metadata file for the VM `metadata.yaml`:
```
instance-id: cloud-vm
local-hostname: cloud-vm
network:
  version: 2
  ethernets:
    nics:
      match:
        name: ens*
      dhcp4: true
      dhcp4-overrides:
        use-dns: false
      nameservers:
        addresses: [8.8.8.8, 8.8.4.4]
```

Create the userdata file `userdata.yaml`:
```
#cloud-config

users:
- default
- name: ${YOUR_USER}
    primary_group: ${YOUR GROUP}
    sudo: ALL=(ALL) NOPASSWD:ALL
    groups: sudo, wheel
    lock_passwd: true
    ssh_authorized_keys:
    - ${YOUR_SSH_PUB_KEY}
```

Create a powered-off Photon VM in vSphere:
```
govc import.ova photon-3-kube.ova
govc vm.markastemplate photon-3-kube
govc vm.clone -on=false -vm /dc0/vm/photon-3-kube cloud-vm
```

Set the guestinfo on the VM while it is powered off:
```
export GUESTINFO_USERDATA="$(cat userdata.yaml | base64 -w0)"
export GUESTINFO_METADATA="$(cat metadata.yaml | base64 -w0)"

govc vm.change -vm /dc0/vm/cloud-vm \
	-e guestinfo.userdata="${GUESTINFO_USERDATA}" \
	-e guestinfo.userdata.encoding="base64" \
	-e guestinfo.metadata="${GUESTINFO_METADATA}" \
	-e guestinfo.metadata.encoding="base64"
```

Power on the VM:
```
govc vm.power -on /dc0/vm/humalog
```

SSH to the VM and check the resulting network config is as expected:
```
ssh ${YOUR_USER}@${CLOUD_VM_IP}
networkctl status
```

See that only the configured DNS servers are in the list and no DNS servers came from DHCP.
This is just one of the several flags that could be toggled but gives an idea if it's wired up correctly.


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
