### PR TITLE
Warn on empty network key

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -853,7 +853,7 @@ class Init:
                 return (None, cfg_source)
             if ncfg:
                 return (ncfg, cfg_source)
-        if not self.cfg["network"]:
+        if not self.cfg.get("network", True):
             LOG.warning("Empty network config found")
         return (
             self.distro.generate_fallback_config(),

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -853,6 +853,8 @@ class Init:
                 return (None, cfg_source)
             if ncfg:
                 return (ncfg, cfg_source)
+        if not self.cfg["network"]:
+            LOG.warning("Empty network config found")
         return (
             self.distro.generate_fallback_config(),
             NetworkConfigSource.FALLBACK,

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -358,9 +358,7 @@ class TestInit:
 
     @mock.patch(M_PATH + "cmdline.read_initramfs_config", return_value={})
     @mock.patch(M_PATH + "cmdline.read_kernel_cmdline_config", return_value={})
-    def test_warn_on_empty_network(
-        self, m_cmdline, m_initramfs, caplog
-    ):
+    def test_warn_on_empty_network(self, m_cmdline, m_initramfs, caplog):
         """funky whitespace can lead to a network key that is None, which then
         causes fallback. Test warning log on empty network key.
         """
@@ -371,9 +369,7 @@ class TestInit:
             "system_info": {"paths": {"cloud_dir": self.tmpdir}},
             "network": None,
         }
-        self.init.datasource = FakeDataSource(
-            network_config={"network": None}
-        )
+        self.init.datasource = FakeDataSource(network_config={"network": None})
 
         self.init.distro.generate_fallback_config = lambda: {}
 

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -356,6 +356,30 @@ class TestInit:
         ) == self.init._find_networking_config()
         assert "network config disabled" not in caplog.text
 
+    @mock.patch(M_PATH + "cmdline.read_initramfs_config", return_value={})
+    @mock.patch(M_PATH + "cmdline.read_kernel_cmdline_config", return_value={})
+    def test_warn_on_empty_network(
+        self, m_cmdline, m_initramfs, caplog
+    ):
+        """funky whitespace can lead to a network key that is None, which then
+        causes fallback. Test warning log on empty network key.
+        """
+        m_cmdline.return_value = {}  # Kernel doesn't disable networking
+        m_initramfs.return_value = {}  # no initramfs network config
+        # Neither datasource nor system_info disable or provide network
+        self.init._cfg = {
+            "system_info": {"paths": {"cloud_dir": self.tmpdir}},
+            "network": None,
+        }
+        self.init.datasource = FakeDataSource(
+            network_config={"network": None}
+        )
+
+        self.init.distro.generate_fallback_config = lambda: {}
+
+        self.init._find_networking_config()
+        assert "Empty network config found" in caplog.text
+
     def test_apply_network_config_disabled(self, caplog):
         """Log when network is disabled by upgraded-network."""
         disable_file = os.path.join(


### PR DESCRIPTION
```
Warn on empty "network" key.

It is possible to create an empty network key that fails
over to fallback network config without warning. Fix it.
```


## Additional Context
Found by copying a config from Launchpad. I think Launchpad may have caused the weird whitespace.