### PR TITLE
Improve Wireguard module idempotency

### DIFF
--- a/cloudinit/config/cc_wireguard.py
+++ b/cloudinit/config/cc_wireguard.py
@@ -163,7 +163,7 @@ def enable_wg(wg_int: dict, cloud: Cloud):
         LOG.debug("Enabling wg-quick@%s at boot", wg_int["name"])
         cloud.distro.manage_service("enable", f'wg-quick@{wg_int["name"]}')
         LOG.debug("Bringing up interface wg-quick@%s", wg_int["name"])
-        cloud.distro.manage_service("start", f'wg-quick@{wg_int["name"]}')
+        cloud.distro.manage_service("restart", f'wg-quick@{wg_int["name"]}')
     except subp.ProcessExecutionError as e:
         raise RuntimeError(
             f"Failed enabling/starting Wireguard interface(s):{NL}{str(e)}"


### PR DESCRIPTION
## Improve Wireguard module idempotency
<!-- Include a proposed commit message because all PRs are squash merged -->

```
When starting `wg-quick` service of an already configured system due to meta-data changed, 
changes in Wireguard config won't be loaded as the service already runs during cloud-init config 
section. Restart `wg-quick` systemd service to fix this behavior and improve idempotency.
```

## Additional Context
<!-- If relevant -->

## Test Steps
no new test steps required

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
