### PR TITLE
cc_ua: consume ua json api for enable commands

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -338,6 +338,8 @@ def configure_ua(token, enable=None):
     # pylint: disable=import-error
     from uaclient.messages import ALREADY_ENABLED
 
+    # pylint: enable=import-error
+
     UA_MC_ALREADY_ENABLED = ALREADY_ENABLED.name
 
     enable_errors: List[dict] = []


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ua: consume ua json api for enable commands

Remove safeguard uaclient imports as uaclient has already been released.
```

## Additional Context
<!-- If relevant -->
https://warthogs.atlassian.net/browse/SC-1253
https://github.com/canonical/cloud-init/pull/1673#discussion_r965352866

Example the UA json api for enable:

```bash
$ sudo ua enable --assume-yes --format json asdf livepatch esm-apps esm-apps | jq
{
  "_schema_version": "0.1",
  "errors": [
    {
      "message": "Cannot install Livepatch on a container.",
      "message_code": "livepatch-error-install-on-container",
      "service": "livepatch",
      "type": "service"
    },
    {
      "message": "UA Apps: ESM is already enabled.\nSee: sudo ua status",
      "message_code": "service-already-enabled",
      "service": "esm-apps",
      "type": "service"
    },
    {
      "message": "UA Apps: ESM is already enabled.\nSee: sudo ua status",
      "message_code": "service-already-enabled",
      "service": "esm-apps",
      "type": "service"
    },
    {
      "message": "Cannot enable unknown service 'asdf'.\nTry cc-eal, cis, esm-infra, fips, fips-updates, livepatch.",
      "message_code": "invalid-service-or-failure",
      "service": null,
      "type": "system"
    }
  ],
  "failed_services": [
    "asdf",
    "esm-apps",
    "livepatch"
  ],
  "needs_reboot": false,
  "processed_services": [],
  "result": "failure",
  "warnings": []
}
```


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
CLOUD_INIT_UA_TOKEN="<token>" tox -e integration-tests -- tests/integration_tests/modules/test_ubuntu_advantage.py::TestUbuntuAdvantage::test_idempotency
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
