### PR TITLE
ci: run json tool on 22.04 rather than 20.04

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -52,11 +52,8 @@ jobs:
   schema-format:
     strategy:
       fail-fast: false
-      matrix:
-        lint-with:
-          - {tip-versions: true, os: ubuntu-latest}
     name: Check json format
-    runs-on: ${{ matrix.lint-with.os }}
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout #1"
         uses: actions/checkout@v3.0.0

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -460,7 +460,7 @@
             "run-user": {
               "type": "string",
               "description": "User to run module commands as. If install-method: pip, the pip install runs as this user as well."
-			},
+            },
             "ansible_config": {
               "description": "Sets the ANSIBLE_CONFIG environment variable. If set, overrides default config.",
               "type": "string"
@@ -472,7 +472,10 @@
                 "repositories": {
                   "type": "array",
                   "items": {
-                    "required": ["path", "source"],
+                    "required": [
+                      "path",
+                      "source"
+                    ],
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {

--- a/tools/check_json_format.sh
+++ b/tools/check_json_format.sh
@@ -5,8 +5,7 @@
 # requires python 3.9 for --indent
 #
 file=$1
-before=$(cat "$file")
-python3 -m json.tool --indent 2 "$file" "$file"
-after=$(cat "$file")
-test "$before" = "$after"
-exit $?
+before=$(cat "$file") &&
+	python3 -m json.tool --indent 2 "$file" "$file" &&
+	after=$(cat "$file") &&
+	test "$before" = "$after"


### PR DESCRIPTION
```
ci: run json format test on 22.04
```

Note that [tests here passed](https://github.com/canonical/cloud-init/actions/runs/3440237672/jobs/5738474966) despite running on a version of Ubuntu that didn't support the --indent flag on python's json.tool. This change fixes the ci setup and also prevents silent failure.