### PR TITLE
Netplan deprecated keys (SC-1050)

### DIFF
--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -118,7 +118,6 @@ def _extract_addresses(config: dict, entry: dict, ifname, features=None):
                 new_route = {
                     "via": subnet.get("gateway"),
                     "to": "default",
-                    "metric": 100,  # do not deprioritize this route
                 }
                 routes.append(new_route)
             if "dns_nameservers" in subnet:

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -46,7 +46,7 @@ def _get_params_dict_by_match(config, match):
 def _extract_addresses(config: dict, entry: dict, ifname, features=None):
     """This method parse a cloudinit.net.network_state dictionary (config) and
        maps netstate keys/values into a dictionary (entry) to represent
-       netplan yaml. (network config v1 -> v2)
+       netplan yaml. (config v1 -> netplan)
 
     An example config dictionary might look like:
 

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -46,7 +46,7 @@ def _get_params_dict_by_match(config, match):
 def _extract_addresses(config: dict, entry: dict, ifname, features=None):
     """This method parse a cloudinit.net.network_state dictionary (config) and
        maps netstate keys/values into a dictionary (entry) to represent
-       netplan yaml.
+       netplan yaml. (network config v1 -> v2)
 
     An example config dictionary might look like:
 
@@ -118,7 +118,7 @@ def _extract_addresses(config: dict, entry: dict, ifname, features=None):
                 new_route = {
                     "via": subnet.get("gateway"),
                     "to": "default",
-                    "metric": 100,
+                    "metric": 100,  # do not deprioritize this route
                 }
                 routes.append(new_route)
             if "dns_nameservers" in subnet:

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -43,7 +43,7 @@ def _get_params_dict_by_match(config, match):
     )
 
 
-def _extract_addresses(config, entry, ifname, features=None):
+def _extract_addresses(config: dict, entry: dict, ifname, features=None):
     """This method parse a cloudinit.net.network_state dictionary (config) and
        maps netstate keys/values into a dictionary (entry) to represent
        netplan yaml.
@@ -81,8 +81,10 @@ def _extract_addresses(config, entry, ifname, features=None):
     """
 
     def _listify(obj, token=" "):
-        "Helper to convert strings to list of strings, handle single string"
-        if not obj or type(obj) not in [str]:
+        """
+        Helper to convert strings to list of strings, handle single string
+        """
+        if not obj or not isinstance(obj, str):
             return obj
         if token in obj:
             return obj.split(token)
@@ -112,12 +114,13 @@ def _extract_addresses(config, entry, ifname, features=None):
             addr = "%s" % subnet.get("address")
             if "prefix" in subnet:
                 addr += "/%d" % subnet.get("prefix")
-            if "gateway" in subnet and subnet.get("gateway"):
-                gateway = subnet.get("gateway")
-                if ":" in gateway:
-                    entry.update({"gateway6": gateway})
-                else:
-                    entry.update({"gateway4": gateway})
+            if subnet.get("gateway"):
+                new_route = {
+                    "via": subnet.get("gateway"),
+                    "to": "default",
+                    "metric": 100,
+                }
+                routes.append(new_route)
             if "dns_nameservers" in subnet:
                 nameservers += _listify(subnet.get("dns_nameservers", []))
             if "dns_search" in subnet:
@@ -302,7 +305,7 @@ class Renderer(renderer.Renderer):
                 "successfully for all devices."
             ) from last_exception
 
-    def _render_content(self, network_state: NetworkState):
+    def _render_content(self, network_state: NetworkState) -> str:
 
         # if content already in netplan format, pass it back
         if network_state.version == 2:

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -330,11 +330,7 @@ class Renderer(renderer.Renderer):
         for config in network_state.iter_interfaces():
             ifname = config.get("name")
             # filter None (but not False) entries up front
-            ifcfg = dict(
-                (key, value)
-                for (key, value) in config.items()
-                if value is not None
-            )
+            ifcfg = dict(filter(lambda it: it[1] is not None, config.items()))
 
             if_type = ifcfg.get("type")
             if if_type == "physical":

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -83,6 +83,16 @@ NET_CONFIG_TO_V2: Dict[str, Dict[str, Any]] = {
 }
 
 
