### PR TITLE
Support string replacement for nocloud seed path

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -49,6 +49,18 @@ class DataSourceNoCloud(sources.DataSource):
         devlist.sort(reverse=True)
         return devlist
 
+    def _var_sub_seed(self, seedfrom):
+        asset_tag = dmi.read_dmi_data("chassis-asset-tag")
+        if "_chassis-asset-tag_" in seedfrom and asset_tag:
+            seedfrom = seedfrom.replace("_chassis-asset-tag_", str(asset_tag))
+
+        serial_num = dmi.read_dmi_data("system-serial-number")
+        if "_system-serial-number_" in seedfrom and serial_num:
+            seedfrom = seedfrom.replace(
+                "_system-serial-number_", str(serial_num)
+            )
+        return seedfrom
+
     def _get_data(self):
         defaults = {
             "instance-id": "nocloud",
@@ -167,6 +179,8 @@ class DataSourceNoCloud(sources.DataSource):
             if not seedfound:
                 LOG.debug("Seed from %s not supported by %s", seedfrom, self)
                 return False
+            # check and replace instances of serial number, asset tags etc
+            seedfrom = self._var_sub_seed(seedfrom)
 
             # This could throw errors, but the user told us to do it
             # so if errors are raised, let them raise

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -50,20 +50,19 @@ class DataSourceNoCloud(sources.DataSource):
         return devlist
 
     def _var_sub_seed(self, seedfrom):
-        
-        if "_chassis-asset-tag_" in seedfrom:
-            asset_tag = dmi.read_dmi_data("chassis-asset-tag")
-            if not asset_tag:
-                asset_tag = ""
-            seedfrom = seedfrom.replace("_chassis-asset-tag_", str(asset_tag))
+        allowed_string_replacements = [
+            "chassis-asset-tag",
+            "system-serial-number",
+        ]
 
-        if "_system-serial-number_" in seedfrom:
-            serial_num = dmi.read_dmi_data("system-serial-number")
-            if not serial_num:
-                serial_num = ""
-            seedfrom = seedfrom.replace(
-                "_system-serial-number_", str(serial_num)
-            )
+        for substr in allowed_string_replacements:
+            substr_formatted = "_{}_".format(substr)
+
+        if substr_formatted in seedfrom:
+            dmi_data_lookup = dmi.read_dmi_data(substr)
+            if not dmi_data_lookup:
+                dmi_data_lookup = ""
+            seedfrom = seedfrom.replace(substr_formatted, str(dmi_data_lookup))
         return seedfrom
 
     def _get_data(self):

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -62,7 +62,10 @@ class DataSourceNoCloud(sources.DataSource):
                 dmi_data_lookup = dmi.read_dmi_data(substr)
                 if not dmi_data_lookup:
                     dmi_data_lookup = ""
-                seedfrom = seedfrom.replace(substr_formatted, str(dmi_data_lookup))
+                seedfrom = seedfrom.replace(
+                    substr_formatted,
+                    str(dmi_data_lookup),
+                )
         return seedfrom
 
     def _get_data(self):

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -58,11 +58,11 @@ class DataSourceNoCloud(sources.DataSource):
         for substr in allowed_string_replacements:
             substr_formatted = "_{}_".format(substr)
 
-        if substr_formatted in seedfrom:
-            dmi_data_lookup = dmi.read_dmi_data(substr)
-            if not dmi_data_lookup:
-                dmi_data_lookup = ""
-            seedfrom = seedfrom.replace(substr_formatted, str(dmi_data_lookup))
+            if substr_formatted in seedfrom:
+                dmi_data_lookup = dmi.read_dmi_data(substr)
+                if not dmi_data_lookup:
+                    dmi_data_lookup = ""
+                seedfrom = seedfrom.replace(substr_formatted, str(dmi_data_lookup))
         return seedfrom
 
     def _get_data(self):

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -50,12 +50,17 @@ class DataSourceNoCloud(sources.DataSource):
         return devlist
 
     def _var_sub_seed(self, seedfrom):
-        asset_tag = dmi.read_dmi_data("chassis-asset-tag")
-        if "_chassis-asset-tag_" in seedfrom and asset_tag:
+        
+        if "_chassis-asset-tag_" in seedfrom:
+            asset_tag = dmi.read_dmi_data("chassis-asset-tag")
+            if not asset_tag:
+                asset_tag = ""
             seedfrom = seedfrom.replace("_chassis-asset-tag_", str(asset_tag))
 
-        serial_num = dmi.read_dmi_data("system-serial-number")
-        if "_system-serial-number_" in seedfrom and serial_num:
+        if "_system-serial-number_" in seedfrom:
+            serial_num = dmi.read_dmi_data("system-serial-number")
+            if not serial_num:
+                serial_num = ""
             seedfrom = seedfrom.replace(
                 "_system-serial-number_", str(serial_num)
             )


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Support string replacement for nocloud seed path

allows the use of serial numbers / asset tags as a variable in seed 
paths .It will replace `_chassis-asset-tag_` or 
`_system-serial-number_` with the related system data.

LP: #1994980 
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
