### PR TITLE
Add support for multiple [Route] sections so device routes work

### DIFF
--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -41,6 +41,10 @@ class CfgParser:
                 self.conf_dict[k].sort()
 
     def update_route_section(self, sec, rid, key, val):
+        """
+        For each route section we use rid as a key, this allows us to isolate
+        this route from others on subsequent calls.
+        """
         for k in self.conf_dict.keys():
             if k == sec:
                 if rid not in self.conf_dict[k]:
@@ -131,6 +135,10 @@ class Renderer(renderer.Renderer):
             cfg.update_section(sec, "MTUBytes", iface["mtu"])
 
     def parse_routes(self, rid, conf, cfg: CfgParser):
+        """
+        Parse a route and use rid as a key in order to isolate the route from
+        others in the route dict.
+        """
         sec = "Route"
         route_cfg_map = {
             "gateway": "Gateway",

--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -176,6 +176,8 @@ class Renderer(renderer.Renderer):
                     dhcp = "yes"
             if "routes" in e and e["routes"]:
                 for i in e["routes"]:
+                    # Use "r" as a dict key prefix for this route to isolate
+                    # it from other sources of routes
                     self.parse_routes(f"r{rid}", i, cfg)
                     rid = rid + 1
             if "address" in e:
@@ -191,6 +193,8 @@ class Renderer(renderer.Renderer):
                             v += "/" + str(e["prefix"])
                         cfg.update_section("Address", subnet_cfg_map[k], v)
                     elif k == "gateway":
+                        # Use "a" as a dict key prefix for this route to
+                        # isolate it from other sources of routes
                         cfg.update_route_section(
                             "Route", f"a{rid}", subnet_cfg_map[k], v
                         )
@@ -313,6 +317,8 @@ class Renderer(renderer.Renderer):
 
             rid = 0
             for route in ns.iter_routes():
+                # Use "c" as a dict key prefix for this route to isolate it
+                # from other sources of routes
                 self.parse_routes(f"c{rid}", route, cfg)
                 rid = rid + 1
 

--- a/tests/unittests/net/test_networkd.py
+++ b/tests/unittests/net/test_networkd.py
@@ -201,6 +201,48 @@ Gateway=2a01:4f8:10a:19d2::2
 
 """
 
+V2_CONFIG_MULTI_SUBNETS = """
+network:
+  version: 2
+  ethernets:
+    eth0:
+      addresses:
+        - 192.168.1.1/24
+        - fec0::1/64
+      gateway4: 192.168.254.254
+      gateway6: "fec0::ffff"
+      routes:
+        - to: 169.254.1.1/32
+        - to: "fe80::1/128"
+"""
+
+V2_CONFIG_MULTI_SUBNETS_RENDERED = """\
+[Address]
+Address=192.168.1.1/24
+
+[Address]
+Address=fec0::1/64
+
+[Match]
+Name=eth0
+
+[Network]
+DHCP=no
+
+[Route]
+Gateway=192.168.254.254
+
+[Route]
+Gateway=fec0::ffff
+
+[Route]
+Destination=169.254.1.1/32
+
+[Route]
+Destination=fe80::1/128
+
+"""
+
 
 class TestNetworkdRenderState:
     def _parse_network_state_from_config(self, config):
@@ -309,5 +351,16 @@ class TestNetworkdRenderState:
 
         assert rendered_content["eth0"] == V1_CONFIG_MULTI_SUBNETS_RENDERED
 
+    def test_networkd_render_v2_multi_subnets(self):
+        """
+        Ensure a device with multiple subnets gets correctly rendered.
 
-# vi: ts=4 expandtab
+        Per systemd-networkd docs, [Route] can only contain a single instance
+        of Gateway.
+        """
+        with mock.patch("cloudinit.net.get_interfaces_by_mac"):
+            ns = self._parse_network_state_from_config(V2_CONFIG_MULTI_SUBNETS)
+            renderer = networkd.Renderer()
+            rendered_content = renderer._render_content(ns)
+
+        assert rendered_content["eth0"] == V2_CONFIG_MULTI_SUBNETS_RENDERED

--- a/tests/unittests/net/test_networkd.py
+++ b/tests/unittests/net/test_networkd.py
@@ -195,6 +195,8 @@ Domains=rgrunbla.github.beta.tailscale.net
 
 [Route]
 Gateway=10.0.0.1
+
+[Route]
 Gateway=2a01:4f8:10a:19d2::2
 
 """


### PR DESCRIPTION
## Proposed Commit Message

```
networkd: Add support for multiple [Route] sections to support device routes

Networkd supports multiple [Route] sections within the same file.  Currently all [Route] section tags are squashed
into one and if there is a default gateway it means defining a device route is not possible as the target is set to the
default gateway.

This patch adds support for multiple [Route] sections allowing us to support device routes. This is done by
tracking each route in the route list individually and ensuring the key-value pairs are maintained within their 
respective [Route] section. This both maintains backwards compatibility with previous behavior and allows
the specification of routes with no destination IP, causing the destination to be added with a device target.

```

## Additional Context

So the problem is with a relatively simple configuration it is impossible to create a device route. Take this snippet for an example...
```
addresses:
  - 192.168.1.1/24
  - fec0::1/64
gateway4: 192.168.254.254
gateway6: "fec0::ffff"
routes:
  - to: 169.254.1.1/32
  - to: "fe80::1/128"
 ```

The result of this is ...
```
...
[Route]
Gateway=192.168.254.254
Gateway=fec0::ffff
Destination=169.254.1.1/32
Destination=fe80::1/128
```

Not so great if you understand that the resulting configuration will route 169.254.1.1 and fe80::1 via 192.168.254 and fec0::ffff respectively.

A comparable manual operation wouldbe...
```
ip route add 169.254.1.1/32 via 192.168.254.254
ip -6 route add fe80::1/128 via fec0::ffff
```

Maybe this doesn't sound like a problem, but it prevents a configuration like this from being created...

```
ip route add 169.254.1.1 dev eno1
ip -6 route add fe80::1/128 dev eno1
ip route add default via 169.254.1.1
ip -6 route add default via fe80::1 dev eno1
```

My solution is to track each [Route] section individually by using a dictionary, we prefix statics with 'a' and routes with 'r' to sort later so it looks a bit better. We keep each routes respective key-value pairs in the same section so we do not pollute one section with another sections tags.

I have modified one test case to cater for multiple route sections, all other tests pass. I do not believe additional documentation is necessary as in the absence of a "via" key, the route should be assumed to have no destination IP and be a device route.

This results in the following configuration...
```
[Route]
Gateway=192.168.254.254

[Route]
Gateway=fec0::ffff

[Route]
Destination=169.254.1.1/32

[Route]
Destination=fe80::1/128
```

Maybe it still doesn't make much sense and one is sitting with a 🤔.

Let us take a technical example where a cloud provider sets up 169.254.1.1/32 and fe80::1/128 on the lan side of containers and virtual machines. The reason for this is if every container/vm has a single default gateway they can be migrated between DC's and regions without the need for any client configuration. This also bypasses the requirement to use private ranges on the LAN and NAT on their network.

The only purpose of these /32 and /128 IP's is to resolve a MAC for the traffic to be routed to. The cloud provider routes IP traffic in the other direction in a similar manner, by adding the and locking the VM/container MAC to an IP and adding this route to their LAN side.

The configuration to get this working would be similar to this...
```
ip route add 169.254.1.1/32 dev eno1
ip -6 route add fe80::1/128 dev eno1
ip route add default via 169.254.1.1 dev eno1
ip -6 route add default via fe80::1 dev eno1
```

This is only possible if we can create a device route in cloud-init with a configuration similar to this with my patch...
```
addresses:
  - 192.168.1.1/32
  - fec0::1/128
gateway4: 169.254.1.1
gateway6: "fe80::1"
routes:
  - to: 169.254.1.1/32
  - to: "fe80::1/128"
```

This does not currently work and results in all the [Route] fields being mangled in a single [Route] section.



## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [X ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
