### PR TITLE
lxd: add support for lxd preseed config (SC-1025)

### DIFF
--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -91,65 +91,65 @@ meta: MetaSchema = {
               preseed:
                 config:
                   core.https_address: 192.168.1.1:9999
-                  preseed:
                 networks:
-                - config:
-                    ipv4.address: 10.42.42.1/24
-                    ipv4.nat: true
-                    ipv6.address: fd42:4242:4242:4242::1/64
-                    ipv6.nat: true
-                  description: ""
-                  name: lxdbr0
-                  type: bridge
-                  project: default
-                  storage_pools:
+                  - config:
+                      ipv4.address: 10.42.42.1/24
+                      ipv4.nat: true
+                      ipv6.address: fd42:4242:4242:4242::1/64
+                      ipv6.nat: true
+                    description: ""
+                    name: lxdbr0
+                    type: bridge
+                    project: default
+                storage_pools:
                   - config:
                       size: 5GiB
                       source: /var/snap/lxd/common/lxd/disks/default.img
                     description: ""
                     name: default
-                    driver: {}
+                    driver: zfs
                 profiles:
-                - config: {}
-                  description: Default LXD profile
-                  devices:
-                    eth0:
-                      name: eth0
-                      network: lxdbr0
-                      type: nic
-                    root:
-                      path: /
-                      pool: default
-                      type: disk
-                  name: default
-                - config: {security.nesting: true}
-                  devices:
-                    eth0:
-                      name: eth0
-                      network: lxdbr0
-                      type: nic
-                    root:
-                      eath: /
-                      pool: default
-                      type: disk
-                  name: nested
+                  - config: {}
+                    description: Default LXD profile
+                    devices:
+                      eth0:
+                        name: eth0
+                        network: lxdbr0
+                        type: nic
+                      root:
+                        path: /
+                        pool: default
+                        type: disk
+                    name: default
+                  - config: {}
+                    security.nesting: true
+                    devices:
+                      eth0:
+                        name: eth0
+                        network: lxdbr0
+                        type: nic
+                      root:
+                        path: /
+                        pool: default
+                        type: disk
+                    name: nested
                 projects:
-                - config:
-                    features.images: true
-                    features.networks: true
-                    features.profiles: true
-                    features.storage.buckets: true
-                    features.storage.volumes: true
-                  description: Default LXD project
-                  name: default
-                - config:
-                    features.images: false
-                    features.networks: true
-                    features.profiles: false
-                    features.storage.buckets: false
-                    features.storage.volumes: false
-                  description: Limited Access LXD project
-                  name: limited
+                  - config:
+                      features.images: true
+                      features.networks: true
+                      features.profiles: true
+                      features.storage.volumes: true
+                    description: Default LXD project
+                    name: default
+                  - config:
+                      features.images: false
+                      features.networks: true
+                      features.profiles: false
+                      features.storage.volumes: false
+                    description: Limited Access LXD project
+                    name: limited
+
+
             """
         ),
     ],
@@ -227,8 +227,8 @@ def handle(
             log.warning("failed to install packages %s: %s", packages, exc)
             return
 
+    subp.subp(["lxd", "waitready", "--timeout=300"])
     if preseed_cfg:
-        subp.subp(["lxd", "waitready", "--timeout=300"])
         subp.subp(
             ["lxd", "init", "--preseed"], data=safeyaml.dumps(preseed_cfg)
         )
@@ -247,8 +247,6 @@ def handle(
             "storage_pool",
             "trust_password",
         )
-
-        subp.subp(["lxd", "waitready", "--timeout=300"])
 
         # Bug https://bugs.launchpad.net/ubuntu/+source/linux-kvm/+bug/1982780
         kernel = util.system_info()["uname"][2]

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1259,6 +1259,7 @@
             "init": {
               "type": "object",
               "additionalProperties": false,
+              "description": "LXD init configuration values to provide to `lxd init --auto` command. Can not be combined with ``lxd.preseed``.",
               "properties": {
                 "network_address": {
                   "type": "string",
@@ -1296,6 +1297,7 @@
               "type": "object",
               "required": ["mode"],
               "additionalProperties": false,
+              "description": "LXD bridge configuration provided to setup the host lxd bridge. Can not be combined with ``lxd.preseed``.",
               "properties": {
                 "mode": {
                   "type": "string",
@@ -1356,6 +1358,11 @@
                   "description": "Domain to advertise to DHCP clients and use for DNS resolution."
                 }
               }
+            },
+            "preseed": {
+              "type": "object",
+              "minProperties": 1,
+              "description": "Opaque LXD preseed YAML config passed directly to lxd init --preseed. See: https://linuxcontainers.org/lxd/docs/master/preseed/ of lxd init --dump for viable config. Can not be combined with either ``lxd.init`` or ``lxd.bridge``."
             }
           }
         }

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1361,7 +1361,6 @@
             },
             "preseed": {
               "type": "string",
-              "minProperties": 1,
               "description": "Opaque LXD preseed YAML config passed via stdin to the command: lxd init --preseed. See: https://linuxcontainers.org/lxd/docs/master/preseed/ or lxd init --dump for viable config. Can not be combined with either ``lxd.init`` or ``lxd.bridge``."
             }
           }

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1360,9 +1360,9 @@
               }
             },
             "preseed": {
-              "type": "object",
+              "type": "string",
               "minProperties": 1,
-              "description": "Opaque LXD preseed YAML config passed directly to lxd init --preseed. See: https://linuxcontainers.org/lxd/docs/master/preseed/ of lxd init --dump for viable config. Can not be combined with either ``lxd.init`` or ``lxd.bridge``."
+              "description": "Opaque LXD preseed YAML config passed via stdin to the command: lxd init --preseed. See: https://linuxcontainers.org/lxd/docs/master/preseed/ or lxd init --dump for viable config. Can not be combined with either ``lxd.init`` or ``lxd.bridge``."
             }
           }
         }

--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -37,7 +37,7 @@ lxd:
 STORAGE_PRESEED_USER_DATA = """\
 #cloud-config
 lxd:
-  preseed:
+  preseed: |
     networks:
     - config:
         ipv4.address: 10.42.42.1/24
@@ -177,7 +177,7 @@ def test_storage_btrfs(client):
 def test_storage_preseed_btrfs(client):
     validate_storage(client, "btrfs-progs", "mkfs.btrfs")
     src_cfg = yaml.safe_load(STORAGE_PRESEED_USER_DATA.format("btrfs"))
-    preseed_cfg = src_cfg["lxd"]["preseed"]
+    preseed_cfg = yaml.safe_load(src_cfg["lxd"]["preseed"])
     validate_preseed_profiles(client, preseed_cfg)
     validate_preseed_storage_pools(client, preseed_cfg)
     validate_preseed_projects(client, preseed_cfg)
@@ -208,7 +208,7 @@ def test_storage_zfs(client):
 def test_storage_preseed_zfs(client):
     validate_storage(client, "zfsutils-linux", "zpool")
     src_cfg = yaml.safe_load(STORAGE_PRESEED_USER_DATA.format("zfs"))
-    preseed_cfg = src_cfg["lxd"]["preseed"]
+    preseed_cfg = yaml.safe_load(src_cfg["lxd"]["preseed"])
     validate_preseed_profiles(client, preseed_cfg)
     validate_preseed_storage_pools(client, preseed_cfg)
     validate_preseed_projects(client, preseed_cfg)

--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -137,7 +137,6 @@ lxd:
         features.networks: "true"
         features.profiles: "true"
         features.storage.volumes: "true"
-        features.storage.buckets: "true"
       description: Default LXD project
       name: default
     - config:
@@ -145,7 +144,6 @@ lxd:
         features.networks: "true"
         features.profiles: "false"
         features.storage.volumes: "true"
-        features.storage.buckets: "true"
       description: Limited project
       name: limited
 """
@@ -220,7 +218,7 @@ def test_storage_btrfs(client):
 @pytest.mark.not_bionic
 def test_storage_preseed_btrfs(setup_image, session_cloud: IntegrationCloud):
     cfg_image_spec = ImageSpecification.from_os_image()
-    if cfg_image_spec.release in ("bionic"):
+    if cfg_image_spec.release in ("bionic",):
         nictype = "nictype: bridged"
         parent = "parent: lxdbr0"
         network = ""
@@ -273,7 +271,7 @@ def test_storage_zfs(client):
 @pytest.mark.not_bionic
 def test_storage_preseed_zfs(setup_image, session_cloud: IntegrationCloud):
     cfg_image_spec = ImageSpecification.from_os_image()
-    if cfg_image_spec.release in ("bionic"):
+    if cfg_image_spec.release in ("bionic",):
         nictype = "nictype: bridged"
         parent = "parent: lxdbr0"
         network = ""

--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -22,7 +22,7 @@ lxd:
     ipv4_netmask: 24
     ipv4_dhcp_first: 10.100.100.100
     ipv4_dhcp_last: 10.100.100.200
-    ipv4_nat: true
+    ipv4_nat: "true"
     domain: lxd
     mtu: 9000
 """
@@ -32,6 +32,81 @@ STORAGE_USER_DATA = """\
 lxd:
   init:
     storage_backend: {}
+"""
+
+STORAGE_PRESEED_USER_DATA = """\
+#cloud-config
+lxd:
+  preseed:
+    networks:
+    - config:
+        ipv4.address: 10.42.42.1/24
+        ipv4.nat: "true"
+        ipv6.address: fd42:4242:4242:4242::1/64
+        ipv6.nat: "true"
+      description: ""
+      name: lxdbr0
+      type: bridge
+      project: default
+    storage_pools:
+    - config:
+        size: 5GiB
+        source: /var/snap/lxd/common/lxd/disks/default.img
+      description: ""
+      name: default
+      driver: {}
+    profiles:
+    - config: {{ }}
+      description: Default LXD profile
+      devices:
+        eth0:
+          nictype: bridged
+          parent: lxdbr0
+          type: nic
+        root:
+          path: /
+          pool: default
+          type: disk
+      name: default
+    - config:
+        user.vendor-data: |
+          #cloud-config
+          write_files:
+          - path: /var/lib/cloud/scripts/per-once/setup-lxc.sh
+            encoding: b64
+            permissions: '0755'
+            owner: root:root
+            content: |
+              IyEvYmluL2Jhc2gKZWNobyBZRVAgPj4gL3Zhci9sb2cvY2xvdWQtaW5pdC5sb2cK
+      devices:
+        config:
+          source: cloud-init:config
+          type: disk
+        eth0:
+          name: eth0
+          network: lxdbr0
+          type: nic
+        root:
+          path: /
+          pool: default
+          type: disk
+      description: Pycloudlib LXD profile for bionic VMs
+      name: bionic-vm-lxc-setup
+    projects:
+    - config:
+        features.images: "true"
+        features.networks: "true"
+        features.profiles: "true"
+        features.storage.volumes: "true"
+      description: Default LXD project
+      name: default
+    - config:
+        features.images: "false"
+        features.networks: "true"
+        features.profiles: "false"
+        features.storage.volumes: "true"
+      description: Limited project
+      name: limited
 """
 
 
@@ -62,6 +137,39 @@ def validate_storage(validate_client, pkg_name, command):
     return log
 
 
+def validate_preseed_profiles(client, preseed_cfg):
+    for src_profile in preseed_cfg["profiles"]:
+        profile = yaml.safe_load(
+            client.execute(f"lxc profile show {src_profile['name']}")
+        )
+        assert src_profile["config"] == profile["config"]
+
+
+def validate_preseed_storage_pools(client, preseed_cfg):
+    for src_storage in preseed_cfg["storage_pools"]:
+        storage_pool = yaml.safe_load(
+            client.execute(f"lxc storage show {src_storage['name']}")
+        )
+        assert storage_pool["config"]["source"] == storage_pool["config"].pop(
+            "volatile.initial_source"
+        )
+        assert storage_pool["config"] == src_storage["config"]
+        assert storage_pool["driver"] == src_storage["driver"]
+
+
+def validate_preseed_projects(client, preseed_cfg):
+    for src_project in preseed_cfg["projects"]:
+        project = yaml.safe_load(
+            client.execute(f"lxc project show {src_project['name']}")
+        )
+        assert [
+            "/1.0/profiles/bionic-vm-lxc-setup",
+            "/1.0/profiles/default",
+            "/1.0/networks/lxdbr0",
+        ] == project.pop("used_by")
+        assert project == src_project
+
+
 @pytest.mark.no_container
 @pytest.mark.user_data(STORAGE_USER_DATA.format("btrfs"))
 def test_storage_btrfs(client):
@@ -69,20 +177,41 @@ def test_storage_btrfs(client):
 
 
 @pytest.mark.no_container
-@pytest.mark.user_data(STORAGE_USER_DATA.format("lvm"))
-def test_storage_lvm(client):
-    log = client.read_from_file("/var/log/cloud-init.log")
+@pytest.mark.user_data(STORAGE_PRESEED_USER_DATA.format("btrfs"))
+def test_storage_preseed_btrfs(client):
+    validate_storage(client, "btrfs-progs", "mkfs.btrfs")
+    src_cfg = yaml.safe_load(STORAGE_PRESEED_USER_DATA.format("btrfs"))
+    preseed_cfg = src_cfg["lxd"]["preseed"]
+    validate_preseed_profiles(client, preseed_cfg)
+    validate_preseed_storage_pools(client, preseed_cfg)
+    validate_preseed_projects(client, preseed_cfg)
 
-    # Note to self
-    if (
-        "doesn't use thinpool by default on Ubuntu due to LP" not in log
-        and "-kvm" not in client.execute("uname -r")
-    ):
-        warnings.warn("LP 1982780 has been fixed, update to allow thinpools")
-    validate_storage(client, "lvm2", "lvcreate")
+    @pytest.mark.no_container
+    @pytest.mark.user_data(STORAGE_USER_DATA.format("lvm"))
+    def test_storage_lvm(client):
+        log = client.read_from_file("/var/log/cloud-init.log")
 
+        # Note to self
+        if (
+            "doesn't use thinpool by default on Ubuntu due to LP" not in log
+            and "-kvm" not in client.execute("uname -r")
+        ):
+            warnings.warn(
+                "LP 1982780 has been fixed, update to allow thinpools"
+            )
+        validate_storage(client, "lvm2", "lvcreate")
 
-@pytest.mark.no_container
-@pytest.mark.user_data(STORAGE_USER_DATA.format("zfs"))
-def test_storage_zfs(client):
-    validate_storage(client, "zfsutils-linux", "zpool")
+    @pytest.mark.no_container
+    @pytest.mark.user_data(STORAGE_USER_DATA.format("zfs"))
+    def test_storage_zfs(client):
+        validate_storage(client, "zfsutils-linux", "zpool")
+
+    @pytest.mark.no_container
+    @pytest.mark.user_data(STORAGE_PRESEED_USER_DATA.format("zfs"))
+    def test_storage_preseed_zfs(client):
+        validate_storage(client, "zfsutils-linux", "zpool")
+        src_cfg = yaml.safe_load(STORAGE_PRESEED_USER_DATA.format("zfs"))
+        preseed_cfg = src_cfg["lxd"]["preseed"]
+        validate_preseed_profiles(client, preseed_cfg)
+        validate_preseed_storage_pools(client, preseed_cfg)
+        validate_preseed_projects(client, preseed_cfg)


### PR DESCRIPTION
## Proposed Commit Message
```
User-data now supports opaque lxd.preseed YAML
which can be provided directly to the command:
  lxd init --preseed

Complex LXD host, network, profile and storage setup
and configuration can be provided via this config entry.

For details on available configuration options and examples
https://linuxcontainers.org/lxd/docs/master/preseed/
- or -
lxd init --dump
```

## Additional Context
<!-- If relevant -->

## Test Steps
```bash
make deb
CLOUD_INIT_KEEP_INSTANCE=true CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_SOURCE=./cloud-init_all.deb  tox -e integration-tests tests/integration_tests/test_lxd.py::test_storage_preseed_btrfs

# also check docs
make doc
xdg-open doc/rtd_html/topics/modules.html
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
