### PR TITLE
tests: Drop httpretty in favor of responses

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -168,6 +168,7 @@ def fixture_utils():
 @pytest.fixture
 def mocked_responses():
     import responses as _responses
+
     with _responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         yield rsps
 

--- a/conftest.py
+++ b/conftest.py
@@ -7,10 +7,11 @@ Any imports that are performed at the top-level here must be installed wherever
 any of these tests run: that is to say, they must be listed in
 ``integration-requirements.txt`` and in ``test-requirements.txt``.
 """
-import os
+from typing import Iterator
 from unittest import mock
 
 import pytest
+import responses as _responses
 
 from cloudinit import helpers, subp, util
 
@@ -167,27 +168,9 @@ def fixture_utils():
 
 
 @pytest.fixture
-def httpretty():
-    """
-    Enable HTTPretty for duration of the testcase, resetting before and after.
-
-    This will also ensure allow_net_connect is set to False, and temporarily
-    unset http_proxy in os.environ if present (to work around
-    https://github.com/gabrielfalcao/HTTPretty/issues/122).
-    """
-    import httpretty as _httpretty
-
-    restore_proxy = os.environ.pop("http_proxy", None)
-    _httpretty.HTTPretty.allow_net_connect = False
-    _httpretty.reset()
-    _httpretty.enable()
-
-    yield _httpretty
-
-    _httpretty.disable()
-    _httpretty.reset()
-    if restore_proxy is not None:
-        os.environ["http_proxy"] = restore_proxy
+def mocked_responses() -> Iterator[_responses.RequestsMock]:
+    with _responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
+        yield rsps
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -7,11 +7,9 @@ Any imports that are performed at the top-level here must be installed wherever
 any of these tests run: that is to say, they must be listed in
 ``integration-requirements.txt`` and in ``test-requirements.txt``.
 """
-from typing import Iterator
 from unittest import mock
 
 import pytest
-import responses as _responses
 
 from cloudinit import helpers, subp, util
 
@@ -168,7 +166,8 @@ def fixture_utils():
 
 
 @pytest.fixture
-def mocked_responses() -> Iterator[_responses.RequestsMock]:
+def mocked_responses():
+    import responses as _responses
     with _responses.RequestsMock(assert_all_requests_are_fired=False) as rsps:
         yield rsps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ module = [
   "configobj",
   "cloudinit.feature_overrides",
   "debconf",
-  "httpretty",
   "httplib",
   "jsonpatch",
   "netifaces",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 # Needed generally in tests
-httpretty>=0.7.1
 pytest
 pytest-cov
 pytest-mock

--- a/tests/unittests/config/test_cc_puppet.py
+++ b/tests/unittests/config/test_cc_puppet.py
@@ -2,8 +2,8 @@
 import logging
 import textwrap
 
-import httpretty
 import pytest
+import responses
 
 from cloudinit import util
 from cloudinit.config import cc_puppet
@@ -409,7 +409,6 @@ URL_MOCK = mock.Mock()
 URL_MOCK.contents = b'#!/bin/bash\necho "Hi Mom"'
 
 
-@httpretty.activate
 @pytest.mark.usefixtures("fake_tempdir")
 @mock.patch("cloudinit.config.cc_puppet.subp.subp", return_value=(None, None))
 @mock.patch(
@@ -471,6 +470,7 @@ class TestInstallPuppetAio:
             ),
         ],
     )
+    @responses.activate
     def test_install_puppet_aio(
         self,
         m_readurl,

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -17,7 +17,7 @@ from typing import ClassVar, List, Union
 from unittest import mock
 from unittest.util import strclass
 
-import httpretty
+import responses
 
 import cloudinit
 from cloudinit import cloud, distros
@@ -373,30 +373,18 @@ class FilesystemMockingTestCase(ResourceUsingTestCase):
             self.patched_funcs.close()
 
 
-class HttprettyTestCase(CiTestCase):
-    # necessary as http_proxy gets in the way of httpretty
-    # https://github.com/gabrielfalcao/HTTPretty/issues/122
-    # Also make sure that allow_net_connect is set to False.
-    # And make sure reset and enable/disable are done.
-
+class ResponsesTestCase(CiTestCase):
     def setUp(self):
-        self.restore_proxy = os.environ.get("http_proxy")
-        if self.restore_proxy is not None:
-            del os.environ["http_proxy"]
-        super(HttprettyTestCase, self).setUp()
-        httpretty.HTTPretty.allow_net_connect = False
-        httpretty.reset()
-        httpretty.enable()
-        # Stop the logging from HttpPretty so our logs don't get mixed
-        # up with its logs
-        logging.getLogger("httpretty.core").setLevel(logging.CRITICAL)
+        super().setUp()
+        self.responses = responses.RequestsMock(
+            assert_all_requests_are_fired=False
+        )
+        self.responses.start()
 
     def tearDown(self):
-        httpretty.disable()
-        httpretty.reset()
-        if self.restore_proxy:
-            os.environ["http_proxy"] = self.restore_proxy
-        super(HttprettyTestCase, self).tearDown()
+        self.responses.stop()
+        self.responses.reset()
+        super().tearDown()
 
 
 class SchemaTestCaseMixin(unittest.TestCase):

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -8,15 +8,15 @@ from pathlib import Path
 from typing import Optional
 from unittest import mock
 
-import httpretty
 import pytest
 import requests
+import responses
 
 import cloudinit.net as net
 from cloudinit.net.ephemeral import EphemeralIPv4Network, EphemeralIPv6Network
 from cloudinit.subp import ProcessExecutionError
 from cloudinit.util import ensure_file, write_file
-from tests.unittests.helpers import CiTestCase, HttprettyTestCase
+from tests.unittests.helpers import CiTestCase, ResponsesTestCase
 
 
 class TestSysDevPath(CiTestCase):
@@ -1210,7 +1210,7 @@ class TestEphemeralIPV6Network:
             assert expected_setup_calls == m_subp.call_args_list
 
 
-class TestHasURLConnectivity(HttprettyTestCase):
+class TestHasURLConnectivity(ResponsesTestCase):
     def setUp(self):
         super(TestHasURLConnectivity, self).setUp()
         self.url = "http://fake/"
@@ -1225,7 +1225,7 @@ class TestHasURLConnectivity(HttprettyTestCase):
         )
 
     def test_true_on_url_connectivity_success(self):
