### PR TITLE
doc: add qemu tutorial

### DIFF
--- a/doc/rtd/index.rst
+++ b/doc/rtd/index.rst
@@ -34,7 +34,7 @@ projects, contributions, suggestions, fixes and constructive feedback.
 Having trouble? We would like to help!
 **************************************
 
-- Check out the :ref:`lxd_tutorial` if you're new to cloud-init
+- Check out the :ref:`tutorial_lxd` if you're new to cloud-init
 - Try the :ref:`FAQ` for answers to some common questions
 - You can also search the cloud-init `mailing list archive`_
 - Find a bug? `Report bugs on Launchpad`_
@@ -44,7 +44,7 @@ Having trouble? We would like to help!
    :titlesonly:
    :caption: Getting Started
 
-   topics/tutorial.rst
+   topics/tutorials/lxd.rst
    topics/availability.rst
    topics/boot.rst
    topics/cli.rst

--- a/doc/rtd/topics/modules.rst
+++ b/doc/rtd/topics/modules.rst
@@ -61,6 +61,9 @@ Module Reference
 .. automodule:: cloudinit.config.cc_ubuntu_drivers
 .. automodule:: cloudinit.config.cc_update_etc_hosts
 .. automodule:: cloudinit.config.cc_update_hostname
+
+.. _mod-users_groups:
+
 .. automodule:: cloudinit.config.cc_users_groups
 .. automodule:: cloudinit.config.cc_wireguard
 .. automodule:: cloudinit.config.cc_write_files

--- a/doc/rtd/topics/tutorials/lxd.rst
+++ b/doc/rtd/topics/tutorials/lxd.rst
@@ -1,7 +1,16 @@
-.. _lxd_tutorial:
+.. _tutorial_lxd:
 
-Tutorial
-********
+Tutorials
+*********
+
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   qemu.rst
+
+LXD
+===
 
 In this tutorial, we will create our first cloud-init user data script
 and deploy it into an LXD container. We'll be using LXD_ for this tutorial

--- a/doc/rtd/topics/tutorials/qemu-debugging.rst
+++ b/doc/rtd/topics/tutorials/qemu-debugging.rst
@@ -3,8 +3,8 @@
 Qemu tutorial debugging
 ***********************
 
-You may wish to test out the commands in this tutorial as a `script`_
-to check for copy-paste mistakes.
+You may wish to test out the commands in this tutorial as a
+:download:`script<qemu-script.sh>` to check for copy-paste mistakes.
 
 If you successfully launched the virtual machine, but couldn't log in,
 there are a few places to check to debug your setup.
@@ -32,8 +32,6 @@ Did the IMDS webserver serve the expected files?
 If the webserver prints out 404 errors when launching Qemu, then first check
 that you started the server in the temp directory.
 
-
-
 Were the configurations inside the file correct?
 ===================================================
 When launching Qemu, if the webserver shows that it succeeded in serving
@@ -41,5 +39,3 @@ When launching Qemu, if the webserver shows that it succeeded in serving
 you may have provided incorrect cloud-config files. If you can mount a copy of
 the virtual machine's filesystem locally to inspect the logs, it should be
 possible to get clues about what went wrong.
-
-.. _script: https://cloudinit.readthedocs.io/en/latest/topics/tutorials/qemu-script.sh

--- a/doc/rtd/topics/tutorials/qemu-debugging.rst
+++ b/doc/rtd/topics/tutorials/qemu-debugging.rst
@@ -1,0 +1,39 @@
+.. _debug information:
+
+Qemu Tutorial Debugging
+***********************
+
+If you successfully launched the virtual machine, but couldn't log in,
+there are a few places to check to debug your setup.
+
+To debug, answer the following questions:
+
+Did cloud-init discover the imds webserver?
+===========================================
+
+The webserver should print a message in the terminal for each request it
+receives.  If it didn't print out any messages when the virtual machine booted,
+then cloud-init was unable to obtain the config. Make sure that the webserver
+can be locally accessed using ``curl`` or ``wget``.
+
+.. code-block:: sh
+
+   $ curl 0.0.0.0:8000/user-data
+   $ curl 0.0.0.0:8000/meta-data
+   $ curl 0.0.0.0:8000/vendor-data
+
+Did the imds webserver serve the files it was expected to serve?
+================================================================
+
+When launching Qemu, if the webserver prints out 404 errors, then try to figure
+out why those files can't be served.
+
+Did you forget to start the server in the temp directory?
+
+Were the configurations inside of the file correct?
+===================================================
+When launching Qemu, if the webserver shows that it succeeded in serving
+``user-data``, ``meta-data``, and ``vendor-data``, but you cannot log in, then
+you may have provided incorrect cloud-config files. If you can mount a copy of
+the virtual machine's filesystem locally to inspect the logs, it should be
+possible to get clues about what went wrong.

--- a/doc/rtd/topics/tutorials/qemu-debugging.rst
+++ b/doc/rtd/topics/tutorials/qemu-debugging.rst
@@ -1,6 +1,6 @@
-.. _debug information:
+.. _qemu_debug_info:
 
-Qemu Tutorial Debugging
+Qemu tutorial debugging
 ***********************
 
 You may wish to test out the commands in this tutorial as a `script`_
@@ -11,7 +11,7 @@ there are a few places to check to debug your setup.
 
 To debug, answer the following questions:
 
