### PR TITLE
Ubuntu/jammy 22.3 hotfix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+22.3.4
+ - Fix Oracle DS primary interface when using IMDS (LP: #1989686)
+
 22.3.3
  - Fix Oracle DS not setting subnet when using IMDS (LP: #1989686)
 

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "22.3.3"
+__VERSION__ = "22.3.4"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cloud-init (22.3.4-0ubuntu1~22.04.1) UNRELEASED; urgency=medium
+
+  * New upstream bugfix release. (LP: #1987318)
+    + Release 22.3.4 (LP: #1986703)
+    + Fix Oracle DS primary interface when using IMDS (#1757)
+      (LP: #1989686)
+
+ -- Brett Holman <brett.holman@canonical.com>  Mon, 03 Oct 2022 10:17:12 -0600
+
 cloud-init (22.3.3-0ubuntu1~22.04.1) jammy; urgency=medium
 
   * New upstream bugfix release. (LP: #1987318)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (22.3.4-0ubuntu1~22.04.1) UNRELEASED; urgency=medium
+cloud-init (22.3.4-0ubuntu1~22.04.1) jammy; urgency=medium
 
   * New upstream bugfix release. (LP: #1987318)
     + Release 22.3.4 (LP: #1986703)


### PR DESCRIPTION

Steps:
```
# Push the 22.3.3 jammy tag as the initial branch to submit this PR against
git checkout ubuntu/22.3.3-0ubuntu1_22.04.1 -B ubuntu/jammy-22.3-hotfix
git push -u upstream ubuntu/jammy-22.3-hotfix

# Create snapshot
new-upstream-snapshot 22.3.4

# Test
build-package
sbuild --resolve-alternatives --dist=jammy --arch=amd64 ../out/cloud-init_22.3.4-0ubuntu1.dsc
```

Note: We need to avoid tag collisions with other series. Continuing the trend from kinetic of following the changelog version number will result in collisions with each series having the same tag (`ubuntu/22.3.4-0ubuntu1`). I propose following the old scheme: `ubuntu/22.3.4-0ubuntu1_22.04.1`