### PR TITLE
refactor: unify aliased OSError exceptions

### DIFF
--- a/cloudinit/cmd/cloud_id.py
+++ b/cloudinit/cmd/cloud_id.py
@@ -76,7 +76,7 @@ def handle_args(name, args):
     try:
         with open(args.instance_data) as file:
             instance_data = json.load(file)
-    except IOError:
+    except OSError:
         return error(
             "File not found '%s'. Provide a path to instance data json file"
             " using --instance-data" % args.instance_data

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -82,7 +82,7 @@ def handle_args(name, args):
     try:
         with open(args.user_data) as stream:
             user_data = stream.read()
-    except IOError:
+    except OSError:
         LOG.error("Missing user-data file: %s", args.user_data)
         return 1
     try:

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -145,7 +145,7 @@ def _read_instance_data(instance_data, user_data, vendor_data) -> dict:
     Non-root users will have redacted INSTANCE_JSON_FILE content and redacted
     vendordata and userdata values.
 
-    :raise: IOError/OSError on absence of instance-data.json file or invalid
+    :raise: OSError on absence of instance-data.json file or invalid
         access perms.
     """
     uid = os.getuid()
@@ -178,7 +178,7 @@ def _read_instance_data(instance_data, user_data, vendor_data) -> dict:
 
     try:
         instance_json = util.load_file(instance_data_fn)
-    except (IOError, OSError) as e:
+    except OSError as e:
         if e.errno == EACCES:
             LOG.error("No read permission on '%s'. Try sudo", instance_data_fn)
         else:
@@ -258,7 +258,7 @@ def handle_args(name, args):
         instance_data = _read_instance_data(
             args.instance_data, args.user_data, args.vendor_data
         )
-    except (IOError, OSError):
+    except OSError:
         return 1
     if args.format:
         payload = "## template: jinja\n{fmt}".format(fmt=args.format)

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -220,7 +220,7 @@ def apply_apt(cfg, cloud, target):
 
     try:
         apply_apt_config(cfg, APT_PROXY_FN, APT_CONFIG_FN)
-    except (IOError, OSError):
+    except OSError:
         LOG.exception("Failed to apply proxy or apt config info:")
 
     # Process 'apt_source -> sources {dict}'
@@ -590,7 +590,7 @@ def add_apt_sources(
         try:
             contents = "%s\n" % (source)
             util.write_file(sourcefn, contents, omode="a")
-        except IOError as detail:
+        except OSError as detail:
             LOG.exception("failed write to file %s: %s", sourcefn, detail)
             raise
 

--- a/cloudinit/config/cc_mcollective.py
+++ b/cloudinit/config/cc_mcollective.py
@@ -102,7 +102,7 @@ def configure(
     try:
         old_contents = util.load_file(server_cfg, quiet=False, decode=False)
         mcollective_config = ConfigObj(io.BytesIO(old_contents))
-    except IOError as e:
+    except OSError as e:
         if e.errno != errno.ENOENT:
             raise
         else:
@@ -139,7 +139,7 @@ def configure(
         # We got all our config as wanted we'll copy
         # the previous server.cfg and overwrite the old with our new one
         util.copy(server_cfg, "%s.old" % (server_cfg))
-    except IOError as e:
+    except OSError as e:
         if e.errno == errno.ENOENT:
             # Doesn't exist to copy...
             pass

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -335,7 +335,7 @@ def setup_swapfile(fname, size=None, maxsize=None):
     if str(size).lower() == "auto":
         try:
             memsize = util.read_meminfo()["total"]
-        except IOError:
+        except OSError:
             LOG.debug("Not creating swap: failed to read meminfo")
             return
 

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -95,7 +95,7 @@ def givecmdline(pid):
             return m.group(2)
         else:
             return util.load_file("/proc/%s/cmdline" % pid)
-    except IOError:
+    except OSError:
         return None
 
 
@@ -252,11 +252,11 @@ def run_after_pid_gone(pid, pidcmdline, timeout, log, condition, func, args):
                 msg = "cmdline changed for %s [now: %s]" % (pid, cmdline)
                 break
 
-        except IOError as ioerr:
+        except OSError as ioerr:
             if ioerr.errno in known_errnos:
                 msg = "pidfile gone [%d]" % ioerr.errno
             else:
-                fatal("IOError during wait: %s" % ioerr)
+                fatal("OSError during wait: %s" % ioerr)
             break
 
         except Exception as e:

--- a/cloudinit/config/cc_refresh_rmc_and_interface.py
+++ b/cloudinit/config/cc_refresh_rmc_and_interface.py
@@ -121,7 +121,7 @@ def disable_ipv6(iface_file):
     # interface and NetworkManager is restarted.
     try:
         contents = util.load_file(iface_file)
-    except IOError as e:
+    except OSError as e:
         if e.errno == errno.ENOENT:
             LOG.debug("IPv6 interface file %s does not exist\n", iface_file)
         else:

--- a/cloudinit/config/cc_seed_random.py
+++ b/cloudinit/config/cc_seed_random.py
@@ -88,7 +88,7 @@ def _decode(data, encoding=None):
     elif encoding.lower() in ["gzip", "gz"]:
         return util.decomp_gzip(data, quiet=False, decode=None)
     else:
-        raise IOError("Unknown random_seed encoding: %s" % (encoding))
+        raise OSError("Unknown random_seed encoding: %s" % (encoding))
 
 
 def handle_random_seed_command(command, required, env=None):

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -158,7 +158,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def _find_tz_file(self, tz):
         tz_file = os.path.join(self.tz_zone_dir, str(tz))
         if not os.path.isfile(tz_file):
-            raise IOError(
+            raise OSError(
                 "Invalid timezone %s, no file found at %s" % (tz, tz_file)
             )
         return tz_file
@@ -404,7 +404,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         for fn in update_files:
             try:
                 self._write_hostname(hostname, fn)
-            except IOError:
+            except OSError:
                 util.logexc(
                     LOG, "Failed to write hostname %s to %s", hostname, fn
                 )
@@ -815,7 +815,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                     sudoers_contents = "\n".join(lines)
                     util.append_file(sudo_base, sudoers_contents)
                 LOG.debug("Added '#includedir %s' to %s", path, sudo_base)
-            except IOError as e:
+            except OSError as e:
                 util.logexc(LOG, "Failed to write %s", sudo_base)
                 raise e
         util.ensure_dir(path, 0o750)
@@ -847,13 +847,13 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             ]
             try:
                 util.write_file(sudo_file, "\n".join(contents), 0o440)
-            except IOError as e:
+            except OSError as e:
                 util.logexc(LOG, "Failed to write sudoers file %s", sudo_file)
                 raise e
         else:
             try:
                 util.append_file(sudo_file, content)
-            except IOError as e:
+            except OSError as e:
                 util.logexc(LOG, "Failed to append sudoers file %s", sudo_file)
                 raise e
 

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -73,7 +73,7 @@ class Distro(distros.Distro):
             # Try to update the previous one
             # so lets see if we can read it first.
             conf = self._read_hostname_conf(filename)
-        except IOError:
+        except OSError:
             pass
         if not conf:
             conf = HostnameConf("")
@@ -94,7 +94,7 @@ class Distro(distros.Distro):
         try:
             conf = self._read_hostname_conf(filename)
             hostname = conf.hostname
-        except IOError:
+        except OSError:
             pass
         if not hostname:
             return default

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -118,7 +118,7 @@ class Distro(distros.Distro):
             # Try to update the previous one
             # so lets see if we can read it first.
             conf = self._read_hostname_conf(filename)
-        except IOError:
+        except OSError:
             pass
         if not conf:
             conf = HostnameConf("")
@@ -139,7 +139,7 @@ class Distro(distros.Distro):
         try:
             conf = self._read_hostname_conf(filename)
             hostname = conf.hostname
-        except IOError:
+        except OSError:
             pass
         if not hostname:
             return default

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -147,7 +147,7 @@ class Distro(distros.Distro):
             # Try to update the previous one
             # so lets see if we can read it first.
             conf = self._read_hostname_conf(filename)
-        except IOError:
+        except OSError:
             pass
         if not conf:
             conf = HostnameConf("")
@@ -168,7 +168,7 @@ class Distro(distros.Distro):
         try:
             conf = self._read_hostname_conf(filename)
             hostname = conf.hostname
-        except IOError:
+        except OSError:
             pass
         if not hostname:
             return default

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -151,7 +151,7 @@ class Distro(cloudinit.distros.bsd.BSD):
             util.logexc(LOG, "Failed to apply locale %s", locale)
             try:
                 util.copy(self.login_conf_fn_bak, self.login_conf_fn)
-            except IOError:
+            except OSError:
                 util.logexc(
                     LOG, "Failed to restore %s backup", self.login_conf_fn
                 )

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -182,7 +182,7 @@ class Distro(distros.Distro):
             # Try to update the previous one
             # so lets see if we can read it first.
             conf = self._read_hostname_conf(filename)
-        except IOError:
+        except OSError:
             pass
         if not conf:
             conf = HostnameConf("")
@@ -208,7 +208,7 @@ class Distro(distros.Distro):
         try:
             conf = self._read_hostname_conf(filename)
             hostname = conf.hostname
-        except IOError:
+        except OSError:
             pass
         if not hostname:
             return default

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -126,7 +126,7 @@ class Distro(distros.Distro):
             try:
                 conf = self._read_hostname_conf(filename)
                 hostname = conf.hostname
-            except IOError:
+            except OSError:
                 pass
             if not hostname:
                 return default
@@ -158,7 +158,7 @@ class Distro(distros.Distro):
                 # Try to update the previous one
                 # so lets see if we can read it first.
                 conf = self._read_hostname_conf(filename)
-            except IOError:
+            except OSError:
                 pass
             if not conf:
                 conf = HostnameConf("")

--- a/cloudinit/distros/parsers/hostname.py
+++ b/cloudinit/distros/parsers/hostname.py
@@ -71,7 +71,7 @@ class HostnameConf(object):
             entries.append(("hostname", [head, tail]))
             hostnames_found.add(head)
         if len(hostnames_found) > 1:
-            raise IOError("Multiple hostnames (%s) found!" % (hostnames_found))
+            raise OSError("Multiple hostnames (%s) found!" % (hostnames_found))
         return entries
 
 

--- a/cloudinit/distros/parsers/resolv_conf.py
+++ b/cloudinit/distros/parsers/resolv_conf.py
@@ -156,7 +156,7 @@ class ResolvConf(object):
             try:
                 (cfg_opt, cfg_values) = head.split(None, 1)
             except (IndexError, ValueError) as e:
-                raise IOError(
+                raise OSError(
                     "Incorrectly formatted resolv.conf line %s" % (i + 1)
                 ) from e
             if cfg_opt not in [
@@ -166,7 +166,7 @@ class ResolvConf(object):
                 "sortlist",
                 "options",
             ]:
-                raise IOError("Unexpected resolv.conf option %s" % (cfg_opt))
+                raise OSError("Unexpected resolv.conf option %s" % (cfg_opt))
             entries.append(("option", [cfg_opt, cfg_values, tail]))
         return entries
 

--- a/cloudinit/distros/rhel_util.py
+++ b/cloudinit/distros/rhel_util.py
@@ -44,7 +44,7 @@ def read_sysconfig_file(fn):
     try:
         contents = util.load_file(fn).splitlines()
         exists = True
-    except IOError:
+    except OSError:
         contents = []
     return (exists, SysConf(contents))
 

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -91,7 +91,7 @@ def render_jinja_payload_from_file(
         )
     try:
         instance_data = load_json(load_file(instance_data_file))
-    except (IOError, OSError) as e:
+    except OSError as e:
         if e.errno == EACCES:
             raise RuntimeError(
                 "Cannot render jinja template vars. No read permission on"

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -78,7 +78,7 @@ class FileSemaphores(object):
         sem_file = self._get_path(name, freq)
         try:
             util.del_file(sem_file)
-        except (IOError, OSError):
+        except OSError:
             util.logexc(LOG, "Failed deleting semaphore %s", sem_file)
             return False
         return True
@@ -86,7 +86,7 @@ class FileSemaphores(object):
     def clear_all(self):
         try:
             util.del_dir(self.sem_path)
-        except (IOError, OSError):
+        except OSError:
             util.logexc(
                 LOG, "Failed deleting semaphore directory %s", self.sem_path
             )
@@ -102,7 +102,7 @@ class FileSemaphores(object):
         contents = "%s: %s\n" % (os.getpid(), time())
         try:
             util.write_file(sem_file, contents)
-        except (IOError, OSError):
+        except OSError:
             util.logexc(LOG, "Failed writing semaphore file %s", sem_file)
             return None
         return FileLock(sem_file)

--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -58,7 +58,7 @@ def flushLoggers(root):
         if isinstance(h, (logging.StreamHandler)):
             try:
                 h.flush()
-            except IOError:
+            except OSError:
                 pass
     flushLoggers(root.parent)
 

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -74,7 +74,7 @@ def read_sys_net(
     dev_path = sys_dev_path(devname, path)
     try:
         contents = util.load_file(dev_path)
-    except (OSError, IOError) as e:
+    except OSError as e:
         e_errno = getattr(e, "errno", None)
         if e_errno in (errno.ENOENT, errno.ENOTDIR):
             if on_enoent is not None:

--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -130,7 +130,7 @@ class BSDRenderer(renderer.Renderer):
                 )
             )
             resolvconf.parse()
-        except IOError:
+        except OSError:
             util.logexc(
                 LOG,
                 "Failed to parse %s, use new empty file",

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -243,7 +243,7 @@ def _decomp_gzip(blob):
         try:
             gzfp = gzip.GzipFile(mode="rb", fileobj=iobuf)
             return gzfp.read()
-        except IOError:
+        except OSError:
             return blob
         finally:
             if gzfp:

--- a/cloudinit/patcher.py
+++ b/cloudinit/patcher.py
@@ -33,7 +33,7 @@ def patch_logging():
         try:
             fallback_handler.handle(record)
             fallback_handler.flush()
-        except IOError:
+        except OSError:
             pass
 
     setattr(logging.Handler, "handleError", handleError)

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -227,7 +227,7 @@ class HyperVKvpReportingHandler(ReportingHandler):
             if os.path.getmtime(kvp_file) < boot_time:
                 with open(kvp_file, "w"):
                     pass
-        except (OSError, IOError) as e:
+        except OSError as e:
             LOG.warning("failed to truncate kvp pool file, %s", e)
         finally:
             cls._already_truncated_pool_file = True
@@ -384,7 +384,7 @@ class HyperVKvpReportingHandler(ReportingHandler):
                         event = None
                 try:
                     self._append_kvp_item(encoded_data)
-                except (OSError, IOError) as e:
+                except OSError as e:
                     LOG.warning("failed posting events to kvp, %s", e)
                 finally:
                     for _ in range(items_from_queue):

--- a/cloudinit/sources/DataSourceAltCloud.py
+++ b/cloudinit/sources/DataSourceAltCloud.py
@@ -60,10 +60,10 @@ def read_user_data_callback(mount_dir):
     # First try deltacloud_user_data_file. On failure try user_data_file.
     try:
         user_data = util.load_file(deltacloud_user_data_file).strip()
-    except IOError:
+    except OSError:
         try:
             user_data = util.load_file(user_data_file).strip()
-        except IOError:
+        except OSError:
             util.logexc(LOG, "Failed accessing user data file.")
             return None
 
@@ -102,7 +102,7 @@ class DataSourceAltCloud(sources.DataSource):
         if os.path.exists(CLOUD_INFO_FILE):
             try:
                 cloud_type = util.load_file(CLOUD_INFO_FILE).strip().upper()
-            except IOError:
+            except OSError:
                 util.logexc(
                     LOG,
                     "Unable to access cloud info file at %s.",

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1934,7 +1934,7 @@ def _check_freebsd_cdrom(cdrom_dev):
         with open(cdrom_dev) as fp:
             fp.read(1024)
             return True
-    except IOError:
+    except OSError:
         LOG.debug("cdrom (%s) is not configured", cdrom_dev)
     return False
 

--- a/cloudinit/sources/DataSourceBigstep.py
+++ b/cloudinit/sources/DataSourceBigstep.py
@@ -42,7 +42,7 @@ class DataSourceBigstep(sources.DataSource):
         )
         try:
             content = util.load_file(url_file)
-        except IOError as e:
+        except OSError as e:
             # If the file doesn't exist, then the server probably isn't a
             # Bigstep instance; otherwise, another problem exists which needs
             # investigation

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -218,7 +218,7 @@ def get_previous_iid(paths):
     fname = os.path.join(paths.get_cpath("data"), "instance-id")
     try:
         return util.load_file(fname).rstrip("\n")
-    except IOError:
+    except OSError:
         return None
 
 
@@ -244,7 +244,7 @@ def write_injected_files(files):
                 filename = os.sep + filename
             try:
                 util.write_file(filename, content, mode=0o660)
-            except IOError:
+            except OSError:
                 util.logexc(LOG, "Failed writing file: %s", filename)
 
 

--- a/cloudinit/sources/DataSourceIBMCloud.py
+++ b/cloudinit/sources/DataSourceIBMCloud.py
@@ -362,7 +362,7 @@ def metadata_from_dir(source_dir):
         raw = None
         try:
             raw = util.load_file(fpath, decode=False)
-        except IOError as e:
+        except OSError as e:
             LOG.debug("Failed reading path '%s': %s", fpath, e)
 
         if raw is None or transl is None:

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -447,7 +447,7 @@ def read_context_disk_dir(source_dir, distro, asuser=None):
             raise BrokenContextDiskDir(
                 "Error processing context.sh: %s" % (e)
             ) from e
-        except IOError as e:
+        except OSError as e:
             raise NonContextDiskDir(
                 "Error reading context.sh: %s" % (e)
             ) from e

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -216,9 +216,9 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
                 raise sources.InvalidMetaDataException(
                     "No active metadata service found"
                 )
-        except IOError as e:
+        except OSError as e:
             raise sources.InvalidMetaDataException(
-                "IOError contacting metadata service: {error}".format(
+                "OSError contacting metadata service: {error}".format(
                     error=str(e)
                 )
             )
@@ -239,7 +239,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             )
         except openstack.NonReadable as e:
             raise sources.InvalidMetaDataException(str(e))
-        except (openstack.BrokenMetadata, IOError) as e:
+        except (openstack.BrokenMetadata, OSError) as e:
             msg = "Broken metadata address {addr}".format(
                 addr=self.metadata_address
             )

--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -809,7 +809,7 @@ def write_boot_content(
             if content and os.path.exists(content_f):
                 util.ensure_dir(os.path.dirname(link))
                 os.symlink(content_f, link)
-        except IOError as e:
+        except OSError as e:
             util.logexc(LOG, "failed establishing content link: %s", e)
 
 

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -670,7 +670,7 @@ def getfqdn(name=""):
         addrs = socket.getaddrinfo(
             name, None, 0, socket.SOCK_DGRAM, 0, socket.AI_CANONNAME
         )
-    except socket.error:
+    except OSError:
         pass
     else:
         for addr in addrs:

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -1043,7 +1043,7 @@ def convert_vendordata(data, recurse=True):
     raise ValueError("Unknown data type for vendordata: %s" % type(data))
 
 
-class BrokenMetadata(IOError):
+class BrokenMetadata(OSError):
     pass
 
 

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -287,7 +287,7 @@ def get_last_log_byte_pushed_to_kvp_index():
     try:
         with open(LOG_PUSHED_TO_KVP_INDEX_FILE, "r") as f:
             return int(f.read())
-    except IOError as e:
+    except OSError as e:
         if e.errno != ENOENT:
             report_diagnostic_event(
                 "Reading LOG_PUSHED_TO_KVP_INDEX_FILE failed: %s." % repr(e),

--- a/cloudinit/sources/helpers/netlink.py
+++ b/cloudinit/sources/helpers/netlink.py
@@ -73,7 +73,7 @@ def create_bound_netlink_socket():
         )
         netlink_socket.bind((os.getpid(), RTMGRP_LINK))
         netlink_socket.setblocking(0)
-    except socket.error as e:
+    except OSError as e:
         msg = "Exception during netlink socket create: %s" % e
         raise NetlinkCreateSocketError(msg) from e
     LOG.debug("Created netlink socket")

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -78,7 +78,7 @@ KNOWN_PHYSICAL_TYPES = (
 )
 
 
-class NonReadable(IOError):
+class NonReadable(OSError):
     pass
 
 
@@ -272,7 +272,7 @@ class BaseReader(metaclass=abc.ABCMeta):
             found = False
             try:
                 data = self._path_read(path)
-            except IOError as e:
+            except OSError as e:
                 if not required:
                     LOG.debug(
                         "Failed reading optional path %s due to: %s", path, e
@@ -328,7 +328,7 @@ class BaseReader(metaclass=abc.ABCMeta):
             try:
                 content = self._read_content_path(net_item, decode=True)
                 results["network_config"] = content
-            except IOError as e:
+            except OSError as e:
                 raise BrokenMetadata(
                     "Failed to read network configuration: %s" % (e)
                 ) from e
@@ -413,7 +413,7 @@ class ConfigDriveReader(BaseReader):
                 path = found[name]
                 try:
                     contents = self._path_read(path)
-                except IOError as e:
+                except OSError as e:
                     raise BrokenMetadata("Failed to read: %s" % path) from e
                 try:
                     # Disable not-callable pylint check; pylint isn't able to

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -194,7 +194,7 @@ def parse_authorized_keys(fnames):
                 lines = util.load_file(fname).splitlines()
                 for line in lines:
                     contents.append(parser.parse(line))
-        except (IOError, OSError):
+        except OSError:
             util.logexc(LOG, "Error reading lines from %s", fname)
 
     return contents
@@ -397,7 +397,7 @@ def check_create_path(username, filename, strictmodes):
         )
         if not permissions:
             return False
-    except (IOError, OSError) as e:
+    except OSError as e:
         util.logexc(LOG, str(e))
         return False
 
@@ -420,7 +420,7 @@ def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
                 key_paths, pw_ent.pw_dir, username
             )
 
-        except (IOError, OSError):
+        except OSError:
             # Give up and use a default key filename
             auth_key_fns[0] = default_authorizedkeys_file
             util.logexc(

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -63,7 +63,7 @@ def prepend_base_command(base_command, commands):
     return fixed_commands
 
 
-class ProcessExecutionError(IOError):
+class ProcessExecutionError(OSError):
 
     MESSAGE_TMPL = (
         "%(description)s\n"
@@ -133,7 +133,7 @@ class ProcessExecutionError(IOError):
             "stderr": self._ensure_string(self.stderr),
             "reason": self._ensure_string(self.reason),
         }
-        IOError.__init__(self, message)
+        OSError.__init__(self, message)
 
     def _ensure_string(self, text):
         """

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -77,7 +77,7 @@ def read_file_or_url(url, **kwargs) -> Union["FileResponse", "UrlResponse"]:
         try:
             with open(file_path, "rb") as fp:
                 contents = fp.read()
-        except IOError as e:
+        except OSError as e:
             code = e.errno
             if e.errno == ENOENT:
                 code = NOT_FOUND
@@ -161,9 +161,9 @@ class UrlResponse(object):
         yield from self._response.iter_content(chunk_size, decode_unicode)
 
 
-class UrlError(IOError):
+class UrlError(OSError):
     def __init__(self, cause, code=None, headers=None, url=None):
-        IOError.__init__(self, str(cause))
+        OSError.__init__(self, str(cause))
         self.cause = cause
         self.code = code
         self.headers = headers

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -263,7 +263,7 @@ class UserDataProcessor(object):
                     if include_url not in message:
                         message += " for url: {0}".format(include_url)
                     _handle_error(message, urle)
-                except IOError as ioe:
+                except OSError as ioe:
                     error_message = "Fetching from {} resulted in {}".format(
                         include_url, ioe
                     )

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -290,7 +290,7 @@ def rand_dict_key(dictionary, postfix=None):
 def read_conf(fname):
     try:
         return load_yaml(load_file(fname), default={})
-    except IOError as e:
+    except OSError as e:
         if e.errno == ENOENT:
             return {}
         else:
@@ -1165,7 +1165,7 @@ def get_fqdn_from_hosts(hostname, filename="/etc/hosts"):
             if hostname in toks[2:]:
                 fqdn = toks[1]
                 break
-    except IOError:
+    except OSError:
         pass
     return fqdn
 
@@ -1200,7 +1200,7 @@ def is_resolvable(name):
                 for (_fam, _stype, _proto, cname, sockaddr) in result:
                     badresults[iname].append("%s: %s" % (cname, sockaddr[0]))
                     badips.add(sockaddr[0])
-            except (socket.gaierror, socket.error):
+            except (socket.gaierror, OSError):
                 pass
         _DNS_REDIRECT_IP = badips
         if badresults:
@@ -1213,7 +1213,7 @@ def is_resolvable(name):
         if addr in _DNS_REDIRECT_IP:
             return False
         return True
-    except (socket.gaierror, socket.error):
+    except (socket.gaierror, OSError):
         return False
 
 
@@ -1476,7 +1476,7 @@ def load_file(fname, read_cb=None, quiet=False, decode=True):
     try:
         with open(fname, "rb") as ifh:
             pipe_in_out(ifh, ofh, chunk_cb=read_cb)
-    except IOError as e:
+    except OSError as e:
         if not quiet:
             raise
         if e.errno != ENOENT:
@@ -1786,7 +1786,7 @@ def mounts():
                 "opts": opts,
             }
         LOG.debug("Fetched %s mounts from %s", mounted, method)
