### PR TITLE
make Makefile make agnostic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,7 @@ PYTHON ?= python3
 
 NUM_ITER ?= 100
 
-ifeq ($(distro),)
-  distro = redhat
-endif
+distro ?= redhat
 
 READ_VERSION=$(shell $(PYTHON) $(CWD)/tools/read-version || echo read-version-failed)
 CODE_VERSION=$(shell $(PYTHON) -c "from cloudinit import version; print(version.version_string())")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
make Makefile make agnostic

remove ifeq assignment, and replace with ?= which should do the same thing

this makes our Makefile make agnostic
```

## Additional Context
this should remove gnu make as our dependency for building, or rather, testing, this in FreeBSD's and OpenBSD's port system

## Test Steps

```
meena@76ix ~/s/c/cloud-init (patch-1)> make distro=fedora srpm
python3 ./packages/brpm --srpm --distro=fedora
usage: brpm [-h] [-d DISTRO] [--srpm] [-b TYPE] [-v] [-s RELEASE] [-p PATCHES]
brpm: error: argument -d/--distro: invalid choice: 'fedora' (choose from 'redhat', 'suse')
make: *** [Makefile:102: srpm] Error 2


meena@76ix ~/s/c/cloud-init (patch-1) [2]> bmake distro=fedora srpm
python3 ./packages/brpm --srpm --distro=fedora
usage: brpm [-h] [-d DISTRO] [--srpm] [-b TYPE] [-v] [-s RELEASE] [-p PATCHES]
brpm: error: argument -d/--distro: invalid choice: 'fedora' (choose from 'redhat', 'suse')
*** Error code 2

Stop.
bmake: stopped in /home/meena/src/cloud/cloud-init
meena@76ix ~/s/c/cloud-init (patch-1) [1]> 
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