-Did cloud-init discover the imds webserver?
+Did cloud-init discover the IMDS webserver?
 ===========================================
 
 The webserver should print a message in the terminal for each request it
@@ -26,16 +26,14 @@ can be locally accessed using ``curl`` or ``wget``.
    $ curl 0.0.0.0:8000/vendor-data
 
 
-Did the imds webserver serve the files it was expected to serve?
+Did the IMDS webserver serve the expected files?
 ================================================================
 
-When launching Qemu, if the webserver prints out 404 errors, then try to figure
-out why those files can't be served.
-
-Did you forget to start the server in the temp directory?
+If the webserver prints out 404 errors when launching Qemu, then first check that you started the server in the temp directory. 
 
 
-Were the configurations inside of the file correct?
+
+Were the configurations inside the file correct?
 ===================================================
 When launching Qemu, if the webserver shows that it succeeded in serving
 ``user-data``, ``meta-data``, and ``vendor-data``, but you cannot log in, then

--- a/doc/rtd/topics/tutorials/qemu-debugging.rst
+++ b/doc/rtd/topics/tutorials/qemu-debugging.rst
@@ -29,7 +29,8 @@ can be locally accessed using ``curl`` or ``wget``.
 Did the IMDS webserver serve the expected files?
 ================================================================
 
-If the webserver prints out 404 errors when launching Qemu, then first check that you started the server in the temp directory. 
+If the webserver prints out 404 errors when launching Qemu, then first check
+that you started the server in the temp directory.
 
 
 

--- a/doc/rtd/topics/tutorials/qemu-debugging.rst
+++ b/doc/rtd/topics/tutorials/qemu-debugging.rst
@@ -3,6 +3,9 @@
 Qemu Tutorial Debugging
 ***********************
 
+You may wish to test out the commands in this tutorial as a `script`_
+to check for copy-paste mistakes.
+
 If you successfully launched the virtual machine, but couldn't log in,
 there are a few places to check to debug your setup.
 
@@ -22,6 +25,7 @@ can be locally accessed using ``curl`` or ``wget``.
    $ curl 0.0.0.0:8000/meta-data
    $ curl 0.0.0.0:8000/vendor-data
 
+
 Did the imds webserver serve the files it was expected to serve?
 ================================================================
 
@@ -30,6 +34,7 @@ out why those files can't be served.
 
 Did you forget to start the server in the temp directory?
 
+
 Were the configurations inside of the file correct?
 ===================================================
 When launching Qemu, if the webserver shows that it succeeded in serving
@@ -37,3 +42,5 @@ When launching Qemu, if the webserver shows that it succeeded in serving
 you may have provided incorrect cloud-config files. If you can mount a copy of
 the virtual machine's filesystem locally to inspect the logs, it should be
 possible to get clues about what went wrong.
+
+.. _script: https://cloudinit.readthedocs.io/en/latest/topics/tutorials/qemu-script.sh

--- a/doc/rtd/topics/tutorials/qemu-script.sh
+++ b/doc/rtd/topics/tutorials/qemu-script.sh
@@ -20,7 +20,7 @@ chpasswd:
 EOF
 
 cat << EOF > meta-data
-instance-id: jammy-01
+instance-id: someid/somehostname
 local-hostname: jammy
 EOF
 
@@ -41,7 +41,7 @@ qemu-system-x86_64                                              \
     -smbios type=1,serial=ds='nocloud-net;s=http://10.0.2.2:8000/'
 
 echo -e "\nTo reuse the image and config files, start the python webserver and "
-echo -e "virtual machine from $(pwd), which contains:\n$(ls -1)"
+echo -e "virtual machine from $(pwd), which contains these files:\n$(ls -1)\n"
 
 # end the python server on exit
 trap "trap - SIGTERM && kill -- -$$" EXIT

--- a/doc/rtd/topics/tutorials/qemu-script.sh
+++ b/doc/rtd/topics/tutorials/qemu-script.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+TEMP_DIR=temp
+IMAGE_URL="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+
+# setup
+mkdir "$TEMP_DIR" && cd "$TEMP_DIR" || {
+		echo "Error: Failed to create directory [$TEMP_DIR], aborting early"
+        exit 1
+}
+
+wget "$IMAGE_URL"
+
+# Create user-data, vendor-data, meta-data
+cat << EOF > user-data
+#cloud-config
+password: password
+chpasswd:
+  expire: False
+EOF
+
+cat << EOF > meta-data
+instance-id: jammy-01
+local-hostname: jammy
+EOF
+
+touch vendor-data
+
+# start ad hoc imds webserver
+python3 -m http.server --directory . &
+
+# start an instance of your image in a virtual machine
+qemu-system-x86_64                                              \
+    -net nic                                                    \
+    -net user                                                   \
+    -machine accel=kvm:tcg                                      \
+    -cpu host                                                   \
+    -m 512                                                      \
+    -nographic                                                  \
+    -hda jammy-server-cloudimg-amd64.img                        \
+    -smbios type=1,serial=ds='nocloud-net;s=http://10.0.2.2:8000/'
+
+echo -e "\nTo reuse the image and config files, start the python webserver and "
+echo -e "virtual machine from $(pwd), which contains:\n$(ls -1)"
+
+# end the python server on exit
+trap "trap - SIGTERM && kill -- -$$" EXIT

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -204,9 +204,9 @@ python webserver (built-in to python).
 Launch a virtual machine with our user data
 ===========================================
 