-    except (IOError, OSError):
+    except OSError:
         logexc(LOG, "Failed fetching mount points")
     return mounted
 
@@ -1851,7 +1851,7 @@ def mount_cb(
                     umount = tmpd  # This forces it to be unmounted (when set)
                     mountpoint = tmpd
                     break
-                except (IOError, OSError) as exc:
+                except OSError as exc:
                     LOG.debug(
                         "Failed to mount device: '%s' with type: '%s' "
                         "using mount command: '%s', "
@@ -2249,7 +2249,7 @@ def is_container():
             return True
         if "LIBVIRT_LXC_UUID" in pid1env:
             return True
-    except (IOError, OSError):
+    except OSError:
         pass
 
     # Detect OpenVZ containers
@@ -2264,7 +2264,7 @@ def is_container():
                 (_key, val) = line.strip().split(":", 1)
                 if val != "0":
                     return True
-    except (IOError, OSError):
+    except OSError:
         pass
 
     return False
@@ -2287,7 +2287,7 @@ def get_proc_env(pid, encoding="utf-8", errors="replace"):
 
     try:
         contents = load_file(fn, decode=False)
-    except (IOError, OSError):
+    except OSError:
         return {}
 
     env = {}
@@ -2667,7 +2667,7 @@ def pathprefix2dict(base, required=None, optional=None, delim=os.path.sep):
     for f in required + optional:
         try:
             ret[f] = load_file(base + delim + f, quiet=False, decode=False)
-        except IOError as e:
+        except OSError as e:
             if e.errno != ENOENT:
                 raise
             if f in required:
@@ -2910,7 +2910,7 @@ def get_proc_ppid(pid):
                     pid,
                     contents,
                 )
-    except IOError as e:
+    except OSError as e:
         LOG.warning("Failed to load /proc/%s/stat. %s", pid, e)
     return ppid
 

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -95,7 +95,7 @@ class IntegrationInstance:
         if result.failed:
             # TODO: Raise here whatever pycloudlib raises when it has
             # a consistent error response
-            raise IOError(
+            raise OSError(
                 "Failed reading remote file via cat: {}\n"
                 "Return code: {}\n"
                 "Stderr: {}\n"

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -182,7 +182,7 @@ class TestQuery:
         [
             (OSError(errno.EACCES, "Not allowed"),),
             (OSError(errno.ENOENT, "Not allowed"),),
-            (IOError,),
+            (OSError,),
         ],
     )
     def test_handle_args_error_when_no_read_permission_init_cfg(

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -85,7 +85,7 @@ class TestRandomSeed(TestCase):
             }
         }
         self.assertRaises(
-            IOError,
+            OSError,
             cc_seed_random.handle,
             "test",
             cfg,

--- a/tests/unittests/config/test_cc_yum_add_repo.py
+++ b/tests/unittests/config/test_cc_yum_add_repo.py
@@ -43,7 +43,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_yum_add_repo.handle("yum_add_repo", cfg, None, LOG, [])
         self.assertRaises(
-            IOError, util.load_file, "/etc/yum.repos.d/epel_testing.repo"
+            OSError, util.load_file, "/etc/yum.repos.d/epel_testing.repo"
         )
 
     def test_write_config(self):

--- a/tests/unittests/config/test_cc_zypper_add_repo.py
+++ b/tests/unittests/config/test_cc_zypper_add_repo.py
@@ -29,7 +29,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_zypper_add_repo._write_repos(cfg["repos"], "/etc/zypp/repos.d")
         self.assertRaises(
-            IOError, util.load_file, "/etc/zypp/repos.d/foo.repo"
+            OSError, util.load_file, "/etc/zypp/repos.d/foo.repo"
         )
 
     def test_write_repos(self):

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -52,15 +52,14 @@ class TestReadSysNet(CiTestCase):
         self.assertEqual(content.strip(), net.read_sys_net("dev", "attr"))
 
     def test_read_sys_net_reraises_oserror(self):
-        """read_sys_net raises OSError/IOError when file doesn't exist."""
-        # Non-specific Exception because versions of python OSError vs IOError.
-        with self.assertRaises(Exception) as context_manager:  # noqa: H202
+        """read_sys_net raises OSError when file doesn't exist."""
+        with self.assertRaises(OSError) as context_manager:  # noqa: H202
             net.read_sys_net("dev", "attr")
         error = context_manager.exception
         self.assertIn("No such file or directory", str(error))
 
     def test_read_sys_net_handles_error_with_on_enoent(self):
-        """read_sys_net handles OSError/IOError with on_enoent if provided."""
+        """read_sys_net handles OSError with on_enoent if provided."""
         handled_errors = []
 
         def on_enoent(e):
@@ -68,7 +67,7 @@ class TestReadSysNet(CiTestCase):
 
         net.read_sys_net("dev", "attr", on_enoent=on_enoent)
         error = handled_errors[0]
-        self.assertIsInstance(error, Exception)
+        self.assertIsInstance(error, OSError)
         self.assertIn("No such file or directory", str(error))
 
     def test_read_sys_net_translates_content(self):

--- a/tests/unittests/sources/helpers/test_netlink.py
+++ b/tests/unittests/sources/helpers/test_netlink.py
@@ -3,7 +3,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import codecs
-import socket
 import struct
 
 from cloudinit.sources.helpers.netlink import (
@@ -45,7 +44,7 @@ class TestCreateBoundNetlinkSocket(CiTestCase):
         """create_bound_netlink_socket catches socket creation exception"""
 
         """NetlinkCreateSocketError is raised when socket creation errors."""
-        m_socket.side_effect = socket.error("Fake socket failure")
+        m_socket.side_effect = OSError("Fake socket failure")
         with self.assertRaises(NetlinkCreateSocketError) as ctx_mgr:
             create_bound_netlink_socket()
         self.assertEqual(

--- a/tests/unittests/sources/test_altcloud.py
+++ b/tests/unittests/sources/test_altcloud.py
@@ -97,7 +97,7 @@ class TestGetCloudType(CiTestCase):
         """Return UNKNOWN when /etc/sysconfig/cloud-info exists but errors."""
         self.assertEqual("/etc/sysconfig/cloud-info", dsac.CLOUD_INFO_FILE)
         dsrc = dsac.DataSourceAltCloud({}, None, self.paths)
-        # Attempting to read the directory generates IOError
+        # Attempting to read the directory generates OSError
         with mock.patch.object(dsac, "CLOUD_INFO_FILE", self.tmp):
             self.assertEqual("UNKNOWN", dsrc.get_cloud_type())
         self.assertIn(
@@ -109,7 +109,7 @@ class TestGetCloudType(CiTestCase):
         dsrc = dsac.DataSourceAltCloud({}, None, self.paths)
         cloud_info = self.tmp_path("cloud-info", dir=self.tmp)
         util.write_file(cloud_info, " OverRiDdeN CloudType ")
-        # Attempting to read the directory generates IOError
+        # Attempting to read the directory generates OSError
         with mock.patch.object(dsac, "CLOUD_INFO_FILE", cloud_info):
             self.assertEqual("OVERRIDDEN CLOUDTYPE", dsrc.get_cloud_type())
 

--- a/tests/unittests/test_merging.py
+++ b/tests/unittests/test_merging.py
@@ -103,14 +103,14 @@ class TestSimpleRun(helpers.ResourceUsingTestCase):
             base_fn = os.path.basename(fn)
             file_id = re.match(r"source(\d+)\-(\d+)[.]yaml", base_fn)
             if not file_id:
-                raise IOError(
+                raise OSError(
                     "File %s does not have a numeric identifier" % (fn)
                 )
             file_id = int(file_id.group(1))
             source_ids[file_id].append(fn)
             expected_fn = os.path.join(merge_root, EXPECTED_PAT % (file_id))
             if not os.path.isfile(expected_fn):
-                raise IOError("No expected file found at %s" % (expected_fn))
+                raise OSError("No expected file found at %s" % (expected_fn))
             expected_files[file_id] = expected_fn
         for i in sorted(source_ids.keys()):
             source_file_contents = []

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -418,7 +418,7 @@ class TestParseSSHConfig:
         "is_file, file_content",
         [
             pytest.param(True, ("",), id="empty-file"),
-            pytest.param(False, IOError, id="not-a-file"),
+            pytest.param(False, OSError, id="not-a-file"),
         ],
     )
     def test_dummy_file(self, m_is_file, m_load_file, is_file, file_content):

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -256,7 +256,7 @@ class TestReadFileOrUrlParameters:
 class TestRetryOnUrlExc(CiTestCase):
     def test_do_not_retry_non_urlerror(self):
         """When exception is not UrlError return False."""
-        myerror = IOError("something unexcpected")
+        myerror = OSError("something unexcpected")
         self.assertFalse(retry_on_url_exc(msg="", exc=myerror))
 
     def test_perform_retries_on_not_found(self):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2251,7 +2251,7 @@ class TestProcessExecutionError(helpers.TestCase):
         )
 
     def test_pexec_error_type(self):
-        self.assertIsInstance(subp.ProcessExecutionError(), IOError)
+        self.assertIsInstance(subp.ProcessExecutionError(), OSError)
 
     def test_pexec_error_empty_msgs(self):
         error = subp.ProcessExecutionError()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
refactor: unify aliased OSError exceptions

Since python3.3 the following exceptions are just alias of OSError and some of them are deprecated:

- EnvironmentError
- IOError
- WindowsError
- socket.error
- select.error
- mmap.error

This commit substitute appearances of them with OSError.
```

## Additional Context
<!-- If relevant -->
https://docs.python.org/3/library/exceptions.html#OSError

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
