### PR TITLE
read-version: When insufficient tags, use cloudinit.version.get_version

### DIFF
--- a/tools/read-version
+++ b/tools/read-version
@@ -90,7 +90,16 @@ if is_gitdir(_tdir) and which("git") and not is_release_branch_ci:
             branch_name,
         ] + flags
 
-        version = tiny_p(cmd).strip()
+        try:
+            version = tiny_p(cmd).strip()
+            version_long = tiny_p(cmd + ["--long"]).strip()
+        except subprocess.CalledProcessError as e:
+            if "No tags can describe" in e.stderr:
+                print(f"{cmd} found no tags. Using cloudinit.verison.py ")
+                version = src_version
+                version_long = ""
+            else:
+                raise
         version_long = tiny_p(cmd + ["--long"]).strip()
 else:
     version = src_version


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
read-version: When insufficient tags, use cloudinit.version.get_version
```


## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
git clone --no-single-branch --depth 50 https://github.com/canonical/cloud-init.git
cd cloud-init
git fetch origin --force --tags --prune --prune-tags --depth 50 pull/1879/head:external-1879
git checkout --force ac0795a9ff76c48ca74ae23b5766543ef6785387
git apply <this patch>
./tools/read-version
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