-Launch the virtual machine. By default, qemu will print to the terminal both
-kernel logs and systemd logs while the operating system boots. This may take a
-few moments to complete.
+Launch the virtual machine. By default, Qemu will print the kernel logs
+and systemd logs to the terminal while the operating system boots. This
+may take a few moments to complete.
 
 If the output stopped scrolling but you don't see a prompt yet, press ``enter``
 to get to login prompt.

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -40,7 +40,7 @@ Create the following file ``user-data``.
 
     $ cat << EOF > user-data
     #cloud-config
-    password: passw0rd
+    password: password
     chpasswd:
       expire: False
 
@@ -63,7 +63,7 @@ Create the following file on your local filesystem at ``meta-data``.
 Define our vendor data
 ======================
 
-Not necessary, but faster (retry wait time).
+Not necessary, but faster as it avoids retry wait time looking for it.
 
 .. code-block:: sh
 
@@ -100,8 +100,9 @@ instance with our user data:
 Verify that cloud-init ran successfully
 =======================================
 
-After launching the virtual machine, we should be able to connect
-to our instance using the User: ``ubuntu`` and Password: ``passw0rd``
+After launching the virtual machine we should be able to connect to our
+instance using the default distro username. In this case the default username
+is ``ubuntu`` and the password we configured is ``password``
 
 If you can log in using the configured password, it worked!
 

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -22,7 +22,7 @@ configurations locally prior to launching in the cloud.
 Why Qemu?
 =========
 
-Qemu is a cross-platform emulator capable of running performant virtual
+Qemu_ is a cross-platform emulator capable of running performant virtual
 machines. Qemu is used at the core of a broad range of production operating
 system deployments and open source software projects (including libvirt, LXD,
 and vagrant) and is capable of running Windows, Linux, and Unix guest operating
@@ -34,21 +34,20 @@ the broad support it has due to its broad adoption and ability to run on
 What is an IMDS?
 ================
 
-Instance Metadata Service is a service provided by most cloud providers
-as a means of providing information to virtual machine instances. This
-service is used by cloud providers to surface information to a virtual machine.
-This service is used for many different things, and is the primary
-mechanism for some clouds to surface cloud-init configuration data to
-the instance.
+Instance Metadata Service is a service provided by most cloud providers as a
+means of providing information to virtual machine instances. This service is
+used by cloud providers to surface information to a virtual machine. This
+service is used for many different things, and is the primary mechanism for
+some clouds to expose cloud-init configuration data to the instance.
 
 
 How does cloud-init use the IMDS?
 =================================
 
-The IMDS contains a private http webserver to each operating
-system instance launched. During early boot, cloud-init sets up network
-access and queries this webserver to gather configuration data. This allows
-cloud-init to configure your operating system while it boots.
+The IMDS uses a private http webserver to provide metadata to each operating
+system instance. During early boot, cloud-init sets up network access and
+queries this webserver to gather configuration data. This allows cloud-init to
+configure your operating system while it boots.
 
 In this tutorial we emulate this workflow using Qemu and a simple python
 webserver. This workflow may be suitable for developing and testing cloud-init
@@ -80,9 +79,9 @@ additional information.
 Create a temporary directory
 ============================
 
-This directory will store our cloud image and configuration files,
-``meta-data`` [add-link], ``vendor-data`` [add-link], and ``user-data``
-[add-link],
+This directory will store our cloud image and configuration files for
+:ref:`user-data<user_data_formats>`, :ref:`meta-data<instance_metadata>`, and
+:ref:`vendor-data<vendordata>`
 
 This tutorial expects that you run all commands from this temporary
 directory. Failure to do so will result in an unconfigured virtual
@@ -152,7 +151,7 @@ You should see the following contents:
       expire: False
 
 The first line starts with ``#cloud-config``, which tells cloud-init
-what kind of configuration is contained. The cloud-config config type uses yaml
+what kind of configuration is contained. The cloud-config config type uses YAML
 format to tell cloud-init how to configure the virtual machine instance.
 Multiple different formats are supported by cloud-init. See the
 :ref:`documentation describing different formats<user_data_formats>`.

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -66,8 +66,6 @@ Each code block is preceded by a description of what the command does.
 Install Qemu
 ============
 
-Install Qemu.
-
 .. code-block:: sh
 
     $ sudo apt install qemu-system-x86
@@ -188,8 +186,8 @@ will speed up the retry wait time.
     $ touch vendor-data
 
 
-Start an ad hoc IMDS Server
-===========================
+Start an ad hoc IMDS webserver
+==============================
 
 In a second terminal, change to your temporary directory and then start the
 python webserver (built-in to python).
@@ -210,7 +208,6 @@ while the operating system boots. This may take a few moments to complete.
 If the output stopped scrolling but you don't see a prompt yet, press ``enter``
 to get to login prompt.
 
-
 .. code-block:: sh
 
     $ qemu-system-x86_64                                            \
@@ -223,6 +220,25 @@ to get to login prompt.
         -hda jammy-server-cloudimg-amd64.img                        \
         -smbios type=1,serial=ds='nocloud-net;s=http://10.0.2.2:8000/'
 
