### PR TITLE
Document Incorrect Prefix For cc_mounts

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1764,7 +1764,7 @@
               "description": "Path to the swap file to create"
             },
             "size": {
-              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. WARNING: Attempts to use IEC prefixes in your configuration will result in unexpected behavior. SI prefixes names (KB, MB) are currently required in your configuration, despite the fact that IEC values are used. In summary, assume 1KB == 1024B, not 1000B.",
+              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. **WARNING: Attempts to use IEC prefixes in your configuration will result in unexpected behavior. SI prefixes names (KB, MB) are currently required, despite the fact that IEC values are used. In summary, assume 1KB == 1024B, not 1000B**",
               "oneOf": [
                 {
                   "enum": [

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1764,7 +1764,7 @@
               "description": "Path to the swap file to create"
             },
             "size": {
-              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. **WARNING: Attempts to use IEC prefixes in your configuration will result in unexpected behavior. SI prefixes names (KB, MB) are currently required, despite the fact that IEC values are used. In summary, assume 1KB == 1024B, not 1000B**",
+              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. **WARNING: Attempts to use IEC prefixes in your configuration prior to cloud-init version 23.1 will result in unexpected behavior. SI prefixes names (KB, MB) are required on these versions, despite the fact that IEC values are used. In summary, assume 1KB == 1024B, not 1000B**",
               "oneOf": [
                 {
                   "enum": [

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1764,7 +1764,7 @@
               "description": "Path to the swap file to create"
             },
             "size": {
-              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. **WARNING: Attempts to use IEC prefixes in your configuration prior to cloud-init version 23.1 will result in unexpected behavior. SI prefixes names (KB, MB) are required on these versions, despite the fact that IEC values are used. In summary, assume 1KB == 1024B, not 1000B**",
+              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. **WARNING: Attempts to use IEC prefixes in your configuration prior to cloud-init version 23.1 will result in unexpected behavior. SI prefixes names (KB, MB) are required on pre-23.1 cloud-init, however IEC values are used. In summary, assume 1KB == 1024B, not 1000B**",
               "oneOf": [
                 {
                   "enum": [

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1764,7 +1764,7 @@
               "description": "Path to the swap file to create"
             },
             "size": {
-              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T.",
+              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. WARNING: Attempts to use IEC prefixes in your configuration will result in unexpected behavior. SI prefixes names (KB, MB) are currently required in your configuration, despite the fact that IEC values are used. In summary, assume 1KB == 1024B, not 1000B.",
               "oneOf": [
                 {
                   "enum": [

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2761,8 +2761,20 @@ def read_meminfo(meminfo="/proc/meminfo", raw=False):
 
 def human2bytes(size):
     """Convert human string or integer to size in bytes
+
+    In the original implementation, SI prefixes parse to IEC values
+    (1KB=1024B). Later, support for parsing IEC prefixes was added,
+    also parsing to IEC values (1KiB=1024B). To maintain backwards
+    compatibility for the long-used implementation, no fix is provided for SI
+    prefixes (to make 1KB=1000B may now violate user expectations).
+
+    Future prospective callers of this function should consider implementing a
+    new function with more standard expectations (1KB=1000B and 1KiB=1024B)
+
+    Examples:
     10M => 10485760
-    .5G => 536870912
+    10MB => 10485760
+    10MiB => 10485760
     """
     size_in = size
     if size.endswith("iB"):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2765,7 +2765,9 @@ def human2bytes(size):
     .5G => 536870912
     """
     size_in = size
-    if size.endswith("B"):
+    if size.endswith("iB"):
+        size = size[:-2]
+    elif size.endswith("B"):
         size = size[:-1]
 
     mpliers = {"B": 1, "K": 2**10, "M": 2**20, "G": 2**30, "T": 2**40}

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2648,6 +2648,11 @@ class TestHuman2Bytes:
             with pytest.raises(ValueError):
                 util.human2bytes(test_i)
 
+    def test_ibibytes2bytes(self):
+
+        assert util.human2bytes("0.5GiB") == 536870912
+        assert util.human2bytes("100MiB") == 104857600
+
 
 class TestKernelVersion:
     """test kernel version function"""


### PR DESCRIPTION
```
mounts: document weird prefix in schema

Add test and support for parsing IEC prefix format.
```

Top search engine link for me:
https://inst.eecs.berkeley.edu/~cs61c/su14/labs/02/iec.pdf

Feel free to suggest better wording/placement. I do think that a warning somewhere is probably warranted, since we're doing something explicitly incorrect without telling the user.

Note: There was a time when these prefixes were less well-defined, but I think that point in time has since passed.