-        httpretty.register_uri(httpretty.GET, self.url)
+        self.responses.add(responses.GET, self.url)
         self.assertTrue(
             net.has_url_connectivity({"url": self.url}),
             "Expected True on url connect",
@@ -1241,7 +1241,7 @@ class TestHasURLConnectivity(HttprettyTestCase):
         )
 
     def test_true_on_url_connectivity_failure(self):
-        httpretty.register_uri(httpretty.GET, self.url, body={}, status=404)
+        self.responses.add(responses.GET, self.url, body=b"", status=404)
         self.assertFalse(
             net.has_url_connectivity({"url": self.url}),
             "Expected False on url fail",

--- a/tests/unittests/sources/helpers/test_ec2.py
+++ b/tests/unittests/sources/helpers/test_ec2.py
@@ -1,18 +1,18 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import httpretty as hp
+import responses
 
 from cloudinit import url_helper as uh
 from cloudinit.sources.helpers import ec2
 from tests.unittests import helpers
 
 
-class TestEc2Util(helpers.HttprettyTestCase):
+class TestEc2Util(helpers.ResponsesTestCase):
     VERSION = "latest"
 
     def test_userdata_fetch(self):
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             "http://169.254.169.254/%s/user-data" % (self.VERSION),
             body="stuff",
             status=200,
@@ -21,8 +21,8 @@ class TestEc2Util(helpers.HttprettyTestCase):
         self.assertEqual("stuff", userdata.decode("utf-8"))
 
     def test_userdata_fetch_fail_not_found(self):
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             "http://169.254.169.254/%s/user-data" % (self.VERSION),
             status=404,
         )
@@ -30,8 +30,8 @@ class TestEc2Util(helpers.HttprettyTestCase):
         self.assertEqual("", userdata)
 
     def test_userdata_fetch_fail_server_dead(self):
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             "http://169.254.169.254/%s/user-data" % (self.VERSION),
             status=500,
         )
@@ -39,8 +39,8 @@ class TestEc2Util(helpers.HttprettyTestCase):
         self.assertEqual("", userdata)
 
     def test_userdata_fetch_fail_server_not_found(self):
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             "http://169.254.169.254/%s/user-data" % (self.VERSION),
             status=404,
         )
@@ -49,26 +49,26 @@ class TestEc2Util(helpers.HttprettyTestCase):
 
     def test_metadata_fetch_no_keys(self):
         base_url = "http://169.254.169.254/%s/meta-data/" % (self.VERSION)
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             base_url,
             status=200,
             body="\n".join(["hostname", "instance-id", "ami-launch-index"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "hostname"),
             status=200,
             body="ec2.fake.host.name.com",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "instance-id"),
             status=200,
             body="123",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "ami-launch-index"),
             status=200,
             body="1",
@@ -80,32 +80,32 @@ class TestEc2Util(helpers.HttprettyTestCase):
 
     def test_metadata_fetch_key(self):
         base_url = "http://169.254.169.254/%s/meta-data/" % (self.VERSION)
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             base_url,
             status=200,
             body="\n".join(["hostname", "instance-id", "public-keys/"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "hostname"),
             status=200,
             body="ec2.fake.host.name.com",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "instance-id"),
             status=200,
             body="123",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "public-keys/"),
             status=200,
             body="0=my-public-key",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "public-keys/0/openssh-key"),
             status=200,
             body="ssh-rsa AAAA.....wZEf my-public-key",
@@ -117,38 +117,38 @@ class TestEc2Util(helpers.HttprettyTestCase):
 
     def test_metadata_fetch_with_2_keys(self):
         base_url = "http://169.254.169.254/%s/meta-data/" % (self.VERSION)
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             base_url,
             status=200,
             body="\n".join(["hostname", "instance-id", "public-keys/"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "hostname"),
             status=200,
             body="ec2.fake.host.name.com",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "instance-id"),
             status=200,
             body="123",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "public-keys/"),
             status=200,
             body="\n".join(["0=my-public-key", "1=my-other-key"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "public-keys/0/openssh-key"),
             status=200,
             body="ssh-rsa AAAA.....wZEf my-public-key",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "public-keys/1/openssh-key"),
             status=200,
             body="ssh-rsa AAAA.....wZEf my-other-key",
