### PR TITLE
sources/azure: retry on connection error when fetching metdata

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -79,7 +79,10 @@ IMDS_RETRY_CODES = (
 imds_readurl_exception_callback = functools.partial(
     retry_on_url_exc,
     retry_codes=IMDS_RETRY_CODES,
-    retry_instances=(requests.Timeout,),
+    retry_instances=(
+        requests.ConnectionError,
+        requests.Timeout,
+    ),
 )
 
 

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3966,6 +3966,7 @@ class TestIMDS:
             fake_http_error_for_code(410),
             fake_http_error_for_code(429),
             fake_http_error_for_code(500),
+            requests.ConnectionError("Fake connection error"),
             requests.Timeout("Fake connection timeout"),
         ],
     )
@@ -4007,6 +4008,7 @@ class TestIMDS:
             fake_http_error_for_code(410),
             fake_http_error_for_code(429),
             fake_http_error_for_code(500),
+            requests.ConnectionError("Fake connection error"),
             requests.Timeout("Fake connection timeout"),
         ],
     )
@@ -4049,7 +4051,6 @@ class TestIMDS:
         [
             fake_http_error_for_code(403),
             fake_http_error_for_code(501),
-            requests.ConnectionError("Fake Network Unreachable"),
         ],
     )
     def test_will_not_retry_errors(


### PR DESCRIPTION
Early attempts to fetch metadata on Azure may fail with connection errors.  While this class of errors is not ideal to retry on, the impact is minimal given that:

1. retries are fairly limited (10)

2. Persistent connection errors would indicate that cloud-init is using a non-primary NIC which is a rare case of failure that will be addressed in the future.

Signed-off-by: Chris Patterson <cpatterson@microsoft.com>