### PR TITLE
Order cloud-init.service after dbus.socket on Ubuntu

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -12,6 +12,9 @@ After=systemd-networkd-wait-online.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 After=networking.service
 {% endif %}
+{% if variant == "ubuntu" %}
+After=dbus.socket
+{% endif %}
 {% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora",
                   "miraclelinux", "openEuler", "openmandriva", "rhel", "rocky", "virtuozzo"] %}
 After=network.service


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Order cloud-init.service after dbus.socket on Ubuntu

Calling "netplan apply" results in an error if cloud-init runs before 
dbus is ready, so ensure cloud-init.service starts after dbus.socket.

LP: #1997124
```

## Additional Context
This will increase boot time for launches that would have otherwise hit the race.

## Test Steps
Our current regression tests found this, but since there is a race involved, it won't be deterministic.