### PR TITLE
Fix Oracle DS not setting subnet when using IMDS

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -14,6 +14,7 @@ Notes:
 """
 
 import base64
+import ipaddress
 from collections import namedtuple
 from typing import Optional, Tuple
 
@@ -296,11 +297,14 @@ class DataSourceOracle(sources.DataSource):
                 )
                 continue
             name = interfaces_by_mac[mac_address]
+            prefix = ipaddress.ip_network(
+                vnic_dict["subnetCidrBlock"]
+            ).prefixlen
 
             if self._network_config["version"] == 1:
                 subnet = {
                     "type": "static",
-                    "address": vnic_dict["privateIp"],
+                    "address": f"{vnic_dict['privateIp']}/{prefix}",
                 }
                 self._network_config["config"].append(
                     {
@@ -313,7 +317,7 @@ class DataSourceOracle(sources.DataSource):
                 )
             elif self._network_config["version"] == 2:
                 self._network_config["ethernets"][name] = {
-                    "addresses": [vnic_dict["privateIp"]],
+                    "addresses": [f"{vnic_dict['privateIp']}/{prefix}"],
                     "mtu": MTU,
                     "dhcp4": False,
                     "dhcp6": False,

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -299,7 +299,7 @@ class TestNetworkConfigFromOpcImds:
         assert 1 == len(secondary_nic_cfg["subnets"])
         subnet_cfg = secondary_nic_cfg["subnets"][0]
         # These values are hard-coded in OPC_VM_SECONDARY_VNIC_RESPONSE
-        assert "10.0.0.231" == subnet_cfg["address"]
+        assert "10.0.0.231/24" == subnet_cfg["address"]
 
     def test_secondary_nic_v2(self, oracle_ds):
         oracle_ds._vnics_data = json.loads(OPC_VM_SECONDARY_VNIC_RESPONSE)
@@ -325,7 +325,7 @@ class TestNetworkConfigFromOpcImds:
 
         assert 1 == len(secondary_nic_cfg["addresses"])
         # These values are hard-coded in OPC_VM_SECONDARY_VNIC_RESPONSE
-        assert "10.0.0.231" == secondary_nic_cfg["addresses"][0]
+        assert "10.0.0.231/24" == secondary_nic_cfg["addresses"][0]
 
     @pytest.mark.parametrize("error_add_network", [None, Exception])
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix Oracle DS not setting subnet when using IMDS

Previous to 6270b50, if iSCSI config was not available, we used the
ephemeral DHCP4 address as the primary address on Oracle. After
6270b50, we instead used the IMDS address configuration. However, the
parsing of IMDS ignored the "subnetCidrBlock" field, causing the
resulting network config to have the wrong subnet.

LP: #1989686
```

## Additional Context
<!-- If relevant -->

## Test Steps
Unfortunately, I have no good way of integration testing this as I don't know how to launch an instance with iSCSI disabled (I asked on the bug if the submitter could provide their launch details).

As a workaround, I applied the following patch:
```diff
diff --git a/cloudinit/sources/DataSourceOracle.py b/cloudinit/sources/DataSourceOracle.py
index 6a684e353..fa10cc6c3 100644
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -204,7 +204,8 @@ class DataSourceOracle(sources.DataSource):
 
     def _is_iscsi_root(self) -> bool:
         """Return whether we are on a iscsi machine."""
-        return self._network_config_source.is_applicable()
+        # return self._network_config_source.is_applicable()
+        return False
 
     def _get_iscsi_config(self) -> dict:
         return self._network_config_source.render_config()
```

then built a deb locally, uploaded, installed, `cloud-init clean --logs`, reboot and check that:
1. I can connect to the instance
2. `/etc/netplan/50-cloud-init.yaml` has the right config:
```
ubuntu@oci-integration-test-0915-082840:~$ cat /etc/netplan/50-cloud-init.yaml 
# This file is generated from information provided by the datasource.  Changes
# to it will not persist across an instance reboot.  To disable cloud-init's
# network configuration capabilities, write a file
# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
# network: {config: disabled}
network:
    version: 2
    ethernets:
        ens3:
            addresses:
            - 10.0.0.42/24
            match:
                macaddress: 02:00:17:08:59:f9
            mtu: 9000
            set-name: ens3
```
3. The config is applied appropriately:
```
ubuntu@oci-integration-test-0915-082840:~$ ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host 
       valid_lft forever preferred_lft forever
2: ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 9000 qdisc pfifo_fast state UP group default qlen 1000
    link/ether 02:00:17:08:59:f9 brd ff:ff:ff:ff:ff:ff
    altname enp0s3
    inet 10.0.0.42/24 brd 10.0.0.255 scope global ens3
       valid_lft forever preferred_lft forever
    inet6 fe80::17ff:fe08:59f9/64 scope link 
       valid_lft forever preferred_lft forever
```


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
