### PR TITLE
tests: Ignore unsupported lxd project keys

### DIFF
--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -201,6 +201,10 @@ def validate_preseed_storage_pools(client, preseed_cfg):
 
 
 def validate_preseed_projects(client: IntegrationInstance, preseed_cfg):
+    # Support for projects by lxd init --preseed was added in lxd 4.12
+    # https://discuss.linuxcontainers.org/t/lxd-4-12-has-been-released/10424#projects-now-supported-by-lxd-init-dump-and-preseed-9
+    if client.instance.series in {"bionic", "focal"}:
+        return
     for src_project in preseed_cfg.get("projects", []):
         proj_name = src_project["name"]
         proj_result = client.execute(f"lxc project show {proj_name}")
@@ -211,12 +215,6 @@ def validate_preseed_projects(client: IntegrationInstance, preseed_cfg):
             client.execute(f"lxc project show {src_project['name']}")
         )
         project.pop("used_by", None)
-
-        # `features.networks` was introduced in lxd 4.6 . More info:
-        # https://discuss.linuxcontainers.org/t/lxd-4-6-has-been-released/8981
-        if client.instance.series in {"bionic", "focal"}:
-            src_project["config"].pop("features.networks", None)
-            project["config"].pop("features.networks", None)
 
         # `features.storage.buckets` was introduced in lxd 5.5 . More info:
         # https://discuss.linuxcontainers.org/t/lxd-5-5-has-been-released/14899


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: Restrict lxd tests to applicable series

Some lxd init --preseed features are only available in specific 
lxd versions.
The use of projects within the preseed is lxd >= 4.12
and `features.storage.buckets` is lxd >= 5.5 

Adapt the tests to perform the assertions only in series that
contain the applicable lxd versions.
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/1789

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
#!/bin/bash -eux

function run_test {
	local SERIES=$1
	local PLATFORM=$2
	LOG_FN="test_preseed_${PLATFORM}_${SERIES}.log"
	CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_PLATFORM=$PLATFORM CLOUD_INIT_OS_IMAGE=$SERIES tox -e integration-tests -- -vv tests/integration_tests/modules/test_lxd.py | tee $LOG_FN
}

for PLATFORM in lxd_container lxd_vm
do
	for SERIES in bionic focal jammy kinetic
	do
		run_test $SERIES $PLATFORM
	done
done
```


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
