### PR TITLE
test: fix lxd preseed

### DIFF
--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -46,7 +46,6 @@ lxd:
         ipv4.address: auto
         ipv6.address: auto
       description: ""
-      managed: false
       name: lxdbr0
       type: ""
     storage_pools:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
test: fix lxd preseed managed network config

Remove managed key in network config on LXD preseed configs
as it is not a valid key in LXD > v4.
```

## Additional Context
<!-- If relevant -->

After the inclusion of the fix of https://github.com/lxc/lxd/issues/11106, we are hitting LXD errors when we pass unknown preseed config keys to `lxd init --preseed` in our integration tests.

More concretely, in https://github.com/canonical/cloud-init/blob/893df0d61179a6722c44267f57c57284543c2f12/tests/integration_tests/modules/test_lxd.py#L49 we hand over a network config with the root key `managed`, which is only compatible in LXD v3.x.y (bionic), and not in v4 nor v5 (newer Ubuntu versions).

[From my understanding](https://linuxcontainers.org/lxd/docs/latest/explanation/networks/), `managed` is implicitly discovered by LXD depending on network types / sub-configs and is not part of the [network POST schema](https://linuxcontainers.org/lxd/docs/stable-4.0/api/#/networks/networks_post) in version 4 and forward.

Jobs failing:

- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-lxd_container/130/
- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-kinetic-ec2/129/

LXD error:

```
cat << EOF > preseed.yaml
config: {}
networks:
- config:
    ipv4.address: auto
  managed: false
  name: lxdbr0
EOF

$ lxc exec k -- sh -c 'cat ./preseed.yaml | lxd init --preseed'
Error: Failed to parse the preseed: yaml: unmarshal errors:
  line 5: field managed not found in type api.InitNetworksProjectPost
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

The failure is reproducible on focal, jammy, kinetic and devel releases.

```
$ CLOUD_INIT_OS_RELEASE=focal CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE='ppa:cloud-init-dev/daily' tox -e integration-tests -- -vv tests/integration_tests/modules/test_lxd.py::test_basic_preseed

...
Error: Failed to parse the preseed: yaml: unmarshal errors:
  line 5: field managed not found in type api.InitNetworksProjectPost
...

```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly

## TODO

The current solution (just removing `managed` from the network config) hits the following `pycloudlib` error, which sounds very similar to https://github.com/canonical/pycloudlib/pull/221:

```
request = <SubRequest 'client' for <Function test_basic_preseed>>, fixture_utils = <class 'conftest._FixtureUtils'>, session_cloud = <tests.integration_tests.clouds.LxdContainerCloud object at 0x7f9ba2e65cf8>
setup_image = None

    @pytest.fixture
    def client(
        request, fixture_utils, session_cloud, setup_image
    ) -> Iterator[IntegrationInstance]:
        """Provide a client that runs for every test."""
        with _client(request, fixture_utils, session_cloud) as client:
>           yield client

tests/integration_tests/conftest.py:271:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../.pyenv/versions/3.6.15/lib/python3.6/contextlib.py:88: in __exit__
    next(self.gen)
tests/integration_tests/conftest.py:262: in _client
    _collect_logs(instance, request.node.nodeid, test_failed)
tests/integration_tests/instances.py:213: in __exit__
    log.info("Keeping Instance, public ip: %s", self.ip())
tests/integration_tests/instances.py:201: in ip
    self._ip = self.instance.ip
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = LXDInstance(name=cloudinit-1124-141924w7627xkq)

    @property
    def ip(self):
        """Return IP address of instance.

        Returns:
            IP address assigned to instance.

        Raises: TimeoutError when exhausting retries trying to parse lxc list
            for ip addresses.
        """
        retries = 150

        while retries != 0:
            command = [
                "lxc",
                "list",
                "^{}$".format(self.name),
                "-c4",
                "--format",
                "csv",
            ]
            result = subp(command)
            if result.ok and result.stdout:
                ip_address = None
                try:
                    # Expect "<ip> (<interface>)" when network fully configured
                    ip_address, _dev = result.stdout.split()
                except ValueError:
                    self._log.debug(
                        "Unable to parse output of cmd: %s. Expected"
                        " <ip> (<interface>), got: %s. Retrying %d time(s)...",
                        command,
                        result.stdout,
                        retries,
                    )
                if ip_address:
                    return ip_address
            retries -= 1
            time.sleep(1)
        raise TimeoutError(
            "Unable to determine IP address after 150 retries."
            " exit:{} stdout: {} stderr: {}".format(
>               result.return_code, result.stdout, result.stderr
            )
        )
E       TimeoutError: Unable to determine IP address after 150 retries. exit:0 stdout: "10.96.250.121 (eth0)
E       10.51.185.1 (lxdbr0)" stderr:
```