### PR TITLE
doc: Fix rtd builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,16 @@
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
 formats: all
 
 python:
   install:
     - path: .
     - requirements: doc-requirements.txt
+
+sphinx:
+  configuration: doc/rtd/conf.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,7 +133,7 @@ matrix:
             TOXENV=lowest-supported
             PYTEST_ADDOPTS=-v  # List all tests run by pytest
           dist: bionic
-        - python: 3.7
+        - python: 3.10
           env: TOXENV=doc
           install:
             - git fetch --unshallow


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
doc: Fix rtd builds

tools/read-version uses `git branch --show-current`,
--show-current was intruduced in git-2.22.0 and the default
rtd build runners seem to be on bionic, which contains git-2.17.1.

Define build.os as jammy in rtd and align python version in travis.
```

## Additional Context
<!-- If relevant -->
* https://warthogs.atlassian.net/browse/SC-1247
* Failed build: https://readthedocs.org/projects/cloudinit/builds/17973660/
* `tools/read-version` change: https://github.com/canonical/cloud-init/pull/1677
* [rtd - reproducible-builds](https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html#don-t-rely-on-implicit-dependencies)
* [Git versions across all Ubuntu series](https://packages.ubuntu.com/search?keywords=git&searchon=names&suite=all&section=all)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
SERIES=bionic
NAME=docs

lxc delete -f $NAME > /dev/null || true
lxc launch ubuntu:$SERIES $NAME
lxc exec $NAME -- cloud-init status --wait

# Mimic rtd build:
lxc exec $NAME -- git clone --no-single-branch "https://github.com/canonical/cloud-init"
lxc exec $NAME --cwd /root/cloud-init -- git checkout --force origin/main

# Reproduce the error
$ lxc exec $NAME -- git --version
git version 2.25.1

$ lxc exec $NAME --cwd /root/cloud-init -- ./tools/read-version
Traceback (most recent call last):
  File "./tools/read-version", line 72, in <module>
    branch_name = tiny_p(["git", "branch", "--show-current"]).strip()
  File "./tools/read-version", line 17, in tiny_p
    cmd, stderr=stderr, stdin=None, universal_newlines=True
  File "/usr/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['git', 'branch', '--show-current']' returned non-zero exit status 129.

$ lxc exec $NAME --cwd /root/cloud-init -- git branch --show-current
error: unknown option `show-current'
usage: git branch [<options>] [-r | -a] [--merged | --no-merged]
   or: git branch [<options>] [-l] [-f] <branch-name> [<start-point>]
   or: git branch [<options>] [-r] (-d | -D) <branch-name>...
   or: git branch [<options>] (-m | -M) [<old-branch>] <new-branch>
   or: git branch [<options>] (-c | -C) [<old-branch>] <new-branch>
   or: git branch [<options>] [-r | -a] [--points-at]
   or: git branch [<options>] [-r | -a] [--format]

Generic options
    -v, --verbose         show hash and subject, give twice for upstream branch
    -q, --quiet           suppress informational messages
    -t, --track           set up tracking mode (see git-pull(1))
    -u, --set-upstream-to <upstream>
                          change the upstream info
    --unset-upstream      Unset the upstream info
    --color[=<when>]      use colored output
    -r, --remotes         act on remote-tracking branches
    --contains <commit>   print only branches that contain the commit
    --no-contains <commit>
                          print only branches that don't contain the commit
    --abbrev[=<n>]        use <n> digits to display SHA-1s

Specific git-branch actions:
    -a, --all             list both remote-tracking and local branches
    -d, --delete          delete fully merged branch
    -D                    delete branch (even if not merged)
    -m, --move            move/rename a branch and its reflog
    -M                    move/rename a branch, even if target exists
    -c, --copy            copy a branch and its reflog
    -C                    copy a branch, even if target exists
    --list                list branch names
    -l, --create-reflog   create the branch's reflog
    --edit-description    edit the description for the branch
    -f, --force           force creation, move/rename, deletion
    --merged <commit>     print only branches that are merged
    --no-merged <commit>  print only branches that are not merged
    --column[=<style>]    list branches in columns
    --sort <key>          field name to sort on
    --points-at <object>  print only branches of the object
    -i, --ignore-case     sorting and filtering are case insensitive
    --format <format>     format to use for the output

echo $?
129
```

Change SERIES=focal and repeat.

Note:
[git branch --show-current](https://git-scm.com/docs/git-branch/2.37.0#Documentation/git-branch.txt---show-current) prints nothing in detached HEAD state (as rtd build is). This could potentially be problematic in `upstream/*` branches, but I tested it (substituting `git checkout --force origin/main` with `git checkout --force 1f1dd5f2cc8912617dfef3c7c8aa45ca21534736` and SERIES=focal in the previous test) and `tools/read-version` does not pass thought the execution path exercising `git branch --show-current`.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
