### PR TITLE
ci: sort and add checks for cla signers file

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -99,4 +99,4 @@ jobs:
       - uses: actions/checkout@v3.0.0
 
       - name: Check CLA signers file
-        run: tools/check-cla-signers.sh
+        run: tools/check-cla-signers

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -92,3 +92,11 @@ jobs:
           TOXENV: doc
         run: |
           tox
+
+  check-cla-signers:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3.0.0
+
+      - name: Check CLA signers file
+        run: tools/check-cla-signers.sh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -88,6 +88,9 @@ Follow these steps to submit your first pull request to ``cloud-init``:
 
   * Note that ``.github-cla-signers`` is sorted alphabetically.
 
+  * You may use ``tools/check-cla-signers`` to sort ``.github-cla-signers``
+    or check that it is sorted.
+
   * If you already have a change that you want to submit, you can
     also include the change to ``tools/.github-cla-signers`` in that
     pull request, there is no need for two separate PRs.

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -73,8 +73,8 @@ lucendio
 lungj
 magnetikonline
 mal
-ManassehZhou
 mamercad
+ManassehZhou
 manuelisimo
 MarkMielke
 marlluslustosa
@@ -104,7 +104,6 @@ rmhsawyer
 rongz609
 s-makin
 SadeghHayeri
-SRv6d
 sarahwzadara
 sbraz
 scorpion44
@@ -114,6 +113,7 @@ shi2wei3
 slingamn
 slyon
 smoser
+SRv6d
 sshedi
 sstallion
 stappersg

--- a/tools/check-cla-signers
+++ b/tools/check-cla-signers
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+CLA_SIGNERS_FILE="tools/.github-cla-signers"
+
+sort -f "${CLA_SIGNERS_FILE}" -o "${CLA_SIGNERS_FILE}"
+
+if [[ -n "$(git status --porcelain -- ${CLA_SIGNERS_FILE})" ]]; then
+    echo "Please make sure that ${CLA_SIGNERS_FILE} is in alphabetical order."
+    git --no-pager diff "${CLA_SIGNERS_FILE}"
+    exit 1
+fi


### PR DESCRIPTION
## ci: sort and add checks for cla signers file
<!-- Include a proposed commit message because all PRs are squash merged -->

```
ci: sort and add checks for cla signers file

This sorts the CLA signers file and adds a convenience script for users
to check and sort the file.

A workflow job - which uses the script - makes sure that the file does
not get merged in an unsorted state.
```

## Additional Context
Feel free to let me know if this is overkill. :)

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
