### PR TITLE
cc_ubuntu_advantage: Handle already attached on Pro

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -398,8 +398,9 @@ def _auto_attach(ua_section: dict):
         if enable_beta is not None or enable is not None:
             # Only warn if the user defined some service to enable/disable.
             LOG.warning(
-                "The instance is already attached."
-                " Leaving Pro services untouched."
+                "The instance is already attached to Pro. Leaving enabled"
+                " services untouched. Ignoring config directives"
+                " ubuntu_advantage: enable and enable_beta"
             )
     except UserFacingError as ex:
         msg = f"Error during `full_auto_attach`: {ex}"

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -395,7 +395,7 @@ def _auto_attach(ua_section: dict):
     try:
         full_auto_attach(options=options)
     except AlreadyAttachedError:
-        if enable_beta is None or enable is None:
+        if enable_beta is not None or enable is not None:
             # Only warn if the user defined some service to enable/disable.
             LOG.warning(
                 "The instance is already attached."

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -34,7 +34,6 @@ package_upgrade: true
 packages:
 - ubuntu-advantage-tools
 bootcmd:
-- sudo systemctl mask ubuntu-advantage-pro.service
 - sudo systemctl mask ubuntu-advantage.service
 """
 

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -45,6 +45,14 @@ class FakeUserFacingError(Exception):
     pass
 
 
+class FakeAlreadyAttachedError(FakeUserFacingError):
+    pass
+
+
+class FakeAlreadyAttachedOnPROError(FakeUserFacingError):
+    pass
+
+
 @pytest.fixture
 def fake_uaclient(mocker):
     mocker.patch.dict("sys.modules")
@@ -54,8 +62,15 @@ def fake_uaclient(mocker):
         "uaclient.api.u.pro.attach.auto.full_auto_attach.v1"
     ] = mock.Mock()
     sys.modules["uaclient.api"] = mock.Mock()
-    _exceptions = namedtuple("exceptions", ["UserFacingError"])(
-        FakeUserFacingError
+    _exceptions = namedtuple(
+        "exceptions",
+        [
+            "UserFacingError",
+            "AlreadyAttachedError",
+        ],
+    )(
+        FakeUserFacingError,
+        FakeAlreadyAttachedError,
     )
     sys.modules["uaclient.api.exceptions"] = _exceptions
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ubuntu_advantage: Handle already attached on Pro

On Pro instances, UA could raise an exception signalizing already
attached instances. Catch it and warn if some service is given in
the cloud-config to be configured.

Improve integration test:
- mask ua services on first boot to upgrade UA on Pro
  instances and let the second boot be clean
- assert the correct services were enabled
- detect instances where cloud-init does yet support custom
  auto-attach and fail the test.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```sh
CLOUD_INIT_PLATFORM=<gce|azure|ec2>  tox -e integration-tests -- tests/integration_tests/modules/test_ubuntu_advantage.py::TestUbuntuAdvantagePro
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
