### PR TITLE
switch unittests to gh actions

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -92,3 +92,28 @@ jobs:
           TOXENV: doc
         run: |
           tox
+  unittests:
+    strategy:
+      matrix:
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
+    name: Python ${{matrix.python-version}} unittest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout #1"
+        uses: actions/checkout@v3.0.0
+
+      - name: "Checkout #2 (for tools/read-version)"
+        run: |
+          git fetch --unshallow
+          git remote add upstream https://git.launchpad.net/cloud-init
+      - name: Install Python ${{matrix.python-version}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.python-version}}
+      - name: Install tox
+        run: pip install tox
+      - name: Run unittest
+        env:
+          TOXENV: py3
+          PYTEST_ADDOPTS: -v
+        run: tox

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -92,28 +92,3 @@ jobs:
           TOXENV: doc
         run: |
           tox
-  unittests:
-    strategy:
-      matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
-    name: Python ${{matrix.python-version}} unittest
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Checkout #1"
-        uses: actions/checkout@v3.0.0
-
-      - name: "Checkout #2 (for tools/read-version)"
-        run: |
-          git fetch --unshallow
-          git remote add upstream https://git.launchpad.net/cloud-init
-      - name: Install Python ${{matrix.python-version}}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{matrix.python-version}}
-      - name: Install tox
-        run: pip install tox
-      - name: Run unittest
-        env:
-          TOXENV: py3
-          PYTEST_ADDOPTS: -v
-        run: tox

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+on:
+  pull_request:
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: sh -ex {0}
+jobs:
+  unittests:
+    strategy:
+      matrix:
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
+    name: Python ${{matrix.python-version}} unittest
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checkout #1"
+        uses: actions/checkout@v3.0.0
+      - name: "Checkout #2 (for tools/read-version)"
+        run: |
+          git fetch --unshallow
+          git remote add upstream https://git.launchpad.net/cloud-init
+      - name: Install Python ${{matrix.python-version}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.python-version}}
+      - name: Install tox
+        run: pip install tox
+      - name: Run unittest
+        env:
+          TOXENV: py3
+          PYTEST_ADDOPTS: -v
+        run: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,6 @@ env:
 matrix:
     fast_finish: true
     include:
-        - python: 3.6
         - name: "Integration Tests"
           if: NOT branch =~ /^ubuntu\//
           env: {}

--- a/.travis.yml
+++ b/.travis.yml
@@ -136,10 +136,5 @@ matrix:
         # Test all supported Python versions (but at the end, so we schedule
         # longer-running jobs first)
         - python: 3.12-dev
-        - python: 3.11
-        - python: "3.10"
-        - python: 3.9
-        - python: 3.8
-        - python: 3.7
     allow_failures:
         - python: 3.12-dev


### PR DESCRIPTION
```
ci: switch unittests to gh actions
```

## Additional Context
Followup to https://github.com/canonical/cloud-init/pull/1951, which introduced Python version installs in gh actions. Same reasons as before: makes failures visible sooner, reduce CI bill.