### PR TITLE
Distro manage service: Improve BSD support

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -923,6 +923,16 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 "try-reload": ["reload-or-try-restart", service],
                 "status": ["status", service],
             }
+        elif "rcctl" in init_cmd:
+            cmds = {
+                "stop": ["stop", service],
+                "start": ["start", service],
+                "enable": ["enable", service],
+                "restart": ["restart", service],
+                "reload": ["restart", service],
+                "try-reload": ["restart", service],
+                "status": ["check", service],
+            }
         else:
             cmds = {
                 "stop": [service, "stop"],

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -44,8 +44,10 @@ OSFAMILIES = {
     "alpine": ["alpine"],
     "arch": ["arch"],
     "debian": ["debian", "ubuntu"],
-    "freebsd": ["freebsd"],
+    "freebsd": ["freebsd", "dragonfly"],
     "gentoo": ["gentoo"],
+    "netbsd": ["netbsd"],
+    "openbsd": ["openbsd"],
     "redhat": [
         "almalinux",
         "amazon",

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -925,16 +925,6 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 "try-reload": ["reload-or-try-restart", service],
                 "status": ["status", service],
             }
-        elif "rcctl" in init_cmd:
-            cmds = {
-                "stop": ["stop", service],
-                "start": ["start", service],
-                "enable": ["enable", service],
-                "restart": ["restart", service],
-                "reload": ["restart", service],
-                "try-reload": ["restart", service],
-                "status": ["check", service],
-            }
         else:
             cmds = {
                 "stop": [service, "stop"],

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -37,6 +37,26 @@ class Distro(cloudinit.distros.bsd.BSD):
     prefer_fqdn = True  # See rc.conf(5) in FreeBSD
     home_dir = "/usr/home"
 
+    def manage_service(self, action: str, service: str):
+        """
+        Perform the requested action on a service. This handles FreeBSD's
+        'service' case as necessary. The FreeBSD 'service' is closer in
+        features systemctl than SysV init's service.
+        May raise ProcessExecutionError
+        """
+        init_cmd = self.init_cmd
+        cmds = {
+            "stop": [service, "stop"],
+            "start": [service, "start"],
+            "enable": [service, "enable"],
+            "restart": [service, "restart"],
+            "reload": [service, "restart"],
+            "try-reload": [service, "restart"],
+            "status": [service, "status"],
+        }
+        cmd = list(init_cmd) + list(cmds[action])
+        return subp.subp(cmd, capture=True)
+
     def _get_add_member_to_group_cmd(self, member_name, group_name):
         return ["pw", "usermod", "-n", member_name, "-G", group_name]
 

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -40,8 +40,8 @@ class Distro(cloudinit.distros.bsd.BSD):
     def manage_service(self, action: str, service: str):
         """
         Perform the requested action on a service. This handles FreeBSD's
-        'service' case as necessary. The FreeBSD 'service' is closer in
-        features systemctl than SysV init's service.
+        'service' case. The FreeBSD 'service' is closer in features to
+        'systemctl' than SysV init's 'service', so we override it.
         May raise ProcessExecutionError
         """
         init_cmd = self.init_cmd

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -26,6 +26,25 @@ class Distro(cloudinit.distros.netbsd.NetBSD):
     def _get_add_member_to_group_cmd(self, member_name, group_name):
         return ["usermod", "-G", group_name, member_name]
 
+    def manage_service(self, action: str, service: str):
+        """
+        Perform the requested action on a service. This handles OpenBSD's
+        'rcctl' case as necessary.
+        May raise ProcessExecutionError
+        """
+        init_cmd = self.init_cmd
+        cmds = {
+            "stop": ["stop", service],
+            "start": ["start", service],
+            "enable": ["enable", service],
+            "restart": ["restart", service],
+            "reload": ["restart", service],
+            "try-reload": ["restart", service],
+            "status": ["check", service],
+        }
+        cmd = list(init_cmd) + list(cmds[action])
+        return subp.subp(cmd, capture=True)
+
     def lock_passwd(self, name):
         try:
             subp.subp(["usermod", "-p", "*", name])

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -29,7 +29,7 @@ class Distro(cloudinit.distros.netbsd.NetBSD):
     def manage_service(self, action: str, service: str):
         """
         Perform the requested action on a service. This handles OpenBSD's
-        'rcctl' case as necessary.
+        'rcctl'.
         May raise ProcessExecutionError
         """
         init_cmd = self.init_cmd

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -14,6 +14,7 @@ LOG = logging.getLogger(__name__)
 
 class Distro(cloudinit.distros.netbsd.NetBSD):
     hostname_conf_fn = "/etc/myname"
+    init_cmd = ["rcctl"]
 
     def _read_hostname(self, filename, default=None):
         return util.load_file(self.hostname_conf_fn)

--- a/tests/unittests/distros/test_manage_service.py
+++ b/tests/unittests/distros/test_manage_service.py
@@ -3,6 +3,8 @@
 from tests.unittests.helpers import CiTestCase, mock
 from tests.unittests.util import MockDistro
 
+from . import _get_distro
+
 
 class TestManageService(CiTestCase):
 
@@ -31,6 +33,7 @@ class TestManageService(CiTestCase):
     @mock.patch.object(MockDistro, "uses_systemd", return_value=False)
     @mock.patch("cloudinit.distros.subp.subp")
     def test_manage_service_rcctl_initcmd(self, m_subp, m_sysd):
+        self.dist = _get_distro("openbsd")
         self.dist.init_cmd = ["rcctl"]
         self.dist.manage_service("start", "myssh")
         m_subp.assert_called_with(["rcctl", "start", "myssh"], capture=True)

--- a/tests/unittests/distros/test_manage_service.py
+++ b/tests/unittests/distros/test_manage_service.py
@@ -1,9 +1,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+from tests.unittests.distros import _get_distro
 from tests.unittests.helpers import CiTestCase, mock
 from tests.unittests.util import MockDistro
-
-from . import _get_distro
 
 
 class TestManageService(CiTestCase):
@@ -30,12 +29,11 @@ class TestManageService(CiTestCase):
         self.dist.manage_service("start", "myssh")
         m_subp.assert_called_with(["service", "myssh", "start"], capture=True)
 
-    @mock.patch.object(MockDistro, "uses_systemd", return_value=False)
     @mock.patch("cloudinit.distros.subp.subp")
-    def test_manage_service_rcctl_initcmd(self, m_subp, m_sysd):
-        self.dist = _get_distro("openbsd")
-        self.dist.init_cmd = ["rcctl"]
-        self.dist.manage_service("start", "myssh")
+    def test_manage_service_rcctl_initcmd(self, m_subp):
+        dist = _get_distro("openbsd")
+        dist.init_cmd = ["rcctl"]
+        dist.manage_service("start", "myssh")
         m_subp.assert_called_with(["rcctl", "start", "myssh"], capture=True)
 
     @mock.patch.object(MockDistro, "uses_systemd", return_value=True)

--- a/tests/unittests/distros/test_manage_service.py
+++ b/tests/unittests/distros/test_manage_service.py
@@ -36,6 +36,13 @@ class TestManageService(CiTestCase):
         dist.manage_service("start", "myssh")
         m_subp.assert_called_with(["rcctl", "start", "myssh"], capture=True)
 
+    @mock.patch("cloudinit.distros.subp.subp")
+    def test_manage_service_fbsd_service_initcmd(self, m_subp):
+        dist = _get_distro("freebsd")
+        dist.init_cmd = ["service"]
+        dist.manage_service("enable", "myssh")
+        m_subp.assert_called_with(["service", "myssh", "enable"], capture=True)
+
     @mock.patch.object(MockDistro, "uses_systemd", return_value=True)
     @mock.patch("cloudinit.distros.subp.subp")
     def test_manage_service_systemctl(self, m_subp, m_sysd):

--- a/tests/unittests/distros/test_manage_service.py
+++ b/tests/unittests/distros/test_manage_service.py
@@ -28,6 +28,13 @@ class TestManageService(CiTestCase):
         self.dist.manage_service("start", "myssh")
         m_subp.assert_called_with(["service", "myssh", "start"], capture=True)
 
+    @mock.patch.object(MockDistro, "uses_systemd", return_value=False)
+    @mock.patch("cloudinit.distros.subp.subp")
+    def test_manage_service_rcctl_initcmd(self, m_subp, m_sysd):
+        self.dist.init_cmd = ["rcctl"]
+        self.dist.manage_service("start", "myssh")
+        m_subp.assert_called_with(["rcctl", "start", "myssh"], capture=True)
+
     @mock.patch.object(MockDistro, "uses_systemd", return_value=True)
     @mock.patch("cloudinit.distros.subp.subp")
     def test_manage_service_systemctl(self, m_subp, m_sysd):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Distro manage service: Improve BSD support

OpenBSD has wrapper called `rcctl` that does the same thing as 'service'.
FreeBSD's 'service' knows about 'enable', so we specialize that, too.
Add support and tests.
NetBSD's service does about as much as the base-case, so no need to do anything there.
To mark the occasion, we also add all other BSD `distros` to `OSFAMILIES`.

Sponsored by: FreeBSD Foundation

LP: #1990070
```

## Additional Context
<!-- If relevant -->

## Test Steps
- update cloud-init on *BSD
- test:
```python
>>> from cloudinit.distros.freebsd import Distro
>>> f = Distro('FreeBSD', cfg={}, paths={})
>>> f.manage_service('enable', 'ntpd')
SubpResult(stdout='ntpd enabled in /etc/rc.conf\n', stderr='')
>>> f.manage_service('restart', 'ntpd')
SubpResult(stdout='Starting ntpd.\n', stderr='ntpd not running? (check /var/db/ntp/ntpd.pid).\n')
>>> f.manage_service('restart', 'ntpd')
SubpResult(stdout='Stopping ntpd.\nWaiting for PIDS: 1127.\nStarting ntpd.\n', stderr='')
>>> 
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
