### PR TITLE
Fix wrong subp syntax in cc_set_passwords.py

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -145,7 +145,14 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
 
     if distro.uses_systemd():
         state = subp.subp(
-            f"systemctl show --property ActiveState --value {service}"
+            [
+                "systemctl",
+                "show",
+                "--property",
+                "ActiveState",
+                "--value",
+                service,
+            ]
         ).stdout
         if state.lower() in ["active", "activating", "reloading"]:
             distro.manage_service("restart", service)

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -18,7 +18,7 @@ from tests.unittests.util import get_cloud
 MODPATH = "cloudinit.config.cc_set_passwords."
 LOG = logging.getLogger(__name__)
 SYSTEMD_CHECK_CALL = mock.call(
-    "systemctl show --property ActiveState --value ssh"
+    ["systemctl", "show", "--property", "ActiveState", "--value", "ssh"]
 )
 SYSTEMD_RESTART_CALL = mock.call(["systemctl", "restart", "ssh"], capture=True)
 SERVICE_RESTART_CALL = mock.call(["service", "ssh", "restart"], capture=True)


### PR DESCRIPTION
Well this one is embarrassing. Added an integration test to check the logs.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix wrong subp syntax in cc_set_passwords.py

In #1909, I added a subp call with incorrect syntax. Fixing that here.
```