### PR TITLE
add proxy support for ansible galaxy

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -96,7 +96,8 @@ class AnsiblePull(abc.ABC):
         if not self.run_user:
             return self.subp(command, env=env, **kwargs)
         return self.distro.do_as(
-            command, self.run_user, env=dict(self.env, **env), **kwargs)
+            command, self.run_user, env=dict(self.env, **env), **kwargs
+        )
 
     def subp(self, command, env={}, **kwargs):
         return subp(command, env=dict(self.env, **env), **kwargs)

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -92,15 +92,17 @@ class AnsiblePull(abc.ABC):
         if not self.is_installed():
             raise ValueError("command: ansible is not installed")
 
-    def do_as(self, command: list, env={}, **kwargs):
+    def do_as(self, command: list, env=None, **kwargs):
         if not self.run_user:
             return self.subp(command, env=env, **kwargs)
+        env = dict(self.env, **env) if env else self.env
         return self.distro.do_as(
             command, self.run_user, env=dict(self.env, **env), **kwargs
         )
 
-    def subp(self, command, env={}, **kwargs):
-        return subp(command, env=dict(self.env, **env), **kwargs)
+    def subp(self, command, env=None, **kwargs):
+        env = dict(self.env, **env) if env else self.env
+        return subp(command, env=env, **kwargs)
 
     @abc.abstractmethod
     def is_installed(self):

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -599,6 +599,17 @@
                       "pattern": "^.*$"
                     }
                   }
+                },
+                "proxy": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^.+$": {
+                      "label": "<environment variable>",
+                      "type": "string",
+                      "description": "Proxy environment variable"
+                    }
+                  }
                 }
               }
             },

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -13,7 +13,7 @@ from tests.integration_tests.util import verify_clean_log
 
 proxy_name = "squid.internal:3128"
 try:
-    socket.gethostbyname(proxy_name.split(':')[0])
+    socket.gethostbyname(proxy_name.split(":")[0])
     if os.getcwd().startswith("/jenkins"):
         proxy = f"""
     proxy:
@@ -101,12 +101,15 @@ runcmd:
   - [systemctl, enable, repo_waiter.service]
 """
 
-INSTALL_METHOD = """
+INSTALL_METHOD = (
+    """
 ansible:
   ansible_config: /etc/ansible/ansible.cfg
   install_method: {method}
   package_name: {package}
-  galaxy:""" + proxy + """
+  galaxy:"""
+    + proxy
+    + """
     actions:
      - ["ansible-galaxy", "collection", "install", "community.grafana"]
   pull:
@@ -114,6 +117,7 @@ ansible:
     playbook_name: ubuntu.yml
     full: true
 """
+)
 
 SETUP_REPO = f"cd {REPO_D}                                    &&\
 git config --global user.name auto                            &&\
@@ -124,7 +128,8 @@ git add {REPO_D}/roles/apt/tasks/main.yml {REPO_D}/ubuntu.yml &&\
 git commit -m auto                                            &&\
 (cd {REPO_D}/.git; git update-server-info)"
 
-ANSIBLE_CONTROL = """\
+ANSIBLE_CONTROL = (
+    """\
 #cloud-config
 #
 # Demonstrate setting up an ansible controller host on boot.
@@ -172,7 +177,9 @@ ansible:
   install_method: pip
   package_name: ansible
   run_user: ansible
-  galaxy:""" + proxy + """
+  galaxy:"""
+    + proxy
+    + """
     actions:
       - ["ansible-galaxy", "collection", "install", "community.general"]
 
@@ -272,6 +279,7 @@ write_files:
 runcmd:
   - [ip, link, delete, lxdbr0]
 """
+)
 
 
 def _test_ansible_pull_from_local_server(my_client):

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -1,4 +1,6 @@
 import pytest
+import socket
+import os
 
 from tests.integration_tests.util import verify_clean_log
 
@@ -7,6 +9,20 @@ from tests.integration_tests.util import verify_clean_log
 # with the running web service and git repo configured.
 # This instrumentation allows the test to run self-contained
 # without network access or external git repos.
+
+proxy_name = 'squid.internal'
+try:
+    socket.gethostbyname(proxy_name)
+    if os.environ["PATH"].startswith("/jenkins"):
+        proxy = f"""
+    proxy:
+      https_proxy: {proxy_name}
+    """
+    else:
+        proxy = ""
+except socket.error:
+    proxy = ""
+
 
 REPO_D = "/root/playbooks"
 USER_DATA = """\
@@ -88,15 +104,15 @@ INSTALL_METHOD = """
 ansible:
   ansible_config: /etc/ansible/ansible.cfg
   install_method: {method}
-  package_name: {package}
-  galaxy:
+  package_name: {package}""" + """
+  galaxy:{}
     actions:
      - ["ansible-galaxy", "collection", "install", "community.grafana"]
   pull:
     url: "http://0.0.0.0:8000/"
     playbook_name: ubuntu.yml
     full: true
-"""
+""".format(proxy)
 
 SETUP_REPO = f"cd {REPO_D}                                    &&\
 git config --global user.name auto                            &&\
@@ -155,7 +171,7 @@ ansible:
   install_method: pip
   package_name: ansible
   run_user: ansible
-  galaxy:
+  galaxy:{}
     actions:
       - ["ansible-galaxy", "collection", "install", "community.general"]
 
