### PR TITLE
apport: address new curtin log and config locations

### DIFF
--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -46,10 +46,30 @@ INSTALLER_APPORT_FILES = [
         "/var/log/installer/subiquity-client-debug.log", "SubiquityClientDebug"
     ),
     ApportFile("/var/log/installer/curtin-install.log", "CurtinLog"),
+    # Legacy single curtin config < 22.1
     ApportFile(
-        "/var/log/installer/subiquity-curtin-install.cfg", "CurtinConfig"
+        "/var/log/installer/subiquity-curtin-install.conf",
+        "CurtinInstallConfig",
     ),
+    ApportFile(
+        "/var/log/installer/curtin-install/subiquity-initial.conf",
+        "CurtinConfigInitial",
+    ),
+    ApportFile(
+        "/var/log/installer/curtin-install/subiquity-curthooks.conf",
+        "CurtinConfigCurtHooks",
+    ),
+    ApportFile(
+        "/var/log/installer/curtin-install/subiquity-extract.conf",
+        "CurtinConfigExtract",
+    ),
+    ApportFile(
+        "/var/log/installer/curtin-install/subiquity-partitioning.conf",
+        "CurtinConfigPartitioning",
+    ),
+    # Legacy curtin < 22.1 curtin error tar path
     ApportFile("/var/log/installer/curtin-error-logs.tar", "CurtinError"),
+    ApportFile("/var/log/installer/curtin-errors.tar", "CurtinError"),
     ApportFile("/var/log/installer/block/probe-data.json", "ProbeData"),
 ]
 


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
apport: address new curtin log and config locations

Retain legacy curtin log and config paths for Bionic, Focal, Jammy.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
