### PR TITLE
cc_ansible: add support for galaxy install

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -1,6 +1,6 @@
 """ansible enables running on first boot either ansible-pull"""
 import abc
-import logging
+from logging import Logger, getLogger
 import os
 import re
 import sys
@@ -61,7 +61,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
-LOG = logging.getLogger(__name__)
+LOG = getLogger(__name__)
 PIP_PKG = "python3-pip"
 CFG_OVERRIDE = "ANSIBLE_CONFIG"
 
@@ -139,7 +139,9 @@ class AnsiblePullDistro(AnsiblePull):
         return bool(which("ansible"))
 
 
-def handle(name: str, cfg: Config, cloud: Cloud, _, __) -> None:
+def handle(
+    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
+) -> None:
 
     ansible_cfg: dict = cfg.get("ansible", {})
     install_method = ansible_cfg.get("install-method")

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -119,13 +119,11 @@ class AnsiblePullPip(AnsiblePull):
         if not self.is_installed():
             # bootstrap pip if required
             try:
-                import pip
+                import pip  # noqa: F401
             except ImportError:
                 self.distro.install_packages(self.distro.pip_package_name)
 
-            self.subp(
-                [sys.executable, "-m", "pip", "install", "--user", pkg_name]
-            )
+            self.subp([sys.executable, "-m", "pip", "install", pkg_name])
 
     def is_installed(self) -> bool:
         stdout, _ = self.subp([sys.executable, "-m", "pip", "list"])

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -1,10 +1,10 @@
 """ansible enables running on first boot either ansible-pull"""
 import abc
-from logging import Logger, getLogger
 import os
 import re
 import sys
 from copy import deepcopy
+from logging import Logger, getLogger
 from textwrap import dedent
 from typing import Optional
 

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -62,7 +62,6 @@ meta: MetaSchema = {
 
 __doc__ = get_meta_doc(meta)
 LOG = getLogger(__name__)
-PIP_PKG = "python3-pip"
 CFG_OVERRIDE = "ANSIBLE_CONFIG"
 
 
@@ -119,7 +118,7 @@ class AnsiblePullPip(AnsiblePull):
         if not self.is_installed():
             # bootstrap pip if required
             if not which("pip3"):
-                self.distro.install_packages(PIP_PKG)
+                self.distro.install_packages(self.distro.pip_package_name)
             self.subp(["python3", "-m", "pip", "install", "--user", pkg_name])
 
     def is_installed(self) -> bool:

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -67,9 +67,11 @@ CFG_OVERRIDE = "ANSIBLE_CONFIG"
 
 
 class AnsiblePull(abc.ABC):
-    cmd_version: list = []
-    cmd_pull: list = []
-    env: dict = {}
+    def __init__(self, distro: Distro):
+        self.cmd_pull = ["ansible-pull"]
+        self.cmd_version = ["ansible-pull", "--version"]
+        self.distro = distro
+        self.env = os.environ.copy()
 
     def get_version(self) -> Optional[Version]:
         stdout, _ = self.subp(self.cmd_version)
@@ -102,11 +104,8 @@ class AnsiblePull(abc.ABC):
 
 class AnsiblePullPip(AnsiblePull):
     def __init__(self, distro: Distro):
-        self.cmd_pull = ["ansible-pull"]
-        self.cmd_version = ["ansible-pull", "--version"]
-        self.distro = distro
+        super().__init__(distro)
 
-        self.env = os.environ.copy()
         old_path = self.env.get("PATH")
         if old_path:
             self.env["PATH"] = ":".join([old_path, "/root/.local/bin/"])
@@ -132,12 +131,6 @@ class AnsiblePullPip(AnsiblePull):
 
 
 class AnsiblePullDistro(AnsiblePull):
-    def __init__(self, distro: Distro):
-        self.cmd_pull = ["ansible-pull"]
-        self.cmd_version = ["ansible-pull", "--version"]
-        self.distro = distro
-        self.env = os.environ.copy()
-
     def install(self, pkg_name: str):
         if not self.is_installed():
             self.distro.install_packages(pkg_name)

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -105,11 +105,12 @@ class AnsiblePullPip(AnsiblePull):
     def __init__(self, distro: Distro):
         super().__init__(distro)
 
+        ansible_path = "/root/.local/bin/"
         old_path = self.env.get("PATH")
         if old_path:
-            self.env["PATH"] = ":".join([old_path, "/root/.local/bin/"])
+            self.env["PATH"] = ":".join([old_path, ansible_path])
         else:
-            self.env["PATH"] = ""
+            self.env["PATH"] = ansible_path
 
     def install(self, pkg_name: str):
         """should cloud-init grow an interface for non-distro package

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -120,10 +120,12 @@ class AnsiblePullPip(AnsiblePull):
             # bootstrap pip if required
             if not which("pip3"):
                 self.distro.install_packages(self.distro.pip_package_name)
-            self.subp(["python3", "-m", "pip", "install", "--user", pkg_name])
+            self.subp(
+                [sys.executable, "-m", "pip", "install", "--user", pkg_name]
+            )
 
     def is_installed(self) -> bool:
-        stdout, _ = self.subp(["python3", "-m", "pip", "list"])
+        stdout, _ = self.subp([sys.executable, "-m", "pip", "list"])
         return "ansible" in stdout
 
     def subp(self, command, **kwargs):

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -62,7 +62,7 @@ meta: MetaSchema = {
 
 __doc__ = get_meta_doc(meta)
 LOG = getLogger(__name__)
-CFG_OVERRIDE = "ANSIBLE_CONFIG"
+CFG_OVERRIDE = "ansible_config"
 
 
 class AnsiblePull(abc.ABC):

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -119,7 +119,7 @@ class AnsiblePullPip(AnsiblePull):
         if not self.is_installed():
             # bootstrap pip if required
             try:
-                import pip  # noqa: F401
+                import pip  # type: ignore # noqa: F401
             except ImportError:
                 self.distro.install_packages(self.distro.pip_package_name)
 

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -118,8 +118,11 @@ class AnsiblePullPip(AnsiblePull):
         """
         if not self.is_installed():
             # bootstrap pip if required
-            if not which("pip3"):
+            try:
+                import pip
+            except ImportError:
                 self.distro.install_packages(self.distro.pip_package_name)
+
             self.subp(
                 [sys.executable, "-m", "pip", "install", "--user", pkg_name]
             )

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -263,8 +263,8 @@
               ],
               "description": "The type of installation for ansible. It can be one of the following values:\n\n - ``distro``\n - ``pip``"
             },
