### PR TITLE
testing: focal lxd datasource discovery (SC-1256)

### DIFF
--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -112,7 +112,6 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
     # Jammy not longer provides nocloud-net seed files (LP: #1958460)
     if ImageSpecification.from_os_image().release in [
         "bionic",
-        "focal",
     ]:
         # Assert NoCloud seed files are still present in non-Jammy images
         # and that NoCloud seed files provide the same content as LXD socket.


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: focal lxd datasource discovery

Stop identifying focal as NoCloud.
```

## Additional Context
Missed one...
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_container/103/testReport/tests.integration_tests.datasources/test_lxd_discovery/test_lxd_datasource_discovery/
