### PR TITLE
cc_puppet: Update puppet service name

### DIFF
--- a/tests/integration_tests/modules/test_puppet.py
+++ b/tests/integration_tests/modules/test_puppet.py
@@ -17,7 +17,12 @@ def test_puppet_service(client: IntegrationInstance):
     """Basic test that puppet gets installed and runs."""
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
-    assert client.execute("systemctl is-active puppet").ok
+    puppet_ok = client.execute("systemctl is-active puppet.service").ok
+    puppet_agent_ok = client.execute(
+        "systemctl is-active puppet-agent.service"
+    ).ok
+    assert True in [puppet_ok, puppet_agent_ok]
+    assert False in [puppet_ok, puppet_agent_ok]
     assert "Running command ['puppet', 'agent'" not in log
 
 


### PR DESCRIPTION
```
cc_puppet: Update puppet service name

From Lunar, we see that the default puppet version is 7.20 which replaces `puppet.service` 
with `puppet-agent.service`. Thus, we need to have a way of calling the appropriate service 
depending with the ubuntu release.


LP: #2002969 
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Run the tests at `tests/integration_tests/modules/test_puppet.py` on `Lunar`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
