### PR TITLE
NoCloud docs: make sure echo properly evaluates the string

### DIFF
--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -68,8 +68,8 @@ sufficient disk by following the example below.
 
     ## 1) create user-data and meta-data files that will be used
     ## to modify image on first boot
-    $ echo "instance-id: iid-local01\nlocal-hostname: cloudimg" > meta-data
-    $ echo "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n" > user-data
+    $ echo -e "instance-id: iid-local01\nlocal-hostname: cloudimg" > meta-data
+    $ echo -e "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n" > user-data
 
     ## 2a) create a disk to attach with some user-data and meta-data
     $ genisoimage  -output seed.iso -volid cidata -joliet -rock user-data meta-data


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
NoCloud docs: make sure echo properly evaluates the string

Not all `echo`s evaluate "strings" by default
but adding `-e` usually helps.
```

## Additional Context
I tried to get the example working and it didn't, with my shell.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
