### PR TITLE
mock host dns in unittests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -157,6 +157,23 @@ def disable_subp_usage(request, fixture_utils):
         yield
 
 
+@pytest.fixture(autouse=True)
+def disable_dns_lookup(request):
+    if "allow_dns_lookup" in request.keywords:
+        yield
+        return
+
+    def side_effect(args, *other_args, **kwargs):
+        raise AssertionError("Unexpectedly used util.is_resolvable")
+
+    with mock.patch(
+        "cloudinit.util.is_resolvable",
+        side_effect=side_effect,
+        autospec=True
+    ):
+        yield
+
+
 @pytest.fixture(scope="session")
 def fixture_utils():
     """Return a namespace containing fixture utility functions.

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -13,6 +13,7 @@ import socket
 import tempfile
 from unittest import TestCase, mock
 from unittest.mock import call
+import pytest
 
 from cloudinit import gpg, subp, util
 from cloudinit.config import cc_apt_configure
@@ -955,6 +956,7 @@ class TestAptSourceConfig(t_help.FilesystemMockingTestCase):
         self.assertEqual(mirrors["PRIMARY"], pmir)
         self.assertEqual(mirrors["SECURITY"], smir)
 
+    @pytest.mark.allow_dns_lookup
     def test_apt_v3_url_resolvable(self):
         """test_apt_v3_url_resolvable - Test resolving urls"""
 

--- a/tests/unittests/sources/test_aliyun.py
+++ b/tests/unittests/sources/test_aliyun.py
@@ -161,8 +161,9 @@ class TestAliYunDatasource(test_helpers.ResponsesTestCase):
             self.default_metadata["hostname"], self.ds.get_hostname().hostname
         )
 
+    @mock.patch("cloudinit.sources.DataSourceEc2.util.is_resolvable")
     @mock.patch("cloudinit.sources.DataSourceAliYun._is_aliyun")
-    def test_with_mock_server(self, m_is_aliyun):
+    def test_with_mock_server(self, m_is_aliyun, m_resolv):
         m_is_aliyun.return_value = True
         self.regist_default_server()
         ret = self.ds.get_data()

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -5,6 +5,7 @@ import json
 import threading
 from unittest import mock
 
+import pytest
 import requests
 import responses
 
@@ -221,6 +222,12 @@ TAGS_METADATA_2021_03_23: dict = {
         }
     },
 }
+
+
+@pytest.fixture(autouse=True)
+def disable_is_resolvable():
+    with mock.patch("cloudinit.sources.DataSourceEc2.util.is_resolvable"):
+        yield
 
 
 def _register_ssh_keys(rfunc, base_url, keys_data):

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -10,6 +10,7 @@ import re
 from io import StringIO
 from urllib.parse import urlparse
 
+import pytest
 import responses
 
 from cloudinit import helpers, settings, util
@@ -74,6 +75,12 @@ EC2_VERSIONS = [
 ]
 
 MOCK_PATH = "cloudinit.sources.DataSourceOpenStack."
+
+
+@pytest.fixture(autouse=True)
+def mock_is_resolvable():
+    with mock.patch(f"{MOCK_PATH}util.is_resolvable"):
+        yield
 
 
 # TODO _register_uris should leverage test_ec2.register_mock_metaserver.

--- a/tox.ini
+++ b/tox.ini
@@ -318,3 +318,4 @@ markers =
     ubuntu: this test should run on Ubuntu
     unstable: skip this test because it is flakey
     user_data: the user data to be passed to the test instance
+	allow_dns_lookup: disable autochecking for host network configuration


### PR DESCRIPTION
```
test: mock dns calls

Add fixture to disallow dns lookups by
default in a common utility function.
```

## Additional Context
We probably shouldn't depend on host dns resolution environment for unittest outcomes. Also this change shaved off a couple of seconds (51.31s vs 48.50s) when I just ran locally, but that could be just noise.

The checker alone yields the following failures:
```
FAILED tests/unittests/config/test_apt_source_v3.py::TestAptSourceConfig::test_apt_v3_url_resolvable - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_aliyun.py::TestAliYunDatasource::test_with_mock_server - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_aws_inaccessible_imds_service_fails_with_retries - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_aws_token_403_fails_without_retries - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_aws_token_redacted - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_classic_instance_false - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_classic_instance_true - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_ec2_local_performs_dhcp_on_non_bsd - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_get_instance_tags - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_network_config_cached_property_refreshed_on_upgrade - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_network_config_property_returns_version_2_network_data - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_network_config_property_secondary_private_ips - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_network_config_property_set_dhcp4 - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_unknown_platform_with_strict_false - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_valid_platform_with_strict_false - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_ec2.py::TestEc2::test_valid_platform_with_strict_true - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_openstack.py::TestOpenStackDataSource::test_bad_datasource_meta - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_openstack.py::TestOpenStackDataSource::test_datasource - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_openstack.py::TestOpenStackDataSource::test_disabled_datasource - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_openstack.py::TestOpenStackDataSource::test_local_datasource - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_openstack.py::TestOpenStackDataSource::test_no_datasource - AssertionError: Unexpectedly used util.is_resolvable
FAILED tests/unittests/sources/test_openstack.py::TestOpenStackDataSource::test_wb__crawl_metadata_does_not_persist - AssertionError: Unexpectedly used util.is_resolvable
```
Which are resolved in the following commit.