### PR TITLE
sources/azure: ensure instance id is always correct

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -825,6 +825,11 @@ class DataSourceAzure(sources.DataSource):
             )
             return {}
 
+    def get_instance_id(self):
+        if not self.metadata or "instance-id" not in self.metadata:
+            return self._iid()
+        return str(self.metadata["instance-id"])
+
     def device_name_to_device(self, name):
         return self.ds_cfg["disk_aliases"].get(name)
 

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -4030,6 +4030,20 @@ class TestIMDS:
         ]
 
 
+class TestInstanceId:
+    def test_metadata(self, azure_ds, mock_dmi_read_dmi_data):
+        azure_ds.metadata = {"instance-id": "test-id"}
+
+        id = azure_ds.get_instance_id()
+
+        assert id == "test-id"
+
+    def test_fallback(self, azure_ds, mock_dmi_read_dmi_data):
+        id = azure_ds.get_instance_id()
+
+        assert id == "fake-system-uuid"
+
+
 class TestProvisioning:
     @pytest.fixture(autouse=True)
     def provisioning_setup(


### PR DESCRIPTION
Currently, get_instance_id() assumes that the instance ID is in the metadata.  If not found, it falls back to a hardcoded string "iid-datasource".

Override this behavior to query the instance id as needed.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>