### PR TITLE
sources/azure: encode health report as utf-8

### DIFF
--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from errno import ENOENT
 from time import sleep, time
-from typing import Callable, List, Optional, ParamSpec, TypeVar, Union
+from typing import Callable, List, Optional, TypeVar, Union
 from xml.etree import ElementTree
 from xml.sax.saxutils import escape
 
@@ -51,10 +51,9 @@ DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE = (
 )
 
 T = TypeVar("T")
-P = ParamSpec("P")
 
 
-def azure_ds_telemetry_reporter(func: Callable[P, T]) -> Callable[P, T]:
+def azure_ds_telemetry_reporter(func: Callable[..., T]) -> Callable[..., T]:
     def impl(*args, **kwargs):
         with events.ReportEventStack(
             name=func.__name__,

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from errno import ENOENT
 from time import sleep, time
-from typing import List, Optional, Union
+from typing import Callable, List, Optional, ParamSpec, TypeVar, Union
 from xml.etree import ElementTree
 from xml.sax.saxutils import escape
 
@@ -50,8 +50,11 @@ DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE = (
     "for more information on remediation."
 )
 
+T = TypeVar("T")
+P = ParamSpec("P")
 
-def azure_ds_telemetry_reporter(func):
+
+def azure_ds_telemetry_reporter(func: Callable[P, T]) -> Callable[P, T]:
     def impl(*args, **kwargs):
         with events.ReportEventStack(
             name=func.__name__,
@@ -335,7 +338,7 @@ def http_with_retries(
     url: str,
     *,
     headers: dict,
-    data: Optional[str] = None,
+    data: Optional[bytes] = None,
     retry_sleep: int = 5,
     timeout_minutes: int = 20,
 ) -> url_helper.UrlResponse:
@@ -440,7 +443,7 @@ class AzureEndpointHttpClient:
         return http_with_retries(url, headers=headers)
 
     def post(
-        self, url, data=None, extra_headers=None
+        self, url, data: Optional[bytes] = None, extra_headers=None
     ) -> url_helper.UrlResponse:
         headers = self.headers
         if extra_headers is not None:
@@ -752,7 +755,7 @@ class GoalStateHealthReporter:
         status: str,
         substatus=None,
         description=None,
-    ) -> str:
+    ) -> bytes:
         health_detail = ""
         if substatus is not None:
             health_detail = self.HEALTH_DETAIL_SUBSECTION_XML_TEMPLATE.format(
@@ -770,10 +773,10 @@ class GoalStateHealthReporter:
             health_detail_subsection=health_detail,
         )
 
-        return health_report
+        return health_report.encode("utf-8")
 
     @azure_ds_telemetry_reporter
-    def _post_health_report(self, document: str) -> None:
+    def _post_health_report(self, document: bytes) -> None:
         push_log_to_kvp()
 
         # Whenever report_diagnostic_event(diagnostic_msg) is invoked in code,

--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -75,6 +75,23 @@ HEALTH_REPORT_XML_TEMPLATE = """\
 </Health>
 """
 
