### PR TITLE
cc_set_passwords: Prevent traceback when restarting ssh

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -108,6 +108,18 @@ def get_users_by_type(users_list: list, pw_type: str) -> list:
     )
 
 
+def _restart_ssh_daemon(distro, service):
+    try:
+        distro.manage_service("restart", service)
+        LOG.debug("Restarted the SSH daemon.")
+    except subp.ProcessExecutionError as e:
+        LOG.warning(
+            "'ssh_pwauth' configuration may not be applied. Cloud-init was "
+            "unable to restart SSH daemon due to error: '%s'",
+            e,
+        )
+
+
 def handle_ssh_pwauth(pw_auth, distro: Distro):
     """Apply sshd PasswordAuthentication changes.
 
@@ -155,20 +167,9 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
             ]
         ).stdout.strip()
         if state.lower() in ["active", "activating", "reloading"]:
-            distro.manage_service("restart", service)
-            LOG.debug("Restarted the SSH daemon.")
-        else:
-            LOG.debug("Not restarting SSH service: service is stopped.")
+            _restart_ssh_daemon(distro, service)
     else:
-        try:
-            distro.manage_service("restart", service)
-            LOG.debug("Restarted the SSH daemon.")
-        except subp.ProcessExecutionError:
-            util.logexc(
-                LOG,
-                "Cloud-init was unable to restart SSH daemon. "
-                "'ssh_pwauth' configuration may not be applied.",
-            )
+        _restart_ssh_daemon(distro, service)
 
 
 def handle(

--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -13,7 +13,7 @@ import yaml
 
 from tests.integration_tests.clouds import ImageSpecification
 from tests.integration_tests.decorators import retry
-from tests.integration_tests.util import get_console_log, verify_clean_log
+from tests.integration_tests.util import get_console_log
 
 COMMON_USER_DATA = """\
 #cloud-config
@@ -199,7 +199,10 @@ class Mixin:
             "'systemctl', 'show', '--property', 'ActiveState', "
             "'--value', 'ssh'" in log
         )
-        verify_clean_log(log)
+        assert (
+            "Restarted the SSH daemon" in log
+            or "'ssh_pwauth' configuration may not be applied" in log
+        )
 
     def test_sshd_config(self, class_client):
         """Test that SSH password auth is enabled."""


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Prevent traceback when restarting ssh

On Bionic in GCE, when restarting ssh, it's not uncommon to see a
traceback with `ssh.service is not active, cannot reload.`. Instead log
a warning.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-gce/171/testReport/junit/tests.integration_tests.modules.test_set_password/TestPasswordListString/test_check_ssh_service/
