### PR TITLE
add function is_virtual to distro/FreeBSD

### DIFF
--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -6,7 +6,9 @@
 
 import os
 import re
+from functools import lru_cache
 from io import StringIO
+from typing import Optional
 
 import cloudinit.distros.bsd
 from cloudinit import log as logging
@@ -192,5 +194,40 @@ class Distro(cloudinit.distros.bsd.BSD):
             freq=PER_INSTANCE,
         )
 
+    @lru_cache()
+    def is_container(self) -> bool:
+        """return whether we're running in a container.
+        Cached, because it's unlikely to change."""
+        jailed, _ = subp.subp(["sysctl", "-n", "security.jail.jailed"])
+        if jailed.strip() == "0":
+            return False
+        return True
 
-# vi: ts=4 expandtab
+    @lru_cache()
+    def virtual(self) -> str:
+        """return the kind of virtualisation system we're running under.
+        Cached, because it's unlikely to change."""
+        if self.is_container():
+            return "jail"
+        # map FreeBSD's kern.vm_guest to systemd-detect-virt, just like we do
+        # in ds-identify
+        VM_GUEST_TO_SYSTEMD = {
+            "hv": "microsoft",
+            "vbox": "oracle",
+            "generic": "vm-other",
+        }
+        vm, _ = subp.subp(["sysctl", "-n", "kern.vm_guest"])
+        vm = vm.strip()
+        if vm in VM_GUEST_TO_SYSTEMD:
+            return VM_GUEST_TO_SYSTEMD[vm]
+        return vm
+
+    @property
+    def is_virtual(self) -> Optional[bool]:
+        """Detect if running on a virtual machine or bare metal.
+
+        This can fail on some platforms, so the signature is Optional[bool]
+        """
+        if self.virtual() == "none":
+            return False
+        return True

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -299,11 +299,13 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         # This mock is called by `sysctl -n kern.vm_guest`
         with mock.patch(
             "cloudinit.distros.subp.subp",
+            # fmt: off
             side_effect=[
-                ("0\n", None), ("hv\n", None),
-                ("0\n", None), ("none\n", None),
-                ("0\n", None), ("hv\n", None),
+                ("0\n", None), ("hv\n", None),  # virtual
+                ("0\n", None), ("none\n", None),  # physical
+                ("0\n", None), ("hv\n", None)  # virtual
             ],
+            # fmt: on
         ):
             self.assertEqual(d.virtual(), "microsoft")
             d.is_container.cache_clear()

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -276,10 +276,11 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
             )
 
     def test_virtualization_on_freebsd(self):
-        # This test function is a crime.
-        # We're using the fact that is_container() and virtual() are @lru_cache
-        # this way, we can nest the various mocks to subp.subp to target the
-        # correct function's subp call.
+        # This test function is a bit unusual:
+        # We need to first mock away the `ifconfig -a` subp call
+        # Then, we can use side-effects to get the results of two subp calls
+        # needed for is_container()/virtual() which is_virtual depends on.
+        # We also have to clear cache between each of those assertions.
 
         cls = distros.fetch("freebsd")
         with mock.patch(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
add function is_virtual to distro/FreeBSD

- is_virtual property dentifies identify if the thing we're running
  is any kind of virtualization
- virtual() identifies what kind of virtualisation we're dealing with
- is_container() tells us if we're running in a container, or in FreeBSD's
  case, in a jail.
- the helper functions are @lru_cached, since this is very unlikely to
  change

Sponsored by: The FreeBSD Foundation
Co-authored-by: Brett Holman <brett.holman@canonical.com>
```

## Additional Context
see discussions in #1923 
We can consider merging this after that PR.

## Test Steps

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
