### PR TITLE
Ensure network ready before cloud-init service runs on RHEL

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -16,6 +16,7 @@ After=networking.service
                   "miraclelinux", "openEuler", "openmandriva", "rhel", "rocky", "virtuozzo"] %}
 After=network.service
 After=NetworkManager.service
+After=NetworkManager-wait-online.service
 {% endif %}
 {% if variant in ["suse"] %}
 After=wicked.service


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Ensure network ready before cloud-init service runs on RHEL

LP: #1998655
```

## Additional Context
See https://bugs.launchpad.net/cloud-init/+bug/1998655
