### PR TITLE
status: handle ds not defined in status.json

### DIFF
--- a/tests/unittests/cmd/test_cloud_id.py
+++ b/tests/unittests/cmd/test_cloud_id.py
@@ -45,6 +45,16 @@ STATUS_DETAILS_RUNNING = status.StatusDetails(
 )
 
 
+STATUS_DETAILS_RUNNING_DS_NONE = status.StatusDetails(
+    status.UXAppStatus.RUNNING,
+    status.UXAppBootStatusCode.UNKNOWN,
+    "",
+    [],
+    "",
+    None,
+)
+
+
 @pytest.fixture(autouse=True)
 def setup_mocks(mocker):
     mocker.patch(
@@ -203,6 +213,7 @@ class TestCloudId:
             (STATUS_DETAILS_DISABLED, 2),
             (STATUS_DETAILS_NOT_RUN, 3),
             (STATUS_DETAILS_RUNNING, 0),
+            (STATUS_DETAILS_RUNNING_DS_NONE, 0),
         ),
     )
     @mock.patch(M_PATH + "get_status_details")

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -38,6 +38,40 @@ def config(tmpdir):
 class TestStatus:
     maxDiff = None
 
+    @mock.patch(
+        M_PATH + "load_file",
+        return_value=(
+            '{"v1": {"datasource": null, "init": {"errors": [], "finished": '
+            'null, "start": null}, "init-local": {"errors": [], "finished": '
+            'null, "start": 1669231096.9621563}, "modules-config": '
+            '{"errors": [], "finished": null, "start": null},'
+            '"modules-final": {"errors": [], "finished": null, '
+            '"start": null}, "modules-init": {"errors": [], "finished": '
+            'null, "start": null}, "stage": "init-local"} }'
+        ),
+    )
+    @mock.patch(M_PATH + "os.path.exists", return_value=True)
+    @mock.patch(
+        M_PATH + "get_bootstatus",
+        return_value=(
+            status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
+            "Cloud-init enabled by systemd cloud-init-generator",
+        ),
+    )
+    def test_get_status_details_ds_none(
+        self, m_get_boot_status, m_p_exists, m_load_json, tmpdir
+    ):
+        paths = mock.Mock()
+        paths.run_dir = str(tmpdir)
+        assert status.StatusDetails(
+            status.UXAppStatus.RUNNING,
+            status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
+            "Running in stage: init-local",
+            [],
+            "Wed, 23 Nov 2022 19:18:16 +0000",
+            None,  # datasource
+        ) == status.get_status_details(paths)
+
     @pytest.mark.parametrize(
         [
             "ensured_file",


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
status: handle ds not defined in status.json

Handles any situation where `status.json` does not yet contain
datasource information, by gracefully fulfilling a 
`datasource=None` in `StatusDetails`.

LP: #1997559
```

## Additional Context
<!-- If relevant -->
https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1997559

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Execute:

```sh
lxc launch --ephemeral ubuntu-daily:lunar test
lxc exec test -- cloud-init status --wait
```

I noticed the error does not arise 100% of times, therefore there is some kind of race condition or non-deterministic behavior happening when using the ephemeral option on LXD.

This PR handles any situation where `status.json` does contain `{"v1": {"datasource": null}}`, in general, by gracefully fulfilling a `datasource=None` in `StatusDetails`.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
