### PR TITLE
Fix typo with package_update/package_upgrade

### DIFF
--- a/doc/examples/cloud-config-ansible-controller.txt
+++ b/doc/examples/cloud-config-ansible-controller.txt
@@ -4,8 +4,8 @@
 # This example installs a playbook repository from a remote private repository
 # and then runs two of the plays.
 
-packages_update: true
-packages_upgrade: true
+package_update: true
+package_upgrade: true
 packages:
   - git
   - python3-pip

--- a/doc/examples/cloud-config-ansible-pull.txt
+++ b/doc/examples/cloud-config-ansible-pull.txt
@@ -1,6 +1,6 @@
 #cloud-config
-packages_update: true
-packages_upgrade: true
+package_update: true
+package_upgrade: true
 
 # if you're already installing other packages, you may
 # wish to manually install ansible to avoid multiple calls

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -12,8 +12,8 @@ REPO_D = "/root/playbooks"
 USER_DATA = """\
 #cloud-config
 version: v1
-packages_update: true
-packages_upgrade: true
+package_update: true
+package_upgrade: true
 packages:
   - git
   - python3-pip
@@ -114,8 +114,8 @@ ANSIBLE_CONTROL = """\
 # This example installs a playbook repository from a remote private repository
 # and then runs two of the plays.
 
-packages_update: true
-packages_upgrade: true
+package_update: true
+package_upgrade: true
 packages:
   - git
   - python3-pip


### PR DESCRIPTION
## Proposed Commit Message

```
Fix typo with package_update/package_upgrade

There's a typo in the docs that can lead to confusion.
packages_update > package_update
packages_upgrade > package_upgrade
```

## Additional Context
https://cloudinit.readthedocs.io/en/latest/topics/modules.html#package-update-upgrade-install

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
