### PR TITLE
Feature: create machine-id

### DIFF
--- a/cloudinit/config/cc_create_machine_id.py
+++ b/cloudinit/config/cc_create_machine_id.py
@@ -1,7 +1,7 @@
 # Author: Fabian Lichtenegger-Lukas <fabian.lichtenegger-lukas@nts.eu>
 # This file is part of cloud-init. See LICENSE file for license information.
 
-"""create-machine-id"""
+"""create_machine_id"""
 from logging import Logger
 
 from cloudinit import log as logging
@@ -19,14 +19,14 @@ This will likely take multiple lines.
 
 meta: MetaSchema = {
     "id": "cc_create_machine_id",
-    "name": "create-machine-id",
+    "name": "create_machine_id",
     "title": "Re/creates machine-id",
     "description": MODULE_DESCRIPTION,
     "distros": ["ubuntu"],
     "frequency": PER_ONCE,
-    "activate_by_schema_keys": ["create-machine-id"],
+    "activate_by_schema_keys": ["create_machine_id"],
     "examples": [
-        "create-machine-id: true",
+        "create_machine_id: true",
     ],
 }
 
@@ -50,13 +50,13 @@ def supplemental_schema_validation(mid: dict):
     """
     errors = []
     for key, value in sorted(mid.items()):
-        if key == "create-machine-id":
+        if key == "create_machine_id":
             if not isinstance(value, bool):
                 errors.append(f"Expected a bool for {key}. Found {value}")
 
     if errors:
         raise ValueError(
-            f"Invalid 'create-machine-id' configuration:{NL}{NL.join(errors)}"
+            f"Invalid 'create_machine_id' configuration:{NL}{NL.join(errors)}"
         )
 
 
@@ -69,6 +69,7 @@ def remove_machine_id(delFiles: frozenset):
     """
     try:
         for file in delFiles:
+            LOG.info("Removing file %s", file)
             util.del_file(file)
     except OSError as e:
         raise RuntimeError(f"Failed to remove file '{file}'") from e
@@ -80,7 +81,9 @@ def create_machine_id():
     @raises: ProcessExecutionError
     """
     try:
-        subp.subp("systemd-machine-id-setup")
+        LOG.info("Creating new machine-id")
+        (out, _) = subp.subp("systemd-machine-id-setup")
+        LOG.info("%s", out)
     except subp.ProcessExecutionError as e:
         util.logexc(LOG, f"Could not create machine-id:{NL}{str(e)}")
         raise
@@ -91,13 +94,13 @@ def handle(
 ) -> None:
     cmid_section = None
 
-    if "create-machine-id" in cfg:
-        LOG.debug("Found create-machine-id section in config")
-        cmid_section = util.get_cfg_option_str(cfg, "create-machine-id", False)
+    if "create_machine_id" in cfg:
+        LOG.debug("Found create_machine_id section in config")
+        cmid_section = util.get_cfg_option_str(cfg, "create_machine_id", False)
     else:
         LOG.debug(
             """Skipping module named %s,
-            no 'create-machine-id' configuration found""",
+            no 'create_machine_id' configuration found""",
             name,
         )
         return

