### PR TITLE
net: set dhclient lease and pid files

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -26,7 +26,7 @@ class NoDHCPLeaseError(Exception):
 
 
 class InvalidDHCPLeaseFileError(NoDHCPLeaseError):
-    """Raised when parsing an empty or invalid dhcp.leases file.
+    """Raised when parsing an empty or invalid dhclient.lease file.
 
     Current uses are DataSourceAzure and DataSourceEc2 during ephemeral
     boot to scrape metadata.
@@ -69,14 +69,7 @@ def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None, tmp_dir=None):
     if not dhclient_path:
         LOG.debug("Skip dhclient configuration: No dhclient command found.")
         raise NoDHCPLeaseMissingDhclientError()
-    with temp_utils.tempdir(
-        rmtree_ignore_errors=True,
-        prefix="cloud-init-dhcp-",
-        needs_exe=True,
-        dir=tmp_dir,
-    ) as tdir:
-        # Use /var/tmp because /run/cloud-init/tmp is mounted noexec
-        return dhcp_discovery(dhclient_path, nic, tdir, dhcp_log_func)
+    return dhcp_discovery(dhclient_path, nic, dhcp_log_func)
 
 
 def parse_dhcp_lease_file(lease_file):
@@ -113,36 +106,24 @@ def parse_dhcp_lease_file(lease_file):
     return dhcp_leases
 
 
-def dhcp_discovery(dhclient_cmd_path, interface, cleandir, dhcp_log_func=None):
+def dhcp_discovery(dhclient_cmd_path, interface, dhcp_log_func=None):
     """Run dhclient on the interface without scripts or filesystem artifacts.
 
     @param dhclient_cmd_path: Full path to the dhclient used.
-    @param interface: Name of the network inteface on which to dhclient.
-    @param cleandir: The directory from which to run dhclient as well as store
-        dhcp leases.
+    @param interface: Name of the network interface on which to dhclient.
     @param dhcp_log_func: A callable accepting the dhclient output and error
         streams.
 
     @return: A list of dicts of representing the dhcp leases parsed from the
-        dhcp.leases file or empty list.
+        dhclient.lease file or empty list.
     """
     LOG.debug("Performing a dhcp discovery on %s", interface)
 
-    # XXX We copy dhclient out of /sbin/dhclient to avoid dealing with strict
-    # app armor profiles which disallow running dhclient -sf <our-script-file>.
     # We want to avoid running /sbin/dhclient-script because of side-effects in
     # /etc/resolv.conf any any other vendor specific scripts in
     # /etc/dhcp/dhclient*hooks.d.
-    sandbox_dhclient_cmd = os.path.join(cleandir, "dhclient")
-    util.copy(dhclient_cmd_path, sandbox_dhclient_cmd)
-    pid_file = os.path.join(cleandir, "dhclient.pid")
-    lease_file = os.path.join(cleandir, "dhcp.leases")
-
-    # In some cases files in /var/tmp may not be executable, launching dhclient
-    # from there will certainly raise 'Permission denied' error. Try launching
-    # the original dhclient instead.
-    if not os.access(sandbox_dhclient_cmd, os.X_OK):
-        sandbox_dhclient_cmd = dhclient_cmd_path
+    pid_file = "/run/dhclient.pid"
+    lease_file = "/run/dhclient.lease"
 
     # ISC dhclient needs the interface up to send initial discovery packets.
     # Generally dhclient relies on dhclient-script PREINIT action to bring the