@@ -160,40 +160,40 @@ class TestEc2Util(helpers.HttprettyTestCase):
 
     def test_metadata_fetch_bdm(self):
         base_url = "http://169.254.169.254/%s/meta-data/" % (self.VERSION)
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             base_url,
             status=200,
             body="\n".join(
                 ["hostname", "instance-id", "block-device-mapping/"]
             ),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "hostname"),
             status=200,
             body="ec2.fake.host.name.com",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "instance-id"),
             status=200,
             body="123",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "block-device-mapping/"),
             status=200,
             body="\n".join(["ami", "ephemeral0"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "block-device-mapping/ami"),
             status=200,
             body="sdb",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "block-device-mapping/ephemeral0"),
             status=200,
             body="sdc",
@@ -208,58 +208,58 @@ class TestEc2Util(helpers.HttprettyTestCase):
 
     def test_metadata_no_security_credentials(self):
         base_url = "http://169.254.169.254/%s/meta-data/" % (self.VERSION)
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             base_url,
             status=200,
             body="\n".join(["instance-id", "iam/"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "instance-id"),
             status=200,
             body="i-0123451689abcdef0",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "iam/"),
             status=200,
             body="\n".join(["info/", "security-credentials/"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "iam/info/"),
             status=200,
             body="LastUpdated",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "iam/info/LastUpdated"),
             status=200,
             body="2016-10-27T17:29:39Z",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "iam/security-credentials/"),
             status=200,
             body="ReadOnly/",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "iam/security-credentials/ReadOnly/"),
             status=200,
             body="\n".join(["LastUpdated", "Expiration"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(
                 base_url, "iam/security-credentials/ReadOnly/LastUpdated"
             ),
             status=200,
             body="2016-10-27T17:28:17Z",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(
                 base_url, "iam/security-credentials/ReadOnly/Expiration"
             ),
@@ -282,31 +282,31 @@ class TestEc2Util(helpers.HttprettyTestCase):
             return False
 
         base_url = "http://169.254.169.254/%s/meta-data/" % (self.VERSION)
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             base_url,
             status=200,
             body="\n".join(["tags/", "ami-launch-index"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "tags/"),
             status=200,
             body="\n".join(["test/invalid", "valid"]),
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "tags/valid"),
             status=200,
             body="OK",
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "tags/test/invalid"),
             status=404,
         )
