### PR TITLE
Add HttpScripts Config Module

### DIFF
--- a/cloudinit/config/cc_http_scripts.py
+++ b/cloudinit/config/cc_http_scripts.py
@@ -3,10 +3,11 @@ import subprocess
 import sys
 import urllib.request
 from logging import Logger, getLogger
-from subprocess import PIPE
+from subprocess import PIPE, STDOUT, CalledProcessError
 from textwrap import dedent
 from typing import List
 
+from cloudinit import subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema, get_meta_doc
@@ -60,20 +61,13 @@ def handle(
             ["/bin/sh"],
             input=script,
             stdout=PIPE,
-            stderr=PIPE,
+            stderr=STDOUT,
             env=environments,
-            check=False,
+            check=True,
         )
-
-        if p.returncode == 0:
-            LOG.debug("succeeded %s", url)
-        else:
-            LOG.debug("failed %s, return %d", url, p.returncode)
 
         if p.stdout:
             sys.stdout.write(f"{p.stdout!r}")
-        if p.stderr:
-            sys.stderr.write(f"{p.stderr!r}")
 
 
 def fetch_script(url: str) -> bytes:

--- a/cloudinit/config/cc_http_scripts.py
+++ b/cloudinit/config/cc_http_scripts.py
@@ -1,4 +1,5 @@
 """HttpScripts Module: Run scripts fetched by http"""
+import traceback
 import subprocess
 import sys
 import urllib.request
@@ -63,11 +64,15 @@ def handle(
             stdout=PIPE,
             stderr=STDOUT,
             env=environments,
-            check=True,
+            check=False,
         )
-
         if p.stdout:
-            sys.stdout.write(f"{p.stdout!r}")
+            sys.stdout.write(p.stdout.decode("utf-8"))
+
+        try:
+            p.check_returncode()
+        except:
+            LOG.exception("url: %s", url)
 
 
 def fetch_script(url: str) -> bytes:

--- a/cloudinit/config/cc_http_scripts.py
+++ b/cloudinit/config/cc_http_scripts.py
@@ -1,0 +1,82 @@
+"""HttpScripts Module: Run scripts fetched by http"""
+import subprocess
+import sys
+import urllib.request
+from logging import Logger, getLogger
+from subprocess import PIPE
+from textwrap import dedent
+from typing import List
+
+from cloudinit.cloud import Cloud
+from cloudinit.config import Config
+from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.distros import ALL_DISTROS
+from cloudinit.settings import PER_INSTANCE
+
+MODULE_DESCRIPTION = """\
+This module is like ``curl http://example.com/install.sh | sh``
+"""
+
+meta: MetaSchema = {
+    "id": "cc_http_scripts",
+    "name": "HttpScripts",
+    "title": "run scripts fetched by http",
+    "description": MODULE_DESCRIPTION,
+    "distros": [ALL_DISTROS],
+    "frequency": PER_INSTANCE,
+    "activate_by_schema_keys": ["http_scripts"],
+    "examples": [
+        dedent(
+            """\
+            http_scripts:
+              - url: http://example.com/install.sh
+                environments:
+                  ENV: val
+            """
+        )
+    ],
+}
+
+__doc__ = get_meta_doc(meta)
+LOG = getLogger(__name__)
+
+
+def handle(
+    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
+) -> None:
+    http_scripts: List[dict] = cfg.get("http_scripts", [])
+    for http_script in http_scripts:
+        if "url" not in http_script:
+            raise ValueError(f"Missing required key 'url' from {http_script}")
+
+        url = http_script.get("url", "")
+        environments = http_script.get("environments", {})
+
+        LOG.debug("fetch script: %s", url)
+        script = fetch_script(url)
+
+        LOG.debug("run script: %s", url)
+        p = subprocess.run(
+            ["/bin/sh"],
+            input=script,
+            stdout=PIPE,
+            stderr=PIPE,
+            env=environments,
+            check=False,
+        )
+
+        if p.returncode == 0:
+            LOG.debug("succeeded %s", url)
+        else:
+            LOG.debug("failed %s, return %d", url, p.returncode)
+
+        if p.stdout:
+            sys.stdout.write(f"{p.stdout!r}")
+        if p.stderr:
+            sys.stderr.write(f"{p.stderr!r}")
+
+
+def fetch_script(url: str) -> bytes:
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req) as res:
+        return res.read()

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1356,8 +1356,10 @@
       "properties": {
         "http_scripts": {
           "type": "array",
+          "additionalProperties": false,
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "required": [
               "url"
             ],
@@ -1371,7 +1373,8 @@
                   "type": "string"
                 }
               }
-            }
+            },
+            "minItems": 1
           }
         }
       }
