### PR TITLE
Fix LXD/nocloud detection on lxd vm tests

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -339,6 +339,8 @@ class TestCombined:
                     f"LXD instance-id is not a UUID: {v1_data['instance_id']}"
                 ) from e
             assert v1_data["subplatform"] == subplatform
+            assert v1_data["platform"] == "lxd"
+            assert v1_data["cloud_id"] == "lxd"
         else:
             cloud_name = "unknown"
             # Pre-Jammy instance-id and instance.name are synonymous
@@ -350,11 +352,11 @@ class TestCombined:
                     "/dev/sr0" in v1_data["subplatform"],
                 ]
             )
+            assert v1_data["platform"] in ["lxd", "nocloud"]
+            assert v1_data["cloud_id"] in ["lxd", "nocloud"]
         assert v1_data["cloud_name"] == cloud_name
-        assert v1_data["platform"] == "lxd"
-        assert v1_data["cloud_id"] == "lxd"
         assert f"{v1_data['cloud_id']}" == client.read_from_file(
-            "/run/cloud-init/cloud-id-lxd"
+            "/run/cloud-init/cloud-id"
         )
 
         assert v1_data["availability_zone"] is None


### PR DESCRIPTION
## Proposed Commit Message
```
Fix LXD/nocloud detection on lxd vm tests
```
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-lxd_vm/130/testReport/junit/tests.integration_tests.modules.test_combined/TestCombined/test_instance_json_lxd_vm/