### PR TITLE
tests: test_lxd assert features.storage.buckets when present

### DIFF
--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -218,14 +218,8 @@ def validate_preseed_projects(client: IntegrationInstance, preseed_cfg):
 
         # `features.storage.buckets` was introduced in lxd 5.5 . More info:
         # https://discuss.linuxcontainers.org/t/lxd-5-5-has-been-released/14899
-        if ImageSpecification.from_os_image().release in (
-            "bionic",
-            "focal",
-            "jammy",
-        ):
-            src_project["config"].pop("features.storage.buckets", None)
-            project["config"].pop("features.storage.buckets", None)
-
+        if "features.storage.buckets" in project["config"]:
+            assert "true" == project["config"].pop("features.storage.buckets")
         assert project == src_project
 
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: test_lxd assert features.storage.buckets when present

LXD v 5.5 introduces a features.storage.buckets default.
Assert features.storage.buckets  when host provides this key.
Cope with versions that do not surface this config.
```

## Additional Context
<!-- If relevant -->
Failed jenkins jobs on kinetic indicate this problem
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-azure/121/testReport/junit/tests.integration_tests.modules/test_lxd/test_storage_preseed_btrfs/

## Test Steps
```
make deb
CLOUD_INIT_PLATFORM=azure CLOUD_INIT_OS_IMAGE=kinetic CLOUD_INIT_CLOUD_INIT_SOURCE=./cloud-init_22.3-107-g661b852c-1~bddeb_all.deb tox -e integration-tests tests/integration_tests/modules/test_lxd.py::test_storage_preseed_btrfs
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
