### PR TITLE
Wait for NetworkManager

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -13,7 +13,8 @@ After=systemd-networkd-wait-online.service
 After=networking.service
 {% endif %}
 {% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora",
-                  "miraclelinux", "openEuler", "openmandriva", "rhel", "rocky", "virtuozzo"] %}
+                  "miraclelinux", "openEuler", "openmandriva", "rhel", "rocky",
+                  "suse", "virtuozzo"] %}
 After=network.service
 After=NetworkManager.service
 After=NetworkManager-wait-online.service


### PR DESCRIPTION


## Proposed Commit Message

Newer SUSE distributions are switching to NetworkManager from wicked. For those distributions we need to wait for NetworkManager before starting the cloud-init service.


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
