### PR TITLE
Release 22.3.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,22 @@
+22.3.1
+ - Fix v2 interface matching when no MAC (LP: #1986551)
+ - test: reduce number of network dependencies in flaky test (#1702)
+ - docs: publish cc_ubuntu_autoinstall docs to rtd (#1696)
+ - net: Fix EphemeraIPNetwork (#1697) [Alberto Contreras]
+ - test: make ansible test work across older versions (#1691)
+ - Networkd multi-address support/fix (#1685) [Teodor Garzdin]
+ - make: drop broken targets (#1688)
+ - net: Passthough v2 netconfigs in netplan systems (#1650)
+   [Alberto Contreras] (LP: #1978543)
+ - NM ipv6 connection does not work on Azure and Openstack (#1616)
+   [Emanuele Giuseppe Esposito]
+ - Fix check_format_tip (#1679) [Alberto Contreras]
+ - DataSourceVMware: fix var use before init (#1674)
+   [Andrew Kutz] (LP: #1987005)
+ - rpm/copr: ensure RPM represents new clean.d dir artifacts (#1680)
+ - test: avoid centos leaked check of /etc/yum.repos.d/epel-testing.repo
+   (#1676)
+
 22.3
  - sources: obj.pkl cache should be written anyime get_data is run (#1669)
  - schema: drop release number from version file (#1664)

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "22.3"
+__VERSION__ = "22.3.1"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [


### PR DESCRIPTION
```
Release 22.3.1
      
Bump the version in cloudinit/version.py to 22.3.1 and
update ChangeLog.
```
