### PR TITLE
Fix default route rendering on v2 ipv6

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -989,7 +989,7 @@ def _normalize_net_keys(network, address_keys=()):
 
     @returns: A dict containing normalized prefix and matching addr_key.
     """
-    net = dict((k, v) for k, v in network.items() if v)
+    net = {k: v for k, v in network.items() if v or v == 0}
     addr_key = None
     for key in address_keys:
         if net.get(key):

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5225,7 +5225,7 @@ USERCTL=no
                 # Created by cloud-init on instance boot automatically, do not edit.
                 #
                 2a00:1730:fff9:100::1/128 via ::0  dev eth0
-                ::0/64 via 2a00:1730:fff9:100::1  dev eth0
+                ::0/0 via 2a00:1730:fff9:100::1  dev eth0
                 """  # noqa: E501
             ),
         }


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix default route rendering on v2 ipv6

::/0 would get rendered as ::/64 rather than ::/0 across all renderers
using ipv6 in a v2 config.

LP: #2003562
```

