### PR TITLE
Support transactional-updates for SUSE based distros

### DIFF
--- a/cloudinit/config/cc_zypper_add_repo.py
+++ b/cloudinit/config/cc_zypper_add_repo.py
@@ -31,7 +31,8 @@ options will be resolved by the way the zypp.conf INI file is parsed.
 The ``repos`` key may be used to add repositories to the system. Beyond the
 required ``id`` and ``baseurl`` attributions, no validation is performed
 on the ``repos`` entries. It is assumed the user is familiar with the
-zypper repository file format.
+zypper repository file format. This configuration is also applicable for
+systems with transactional-updates.
 """
 meta: MetaSchema = {
     "id": "cc_zypper_add_repo",

--- a/tests/unittests/distros/test_opensuse.py
+++ b/tests/unittests/distros/test_opensuse.py
@@ -1,10 +1,331 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from tests.unittests.distros import _get_distro
-from tests.unittests.helpers import CiTestCase
+from unittest import mock
+
+from cloudinit import distros
 
 
-class TestopenSUSE(CiTestCase):
-    def test_get_distro(self):
-        distro = _get_distro("opensuse")
-        self.assertEqual(distro.osfamily, "suse")
+@mock.patch("cloudinit.distros.opensuse.subp.subp")
+class TestPackageCommands:
+    distro = distros.fetch("opensuse")("opensuse", {}, None)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "xfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / xfs rw,bar\n",
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.os.path.exists", return_value=False
+    )
+    def test_upgrade_not_btrfs(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("upgrade")
+        expected_cmd = ["zypper", "--non-interactive", "update"]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "xfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / xfs rw,bar\n",
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.os.path.exists", return_value=False
+    )
+    def test_upgrade_not_btrfs_pkg(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("upgrade", None, ["python36", "gzip"])
+        expected_cmd = [
+            "zypper",
+            "--non-interactive",
+            "update",
+            "python36",
+            "gzip",
+        ]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "xfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / xfs rw,bar\n",
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.os.path.exists", return_value=False
+    )
+    def test_update_not_btrfs(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("update")
+        expected_cmd = ["zypper", "--non-interactive", "update"]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "xfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / xfs rw,bar\n",
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.os.path.exists", return_value=False
+    )
+    def test_update_not_btrfs_pkg(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("update", None, ["python36", "gzip"])
+        expected_cmd = [
+            "zypper",
+            "--non-interactive",
+            "update",
+            "python36",
+            "gzip",
+        ]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "xfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / xfs rw,bar\n",
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.os.path.exists", return_value=False
+    )
+    def test_install_not_btrfs_pkg(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.install_packages(["python36", "gzip"])
+        expected_cmd = [
+            "zypper",
+            "--non-interactive",
+            "install",
+            "--auto-agree-with-licenses",
+            "python36",
+            "gzip",
+        ]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "btrfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
+    )
+    @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
+    def test_upgrade_btrfs(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("upgrade")
+        expected_cmd = [
+            "transactional-update",
+            "--non-interactive",
+            "--drop-if-no-change",
+            "up",
+        ]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "btrfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
+    )
+    @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
+    def test_upgrade_btrfs_pkg(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("upgrade", None, ["python36", "gzip"])
+        expected_cmd = [
+            "transactional-update",
+            "--non-interactive",
+            "--drop-if-no-change",
+            "pkg",
+            "update",
+            "python36",
+            "gzip",
+        ]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "btrfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / btrf rw,bar\n",
+    )
+    @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
+    def test_update_btrfs(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("update")
+        expected_cmd = [
+            "transactional-update",
+            "--non-interactive",
+            "--drop-if-no-change",
+            "up",
+        ]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "btrfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
+    )
+    @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
+    def test_update_btrfs_pkg(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("update", None, ["python36", "gzip"])
+        expected_cmd = [
+            "transactional-update",
+            "--non-interactive",
+            "--drop-if-no-change",
+            "pkg",
+            "update",
+            "python36",
+            "gzip",
+        ]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "btrfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
+    )
+    @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
+    def test_install_btrfs_pkg(self, m_tu_path, m_mounts, m_minfo, m_subp):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.install_packages(["python36", "gzip"])
+        expected_cmd = [
+            "transactional-update",
+            "--non-interactive",
+            "--drop-if-no-change",
+            "pkg",
+            "install",
+            "--auto-agree-with-licenses",
+            "python36",
+            "gzip",
+        ]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "btrfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / btrfs ro,bar\n",
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.os.path.exists", return_value=False
+    )
+    def test_upgrade_no_transact_up_ro_root(
+        self, m_tu_path, m_mounts, m_minfo, m_subp
+    ):
+        # Reset state
+        self.distro.update_method = None
+
+        result = self.distro.package_command("upgrade")
+        assert self.distro.read_only_root
+        assert result is None
+        assert not m_subp.called
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "btrfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.os.path.exists", return_value=False
+    )
+    def test_upgrade_no_transact_up_rw_root_btrfs(
+        self, m_tu_path, m_mounts, m_minfo, m_subp
+    ):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("upgrade")
+        assert self.distro.update_method == "zypper"
+        assert self.distro.read_only_root is False
+        expected_cmd = ["zypper", "--non-interactive", "update"]
+        m_subp.assert_called_with(expected_cmd, capture=False)
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "xfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / xfs ro,bar\n",
+    )
+    @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
+    def test_upgrade_transact_up_ro_root(
+        self, m_tu_path, m_mounts, m_minfo, m_subp
+    ):
+        # Reset state
+        self.distro.update_method = None
+
+        result = self.distro.package_command("upgrade")
+        assert self.distro.update_method == "zypper"
+        assert self.distro.read_only_root
+        assert result is None
+        assert not m_subp.called
+
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.get_mount_info",
+        return_value=("/dev/sda1", "btrfs", "/"),
+    )
+    @mock.patch(
+        "cloudinit.distros.opensuse.util.load_file",
+        return_value="foo\n/dev/sda1 / btrfs ro,bar\n",
+    )
+    @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
+    def test_refresh_transact_up_ro_root_btrfs(
+        self, m_tu_path, m_mounts, m_minfo, m_subp
+    ):
+        # Reset state
+        self.distro.update_method = None
+
+        self.distro.package_command("refresh")
+        assert self.distro.update_method == "transactional"
+        assert self.distro.read_only_root
+        expected_cmd = ["zypper", "--non-interactive", "refresh"]
+        m_subp.assert_called_with(expected_cmd, capture=False)


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

openSUSE/SUSE has distros that use read only root and btrfs. To update a running system in such a setup the transactional-update command needs to be used. This change implements support for use of the transactional-update commend when appropriate.
```
summary: no more than 70 characters

Support transactional-updates for SUSE based distros
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
