### PR TITLE
tests: replace missed ansible install-method with underscore

### DIFF
--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -269,7 +269,7 @@ class TestAnsible:
             (
                 {
                     "ansible": {
-                        "install-method": "pip",
+                        "install_method": "pip",
                         "pull": {
                             "url": "https://github/holmanb/vmboot",
                         },


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: replace ansible install-method with underscore

Also support test runs in environments without pip
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
