### PR TITLE
ci: doc to gh actions

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -79,7 +79,7 @@ jobs:
       - name: "Install Python 3.10"
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.10.8'
       - name: "Install dependencies"
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -76,7 +76,10 @@ jobs:
         run: |
           git fetch --unshallow
           git remote add upstream https://git.launchpad.net/cloud-init
-
+      - name: "Install Python 3.10"
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
       - name: "Install dependencies"
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -62,3 +62,26 @@ jobs:
         run: |
           tools/check_json_format.sh cloudinit/config/schemas/schema-cloud-config-v1.json
           tools/check_json_format.sh cloudinit/config/schemas/versions.schema.cloud-config.json
+
+  doc:
+    strategy:
+      fail-fast: false
+    name: Check docs
+    runs-on: ubuntu-22.04
+    steps:
+      - name: "Checkout #1"
+        uses: actions/checkout@v3.0.0
+
+      - name: "Checkout #2 (for tools/read-version)"
+        run: |
+          git fetch --unshallow
+          git remote add upstream https://git.launchpad.net/cloud-init
+
+      - name: "1. Install dependencies 2. Spellcheck 3. Build docs"
+        env:
+          TOXENV: doc
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox lintian
+          make check_spelling
+          tox

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -77,11 +77,15 @@ jobs:
           git fetch --unshallow
           git remote add upstream https://git.launchpad.net/cloud-init
 
-      - name: "1. Install dependencies 2. Spellcheck 3. Build docs"
-        env:
-          TOXENV: doc
+      - name: "Install dependencies"
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox lintian
+      - name: "Spellcheck"
+        run: |
           make check_spelling
+      - name: "Build docs"
+        env:
+          TOXENV: doc
+        run: |
           tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -133,17 +133,6 @@ matrix:
             TOXENV=lowest-supported
             PYTEST_ADDOPTS=-v  # List all tests run by pytest
           dist: bionic
-        - python: 3.10
-          env: TOXENV=doc
-          install:
-            - git fetch --unshallow
-            # Not pinning setuptools can cause failures on python 3.7 and 3.8 builds
-            # See https://github.com/pypa/setuptools/issues/3118
-            - pip install setuptools==59.6.0
-            - sudo apt-get install lintian
-            - pip install tox
-          script:
-            - make check_spelling && tox
         # Test all supported Python versions (but at the end, so we schedule
         # longer-running jobs first)
         - python: 3.12-dev


### PR DESCRIPTION
```
test: move doc test from travis to actions

Changes:
- drop unnecessary setuptools pin
- use current RTD Python version 3.10.8
```

## Additional Context
Makes doc failures visible sooner via gh actions, plus reduce CI bill. This is mostly just copy / paste from existing gh actions tests and the current travis test - low impact / low effort.

FYI @s-makin I mentioned this would be possible today while we were wrapping up #1933.