+How is Qemu configured for cloud-init?
+======================================
+
+When launching Qemu, machine configuration is specified on the command
+line. Many things may be configured: memory size, graphical output, networking
+information, hard drives and more.
+
+Examine the last two lines of this command. This one,
+``-hda jammy-server-cloudimg-amd64.img``, tells qemu to use the cloud
+image as a virtual hard drive. This will cause the virtual machine to
+boot Ubuntu which already has cloud-init installed.
+
+The last line tells cloud-init where it can find user-data using the
+:ref:`NoCloud datasource<datasource_nocloud>`. During boot cloud-init checks
+the ``SMBIOS`` serial number for `ds=nocloud-net`. If found, cloud-init will
+use the specified URL to source its userdata config files. In this case we use
+the default gateway of the virtual machine (``10.0.2.2``) and default port
+number of the python webserver (``8000``), so that cloud-init in the virtual
+machine will query the server running on host.
 
 Verify that cloud-init ran successfully
 =======================================

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -15,7 +15,7 @@ Install Qemu
 
     $ sudo apt install qemu-system-x86
 
-See qemu's `install instructions <https://www.qemu.org/download/#linux>`_.
+If you are not using Ubuntu, you can visit Qemu's `install instructions <https://www.qemu.org/download/#linux>`_ for additional information.
 
 Download a Cloud Image
 ======================
@@ -63,7 +63,7 @@ Create the following file on your local filesystem at ``meta-data``.
 Define our vendor data
 ======================
 
-Not necessary, but faster as it avoids retry wait time looking for it.
+Now create the empty file ``vendor-data`` in your temporary directory. This will speed up the retry wait time.
 
 .. code-block:: sh
 
@@ -78,7 +78,7 @@ Start an ad hoc IMDS Server
     $ python3 -m http.server --directory . &
 
 
-Launch a vm with our user data
+Launch a virtual machine (VM) with our user data
 ==============================
 
 Now that we have LXD setup and our user data defined, we can launch an
@@ -118,7 +118,7 @@ Check the cloud-init status:
 Tear down
 =========
 
-Exit the qemu shell using ``ctrl-a x`` (that's ctrl and a
+Exit the Qemu shell using ``ctrl-a x`` (that's ``ctrl`` and ``a``
 simultaneously, followed by ``x``).
 
 If you started the python webserver in the background (using ``&``),
@@ -132,7 +132,7 @@ What's next?
 In this tutorial, we configured the default user's password.
 The full list of modules available can be found in
 :ref:`modules documentation<modules>`.
-Each module contains examples of how to use it.
+The documentation for each module contains examples of how to use it.
 
 You can also head over to the :ref:`examples<yaml_examples>` page for
 examples of more common use cases.

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -173,7 +173,7 @@ is ``password``.
 
 If you can log in using the configured password, it worked!
 
-If you cloudn't log in, try this :ref:`debug information`.
+If you cloudn't log in, see :ref:`debug information`.
 
 
 Check cloud-init status
@@ -197,7 +197,6 @@ simultaneously, followed by ``x``).
 
 Stop the python webserver that was started in a different terminal
 (``ctrl-c``).
-
 
 
 What's next?

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -174,7 +174,7 @@ configuration data.
 .. code-block:: sh
 
     $ cat << EOF > meta-data
-    instance-id: jammy-01
+    instance-id: someid/somehostname
     local-hostname: jammy
 
     EOF

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -3,6 +3,13 @@
 Qemu Tutorial
 *************
 
+.. toctree::
+   :titlesonly:
+   :hidden:
+
+   qemu-debugging.rst
+
+
 In this tutorial, we will create our first cloud-init user data config and
 deploy it into a Qemu_ virtual machine. We'll be using Qemu for this tutorial
 which is a popular emulator for running virtual machines on Linux. Several
@@ -166,49 +173,20 @@ is ``password``.
 
 If you can log in using the configured password, it worked!
 
-Check the cloud-init status:
+If you cloudn't log in, try this :ref:`debug information`.
+
+
+Check cloud-init status
+=======================
 
 .. code-block:: sh
 
     $ cloud-init status --wait
-    .....
-    cloud-init status: done
 
+If you see ``status: done`` in the output, it succeeded!
 
-Debugging tips
-==============
-
-If you successfully launched the virtual machine, but couldn't log in,
-there are a few places to check to debug your setup.
-
-- The webserver should print out a message for each request it receives.
-  If it didn't print out any messages when the virtual machine booted,
-  then cloud-init was unable to obtain the config. Make sure that the
-  webserver can be locally accessed using ``curl`` or ``wget``.
-
-.. code-block:: sh
-
-   $ curl 0.0.0.0:8000/user-data
-   $ curl 0.0.0.0:8000/meta-data
-   $ curl 0.0.0.0:8000/vendor-data
-
-- When launching Qemu, if the webserver prints out 404 errors, then try to
-  figure out why those files can't be served (did you forget to start the
-  server in the temp directory?)
-  
-
-- When launching Qemu, if the webserver shows that it succeeded in serving
-  ``user-data``, ``meta-data``, and ``vendor-data``, but you cannot log
-  in, then you may have provided incorrect cloud-config files.
-
-
-  If you do not see any new output, then cloud-init didn't discover its
-  datasource correctly.
-
-
-   If you cannot hit these files, figure out why (verify they exist
-   where the python webserver is running, check your local firewall, etc)
-
+If you see a failed status, you'll want to check ``/var/log/cloud-init.log``
+for warning/error messages.
 
 
 Tear down

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -191,7 +191,7 @@ will speed up the retry wait time.
 Start an ad hoc IMDS Server
 ===========================
 
