### PR TITLE
Use btrfs enquque when available

### DIFF
--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -60,15 +60,28 @@ def _resize_btrfs(mount_point, devpth):
     if not util.mount_is_read_write(mount_point) and os.path.isdir(
         "%s/.snapshots" % mount_point
     ):
-        return (
+        cmd = [
             "btrfs",
             "filesystem",
             "resize",
             "max",
             "%s/.snapshots" % mount_point,
-        )
+        ]
     else:
-        return ("btrfs", "filesystem", "resize", "max", mount_point)
+        cmd = ["btrfs", "filesystem", "resize", "max", mount_point]
+
+    # btrfs has exclusive operations and resize may fail if btrfs is busy
+    # doing one of the operations that prevents resize. As of btrfs 5.10
+    # the resize operation can be queued
+    btrfs_with_queue = util.Version().from_str("5.10")
+    system_btrfs_ver = util.Version().from_str(
+        subp.subp(["btrfs", "--version"])[0].split("v")[-1].strip()
+    )
+    if system_btrfs_ver >= btrfs_with_queue:
+        idx = cmd.index("resize")
+        cmd.insert(idx + 1, "--enqueue")
+
+    return tuple(cmd)
 
 
 def _resize_ext(mount_point, devpth):

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -73,8 +73,8 @@ def _resize_btrfs(mount_point, devpth):
     # btrfs has exclusive operations and resize may fail if btrfs is busy
     # doing one of the operations that prevents resize. As of btrfs 5.10
     # the resize operation can be queued
-    btrfs_with_queue = util.Version().from_str("5.10")
-    system_btrfs_ver = util.Version().from_str(
+    btrfs_with_queue = util.Version.from_str("5.10")
+    system_btrfs_ver = util.Version.from_str(
         subp.subp(["btrfs", "--version"])[0].split("v")[-1].strip()
     )
     if system_btrfs_ver >= btrfs_with_queue:


### PR DESCRIPTION


## Proposed Commit Message
enqueue the btrfs resize operation when supported

```
Use btrfs enquque when available

btrfs has operations that are blocking and when we try to resize a btrfs filesystem we may be in a race condition with blocking operations. Use the enqueue feature introduced in btrfs 5.10 to queue our resize request until resize if possible to avoid the race condition.
```

## Additional Context
<!-- If relevant -->

## Test Steps
This is a race condition and as such difficult to reproduce. Introduce the need for btrfs to do a resize blocking operation, such as rebalancing. Then trigger the resize request, it will fail. With a sufficiently new version of btrfs and this new code the resize will succeed.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
