### PR TITLE
nocloud: add support for dmi variable expansion for seedfrom URL

### DIFF
--- a/cloudinit/dmi.py
+++ b/cloudinit/dmi.py
@@ -183,22 +183,13 @@ def read_dmi_data(key: str) -> Optional[str]:
     return None
 
 
-def _get_dmi_keys():
-    """Return a list of valid DMI keys which can be used by sub_dmi_vars"""
-    attr_name = "freebsd" if is_FreeBSD() else "linux"
-    return list(DMIDECODE_TO_KERNEL.keys()) + [
-        getattr(kernelname, attr_name)
-        for kernelname in DMIDECODE_TO_KERNEL.values()
-    ]
-
-
 def sub_dmi_vars(src: str) -> str:
     """Replace %dmi.VARNAME% with DMI values from either sysfs or kenv."""
     if "%" not in src:
         return src
-    matches = re.findall(r"\%dmi\.([-_.\w]+)\%", src)
+    matches = re.findall(r"\%dmi\.([-.\w]+)\%", src)
+    valid_dmi_keys = DMIDECODE_TO_KERNEL.keys()
     if matches:
-        valid_dmi_keys = _get_dmi_keys()
         for match in matches:
             if match not in valid_dmi_keys:
                 LOG.warning(

--- a/cloudinit/dmi.py
+++ b/cloudinit/dmi.py
@@ -202,12 +202,12 @@ def sub_dmi_vars(src: str) -> str:
             dmi_value = read_dmi_data(match)
             if not dmi_value:
                 dmi_value = ""
-                LOG.debug(
-                    "Replacing $dmi.%s in '%s' with '%s'.",
-                    match,
-                    src,
-                    dmi_value,
-                )
+            LOG.debug(
+                "Replacing $dmi.%s in '%s' with '%s'.",
+                match,
+                src,
+                dmi_value,
+            )
             src = src.replace(f"%dmi.{match}%", dmi_value)
     return src
 

--- a/cloudinit/dmi.py
+++ b/cloudinit/dmi.py
@@ -184,16 +184,16 @@ def read_dmi_data(key: str) -> Optional[str]:
 
 
 def sub_dmi_vars(src: str) -> str:
-    """Replace %dmi.VARNAME% with DMI values from either sysfs or kenv."""
-    if "%" not in src:
+    """Replace __dmi.VARNAME__ with DMI values from either sysfs or kenv."""
+    if "__" not in src:
         return src
-    matches = re.findall(r"\%dmi\.([-.\w]+)\%", src)
+    matches = re.findall(r"__dmi\.([^_]+)__", src)
     valid_dmi_keys = DMIDECODE_TO_KERNEL.keys()
     if matches:
         for match in matches:
             if match not in valid_dmi_keys:
                 LOG.warning(
-                    "Ignoring invalid %%dmi.%s%% in %s. Expected one of: %s.",
+                    "Ignoring invalid __dmi.%s__ in %s. Expected one of: %s.",
                     match,
                     src,
                     valid_dmi_keys,
@@ -203,12 +203,12 @@ def sub_dmi_vars(src: str) -> str:
             if not dmi_value:
                 dmi_value = ""
             LOG.debug(
-                "Replacing $dmi.%s in '%s' with '%s'.",
+                "Replacing __dmi.%s__ in '%s' with '%s'.",
                 match,
                 src,
                 dmi_value,
             )
-            src = src.replace(f"%dmi.{match}%", dmi_value)
+            src = src.replace(f"__dmi.{match}__", dmi_value)
     return src
 
 

--- a/cloudinit/dmi.py
+++ b/cloudinit/dmi.py
@@ -187,28 +187,26 @@ def sub_dmi_vars(src: str) -> str:
     """Replace __dmi.VARNAME__ with DMI values from either sysfs or kenv."""
     if "__" not in src:
         return src
-    matches = re.findall(r"__dmi\.([^_]+)__", src)
     valid_dmi_keys = DMIDECODE_TO_KERNEL.keys()
-    if matches:
-        for match in matches:
-            if match not in valid_dmi_keys:
-                LOG.warning(
-                    "Ignoring invalid __dmi.%s__ in %s. Expected one of: %s.",
-                    match,
-                    src,
-                    valid_dmi_keys,
-                )
-                continue
-            dmi_value = read_dmi_data(match)
-            if not dmi_value:
-                dmi_value = ""
-            LOG.debug(
-                "Replacing __dmi.%s__ in '%s' with '%s'.",
+    for match in re.findall(r"__dmi\.([^_]+)__", src):
+        if match not in valid_dmi_keys:
+            LOG.warning(
+                "Ignoring invalid __dmi.%s__ in %s. Expected one of: %s.",
                 match,
                 src,
-                dmi_value,
+                valid_dmi_keys,
             )
-            src = src.replace(f"__dmi.{match}__", dmi_value)
+            continue
+        dmi_value = read_dmi_data(match)
+        if not dmi_value:
+            dmi_value = ""
+        LOG.debug(
+            "Replacing __dmi.%s__ in '%s' with '%s'.",
+            match,
+            src,
+            dmi_value,
+        )
+        src = src.replace(f"__dmi.{match}__", dmi_value)
     return src
 
 

--- a/cloudinit/features.py
+++ b/cloudinit/features.py
@@ -69,6 +69,17 @@ world-readable. Prior to 23.1, netplan configuration is world-readable.
 (This flag can be removed after Jammy is no longer supported.)
 """
 
+
+NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH = True
+"""
+Append a forward slash '/' if NoCloud seedurl does not end with either
+a querystring or forward slash. Prior to 23.1, nocloud seedurl would be used
+unaltered, appending meta-data, user-data and vendor-data to without URL path
+separators.
+
+(This flag can be removed when Jammy is no longer supported.)
+"""
+
 try:
     # pylint: disable=wildcard-import
     from cloudinit.feature_overrides import *  # noqa

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -156,7 +156,7 @@ class DataSourceNoCloud(sources.DataSource):
         # The special argument "seedfrom" indicates we should
         # attempt to seed the userdata / metadata from its value
         # its primarily value is in allowing the user to type less
-        # on the command line, ie: ds=nocloud;s=http://bit.ly/abcdefg
+        # on the command line, ie: ds=nocloud;s=http://bit.ly/abcdefg/
         if "seedfrom" in mydata["meta-data"]:
             seedfrom = mydata["meta-data"]["seedfrom"]
             seedfound = False
@@ -168,7 +168,7 @@ class DataSourceNoCloud(sources.DataSource):
                 LOG.debug("Seed from %s not supported by %s", seedfrom, self)
                 return False
             # check and replace instances of known dmi.<dmi_keys> such as
-            # chass-board, serial number etc.
+            # chassis-serial-number or baseboard-product-name
             seedfrom = dmi.sub_dmi_vars(seedfrom)
 
             # This could throw errors, but the user told us to do it

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -167,6 +167,9 @@ class DataSourceNoCloud(sources.DataSource):
             if not seedfound:
                 LOG.debug("Seed from %s not supported by %s", seedfrom, self)
                 return False
+            # check and replace instances of known dmi.<dmi_keys> such as
+            # chass-board, serial number etc.
+            seedfrom = dmi.sub_dmi_vars(seedfrom)
 
             # This could throw errors, but the user told us to do it
             # so if errors are raised, let them raise

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -980,10 +980,13 @@ def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
         vd_url = base % ("vendor-data" + ext)
         md_url = base % ("meta-data" + ext)
     else:
+        # RELEASE_BLOCKER(do not append trailing slash on stable releases)
+        if base[-1] != "/" and parse.urlparse(base).query == "":
+            # Append fwd slash when no query string and no %s
+            base += "/"
         ud_url = "%s%s%s" % (base, "user-data", ext)
         vd_url = "%s%s%s" % (base, "vendor-data", ext)
         md_url = "%s%s%s" % (base, "meta-data", ext)
-
     md_resp = url_helper.read_file_or_url(
         md_url, timeout=timeout, retries=retries
     )

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -976,9 +976,9 @@ def load_yaml(blob, default=None, allowed=(dict,)):
 
 def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
     if base.find("%s") >= 0:
-        ud_url = base % ("user-data" + ext)
-        vd_url = base % ("vendor-data" + ext)
-        md_url = base % ("meta-data" + ext)
+        ud_url = base.replace("%s", "user-data" + ext)
+        vd_url = base.replace("%s", "vendor-data" + ext)
+        md_url = base.replace("%s", "meta-data" + ext)
     else:
         # RELEASE_BLOCKER(do not append trailing slash on stable releases)
         if base[-1] != "/" and parse.urlparse(base).query == "":

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -38,7 +38,7 @@ from functools import lru_cache, total_ordering
 from typing import Callable, Deque, Dict, List, TypeVar
 from urllib import parse
 
-from cloudinit import importer
+from cloudinit import features, importer
 from cloudinit import log as logging
 from cloudinit import (
     mergers,
@@ -980,10 +980,10 @@ def read_seeded(base="", ext="", timeout=5, retries=10, file_retries=0):
         vd_url = base.replace("%s", "vendor-data" + ext)
         md_url = base.replace("%s", "meta-data" + ext)
     else:
-        # RELEASE_BLOCKER(do not append trailing slash on stable releases)
-        if base[-1] != "/" and parse.urlparse(base).query == "":
-            # Append fwd slash when no query string and no %s
-            base += "/"
+        if features.NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH:
+            if base[-1] != "/" and parse.urlparse(base).query == "":
+                # Append fwd slash when no query string and no %s
+                base += "/"
         ud_url = "%s%s%s" % (base, "user-data", ext)
         vd_url = "%s%s%s" % (base, "vendor-data", ext)
         md_url = "%s%s%s" % (base, "meta-data", ext)

--- a/doc/examples/cloud-config-datasources.txt
+++ b/doc/examples/cloud-config-datasources.txt
@@ -31,7 +31,7 @@ datasource:
     # default seedfrom is None
     # if found, then it should contain a url with:
     #    <url>/user-data and <url>/meta-data
-    # seedfrom: http://my.example.com/i-abcde
+    # seedfrom: http://my.example.com/i-abcde/
     seedfrom: None
 
     # fs_label: the label on filesystems to be searched for NoCloud source

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -35,81 +35,43 @@ With ``ds=nocloud``, the ``seedfrom`` value must start with ``/`` or
 with ``http://`` or ``https://`` and end with a trailing ``/``.
 
 Cloud-init performs variable expansion of the seedfrom URL for any DMI kernel
-variables present in ``/sys/class/dmi/id`` or FreeBSD's kenv.
-Your ``seedfrom`` URL can contain variable names of the format `:dmi.varname:`
-to indicate to cloud-init NoCloud datasource that variable expansion to the
-actual value of the DMI system attribute is wanted. The leading and trailing
-colon `:` before and after any `:dmi.<varname>:` are used because other
-metacharacters would hae to be escaped to avoid Grub interpreting those chars.
+variables present in ``/sys/class/dmi/id`` (kenv on FreeBSD).
+Your ``seedfrom`` URL can contain variable names of the format
+``%dmi.varname%`` to indicate to cloud-init NoCloud datasource that dmi.varname
+should be expanded to the actual value of the DMI system attribute is wanted.
+The leading and trailing percent ``%`` in ``%dmi.<varname>%`` are used because
+other metacharacters would have to be escaped to avoid Grub interpreting those
+chars.
 Typically you want to use cloud-init's distro-agnostic alias
 
 .. list-table:: Available DMI variables for expansion in ``seedfrom`` URL
-  :widths: 25 25 50
-  :header-rows: 1
+  :widths: 35 35 30
+  :header-rows: 0
 
-  * - Distro-agnostic DMI string
-    - Linux-specific /sys/class/dmi/id key
-    - FreeBSD-specific kenv key
-  * - dmi.baseboard-asset-tag
-    - dmi.board_asset_tag
-    - dmi.smbios.planar.tag
-  * - dmi.baseboard-manufacturer
-    - dmi.board_vendor
-    - dmi.smbios.planar.maker
-  * - dmi.baseboard-version
-    - dmi.board_version
-    - dmi.smbios.planar.version
-  * - dmi.bios-release-date
-    - dmi.bios_date
-    - dmi.smbios.bios.reldate
-  * - dmi.bios-vendor
-    - dmi.bios_vendor
-    - dmi.smbios.bios.vendor
-  * - dmi.bios-version
-    - dmi.bios_version
-    - dmi.smbios.bios.version
-  * - dmi.chassis-asset-tag
-    - dmi.chassis_asset_tag
-    - dmi.smbios.chassis.tag
-  * - dmi.chassis-manufacturer
-    - dmi.chassis_vendor
-    - dmi.smbios.chassis.maker
-  * - dmi.chassis-serial-number
-    - dmi.chassis_serial
-    - dmi.smbios.chassis.serial
-  * - dmi.chassis-version
-    - dmi.chassis_version
-    - dmi.smbios.chassis.version
-  * - dmi.system-manufacturer
-    - dmi.sys_vendor
-    - dmi.smbios.system.maker
-  * - dmi.system-product-name
-    - dmi.product_name
-    - dmi.smbios.system.product
-  * - dmi.system-serial-number
-    - dmi.product_serial
-    - dmi.smbios.system.serial
-  * - dmi.system-uuid
-    - dmi.product_uuid
-    - dmi.smbios.system.uuid
-  * - dmi.system-version
-    - dmi.product_version
-    - dmi.smbios.system.version
+  * - ``dmi.baseboard-asset-tag``
+    - ``dmi.baseboard-manufacturer``
+    - ``dmi.baseboard-version``
+  * - ``dmi.bios-release-date``
+    - ``dmi.bios-vendor``
+    - ``dmi.bios-version``
+  * - ``dmi.chassis-asset-tag``
+    - ``dmi.chassis-manufacturer``
+    - ``dmi.chassis-serial-number``
+  * - ``dmi.chassis-version``
+    - ``dmi.system-manufacturer``
+    - ``dmi.system-product-name``
+  * - ``dmi.system-serial-number``
+    - ``dmi.system-uuid``
+    - ``dmi.system-version``
 
 
-e.g. you can pass this option to QEMU
+For example, you can pass this option to QEMU
 
 ::
 
   -smbios type=1,serial=ds=nocloud-net;s=http://10.10.0.1:8000/%dmi.chassis-serial-number%/
 
-or append the following GRUB kernel commandline on your Ubuntu Live server/desktop installer
-
-::
-
-  autostart ds=nocloud-net;s=http://10.10.0.1:8000/%dmi.chassis-serial-number%/
-
-to cause NoCloud to fetch the full meta-data for YOUR_SERIAL_NUMBER as seen in `/sys/class/dmi/id/chassis_serial_number` or kenv on FreeBSD from http://10.10.0.1:8000/YOUR_SERIAL_NUMBER/meta-data
+to cause NoCloud to fetch the full meta-data for YOUR_SERIAL_NUMBER as seen in `/sys/class/dmi/id/chassis_serial_number` (kenv on FreeBSD) from http://10.10.0.1:8000/YOUR_SERIAL_NUMBER/meta-data
 after the network initialization is complete.
 
 These user-data and meta-data files are expected to be in the following format.

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -32,15 +32,84 @@ The permitted keys are:
 
 With ``ds=nocloud``, the ``seedfrom`` value must start with ``/`` or
 ``file://``.  With ``ds=nocloud-net``, the ``seedfrom`` value must start
-with ``http://`` or ``https://``.
+with ``http://`` or ``https://`` and end with a trailing ``/``.
 
-e.g. you can pass this option to QEMU:
+Cloud-init performs variable expansion of the seedfrom URL for any DMI kernel
+variables present in ``/sys/class/dmi/id`` or FreeBSD's kenv.
+Your ``seedfrom`` URL can contain variable names of the format `:dmi.varname:`
+to indicate to cloud-init NoCloud datasource that variable expansion to the
+actual value of the DMI system attribute is wanted. The leading and trailing
+colon `:` before and after any `:dmi.<varname>:` are used because other
+metacharacters would hae to be escaped to avoid Grub interpreting those chars.
+Typically you want to use cloud-init's distro-agnostic alias
+
+.. list-table:: Available DMI variables for expansion in ``seedfrom`` URL
+  :widths: 25 25 50
+  :header-rows: 1
+
+  * - Distro-agnostic DMI string
+    - Linux-specific /sys/class/dmi/id key
+    - FreeBSD-specific kenv key
+  * - dmi.baseboard-asset-tag
+    - dmi.board_asset_tag
+    - dmi.smbios.planar.tag
+  * - dmi.baseboard-manufacturer
+    - dmi.board_vendor
+    - dmi.smbios.planar.maker
+  * - dmi.baseboard-version
+    - dmi.board_version
+    - dmi.smbios.planar.version
+  * - dmi.bios-release-date
+    - dmi.bios_date
+    - dmi.smbios.bios.reldate
+  * - dmi.bios-vendor
+    - dmi.bios_vendor
+    - dmi.smbios.bios.vendor
+  * - dmi.bios-version
+    - dmi.bios_version
+    - dmi.smbios.bios.version
+  * - dmi.chassis-asset-tag
+    - dmi.chassis_asset_tag
+    - dmi.smbios.chassis.tag
+  * - dmi.chassis-manufacturer
+    - dmi.chassis_vendor
+    - dmi.smbios.chassis.maker
+  * - dmi.chassis-serial-number
+    - dmi.chassis_serial
+    - dmi.smbios.chassis.serial
+  * - dmi.chassis-version
+    - dmi.chassis_version
+    - dmi.smbios.chassis.version
+  * - dmi.system-manufacturer
+    - dmi.sys_vendor
+    - dmi.smbios.system.maker
+  * - dmi.system-product-name
+    - dmi.product_name
+    - dmi.smbios.system.product
+  * - dmi.system-serial-number
+    - dmi.product_serial
+    - dmi.smbios.system.serial
+  * - dmi.system-uuid
+    - dmi.product_uuid
+    - dmi.smbios.system.uuid
+  * - dmi.system-version
+    - dmi.product_version
+    - dmi.smbios.system.version
+
+
+e.g. you can pass this option to QEMU
 
 ::
 
-  -smbios type=1,serial=ds=nocloud-net;s=http://10.10.0.1:8000/
+  -smbios type=1,serial=ds=nocloud-net;s=http://10.10.0.1:8000/%dmi.chassis-serial-number%/
 
-to cause NoCloud to fetch the full meta-data from http://10.10.0.1:8000/meta-data
+or append the following GRUB kernel commandline on your Ubuntu Live server/desktop installer
+
+::
+
+  autostart ds=nocloud-net;s=http://10.10.0.1:8000/%dmi.chassis-serial-number%/
+
+to cause NoCloud to fetch the full meta-data for YOUR_SERIAL_NUMBER as seen in `/sys/class/dmi/id/chassis_serial_number` or kenv on FreeBSD from http://10.10.0.1:8000/YOUR_SERIAL_NUMBER/meta-data
 after the network initialization is complete.
 
 These user-data and meta-data files are expected to be in the following format.

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -37,12 +37,12 @@ with ``http://`` or ``https://`` and end with a trailing ``/``.
 Cloud-init performs variable expansion of the seedfrom URL for any DMI kernel
 variables present in ``/sys/class/dmi/id`` (kenv on FreeBSD).
 Your ``seedfrom`` URL can contain variable names of the format
-``%dmi.varname%`` to indicate to cloud-init NoCloud datasource that dmi.varname
-should be expanded to the value of the DMI system attribute wanted.
-The leading and trailing percent ``%`` in ``%dmi.<varname>%`` are used because
-other metacharacters would have to be escaped to avoid Grub interpreting those
-chars.
-Typically you want to use cloud-init's distro-agnostic alias
+``__dmi.varname__`` to indicate to cloud-init NoCloud datasource that
+dmi.varname should be expanded to the value of the DMI system attribute wanted.
+The leading and trailing double-underscores ``__`` in ``__dmi.<varname>__`` are
+used because they are URL safe characters in case URL parsing touches this
+value as well as 'safe' from any Grub variable expansion performed when
+seedfrom value is provided as appended kernel command line parameters.
 
 .. list-table:: Available DMI variables for expansion in ``seedfrom`` URL
   :widths: 35 35 30
@@ -65,16 +65,17 @@ Typically you want to use cloud-init's distro-agnostic alias
     - ``dmi.system-version``
 
 
-For example, you can pass this option to QEMU
+For example, passing this option to QEMU
 
 ::
 
-  -smbios type=1,serial=ds=nocloud-net;s=http://10.10.0.1:8000/%dmi.chassis-serial-number%/
+  -smbios type=1,serial=ds=nocloud-net;s=http://10.10.0.1:8000/__dmi.chassis-serial-number__/
 
-to cause NoCloud to fetch the full meta-data for YOUR_SERIAL_NUMBER as seen in `/sys/class/dmi/id/chassis_serial_number` (kenv on FreeBSD) from http://10.10.0.1:8000/YOUR_SERIAL_NUMBER/meta-data
+causes NoCloud to fetch the full meta-data from a URL based on YOUR_SERIAL_NUMBER as seen in `/sys/class/dmi/id/chassis_serial_number` (kenv on FreeBSD) from http://10.10.0.1:8000/YOUR_SERIAL_NUMBER/meta-data
 after the network initialization is complete.
 
-These user-data and meta-data files are expected to be in the following format.
+These user-data and meta-data files are required as separate files at the same
+base URL.
 
 ::
 
@@ -83,10 +84,12 @@ These user-data and meta-data files are expected to be in the following format.
 
 Both files are required to be present for it to be considered a valid seed ISO.
 
-Basically, user-data is simply user-data and meta-data is a YAML formatted file
-representing what you'd find in the EC2 metadata service.
+Basically, user-data is simply :ref:`user data<user_data_formats>` and
+meta-data is a YAML formatted file representing what you'd find in the EC2
+metadata service.
 
-You may also optionally provide a vendor-data file in the following format.
+You may also optionally provide a vendor-data file as a separate file adhering
+to :ref:`user data formats<user_data_formats>` in the same base URL.
 
 ::
 

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -39,10 +39,6 @@ variables present in ``/sys/class/dmi/id`` (kenv on FreeBSD).
 Your ``seedfrom`` URL can contain variable names of the format
 ``__dmi.varname__`` to indicate to cloud-init NoCloud datasource that
 dmi.varname should be expanded to the value of the DMI system attribute wanted.
-The leading and trailing double-underscores ``__`` in ``__dmi.<varname>__`` are
-used because they are URL safe characters in case URL parsing touches this
-value as well as 'safe' from any Grub variable expansion performed when
-seedfrom value is provided as appended kernel command line parameters.
 
 .. list-table:: Available DMI variables for expansion in ``seedfrom`` URL
   :widths: 35 35 30

--- a/doc/rtd/topics/datasources/nocloud.rst
+++ b/doc/rtd/topics/datasources/nocloud.rst
@@ -38,7 +38,7 @@ Cloud-init performs variable expansion of the seedfrom URL for any DMI kernel
 variables present in ``/sys/class/dmi/id`` (kenv on FreeBSD).
 Your ``seedfrom`` URL can contain variable names of the format
 ``%dmi.varname%`` to indicate to cloud-init NoCloud datasource that dmi.varname
-should be expanded to the actual value of the DMI system attribute is wanted.
+should be expanded to the value of the DMI system attribute wanted.
 The leading and trailing percent ``%`` in ``%dmi.<varname>%`` are used because
 other metacharacters would have to be escaped to avoid Grub interpreting those
 chars.

--- a/tests/unittests/test_dmi.py
+++ b/tests/unittests/test_dmi.py
@@ -175,7 +175,7 @@ class TestReadDMIData(helpers.FilesystemMockingTestCase):
 class TestSubDMIVars:
 
     DMI_SRC = (
-        "dmi.nope%dmi.system-uuid%/%dmi.product_uuid%%dmi.smbios.system.uuid%"
+        "dmi.nope__dmi.system-uuid__/__dmi.uuid____dmi.smbios.system.uuid__"
     )
 
     @pytest.mark.parametrize(
@@ -186,10 +186,10 @@ class TestSubDMIVars:
                 DMI_SRC,
                 [mock.call("system-uuid")],
                 [
-                    "Ignoring invalid %dmi.smbios.system.uuid%",
-                    "Ignoring invalid %dmi.product_uuid%",
+                    "Ignoring invalid __dmi.smbios.system.uuid__",
+                    "Ignoring invalid __dmi.uuid__",
                 ],
-                "dmi.nope1/%dmi.product_uuid%%dmi.smbios.system.uuid%",
+                "dmi.nope1/__dmi.uuid____dmi.smbios.system.uuid__",
                 id="match_dmi_distro_agnostic_strings_warn_on_unknown",
             ),
             pytest.param(
@@ -197,10 +197,10 @@ class TestSubDMIVars:
                 DMI_SRC,
                 [mock.call("system-uuid")],
                 [
-                    "Ignoring invalid %dmi.smbios.system.uuid%",
-                    "Ignoring invalid %dmi.product_uuid%",
+                    "Ignoring invalid __dmi.smbios.system.uuid__",
+                    "Ignoring invalid __dmi.uuid__",
                 ],
-                "dmi.nope1/%dmi.product_uuid%%dmi.smbios.system.uuid%",
+                "dmi.nope1/__dmi.uuid____dmi.smbios.system.uuid__",
                 id="match_dmi_agnostic_and_freebsd_dmi_keys_warn_on_unknown",
             ),
         ),

--- a/tools/read-version
+++ b/tools/read-version
@@ -100,7 +100,6 @@ if is_gitdir(_tdir) and which("git") and not is_release_branch_ci:
                 version_long = ""
             else:
                 raise
-        version_long = tiny_p(cmd + ["--long"]).strip()
 else:
     version = src_version
     version_long = ""


### PR DESCRIPTION
 
## Proposed Commit Message
```
nocloud: add support for dmi variable expansion for seedfrom URL

NoCloud meta-data seedfrom (or kernel commandline seedfrom) URL can
now provide variable expansion for system-specific DMI values as seen
in /sys/class/dmi/id on Linux or kenv on FreeBSD platforms.

Variable names of the format __dmi.SOME_VAR__ will be replaced when
determining the URL from which NoCloud datasource GETs its user-data
and meta-data.

This allows for a common templated seedfrom URL which can be reused
for mass deployments, but can allow for unique URLs based on classes
of DMI system characteristics such as chassis serial, product name,
UUID etc.

LP: #1994980
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