-In a separate terminal, change to your temporary directory and then start the
+In a second terminal, change to your temporary directory and then start the
 python webserver (built-in to python).
 
 .. code-block:: sh
@@ -203,9 +203,9 @@ python webserver (built-in to python).
 Launch a virtual machine with our user data
 ===========================================
 
-Launch the virtual machine. By default, Qemu will print the kernel logs
-and systemd logs to the terminal while the operating system boots. This
-may take a few moments to complete.
+Switch back to your original terminal so we can launch the virtual machine.
+By default, Qemu will print the kernel logs and systemd logs to the terminal
+while the operating system boots. This may take a few moments to complete.
 
 If the output stopped scrolling but you don't see a prompt yet, press ``enter``
 to get to login prompt.

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -1,0 +1,139 @@
+.. _tutorial_qemu:
+
+Qemu
+****
+
+In this tutorial, we will create our first cloud-init user data config and
+deploy it into a Qemu_ virtual machine. We'll be using Qemu for this tutorial
+which is a popular emulator for running virtual machines on Linux. Several
+popular virtual machine tools use Qemu, including Libvirt, LXD, and Vagrant.
+
+Install Qemu
+============
+
+.. code-block:: sh
+
+    $ sudo apt install qemu-system-x86
+
+See qemu's `install instructions <https://www.qemu.org/download/#linux>`_.
+
+Download a Cloud Image
+======================
+
+All commands should be executed from a single directory; some
+commands create files that are used by later commands. One might want to
+use a temporary directory for easy clean up afterwards.
+
+.. code-block:: sh
+
+    $ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+
+Cloud images have cloud-init pre-installed.
+
+
+Define our user data
+====================
+
+Create the following file ``user-data``.
+
+.. code-block:: sh
+
+    $ cat << EOF > user-data
+    #cloud-config
+    password: passw0rd
+    chpasswd:
+      expire: False
+
+    EOF
+
+Define our meta data
+====================
+
+Create the following file on your local filesystem at ``meta-data``.
+
+.. code-block:: sh
+
+    $ cat << EOF > meta-data
+    instance-id: id-007
+    local-hostname: jammy
+
+    EOF
+
+
+Define our vendor data
+======================
+
+Not necessary, but faster (retry wait time).
+
+.. code-block:: sh
+
+    $ touch vendor-data
+
+
+Start an ad hoc IMDS Server
+===========================
+
+.. code-block:: sh
+
+    $ python3 -m http.server --directory . &
+
+
+Launch a vm with our user data
+==============================
+
+Now that we have LXD setup and our user data defined, we can launch an
+instance with our user data:
+
+.. code-block:: sh
+
+    $ qemu-system-x86_64                                            \
+        -net nic                                                    \
+        -net user                                                   \
+        -machine accel=kvm,type=q35                                 \
+        -cpu host                                                   \
+        -m 512                                                      \
+        -nographic                                                  \
+        -hda jammy-server-cloudimg-amd64.img                        \
+        -smbios type=1,serial=ds='nocloud-net;s=http://10.0.2.2:8000/'
+
+
+Verify that cloud-init ran successfully
+=======================================
+
+After launching the virtual machine, we should be able to connect
+to our instance using the User: ``ubuntu`` and Password: ``passw0rd``
+
+If you can log in using the configured password, it worked!
+
+Check the cloud-init status:
+
+.. code-block:: sh
+
+    $ cloud-init status --wait
+    .....
+    cloud-init status: done
+
+
+Tear down
+=========
+
+Exit the qemu shell using ``ctrl-a x`` (that's ctrl and a
+simultaneously, followed by ``x``).
+
+If you started the python webserver in the background (using ``&``),
+then don't forget to bring it to the foreground (``fg``) and kill it
+(``ctrl-c``).
+
+
+What's next?
+============
+
+In this tutorial, we configured the default user's password.
+The full list of modules available can be found in
+:ref:`modules documentation<modules>`.
+Each module contains examples of how to use it.
+
+You can also head over to the :ref:`examples<yaml_examples>` page for
+examples of more common use cases.
+
+.. _Qemu: https://www.qemu.org

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -10,15 +10,40 @@ Qemu Tutorial
    qemu-debugging.rst
 
 
-In this tutorial, we will create our first cloud-init user data config and
-deploy it into a Qemu_ virtual machine. We'll be using Qemu for this tutorial
-which is a popular emulator for running virtual machines on Linux. Several
-popular virtual machine tools use Qemu, including Libvirt, LXD, and Vagrant.
+Tutorial overview
+=================
+In this tutorial, we will demonstrate launching an Ubuntu virtual machine that
+uses cloud-init to pre-configure the instance during boot.
+
+The goal of this tutorial is to provide a minimal demonstration of cloud-init
+that users can use as a development environment to test cloud-init
+configurations locally prior to launching in the cloud.
+
+
+Why Qemu?
+=========
+Qemu is a cross-platform emulator capable of running performant virtual
+machines. Qemu is used at the core of a broad range of production operating
+system deployments and open source software projects (including libvirt, LXD,
+and vagrant) and is capable of running Windows, Linux, and Unix-based operating
+systems. While Qemu is flexibile and feature-rich, we are using it because of
+the broad support it has due to its broad adoption and ability to run on
+\*nix-derived operating systems.
 
 What is an IMDS?
 ================
 
