### PR TITLE
testing: fully mock noexec calls

### DIFF
--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1134,6 +1134,7 @@ scbus-1 on xpt0 bus 0
         if isinstance(distro, str):
             distro_cls = distros.fetch(distro)
             distro = distro_cls(distro, data.get("sys_cfg", {}), self.paths)
+        distro.get_tmp_exec_path = mock.Mock(side_effect=self.tmp_dir)
         dsrc = dsaz.DataSourceAzure(
             data.get("sys_cfg", {}), distro=distro, paths=self.paths
         )

--- a/tests/unittests/test_temp_utils.py
+++ b/tests/unittests/test_temp_utils.py
@@ -48,6 +48,7 @@ class TestTempUtils(CiTestCase):
                 "tempfile.mkdtemp": {"side_effect": fake_mkdtemp},
                 "_TMPDIR": {"new": None},
                 "os.path.isdir": True,
+                "util.has_mount_opt": True,
             },
             mkdtemp,
             needs_exe=True,


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: fully mock noexec calls

Mock calls to `utils.has_mount_opt` and `Distro.get_tmp_exe_dir`.
```

## Additional Context
<!-- If relevant -->
After merging https://github.com/canonical/cloud-init/pull/1690, our daily builds show that we are not fully mocking everything while unit-testing:
- https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily/+build/24334448
- https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily/+build/24334437
- https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily/+build/24334441
- https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily/+build/24334444

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
