### PR TITLE
Make 3.12 failures not fail the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,3 +152,5 @@ matrix:
         - python: 3.9
         - python: 3.8
         - python: 3.7
+    allow_failures:
+        - python: 3.12-dev


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Make 3.12 failures not fail the build

Since 3.12 is the development release, failures of it
shouldn't fail the overall build.
```

## Additional Context
https://app.travis-ci.com/github/canonical/cloud-init/jobs/588960329
and
https://docs.python.org/3.12/whatsnew/3.12.html
