### PR TITLE
networkd: Add test and improve typing.

### DIFF
--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -87,7 +87,7 @@ class Renderer(renderer.Renderer):
             "network_conf_dir", "/etc/systemd/network/"
         )
 
-    def generate_match_section(self, iface, cfg):
+    def generate_match_section(self, iface, cfg: CfgParser):
         sec = "Match"
         match_dict = {
             "name": "Name",
@@ -104,7 +104,7 @@ class Renderer(renderer.Renderer):
 
         return iface["name"]
 
-    def generate_link_section(self, iface, cfg):
+    def generate_link_section(self, iface, cfg: CfgParser):
         sec = "Link"
 
         if not iface:
@@ -113,7 +113,7 @@ class Renderer(renderer.Renderer):
         if "mtu" in iface and iface["mtu"]:
             cfg.update_section(sec, "MTUBytes", iface["mtu"])
 
-    def parse_routes(self, conf, cfg):
+    def parse_routes(self, conf, cfg: CfgParser):
         sec = "Route"
         route_cfg_map = {
             "gateway": "Gateway",
@@ -133,7 +133,7 @@ class Renderer(renderer.Renderer):
                 v += prefix
             cfg.update_section(sec, route_cfg_map[k], v)
 
-    def parse_subnets(self, iface, cfg):
+    def parse_subnets(self, iface, cfg: CfgParser):
         dhcp = "no"
         sec = "Network"
         for e in iface.get("subnets", []):
@@ -178,7 +178,7 @@ class Renderer(renderer.Renderer):
         return dhcp
 
     # This is to accommodate extra keys present in VMware config
-    def dhcp_domain(self, d, cfg):
+    def dhcp_domain(self, d, cfg: CfgParser):
         for item in ["dhcp4domain", "dhcp6domain"]:
             if item not in d:
                 continue
@@ -196,7 +196,7 @@ class Renderer(renderer.Renderer):
                 section = "DHCPv6"
             cfg.update_section(section, "UseDomains", ret)
 
-    def parse_dns(self, iface, cfg, ns):
+    def parse_dns(self, iface, cfg: CfgParser, ns: NetworkState):
         sec = "Network"
 
         dns_cfg_map = {
@@ -218,7 +218,7 @@ class Renderer(renderer.Renderer):
             if k in dns and dns[k]:
                 cfg.update_section(sec, v, " ".join(dns[k]))
 
-    def parse_dhcp_overrides(self, cfg, device, dhcp, version):
+    def parse_dhcp_overrides(self, cfg: CfgParser, device, dhcp, version):
         dhcp_config_maps = {
             "UseDNS": "use-dns",
             "UseDomains": "use-domains",
@@ -271,7 +271,7 @@ class Renderer(renderer.Renderer):
         for k, v in ret_dict.items():
             self.create_network_file(k, v, network_dir)
 
-    def _render_content(self, ns):
+    def _render_content(self, ns: NetworkState) -> dict:
         ret_dict = {}
         for iface in ns.iter_interfaces():
             cfg = CfgParser()
@@ -335,6 +335,6 @@ def available(target=None):
     return True
 
 
-def network_state_to_networkd(ns):
+def network_state_to_networkd(ns: NetworkState):
     renderer = Renderer({})
     return renderer._render_content(ns)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
networkd: Add test and improve typing.

Add test covering when the original v1 conf contains multiple
subnets associated with a single device.

The issue was already fixed by #1685.

LP: #1973724
```

## Additional Context
<!-- If relevant -->
During the investigation of [lp1973724](https://bugs.launchpad.net/cloud-init/+bug/1973724),
I found out the issue was already fixed in https://github.com/canonical/cloud-init/pull/1685.
Nevertheless, I added a unit test covering the case and some type annotations.

I keep the LP reference in the commit msg to let our tooling close the ticket once released.

https://www.freedesktop.org/software/systemd/man/systemd.network.html
https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v1.html

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
