### PR TITLE
tests: test_lxd assert features.networks.zones when present

### DIFF
--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -219,6 +219,10 @@ def validate_preseed_projects(client: IntegrationInstance, preseed_cfg):
         # https://discuss.linuxcontainers.org/t/lxd-5-5-has-been-released/14899
         if "features.storage.buckets" in project["config"]:
             assert "true" == project["config"].pop("features.storage.buckets")
+        # `features.networks.zones` was introduced in lxd 5.9. More info:
+        # https://discuss.linuxcontainers.org/t/lxd-5-9-has-been-released/
+        if "features.networks.zones" in project["config"]:
+            assert "true" == project["config"].pop("features.networks.zones")
         assert project == src_project
 
 


### PR DESCRIPTION
LXD v 5.9 introduces a features.networks.zones default. Assert features.networks.zones when host provides this key. Cope with versions that do not surface this config.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: test_lxd assert features.networks.zones when present

LXD v 5.9 introduces a features.networks.zones default.
Assert features.networks.zones when host provides this key.
Cope with versions that do not surface this config.
```

## Additional Context
failures on lunar:
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-lunar-ec2/5/#showFailuresLink

## Test Steps
```
CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=lunar tox -e integration-tests tests/integration_tests/modules/test_lxd.py
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
