### PR TITLE
Srv6d openstack dualstack

### DIFF
--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -18,7 +18,7 @@ from cloudinit.sources.helpers import openstack
 LOG = logging.getLogger(__name__)
 
 # Various defaults/constants...
-DEF_MD_URL = "http://169.254.169.254"
+DEF_MD_URLS = ["http://[fe80::a9fe:a9fe]", "http://169.254.169.254"]
 DEFAULT_IID = "iid-dsopenstack"
 DEFAULT_METADATA = {
     "instance-id": DEFAULT_IID,
@@ -74,7 +74,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
         return mstr
 
     def wait_for_metadata_service(self):
-        urls = self.ds_cfg.get("metadata_urls", [DEF_MD_URL])
+        urls = self.ds_cfg.get("metadata_urls", DEF_MD_URLS)
         filtered = [x for x in urls if util.is_resolvable_url(x)]
         if set(filtered) != set(urls):
             LOG.debug(
@@ -85,7 +85,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             urls = filtered
         else:
             LOG.warning("Empty metadata url list! using default list")
-            urls = [DEF_MD_URL]
+            urls = DEF_MD_URLS
 
         md_urls = []
         url2base = {}
@@ -100,6 +100,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             urls=md_urls,
             max_wait=url_params.max_wait_seconds,
             timeout=url_params.timeout_seconds,
+            connect_synchronously=False,
         )
         if avail_url:
             LOG.debug("Using metadata source: '%s'", url2base[avail_url])

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -95,6 +95,7 @@ riedel
 rongz609
 s-makin
 SadeghHayeri
+SRv6d
 sarahwzadara
 scorpion44
 shaardie
@@ -128,4 +129,3 @@ xnox
 yangzz-97
 yawkat
 zhuzaifangxuele
-srv6d

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -128,3 +128,4 @@ xnox
 yangzz-97
 yawkat
 zhuzaifangxuele
+srv6d


### PR DESCRIPTION
## Proposed Commit Message
Add Support for IPv6 metadata to `DataSourceOpenStack`

```
Add Support for IPv6 metadata to `DataSourceOpenStack`

- Add openstack IPv6 metadata url `fe80::a9fe:a9fe`
- Enable requesting multiple metadata sources in parallel

This PR is very similar to #1160, reusing the provided `url_heper` logic.

LP: #1906849 
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
cloud-init clean --logs
cloud-init init --local
```
Will successfully request metadata over IPv6 from the openstack provider, given
it is reachable over IPv6. If not, or if IPv4 is faster it will be used instead.
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
