### PR TITLE
Realpath logfiles

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -4,6 +4,8 @@
 
 """Cloud-init apport interface"""
 
+import os
+
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.cmd.devel.logs import (
     INSTALLER_APPORT_FILES,
@@ -125,7 +127,8 @@ def attach_installer_files(report, ui=None):
     python modules.
     """
     for apport_file in INSTALLER_APPORT_FILES:
-        attach_file_if_exists(report, apport_file.path, apport_file.label)
+        realpath = os.path.realpath(apport_file.path)
+        attach_file_if_exists(report, realpath, apport_file.label)
 
 
 def attach_user_data(report, ui=None):
@@ -144,9 +147,8 @@ def attach_user_data(report, ui=None):
         if response:
             attach_file(report, user_data_file, "user_data.txt")
             for apport_file in INSTALLER_APPORT_SENSITIVE_FILES:
-                attach_file_if_exists(
-                    report, apport_file.path, apport_file.label
-                )
+                realpath = os.path.realpath(apport_file.path)
+                attach_file_if_exists(report, realpath, apport_file.label)
 
 
 def add_bug_tags(report):

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -145,7 +145,8 @@ def attach_user_data(report, ui=None):
         if response is None:
             raise StopIteration  # User cancelled
         if response:
-            attach_file(report, user_data_file, "user_data.txt")
+            realpath = os.path.realpath(user_data_file)
+            attach_file(report, realpath, "user_data.txt")
             for apport_file in INSTALLER_APPORT_SENSITIVE_FILES:
                 realpath = os.path.realpath(apport_file.path)
                 attach_file_if_exists(report, realpath, apport_file.label)

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -40,10 +40,10 @@ INSTALLER_APPORT_SENSITIVE_FILES = [
 INSTALLER_APPORT_FILES = [
     ApportFile("/var/log/installer/ubuntu_desktop_installer.log", "UdiLog"),
     ApportFile(
-        "/var/log/installer/subiquity-server-debug.log", "SubiquityLog"
+        "/var/log/installer/subiquity-server-debug.log", "SubiquityServerDebug"
     ),
     ApportFile(
-        "/var/log/installer/subiquity-client-debug.log", "SubiquityClientLog"
+        "/var/log/installer/subiquity-client-debug.log", "SubiquityClientDebug"
     ),
     ApportFile("/var/log/installer/curtin-install.log", "CurtinLog"),
     ApportFile(

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -29,6 +29,7 @@ Conan-Kudo
 cvstealth
 dankenigsberg
 david-caro
+dbungert
 ddymko
 dermotbradley
 dhensby


### PR DESCRIPTION
## Proposed Commit Message
```
apport: fix some data collection failures due to symlinks

Apport screens out symlinks, so we should send realpath() normalized
paths instead.
```

## Additional Context
In the LP: #[1993011](http://pad.lv/1993011) test bug, some failures related to symlinks can be seen.  Fix that.

## Test Steps
Run `ubuntu-bug` in a Subiquity live-server ephemeral environment with the affected version of cloud-init installed.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