-Many cloud providers supply a private http webserver to each operating
+Instance Metadata Service is a service provided by most cloud providers
+as a means of providing information to virtual machine instances. This
+service is used by cloud providers to surface information to a virtual machine.
+This service is used for many different things, and is the primary
+mechanism for some clouds to surface cloud-init configuration data to
+the instance.
+
+How does cloud-init use the IMDS?
+=================================
+
+The IMDS contains a private http webserver to each operating
 system instance launched. During early boot, cloud-init sets up network
 access and queries this webserver to gather configuration data. This allows
 cloud-init to configure your operating system while it boots.
@@ -27,11 +52,11 @@ In this tutorial we emulate this workflow using Qemu and a simple python
 webserver. This workflow may be suitable for developing and testing cloud-init
 configurations prior to cloud deployments.
 
-How to use this tutorial:
-=========================
+How to use this tutorial
+========================
 
 In this tutorial each code block is to be copied and pasted directly
-into the terminal then executed. Omit the prompt `$` before each command.
+into the terminal then executed. Omit the prompt ``$`` before each command.
 
 Each code block is preceded by a description of what the command does.
 

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -12,6 +12,7 @@ Qemu Tutorial
 
 Tutorial overview
 =================
+
 In this tutorial, we will demonstrate launching an Ubuntu virtual machine that
 uses cloud-init to pre-configure the instance during boot.
 
@@ -22,13 +23,15 @@ configurations locally prior to launching in the cloud.
 
 Why Qemu?
 =========
+
 Qemu is a cross-platform emulator capable of running performant virtual
 machines. Qemu is used at the core of a broad range of production operating
 system deployments and open source software projects (including libvirt, LXD,
-and vagrant) and is capable of running Windows, Linux, and Unix-based operating
+and vagrant) and is capable of running Windows, Linux, and Unix guest operating
 systems. While Qemu is flexibile and feature-rich, we are using it because of
 the broad support it has due to its broad adoption and ability to run on
 \*nix-derived operating systems.
+
 
 What is an IMDS?
 ================
@@ -39,6 +42,7 @@ service is used by cloud providers to surface information to a virtual machine.
 This service is used for many different things, and is the primary
 mechanism for some clouds to surface cloud-init configuration data to
 the instance.
+
 
 How does cloud-init use the IMDS?
 =================================
@@ -52,6 +56,7 @@ In this tutorial we emulate this workflow using Qemu and a simple python
 webserver. This workflow may be suitable for developing and testing cloud-init
 configurations prior to cloud deployments.
 
+
 How to use this tutorial
 ========================
 
@@ -59,6 +64,7 @@ In this tutorial each code block is to be copied and pasted directly
 into the terminal then executed. Omit the prompt ``$`` before each command.
 
 Each code block is preceded by a description of what the command does.
+
 
 Install Qemu
 ============
@@ -71,6 +77,7 @@ Install Qemu.
 
 If you are not using Ubuntu, you can visit Qemu's `install instructions`_ for
 additional information.
+
 
 Create a temporary directory
 ============================
@@ -91,6 +98,7 @@ Create a temporary directory and make it your current working directory with
    $ mkdir temp
    $ cd temp
 
+
 Download a cloud image
 ======================
 
@@ -104,6 +112,7 @@ Download the server image using ``wget``.
 .. code-block:: sh
 
     $ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+
 
 Define our user data
 ====================
@@ -124,6 +133,37 @@ configuration data.
       expire: False
 
     EOF
+
+
+What is user data?
+==================
+
+Before moving forward, let's inspect our user data file.
+
+.. code-block:: sh
+
+   $ cat user-data
+
+You should see the following contents:
+
+.. code-block:: yaml
+
+    #cloud-config
+    password: password
+    chpasswd:
+      expire: False
+
+The first line starts with ``#cloud-config``, which tells cloud-init
+what kind of configuration is contained. The cloud-config config type uses yaml
+format to tell cloud-init how to configure the virtual machine instance.
+Multiple different formats are supported by cloud-init. See the
+:ref:`documentation describing different formats<user_data_formats>`.
+
+The second line, ``password: password``, per :ref:`the docs<mod-users_groups>`,
+sets the default user's password to ``password``.
+
+The third and fourth lines direct cloud-init to set this default password to
+never expire.
 
 Define our meta data
 ====================
@@ -198,7 +238,8 @@ is ``password``.
 
 If you can log in using the configured password, it worked!
 
-If you cloudn't log in, see :ref:`debug information`.
+If you cloudn't log in, see
+:ref:`this page for debug information<debug information>`.
 
 
 Check cloud-init status

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -36,7 +36,7 @@ What is an IMDS?
 
 Instance Metadata Service is a service provided by most cloud providers as a
 means of providing information to virtual machine instances. This service is
