### PR TITLE
tests: Use LXD metadata to determine NoCloud status

### DIFF
--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -5,7 +5,7 @@ import yaml
 
 from tests.integration_tests.clouds import ImageSpecification
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import lxd_has_nocloud, verify_clean_log
 
 
 def _customize_environment(client: IntegrationInstance):
@@ -109,10 +109,8 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
     )
     assert "#cloud-config\ninstance-id" in ds_cfg["meta-data"]
 
-    # Jammy not longer provides nocloud-net seed files (LP: #1958460)
-    if ImageSpecification.from_os_image().release in [
-        "bionic",
-    ]:
+    # Some series no longer provide nocloud-net seed files (LP: #1958460)
+    if lxd_has_nocloud(client):
         # Assert NoCloud seed files are still present in non-Jammy images
         # and that NoCloud seed files provide the same content as LXD socket.
         nocloud_metadata = yaml.safe_load(

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -20,6 +20,7 @@ from tests.integration_tests.decorators import retry
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import (
     get_inactive_modules,
+    lxd_has_nocloud,
     verify_clean_log,
     verify_ordered_items_in_text,
 )
@@ -217,7 +218,7 @@ class TestCombined:
         parsed_datasource = json.loads(status_file)["v1"]["datasource"]
 
         if client.settings.PLATFORM in ["lxd_container", "lxd_vm"]:
-            if ImageSpecification.from_os_image().release == "bionic":
+            if lxd_has_nocloud(client):
                 datasource = "DataSourceNoCloud"
             else:
                 datasource = "DataSourceLXD"
@@ -291,7 +292,7 @@ class TestCombined:
         data = json.loads(instance_json_file)
         self._check_common_metadata(data)
         v1_data = data["v1"]
-        if ImageSpecification.from_os_image().release != "bionic":
+        if not lxd_has_nocloud(client):
             cloud_name = "lxd"
             subplatform = "LXD socket API v. 1.0 (/dev/lxd/sock)"
             # instance-id should be a UUID
@@ -327,7 +328,7 @@ class TestCombined:
         data = json.loads(instance_json_file)
         self._check_common_metadata(data)
         v1_data = data["v1"]
-        if ImageSpecification.from_os_image().release != "bionic":
+        if not lxd_has_nocloud(client):
             cloud_name = "lxd"
             subplatform = "LXD socket API v. 1.0 (/dev/lxd/sock)"
             # instance-id should be a UUID

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -5,12 +5,14 @@ import re
 import time
 from collections import namedtuple
 from contextlib import contextmanager
+from functools import lru_cache
 from itertools import chain
 from pathlib import Path
 from typing import Set
 
 import pytest
 
+from cloudinit.subp import subp
 from tests.integration_tests.instances import IntegrationInstance
 
 log = logging.getLogger("integration_testing")
@@ -161,3 +163,12 @@ def get_console_log(client: IntegrationInstance):
     if console_log.lower().startswith("no console output"):
         pytest.fail("no console output")
     return console_log
+
+
+@lru_cache()
+def lxd_has_nocloud(client: IntegrationInstance) -> bool:
+    # Bionic or Focal may be detected as NoCloud rather than LXD
+    lxd_image_metadata = subp(
+        ["lxc", "config", "metadata", "show", client.instance.name]
+    )
+    return "/var/lib/cloud/seed/nocloud" in lxd_image_metadata.stdout


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: Use LXD metadata to determine NoCloud status

Rather than hardcoding a series name, use the LXD metadata to determine
if the current instance should use NoCloud rather than LXD datasource.
```
