### PR TITLE
Support snap in Ubuntu's 'install_packages'

### DIFF
--- a/cloudinit/distros/ubuntu.py
+++ b/cloudinit/distros/ubuntu.py
@@ -10,8 +10,31 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import copy
+from contextlib import suppress
+from typing import List
 
+from cloudinit import subp
 from cloudinit.distros import PREFERRED_NTP_CLIENTS, debian
+
+
+def get_available_apt_packages(pkglist) -> List[str]:
+    apt_packages = []
+    for pkg in pkglist:
+        output: str = subp.subp(
+            ["apt-cache", "search", "--names-only", f"^{pkg}$"]
+        ).stdout.strip()
+        if output:
+            apt_packages.append(pkg)
+    return apt_packages
+
+
+def get_available_snap_packages(pkglist) -> List[str]:
+    snap_packages = []
+    for pkg in pkglist:
+        with suppress(subp.ProcessExecutionError):
+            subp.subp(["snap", "info", pkg])
+            snap_packages.append(pkg)
+    return snap_packages
 
 
 class Distro(debian.Distro):
@@ -41,5 +64,37 @@ class Distro(debian.Distro):
             self._preferred_ntp_clients = copy.deepcopy(PREFERRED_NTP_CLIENTS)
         return self._preferred_ntp_clients
 
+    def install_snap_packages(self, pkglist):
+        for pkg in pkglist:
+            subp.subp(["snap", "install", pkg])
 
-# vi: ts=4 expandtab
+    def install_packages(self, pkglist):
+        """Install packages from either apt or snap.
+
+        We prefer apt here as to not unexpectedly install a snap when
+        a user was previously using an apt installed package. This will result
+        in a snap install needing to wait for an apt update. If you know your
+        package is a snap, call "install_snap_packages" directly.
+        """
+        if not subp.which("snap"):
+            return super().install_packages(pkglist)
+
+        # We need to update sources before checking apt cache
+        super().update_package_sources()
+
+        apt_packages = get_available_apt_packages(pkglist)
+        remaining_packages = [p for p in pkglist if p not in apt_packages]
+        snap_packages = get_available_snap_packages(remaining_packages)
+        remaining_packages = [
+            p for p in remaining_packages if p not in snap_packages
+        ]
+        if remaining_packages:
+            raise ValueError(
+                f"Could not find package(s) {remaining_packages} "
+                "in apt or snap."
+            )
+
+        if apt_packages:
+            self.package_command("install", pkgs=apt_packages)
+        if snap_packages:
+            self.install_snap_packages(snap_packages)

