### PR TITLE
Fix cloud-user for is_rhel derivatives in cloud.cfg.tmpl

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -260,7 +260,7 @@ system_info:
      name: ec2-user
      lock_passwd: True
      gecos: EC2 Default User
-{% elif variant in ["rhel", "centos"] %}
+{% elif is_rhel and variant != "eurolinux" %}
      name: cloud-user
      lock_passwd: true
      gecos: Cloud User


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Fix cloud-user for is_rhel derivatives in cloud.cfg.tmpl

The previous change in PR #1887 attempted to fix some issues created by
PR's #1431 and #1639. Unfortunately this change wrongly assumed all
derivatives were not expecting cloud-user. This attempts to correct that.
```

## Additional Context
In current installations of cloud-init in rhel/centos/other derivatives, cloud-user has generally been expected. Downstream patches generally don't deviate from cloud-user as well. This PR is simply a minor correction to an assumption in #1887.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
