### PR TITLE
net: skip duplicate mac check for netvsc nic and its VF

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1001,11 +1001,16 @@ def get_interfaces_by_mac_on_linux(blacklist_drivers=None) -> dict:
     Bridges and any devices that have a 'stolen' mac are excluded."""
     ret: dict = {}
     driver_map: dict = {}
-    for name, mac, _driver, _devid in get_interfaces(
+    for name, mac, driver, _devid in get_interfaces(
         blacklist_drivers=blacklist_drivers
     ):
         if mac in ret:
-            raise_error = True
+            raise_duplicate_mac_error = True
+            msg = "duplicate mac found! both '%s' and '%s' have mac '%s'." % (
+                name,
+                ret[mac],
+                mac,
+            )
             # Hyper-V netvsc driver will register a VF with the same mac
             #
             # The VF will be enslaved to the master nic shortly after
@@ -1013,19 +1018,27 @@ def get_interfaces_by_mac_on_linux(blacklist_drivers=None) -> dict:
             # before the completion of the enslaving process, it will see
             # two different nics with duplicate mac. Cloud-init should ignore
             # the slave nic (which does not have hv_netvsc driver).
-            if _driver != driver_map[mac]:
+            if driver != driver_map[mac]:
                 if driver_map[mac] == "hv_netvsc":
+                    LOG.warning(
+                        msg + " Ignoring '%s' due to driver '%s' and "
+                        "'%s' having driver hv_netvsc."
+                        % (name, driver, ret[mac])
+                    )
                     continue
-                if _driver == "hv_netvsc":
-                    raise_error = False
+                if driver == "hv_netvsc":
+                    raise_duplicate_mac_error = False
+                    LOG.warning(
+                        msg + " Ignoring '%s' due to driver '%s' and "
+                        "'%s' having driver hv_netvsc."
+                        % (ret[mac], driver_map[mac], name)
+                    )
 
-            if raise_error:
-                raise RuntimeError(
-                    "duplicate mac found! both '%s' and '%s' have mac '%s'"
-                    % (name, ret[mac], mac)
-                )
+            if raise_duplicate_mac_error:
+                raise RuntimeError(msg)
+
         ret[mac] = name
-        driver_map[mac] = _driver
+        driver_map[mac] = driver
 
         # Pretend that an Infiniband GUID is an ethernet address for Openstack
         # configuration purposes

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -7683,6 +7683,8 @@ class TestGetInterfacesByMac(CiTestCase):
             "bridge1",
             "bond1.101",
             "lo",
+            "netvsc0-vf",
+            "netvsc0",
         ],
         "macs": {
             "enp0s1": "aa:aa:aa:aa:aa:01",
@@ -7693,13 +7695,22 @@ class TestGetInterfacesByMac(CiTestCase):
             "bridge1-nic": "aa:aa:aa:aa:aa:03",
             "lo": "00:00:00:00:00:00",
             "greptap0": "00:00:00:00:00:00",
+            "netvsc0-vf": "aa:aa:aa:aa:aa::04",
+            "netvsc0": "aa:aa:aa:aa:aa::04",
             "tun0": None,
+        },
+        "drivers": {
+            "netvsc0": "hv_netvsc",
+            "netvsc0-vf": "foo",
         },
     }
     data: dict = {}
 
     def _se_get_devicelist(self):
         return list(self.data["devices"])
+
+    def _se_device_driver(self, name):
+        return self.data["drivers"].get(name, None)
 
     def _se_get_interface_mac(self, name):
         return self.data["macs"][name]
@@ -7722,6 +7733,7 @@ class TestGetInterfacesByMac(CiTestCase):
         self.data["devices"] = set(list(self.data["macs"].keys()))
         mocks = (
             "get_devicelist",
+            "device_driver",
             "get_interface_mac",
             "is_bridge",
             "interface_has_own_mac",
@@ -7759,6 +7771,7 @@ class TestGetInterfacesByMac(CiTestCase):
                 "aa:aa:aa:aa:aa:02": "enp0s2",
                 "aa:aa:aa:aa:aa:03": "bridge1-nic",
                 "00:00:00:00:00:00": "lo",
+                "aa:aa:aa:aa:aa::04": "netvsc0",
             },
             ret,
         )

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -7685,6 +7685,8 @@ class TestGetInterfacesByMac(CiTestCase):
             "lo",
             "netvsc0-vf",
             "netvsc0",
+            "netvsc1",
+            "netvsc1-vf",
         ],
         "macs": {
             "enp0s1": "aa:aa:aa:aa:aa:01",
@@ -7697,11 +7699,15 @@ class TestGetInterfacesByMac(CiTestCase):
             "greptap0": "00:00:00:00:00:00",
             "netvsc0-vf": "aa:aa:aa:aa:aa:04",
             "netvsc0": "aa:aa:aa:aa:aa:04",
+            "netvsc1-vf": "aa:aa:aa:aa:aa:05",
+            "netvsc1": "aa:aa:aa:aa:aa:05",
             "tun0": None,
         },
         "drivers": {
             "netvsc0": "hv_netvsc",
             "netvsc0-vf": "foo",
+            "netvsc1": "hv_netvsc",
+            "netvsc1-vf": "bar",
         },
     }
     data: dict = {}
@@ -7753,6 +7759,11 @@ class TestGetInterfacesByMac(CiTestCase):
         self.data["macs"]["bridge1-nic"] = self.data["macs"]["enp0s1"]
         self.assertRaises(RuntimeError, net.get_interfaces_by_mac)
 
+    def test_raise_exception_on_duplicate_netvsc_macs(self):
+        self._mock_setup()
+        self.data["macs"]["netvsc0"] = self.data["macs"]["netvsc1"]
+        self.assertRaises(RuntimeError, net.get_interfaces_by_mac)
+
     def test_excludes_any_without_mac_address(self):
         self._mock_setup()
         ret = net.get_interfaces_by_mac()
@@ -7772,6 +7783,7 @@ class TestGetInterfacesByMac(CiTestCase):
                 "aa:aa:aa:aa:aa:03": "bridge1-nic",
                 "00:00:00:00:00:00": "lo",
                 "aa:aa:aa:aa:aa:04": "netvsc0",
+                "aa:aa:aa:aa:aa:05": "netvsc1",
             },
             ret,
         )

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -7695,8 +7695,8 @@ class TestGetInterfacesByMac(CiTestCase):
             "bridge1-nic": "aa:aa:aa:aa:aa:03",
             "lo": "00:00:00:00:00:00",
             "greptap0": "00:00:00:00:00:00",
-            "netvsc0-vf": "aa:aa:aa:aa:aa::04",
-            "netvsc0": "aa:aa:aa:aa:aa::04",
+            "netvsc0-vf": "aa:aa:aa:aa:aa:04",
+            "netvsc0": "aa:aa:aa:aa:aa:04",
             "tun0": None,
         },
         "drivers": {
@@ -7771,7 +7771,7 @@ class TestGetInterfacesByMac(CiTestCase):
                 "aa:aa:aa:aa:aa:02": "enp0s2",
                 "aa:aa:aa:aa:aa:03": "bridge1-nic",
                 "00:00:00:00:00:00": "lo",
-                "aa:aa:aa:aa:aa::04": "netvsc0",
+                "aa:aa:aa:aa:aa:04": "netvsc0",
             },
             ret,
         )


### PR DESCRIPTION
## Proposed Commit Message
net: Skip duplicate mac check for netvsc nic and its VF
```
summary: 
When accelerated network is enabled on Azure, the host presents
two network interfaces with the same mac address to the VM: 
a synthetic nic (netvsc) and a VF nic, which is enslaved to the synthetic 
nic. 

The net module is already excluding slave nics when enumerating
interfaces. However, if cloud-init starts enumerating after the kernel
makes the VF visible to userspace, but before the enslaving has finished,
cloud-init will see two nics with duplicate mac.

This change will skip the duplicate mac error if one of the two nics 
with duplicate mac is a netvsc nic

LP: #1844191

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
