### PR TITLE
Networking Clarification

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -801,11 +801,10 @@ class Init:
         # Run the handlers
         self._do_handlers(user_data_msg, c_handlers_list, frequency)
 
-    def _remove_top_level_network_key(self, cfg):
-        """If network-config contains top level 'network' key, then remove it.
-
-        Some providers of network configuration skip the top-level network
-        key, so ensure both methods works.
+    def _get_network_config(self, cfg) -> dict:
+        """
+        Network configuration can be passed as a dict under a "network" key, or
+        optionally at the top level. In both cases, return the config.
         """
         if cfg and "network" in cfg:
             return cfg["network"]
@@ -848,7 +847,7 @@ class Init:
                     cfg_source,
                 )
                 continue
-            ncfg = self._remove_top_level_network_key(
+            ncfg = self._get_network_config(
                 available_cfgs[cfg_source]
             )
             if net.is_disabled_cfg(ncfg):

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -801,7 +801,7 @@ class Init:
         # Run the handlers
         self._do_handlers(user_data_msg, c_handlers_list, frequency)
 
-    def _get_network_config(self, cfg) -> dict:
+    def _get_network_key_contents(self, cfg) -> dict:
         """
         Network configuration can be passed as a dict under a "network" key, or
         optionally at the top level. In both cases, return the config.
@@ -847,7 +847,7 @@ class Init:
                     cfg_source,
                 )
                 continue
-            ncfg = self._get_network_config(
+            ncfg = self._get_network_key_contents(
                 available_cfgs[cfg_source]
             )
             if net.is_disabled_cfg(ncfg):

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -847,9 +847,7 @@ class Init:
                     cfg_source,
                 )
                 continue
-            ncfg = self._get_network_key_contents(
-                available_cfgs[cfg_source]
-            )
+            ncfg = self._get_network_key_contents(available_cfgs[cfg_source])
             if net.is_disabled_cfg(ncfg):
                 LOG.debug("network config disabled by %s", cfg_source)
                 return (None, cfg_source)


### PR DESCRIPTION
```
net: clarify network function name and docstring
```

## Additional Context
It doesn't seem intuitive to me to describe a function as "removing" a key, when it returns the value in the dict referenced by that key, since I would typically remove a key from a dict using `pop()`, which modifies the dict. 

I propose as alternative `dereference`, `find`, or simply `get`. Thoughts?


```python
pop(...)
    D.pop(k[,d]) -> v, remove specified key and return the corresponding value.
    
    If the key is not found, return the default if given; otherwise,
    raise a KeyError.
``` 


