### PR TITLE
doc: add how to render new module doc

### DIFF
--- a/doc/rtd/topics/module_creation.rst
+++ b/doc/rtd/topics/module_creation.rst
@@ -74,6 +74,8 @@ Guidelines
   under ``$defs.all_modules``, in order to be accepted as a module key in
   the :ref:`base config<base_config_reference>`.
 
+* Add the new module to `Module Reference`_.
+
 * If your module introduces any new cloud-config keys, you must provide a
   schema definition in `schema-cloud-config.json`_.
 * The ``meta`` variable must exist and be of type `MetaSchema`_.
@@ -130,3 +132,4 @@ in the ``cloud_final_modules`` section before the ``final-message`` module.
 .. _cloud_init_modules: https://github.com/canonical/cloud-init/blob/b4746b6aed7660510071395e70b2d6233fbdc3ab/config/cloud.cfg.tmpl#L70
 .. _cloud_config_modules: https://github.com/canonical/cloud-init/blob/b4746b6aed7660510071395e70b2d6233fbdc3ab/config/cloud.cfg.tmpl#L101
 .. _cloud_final_modules: https://github.com/canonical/cloud-init/blob/b4746b6aed7660510071395e70b2d6233fbdc3ab/config/cloud.cfg.tmpl#L144
+.. _Module Reference: https://github.com/canonical/cloud-init/blob/main/doc/rtd/topics/modules.rst


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
doc: add how to render new module doc
```

## Additional Context
<!-- If relevant -->
Reviewing https://github.com/canonical/cloud-init/pull/1756, I realize we do not explain how to render a newly created module's doc.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