+def warn_deprecated_all_devices(dikt: dict) -> None:
+    """Warn about deprecations of v2 properties for all devices"""
+    if "gateway4" in dikt or "gateway6" in dikt:
+        LOG.warning(
+            "DEPRECATED: The use of `gateway4` and `gateway6` is"
+            " deprecated. For more info check out: "
+            "https://cloudinit.readthedocs.io/en/latest/topics/network-config-format-v2.html"  # noqa: E501
+        )
+
+
 def from_state_file(state_file):
     state = util.read_conf(state_file)
     nsi = NetworkStateInterpreter()
@@ -750,6 +760,8 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
                 if key in cfg:
                     phy_cmd[key] = cfg[key]
 
+            warn_deprecated_all_devices(cfg)
+
             subnets = self._v2_to_v1_ipcfg(cfg)
             if len(subnets) > 0:
                 phy_cmd.update({"subnets": subnets})
@@ -784,6 +796,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
             }
             if "mtu" in cfg:
                 vlan_cmd["mtu"] = cfg["mtu"]
+            warn_deprecated_all_devices(cfg)
             subnets = self._v2_to_v1_ipcfg(cfg)
             if len(subnets) > 0:
                 vlan_cmd.update({"subnets": subnets})
@@ -852,6 +865,8 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
             }
             if "mtu" in item_cfg:
                 v1_cmd["mtu"] = item_cfg["mtu"]
+
+            warn_deprecated_all_devices(item_cfg)
             subnets = self._v2_to_v1_ipcfg(item_cfg)
             if len(subnets) > 0:
                 v1_cmd.update({"subnets": subnets})

--- a/doc/rtd/topics/network-config-format-v2.rst
+++ b/doc/rtd/topics/network-config-format-v2.rst
@@ -233,6 +233,7 @@ Example: ``addresses: [192.168.14.2/24, 2001:1::1/64]``
 
 **gateway4**: or **gateway6**: *<(scalar)>*
 
+Deprecated, see `netplan#default-routes`_.
 Set default gateway for IPv4/6, for manual address configuration. This
 requires setting ``addresses`` too. Gateway IPs must be in a form
 recognized by ``inet_pton(3)``
@@ -572,5 +573,6 @@ This is a complex example which shows most available features: ::
         dhcp4: yes
 
 .. _netplan: https://netplan.io
+.. _netplan#default-routes: https://netplan.io/reference#default-routes
 .. _netplan#dhcp-overrides: https://netplan.io/reference#dhcp-overrides
 .. vi: textwidth=79

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -187,8 +187,7 @@ network:
             addresses:
             - 192.168.1.5/24
             routes:
-            -   metric: 100
-                to: default
+            -   to: default
                 via: 192.168.1.254
         eth1:
             dhcp4: true
@@ -207,8 +206,7 @@ network:
             addresses:
             - 2607:f0d0:1002:0011::2/64
             routes:
-            -   metric: 100
-                to: default
+            -   to: default
                 via: 2607:f0d0:1002:0011::1
         eth1:
             dhcp4: true
@@ -974,8 +972,7 @@ class TestNetCfgDistroArch(TestNetCfgDistroBase):
                             addresses:
                             - 192.168.1.5/24
                             routes:
-                            -   metric: 100
-                                to: default
+                            -   to: default
                                 via: 192.168.1.254
                         eth1:
                             dhcp4: true

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -186,7 +186,10 @@ network:
         eth0:
             addresses:
             - 192.168.1.5/24
-            gateway4: 192.168.1.254
+            routes:
+            -   metric: 100
+                to: default
+                via: 192.168.1.254
         eth1:
             dhcp4: true
 """
@@ -203,7 +206,10 @@ network:
         eth0:
             addresses:
             - 2607:f0d0:1002:0011::2/64
-            gateway6: 2607:f0d0:1002:0011::1
+            routes:
+            -   metric: 100
+                to: default
+                via: 2607:f0d0:1002:0011::1
         eth1:
             dhcp4: true
 """
@@ -967,7 +973,10 @@ class TestNetCfgDistroArch(TestNetCfgDistroBase):
                         eth0:
                             addresses:
                             - 192.168.1.5/24
