### PR TITLE
net: netplan config root read-only as wifi config  can contain creds

### DIFF
--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -260,7 +260,8 @@ class Renderer(renderer.Renderer):
 
         if not header.endswith("\n"):
             header += "\n"
-        util.write_file(fpnplan, header + content)
+
+        util.write_file(fpnplan, header + content, mode=0o600)
 
         if self.clean_default:
             _clean_default(target=target)

--- a/tests/integration_tests/datasources/test_lxd_hotplug.py
+++ b/tests/integration_tests/datasources/test_lxd_hotplug.py
@@ -148,6 +148,10 @@ class TestLxdHotplug:
         assert post_netplan == expected_netplan, client.read_from_file(
             "/var/log/cloud-init.log"
         )
+        netplan_perms = client.execute(
+            "stat -c %a /etc/netplan/50-cloud-init.yaml"
+        )
+        assert "600" == netplan_perms.stdout.strip()
         ip_info = json.loads(client.execute("ip --json address"))
         eth2s = [i for i in ip_info if i["ifname"] == "eth2"]
         assert len(eth2s) == 1

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -77,6 +77,17 @@ timezone: US/Aleutian
 @pytest.mark.ci
 @pytest.mark.user_data(USER_DATA)
 class TestCombined:
+    @pytest.mark.ubuntu  # Because netplan
+    def test_netplan_permissions(self, class_client: IntegrationInstance):
+        """
+        Test that netplan config file is generated with proper permissions
+        """
+        response = class_client.execute(
+            "stat -c %a /etc/netplan/50-cloud-init.yaml"
+        )
+        assert response.ok, "Unable to check perms on 50-cloud-init.yaml"
+        assert "600" == response.stdout.strip()
+
     def test_final_message(self, class_client: IntegrationInstance):
         """Test that final_message module works as expected.
 

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -569,7 +569,7 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
             print(results[cfgpath])
             print("----------")
             self.assertEqual(expected, results[cfgpath])
-            self.assertEqual(0o644, get_mode(cfgpath, tmpd))
+            self.assertEqual(0o600, get_mode(cfgpath, tmpd))
 
     def netplan_path(self):
         return "/etc/netplan/50-cloud-init.yaml"
@@ -937,6 +937,7 @@ class TestNetCfgDistroArch(TestNetCfgDistroBase):
                 apply_fn(config, bringup)
 
         results = dir2dict(tmpd)
+        mode = 0o600 if with_netplan else 0o644
         for cfgpath, expected in expected_cfgs.items():
             print("----------")
             print(expected)
@@ -944,7 +945,7 @@ class TestNetCfgDistroArch(TestNetCfgDistroBase):
             print(results[cfgpath])
             print("----------")
             self.assertEqual(expected, results[cfgpath])
-            self.assertEqual(0o644, get_mode(cfgpath, tmpd))
+            self.assertEqual(mode, get_mode(cfgpath, tmpd))
 
     def netctl_path(self, iface):
         return "/etc/netctl/%s" % iface


### PR DESCRIPTION
## Proposed Commit Message
```
Restrict read access of /etc/netplan/50-cloud-init.yaml.

On netplan systems, network v2 is passed directly though and written
to /etc/netplan/50-cloud-init.yaml without validation. Current netplan
configuration provides the ability to configure sensitive information
such as `wifi:access-points:password`.

Limit permissions for /etc/network/50-cloud-init.yaml as read-only
for root. Since configuration or modification or netplan config
needs to be performed by an admin user this permission restriction
aligns with netplan tooling.

Set root read-only only always and not just 'if' sensitive material
exists within custom config because it will add confusion to have
two expected modes for this file based on external conditions.
```

## Additional Context
feature tracking improved netplan config security & validation phase 1
https://warthogs.atlassian.net/browse/SC-1365

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
