### PR TITLE
udevadm_settle should handle non-udev system grace…

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2933,6 +2933,10 @@ def mount_is_read_write(mount_point):
 
 def udevadm_settle(exists=None, timeout=None):
     """Invoke udevadm settle with optional exists and timeout parameters"""
+    if not subp.which("udevadm"):
+        # a distro, such as Alpine, may not have udev installed if
+        # it relies on a udev alternative such as mdev/mdevd.
+        return
     settle_cmd = ["udevadm", "settle"]
     if exists:
         # skip the settle if the requested path already exists

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -808,46 +808,60 @@ class TestBlkid(CiTestCase):
         )
 
 
+@mock.patch("cloudinit.subp.which")
 @mock.patch("cloudinit.subp.subp")
 class TestUdevadmSettle(CiTestCase):
-    def test_with_no_params(self, m_subp):
+    def test_with_no_params(self, m_which, m_subp):
         """called with no parameters."""
+        m_which.side_effect = lambda m: m in ("udevadm",)
         util.udevadm_settle()
         m_subp.called_once_with(mock.call(["udevadm", "settle"]))
 
-    def test_with_exists_and_not_exists(self, m_subp):
+    def test_udevadm_not_present(self, m_which, m_subp):
+        """where udevadm program does not exist should not invoke subp."""
+        m_which.side_effect = lambda m: m in ("",)
+        util.udevadm_settle()
+        m_subp.called_once_with(["which", "udevadm"])
+
+    def test_with_exists_and_not_exists(self, m_which, m_subp):
         """with exists=file where file does not exist should invoke subp."""
+        m_which.side_effect = lambda m: m in ("udevadm",)
         mydev = self.tmp_path("mydev")
         util.udevadm_settle(exists=mydev)
         m_subp.called_once_with(
             ["udevadm", "settle", "--exit-if-exists=%s" % mydev]
         )
 
-    def test_with_exists_and_file_exists(self, m_subp):
-        """with exists=file where file does exist should not invoke subp."""
+    def test_with_exists_and_file_exists(self, m_which, m_subp):
+        """with exists=file where file does exist should only invoke subp
+        once for 'which' call."""
+        m_which.side_effect = lambda m: m in ("udevadm",)
         mydev = self.tmp_path("mydev")
         util.write_file(mydev, "foo\n")
         util.udevadm_settle(exists=mydev)
-        self.assertIsNone(m_subp.call_args)
+        m_subp.called_once_with(["which", "udevadm"])
 
-    def test_with_timeout_int(self, m_subp):
+    def test_with_timeout_int(self, m_which, m_subp):
         """timeout can be an integer."""
+        m_which.side_effect = lambda m: m in ("udevadm",)
         timeout = 9
         util.udevadm_settle(timeout=timeout)
         m_subp.called_once_with(
             ["udevadm", "settle", "--timeout=%s" % timeout]
         )
 
-    def test_with_timeout_string(self, m_subp):
+    def test_with_timeout_string(self, m_which, m_subp):
         """timeout can be a string."""
+        m_which.side_effect = lambda m: m in ("udevadm",)
         timeout = "555"
         util.udevadm_settle(timeout=timeout)
-        m_subp.assert_called_once_with(
+        m_subp.called_once_with(
             ["udevadm", "settle", "--timeout=%s" % timeout]
         )
 
-    def test_with_exists_and_timeout(self, m_subp):
+    def test_with_exists_and_timeout(self, m_which, m_subp):
         """test call with both exists and timeout."""
+        m_which.side_effect = lambda m: m in ("udevadm",)
         mydev = self.tmp_path("mydev")
         timeout = "3"
         util.udevadm_settle(exists=mydev)
@@ -860,7 +874,8 @@ class TestUdevadmSettle(CiTestCase):
             ]
         )
 
-    def test_subp_exception_raises_to_caller(self, m_subp):
+    def test_subp_exception_raises_to_caller(self, m_which, m_subp):
+        m_which.side_effect = lambda m: m in ("udevadm",)
         m_subp.side_effect = subp.ProcessExecutionError("BOOM")
         self.assertRaises(subp.ProcessExecutionError, util.udevadm_settle)
 


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
udevadm_settle should handle non-udev system gracefully

Not all Linux systems use udev (and therefore udevadm). Specifically
an Alpine Linux system may have either udev (via "eudev" package)
or mdev, or mdevd installed.

Change the udev_settle function to check for the presence of the
udevadm binary before calling it - if it is not present then
silently exit the function.

This change will enable cloud-init to run on Alpine systems using
mdev/mdevd rather than udev.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ x ] I have updated or added any unit tests accordingly
 - [ x ] I have updated or added any documentation accordingly
