### PR TITLE
tests: Simplify does_not_raise

### DIFF
--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -18,7 +18,6 @@ from unittest import mock
 from unittest.util import strclass
 
 import httpretty
-import pytest
 
 import cloudinit
 from cloudinit import cloud, distros
@@ -585,10 +584,7 @@ def does_not_raise():
     >>>         assert (0 / example_input) is not None
 
     """
-    try:
-        yield
-    except Exception as ex:
-        raise pytest.fail("DID RAISE {0}".format(ex))
+    yield
 
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: Simplify does_not_raise

With this the backtraces during an exception within a does_not_raise
context are more simple and easy to read.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Apply the following diff:

```diff
diff --git a/tests/unittests/test__init__.py b/tests/unittests/test__init__.py
index 44a06b2cd..78b4563a0 100644
--- a/tests/unittests/test__init__.py
+++ b/tests/unittests/test__init__.py
@@ -9,7 +9,12 @@ import pytest
 
 from cloudinit import handlers, helpers, settings, url_helper, util
 from cloudinit.cmd import main
-from tests.unittests.helpers import ExitStack, TestCase, mock
+from tests.unittests.helpers import ExitStack, TestCase, does_not_raise, mock
+
+
+def test_division():
+    with does_not_raise():
+        assert (1 / 0) is not None
 
 
 class FakeModule(handlers.Handler):
```

and run `pytest -vv tests/unittests/test__init__.py::test_division`

Previous logs:

```text
tests/unittests/test__init__.py::test_division FAILED                                                                                                                                                [100%]

================================================================================================= FAILURES =================================================================================================
______________________________________________________________________________________________ test_division _______________________________________________________________________________________________

    @contextmanager
    def does_not_raise():
        """Context manager to parametrize tests raising and not raising exceptions
    
        Note: In python-3.7+, this can be substituted by contextlib.nullcontext
        More info:
        https://docs.pytest.org/en/6.2.x/example/parametrize.html?highlight=does_not_raise#parametrizing-conditional-raising
    
        Example:
        --------
        >>> @pytest.mark.parametrize(
        >>>     "example_input,expectation",
        >>>     [
        >>>         (1, does_not_raise()),
        >>>         (0, pytest.raises(ZeroDivisionError)),
        >>>     ],
        >>> )
        >>> def test_division(example_input, expectation):
        >>>     with expectation:
        >>>         assert (0 / example_input) is not None
    
        """
        try:
>           yield

tests/unittests/helpers.py:589: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def test_division():
        with does_not_raise():
>           assert (1 / 0) is not None
E           ZeroDivisionError: division by zero

tests/unittests/test__init__.py:17: ZeroDivisionError

During handling of the above exception, another exception occurred:

    def test_division():
        with does_not_raise():
>           assert (1 / 0) is not None

tests/unittests/test__init__.py:17: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
../../.pyenv/versions/3.6.15/lib/python3.6/contextlib.py:99: in __exit__
    self.gen.throw(type, value, traceback)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    @contextmanager
    def does_not_raise():
        """Context manager to parametrize tests raising and not raising exceptions
    
        Note: In python-3.7+, this can be substituted by contextlib.nullcontext
        More info:
        https://docs.pytest.org/en/6.2.x/example/parametrize.html?highlight=does_not_raise#parametrizing-conditional-raising
    
        Example:
        --------
        >>> @pytest.mark.parametrize(
        >>>     "example_input,expectation",
        >>>     [
        >>>         (1, does_not_raise()),
        >>>         (0, pytest.raises(ZeroDivisionError)),
        >>>     ],
        >>> )
        >>> def test_division(example_input, expectation):
        >>>     with expectation:
        >>>         assert (0 / example_input) is not None
    
        """
        try:
            yield
        except Exception as ex:
>           pytest.fail("DID RAISE {0}".format(ex))
E           Failed: DID RAISE division by zero

tests/unittests/helpers.py:591: Failed
```

with this change:

```text
tests/unittests/test__init__.py::test_division FAILED                                                                                                                                                                                                                                                                         [100%]

================================================================================================= FAILURES =================================================================================================
______________________________________________________________________________________________ test_division _______________________________________________________________________________________________

    def test_division():
        with does_not_raise():
>           assert (1 / 0) is not None
E           ZeroDivisionError: division by zero

tests/unittests/test__init__.py:17: ZeroDivisionError
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