@@ -150,7 +131,7 @@ def dhcp_discovery(dhclient_cmd_path, interface, cleandir, dhcp_log_func=None):
     # we need to do that "link up" ourselves first.
     subp.subp(["ip", "link", "set", "dev", interface, "up"], capture=True)
     cmd = [
-        sandbox_dhclient_cmd,
+        dhclient_cmd_path,
         "-1",
         "-v",
         "-lf",

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -4,6 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import contextlib
 import logging
 import os
 import re
@@ -124,6 +125,12 @@ def dhcp_discovery(dhclient_cmd_path, interface, dhcp_log_func=None):
     # /etc/dhcp/dhclient*hooks.d.
     pid_file = "/run/dhclient.pid"
     lease_file = "/run/dhclient.lease"
+
+    # this function waits for these files to exist, clean previous runs
+    # to avoid false positive in wait_for_files
+    with contextlib.suppress(FileNotFoundError):
+        os.remove(pid_file)
+        os.remove(lease_file)
 
     # ISC dhclient needs the interface up to send initial discovery packets.
     # Generally dhclient relies on dhclient-script PREINIT action to bring the

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -13,7 +13,7 @@ from io import StringIO
 
 import configobj
 
-from cloudinit import subp, temp_utils, util
+from cloudinit import subp, util
 from cloudinit.net import find_fallback_nic, get_devicelist
 
 LOG = logging.getLogger(__name__)

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -25,12 +25,12 @@ from tests.unittests.helpers import (
     HttprettyTestCase,
     mock,
     populate_dir,
-    wrap_and_call,
 )
 
 PID_F = "/run/dhclient.pid"
 LEASE_F = "/run/dhclient.lease"
 DHCLIENT = "/sbin/dhclient"
+
 
 class TestParseDHCPLeasesFile(CiTestCase):
     def test_parse_empty_lease_file_errors(self):
@@ -380,9 +380,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.os.kill")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
     @mock.patch("cloudinit.net.dhcp.util.wait_for_files", return_value=False)
-    def test_dhcp_discovery_warns_invalid_pid(
-        self, m_wait, m_subp, m_kill
-    ):
+    def test_dhcp_discovery_warns_invalid_pid(self, m_wait, m_subp, m_kill):
         """dhcp_discovery logs a warning when pidfile contains invalid content.
 
         Lease processing still occurs and no proc kill is attempted.
@@ -401,7 +399,8 @@ class TestDHCPDiscoveryClean(CiTestCase):
         )
 
         with mock.patch(
-                "cloudinit.util.load_file", return_value=lease_content):
+            "cloudinit.util.load_file", return_value=lease_content
+        ):
             self.assertCountEqual(
                 [
                     {
@@ -470,7 +469,9 @@ class TestDHCPDiscoveryClean(CiTestCase):
         my_pid = 1
         m_getppid.return_value = 1  # Indicate that dhclient has daemonized
 
-        with mock.patch("cloudinit.util.load_file", side_effect=["1", lease_content]):
+        with mock.patch(
+            "cloudinit.util.load_file", side_effect=["1", lease_content]
+        ):
             self.assertCountEqual(
                 [
                     {
@@ -480,7 +481,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
                         "routers": "192.168.2.1",
                     }
                 ],
-                dhcp_discovery('/sbin/dhclient', "eth9")
+                dhcp_discovery("/sbin/dhclient", "eth9"),
             )
         # Interface was brought up before dhclient called
         m_subp.assert_has_calls(
@@ -512,9 +513,9 @@ class TestDHCPDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.subp.subp")
     @mock.patch("cloudinit.util.wait_for_files", return_value=False)
     def test_dhcp_discovery_setup_and_run_dhclient(
-            self, m_wait, m_subp, m_kill, m_getppid):
-        """dhcp_discovery brings up the interface and runs dhclient.
-        """
+        self, m_wait, m_subp, m_kill, m_getppid
+    ):
+        """dhcp_discovery brings up the interface and runs dhclient."""
         m_subp.return_value = ("", "")
         my_pid = 1
         m_getppid.return_value = 1  # Indicate that dhclient has daemonized
@@ -527,8 +528,11 @@ class TestDHCPDiscoveryClean(CiTestCase):
               option subnet-mask 255.255.255.0;
               option routers 192.168.2.1;
             }
-        """)
-        with mock.patch("cloudinit.util.load_file", side_effect=["1", lease_content]):
+        """
+        )
+        with mock.patch(
+            "cloudinit.util.load_file", side_effect=["1", lease_content]
+        ):
             self.assertCountEqual(
                 [
                     {
@@ -538,7 +542,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
                         "routers": "192.168.2.1",
                     }
                 ],
-                dhcp_discovery('/sbin/dhclient', "eth9"),
+                dhcp_discovery("/sbin/dhclient", "eth9"),
             )
 
         # Interface was brought up before dhclient called
@@ -598,9 +602,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
             self.assertEqual(out, dhclient_out)
             self.assertEqual(err, dhclient_err)
 
-        dhcp_discovery(
-            DHCLIENT, "eth9", dhcp_log_func=dhcp_log_func
-        )
+        dhcp_discovery(DHCLIENT, "eth9", dhcp_log_func=dhcp_log_func)
 
 
 class TestSystemdParseLeases(CiTestCase):


### PR DESCRIPTION
```
net: set dhclient lease and pid files

This commit drops the sandboxing requirement by
invoking dhclient using pid and lease files that
apparmor already allows[1].

This is desirable as relocating the dhclient binary
has led to some bug fixes[2].

[1] dhclient's apparmor profile allow writing to:

/{,var/}run/dhclient*.pid lrw,
/{,var/}run/dhclient*.lease* lrw,

[2] fix hashes:

db86753f81af
919e22dc1d77
```

## Local Test Steps


<details>
<summary>I have been testing locally in LXD on jammy by forcing a call to dhclient during init-local (patch and logs in the dropdown).
</summary>
<br>

```
diff --git a/cloudinit/sources/DataSourceLXD.py b/cloudinit/sources/DataSourceLXD.py
index 34e4e00eb..a76c4cda0 100644
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -24,6 +24,7 @@ from urllib3.connectionpool import HTTPConnectionPool
 
 from cloudinit import log as logging
 from cloudinit import sources, subp, util
+from cloudinit.net.dhcp import maybe_perform_dhcp_discovery
 
 LOG = logging.getLogger(__name__)
 
@@ -153,6 +154,7 @@ class DataSourceLXD(sources.DataSource):
         if not self._is_platform_viable():
             LOG.debug("Not an LXD datasource: No LXD socket found.")
             return False
+        maybe_perform_dhcp_discovery()
 
         self._crawled_metadata = util.log_time(
             logfunc=LOG.debug,
diff --git a/tests/unittests/sources/test_lxd.py b/tests/unittests/sources/test_lxd.py
index e60bb71fa..d85302c01 100644
--- a/tests/unittests/sources/test_lxd.py
+++ b/tests/unittests/sources/test_lxd.py
@@ -165,49 +165,49 @@ class TestDataSourceLXD:
     def test_subplatform(self, lxd_ds):
         assert "LXD socket API v. 1.0 (/dev/lxd/sock)" == lxd_ds.subplatform
 
-    def test__get_data(self, lxd_ds):
-        """get_data calls read_metadata, setting appropiate instance attrs."""
-        assert UNSET == lxd_ds._crawled_metadata
-        assert UNSET == lxd_ds._network_config
-        assert None is lxd_ds.userdata_raw
-        assert True is lxd_ds._get_data()
-        assert LXD_V1_METADATA == lxd_ds._crawled_metadata
-        # network-config is dumped from YAML
-        assert NETWORK_V1 == lxd_ds._network_config
-        # Any user-data and vendor-data are saved as raw
-        assert LXD_V1_METADATA["user-data"] == lxd_ds.userdata_raw
-        assert LXD_V1_METADATA["vendor-data"] == lxd_ds.vendordata_raw
-
-    def test_network_config_when_unset(self, lxd_ds):
-        """network_config is correctly computed when _network_config and
-        _crawled_metadata are unset.
-        """
-        assert UNSET == lxd_ds._crawled_metadata
-        assert UNSET == lxd_ds._network_config
-        assert None is lxd_ds.userdata_raw
-        # network-config is dumped from YAML
-        assert NETWORK_V1 == lxd_ds.network_config
-        assert LXD_V1_METADATA == lxd_ds._crawled_metadata
-
-    def test_network_config_crawled_metadata_no_network_config(
-        self, lxd_ds_no_network_config
-    ):
-        """network_config is correctly computed when _network_config is unset
-        and _crawled_metadata does not contain network_config.
-        """
-        lxd.generate_fallback_network_config = mock.Mock(
-            return_value=NETWORK_V1
-        )
-        assert UNSET == lxd_ds_no_network_config._crawled_metadata
-        assert UNSET == lxd_ds_no_network_config._network_config
-        assert None is lxd_ds_no_network_config.userdata_raw
-        # network-config is dumped from YAML
-        assert NETWORK_V1 == lxd_ds_no_network_config.network_config
-        assert (
-            LXD_V1_METADATA_NO_NETWORK_CONFIG
-            == lxd_ds_no_network_config._crawled_metadata
-        )
-        assert 1 == lxd.generate_fallback_network_config.call_count
+#    def test__get_data(self, lxd_ds):
+#        """get_data calls read_metadata, setting appropiate instance attrs."""
+#        assert UNSET == lxd_ds._crawled_metadata
+#        assert UNSET == lxd_ds._network_config
+#        assert None is lxd_ds.userdata_raw
+#        assert True is lxd_ds._get_data()
+#        assert LXD_V1_METADATA == lxd_ds._crawled_metadata
+#        # network-config is dumped from YAML
+#        assert NETWORK_V1 == lxd_ds._network_config
+#        # Any user-data and vendor-data are saved as raw
+#        assert LXD_V1_METADATA["user-data"] == lxd_ds.userdata_raw
+#        assert LXD_V1_METADATA["vendor-data"] == lxd_ds.vendordata_raw
+
+#    def test_network_config_when_unset(self, lxd_ds):
+#        """network_config is correctly computed when _network_config and
+#        _crawled_metadata are unset.
+#        """
+#        assert UNSET == lxd_ds._crawled_metadata
+#        assert UNSET == lxd_ds._network_config
+#        assert None is lxd_ds.userdata_raw
+#        # network-config is dumped from YAML
+#        assert NETWORK_V1 == lxd_ds.network_config
+#        assert LXD_V1_METADATA == lxd_ds._crawled_metadata
+
+#    def test_network_config_crawled_metadata_no_network_config(
+#        self, lxd_ds_no_network_config
+#    ):
+#        """network_config is correctly computed when _network_config is unset
+#        and _crawled_metadata does not contain network_config.
+#        """
+#        lxd.generate_fallback_network_config = mock.Mock(
+#            return_value=NETWORK_V1
+#        )
+#        assert UNSET == lxd_ds_no_network_config._crawled_metadata
+#        assert UNSET == lxd_ds_no_network_config._network_config
+#        assert None is lxd_ds_no_network_config.userdata_raw
+#        # network-config is dumped from YAML
+#        assert NETWORK_V1 == lxd_ds_no_network_config.network_config
+#        assert (
+#            LXD_V1_METADATA_NO_NETWORK_CONFIG
+#            == lxd_ds_no_network_config._crawled_metadata
+#        )
+#        assert 1 == lxd.generate_fallback_network_config.call_count
 
 
 class TestIsPlatformViable:
