### PR TITLE
disk_setup: use byte string when purging the partition table

### DIFF
--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -657,7 +657,7 @@ def get_partition_gpt_layout(size, layout):
 def purge_disk_ptable(device):
     # wipe the first and last megabyte of a disk (or file)
     # gpt stores partition table both at front and at end.
-    null = "\0"
+    null = b"\0"
     start_len = 1024 * 1024
     end_len = 1024 * 1024
     with open(device, "rb+") as fp:

--- a/tests/unittests/config/test_cc_disk_setup.py
+++ b/tests/unittests/config/test_cc_disk_setup.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import random
+import tempfile
 
 import pytest
 
@@ -200,6 +201,23 @@ class TestUpdateFsSetupDevices(TestCase):
         )
 
 
+class TestPurgeDisk(TestCase):
+    @mock.patch(
+        "cloudinit.config.cc_disk_setup.read_parttbl", return_value=None
+    )
+    def test_purge_disk_ptable(self, *args):
+        pseudo_device = tempfile.NamedTemporaryFile()
+
+        cc_disk_setup.purge_disk_ptable(pseudo_device.name)
+
+        with pseudo_device as f:
+            actual = f.read()
+
+        expected = b"\0" * (1024 * 1024)
+
+        self.assertEqual(expected, actual)
+
+
 @mock.patch(
     "cloudinit.config.cc_disk_setup.assert_and_settle_device",
     return_value=None,
@@ -211,7 +229,6 @@ class TestUpdateFsSetupDevices(TestCase):
 @mock.patch("cloudinit.config.cc_disk_setup.device_type", return_value=None)
 @mock.patch("cloudinit.config.cc_disk_setup.subp.subp", return_value=("", ""))
 class TestMkfsCommandHandling(CiTestCase):
-
     with_logs = True
 
     def test_with_cmd(self, subp, *args):


### PR DESCRIPTION
## disk_setup: use byte string when purging the partition table
<!-- Include a proposed commit message because all PRs are squash merged -->

```
disk_setup: use byte string when purging the partition table

This writes a byte string to the device instead of a string when
purging the partition table.

Essentially, this will prevent the error "a bytes-like object is
required, not 'str'" from happening.
```

## Additional Context

This will prevent the error "a bytes-like object is required, not 'str'" from happening.

## Test Steps

Using the following disk setup in the user-data:

```yaml
device_aliases:
  my_disk: /dev/vdb

disk_setup:
  my_disk:
    layout: remove
    overwrite: true
```

Results in an error/warning in the cloud-init log:

```
2023-02-08 20:48:55,158 - util.py[WARNING]: Failed partitioning operation
a bytes-like object is required, not 'str'
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
