### PR TITLE
docs: fix 404 CSS render use default notfound_urls_prefix in RTD conf

### DIFF
--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -85,7 +85,6 @@ autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2
 
 # Sphinx-copybutton config options:
-notfound_urls_prefix = "/"
 notfound_body = (
     "<h1>Page not found</h1><p>Sorry we missed you! Our docs have had a"
     " remodel and some deprecated links have changed.</p><p>"


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
docs: fix 404 CSS render use default notfound_urls_prefix in RTD conf

404 styling was off due to invalid config
notfound_urls_prefix = "/"

Drop custom config. The default "/en/latest"
value properly renders the 404 page with style.
```

## Additional Context
Current poor 404 rendering:
https://cloudinit.readthedocs.io/en/asdf

Test rendering built using this branch
https://cloudinit.readthedocs.io/en/rtd-build/asdf



## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
