### PR TITLE
Fix Vultr cloud_interfaces usage

### DIFF
--- a/cloudinit/sources/DataSourceVultr.py
+++ b/cloudinit/sources/DataSourceVultr.py
@@ -70,10 +70,12 @@ class DataSourceVultr(sources.DataSource):
         if "cloud_interfaces" in md:
             # In the future we will just drop pre-configured
             # network configs into the array. They need names though.
-            self.netcfg = vultr.add_interface_names(md["cloud_interfaces"])
+            print("FOUND!")
+            vultr.add_interface_names(md["cloud_interfaces"])
+            self.netcfg = md["cloud_interfaces"]
         else:
             self.netcfg = vultr.generate_network_config(md["interfaces"])
-
+        print("RAN!")
         # Grab vendordata
         self.vendordata_raw = md["vendor-data"]
 

--- a/cloudinit/sources/DataSourceVultr.py
+++ b/cloudinit/sources/DataSourceVultr.py
@@ -70,12 +70,10 @@ class DataSourceVultr(sources.DataSource):
         if "cloud_interfaces" in md:
             # In the future we will just drop pre-configured
             # network configs into the array. They need names though.
-            print("FOUND!")
             vultr.add_interface_names(md["cloud_interfaces"])
             self.netcfg = md["cloud_interfaces"]
         else:
             self.netcfg = vultr.generate_network_config(md["interfaces"])
-        print("RAN!")
         # Grab vendordata
         self.vendordata_raw = md["vendor-data"]
 

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -280,7 +280,7 @@ def add_interface_names(netcfg):
     for interface in netcfg["config"]:
         if interface["type"] != "physical":
             continue
-        interface_name = get_interface_name(interface["mac"])
+        interface_name = get_interface_name(interface["mac_address"])
         if not interface_name:
             raise RuntimeError(
                 "Interface: %s could not be found on the system"

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -284,10 +284,9 @@ def add_interface_names(netcfg):
         if not interface_name:
             raise RuntimeError(
                 "Interface: %s could not be found on the system"
-                % interface["mac"]
+                % interface["mac_address"]
             )
         interface["name"] = interface_name
-
     return netcfg
 
 

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -276,8 +276,10 @@ def generate_interface_additional_addresses(interface, netcfg):
 
 
 # Make required adjustments to the network configs provided
-def add_interface_names(interfaces):
-    for interface in interfaces:
+def add_interface_names(netcfg):
+    for interface in netcfg["config"]:
+        if interface["type"] != "physical":
+            continue
         interface_name = get_interface_name(interface["mac"])
         if not interface_name:
             raise RuntimeError(
@@ -286,7 +288,7 @@ def add_interface_names(interfaces):
             )
         interface["name"] = interface_name
 
-    return interfaces
+    return netcfg
 
 
 # vi: ts=4 expandtab

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -287,7 +287,6 @@ def add_interface_names(netcfg):
                 % interface["mac_address"]
             )
         interface["name"] = interface_name
-    return netcfg
 
 
 # vi: ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
```
cloud_interfaces is intended to be a netcfg. Change the helper function to reflect this.
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/hacking.html)
 - [X] I have updated or added any unit tests accordingly
 - [X] I have updated or added any documentation accordingly