--- a/tests/unittests/distros/test_ubuntu.py
+++ b/tests/unittests/distros/test_ubuntu.py
@@ -1,0 +1,94 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from unittest import mock
+
+import pytest
+
+from cloudinit import distros
+
+
+class TestInstallPackages:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        mocker.patch("cloudinit.subp.which", return_value=True)
+        self.m_install = mocker.patch(
+            "cloudinit.distros.debian.Distro.install_packages"
+        )
+        self.m_package = mocker.patch(
+            "cloudinit.distros.debian.Distro.package_command"
+        )
+        mocker.patch("cloudinit.distros.debian.Distro.update_package_sources")
+        mocker.patch(
+            "cloudinit.distros.ubuntu.get_available_apt_packages",
+            return_value=[],
+        )
+        mocker.patch(
+            "cloudinit.distros.ubuntu.get_available_snap_packages",
+            return_value=[],
+        )
+        self.m_subp = mocker.patch("cloudinit.subp.subp")
+        self.distro = distros.fetch("ubuntu")("ubuntu", {}, None)
+
+    def test_apt_and_snap_packages(self, mocker):
+        mocker.patch(
+            "cloudinit.distros.ubuntu.get_available_apt_packages",
+            return_value=["apt1", "apt2"],
+        )
+        mocker.patch(
+            "cloudinit.distros.ubuntu.get_available_snap_packages",
+            return_value=["snap1", "snap2"],
+        )
+
+        self.distro.install_packages(["apt1", "snap1", "apt2", "snap2"])
+        assert self.m_package.call_args == mock.call(
+            "install", pkgs=["apt1", "apt2"]
+        )
+        assert self.m_subp.call_args_list == [
+            mock.call(["snap", "install", "snap1"]),
+            mock.call(["snap", "install", "snap2"]),
+        ]
+
+    def test_only_apt_packages(self, mocker):
+        mocker.patch(
+            "cloudinit.distros.ubuntu.get_available_apt_packages",
+            return_value=["apt1", "apt2"],
+        )
+        self.distro.install_packages(["apt1", "apt2"])
+        assert self.m_package.call_args == mock.call(
+            "install", pkgs=["apt1", "apt2"]
+        )
+        assert self.m_subp.call_args is None
+
+    def test_only_snap_packages(self, mocker):
+        mocker.patch(
+            "cloudinit.distros.ubuntu.get_available_snap_packages",
+            return_value=["snap1", "snap2"],
+        )
+
+        self.distro.install_packages(["snap1", "snap2"])
+        assert self.m_subp.call_args_list == [
+            mock.call(["snap", "install", "snap1"]),
+            mock.call(["snap", "install", "snap2"]),
+        ]
+
+        assert self.m_package.call_args is None
+
+    def test_package_not_in_apt_or_snap(self, mocker):
+        mocker.patch(
+            "cloudinit.distros.ubuntu.get_available_apt_packages",
+            return_value=["apt1", "apt2"],
+        )
+        mocker.patch(
+            "cloudinit.distros.ubuntu.get_available_snap_packages",
+            return_value=["snap1", "snap2"],
+        )
+
+        with pytest.raises(ValueError):
+            self.distro.install_packages(
+                ["apt1", "apt2", "snap1", "snap2", "OhNo"]
+            )
+
+    def test_snap_not_installed(self, mocker):
+        mocker.patch("cloudinit.subp.which", return_value=False)
+        self.distro.install_packages(["apt1", "apt2"])
+        assert self.m_install.call_args == mock.call(["apt1", "apt2"])


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Support snap in Ubuntu's 'install_packages'

Ubuntu.py doesn't override the debian version of install_packages()
and will only install from apt. Given that many core Ubuntu packages
have moved or are moving to snap, we should support passing snap names
to install_packages() as well.

This commit modify's Ubuntu's install_packages() to install packages
from either apt or snap, preferring apt.

LP: #2001552
```

## Additional Context
While 2001552 shouldn't be a problem in our standard cloud images because lxd should come pre-installed, this is still a problem for any apt package migrating to snaps. This commit's behavior is to search and install apt first, and then only use snap if no apt package is found, so there shouldn't be any backwards incompatibility here. The only problem is that to search apt, we first need to do an apt update, so if the package is a snap, that's going to waste some time. If somebody knows they'll be installing a snap, they can call `install_snap_packages` directly.

## Test Steps
Manually tested with the following config:
```yaml
#cloud-config
packages:
 - feedreader
 - spotify
 - mg
