### PR TITLE
Docs: adding relative links

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,7 +20,7 @@ Before any pull request can be accepted, you must do the following:
   to track CLA signatures:
   `tools/.github-cla-signers`_
 * Add or update any :ref:`unit tests<testing>` accordingly
-* Add or update any :ref:`integration tests` (if applicable)
+* Add or update any :ref:`integration_tests` (if applicable)
 * Format code (using black and isort) with `tox -e do_format`
 * Ensure unit tests and linting pass using `tox`_
 * Submit a PR against the `main` branch of the `cloud-init` repository
@@ -76,7 +76,7 @@ Follow these steps to submit your first pull request to cloud-init:
     git remote add upstream git@github.com:canonical/cloud-init.git
     git push origin main
 
-* Read through the cloud-init `Code Review Process`_, so you understand
+* Read through the cloud-init :ref:`Code Review Process<code_review_process>`, so you understand
   how your changes will end up in cloud-init's codebase.
 
 * Submit your first cloud-init pull request, adding your Github username to the
@@ -181,7 +181,7 @@ Do these things for each feature or bug
   - Click 'Create Pull Request`
 
 Then, a cloud-init committer will review your changes and
-follow up in the pull request.  Look at the :ref:`Code Review Process<code-review-process>` doc
+follow up in the pull request.  Look at the :ref:`Code Review Process<code_review_process>` doc
 to understand the following steps.
 
 Feel free to ping and/or join ``#cloud-init`` on Libera irc if you

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,3 +1,5 @@
+.. _contributing:
+
 Contributing to cloud-init
 **************************
 
@@ -17,14 +19,11 @@ Before any pull request can be accepted, you must do the following:
 * Add your Github username (alphabetically) to the in-repository list that we use
   to track CLA signatures:
   `tools/.github-cla-signers`_
-* Add or update any `unit tests`_ accordingly
-* Add or update any `integration tests`_ (if applicable)
+* Add or update any :ref:`unit tests<testing>` accordingly
+* Add or update any :ref:`integration tests` (if applicable)
 * Format code (using black and isort) with `tox -e do_format`
 * Ensure unit tests and linting pass using `tox`_
 * Submit a PR against the `main` branch of the `cloud-init` repository
-
-.. _unit tests: https://cloudinit.readthedocs.io/en/latest/topics/testing.html
-.. _integration tests: https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 
 The detailed instructions
 -------------------------
@@ -182,14 +181,13 @@ Do these things for each feature or bug
   - Click 'Create Pull Request`
 
 Then, a cloud-init committer will review your changes and
-follow up in the pull request.  Look at the `Code Review Process`_ doc
+follow up in the pull request.  Look at the :ref:`Code Review Process<code-review-process>` doc
 to understand the following steps.
 
 Feel free to ping and/or join ``#cloud-init`` on Libera irc if you
 have any questions.
 
 .. _tox: https://tox.readthedocs.io/en/latest/
-.. _Code Review Process: https://cloudinit.readthedocs.io/en/latest/topics/code_review.html
 
 Design
 ======

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -3,4 +3,4 @@ furo
 m2r2
 pyyaml
 sphinx
-sphinx-design
+sphinx_design

--- a/doc/rtd/index.rst
+++ b/doc/rtd/index.rst
@@ -1,6 +1,6 @@
 .. _index:
 
-cloud-init Documentation
+cloud-init documentation
 ########################
 
 Cloud-init is the *industry standard* multi-distribution method for
@@ -28,7 +28,7 @@ projects, contributions, suggestions, fixes and constructive feedback.
 * Read our `Code of conduct`_
 * Ask questions in the ``#cloud-init`` `IRC channel on Libera`_
 * Join the `cloud-init mailing list`_
-* `Contribute on Github`_
+* :ref:`Contribute on Github<contributing>`
 * `Release schedule`_
 
 Having trouble? We would like to help!
@@ -107,6 +107,5 @@ Having trouble? We would like to help!
 .. _IRC channel on Libera: https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init
 .. _cloud-init mailing list: https://launchpad.net/~cloud-init
 .. _mailing list archive: https://lists.launchpad.net/cloud-init/
-.. _Contribute on Github: https://cloudinit.readthedocs.io/en/latest/topics/contributing.html
 .. _Release schedule: https://discourse.ubuntu.com/t/cloud-init-release-schedule/32244
 .. _Report bugs on Launchpad: https://bugs.launchpad.net/cloud-init/+filebug

--- a/doc/rtd/topics/code_review.rst
+++ b/doc/rtd/topics/code_review.rst
@@ -1,6 +1,5 @@
-.. _code-review-process:
+.. _code_review_process:
 
-*******************
 Code Review Process
 *******************
 

--- a/doc/rtd/topics/code_review.rst
+++ b/doc/rtd/topics/code_review.rst
@@ -1,3 +1,5 @@
+.. _code-review-process:
+
 *******************
 Code Review Process
 *******************

--- a/doc/rtd/topics/module_creation.rst
+++ b/doc/rtd/topics/module_creation.rst
@@ -70,14 +70,8 @@ Guidelines
     module definition in ``/etc/cloud/cloud.cfg[.d]`` has been modified
     to pass arguments to this module.
 
-* Your module name must be included in `schema-cloud-config.json`_
-  under ``$defs.all_modules``, in order to be accepted as a module key in
-  the :ref:`base config<base_config_reference>`.
-
-* Add the new module to `Module Reference`_.
-
 * If your module introduces any new cloud-config keys, you must provide a
