### PR TITLE
netplan: define features.NETPLAN_CONFIG_ROOT_READ_ONLY flag

### DIFF
--- a/cloudinit/features.py
+++ b/cloudinit/features.py
@@ -59,6 +59,16 @@ only non-hashed passwords were expired.
 (This flag can be removed after Jammy is no longer supported.)
 """
 
+NETPLAN_CONFIG_ROOT_READ_ONLY = True
+"""
+If ``NETPLAN_CONFIG_ROOT_READ_ONLY`` is True, then netplan configuration will
+be written as a single root readon-only file /etc/netplan/50-cloud-init.yaml.
+This prevents wifi passwords in network v2 configuration from being
+world-readable. Prior to 23.1, netplan configuration is world-readable.
+
+(This flag can be removed after Jammy is no longer supported.)
+"""
+
 try:
     # pylint: disable=wildcard-import
     from cloudinit.feature_overrides import *  # noqa

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -5,6 +5,7 @@ import os
 import textwrap
 from typing import Optional, cast
 
+from cloudinit import features
 from cloudinit import log as logging
 from cloudinit import safeyaml, subp, util
 from cloudinit.net import (
@@ -261,7 +262,8 @@ class Renderer(renderer.Renderer):
         if not header.endswith("\n"):
             header += "\n"
 
-        util.write_file(fpnplan, header + content, mode=0o600)
+        mode = 0o600 if features.NETPLAN_CONFIG_ROOT_READ_ONLY else 0o644
+        util.write_file(fpnplan, header + content, mode=mode)
 
         if self.clean_default:
             _clean_default(target=target)

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -172,3 +172,13 @@ def lxd_has_nocloud(client: IntegrationInstance) -> bool:
         ["lxc", "config", "metadata", "show", client.instance.name]
     )
     return "/var/lib/cloud/seed/nocloud" in lxd_image_metadata.stdout
+
+
+def get_feature_flag_value(client: IntegrationInstance, key):
+    value = client.execute(
+        'python3 -c "from cloudinit import features; '
+        f'print(features.{key})"'
+    ).strip()
+    if "NameError" in value:
+        raise NameError(f"name '{key}' is not defined")
+    return value


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
netplan: define features.NETPLAN_CONFIG_ROOT_READ_ONLY flag

To make retaining original behavior in stable releases, provide a feature flag NETPLAN_CONFIG_ROOT_READ_ONLY so we can retain world-readable /etc/netplan/50-cloud-init.yaml in downstreams.

Set this flag False to ensure world-readable 50-cloud-init.yaml.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
