### PR TITLE
network/netplan: add gateways as on-link when necessary

### DIFF
--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -6289,6 +6289,44 @@ class TestNetplanNetRendering:
                 """,
                 id="one_subnet_old_new_gateway46",
             ),
+            # Assert gateways outside of the subnet's network are added with
+            # the on-link flag
+            pytest.param(
+                """
+                version: 1
+                config:
+                  - type: physical
+                    name: interface0
+                    mac_address: '00:11:22:33:44:55'
+                    subnets:
+                      - type: static
+                        address: 192.168.23.14/24
+                        gateway: 192.168.255.1
+                      - type: static
+                        address: 2001:cafe::/64
+                        gateway: 2001:ffff::1
+                """,
+                """
+                network:
+                  version: 2
+                  ethernets:
+                    interface0:
+                      addresses:
+                      - 192.168.23.14/24
+                      - 2001:cafe::/64
+                      match:
+                        macaddress: 00:11:22:33:44:55
+                      routes:
+                      -   to: default
+                          via: 192.168.255.1
+                          on-link: true
+                      -   to: default
+                          via: 2001:ffff::1
+                          on-link: true
+                      set-name: interface0
+                """,
+                id="onlink_gateways",
+            ),
         ],
     )
     @mock.patch(

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -103,6 +103,7 @@ s-makin
 SadeghHayeri
 SRv6d
 sarahwzadara
+sbraz
 scorpion44
 shaardie
 shell-skrimp


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
network/netplan: add gateways as on-link when necessary

When the gateway isn't part of the subnet's network, the "on-link" flag is required for the route to work.

LP: #2000596
```

## Additional Context
This is a fix for https://bugs.launchpad.net/cloud-init/+bug/2000596
I don't know if I should also do this for additional `routes`, please let me know.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
I have added a unit test which adds an on-link IPv4 and IPv6 gateways.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
