### PR TITLE
Fix inconsistency between comment and statement

### DIFF
--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -1,6 +1,6 @@
 #cloud-config
 # Add groups to the system
-# The following example adds the ubuntu group with members 'root' and 'sys'
+# The following example adds the 'admingroup' group with members 'root' and 'sys'
 # and the empty group cloud-users.
 groups:
   - admingroup: [root,sys]


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix inconsistency between comment and statement

Line 3 was stating that the "ubuntu" group is created while the yml indicates "sysadmin"
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

N/A

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 -  My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html) (N/A)
 -  I have updated or added any unit tests accordingly (N/A)
 - [X] I have updated or added any documentation accordingly