```

a log snippet of the results:
```
2022-09-02 02:16:12,927 - dhcp.py[DEBUG]: Performing a dhcp discovery on enp5s0
2022-09-02 02:16:12,927 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'dev', 'enp5s0', 'up'] with allowed return codes [0] (shell=False, capture=True)
2022-09-02 02:16:12,935 - subp.py[DEBUG]: Running command ['/usr/sbin/dhclient', '-1', '-v', '-lf', '/run/dhclient.lease', '-pf', '/run/dhclient.pid', 'enp5s0', '-sf', '/bin/true'] with allowed return codes [0] (shell=False, capture=True)
2022-09-02 02:16:12,969 - util.py[DEBUG]: All files appeared after 0 seconds: ['/run/dhclient.pid', '/run/dhclient.lease']
2022-09-02 02:16:12,970 - util.py[DEBUG]: Reading from /run/dhclient.pid (quiet=False)
2022-09-02 02:16:12,970 - util.py[DEBUG]: Read 5 bytes from /run/dhclient.pid
2022-09-02 02:16:12,970 - util.py[DEBUG]: Reading from /proc/2743/stat (quiet=True)
2022-09-02 02:16:12,970 - util.py[DEBUG]: Read 312 bytes from /proc/2743/stat
2022-09-02 02:16:12,971 - dhcp.py[DEBUG]: killing dhclient with pid=2743
2022-09-02 02:16:12,973 - util.py[DEBUG]: Reading from /run/dhclient.lease (quiet=False)
2022-09-02 02:16:12,973 - util.py[DEBUG]: Read 1082 bytes from /run/dhclient.lease
```

</details>

## Cloud Test Steps

I grabbed the `cloud-init.log` files while manually testing on the following distros. The test was basically:
```
apt install ./cloud-init_22.3-21-g8c86e1f3-1~bddeb_all.deb
cloud-init clean --logs --reboot
# scp /var/log/cloud-init.log out
```
- [x] ubuntu/bionic [log](https://github.com/canonical/cloud-init/files/9522215/bionic.log)
- [x] ubuntu/focal [log](https://github.com/canonical/cloud-init/files/9522214/focal.log)
- [x] ubuntu/jammy [log](https://github.com/canonical/cloud-init/files/9522213/jammy.log)
- [x] upstream debian [log](https://github.com/canonical/cloud-init/files/9523336/debian.log)

<details>
<summary>The debian test passed, however.... 
</summary>

**tl;dr** debian packages apparmor profiles separate from individual packages (`apparmor-profiles`), and doesn't enable the dhclient apparmor profile by default on ec2.

Not only is the profile not installed by default, but it appears that I cannot even get the profile to load currently.
```
holmanb@ip-172-31-24-126:~$ sudo /usr/sbin/aa-enforce -d /usr/share/apparmor/extra-profiles/ dhclient

