### PR TITLE
FreeBSD init: use cloudinit_enable as only rcvar

### DIFF
--- a/sysvinit/freebsd/cloudconfig
+++ b/sysvinit/freebsd/cloudconfig
@@ -21,8 +21,8 @@ cloudconfig_start()
 	${command} modules --mode config
 }
 
-load_rc_config $name
+load_rc_config 'cloudinit'
 
-: ${cloudconfig_enable="NO"}
+: ${cloudinit_enable="NO"}
 
 run_rc_command "$1"

--- a/sysvinit/freebsd/cloudfinal
+++ b/sysvinit/freebsd/cloudfinal
@@ -21,8 +21,8 @@ cloudfinal_start()
 	${command} modules --mode final
 }
 
-load_rc_config $name
+load_rc_config 'cloudinit'
 
-: ${cloudfinal_enable="NO"}
+: ${cloudinit_enable="NO"}
 
 run_rc_command "$1"

--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -21,7 +21,7 @@ cloudinit_start()
 	${command} init
 }
 
-load_rc_config $name
+load_rc_config 'cloudinit'
 
 : ${cloudinit_enable="NO"}
 

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -21,8 +21,8 @@ cloudlocal_start()
 	${command} init --local
 }
 
-load_rc_config $name
+load_rc_config 'cloudinit'
 
-: ${cloudinitlocal_enable="NO"}
+: ${cloudinit_enable="NO"}
 
 run_rc_command "$1"


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
FreeBSD init: use cloudinit_enable as only rcvar

all components of cloudinit need to run, and in a specific order.
If cloudinit is to be enabled, it should only rely on one variable.
This change better encodes that, than #161 

Sponsored by: FreeBSD Foundation
```

## Additional Context
Currently, when cloud-init isn't enabled, some of its components issue rc warnings.
Previously, in https://github.com/canonical/cloud-init/pull/161 we went overboard, by giving each its own variable

## Test Steps
install this patch, reboot, see no more warnings.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
