### PR TITLE
feat: add support for aliyun metadata security harden mode

### DIFF
--- a/cloudinit/sources/DataSourceAliYun.py
+++ b/cloudinit/sources/DataSourceAliYun.py
@@ -18,6 +18,11 @@ class DataSourceAliYun(EC2.DataSourceEc2):
     min_metadata_version = "2016-01-01"
     extended_metadata_versions: List[str] = []
 
+    # Aliyun metadata server security enhanced mode overwrite
+    @property
+    def imdsv2_token_put_header(self):
+        return "X-aliyun-ecs-metadata-token"
+
     def get_hostname(self, fqdn=False, resolve_ip=False, metadata_only=False):
         hostname = self.metadata.get("hostname")
         is_default = False

--- a/tests/unittests/sources/test_aliyun.py
+++ b/tests/unittests/sources/test_aliyun.py
@@ -98,6 +98,15 @@ class TestAliYunDatasource(test_helpers.ResponsesTestCase):
             "instance-identity",
         )
 
+    @property
+    def token_url(self):
+        return os.path.join(
+            self.metadata_address,
+            "latest",
+            "api",
+            "token",
+        )
+
     def register_mock_metaserver(self, base_url, data):
         def register_helper(register, base_url, body):
             if isinstance(body, str):
@@ -127,6 +136,7 @@ class TestAliYunDatasource(test_helpers.ResponsesTestCase):
         self.register_mock_metaserver(self.metadata_url, self.default_metadata)
         self.register_mock_metaserver(self.userdata_url, self.default_userdata)
         self.register_mock_metaserver(self.identity_url, self.default_identity)
+        self.responses.add(responses.PUT, self.token_url, "API-TOKEN")
 
     def _test_get_data(self):
         self.assertEqual(self.ds.metadata, self.default_metadata)

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -303,7 +303,7 @@ def register_mock_metaserver(base_url, data, responses_mock=None):
 
     def myreg(*argc, **kwargs):
         url, body = argc
-        method = responses.PUT if ec2.API_TOKEN_ROUTE in url else responses.GET
+        method = responses.PUT if "latest/api/token" in url else responses.GET
         status = kwargs.get("status", 200)
         return responses_mock.add(method, url, body, status=status)
 
@@ -1178,6 +1178,16 @@ class TesIdentifyPlatform(test_helpers.CiTestCase):
         }
         unspecial.update(**kwargs)
         return unspecial
+
+    @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
+    def test_identify_aliyun(self, m_collect):
+        """aliyun should be identified if product name equals to
+        Alibaba Cloud ECS
+        """
+        m_collect.return_value = self.collmock(
+            product_name="Alibaba Cloud ECS"
+        )
+        self.assertEqual(ec2.CloudNames.ALIYUN, ec2.identify_platform())
 
     @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
     def test_identify_zstack(self, m_collect):

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -72,6 +72,7 @@ lucendio
 lungj
 magnetikonline
 mal
+ManassehZhou
 mamercad
 manuelisimo
 marlluslustosa


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
feat: add support Aliyun metadata security hardening mode

currently, Alibaba cloud provides a security hardening mode for its metadata server, which is alike IMDSv2, and we should support it.

Detailed information be found here: https://www.alibabacloud.com/help/en/elastic-compute-service/latest/view-instance-metadata#concept-dwj-y1x-wgb
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly (not suitable, since no document need to be changed)
