### PR TITLE
netplan: keep original permissions when 50-cloud-init.yaml exists

### DIFF
--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -263,9 +263,12 @@ class Renderer(renderer.Renderer):
             header += "\n"
 
         mode = 0o600 if features.NETPLAN_CONFIG_ROOT_READ_ONLY else 0o644
-        util.write_file(
-            fpnplan, header + content, mode=mode, preserve_mode=True
-        )
+        if os.path.exists(fpnplan):
+            current_mode = util.get_permissions(fpnplan)
+            if current_mode & mode == current_mode:
+                # preserve mode if existing perms are more strict than default
+                mode = current_mode
+        util.write_file(fpnplan, header + content, mode=mode)
 
         if self.clean_default:
             _clean_default(target=target)

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -263,7 +263,9 @@ class Renderer(renderer.Renderer):
             header += "\n"
 
         mode = 0o600 if features.NETPLAN_CONFIG_ROOT_READ_ONLY else 0o644
-        util.write_file(fpnplan, header + content, mode=mode)
+        util.write_file(
+            fpnplan, header + content, mode=mode, preserve_mode=True
+        )
 
         if self.clean_default:
             _clean_default(target=target)

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -265,7 +265,8 @@ class Renderer(renderer.Renderer):
         mode = 0o600 if features.NETPLAN_CONFIG_ROOT_READ_ONLY else 0o644
         if os.path.exists(fpnplan):
             current_mode = util.get_permissions(fpnplan)
-            if current_mode & mode == current_mode:
+            current_suid_sticky_bits = current_mode & 0o7000
+            if current_mode & mode | current_suid_sticky_bits == current_mode:
                 # preserve mode if existing perms are more strict than default
                 mode = current_mode
         util.write_file(fpnplan, header + content, mode=mode)

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -265,8 +265,7 @@ class Renderer(renderer.Renderer):
         mode = 0o600 if features.NETPLAN_CONFIG_ROOT_READ_ONLY else 0o644
         if os.path.exists(fpnplan):
             current_mode = util.get_permissions(fpnplan)
-            current_suid_sticky_bits = current_mode & 0o7000
-            if current_mode & mode | current_suid_sticky_bits == current_mode:
+            if current_mode & mode == current_mode:
                 # preserve mode if existing perms are more strict than default
                 mode = current_mode
         util.write_file(fpnplan, header + content, mode=mode)

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -622,20 +622,20 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
     def test_apply_network_config_v2_passthrough_retain_orig_perms(self):
         """Custom permissions on existing netplan is kept when more strict."""
         expected_cfgs = (
-            (self.netplan_path(), V2_TO_V2_NET_CFG_OUTPUT, 0o640),
+            (self.netplan_path(), V2_TO_V2_NET_CFG_OUTPUT, 0o1640),
         )
-        tmpd = None
         with mock.patch.object(
             features, "NETPLAN_CONFIG_ROOT_READ_ONLY", False
         ):
             # When NETPLAN_CONFIG_ROOT_READ_ONLY is False default perms are 644
-            # we keep 640 because it's more strict.
+            # we keep 1640 because it's more strict.
+            # 1640 is used to assert sticky bit preserved across write
             self._apply_and_verify_netplan(
                 self.distro.apply_network_config,
                 V2_NET_CFG,
                 expected_cfgs=expected_cfgs,
                 previous_files=(
-                    ("/etc/netplan/50-cloud-init.yaml", "a", 0o640),
+                    ("/etc/netplan/50-cloud-init.yaml", "a", 0o1640),
                 ),
             )
 
@@ -1315,7 +1315,7 @@ class TestNetCfgDistroMariner(TestNetCfgDistroBase):
 
 
 def get_mode(path, target=None):
-    return os.stat(subp.target_path(target, path)).st_mode & 0o777
+    return os.stat(subp.target_path(target, path)).st_mode & 0o7777
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -485,7 +485,6 @@ class TestNetCfgDistroUbuntuEni(TestNetCfgDistroBase):
         expected_cfgs = {
             self.eni_path(): V1_NET_CFG_OUTPUT,
         }
-        # ub_distro.apply_network_config(V1_NET_CFG, False)
         with mock.patch(
             "cloudinit.net.activators.select_activator"
         ) as select_activator:
@@ -529,7 +528,6 @@ class TestNetCfgDistroUbuntuEni(TestNetCfgDistroBase):
         expected_cfgs = {
             self.eni_path(): V1_NET_CFG_OUTPUT,
         }
-        # ub_distro.apply_network_config(V1_NET_CFG, False)
         self._apply_and_verify_eni(
             self.distro.apply_network_config,
             V1_NET_CFG,
@@ -594,7 +592,6 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
             (self.netplan_path(), V1_TO_V2_NET_CFG_OUTPUT, 0o600),
         )
 