@@ -254,7 +270,7 @@ write_files:
 # [1] https://github.com/canonical/pycloudlib/issues/220
 runcmd:
   - [ip, link, delete, lxdbr0]
-"""
+""".format(proxy)
 
 
 def _test_ansible_pull_from_local_server(my_client):

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -14,7 +14,7 @@ from tests.integration_tests.util import verify_clean_log
 proxy_name = "squid.internal:3128"
 try:
     socket.gethostbyname(proxy_name)
-    if os.environ["PATH"].startswith("/jenkins"):
+    if os.environ["PWD"].startswith("/jenkins"):
         proxy = f"""
     proxy:
       https_proxy: {proxy_name}

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -14,7 +14,7 @@ from tests.integration_tests.util import verify_clean_log
 proxy_name = "squid.internal:3128"
 try:
     socket.gethostbyname(proxy_name.split(':')[0])
-    if os.environ["PWD"].startswith("/jenkins"):
+    if os.getcwd().startswith("/jenkins"):
         proxy = f"""
     proxy:
       https_proxy: {proxy_name}
@@ -105,17 +105,15 @@ INSTALL_METHOD = """
 ansible:
   ansible_config: /etc/ansible/ansible.cfg
   install_method: {method}
-  package_name: {package}""" + """
-  galaxy:{}
+  package_name: {package}
+  galaxy:""" + proxy + """
     actions:
      - ["ansible-galaxy", "collection", "install", "community.grafana"]
   pull:
     url: "http://0.0.0.0:8000/"
     playbook_name: ubuntu.yml
     full: true
-""".format(
-    proxy
-)
+"""
 
 SETUP_REPO = f"cd {REPO_D}                                    &&\
 git config --global user.name auto                            &&\
@@ -174,7 +172,7 @@ ansible:
   install_method: pip
   package_name: ansible
   run_user: ansible
-  galaxy:{}
+  galaxy:""" + proxy + """
     actions:
       - ["ansible-galaxy", "collection", "install", "community.general"]
 
@@ -273,9 +271,7 @@ write_files:
 # [1] https://github.com/canonical/pycloudlib/issues/220
 runcmd:
   - [ip, link, delete, lxdbr0]
-""".format(
-    proxy
-)
+"""
 
 
 def _test_ansible_pull_from_local_server(my_client):

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -10,7 +10,7 @@ from tests.integration_tests.util import verify_clean_log
 # This instrumentation allows the test to run self-contained
 # without network access or external git repos.
 
-proxy_name = 'squid.internal'
+proxy_name = 'squid.internal:3128'
 try:
     socket.gethostbyname(proxy_name)
     if os.environ["PATH"].startswith("/jenkins"):

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -1,6 +1,7 @@
-import pytest
-import socket
 import os
+import socket
+
+import pytest
 
 from tests.integration_tests.util import verify_clean_log
 
@@ -10,7 +11,7 @@ from tests.integration_tests.util import verify_clean_log
 # This instrumentation allows the test to run self-contained
 # without network access or external git repos.
 
-proxy_name = 'squid.internal:3128'
+proxy_name = "squid.internal:3128"
 try:
     socket.gethostbyname(proxy_name)
     if os.environ["PATH"].startswith("/jenkins"):
@@ -112,7 +113,9 @@ ansible:
     url: "http://0.0.0.0:8000/"
     playbook_name: ubuntu.yml
     full: true
-""".format(proxy)
+""".format(
+    proxy
+)
 
 SETUP_REPO = f"cd {REPO_D}                                    &&\
 git config --global user.name auto                            &&\
@@ -270,7 +273,9 @@ write_files:
 # [1] https://github.com/canonical/pycloudlib/issues/220
 runcmd:
   - [ip, link, delete, lxdbr0]
-""".format(proxy)
+""".format(
+    proxy
+)
 
 
 def _test_ansible_pull_from_local_server(my_client):

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -14,7 +14,7 @@ from tests.integration_tests.util import verify_clean_log
 proxy_name = "squid.internal:3128"
 try:
     socket.gethostbyname(proxy_name.split(":")[0])
-    if os.getcwd().startswith("/jenkins"):
+    if os.environ.get("JENKINS_HOME"):
         proxy = f"""
     proxy:
       https_proxy: {proxy_name}

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -13,7 +13,7 @@ from tests.integration_tests.util import verify_clean_log
 
 proxy_name = "squid.internal:3128"
 try:
-    socket.gethostbyname(proxy_name)
+    socket.gethostbyname(proxy_name.split(':')[0])
     if os.environ["PWD"].startswith("/jenkins"):
         proxy = f"""
     proxy:


### PR DESCRIPTION
```
ansible: add proxy support and test
```

## Additional Context
Some environments, like our own Jenkins environment, require proxy support to reach Ansible Galaxy. Implement it, and add integration test coverage.

## Test

Local Machine:
```
tox -e integration-tests -- tests/integration_tests/modules/test_ansible.py
```

Jenkins:
```bash
mkdir /jenkins/tmp
cd /jenkins/tmp
git clone https://github.com/holmanb/cloud-init.git
cd cloud-init
git checkout holmanb/ansible-proxy
sed -i 's/NONE/IN_PLACE/' tests/integration_tests/integration_settings.py
tox -e integration-tests -- tests/integration_tests/modules/test_ansible.py
```