-            "ANSIBLE_CONFIG": {
-              "description": "If set, overrides default config.",
+            "ansible_config": {
+              "description": "Sets the ANSIBLE_CONFIG environment variable. If set, overrides default config.",
               "type": "string"
             },
             "galaxy": {

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -263,6 +263,27 @@
               ],
               "description": "The type of installation for ansible. It can be one of the following values:\n\n - ``distro``\n - ``pip``"
             },
+			"galaxy": {
+                "required": ["actions"],
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"actions": {
+                      "type": "array",
+                      "items": {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "pattern": "^.*$"
+                        }
+                      }
+					},
+					"ANSIBLE_CONFIG": {
+						"description": "If set, overrides default config.",
+						"type": "string"
+					}
+				}
+			},
             "package-name": {
               "type": "string",
               "default": "ansible"

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -263,27 +263,27 @@
               ],
               "description": "The type of installation for ansible. It can be one of the following values:\n\n - ``distro``\n - ``pip``"
             },
-			"galaxy": {
-                "required": ["actions"],
-				"type": "object",
-				"additionalProperties": false,
-				"properties": {
-					"actions": {
-                      "type": "array",
-                      "items": {
-                        "type": "array",
-                        "items": {
-                          "type": "string",
-                          "pattern": "^.*$"
-                        }
-                      }
-					},
-					"ANSIBLE_CONFIG": {
-						"description": "If set, overrides default config.",
-						"type": "string"
-					}
-				}
-			},
+            "ANSIBLE_CONFIG": {
+              "description": "If set, overrides default config.",
+              "type": "string"
+            },
+            "galaxy": {
+              "required": ["actions"],
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "actions": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "pattern": "^.*$"
+                    }
+                  }
+                }
+              }
+            },
             "package-name": {
               "type": "string",
               "default": "ansible"

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -79,7 +79,7 @@ LDH_ASCII_CHARS = string.ascii_letters + string.digits + "-"
 
 
 class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
-
+    pip_package_name = "python3-pip"
     usr_lib_exec = "/usr/lib"
     hosts_fn = "/etc/hosts"
     ci_sudoers_fn = "/etc/sudoers.d/90-cloud-init-users"

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -21,6 +21,7 @@ NETWORK_FILE_HEADER = """\
 
 
 class Distro(distros.Distro):
+    pip_package_name = "py3-pip"
     init_cmd = ["rc-service"]  # init scripts
     locale_conf_fn = "/etc/profile.d/locale.sh"
     network_conf_fn = "/etc/network/interfaces"

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -118,8 +118,12 @@ def _test_ansible_pull_from_local_server(my_client):
     output_log = my_client.read_from_file("/var/log/cloud-init-output.log")
     assert "ok=3" in output_log
     assert "SUCCESS: config-ansible ran successfully" in log
-    collection = my_client.execute("ansible-galaxy collection list")
-    assert "community.grafana" in collection.stdout
+
+    # binary location is dependent on install-type, check the filepath
+    # to ensure that the installed collection directory exists
+    output = my_client.execute(
+        "ls /root/.ansible/collections/ansible_collections/community/grafana")
+    assert not output.stderr.strip() and output.ok
 
 
 @pytest.mark.user_data(

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -118,6 +118,8 @@ def _test_ansible_pull_from_local_server(my_client):
     output_log = my_client.read_from_file("/var/log/cloud-init-output.log")
     assert "ok=3" in output_log
     assert "SUCCESS: config-ansible ran successfully" in log
+    collection = my_client.execute("ansible-galaxy collection list")
+    assert "community.grafana" in collection.stdout
 
 
 @pytest.mark.user_data(

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -86,6 +86,7 @@ runcmd:
 
 INSTALL_METHOD = """
 ansible:
+  ansible_config: /etc/ansible/ansible.cfg
   install-method: {method}
   package-name: {package}
   galaxy:

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -122,7 +122,8 @@ def _test_ansible_pull_from_local_server(my_client):
     # binary location is dependent on install-type, check the filepath
     # to ensure that the installed collection directory exists
     output = my_client.execute(
-        "ls /root/.ansible/collections/ansible_collections/community/grafana")
+        "ls /root/.ansible/collections/ansible_collections/community/grafana"
+    )
     assert not output.stderr.strip() and output.ok
 
 

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -88,6 +88,9 @@ INSTALL_METHOD = """
 ansible:
   install-method: {method}
   package-name: {package}
+  galaxy:
+    actions:
+     - ["ansible-galaxy", "collection", "install", "community.grafana"]
   pull:
     url: "http://0.0.0.0:8000/"
     playbook-name: ubuntu.yml

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -1,4 +1,5 @@
 import re
+import sys
 from copy import deepcopy
 from textwrap import dedent
 from unittest import mock
@@ -252,16 +253,15 @@ class TestAnsible:
                 m_subp.assert_has_calls(
                     [
                         call(
-                            args=["python3", "-m", "pip", "list"],
+                            args=[sys.executable, "-m", "pip", "list"],
                             env={"PATH": "/root/.local/bin/"},
                         ),
                         call(
                             args=[
-                                "python3",
+                                sys.executable,
                                 "-m",
                                 "pip",
                                 "install",
-                                "--user",
                                 "ansible",
                             ],
                             env={"PATH": "/root/.local/bin/"},
@@ -293,8 +293,11 @@ class TestAnsible:
     @mock.patch(M_PATH + "which", return_value=False)
     @mock.patch(M_PATH + "subp", return_value=("stdout", "stderr"))
     def test_pip_bootstrap(self, m_which, m_subp):
+
         distro = get_cloud(mocked_distro=True).distro
-        cc_ansible.AnsiblePullPip(distro).install("")
+        ansible = cc_ansible.AnsiblePullPip(distro)
+        with mock.patch("builtins.__import__", side_effect=ImportError):
+            ansible.install("")
         distro.install_packages.assert_called_once()
 
     @mock.patch(M_PATH + "which", return_value=True)

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -16,7 +16,6 @@ from cloudinit.config.schema import (
 from tests.unittests.helpers import skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
 
-
 M_PATH = "cloudinit.config.cc_ansible."
 distro_version = dedent(
     """ansible 2.10.8
