### PR TITLE
lxd: handle 404 from missing devices route for LXD 4.0

### DIFF
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -277,6 +277,14 @@ def _get_json_response(
     session: requests.Session, url: str, do_raise: bool = True
 ):
     url_response = _do_request(session, url, do_raise)
+    if not url_response.ok:
+        LOG.debug(
+            "Skipping %s on [HTTP:%d]:%s",
+            url,
+            url_response.status_code,
+            url_response.text,
+        )
+        return {}
     try:
         return url_response.json()
     except JSONDecodeError as exc:
@@ -386,7 +394,9 @@ class _MetaDataReader:
                 md.update(self._process_config(session))
             if MetaDataKeys.DEVICES in metadata_keys:
                 url = url_helper.combine_url(self._version_url, "devices")
-                md["devices"] = _get_json_response(session, url)
+                devices = _get_json_response(session, url, do_raise=False)
+                if devices:
+                    md["devices"] = devices
             return md
 
 

--- a/tests/unittests/sources/test_lxd.py
+++ b/tests/unittests/sources/test_lxd.py
@@ -440,18 +440,22 @@ class TestReadMetadata:
                     "[GET] [HTTP:200] http://lxd/1.0/config",
                 ],
             ),
-            (  # Assert 404 on devices
+            (  # Assert 404 on devices logs about skipping
                 True,
                 {
                     "http://lxd/1.0/meta-data": "local-hostname: md\n",
                     "http://lxd/1.0/config": "[]",
+                    # No devices URL response, so 404 raised
                 },
-                InvalidMetaDataException(
-                    "Invalid HTTP response [404] from http://lxd/1.0/devices"
-                ),
+                {
+                    "_metadata_api_version": lxd.LXD_SOCKET_API_VERSION,
+                    "config": {},
+                    "meta-data": "local-hostname: md\n",
+                },
                 [
                     "[GET] [HTTP:200] http://lxd/1.0/meta-data",
                     "[GET] [HTTP:200] http://lxd/1.0/config",
+                    "Skipping http://lxd/1.0/devices on [HTTP:404]",
                 ],
             ),
             (  # Assert non-JSON format from devices


### PR DESCRIPTION
LXD 4.0 will not get a backport of the  devices route on LXD socket API. This prevented launching Jammy from hosts with LXD 4.0.

Allow cloud-init to support LXD backplanes without the "devices" route and use fallback network config when absent.

LP: #2001737

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
lxd: handle 404 from missing devices route for LXD 4.0

LXD 4.0 will not get a backport of the  devices route on LXD socket
API. This prevented launching Jammy from hosts with LXD 4.0.

Allow cloud-init to support LXD backplanes without the "devices"
route and use fallback network config when absent.

LP: #2001737
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