--- a/cloudinit/config/cc_create_machine_id.py
+++ b/cloudinit/config/cc_create_machine_id.py
@@ -1,0 +1,114 @@
+# Author: Fabian Lichtenegger-Lukas <fabian.lichtenegger-lukas@nts.eu>
+# This file is part of cloud-init. See LICENSE file for license information.
+
+"""create-machine-id"""
+from logging import Logger
+
+from cloudinit import log as logging
+from cloudinit import subp, util
+from cloudinit.cloud import Cloud
+from cloudinit.config import Config
+from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.settings import PER_ONCE
+
+MODULE_DESCRIPTION = """\
+Description that will be used in module documentation.
+
+This will likely take multiple lines.
+"""
+
+meta: MetaSchema = {
+    "id": "cc_create_machine_id",
+    "name": "create-machine-id",
+    "title": "Re/creates machine-id",
+    "description": MODULE_DESCRIPTION,
+    "distros": ["ubuntu"],
+    "frequency": PER_ONCE,
+    "activate_by_schema_keys": ["create-machine-id"],
+    "examples": [
+        "create-machine-id: true",
+    ],
+}
+
+MACHINE_ID_FILES = frozenset(["/etc/machine-id", "/var/lib/dbus/machine-id"])
+NL = "\n"
+
+__doc__ = get_meta_doc(meta)
+
+LOG = logging.getLogger(__name__)
+
+
+def supplemental_schema_validation(mid: dict):
+    """Validate user-provided machine-id option values.
+
+    This function supplements flexible jsonschema validation with specific
+    value checks to aid in triage of invalid user-provided configuration.
+
+    @param mid: Dict of configuration value under 'machine-id'.
+
+    @raises: ValueError describing invalid values provided.
+    """
+    errors = []
+    for key, value in sorted(mid.items()):
+        if key == "create-machine-id":
+            if not isinstance(value, bool):
+                errors.append(f"Expected a bool for {key}. Found {value}")
+
+    if errors:
+        raise ValueError(
+            f"Invalid 'create-machine-id' configuration:{NL}{NL.join(errors)}"
+        )
+
+
+def remove_machine_id(delFiles: frozenset):
+    """Removes following files:
+      # /etc/machine-id
+      # /var/lib/dbus/machine-id
+
+    @raises: OSError
+    """
+    try:
+        for file in delFiles:
+            util.del_file(file)
+    except OSError as e:
+        raise RuntimeError(f"Failed to remove file '{file}'") from e
+
+
+def create_machine_id():
+    """Creates new machine-id with systemd-machine-id-setup
+
+    @raises: ProcessExecutionError
+    """
+    try:
+        subp.subp("systemd-machine-id-setup")
+    except subp.ProcessExecutionError as e:
+        util.logexc(LOG, f"Could not create machine-id:{NL}{str(e)}")
+        raise
+
+
+def handle(
+    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
+) -> None:
+    cmid_section = None
+
+    if "create-machine-id" in cfg:
+        LOG.debug("Found create-machine-id section in config")
+        cmid_section = util.get_cfg_option_str(cfg, "create-machine-id", False)
+    else:
+        LOG.debug(
+            """Skipping module named %s,
+            no 'create-machine-id' configuration found""",
+            name,
+        )
+        return
+
+    # Check if OS uses systemd
+    if not subp.which("systemd"):
+        LOG.error("systemd is not installed! Won't execute module!")
+        return
+
+    supplemental_schema_validation(cmid_section)
+
+    if cmid_section:
+        remove_machine_id(MACHINE_ID_FILES)
+        create_machine_id()

--- a/cloudinit/config/cc_create_machine_id.py
+++ b/cloudinit/config/cc_create_machine_id.py
@@ -38,26 +38,6 @@ __doc__ = get_meta_doc(meta)
 LOG = logging.getLogger(__name__)
 
 
-def supplemental_schema_validation(mid: str):
-    """Validate user-provided machine-id option values.
-
-    This function supplements flexible jsonschema validation with specific
-    value checks to aid in triage of invalid user-provided configuration.
-
-    @param mid: String
-
-    @raises: ValueError describing invalid values provided.
-    """
-    errors = []
-    if not isinstance(mid, bool):
-        errors.append(f"Expected a bool for create_machine_id. Found {mid}")
-
-    if errors:
-        raise ValueError(
-            f"Invalid 'create_machine_id' configuration:{NL}{NL.join(errors)}"
-        )
-
-
 def remove_machine_id(delFiles: frozenset):
     """Removes following files:
       # /etc/machine-id
@@ -92,11 +72,11 @@ def create_machine_id():
 def handle(
     name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
 ) -> None:
-    cmid_section = None
+    cmid_sctn = None
 
     if "create_machine_id" in cfg:
         LOG.debug("Found create_machine_id section in config")
-        cmid_section = util.get_cfg_option_str(cfg, "create_machine_id", False)
+        cmid_sctn = util.get_cfg_option_bool(cfg, "create_machine_id", False)
     else:
         LOG.debug(
             """Skipping module named %s,
