### PR TITLE
BSD: fix duplicate macs in Ifconfig parser

### DIFF
--- a/cloudinit/distros/parsers/ifconfig.py
+++ b/cloudinit/distros/parsers/ifconfig.py
@@ -120,7 +120,7 @@ class Ifconfig:
                     curif = curif[:-1]
                 dev = Ifstate(curif)
                 dev.index = ifindex
-                self._ifs.append([curif, dev])
+                self._ifs[curif].append(dev)
 
             toks = line.lower().strip().split()
 
@@ -158,10 +158,10 @@ class Ifconfig:
             if toks[0] == "ether":
                 dev.mac = toks[1]
                 dev.macs.append(toks[1])
-                self._ifs.append([toks[1], dev])
+                self._ifs[toks[1]].append(dev)
             if toks[0] == "hwaddr":
                 dev.macs.append(toks[1])
-                self._ifs.append([toks[1], dev])
+                self._ifs[toks[1]].append(dev)
 
             if toks[0] == "groups:":
                 dev.groups += toks[1:]

--- a/tests/data/netinfo/freebsd-duplicate-macs-ifconfig-output
+++ b/tests/data/netinfo/freebsd-duplicate-macs-ifconfig-output
@@ -1,0 +1,13 @@
+hn0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+	options=8051b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,TSO4,LRO,LINKSTATE>
+	ether 00:0d:3a:54:ad:1e
+	inet 10.0.0.35 netmask 0xffffff00 broadcast 10.0.0.255
+	media: Ethernet 100GBase-CR4 <full-duplex,rxpause,txpause>
+	status: active
+	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
+mce0: flags=8a43<UP,BROADCAST,RUNNING,ALLMULTI,SIMPLEX,MULTICAST> metric 0 mtu 1500
+	options=8805bb<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,JUMBO_MTU,VLAN_HWCSUM,TSO4,LRO,LINKSTATE>
+	ether 00:0d:3a:54:ad:1e
+	media: Ethernet 100GBase-CR4 <full-duplex,rxpause,txpause>
+	status: active
+	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>

--- a/tests/data/netinfo/freebsd-ifconfig-output
+++ b/tests/data/netinfo/freebsd-ifconfig-output
@@ -39,3 +39,16 @@ lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
 	inet 127.0.0.1 netmask 0xff000000 
 	groups: lo
 	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
+hn0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
+	options=8051b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,TSO4,LRO,LINKSTATE>
+	ether 00:0d:3a:54:ad:1e
+	inet 10.0.0.35 netmask 0xffffff00 broadcast 10.0.0.255
+	media: Ethernet 100GBase-CR4 <full-duplex,rxpause,txpause>
+	status: active
+	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
+mce0: flags=8a43<UP,BROADCAST,RUNNING,ALLMULTI,SIMPLEX,MULTICAST> metric 0 mtu 1500
+	options=8805bb<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,JUMBO_MTU,VLAN_HWCSUM,TSO4,LRO,LINKSTATE>
+	ether 00:0d:3a:54:ad:1e
+	media: Ethernet 100GBase-CR4 <full-duplex,rxpause,txpause>
+	status: active
+	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>

--- a/tests/data/netinfo/freebsd-ifconfig-output
+++ b/tests/data/netinfo/freebsd-ifconfig-output
@@ -39,16 +39,3 @@ lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> metric 0 mtu 16384
 	inet 127.0.0.1 netmask 0xff000000 
 	groups: lo
 	nd6 options=21<PERFORMNUD,AUTO_LINKLOCAL>
-hn0: flags=8843<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> metric 0 mtu 1500
-	options=8051b<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,TSO4,LRO,LINKSTATE>
-	ether 00:0d:3a:54:ad:1e
-	inet 10.0.0.35 netmask 0xffffff00 broadcast 10.0.0.255
-	media: Ethernet 100GBase-CR4 <full-duplex,rxpause,txpause>
-	status: active
-	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>
-mce0: flags=8a43<UP,BROADCAST,RUNNING,ALLMULTI,SIMPLEX,MULTICAST> metric 0 mtu 1500
-	options=8805bb<RXCSUM,TXCSUM,VLAN_MTU,VLAN_HWTAGGING,JUMBO_MTU,VLAN_HWCSUM,TSO4,LRO,LINKSTATE>
-	ether 00:0d:3a:54:ad:1e
-	media: Ethernet 100GBase-CR4 <full-duplex,rxpause,txpause>
-	status: active
-	nd6 options=29<PERFORMNUD,IFDISABLED,AUTO_LINKLOCAL>

--- a/tests/unittests/distros/test_ifconfig.py
+++ b/tests/unittests/distros/test_ifconfig.py
@@ -42,6 +42,9 @@ class TestIfconfigParserFreeBSD(TestCase):
         """
         assert that we can have duplicate macs, and that it's not an accident
         """
+        self.ifs_txt = readResource(
+            "netinfo/freebsd-duplicate-macs-ifconfig-output"
+        )
         ifc = Ifconfig()
         ifc.parse(self.ifs_txt)
         ifs_by_mac = ifc.ifs_by_mac()

--- a/tests/unittests/distros/test_ifconfig.py
+++ b/tests/unittests/distros/test_ifconfig.py
@@ -38,6 +38,19 @@ class TestIfconfigParserFreeBSD(TestCase):
         ifs = Ifconfig().parse(self.ifs_txt)
         assert "txcsum" in ifs["vtnet0"].options
 
+    def test_duplicate_mac(self):
+        """
+        assert that we can have duplicate macs, and that it's not an accident
+        """
+        ifc = Ifconfig()
+        ifc.parse(self.ifs_txt)
+        ifs_by_mac = ifc.ifs_by_mac()
+        assert len(ifs_by_mac["00:0d:3a:54:ad:1e"]) == 2
+        assert (
+            ifs_by_mac["00:0d:3a:54:ad:1e"][0].name
+            != ifs_by_mac["00:0d:3a:54:ad:1e"][1].name
+        )
+
 
 class TestIfconfigParserOpenBSD(TestCase):
     def setUp(self):


### PR DESCRIPTION
## Proposed Commit Message

```
BSD: fix duplicate macs in Ifconfig parser

Some cloud providers can have more than one device with the same MAC
address. This PR allows parsing and storing and retrieving such
configurations.

We now use `defaultdict` to retrieve `ifs_by_mac`, before converting it
all to a `dict`. We also store the two in separate variables.

Add test case from Azure to verify, and test data in a new file, since
our old cloudinit.net functions can't handle it.

Sponsored by: FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:

 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
