### PR TITLE
distros/rhel.py: _read_hostname() missing strip on "hostname"

### DIFF
--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -132,6 +132,7 @@ class Distro(distros.Distro):
             return util.load_file(filename).strip()
         elif self.uses_systemd():
             (out, _err) = subp.subp(["hostname"])
+            out = out.strip()
             if len(out):
                 return out
             else:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -75,6 +75,7 @@ mal
 ManassehZhou
 mamercad
 manuelisimo
+MarkMielke
 marlluslustosa
 matthewruffell
 maxnet


### PR DESCRIPTION
Debugging a related issue, I found that the determination of the "previous-hostname" was wrong an RHEL-based distributions.

In `distros/__init__.py`: update_hostname() has this code:

```
            prev_hostname = self._read_hostname(prev_hostname_fn)
...
        (sys_fn, sys_hostname) = self._read_system_hostname()
...
        if sys_hostname and prev_hostname and sys_hostname != prev_hostname:
            LOG.info(
                "%s differs from %s, assuming user maintained hostname.",
                prev_hostname_fn,
                sys_fn,
            )
            return
```

sys_hostname was found to contain a trailing newline, while prev_hostname did not. `sys_hostname != prev_hostname` is therefore always true. The check effectively reduces to:

```
        if sys_hostname and prev_hostname:
```

Evidence can be found in the log file, as "assuming user maintained hostname", even when this is not true.

prev_hostname is determined using _read_hostname().

sys_hostname is determined using _read_system_hostname() which also calls _read_hostname().

However, only the prev_hostname is being stripped by _read_hostname():

```
        if self.uses_systemd() and filename.endswith("/previous-hostname"):
            return util.load_file(filename).strip()
        elif self.uses_systemd():
            (out, _err) = subp.subp(["hostname"])
            if len(out):
                return out
```

I was unable to determine when this problem was introduced. It may
exist as far back as since "self.uses_systemd()" has been returning true?

The fix is to add a call to strip on the result of the call to command "hostname" the same way the strip is done on the file containing the "previous-hostname".

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate bug reference or remove
this line entirely if there is no associated bug)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