@@ -3462,6 +3465,9 @@
     },
     {
       "$ref": "#/$defs/cc_grub_dpkg"
+    },
+    {
+      "$ref": "#/$defs/cc_http_scripts"
     },
     {
       "$ref": "#/$defs/cc_install_hotplug"

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -25,6 +25,8 @@
         "growpart",
         "grub-dpkg",
         "grub_dpkg",
+        "http-scripts",
+        "http_scripts",
         "install-hotplug",
         "install_hotplug",
         "keyboard",
@@ -1346,6 +1348,31 @@
           "type": "object",
           "description": "Use ``grub_dpkg`` instead",
           "deprecated": true
+        }
+      }
+    },
+    "cc_http_scripts": {
+      "type": "object",
+      "properties": {
+        "http_scripts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "url"
+            ],
+            "properties": {
+              "url": {
+                "type": "string"
+              },
+              "environments": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            }
+          }
         }
       }
     },

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -160,6 +160,7 @@ cloud_config_modules:
 {% if variant in ["ubuntu", "unknown", "debian"] %}
  - byobu
 {% endif %}
+ - http_scripts
 
 # The modules that run in the 'final' stage
 cloud_final_modules:

--- a/doc/examples/cloud-config-http-scripts.txt
+++ b/doc/examples/cloud-config-http-scripts.txt
@@ -1,0 +1,7 @@
+#cloud-config
+
+http_scripts:
+  - url: http://example.com/install.sh
+    environments:
+      ENV1: value1
+      ENV2: value2

--- a/doc/rtd/topics/examples.rst
+++ b/doc/rtd/topics/examples.rst
@@ -143,6 +143,13 @@ Create partitions and filesystems
    :language: yaml
    :linenos:
 
+Run scripts fetched by http
+===========================
+
+.. literalinclude:: ../../examples/cloud-config-http-scripts.txt
+   :language: yaml
+   :linenos:
+
 .. _chef: http://www.chef.io/chef/
 .. _puppet: http://puppetlabs.com/
 .. _ansible: https://docs.ansible.com/ansible/latest/

--- a/doc/rtd/topics/modules.rst
+++ b/doc/rtd/topics/modules.rst
@@ -18,6 +18,7 @@ Module Reference
 .. automodule:: cloudinit.config.cc_final_message
 .. automodule:: cloudinit.config.cc_growpart
 .. automodule:: cloudinit.config.cc_grub_dpkg
+.. automodule:: cloudinit.config.cc_http_scripts
 .. automodule:: cloudinit.config.cc_install_hotplug
 .. automodule:: cloudinit.config.cc_keyboard
 .. automodule:: cloudinit.config.cc_keys_to_console

--- a/tests/unittests/config/test_cc_http_scripts.py
+++ b/tests/unittests/config/test_cc_http_scripts.py
@@ -1,14 +1,121 @@
 import re
 import pytest
 
+from logging import Logger
+from unittest import mock
+from textwrap import dedent
+import urllib.request
+
 from cloudinit.config.schema import (
     SchemaValidationError,
     get_schema,
     validate_cloudconfig_schema,
 )
+from cloudinit.config.cc_http_scripts import handle, fetch_script
 from tests.unittests.helpers import (
     skipUnlessJsonSchema,
 )
+
+
+class TestHandle:
+    """Tests cc_http_scripts.handle()"""
+
+    @pytest.mark.parametrize(
+        "script, want, is_exception",
+        [
+            (dedent(
+                """\
+                #!/bin/sh
+                echo "hello world"
+                """
+            ),
+                "hello world\n",
+                False,
+            ),
+            (
+                dedent(
+                    """\
+                    #!/bin/sh
+                    exit 1
+                    """
+                ),
+                "",
+                True,
+            ),
+            (
+                dedent(
+                    """\
+                    #!/bin/sh
+                    echo "invalid" 1>&2    
+                    exit 1
+                    """
+                ),
+                "invalid\n",
+                True,
+            ),
+        ]
+    )
+    @mock.patch("cloudinit.config.cc_http_scripts.fetch_script")
+    @mock.patch("cloudinit.config.cc_http_scripts.LOG")
+    def test_handle(
+        self,
+        m_LOG,
+        m_fetch_script,
+        script,
+        want,
+        is_exception,
+        capfd,
+    ):
+        m_fetch_script.return_value = script.encode("utf-8")
+        cfg = {"http_scripts": [{"url": "http://example.com"}]}
+
+        handle(mock.Mock(), cfg, mock.Mock(), mock.Mock(), mock.Mock())
+        output, _ = capfd.readouterr()
+        assert output == want
+        m_LOG.debug.assert_any_call(
+            "fetch script: %s", "http://example.com",
+        )
+        m_LOG.debug.assert_any_call(
+            "run script: %s", "http://example.com",
+        )
+
+        if is_exception:
+            m_LOG.exception.assert_any_call(
+                "url: %s", "http://example.com",
+            )
+
+
+class TestFetchScript:
+    """Tests cc_http_scripts.fetch_script()"""
+
+    @pytest.mark.parametrize(
+        "url, error_msg",
+        [
+            ("http://example.com", None),
+            ("https://example.com", None),
+            ("example.com", "unknown url type: 'example.com'"),
+        ]
+    )
+    @mock.patch("cloudinit.config.cc_http_scripts.urllib.request.urlopen")
+    def test_fetch_script(
+        self,
+        m_urlopen: mock.MagicMock,
+        url: str,
+        error_msg: str,
+    ):
+        m_urlopen.return_value.__enter__.return_value.read.return_value = b"script"
+
+        if error_msg is None:
+            got = fetch_script(url)
+            req = m_urlopen.call_args[0][0]
+            assert m_urlopen.call_count == 1
+            assert type(req) == urllib.request.Request
+            assert req.full_url == url
+            assert got == b"script"
+        else:
+            with pytest.raises(ValueError, match=error_msg):
+                got = fetch_script(url)
+            assert m_urlopen.call_count == 0
 
 
 @skipUnlessJsonSchema()

