### PR TITLE
schema: fix gpt labels, use type string for GUID

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1144,7 +1144,14 @@
                           {
                             "type": "array",
                             "items": {
-                              "type": "integer"
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "string"
+                                }
+                              ]
                             },
                             "minItems": 2,
                             "maxItems": 2

--- a/tests/unittests/config/test_cc_disk_setup.py
+++ b/tests/unittests/config/test_cc_disk_setup.py
@@ -321,5 +321,25 @@ class TestDebugSchema:
         with pytest.raises(SchemaValidationError, match=error_msg):
             validate_cloudconfig_schema(config, schema, strict=True)
 
-
-# vi: ts=4 expandtab
+    @pytest.mark.parametrize(
+        "config",
+        (
+            (
+                {
+                    "disk_setup": {
+                        "/dev/disk/by-id/google-home": {
+                            "table_type": "gpt",
+                            "layout": [
+                                [100, "933AC7E1-2EB4-4F13-B844-0E14E2AEF915"]
+                            ],
+                        }
+                    }
+                }
+            ),
+        ),
+    )
+    @skipUnlessJsonSchema()
+    def test_valid_schema(self, config):
+        """Assert expected schema validation and no error messages."""
+        schema = get_schema()
+        validate_cloudconfig_schema(config, schema, strict=True)


### PR DESCRIPTION
```
schema: fix gpt labels, support type string for GUID

LP #2004599
```

## Additional Context
https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2004599
