### PR TITLE
testing: check logs for critical errors

### DIFF
--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -47,7 +47,7 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         )
         log = "\n".join(log_lines)
 
-    error_logs = re.findall("ERROR.*", log)
+    error_logs = re.findall("CRITICAL.*", log) + re.findall("ERROR.*", log)
     if error_logs:
         raise AssertionError(
             "Found unexpected errors: %s" % "\n".join(error_logs)


### PR DESCRIPTION
Having recently noticed that LOG.critical() is used in cloudinit, update integration tests to check for CRITICAL.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>