ERROR: Include file /usr/share/apparmor/extra-profiles/tunables/global not found
holmanb@ip-172-31-24-126:~$ dpkg -S /usr/share/apparmor/extra-profiles/sbin.dhclient
apparmor-profiles: /usr/share/apparmor/extra-profiles/sbin.dhclient
```
Since this error occurred, I couldn't actually load the profile to test it. So for all intents and purposes this test passed without apparmor, and didn't appear testable with apparmor.

Test Process:
-------------
Debian 11 Buster, the default image on EC2 is running a 20.x version of cloud-init. To ensure cloud-init dependencies were part of the image, I upgraded to bookworm (cloud-init 22.2) and did a test `cloud-init clean --logs --reboot` - there were some warnings, but nothing that looked like it would get in the way of the test.

Then I installed my test package, did a `cloud-init clean --reboot` and grabbed the logs.
<br>
</details>

Regarding Selinux:
------------------
Worth noting is that db86753f81af7382615 proposed by Redhat works around noexec issues by just calling the original binary. I'm hoping that this means that Selinux policies allow writing to `/run/dhclient.*` as well. Supporting this theory, I'm hopeful that [this might be the Selinux policy that enables that](https://github.com/SELinuxProject/refpolicy/blob/3a22e9279c1e80b58f35a0a77a8d6f7d164a0679/policy/modules/system/sysnetwork.fc#L83)?



