### PR TITLE
Fix Oracle DS not setting default route when using IMDS

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -307,7 +307,7 @@ class DataSourceOracle(sources.DataSource):
                     "routes": [
                         {
                             "network": str(network.network_address),
-                            "netmask": network.netmask,
+                            "netmask": str(network.netmask),
                             "gateway": gateway,
                         },
                     ],

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -306,7 +306,7 @@ class DataSourceOracle(sources.DataSource):
                     "address": f"{vnic_dict['privateIp']}/{network.prefixlen}",
                     "routes": [
                         {
-                            "network": str(network.network_address),
+                            "network": "0.0.0.0/0",
                             "netmask": str(network.netmask),
                             "gateway": gateway,
                         },
@@ -332,7 +332,7 @@ class DataSourceOracle(sources.DataSource):
                     "match": {"macaddress": mac_address},
                     "routes": [
                         {
-                            "to": str(network.network_address),
+                            "to": "default",
                             "via": gateway,
                         },
                     ],

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -307,7 +307,7 @@ class DataSourceOracle(sources.DataSource):
                     "routes": [
                         {
                             "network": str(network.network_address),
-                            "prefix": network.prefixlen,
+                            "netmask": network.netmask,
                             "gateway": gateway,
                         },
                     ],

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -306,7 +306,7 @@ class DataSourceOracle(sources.DataSource):
                     "address": f"{vnic_dict['privateIp']}/{network.prefixlen}",
                     "routes": [
                         {
-                            "network": "0.0.0.0/0",
+                            "network": str(network.network_address),
                             "netmask": str(network.netmask),
                             "gateway": gateway,
                         },
@@ -332,7 +332,7 @@ class DataSourceOracle(sources.DataSource):
                     "match": {"macaddress": mac_address},
                     "routes": [
                         {
-                            "to": "default",
+                            "to": str(network.network_address),
                             "via": gateway,
                         },
                     ],

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -275,63 +275,91 @@ class TestNetworkConfigFromOpcImds:
         )
         assert 1 == caplog.text.count(" not found; skipping")
 
-    def test_secondary_nic(self, oracle_ds):
+    @pytest.mark.parametrize(
+        "set_primary",
+        [True, False],
+    )
+    def test_imds_nic_setup_v1(self, set_primary, oracle_ds):
         oracle_ds._vnics_data = json.loads(OPC_VM_SECONDARY_VNIC_RESPONSE)
         oracle_ds._network_config = {
             "version": 1,
             "config": [{"primary": "nic"}],
         }
-        mac_addr, nic_name = MAC_ADDR, "ens3"
         with mock.patch(
-            DS_PATH + ".get_interfaces_by_mac",
-            return_value={mac_addr: nic_name},
+            f"{DS_PATH}.get_interfaces_by_mac",
+            return_value={
+                "02:00:17:05:d1:db": "ens3",
+                "00:00:17:02:2b:b1": "ens4",
+            },
         ):
-            oracle_ds._add_network_config_from_opc_imds(set_primary=False)
+            oracle_ds._add_network_config_from_opc_imds(
+                set_primary=set_primary
+            )
 
-        # The input is mutated
-        assert 2 == len(oracle_ds.network_config["config"])
+        secondary_nic_index = 1
+        nic_cfg = oracle_ds.network_config["config"]
+        if set_primary:
+            primary_cfg = nic_cfg[1]
+            secondary_nic_index += 1
 
-        secondary_nic_cfg = oracle_ds.network_config["config"][1]
-        assert nic_name == secondary_nic_cfg["name"]
-        assert "physical" == secondary_nic_cfg["type"]
-        assert mac_addr == secondary_nic_cfg["mac_address"]
-        assert 9000 == secondary_nic_cfg["mtu"]
+            assert "ens3" == primary_cfg["name"]
+            assert "physical" == primary_cfg["type"]
+            assert "02:00:17:05:d1:db" == primary_cfg["mac_address"]
+            assert 9000 == primary_cfg["mtu"]
+            assert 1 == len(primary_cfg["subnets"])
+            assert "10.0.0.230/24" == primary_cfg["subnets"][0]["address"]
+            assert "dhcp" == primary_cfg["subnets"][0]["type"]
+        secondary_cfg = nic_cfg[secondary_nic_index]
+        assert "ens4" == secondary_cfg["name"]
+        assert "physical" == secondary_cfg["type"]
+        assert "00:00:17:02:2b:b1" == secondary_cfg["mac_address"]
+        assert 9000 == secondary_cfg["mtu"]
+        assert 1 == len(secondary_cfg["subnets"])
+        assert "10.0.0.231/24" == secondary_cfg["subnets"][0]["address"]
+        assert "static" == secondary_cfg["subnets"][0]["type"]
 
-        assert 1 == len(secondary_nic_cfg["subnets"])
-
-        subnet_cfg = secondary_nic_cfg["subnets"][0]
-        assert "10.0.0.231/24" == subnet_cfg["address"]
-        assert "10.0.0.1" == subnet_cfg["routes"][0]["gateway"]
-        assert 24 == subnet_cfg["routes"][0]["prefix"]
-        assert "10.0.0.0" == subnet_cfg["routes"][0]["network"]
-
-    def test_secondary_nic_v2(self, oracle_ds):
+    @pytest.mark.parametrize(
+        "set_primary",
+        [True, False],
+    )
+    def test_secondary_nic_v2(self, set_primary, oracle_ds):
         oracle_ds._vnics_data = json.loads(OPC_VM_SECONDARY_VNIC_RESPONSE)
         oracle_ds._network_config = {
             "version": 2,
             "ethernets": {"primary": {"nic": {}}},
         }
-        mac_addr, nic_name = MAC_ADDR, "ens3"
         with mock.patch(
-            DS_PATH + ".get_interfaces_by_mac",
-            return_value={mac_addr: nic_name},
+            f"{DS_PATH}.get_interfaces_by_mac",
+            return_value={
+                "02:00:17:05:d1:db": "ens3",
+                "00:00:17:02:2b:b1": "ens4",
+            },
         ):
-            oracle_ds._add_network_config_from_opc_imds(set_primary=False)
+            oracle_ds._add_network_config_from_opc_imds(
+                set_primary=set_primary
+            )
 
-        # The input is mutated
-        assert 2 == len(oracle_ds.network_config["ethernets"])
+        nic_cfg = oracle_ds.network_config["ethernets"]
+        if set_primary:
+            assert "ens3" in nic_cfg
+            primary_cfg = nic_cfg["ens3"]
 
-        secondary_nic_cfg = oracle_ds.network_config["ethernets"]["ens3"]
-        assert secondary_nic_cfg["dhcp4"] is False
-        assert secondary_nic_cfg["dhcp6"] is False
-        assert mac_addr == secondary_nic_cfg["match"]["macaddress"]
-        assert 9000 == secondary_nic_cfg["mtu"]
+            assert primary_cfg["dhcp4"] is True
+            assert primary_cfg["dhcp6"] is False
+            assert "02:00:17:05:d1:db" == primary_cfg["match"]["macaddress"]
+            assert 9000 == primary_cfg["mtu"]
+            assert 1 == len(primary_cfg["addresses"])
+            assert "10.0.0.230/24" == primary_cfg["addresses"][0]
 
-        assert 1 == len(secondary_nic_cfg["addresses"])
-        # These values are hard-coded in OPC_VM_SECONDARY_VNIC_RESPONSE
-        assert "10.0.0.231/24" == secondary_nic_cfg["addresses"][0]
-        assert "10.0.0.1" == secondary_nic_cfg["routes"][0]["via"]
-        assert "10.0.0.0" == secondary_nic_cfg["routes"][0]["to"]
+        assert "ens4" in nic_cfg
+        secondary_cfg = nic_cfg["ens4"]
+        assert secondary_cfg["dhcp4"] is False
+        assert secondary_cfg["dhcp6"] is False
+        assert "00:00:17:02:2b:b1" == secondary_cfg["match"]["macaddress"]
+        assert 9000 == secondary_cfg["mtu"]
+
+        assert 1 == len(secondary_cfg["addresses"])
+        assert "10.0.0.231/24" == secondary_cfg["addresses"][0]
 
     @pytest.mark.parametrize("error_add_network", [None, Exception])
     @pytest.mark.parametrize(

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -298,9 +298,12 @@ class TestNetworkConfigFromOpcImds:
         assert 9000 == secondary_nic_cfg["mtu"]
 
         assert 1 == len(secondary_nic_cfg["subnets"])
+
         subnet_cfg = secondary_nic_cfg["subnets"][0]
-        # These values are hard-coded in OPC_VM_SECONDARY_VNIC_RESPONSE
         assert "10.0.0.231/24" == subnet_cfg["address"]
+        assert "10.0.0.1" == subnet_cfg["routes"][0]["gateway"]
+        assert 24 == subnet_cfg["routes"][0]["prefix"]
+        assert "10.0.0.0" == subnet_cfg["routes"][0]["network"]
 
     def test_secondary_nic_v2(self, oracle_ds):
         oracle_ds._vnics_data = json.loads(OPC_VM_SECONDARY_VNIC_RESPONSE)
@@ -327,6 +330,8 @@ class TestNetworkConfigFromOpcImds:
         assert 1 == len(secondary_nic_cfg["addresses"])
         # These values are hard-coded in OPC_VM_SECONDARY_VNIC_RESPONSE
         assert "10.0.0.231/24" == secondary_nic_cfg["addresses"][0]
+        assert "10.0.0.1" == secondary_nic_cfg["routes"][0]["via"]
+        assert "10.0.0.0" == secondary_nic_cfg["routes"][0]["to"]
 
     @pytest.mark.parametrize("error_add_network", [None, Exception])
     @pytest.mark.parametrize(

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -307,7 +307,7 @@ class TestNetworkConfigFromOpcImds:
             assert "02:00:17:05:d1:db" == primary_cfg["mac_address"]
             assert 9000 == primary_cfg["mtu"]
             assert 1 == len(primary_cfg["subnets"])
-            assert "10.0.0.230/24" == primary_cfg["subnets"][0]["address"]
+            assert "address" not in primary_cfg["subnets"][0]
             assert "dhcp" == primary_cfg["subnets"][0]["type"]
         secondary_cfg = nic_cfg[secondary_nic_index]
         assert "ens4" == secondary_cfg["name"]
@@ -348,8 +348,7 @@ class TestNetworkConfigFromOpcImds:
             assert primary_cfg["dhcp6"] is False
             assert "02:00:17:05:d1:db" == primary_cfg["match"]["macaddress"]
             assert 9000 == primary_cfg["mtu"]
-            assert 1 == len(primary_cfg["addresses"])
-            assert "10.0.0.230/24" == primary_cfg["addresses"][0]
+            assert "addresses" not in primary_cfg
 
         assert "ens4" in nic_cfg
         secondary_cfg = nic_cfg["ens4"]


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix Oracle DS primary interface when using IMDS

If /run/net* files aren't available, we use IMDS for configuring the
default interface. Rather than attempt a static configuration, grab
the IP and let DHCP do the rest (as it does when /run/net*
is available).

LP: #1989686
```

## Additional Context
https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1989686

## Test Steps
On my instance, `curl --header "Authorization: Bearer Oracle" http://169.254.169.254/opc/v2/vnics` gives:
```
[
  {
    "macAddr": "02:00:17:08:BB:E1",
    "privateIp": "10.0.2.60",
    "subnetCidrBlock": "10.0.2.0/24",
    "virtualRouterIp": "10.0.2.1",
    "vlanTag": 1320,
    "vnicId": "ocid1.vnic.oc1.phx.abyhqljrmna323fjjscndxh2xfa3rkhhrgdwelqhdl6jumhqr3arm44rhuyq"
  }
]
```

Generated deb and installed on Oracle. Moved `/run/net-ens3.conf` to `/run/net-ens3.conf.bak`. Ran `cloud-init clean --logs; cloud-init init --local`. This gives the following netplan config at `/etc/netplan/50-cloud-init.yaml`:
```
network:
    version: 2
    ethernets:
        ens3:
            addresses:
            - 10.0.2.60/24
            match:
                macaddress: 02:00:17:08:bb:e1
            mtu: 9000
            routes:
            -   to: 10.0.2.0/24
                via: 10.0.2.1
            set-name: ens3
```

This was generated from the v1 config. Not sure a great way to show the generation from v2, but it should be fairly straightforward in the code.

Also, not sure a great way to test the generation of routes because even after netplan apply, the routes that the system booted with are still there.

`ip r` before netplan apply:
```
default via 10.0.2.1 dev ens3 proto dhcp src 10.0.2.60 metric 100 
10.0.2.0/24 dev ens3 proto kernel scope link src 10.0.2.60 metric 100 
10.0.2.1 dev ens3 proto dhcp scope link src 10.0.2.60 metric 100 
169.254.169.254 via 10.0.2.1 dev ens3 proto dhcp src 10.0.2.60 metric 100 
```

`ip r` after netplan apply:
```
default via 10.0.2.1 dev ens3 proto dhcp src 10.0.2.60 metric 100 
10.0.2.0/24 via 10.0.2.1 dev ens3 proto static 
10.0.2.0/24 dev ens3 proto kernel scope link src 10.0.2.60 metric 100 
10.0.2.1 dev ens3 proto dhcp scope link src 10.0.2.60 metric 100 
169.254.169.254 via 10.0.2.1 dev ens3 proto dhcp src 10.0.2.60 metric 100 
```

# Other considerations
The default configuration (from /run/net-ens3.conf) is:
```
root@instance20220927160159:/run# cat net-ens3.conf.bak 
DEVICE='ens3'
PROTO='dhcp'
IPV4PROTO='dhcp'
IPV4ADDR='10.0.2.60'
IPV4NETMASK='255.255.255.0'
IPV4BROADCAST='10.0.2.255'
IPV4GATEWAY='10.0.2.1'
IPV4DNS0='169.254.169.254'
ROOTSERVER='10.0.2.1'
HOSTNAME=''
DNSDOMAIN='default.oraclevcn.com'
DOMAINSEARCH='default.oraclevcn.com'
```
The 'dhcp' option makes the resulting netplan config much simpler:
```
network:
    version: 2
    ethernets:
        ens3:
            dhcp4: true
            match:
                macaddress: 02:00:17:08:bb:e1
            set-name: ens3
```
Such a 'dhcp' key isn't present when querying IMDS, but I do wonder if things would be less error-prone if we relied on DHCP for the primary interface. Things "sorta" worked ok back when we relied on the ephemeral configuration to be the configuration for the primary interface. The problem came when we chose the wrong interface as primary, but if we could match the primary mac  and then use DHCP for only that interface, we shouldn't have that problem nor any of the problems we're having with static config.