### PR TITLE
OpenBSD: remove pkg_cmd_environ function

### DIFF
--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -176,7 +176,8 @@ class Distro(cloudinit.distros.bsd.BSD):
                 )
 
     def _get_pkg_cmd_environ(self):
-        """Return environment vars used in FreeBSD package_command operations"""
+        """Return environment vars used in FreeBSD package_command
+        operations"""
         e = os.environ.copy()
         e["ASSUME_ALWAYS_YES"] = "YES"
         return e

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -176,7 +176,7 @@ class Distro(cloudinit.distros.bsd.BSD):
                 )
 
     def _get_pkg_cmd_environ(self):
-        """Return environment vars used in *BSD package_command operations"""
+        """Return environment vars used in FreeBSD package_command operations"""
         e = os.environ.copy()
         e["ASSUME_ALWAYS_YES"] = "YES"
         return e

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -57,13 +57,7 @@ class Distro(cloudinit.distros.netbsd.NetBSD):
 
     def _get_pkg_cmd_environ(self):
         """Return env vars used in OpenBSD package_command operations"""
-        os_release = platform.release()
-        os_arch = platform.machine()
         e = os.environ.copy()
-        e["PKG_PATH"] = (
-            "ftp://ftp.openbsd.org/pub/OpenBSD/{os_release}/"
-            "packages/{os_arch}/"
-        ).format(os_arch=os_arch, os_release=os_release)
         return e
 
 

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -3,7 +3,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import os
-import platform
 
 import cloudinit.distros.netbsd
 from cloudinit import log as logging


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
OpenBSD: remove pkg_cmd_environ function

This environment variable is being set to the main mirror, which is
heavily under load. It also sets it to a deprecated and highly insecure
protocol.

OpenBSD's default behaviour is to read a list of mirrors from
installurl(5): https://man.openbsd.org/installurl.5

We can restore this behaviour by removing the contents of this function.
Note that the Equivalent NetBSD function makes vastly more sense.

LP: 1991567

Sponsored by: FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
Try install a package thru a REPL.
If this code ever did anything, it should now be faster.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