-used by cloud providers to surface information to a virtual machine. This
+used by cloud providers to expose information to a virtual machine. This
 service is used for many different things, and is the primary mechanism for
 some clouds to expose cloud-init configuration data to the instance.
 

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -1,40 +1,87 @@
 .. _tutorial_qemu:
 
-Qemu
-****
+Qemu Tutorial
+*************
 
 In this tutorial, we will create our first cloud-init user data config and
 deploy it into a Qemu_ virtual machine. We'll be using Qemu for this tutorial
 which is a popular emulator for running virtual machines on Linux. Several
 popular virtual machine tools use Qemu, including Libvirt, LXD, and Vagrant.
 
+What is an IMDS?
+================
+
+Many cloud providers supply a private http webserver to each operating
+system instance launched. During early boot, cloud-init sets up network
+access and queries this webserver to gather configuration data. This allows
+cloud-init to configure your operating system while it boots.
+
+In this tutorial we emulate this workflow using Qemu and a simple python
+webserver. This workflow may be suitable for developing and testing cloud-init
+configurations prior to cloud deployments.
+
+How to use this tutorial:
+=========================
+
+In this tutorial each code block is to be copied and pasted directly
+into the terminal then executed. Omit the prompt `$` before each command.
+
+Each code block is preceded by a description of what the command does.
+
 Install Qemu
 ============
+
+Install Qemu.
 
 .. code-block:: sh
 
     $ sudo apt install qemu-system-x86
 
-If you are not using Ubuntu, you can visit Qemu's `install instructions <https://www.qemu.org/download/#linux>`_ for additional information.
+If you are not using Ubuntu, you can visit Qemu's `install instructions`_ for
+additional information.
 
-Download a Cloud Image
+Create a temporary directory
+============================
+
+This directory will store our cloud image and configuration files,
+``meta-data`` [add-link], ``vendor-data`` [add-link], and ``user-data``
+[add-link],
+
+This tutorial expects that you run all commands from this temporary
+directory. Failure to do so will result in an unconfigured virtual
+machine.
+
+Create a temporary directory and make it your current working directory with
+``cd``.
+
+.. code-block:: sh
+
+   $ mkdir temp
+   $ cd temp
+
+Download a cloud image
 ======================
 
-All commands should be executed from a single directory; some
-commands create files that are used by later commands. One might want to
-use a temporary directory for easy clean up afterwards.
+Cloud images typically come with cloud-init pre-installed and configured to run
+on first boot. Users should not need to worry about installing cloud-init
+unless they are manually creating their own images. In this case we select the
+latest Ubuntu LTS_.
+
+Download the server image using ``wget``.
 
 .. code-block:: sh
 
     $ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 
-Cloud images have cloud-init pre-installed.
-
-
 Define our user data
 ====================
 
-Create the following file ``user-data``.
+Create the following file ``user-data``. This user-data cloud-config
+sets the password of the default user and sets it to never expire. For
+more details see this module_.
+
+Execute the following command, which creates a file named ``user-data`` with
+configuration data.
 
 .. code-block:: sh
 
@@ -49,12 +96,13 @@ Create the following file ``user-data``.
 Define our meta data
 ====================
 
-Create the following file on your local filesystem at ``meta-data``.
+Execute the following command, which creates a file named ``meta-data`` with
+configuration data.
 
 .. code-block:: sh
 
     $ cat << EOF > meta-data
-    instance-id: id-007
+    instance-id: jammy-01
     local-hostname: jammy
 
     EOF
@@ -63,7 +111,8 @@ Create the following file on your local filesystem at ``meta-data``.
 Define our vendor data
 ======================
 
-Now create the empty file ``vendor-data`` in your temporary directory. This will speed up the retry wait time.
+Now create the empty file ``vendor-data`` in your temporary directory. This
+will speed up the retry wait time.
 
 .. code-block:: sh
 
@@ -73,23 +122,32 @@ Now create the empty file ``vendor-data`` in your temporary directory. This will
 Start an ad hoc IMDS Server
 ===========================
 
+In a separate terminal, change to your temporary directory and then start the
+python webserver (built-in to python).
+
 .. code-block:: sh
 
-    $ python3 -m http.server --directory . &
+    $ cd temp
+    $ python3 -m http.server --directory .
 
 
-Launch a virtual machine (VM) with our user data
-==============================
+Launch a virtual machine with our user data
+===========================================
 
-Now that we have LXD setup and our user data defined, we can launch an
-instance with our user data:
+Launch the virtual machine. By default, qemu will print to the terminal both
+kernel logs and systemd logs while the operating system boots. This may take a
+few moments to complete.
+
+If the output stopped scrolling but you don't see a prompt yet, type ``enter``
+to get to login prompt.
+
 
 .. code-block:: sh
 
     $ qemu-system-x86_64                                            \
         -net nic                                                    \
         -net user                                                   \
-        -machine accel=kvm,type=q35                                 \
+        -machine accel=kvm:tcg                                      \
         -cpu host                                                   \
         -m 512                                                      \
         -nographic                                                  \
@@ -101,8 +159,10 @@ Verify that cloud-init ran successfully
 =======================================
 
 After launching the virtual machine we should be able to connect to our
-instance using the default distro username. In this case the default username
-is ``ubuntu`` and the password we configured is ``password``
+instance using the default distro username.
+
+In this case the default username is ``ubuntu`` and the password we configured
+is ``password``.
 
 If you can log in using the configured password, it worked!
 
