### PR TITLE
tests: Fix ntp installation

### DIFF
--- a/tests/integration_tests/modules/test_ntp_servers.py
+++ b/tests/integration_tests/modules/test_ntp_servers.py
@@ -16,6 +16,8 @@ from tests.integration_tests.instances import IntegrationInstance
 
 USER_DATA = """\
 #cloud-config
+package_update: true
+package_upgrade: true
 ntp:
   ntp_client: ntp
   servers:
@@ -74,6 +76,8 @@ class TestNtpServers:
 
 CHRONY_DATA = """\
 #cloud-config
+package_update: true
+package_upgrade: true
 ntp:
   enabled: true
   ntp_client: chrony
@@ -94,6 +98,8 @@ def test_chrony(client: IntegrationInstance):
 
 TIMESYNCD_DATA = """\
 #cloud-config
+package_update: true
+package_upgrade: true
 ntp:
   enabled: true
   ntp_client: systemd-timesyncd
@@ -112,6 +118,8 @@ def test_timesyncd(client: IntegrationInstance):
 
 EMPTY_NTP = """\
 #cloud-config
+package_update: true
+package_upgrade: true
 ntp:
   ntp_client: ntp
   pools: []


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: Fix ntp installation

On daily images, the installation of ntp might fail due unmet deps.
Add update and upgrade to these test to avoid that.
```

## Additional Context
<!-- If relevant -->
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-lxd_vm/81
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-lxd_container/77

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_OS_IMAGE=kinetic tox -e integration-tests -- -vv tests/integration_tests/modules/test_ntp_servers.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
