### PR TITLE
Allow jinja templating in /etc/cloud (SC-1170)

### DIFF
--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -9,7 +9,10 @@ import os
 import sys
 
 from cloudinit import log
-from cloudinit.handlers.jinja_template import render_jinja_payload_from_file
+from cloudinit.handlers.jinja_template import (
+    JinjaLoadError,
+    render_jinja_payload_from_file,
+)
 
 from . import addLogHandlerCLI, read_cfg_paths
 
@@ -92,7 +95,7 @@ def handle_args(name, args):
             instance_data_file=instance_data_fn,
             debug=True if args.debug else False,
         )
-    except RuntimeError as e:
+    except JinjaLoadError as e:
         LOG.error("Cannot render from instance data: %s", str(e))
         return 1
     if not rendered_payload:

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -98,7 +98,7 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
         )
     except (JinjaLoadError, NotJinjaError) as e:
         LOG.error(
-            f"Cannot render from instance data due to exception: {repr(e)}"
+            "Cannot render from instance data due to exception: %s", repr(e)
         )
         return 1
     if not rendered_payload:

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -11,6 +11,7 @@ import sys
 from cloudinit import log
 from cloudinit.handlers.jinja_template import (
     JinjaLoadError,
+    NotJinjaError,
     render_jinja_payload_from_file,
 )
 
@@ -53,7 +54,7 @@ def get_parser(parser=None):
     return parser
 
 
-def handle_args(name, args):
+def render_template(user_data_path, instance_data_path=None, debug=False):
     """Render the provided user-data template file using instance-data values.
 
     Also setup CLI log handlers to report to stderr since this is a development
@@ -61,9 +62,9 @@ def handle_args(name, args):
 
     @return 0 on success, 1 on failure.
     """
-    addLogHandlerCLI(LOG, log.DEBUG if args.debug else log.WARNING)
-    if args.instance_data:
-        instance_data_fn = args.instance_data
+    addLogHandlerCLI(LOG, log.DEBUG if debug else log.WARNING)
+    if instance_data_path:
+        instance_data_fn = instance_data_path
     else:
         paths = read_cfg_paths()
         uid = os.getuid()
@@ -83,32 +84,33 @@ def handle_args(name, args):
         LOG.error("Missing instance-data.json file: %s", instance_data_fn)
         return 1
     try:
-        with open(args.user_data) as stream:
+        with open(user_data_path) as stream:
             user_data = stream.read()
     except IOError:
-        LOG.error("Missing user-data file: %s", args.user_data)
+        LOG.error("Missing user-data file: %s", user_data_path)
         return 1
     try:
         rendered_payload = render_jinja_payload_from_file(
             payload=user_data,
-            payload_fn=args.user_data,
+            payload_fn=user_data_path,
             instance_data_file=instance_data_fn,
-            debug=True if args.debug else False,
+            debug=True if debug else False,
         )
-    except JinjaLoadError as e:
-        LOG.error("Cannot render from instance data: %s", str(e))
+    except (JinjaLoadError, NotJinjaError) as e:
+        LOG.error(
+            f"Cannot render from instance data due to exception: {repr(e)}"
+        )
         return 1
     if not rendered_payload:
-        LOG.error("Unable to render user-data file: %s", args.user_data)
+        LOG.error("Unable to render user-data file: %s", user_data_path)
         return 1
     sys.stdout.write(rendered_payload)
     return 0
 
 
-def main():
-    args = get_parser().parse_args()
-    return handle_args(NAME, args)
+def handle_args(_name, args):
+    return render_template(args.user_data, args.instance_data, args.debug)
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(handle_args(NAME, get_parser().parse_args()))