@@ -110,8 +90,6 @@ def handle(
         LOG.error("systemd is not installed! Won't execute module!")
         return
 
-    supplemental_schema_validation(cmid_section)
-
-    if cmid_section:
+    if cmid_sctn:
         remove_machine_id(MACHINE_ID_FILES)
         create_machine_id()

--- a/cloudinit/config/cc_create_machine_id.py
+++ b/cloudinit/config/cc_create_machine_id.py
@@ -63,13 +63,15 @@ def remove_machine_id(delFiles: frozenset):
       # /etc/machine-id
       # /var/lib/dbus/machine-id
 
-    @raises: OSError
+    @param: frozenset of files to delete
+
+    @raises: Exception
     """
     try:
         for file in delFiles:
             LOG.info("Removing file %s", file)
             util.del_file(file)
-    except OSError as e:
+    except Exception as e:
         raise RuntimeError(f"Failed to remove file '{file}'") from e
 
 

--- a/cloudinit/config/cc_create_machine_id.py
+++ b/cloudinit/config/cc_create_machine_id.py
@@ -38,21 +38,19 @@ __doc__ = get_meta_doc(meta)
 LOG = logging.getLogger(__name__)
 
 
-def supplemental_schema_validation(mid: dict):
+def supplemental_schema_validation(mid: str):
     """Validate user-provided machine-id option values.
 
     This function supplements flexible jsonschema validation with specific
     value checks to aid in triage of invalid user-provided configuration.
 
-    @param mid: Dict of configuration value under 'machine-id'.
+    @param mid: String
 
     @raises: ValueError describing invalid values provided.
     """
     errors = []
-    for key, value in sorted(mid.items()):
-        if key == "create_machine_id":
-            if not isinstance(value, bool):
-                errors.append(f"Expected a bool for {key}. Found {value}")
+    if not isinstance(mid, bool):
+        errors.append(f"Expected a bool for create_machine_id. Found {mid}")
 
     if errors:
         raise ValueError(

--- a/cloudinit/config/cc_create_machine_id.py
+++ b/cloudinit/config/cc_create_machine_id.py
@@ -12,9 +12,17 @@ from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.settings import PER_ONCE
 
 MODULE_DESCRIPTION = """\
-Description that will be used in module documentation.
+This module is responsible for creating a new machine-id
+during cloud-init's init stage.
 
-This will likely take multiple lines.
+How this module works:
+  1. Remove the following files and links:
+      - /etc/machine-id
+      - /var/lib/dbus/machine-id
+  2. Create new machine-id with "systemd-machine-id-setup"
+
+Attention, this module will only work with systemd
+installed.
 """
 
 meta: MetaSchema = {

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -701,6 +701,16 @@
         }
       }
     },
+    "cc_create_machine_id": {
+      "type": "object",
+      "properties": {
+        "create-machine-id": {
+          "type": "boolean",
+          "default": false,
+          "description": "Creates an machine-id"
+        }
+      }
+    },
     "cc_disable_ec2_metadata": {
       "type": "object",
       "properties": {
@@ -2651,6 +2661,7 @@
     { "$ref": "#/$defs/cc_byobu" },
     { "$ref": "#/$defs/cc_ca_certs" },
     { "$ref": "#/$defs/cc_chef" },
+    { "$ref": "#/$defs/cc_create_machine_id" },
     { "$ref": "#/$defs/cc_disable_ec2_metadata" },
     { "$ref": "#/$defs/cc_disk_setup" },
     { "$ref": "#/$defs/cc_fan" },

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -704,7 +704,7 @@
     "cc_create_machine_id": {
       "type": "object",
       "properties": {
-        "create-machine-id": {
+        "create_machine_id": {
           "type": "boolean",
           "default": false,
           "description": "Creates an machine-id"

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -85,6 +85,9 @@ cloud_init_modules:
 {% if variant not in ["netbsd"] %}
  - seed_random
 {% endif %}
+{% if variant in ["ubuntu"] %}
+ - create_machine_id
+{% endif %}
  - bootcmd
  - write-files
 {% if variant not in ["netbsd", "openbsd"] %}

--- a/doc/rtd/topics/modules.rst
+++ b/doc/rtd/topics/modules.rst
@@ -13,6 +13,7 @@ Module Reference
 .. automodule:: cloudinit.config.cc_byobu
 .. automodule:: cloudinit.config.cc_ca_certs
 .. automodule:: cloudinit.config.cc_chef
+.. automodule:: cloudinit.config.cc_create_machine_id
 .. automodule:: cloudinit.config.cc_disable_ec2_metadata
 .. automodule:: cloudinit.config.cc_disk_setup
 .. automodule:: cloudinit.config.cc_fan

--- a/tests/integration_tests/modules/test_create_machine_id.py
+++ b/tests/integration_tests/modules/test_create_machine_id.py
@@ -7,8 +7,6 @@ from tests.integration_tests.util import verify_clean_log
 USER_DATA = """\
 #cloud-config
 create_machine_id: true
-runcmd:
-  - "touch /test.txt"
 """
 
 
@@ -46,3 +44,4 @@ class TestCreateMachineID:
         cloud_init_log = class_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(cloud_init_log)
         assert "Removing file /etc/machine-id" in cloud_init_log
+        assert "Creating new machine-id" in cloud_init_log

--- a/tests/integration_tests/modules/test_create_machine_id.py
+++ b/tests/integration_tests/modules/test_create_machine_id.py
@@ -45,4 +45,4 @@ class TestCreateMachineID:
     def test_check_log(self, class_client: IntegrationInstance):
         cloud_init_log = class_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(cloud_init_log)
-        assert "Removing file" in cloud_init_log
+        assert "Removing file /etc/machine-id" in cloud_init_log

--- a/tests/integration_tests/modules/test_create_machine_id.py
+++ b/tests/integration_tests/modules/test_create_machine_id.py
@@ -1,0 +1,48 @@
+"""Integration test for the create_machine_id module."""
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+USER_DATA = """\
+#cloud-config
+create_machine_id: true
+runcmd:
+  - "touch /test.txt"
+"""
+
+
+@pytest.mark.ci
+@pytest.mark.user_data(USER_DATA)
+@pytest.mark.lxd_vm
+@pytest.mark.lxd_container
+@pytest.mark.gce
+@pytest.mark.ec2
+@pytest.mark.azure
+@pytest.mark.openstack
+@pytest.mark.oci
+@pytest.mark.ubuntu
+class TestCreateMachineID:
+    @pytest.mark.parametrize(
+        "cmd,expected_out",
+        (
+            # test if file was written for machine-id
+            (
+                "stat -c '%N' /etc/machine-id",
+                r"'/etc/machine-id'",
+            ),
+            # check permissions for machine-id
+            ("stat -c '%U %a' /etc/machine-id", r"root 444"),
+        ),
+    )
+    def test_create_machine_id(
+        self, cmd, expected_out, class_client: IntegrationInstance
+    ):
+        result = class_client.execute(cmd)
+        assert result.ok
+        assert expected_out in result.stdout
+
+    def test_check_log(self, class_client: IntegrationInstance):
+        cloud_init_log = class_client.read_from_file("/var/log/cloud-init.log")
+        verify_clean_log(cloud_init_log)
+        assert "Removing file" in cloud_init_log

--- a/tests/unittests/config/test_cc_create_machine_id.py
+++ b/tests/unittests/config/test_cc_create_machine_id.py
@@ -30,7 +30,7 @@ class TestCreateMachineID(CiTestCase):
 
     def test_suppl_schema_non_boolean_values(self):
         """ValueError raised for any values expected as boolean type."""
-        cmid_enabled = {"create_machine_id": "not-a-bool"}
+        cmid_enabled = "not-a-bool"
         match = (
             f"Invalid 'create_machine_id' configuration:{NL}"
             "Expected a bool for create_machine_id. Found not-a-bool"

--- a/tests/unittests/config/test_cc_create_machine_id.py
+++ b/tests/unittests/config/test_cc_create_machine_id.py
@@ -30,10 +30,10 @@ class TestCreateMachineID(CiTestCase):
 
     def test_suppl_schema_non_boolean_values(self):
         """ValueError raised for any values expected as boolean type."""
-        cmid_enabled = {"create-machine-id": "not-a-bool"}
+        cmid_enabled = {"create_machine_id": "not-a-bool"}
         match = (
-            f"Invalid 'create-machine-id' configuration:{NL}"
-            "Expected a bool for create-machine-id. Found not-a-bool"
+            f"Invalid 'create_machine_id' configuration:{NL}"
+            "Expected a bool for create_machine_id. Found not-a-bool"
         )
         with self.assertRaisesRegex(ValueError, match):
             cc_create_machine_id.supplemental_schema_validation(cmid_enabled)
@@ -73,7 +73,7 @@ class TestCreateMachineIDSchema:
         [
             # Valid schemas
             (
-                {"create-machine-id": True},
+                {"create_machine_id": True},
                 None,
             ),
         ],

--- a/tests/unittests/config/test_cc_create_machine_id.py
+++ b/tests/unittests/config/test_cc_create_machine_id.py
@@ -28,16 +28,16 @@ class TestCreateMachineID(CiTestCase):
         super(TestCreateMachineID, self).setUp()
         self.tmp = self.tmp_dir()
 
-#    def test_remove_machine_id_failed(self):
-#        """OSError when machine-id gets removed"""
-#        machine_id_files = frozenset(["/etc/machine-id"])
-#
-#        with self.assertRaises(RuntimeError) as context_mgr:
-#            cc_create_machine_id.remove_machine_id(machine_id_files)
-#        self.assertIn(
-#            "Failed to remove file '/etc/machine-id'",
-#            str(context_mgr.exception),
-#        )
+    def test_remove_machine_id_failed(self):
+        """OSError when machine-id gets removed"""
+        machine_id_files = frozenset(["/etc/machine-id"])
+
+        with self.assertRaises(RuntimeError) as context_mgr:
+            cc_create_machine_id.remove_machine_id(machine_id_files)
+        self.assertIn(
+            "Failed to remove file '/etc/machine-id'",
+            str(context_mgr.exception),
+        )
 
     @mock.patch("%s.subp.subp" % MPATH)
     def test_create_machine_id_failed(self, m_subp):

--- a/tests/unittests/config/test_cc_create_machine_id.py
+++ b/tests/unittests/config/test_cc_create_machine_id.py
@@ -28,16 +28,16 @@ class TestCreateMachineID(CiTestCase):
         super(TestCreateMachineID, self).setUp()
         self.tmp = self.tmp_dir()
 
-    def test_remove_machine_id_failed(self):
-        """OSError when machine-id gets removed"""
-        machine_id_files = frozenset(["/etc/machine-id"])
-
-        with self.assertRaises(RuntimeError) as context_mgr:
-            cc_create_machine_id.remove_machine_id(machine_id_files)
-        self.assertIn(
-            "Failed to remove file '/etc/machine-id'",
-            str(context_mgr.exception),
-        )
+#    def test_remove_machine_id_failed(self):
+#        """OSError when machine-id gets removed"""
+#        machine_id_files = frozenset(["/etc/machine-id"])
+#
+#        with self.assertRaises(RuntimeError) as context_mgr:
+#            cc_create_machine_id.remove_machine_id(machine_id_files)
+#        self.assertIn(
+#            "Failed to remove file '/etc/machine-id'",
+#            str(context_mgr.exception),
+#        )
 
     @mock.patch("%s.subp.subp" % MPATH)
     def test_create_machine_id_failed(self, m_subp):

--- a/tests/unittests/config/test_cc_create_machine_id.py
+++ b/tests/unittests/config/test_cc_create_machine_id.py
@@ -28,16 +28,6 @@ class TestCreateMachineID(CiTestCase):
         super(TestCreateMachineID, self).setUp()
         self.tmp = self.tmp_dir()
 
-    def test_suppl_schema_non_boolean_values(self):
-        """ValueError raised for any values expected as boolean type."""
-        cmid_enabled = "not-a-bool"
-        match = (
-            f"Invalid 'create_machine_id' configuration:{NL}"
-            "Expected a bool for create_machine_id. Found not-a-bool"
-        )
-        with self.assertRaisesRegex(ValueError, match):
-            cc_create_machine_id.supplemental_schema_validation(cmid_enabled)
-
     def test_remove_machine_id_failed(self):
         """OSError when machine-id gets removed"""
         machine_id_files = frozenset(["/etc/machine-id"])

--- a/tests/unittests/config/test_cc_create_machine_id.py
+++ b/tests/unittests/config/test_cc_create_machine_id.py
@@ -1,0 +1,90 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+import pytest
+
+from cloudinit import subp
+from cloudinit.config import cc_create_machine_id
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
+from tests.unittests.helpers import CiTestCase, mock, skipUnlessJsonSchema
+
+NL = "\n"
+# Module path used in mocks
+MPATH = "cloudinit.config.cc_create_machine_id"
+
+
+class FakeCloud(object):
+    def __init__(self, distro):
+        self.distro = distro
+
+
+class TestCreateMachineID(CiTestCase):
+    with_logs = True
+    allowed_subp = [CiTestCase.SUBP_SHELL_TRUE]
+
+    def setUp(self):
+        super(TestCreateMachineID, self).setUp()
+        self.tmp = self.tmp_dir()
+
+    def test_suppl_schema_non_boolean_values(self):
+        """ValueError raised for any values expected as boolean type."""
+        cmid_enabled = {"create-machine-id": "not-a-bool"}
+        match = (
+            f"Invalid 'create-machine-id' configuration:{NL}"
+            "Expected a bool for create-machine-id. Found not-a-bool"
+        )
+        with self.assertRaisesRegex(ValueError, match):
+            cc_create_machine_id.supplemental_schema_validation(cmid_enabled)
+
+    def test_remove_machine_id_failed(self):
+        """OSError when machine-id gets removed"""
+        machine_id_files = frozenset(["/etc/machine-id"])
+
+        with self.assertRaises(RuntimeError) as context_mgr:
+            cc_create_machine_id.remove_machine_id(machine_id_files)
+        self.assertIn(
+            "Failed to remove file '/etc/machine-id'",
+            str(context_mgr.exception),
+        )
+
+    @mock.patch("%s.subp.subp" % MPATH)
+    def test_create_machine_id_failed(self, m_subp):
+        """"""
+        m_subp.side_effect = subp.ProcessExecutionError("some exec error")
+        with self.assertRaises(subp.ProcessExecutionError) as context_manager:
+            cc_create_machine_id.create_machine_id()
+        self.assertEqual(
+            "Unexpected error while running command.\n"
+            "Command: -\nExit code: -\nReason: -\n"
+            "Stdout: some exec error\n"
+            "Stderr: -",
+            str(context_manager.exception),
+        )
+        self.assertIn(
+            "WARNING: Could not create machine-id:\n", self.logs.getvalue()
+        )
+
+
+class TestCreateMachineIDSchema:
+    @pytest.mark.parametrize(
+        "config, error_msg",
+        [
+            # Valid schemas
+            (
+                {"create-machine-id": True},
+                None,
+            ),
+        ],
+    )
+    @skipUnlessJsonSchema()
+    def test_schema_validation(self, config, error_msg):
+        if error_msg is not None:
+            with pytest.raises(SchemaValidationError, match=error_msg):
+                validate_cloudconfig_schema(config, get_schema(), strict=True)
+        else:
+            validate_cloudconfig_schema(config, get_schema(), strict=True)
+
+
+# vi: ts=4 expandtab

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -174,6 +174,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_byobu"},
             {"$ref": "#/$defs/cc_ca_certs"},
             {"$ref": "#/$defs/cc_chef"},
+            {"$ref": "#/$defs/cc_create_machine_id"},
             {"$ref": "#/$defs/cc_disable_ec2_metadata"},
             {"$ref": "#/$defs/cc_disk_setup"},
             {"$ref": "#/$defs/cc_fan"},


### PR DESCRIPTION
## Proposed Commit Message
```
cc_create_machine_id:
This module is responsible for creating a new machine-id during cloud-init's init stage.

How this module works:
  1. Remove the following files and links:
      - /etc/machine-id
      - /var/lib/dbus/machine-id
  2. Create new machine-id with "systemd-machine-id-setup"

Attention, this module will only work with systemd installed.
```

## Additional Context
Implements a feature from wishlist.

LP: [#1563951](https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1563951)

## Test Steps
integration test included
Only tested for Ubuntu.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
