### PR TITLE
grub: clarify docs

### DIFF
--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -21,10 +21,9 @@ from cloudinit.subp import ProcessExecutionError
 
 MODULE_DESCRIPTION = """\
 Configure which device is used as the target for grub installation. This module
-should work correctly by default without any user configuration. It can be
-enabled/disabled using the ``enabled`` config key in the ``grub_dpkg`` config
-dict. The global config key ``grub-dpkg`` is an alias for ``grub_dpkg``. If no
-installation device is specified this module will execute grub-probe to
+can be enabled/disabled using the ``enabled`` config key in the ``grub_dpkg``
+config dict. The global config key ``grub-dpkg`` is an alias for ``grub_dpkg``.
+If no installation device is specified this module will execute grub-probe to
 determine which disk the /boot directory is associated with.
 
 The value which is placed into the debconf database is in the format which the


### PR DESCRIPTION
```
cc_grub: reword docs for clarity
```
This change may seem excessively pedantic, however I did misunderstand this sentence myself while reading the docs and it does seem contradictory to me. I'm open to other suggestions to improve these docs. This change makes it clearer for me.


Drop this sentence for clarity:

> This module should work correctly by default without any user configuration.

User configuration is in fact required for this module to run (`grub_dpkg: {enabled: true}`), which leaves this statement in conflict[1] with the sentence it precedes:

> It can be enabled/disabled using the ``enabled`` config key in the ``grub_dpkg`` config dict.


I think the intention behind this statement is covered in this sentance:

> If no installation device is specified this module will execute grub-probe to determine which disk the /boot directory is associated with.

I think this is just a matter of reading the sentence knowing what the module is supposed to do vs reading it trying to figure out what it's supposed to do.

[1] Alternatively if you treat this statement as correct it leads to an interpretation where "work correctly" means "do nothing", which accidentally makes sense in the context of booting instances on clouds[2], but doesn't make sense in the context of using this module and installing an operating system.
[2] This interpretation is what led to [this comment](https://bugs.launchpad.net/cloud-init/+bug/1993503/comments/7) "cloud-init will not run this module unless configured to do so"