### PR TITLE
improve resolvconf and network docs

### DIFF
--- a/cloudinit/config/cc_resolv_conf.py
+++ b/cloudinit/config/cc_resolv_conf.py
@@ -26,12 +26,18 @@ RESOLVE_CONFIG_TEMPLATE_MAP = {
 }
 
 MODULE_DESCRIPTION = """\
+Unless manually editing :file:`/etc/resolv.conf` is the correct way to manage
+nameserver information on your operating system, you do not want to use
+this module. Many distros have moved away from manually editing ``resolv.conf``
+so please verify that this is the preferred nameserver management method for
+your distro :file:`/etc/resolv.conf` before using this module.
+
+Note that using :ref:`network_config` is preferred to this module, when
+possible.
+
 This module is intended to manage resolv.conf in environments where early
 configuration of resolv.conf is necessary for further bootstrapping and/or
 where configuration management such as puppet or chef own DNS configuration.
-As Debian/Ubuntu will, by default, utilize resolvconf, and similarly Red Hat
-will use sysconfig, this module is likely to be of little use unless those
-are configured correctly.
 
 When using a :ref:`datasource_config_drive` and a RHEL-like system,
 resolv.conf will also be managed automatically due to the available
@@ -44,10 +50,6 @@ must be set ``true``.
 .. note::
     For Red Hat with sysconfig, be sure to set PEERDNS=no for all DHCP
     enabled NICs.
-
-.. note::
-    And, in Ubuntu/Debian it is recommended that DNS be configured via the
-    standard /etc/network/interfaces configuration file.
 """
 
 meta: MetaSchema = {

--- a/cloudinit/config/cc_resolv_conf.py
+++ b/cloudinit/config/cc_resolv_conf.py
@@ -32,8 +32,8 @@ this module. Many distros have moved away from manually editing ``resolv.conf``
 so please verify that this is the preferred nameserver management method for
 your distro before using this module.
 
-Note that using :ref:`network_config` is preferred, rather than using this module, when
-possible.
+Note that using :ref:`network_config` is preferred, rather than using this
+module, when possible.
 
 This module is intended to manage resolv.conf in environments where early
 configuration of resolv.conf is necessary for further bootstrapping and/or

--- a/cloudinit/config/cc_resolv_conf.py
+++ b/cloudinit/config/cc_resolv_conf.py
@@ -30,7 +30,7 @@ Unless manually editing :file:`/etc/resolv.conf` is the correct way to manage
 nameserver information on your operating system, you do not want to use
 this module. Many distros have moved away from manually editing ``resolv.conf``
 so please verify that this is the preferred nameserver management method for
-your distro :file:`/etc/resolv.conf` before using this module.
+your distro before using this module.
 
 Note that using :ref:`network_config` is preferred to this module, when
 possible.

--- a/cloudinit/config/cc_resolv_conf.py
+++ b/cloudinit/config/cc_resolv_conf.py
@@ -42,7 +42,7 @@ where configuration management such as puppet or chef own DNS configuration.
 When using a :ref:`datasource_config_drive` and a RHEL-like system,
 resolv.conf will also be managed automatically due to the available
 information provided for DNS servers in the :ref:`network_config_v2` format.
-For those that with to have different settings, use this module.
+For those that wish to have different settings, use this module.
 
 In order for the ``resolv_conf`` section to be applied, ``manage_resolv_conf``
 must be set ``true``.

--- a/cloudinit/config/cc_resolv_conf.py
+++ b/cloudinit/config/cc_resolv_conf.py
@@ -32,7 +32,7 @@ this module. Many distros have moved away from manually editing ``resolv.conf``
 so please verify that this is the preferred nameserver management method for
 your distro before using this module.
 
-Note that using :ref:`network_config` is preferred to this module, when
+Note that using :ref:`network_config` is preferred, rather than using this module, when
 possible.
 
 This module is intended to manage resolv.conf in environments where early

--- a/doc/rtd/reference/network-config.rst
+++ b/doc/rtd/reference/network-config.rst
@@ -126,6 +126,10 @@ The following datasources optionally provide network configuration:
 
   - `DigitalOcean JSON metadata`_
 
+- :ref:`datasource_lxd`
+
+  - `LXD`_
+
 - :ref:`datasource_nocloud`
 
   - :ref:`network_config_v1`
@@ -313,6 +317,7 @@ Example output:
 
 
 .. _Cloud-init: https://launchpad.net/cloud-init
+.. _LXD: https://linuxcontainers.org/lxd/docs/master/cloud-init/#custom-network-configuration
 .. _NetworkManager: https://networkmanager.dev
 .. _Netplan: https://netplan.io/
 .. _DigitalOcean JSON metadata: https://developers.digitalocean.com/documentation/metadata/


### PR DESCRIPTION
```
docs: Clarify networking docs

- Add stronger warnings for resolv_conf module.
- Add link to lxd network config docs.
```

## Additional Context
I really don't like the current [networking docs](https://cloudinit.readthedocs.io/en/latest/reference/network-config.html), which has just a list of links to datasources and which formats they support. I think we could do a lot to improve user discovery of information for "how to use the format", however I don't want so do that in this PR so I'm just adding the LXD external link and kicking the "refactor network docs" can down the road.

Additionally I think stronger wording around the resolv_conf module is warranted, and some outdated statements removed.

[LP: #2004131](https://bugs.launchpad.net/cloud-init/+bug/2004131)