--- a/tests/unittests/config/test_cc_http_scripts.py
+++ b/tests/unittests/config/test_cc_http_scripts.py
@@ -1,0 +1,76 @@
+import re
+import pytest
+
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
+from tests.unittests.helpers import (
+    skipUnlessJsonSchema,
+)
+
+
+@skipUnlessJsonSchema()
+class TestHttpScriptsSchema:
+    @pytest.mark.parametrize(
+        "config, error_msg",
+        (
+            ({"http_scripts": [{"url": "http://example.com"}]}, None),
+            (
+                {
+                    "http_scripts": [
+                        {"url": "http://example.com"},
+                        {"url": "http://example.com"},
+                    ]
+                },
+                None,
+            ),
+            (
+                {
+                    "http_scripts": [
+                        {
+                            "url": "http://example.com",
+                            "environments": {
+                                "ENV1": "value1",
+                                "ENV2": "value2",
+                            },
+                        }
+                    ]
+                },
+                None,
+            ),
+            # Invalid schemas
+            (
+                {"http_scripts": {"url": "http://example.com"}},
+                re.escape(
+                    "{'url': 'http://example.com'} is not of type 'array'"
+                ),
+            ),
+            (
+                {"http_scripts": [{}]},
+                re.escape("http_scripts.0: 'url' is a required property"),
+            ),
+            (
+                {
+                    "http_scripts": [
+                        {"environments": {"ENV1": "value1", "ENV2": "value2"}}
+                    ]
+                },
+                re.escape("http_scripts.0: 'url' is a required property"),
+            ),
+            (
+                {"http_scripts": [{"invalidprop": True}]},
+                re.escape(
+                    "Additional properties are not allowed ('invalidprop"
+                ),
+            ),
+        ),
+    )
+    @skipUnlessJsonSchema()
+    def test_schema_validation(self, config, error_msg):
+        if error_msg is None:
+            validate_cloudconfig_schema(config, get_schema(), strict=True)
+        else:
+            with pytest.raises(SchemaValidationError, match=error_msg):
+                validate_cloudconfig_schema(config, get_schema(), strict=True)

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -181,6 +181,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_final_message"},
             {"$ref": "#/$defs/cc_growpart"},
             {"$ref": "#/$defs/cc_grub_dpkg"},
+            {"$ref": "#/$defs/cc_http_scripts"},
             {"$ref": "#/$defs/cc_install_hotplug"},
             {"$ref": "#/$defs/cc_keyboard"},
             {"$ref": "#/$defs/cc_keys_to_console"},

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -90,6 +90,7 @@ nkukard
 olivierlemasle
 omBratteng
 onitake
+ophum
 Oursin
 outscale-mdr
 qubidt


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add HttpScripts Config Module

HttpScripts is fetch some setup script by http and run its.
This is something like below command.

curl http://example.com/install.sh | sh

```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

using lxd

1. create image pre-installed this module
2. run http.server on host machine
  a. hosted sample script
![スクリーンショット 2022-12-26 17 24 56](https://user-images.githubusercontent.com/18211283/209525194-8b504066-ac63-4195-919a-923d0a051001.png)
3. launch container with user-data
  a. `http://10.92.204.1:8000/install.sh` is hosted by host machine. run with environments(`ENV1=value1` `ENV2=value2`)
  b. `https://get.k0s.sh` is k0s install script
![スクリーンショット 2022-12-26 17 26 46](https://user-images.githubusercontent.com/18211283/209525382-365c03e4-5b5c-4ea9-8eb4-e9d6e34a3bec.png)
4. Check `/var/log/cloud-init.log`
![スクリーンショット 2022-12-26 17 27 07](https://user-images.githubusercontent.com/18211283/209525341-e8920365-56b5-4e9e-a5f1-588692780c2b.png)
5. Check `/var/log/cloud-init-output.log`
![スクリーンショット 2022-12-26 17 27 30](https://user-images.githubusercontent.com/18211283/209526000-88866937-ec24-4310-8f14-dd93e511aaea.png)
6. Check installed `k0s` command
![スクリーンショット 2022-12-26 17 27 48](https://user-images.githubusercontent.com/18211283/209526037-22778d62-e6f4-4cdb-a818-7876b0f43158.png)

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
