### PR TITLE
read-version: Make it compatible with bionic

### DIFF
--- a/tools/read-version
+++ b/tools/read-version
@@ -69,7 +69,9 @@ travis_ci_release_br = bool(
 is_release_branch_ci = bool(github_ci_release_br or travis_ci_release_br)
 
 if is_gitdir(_tdir) and which("git") and not is_release_branch_ci:
-    branch_name = tiny_p(["git", "branch", "--show-current"]).strip()
+    # This cmd can be simplified to ["git", "branch", "--show-current"]
+    # after bionic EOL.
+    branch_name = tiny_p(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
     if branch_name.startswith(f"upstream/{src_version}"):
         version = src_version
         version_long = None


### PR DESCRIPTION
`git branch --show-current` option flag is only available in focal+. Use `git rev-parse --abbrev-ref HEAD` instead.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
read-version: Make it compatible with bionic

`git branch --show-current` option flag is only available in focal+. Use `git rev-parse --abbrev-ref HEAD` instead.
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/1718

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
$ tox --recreate -e integration-tests -- --collect-only tests/integration_tests/
GLOB sdist-make: /home/ubuntu/cloud-init/setup.py
ERROR: invocation failed (exit code 1), logfile: /home/ubuntu/cloud-init/.tox/log/tox-0.log
ERROR: actionid: tox
msg: packaging
cmdargs: ['/usr/bin/python3', local('/home/ubuntu/cloud-init/setup.py'), 'sdist', '--formats=zip', '--dist-dir', local('/home/ubuntu/cloud-init/.tox/dist')]
env: None

Traceback (most recent call last):
  File "tools/read-version", line 72, in <module>
    branch_name = tiny_p(["git", "branch", "--show-current"]).strip()
  File "tools/read-version", line 17, in tiny_p
    cmd, stderr=stderr, stdin=None, universal_newlines=True
  File "/usr/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['git', 'branch', '--show-current']' returned non-zero exit status 129.
Traceback (most recent call last):
  File "setup.py", line 336, in <module>
    version=get_version(),
  File "setup.py", line 75, in get_version
    ver = subprocess.check_output(cmd)
  File "/usr/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 438, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/bin/python3', 'tools/read-version']' returned non-zero exit status 1.

ERROR: FAIL could not package project - v = InvocationError('/usr/bin/python3 /home/ubuntu/cloud-init/setup.py sdist --formats=zip --dist-dir /home/ubuntu/cloud-init/.tox/dist (see /home/ubuntu/cloud-init/.tox/log/tox-0.log)', 1)
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