-  schema definition in `schema-cloud-config.json`_.
+  schema definition in `cloud-init-schema.json`_.
 * The ``meta`` variable must exist and be of type `MetaSchema`_.
 
   * ``id``: The module id. In most cases this will be the filename without
@@ -127,9 +121,8 @@ in the ``cloud_final_modules`` section before the ``final-message`` module.
 .. _MetaSchema: https://github.com/canonical/cloud-init/blob/3bcffacb216d683241cf955e4f7f3e89431c1491/cloudinit/config/schema.py#L58
 .. _OSFAMILIES: https://github.com/canonical/cloud-init/blob/3bcffacb216d683241cf955e4f7f3e89431c1491/cloudinit/distros/__init__.py#L35
 .. _settings.py: https://github.com/canonical/cloud-init/blob/3bcffacb216d683241cf955e4f7f3e89431c1491/cloudinit/settings.py#L66
-.. _schema-cloud-config.json: https://github.com/canonical/cloud-init/blob/main/cloudinit/config/schemas/schema-cloud-config-v1.json
+.. _cloud-init-schema.json: https://github.com/canonical/cloud-init/blob/main/cloudinit/config/schemas/versions.schema.cloud-config.json
 .. _cloud.cfg.tmpl: https://github.com/canonical/cloud-init/blob/main/config/cloud.cfg.tmpl
 .. _cloud_init_modules: https://github.com/canonical/cloud-init/blob/b4746b6aed7660510071395e70b2d6233fbdc3ab/config/cloud.cfg.tmpl#L70
 .. _cloud_config_modules: https://github.com/canonical/cloud-init/blob/b4746b6aed7660510071395e70b2d6233fbdc3ab/config/cloud.cfg.tmpl#L101
 .. _cloud_final_modules: https://github.com/canonical/cloud-init/blob/b4746b6aed7660510071395e70b2d6233fbdc3ab/config/cloud.cfg.tmpl#L144
-.. _Module Reference: https://github.com/canonical/cloud-init/blob/main/doc/rtd/topics/modules.rst

--- a/doc/rtd/topics/modules.rst
+++ b/doc/rtd/topics/modules.rst
@@ -37,6 +37,9 @@ Module Reference
 .. automodule:: cloudinit.config.cc_rh_subscription
 .. automodule:: cloudinit.config.cc_rightscale_userdata
 .. automodule:: cloudinit.config.cc_rsyslog
+
+.. _mod-runcmd:
+
 .. automodule:: cloudinit.config.cc_runcmd
 .. automodule:: cloudinit.config.cc_salt_minion
 .. automodule:: cloudinit.config.cc_scripts_per_boot

--- a/doc/rtd/topics/network-config-format-v2.rst
+++ b/doc/rtd/topics/network-config-format-v2.rst
@@ -233,7 +233,6 @@ Example: ``addresses: [192.168.14.2/24, 2001:1::1/64]``
 
 **gateway4**: or **gateway6**: *<(scalar)>*
 
-Deprecated, see `netplan#default-routes`_.
 Set default gateway for IPv4/6, for manual address configuration. This
 requires setting ``addresses`` too. Gateway IPs must be in a form
 recognized by ``inet_pton(3)``
@@ -573,6 +572,5 @@ This is a complex example which shows most available features: ::
         dhcp4: yes
 
 .. _netplan: https://netplan.io
-.. _netplan#default-routes: https://netplan.io/reference#default-routes
 .. _netplan#dhcp-overrides: https://netplan.io/reference#dhcp-overrides
 .. vi: textwidth=79

--- a/doc/rtd/topics/tutorial.rst
+++ b/doc/rtd/topics/tutorial.rst
@@ -48,7 +48,7 @@ following file on your local filesystem at ``/tmp/my-user-data``:
 
 Here we are defining our cloud-init user data in the
 :ref:`cloud-config<topics/format:Cloud Config Data>` format, using the
-`runcmd`_ module to define a command to run. When applied, it
+:ref:`runcmd module <mod-runcmd>` to define a command to run. When applied, it
 should write ``Hello, World!`` to ``/var/tmp/hello-world.txt``.
 
 Launch a container with our user data
@@ -128,8 +128,8 @@ and we can remove the container using:
 What's next?
 ============
 
-In this tutorial, we used the runcmd_ module to execute a shell command.
-The full list of modules available can be found in
+In this tutorial, we used the :ref:`runcmd module <mod-runcmd>` to execute a
+shell command. The full list of modules available can be found in
 :ref:`modules documentation<modules>`.
 Each module contains examples of how to use it.
 
@@ -138,4 +138,3 @@ examples of more common use cases.
 
 .. _LXD: https://linuxcontainers.org/lxd/
 .. _other installation options: https://linuxcontainers.org/lxd/getting-started-cli/#other-installation-options
-.. _runcmd: https://cloudinit.readthedocs.io/en/latest/topics/modules.html#runcmd


### PR DESCRIPTION
## Proposed Commit Message
```
docs: changed all internal links to be relative

In preparation for migrating the docs to RTD.com, identified all 
links that point to the RTD.org links and changed them to be 
relative so that it doesn't matter where they are rendered. 

Also fixed the sphinx-design extension - although it's not used
yet, I will be using it to create the Diataxis home page sections.
```
