### PR TITLE
cc_ubuntu_advantage: add ua_config in auto-attach

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -138,7 +138,7 @@ ERROR_MSG_SHOULD_AUTO_ATTACH = (
     "Unable to determine if this is an Ubuntu Pro instance."
     " Fallback to normal UA attach."
 )
-UA_CONFIG_PROPS = (
+KNOWN_UA_CONFIG_PROPS = (
     "http_proxy",
     "https_proxy",
     "global_apt_http_proxy",
@@ -190,12 +190,14 @@ def supplemental_schema_validation(ua_config: dict):
     """
     errors = []
     for key, value in sorted(ua_config.items()):
-        if key not in UA_CONFIG_PROPS:
+        if key not in KNOWN_UA_CONFIG_PROPS:
             LOG.warning(
-                "Ignoring unknown ubuntu_advantage.config.%s property", key
+                "Not validating unknown ubuntu_advantage.config.%s property",
+                key,
             )
             continue
-        elif value is None:  # key will be unset
+        elif value is None:
+            # key will be unset. No extra validation needed.
             continue
         try:
             parsed_url = urlparse(value)
@@ -227,8 +229,6 @@ def set_ua_config(ua_config: Any = None):
 
     enable_errors = []
     for key, value in sorted(ua_config.items()):
-        if key not in UA_CONFIG_PROPS:
-            continue  # Already logged in `supplemental_schema_validation`
         redacted_key_value = None
         subp_kwargs: dict = {}
         if value is None:

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -30,8 +30,8 @@ meta: MetaSchema = {
         FIPS and FIPS Updates. When attaching a machine to Ubuntu Advantage,
         one can also specify services to enable. When the 'enable'
         list is present, only named services will be activated. Whereas
-        'enable' list is not present, the contract-default services will be
-        enabled.
+        if the 'enable' list is not present, the contract's default
+        services will be enabled.
 
         On Pro instances, when ``ubuntu_advantage`` config is provided to
         cloud-init, Pro's auto-attach feature will be disabled and cloud-init

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2229,37 +2229,38 @@
             },
             "config": {
               "type": "object",
-              "description": "Configuration settings or override Ubuntu Advantage config. Only used in non Ubuntu Pro instances.",
+              "description": "Configuration settings or override Ubuntu Advantage config.",
+              "additionalProperties": false,
               "properties": {
                 "http_proxy": {
-                  "type": "string",
+                  "type": ["string", "null"],
                   "format": "uri",
-                  "description": "Ubuntu Advantage HTTP Proxy URL"
+                  "description": "Ubuntu Advantage HTTP Proxy URL or null to unset."
                 },
                 "https_proxy": {
-                  "type": "string",
+                  "type": ["string", "null"],
                   "format": "uri",
-                  "description": "Ubuntu Advantage HTTPS Proxy URL"
+                  "description": "Ubuntu Advantage HTTPS Proxy URL or null to unset."
                 },
                 "global_apt_http_proxy": {
-                  "type": "string",
+                  "type": ["string", "null"],
                   "format": "uri",
-                  "description": "HTTP Proxy URL used for all APT repositories on a system. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
+                  "description": "HTTP Proxy URL used for all APT repositories on a system or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
                 },
                 "global_apt_https_proxy": {
-                  "type": "string",
+                  "type": ["string", "null"],
                   "format": "uri",
-                  "description": "HTTPS Proxy URL used for all APT repositories on a system. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
+                  "description": "HTTPS Proxy URL used for all APT repositories on a system or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
                 },
                 "ua_apt_http_proxy": {
-                  "type": "string",
+                  "type": ["string", "null"],
                   "format": "uri",
-                   "description": "HTTP Proxy URL used only for Ubuntu Advantage APT repositories. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
+                   "description": "HTTP Proxy URL used only for Ubuntu Advantage APT repositories or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
                 },
                 "ua_apt_https_proxy": {
-                  "type": "string",
+                  "type": ["string", "null"],
                   "format": "uri",
-                  "description": "HTTPS Proxy URL used only for Ubuntu Advantage APT repositories. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
+                  "description": "HTTPS Proxy URL used only for Ubuntu Advantage APT repositories or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
                 }
               }
             }

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2230,7 +2230,7 @@
             "config": {
               "type": "object",
               "description": "Configuration settings or override Ubuntu Advantage config.",
-              "additionalProperties": false,
+              "additionalProperties": true,
               "properties": {
                 "http_proxy": {
                   "type": ["string", "null"],


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ubuntu_advantage: add ua_config in auto-attach

- Fix and document how to unset ua_config props.
- Redact ua_config values as they could contain sensitive auth info.
- Increase unit test coverage.
```

## Additional Context
<!-- If relevant -->
https://warthogs.atlassian.net/browse/SC-1257
https://github.com/canonical/cloud-init/pull/1583#pullrequestreview-1110047636

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
