### PR TITLE
Fix exception in BSD networking code-path

### DIFF
--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -190,6 +190,7 @@ class BSDNetworking(Networking):
         self.ifc = ifconfig.Ifconfig()
         self.ifs = {}
         self._update_ifs()
+        super().__init__()
 
     def _update_ifs(self):
         ifconf = subp.subp(["ifconfig", "-a"])


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix exception in BSD networking code-path

overriding __init__() means we need to call super().__init__()

Sponsored By: FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
re-boot with this patch
notice lack of this exception:

```python-traceback
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/cloudinit/cmd/main.py", line 767, in status_wrapper
    ret = functor(name, args)
  File "/usr/local/lib/python3.9/site-packages/cloudinit/cmd/main.py", line 433, in main_init
    init.apply_network_config(bring_up=bring_up_interfaces)
  File "/usr/local/lib/python3.9/site-packages/cloudinit/stages.py", line 924, in apply_network_config
    self.distro.networking.wait_for_physdevs(netcfg)
  File "/usr/local/lib/python3.9/site-packages/cloudinit/distros/networking.py", line 149, in wait_for_physdevs
    present_macs = self.get_interfaces_by_mac().keys()
  File "/usr/local/lib/python3.9/site-packages/cloudinit/distros/networking.py", line 77, in get_interfaces_by_mac
    blacklist_drivers=self.blacklist_drivers
AttributeError: 'FreeBSDNetworking' object has no attribute 'blacklist_drivers'

```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
