### PR TITLE
ansible: s/-/_/g

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -224,7 +224,11 @@ def validate_config(cfg: dict):
 
 def filter_args(cfg: dict) -> dict:
     """remove boolean false values"""
-    return {key.replace("_", "-"): value for (key, value) in cfg.items() if value is not False}
+    return {
+        key.replace("_", "-"): value
+        for (key, value) in cfg.items()
+        if value is not False
+    }
 
 
 def run_ansible_pull(pull: AnsiblePull, cfg: dict):

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -39,20 +39,20 @@ meta: MetaSchema = {
         dedent(
             """\
             ansible:
-              install-method: distro
+              install_method: distro
               pull:
                 url: "https://github.com/holmanb/vmboot.git"
-                playbook-name: ubuntu.yml
+                playbook_name: ubuntu.yml
             """
         ),
         dedent(
             """\
             ansible:
-              package-name: ansible-core
-              install-method: pip
+              package_name: ansible-core
+              install_method: pip
               pull:
                 url: "https://github.com/holmanb/vmboot.git"
-                playbook-name: ubuntu.yml
+                playbook_name: ubuntu.yml
             """
         ),
     ],
@@ -160,13 +160,13 @@ def handle(
 ) -> None:
 
     ansible_cfg: dict = cfg.get("ansible", {})
-    ansible_user = ansible_cfg.get("run-user")
-    install_method = ansible_cfg.get("install-method")
+    ansible_user = ansible_cfg.get("run_user")
+    install_method = ansible_cfg.get("install_method")
     setup_controller = ansible_cfg.get("setup_controller")
 
     galaxy_cfg = ansible_cfg.get("galaxy")
     pull_cfg = ansible_cfg.get("pull")
-    package_name = ansible_cfg.get("package-name", "")
+    package_name = ansible_cfg.get("package_name", "")
 
     if ansible_cfg:
         ansible: AnsiblePull
@@ -196,14 +196,14 @@ def handle(
 
 def validate_config(cfg: dict):
     required_keys = (
-        "install-method",
-        "package-name",
+        "install_method",
+        "package_name",
     )
     for key in required_keys:
         if not get_cfg_by_path(cfg, key):
             raise ValueError(f"Missing required key '{key}' from {cfg}")
     if cfg.get("pull"):
-        for key in "pull/url", "pull/playbook-name":
+        for key in "pull/url", "pull/playbook_name":
             if not get_cfg_by_path(cfg, key):
                 raise ValueError(f"Missing required key '{key}' from {cfg}")
 
@@ -217,18 +217,18 @@ def validate_config(cfg: dict):
         ):
             raise ValueError(f"Missing required key from {controller_cfg}")
 
-    install = cfg["install-method"]
+    install = cfg["install_method"]
     if install not in ("pip", "distro"):
         raise ValueError("Invalid install method {install}")
 
 
 def filter_args(cfg: dict) -> dict:
     """remove boolean false values"""
-    return {key: value for (key, value) in cfg.items() if value is not False}
+    return {key.replace("_", "-"): value for (key, value) in cfg.items() if value is not False}
 
 
 def run_ansible_pull(pull: AnsiblePull, cfg: dict):
-    playbook_name: str = cfg.pop("playbook-name")
+    playbook_name: str = cfg.pop("playbook_name")
 
     v = pull.get_version()
     if not v:
@@ -266,8 +266,8 @@ def ansible_controller(cfg: dict, ansible: AnsiblePull):
             ["git", "clone", repository["source"], repository["path"]]
         )
     for args in cfg.get("run_ansible", []):