-        hp.register_uri(
-            hp.GET,
+        self.responses.add(
+            responses.GET,
             uh.combine_url(base_url, "ami-launch-index"),
             status=200,
             body="1",

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -880,11 +880,13 @@ class TestGetMetadataFromIMDS(ResponsesTestCase):
     @mock.patch("cloudinit.url_helper.time.sleep")
     def test_get_metadata_from_imds_empty_when_no_imds_present(self, m_sleep):
         """Return empty dict when IMDS network metadata is absent."""
+        # Workaround https://github.com/getsentry/responses/pull/166
+        # url path can be reverted to "/instance?api-version=2019-12-01"
         response = requests.Response()
         response.status_code = 404
         self.responses.add(
             responses.GET,
-            dsaz.IMDS_URL + "/instance?api-version=2019-12-01",
+            dsaz.IMDS_URL + "/instance",
             body=requests.HTTPError("...", response=response),
             status=404,
         )

--- a/tests/unittests/sources/test_bigstep.py
+++ b/tests/unittests/sources/test_bigstep.py
@@ -1,8 +1,8 @@
 import json
 import os
 
-import httpretty
 import pytest
+import responses
 
 from cloudinit import helpers
 from cloudinit.sources import DataSourceBigstep as bigstep
@@ -21,11 +21,11 @@ METADATA_BODY = json.dumps(
 
 
 class TestBigstep:
-    @httpretty.activate
     @pytest.mark.parametrize("custom_paths", [False, True])
     @mock.patch(M_PATH + "util.load_file", return_value=IMDS_URL)
+    @responses.activate
     def test_get_data_honor_cloud_dir(self, m_load_file, custom_paths, tmpdir):
-        httpretty.register_uri(httpretty.GET, IMDS_URL, body=METADATA_BODY)
+        responses.add(responses.GET, IMDS_URL, body=METADATA_BODY)
 
         paths = {}
         url_file = "/var/lib/cloud/data/seed/bigstep/url"

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -547,20 +547,20 @@ class TestEc2(test_helpers.ResponsesTestCase):
         self.assertTrue(ds.get_data())
 
         # Workaround https://github.com/getsentry/responses/issues/212
-        if hasattr(responses.mock, "_urls"):
+        if hasattr(self.responses, "_urls"):
             # Can be removed when Bionic is EOL
-            for index, url in enumerate(responses.mock._urls):
+            for index, url in enumerate(self.responses._urls):
                 if url["url"].startswith(
                     "http://169.254.169.254/2009-04-04/meta-data/"
                 ):
-                    del responses.mock._urls[index]
-        elif hasattr(responses.mock, "_matches"):
+                    del self.responses._urls[index]
+        elif hasattr(self.responses, "_matches"):
             # Can be removed when Focal is EOL
-            for index, response in enumerate(responses.mock._matches):
+            for index, response in enumerate(self.responses._matches):
                 if response.url.startswith(
                     "http://169.254.169.254/2009-04-04/meta-data/"
                 ):
-                    del responses.mock._matches[index]
+                    del self.responses._matches[index]
 
         # Provide new revision of metadata that contains network data
         register_mock_metaserver(

--- a/tests/unittests/sources/test_exoscale.py
+++ b/tests/unittests/sources/test_exoscale.py
@@ -4,8 +4,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import os
 
-import httpretty
 import requests
+import responses
 
 from cloudinit import helpers, util
 from cloudinit.sources.DataSourceExoscale import (
@@ -16,7 +16,7 @@ from cloudinit.sources.DataSourceExoscale import (
     get_password,
     read_metadata,
 )
-from tests.unittests.helpers import HttprettyTestCase, mock
+from tests.unittests.helpers import ResponsesTestCase, mock
 
 TEST_PASSWORD_URL = "{}:{}/{}/".format(
     METADATA_URL, PASSWORD_SERVER_PORT, API_VERSION
@@ -27,8 +27,7 @@ TEST_METADATA_URL = "{}/{}/meta-data/".format(METADATA_URL, API_VERSION)
 TEST_USERDATA_URL = "{}/{}/user-data".format(METADATA_URL, API_VERSION)
 
 
-@httpretty.activate
-class TestDatasourceExoscale(HttprettyTestCase):
+class TestDatasourceExoscale(ResponsesTestCase):
     def setUp(self):
         super(TestDatasourceExoscale, self).setUp()
         self.tmp = self.tmp_dir()
@@ -39,23 +38,23 @@ class TestDatasourceExoscale(HttprettyTestCase):
     def test_password_saved(self):
         """The password is not set when it is not found
         in the metadata service."""
-        httpretty.register_uri(
-            httpretty.GET, self.password_url, body="saved_password"
+        self.responses.add(
+            responses.GET, self.password_url, body="saved_password"
         )
         self.assertFalse(get_password())
 
     def test_password_empty(self):
         """No password is set if the metadata service returns
         an empty string."""
-        httpretty.register_uri(httpretty.GET, self.password_url, body="")
+        self.responses.add(responses.GET, self.password_url, body="")
         self.assertFalse(get_password())
 
     def test_password(self):
         """The password is set to what is found in the metadata
         service."""
         expected_password = "p@ssw0rd"
-        httpretty.register_uri(
-            httpretty.GET, self.password_url, body=expected_password
+        self.responses.add(
+            responses.GET, self.password_url, body=expected_password
         )
         password = get_password()
         self.assertEqual(expected_password, password)
@@ -82,24 +81,24 @@ class TestDatasourceExoscale(HttprettyTestCase):
         expected_id = "12345"
         expected_hostname = "myname"
         expected_userdata = "#cloud-config"
-        httpretty.register_uri(
-            httpretty.GET, self.userdata_url, body=expected_userdata
+        self.responses.add(
+            responses.GET, self.userdata_url, body=expected_userdata
         )
-        httpretty.register_uri(
-            httpretty.GET, self.password_url, body=expected_password
+        self.responses.add(
+            responses.GET, self.password_url, body=expected_password
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             self.metadata_url,
             body="instance-id\nlocal-hostname",
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             "{}local-hostname".format(self.metadata_url),
             body=expected_hostname,
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             "{}instance-id".format(self.metadata_url),
             body=expected_id,
         )
@@ -130,24 +129,24 @@ class TestDatasourceExoscale(HttprettyTestCase):
         expected_id = "12345"
         expected_hostname = "myname"
         expected_userdata = "#cloud-config"
-        httpretty.register_uri(
-            httpretty.GET, self.userdata_url, body=expected_userdata
+        self.responses.add(
+            responses.GET, self.userdata_url, body=expected_userdata
         )
-        httpretty.register_uri(
-            httpretty.GET, self.password_url, body=expected_answer
+        self.responses.add(
+            responses.GET, self.password_url, body=expected_answer
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             self.metadata_url,
             body="instance-id\nlocal-hostname",
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             "{}local-hostname".format(self.metadata_url),
             body=expected_hostname,
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             "{}instance-id".format(self.metadata_url),
             body=expected_id,
         )
@@ -169,24 +168,24 @@ class TestDatasourceExoscale(HttprettyTestCase):
         expected_id = "12345"
         expected_hostname = "myname"
         expected_userdata = "#cloud-config"
-        httpretty.register_uri(
-            httpretty.GET, self.userdata_url, body=expected_userdata
+        self.responses.add(
+            responses.GET, self.userdata_url, body=expected_userdata
         )
-        httpretty.register_uri(
-            httpretty.GET, self.password_url, body=expected_answer
+        self.responses.add(
+            responses.GET, self.password_url, body=expected_answer
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             self.metadata_url,
             body="instance-id\nlocal-hostname",
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             "{}local-hostname".format(self.metadata_url),
             body=expected_hostname,
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             "{}instance-id".format(self.metadata_url),
             body=expected_id,
         )
@@ -207,21 +206,21 @@ class TestDatasourceExoscale(HttprettyTestCase):
         expected_userdata = "#cloud-config"
 
         m_password.side_effect = requests.Timeout("Fake Connection Timeout")
-        httpretty.register_uri(
-            httpretty.GET, self.userdata_url, body=expected_userdata
+        self.responses.add(
+            responses.GET, self.userdata_url, body=expected_userdata
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             self.metadata_url,
             body="instance-id\nlocal-hostname",
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             "{}local-hostname".format(self.metadata_url),
             body=expected_hostname,
         )
-        httpretty.register_uri(
-            httpretty.GET,
+        self.responses.add(
+            responses.GET,
             "{}instance-id".format(self.metadata_url),
             body=expected_id,
         )

--- a/tests/unittests/sources/test_gce.py
+++ b/tests/unittests/sources/test_gce.py
@@ -11,11 +11,14 @@ from base64 import b64decode, b64encode
 from unittest import mock
 from urllib.parse import urlparse
 
-import httpretty
+import responses
+from responses import matchers
 
 from cloudinit import distros, helpers, settings
 from cloudinit.sources import DataSourceGCE
 from tests.unittests import helpers as test_helpers
+
+M_PATH = "cloudinit.sources.DataSourceGCE."
 
 GCE_META = {
     "instance/id": "123",
@@ -58,32 +61,7 @@ GUEST_ATTRIBUTES_URL = (
 )
 
 
-def _set_mock_metadata(gce_meta=None):
-    if gce_meta is None:
-        gce_meta = GCE_META
-
-    def _request_callback(method, uri, headers):
-        url_path = urlparse(uri).path
-        if url_path.startswith("/computeMetadata/v1/"):
-            path = url_path.split("/computeMetadata/v1/")[1:][0]
-            recursive = path.endswith("/")
-            path = path.rstrip("/")
-        else:
-            path = None
-        if path in gce_meta:
-            response = gce_meta.get(path)
-            if recursive:
-                response = json.dumps(response)
-            return (200, headers, response)
-        else:
-            return (404, headers, "")
-
-    # reset is needed. https://github.com/gabrielfalcao/HTTPretty/issues/316
-    httpretty.register_uri(httpretty.GET, MD_URL_RE, body=_request_callback)
-
-
-@httpretty.activate
-class TestDataSourceGCE(test_helpers.HttprettyTestCase):
+class TestDataSourceGCE(test_helpers.ResponsesTestCase):
     def _make_distro(self, dtype, def_user=None):
         cfg = dict(settings.CFG_BUILTIN)
         cfg["system_info"]["distro"] = dtype
@@ -99,30 +77,61 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         self.ds = DataSourceGCE.DataSourceGCE(
             settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": tmp})
         )
+
         ppatch = self.m_platform_reports_gce = mock.patch(
-            "cloudinit.sources.DataSourceGCE.platform_reports_gce"
+            M_PATH + "platform_reports_gce"
         )
         self.m_platform_reports_gce = ppatch.start()
         self.m_platform_reports_gce.return_value = True
         self.addCleanup(ppatch.stop)
+
+        pppatch = self.m_is_resolvable_url = mock.patch(
+            M_PATH + "util.is_resolvable_url", return_value=True
+        )
+        self.m_is_resolvable_url = pppatch.start()
+        self.addCleanup(pppatch.stop)
+
         self.add_patch("time.sleep", "m_sleep")  # just to speed up tests
         super(TestDataSourceGCE, self).setUp()
 
+    def _set_mock_metadata(self, gce_meta=None):
+        if gce_meta is None:
+            gce_meta = GCE_META
+
+        def _request_callback(request):
+            url_path = urlparse(request.url).path
+            if url_path.startswith("/computeMetadata/v1/"):
+                path = url_path.split("/computeMetadata/v1/")[1:][0]
+                recursive = path.endswith("/")
+                path = path.rstrip("/")
+            else:
+                path = None
+            if path in gce_meta:
+                response = gce_meta.get(path)
+                if recursive:
+                    response = json.dumps(response)
+                return (200, request.headers, response)
+            else:
+                return (404, request.headers, "")
+
+        self.responses.add_callback(
+            responses.GET,
+            MD_URL_RE,
+            callback=_request_callback,
+            match=[matchers.header_matcher(HEADERS)],
+        )
+
     def test_connection(self):
-        _set_mock_metadata()
+        self._set_mock_metadata()
         success = self.ds.get_data()
         self.assertTrue(success)
-
-        req_header = httpretty.last_request().headers
-        for header_name, expected_value in HEADERS.items():
-            self.assertEqual(expected_value, req_header.get(header_name))
 
     def test_metadata(self):
         # UnicodeDecodeError if set to ds.userdata instead of userdata_raw
         meta = GCE_META.copy()
         meta["instance/attributes/user-data"] = b"/bin/echo \xff\n"
 
-        _set_mock_metadata()
+        self._set_mock_metadata()
         self.ds.get_data()
 
         shostname = GCE_META.get("instance/hostname").split(".")[0]
@@ -137,9 +146,9 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
             self.ds.get_userdata_raw(),
         )
 
-    # test partial metadata (missing user-data in particular)
     def test_metadata_partial(self):
-        _set_mock_metadata(GCE_META_PARTIAL)
+        """test partial metadata (missing user-data in particular)"""
+        self._set_mock_metadata(GCE_META_PARTIAL)
         self.ds.get_data()
 
         self.assertEqual(
@@ -151,7 +160,7 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
 
     def test_userdata_no_encoding(self):
         """check that user-data is read."""
-        _set_mock_metadata(GCE_USER_DATA_TEXT)
+        self._set_mock_metadata(GCE_USER_DATA_TEXT)
         self.ds.get_data()
         self.assertEqual(
             GCE_USER_DATA_TEXT["instance/attributes"]["user-data"].encode(),
@@ -160,7 +169,7 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
 
     def test_metadata_encoding(self):
         """user-data is base64 encoded if user-data-encoding is 'base64'."""
-        _set_mock_metadata(GCE_META_ENCODING)
+        self._set_mock_metadata(GCE_META_ENCODING)
         self.ds.get_data()
 
         instance_data = GCE_META_ENCODING.get("instance/attributes")
@@ -175,12 +184,12 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         ]:
             meta = GCE_META_PARTIAL.copy()
             del meta[required_key]
-            _set_mock_metadata(meta)
+            self._set_mock_metadata(meta)
             self.assertEqual(False, self.ds.get_data())
-            httpretty.reset()
+            self.responses.reset()
 
     def test_no_ssh_keys_metadata(self):
-        _set_mock_metadata()
+        self._set_mock_metadata()
         self.ds.get_data()
         self.assertEqual([], self.ds.get_public_ssh_keys())
 
@@ -215,13 +224,13 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         meta["project/attributes"] = project_attributes
         meta["instance/attributes"] = instance_attributes
 
-        _set_mock_metadata(meta)
+        self._set_mock_metadata(meta)
         self.ds.get_data()
 
         expected = [valid_key.format(key) for key in range(3)]
         self.assertEqual(set(expected), set(self.ds.get_public_ssh_keys()))
 
-    @mock.patch("cloudinit.sources.DataSourceGCE.ug_util")
+    @mock.patch(M_PATH + "ug_util")
     def test_default_user_ssh_keys(self, mock_ug_util):
         mock_ug_util.normalize_users_groups.return_value = None, None
         mock_ug_util.extract_default.return_value = "ubuntu", None
@@ -261,7 +270,7 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         meta["project/attributes"] = project_attributes
         meta["instance/attributes"] = instance_attributes
 
-        _set_mock_metadata(meta)
+        self._set_mock_metadata(meta)
         ubuntu_ds.get_data()
 
         expected = [valid_key.format(key) for key in range(3)]
@@ -284,7 +293,7 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         meta["project/attributes"] = project_attributes
         meta["instance/attributes"] = instance_attributes
 
-        _set_mock_metadata(meta)
+        self._set_mock_metadata(meta)
         self.ds.get_data()
 
         expected = [valid_key.format(key) for key in range(2)]
@@ -306,14 +315,14 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         meta["project/attributes"] = project_attributes
         meta["instance/attributes"] = instance_attributes
 
-        _set_mock_metadata(meta)
+        self._set_mock_metadata(meta)
         self.ds.get_data()
 
         expected = [valid_key.format(0)]
         self.assertEqual(set(expected), set(self.ds.get_public_ssh_keys()))
 
     def test_only_last_part_of_zone_used_for_availability_zone(self):
-        _set_mock_metadata()
+        self._set_mock_metadata()
         r = self.ds.get_data()
         self.assertEqual(True, r)
         self.assertEqual("bar", self.ds.availability_zone)
@@ -388,14 +397,12 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         m_readurl.assert_has_calls(readurl_expected_calls, any_order=True)
 
     @mock.patch(
-        "cloudinit.sources.DataSourceGCE.EphemeralDHCPv4",
+        M_PATH + "EphemeralDHCPv4",
         autospec=True,
     )
-    @mock.patch(
-        "cloudinit.sources.DataSourceGCE.DataSourceGCELocal.fallback_interface"
-    )
+    @mock.patch(M_PATH + "DataSourceGCELocal.fallback_interface")
     def test_local_datasource_uses_ephemeral_dhcp(self, _m_fallback, m_dhcp):
-        _set_mock_metadata()
+        self._set_mock_metadata()
         distro = mock.MagicMock()
         distro.get_tmp_exec_path = self.tmp_dir
         ds = DataSourceGCE.DataSourceGCELocal(
@@ -405,11 +412,11 @@ class TestDataSourceGCE(test_helpers.HttprettyTestCase):
         assert m_dhcp.call_count == 1
 
     @mock.patch(
-        "cloudinit.sources.DataSourceGCE.EphemeralDHCPv4",
+        M_PATH + "EphemeralDHCPv4",
         autospec=True,
     )
     def test_datasource_doesnt_use_ephemeral_dhcp(self, m_dhcp):
-        _set_mock_metadata()
+        self._set_mock_metadata()
         ds = DataSourceGCE.DataSourceGCE(sys_cfg={}, distro=None, paths=None)
         ds._get_data()
         assert m_dhcp.call_count == 0

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -369,7 +369,6 @@ class TestDataSourceScaleway(ResponsesTestCase):
         self.responses.add_callback(
             responses.GET, self.vendordata_url, callback=DataResponses.empty
         )
-        # import pdb; pdb.set_trace()
         self.datasource.get_data()
         self.assertIsNone(self.datasource.get_userdata_raw())
         self.assertIsNone(self.datasource.get_vendordata_raw())

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -13,8 +13,8 @@ from io import BytesIO, StringIO
 from pathlib import Path
 from unittest import mock
 
-import httpretty
 import pytest
+import responses
 
 from cloudinit import handlers
 from cloudinit import helpers as c_helpers
@@ -638,21 +638,21 @@ c: 4
         self.assertEqual("quxC", cfg["foo"])
 
 
-class TestConsumeUserDataHttp(TestConsumeUserData, helpers.HttprettyTestCase):
+class TestConsumeUserDataHttp(TestConsumeUserData, helpers.ResponsesTestCase):
     def setUp(self):
         TestConsumeUserData.setUp(self)
-        helpers.HttprettyTestCase.setUp(self)
+        helpers.ResponsesTestCase.setUp(self)
 
     def tearDown(self):
         TestConsumeUserData.tearDown(self)
-        helpers.HttprettyTestCase.tearDown(self)
+        helpers.ResponsesTestCase.tearDown(self)
 
     @mock.patch("cloudinit.url_helper.time.sleep")
     def test_include(self, mock_sleep):
         """Test #include."""
         included_url = "http://hostname/path"
         included_data = "#cloud-config\nincluded: true\n"
-        httpretty.register_uri(httpretty.GET, included_url, included_data)
+        self.responses.add(responses.GET, included_url, included_data)
 
         blob = "#include\n%s\n" % included_url
 
@@ -670,11 +670,11 @@ class TestConsumeUserDataHttp(TestConsumeUserData, helpers.HttprettyTestCase):
         """Test #include with a bad URL."""
         bad_url = "http://bad/forbidden"
         bad_data = "#cloud-config\nbad: true\n"
-        httpretty.register_uri(httpretty.GET, bad_url, bad_data, status=403)
+        self.responses.add(responses.GET, bad_url, bad_data, status=403)
 
         included_url = "http://hostname/path"
         included_data = "#cloud-config\nincluded: true\n"
-        httpretty.register_uri(httpretty.GET, included_url, included_data)
+        self.responses.add(responses.GET, included_url, included_data)
 
         blob = "#include\n%s\n%s" % (bad_url, included_url)
 
@@ -697,11 +697,11 @@ class TestConsumeUserDataHttp(TestConsumeUserData, helpers.HttprettyTestCase):
         """Test #include with a bad URL and failure disabled"""
         bad_url = "http://bad/forbidden"
         bad_data = "#cloud-config\nbad: true\n"
-        httpretty.register_uri(httpretty.GET, bad_url, bad_data, status=403)
+        self.responses.add(responses.GET, bad_url, bad_data, status=403)
 
         included_url = "http://hostname/path"
         included_data = "#cloud-config\nincluded: true\n"
-        httpretty.register_uri(httpretty.GET, included_url, included_data)
+        self.responses.add(responses.GET, included_url, included_data)
 
         blob = "#include\n%s\n%s" % (bad_url, included_url)
 

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import requests
 import responses
 
 from cloudinit import handlers
@@ -696,8 +697,14 @@ class TestConsumeUserDataHttp(TestConsumeUserData, helpers.ResponsesTestCase):
     def test_include_bad_url_no_fail(self, mock_sleep):
         """Test #include with a bad URL and failure disabled"""
         bad_url = "http://bad/forbidden"
-        bad_data = "#cloud-config\nbad: true\n"
-        self.responses.add(responses.GET, bad_url, bad_data, status=403)
+        self.responses.add(
+            responses.GET,
+            bad_url,
+            body=requests.HTTPError(
+                f"403 Client Error: Forbidden for url: {bad_url}"
+            ),
+            status=403,
+        )
 
         included_url = "http://hostname/path"
         included_data = "#cloud-config\nincluded: true\n"

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -5,10 +5,10 @@ from functools import partial
 from threading import Event
 from time import process_time
 
-import httpretty
 import pytest
 import requests
 import responses
+from responses import matchers
 
 from cloudinit import util, version
 from cloudinit.url_helper import (
@@ -82,56 +82,53 @@ class TestReadFileOrUrl(CiTestCase):
         self.assertEqual(result.contents, data)
         self.assertEqual(str(result), data.decode("utf-8"))
 
-    @httpretty.activate
+    @responses.activate
     def test_read_file_or_url_str_from_url(self):
         """Test that str(result.contents) on url is text version of contents.
         It should not be "b'data'", but just "'data'" """
         url = "http://hostname/path"
         data = b"This is my url content\n"
-        httpretty.register_uri(httpretty.GET, url, data)
+        responses.add(responses.GET, url, data)
         result = read_file_or_url(url)
         self.assertEqual(result.contents, data)
         self.assertEqual(str(result), data.decode("utf-8"))
 
-    @httpretty.activate
+    @responses.activate
     def test_read_file_or_url_str_from_url_streamed(self):
         """Test that str(result.contents) on url is text version of contents.
         It should not be "b'data'", but just "'data'" """
         url = "http://hostname/path"
         data = b"This is my url content\n"
-        httpretty.register_uri(httpretty.GET, url, data)
+        responses.add(responses.GET, url, data)
         result = read_file_or_url(url, stream=True)
         assert isinstance(result, UrlResponse)
         self.assertEqual(result.contents, data)
         self.assertEqual(str(result), data.decode("utf-8"))
 
-    @httpretty.activate
+    @responses.activate
     def test_read_file_or_url_str_from_url_redacting_headers_from_logs(self):
         """Headers are redacted from logs but unredacted in requests."""
         url = "http://hostname/path"
         headers = {"sensitive": "sekret", "server": "blah"}
-        httpretty.register_uri(httpretty.GET, url)
-        # By default, httpretty will log our request along with the header,
-        # so if we don't change this the secret will show up in the logs
-        logging.getLogger("httpretty.core").setLevel(logging.CRITICAL)
+        responses.add(
+            responses.GET, url, match=[matchers.header_matcher(headers)]
+        )
 
         read_file_or_url(url, headers=headers, headers_redact=["sensitive"])
         logs = self.logs.getvalue()
-        for k in headers.keys():
-            self.assertEqual(headers[k], httpretty.last_request().headers[k])
         self.assertIn(REDACTED, logs)
         self.assertNotIn("sekret", logs)
 
-    @httpretty.activate
+    @responses.activate
     def test_read_file_or_url_str_from_url_redacts_noheaders(self):
         """When no headers_redact, header values are in logs and requests."""
         url = "http://hostname/path"
         headers = {"sensitive": "sekret", "server": "blah"}
-        httpretty.register_uri(httpretty.GET, url)
+        responses.add(
+            responses.GET, url, match=[matchers.header_matcher(headers)]
+        )
 
         read_file_or_url(url, headers=headers)
-        for k in headers.keys():
-            self.assertEqual(headers[k], httpretty.last_request().headers[k])
         logs = self.logs.getvalue()
         self.assertNotIn(REDACTED, logs)
         self.assertIn("sekret", logs)
@@ -514,7 +511,7 @@ class TestUrlHelper:
         If this test proves flaky, increase wait time. Since it is async,
         increasing wait time for the non-responding endpoint should not
         increase total test time, assuming async_delay=0 is used and at least
-        one non-waiting endpoint is registered with httpretty.
+        one non-waiting endpoint is registered with responses.
         Subsequent tests will continue execution after the first response is
         received.
         """

--- a/tox.ini
+++ b/tox.ini
@@ -165,17 +165,14 @@ commands = {envpython} -X tracemalloc=40 -Wall -m pytest \
             tests/unittests}
 
 
-[lowest-supported-deps]
+[testenv:lowest-supported]
 # Tox is going to install requirements from pip. This is fine for
 # testing python version compatibility, but when we build cloud-init, we are
 # building against the dependencies in the OS repo, not pip. The OS
 # dependencies will generally be older than what is found in pip.
 
 # To obtain these versions, check the versions of these libraries
-# in the oldest support Ubuntu distro.
-
-# httpretty isn't included here because python2.7 requires a higher version
-# than whats run on bionic, so we need two different definitions.
+# in the oldest support Ubuntu distro. Theses versions are from bionic.
 deps =
     jinja2==2.10
     oauthlib==2.0.6
@@ -193,22 +190,6 @@ deps =
     # Needed by pytest and default causes failures
     attrs==17.4.0
     responses==0.5.1
-
-[testenv:lowest-supported]
-# This definition will run on bionic with the version of httpretty
-# that runs there
-deps =
-    {[lowest-supported-deps]deps}
-    httpretty==0.8.14
-commands = {[testenv:py3]commands}
-
-[testenv:lowest-supported-dev]
-# The oldest httpretty version to work with Python 3.7+ is 0.9.5,
-# because it is the first to include this commit:
-# https://github.com/gabrielfalcao/HTTPretty/commit/5776d97da3992b9071db5e21faf175f6e8729060
-deps =
-    {[lowest-supported-deps]deps}
-    httpretty==0.9.5
 commands = {[testenv:py3]commands}
 
 [testenv:doc]


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: Drop httpretty in favor of responses
```

## Additional Context
<!-- If relevant -->
[SC-937](https://warthogs.atlassian.net/browse/SC-937)
After this PR, we could drop `python3-httpretty` from `debian/control` in `ubuntu/<series>` branches.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`tox`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
