### PR TITLE
cli: schema also validate vendor-data fix nested annotations

### DIFF
--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -166,7 +166,6 @@ class UserDataProcessor:
             # TODO(harlowja): Should this be happening, shouldn't
             # the part header be modified and not the base?
             _replace_header(base_msg, CONTENT_TYPE, ctype)
-
             self._attach_part(append_msg, part)
 
     def _attach_launch_index(self, msg):

--- a/tests/unittests/test_safeyaml.py
+++ b/tests/unittests/test_safeyaml.py
@@ -12,45 +12,60 @@ class TestLoadWithMarks:
         "source_yaml,loaded_yaml,schemamarks",
         (
             # Invalid cloud-config, non-dict types don't cause an error
-            (b"scalar", "scalar", {}),
-            # Multiple keys account for comments and whitespace lines
-            (
+            pytest.param(b"scalar", "scalar", {}, id="invalid_nondict_config"),
+            pytest.param(
                 b"#\na: va\n  \nb: vb\n#\nc: vc",
                 {"a": "va", "b": "vb", "c": "vc"},
                 {"a": 2, "b": 4, "c": 6},
+                id="handle_whitespace_and_comments",
             ),
-            # List items represented on correct line number
-            (
+            pytest.param(
                 b"a:\n - a1\n\n - a2\n",
                 {"a": ["a1", "a2"]},
                 {"a": 1, "a.0": 2, "a.1": 4},
+                id="list_items",
             ),
-            # Nested dicts represented on correct line number
-            (
+            pytest.param(
                 b"a:\n a1:\n\n  aa1: aa1v\n",
                 {"a": {"a1": {"aa1": "aa1v"}}},
                 {"a": 1, "a.a1": 2, "a.a1.aa1": 4},
+                id="nested_dicts_within_dicts",
             ),
-            (b"[list, of, scalar]", ["list", "of", "scalar"], {}),
-            (
+            pytest.param(
+                b"a:\n- a1\n\n- a2: av2\n  a2b: av2b\n",
+                {"a": ["a1", {"a2": "av2", "a2b": "av2b"}]},
+                {"a": 1, "a.0": 2, "a.1": 4, "a.1.a2": 4, "a.1.a2b": 5},
+                id="nested_dicts_within_list",
+            ),
+            pytest.param(
+                b"[list, of, scalar]",
+                ["list", "of", "scalar"],
+                {},
+                id="list_of_scalar",
+            ),
+            pytest.param(
                 b"{a: [a1, a2], b: [b3]}",
                 {"a": ["a1", "a2"], "b": ["b3"]},
                 {"a": 1, "a.0": 1, "a.1": 1, "b": 1},
+                id="dict_of_lists_oneline",
             ),
-            (
+            pytest.param(
                 b"a: [a1, a2]\nb: [b3]",
                 {"a": ["a1", "a2"], "b": ["b3"]},
                 {"a": 1, "a.0": 1, "a.1": 1, "b": 2, "b.0": 2},
+                id="dict_of_lists_multiline",
             ),
-            (
+            pytest.param(
                 b"a:\n- a1\n- a2\nb: [b3]",
                 {"a": ["a1", "a2"], "b": ["b3"]},
                 {"a": 1, "a.0": 2, "a.1": 3, "b": 4, "b.0": 4},
+                id="separate_dicts_scalar_vs_nested_list",
             ),
-            (
+            pytest.param(
                 b"a:\n- a1\n- a2\nb:\n- b3",
                 {"a": ["a1", "a2"], "b": ["b3"]},
                 {"a": 1, "a.0": 2, "a.1": 3, "b": 4, "b.0": 5},
+                id="separate_dicts_nestes_lists",
             ),
         ),
     )


### PR DESCRIPTION
Fix a bug in nested mapping annotations:
  The following now can be annotated without keyerrors

users:
- default
-   lock-passwd: false
    name: root

## Proposed Commit Message
```
cli: schema validate vendor-data fix nested annotations

Fix a bug in nested mapping annotations:
  The following now can be annotated without keyerrors

users:
- default
-   lock-passwd: false
    name: root
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