-        playbook_dir = args.pop("playbook-dir")
-        playbook_name = args.pop("playbook-name")
+        playbook_dir = args.pop("playbook_dir")
+        playbook_name = args.pop("playbook_name")
         command = [
             "ansible-playbook",
             playbook_name,

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -448,7 +448,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "install-method": {
+            "install_method": {
               "type": "string",
               "default": "distro",
               "enum": [
@@ -457,9 +457,9 @@
               ],
               "description": "The type of installation for ansible. It can be one of the following values:\n\n - ``distro``\n - ``pip``"
             },
-            "run-user": {
+            "run_user": {
               "type": "string",
-              "description": "User to run module commands as. If install-method: pip, the pip install runs as this user as well."
+              "description": "User to run module commands as. If install_method: pip, the pip install runs as this user as well."
             },
             "ansible_config": {
               "description": "Sets the ANSIBLE_CONFIG environment variable. If set, overrides default config.",
@@ -492,23 +492,23 @@
                   "type": "array",
                   "items": {
                     "properties": {
-                      "playbook-name": {
+                      "playbook_name": {
                         "type": "string"
                       },
-                      "playbook-dir": {
+                      "playbook_dir": {
                         "type": "string"
                       },
-                      "become-password-file": {
+                      "become_password_file": {
                         "type": "string"
                       },
-                      "connection-password-file": {
+                      "connection_password_file": {
                         "type": "string"
                       },
-                      "list-hosts": {
+                      "list_hosts": {
                         "type": "boolean",
                         "default": false
                       },
-                      "syntax-check": {
+                      "syntax_check": {
                         "type": "boolean",
                         "default": false
                       },
@@ -516,10 +516,10 @@
                         "type": "number",
                         "minimum": 0
                       },
-                      "vault-id": {
+                      "vault_id": {
                         "type": "string"
                       },
-                      "vault-password-file": {
+                      "vault_password_file": {
                         "type": "string"
                       },
                       "background": {
@@ -534,7 +534,7 @@
                         "type": "boolean",
                         "default": false
                       },
-                      "module-path": {
+                      "module_path": {
                         "type": "string"
                       },
                       "poll": {
@@ -544,7 +544,7 @@
                       "args": {
                         "type": "string"
                       },
-                      "extra-vars": {
+                      "extra_vars": {
                         "type": "string"
                       },
                       "forks": {
@@ -554,19 +554,19 @@
                       "inventory": {
                         "type": "string"
                       },
-                      "scp-extra-args": {
+                      "scp_extra_args": {
                         "type": "string"
                       },
-                      "sftp-extra-args": {
+                      "sftp_extra_args": {
                         "type": "string"
                       },
-                      "private-key": {
+                      "private_key": {
                         "type": "string"
                       },
                       "connection": {
                         "type": "string"
                       },
-                      "module-name": {
+                      "module_name": {
                         "type": "string"
                       },
                       "sleep": {
@@ -575,7 +575,7 @@
                       "tags": {
                         "type": "string"
                       },
-                      "skip-tags": {
+                      "skip_tags": {
                         "type": "string"
                       }
                     }
@@ -602,19 +602,19 @@
                 }
               }
             },
-            "package-name": {
+            "package_name": {
               "type": "string",
               "default": "ansible"
             },
             "pull": {
               "required": [
                 "url",
-                "playbook-name"
+                "playbook_name"
               ],
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "accept-host-key": {
+                "accept_host_key": {
                   "type": "boolean",
                   "default": false
                 },
@@ -630,22 +630,22 @@
                   "type": "boolean",
                   "default": false
                 },
-                "ssh-common-args": {
+                "ssh_common_args": {
                   "type": "string"
                 },
-                "scp-extra-args": {
+                "scp_extra_args": {
                   "type": "string"
                 },
-                "sftp-extra-args": {
+                "sftp_extra_args": {
                   "type": "string"
                 },
-                "private-key": {
+                "private_key": {
                   "type": "string"
                 },
                 "checkout": {
                   "type": "string"
                 },
-                "module-path": {
+                "module_path": {
                   "type": "string"
                 },
                 "timeout": {
@@ -657,13 +657,13 @@
                 "connection": {
                   "type": "string"
                 },
-                "vault-id": {
+                "vault_id": {
                   "type": "string"
                 },
-                "vault-password-file": {
+                "vault_password_file": {
                   "type": "string"
                 },
-                "module-name": {
+                "module_name": {
                   "type": "string"
                 },
                 "sleep": {
@@ -672,10 +672,10 @@
                 "tags": {
                   "type": "string"
                 },
-                "skip-tags": {
+                "skip_tags": {
                   "type": "string"
                 },
-                "playbook-name": {
+                "playbook_name": {
                   "type": "string"
                 }
               }

--- a/doc/examples/cloud-config-ansible-controller.txt
+++ b/doc/examples/cloud-config-ansible-controller.txt
@@ -42,9 +42,9 @@ lxd:
 # [2] https://github.com/holmanb/ansible-lxd-public
 #
 ansible:
-  install-method: pip
-  package-name: ansible
-  run-user: ansible
+  install_method: pip
+  package_name: ansible
+  run_user: ansible
   galaxy:
     actions:
       - ["ansible-galaxy", "collection", "install", "community.general"]
@@ -54,17 +54,17 @@ ansible:
       - path: /home/ansible/my-repo/
         source: git@github.com:holmanb/ansible-lxd-private.git
     run_ansible:
-      - playbook-dir: /home/ansible/my-repo
-        playbook-name: start-lxd.yml
+      - playbook_dir: /home/ansible/my-repo
+        playbook_name: start-lxd.yml
         timeout: 120
         forks: 1
-        private-key: /home/ansible/.ssh/id_rsa
-      - playbook-dir: /home/ansible/my-repo
-        playbook-name: configure-lxd.yml
-        become-user: ansible
+        private_key: /home/ansible/.ssh/id_rsa
+      - playbook_dir: /home/ansible/my-repo
+        playbook_name: configure-lxd.yml
+        become_user: ansible
         timeout: 120
         forks: 1
-        private-key: /home/ansible/.ssh/id_rsa
+        private_key: /home/ansible/.ssh/id_rsa
         inventory: new_ansible_hosts
 
 # Write a deploy key to the filesystem for ansible.

--- a/doc/examples/cloud-config-ansible-pull.txt
+++ b/doc/examples/cloud-config-ansible-pull.txt
@@ -8,7 +8,7 @@ packages_upgrade: true
 packages:
   - git
 ansible:
-  install-method: pip
+  install_method: pip
   pull:
     url: "https://github.com/holmanb/vmboot.git"
-    playbook-name: ubuntu.yml
+    playbook_name: ubuntu.yml

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -87,14 +87,14 @@ runcmd:
 INSTALL_METHOD = """
 ansible:
   ansible_config: /etc/ansible/ansible.cfg
-  install-method: {method}
-  package-name: {package}
+  install_method: {method}
+  package_name: {package}
   galaxy:
     actions:
      - ["ansible-galaxy", "collection", "install", "community.grafana"]
   pull:
     url: "http://0.0.0.0:8000/"
-    playbook-name: ubuntu.yml
+    playbook_name: ubuntu.yml
     full: true
 """
 

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -45,8 +45,8 @@ pip_version = dedent(
 
 CFG_CTRL = {
     "ansible": {
-        "install-method": "distro",
-        "package-name": "ansible-core",
+        "install_method": "distro",
+        "package_name": "ansible-core",
         "ansible_config": "/etc/ansible/ansible.cfg",
         "galaxy": {
             "actions": [["ansible-galaxy", "install", "debops.apt"]],
@@ -68,23 +68,23 @@ CFG_CTRL = {
             ],
             "run_ansible": [
                 {
-                    "playbook-dir": "/home/ansible/my-repo",
-                    "playbook-name": "start-lxd.yml",
+                    "playbook_dir": "/home/ansible/my-repo",
+                    "playbook_name": "start-lxd.yml",
                     "timeout": 120,
                     "forks": 1,
-                    "private-key": "/home/ansible/.ssh/id_rsa",
+                    "private_key": "/home/ansible/.ssh/id_rsa",
                 },
                 {
-                    "playbook-name": "configure-lxd.yml",
-                    "become-user": "ansible",
+                    "playbook_name": "configure-lxd.yml",
+                    "become_user": "ansible",
                     "timeout": 120,
                     "forks": 1,
-                    "private-key": "/home/ansible/.ssh/id_rsa",
-                    "become-password-file": "/path/less/traveled",
+                    "private_key": "/home/ansible/.ssh/id_rsa",
+                    "become_password_file": "/path/less/traveled",
                     "connection-password-file": "/path/more/traveled",
-                    "module-path": "/path/head/traveled",
-                    "vault-password-file": "/path/tail/traveled",
-                    "playbook-dir": "/path/to/nowhere",
+                    "module_path": "/path/head/traveled",
+                    "vault_password_file": "/path/tail/traveled",
+                    "playbook_dir": "/path/to/nowhere",
                     "inventory": "/a/file/as/well",
                 },
             ],
@@ -94,46 +94,46 @@ CFG_CTRL = {
 
 CFG_FULL_PULL = {
     "ansible": {
-        "install-method": "distro",
-        "package-name": "ansible-core",
+        "install_method": "distro",
+        "package_name": "ansible-core",
         "ansible_config": "/etc/ansible/ansible.cfg",
         "galaxy": {
             "actions": [["ansible-galaxy", "install", "debops.apt"]],
         },
         "pull": {
             "url": "https://github/holmanb/vmboot",
-            "playbook-name": "arch.yml",
-            "accept-host-key": True,
+            "playbook_name": "arch.yml",
+            "accept_host_key": True,
             "clean": True,
             "full": True,
             "diff": False,
-            "ssh-common-args": "-y",
-            "scp-extra-args": "-l",
-            "sftp-extra-args": "-f",
+            "ssh_common_args": "-y",
+            "scp_extra_args": "-l",
+            "sftp_extra_args": "-f",
             "checkout": "tree",
-            "module-path": "~/.ansible/plugins/modules:"
+            "module_path": "~/.ansible/plugins/modules:"
             "/usr/share/ansible/plugins/modules",
             "timeout": "10",
-            "vault-id": "me",
+            "vault_id": "me",
             "connection": "smart",
-            "vault-password-file": "/path/to/file",
-            "module-name": "git",
+            "vault_password_file": "/path/to/file",
+            "module_name": "git",
             "sleep": "1",
             "tags": "cumulus",
-            "skip-tags": "cisco",
-            "private-key": "{nope}",
+            "skip_tags": "cisco",
+            "private_key": "{nope}",
         },
     }
 }
 
 CFG_MINIMAL = {
     "ansible": {
-        "install-method": "pip",
-        "package-name": "ansible",
-        "run-user": "ansible",
+        "install_method": "pip",
+        "package_name": "ansible",
+        "run_user": "ansible",
         "pull": {
             "url": "https://github/holmanb/vmboot",
-            "playbook-name": "ubuntu.yml",
+            "playbook_name": "ubuntu.yml",
         },
     }
 }
@@ -151,10 +151,10 @@ class TestSchema:
             param(
                 {
                     "ansible": {
-                        "install-method": "distro",
+                        "install_method": "distro",
                         "pull": {
                             "url": "https://github/holmanb/vmboot",
-                            "playbook-name": "centos.yml",
+                            "playbook_name": "centos.yml",
                             "dance": "bossa nova",
                         },
                     }
@@ -175,10 +175,10 @@ class TestSchema:
             param(
                 {
                     "ansible": {
-                        "install-method": "true",
+                        "install_method": "true",
                         "pull": {
                             "url": "https://github/holmanb/vmboot",
-                            "playbook-name": "debian.yml",
+                            "playbook_name": "debian.yml",
                         },
                     }
                 },
@@ -188,9 +188,9 @@ class TestSchema:
             param(
                 {
                     "ansible": {
-                        "install-method": "pip",
+                        "install_method": "pip",
                         "pull": {
-                            "playbook-name": "fedora.yml",
+                            "playbook_name": "fedora.yml",
                         },
                     }
                 },
@@ -200,13 +200,13 @@ class TestSchema:
             param(
                 {
                     "ansible": {
-                        "install-method": "pip",
+                        "install_method": "pip",
                         "pull": {
                             "url": "gophers://encrypted-gophers/",
                         },
                     }
                 },
-                "'playbook-name' is a required property",
+                "'playbook_name' is a required property",
                 id="require-url",
             ),
         ),
@@ -257,10 +257,10 @@ class TestAnsible:
             (
                 {
                     "ansible": {
-                        "package-name": "ansible-core",
-                        "install-method": "distro",
+                        "package_name": "ansible-core",
+                        "install_method": "distro",
                         "pull": {
-                            "playbook-name": "ubuntu.yml",
+                            "playbook_name": "ubuntu.yml",
                         },
                     }
                 },
@@ -297,7 +297,7 @@ class TestAnsible:
                 cc_ansible.handle("", cfg, get_cloud(), None, None)
         else:
             cloud = get_cloud(mocked_distro=True)
-            install = cfg["ansible"]["install-method"]
+            install = cfg["ansible"]["install_method"]
             cc_ansible.handle("", cfg, cloud, None, None)
             if install == "distro":
                 cloud.distro.install_packages.assert_called_once()
@@ -370,7 +370,7 @@ class TestAnsible:
     )
     def test_ansible_pull(self, m_subp1, m_subp2, m_which, cfg, expected):
         """verify expected ansible invocation from userdata config"""
-        pull_type = cfg["ansible"]["install-method"]
+        pull_type = cfg["ansible"]["install_method"]
         distro = get_cloud().distro
         with mock.patch.dict(M_PATH + "os.environ", clear=True):
             ansible_pull = (


### PR DESCRIPTION
```
ansible: standardize schema keys

The cloud-config schema definition standardizes on underscores
instead of hyphenated key names. This makes for standard config keys
and reduces the burden of supporting aliases for either hyphenated or
underscore-delimited keys.
```
Note:
-----
The `.replace("_", "-")` is because there was previously almost[1] a 1:1 mapping between schema keys and ansible arguments.

[1] "almost" because boolean values are indicated be the absence or presence of a `--$FLAGNAME`