### PR TITLE
oracle-ds: prefer system_cfg over ds network config source (SC-1414)

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -118,9 +118,9 @@ class DataSourceOracle(sources.DataSource):
     vendordata_pure = None
     network_config_sources: Tuple[sources.NetworkConfigSource, ...] = (
         sources.NetworkConfigSource.CMD_LINE,
+        sources.NetworkConfigSource.SYSTEM_CFG,
         sources.NetworkConfigSource.DS,
         sources.NetworkConfigSource.INITRAMFS,
-        sources.NetworkConfigSource.SYSTEM_CFG,
     )
 
     _network_config: dict = {"config": [], "version": 1}

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -1134,6 +1134,15 @@ class TestNetworkConfig:
         initramfs_idx = config_sources.index(NetworkConfigSource.INITRAMFS)
         assert ds_idx < initramfs_idx
 
+    def test_system_network_cfg_preferred_over_ds(
+        self, m_get_interfaces_by_mac
+    ):
+        """Ensure that system net config is preferred over DS config"""
+        config_sources = oracle.DataSourceOracle.network_config_sources
+        ds_idx = config_sources.index(NetworkConfigSource.DS)
+        system_idx = config_sources.index(NetworkConfigSource.SYSTEM_CFG)
+        assert system_idx < ds_idx
+
     @pytest.mark.parametrize("set_primary", [True, False])
     def test__add_network_config_from_opc_imds_no_vnics_data(
         self,


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
oracle-ds: prefer system_cfg over ds network config source

Bump system_cfg over ds network_config_source for Oracle DS,
so that if network config is defined under /etc/cloud,
it will be honored.

In a previous change, we moved the initramfs and system_cfg
bellow ds to favor ds, but this implied system-wide configs
were always not honored.

LP: #1956788
```

## Additional Context
<!-- If relevant -->
https://bugs.launchpad.net/cloud-init/+bug/1956788
https://warthogs.atlassian.net/browse/SC-1414
https://warthogs.atlassian.net/browse/CPC-1975

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
CLOUD_INIT_PLATFORM="oci" CLOUD_INIT_CLOUD_INIT_SOURCE=$(ls cloud*.deb) tox -e integration-tests -- -vv tests/integration_tests/datasources/test_oci_networking.py::test_oci_networking_system_cfg
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
