### PR TITLE
Rewrite the doc for final_message so it works for multi-line output

### DIFF
--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -40,10 +40,10 @@ meta: MetaSchema = {
         dedent(
             """\
             final_message: |
-              cloud-init has finished
-              version: $version
-              timestamp: $timestamp
-              datasource: $datasource
+              cloud-init has finished \n
+              version: $version \n
+              timestamp: $timestamp \n
+              datasource: $datasource \n
               uptime: $uptime
             """
         )


### PR DESCRIPTION
Signed-off-by: Jiří Herrmann <jherrman@redhat.com>

## Proposed Commit Message
Rewriting the doc for final_message so it works for multi-line output

```
Summary: Rewriting the foc final_message so it works for multi-line output

```

## Additional Context

If the current syntax of the final_message is followed, it ends up displaying as a single line. Adding `\n`s changes to output to multiple lines as intended.

For more info, see See also https://access.redhat.com/solutions/6184961