### PR TITLE
sources/azure: drop description for report_failure_to_fabric()

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -31,7 +31,6 @@ from cloudinit.net.ephemeral import EphemeralDHCPv4
 from cloudinit.reporting import events
 from cloudinit.sources.helpers import netlink
 from cloudinit.sources.helpers.azure import (
-    DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE,
     DEFAULT_WIRESERVER_ENDPOINT,
     BrokenAzureDataSource,
     ChassisAssetTag,
@@ -752,9 +751,7 @@ class DataSourceAzure(sources.DataSource):
             report_diagnostic_event(
                 "Could not crawl Azure metadata: %s" % e, logger_func=LOG.error
             )
-            self._report_failure(
-                description=DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE
-            )
+            self._report_failure()
             return False
         finally:
             self._teardown_ephemeral_networking()
@@ -1384,7 +1381,7 @@ class DataSourceAzure(sources.DataSource):
         return reprovision_data
 
     @azure_ds_telemetry_reporter
-    def _report_failure(self, description: Optional[str] = None) -> bool:
+    def _report_failure(self) -> bool:
         """Tells the Azure fabric that provisioning has failed.
 
         @param description: A description of the error encountered.
@@ -1397,10 +1394,7 @@ class DataSourceAzure(sources.DataSource):
                     "to report failure to Azure",
                     logger_func=LOG.debug,
                 )
-                report_failure_to_fabric(
-                    endpoint=self._wireserver_endpoint,
-                    description=description,
-                )
+                report_failure_to_fabric(endpoint=self._wireserver_endpoint)
                 return True
             except Exception as e:
                 report_diagnostic_event(
@@ -1420,9 +1414,7 @@ class DataSourceAzure(sources.DataSource):
             except NoDHCPLeaseError:
                 # Reporting failure will fail, but it will emit telemetry.
                 pass
-            report_failure_to_fabric(
-                endpoint=self._wireserver_endpoint, description=description
-            )
+            report_failure_to_fabric(endpoint=self._wireserver_endpoint)
             return True
         except Exception as e:
             report_diagnostic_event(

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -1053,10 +1053,9 @@ def get_metadata_from_fabric(
 
 
 @azure_ds_telemetry_reporter
-def report_failure_to_fabric(endpoint: str, description: Optional[str] = None):
+def report_failure_to_fabric(endpoint: str):
     shim = WALinuxAgentShim(endpoint=endpoint)
-    if not description:
-        description = DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE
+    description = DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE
     try:
         shim.register_with_azure_and_report_failure(description=description)
     finally:

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1317,7 +1317,7 @@ scbus-1 on xpt0 bus 0
             self.assertEqual(1, m_crawl_metadata.call_count)
             self.assertFalse(ret)
 
-    def test_crawl_metadata_exception_should_report_failure_with_msg(self):
+    def test_crawl_metadata_exception_should_report_failure(self):
         data = {}
         dsrc = self._get_ds(data)
         with mock.patch.object(
@@ -1328,9 +1328,7 @@ scbus-1 on xpt0 bus 0
             m_crawl_metadata.side_effect = Exception
             dsrc.get_data()
             self.assertEqual(1, m_crawl_metadata.call_count)
-            m_report_failure.assert_called_once_with(
-                description=dsaz.DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE
-            )
+            m_report_failure.assert_called_once_with()
 
     def test_crawl_metadata_exc_should_log_could_not_crawl_msg(self):
         data = {}
@@ -2065,28 +2063,15 @@ scbus-1 on xpt0 bus 0
             self.assertFalse(dsrc._report_failure())
             self.assertEqual(2, self.m_report_failure_to_fabric.call_count)
 
-    def test_dsaz_report_failure_description_msg(self):
-        dsrc = self._get_ds({"ovfcontent": construct_ovf_env()})
-
-        with mock.patch.object(dsrc, "crawl_metadata") as m_crawl_metadata:
-            # mock crawl metadata failure to cause report failure
-            m_crawl_metadata.side_effect = Exception
-
-            test_msg = "Test report failure description message"
-            self.assertTrue(dsrc._report_failure(description=test_msg))
-            self.m_report_failure_to_fabric.assert_called_once_with(
-                endpoint="168.63.129.16", description=test_msg
-            )
-
-    def test_dsaz_report_failure_no_description_msg(self):
+    def test_dsaz_report_failure(self):
         dsrc = self._get_ds({"ovfcontent": construct_ovf_env()})
 
         with mock.patch.object(dsrc, "crawl_metadata") as m_crawl_metadata:
             m_crawl_metadata.side_effect = Exception
 
-            self.assertTrue(dsrc._report_failure())  # no description msg
+            self.assertTrue(dsrc._report_failure())
             self.m_report_failure_to_fabric.assert_called_once_with(
-                endpoint="168.63.129.16", description=None
+                endpoint="168.63.129.16"
             )
 
     def test_dsaz_report_failure_uses_cached_ephemeral_dhcp_ctx_lease(self):
@@ -2104,7 +2089,7 @@ scbus-1 on xpt0 bus 0
 
             # ensure called with cached ephemeral dhcp lease option 245
             self.m_report_failure_to_fabric.assert_called_once_with(
-                endpoint="test-ep", description=mock.ANY
+                endpoint="test-ep"
             )
 
     def test_dsaz_report_failure_no_net_uses_new_ephemeral_dhcp_lease(self):
@@ -2126,7 +2111,7 @@ scbus-1 on xpt0 bus 0
             # ensure called with the newly discovered
             # ephemeral dhcp lease option 245
             self.m_report_failure_to_fabric.assert_called_once_with(
-                endpoint="1.2.3.4", description=mock.ANY
+                endpoint="1.2.3.4"
             )
 
     def test_exception_fetching_fabric_data_doesnt_propagate(self):

--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -1396,34 +1396,10 @@ class TestGetMetadataGoalStateXMLAndReportFailureToFabric(CiTestCase):
         )
         self.assertEqual(1, self.m_shim.return_value.clean_up.call_count)
 
-    def test_report_failure_to_fabric_with_desc_calls_shim_report_failure(
-        self,
-    ):
-        azure_helper.report_failure_to_fabric(
-            endpoint="test_endpoint", description="TestDesc"
-        )
-        self.m_shim.return_value.register_with_azure_and_report_failure.assert_called_once_with(  # noqa: E501
-            description="TestDesc"
-        )
-
-    def test_report_failure_to_fabric_with_no_desc_calls_shim_report_failure(
+    def test_report_failure_to_fabric_calls_shim_report_failure(
         self,
     ):
         azure_helper.report_failure_to_fabric(endpoint="test_endpoint")
-        # default err message description should be shown to the user
-        # if no description is passed in
-        self.m_shim.return_value.register_with_azure_and_report_failure.assert_called_once_with(  # noqa: E501
-            description=(
-                azure_helper.DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE
-            )
-        )
-
-    def test_report_failure_to_fabric_empty_desc_calls_shim_report_failure(
-        self,
-    ):
-        azure_helper.report_failure_to_fabric(
-            endpoint="test_endpoint", description=""
-        )
         # default err message description should be shown to the user
         # if an empty description is passed in
         self.m_shim.return_value.register_with_azure_and_report_failure.assert_called_once_with(  # noqa: E501


### PR DESCRIPTION
The same default description is used for all error cases.

Remove this parameter in favor of assuming the default in all cases.  Future work will allow for error reporting with a customizable description using a different interface.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>