### PR TITLE
tests: Remove restart check from test

### DIFF
--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -199,10 +199,6 @@ class Mixin:
             "'systemctl', 'show', '--property', 'ActiveState', "
             "'--value', 'ssh'" in log
         )
-        assert (
-            "Restarted the SSH daemon" in log
-            or "'ssh_pwauth' configuration may not be applied" in log
-        )
 
     def test_sshd_config(self, class_client):
         """Test that SSH password auth is enabled."""


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: Remove restart check from test

If no SSH restart happens, we get no log. Since this is perfectly
normal, we shouldn't be checking for a log.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