```
feedreader has both an apt package and a snap.

After running:
```bash
root@me:~# dpkg -l | grep mg
ii  libmagic-mgc                         1:5.41-3                                amd64        File type determination library using "magic" numbers (compiled magic file)
ii  mg                                   20200723-1                              amd64        microscopic GNU Emacs-style editor
ii  powermgmt-base                       1.36                                    all          common utils for power management
root@me:~# dpkg -l | grep feedreader
ii  feedreader                           2.10.0-1.1build1                        amd64        simple client for online RSS services like tt-rss and others
root@me:~# snap list
Name               Version                     Rev    Tracking       Publisher   Notes
bare               1.0                         5      latest/stable  canonical✓  base
core18             20221212                    2667   latest/stable  canonical✓  base
core20             20221212                    1778   latest/stable  canonical✓  base
gnome-3-28-1804    3.28.0-19-g98f9e67.98f9e67  161    latest/stable  canonical✓  -
gtk-common-themes  0.1-81-g442e511             1535   latest/stable  canonical✓  -
lxd                5.0.1-9dcf35b               23541  5.0/stable/…   canonical✓  -
snapd              2.57.6                      17883  latest/stable  canonical✓  snapd
spotify            1.1.84.716.gc5f8b819        60     latest/stable  spotify✓    -
```

```
2023-01-11 20:50:19,013 - handlers.py[DEBUG]: start: modules-final/config-package-update-upgrade-install: running config-package-update-upgrade-install with frequency once-per-instance
2023-01-11 20:50:19,013 - util.py[DEBUG]: Writing to /var/lib/cloud/instances/f3831c2e-4a71-4510-ac58-3595c3b37c71/sem/config_package_update_upgrade_install - wb: [644] 23 bytes
2023-01-11 20:50:19,013 - helpers.py[DEBUG]: Running config-package-update-upgrade-install using lock (<FileLock using file '/var/lib/cloud/instances/f3831c2e-4a71-4510-ac58-3595c3b37c71/sem/config_package_update_upgrade_install'>)
2023-01-11 20:50:19,014 - util.py[DEBUG]: Writing to /var/lib/cloud/instances/f3831c2e-4a71-4510-ac58-3595c3b37c71/sem/update_sources - wb: [644] 24 bytes
2023-01-11 20:50:19,014 - helpers.py[DEBUG]: Running update-sources using lock (<FileLock using file '/var/lib/cloud/instances/f3831c2e-4a71-4510-ac58-3595c3b37c71/sem/update_sources'>)
2023-01-11 20:50:19,014 - debian.py[DEBUG]: Waiting for apt lock
2023-01-11 20:50:19,014 - debian.py[DEBUG]: apt lock available
2023-01-11 20:50:19,014 - subp.py[DEBUG]: Running command ['eatmydata', 'apt-get', '--option=Dpkg::Options::=--force-confold', '--option=Dpkg::options::=--force-unsafe-io', '--assume-yes', '--quiet', 'update'] with allowed return codes [0] (shell=False, c
apture=False)
2023-01-11 20:50:30,249 - util.py[DEBUG]: apt-update [eatmydata apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet update] took 11.234 seconds
2023-01-11 20:50:30,249 - helpers.py[DEBUG]: update-sources already ran (freq=once-per-instance)
2023-01-11 20:50:30,249 - subp.py[DEBUG]: Running command ['apt-cache', 'search', '--names-only', '^feedreader$'] with allowed return codes [0] (shell=False, capture=True)
2023-01-11 20:50:30,382 - subp.py[DEBUG]: Running command ['apt-cache', 'search', '--names-only', '^spotify$'] with allowed return codes [0] (shell=False, capture=True)
2023-01-11 20:50:30,502 - subp.py[DEBUG]: Running command ['apt-cache', 'search', '--names-only', '^mg$'] with allowed return codes [0] (shell=False, capture=True)
2023-01-11 20:50:30,612 - subp.py[DEBUG]: Running command ['snap', 'info', 'spotify'] with allowed return codes [0] (shell=False, capture=True)
2023-01-11 20:50:31,333 - debian.py[DEBUG]: Waiting for apt lock
2023-01-11 20:50:31,334 - debian.py[DEBUG]: apt lock available
2023-01-11 20:50:31,334 - subp.py[DEBUG]: Running command ['eatmydata', 'apt-get', '--option=Dpkg::Options::=--force-confold', '--option=Dpkg::options::=--force-unsafe-io', '--assume-yes', '--quiet', 'install', 'feedreader', 'mg'] with allowed return codes [0] (shell=False, capture=False)
2023-01-11 20:50:54,417 - util.py[DEBUG]: apt-install [eatmydata apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet install feedreader mg] took 23.083 seconds
2023-01-11 20:50:54,417 - subp.py[DEBUG]: Running command ['snap', 'install', 'spotify'] with allowed return codes [0] (shell=False, capture=True)
2023-01-11 20:51:49,920 - handlers.py[DEBUG]: finish: modules-final/config-package-update-upgrade-install: SUCCESS: config-package-update-upgrade-install ran successfully
```




## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