-                            gateway4: 192.168.1.254
+                            routes:
+                            -   metric: 100
+                                to: default
+                                via: 192.168.1.254
                         eth1:
                             dhcp4: true
                 """

--- a/tests/unittests/net/test_net_rendering.py
+++ b/tests/unittests/net/test_net_rendering.py
@@ -88,7 +88,7 @@ def _check_network_manager(network_state: NetworkState, tmp_path: Path):
     "test_name, renderers",
     [("no_matching_mac_v2", Renderer.Netplan | Renderer.NetworkManager)],
 )
-def test_convert(test_name, renderers, tmp_path, caplog):
+def test_convert(test_name, renderers, tmp_path):
     network_config = safeyaml.load(
         Path(ARTIFACT_DIR, f"{test_name}.yaml").read_text()
     )

--- a/tests/unittests/net/test_net_rendering.py
+++ b/tests/unittests/net/test_net_rendering.py
@@ -88,7 +88,7 @@ def _check_network_manager(network_state: NetworkState, tmp_path: Path):
     "test_name, renderers",
     [("no_matching_mac_v2", Renderer.Netplan | Renderer.NetworkManager)],
 )
-def test_convert(test_name, renderers, tmp_path):
+def test_convert(test_name, renderers, tmp_path, caplog):
     network_config = safeyaml.load(
         Path(ARTIFACT_DIR, f"{test_name}.yaml").read_text()
     )

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -402,8 +402,7 @@ network:
                 transmit-hash-policy: layer3+4
                 up-delay: 0
             routes:
-            -   metric: 100
-                to: default
+            -   to: default
                 via: 10.101.11.254
     vlans:
         bond0.3502:
@@ -2264,8 +2263,7 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                             - sacchromyces.maas
                             - brettanomyces.maas
                         routes:
-                        -   metric: 100
-                            to: default
+                        -   to: default
                             via: 192.168.0.1
         """
         ).rstrip(" "),
@@ -2994,8 +2992,7 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                          transmit-hash-policy: layer3+4
                          up-delay: 20
                      routes:
-                     -   metric: 100
-                         to: default
+                     -   to: default
                          via: 192.168.0.1
                      -   to: 10.1.3.0/24
                          via: 192.168.0.3
@@ -6051,10 +6048,8 @@ class TestNetplanNetRendering:
                       routes:
                         - to: default
                           via: 192.168.23.1
-                          metric: 100
                         - to: default
                           via: 11.0.0.1
-                          metric: 100
                 """,
                 id="one_gateway4",
             ),

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -6017,8 +6017,8 @@ class TestNetplanNetRendering:
                 """,
                 id="default_generation",
             ),
-            # Asserts a netconf v1 with two gateways does not produce a
-            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            # Asserts a netconf v1 with a physical device and two gateways
+            # does not produce deprecated keys, `gateway{46}`, in Netplan v2
             pytest.param(
                 """
                 version: 1
@@ -6053,8 +6053,8 @@ class TestNetplanNetRendering:
                 """,
                 id="physical_gateway46",
             ),
-            # Asserts a netconf v1 with two gateways does not produce a
-            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            # Asserts a netconf v1 with a bond device and two gateways
+            # does not produce deprecated keys, `gateway{46}`, in Netplan v2
             pytest.param(
                 """
                 version: 1
@@ -6094,8 +6094,8 @@ class TestNetplanNetRendering:
                 """,
                 id="bond_gateway46",
             ),
-            # Asserts a netconf v1 with two gateways does not produce a
-            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            # Asserts a netconf v1 with a bridge device and two gateways
+            # does not produce deprecated keys, `gateway{46}`, in Netplan v2
             pytest.param(
                 """
                 version: 1
@@ -6131,8 +6131,8 @@ class TestNetplanNetRendering:
                 """,
                 id="bridge_gateway46",
             ),
-            # Asserts a netconf v1 with two gateways does not produce a
-            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            # Asserts a netconf v1 with a vlan device and two gateways
+            # does not produce deprecated keys, `gateway{46}`, in Netplan v2
             pytest.param(
                 """
                 version: 1
@@ -6167,8 +6167,8 @@ class TestNetplanNetRendering:
                 """,
                 id="vlan_gateway46",
             ),