--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -135,7 +135,7 @@ def handle(
     post_list = ph_cfg.get("post", "all")
     tries = ph_cfg.get("tries")
     try:
-        tries = int(tries)  # pyright: ignore
+        tries = int(tries)  # type: ignore
     except (ValueError, TypeError):
         tries = 10
         util.logexc(

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -324,9 +324,10 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
         except JinjaLoadError as e:
             LOG.warning(
                 "Could not apply Jinja template '%s' to '%s'. "
-                f"Exception: {repr(e)}",
+                "Exception: %s",
                 instance_data_file,
                 config_file,
+                repr(e),
             )
     if config_file is None:
         return {}

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -35,7 +35,7 @@ from base64 import b64decode, b64encode
 from collections import deque, namedtuple
 from errno import EACCES, ENOENT
 from functools import lru_cache, total_ordering
-from typing import Callable, List, TypeVar
+from typing import Callable, Deque, Dict, List, TypeVar
 from urllib import parse
 
 from cloudinit import importer
@@ -287,14 +287,49 @@ def rand_dict_key(dictionary, postfix=None):
     return newkey
 
 
-def read_conf(fname):
+def read_conf(fname, *, instance_data_file=None) -> Dict:
+    """Read a yaml config with optional template, and convert to dict"""
+    # Avoid circular import
+    from cloudinit.handlers.jinja_template import (
+        JinjaLoadError,
+        NotJinjaError,
+        render_jinja_payload_from_file,
+    )
+
     try:
-        return load_yaml(load_file(fname), default={})
+        config_file = load_file(fname)
     except IOError as e:
         if e.errno == ENOENT:
             return {}
         else:
             raise
+
+    if instance_data_file and os.path.exists(instance_data_file):
+        try:
+            config_file = render_jinja_payload_from_file(
+                config_file,
+                fname,
+                instance_data_file,
+            )
+            LOG.debug(
+                "Applied instance data in '%s' to "
+                "configuration loaded from '%s'",
+                instance_data_file,
+                fname,
+            )
+        except NotJinjaError:
+            # A log isn't appropriate here as we generally expect most
+            # cloud.cfgs to not be templated. The other path is logged
+            pass
+        except JinjaLoadError:
+            LOG.warning(
+                "Could not apply Jinja template '%s' to '%s'.",
+                instance_data_file,
+                config_file,
+            )
+    if config_file is None:
+        return {}
+    return load_yaml(config_file, default={})  # pyright: ignore
 
 
 # Merges X lists, and then keeps the
@@ -976,7 +1011,7 @@ def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
     return (md, ud, vd)
 
 
-def read_conf_d(confd):
+def read_conf_d(confd, *, instance_data_file=None) -> dict:
     """Read configuration directory."""
     # Get reverse sorted list (later trumps newer)
     confs = sorted(os.listdir(confd), reverse=True)
@@ -991,7 +1026,12 @@ def read_conf_d(confd):
     cfgs = []
     for fn in confs:
         try:
-            cfgs.append(read_conf(os.path.join(confd, fn)))
+            cfgs.append(
+                read_conf(
+                    os.path.join(confd, fn),
+                    instance_data_file=instance_data_file,
+                )
+            )
         except OSError as e:
             if e.errno == EACCES:
                 LOG.warning(
@@ -1001,18 +1041,29 @@ def read_conf_d(confd):
     return mergemanydict(cfgs)
 
 
-def read_conf_with_confd(cfgfile):
-    cfgs = deque()
+def read_conf_with_confd(cfgfile, *, instance_data_file=None) -> dict:
+    """Read yaml file along with optional ".d" directory, return merged config
+
+    Given a yaml file, load the file as a dictionary. Additionally, if there
+    exists a same-named directory with .d extension, read all files from
+    that directory in order and return the merged config. The template
+    file is optional and will be applied to any applicable jinja file
+    in the configs.
+
+    For example, this function can read both /etc/cloud/cloud.cfg and all
+    files in /etc/cloud/cloud.cfg.d and merge all configs into a single dict.
+    """
+    cfgs: Deque[Dict] = deque()
     cfg: dict = {}
     try:
-        cfg = read_conf(cfgfile)
+        cfg = read_conf(cfgfile, instance_data_file=instance_data_file)
     except OSError as e:
         if e.errno == EACCES:
             LOG.warning("REDACTED config part %s for non-root user", cfgfile)
     else:
         cfgs.append(cfg)
 
-    confd = False
+    confd = ""
     if "conf_d" in cfg:
         confd = cfg["conf_d"]
         if confd:
@@ -1023,12 +1074,12 @@ def read_conf_with_confd(cfgfile):
                 )
             else:
                 confd = str(confd).strip()
-    elif os.path.isdir("%s.d" % cfgfile):
-        confd = "%s.d" % cfgfile
+    elif os.path.isdir(f"{cfgfile}.d"):
+        confd = f"{cfgfile}.d"
 
     if confd and os.path.isdir(confd):
         # Conf.d settings override input configuration
-        confd_cfg = read_conf_d(confd)
+        confd_cfg = read_conf_d(confd, instance_data_file=instance_data_file)
         cfgs.appendleft(confd_cfg)
 
     return mergemanydict(cfgs)

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -321,9 +321,10 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
             # A log isn't appropriate here as we generally expect most
             # cloud.cfgs to not be templated. The other path is logged
             pass
-        except JinjaLoadError:
+        except JinjaLoadError as e:
             LOG.warning(
-                "Could not apply Jinja template '%s' to '%s'.",
+                "Could not apply Jinja template '%s' to '%s'. "
+                f"Exception: {repr(e)}",
                 instance_data_file,
                 config_file,
             )

--- a/tests/integration_tests/modules/test_jinja_templating.py
+++ b/tests/integration_tests/modules/test_jinja_templating.py
@@ -2,7 +2,15 @@
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_ordered_items_in_text
+from tests.integration_tests.util import (
+    verify_clean_log,
+    verify_ordered_items_in_text,
+)
+
+MERGED_CFG_DOC = (
+    "Merged cloud-init system config from /etc/cloud/cloud.cfg "
+    "and /etc/cloud/cloud.cfg.d/"
+)
 
 USER_DATA = """\
 ## template: jinja
@@ -23,11 +31,101 @@ def test_runcmd_with_variable_substitution(client: IntegrationInstance):
     LP: #1931392.
     """
     hostname = client.execute("hostname").stdout.strip()
-    expected = [
-        hostname,
-        "Merged cloud-init system config from /etc/cloud/cloud.cfg and "
-        "/etc/cloud/cloud.cfg.d/",
-        hostname,
-    ]
+    expected = [hostname, MERGED_CFG_DOC, hostname]
     output = client.read_from_file("/var/tmp/runcmd_output")
     verify_ordered_items_in_text(expected, output)
+
+
+@pytest.mark.ci
+def test_substitution_in_etc_cloud(client: IntegrationInstance):
+    orig_etc_cloud = client.read_from_file("/etc/cloud/cloud.cfg")
+    assert "## template: jinja" not in orig_etc_cloud
+
+    new_etc_cloud = (
+        "## template: jinja\n\n"
+        f"{orig_etc_cloud}\n\n"
+        "runcmd:\n"
+        " - echo {{v1.local_hostname}} > /var/tmp/runcmd_output\n"
+    )
+    client.write_to_file("/etc/cloud/cloud.cfg", new_etc_cloud)
+
+    new_cloud_part = (
+        "## template: jinja\n"
+        "bootcmd:\n"
+        " - echo {{merged_cfg._doc}} > /var/tmp/bootcmd_output\n"
+    )
+    client.write_to_file(
+        "/etc/cloud/cloud.cfg.d/50-jinja-test.cfg", new_cloud_part
+    )
+
+    cloud_part_no_jinja = (
+        "write_files:\n"
+        " - content: hi {{v1.local_hostname}}\n"
+        "   path: /var/tmp/writefiles_output\n"
+    )
+    client.write_to_file(
+        "/etc/cloud/cloud.cfg.d/70-no-jinja-test.cfg", cloud_part_no_jinja
+    )
+
+    client.execute("cloud-init clean --logs")
+    client.restart()
+
+    verify_clean_log(client.read_from_file("/var/log/cloud-init.log"))
+
+    # Ensure /etc/cloud/cloud.cfg template works as expected
+    hostname = client.execute("hostname").stdout.strip()
+    assert client.read_from_file("/var/tmp/runcmd_output").strip() == hostname
+
+    # Ensure /etc/cloud/cloud.cfg.d template works as expected
+    assert (
+        client.read_from_file("/var/tmp/bootcmd_output").strip()
+        == MERGED_CFG_DOC
+    )
+
+    # Ensure a file without '## template: jinja' isn't interpreted as jinja
+    assert (
+        client.read_from_file("/var/tmp/writefiles_output").strip()
+        == "hi {{v1.local_hostname}}"
+    )
+
+
+def test_invalid_etc_cloud_substitution(client: IntegrationInstance):
+    no_var_part = (
+        "## template: jinja\n"
+        "runcmd:\n"
+        " - echo {{bad}} > /var/tmp/runcmd_bad\n"
+        " - echo {{v1.local_hostname}} > /var/tmp/runcmd_output\n"
+        "write_files:\n"
+        " - content: {{v1.local_hostname}}\n"
+        "   path: /var/tmp/writefiles_output\n"
+    )
+    client.write_to_file("/etc/cloud/cloud.cfg.d/50-no-var.cfg", no_var_part)
+
+    normal_part = "bootcmd:\n" " - echo hi > /var/tmp/bootcmd_output\n"
+    client.write_to_file("/etc/cloud/cloud.cfg.d/60-normal.cfg", normal_part)
+
+    client.execute("cloud-init clean --logs")
+    client.restart()
+
+    log = client.read_from_file("/var/log/cloud-init.log")
+
+    # Ensure we get warning from invalid jinja var
+    assert (
+        "jinja_template.py[WARNING]: Could not render jinja template "
+        "variables in file '/etc/cloud/cloud.cfg.d/50-no-var.cfg': "
+        "'bad'"
+    ) in log
+
+    # Ensure the file was still processed with invalid var
+    assert (
+        client.read_from_file("/var/tmp/runcmd_bad").strip()
+        == "CI_MISSING_JINJA_VAR/bad"
+    )
+    hostname = client.execute("hostname").stdout.strip()
+    assert client.read_from_file("/var/tmp/runcmd_output").strip() == hostname
+    assert (
+        client.read_from_file("/var/tmp/writefiles_output").strip() == hostname
+    )
+
+    # Ensure other files continue to load correctly
+    assert client.read_from_file("/var/tmp/bootcmd_output").strip() == "hi"

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -5,7 +5,6 @@ from io import StringIO
 import pytest
 
 from cloudinit.cmd.devel import render
-from cloudinit.handlers.jinja_template import JinjaLoadError
 from cloudinit.helpers import Paths
 from cloudinit.util import ensure_dir, write_file
 from tests.unittests.helpers import mock, skipUnlessJinja

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -1,9 +1,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from collections import namedtuple
 from io import StringIO
 
+import pytest
+
 from cloudinit.cmd.devel import render
+from cloudinit.handlers.jinja_template import JinjaLoadError
 from cloudinit.helpers import Paths
 from cloudinit.util import ensure_dir, write_file
 from tests.unittests.helpers import mock, skipUnlessJinja
@@ -12,51 +14,40 @@ M_PATH = "cloudinit.cmd.devel.render."
 
 
 class TestRender:
+    @pytest.fixture(autouse=True)
+    def mocks(self, mocker):
+        mocker.patch("sys.stderr", new_callable=StringIO)
 
-    Args = namedtuple("Args", "user_data instance_data debug")
-
-    def test_handle_args_error_on_missing_user_data(self, caplog, tmpdir):
+    def test_error_on_missing_user_data(self, caplog, tmpdir):
         """When user_data file path does not exist, log an error."""
         absent_file = tmpdir.join("user-data")
         instance_data = tmpdir.join("instance-data")
         write_file(instance_data, "{}")
-        args = self.Args(
-            user_data=absent_file, instance_data=instance_data, debug=False
-        )
-        with mock.patch("sys.stderr", new_callable=StringIO):
-            assert render.handle_args("anyname", args) == 1
-        assert "Missing user-data file: %s" % absent_file in caplog.text
+        assert render.render_template(absent_file, instance_data, False) == 1
+        assert f"Missing user-data file: {absent_file}" in caplog.text
 
-    def test_handle_args_error_on_missing_instance_data(self, caplog, tmpdir):
+    def test_error_on_missing_instance_data(self, caplog, tmpdir):
         """When instance_data file path does not exist, log an error."""
         user_data = tmpdir.join("user-data")
         absent_file = tmpdir.join("instance-data")
-        args = self.Args(
-            user_data=user_data, instance_data=absent_file, debug=False
-        )
-        with mock.patch("sys.stderr", new_callable=StringIO):
-            assert render.handle_args("anyname", args) == 1
-        assert (
-            "Missing instance-data.json file: %s" % absent_file in caplog.text
-        )
+        assert render.render_template(user_data, absent_file, False) == 1
+        assert f"Missing instance-data.json file: {absent_file}" in caplog.text
 
-    @mock.patch(M_PATH + "read_cfg_paths")
-    def test_handle_args_defaults_instance_data(self, m_paths, caplog, tmpdir):
+    @mock.patch(f"{M_PATH}read_cfg_paths")
+    def test_default_instance_data(self, m_paths, caplog, tmpdir):
         """When no instance_data argument, default to configured run_dir."""
         user_data = tmpdir.join("user-data")
         run_dir = tmpdir.join("run_dir")
         ensure_dir(run_dir)
         paths = Paths({"run_dir": run_dir})
         m_paths.return_value = paths
-        args = self.Args(user_data=user_data, instance_data=None, debug=False)
-        with mock.patch("sys.stderr", new_callable=StringIO):
-            assert render.handle_args("anyname", args) == 1
+        assert render.render_template(user_data, None, False) == 1
         json_file = paths.get_runpath("instance_data")
-        msg = "Missing instance-data.json file: %s" % json_file
+        msg = f"Missing instance-data.json file: {json_file}"
         assert msg in caplog.text
 
-    @mock.patch(M_PATH + "read_cfg_paths")
-    def test_handle_args_root_fallback_from_sensitive_instance_data(
+    @mock.patch(f"{M_PATH}read_cfg_paths")
+    def test_root_fallback_from_sensitive_instance_data(
         self, m_paths, caplog, tmpdir
     ):
         """When root user defaults to sensitive.json."""
@@ -65,24 +56,20 @@ class TestRender:
         ensure_dir(run_dir)
         paths = Paths({"run_dir": run_dir})
         m_paths.return_value = paths
-        args = self.Args(user_data=user_data, instance_data=None, debug=False)
-        with mock.patch("sys.stderr", new_callable=StringIO):
-            with mock.patch("os.getuid") as m_getuid:
-                m_getuid.return_value = 0
-                assert render.handle_args("anyname", args) == 1
+        with mock.patch("os.getuid") as m_getuid:
+            m_getuid.return_value = 0
+            assert render.render_template(user_data, None, False) == 1
         json_file = paths.get_runpath("instance_data")
         json_sensitive = paths.get_runpath("instance_data_sensitive")
         assert (
-            "Missing root-readable %s. Using redacted %s"
-            % (json_sensitive, json_file)
-            in caplog.text
+            f"Missing root-readable {json_sensitive}. "
+            f"Using redacted {json_file}" in caplog.text
         )
-        assert "Missing instance-data.json file: %s" % json_file in caplog.text
 
-    @mock.patch(M_PATH + "read_cfg_paths")
-    def test_handle_args_root_uses_sensitive_instance_data(
-        self, m_paths, tmpdir
-    ):
+        assert f"Missing instance-data.json file: {json_file}" in caplog.text
+
+    @mock.patch(f"{M_PATH}read_cfg_paths")
+    def test_root_uses_sensitive_instance_data(self, m_paths, tmpdir):
         """When root user, and no instance-data arg, use sensitive.json."""
         user_data = tmpdir.join("user-data")
         write_file(user_data, "##template: jinja\nrendering: {{ my_var }}")
@@ -90,31 +77,25 @@ class TestRender:
         json_sensitive = Paths({"run_dir": run_dir}).get_runpath(
             "instance_data_sensitive"
         )
+
         ensure_dir(run_dir)
         write_file(json_sensitive, '{"my-var": "jinja worked"}')
         m_paths.return_value = Paths({"run_dir": run_dir})
-        args = self.Args(user_data=user_data, instance_data=None, debug=False)
         with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
             with mock.patch("os.getuid") as m_getuid:
                 m_getuid.return_value = 0
-                assert render.handle_args("anyname", args) == 0
+                assert render.render_template(user_data, None, False) == 0
         assert "rendering: jinja worked" in m_stdout.getvalue()
 
     @skipUnlessJinja()
-    def test_handle_args_renders_instance_data_vars_in_template(
-        self, caplog, tmpdir
-    ):
+    def test_renders_instance_data_vars_in_template(self, caplog, tmpdir):
         """If user_data file is a jinja template render instance-data vars."""
         user_data = tmpdir.join("user-data")
         write_file(user_data, "##template: jinja\nrendering: {{ my_var }}")
         instance_data = tmpdir.join("instance-data")
         write_file(instance_data, '{"my-var": "jinja worked"}')
-        args = self.Args(
-            user_data=user_data, instance_data=instance_data, debug=True
-        )
-        with mock.patch("sys.stderr", new_callable=StringIO):
-            with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
-                assert render.handle_args("anyname", args) == 0
+        with mock.patch("sys.stdout", new_callable=StringIO) as m_stdout:
+            assert render.render_template(user_data, instance_data, True) == 0
         # Make sure the log is correctly captured. There is an issue
         # with this fixture in pytest==4.6.9 (focal):
         assert (
@@ -123,7 +104,7 @@ class TestRender:
         assert "rendering: jinja worked" == m_stdout.getvalue()
 
     @skipUnlessJinja()
-    def test_handle_args_warns_and_gives_up_on_invalid_jinja_operation(
+    def test_render_warns_and_gives_up_on_invalid_jinja_operation(
         self, caplog, tmpdir
     ):
         """If user_data file has invalid jinja operations log warnings."""
@@ -131,16 +112,40 @@ class TestRender:
         write_file(user_data, "##template: jinja\nrendering: {{ my-var }}")
         instance_data = tmpdir.join("instance-data")
         write_file(instance_data, '{"my-var": "jinja worked"}')
-        args = self.Args(
-            user_data=user_data, instance_data=instance_data, debug=True
-        )
-        with mock.patch("sys.stderr", new_callable=StringIO):
-            assert render.handle_args("anyname", args) == 1
+        assert render.render_template(user_data, instance_data, True) == 1
         assert (
             "Ignoring jinja template for %s: Undefined jinja"
             ' variable: "my-var". Jinja tried subtraction. Perhaps you meant'
             ' "my_var"?' % user_data
         ) in caplog.text
 
+    @skipUnlessJinja()
+    def test_jinja_load_error(self, caplog, tmpdir):
+        user_data = tmpdir.join("user-data")
+        write_file(user_data, "##template: jinja\nrendering: {{ my-var }}")
+        instance_data = tmpdir.join("instance-data")
+        write_file(instance_data, '{"my-var": "jinja failed"')
+        render.render_template(user_data, instance_data, False)
+        assert (
+            "Cannot render from instance data due to exception" in caplog.text
+        )
 
-# vi: ts=4 expandtab
+    @skipUnlessJinja()
+    def test_not_jinja_error(self, caplog, tmpdir):
+        user_data = tmpdir.join("user-data")
+        write_file(user_data, "{{ my-var }}")
+        instance_data = tmpdir.join("instance-data")
+        write_file(instance_data, '{"my-var": "jinja worked"}')
+        render.render_template(user_data, instance_data, False)
+        assert (
+            "Cannot render from instance data due to exception" in caplog.text
+        )
+
+    @skipUnlessJinja()
+    def test_no_user_data(self, caplog, tmpdir):
+        user_data = tmpdir.join("user-data")
+        write_file(user_data, "##template: jinja")
+        instance_data = tmpdir.join("instance-data")
+        write_file(instance_data, '{"my-var": "jinja worked"}')
+        render.render_template(user_data, instance_data, False)
+        assert "Unable to render user-data file" in caplog.text

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -13,6 +13,7 @@ from cloudinit import handlers, helpers, util
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.handlers.cloud_config import CloudConfigPartHandler
 from cloudinit.handlers.jinja_template import (
+    JinjaLoadError,
     JinjaTemplatePartHandler,
     convert_jinja_instance_data,
     render_jinja_payload,
@@ -160,7 +161,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         """If instance-data is absent, raise an error from handle_part."""
         script_handler = ShellScriptPartHandler(self.paths)
         h = JinjaTemplatePartHandler(self.paths, sub_handlers=[script_handler])
-        with self.assertRaises(RuntimeError) as context_manager:
+        with self.assertRaises(JinjaLoadError) as context_manager:
             h.handle_part(
                 data="data",
                 ctype="!" + handlers.CONTENT_START,
@@ -187,7 +188,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         util.write_file(instance_json, util.json_dumps({}))
         h = JinjaTemplatePartHandler(self.paths, sub_handlers=[script_handler])
         with mock.patch(self.mpath + "load_file") as m_load:
-            with self.assertRaises(RuntimeError) as context_manager:
+            with self.assertRaises(JinjaLoadError) as context_manager:
                 m_load.side_effect = OSError(errno.EACCES, "Not allowed")
                 h.handle_part(
                     data="data",

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -13,6 +13,7 @@ from io import BytesIO, StringIO
 from unittest import mock
 
 import httpretty
+import pytest
 
 from cloudinit import handlers
 from cloudinit import helpers as c_helpers
@@ -23,6 +24,8 @@ from cloudinit.config.modules import Modules
 from cloudinit.settings import PER_INSTANCE
 from tests.unittests import helpers
 from tests.unittests.util import FakeDataSource
+
+MPATH = "cloudinit.stages"
 
 
 def count_messages(root):
@@ -766,99 +769,88 @@ class TestConvertString(helpers.TestCase):
         self.assertEqual("Just text", msg.get_payload(decode=False))
 
 
-class TestFetchBaseConfig(helpers.TestCase):
-    def test_only_builtin_gets_builtin(self):
-        ret = helpers.wrap_and_call(
-            "cloudinit.stages",
-            {
-                "util.read_conf_with_confd": None,
-                "util.read_conf_from_cmdline": None,
-                "read_runtime_config": {"return_value": {}},
-            },
-            stages.fetch_base_config,
-        )
-        self.assertEqual(util.get_builtin_cfg(), ret)
+class TestFetchBaseConfig:
+    @pytest.fixture(autouse=True)
+    def mocks(self, mocker):
+        mocker.patch(f"{MPATH}.util.read_conf_with_confd")
+        mocker.patch(f"{MPATH}.util.read_conf_from_cmdline")
+        mocker.patch(f"{MPATH}.read_runtime_config")
 
-    def test_conf_d_overrides_defaults(self):
+    def test_only_builtin_gets_builtin(self, mocker):
+        mocker.patch(f"{MPATH}.read_runtime_config", return_value={})
+        config = stages.fetch_base_config()
+        assert util.get_builtin_cfg() == config
+
+    def test_conf_d_overrides_defaults(self, mocker):
         builtin = util.get_builtin_cfg()
         test_key = sorted(builtin)[0]
         test_value = "test"
-        ret = helpers.wrap_and_call(
-            "cloudinit.stages",
-            {
-                "util.read_conf_with_confd": {
-                    "return_value": {test_key: test_value}
-                },
-                "util.read_conf_from_cmdline": None,
-                "read_runtime_config": {"return_value": {}},
-            },
-            stages.fetch_base_config,
-        )
-        self.assertEqual(ret.get(test_key), test_value)
-        builtin[test_key] = test_value
-        self.assertEqual(ret, builtin)
 
-    def test_cmdline_overrides_defaults(self):
+        mocker.patch(
+            f"{MPATH}.util.read_conf_with_confd",
+            return_value={test_key: test_value},
+        )
+        mocker.patch(f"{MPATH}.read_runtime_config", return_value={})
+        config = stages.fetch_base_config()
+        assert config.get(test_key) == test_value
+        builtin[test_key] = test_value
+        assert config == builtin
+
+    def test_cmdline_overrides_defaults(self, mocker):
         builtin = util.get_builtin_cfg()
         test_key = sorted(builtin)[0]
         test_value = "test"
         cmdline = {test_key: test_value}
-        ret = helpers.wrap_and_call(
-            "cloudinit.stages",
-            {
-                "util.read_conf_from_cmdline": {"return_value": cmdline},
-                "util.read_conf_with_confd": None,
-                "read_runtime_config": None,
-            },
-            stages.fetch_base_config,
-        )
-        self.assertEqual(ret.get(test_key), test_value)
-        builtin[test_key] = test_value
-        self.assertEqual(ret, builtin)
 
-    def test_cmdline_overrides_confd_runtime_and_defaults(self):
+        mocker.patch(
+            f"{MPATH}.util.read_conf_from_cmdline",
+            return_value=cmdline,
+        )
+        mocker.patch(f"{MPATH}.read_runtime_config")
+        config = stages.fetch_base_config()
+        assert config.get(test_key) == test_value
+        builtin[test_key] = test_value
+        assert config == builtin
+
+    def test_cmdline_overrides_confd_runtime_and_defaults(self, mocker):
         builtin = {"key1": "value0", "key3": "other2"}
         conf_d = {"key1": "value1", "key2": "other1"}
         cmdline = {"key3": "other3", "key2": "other2"}
         runtime = {"key3": "runtime3"}
-        ret = helpers.wrap_and_call(
-            "cloudinit.stages",
-            {
-                "util.read_conf_with_confd": {"return_value": conf_d},
-                "util.get_builtin_cfg": {"return_value": builtin},
-                "read_runtime_config": {"return_value": runtime},
-                "util.read_conf_from_cmdline": {"return_value": cmdline},
-            },
-            stages.fetch_base_config,
-        )
-        self.assertEqual(
-            ret, {"key1": "value1", "key2": "other2", "key3": "other3"}
+
+        mocker.patch(f"{MPATH}.util.read_conf_with_confd", return_value=conf_d)
+        mocker.patch(f"{MPATH}.util.get_builtin_cfg", return_value=builtin)
+        mocker.patch(f"{MPATH}.read_runtime_config", return_value=runtime)
+        mocker.patch(
+            f"{MPATH}.util.read_conf_from_cmdline",
+            return_value=cmdline,
         )
 
-    def test_order_precedence_is_builtin_system_runtime_cmdline(self):
+        config = stages.fetch_base_config()
+        assert config == {"key1": "value1", "key2": "other2", "key3": "other3"}
+
+    def test_order_precedence_is_builtin_system_runtime_cmdline(self, mocker):
         builtin = {"key1": "builtin0", "key3": "builtin3"}
         conf_d = {"key1": "confd1", "key2": "confd2", "keyconfd1": "kconfd1"}
         runtime = {"key1": "runtime1", "key2": "runtime2"}
         cmdline = {"key1": "cmdline1"}
-        ret = helpers.wrap_and_call(
-            "cloudinit.stages",
-            {
-                "util.read_conf_with_confd": {"return_value": conf_d},
-                "util.get_builtin_cfg": {"return_value": builtin},
-                "util.read_conf_from_cmdline": {"return_value": cmdline},
-                "read_runtime_config": {"return_value": runtime},
-            },
-            stages.fetch_base_config,
+
+        mocker.patch(f"{MPATH}.util.read_conf_with_confd", return_value=conf_d)
+        mocker.patch(f"{MPATH}.util.get_builtin_cfg", return_value=builtin)
+        mocker.patch(
+            f"{MPATH}.util.read_conf_from_cmdline",
+            return_value=cmdline,
         )
-        self.assertEqual(
-            ret,
-            {
-                "key1": "cmdline1",
-                "key2": "runtime2",
-                "key3": "builtin3",
-                "keyconfd1": "kconfd1",
-            },
-        )
+        mocker.patch(f"{MPATH}.read_runtime_config", return_value=runtime)
+
+        config = stages.fetch_base_config()
+
+        assert config == {
+            "key1": "cmdline1",
+            "key2": "runtime2",
+            "key3": "builtin3",
+            "keyconfd1": "kconfd1",
+        }
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -25,7 +25,7 @@ from cloudinit.helpers import Paths
 from cloudinit.sources import DataSourceHostname
 from cloudinit.subp import SubpResult
 from tests.unittests import helpers
-from tests.unittests.helpers import CiTestCase
+from tests.unittests.helpers import CiTestCase, skipUnlessJinja
 
 LOG = logging.getLogger(__name__)
 M_PATH = "cloudinit.util."
@@ -384,6 +384,59 @@ class TestUtil:
         is_rw = util.mount_is_read_write("/")
         assert is_rw is False
 
+    def test_read_conf(self, mocker):
+        mocker.patch("cloudinit.util.load_file", return_value='{"a": "b"}')
+        assert util.read_conf("any") == {"a": "b"}
+
+    @skipUnlessJinja()
+    def test_read_conf_with_template(self, mocker, caplog):
+        mocker.patch("os.path.exists", return_value=True)
+        mocker.patch(
+            "cloudinit.util.load_file",
+            return_value='## template: jinja\n{"a": "{{c}}"}',
+        )
+        mocker.patch(
+            "cloudinit.handlers.jinja_template.load_file",
+            return_value='{"c": "d"}',
+        )
+
+        conf = util.read_conf("cfg_path", instance_data_file="vars_path")
+        assert conf == {"a": "d"}
+        assert (
+            "Applied instance data in 'vars_path' to configuration loaded "
+            "from 'cfg_path'"
+        ) in caplog.text
+
+    @skipUnlessJinja()
+    def test_read_conf_with_failed_template(self, mocker, caplog):
+        mocker.patch("os.path.exists", return_value=True)
+        mocker.patch(
+            "cloudinit.util.load_file",
+            return_value='## template: jinja\n{"a": "{{c}}"',  # missing }
+        )
+        mocker.patch(
+            "cloudinit.handlers.jinja_template.load_file",
+            return_value='{"c": "d"}',
+        )
+        conf = util.read_conf("cfg_path", instance_data_file="vars_path")
+        assert "Failed loading yaml blob" in caplog.text
+        assert conf == {}
+
+    @skipUnlessJinja()
+    def test_read_conf_with_failed_vars(self, mocker, caplog):
+        mocker.patch("os.path.exists", return_value=True)
+        mocker.patch(
+            "cloudinit.util.load_file",
+            return_value='## template: jinja\n{"a": "{{c}}"}',
+        )
+        mocker.patch(
+            "cloudinit.handlers.jinja_template.load_file",
+            return_value='{"c": "d"',  # missing }
+        )
+        conf = util.read_conf("cfg_path", instance_data_file="vars_path")
+        assert "Could not apply Jinja template" in caplog.text
+        assert conf == {"a": "{{c}}"}
+
     @mock.patch(
         M_PATH + "read_conf",
         side_effect=(OSError(errno.EACCES, "Not allowed"), {"0": "0"}),
@@ -459,7 +512,9 @@ class TestUtil:
         assert not out
         assert not err
         if create_confd:
-            assert [mock.call(confd_fn)] == m_read_confd.call_args_list
+            assert [
+                mock.call(confd_fn, instance_data_file=None)
+            ] == m_read_confd.call_args_list
         assert [expected_call] == m_mergemanydict.call_args_list
 
     @pytest.mark.parametrize("custom_cloud_dir", [True, False])


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Allow jinja templating in /etc/cloud

There have been multiple requests to allow jinja templating in
/etc/cloud configs the same way we allow jinja templating in vendordata
and userdata. This commit allows for templating both
/etc/cloud/cloud.cfg and any file in /etc/cloud/cloud.cfg.d. The same
instance data used for substitution in vendordata and userdata will be
used here.

Note that these configs get loaded multiple times during the lifetime
of cloud-init, and during cloud-init's earlier loads, instance data
is not yet available.

LP: #1913461
```

## Additional Context
There's little documentation about how our configuration gets loaded and overlaid, so there's really any documentation to be updated. We have a separate ticket for clarifying docs around /etc/cloud, and I think the changes here can be reflected there.

## Test Steps
See new integration tests

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
