### PR TITLE
Ignore duplicate macs from mscc_felix and fsl_enetc

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1034,6 +1034,16 @@ def get_interfaces_by_mac_on_linux(blacklist_drivers=None) -> dict:
                         % (ret[mac], driver_map[mac], name)
                     )
 
+            # This is intended to be a short-term fix of LP: #1997922
+            # Long term, we should better handle configuration of virtual
+            # devices where duplicate MACs are expected early in boot if
+            # cloud-init happens to enumerate network interfaces before drivers
+            # have fully initialized the leader/subordinate relationships for
+            # those devices or switches.
+            if driver == "mscc_felix" or driver == "fsl_enetc":
+                raise_duplicate_mac_error = False
+                continue
+
             if raise_duplicate_mac_error:
                 raise RuntimeError(msg)
 

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -8220,6 +8220,19 @@ class TestGetInterfacesByMac(CiTestCase):
         }
         self.assertEqual(expected, result)
 
+    def test_duplicate_ignored_macs(self):
+        # LP: #199792
+        self._data = copy.deepcopy(self._data)
+        self._data["macs"]["swp0"] = "9a:57:7d:78:47:c0"
+        self._data["macs"]["swp1"] = "9a:57:7d:78:47:c0"
+        self._data["own_macs"].append("swp0")
+        self._data["own_macs"].append("swp1")
+        self._data["drivers"]["swp0"] = "mscc_felix"
+        self._data["drivers"]["swp1"] = "mscc_felix"
+        self._mock_setup()
+        net.get_interfaces_by_mac()
+        # If the previous statement didn't Traceback, then test passed
+
 
 class TestInterfacesSorting(CiTestCase):
     def test_natural_order(self):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Ignore duplicate macs from mscc_felix and fsl_enetc

mscc_felix and fsl_enetc are drivers representing a switch that is
expected to have duplicate macs. If we encounter either of these
drivers, we should not raise the duplicate mac exception.

LP: #1997922
```

## Additional Context
https://bugs.launchpad.net/cloud-init/+bug/1997922
