### PR TITLE
docs: uprate analyze to performance page

### DIFF
--- a/doc/rtd/topics/analyze.rst
+++ b/doc/rtd/topics/analyze.rst
@@ -110,7 +110,7 @@ Show
 
 The ``show`` action is similar to ``systemd-analyze critical-chain`` which
 prints a list of units, the time they started and how long they took.
-Cloud-init has four :ref:`boot_stages`, and within each stage a number of modules may
+Cloud-init has four :ref:`boot stages<boot_stages>`, and within each stage a number of modules may
 run depending on configuration. ``cloudinit-analyze show`` will, for each boot,
 print this information and a summary of the total time.
 

--- a/doc/rtd/topics/analyze.rst
+++ b/doc/rtd/topics/analyze.rst
@@ -110,7 +110,7 @@ Show
 
 The ``show`` action is similar to ``systemd-analyze critical-chain`` which
 prints a list of units, the time they started and how long they took.
-Cloud-init has four boot stages, and within each stage a number of modules may
+Cloud-init has four :ref:`boot_stages`, and within each stage a number of modules may
 run depending on configuration. ``cloudinit-analyze show`` will, for each boot,
 print this information and a summary of the total time.
 

--- a/doc/rtd/topics/analyze.rst
+++ b/doc/rtd/topics/analyze.rst
@@ -27,8 +27,8 @@ The analyze command requires one of the four subcommands:
 Availability
 ============
 
-The analyze subcommand is generally available across all distributions, with
-the exception of Gentoo and FreeBSD.
+The ``analyze`` subcommand is generally available across all distributions,
+with the exception of Gentoo and FreeBSD.
 
 Subcommands
 ===========

--- a/doc/rtd/topics/analyze.rst
+++ b/doc/rtd/topics/analyze.rst
@@ -1,9 +1,9 @@
 .. _analyze:
 
-Analyze
-*******
+Performance
+***********
 
-The analyze subcommand was added to cloud-init in order to help analyze
+The ``analyze`` subcommand was added to cloud-init to help analyze
 cloud-init boot time performance. It is loosely based on systemd-analyze where
 there are four subcommands:
 
@@ -27,8 +27,8 @@ The analyze command requires one of the four subcommands:
 Availability
 ============
 
-The analyze subcommand is generally available across all distributions with the
-exception of Gentoo and FreeBSD.
+The analyze subcommand is generally available across all distributions, with
+the exception of Gentoo and FreeBSD.
 
 Subcommands
 ===========
@@ -37,7 +37,7 @@ Blame
 -----
 
 The ``blame`` action matches ``systemd-analyze blame`` where it prints, in
-descending order, the units that took the longest to run.  This output is
+descending order, the units that took the longest to run. This output is
 highly useful for examining where cloud-init is spending its time during
 execution.
 
@@ -110,9 +110,9 @@ Show
 
 The ``show`` action is similar to ``systemd-analyze critical-chain`` which
 prints a list of units, the time they started and how long they took.
-Cloud-init has four stages and within each stage a number of modules may run
-depending on configuration. ``cloudinit-analyze show`` will, for each boot,
-print this information and a summary total time, per boot.
+Cloud-init has four boot stages, and within each stage a number of modules may
+run depending on configuration. ``cloudinit-analyze show`` will, for each boot,
+print this information and a summary of the total time.
 
 The following is an abbreviated example of the show output:
 


### PR DESCRIPTION
## Proposed Commit Message
```
docs: uprate analyze to performance page

As previously discussed, the Analyze page contains the content we want
to present under the "Performance" topic and should be uprated. 

I have changed the title of the "Analyze" page to "Performance" so that
it shows correctly in the LHS menu. The anchors are the same, and I have 
not changed the file name so as to avoid having to update any links.

I took the opportunity to make some minor tidying edits to the text.
Hopefully these will add clarity and not change the intended meaning. 
```