### PR TITLE
docs: add themed RTD 404 page and pointer to readthedocs-hosted

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -5,3 +5,4 @@ pyyaml
 sphinx
 sphinx-design
 sphinx-copybutton
+sphinx-notfound-page

--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.abspath("."))
 
 # General information about the project.
 project = "cloud-init"
-copyright = "2022, Canonical Ltd."
+copyright = "Canonical Ltd."
 
 # -- General configuration ----------------------------------------------------
 
@@ -29,6 +29,7 @@ needs_sphinx = "4.0"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     "m2r2",
+    "notfound.extension",
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx.ext.autodoc",
@@ -82,3 +83,10 @@ html_theme_options = {
 # Make sure the target is unique
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2
+
+# Sphinx-copybutton config options:
+notfound_urls_prefix = '/'
+notfound_context = {
+    "title": "Page not found",
+    "body": "<h1>Page not found</h1><p>Sorry we missed you! Our docs have had a remodel and some deprecated links have changed.</p><p>We are also now hosted at: <a href='https://canonical-cloud-init.readthedocs-hosted.com'>https://canonical-cloud-init.readthedocs-hosted.com</a></p>"
+}


### PR DESCRIPTION
cloud-init is migrating to a paid readthedocs offering to avoid RTD inline advertisements.
We will setup site-wide default redirects from cloudinit.readthedocs.io -> canonical-cloud-init.readthedocs-hosted.com.

In the event that there are stale links that have been reorganized in our new docs site, we want a 404 page to catch any misses and redirect them to the new site name.

Mid-term, there will be a simpler new CNAME we will host for this docs content. In the meantime, we want to generally make sure all docs rendered are ad-free and any 404 messaging points to the hosted site instead of the free-(ad-supported) site.


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
docs: add themed RTD 404 page and pointer to readthedocs-hosted
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
