### PR TITLE
alpine.py: Add Alpine-specific manage_service function and update tests

### DIFF
--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -463,7 +463,12 @@ class TestNtp(FilesystemMockingTestCase):
 
             if distro == "alpine":
                 uses_systemd = False
-                expected_service_call = ["rc-service", service_name, "restart"]
+                expected_service_call = [
+                    "rc-service",
+                    "--nocolor",
+                    service_name,
+                    "restart",
+                ]
                 # _mock_ntp_client_config call above did not specify a client
                 # value and so it defaults to "ntp" which on Alpine Linux only
                 # supports servers and not pools.

--- a/tests/unittests/distros/test_manage_service.py
+++ b/tests/unittests/distros/test_manage_service.py
@@ -29,6 +29,25 @@ class TestManageService(CiTestCase):
         self.dist.manage_service("start", "myssh")
         m_subp.assert_called_with(["service", "myssh", "start"], capture=True)
 
+    @mock.patch.object(MockDistro, "uses_systemd", return_value=False)
+    @mock.patch("cloudinit.distros.subp.subp")
+    def test_manage_service_rcservice_initcmd(self, m_subp, m_sysd):
+        dist = _get_distro("alpine")
+        dist.init_cmd = ["rc-service", "--nocolor"]
+        dist.manage_service("start", "myssh")
+        m_subp.assert_called_with(
+            ["rc-service", "--nocolor", "myssh", "start"], capture=True
+        )
+
+    @mock.patch("cloudinit.distros.subp.subp")
+    def test_manage_service_alpine_rcupdate_cmd(self, m_subp):
+        dist = _get_distro("alpine")
+        dist.update_cmd = ["rc-update", "--nocolor"]
+        dist.manage_service("enable", "myssh")
+        m_subp.assert_called_with(
+            ["rc-update", "--nocolor", "add", "myssh"], capture=True
+        )
+
     @mock.patch("cloudinit.distros.subp.subp")
     def test_manage_service_rcctl_initcmd(self, m_subp):
         dist = _get_distro("openbsd")


### PR DESCRIPTION

## Proposed Commit Message

alpine.py: Add Alpine-specific manage_service function and update tests

```
Alpine uses OpenRC rather than Systemd. Add a
distro-specific manage_service in alpine.py and
update some affected testcases appropriately.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
