### PR TITLE
Append derivatives to is_rhel list in cloud.cfg.tmpl

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -260,7 +260,7 @@ system_info:
      name: ec2-user
      lock_passwd: True
      gecos: EC2 Default User
-{% elif is_rhel and variant not in ["eurolinux"] %}
+{% elif variant in ["rhel", "centos"] %}
      name: cloud-user
      lock_passwd: true
      gecos: Cloud User

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -3,7 +3,8 @@
 # The top level settings are used as module
 # and base configuration.
 {% set is_bsd = variant in ["dragonfly", "freebsd", "netbsd", "openbsd"] %}
-{% set is_rhel = variant in ["rhel", "centos"] %}
+{% set is_rhel = variant in ["almalinux", "centos", "cloudlinux", "eurolinux",
+                             "miraclelinux", "rhel", "rocky", "virtuozzo" ] %}
 {% if is_bsd %}
 syslog_fix_perms: root:wheel
 {% elif variant in ["suse"] %}
@@ -34,8 +35,7 @@ disable_root: false
 disable_root: true
 {% endif %}
 
-{% if variant in ["almalinux", "alpine", "amazon", "cloudlinux", "eurolinux",
-                  "fedora", "miraclelinux", "openEuler", "openmandriva", "rocky", "virtuozzo"] or is_rhel %}
+{% if variant in ["alpine", "amazon", "fedora", "openEuler", "openmandriva"] or is_rhel %}
 {% if is_rhel %}
 mount_default_fields: [~, ~, 'auto', 'defaults,nofail,x-systemd.requires=cloud-init.service,_netdev', '0', '2']
 {% else %}
@@ -197,9 +197,9 @@ cloud_final_modules:
 # (not accessible to handlers/transforms)
 system_info:
    # This will affect which distro class gets used
-{% if variant in ["almalinux", "alpine", "amazon", "arch", "cloudlinux", "debian",
-                  "eurolinux", "fedora", "freebsd", "gentoo", "netbsd", "mariner", "miraclelinux", "openbsd", "openEuler",
-                  "openmandriva", "photon", "rocky", "suse", "ubuntu", "virtuozzo"] or is_rhel %}
+{% if variant in ["alpine", "amazon", "arch", "debian", "fedora", "freebsd",
+                  "gentoo", "netbsd", "mariner", "openbsd", "openEuler",
+                  "openmandriva", "photon", "suse", "ubuntu"] or is_rhel %}
    distro: {{ variant }}
 {% elif variant in ["dragonfly"] %}
    distro: dragonflybsd
@@ -252,15 +252,15 @@ system_info:
          primary: http://ports.ubuntu.com/ubuntu-ports
          security: http://ports.ubuntu.com/ubuntu-ports
    ssh_svcname: ssh
-{% elif variant in ["almalinux", "alpine", "amazon", "arch", "cloudlinux", "eurolinux",
-                    "fedora", "gentoo", "miraclelinux", "openEuler", "openmandriva", "rocky", "suse", "virtuozzo"] or is_rhel %}
+{% elif variant in ["alpine", "amazon", "arch", "fedora",
+                    "gentoo", "openEuler", "openmandriva", "suse"] or is_rhel %}
    # Default user name + that default users groups (if added/used)
    default_user:
 {% if variant == "amazon" %}
      name: ec2-user
      lock_passwd: True
      gecos: EC2 Default User
-{% elif is_rhel %}
+{% elif is_rhel and variant not in ["eurolinux"] %}
      name: cloud-user
      lock_passwd: true
      gecos: Cloud User


### PR DESCRIPTION
## Proposed Commit Message
```
summary: Append derivatives to is_rhel list in cloud.cfg.tmpl

This commit adds Rocky Linux, AlmaLinux, CloudLinux, EuroLinux, Miracle
Linux, and Virtuozzo to the is_rhel list. Recent downstream patch from
Red Hat causes issues with RHEL derivatives with the cloud.cfg template,
which leads to derivatives having to make small changes to bring back
expected functionality.
```

## Additional Context
In RHEL 8.7 and 9.1, and thus Rocky Linux 8.7 and 9.1, cloud-init was rebased to 22.1. In this update, Red Hat backported #1431. In CentOS Stream 8 and 9, they also backported #1639. Unfortunately, this caused some issues with our cloud images as the cloud configuration is now missing some pieces that were once there that would work the same RHEL or CentOS Stream. We had to create a downstream patch in our own package to address a bug report we received for the issue. This PR addresses not just Rocky Linux, but other derivatives as they are likely to run into the same issues.

We received a bug report for this at our bug tracker: https://bugs.rockylinux.org/view.php?id=1189

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
