### PR TITLE
test: fix pro integration test

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -450,7 +450,7 @@ def _auto_attach(ua_section: dict):
                 " ubuntu_advantage: enable and enable_beta"
             )
     except UserFacingError as ex:
-        msg = f"Error during `full_auto_attach`: {ex}"
+        msg = f"Error during `full_auto_attach`: {ex.msg}"
         LOG.error(msg)
         raise RuntimeError(msg) from ex
 

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -21,7 +21,7 @@ ATTACH_FALLBACK = """\
 #cloud-config
 ubuntu_advantage:
   features:
-    disable_auto_attach: True
+    disable_auto_attach: true
   token: {token}
 """
 
@@ -37,7 +37,7 @@ PRO_AUTO_ATTACH_DISABLED = """\
 #cloud-config
 ubuntu_advantage:
   features:
-    disable_auto_attach: True
+    disable_auto_attach: true
 """
 
 PRO_DAEMON_DISABLED = """\
@@ -45,7 +45,7 @@ PRO_DAEMON_DISABLED = """\
 # Disable UA daemon (only needed in GCE)
 ubuntu_advantage:
   features:
-    disable_auto_attach: True
+    disable_auto_attach: true
 bootcmd:
 - sudo systemctl mask ubuntu-advantage.service
 """
@@ -110,17 +110,18 @@ def get_services_status(client: IntegrationInstance) -> dict:
 
 @pytest.mark.adhoc
 @pytest.mark.ubuntu
+@pytest.mark.skipif(
+    not CLOUD_INIT_UA_TOKEN, reason="CLOUD_INIT_UA_TOKEN env var not provided"
+)
 class TestUbuntuAdvantage:
     @pytest.mark.user_data(ATTACH_FALLBACK.format(token=CLOUD_INIT_UA_TOKEN))
     def test_valid_token(self, client: IntegrationInstance):
-        assert CLOUD_INIT_UA_TOKEN, "CLOUD_INIT_UA_TOKEN env var not provided"
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
         assert is_attached(client)
 
     @pytest.mark.user_data(ATTACH.format(token=CLOUD_INIT_UA_TOKEN))
     def test_idempotency(self, client: IntegrationInstance):
-        assert CLOUD_INIT_UA_TOKEN, "CLOUD_INIT_UA_TOKEN env var not provided"
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
         assert is_attached(client)

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -31,7 +31,8 @@ MPATH = "cloudinit.config.cc_ubuntu_advantage"
 
 
 class FakeUserFacingError(Exception):
-    pass
+    def __init__(self, msg: str):
+        self.msg = msg
 
 
 class FakeAlreadyAttachedError(FakeUserFacingError):


### PR DESCRIPTION
Ensure Pro instances are detached before the test run and that the test only runs on LTS releases.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
test: fix pro integration test

Ensure Pro instances are detached before the test run and that
the test only runs on LTS releases.

As ua.UserFacingError is not properly converted to str,
manually pick its msg to provide the user a more informative
logging msg.
```

## Additional Context
<!-- If relevant -->
- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-ec2/139/testReport/tests.integration_tests.modules.test_ubuntu_advantage/TestUbuntuAdvantagePro/test_custom_services/
- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-ec2/lastCompletedBuild/testReport/tests.integration_tests.modules.test_ubuntu_advantage/TestUbuntuAdvantagePro/test_custom_services/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Execute the following test in ec2, gce and azure platforms and bionic, focal and jammy series.

```sh
CLOUD_INIT_PLATFORM=ec2 CLOUD_INIT_OS_IMAGE=bionic CLOUD_INIT_CLOUD_INIT_SOURCE='ppa:cloud-init-dev/daily' tox -e integration-tests -- -vv tests/integration_tests/modules/test_ubuntu_advantage.py::TestUbuntuAdvantagePro
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
