### PR TITLE
RFC: Option to warn on duplicate mac

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -37,6 +37,7 @@ from cloudinit.sources import NetworkConfigSource
 LOG = logging.getLogger(__name__)
 
 NO_PREVIOUS_INSTANCE_ID = "NO_PREVIOUS_INSTANCE_ID"
+_base_config = None
 
 
 def update_event_enabled(
@@ -958,7 +959,10 @@ def read_runtime_config():
 
 
 def fetch_base_config(*, instance_data_file=None) -> dict:
-    return util.mergemanydict(
+    global _base_config
+    if _base_config is not None:
+        return _base_config
+    _base_config = util.mergemanydict(
         [
             # builtin config, hardcoded in settings.py.
             util.get_builtin_cfg(),
@@ -973,3 +977,4 @@ def fetch_base_config(*, instance_data_file=None) -> dict:
         ],
         reverse=True,
     )
+    return _base_config

--- a/doc/rtd/topics/base_config_reference.rst
+++ b/doc/rtd/topics/base_config_reference.rst
@@ -216,6 +216,11 @@ Format is a dict with ``enabled`` and ``prefix`` keys:
 * **enabled**: Boolean indicating whether to enable or disable the vendor_data
 * **prefix**: A path to prepend to any vendor_data provided script
 
+**warn_on_duplicate_mac**: When set true, allows cloud-init to continue
+running if it discovers multiple interfaces with the same network MAC address.
+Standard cloud-init behavior is to exit with an exception when multiple
+interfaces have the same MAC address.
+
 Example
 =======
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
TODO
```

WIP...looking for feedback. Tests currently fail.

This feels hacky to me, but I can't think of a better way of doing this that doesn't involve sending the config through multiple levels of networking functions that currently don't take the config. That's certainly doable but would be a much more significant refactor. I'm open to any better ideas.


