### PR TITLE
integration-tests: fix LXD ds assertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,3 @@ features or to verify bug fixes.
 For Ubuntu, see the [Daily PPAs](https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily)
 
 For CentOS, see the [COPR build repos](https://copr.fedorainfracloud.org/coprs/g/cloud-init/cloud-init-dev/)
-hola

--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ features or to verify bug fixes.
 For Ubuntu, see the [Daily PPAs](https://code.launchpad.net/~cloud-init-dev/+archive/ubuntu/daily)
 
 For CentOS, see the [COPR build repos](https://copr.fedorainfracloud.org/coprs/g/cloud-init/cloud-init-dev/)
+hola

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -217,14 +217,7 @@ class TestCombined:
         parsed_datasource = json.loads(status_file)["v1"]["datasource"]
 
         if client.settings.PLATFORM in ["lxd_container", "lxd_vm"]:
-            if ImageSpecification.from_os_image().release in [
-                "bionic",
-                "focal",
-            ]:
-                datasource = "DataSourceNoCloud"
-            else:
-                datasource = "DataSourceLXD"
-            assert parsed_datasource.startswith(datasource)
+            assert parsed_datasource.startswith("DataSourceLXD")
         else:
             platform_datasources = {
                 "azure": "DataSourceAzure [seed=/dev/sr0]",
@@ -294,26 +287,19 @@ class TestCombined:
         data = json.loads(instance_json_file)
         self._check_common_metadata(data)
         v1_data = data["v1"]
-        if ImageSpecification.from_os_image().release not in [
-            "bionic",
-            "focal",
-        ]:
-            cloud_name = "lxd"
-            subplatform = "LXD socket API v. 1.0 (/dev/lxd/sock)"
-            # instance-id should be a UUID
-            try:
-                uuid.UUID(v1_data["instance_id"])
-            except ValueError:
-                raise AssertionError(
-                    f"LXD instance-id is not a UUID: {v1_data['instance_id']}"
-                )
-        else:
-            cloud_name = "unknown"
-            subplatform = "seed-dir (/var/lib/cloud/seed/nocloud-net)"
-            # Pre-Jammy instance-id and instance.name are synonymous
-            assert v1_data["instance_id"] == client.instance.name
-        assert v1_data["cloud_name"] == cloud_name
-        assert v1_data["subplatform"] == subplatform
+
+        # instance-id should be a UUID
+        try:
+            uuid.UUID(v1_data["instance_id"])
+        except ValueError:
+            raise AssertionError(
+                f"LXD instance-id is not a UUID: {v1_data['instance_id']}"
+            )
+
+        assert v1_data["cloud_name"] == "lxd"
+        assert (
+            v1_data["subplatform"] == "LXD socket API v. 1.0 (/dev/lxd/sock)"
+        )
         assert v1_data["platform"] == "lxd"
         assert v1_data["cloud_id"] == "lxd"
         assert f"{v1_data['cloud_id']}" == client.read_from_file(
@@ -333,32 +319,19 @@ class TestCombined:
         data = json.loads(instance_json_file)
         self._check_common_metadata(data)
         v1_data = data["v1"]
-        if ImageSpecification.from_os_image().release not in [
-            "bionic",
-            "focal",
-        ]:
-            cloud_name = "lxd"
-            subplatform = "LXD socket API v. 1.0 (/dev/lxd/sock)"
-            # instance-id should be a UUID
-            try:
-                uuid.UUID(v1_data["instance_id"])
-            except ValueError as e:
-                raise AssertionError(
-                    f"LXD instance-id is not a UUID: {v1_data['instance_id']}"
-                ) from e
-            assert v1_data["subplatform"] == subplatform
-        else:
-            cloud_name = "unknown"
-            # Pre-Jammy instance-id and instance.name are synonymous
-            assert v1_data["instance_id"] == client.instance.name
-            assert any(
-                [
-                    "/var/lib/cloud/seed/nocloud-net"
-                    in v1_data["subplatform"],
-                    "/dev/sr0" in v1_data["subplatform"],
-                ]
-            )
-        assert v1_data["cloud_name"] == cloud_name
+
+        # instance-id should be a UUID
+        try:
+            uuid.UUID(v1_data["instance_id"])
+        except ValueError as e:
+            raise AssertionError(
+                f"LXD instance-id is not a UUID: {v1_data['instance_id']}"
+            ) from e
+
+        assert v1_data["cloud_name"] == "lxd"
+        assert (
+            v1_data["subplatform"] == "LXD socket API v. 1.0 (/dev/lxd/sock)"
+        )
         assert v1_data["platform"] == "lxd"
         assert v1_data["cloud_id"] == "lxd"
         assert f"{v1_data['cloud_id']}" == client.read_from_file(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
integration-tests: fix LXD ds assertion
    
After [1], lxd ubuntu images will be detected as
DataSourceLXD and previously they were detected as
DataSourceNone in bionic and focal.

[1] https://bugs.launchpad.net/cloud-images/+bug/1988401
```

## Additional Context
<!-- If relevant -->
https://bugs.launchpad.net/cloud-images/+bug/1988401

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Run with <platform> in {lxd_vm, lxd_container} and <os_image> in {bionic, focal}.

```bash
CLOUD_INIT_PLATFORM=<platform> CLOUD_INIT_OS_IMAGE=<os_image> tox -e integration-tests -- -vv --pdb tests/integration_tests/modules/test_combined.py
```

Note: As of this moment, the bionic image containing serial >= 20220913 has not been published. More info: https://bugs.launchpad.net/cloud-images/+bug/1988401/comments/8

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
