### PR TITLE
testing: Fix test regression in test_combined

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -428,5 +428,4 @@ class TestCombinedNoCI:
         client = class_client
         ssh_output = client.read_from_file("/home/ubuntu/.ssh/authorized_keys")
 
-        assert "# ssh-import-id gh:powersj" in ssh_output
         assert "# ssh-import-id lp:smoser" in ssh_output


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: Fix test regression in test_combined
```

## Additional Context
<!-- If relevant -->
After https://github.com/canonical/cloud-init/pull/1702 -> https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-azure/89/ fails.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