+
+def get_formatted_health_report_xml_bytes(
+    container_id: str,
+    incarnation: int,
+    instance_id: str,
+    health_status: str,
+    health_detail_subsection: str,
+) -> bytes:
+    return HEALTH_REPORT_XML_TEMPLATE.format(
+        container_id=container_id,
+        incarnation=incarnation,
+        instance_id=instance_id,
+        health_status=health_status,
+        health_detail_subsection=health_detail_subsection,
+    ).encode("utf-8")
+
+
 HEALTH_DETAIL_SUBSECTION_XML_TEMPLATE = dedent(
     """\
     <Details>
@@ -626,14 +643,11 @@ class TestGoalStateHealthReporter(CiTestCase):
             return element.text
         return None
 
-    def _get_formatted_health_report_xml_string(self, **kwargs):
-        return HEALTH_REPORT_XML_TEMPLATE.format(**kwargs)
-
     def _get_formatted_health_detail_subsection_xml_string(self, **kwargs):
         return HEALTH_DETAIL_SUBSECTION_XML_TEMPLATE.format(**kwargs)
 
     def _get_report_ready_health_document(self):
-        return self._get_formatted_health_report_xml_string(
+        return get_formatted_health_report_xml_bytes(
             incarnation=escape(str(self.default_parameters["incarnation"])),
             container_id=escape(self.default_parameters["container_id"]),
             instance_id=escape(self.default_parameters["instance_id"]),
@@ -651,7 +665,7 @@ class TestGoalStateHealthReporter(CiTestCase):
             )
         )
 
-        return self._get_formatted_health_report_xml_string(
+        return get_formatted_health_report_xml_bytes(
             incarnation=escape(str(self.default_parameters["incarnation"])),
             container_id=escape(self.default_parameters["container_id"]),
             instance_id=escape(self.default_parameters["instance_id"]),
@@ -887,7 +901,7 @@ class TestGoalStateHealthReporter(CiTestCase):
                 health_description=escape(health_description),
             )
         )
-        health_document = self._get_formatted_health_report_xml_string(
+        health_document = get_formatted_health_report_xml_bytes(
             incarnation=escape(incarnation),
             container_id=escape(container_id),
             instance_id=escape(instance_id),
@@ -1132,9 +1146,9 @@ class TestWALinuxAgentShim(CiTestCase):
         posted_document = (
             self.AzureEndpointHttpClient.return_value.post.call_args[1]["data"]
         )
-        self.assertIn(self.test_incarnation, posted_document)
-        self.assertIn(self.test_container_id, posted_document)
-        self.assertIn(self.test_instance_id, posted_document)
+        self.assertIn(self.test_incarnation.encode("utf-8"), posted_document)
+        self.assertIn(self.test_container_id.encode("utf-8"), posted_document)
+        self.assertIn(self.test_instance_id.encode("utf-8"), posted_document)
 
     def test_goal_state_values_used_for_report_failure(self):
         shim = wa_shim(endpoint="test_endpoint")
@@ -1142,14 +1156,14 @@ class TestWALinuxAgentShim(CiTestCase):
         posted_document = (
             self.AzureEndpointHttpClient.return_value.post.call_args[1]["data"]
         )
-        self.assertIn(self.test_incarnation, posted_document)
-        self.assertIn(self.test_container_id, posted_document)
-        self.assertIn(self.test_instance_id, posted_document)
+        self.assertIn(self.test_incarnation.encode("utf-8"), posted_document)
+        self.assertIn(self.test_container_id.encode("utf-8"), posted_document)
+        self.assertIn(self.test_instance_id.encode("utf-8"), posted_document)
 
     def test_xml_elems_in_report_ready_post(self):
         shim = wa_shim(endpoint="test_endpoint")
         shim.register_with_azure_and_fetch_data()
-        health_document = HEALTH_REPORT_XML_TEMPLATE.format(
+        health_document = get_formatted_health_report_xml_bytes(
             incarnation=escape(self.test_incarnation),
             container_id=escape(self.test_container_id),
             instance_id=escape(self.test_instance_id),
@@ -1164,7 +1178,7 @@ class TestWALinuxAgentShim(CiTestCase):
     def test_xml_elems_in_report_failure_post(self):
         shim = wa_shim(endpoint="test_endpoint")
         shim.register_with_azure_and_report_failure(description="TestDesc")
-        health_document = HEALTH_REPORT_XML_TEMPLATE.format(
+        health_document = get_formatted_health_report_xml_bytes(
             incarnation=escape(self.test_incarnation),
             container_id=escape(self.test_container_id),
             instance_id=escape(self.test_instance_id),


### PR DESCRIPTION
If utf-8 characters are used in the report, it will fail to encode:

```
azure.py[ERROR]: exception while reporting ready: 'latin-1' codec can't
encode characters in position 392-397:
Body ('乱写一些单词') is not valid Latin-1.
Use body.encode('utf-8') if you want to send it encoded in UTF-8.
```

Explicitly encode document as utf-8.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>