### PR TITLE
Set ownership for new folders

### DIFF
--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -182,7 +182,9 @@ def write_files(name, files, owner: str):
         (u, g) = util.extract_usergroup(f_info.get("owner", owner))
         perms = decode_perms(f_info.get("permissions"), DEFAULT_PERMS)
         omode = "ab" if util.get_cfg_option_bool(f_info, "append") else "wb"
-        util.write_file(path, contents, omode=omode, mode=perms)
+        util.write_file(
+            path, contents, omode=omode, mode=perms, user=u, group=g
+        )
         util.chownbyname(path, u, g)
 
 

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -3122,7 +3122,7 @@
               "owner": {
                 "type": "string",
                 "default": "root:root",
-                "description": "Optional owner:group to chown on the file. Default: ``root:root``"
+                "description": "Optional owner:group to chown on the file and new directories. Default: ``root:root``"
               },
               "permissions": {
                 "type": "string",

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1596,7 +1596,7 @@ def chownbyid(fname, uid=None, gid=None):
     os.chown(fname, uid, gid)
 
 
-def chownbyname(fname, user=None, group=None, recursive=False):
+def chownbyname(fname, user=None, group=None):
     uid = -1
     gid = -1
     try:
@@ -1607,10 +1607,6 @@ def chownbyname(fname, user=None, group=None, recursive=False):
     except KeyError as e:
         raise OSError("Unknown user or group: %s" % (e)) from e
     chownbyid(fname, uid, gid)
-    if recursive and os.path.isdir(fname):
-        for root, dirs, _ in os.walk(fname):
-            for d in dirs:
-                chownbyid(os.path.join(root, d), uid, gid)
 
 
 # Always returns well formated values
@@ -1796,7 +1792,7 @@ def get_non_exist_parent_dir(path):
     """Get the last directory in a path that does not exist.
 
     Example: when path=/usr/a/b and /usr/a does not exis but /usr does,
-    return /usr
+    return /usr/a
     """
     p_path = os.path.dirname(path)
     # Check if parent directory of path is root

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1707,6 +1707,21 @@ class TestWriteFile(helpers.TestCase):
         self.assertTrue(os.path.isdir(dirname))
         self.assertTrue(os.path.isfile(path))
 
+    def test_dir_ownership(self):
+        """Verifiy that directories is created with appropriate ownership."""
+        dirname = os.path.join(self.tmp, "subdir")
+        path = os.path.join(dirname, "NewFile.txt")
+        contents = "Hey there"
+        user = "foo"
+        group = "foo"
+
+        with mock.patch.object(
+            util, "chownbyname", return_value=None
+        ) as mockobj:
+            util.write_file(path, contents, user=user, group=group)
+
+        mockobj.assert_called_once_with(dirname, user, group, recursive=True)
+
     def test_dir_is_not_created_if_ensure_dir_false(self):
         """Verify directories are not created if ensure_dir_exists is False."""
         dirname = os.path.join(self.tmp, "subdir")

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -14,6 +14,7 @@ import shutil
 import stat
 import tempfile
 from collections import deque
+from pathlib import Path
 from textwrap import dedent
 from unittest import mock
 from urllib.parse import urlparse
@@ -1709,7 +1710,7 @@ class TestWriteFile(helpers.TestCase):
 
     def test_dir_ownership(self):
         """Verifiy that directories is created with appropriate ownership."""
-        dirname = os.path.join(self.tmp, "subdir")
+        dirname = os.path.join(self.tmp, "subdir", "subdir2")
         path = os.path.join(dirname, "NewFile.txt")
         contents = "Hey there"
         user = "foo"
@@ -1720,7 +1721,11 @@ class TestWriteFile(helpers.TestCase):
         ) as mockobj:
             util.write_file(path, contents, user=user, group=group)
 
-        mockobj.assert_called_once_with(dirname, user, group, recursive=True)
+        calls = [
+            mock.call(os.path.join(self.tmp, "subdir"), user, group),
+            mock.call(Path(dirname), user, group),
+        ]
+        mockobj.assert_has_calls(calls, any_order=False)
 
     def test_dir_is_not_created_if_ensure_dir_false(self):
         """Verify directories are not created if ensure_dir_exists is False."""

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -139,4 +139,5 @@ xiaoge1001
 xnox
 yangzz-97
 yawkat
+zhan9san
 zhuzaifangxuele


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Set ownership for new folders in Write Files Module

The parent directory would be created automatically if it does not exist. But the ownership of newly-created parent directory would always be root.

With this change, it would be set the same as `owner`.

LP: #1990513
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```yaml
write_files:
  - path: /home/ubuntu/.help/file-in.txt
    content: |
      hi in
    owner: 'ubuntu:ubuntu'
    permissions: '0644'
    defer: true
```

With this change, the owner of `/home/ubuntu/.help`  would be `ubuntu`.
Without this change, the owner of `/home/ubuntu/.help`  would be `root`.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