@@ -398,7 +397,10 @@ class TestAnsible:
     @mock.patch(M_PATH + "which", return_value=True)
     def test_ansible_env_var(self, m_which, m_subp):
         cc_ansible.handle("", CFG_FULL, get_cloud(), mock.Mock(), [])
-        assert (
-            "/etc/ansible/ansible.cfg"
-            == m_subp.call_args.kwargs["env"]["ANSIBLE_CONFIG"]
-        )
+
+        # python 3.8 required for Mock.call_args.kwargs attribute
+        if hasattr(m_subp.call_args, "kwargs"):
+            assert (
+                "/etc/ansible/ansible.cfg"
+                == m_subp.call_args.kwargs["env"]["ANSIBLE_CONFIG"]
+            )

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -398,8 +398,8 @@ class TestAnsible:
     def test_ansible_env_var(self, m_which, m_subp):
         cc_ansible.handle("", CFG_FULL, get_cloud(), mock.Mock(), [])
 
-        # python 3.8 required for Mock.call_args.kwargs attribute
-        if hasattr(m_subp.call_args, "kwargs"):
+        # python 3.8 required for Mock.call_args.kwargs dict attribute
+        if isinstance(m_subp.call_args.kwargs, dict):
             assert (
                 "/etc/ansible/ansible.cfg"
                 == m_subp.call_args.kwargs["env"]["ANSIBLE_CONFIG"]

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -354,7 +354,8 @@ class TestAnsible:
 
         if pull_type == "pip":
             assert m_subp.call_args == call(
-                args=expected, env={"PATH": "/root/.local/bin/"})
+                args=expected, env={"PATH": "/root/.local/bin/"}
+            )
         else:
             assert m_subp.call_args == call(expected)
 

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -46,9 +46,9 @@ CFG_FULL = {
     "ansible": {
         "install-method": "distro",
         "package-name": "ansible-core",
+        "ANSIBLE_CONFIG": "/etc/ansible/ansible.cfg",
         "galaxy": {
             "actions": [["ansible-galaxy", "install", "debops.apt"]],
-            "ANSIBLE_CONFIG": "/etc/ansible/ansible.cfg",
         },
         "pull": {
             "url": "https://github/holmanb/vmboot",

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -46,7 +46,7 @@ CFG_FULL = {
     "ansible": {
         "install-method": "distro",
         "package-name": "ansible-core",
-        "ANSIBLE_CONFIG": "/etc/ansible/ansible.cfg",
+        "ansible_config": "/etc/ansible/ansible.cfg",
         "galaxy": {
             "actions": [["ansible-galaxy", "install", "debops.apt"]],
         },
@@ -253,7 +253,7 @@ class TestAnsible:
                     [
                         call(
                             args=["python3", "-m", "pip", "list"],
-                            env={"PATH": ""},
+                            env={"PATH": "/root/.local/bin/"},
                         ),
                         call(
                             args=[
@@ -264,7 +264,7 @@ class TestAnsible:
                                 "--user",
                                 "ansible",
                             ],
-                            env={"PATH": ""},
+                            env={"PATH": "/root/.local/bin/"},
                         ),
                     ]
                 )
@@ -276,7 +276,7 @@ class TestAnsible:
                         "--url=https://github/holmanb/vmboot",
                         "ubuntu.yml",
                     ],
-                    env={"PATH": ""},
+                    env={"PATH": "/root/.local/bin/"},
                 )
 
     @mock.patch(M_PATH + "which", return_value=False)
@@ -353,7 +353,8 @@ class TestAnsible:
         )
 
         if pull_type == "pip":
-            assert m_subp.call_args == call(args=expected, env={"PATH": ""})
+            assert m_subp.call_args == call(
+                args=expected, env={"PATH": "/root/.local/bin/"})
         else:
             assert m_subp.call_args == call(expected)
 

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -16,6 +16,7 @@ from cloudinit.config.schema import (
 from tests.unittests.helpers import skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
 
+
 M_PATH = "cloudinit.config.cc_ansible."
 distro_version = dedent(
     """ansible 2.10.8
@@ -357,7 +358,7 @@ class TestAnsible:
                 args=expected, env={"PATH": "/root/.local/bin/"}
             )
         else:
-            assert m_subp.call_args == call(expected)
+            assert m_subp.call_args == call(expected, env={})
 
     @mock.patch(M_PATH + "validate_config")
     def test_do_not_run(self, m_validate):
@@ -391,4 +392,13 @@ class TestAnsible:
         assert (
             util.Version(2, 1, 0, -1)
             == cc_ansible.AnsiblePullDistro(distro).get_version()
+        )
+
+    @mock.patch(M_PATH + "subp", return_value=("stdout", "stderr"))
+    @mock.patch(M_PATH + "which", return_value=True)
+    def test_ansible_env_var(self, m_which, m_subp):
+        cc_ansible.handle("", CFG_FULL, get_cloud(), mock.Mock(), [])
+        assert (
+            "/etc/ansible/ansible.cfg"
+            == m_subp.call_args.kwargs["env"]["ANSIBLE_CONFIG"]
         )

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -402,5 +402,5 @@ class TestAnsible:
         if isinstance(m_subp.call_args.kwargs, dict):
             assert (
                 "/etc/ansible/ansible.cfg"
-                == m_subp.call_args.kwargs["env"]["ANSIBLE_CONFIG"]
+                == m_subp.call_args.kwargs["env"]["ansible_config"]
             )


### PR DESCRIPTION
```
modules: add ansible-galaxy support to ansible

This is intended to allow users to install roles
and collections directly with the user-data
cloud-config for use in ansible playbooks during boot.
```

## Additional Context
This allows community reuse of roles and collections, which users
may use in their own ansible playbooks.

There is [more work](https://docs.google.com/document/d/1hHEijcgxZNbWZvbVlL5YkDCDBv52Sb49nEJ7FDU5LcI/edit#) to do with this module, but since this is usable with ansible-pull as well, I'm submitting it as is to keep reviews smaller.

https://galaxy.ansible.com/
https://docs.ansible.com/ansible/latest/cli/ansible-galaxy.html

## Test Steps
integration test included to install from galaxy
