### PR TITLE
Fix permission of SSH host keys

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -188,7 +188,7 @@ for k in GENERATE_KEY_NAMES:
         {
             f"{k}_private": (KEY_FILE_TPL % k, 0o600),
             f"{k}_public": (f"{KEY_FILE_TPL % k}.pub", 0o644),
-            f"{k}_certificate": (f"{KEY_FILE_TPL % k}-cert.pub", 0o600),
+            f"{k}_certificate": (f"{KEY_FILE_TPL % k}-cert.pub", 0o644),
         }
     )
     PRIV_TO_PUB[f"{k}_private"] = f"{k}_public"

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -187,7 +187,7 @@ for k in GENERATE_KEY_NAMES:
     CONFIG_KEY_TO_FILE.update(
         {
             f"{k}_private": (KEY_FILE_TPL % k, 0o600),
-            f"{k}_public": (f"{KEY_FILE_TPL % k}.pub", 0o600),
+            f"{k}_public": (f"{KEY_FILE_TPL % k}.pub", 0o644),
             f"{k}_certificate": (f"{KEY_FILE_TPL % k}-cert.pub", 0o600),
         }
     )
@@ -278,7 +278,7 @@ def handle(
                     if gid != -1:
                         # perform same "sanitize permissions" as sshd-keygen
                         os.chown(keyfile, -1, gid)
-                        os.chmod(keyfile, 0o640)
+                        os.chmod(keyfile, 0o600)
                         os.chmod(keyfile + ".pub", 0o644)
                 except subp.ProcessExecutionError as e:
                     err = util.decode_binary(e.stderr).lower()

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -278,7 +278,7 @@ def handle(
                     if gid != -1:
                         # perform same "sanitize permissions" as sshd-keygen
                         os.chown(keyfile, -1, gid)
-                        os.chmod(keyfile, 0o600)
+                        os.chmod(keyfile, 0o640)
                         os.chmod(keyfile + ".pub", 0o644)
                 except subp.ProcessExecutionError as e:
                     err = util.decode_binary(e.stderr).lower()

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -330,17 +330,17 @@ class TestHandleSsh:
                     mock.call(
                         "/etc/ssh/ssh_host_{}_key".format(key_type),
                         private_value,
-                        384,
+                        0o600,
                     ),
                     mock.call(
                         "/etc/ssh/ssh_host_{}_key.pub".format(key_type),
                         public_value,
-                        384,
+                        0o644,
                     ),
                     mock.call(
                         "/etc/ssh/ssh_host_{}_key-cert.pub".format(key_type),
                         cert_value,
-                        384,
+                        0o600,
                     ),
                     mock.call(
                         sshd_conf_fname,

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -340,7 +340,7 @@ class TestHandleSsh:
                     mock.call(
                         "/etc/ssh/ssh_host_{}_key-cert.pub".format(key_type),
                         cert_value,
-                        0o600,
+                        0o644,
                     ),
                     mock.call(
                         sshd_conf_fname,

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -80,6 +80,7 @@ MarkMielke
 marlluslustosa
 matthewruffell
 maxnet
+Mazorius
 megian
 michaelrommel
 mitechie


### PR DESCRIPTION
private keys should have 0600: https://www.tenable.com/audits/items/CIS_Google_Container_Optimized_OS_v1.0.0_L1_Server.audit:6225b8224fbd4f360ebdc72c56f3eae9
public keys should have 0644: https://www.tenable.com/audits/items/CIS_Google_Container_Optimized_OS_v1.0.0_L1_Server.audit:7f016cd406100a1ee2ad94834111f005

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
fix: permissions for SSH host keys

If the host-keys are automatically generated the private key has 0640 which should be 0600 so no group or other can see the private key. The public key is correctly set to 0644.

If the host-keys are provided the script generated the private key with 0600 which is indeed correct. But the public key is also 0600 which should be instead 0644.

With this change the private key is always 0600 and the public key is always 0644.
```

## Additional Context

During the execution of Terraform the keys permission were not set correctly.
The application could not generate the public fingerprint as it could not read the public host key.

After changing the private key to 0600 and the public to 0644 everything works as expected.

## Test Steps

Install a tool like GitLab via Omnibus that require to generate the public host key fingerprint.
Open this page after setup: https://gitlab.example.com/help/configuration .

Which the correct permission the page should be open. With the wrong permission the page should throw a 500 HTTP Code.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