@@ -115,15 +175,51 @@ Check the cloud-init status:
     cloud-init status: done
 
 
+Debugging tips
+==============
+
+If you successfully launched the virtual machine, but couldn't log in,
+there are a few places to check to debug your setup.
+
+- The webserver should print out a message for each request it receives.
+  If it didn't print out any messages when the virtual machine booted,
+  then cloud-init was unable to obtain the config. Make sure that the
+  webserver can be locally accessed using ``curl`` or ``wget``.
+
+.. code-block:: sh
+
+   $ curl 0.0.0.0:8000/user-data
+   $ curl 0.0.0.0:8000/meta-data
+   $ curl 0.0.0.0:8000/vendor-data
+
+- When launching Qemu, if the webserver prints out 404 errors, then try to
+  figure out why those files can't be served (did you forget to start the
+  server in the temp directory?)
+  
+
+- When launching Qemu, if the webserver shows that it succeeded in serving
+  ``user-data``, ``meta-data``, and ``vendor-data``, but you cannot log
+  in, then you may have provided incorrect cloud-config files.
+
+
+  If you do not see any new output, then cloud-init didn't discover its
+  datasource correctly.
+
+
+   If you cannot hit these files, figure out why (verify they exist
+   where the python webserver is running, check your local firewall, etc)
+
+
+
 Tear down
 =========
 
 Exit the Qemu shell using ``ctrl-a x`` (that's ``ctrl`` and ``a``
 simultaneously, followed by ``x``).
 
-If you started the python webserver in the background (using ``&``),
-then don't forget to bring it to the foreground (``fg``) and kill it
+Stop the python webserver that was started in a different terminal
 (``ctrl-c``).
+
 
 
 What's next?
@@ -138,3 +234,6 @@ You can also head over to the :ref:`examples<yaml_examples>` page for
 examples of more common use cases.
 
 .. _Qemu: https://www.qemu.org
+.. _module: https://cloudinit.readthedocs.io/en/latest/topics/modules.html#set-passwords
+.. _install instructions: https://www.qemu.org/download/#linux
+.. _LTS: https://wiki.ubuntu.com/Releases

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -10,14 +10,12 @@ Qemu Tutorial
    qemu-debugging.rst
 
 
-Tutorial overview
-=================
 
 In this tutorial, we will demonstrate launching an Ubuntu cloud image in a
 virtual machine that uses cloud-init to pre-configure the system during boot.
 
 The goal of this tutorial is to provide a minimal demonstration of cloud-init
-that users can use as a development environment to test cloud-init
+that you can use as a development environment to test cloud-init
 configurations locally prior to launching in the cloud.
 
 
@@ -210,7 +208,7 @@ Launch the virtual machine. By default, qemu will print to the terminal both
 kernel logs and systemd logs while the operating system boots. This may take a
 few moments to complete.
 
-If the output stopped scrolling but you don't see a prompt yet, type ``enter``
+If the output stopped scrolling but you don't see a prompt yet, press ``enter``
 to get to login prompt.
 
 
@@ -239,7 +237,7 @@ is ``password``.
 If you can log in using the configured password, it worked!
 
 If you cloudn't log in, see
-:ref:`this page for debug information<debug information>`.
+:ref:`this page for debug information<qemu_debug_info>`.
 
 
 Check cloud-init status

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -13,8 +13,8 @@ Qemu Tutorial
 Tutorial overview
 =================
 
-In this tutorial, we will demonstrate launching an Ubuntu virtual machine that
-uses cloud-init to pre-configure the instance during boot.
+In this tutorial, we will demonstrate launching an Ubuntu cloud image in a
+virtual machine that uses cloud-init to pre-configure the system during boot.
 
 The goal of this tutorial is to provide a minimal demonstration of cloud-init
 that users can use as a development environment to test cloud-init

--- a/doc/rtd/topics/tutorials/qemu.rst
+++ b/doc/rtd/topics/tutorials/qemu.rst
@@ -151,16 +151,16 @@ You should see the following contents:
       expire: False
 
 The first line starts with ``#cloud-config``, which tells cloud-init
-what kind of configuration is contained. The cloud-config config type uses YAML
-format to tell cloud-init how to configure the virtual machine instance.
-Multiple different formats are supported by cloud-init. See the
+which type of user-data is in the config. Cloud-config is a YAML-based
+configuration type that tells cloud-init how to configure the virtual machine
+instance. Multiple different format types are supported by cloud-init. See the
 :ref:`documentation describing different formats<user_data_formats>`.
 
 The second line, ``password: password``, per :ref:`the docs<mod-users_groups>`,
 sets the default user's password to ``password``.
 
-The third and fourth lines direct cloud-init to set this default password to
-never expire.
+The third and fourth lines direct cloud-init to not require password reset on
+first login.
 
 Define our meta data
 ====================


### PR DESCRIPTION
```
doc: add qemu tutorial
```

## Additional Context
The [NoCloud docs](https://cloudinit.readthedocs.io/en/latest/topics/datasources/nocloud.html) for more information about the datasource in use in this tutorial.

When more tutorials come into existance, a landing page/tutorial index for selecting which datasource to use may become desirable, but at only 2 total tutorials as of this PR, I don't know how much sense that would make. Thoughts?