-        # ub_distro.apply_network_config(V1_NET_CFG, False)
         self._apply_and_verify_netplan(
             self.distro.apply_network_config,
             V1_NET_CFG,
@@ -606,7 +603,6 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
             (self.netplan_path(), V1_TO_V2_NET_CFG_IPV6_OUTPUT, 0o600),
         )
 
-        # ub_distro.apply_network_config(V1_NET_CFG_IPV6, False)
         self._apply_and_verify_netplan(
             self.distro.apply_network_config,
             V1_NET_CFG_IPV6,
@@ -617,7 +613,6 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
         expected_cfgs = (
             (self.netplan_path(), V2_TO_V2_NET_CFG_OUTPUT, 0o600),
         )
-        # ub_distro.apply_network_config(V2_NET_CFG, False)
         self._apply_and_verify_netplan(
             self.distro.apply_network_config,
             V2_NET_CFG,
@@ -629,7 +624,6 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
         expected_cfgs = (
             (self.netplan_path(), V2_TO_V2_NET_CFG_OUTPUT, 0o640),
         )
-        # ub_distro.apply_network_config(V2_NET_CFG, False)
         tmpd = None
         with mock.patch.object(
             features, "NETPLAN_CONFIG_ROOT_READ_ONLY", False
@@ -650,7 +644,6 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
         expected_cfgs = (
             (self.netplan_path(), V2_TO_V2_NET_CFG_OUTPUT, 0o644),
         )
-        # ub_distro.apply_network_config(V2_NET_CFG, False)
         with mock.patch.object(
             features, "NETPLAN_CONFIG_ROOT_READ_ONLY", False
         ):
@@ -664,7 +657,6 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
         expected_cfgs = (
             (self.netplan_path(), V2_PASSTHROUGH_NET_CFG_OUTPUT, 0o600),
         )
-        # ub_distro.apply_network_config(V2_PASSTHROUGH_NET_CFG, False)
         self._apply_and_verify_netplan(
             self.distro.apply_network_config,
             V2_PASSTHROUGH_NET_CFG,
@@ -1034,7 +1026,6 @@ class TestNetCfgDistroArch(TestNetCfgDistroBase):
             ),
         }
 
-        # ub_distro.apply_network_config(V1_NET_CFG, False)
         self._apply_and_verify(
             self.distro.apply_network_config,
             V1_NET_CFG,

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -622,20 +622,20 @@ class TestNetCfgDistroUbuntuNetplan(TestNetCfgDistroBase):
     def test_apply_network_config_v2_passthrough_retain_orig_perms(self):
         """Custom permissions on existing netplan is kept when more strict."""
         expected_cfgs = (
-            (self.netplan_path(), V2_TO_V2_NET_CFG_OUTPUT, 0o1640),
+            (self.netplan_path(), V2_TO_V2_NET_CFG_OUTPUT, 0o640),
         )
         with mock.patch.object(
             features, "NETPLAN_CONFIG_ROOT_READ_ONLY", False
         ):
             # When NETPLAN_CONFIG_ROOT_READ_ONLY is False default perms are 644
-            # we keep 1640 because it's more strict.
+            # we keep 640 because it's more strict.
             # 1640 is used to assert sticky bit preserved across write
             self._apply_and_verify_netplan(
                 self.distro.apply_network_config,
                 V2_NET_CFG,
                 expected_cfgs=expected_cfgs,
                 previous_files=(
-                    ("/etc/netplan/50-cloud-init.yaml", "a", 0o1640),
+                    ("/etc/netplan/50-cloud-init.yaml", "a", 0o640),
                 ),
             )
 
@@ -1316,7 +1316,7 @@ class TestNetCfgDistroMariner(TestNetCfgDistroBase):
 
 def get_mode(path, target=None):
     # Mask upper st_mode bits like S_IFREG bit preserve sticky and isuid/osgid
-    return os.stat(subp.target_path(target, path)).st_mode & 0o7777
+    return os.stat(subp.target_path(target, path)).st_mode & 0o777
 
 
 # vi: ts=4 expandtab

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -1315,6 +1315,7 @@ class TestNetCfgDistroMariner(TestNetCfgDistroBase):
 
 
 def get_mode(path, target=None):
+    # Mask upper st_mode bits like S_IFREG bit preserve sticky and isuid/osgid
     return os.stat(subp.target_path(target, path)).st_mode & 0o7777
 
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
netplan: keep original permissions when 50-cloud-init.yaml exists

To avoid limiting permissions of netplan config across package
upgrade, pass preserve_mode=True when writing 50-cloud-init.yaml.

Ensure any custom permissions are retained across package upgrade
even when netplan config is rewritten across system reboot
```

## Additional Context
https://warthogs.atlassian.net/browse/SC-1375

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