-            # Asserts a netconf v1 with two gateways does not produce a
-            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            # Asserts a netconf v1 with a nameserver device and two gateways
+            # does not produce deprecated keys, `gateway{46}`, in Netplan v2
             pytest.param(
                 """
                 version: 1
@@ -6216,8 +6216,8 @@ class TestNetplanNetRendering:
                 """,
                 id="nameserver_gateway4",
             ),
-            # Asserts a netconf v1 with two gateways does not produce a
-            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            # Asserts a netconf v1 with two subnets with two gateways does
+            # not clash
             pytest.param(
                 """
                 version: 1
@@ -6226,13 +6226,50 @@ class TestNetplanNetRendering:
                     name: interface0
                     mac_address: '00:11:22:33:44:55'
                     subnets:
-                       - type: static
-                         address: 192.168.23.14/24
-                         gateway: 192.168.23.1
-                  - type: route
-                    destination: 192.168.24.0/24
-                    gateway: 192.168.24.1
-                    metric: 3
+                      - type: static
+                        address: 192.168.23.14/24
+                        gateway: 192.168.23.1
+                      - type: static
+                        address: 10.184.225.122
+                        routes:
+                          - network: 10.176.0.0
+                            gateway: 10.184.225.121
+                """,
+                """
+                network:
+                  version: 2
+                  ethernets:
+                    interface0:
+                      addresses:
+                      - 192.168.23.14/24
+                      - 10.184.225.122/24
+                      match:
+                        macaddress: 00:11:22:33:44:55
+                      routes:
+                      -   to: default
+                          via: 192.168.23.1
+                      -   to: 10.176.0.0/24
+                          via: 10.184.225.121
+                      set-name: interface0
+                """,
+                id="two_subnets_old_new_gateway46",
+            ),
+            # Asserts a netconf v1 with one subnet with two gateways does
+            # not clash
+            pytest.param(
+                """
+                version: 1
+                config:
+                  - type: physical
+                    name: interface0
+                    mac_address: '00:11:22:33:44:55'
+                    subnets:
+                      - type: static
+                        address: 192.168.23.14/24
+                        gateway: 192.168.23.1
+                        routes:
+                          - network: 192.167.225.122
+                            gateway: 192.168.23.1
                 """,
                 """
                 network:
@@ -6246,9 +6283,11 @@ class TestNetplanNetRendering:
                       routes:
                       -   to: default
                           via: 192.168.23.1
+                      -   to: 192.167.225.122/24
+                          via: 192.168.23.1
                       set-name: interface0
                 """,
-                id="route_gateway46",
+                id="one_subnet_old_new_gateway46",
             ),
         ],
     )

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -6051,7 +6051,204 @@ class TestNetplanNetRendering:
                         - to: default
                           via: 11.0.0.1
                 """,
-                id="one_gateway4",
+                id="physical_gateway46",
+            ),
+            # Asserts a netconf v1 with two gateways does not produce a
+            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            pytest.param(
+                """
+                version: 1
+                config:
+                  - type: bond
+                    name: bond0
+                    bond_interfaces:
+                    - eth0
+                    - eth1
+                    params: {}
+                    subnets:
+                      - type: static
+                        address: 192.168.23.14/27
+                        gateway: 192.168.23.1
+                      - type: static
+                        address: 11.0.0.11/24
+                        gateway: 11.0.0.1
+                """,
+                """
+                network:
+                  version: 2
+                  bonds:
+                    bond0:
+                      addresses:
+                      - 192.168.23.14/27
+                      - 11.0.0.11/24
+                      interfaces:
+                      - eth0
+                      - eth1
+                      routes:
+                        - to: default
+                          via: 192.168.23.1
+                        - to: default
+                          via: 11.0.0.1
+                    eth0: {}
+                    eth1: {}
+                """,
+                id="bond_gateway46",
+            ),
+            # Asserts a netconf v1 with two gateways does not produce a
+            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            pytest.param(
+                """
+                version: 1
+                config:
+                  - type: bridge
+                    name: bridge0
+                    bridge_interfaces:
+                    - eth0
+                    params: {}
+                    subnets:
+                      - type: static
+                        address: 192.168.23.14/27
+                        gateway: 192.168.23.1
+                      - type: static
+                        address: 11.0.0.11/24
+                        gateway: 11.0.0.1
+                """,
+                """
+                network:
+                  version: 2
+                  bridges:
+                    bridge0:
+                      addresses:
+                      - 192.168.23.14/27
+                      - 11.0.0.11/24
+                      interfaces:
+                      - eth0
+                      routes:
+                        - to: default
+                          via: 192.168.23.1
+                        - to: default
+                          via: 11.0.0.1
+                """,
+                id="bridge_gateway46",
+            ),
+            # Asserts a netconf v1 with two gateways does not produce a
+            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            pytest.param(
+                """
+                version: 1
+                config:
+                  - type: vlan
+                    name: vlan0
+                    vlan_link: eth0
+                    vlan_id: 101
+                    subnets:
+                      - type: static
+                        address: 192.168.23.14/27
+                        gateway: 192.168.23.1
+                      - type: static
+                        address: 11.0.0.11/24
+                        gateway: 11.0.0.1
+                """,
+                """
+                network:
+                  version: 2
+                  vlans:
+                    vlan0:
+                      addresses:
+                      - 192.168.23.14/27
+                      - 11.0.0.11/24
+                      id: 101
+                      link: eth0
+                      routes:
+                        - to: default
+                          via: 192.168.23.1
+                        - to: default
+                          via: 11.0.0.1
+                """,
+                id="vlan_gateway46",
+            ),
+            # Asserts a netconf v1 with two gateways does not produce a
+            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            pytest.param(
+                """
+                version: 1
+                config:
+                  - type: physical
+                    name: interface0
+                    mac_address: '00:11:22:33:44:55'
+                    subnets:
+                      - type: static
+                        address: 192.168.23.14/27
+                        gateway: 192.168.23.1
+                  - type: nameserver
+                    address:
+                      - 192.168.23.14/27
+                      - 11.0.0.11/24
+                    search:
+                    - exemplary
+                    subnets:
+                      - type: static
+                        address: 192.168.23.14/27
+                        gateway: 192.168.23.1
+                      - type: static
+                        address: 11.0.0.11/24
+                        gateway: 11.0.0.1
+                """,
+                """
+                network:
+                  version: 2
+                  ethernets:
+                    interface0:
+                      addresses:
+                      - 192.168.23.14/27
+                      match:
+                        macaddress: 00:11:22:33:44:55
+                      nameservers:
+                        addresses:
+                        - 192.168.23.14/27
+                        - 11.0.0.11/24
+                        search:
+                        - exemplary
+                      set-name: interface0
+                      routes:
+                        - to: default
+                          via: 192.168.23.1
+                """,
+                id="nameserver_gateway4",
+            ),
+            # Asserts a netconf v1 with two gateways does not produce a
+            # deprecated keys, `gateway4` and `gateway6` , in Netplan v2
+            pytest.param(
+                """
+                version: 1
+                config:
+                  - type: physical
+                    name: interface0
+                    mac_address: '00:11:22:33:44:55'
+                    subnets:
+                       - type: static
+                         address: 192.168.23.14/24
+                         gateway: 192.168.23.1
+                  - type: route
+                    destination: 192.168.24.0/24
+                    gateway: 192.168.24.1
+                    metric: 3
+                """,
+                """
+                network:
+                  version: 2
+                  ethernets:
+                    interface0:
+                      addresses:
+                      - 192.168.23.14/24
+                      match:
+                        macaddress: 00:11:22:33:44:55
+                      routes:
+                      -   to: default
+                          via: 192.168.23.1
+                      set-name: interface0
+                """,
+                id="route_gateway46",
             ),
         ],
     )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
network: Deprecate gateway{4,6} keys in network config v2

- Do not render gateway{4,6} when transforming from network config v1 to v2.
- Issue a warning if gateway{4,6} is present in network config v2.
  This warning is not issued if a passthrough to netplan is performed.

LP: #1992512
```

## Additional Context
<!-- If relevant -->
https://netplan.io/reference#default-routes

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly

## TODO:

- [x] Increase unit test coverage of v1 configs with different device types
