### PR TITLE
Ubuntu/bionic

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (22.4-0ubuntu0~18.04.2) UNRELEASED; urgency=medium
+
+  * d/patches/retain-netplan.patch: netplan-retain-world-readable.patch
+    + Leave 50-cloud-init.yaml permis 644 instead of setting it root read-only
+
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 08 Dec 2022 22:33:02 -0700
+
 cloud-init (22.4-0ubuntu0~18.04.1) bionic; urgency=medium
 
   * d/control: drop python3-httpretty from Build-Depends

--- a/debian/patches/netplan-retain-world-readable.patch
+++ b/debian/patches/netplan-retain-world-readable.patch
@@ -1,0 +1,71 @@
+Description: Retain netplan/50-cloud-init.yaml as world-readable 644 
+ Upstream cloud-init sets perms 600 ifor 50-cloud-init.yaml to protect
+ passthrough network v2 config which could contain wifi passwords.
+ Stable releases should not change permissions on this config file.
+Author: chad.smith@canonical.com
+Origin: backport
+Forwarded: not-needed
+Last-Update: 2022-12-08
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Index: cloud-init/cloudinit/net/netplan.py
+===================================================================
+--- cloud-init.orig/cloudinit/net/netplan.py
++++ cloud-init/cloudinit/net/netplan.py
+@@ -261,7 +261,7 @@ class Renderer(renderer.Renderer):
+         if not header.endswith("\n"):
+             header += "\n"
+ 
+-        util.write_file(fpnplan, header + content, mode=0o600)
++        util.write_file(fpnplan, header + content)
+ 
+         if self.clean_default:
+             _clean_default(target=target)
+Index: cloud-init/tests/integration_tests/datasources/test_lxd_hotplug.py
+===================================================================
+--- cloud-init.orig/tests/integration_tests/datasources/test_lxd_hotplug.py
++++ cloud-init/tests/integration_tests/datasources/test_lxd_hotplug.py
+@@ -151,7 +151,7 @@ class TestLxdHotplug:
+         netplan_perms = client.execute(
+             "stat -c %a /etc/netplan/50-cloud-init.yaml"
+         )
+-        assert "600" == netplan_perms.stdout.strip()
++        assert "644" == netplan_perms.stdout.strip()
+         ip_info = json.loads(client.execute("ip --json address"))
+         eth2s = [i for i in ip_info if i["ifname"] == "eth2"]
+         assert len(eth2s) == 1
+Index: cloud-init/tests/integration_tests/modules/test_combined.py
+===================================================================
+--- cloud-init.orig/tests/integration_tests/modules/test_combined.py
++++ cloud-init/tests/integration_tests/modules/test_combined.py
+@@ -86,7 +86,7 @@ class TestCombined:
+             "stat -c %a /etc/netplan/50-cloud-init.yaml"
+         )
+         assert response.ok, "Unable to check perms on 50-cloud-init.yaml"
+-        assert "600" == response.stdout.strip()
++        assert "644" == response.stdout.strip()
+ 
+     def test_final_message(self, class_client: IntegrationInstance):
+         """Test that final_message module works as expected.
+Index: cloud-init/tests/unittests/distros/test_netconfig.py
+===================================================================
+--- cloud-init.orig/tests/unittests/distros/test_netconfig.py
++++ cloud-init/tests/unittests/distros/test_netconfig.py
+@@ -569,7 +569,7 @@ class TestNetCfgDistroUbuntuNetplan(Test
+             print(results[cfgpath])
+             print("----------")
+             self.assertEqual(expected, results[cfgpath])
+-            self.assertEqual(0o600, get_mode(cfgpath, tmpd))
++            self.assertEqual(0o644, get_mode(cfgpath, tmpd))
+ 
+     def netplan_path(self):
+         return "/etc/netplan/50-cloud-init.yaml"
+@@ -937,7 +937,7 @@ class TestNetCfgDistroArch(TestNetCfgDis
+                 apply_fn(config, bringup)
+ 
+         results = dir2dict(tmpd)
+-        mode = 0o600 if with_netplan else 0o644
++        mode = 0o644
+         for cfgpath, expected in expected_cfgs.items():
+             print("----------")
+             print(expected)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@ ec2-dont-apply-full-imds-network-config.patch
 renderer-do-not-prefer-netplan.patch
 retain-apt-partner-pocket.patch
 expire-on-hashed-users.patch
+netplan-retain-world-readable.patch


### PR DESCRIPTION
## Do not squash merge

Upstream commit bbf200f3b2f89ab540a31fb61cf0e6a1bc1cfd07 changes netplan/50-cloud-init.yaml to be root read-only. 
We don't want a breaking change in downstream stable releases. Add a quilt patch to retain original behavior on bionic.


## Additional Context

Note that landing the quilt patch now means that:
 1. our [daily build recipes](https://code.launchpad.net/~cloud-init-dev/+recipe/cloud-init-daily-bionic) will continue to work because they first merge the ubuntu/bionic branch into main, and only then try to apply quilt patches.
 2. people trying to debuild, sbuild or dpkg-buildpackage directly from ubuntu/bionic will not be able to apply quilt patches because this new quilt patch will not apply unless all upstream commits from main are already merged
 
Historically we used to new-upstream-snapshot into ubuntu/bionic prior to introducing the quilt patches, but I'm not certain we have a good use-case or direct consumers of our `upstream/ubuntu/*` branches. And git-ubuntu clone cloud-init; git checkout pkg/ubuntu/bionic-updates would get a buildable source tree with the appropriate patches for anything that we officially released.

## Test Steps

git fetch upstream;
git checkout upstream/main
git merge <this_branch>
quilt push -a # make sure all patches apply
tox -e py3
tox -e do_format
quilt pop -a # make sure all patches can be removed

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
