### PR TITLE
Ubuntu/focal

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (22.4-0ubuntu0~20.04.2) UNRELEASED; urgency=medium
+
+  * d/patches/retain-netplan-world-readable.patch:
+    - Retain original world-readable perms of /etc/netplan/50-cloud-init.yaml.
+      Lunar made the config root read-only.
+
+ -- Chad Smith <chad.smith@canonical.com>  Mon, 09 Jan 2023 09:51:18 -0700
+
 cloud-init (22.4-0ubuntu0~20.04.1) focal; urgency=medium
 
   * d/control: drop python3-httpretty from Build-Depends

--- a/debian/patches/retain-netplan-world-readable.patch
+++ b/debian/patches/retain-netplan-world-readable.patch
@@ -1,0 +1,49 @@
+Description: Retain world-readable /etc/netplan/50-cloud-init.yaml
+ To avoid change in behavior stable releases wil not adopt root read-only
+ /etc/netplan/50-cloud-init.yaml. which is present in Lunar and newer.
+Author: chad.smith@canonical.com
+Origin: backport
+Forwarded: not-needed
+Last-Update: 2023-01-09 
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+Index: cloud-init/cloudinit/features.py
+===================================================================
+--- cloud-init.orig/cloudinit/features.py
++++ cloud-init/cloudinit/features.py
+@@ -59,7 +59,7 @@ only non-hashed passwords were expired.
+ (This flag can be removed after Jammy is no longer supported.)
+ """
+ 
+-NETPLAN_CONFIG_ROOT_READ_ONLY = True
++NETPLAN_CONFIG_ROOT_READ_ONLY = False
+ """
+ If ``NETPLAN_CONFIG_ROOT_READ_ONLY`` is True, then netplan configuration will
+ be written as a single root readon-only file /etc/netplan/50-cloud-init.yaml.
+Index: cloud-init/tests/unittests/distros/test_netconfig.py
+===================================================================
+--- cloud-init.orig/tests/unittests/distros/test_netconfig.py
++++ cloud-init/tests/unittests/distros/test_netconfig.py
+@@ -1039,12 +1039,16 @@ class TestNetCfgDistroArch(TestNetCfgDis
+         with mock.patch(
+             "cloudinit.net.netplan.get_devicelist", return_value=[]
+         ):
+-            self._apply_and_verify(
+-                self.distro.apply_network_config,
+-                V1_NET_CFG,
+-                expected_cfgs=expected_cfgs.copy(),
+-                with_netplan=True,
+-            )
++            with mock.patch.object(
++                features, "NETPLAN_CONFIG_ROOT_READ_ONLY"
++            ) as netplan_readonly:
++                netplan_readonly = True
++                self._apply_and_verify(
++                    self.distro.apply_network_config,
++                    V1_NET_CFG,
++                    expected_cfgs=expected_cfgs.copy(),
++                    with_netplan=True,
++                )
+ 
+ 
+ class TestNetCfgDistroPhoton(TestNetCfgDistroBase):

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 retain-apt-partner-pocket.patch
 expire-on-hashed-users.patch
+retain-netplan-world-readable.patch


### PR DESCRIPTION
## do not squash merge
Stable releases need to keep 50-cloud-init.yaml world-readable to avoid change in behavior.
This change was introduced in Lunar, so Bionic, Focal, Jammy and Kinetic need to set this feature False.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
* update changelog 


* Add patch retain-netplan-world-readable.patch

Keep /etc/netplan/50-cloud-init.yaml a world-readable.
Backport of 9e6f7ed6e.
```

## Additional Context
Branch build procedure:
```
git checkout main
quilt push -a
quilt new retain-netplan-world-readable.patch
quilt edit cloudinit/features.py
quilt edit tests/unittests/distros/test_netconfig.py
quilt refresh
quilt header --dep3 -e
quilt pop -a
git checkout ubuntu/focal
git add debian
git commit -a
dch -i 
git add debian/changelog
git commit -am 'update changelog'
```

<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
