### PR TITLE
Autoinstall clarification

### DIFF
--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -206,12 +206,12 @@ Since cloud-init ignores top level userdata cloud-config keys, other projects
 such as Juju and subiquity_ autoinstaller use a yaml-formatted config
 that combines cloud-init's userdata cloud-config yaml format with their custom
 yaml keys. These combined yaml configurations may be valid cloud-config files,
-however keys such as autoinstall, preruncmd, and postruncmd are ignored by
-cloud-init. If you are unsure whether cloud-init uses a specific key,
-you may view cloud-init's schema_ or documentation_.
+however keys such as autoinstall, preruncmd, and postruncmd are not used by
+cloud-init to configure anything.
 
 Please direct bugs and questions related to the autoinstaller, Juju, and
 other similar projects to their respective support channels.
+
 
 How can I make a module run on every boot?
 ==========================================
@@ -442,5 +442,3 @@ Whitepapers:
 .. _cloud-init Summit 2018: https://powersj.io/post/cloud-init-summit18/
 .. _cloud-init Summit 2017: https://powersj.io/post/cloud-init-summit17/
 .. _subiquity: https://ubuntu.com/server/docs/install/autoinstall
-.. _schema: https://github.com/canonical/cloud-init/blob/main/cloudinit/config/schemas/schema-cloud-config-v1.json
-.. _documentation: https://cloudinit.readthedocs.io/en/latest/topics/modules.html

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -206,7 +206,7 @@ Since cloud-init ignores top level userdata cloud-config keys, other projects
 such as Juju and subiquity_ autoinstaller use a yaml-formatted config
 that combines cloud-init's userdata cloud-config yaml format with their custom
 yaml keys. These combined yaml configurations may be valid cloud-config files,
-however keys such as autoinstall, preruncmd, and postruncmd are not used by
+however keys such as ``autoinstall``, ``preruncmd``, and ``postruncmd`` are not used by
 cloud-init to configure anything.
 
 Please direct bugs and questions related to the autoinstaller, Juju, and

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -200,6 +200,19 @@ systemd, please make sure to include the following logs.
         $ systemctl --failed
 
 
+Autoinstall, Preruncmd, Postruncmd
+==================================
+Since cloud-init ignores top level userdata cloud-config keys, other projects
+such as Juju and subiquity_ autoinstaller use a yaml-formatted config
+that combines cloud-init's userdata cloud-config yaml format with their custom
+yaml keys. These combined yaml configurations may be valid cloud-config files,
+however keys such as autoinstall, preruncmd, and postruncmd are ignored by
+cloud-init. If you are unsure whether cloud-init uses a specific key,
+you may view cloud-init's schema_ or documentation_.
+
+Please direct bugs and questions related to the autoinstaller, Juju, and
+other similar projects to their respective support channels.
+
 How can I make a module run on every boot?
 ==========================================
 Modules have a default frequency that can be overridden. This is done
@@ -428,3 +441,6 @@ Whitepapers:
 .. _cloud-init Summit 2019: https://powersj.io/post/cloud-init-summit19/
 .. _cloud-init Summit 2018: https://powersj.io/post/cloud-init-summit18/
 .. _cloud-init Summit 2017: https://powersj.io/post/cloud-init-summit17/
+.. _subiquity: https://ubuntu.com/server/docs/install/autoinstall
+.. _schema: https://github.com/canonical/cloud-init/blob/main/cloudinit/config/schemas/schema-cloud-config-v1.json
+.. _documentation: https://cloudinit.readthedocs.io/en/latest/topics/modules.html

--- a/doc/rtd/topics/faq.rst
+++ b/doc/rtd/topics/faq.rst
@@ -151,9 +151,6 @@ provided to the system:
 
     $ cloud-init schema --system --annotate
 
-As launching instances in the cloud can cost money and take a bit longer,
-sometimes it is easier to launch instances locally using Multipass or LXD:
-
 Why did cloud-init never complete?
 ==================================
 
@@ -203,14 +200,17 @@ systemd, please make sure to include the following logs.
 Autoinstall, Preruncmd, Postruncmd
 ==================================
 Since cloud-init ignores top level userdata cloud-config keys, other projects
-such as Juju and subiquity_ autoinstaller use a yaml-formatted config
-that combines cloud-init's userdata cloud-config yaml format with their custom
-yaml keys. These combined yaml configurations may be valid cloud-config files,
-however keys such as ``autoinstall``, ``preruncmd``, and ``postruncmd`` are not used by
-cloud-init to configure anything.
+such as `Juju <https://ubuntu.com/blog/topics/juju>`_ and subiquity_
+autoinstaller use a YAML-formatted config that combines cloud-init's userdata
+cloud-config YAML format with their custom YAML keys. Since cloud-init ignores
+unused top level keys, these combined YAML configurations may be valid
+cloud-config files, however keys such as ``autoinstall``, ``preruncmd``, and
+``postruncmd`` are not used by cloud-init to configure anything.
 
-Please direct bugs and questions related to the autoinstaller, Juju, and
-other similar projects to their respective support channels.
+Please direct bugs and questions about other projects that use cloud-init to
+their respective support channels. For Subiquity autoinstaller that is via IRC
+#ubuntu-server on Libera or Discourse. For Juju support see their
+`discourse page <https://discourse.charmhub.io>`_.
 
 
 How can I make a module run on every boot?
@@ -442,3 +442,4 @@ Whitepapers:
 .. _cloud-init Summit 2018: https://powersj.io/post/cloud-init-summit18/
 .. _cloud-init Summit 2017: https://powersj.io/post/cloud-init-summit17/
 .. _subiquity: https://ubuntu.com/server/docs/install/autoinstall
+.. _juju_project: https://discourse.charmhub.io/t/model-config-cloudinit-userdata/512

--- a/doc/rtd/topics/modules.rst
+++ b/doc/rtd/topics/modules.rst
@@ -57,7 +57,6 @@ Module Reference
 .. automodule:: cloudinit.config.cc_ssh_import_id
 .. automodule:: cloudinit.config.cc_timezone
 .. automodule:: cloudinit.config.cc_ubuntu_advantage
-.. automodule:: cloudinit.config.cc_ubuntu_autoinstall
 .. automodule:: cloudinit.config.cc_ubuntu_drivers
 .. automodule:: cloudinit.config.cc_update_etc_hosts
 .. automodule:: cloudinit.config.cc_update_hostname


### PR DESCRIPTION
```
autoinstall: clarify docs for users
```
Add autoinstall pointer to subiquity docs to FAQ.

Remove cc_ubuntu_autoinstall from docs module definitions, since it doesn't give users actionable information.

Leave the module definition intact in the code, since it does add context that may be valuable for developers.

The net affect of this is PR that future searches of the website for "autoinstall" will lead users to the FAQ (and then to subiquity docs), which makes sense because we don't have autoinstall-specific documentation in the cloud-init docs.