### PR TITLE
tests: ds-id mocks for vmware-rpctool as utility may not exist in env

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1608,6 +1608,11 @@ VALID_CFG = {
         "ds": "VMware",
         "mocks": [
             MOCK_VIRT_IS_VMWARE,
+            {
+                "name": "vmware_has_rpctool",
+                "ret": 0,
+                "out": "/usr/bin/vmware-rpctool",
+            },
         ],
         "files": {
             # Setup vmware customization enabled


### PR DESCRIPTION
Some build environments will not have open-vm-tools and consequently vmware-rpctool installed. Since we are mocking behavior of tests we fake the presence of this utility to ensure VMware is properly detected.

## Proposed Commit Message
```
tests: ds-id mocks for vmware-rpctool as utility may not exist in env

Some build environments will not have open-vm-tools and consequently
vmware-rpctool installed. Since we are mocking behavior of tests
we fake the presence of this utility to ensure VMware is properly
detected.
```

## Additional Context
<!-- If relevant -->
launchpad daily build failures point to environments with no open-vm-tools installed
https://launchpadlibrarian.net/634162856/buildlog_ubuntu-lunar-amd64.cloud-init_22.4.daily-202211171631-33eb9b13~ubuntu23.04.1_BUILDING.txt.gz

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
lxc launch ubuntu-daily:bionic dev-b
lxc exec dev-b bash
git clone cloud-init.... 
apt remove open-vm-tools (and ubuntu-server metapkg)
tox -e py3 tests/unittest/test_ds_identify.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
