### PR TITLE
tests: Fix ip log during instance destruction

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -210,4 +210,4 @@ class IntegrationInstance:
         if not self.settings.KEEP_INSTANCE:
             self.destroy()
         else:
-            log.info("Keeping Instance, public ip: %s", self.ip)
+            log.info("Keeping Instance, public ip: %s", self.ip())


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: Fix ip log during instance destruction
```

## Additional Context
<!-- If relevant -->
I noticed the following message during integration tests execution:

```text
integration_testing:instances.py:213 Keeping Instance, public ip: <bound method IntegrationInstance.ip of <tests.integration_tests.instances.IntegrationInstance object at 0x7fb1fcbf6518>>
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
