### PR TITLE
Stop using devices endpoint for LXD network config

### DIFF
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -73,13 +73,16 @@ def generate_network_config(
     nics: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Return network config V1 dict representing instance network config."""
-    if not nics:
+    # TODO: The original intent of this function was to use the nics retrieved
+    # from LXD's devices endpoint to determine the primary nic and write
+    # that out to network config. However, for LXD VMs, the device name
+    # may differ from the interface name in the VM, so we'll instead rely
+    # on our fallback nic code. Once LXD's devices endpoint grows the
+    # ability to provide a MAC address, we should rely on that information
+    # rather than just the glorified guessing that we're doing here.
+    primary_nic = find_fallback_nic()
+    if not primary_nic:
         primary_nic = _get_fallback_interface_name()
-    elif len(nics) > 1:
-        fallback_nic = find_fallback_nic()
-        primary_nic = nics[0] if fallback_nic not in nics else fallback_nic
-    else:
-        primary_nic = nics[0]
 
     return {
         "version": 1,

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -81,8 +81,19 @@ def generate_network_config(
     # ability to provide a MAC address, we should rely on that information
     # rather than just the glorified guessing that we're doing here.
     primary_nic = find_fallback_nic()
-    if not primary_nic:
+    if primary_nic:
+        LOG.debug(
+            "LXD datasource generating network from discovered active"
+            " device: %s",
+            primary_nic,
+        )
+    else:
         primary_nic = _get_fallback_interface_name()
+        LOG.debug(
+            "LXD datasource generating network from systemd-detect-virt"
+            " platform default device: %s",
+            primary_nic,
+        )
 
     return {
         "version": 1,
@@ -244,11 +255,6 @@ class DataSourceLXD(sources.DataSource):
                         for k, v in self._crawled_metadata["devices"].items()
                         if v["type"] == "nic"
                     ]
-                    LOG.debug(
-                        "LXD datasource generating network config using "
-                        "devices: %s",
-                        ", ".join(devices),
-                    )
                     self._network_config = generate_network_config(devices)
         if self._network_config == sources.UNSET:
             # We know nothing about network, so setup fallback

--- a/tests/integration_tests/datasources/test_lxd_hotplug.py
+++ b/tests/integration_tests/datasources/test_lxd_hotplug.py
@@ -56,8 +56,9 @@ def _prefer_lxd_datasource_over_nocloud(client: IntegrationInstance):
     client.restart()
 
 
+# TODO: Once LXD adds MACs to the devices endpoint, support LXD VMs here
+# Currently the names are too unpredictable to be worth testing on VMs.
 @pytest.mark.lxd_container
-@pytest.mark.lxd_vm
 @pytest.mark.user_data(USER_DATA)
 class TestLxdHotplug:
     @pytest.fixture(autouse=True, scope="class")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Stop using devices endpoint for LXD network config

When using the LXD datasource, we switched to using the "devices"
endpoint to configure network config. On LXD VMs, this endpoint can
contain incorrect device names, so instead switch to setting up the
fallback NIC until the devices endpoint can surface MAC addresses.
```

## Additional Context
<!-- If relevant -->

## Test Steps
The lxd integration tests (`test_lxd.py` `test_lxd_hotplug.py` `test_lxd_discovery.py`) should cover all cases.
