### PR TITLE
refactor: stop passing log instances to cc_* handlers

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -26,8 +26,9 @@ jobs=4
 # W1401(anomalous-backslash-in-string)
 # W1514(unspecified-encoding)
 # E0012(bad-option-value)
+# W1203(logging-fstring-interpolation)
 
-disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401, W1514, E0012
+disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401, W1514, E0012, W1203
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -26,9 +26,8 @@ jobs=4
 # W1401(anomalous-backslash-in-string)
 # W1514(unspecified-encoding)
 # E0012(bad-option-value)
-# W1203(logging-fstring-interpolation)
 
-disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401, W1514, E0012, W1203
+disable=C, F, I, R, W0201, W0212, W0221, W0222, W0223, W0231, W0311, W0511, W0602, W0603, W0611, W0613, W0621, W0622, W0631, W0703, W1401, W1514, E0012
 
 
 [REPORTS]

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -821,7 +821,7 @@ def _maybe_set_hostname(init, stage, retry_stage):
     )
     if hostname:  # meta-data or user-data hostname content
         try:
-            cc_set_hostname.handle("set-hostname", init.cfg, cloud, LOG, None)
+            cc_set_hostname.handle("set-hostname", init.cfg, cloud, None)
         except cc_set_hostname.SetHostnameError as e:
             LOG.debug(
                 "Failed setting hostname in %s stage. Will"

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 from copy import deepcopy
-from logging import Logger, getLogger
+from logging import getLogger
 from textwrap import dedent
 from typing import Optional
 
@@ -156,9 +156,7 @@ class AnsiblePullDistro(AnsiblePull):
         return bool(which("ansible"))
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     ansible_cfg: dict = cfg.get("ansible", {})
     ansible_user = ansible_cfg.get("run_user")

--- a/cloudinit/config/cc_apk_configure.py
+++ b/cloudinit/config/cc_apk_configure.py
@@ -6,7 +6,6 @@
 
 """Apk Configure: Configures apk repositories file."""
 
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -109,9 +108,7 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """
     Call to handle apk_repos sections in cloud-config file.
 

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -12,7 +12,6 @@ import glob
 import os
 import pathlib
 import re
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import gpg
@@ -170,17 +169,12 @@ def get_default_mirrors(arch=None, target=None):
     raise ValueError("No default mirror known for arch %s" % arch)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """process the config for apt_config. This can be called from
     curthooks if a global apt config was provided or via the "apt"
     standalone command."""
     # keeping code close to curtin codebase via entry handler
     target = None
-    if log is not None:
-        global LOG
-        LOG = log
     # feed back converted config, but only work on the subset under 'apt'
     cfg = convert_to_v3_apt_format(cfg)
     apt_cfg = cfg.get("apt", {})

--- a/cloudinit/config/cc_apt_pipelining.py
+++ b/cloudinit/config/cc_apt_pipelining.py
@@ -6,7 +6,7 @@
 
 """Apt Pipelining: configure apt pipelining."""
 
-from logging import Logger
+import logging
 from textwrap import dedent
 
 from cloudinit import util
@@ -14,6 +14,8 @@ from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.settings import PER_INSTANCE
+
+LOG = logging.getLogger(__name__)
 
 frequency = PER_INSTANCE
 distros = ["ubuntu", "debian"]
@@ -59,20 +61,18 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     apt_pipe_value = cfg.get("apt_pipelining", "os")
     apt_pipe_value_s = str(apt_pipe_value).lower().strip()
 
     if apt_pipe_value_s == "false":
-        write_apt_snippet("0", log, DEFAULT_FILE)
+        write_apt_snippet("0", LOG, DEFAULT_FILE)
     elif apt_pipe_value_s in ("none", "unchanged", "os"):
         return
     elif apt_pipe_value_s in [str(b) for b in range(0, 6)]:
-        write_apt_snippet(apt_pipe_value_s, log, DEFAULT_FILE)
+        write_apt_snippet(apt_pipe_value_s, LOG, DEFAULT_FILE)
     else:
-        log.warning("Invalid option for apt_pipelining: %s", apt_pipe_value)
+        LOG.warning("Invalid option for apt_pipelining: %s", apt_pipe_value)
 
 
 def write_apt_snippet(setting, log, f_name):

--- a/cloudinit/config/cc_bootcmd.py
+++ b/cloudinit/config/cc_bootcmd.py
@@ -9,8 +9,8 @@
 
 """Bootcmd: run arbitrary commands early in the boot process."""
 
+import logging
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import subp, temp_utils, util
@@ -18,6 +18,8 @@ from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.settings import PER_ALWAYS
+
+LOG = logging.getLogger(__name__)
 
 frequency = PER_ALWAYS
 
@@ -63,12 +65,10 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     if "bootcmd" not in cfg:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, no 'bootcmd' key in configuration", name
         )
         return
@@ -79,7 +79,7 @@ def handle(
             tmpf.write(util.encode_text(content))
             tmpf.flush()
         except Exception as e:
-            util.logexc(log, "Failed to shellify bootcmd: %s", str(e))
+            util.logexc(LOG, "Failed to shellify bootcmd: %s", str(e))
             raise
 
         try:
@@ -90,7 +90,7 @@ def handle(
             cmd = ["/bin/sh", tmpf.name]
             subp.subp(cmd, env=env, capture=False)
         except Exception:
-            util.logexc(log, "Failed to run bootcmd module %s", name)
+            util.logexc(LOG, "Failed to run bootcmd module %s", name)
             raise
 
 

--- a/cloudinit/config/cc_byobu.py
+++ b/cloudinit/config/cc_byobu.py
@@ -8,7 +8,7 @@
 
 """Byobu: Enable/disable byobu system wide and for default user."""
 
-from logging import Logger
+import logging
 
 from cloudinit import subp, util
 from cloudinit.cloud import Cloud
@@ -36,6 +36,8 @@ Valid configuration options for this module are:
 """
 distros = ["ubuntu", "debian"]
 
+LOG = logging.getLogger(__name__)
+
 meta: MetaSchema = {
     "id": "cc_byobu",
     "name": "Byobu",
@@ -53,16 +55,14 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if len(args) != 0:
         value = args[0]
     else:
         value = util.get_cfg_option_str(cfg, "byobu_by_default", "")
 
     if not value:
-        log.debug("Skipping module named %s, no 'byobu' values found", name)
+        LOG.debug("Skipping module named %s, no 'byobu' values found", name)
         return
 
     if value == "user" or value == "system":
@@ -77,7 +77,7 @@ def handle(
         "disable",
     )
     if value not in valid:
-        log.warning("Unknown value %s for byobu_by_default", value)
+        LOG.warning("Unknown value %s for byobu_by_default", value)
 
     mod_user = value.endswith("-user")
     mod_sys = value.endswith("-system")
@@ -97,7 +97,7 @@ def handle(
         (users, _groups) = ug_util.normalize_users_groups(cfg, cloud.distro)
         (user, _user_config) = ug_util.extract_default(users)
         if not user:
-            log.warning(
+            LOG.warning(
                 "No default byobu user provided, "
                 "can not launch %s for the default user",
                 bl_inst,
@@ -112,7 +112,7 @@ def handle(
 
     if len(shcmd):
         cmd = ["/bin/sh", "-c", "%s %s %s" % ("X=0;", shcmd, "exit $X")]
-        log.debug("Setting byobu to %s", value)
+        LOG.debug("Setting byobu to %s", value)
         subp.subp(cmd, capture=False)
 
 

--- a/cloudinit/config/cc_ca_certs.py
+++ b/cloudinit/config/cc_ca_certs.py
@@ -5,7 +5,6 @@
 """CA Certs: Add ca certificates."""
 
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -231,9 +230,7 @@ def remove_default_ca_certs(distro_cfg):
     util.delete_dir_contents(distro_cfg["ca_cert_local_path"])
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """
     Call to handle ca_cert sections in cloud-config file.
 

--- a/cloudinit/config/cc_disable_ec2_metadata.py
+++ b/cloudinit/config/cc_disable_ec2_metadata.py
@@ -8,7 +8,7 @@
 
 """Disable EC2 Metadata: Disable AWS EC2 metadata."""
 
-from logging import Logger
+import logging
 from textwrap import dedent
 
 from cloudinit import subp, util
@@ -20,6 +20,8 @@ from cloudinit.settings import PER_ALWAYS
 
 REJECT_CMD_IF = ["route", "add", "-host", "169.254.169.254", "reject"]
 REJECT_CMD_IP = ["ip", "route", "add", "prohibit", "169.254.169.254"]
+
+LOG = logging.getLogger(__name__)
 
 meta: MetaSchema = {
     "id": "cc_disable_ec2_metadata",
@@ -40,9 +42,7 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     disabled = util.get_cfg_option_bool(cfg, "disable_ec2_metadata", False)
     if disabled:
         reject_cmd = None
@@ -51,14 +51,14 @@ def handle(
         elif subp.which("ifconfig"):
             reject_cmd = REJECT_CMD_IF
         else:
-            log.error(
+            LOG.error(
                 'Neither "route" nor "ip" command found, unable to '
                 "manipulate routing table"
             )
             return
         subp.subp(reject_cmd, capture=False)
     else:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, disabling the ec2 route not enabled",
             name,
         )

--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -10,7 +10,6 @@
 import logging
 import os
 import shlex
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import subp, util
@@ -112,9 +111,7 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """
     See doc/examples/cloud-config-disk-setup.txt for documentation on the
     format.
@@ -128,14 +125,14 @@ def handle(
     disk_setup = cfg.get("disk_setup")
     if isinstance(disk_setup, dict):
         update_disk_setup_devices(disk_setup, alias_to_device)
-        log.debug("Partitioning disks: %s", str(disk_setup))
+        LOG.debug("Partitioning disks: %s", str(disk_setup))
         for disk, definition in disk_setup.items():
             if not isinstance(definition, dict):
-                log.warning("Invalid disk definition for %s" % disk)
+                LOG.warning(f"Invalid disk definition for {disk}")
                 continue
 
             try:
-                log.debug("Creating new partition table/disk")
+                LOG.debug("Creating new partition table/disk")
                 util.log_time(
                     logfunc=LOG.debug,
                     msg="Creating partition on %s" % disk,
@@ -147,15 +144,15 @@ def handle(
 
     fs_setup = cfg.get("fs_setup")
     if isinstance(fs_setup, list):
-        log.debug("setting up filesystems: %s", str(fs_setup))
+        LOG.debug("setting up filesystems: %s", str(fs_setup))
         update_fs_setup_devices(fs_setup, alias_to_device)
         for definition in fs_setup:
             if not isinstance(definition, dict):
-                log.warning("Invalid file system definition: %s" % definition)
+                LOG.warning(f"Invalid file system definition: {definition}")
                 continue
 
             try:
-                log.debug("Creating new filesystem.")
+                LOG.debug("Creating new filesystem.")
                 device = definition.get("device")
                 util.log_time(
                     logfunc=LOG.debug,

--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -128,7 +128,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         LOG.debug("Partitioning disks: %s", str(disk_setup))
         for disk, definition in disk_setup.items():
             if not isinstance(definition, dict):
-                LOG.warning(f"Invalid disk definition for {disk}")
+                LOG.warning("Invalid disk definition for %s", disk)
                 continue
 
             try:
@@ -148,7 +148,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         update_fs_setup_devices(fs_setup, alias_to_device)
         for definition in fs_setup:
             if not isinstance(definition, dict):
-                LOG.warning(f"Invalid file system definition: {definition}")
+                LOG.warning("Invalid file system definition: %s", definition)
                 continue
 
             try:

--- a/cloudinit/config/cc_fan.py
+++ b/cloudinit/config/cc_fan.py
@@ -5,7 +5,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Fan: Configure ubuntu fan networking"""
 
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -87,9 +86,7 @@ def stop_update_start(distro, service, config_file, content):
     distro.manage_service("enable", service)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     cfgin = cfg.get("fan")
     if not cfgin:
         cfgin = {}

--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -7,7 +7,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Final Message: Output final message when cloud-init has finished"""
 
-from logging import Logger
+import logging
 from textwrap import dedent
 
 from cloudinit import templater, util, version
@@ -56,6 +56,7 @@ meta: MetaSchema = {
     "activate_by_schema_keys": [],
 }
 
+LOG = logging.getLogger(__name__)
 __doc__ = get_meta_doc(meta)
 
 # Jinja formated default message
@@ -66,9 +67,7 @@ FINAL_MESSAGE_DEF = (
 )
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     msg_in = ""
     if len(args) != 0:
@@ -95,20 +94,20 @@ def handle(
             "%s\n" % (templater.render_string(msg_in, subs)),
             console=False,
             stderr=True,
-            log=log,
+            log=LOG,
         )
     except Exception:
-        util.logexc(log, "Failed to render final message template")
+        util.logexc(LOG, "Failed to render final message template")
 
     boot_fin_fn = cloud.paths.boot_finished
     try:
         contents = "%s - %s - v. %s\n" % (uptime, ts, cver)
         util.write_file(boot_fin_fn, contents, ensure_dir_exists=False)
     except Exception:
-        util.logexc(log, "Failed to write boot finished file %s", boot_fin_fn)
+        util.logexc(LOG, "Failed to write boot finished file %s", boot_fin_fn)
 
     if cloud.datasource.is_disconnected:
-        log.warning("Used fallback datasource")
+        LOG.warning("Used fallback datasource")
 
 
 # vi: ts=4 expandtab

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -16,7 +16,6 @@ import re
 import stat
 from abc import ABC, abstractmethod
 from contextlib import suppress
-from logging import Logger
 from pathlib import Path
 from textwrap import dedent
 from typing import Tuple
@@ -566,18 +565,16 @@ def resize_devices(resizer, devices):
     return info
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if "growpart" not in cfg:
-        log.debug(
-            "No 'growpart' entry in cfg.  Using default: %s" % DEFAULT_CONFIG
+        LOG.debug(
+            f"No 'growpart' entry in cfg.  Using default: {DEFAULT_CONFIG}"
         )
         cfg["growpart"] = DEFAULT_CONFIG
 
     mycfg = cfg.get("growpart")
     if not isinstance(mycfg, dict):
-        log.warning("'growpart' in config was not a dict")
+        LOG.warning("'growpart' in config was not a dict")
         return
 
     mode = mycfg.get("mode", "auto")
@@ -588,39 +585,39 @@ def handle(
                 deprecated_version="22.2",
                 extra_message="Use 'off' instead.",
             )
-        log.debug("growpart disabled: mode=%s" % mode)
+        LOG.debug(f"growpart disabled: mode={mode}")
         return
 
     if util.is_false(mycfg.get("ignore_growroot_disabled", False)):
         if os.path.isfile("/etc/growroot-disabled"):
-            log.debug("growpart disabled: /etc/growroot-disabled exists")
-            log.debug("use ignore_growroot_disabled to ignore")
+            LOG.debug("growpart disabled: /etc/growroot-disabled exists")
+            LOG.debug("use ignore_growroot_disabled to ignore")
             return
 
     devices = util.get_cfg_option_list(mycfg, "devices", ["/"])
     if not len(devices):
-        log.debug("growpart: empty device list")
+        LOG.debug("growpart: empty device list")
         return
 
     try:
         resizer = resizer_factory(mode, cloud.distro)
     except (ValueError, TypeError) as e:
-        log.debug("growpart unable to find resizer for '%s': %s" % (mode, e))
+        LOG.debug(f"growpart unable to find resizer for '{mode}': {e}")
         if mode != "auto":
             raise e
         return
 
     resized = util.log_time(
-        logfunc=log.debug,
+        logfunc=LOG.debug,
         msg="resize_devices",
         func=resize_devices,
         args=(resizer, devices),
     )
     for (entry, action, msg) in resized:
         if action == RESIZE.CHANGED:
-            log.info("'%s' resized: %s" % (entry, msg))
+            LOG.info(f"{entry}' resized: {msg}")
         else:
-            log.debug("'%s' %s: %s" % (entry, action, msg))
+            LOG.debug(f"'{entry}' {action}: {msg}")
 
 
 RESIZERS = (("growpart", ResizeGrowPart), ("gpart", ResizeGpart))

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -568,7 +568,7 @@ def resize_devices(resizer, devices):
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if "growpart" not in cfg:
         LOG.debug(
-            f"No 'growpart' entry in cfg.  Using default: {DEFAULT_CONFIG}"
+            "No 'growpart' entry in cfg.  Using default: %s", DEFAULT_CONFIG
         )
         cfg["growpart"] = DEFAULT_CONFIG
 
@@ -585,7 +585,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
                 deprecated_version="22.2",
                 extra_message="Use 'off' instead.",
             )
-        LOG.debug(f"growpart disabled: mode={mode}")
+        LOG.debug("growpart disabled: mode=%s", mode)
         return
 
     if util.is_false(mycfg.get("ignore_growroot_disabled", False)):
@@ -602,7 +602,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     try:
         resizer = resizer_factory(mode, cloud.distro)
     except (ValueError, TypeError) as e:
-        LOG.debug(f"growpart unable to find resizer for '{mode}': {e}")
+        LOG.debug("growpart unable to find resizer for '%s': %s", mode, e)
         if mode != "auto":
             raise e
         return
@@ -615,9 +615,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     )
     for (entry, action, msg) in resized:
         if action == RESIZE.CHANGED:
-            LOG.info(f"{entry}' resized: {msg}")
+            LOG.info("'%s' resized: %s", entry, msg)
         else:
-            LOG.debug(f"'{entry}' {action}: {msg}")
+            LOG.debug("'%s' %s: %s", entry, action, msg)
 
 
 RESIZERS = (("growpart", ResizeGrowPart), ("gpart", ResizeGpart))

--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -141,7 +141,6 @@ def is_efi_booted() -> bool:
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
-
     mycfg = cfg.get("grub_dpkg", cfg.get("grub-dpkg", {}))
     if not mycfg:
         mycfg = {}
@@ -153,31 +152,6 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     dconf_sel = get_debconf_config(mycfg)
     LOG.debug("Setting grub debconf-set-selections with '%s'", dconf_sel)
-    idevs = util.get_cfg_option_str(mycfg, "grub-pc/install_devices", None)
-    if idevs is None:
-        idevs = fetch_idevs()
-
-    idevs_empty = mycfg.get("grub-pc/install_devices_empty")
-    if idevs_empty is None:
-        idevs_empty = not idevs
-    elif not isinstance(idevs_empty, bool):
-        idevs_empty = util.translate_bool(idevs_empty)
-    idevs_empty = str(idevs_empty).lower()
-
-    # now idevs and idevs_empty are set to determined values
-    # or, those set by user
-
-    dconf_sel = (
-        "grub-pc grub-pc/install_devices string %s\n"
-        "grub-pc grub-pc/install_devices_empty boolean %s\n"
-        % (idevs, idevs_empty)
-    )
-
-    LOG.debug(
-        "Setting grub debconf-set-selections with '%s','%s'",
-        idevs,
-        idevs_empty,
-    )
 
     try:
         subp.subp(["debconf-set-selections"], dconf_sel)

--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -8,8 +8,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Grub Dpkg: Configure grub debconf installation device"""
 
+import logging
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import subp, util
@@ -57,9 +57,10 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
-def fetch_idevs(log: Logger):
+def fetch_idevs():
     """
     Fetches the /dev/disk/by-id device grub is installed to.
     Falls back to plain disk name if no by-id entry is present.
@@ -71,7 +72,7 @@ def fetch_idevs(log: Logger):
     # EFI mode systems use /boot/efi and the partition path.
     probe_target = "disk"
     probe_mount = "/boot"
-    if is_efi_booted(log):
+    if is_efi_booted():
         probe_target = "device"
         probe_mount = "/boot/efi"
 
@@ -84,18 +85,18 @@ def fetch_idevs(log: Logger):
         # grub-common may not be installed, especially on containers
         # FileNotFoundError is a nested exception of ProcessExecutionError
         if isinstance(e.reason, FileNotFoundError):
-            log.debug("'grub-probe' not found in $PATH")
+            LOG.debug("'grub-probe' not found in $PATH")
         # disks from the container host are present in /proc and /sys
         # which is where grub-probe determines where /boot is.
         # it then checks for existence in /dev, which fails as host disks
         # are not exposed to the container.
         elif "failed to get canonical path" in e.stderr:
-            log.debug("grub-probe 'failed to get canonical path'")
+            LOG.debug("grub-probe 'failed to get canonical path'")
         else:
             # something bad has happened, continue to log the error
             raise
     except Exception:
-        util.logexc(log, "grub-probe failed to execute for grub-dpkg")
+        util.logexc(LOG, "grub-probe failed to execute for grub-dpkg")
 
     if not disk or not os.path.exists(disk):
         # If we failed to detect a disk, we can return early
@@ -113,73 +114,95 @@ def fetch_idevs(log: Logger):
         )
     except Exception:
         util.logexc(
-            log, "udevadm DEVLINKS symlink query failed for disk='%s'", disk
+            LOG, "udevadm DEVLINKS symlink query failed for disk='%s'", disk
         )
 
-    log.debug("considering these device symlinks: %s", ",".join(devices))
+    LOG.debug("considering these device symlinks: %s", ",".join(devices))
     # filter symlinks for /dev/disk/by-id entries
     devices = [dev for dev in devices if "disk/by-id" in dev]
-    log.debug("filtered to these disk/by-id symlinks: %s", ",".join(devices))
+    LOG.debug("filtered to these disk/by-id symlinks: %s", ",".join(devices))
     # select first device if there is one, else fall back to plain name
     idevs = sorted(devices)[0] if devices else disk
-    log.debug("selected %s", idevs)
+    LOG.debug("selected %s", idevs)
 
     return idevs
 
 
-def is_efi_booted(log: Logger) -> bool:
+def is_efi_booted() -> bool:
     """
     Check if the system is booted in EFI mode.
     """
     try:
         return os.path.exists("/sys/firmware/efi")
     except OSError as e:
-        log.error("Failed to determine if system is booted in EFI mode: %s", e)
+        LOG.error("Failed to determine if system is booted in EFI mode: %s", e)
         # If we can't determine if we're booted in EFI mode, assume we're not.
         return False
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
+
     mycfg = cfg.get("grub_dpkg", cfg.get("grub-dpkg", {}))
     if not mycfg:
         mycfg = {}
 
     enabled = mycfg.get("enabled", True)
     if util.is_false(enabled):
-        log.debug("%s disabled by config grub_dpkg/enabled=%s", name, enabled)
+        LOG.debug("%s disabled by config grub_dpkg/enabled=%s", name, enabled)
         return
 
-    dconf_sel = get_debconf_config(mycfg, log)
-    log.debug("Setting grub debconf-set-selections with '%s'" % dconf_sel)
+    dconf_sel = get_debconf_config(mycfg)
+    LOG.debug("Setting grub debconf-set-selections with '%s'", dconf_sel)
+    idevs = util.get_cfg_option_str(mycfg, "grub-pc/install_devices", None)
+    if idevs is None:
+        idevs = fetch_idevs()
+
+    idevs_empty = mycfg.get("grub-pc/install_devices_empty")
+    if idevs_empty is None:
+        idevs_empty = not idevs
+    elif not isinstance(idevs_empty, bool):
+        idevs_empty = util.translate_bool(idevs_empty)
+    idevs_empty = str(idevs_empty).lower()
+
+    # now idevs and idevs_empty are set to determined values
+    # or, those set by user
+
+    dconf_sel = (
+        "grub-pc grub-pc/install_devices string %s\n"
+        "grub-pc grub-pc/install_devices_empty boolean %s\n"
+        % (idevs, idevs_empty)
+    )
+
+    LOG.debug(
+        f"Setting grub debconf-set-selections with '{idevs}','{idevs_empty}'"
+    )
 
     try:
         subp.subp(["debconf-set-selections"], dconf_sel)
     except Exception as e:
         util.logexc(
-            log, "Failed to run debconf-set-selections for grub_dpkg: %s", e
+            LOG, "Failed to run debconf-set-selections for grub_dpkg: %s", e
         )
 
 
-def get_debconf_config(mycfg: Config, log: Logger) -> str:
+def get_debconf_config(mycfg: Config) -> str:
     """
     Returns the debconf config for grub-pc or
     grub-efi depending on the systems boot mode.
     """
-    if is_efi_booted(log):
+    if is_efi_booted():
         idevs = util.get_cfg_option_str(
             mycfg, "grub-efi/install_devices", None
         )
 
         if idevs is None:
-            idevs = fetch_idevs(log)
+            idevs = fetch_idevs()
 
         return "grub-pc grub-efi/install_devices string %s\n" % idevs
     else:
         idevs = util.get_cfg_option_str(mycfg, "grub-pc/install_devices", None)
         if idevs is None:
-            idevs = fetch_idevs(log)
+            idevs = fetch_idevs()
 
         idevs_empty = mycfg.get("grub-pc/install_devices_empty")
         if idevs_empty is None:

--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -174,7 +174,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     )
 
     LOG.debug(
-        f"Setting grub debconf-set-selections with '{idevs}','{idevs_empty}'"
+        "Setting grub debconf-set-selections with '%s','%s'",
+        idevs,
+        idevs_empty,
     )
 
     try:

--- a/cloudinit/config/cc_keyboard.py
+++ b/cloudinit/config/cc_keyboard.py
@@ -6,7 +6,6 @@
 
 """keyboard: set keyboard layout"""
 
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import distros
@@ -60,9 +59,7 @@ __doc__ = get_meta_doc(meta)
 LOG = logging.getLogger(__name__)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if "keyboard" not in cfg:
         LOG.debug(
             "Skipping module named %s, no 'keyboard' section found", name

--- a/cloudinit/config/cc_keys_to_console.py
+++ b/cloudinit/config/cc_keys_to_console.py
@@ -8,8 +8,8 @@
 
 """Keys to Console: Control which SSH host keys may be written to console"""
 
+import logging
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import subp, util
@@ -68,6 +68,8 @@ meta: MetaSchema = {
 }
 __doc__ = get_meta_doc(meta)
 
+LOG = logging.getLogger(__name__)
+
 
 def _get_helper_tool_path(distro):
     try:
@@ -77,18 +79,16 @@ def _get_helper_tool_path(distro):
     return HELPER_TOOL_TPL % base_lib
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if util.is_false(cfg.get("ssh", {}).get("emit_keys_to_console", True)):
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, logging of SSH host keys disabled", name
         )
         return
 
     helper_path = _get_helper_tool_path(cloud.distro)
     if not os.path.exists(helper_path):
-        log.warning(
+        LOG.warning(
             "Unable to activate module %s, helper tool not found at %s",
             name,
             helper_path,
@@ -107,7 +107,7 @@ def handle(
         (stdout, _stderr) = subp.subp(cmd)
         util.multi_log("%s\n" % (stdout.strip()), stderr=False, console=True)
     except Exception:
-        log.warning("Writing keys to the system console failed!")
+        LOG.warning("Writing keys to the system console failed!")
         raise
 
 

--- a/cloudinit/config/cc_landscape.py
+++ b/cloudinit/config/cc_landscape.py
@@ -8,9 +8,9 @@
 
 """install and configure landscape client"""
 
+import logging
 import os
 from io import BytesIO
-from logging import Logger
 from textwrap import dedent
 
 from configobj import ConfigObj
@@ -98,11 +98,10 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """
     Basically turn a top level 'landscape' entry with a 'client' dict
     and render it to ConfigObj format under '[client]' section in
@@ -135,7 +134,7 @@ def handle(
 
     util.ensure_dir(os.path.dirname(LSC_CLIENT_CFG_FILE))
     util.write_file(LSC_CLIENT_CFG_FILE, contents.getvalue())
-    log.debug("Wrote landscape config file to %s", LSC_CLIENT_CFG_FILE)
+    LOG.debug("Wrote landscape config file to %s", LSC_CLIENT_CFG_FILE)
 
     util.write_file(LS_DEFAULT_FILE, "RUN=1\n")
     subp.subp(["service", "landscape-client", "restart"])

--- a/cloudinit/config/cc_locale.py
+++ b/cloudinit/config/cc_locale.py
@@ -8,7 +8,7 @@
 
 """Locale: set system locale"""
 
-from logging import Logger
+import logging
 from textwrap import dedent
 
 from cloudinit import util
@@ -49,23 +49,22 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if len(args) != 0:
         locale = args[0]
     else:
         locale = util.get_cfg_option_str(cfg, "locale", cloud.get_locale())
 
     if util.is_false(locale):
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, disabled by config: %s", name, locale
         )
         return
 
-    log.debug("Setting locale to %s", locale)
+    LOG.debug("Setting locale to %s", locale)
     locale_cfgfile = util.get_cfg_option_str(cfg, "locale_configfile")
     cloud.distro.apply_locale(locale, locale_cfgfile)
 

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -7,7 +7,6 @@
 """LXD: configure lxd with ``lxd init`` and optionally lxd-bridge"""
 
 import os
-from logging import Logger
 from textwrap import dedent
 from typing import List, Tuple
 
@@ -197,13 +196,11 @@ def supplemental_schema_validation(
         raise ValueError(". ".join(errors))
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # Get config
     lxd_cfg = cfg.get("lxd")
     if not lxd_cfg:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, not present or disabled by cfg", name
         )
         return
@@ -224,7 +221,7 @@ def handle(
         try:
             cloud.distro.install_packages(packages)
         except subp.ProcessExecutionError as exc:
-            log.warning("failed to install packages %s: %s", packages, exc)
+            LOG.warning("failed to install packages %s: %s", packages, exc)
             return
 
     subp.subp(["lxd", "waitready", "--timeout=300"])
@@ -251,7 +248,7 @@ def handle(
         if init_cfg["storage_backend"] == "lvm" and not os.path.exists(
             f"/lib/modules/{kernel}/kernel/drivers/md/dm-thin-pool.ko"
         ):
-            log.warning(
+            LOG.warning(
                 "cloud-init doesn't use thinpool by default on Ubuntu due to "
                 "LP #1982780. This behavior will change in the future.",
             )
@@ -294,7 +291,7 @@ def handle(
 
             # Update debconf database
             try:
-                log.debug("Setting lxd debconf via " + dconf_comm)
+                LOG.debug(f"Setting lxd debconf via {dconf_comm}")
                 data = (
                     "\n".join(
                         ["set %s %s" % (k, v) for k, v in debconf.items()]
@@ -304,14 +301,14 @@ def handle(
                 subp.subp(["debconf-communicate"], data)
             except Exception:
                 util.logexc(
-                    log, "Failed to run '%s' for lxd with" % dconf_comm
+                    LOG, "Failed to run '%s' for lxd with" % dconf_comm
                 )
 
             # Remove the existing configuration file (forces re-generation)
             util.del_file("/etc/default/lxd-bridge")
 
             # Run reconfigure
-            log.debug("Running dpkg-reconfigure for lxd")
+            LOG.debug("Running dpkg-reconfigure for lxd")
             subp.subp(["dpkg-reconfigure", "lxd", "--frontend=noninteractive"])
         else:
             # Built-in LXD bridge support
@@ -323,12 +320,12 @@ def handle(
                 attach=bool(cmd_attach),
             )
             if cmd_create:
-                log.debug("Creating lxd bridge: %s" % " ".join(cmd_create))
+                LOG.debug("Creating lxd bridge: %s", " ".join(cmd_create))
                 _lxc(cmd_create)
 
             if cmd_attach:
-                log.debug(
-                    "Setting up default lxd bridge: %s" % " ".join(cmd_attach)
+                LOG.debug(
+                    "Setting up default lxd bridge: %s", " ".join(cmd_attach)
                 )
                 _lxc(cmd_attach)
 

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -291,7 +291,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
             # Update debconf database
             try:
-                LOG.debug(f"Setting lxd debconf via {dconf_comm}")
+                LOG.debug("Setting lxd debconf via %s", dconf_comm)
                 data = (
                     "\n".join(
                         ["set %s %s" % (k, v) for k, v in debconf.items()]

--- a/cloudinit/config/cc_mcollective.py
+++ b/cloudinit/config/cc_mcollective.py
@@ -11,7 +11,6 @@
 
 import errno
 import io
-from logging import Logger
 from textwrap import dedent
 
 # Used since this can maintain comments
@@ -89,6 +88,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
 def configure(
@@ -152,13 +152,11 @@ def configure(
     util.write_file(server_cfg, contents.getvalue(), mode=0o644)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     # If there isn't a mcollective key in the configuration don't do anything
     if "mcollective" not in cfg:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, no 'mcollective' key in configuration",
             name,
         )

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -12,7 +12,6 @@ import logging
 import math
 import os
 import re
-from logging import Logger
 from string import whitespace
 from textwrap import dedent
 
@@ -163,15 +162,15 @@ def _is_block_device(device_path, partition_path=None):
     return os.path.exists(sys_path)
 
 
-def sanitize_devname(startname, transformer, log, aliases=None):
-    log.debug("Attempting to determine the real name of %s", startname)
+def sanitize_devname(startname, transformer, aliases=None):
+    LOG.debug("Attempting to determine the real name of %s", startname)
 
     # workaround, allow user to specify 'ephemeral'
     # rather than more ec2 correct 'ephemeral0'
     devname = startname
     if devname == "ephemeral":
         devname = "ephemeral0"
-        log.debug("Adjusted mount option from ephemeral to ephemeral0")
+        LOG.debug("Adjusted mount option from ephemeral to ephemeral0")
 
     if is_network_device(startname):
         return startname
@@ -182,7 +181,7 @@ def sanitize_devname(startname, transformer, log, aliases=None):
     if aliases:
         device_path = aliases.get(device_path, device_path)
         if orig != device_path:
-            log.debug("Mapped device alias %s to %s", orig, device_path)
+            LOG.debug("Mapped device alias %s to %s", orig, device_path)
 
     if is_meta_device_name(device_path):
         device_path = transformer(device_path)
@@ -190,7 +189,7 @@ def sanitize_devname(startname, transformer, log, aliases=None):
             return None
         if not device_path.startswith("/"):
             device_path = "/dev/%s" % (device_path,)
-        log.debug("Mapped metadata name %s to %s", orig, device_path)
+        LOG.debug("Mapped metadata name %s to %s", orig, device_path)
     else:
         if DEVICE_NAME_RE.match(startname):
             device_path = "/dev/%s" % (device_path,)
@@ -407,9 +406,7 @@ def handle_swapcfg(swapcfg):
     return None
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno
     def_mnt_opts = "defaults,nobootwait"
     uses_systemd = cloud.distro.uses_systemd()
@@ -455,7 +452,7 @@ def handle(
     for i in range(len(cfgmnt)):
         # skip something that wasn't a list
         if not isinstance(cfgmnt[i], list):
-            log.warning(
+            LOG.warning(
                 "Mount option %s not a list, got a %s instead",
                 (i + 1),
                 type_utils.obj_name(cfgmnt[i]),
@@ -464,16 +461,16 @@ def handle(
 
         start = str(cfgmnt[i][0])
         sanitized = sanitize_devname(
-            start, cloud.device_name_to_device, log, aliases=device_aliases
+            start, cloud.device_name_to_device, aliases=device_aliases
         )
         if sanitized != start:
-            log.debug("changed %s => %s" % (start, sanitized))
+            LOG.debug(f"changed {start} => {sanitized}")
 
         if sanitized is None:
-            log.debug("Ignoring nonexistent named mount %s", start)
+            LOG.debug(f"Ignoring nonexistent named mount {start}")
             continue
         elif sanitized in fstab_devs:
-            log.info(
+            LOG.info(
                 "Device %s already defined in fstab: %s",
                 sanitized,
                 fstab_devs[sanitized],
@@ -511,16 +508,16 @@ def handle(
     for defmnt in defmnts:
         start = defmnt[0]
         sanitized = sanitize_devname(
-            start, cloud.device_name_to_device, log, aliases=device_aliases
+            start, cloud.device_name_to_device, aliases=device_aliases
         )
         if sanitized != start:
-            log.debug("changed default device %s => %s" % (start, sanitized))
+            LOG.debug(f"changed default device {start} => {sanitized}")
 
         if sanitized is None:
-            log.debug("Ignoring nonexistent default named mount %s", start)
+            LOG.debug("Ignoring nonexistent default named mount %s", start)
             continue
         elif sanitized in fstab_devs:
-            log.debug(
+            LOG.debug(
                 "Device %s already defined in fstab: %s",
                 sanitized,
                 fstab_devs[sanitized],
@@ -536,7 +533,7 @@ def handle(
                 break
 
         if cfgmnt_has:
-            log.debug("Not including %s, already previously included", start)
+            LOG.debug("Not including %s, already previously included", start)
             continue
         cfgmnt.append(defmnt)
 
@@ -545,7 +542,7 @@ def handle(
     actlist = []
     for x in cfgmnt:
         if x[1] is None:
-            log.debug("Skipping nonexistent device named %s", x[0])
+            LOG.debug("Skipping nonexistent device named %s", x[0])
         else:
             actlist.append(x)
 
@@ -554,7 +551,7 @@ def handle(
         actlist.append([swapret, "none", "swap", "sw", "0", "0"])
 
     if len(actlist) == 0:
-        log.debug("No modifications to fstab needed")
+        LOG.debug("No modifications to fstab needed")
         return
 
     cc_lines = []
@@ -577,7 +574,7 @@ def handle(
         try:
             util.ensure_dir(d)
         except Exception:
-            util.logexc(log, "Failed to make '%s' config-mount", d)
+            util.logexc(LOG, "Failed to make '%s' config-mount", d)
         # dirs is list of directories on which a volume should be mounted.
         # If any of them does not already show up in the list of current
         # mount points, we will definitely need to do mount -a.
@@ -600,9 +597,9 @@ def handle(
         activate_cmds.append(["swapon", "-a"])
 
     if len(sops) == 0:
-        log.debug("No changes to /etc/fstab made.")
+        LOG.debug("No changes to /etc/fstab made.")
     else:
-        log.debug("Changes to fstab: %s", sops)
+        LOG.debug("Changes to fstab: %s", sops)
         need_mount_all = True
 
     if need_mount_all:
@@ -615,10 +612,10 @@ def handle(
         fmt = "Activate mounts: %s:" + " ".join(cmd)
         try:
             subp.subp(cmd)
-            log.debug(fmt, "PASS")
+            LOG.debug(fmt, "PASS")
         except subp.ProcessExecutionError:
-            log.warning(fmt, "FAIL")
-            util.logexc(log, fmt, "FAIL")
+            LOG.warning(fmt, "FAIL")
+            util.logexc(LOG, fmt, "FAIL")
 
 
 # vi: ts=4 expandtab

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -464,10 +464,10 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             start, cloud.device_name_to_device, aliases=device_aliases
         )
         if sanitized != start:
-            LOG.debug(f"changed {start} => {sanitized}")
+            LOG.debug("changed %s => %s", start, sanitized)
 
         if sanitized is None:
-            LOG.debug(f"Ignoring nonexistent named mount {start}")
+            LOG.debug("Ignoring nonexistent named mount %s", start)
             continue
         elif sanitized in fstab_devs:
             LOG.info(
@@ -511,7 +511,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             start, cloud.device_name_to_device, aliases=device_aliases
         )
         if sanitized != start:
-            LOG.debug(f"changed default device {start} => {sanitized}")
+            LOG.debug("changed default device %s => %s", start, sanitized)
 
         if sanitized is None:
             LOG.debug("Ignoring nonexistent default named mount %s", start)

--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -8,7 +8,6 @@
 
 import copy
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -548,9 +547,7 @@ def supplemental_schema_validation(ntp_config):
         )
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """Enable and configure ntp."""
     if "ntp" not in cfg:
         LOG.debug(

--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -8,7 +8,7 @@
 
 """Phone Home: Post data to url"""
 
-from logging import Logger
+import logging
 from textwrap import dedent
 
 from cloudinit import templater, url_helper, util
@@ -95,7 +95,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
-
+LOG = logging.getLogger(__name__)
 # phone_home:
 #  url: http://my.foo.bar/$INSTANCE/
 #  post: all
@@ -108,14 +108,12 @@ __doc__ = get_meta_doc(meta)
 #
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if len(args) != 0:
         ph_cfg = util.read_conf(args[0])
     else:
         if "phone_home" not in cfg:
-            log.debug(
+            LOG.debug(
                 "Skipping module named %s, "
                 "no 'phone_home' configuration found",
                 name,
@@ -124,7 +122,7 @@ def handle(
         ph_cfg = cfg["phone_home"]
 
     if "url" not in ph_cfg:
-        log.warning(
+        LOG.warning(
             "Skipping module named %s, "
             "no 'url' found in 'phone_home' configuration",
             name,
@@ -139,7 +137,7 @@ def handle(
     except (ValueError, TypeError):
         tries = 10
         util.logexc(
-            log,
+            LOG,
             "Configuration entry 'tries' is not an integer, using %s instead",
             tries,
         )
@@ -165,7 +163,7 @@ def handle(
             all_keys[n] = util.load_file(path)
         except Exception:
             util.logexc(
-                log, "%s: failed to open, can not phone home that data!", path
+                LOG, "%s: failed to open, can not phone home that data!", path
             )
 
     submit_keys = {}
@@ -174,7 +172,7 @@ def handle(
             submit_keys[k] = all_keys[k]
         else:
             submit_keys[k] = None
-            log.warning(
+            LOG.warning(
                 "Requested key %s from 'post'"
                 " configuration list not available",
                 k,
@@ -203,7 +201,7 @@ def handle(
         )
     except Exception:
         util.logexc(
-            log, "Failed to post phone home data to %s in %s tries", url, tries
+            LOG, "Failed to post phone home data to %s in %s tries", url, tries
         )
 
 

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -7,11 +7,11 @@
 """Power State Change: Change power state"""
 
 import errno
+import logging
 import os
 import re
 import subprocess
 import time
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import subp, util
@@ -79,6 +79,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
 def givecmdline(pid):
@@ -99,10 +100,9 @@ def givecmdline(pid):
         return None
 
 
-def check_condition(cond, log=None):
+def check_condition(cond):
     if isinstance(cond, bool):
-        if log:
-            log.debug("Static Condition: %s" % cond)
+        LOG.debug("Static Condition: %s", cond)
         return cond
 
     pre = "check_condition command (%s): " % cond
@@ -111,58 +111,49 @@ def check_condition(cond, log=None):
         proc.communicate()
         ret = proc.returncode
         if ret == 0:
-            if log:
-                log.debug(pre + "exited 0. condition met.")
+            LOG.debug(f"{pre}exited 0. condition met.")
             return True
         elif ret == 1:
-            if log:
-                log.debug(pre + "exited 1. condition not met.")
+            LOG.debug(f"{pre}exited 1. condition not met.")
             return False
         else:
-            if log:
-                log.warning(
-                    pre + "unexpected exit %s. " % ret + "do not apply change."
-                )
+            LOG.warning(f"{pre}unexpected exit {ret}. do not apply change.")
             return False
     except Exception as e:
-        if log:
-            log.warning(pre + "Unexpected error: %s" % e)
+        LOG.warning("%sUnexpected error: %s", pre, e)
         return False
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     try:
         (args, timeout, condition) = load_power_state(cfg, cloud.distro)
         if args is None:
-            log.debug("no power_state provided. doing nothing")
+            LOG.debug("no power_state provided. doing nothing")
             return
     except Exception as e:
-        log.warning("%s Not performing power state change!" % str(e))
+        LOG.warning(f"{str(e)} Not performing power state change!")
         return
 
     if condition is False:
-        log.debug("Condition was false. Will not perform state change.")
+        LOG.debug("Condition was false. Will not perform state change.")
         return
 
     mypid = os.getpid()
 
     cmdline = givecmdline(mypid)
     if not cmdline:
-        log.warning("power_state: failed to get cmdline of current process")
+        LOG.warning("power_state: failed to get cmdline of current process")
         return
 
     devnull_fp = open(os.devnull, "w")
 
-    log.debug("After pid %s ends, will execute: %s" % (mypid, " ".join(args)))
+    LOG.debug("After pid %s ends, will execute: %s", mypid, " ".join(args))
 
     util.fork_cb(
         run_after_pid_gone,
         mypid,
         cmdline,
         timeout,
-        log,
         condition,
         execmd,
         [args, devnull_fp],
@@ -227,7 +218,7 @@ def execmd(exe_args, output=None, data_in=None):
     doexit(ret)
 
 
-def run_after_pid_gone(pid, pidcmdline, timeout, log, condition, func, args):
+def run_after_pid_gone(pid, pidcmdline, timeout, condition, func, args):
     # wait until pid, with /proc/pid/cmdline contents of pidcmdline
     # is no longer alive.  After it is gone, or timeout has passed
     # execute func(args)
@@ -235,8 +226,7 @@ def run_after_pid_gone(pid, pidcmdline, timeout, log, condition, func, args):
     end_time = time.time() + timeout
 
     def fatal(msg):
-        if log:
-            log.warning(msg)
+        LOG.warning(msg)
         doexit(EXIT_FAIL)
 
     known_errnos = (errno.ENOENT, errno.ESRCH)
@@ -267,11 +257,10 @@ def run_after_pid_gone(pid, pidcmdline, timeout, log, condition, func, args):
     if not msg:
         fatal("Unexpected error in run_after_pid_gone")
 
-    if log:
-        log.debug(msg)
+    LOG.debug(msg)
 
     try:
-        if not check_condition(condition, log):
+        if not check_condition(condition):
             return
     except Exception as e:
         fatal("Unexpected Exception when checking condition: %s" % e)

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -111,13 +111,13 @@ def check_condition(cond):
         proc.communicate()
         ret = proc.returncode
         if ret == 0:
-            LOG.debug(f"{pre}exited 0. condition met.")
+            LOG.debug("%sexited 0. condition met.", pre)
             return True
         elif ret == 1:
-            LOG.debug(f"{pre}exited 1. condition not met.")
+            LOG.debug("%sexited 1. condition not met.", pre)
             return False
         else:
-            LOG.warning(f"{pre}unexpected exit {ret}. do not apply change.")
+            LOG.warning("%sunexpected exit %s. do not apply change.", pre, ret)
             return False
     except Exception as e:
         LOG.warning("%sUnexpected error: %s", pre, e)
@@ -131,7 +131,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             LOG.debug("no power_state provided. doing nothing")
             return
     except Exception as e:
-        LOG.warning(f"{str(e)} Not performing power state change!")
+        LOG.warning("%s Not performing power state change!", str(e))
         return
 
     if condition is False:

--- a/cloudinit/config/cc_refresh_rmc_and_interface.py
+++ b/cloudinit/config/cc_refresh_rmc_and_interface.py
@@ -8,7 +8,6 @@
 Ensure Network Manager is not managing IPv6 interface"""
 
 import errno
-from logging import Logger
 
 from cloudinit import log as logging
 from cloudinit import netinfo, subp, util
@@ -57,9 +56,7 @@ LOG = logging.getLogger(__name__)
 RMCCTRL = "rmcctrl"
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if not subp.which(RMCCTRL):
         LOG.debug("No '%s' in path, disabled", RMCCTRL)
         return

--- a/cloudinit/config/cc_reset_rmc.py
+++ b/cloudinit/config/cc_reset_rmc.py
@@ -7,7 +7,6 @@
 
 
 import os
-from logging import Logger
 
 from cloudinit import log as logging
 from cloudinit import subp, util
@@ -65,9 +64,7 @@ LOG = logging.getLogger(__name__)
 NODE_ID_FILE = "/etc/ct_node_id"
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # Ensuring node id has to be generated only once during first boot
     if cloud.datasource.platform_type == "none":
         LOG.debug("Skipping creation of new ct_node_id node")

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -213,12 +213,16 @@ def maybe_get_writable_device_path(devpath, info):
     if not stat.S_ISBLK(statret.st_mode) and not stat.S_ISCHR(statret.st_mode):
         if container:
             LOG.debug(
-                f"device '{devpath}' not a block device in container."
-                f" cannot resize: {info}"
+                "device '%s' not a block device in container."
+                " cannot resize: %s",
+                devpath,
+                info,
             )
         else:
             LOG.warning(
-                f"device '{devpath}' not a block device. cannot resize: {info}"
+                "device '%s' not a block device. cannot resize: %s",
+                devpath,
+                info,
             )
         return None
     return devpath  # The writable block devpath
@@ -255,7 +259,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         resize_what = zpool
 
     info = "dev=%s mnt_point=%s path=%s" % (devpth, mount_point, resize_what)
-    LOG.debug(f"resize_info: {info}")
+    LOG.debug("resize_info: %s", info)
 
     devpth = maybe_get_writable_device_path(devpth, info)
     if not devpth:

--- a/cloudinit/config/cc_resolv_conf.py
+++ b/cloudinit/config/cc_resolv_conf.py
@@ -8,7 +8,6 @@
 
 """Resolv Conf: configure resolv.conf"""
 
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -122,9 +121,7 @@ def generate_resolv_conf(template_fn, params, target_fname):
     templater.render_to_file(template_fn, target_fname, params)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """
     Handler for resolv.conf
 
@@ -135,7 +132,7 @@ def handle(
     @param args: Any module arguments from cloud.cfg
     """
     if "manage_resolv_conf" not in cfg:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s,"
             " no 'manage_resolv_conf' key in configuration",
             name,
@@ -143,7 +140,7 @@ def handle(
         return
 
     if not util.get_cfg_option_bool(cfg, "manage_resolv_conf", False):
-        log.debug(
+        LOG.debug(
             "Skipping module named %s,"
             " 'manage_resolv_conf' present but set to False",
             name,
@@ -151,7 +148,7 @@ def handle(
         return
 
     if "resolv_conf" not in cfg:
-        log.warning("manage_resolv_conf True but no parameters provided!")
+        LOG.warning("manage_resolv_conf True but no parameters provided!")
         return
 
     try:
@@ -159,7 +156,7 @@ def handle(
             RESOLVE_CONFIG_TEMPLATE_MAP[cloud.distro.resolve_conf_fn]
         )
     except KeyError:
-        log.warning("No template found, not rendering resolve configs")
+        LOG.warning("No template found, not rendering resolve configs")
         return
 
     generate_resolv_conf(

--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -5,7 +5,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Red Hat Subscription: Register Red Hat Enterprise Linux based system"""
 
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -80,12 +79,10 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
-    sm = SubscriptionManager(cfg, log=log)
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
+    sm = SubscriptionManager(cfg, log=LOG)
     if not sm.is_configured():
-        log.debug("%s: module not configured.", name)
+        LOG.debug("%s: module not configured.", name)
         return None
 
     if not sm.is_registered():

--- a/cloudinit/config/cc_rightscale_userdata.py
+++ b/cloudinit/config/cc_rightscale_userdata.py
@@ -6,8 +6,8 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import logging
 import os
-from logging import Logger
 from urllib.parse import parse_qs
 
 from cloudinit import url_helper as uhelp
@@ -51,6 +51,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 #
 # The purpose of this script is to allow cloud-init to consume
@@ -70,19 +71,17 @@ __doc__ = get_meta_doc(meta)
 #
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     get_userdata_raw = getattr(cloud, "get_userdata_raw", None)
     if not get_userdata_raw or not callable(get_userdata_raw):
-        log.debug("Failed to get raw userdata in module %s", name)
+        LOG.debug("Failed to get raw userdata in module %s", name)
         return
 
     ud = get_userdata_raw()
     try:
         mdict = parse_qs(ud)
         if not mdict or MY_HOOKNAME not in mdict:
-            log.debug(
+            LOG.debug(
                 "Skipping module %s, did not find %s in parsed raw userdata",
                 name,
                 MY_HOOKNAME,
@@ -90,7 +89,7 @@ def handle(
             return
     except Exception:
         util.logexc(
-            log, "Failed to parse query string %s into a dictionary", ud
+            LOG, "Failed to parse query string %s into a dictionary", ud
         )
         raise
 
@@ -113,18 +112,18 @@ def handle(
         except Exception as e:
             captured_excps.append(e)
             util.logexc(
-                log, "%s failed to read %s and write %s", MY_NAME, url, fname
+                LOG, "%s failed to read %s and write %s", MY_NAME, url, fname
             )
 
     if wrote_fns:
-        log.debug("Wrote out rightscale userdata to %s files", len(wrote_fns))
+        LOG.debug("Wrote out rightscale userdata to %s files", len(wrote_fns))
 
     if len(wrote_fns) != len(urls):
         skipped = len(urls) - len(wrote_fns)
-        log.debug("%s urls were skipped or failed", skipped)
+        LOG.debug("%s urls were skipped or failed", skipped)
 
     if captured_excps:
-        log.warning(
+        LOG.warning(
             "%s failed with exceptions, re-raising the last one",
             len(captured_excps),
         )

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -333,7 +333,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         restarted = reload_syslog(cloud.distro, command=mycfg[KEYNAME_RELOAD])
     except subp.ProcessExecutionError as e:
         restarted = False
-        LOG.warning(f"Failed to reload syslog {str(e)}")
+        LOG.warning("Failed to reload syslog %s", str(e))
 
     if restarted:
         # This only needs to run if we *actually* restarted

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -10,7 +10,6 @@
 
 import os
 import re
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -297,11 +296,9 @@ def remotes_to_rsyslog_cfg(remotes, header=None, footer=None):
     return "\n".join(lines) + "\n"
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if "rsyslog" not in cfg:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, no 'rsyslog' key in configuration", name
         )
         return
@@ -319,7 +316,7 @@ def handle(
         )
 
     if not mycfg["configs"]:
-        log.debug("Empty config rsyslog['configs'], nothing to do")
+        LOG.debug("Empty config rsyslog['configs'], nothing to do")
         return
 
     changes = apply_rsyslog_changes(
@@ -329,14 +326,14 @@ def handle(
     )
 
     if not changes:
-        log.debug("restart of syslog not necessary, no changes made")
+        LOG.debug("restart of syslog not necessary, no changes made")
         return
 
     try:
         restarted = reload_syslog(cloud.distro, command=mycfg[KEYNAME_RELOAD])
     except subp.ProcessExecutionError as e:
         restarted = False
-        log.warning("Failed to reload syslog", e)
+        LOG.warning(f"Failed to reload syslog {str(e)}")
 
     if restarted:
         # This only needs to run if we *actually* restarted
@@ -344,7 +341,7 @@ def handle(
         cloud.cycle_logging()
         # This should now use rsyslog if
         # the logging was setup to use it...
-        log.debug("%s configured %s files", name, changes)
+        LOG.debug("%s configured %s files", name, changes)
 
 
 # vi: ts=4 expandtab syntax=python

--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -8,8 +8,8 @@
 
 """Runcmd: run arbitrary commands at rc.local with output to the console"""
 
+import logging
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import util
@@ -75,12 +75,12 @@ meta: MetaSchema = {
 
 __doc__ = get_meta_doc(meta)
 
+LOG = logging.getLogger(__name__)
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if "runcmd" not in cfg:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, no 'runcmd' key in configuration", name
         )
         return

--- a/cloudinit/config/cc_salt_minion.py
+++ b/cloudinit/config/cc_salt_minion.py
@@ -4,8 +4,8 @@
 
 """Salt Minion: Setup and run salt minion"""
 
+import logging
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import safeyaml, subp, util
@@ -65,6 +65,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 # Note: see https://docs.saltstack.com/en/latest/topics/installation/
 # Note: see https://docs.saltstack.com/en/latest/ref/configuration/
@@ -98,12 +99,10 @@ class SaltConstants:
         )
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # If there isn't a salt key in the configuration don't do anything
     if "salt_minion" not in cfg:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, no 'salt_minion' key in configuration",
             name,
         )

--- a/cloudinit/config/cc_scripts_per_boot.py
+++ b/cloudinit/config/cc_scripts_per_boot.py
@@ -7,8 +7,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Scripts Per Boot: Run per boot scripts"""
 
+import logging
 import os
-from logging import Logger
 
 from cloudinit import subp
 from cloudinit.cloud import Cloud
@@ -37,20 +37,19 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 SCRIPT_SUBDIR = "per-boot"
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # Comes from the following:
     # https://forums.aws.amazon.com/thread.jspa?threadID=96918
     runparts_path = os.path.join(cloud.get_cpath(), "scripts", SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
     except Exception:
-        log.warning(
+        LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,
             SCRIPT_SUBDIR,

--- a/cloudinit/config/cc_scripts_per_instance.py
+++ b/cloudinit/config/cc_scripts_per_instance.py
@@ -7,8 +7,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Scripts Per Instance: Run per instance scripts"""
 
+import logging
 import os
-from logging import Logger
 
 from cloudinit import subp
 from cloudinit.cloud import Cloud
@@ -38,21 +38,19 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
-
+LOG = logging.getLogger(__name__)
 
 SCRIPT_SUBDIR = "per-instance"
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # Comes from the following:
     # https://forums.aws.amazon.com/thread.jspa?threadID=96918
     runparts_path = os.path.join(cloud.get_cpath(), "scripts", SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
     except Exception:
-        log.warning(
+        LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,
             SCRIPT_SUBDIR,

--- a/cloudinit/config/cc_scripts_per_once.py
+++ b/cloudinit/config/cc_scripts_per_once.py
@@ -7,8 +7,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Scripts Per Once: Run one time scripts"""
 
+import logging
 import os
-from logging import Logger
 
 from cloudinit import subp
 from cloudinit.cloud import Cloud
@@ -37,20 +37,19 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 SCRIPT_SUBDIR = "per-once"
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # Comes from the following:
     # https://forums.aws.amazon.com/thread.jspa?threadID=96918
     runparts_path = os.path.join(cloud.get_cpath(), "scripts", SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
     except Exception:
-        log.warning(
+        LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,
             SCRIPT_SUBDIR,

--- a/cloudinit/config/cc_scripts_user.py
+++ b/cloudinit/config/cc_scripts_user.py
@@ -7,8 +7,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Scripts User: Run user scripts"""
 
+import logging
 import os
-from logging import Logger
 
 from cloudinit import subp
 from cloudinit.cloud import Cloud
@@ -38,14 +38,13 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
 SCRIPT_SUBDIR = "scripts"
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # This is written to by the user data handlers
     # Ie, any custom shell scripts that come down
     # go here...
@@ -53,7 +52,7 @@ def handle(
     try:
         subp.runparts(runparts_path)
     except Exception:
-        log.warning(
+        LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,
             SCRIPT_SUBDIR,

--- a/cloudinit/config/cc_scripts_vendor.py
+++ b/cloudinit/config/cc_scripts_vendor.py
@@ -5,8 +5,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Scripts Vendor: Run vendor scripts"""
 
+import logging
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import subp, util
@@ -59,14 +59,13 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
 SCRIPT_SUBDIR = "vendor"
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # This is written to by the vendor data handlers
     # any vendor data shell scripts get placed in runparts_path
     runparts_path = os.path.join(
@@ -78,7 +77,7 @@ def handle(
     try:
         subp.runparts(runparts_path, exe_prefix=prefix)
     except Exception:
-        log.warning(
+        LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,
             SCRIPT_SUBDIR,

--- a/cloudinit/config/cc_seed_random.py
+++ b/cloudinit/config/cc_seed_random.py
@@ -11,7 +11,6 @@
 import base64
 import os
 from io import BytesIO
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -110,9 +109,7 @@ def handle_random_seed_command(command, required, env=None):
     subp.subp(command, env=env, capture=False)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     mycfg = cfg.get("random_seed", {})
     seed_path = mycfg.get("file", "/dev/urandom")
     seed_data = mycfg.get("data", b"")
@@ -129,7 +126,7 @@ def handle(
 
     seed_data = seed_buf.getvalue()
     if len(seed_data):
-        log.debug(
+        LOG.debug(
             "%s: adding %s bytes of random seed entropy to %s",
             name,
             len(seed_data),
@@ -144,7 +141,7 @@ def handle(
         env["RANDOM_SEED_FILE"] = seed_path
         handle_random_seed_command(command=command, required=req, env=env)
     except ValueError as e:
-        log.warning("handling random command [%s] failed: %s", command, e)
+        LOG.warning("handling random command [%s] failed: %s", command, e)
         raise e
 
 

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -8,7 +8,6 @@
 """Set Passwords: Set user passwords and enable/disable SSH password auth"""
 
 import re
-from logging import Logger
 from string import ascii_letters, digits
 from textwrap import dedent
 from typing import List
@@ -172,9 +171,7 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
         _restart_ssh_daemon(distro, service)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     distro: Distro = cloud.distro
     if args:
         # if run from command line, and give args, wipe the chpasswd['list']
@@ -198,7 +195,7 @@ def handle(
                 extra_message="Use 'users' instead.",
             )
             if isinstance(chfg["list"], list):
-                log.debug("Handling input for chpasswd as list.")
+                LOG.debug("Handling input for chpasswd as list.")
                 plist = util.get_cfg_option_list(chfg, "list", plist)
             else:
                 util.deprecate(
@@ -206,7 +203,7 @@ def handle(
                     deprecated_version="22.2",
                     extra_message="Use string type instead.",
                 )
-                log.debug("Handling input for chpasswd as multiline string.")
+                LOG.debug("Handling input for chpasswd as multiline string.")
                 multiline = util.get_cfg_option_str(chfg, "list")
                 if multiline:
                     plist = multiline.splitlines()
@@ -219,7 +216,7 @@ def handle(
         if user:
             plist = ["%s:%s" % (user, password)]
         else:
-            log.warning("No default or defined user to change password for.")
+            LOG.warning("No default or defined user to change password for.")
 
     errors = []
     if plist or users_list:
@@ -259,22 +256,22 @@ def handle(
                 users.append(u)
         if users:
             try:
-                log.debug("Changing password for %s:", users)
+                LOG.debug("Changing password for %s:", users)
                 distro.chpasswd(plist_in, hashed=False)
             except Exception as e:
                 errors.append(e)
                 util.logexc(
-                    log, "Failed to set passwords with chpasswd for %s", users
+                    LOG, "Failed to set passwords with chpasswd for %s", users
                 )
 
         if hashed_users:
             try:
-                log.debug("Setting hashed password for %s:", hashed_users)
+                LOG.debug("Setting hashed password for %s:", hashed_users)
                 distro.chpasswd(hashed_plist_in, hashed=True)
             except Exception as e:
                 errors.append(e)
                 util.logexc(
-                    log,
+                    LOG,
                     "Failed to set hashed passwords with chpasswd for %s",
                     hashed_users,
                 )
@@ -299,14 +296,14 @@ def handle(
                     expired_users.append(u)
                 except Exception as e:
                     errors.append(e)
-                    util.logexc(log, "Failed to set 'expire' for %s", u)
+                    util.logexc(LOG, "Failed to set 'expire' for %s", u)
             if expired_users:
-                log.debug("Expired passwords for: %s users", expired_users)
+                LOG.debug("Expired passwords for: %s users", expired_users)
 
     handle_ssh_pwauth(cfg.get("ssh_pwauth"), distro)
 
     if len(errors):
-        log.debug("%s errors occurred, re-raising the last one", len(errors))
+        LOG.debug("%s errors occurred, re-raising the last one", len(errors))
         raise errors[-1]
 
 

--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -6,7 +6,6 @@
 
 import os
 import sys
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -186,9 +185,7 @@ def run_commands(commands):
         raise RuntimeError(msg)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     cfgin = cfg.get("snap", {})
     if not cfgin:
         LOG.debug(

--- a/cloudinit/config/cc_spacewalk.py
+++ b/cloudinit/config/cc_spacewalk.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Spacewalk: Install and configure spacewalk"""
 
-from logging import Logger
+import logging
 from textwrap import dedent
 
 from cloudinit import subp
@@ -41,6 +41,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
 distros = ["redhat", "fedora"]
@@ -67,15 +68,13 @@ def do_register(
     profile_name,
     ca_cert_path=def_ca_cert_path,
     proxy=None,
-    log=None,
     activation_key=None,
 ):
-    if log is not None:
-        log.info(
-            "Registering using `rhnreg_ks` profile '%s' into server '%s'",
-            profile_name,
-            server,
-        )
+    LOG.info(
+        "Registering using `rhnreg_ks` profile '%s' into server '%s'",
+        profile_name,
+        server,
+    )
     cmd = ["rhnreg_ks"]
     cmd.extend(["--serverUrl", "https://%s/XMLRPC" % server])
     cmd.extend(["--profilename", str(profile_name)])
@@ -88,11 +87,9 @@ def do_register(
     subp.subp(cmd, capture=False)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if "spacewalk" not in cfg:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, no 'spacewalk' key in configuration",
             name,
         )
@@ -107,11 +104,10 @@ def handle(
                 spacewalk_server,
                 cloud.datasource.get_hostname(fqdn=True).hostname,
                 proxy=cfg.get("proxy"),
-                log=log,
                 activation_key=cfg.get("activation_key"),
             )
     else:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, 'spacewalk/server' key"
             " was not found in configuration",
             name,

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -245,7 +245,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
                 with util.SeLinuxGuard("/etc/ssh", recursive=True):
                     subp.subp(cmd, capture=False)
                 LOG.debug(
-                    f"Generated a key for {public_file} from {private_file}"
+                    "Generated a key for %s from %s", public_file, private_file
                 )
             except Exception:
                 util.logexc(

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -8,10 +8,10 @@
 """SSH: Configure SSH and SSH keys"""
 
 import glob
+import logging
 import os
 import re
 import sys
-from logging import Logger
 from textwrap import dedent
 from typing import List, Optional, Sequence
 
@@ -170,6 +170,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 GENERATE_KEY_NAMES = ["rsa", "dsa", "ecdsa", "ed25519"]
 pattern_unsupported_config_keys = re.compile(
@@ -196,9 +197,7 @@ for k in GENERATE_KEY_NAMES:
 KEY_GEN_TPL = 'o=$(ssh-keygen -yf "%s") && echo "$o" root@localhost > "%s"'
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     # remove the static keys from the pristine image
     if cfg.get("ssh_deletekeys", True):
@@ -207,7 +206,7 @@ def handle(
             try:
                 util.del_file(f)
             except Exception:
-                util.logexc(log, "Failed deleting key file %s", f)
+                util.logexc(LOG, "Failed deleting key file %s", f)
 
     if "ssh_keys" in cfg:
         # if there are keys and/or certificates in cloud-config, use them
@@ -218,7 +217,7 @@ def handle(
                     reason = "unsupported"
                 else:
                     reason = "unrecognized"
-                log.warning('Skipping %s ssh_keys entry: "%s"', reason, key)
+                LOG.warning('Skipping %s ssh_keys entry: "%s"', reason, key)
                 continue
             tgt_fn = CONFIG_KEY_TO_FILE[key][0]
             tgt_perms = CONFIG_KEY_TO_FILE[key][1]
@@ -245,12 +244,12 @@ def handle(
                 # TODO(harlowja): Is this guard needed?
                 with util.SeLinuxGuard("/etc/ssh", recursive=True):
                     subp.subp(cmd, capture=False)
-                log.debug(
+                LOG.debug(
                     f"Generated a key for {public_file} from {private_file}"
                 )
             except Exception:
                 util.logexc(
-                    log,
+                    LOG,
                     "Failed generating a key for "
                     f"{public_file} from {private_file}",
                 )
@@ -288,10 +287,10 @@ def handle(
                     if e.exit_code == 1 and err.lower().startswith(
                         "unknown key"
                     ):
-                        log.debug("ssh-keygen: unknown key type '%s'", keytype)
+                        LOG.debug("ssh-keygen: unknown key type '%s'", keytype)
                     else:
                         util.logexc(
-                            log,
+                            LOG,
                             "Failed generating key type %s to file %s",
                             keytype,
                             keyfile,
@@ -315,7 +314,7 @@ def handle(
         try:
             cloud.datasource.publish_host_keys(hostkeys)
         except Exception:
-            util.logexc(log, "Publishing host keys failed!")
+            util.logexc(LOG, "Publishing host keys failed!")
 
     try:
         (users, _groups) = ug_util.normalize_users_groups(cfg, cloud.distro)
@@ -329,7 +328,7 @@ def handle(
         if util.get_cfg_option_bool(cfg, "allow_public_ssh_keys", True):
             keys = cloud.get_public_ssh_keys() or []
         else:
-            log.debug(
+            LOG.debug(
                 "Skipping import of publish SSH keys per "
                 "config setting: allow_public_ssh_keys=False"
             )
@@ -340,7 +339,7 @@ def handle(
 
         apply_credentials(keys, user, disable_root, disable_root_opts)
     except Exception:
-        util.logexc(log, "Applying SSH credentials failed!")
+        util.logexc(LOG, "Applying SSH credentials failed!")
 
 
 def apply_credentials(keys, user, disable_root, disable_root_opts):

--- a/cloudinit/config/cc_ssh_authkey_fingerprints.py
+++ b/cloudinit/config/cc_ssh_authkey_fingerprints.py
@@ -7,7 +7,7 @@
 
 import base64
 import hashlib
-from logging import Logger
+import logging
 
 from cloudinit import ssh_util, util
 from cloudinit.cloud import Cloud
@@ -38,6 +38,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
 def _split_hash(bin_hash):
@@ -115,11 +116,9 @@ def _pprint_key_entries(
         )
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if util.is_true(cfg.get("no_ssh_fingerprints", False)):
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, logging of SSH fingerprints disabled",
             name,
         )
@@ -129,7 +128,7 @@ def handle(
     (users, _groups) = ug_util.normalize_users_groups(cfg, cloud.distro)
     for (user_name, _cfg) in users.items():
         if _cfg.get("no_create_home") or _cfg.get("system"):
-            log.debug(
+            LOG.debug(
                 "Skipping printing of ssh fingerprints for user '%s' because "
                 "no home directory is created",
                 user_name,

--- a/cloudinit/config/cc_timezone.py
+++ b/cloudinit/config/cc_timezone.py
@@ -7,7 +7,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """Timezone: Set the system timezone"""
 
-from logging import Logger
+import logging
 
 from cloudinit import util
 from cloudinit.cloud import Cloud
@@ -34,18 +34,17 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if len(args) != 0:
         timezone = args[0]
     else:
         timezone = util.get_cfg_option_str(cfg, "timezone", False)
 
     if not timezone:
-        log.debug("Skipping module named %s, no 'timezone' specified", name)
+        LOG.debug("Skipping module named %s, no 'timezone' specified", name)
         return
 
     # Let the distro handle settings its timezone

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -4,7 +4,6 @@
 
 import json
 import re
-from logging import Logger
 from textwrap import dedent
 from typing import Any, List
 from urllib.parse import urlparse
@@ -464,9 +463,7 @@ def _auto_attach(ua_section: dict):
         raise RuntimeError(msg) from ex
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     ua_section = None
     if "ubuntu-advantage" in cfg:
         LOG.warning(

--- a/cloudinit/config/cc_ubuntu_autoinstall.py
+++ b/cloudinit/config/cc_ubuntu_autoinstall.py
@@ -3,7 +3,6 @@
 """Autoinstall: Support ubuntu live-server autoinstall syntax."""
 
 import re
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -75,9 +74,7 @@ __doc__ = get_meta_doc(meta)
 LIVE_INSTALLER_SNAPS = ("subiquity", "ubuntu-desktop-installer")
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     if "autoinstall" not in cfg:
         LOG.debug(

--- a/cloudinit/config/cc_ubuntu_drivers.py
+++ b/cloudinit/config/cc_ubuntu_drivers.py
@@ -16,7 +16,6 @@ except ImportError:
     debconf = None
     HAS_DEBCONF = False
 
-from logging import Logger
 
 from cloudinit import log as logging
 from cloudinit import subp, temp_utils, type_utils, util
@@ -140,14 +139,12 @@ def install_drivers(cfg, pkg_install_func, distro: Distro):
         raise
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if "drivers" not in cfg:
-        log.debug("Skipping module named %s, no 'drivers' key in config", name)
+        LOG.debug("Skipping module named %s, no 'drivers' key in config", name)
         return
     if not HAS_DEBCONF:
-        log.warning(
+        LOG.warning(
             "Skipping module named %s, 'python3-debconf' is not installed",
             name,
         )

--- a/cloudinit/config/cc_update_etc_hosts.py
+++ b/cloudinit/config/cc_update_etc_hosts.py
@@ -8,7 +8,7 @@
 
 """Update Etc Hosts: Update the hosts file (usually ``/etc/hosts``)"""
 
-from logging import Logger
+import logging
 from textwrap import dedent
 
 from cloudinit import templater, util
@@ -95,11 +95,10 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     manage_hosts = util.get_cfg_option_str(cfg, "manage_etc_hosts", False)
 
     hosts_fn = cloud.distro.hosts_fn
@@ -113,7 +112,7 @@ def handle(
             )
         (hostname, fqdn, _) = util.get_hostname_fqdn(cfg, cloud)
         if not hostname:
-            log.warning(
+            LOG.warning(
                 "Option 'manage_etc_hosts' was set, but no hostname was found"
             )
             return
@@ -135,15 +134,15 @@ def handle(
     elif manage_hosts == "localhost":
         (hostname, fqdn, _) = util.get_hostname_fqdn(cfg, cloud)
         if not hostname:
-            log.warning(
+            LOG.warning(
                 "Option 'manage_etc_hosts' was set, but no hostname was found"
             )
             return
 
-        log.debug("Managing localhost in %s", hosts_fn)
+        LOG.debug("Managing localhost in %s", hosts_fn)
         cloud.distro.update_etc_hosts(hostname, fqdn)
     else:
-        log.debug(
+        LOG.debug(
             "Configuration option 'manage_etc_hosts' is not set,"
             " not managing %s in module %s",
             hosts_fn,

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -8,8 +8,8 @@
 
 """Update Hostname: Update hostname and fqdn"""
 
+import logging
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import util
@@ -80,13 +80,12 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if util.get_cfg_option_bool(cfg, "preserve_hostname", False):
-        log.debug(
+        LOG.debug(
             "Configuration option 'preserve_hostname' is set,"
             " not updating the hostname in module %s",
             name,
@@ -103,16 +102,16 @@ def handle(
     (hostname, fqdn, is_default) = util.get_hostname_fqdn(cfg, cloud)
     if is_default and hostname == "localhost":
         # https://github.com/systemd/systemd/commit/d39079fcaa05e23540d2b1f0270fa31c22a7e9f1
-        log.debug("Hostname is localhost. Let other services handle this.")
+        LOG.debug("Hostname is localhost. Let other services handle this.")
         return
 
     try:
         prev_fn = os.path.join(cloud.get_cpath("data"), "previous-hostname")
-        log.debug("Updating hostname to %s (%s)", fqdn, hostname)
+        LOG.debug("Updating hostname to %s (%s)", fqdn, hostname)
         cloud.distro.update_hostname(hostname, fqdn, prev_fn)
     except Exception:
         util.logexc(
-            log, "Failed to update the hostname to %s (%s)", fqdn, hostname
+            LOG, "Failed to update the hostname to %s (%s)", fqdn, hostname
         )
         raise
 

--- a/cloudinit/config/cc_users_groups.py
+++ b/cloudinit/config/cc_users_groups.py
@@ -6,7 +6,6 @@
 
 "Users and Groups: Configure users and groups"
 
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -161,9 +160,7 @@ NO_HOME = ("no_create_home", "system")
 NEED_HOME = ("ssh_authorized_keys", "ssh_import_id", "ssh_redirect_user")
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     (users, groups) = ug_util.normalize_users_groups(cfg, cloud.distro)
     (default_user, _user_config) = ug_util.extract_default(users)
     cloud_keys = cloud.get_public_ssh_keys() or []

--- a/cloudinit/config/cc_wireguard.py
+++ b/cloudinit/config/cc_wireguard.py
@@ -4,7 +4,6 @@
 
 """Wireguard"""
 import re
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -258,9 +257,7 @@ def load_wireguard_kernel_module():
         raise
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     wg_section = None
 
     if "wireguard" in cfg:

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -8,7 +8,6 @@
 
 import base64
 import os
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import log as logging
@@ -119,9 +118,7 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     file_list = cfg.get("write_files", [])
     filtered_files = [
         f
@@ -129,7 +126,7 @@ def handle(
         if not util.get_cfg_option_bool(f, "defer", DEFAULT_DEFER)
     ]
     if not filtered_files:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s,"
             " no/empty 'write_files' key in configuration",
             name,

--- a/cloudinit/config/cc_write_files_deferred.py
+++ b/cloudinit/config/cc_write_files_deferred.py
@@ -4,7 +4,7 @@
 
 """Write Files Deferred: Defer writing certain files"""
 
-from logging import Logger
+import logging
 
 from cloudinit import util
 from cloudinit.cloud import Cloud
@@ -36,11 +36,10 @@ meta: MetaSchema = {
 
 # This module is undocumented in our schema docs
 __doc__ = ""
+LOG = logging.getLogger(__name__)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     file_list = cfg.get("write_files", [])
     filtered_files = [
         f
@@ -48,7 +47,7 @@ def handle(
         if util.get_cfg_option_bool(f, "defer", DEFAULT_DEFER)
     ]
     if not filtered_files:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s,"
             " no deferred file defined in configuration",
             name,

--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -7,9 +7,9 @@
 "Yum Add Repo: Add yum repository configuration to the system"
 
 import io
+import logging
 import os
 from configparser import ConfigParser
-from logging import Logger
 from textwrap import dedent
 
 from cloudinit import util
@@ -123,6 +123,7 @@ meta: MetaSchema = {
 }
 
 __doc__ = get_meta_doc(meta)
+LOG = logging.getLogger(__name__)
 
 
 def _canonicalize_id(repo_id: str) -> str:
@@ -169,12 +170,10 @@ def _format_repository_config(repo_id, repo_config):
     return "".join(lines)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     repos = cfg.get("yum_repos")
     if not repos:
-        log.debug(
+        LOG.debug(
             "Skipping module named %s, no 'yum_repos' configuration found",
             name,
         )
@@ -188,14 +187,14 @@ def handle(
         canon_repo_id = _canonicalize_id(repo_id)
         repo_fn_pth = os.path.join(repo_base_path, "%s.repo" % (canon_repo_id))
         if os.path.exists(repo_fn_pth):
-            log.info(
+            LOG.info(
                 "Skipping repo %s, file %s already exists!",
                 repo_id,
                 repo_fn_pth,
             )
             continue
         elif canon_repo_id in repo_locations:
-            log.info(
+            LOG.info(
                 "Skipping repo %s, file %s already pending!",
                 repo_id,
                 repo_fn_pth,
@@ -213,7 +212,7 @@ def handle(
         missing_required = 0
         for req_field in ["baseurl"]:
             if req_field not in repo_config:
-                log.warning(
+                LOG.warning(
                     "Repository %s does not contain a %s"
                     " configuration 'required' entry",
                     repo_id,
@@ -224,7 +223,7 @@ def handle(
             repo_configs[canon_repo_id] = repo_config
             repo_locations[canon_repo_id] = repo_fn_pth
         else:
-            log.warning(
+            LOG.warning(
                 "Repository %s is missing %s required fields, skipping!",
                 repo_id,
                 missing_required,

--- a/cloudinit/config/cc_zypper_add_repo.py
+++ b/cloudinit/config/cc_zypper_add_repo.py
@@ -6,7 +6,6 @@
 """zypper_add_repo: Add zypper repositories to the system"""
 
 import os
-from logging import Logger
 from textwrap import dedent
 
 import configobj
@@ -190,9 +189,7 @@ def _write_zypp_config(zypper_config):
     util.write_file(zypp_config, new_config)
 
 
-def handle(
-    name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
-) -> None:
+def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     zypper_section = cfg.get("zypper")
     if not zypper_section:
         LOG.debug(

--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -222,7 +222,7 @@ class Modules:
         # and which ones failed + the exception of why it failed
         failures = []
         which_ran = []
-        for (mod, name, freq, args) in mostly_mods:
+        for mod, name, freq, args in mostly_mods:
             try:
                 LOG.debug(
                     "Running module %s (%s) with frequency %s", name, mod, freq
@@ -248,9 +248,9 @@ class Modules:
                     func_signature = signature(mod.handle)
                     func_params = func_signature.parameters
                     if len(func_params) == 5:
-                        LOG.warning(
-                            "DEPRECATED: The use of modules with a `log` "
-                            "parameter is depecrated"
+                        util.deprecate(
+                            deprecated="Config modules with a `log` parameter",
+                            deprecated_version="23.2",
                         )
                         func_args.update({"log": LOG})
                     ran, _r = cc.run(

--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -7,6 +7,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import copy
+from inspect import signature
 from types import ModuleType
 from typing import Dict, List, NamedTuple, Optional
 
@@ -227,7 +228,6 @@ class Modules:
                     "Running module %s (%s) with frequency %s", name, mod, freq
                 )
 
-                func_args = [name, self.cfg, cc, args]
                 # Mark it as having started running
                 which_ran.append(name)
                 # This name will affect the semaphore name created
@@ -237,8 +237,18 @@ class Modules:
                 myrep = ReportEventStack(
                     name=run_name, description=desc, parent=self.reporter
                 )
+                func_args = {
+                    "name": name,
+                    "cfg": self.cfg,
+                    "cloud": cc,
+                    "args": args,
+                }
 
                 with myrep:
+                    func_signature = signature(mod.handle)
+                    func_params = func_signature.parameters
+                    if len(func_params) == 5:
+                        func_args.update({"log": LOG})
                     ran, _r = cc.run(
                         run_name, mod.handle, func_args, freq=freq
                     )

--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -227,11 +227,7 @@ class Modules:
                     "Running module %s (%s) with frequency %s", name, mod, freq
                 )
 
-                # Use the configs logger and not our own
-                # TODO(harlowja): possibly check the module
-                # for having a LOG attr and just give it back
-                # its own logger?
-                func_args = [name, self.cfg, cc, LOG, args]
+                func_args = [name, self.cfg, cc, args]
                 # Mark it as having started running
                 which_ran.append(name)
                 # This name will affect the semaphore name created

--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -248,6 +248,10 @@ class Modules:
                     func_signature = signature(mod.handle)
                     func_params = func_signature.parameters
                     if len(func_params) == 5:
+                        LOG.warning(
+                            "DEPRECATED: The use of modules with a `log` "
+                            "parameter is depecrated"
+                        )
                         func_args.update({"log": LOG})
                     ran, _r = cc.run(
                         run_name, mod.handle, func_args, freq=freq

--- a/doc/rtd/development/module_creation.rst
+++ b/doc/rtd/development/module_creation.rst
@@ -15,8 +15,7 @@ Example
     # This file is part of cloud-init. See LICENSE file for license information.
     """Example Module: Shows how to create a module"""
 
-    from logging import Logger
-
+    import logging
     from cloudinit.cloud import Cloud
     from cloudinit.config import Config
     from cloudinit.config.schema import MetaSchema, get_meta_doc
@@ -28,6 +27,8 @@ Example
 
     This will likely take multiple lines.
     """
+
+    LOG = logging.getLogger(__name__)
 
     meta: MetaSchema = {
         "id": "cc_example",
@@ -47,9 +48,9 @@ Example
 
 
     def handle(
-        name: str, cfg: Config, cloud: Cloud, log: Logger, args: list
+        name: str, cfg: Config, cloud: Cloud, args: list
     ) -> None:
-        log.debug(f"Hi from module {name}")
+        LOG.debug(f"Hi from module {name}")
 
 .. _module_creation-Guidelines:
 
@@ -66,7 +67,6 @@ Guidelines
   * ``cloud``: A cloud object that can be used to access various datasource
     and paths for the given distro and data provided by the various datasource
     instance types.
-  * ``log``: A logger object that can be used to log messages.
   * ``args``: An argument list. This is usually empty and is only populated
     if the module is called independently from the command line or if the
     module definition in :file:`/etc/cloud/cloud.cfg[.d]` has been modified

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -112,7 +112,7 @@ class TestMain(FilesystemMockingTestCase):
             subcommand="init",
         )
 
-        def set_hostname(name, cfg, cloud, log, args):
+        def set_hostname(name, cfg, cloud, args):
             self.assertEqual("set-hostname", name)
             updated_cfg = copy.deepcopy(self.cfg)
             updated_cfg.update(
@@ -132,7 +132,6 @@ class TestMain(FilesystemMockingTestCase):
             updated_cfg.pop("system_info")
 
             self.assertEqual(updated_cfg, cfg)
-            self.assertEqual(main.LOG, log)
             self.assertIsNone(args)
 
         (_item1, item2) = wrap_and_call(

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -3,7 +3,6 @@
 """ test_handler_apt_configure_sources_list
 Test templating of sources list
 """
-import logging
 import os
 import shutil
 import tempfile
@@ -14,8 +13,6 @@ from cloudinit.config import cc_apt_configure
 from cloudinit.distros.debian import Distro
 from tests.unittests import helpers as t_help
 from tests.unittests.util import get_cloud
-
-LOG = logging.getLogger(__name__)
 
 YAML_TEXT_CUSTOM_SL = """
 apt_mirror: http://archive.ubuntu.com/ubuntu/
@@ -97,9 +94,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
                         templater, "render_string", return_value="fake"
                     ) as mockrnd:
                         with mock.patch.object(util, "rename"):
-                            cc_apt_configure.handle(
-                                "test", cfg, mycloud, LOG, None
-                            )
+                            cc_apt_configure.handle("test", cfg, mycloud, None)
 
         mockisfile.assert_any_call(
             "/etc/cloud/templates/sources.list.%s.tmpl" % distro
@@ -182,9 +177,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
-                    cc_apt_configure.handle(
-                        "notimportant", cfg, mycloud, LOG, None
-                    )
+                    cc_apt_configure.handle("notimportant", cfg, mycloud, None)
 
         mockwrite.assert_called_once_with(
             "/etc/apt/sources.list", EXPECTED_CONVERTED_CONTENT, mode=420

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -3,7 +3,6 @@
 """ test_apt_custom_sources_list
 Test templating of custom sources list
 """
-import logging
 import os
 import shutil
 import tempfile
@@ -16,8 +15,6 @@ from cloudinit.config import cc_apt_configure
 from cloudinit.distros.debian import Distro
 from tests.unittests import helpers as t_help
 from tests.unittests.util import get_cloud
-
-LOG = logging.getLogger(__name__)
 
 TARGET = "/"
 
@@ -129,7 +126,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             mock_shouldcfg = stack.enter_context(
                 mock.patch(cfg_func, return_value=(cfg_on_empty, "test"))
             )
-            cc_apt_configure.handle("test", cfg, mycloud, LOG, None)
+            cc_apt_configure.handle("test", cfg, mycloud, None)
 
             return mock_writefile, mock_loadfile, mock_isfile, mock_shouldcfg
 
@@ -185,7 +182,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             with mock.patch.object(
                 util, "system_is_snappy", return_value=True
             ) as mock_issnappy:
-                cc_apt_configure.handle("test", cfg, mycloud, LOG, None)
+                cc_apt_configure.handle("test", cfg, mycloud, None)
 
         self.assertEqual(0, mock_writefile.call_count)
         self.assertEqual(1, mock_issnappy.call_count)
@@ -233,9 +230,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
-                    cc_apt_configure.handle(
-                        "notimportant", cfg, mycloud, LOG, None
-                    )
+                    cc_apt_configure.handle("notimportant", cfg, mycloud, None)
 
         calls = [
             call(

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -111,7 +111,7 @@ class TestAptSourceConfig(TestCase):
         """
         cfg = self.wrapv1conf(cfg)
 
-        cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+        cc_apt_configure.handle("test", cfg, self.cloud, None)
 
         self.assertTrue(os.path.isfile(filename))
 
@@ -266,7 +266,7 @@ class TestAptSourceConfig(TestCase):
         """
         cfg = self.wrapv1conf(cfg)
         params = self._get_default_params()
-        cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+        cc_apt_configure.handle("test", cfg, self.cloud, None)
 
         self.assertTrue(os.path.isfile(filename))
 
@@ -357,7 +357,7 @@ class TestAptSourceConfig(TestCase):
         cfg = self.wrapv1conf(cfg)
 
         with mock.patch.object(cc_apt_configure, "add_apt_key") as mockobj:
-            cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+            cc_apt_configure.handle("test", cfg, self.cloud, None)
 
         # check if it added the right number of keys
         calls = []
@@ -483,7 +483,7 @@ class TestAptSourceConfig(TestCase):
         cfg = self.wrapv1conf([cfg])
 
         with mock.patch.object(cc_apt_configure, "add_apt_key") as mockobj:
-            cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+            cc_apt_configure.handle("test", cfg, self.cloud, None)
 
         # check if it added the right amount of keys
         sources = cfg["apt"]["sources"]
@@ -544,7 +544,7 @@ class TestAptSourceConfig(TestCase):
         cfg = {"key": "fakekey 4242", "filename": self.aptlistfile}
         cfg = self.wrapv1conf([cfg])
         with mock.patch.object(cc_apt_configure, "apt_key") as mockobj:
-            cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+            cc_apt_configure.handle("test", cfg, self.cloud, None)
 
         calls = (
             call(
@@ -568,7 +568,7 @@ class TestAptSourceConfig(TestCase):
             subp, "subp", return_value=("fakekey 1212", "")
         ):
             with mock.patch.object(cc_apt_configure, "apt_key") as mockobj:
-                cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+                cc_apt_configure.handle("test", cfg, self.cloud, None)
 
         calls = (
             call(
@@ -597,7 +597,7 @@ class TestAptSourceConfig(TestCase):
             with mock.patch.object(
                 gpg, "getkeybyid", return_value=expectedkey
             ) as mockgetkey:
-                cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+                cc_apt_configure.handle("test", cfg, self.cloud, None)
         if is_hardened is not None:
             mockkey.assert_called_with(
                 expectedkey, self.aptlistfile, hardened=is_hardened
@@ -643,7 +643,7 @@ class TestAptSourceConfig(TestCase):
         cfg = self.wrapv1conf([cfg])
 
         with mock.patch.object(subp, "subp") as mockobj:
-            cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+            cc_apt_configure.handle("test", cfg, self.cloud, None)
         mockobj.assert_called_once_with(
             [
                 "add-apt-repository",
@@ -673,7 +673,7 @@ class TestAptSourceConfig(TestCase):
         cfg = self.wrapv1conf([cfg1, cfg2, cfg3])
 
         with mock.patch.object(subp, "subp") as mockobj:
-            cc_apt_configure.handle("test", cfg, self.cloud, None, None)
+            cc_apt_configure.handle("test", cfg, self.cloud, None)
         calls = [
             call(
                 [

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -301,12 +301,12 @@ class TestAnsible:
         mocker.patch.dict(M_PATH + "os.environ", clear=True)
         if exception:
             with raises(exception):
-                cc_ansible.handle("", cfg, get_cloud(), None, None)
+                cc_ansible.handle("", cfg, get_cloud(), None)
         else:
             cloud = get_cloud(mocked_distro=True)
             cloud.distro.pip_package_name = "python3-pip"
             install = cfg["ansible"]["install_method"]
-            cc_ansible.handle("", cfg, cloud, None, None)
+            cc_ansible.handle("", cfg, cloud, None)
             if install == "distro":
                 cloud.distro.install_packages.assert_called_once()
                 cloud.distro.install_packages.assert_called_with(
@@ -404,7 +404,7 @@ class TestAnsible:
     @mock.patch(M_PATH + "validate_config")
     def test_do_not_run(self, m_validate):
         """verify that if ansible key not included, don't do anything"""
-        cc_ansible.handle("", {}, get_cloud(), None, None)  # pyright: ignore
+        cc_ansible.handle("", {}, get_cloud(), None)  # pyright: ignore
         assert not m_validate.called
 
     @mock.patch(
@@ -429,7 +429,7 @@ class TestAnsible:
     @mock.patch(M_PATH + "subp", return_value=("stdout", "stderr"))
     @mock.patch(M_PATH + "which", return_value=True)
     def test_ansible_env_var(self, m_which, m_subp):
-        cc_ansible.handle("", CFG_FULL_PULL, get_cloud(), mock.Mock(), [])
+        cc_ansible.handle("", CFG_FULL_PULL, get_cloud(), [])
 
         # python 3.8 required for Mock.call_args.kwargs dict attribute
         if isinstance(m_subp.call_args.kwargs, dict):

--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -4,7 +4,6 @@
 Test creation of repositories file
 """
 
-import logging
 import os
 import re
 import textwrap
@@ -35,7 +34,6 @@ class TestNoConfig(FilesystemMockingTestCase):
         self.add_patch(CC_APK + "._write_repositories_file", "m_write_repos")
         self.name = "apk-configure"
         self.cloud_init = None
-        self.log = logging.getLogger("TestNoConfig")
         self.args = []
 
     def test_no_config(self):
@@ -45,9 +43,7 @@ class TestNoConfig(FilesystemMockingTestCase):
         """
         config = util.get_builtin_cfg()
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud_init, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud_init, self.args)
 
         self.assertEqual(0, self.m_write_repos.call_count)
 
@@ -62,7 +58,6 @@ class TestConfig(FilesystemMockingTestCase):
         self.paths = helpers.Paths({"templates_dir": self.new_root})
         self.name = "apk-configure"
         self.cloud = cloud.Cloud(None, self.paths, None, None, None)
-        self.log = logging.getLogger("TestNoConfig")
         self.args = []
 
     @mock.patch(CC_APK + "._write_repositories_file")
@@ -73,9 +68,7 @@ class TestConfig(FilesystemMockingTestCase):
         """
         config = {"apk_repos": {}}
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud, self.args)
 
         self.assertEqual(0, m_write_repos.call_count)
 
@@ -86,9 +79,7 @@ class TestConfig(FilesystemMockingTestCase):
         """
         config = {"apk_repos": {"alpine_repo": []}}
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud, self.args)
 
         self.assertEqual(0, m_write_repos.call_count)
 
@@ -99,9 +90,7 @@ class TestConfig(FilesystemMockingTestCase):
         alpine_version = "v3.12"
         config = {"apk_repos": {"alpine_repo": {"version": alpine_version}}}
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud, self.args)
 
         expected_content = textwrap.dedent(
             """\
@@ -135,9 +124,7 @@ class TestConfig(FilesystemMockingTestCase):
             }
         }
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud, self.args)
 
         expected_content = textwrap.dedent(
             """\
@@ -173,9 +160,7 @@ class TestConfig(FilesystemMockingTestCase):
             }
         }
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud, self.args)
 
         expected_content = textwrap.dedent(
             """\
@@ -215,9 +200,7 @@ class TestConfig(FilesystemMockingTestCase):
             }
         }
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud, self.args)
 
         expected_content = textwrap.dedent(
             """\
@@ -256,9 +239,7 @@ class TestConfig(FilesystemMockingTestCase):
             }
         }
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud, self.args)
 
         expected_content = textwrap.dedent(
             """\
@@ -305,9 +286,7 @@ class TestConfig(FilesystemMockingTestCase):
             }
         }
 
-        cc_apk_configure.handle(
-            self.name, config, self.cloud, self.log, self.args
-        )
+        cc_apk_configure.handle(self.name, config, self.cloud, self.args)
 
         expected_content = textwrap.dedent(
             """\

--- a/tests/unittests/config/test_cc_apt_pipelining.py
+++ b/tests/unittests/config/test_cc_apt_pipelining.py
@@ -17,14 +17,14 @@ class TestAptPipelining:
     @mock.patch("cloudinit.config.cc_apt_pipelining.util.write_file")
     def test_not_disabled_by_default(self, m_write_file):
         """ensure that default behaviour is to not disable pipelining"""
-        cc_apt_pipelining.handle("foo", {}, None, mock.MagicMock(), None)
+        cc_apt_pipelining.handle("foo", {}, None, None)
         assert 0 == m_write_file.call_count
 
     @mock.patch("cloudinit.config.cc_apt_pipelining.util.write_file")
     def test_false_disables_pipelining(self, m_write_file):
         """ensure that pipelining can be disabled with correct config"""
         cc_apt_pipelining.handle(
-            "foo", {"apt_pipelining": "false"}, None, mock.MagicMock(), None
+            "foo", {"apt_pipelining": "false"}, None, None
         )
         assert 1 == m_write_file.call_count
         args, _ = m_write_file.call_args

--- a/tests/unittests/config/test_cc_bootcmd.py
+++ b/tests/unittests/config/test_cc_bootcmd.py
@@ -1,5 +1,4 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-import logging
 import re
 import tempfile
 
@@ -14,8 +13,6 @@ from cloudinit.config.schema import (
 )
 from tests.unittests.helpers import CiTestCase, mock, skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
-
-LOG = logging.getLogger(__name__)
 
 
 class FakeExtendedTempFile:
@@ -50,7 +47,7 @@ class TestBootcmd(CiTestCase):
         """When the provided config doesn't contain bootcmd, skip it."""
         cfg = {}
         mycloud = get_cloud()
-        handle("notimportant", cfg, mycloud, LOG, None)
+        handle("notimportant", cfg, mycloud, None)
         self.assertIn(
             "Skipping module named notimportant, no 'bootcmd' key",
             self.logs.getvalue(),
@@ -61,7 +58,7 @@ class TestBootcmd(CiTestCase):
         invalid_config = {"bootcmd": 1}
         cc = get_cloud()
         with self.assertRaises(TypeError) as context_manager:
-            handle("cc_bootcmd", invalid_config, cc, LOG, [])
+            handle("cc_bootcmd", invalid_config, cc, [])
         self.assertIn("Failed to shellify bootcmd", self.logs.getvalue())
         self.assertEqual(
             "Input to shellify was type 'int'. Expected list or tuple.",
@@ -73,7 +70,7 @@ class TestBootcmd(CiTestCase):
         }
         cc = get_cloud()
         with self.assertRaises(TypeError) as context_manager:
-            handle("cc_bootcmd", invalid_config, cc, LOG, [])
+            handle("cc_bootcmd", invalid_config, cc, [])
         logs = self.logs.getvalue()
         self.assertIn("Failed to shellify", logs)
         self.assertEqual(
@@ -93,7 +90,7 @@ class TestBootcmd(CiTestCase):
 
         with mock.patch(self._etmpfile_path, FakeExtendedTempFile):
             with self.allow_subp(["/bin/sh"]):
-                handle("cc_bootcmd", valid_config, cc, LOG, [])
+                handle("cc_bootcmd", valid_config, cc, [])
         self.assertEqual(
             my_id + " iid-datasource-none\n", util.load_file(out_file)
         )
@@ -106,7 +103,7 @@ class TestBootcmd(CiTestCase):
         with mock.patch(self._etmpfile_path, FakeExtendedTempFile):
             with self.allow_subp(["/bin/sh"]):
                 with self.assertRaises(subp.ProcessExecutionError) as ctxt:
-                    handle("does-not-matter", valid_config, cc, LOG, [])
+                    handle("does-not-matter", valid_config, cc, [])
         self.assertIn(
             "Unexpected error while running command.\nCommand: ['/bin/sh',",
             str(ctxt.exception),

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -1,5 +1,4 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-import logging
 import re
 import shutil
 import tempfile
@@ -27,7 +26,6 @@ class TestNoConfig(unittest.TestCase):
         super(TestNoConfig, self).setUp()
         self.name = "ca-certs"
         self.cloud_init = None
-        self.log = logging.getLogger("TestNoConfig")
         self.args = []
 
     def test_no_config(self):
@@ -43,9 +41,7 @@ class TestNoConfig(unittest.TestCase):
                 mock.patch.object(cc_ca_certs, "update_ca_certs")
             )
 
-            cc_ca_certs.handle(
-                self.name, config, self.cloud_init, self.log, self.args
-            )
+            cc_ca_certs.handle(self.name, config, self.cloud_init, self.args)
 
             self.assertEqual(util_mock.call_count, 0)
             self.assertEqual(certs_mock.call_count, 0)
@@ -56,7 +52,6 @@ class TestConfig(TestCase):
         super(TestConfig, self).setUp()
         self.name = "ca-certs"
         self.paths = None
-        self.log = logging.getLogger("TestNoConfig")
         self.args = []
 
     def _fetch_distro(self, kind):
@@ -93,7 +88,7 @@ class TestConfig(TestCase):
         for distro_name in cc_ca_certs.distros:
             self._mock_init()
             cloud = get_cloud(distro_name)
-            cc_ca_certs.handle(self.name, config, cloud, self.log, self.args)
+            cc_ca_certs.handle(self.name, config, cloud, self.args)
 
             self.assertEqual(self.mock_add.call_count, 0)
             self.assertEqual(self.mock_update.call_count, 1)
@@ -110,7 +105,7 @@ class TestConfig(TestCase):
         for distro_name in cc_ca_certs.distros:
             self._mock_init()
             cloud = get_cloud(distro_name)
-            cc_ca_certs.handle(self.name, config, cloud, self.log, self.args)
+            cc_ca_certs.handle(self.name, config, cloud, self.args)
 
             self.assertEqual(self.mock_add.call_count, 0)
             self.assertEqual(self.mock_update.call_count, 1)
@@ -128,7 +123,7 @@ class TestConfig(TestCase):
             self._mock_init()
             cloud = get_cloud(distro_name)
             conf = cc_ca_certs._distro_ca_certs_configs(distro_name)
-            cc_ca_certs.handle(self.name, config, cloud, self.log, self.args)
+            cc_ca_certs.handle(self.name, config, cloud, self.args)
 
             self.mock_add.assert_called_once_with(conf, ["CERT1"])
             self.assertEqual(self.mock_update.call_count, 1)
@@ -146,7 +141,7 @@ class TestConfig(TestCase):
             self._mock_init()
             cloud = get_cloud(distro_name)
             conf = cc_ca_certs._distro_ca_certs_configs(distro_name)
-            cc_ca_certs.handle(self.name, config, cloud, self.log, self.args)
+            cc_ca_certs.handle(self.name, config, cloud, self.args)
 
             self.mock_add.assert_called_once_with(conf, ["CERT1", "CERT2"])
             self.assertEqual(self.mock_update.call_count, 1)
@@ -163,7 +158,7 @@ class TestConfig(TestCase):
         for distro_name in cc_ca_certs.distros:
             self._mock_init()
             cloud = get_cloud(distro_name)
-            cc_ca_certs.handle(self.name, config, cloud, self.log, self.args)
+            cc_ca_certs.handle(self.name, config, cloud, self.args)
 
             self.assertEqual(self.mock_add.call_count, 0)
             self.assertEqual(self.mock_update.call_count, 1)
@@ -180,7 +175,7 @@ class TestConfig(TestCase):
         for distro_name in cc_ca_certs.distros:
             self._mock_init()
             cloud = get_cloud(distro_name)
-            cc_ca_certs.handle(self.name, config, cloud, self.log, self.args)
+            cc_ca_certs.handle(self.name, config, cloud, self.args)
 
             self.assertEqual(self.mock_add.call_count, 0)
             self.assertEqual(self.mock_update.call_count, 1)
@@ -200,7 +195,7 @@ class TestConfig(TestCase):
             self._mock_init()
             cloud = get_cloud(distro_name)
             conf = cc_ca_certs._distro_ca_certs_configs(distro_name)
-            cc_ca_certs.handle(self.name, config, cloud, self.log, self.args)
+            cc_ca_certs.handle(self.name, config, cloud, self.args)
 
             self.assertEqual(self.mock_remove.call_count, 1)
             self.mock_add.assert_called_once_with(conf, ["CERT1"])
@@ -441,7 +436,7 @@ class TestCACertsSchema:
         logger.setupLogging()
         cloud = get_cloud("ubuntu")
         cc_ca_certs.handle(
-            "IGNORE", {"ca-certs": {"remove-defaults": False}}, cloud, None, []
+            "IGNORE", {"ca-certs": {"remove-defaults": False}}, cloud, []
         )
         expected_warnings = [
             "Key 'ca-certs' is deprecated in",
@@ -463,7 +458,6 @@ class TestCACertsSchema:
                 "ca_certs": {"remove_defaults": False},
             },
             cloud,
-            None,
             [],
         )
         expected_warning = (

--- a/tests/unittests/config/test_cc_chef.py
+++ b/tests/unittests/config/test_cc_chef.py
@@ -1,7 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import json
-import logging
 import os
 import re
 
@@ -24,8 +23,6 @@ from tests.unittests.helpers import (
     skipUnlessJsonSchema,
 )
 from tests.unittests.util import MockDistro, get_cloud
-
-LOG = logging.getLogger(__name__)
 
 CLIENT_TEMPL = cloud_init_project_dir("templates/chef_client.rb.tmpl")
 
@@ -128,7 +125,7 @@ class TestChef(FilesystemMockingTestCase):
         self.patchOS(self.tmp)
 
         cfg = {}
-        cc_chef.handle("chef", cfg, get_cloud(), LOG, [])
+        cc_chef.handle("chef", cfg, get_cloud(), [])
         for d in cc_chef.CHEF_DIRS:
             self.assertFalse(os.path.isdir(d))
 
@@ -175,7 +172,7 @@ class TestChef(FilesystemMockingTestCase):
                 ),
             },
         }
-        cc_chef.handle("chef", cfg, get_cloud(), LOG, [])
+        cc_chef.handle("chef", cfg, get_cloud(), [])
         for d in cc_chef.CHEF_DIRS:
             self.assertTrue(os.path.isdir(d))
         c = util.load_file(cc_chef.CHEF_RB_PATH)
@@ -210,7 +207,7 @@ class TestChef(FilesystemMockingTestCase):
                 },
             },
         }
-        cc_chef.handle("chef", cfg, get_cloud(), LOG, [])
+        cc_chef.handle("chef", cfg, get_cloud(), [])
         c = util.load_file(cc_chef.CHEF_FB_PATH)
         self.assertEqual(
             {
@@ -237,7 +234,7 @@ class TestChef(FilesystemMockingTestCase):
                 "show_time": None,
             },
         }
-        cc_chef.handle("chef", cfg, get_cloud(), LOG, [])
+        cc_chef.handle("chef", cfg, get_cloud(), [])
         c = util.load_file(cc_chef.CHEF_RB_PATH)
         self.assertNotIn("json_attribs", c)
         self.assertNotIn("Formatter.show_time", c)
@@ -262,7 +259,7 @@ class TestChef(FilesystemMockingTestCase):
                 "validation_cert": v_cert,
             },
         }
-        cc_chef.handle("chef", cfg, get_cloud(), LOG, [])
+        cc_chef.handle("chef", cfg, get_cloud(), [])
         content = util.load_file(cc_chef.CHEF_RB_PATH)
         self.assertIn(v_path, content)
         util.load_file(v_path)
@@ -287,7 +284,7 @@ class TestChef(FilesystemMockingTestCase):
         }
         util.write_file("/etc/cloud/templates/chef_client.rb.tmpl", tpl_file)
         util.write_file(v_path, expected_cert)
-        cc_chef.handle("chef", cfg, get_cloud(), LOG, [])
+        cc_chef.handle("chef", cfg, get_cloud(), [])
         content = util.load_file(cc_chef.CHEF_RB_PATH)
         self.assertIn(v_path, content)
         util.load_file(v_path)

--- a/tests/unittests/config/test_cc_disable_ec2_metadata.py
+++ b/tests/unittests/config/test_cc_disable_ec2_metadata.py
@@ -2,7 +2,6 @@
 
 """Tests cc_disable_ec2_metadata handler"""
 
-import logging
 
 import pytest
 
@@ -14,8 +13,6 @@ from cloudinit.config.schema import (
 )
 from tests.unittests.helpers import CiTestCase, mock, skipUnlessJsonSchema
 
-LOG = logging.getLogger(__name__)
-
 DISABLE_CFG = {"disable_ec2_metadata": "true"}
 
 
@@ -25,7 +22,7 @@ class TestEC2MetadataRoute(CiTestCase):
     def test_disable_ifconfig(self, m_subp, m_which):
         """Set the route if ifconfig command is available"""
         m_which.side_effect = lambda x: x if x == "ifconfig" else None
-        ec2_meta.handle("foo", DISABLE_CFG, None, LOG, None)
+        ec2_meta.handle("foo", DISABLE_CFG, None, None)
         m_subp.assert_called_with(
             ["route", "add", "-host", "169.254.169.254", "reject"],
             capture=False,
@@ -36,7 +33,7 @@ class TestEC2MetadataRoute(CiTestCase):
     def test_disable_ip(self, m_subp, m_which):
         """Set the route if ip command is available"""
         m_which.side_effect = lambda x: x if x == "ip" else None
-        ec2_meta.handle("foo", DISABLE_CFG, None, LOG, None)
+        ec2_meta.handle("foo", DISABLE_CFG, None, None)
         m_subp.assert_called_with(
             ["ip", "route", "add", "prohibit", "169.254.169.254"],
             capture=False,
@@ -47,7 +44,7 @@ class TestEC2MetadataRoute(CiTestCase):
     def test_disable_no_tool(self, m_subp, m_which):
         """Log error when neither route nor ip commands are available"""
         m_which.return_value = None  # Find neither ifconfig nor ip
-        ec2_meta.handle("foo", DISABLE_CFG, None, LOG, None)
+        ec2_meta.handle("foo", DISABLE_CFG, None, None)
         self.assertEqual(
             [mock.call("ip"), mock.call("ifconfig")], m_which.call_args_list
         )

--- a/tests/unittests/config/test_cc_final_message.py
+++ b/tests/unittests/config/test_cc_final_message.py
@@ -1,5 +1,4 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-import logging
 from unittest import mock
 
 import pytest
@@ -36,7 +35,7 @@ class TestHandle:
             paths=mock.Mock(boot_finished=boot_finished.strpath)
         )
 
-        handle(None, {}, m_cloud, logging.getLogger(), [])
+        handle(None, {}, m_cloud, [])
 
         # We should not change the status of the instance directory
         assert instance_dir_exists == instance_dir.exists()

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -102,7 +102,6 @@ class TestDisabled(unittest.TestCase):
         super(TestDisabled, self).setUp()
         self.name = "growpart"
         self.cloud = None
-        self.log = logging.getLogger("TestDisabled")
         self.args = []
 
         self.handle = cc_growpart.handle
@@ -114,7 +113,7 @@ class TestDisabled(unittest.TestCase):
         config = {"growpart": {"mode": "off"}}
 
         with mock.patch.object(cc_growpart, "resizer_factory") as mockobj:
-            self.handle(self.name, config, self.cloud, self.log, self.args)
+            self.handle(self.name, config, self.cloud, self.args)
             self.assertEqual(mockobj.call_count, 0)
 
 
@@ -144,7 +143,7 @@ class TestConfig(TestCase):
         ) as mockobj:
 
             config = {"growpart": {"mode": "auto"}}
-            self.handle(self.name, config, self.cloud, self.log, self.args)
+            self.handle(self.name, config, self.cloud, self.args)
 
             mockobj.assert_has_calls(
                 [
@@ -167,7 +166,6 @@ class TestConfig(TestCase):
                 self.name,
                 config,
                 self.cloud,
-                self.log,
                 self.args,
             )
 
@@ -271,7 +269,7 @@ class TestConfig(TestCase):
                 )
             )
 
-            self.handle(self.name, {}, self.cloud, self.log, self.args)
+            self.handle(self.name, {}, self.cloud, self.args)
 
             factory.assert_called_once_with("auto", self.distro)
             rsdevs.assert_called_once_with(myresizer, ["/"])

--- a/tests/unittests/config/test_cc_grub_dpkg.py
+++ b/tests/unittests/config/test_cc_grub_dpkg.py
@@ -157,10 +157,9 @@ class TestHandle:
                 None,
                 "/dev/disk/by-id/nvme-Company_hash000",
                 (
-                    "Setting grub debconf-set-selections with ",
-                    "'grub-pc grub-pc/install_devices string "
-                    "/dev/disk/by-id/nvme-Company_hash000\n",
-                    "grub-pc grub-pc/install_devices_empty boolean false\n'",
+                    "Setting grub debconf-set-selections with '%s','%s'",
+                    "/dev/disk/by-id/nvme-Company_hash000",
+                    "false",
                 ),
                 False,
             ),
@@ -170,9 +169,9 @@ class TestHandle:
                 None,
                 "/dev/sda",
                 (
-                    "Setting grub debconf-set-selections with ",
-                    "'grub-pc grub-pc/install_devices string /dev/sda\n",
-                    "grub-pc grub-pc/install_devices_empty boolean false\n'",
+                    "Setting grub debconf-set-selections with '%s','%s'",
+                    "/dev/sda",
+                    "false",
                 ),
                 False,
             ),
@@ -182,9 +181,9 @@ class TestHandle:
                 "true",
                 "/dev/xvda",
                 (
-                    "Setting grub debconf-set-selections with ",
-                    "'grub-pc grub-pc/install_devices string /dev/xvda\n",
-                    "grub-pc grub-pc/install_devices_empty boolean true\n'",
+                    "Setting grub debconf-set-selections with '%s','%s'",
+                    "/dev/xvda",
+                    "true",
                 ),
                 False,
             ),
@@ -194,9 +193,9 @@ class TestHandle:
                 False,
                 "/dev/disk/by-id/company-user-1",
                 (
-                    "Setting grub debconf-set-selections with ",
-                    "'grub-pc grub-pc/install_devices string /dev/vda\n",
-                    "grub-pc grub-pc/install_devices_empty boolean false\n'",
+                    "Setting grub debconf-set-selections with '%s','%s'",
+                    "/dev/vda",
+                    "false",
                 ),
                 False,
             ),
@@ -207,9 +206,9 @@ class TestHandle:
                 True,
                 "",
                 (
-                    "Setting grub debconf-set-selections with ",
-                    "'grub-pc grub-pc/install_devices string /dev/nvme0n1\n",
-                    "grub-pc grub-pc/install_devices_empty boolean true\n'",
+                    "Setting grub debconf-set-selections with '%s','%s'",
+                    "/dev/nvme0n1",
+                    "true",
                 ),
                 False,
             ),
@@ -253,7 +252,8 @@ class TestHandle:
         if cfg_idevs_empty is not None:
             cfg["grub_dpkg"]["grub-pc/install_devices_empty"] = cfg_idevs_empty
         handle(mock.Mock(), cfg, mock.Mock(), mock.Mock())
-        m_log.debug.assert_called_with("".join(expected_log_output))
+        print(m_log.debug.call_args_list)
+        m_log.debug.assert_called_with(*expected_log_output)
 
 
 class TestGrubDpkgSchema:

--- a/tests/unittests/config/test_cc_grub_dpkg.py
+++ b/tests/unittests/config/test_cc_grub_dpkg.py
@@ -157,9 +157,10 @@ class TestHandle:
                 None,
                 "/dev/disk/by-id/nvme-Company_hash000",
                 (
-                    "Setting grub debconf-set-selections with '%s','%s'",
-                    "/dev/disk/by-id/nvme-Company_hash000",
-                    "false",
+                    "Setting grub debconf-set-selections with '%s'",
+                    "grub-pc grub-pc/install_devices string "
+                    "/dev/disk/by-id/nvme-Company_hash000\n"
+                    "grub-pc grub-pc/install_devices_empty boolean false\n",
                 ),
                 False,
             ),
@@ -169,9 +170,9 @@ class TestHandle:
                 None,
                 "/dev/sda",
                 (
-                    "Setting grub debconf-set-selections with '%s','%s'",
-                    "/dev/sda",
-                    "false",
+                    "Setting grub debconf-set-selections with '%s'",
+                    "grub-pc grub-pc/install_devices string /dev/sda\n"
+                    "grub-pc grub-pc/install_devices_empty boolean false\n",
                 ),
                 False,
             ),
@@ -181,9 +182,9 @@ class TestHandle:
                 "true",
                 "/dev/xvda",
                 (
-                    "Setting grub debconf-set-selections with '%s','%s'",
-                    "/dev/xvda",
-                    "true",
+                    "Setting grub debconf-set-selections with '%s'",
+                    "grub-pc grub-pc/install_devices string /dev/xvda\n"
+                    "grub-pc grub-pc/install_devices_empty boolean true\n",
                 ),
                 False,
             ),
@@ -193,9 +194,9 @@ class TestHandle:
                 False,
                 "/dev/disk/by-id/company-user-1",
                 (
-                    "Setting grub debconf-set-selections with '%s','%s'",
-                    "/dev/vda",
-                    "false",
+                    "Setting grub debconf-set-selections with '%s'",
+                    "grub-pc grub-pc/install_devices string /dev/vda\n"
+                    "grub-pc grub-pc/install_devices_empty boolean false\n",
                 ),
                 False,
             ),
@@ -206,9 +207,9 @@ class TestHandle:
                 True,
                 "",
                 (
-                    "Setting grub debconf-set-selections with '%s','%s'",
-                    "/dev/nvme0n1",
-                    "true",
+                    "Setting grub debconf-set-selections with '%s'",
+                    "grub-pc grub-pc/install_devices string /dev/nvme0n1\n"
+                    "grub-pc grub-pc/install_devices_empty boolean true\n",
                 ),
                 False,
             ),
@@ -218,8 +219,8 @@ class TestHandle:
                 False,
                 "/dev/sda1",
                 (
-                    "Setting grub debconf-set-selections with ",
-                    "'grub-pc grub-efi/install_devices string /dev/sda1\n'",
+                    "Setting grub debconf-set-selections with '%s'",
+                    "grub-pc grub-efi/install_devices string /dev/sda1\n",
                 ),
                 True,
             ),

--- a/tests/unittests/config/test_cc_install_hotplug.py
+++ b/tests/unittests/config/test_cc_install_hotplug.py
@@ -57,7 +57,7 @@ class TestInstallHotplug:
         else:
             libexecdir = "/usr/lib/cloud-init"
         with mock.patch("os.path.exists", return_value=libexec_exists):
-            handle(None, {}, m_cloud, mock.Mock(), None)
+            handle(None, {}, m_cloud, None)
             mocks.m_write.assert_called_once_with(
                 filename=HOTPLUG_UDEV_PATH,
                 content=HOTPLUG_UDEV_RULES_TEMPLATE.format(
@@ -80,7 +80,7 @@ class TestInstallHotplug:
         m_cloud = mock.MagicMock()
         m_cloud.datasource.get_supported_events.return_value = {}
 
-        handle(None, {}, m_cloud, mock.Mock(), None)
+        handle(None, {}, m_cloud, None)
         assert mocks.m_write.call_args_list == []
         assert mocks.m_del.call_args_list == []
         assert mocks.m_subp.call_args_list == []
@@ -92,7 +92,7 @@ class TestInstallHotplug:
             EventScope.NETWORK: {EventType.HOTPLUG}
         }
 
-        handle(None, {}, m_cloud, mock.Mock(), None)
+        handle(None, {}, m_cloud, None)
         assert mocks.m_write.call_args_list == []
         assert mocks.m_del.call_args_list == []
         assert mocks.m_subp.call_args_list == []
@@ -103,7 +103,7 @@ class TestInstallHotplug:
         m_cloud = mock.MagicMock()
         m_cloud.datasource.get_supported_events.return_value = {}
 
-        handle(None, {}, m_cloud, mock.Mock(), None)
+        handle(None, {}, m_cloud, None)
         mocks.m_del.assert_called_with(HOTPLUG_UDEV_PATH)
         assert mocks.m_subp.call_args_list == [
             mock.call(
@@ -123,7 +123,7 @@ class TestInstallHotplug:
             EventScope.NETWORK: {EventType.HOTPLUG}
         }
 
-        handle(None, {}, m_cloud, mock.Mock(), None)
+        handle(None, {}, m_cloud, None)
         assert mocks.m_del.call_args_list == []
         assert mocks.m_write.call_args_list == []
         assert mocks.m_subp.call_args_list == []

--- a/tests/unittests/config/test_cc_keys_to_console.py
+++ b/tests/unittests/config/test_cc_keys_to_console.py
@@ -42,7 +42,7 @@ class TestHandle:
         m_path_exists.return_value = True
         m_subp.return_value = ("", "")
 
-        cc_keys_to_console.handle("name", cfg, mock.Mock(), mock.Mock(), ())
+        cc_keys_to_console.handle("name", cfg, mock.Mock(), ())
 
         assert subp_called == (m_subp.call_count == 1)
 

--- a/tests/unittests/config/test_cc_landscape.py
+++ b/tests/unittests/config/test_cc_landscape.py
@@ -42,7 +42,7 @@ class TestLandscape(FilesystemMockingTestCase):
         mycloud = get_cloud("ubuntu")
         mycloud.distro = mock.MagicMock()
         cfg = {"landscape": {}}
-        cc_landscape.handle("notimportant", cfg, mycloud, LOG, None)
+        cc_landscape.handle("notimportant", cfg, mycloud, None)
         self.assertFalse(mycloud.distro.install_packages.called)
 
     def test_handler_error_on_invalid_landscape_type(self):
@@ -50,7 +50,7 @@ class TestLandscape(FilesystemMockingTestCase):
         mycloud = get_cloud("ubuntu")
         cfg = {"landscape": "wrongtype"}
         with self.assertRaises(RuntimeError) as context_manager:
-            cc_landscape.handle("notimportant", cfg, mycloud, LOG, None)
+            cc_landscape.handle("notimportant", cfg, mycloud, None)
         self.assertIn(
             "'landscape' key existed in config, but not a dict",
             str(context_manager.exception),
@@ -68,7 +68,6 @@ class TestLandscape(FilesystemMockingTestCase):
             "notimportant",
             cfg,
             mycloud,
-            LOG,
             None,
         )
         self.assertEqual(
@@ -99,7 +98,6 @@ class TestLandscape(FilesystemMockingTestCase):
             "notimportant",
             cfg,
             mycloud,
-            LOG,
             None,
         )
         self.assertEqual(
@@ -136,7 +134,6 @@ class TestLandscape(FilesystemMockingTestCase):
             "notimportant",
             cfg,
             mycloud,
-            LOG,
             None,
         )
         self.assertEqual(expected, dict(ConfigObj(self.conf)))
@@ -167,7 +164,6 @@ class TestLandscape(FilesystemMockingTestCase):
             "notimportant",
             cfg,
             mycloud,
-            LOG,
             None,
         )
         self.assertEqual(expected, dict(ConfigObj(self.conf)))

--- a/tests/unittests/config/test_cc_locale.py
+++ b/tests/unittests/config/test_cc_locale.py
@@ -47,7 +47,7 @@ class TestLocale(FilesystemMockingTestCase):
 
         with mock.patch("cloudinit.distros.arch.subp.subp") as m_subp:
             with mock.patch("cloudinit.distros.arch.LOG.warning") as m_LOG:
-                cc_locale.handle("cc_locale", cfg, cc, LOG, [])
+                cc_locale.handle("cc_locale", cfg, cc, [])
                 m_LOG.assert_called_with(
                     "Invalid locale_configfile %s, "
                     "only supported value is "
@@ -67,7 +67,7 @@ class TestLocale(FilesystemMockingTestCase):
             "locale": "My.Locale",
         }
         cc = get_cloud("sles")
-        cc_locale.handle("cc_locale", cfg, cc, LOG, [])
+        cc_locale.handle("cc_locale", cfg, cc, [])
         if cc.distro.uses_systemd():
             locale_conf = cc.distro.systemd_locale_conf_fn
         else:
@@ -82,7 +82,7 @@ class TestLocale(FilesystemMockingTestCase):
     def test_set_locale_sles_default(self):
         cfg = {}
         cc = get_cloud("sles")
-        cc_locale.handle("cc_locale", cfg, cc, LOG, [])
+        cc_locale.handle("cc_locale", cfg, cc, [])
 
         if cc.distro.uses_systemd():
             locale_conf = cc.distro.systemd_locale_conf_fn
@@ -105,7 +105,7 @@ class TestLocale(FilesystemMockingTestCase):
             with mock.patch(
                 "cloudinit.distros.debian.LOCALE_CONF_FN", locale_conf
             ):
-                cc_locale.handle("cc_locale", cfg, cc, LOG, [])
+                cc_locale.handle("cc_locale", cfg, cc, [])
                 m_subp.assert_called_with(
                     [
                         "update-locale",
@@ -123,7 +123,7 @@ class TestLocale(FilesystemMockingTestCase):
         with mock.patch.object(cc.distro, "uses_systemd") as m_use_sd:
             m_use_sd.return_value = True
             with mock.patch(update_sysconfig) as m_update_syscfg:
-                cc_locale.handle("cc_locale", cfg, cc, LOG, [])
+                cc_locale.handle("cc_locale", cfg, cc, [])
                 m_update_syscfg.assert_called_with(
                     "/etc/locale.conf", {"LANG": "en_US.UTF-8"}
                 )

--- a/tests/unittests/config/test_cc_lxd.py
+++ b/tests/unittests/config/test_cc_lxd.py
@@ -53,7 +53,7 @@ class TestLxd(t_help.CiTestCase):
             subp.call_args_list = []
             install.call_args_list = []
             exists.call_args_list = []
-            cc_lxd.handle("cc_lxd", lxd_cfg, cc, self.logger, [])
+            cc_lxd.handle("cc_lxd", lxd_cfg, cc, [])
             if cmd:
                 which.assert_called_with(cmd)
             # no bridge config, so maybe_cleanup should not be called.
@@ -100,10 +100,10 @@ class TestLxd(t_help.CiTestCase):
         cc = get_cloud()
         cc.distro = mock.MagicMock()
         mock_subp.which.return_value = None
-        cc_lxd.handle("cc_lxd", LXD_INIT_CFG, cc, self.logger, [])
+        cc_lxd.handle("cc_lxd", LXD_INIT_CFG, cc, [])
         self.assertNotIn("WARN", self.logs.getvalue())
         self.assertTrue(cc.distro.install_packages.called)
-        cc_lxd.handle("cc_lxd", LXD_INIT_CFG, cc, self.logger, [])
+        cc_lxd.handle("cc_lxd", LXD_INIT_CFG, cc, [])
         self.assertFalse(m_maybe_clean.called)
         install_pkg = cc.distro.install_packages.call_args_list[0][0][0]
         self.assertEqual(sorted(install_pkg), ["lxd", "zfsutils-linux"])
@@ -113,7 +113,7 @@ class TestLxd(t_help.CiTestCase):
     def test_no_init_does_nothing(self, mock_subp, m_maybe_clean):
         cc = get_cloud()
         cc.distro = mock.MagicMock()
-        cc_lxd.handle("cc_lxd", {"lxd": {}}, cc, self.logger, [])
+        cc_lxd.handle("cc_lxd", {"lxd": {}}, cc, [])
         self.assertFalse(cc.distro.install_packages.called)
         self.assertFalse(mock_subp.subp.called)
         self.assertFalse(m_maybe_clean.called)
@@ -123,7 +123,7 @@ class TestLxd(t_help.CiTestCase):
     def test_no_lxd_does_nothing(self, mock_subp, m_maybe_clean):
         cc = get_cloud()
         cc.distro = mock.MagicMock()
-        cc_lxd.handle("cc_lxd", {"package_update": True}, cc, self.logger, [])
+        cc_lxd.handle("cc_lxd", {"package_update": True}, cc, [])
         self.assertFalse(cc.distro.install_packages.called)
         self.assertFalse(mock_subp.subp.called)
         self.assertFalse(m_maybe_clean.called)
@@ -136,7 +136,6 @@ class TestLxd(t_help.CiTestCase):
             "cc_lxd",
             {"lxd": {"preseed": '{"chad": True}'}},
             cc,
-            self.logger,
             [],
         )
         self.assertEqual(

--- a/tests/unittests/config/test_cc_mcollective.py
+++ b/tests/unittests/config/test_cc_mcollective.py
@@ -149,7 +149,7 @@ class TestHandler(t_help.TestCase):
         cc.distro = t_help.mock.MagicMock()
         mock_util.load_file.return_value = b""
         mycfg = {"mcollective": {"conf": {"loglevel": "debug"}}}
-        cc_mcollective.handle("cc_mcollective", mycfg, cc, LOG, [])
+        cc_mcollective.handle("cc_mcollective", mycfg, cc, [])
         self.assertTrue(cc.distro.install_packages.called)
         install_pkg = cc.distro.install_packages.call_args_list[0][0][0]
         self.assertEqual(install_pkg, ("mcollective",))

--- a/tests/unittests/config/test_cc_mounts.py
+++ b/tests/unittests/config/test_cc_mounts.py
@@ -64,7 +64,7 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.mock_existence_of_disk(disk_path)
         self.assertEqual(
             disk_path,
-            cc_mounts.sanitize_devname(disk_path, lambda x: None, mock.Mock()),
+            cc_mounts.sanitize_devname(disk_path, lambda x: None),
         )
 
     def test_existent_disk_name_returns_full_path(self):
@@ -73,7 +73,7 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.mock_existence_of_disk(disk_path)
         self.assertEqual(
             disk_path,
-            cc_mounts.sanitize_devname(disk_name, lambda x: None, mock.Mock()),
+            cc_mounts.sanitize_devname(disk_name, lambda x: None),
         )
 
     def test_existent_meta_disk_is_returned(self):
@@ -82,7 +82,8 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.assertEqual(
             actual_disk_path,
             cc_mounts.sanitize_devname(
-                "ephemeral0", lambda x: actual_disk_path, mock.Mock()
+                "ephemeral0",
+                lambda x: actual_disk_path,
             ),
         )
 
@@ -93,7 +94,8 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.assertEqual(
             actual_partition_path,
             cc_mounts.sanitize_devname(
-                "ephemeral0.1", lambda x: disk_name, mock.Mock()
+                "ephemeral0.1",
+                lambda x: disk_name,
             ),
         )
 
@@ -104,7 +106,8 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.assertEqual(
             actual_partition_path,
             cc_mounts.sanitize_devname(
-                "ephemeral0.1", lambda x: disk_name, mock.Mock()
+                "ephemeral0.1",
+                lambda x: disk_name,
             ),
         )
 
@@ -115,7 +118,8 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.assertEqual(
             actual_partition_path,
             cc_mounts.sanitize_devname(
-                "ephemeral0", lambda x: disk_name, mock.Mock()
+                "ephemeral0",
+                lambda x: disk_name,
             ),
         )
 
@@ -126,27 +130,35 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.assertEqual(
             actual_partition_path,
             cc_mounts.sanitize_devname(
-                "ephemeral0.3", lambda x: disk_name, mock.Mock()
+                "ephemeral0.3",
+                lambda x: disk_name,
             ),
         )
 
     def test_transformer_returning_none_returns_none(self):
         self.assertIsNone(
             cc_mounts.sanitize_devname(
-                "ephemeral0", lambda x: None, mock.Mock()
+                "ephemeral0",
+                lambda x: None,
             )
         )
 
     def test_missing_device_returns_none(self):
         self.assertIsNone(
-            cc_mounts.sanitize_devname("/dev/sda", None, mock.Mock())
+            cc_mounts.sanitize_devname(
+                "/dev/sda",
+                None,
+            )
         )
 
     def test_missing_sys_returns_none(self):
         disk_path = "/dev/sda"
         self._makedirs(disk_path)
         self.assertIsNone(
-            cc_mounts.sanitize_devname(disk_path, None, mock.Mock())
+            cc_mounts.sanitize_devname(
+                disk_path,
+                None,
+            )
         )
 
     def test_existent_disk_but_missing_partition_returns_none(self):
@@ -154,14 +166,19 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.mock_existence_of_disk(disk_path)
         self.assertIsNone(
             cc_mounts.sanitize_devname(
-                "ephemeral0.1", lambda x: disk_path, mock.Mock()
+                "ephemeral0.1",
+                lambda x: disk_path,
             )
         )
 
     def test_network_device_returns_network_device(self):
         disk_path = "netdevice:/path"
         self.assertEqual(
-            disk_path, cc_mounts.sanitize_devname(disk_path, None, mock.Mock())
+            disk_path,
+            cc_mounts.sanitize_devname(
+                disk_path,
+                None,
+            ),
         )
 
     def test_device_aliases_remapping(self):
@@ -170,7 +187,7 @@ class TestSanitizeDevname(test_helpers.FilesystemMockingTestCase):
         self.assertEqual(
             disk_path,
             cc_mounts.sanitize_devname(
-                "mydata", lambda x: None, mock.Mock(), {"mydata": disk_path}
+                "mydata", lambda x: None, {"mydata": disk_path}
             ),
         )
 
@@ -239,7 +256,7 @@ class TestSwapFileCreation(test_helpers.FilesystemMockingTestCase):
         m_kernel_version.return_value = (4, 20)
         m_get_mount_info.return_value = ["", "xfs"]
 
-        cc_mounts.handle(None, self.cc, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, self.cc, self.mock_cloud, [])
         self.m_subp_subp.assert_has_calls(
             [
                 mock.call(
@@ -258,7 +275,7 @@ class TestSwapFileCreation(test_helpers.FilesystemMockingTestCase):
         m_kernel_version.return_value = (3, 18)
         m_get_mount_info.return_value = ["", "xfs"]
 
-        cc_mounts.handle(None, self.cc, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, self.cc, self.mock_cloud, [])
         self.m_subp_subp.assert_has_calls(
             [
                 mock.call(
@@ -284,7 +301,7 @@ class TestSwapFileCreation(test_helpers.FilesystemMockingTestCase):
         m_kernel_version.return_value = (4, 20)
         m_get_mount_info.return_value = ["", "btrfs"]
 
-        cc_mounts.handle(None, self.cc, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, self.cc, self.mock_cloud, [])
         self.m_subp_subp.assert_has_calls(
             [
                 mock.call(
@@ -310,7 +327,7 @@ class TestSwapFileCreation(test_helpers.FilesystemMockingTestCase):
         m_kernel_version.return_value = (5, 14)
         m_get_mount_info.return_value = ["", "ext4"]
 
-        cc_mounts.handle(None, self.cc, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, self.cc, self.mock_cloud, [])
         self.m_subp_subp.assert_has_calls(
             [
                 mock.call(
@@ -385,7 +402,7 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
             "%s\tnone\tswap\tsw,comment=cloudconfig\t0\t0\n"
             % (self.swap_path,)
         )
-        cc_mounts.handle(None, {}, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, {}, self.mock_cloud, [])
         with open(cc_mounts.FSTAB_PATH, "r") as fd:
             fstab_new_content = fd.read()
             self.assertEqual(fstab_expected_content, fstab_new_content)
@@ -400,7 +417,7 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
         with open(cc_mounts.FSTAB_PATH, "w") as fd:
             fd.write(fstab)
         cc = {"swap": ["filename: /swap.img", "size: 512", "maxsize: 512"]}
-        cc_mounts.handle(None, cc, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, cc, self.mock_cloud, [])
 
     def test_fstab_no_swap_device(self):
         """Ensure that cloud-init adds a discovered swap partition
@@ -415,7 +432,7 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
         with open(cc_mounts.FSTAB_PATH, "w") as fd:
             fd.write(fstab_original_content)
 
-        cc_mounts.handle(None, {}, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, {}, self.mock_cloud, [])
 
         with open(cc_mounts.FSTAB_PATH, "r") as fd:
             fstab_new_content = fd.read()
@@ -433,7 +450,7 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
         with open(cc_mounts.FSTAB_PATH, "w") as fd:
             fd.write(fstab_original_content)
 
-        cc_mounts.handle(None, {}, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, {}, self.mock_cloud, [])
 
         with open(cc_mounts.FSTAB_PATH, "r") as fd:
             fstab_new_content = fd.read()
@@ -454,7 +471,7 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
         with open(cc_mounts.FSTAB_PATH, "w") as fd:
             fd.write(fstab_original_content)
 
-        cc_mounts.handle(None, {}, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, {}, self.mock_cloud, [])
 
         with open(cc_mounts.FSTAB_PATH, "r") as fd:
             fstab_new_content = fd.read()
@@ -474,7 +491,7 @@ class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
         with open(cc_mounts.FSTAB_PATH, "r") as fd:
             fstab_new_content = fd.read()
             self.assertEqual(fstab_expected_content, fstab_new_content)
-        cc_mounts.handle(None, cc, self.mock_cloud, self.mock_log, [])
+        cc_mounts.handle(None, cc, self.mock_cloud, [])
         self.m_subp_subp.assert_has_calls(
             [
                 mock.call(["mount", "-a"]),

--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -357,7 +357,7 @@ class TestNtp(FilesystemMockingTestCase):
 
     def test_no_ntpcfg_does_nothing(self):
         """When no ntp section is defined handler logs a warning and noops."""
-        cc_ntp.handle("cc_ntp", {}, None, None, [])
+        cc_ntp.handle("cc_ntp", {}, None, [])
         self.assertEqual(
             "DEBUG: Skipping module named cc_ntp, "
             "not present or disabled by cfg\n",
@@ -380,7 +380,7 @@ class TestNtp(FilesystemMockingTestCase):
                 ntpconfig = self._mock_ntp_client_config(distro=distro)
                 confpath = ntpconfig["confpath"]
                 m_select.return_value = ntpconfig
-                cc_ntp.handle("cc_ntp", valid_empty_config, mycloud, None, [])
+                cc_ntp.handle("cc_ntp", valid_empty_config, mycloud, [])
                 if distro == "alpine":
                     # _mock_ntp_client_config call above did not specify a
                     # client value and so it defaults to "ntp" which on
@@ -415,7 +415,7 @@ class TestNtp(FilesystemMockingTestCase):
             )
             confpath = ntpconfig["confpath"]
             m_select.return_value = ntpconfig
-            cc_ntp.handle("cc_ntp", cfg, mycloud, None, [])
+            cc_ntp.handle("cc_ntp", cfg, mycloud, [])
             self.assertEqual(
                 "[Time]\nNTP=192.168.2.1 192.168.2.2 0.mypool.org \n",
                 util.load_file(confpath),
@@ -427,7 +427,7 @@ class TestNtp(FilesystemMockingTestCase):
         cfg = {"ntp": {"enabled": False}}
         for distro in cc_ntp.distros:
             mycloud = self._get_cloud(distro)
-            cc_ntp.handle("notimportant", cfg, mycloud, None, None)
+            cc_ntp.handle("notimportant", cfg, mycloud, None)
             self.assertEqual(0, m_select.call_count)
 
     @mock.patch("cloudinit.subp.subp")
@@ -502,7 +502,7 @@ class TestNtp(FilesystemMockingTestCase):
                 m_util.is_BSD.return_value = is_FreeBSD or is_OpenBSD
                 m_util.is_FreeBSD.return_value = is_FreeBSD
                 m_util.is_OpenBSD.return_value = is_OpenBSD
-                cc_ntp.handle("notimportant", cfg, mycloud, None, None)
+                cc_ntp.handle("notimportant", cfg, mycloud, None)
                 m_subp.assert_called_with(expected_service_call, capture=True)
 
             self.assertEqual(expected_content, util.load_file(confpath))
@@ -610,7 +610,7 @@ class TestNtp(FilesystemMockingTestCase):
             with mock.patch.object(
                 mycloud.distro, "install_packages"
             ) as m_install:
-                cc_ntp.handle("notimportant", cfg, mycloud, None, None)
+                cc_ntp.handle("notimportant", cfg, mycloud, None)
             m_install.assert_called_with([client])
             m_which.assert_called_with(client)
 
@@ -667,7 +667,7 @@ class TestNtp(FilesystemMockingTestCase):
             mycloud = self._get_cloud(distro)
             mock_path = "cloudinit.config.cc_ntp.temp_utils._TMPDIR"
             with mock.patch(mock_path, self.new_root):
-                cc_ntp.handle("notimportant", cfg, mycloud, None, None)
+                cc_ntp.handle("notimportant", cfg, mycloud, None)
             self.assertEqual(
                 "servers []\npools ['mypool.org']\n%s" % custom,
                 util.load_file(confpath),
@@ -707,9 +707,7 @@ class TestNtp(FilesystemMockingTestCase):
             m_select.return_value = ntpconfig
             mock_path = "cloudinit.config.cc_ntp.temp_utils._TMPDIR"
             with mock.patch(mock_path, self.new_root):
-                cc_ntp.handle(
-                    "notimportant", {"ntp": cfg}, mycloud, None, None
-                )
+                cc_ntp.handle("notimportant", {"ntp": cfg}, mycloud, None)
             self.assertEqual(
                 "servers []\npools ['mypool.org']\n%s" % custom,
                 util.load_file(confpath),

--- a/tests/unittests/config/test_cc_phone_home.py
+++ b/tests/unittests/config/test_cc_phone_home.py
@@ -1,4 +1,3 @@
-import logging
 from functools import partial
 from itertools import count
 from unittest import mock
@@ -14,8 +13,7 @@ from cloudinit.config.schema import (
 from tests.unittests.helpers import skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
 
-LOG = logging.getLogger("TestNoConfig")
-phone_home = partial(handle, name="test", cloud=get_cloud(), log=LOG, args=[])
+phone_home = partial(handle, name="test", cloud=get_cloud(), args=[])
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unittests/config/test_cc_power_state_change.py
+++ b/tests/unittests/config/test_cc_power_state_change.py
@@ -126,11 +126,9 @@ class TestCheckCondition(t_help.TestCase):
     def test_cmd_exit_one_false(self):
         self.assertEqual(psc.check_condition(self.cmd_with_exit(1)), False)
 
-    def test_cmd_exit_nonzero_warns(self):
-        mocklog = mock.Mock()
-        self.assertEqual(
-            psc.check_condition(self.cmd_with_exit(2), mocklog), False
-        )
+    @mock.patch("cloudinit.config.cc_power_state_change.LOG")
+    def test_cmd_exit_nonzero_warns(self, mocklog):
+        self.assertEqual(psc.check_condition(self.cmd_with_exit(2)), False)
         self.assertEqual(mocklog.warning.call_count, 1)
 
 

--- a/tests/unittests/config/test_cc_puppet.py
+++ b/tests/unittests/config/test_cc_puppet.py
@@ -1,5 +1,4 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-import logging
 import textwrap
 
 import pytest
@@ -15,8 +14,6 @@ from cloudinit.config.schema import (
 from cloudinit.subp import ProcessExecutionError
 from tests.unittests.helpers import CiTestCase, mock, skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
-
-LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture
@@ -36,7 +33,7 @@ class TestManagePuppetServices(CiTestCase):
         self,
         m_subp,
     ):
-        cc_puppet._manage_puppet_services(LOG, self.cloud, "enable")
+        cc_puppet._manage_puppet_services(self.cloud, "enable")
         expected_calls = [
             mock.call(
                 ["systemctl", "enable", "puppet-agent.service"],
@@ -49,7 +46,7 @@ class TestManagePuppetServices(CiTestCase):
         self,
         m_subp,
     ):
-        cc_puppet._manage_puppet_services(LOG, self.cloud, "start")
+        cc_puppet._manage_puppet_services(self.cloud, "start")
         expected_calls = [
             mock.call(
                 ["systemctl", "start", "puppet-agent.service"],
@@ -60,7 +57,7 @@ class TestManagePuppetServices(CiTestCase):
 
     def test_enable_fallback_on_failure(self, m_subp):
         m_subp.side_effect = (ProcessExecutionError, 0)
-        cc_puppet._manage_puppet_services(LOG, self.cloud, "enable")
+        cc_puppet._manage_puppet_services(self.cloud, "enable")
         expected_calls = [
             mock.call(
                 ["systemctl", "enable", "puppet-agent.service"],
@@ -90,7 +87,7 @@ class TestPuppetHandle(CiTestCase):
         """Cloud-config containing no 'puppet' key is skipped."""
 
         cfg = {}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertIn("no 'puppet' configuration found", self.logs.getvalue())
         self.assertEqual(0, m_man_puppet.call_count)
 
@@ -99,11 +96,11 @@ class TestPuppetHandle(CiTestCase):
         """Cloud-config 'puppet' configuration starts puppet."""
 
         cfg = {"puppet": {"install": False}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(2, m_man_puppet.call_count)
         expected_calls = [
-            mock.call(LOG, self.cloud, "enable"),
-            mock.call(LOG, self.cloud, "start"),
+            mock.call(self.cloud, "enable"),
+            mock.call(self.cloud, "start"),
         ]
         self.assertEqual(expected_calls, m_man_puppet.call_args_list)
 
@@ -113,7 +110,7 @@ class TestPuppetHandle(CiTestCase):
 
         self.cloud.distro = mock.MagicMock()
         cfg = {"puppet": {}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(
             [mock.call(("puppet-agent", None))],
             self.cloud.distro.install_packages.call_args_list,
@@ -125,7 +122,7 @@ class TestPuppetHandle(CiTestCase):
 
         self.cloud.distro = mock.MagicMock()
         cfg = {"puppet": {"install": True}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertIn(
             [mock.call(("puppet-agent", None))],
             self.cloud.distro.install_packages.call_args_list,
@@ -139,7 +136,7 @@ class TestPuppetHandle(CiTestCase):
         distro = mock.MagicMock()
         self.cloud.distro = distro
         cfg = {"puppet": {"install": True, "install_type": "aio"}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         m_aio.assert_called_with(
             distro, cc_puppet.AIO_INSTALL_URL, None, None, True
         )
@@ -160,7 +157,7 @@ class TestPuppetHandle(CiTestCase):
                 "install_type": "aio",
             }
         }
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         m_aio.assert_called_with(
             distro, cc_puppet.AIO_INSTALL_URL, "6.24.0", None, True
         )
@@ -181,7 +178,7 @@ class TestPuppetHandle(CiTestCase):
                 "install_type": "aio",
             }
         }
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         m_aio.assert_called_with(
             distro, cc_puppet.AIO_INSTALL_URL, None, "puppet6", True
         )
@@ -202,7 +199,7 @@ class TestPuppetHandle(CiTestCase):
                 "install_type": "aio",
             }
         }
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         m_aio.assert_called_with(
             distro, "http://test.url/path/to/script.sh", None, None, True
         )
@@ -223,7 +220,7 @@ class TestPuppetHandle(CiTestCase):
                 "install_type": "aio",
             }
         }
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         m_aio.assert_called_with(
             distro, cc_puppet.AIO_INSTALL_URL, None, None, False
         )
@@ -234,7 +231,7 @@ class TestPuppetHandle(CiTestCase):
 
         self.cloud.distro = mock.MagicMock()
         cfg = {"puppet": {"version": "3.8"}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(
             [mock.call(("puppet-agent", "3.8"))],
             self.cloud.distro.install_packages.call_args_list,
@@ -259,7 +256,7 @@ class TestPuppetHandle(CiTestCase):
         }
         util.write_file(self.conf, "[agent]\nserver = origpuppet\nother = 3")
         self.cloud.distro = mock.MagicMock()
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         content = util.load_file(self.conf)
         expected = "[agent]\nserver = puppetserver.example.org\nother = 3\n\n"
         self.assertEqual(expected, content)
@@ -296,7 +293,7 @@ class TestPuppetHandle(CiTestCase):
                 }
             }
         }
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         content = util.load_file(self.csr_attributes_path)
         expected = textwrap.dedent(
             """\
@@ -315,11 +312,11 @@ class TestPuppetHandle(CiTestCase):
         """Run puppet with default args if 'exec' is set to True."""
 
         cfg = {"puppet": {"exec": True}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(2, m_man_puppet.call_count)
         expected_calls = [
-            mock.call(LOG, self.cloud, "enable"),
-            mock.call(LOG, self.cloud, "start"),
+            mock.call(self.cloud, "enable"),
+            mock.call(self.cloud, "start"),
         ]
         self.assertEqual(expected_calls, m_man_puppet.call_args_list)
         self.assertIn(
@@ -332,11 +329,11 @@ class TestPuppetHandle(CiTestCase):
         """Run puppet with default args if 'exec' is set to True."""
 
         cfg = {"puppet": {}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(2, m_man_puppet.call_count)
         expected_calls = [
-            mock.call(LOG, self.cloud, "enable"),
-            mock.call(LOG, self.cloud, "start"),
+            mock.call(self.cloud, "enable"),
+            mock.call(self.cloud, "start"),
         ]
         self.assertEqual(expected_calls, m_man_puppet.call_args_list)
 
@@ -345,7 +342,7 @@ class TestPuppetHandle(CiTestCase):
         """Run puppet with default args if 'exec' is set to True."""
 
         cfg = {"puppet": {"start_service": False}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(0, m_man_puppet.call_count)
         self.assertNotIn(
             [mock.call(["systemctl", "start", "puppet-agent"], capture=False)],
@@ -364,7 +361,7 @@ class TestPuppetHandle(CiTestCase):
                 "exec_args": ["--onetime", "--detailed-exitcodes"],
             }
         }
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(2, m_man_puppet.call_count)
         self.assertIn(
             [
@@ -388,7 +385,7 @@ class TestPuppetHandle(CiTestCase):
                 "exec_args": "--onetime --detailed-exitcodes",
             }
         }
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(2, m_man_puppet.call_count)
         self.assertIn(
             [
@@ -409,10 +406,10 @@ class TestPuppetHandle(CiTestCase):
             # puppet-agent not installed, but puppet is
             install_pkg.side_effect = (ProcessExecutionError, 0)
 
-            cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+            cc_puppet.handle("notimportant", cfg, self.cloud, None)
             expected_calls = [
-                mock.call(LOG, self.cloud, "enable"),
-                mock.call(LOG, self.cloud, "start"),
+                mock.call(self.cloud, "enable"),
+                mock.call(self.cloud, "start"),
             ]
             self.assertEqual(expected_calls, m_man_puppet.call_args_list)
 
@@ -425,7 +422,7 @@ class TestPuppetHandle(CiTestCase):
             # puppet-agent not installed, but puppet is
             install_pkg.side_effect = (ProcessExecutionError, 0)
             with pytest.raises(ProcessExecutionError):
-                cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+                cc_puppet.handle("notimportant", cfg, self.cloud, None)
             self.assertEqual(0, m_man_puppet.call_count)
             self.assertNotIn(
                 [
@@ -439,7 +436,7 @@ class TestPuppetHandle(CiTestCase):
     @mock.patch("cloudinit.config.cc_puppet.subp.subp", return_value=("", ""))
     def test_puppet_with_conf_package_name_success(self, m_subp, m_man_puppet):
         cfg = {"puppet": {"package_name": "puppet"}}
-        cc_puppet.handle("notimportant", cfg, self.cloud, LOG, None)
+        cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(2, m_man_puppet.call_count)
 
 

--- a/tests/unittests/config/test_cc_refresh_rmc_and_interface.py
+++ b/tests/unittests/config/test_cc_refresh_rmc_and_interface.py
@@ -129,7 +129,7 @@ class TestRsctNodeFile(t_help.CiTestCase):
         correct things?
         """
         m_netdev_info.return_value = NET_INFO
-        ccrmci.handle("refresh_rmc_and_interface", None, None, None, None)
+        ccrmci.handle("refresh_rmc_and_interface", None, None, None)
         self.assertEqual(1, m_netdev_info.call_count)
         m_refresh_ipv6.assert_called_with("env5")
         m_disable_ipv6.assert_called_with(

--- a/tests/unittests/config/test_cc_resizefs.py
+++ b/tests/unittests/config/test_cc_resizefs.py
@@ -83,37 +83,42 @@ class TestResizefs(CiTestCase):
     def test_handle_noops_on_disabled(self):
         """The handle function logs when the configuration disables resize."""
         cfg = {"resize_rootfs": False}
-        handle("cc_resizefs", cfg, cloud=None, log=LOG, args=[])
+        handle("cc_resizefs", cfg, cloud=None, args=[])
         self.assertIn(
             "DEBUG: Skipping module named cc_resizefs, resizing disabled\n",
             self.logs.getvalue(),
         )
 
     @mock.patch("cloudinit.config.cc_resizefs.util.get_mount_info")
-    def test_handle_warns_on_unknown_mount_info(self, m_get_mount_info):
+    @mock.patch("cloudinit.config.cc_resizefs.LOG")
+    def test_handle_warns_on_unknown_mount_info(self, m_log, m_get_mount_info):
         """handle warns when get_mount_info sees unknown filesystem for /."""
         m_get_mount_info.return_value = None
         cfg = {"resize_rootfs": True}
-        handle("cc_resizefs", cfg, cloud=None, log=LOG, args=[])
+        handle("cc_resizefs", cfg, cloud=None, args=[])
         logs = self.logs.getvalue()
         self.assertNotIn(
             "WARNING: Invalid cloud-config provided:\nresize_rootfs:", logs
         )
-        self.assertIn(
-            "WARNING: Could not determine filesystem type of /\n", logs
+        self.assertEqual(
+            ("Could not determine filesystem type of %s", "/"),
+            m_log.warning.call_args[0],
         )
         self.assertEqual(
-            [mock.call("/", LOG)], m_get_mount_info.call_args_list
+            [mock.call("/", m_log)], m_get_mount_info.call_args_list
         )
 
-    def test_handle_warns_on_undiscoverable_root_path_in_commandline(self):
+    @mock.patch("cloudinit.config.cc_resizefs.LOG")
+    def test_handle_warns_on_undiscoverable_root_path_in_commandline(
+        self, m_log
+    ):
         """handle noops when the root path is not found on the commandline."""
         cfg = {"resize_rootfs": True}
         exists_mock_path = "cloudinit.config.cc_resizefs.os.path.exists"
 
         def fake_mount_info(path, log):
             self.assertEqual("/", path)
-            self.assertEqual(LOG, log)
+            self.assertEqual(m_log, log)
             return ("/dev/root", "ext4", "/")
 
         with mock.patch(exists_mock_path) as m_exists:
@@ -129,11 +134,11 @@ class TestResizefs(CiTestCase):
                 "cc_resizefs",
                 cfg,
                 cloud=None,
-                log=LOG,
                 args=[],
             )
-        logs = self.logs.getvalue()
-        self.assertIn("WARNING: Unable to find device '/dev/root'", logs)
+        self.assertIn(
+            "Unable to find device '/dev/root'", m_log.warning.call_args[0]
+        )
 
     def test_resize_zfs_cmd_return(self):
         zpool = "zroot"
@@ -183,8 +188,8 @@ class TestResizefs(CiTestCase):
         cfg = {"resize_rootfs": True}
 
         with mock.patch("cloudinit.config.cc_resizefs.do_resize") as dresize:
-            handle("cc_resizefs", cfg, cloud=None, log=LOG, args=[])
-            ret = dresize.call_args[0][0]
+            handle("cc_resizefs", cfg, cloud=None, args=[])
+            ret = dresize.call_args[0]
 
         self.assertEqual(("zpool", "online", "-e", "vmzroot", disk), ret)
 
@@ -217,11 +222,10 @@ class TestResizefs(CiTestCase):
         with mock.patch("cloudinit.config.cc_resizefs.do_resize") as dresize:
             with mock.patch("cloudinit.config.cc_resizefs.os.stat") as m_stat:
                 m_stat.side_effect = fake_stat
-                handle("cc_resizefs", cfg, cloud=None, log=LOG, args=[])
-
+                handle("cc_resizefs", cfg, cloud=None, args=[])
         self.assertEqual(
             ("zpool", "online", "-e", "zroot", "/dev/" + disk),
-            dresize.call_args[0][0],
+            dresize.call_args[0],
         )
 
 

--- a/tests/unittests/config/test_cc_resizefs.py
+++ b/tests/unittests/config/test_cc_resizefs.py
@@ -280,7 +280,6 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
             maybe_get_writable_device_path,
             "overlayroot",
             info,
-            LOG,
         )
         self.assertIsNone(devpath)
         self.assertIn(
@@ -310,7 +309,6 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
                 maybe_get_writable_device_path,
                 "/dev/root",
                 info,
-                LOG,
             )
         self.assertIsNone(devpath)
         logs = self.logs.getvalue()
@@ -325,7 +323,6 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
             maybe_get_writable_device_path,
             "/dev/I/dont/exist",
             info,
-            LOG,
         )
         self.assertIsNone(devpath)
         self.assertIn(
@@ -343,7 +340,6 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
             maybe_get_writable_device_path,
             "/dev/I/dont/exist",
             info,
-            LOG,
         )
         self.assertIsNone(devpath)
         self.assertIn(
@@ -367,7 +363,6 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
                 maybe_get_writable_device_path,
                 "/dev/I/dont/exist",
                 info,
-                LOG,
             )
         self.assertEqual(
             "Something unexpected", str(context_manager.exception)
@@ -385,7 +380,6 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
             maybe_get_writable_device_path,
             fake_devpath,
             info,
-            LOG,
         )
         self.assertIsNone(devpath)
         self.assertIn(
@@ -407,7 +401,6 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
             maybe_get_writable_device_path,
             fake_devpath,
             info,
-            LOG,
         )
         self.assertIsNone(devpath)
         self.assertIn(
@@ -437,7 +430,6 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
             maybe_get_writable_device_path,
             "/dev/root",
             info,
-            LOG,
         )
         self.assertEqual("/dev/disk/by-uuid/my-uuid", devpath)
         self.assertIn(
@@ -494,7 +486,7 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
     ):
         freebsd.return_value = True
         info = "dev=gpt/system mnt_point=/ path=/"
-        devpth = maybe_get_writable_device_path("gpt/system", info, LOG)
+        devpth = maybe_get_writable_device_path("gpt/system", info)
         self.assertEqual("gpt/system", devpth)
 
 

--- a/tests/unittests/config/test_cc_resolv_conf.py
+++ b/tests/unittests/config/test_cc_resolv_conf.py
@@ -55,7 +55,7 @@ class TestResolvConf(FilesystemMockingTestCase):
             distro = self._fetch_distro(distro_name, conf)
             paths = helpers.Paths({"cloud_dir": self.tmp})
             cc = cloud.Cloud(ds, paths, {}, distro, None)
-        cc_resolv_conf.handle("cc_resolv_conf", conf, cc, LOG, [])
+        cc_resolv_conf.handle("cc_resolv_conf", conf, cc, [])
 
     @mock.patch("cloudinit.config.cc_resolv_conf.templater.render_to_file")
     def test_resolv_conf_systemd_resolved(self, m_render_to_file):

--- a/tests/unittests/config/test_cc_rh_subscription.py
+++ b/tests/unittests/config/test_cc_rh_subscription.py
@@ -55,9 +55,7 @@ class GoodTests(CiTestCase):
         Emulates a system that is already registered. Ensure it gets
         a non-ProcessExecution error from is_registered()
         """
-        self.handle(
-            self.name, self.config, self.cloud_init, self.log, self.args
-        )
+        self.handle(self.name, self.config, self.cloud_init, self.args)
         self.assertEqual(m_sman_cli.call_count, 1)
         self.assertIn("System is already registered", self.logs.getvalue())
 
@@ -70,9 +68,7 @@ class GoodTests(CiTestCase):
             " 12345678-abde-abcde-1234-1234567890abc"
         )
         m_sman_cli.side_effect = [subp.ProcessExecutionError, (reg, "bar")]
-        self.handle(
-            self.name, self.config, self.cloud_init, self.log, self.args
-        )
+        self.handle(self.name, self.config, self.cloud_init, self.args)
         self.assertIn(mock.call(["identity"]), m_sman_cli.call_args_list)
         self.assertIn(
             mock.call(
@@ -131,9 +127,7 @@ class GoodTests(CiTestCase):
             ("Repo ID: repo2\nRepo ID: repo3\nRepo ID: repo4", ""),
             ("", ""),
         ]
-        self.handle(
-            self.name, self.config_full, self.cloud_init, self.log, self.args
-        )
+        self.handle(self.name, self.config_full, self.cloud_init, self.args)
         self.assertEqual(m_sman_cli.call_count, 9)
         for call in call_lists:
             self.assertIn(mock.call(call), m_sman_cli.call_args_list)
@@ -213,7 +207,6 @@ class TestBadInput(CiTestCase):
             self.name,
             self.config_no_password,
             self.cloud_init,
-            self.log,
             self.args,
         )
         self.assertEqual(m_sman_cli.call_count, 0)
@@ -221,9 +214,7 @@ class TestBadInput(CiTestCase):
     def test_no_org(self, m_sman_cli):
         """Attempt to register without the org key/value."""
         m_sman_cli.side_effect = [subp.ProcessExecutionError]
-        self.handle(
-            self.name, self.config_no_key, self.cloud_init, self.log, self.args
-        )
+        self.handle(self.name, self.config_no_key, self.cloud_init, self.args)
         m_sman_cli.assert_called_with(["identity"])
         self.assertEqual(m_sman_cli.call_count, 1)
         self.assert_logged_warnings(
@@ -245,7 +236,6 @@ class TestBadInput(CiTestCase):
             self.name,
             self.config_service,
             self.cloud_init,
-            self.log,
             self.args,
         )
         self.assertEqual(m_sman_cli.call_count, 1)
@@ -268,7 +258,6 @@ class TestBadInput(CiTestCase):
             self.name,
             self.config_badpool,
             self.cloud_init,
-            self.log,
             self.args,
         )
         self.assertEqual(m_sman_cli.call_count, 2)
@@ -291,7 +280,6 @@ class TestBadInput(CiTestCase):
             self.name,
             self.config_badrepo,
             self.cloud_init,
-            self.log,
             self.args,
         )
         self.assertEqual(m_sman_cli.call_count, 2)
@@ -311,9 +299,7 @@ class TestBadInput(CiTestCase):
             subp.ProcessExecutionError,
             (self.reg, "bar"),
         ]
-        self.handle(
-            self.name, self.config_badkey, self.cloud_init, self.log, self.args
-        )
+        self.handle(self.name, self.config_badkey, self.cloud_init, self.args)
         self.assertEqual(m_sman_cli.call_count, 1)
         self.assert_logged_warnings(
             (

--- a/tests/unittests/config/test_cc_runcmd.py
+++ b/tests/unittests/config/test_cc_runcmd.py
@@ -37,7 +37,7 @@ class TestRuncmd(FilesystemMockingTestCase):
         """When the provided config doesn't contain runcmd, skip it."""
         cfg = {}
         mycloud = get_cloud(paths=self.paths)
-        handle("notimportant", cfg, mycloud, LOG, None)
+        handle("notimportant", cfg, mycloud, None)
         self.assertIn(
             "Skipping module named notimportant, no 'runcmd' key",
             self.logs.getvalue(),
@@ -51,7 +51,7 @@ class TestRuncmd(FilesystemMockingTestCase):
         cc = get_cloud(paths=self.paths)
         with self.assertRaises(TypeError) as cm:
             with self.allow_subp(["/bin/sh"]):
-                handle("cc_runcmd", valid_config, cc, LOG, None)
+                handle("cc_runcmd", valid_config, cc, None)
         self.assertIn("Failed to shellify", str(cm.exception))
 
     def test_handler_invalid_command_set(self):
@@ -59,7 +59,7 @@ class TestRuncmd(FilesystemMockingTestCase):
         invalid_config = {"runcmd": 1}
         cc = get_cloud(paths=self.paths)
         with self.assertRaises(TypeError) as cm:
-            handle("cc_runcmd", invalid_config, cc, LOG, [])
+            handle("cc_runcmd", invalid_config, cc, [])
         self.assertIn(
             "Failed to shellify 1 into file"
             " /var/lib/cloud/instances/iid-datasource-none/scripts/runcmd",
@@ -70,7 +70,7 @@ class TestRuncmd(FilesystemMockingTestCase):
         """Valid runcmd schema is written to a runcmd shell script."""
         valid_config = {"runcmd": [["ls", "/"]]}
         cc = get_cloud(paths=self.paths)
-        handle("cc_runcmd", valid_config, cc, LOG, [])
+        handle("cc_runcmd", valid_config, cc, [])
         runcmd_file = os.path.join(
             self.new_root,
             "var/lib/cloud/instances/iid-datasource-none/scripts/runcmd",

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -71,7 +71,7 @@ class TestRandomSeed(TestCase):
                 "data": "tiny-tim-was-here",
             }
         }
-        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), LOG, [])
+        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_file(self._seed_file)
         self.assertEqual("tiny-tim-was-here", contents)
 
@@ -90,7 +90,6 @@ class TestRandomSeed(TestCase):
             "test",
             cfg,
             get_cloud("ubuntu"),
-            LOG,
             [],
         )
 
@@ -103,7 +102,7 @@ class TestRandomSeed(TestCase):
                 "encoding": "gzip",
             }
         }
-        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), LOG, [])
+        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_file(self._seed_file)
         self.assertEqual("tiny-toe", contents)
 
@@ -116,7 +115,7 @@ class TestRandomSeed(TestCase):
                 "encoding": "gz",
             }
         }
-        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), LOG, [])
+        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_file(self._seed_file)
         self.assertEqual("big-toe", contents)
 
@@ -129,7 +128,7 @@ class TestRandomSeed(TestCase):
                 "encoding": "base64",
             }
         }
-        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), LOG, [])
+        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_file(self._seed_file)
         self.assertEqual("bubbles", contents)
 
@@ -142,7 +141,7 @@ class TestRandomSeed(TestCase):
                 "encoding": "b64",
             }
         }
-        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), LOG, [])
+        cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_file(self._seed_file)
         self.assertEqual("kit-kat", contents)
 
@@ -154,7 +153,7 @@ class TestRandomSeed(TestCase):
             }
         }
         c = get_cloud("ubuntu", metadata={"random_seed": "-so-was-josh"})
-        cc_seed_random.handle("test", cfg, c, LOG, [])
+        cc_seed_random.handle("test", cfg, c, [])
         contents = util.load_file(self._seed_file)
         self.assertEqual("tiny-tim-was-here-so-was-josh", contents)
 
@@ -162,7 +161,7 @@ class TestRandomSeed(TestCase):
         c = get_cloud("ubuntu")
         self.whichdata = {"pollinate": "/usr/bin/pollinate"}
         cfg = {"random_seed": {"command": ["pollinate", "-q"]}}
-        cc_seed_random.handle("test", cfg, c, LOG, [])
+        cc_seed_random.handle("test", cfg, c, [])
 
         subp_args = [f["args"] for f in self.subp_called]
         self.assertIn(["pollinate", "-q"], subp_args)
@@ -170,7 +169,7 @@ class TestRandomSeed(TestCase):
     def test_seed_command_not_provided(self):
         c = get_cloud("ubuntu")
         self.whichdata = {}
-        cc_seed_random.handle("test", {}, c, LOG, [])
+        cc_seed_random.handle("test", {}, c, [])
 
         # subp should not have been called as which would say not available
         self.assertFalse(self.subp_called)
@@ -185,14 +184,14 @@ class TestRandomSeed(TestCase):
             }
         }
         self.assertRaises(
-            ValueError, cc_seed_random.handle, "test", cfg, c, LOG, []
+            ValueError, cc_seed_random.handle, "test", cfg, c, []
         )
 
     def test_seed_command_and_required(self):
         c = get_cloud("ubuntu")
         self.whichdata = {"foo": "foo"}
         cfg = {"random_seed": {"command_required": True, "command": ["foo"]}}
-        cc_seed_random.handle("test", cfg, c, LOG, [])
+        cc_seed_random.handle("test", cfg, c, [])
 
         self.assertIn(["foo"], [f["args"] for f in self.subp_called])
 
@@ -206,7 +205,7 @@ class TestRandomSeed(TestCase):
                 "file": self._seed_file,
             }
         }
-        cc_seed_random.handle("test", cfg, c, LOG, [])
+        cc_seed_random.handle("test", cfg, c, [])
 
         # this just instists that the first time subp was called,
         # RANDOM_SEED_FILE was in the environment set up correctly

--- a/tests/unittests/config/test_cc_set_hostname.py
+++ b/tests/unittests/config/test_cc_set_hostname.py
@@ -45,7 +45,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         ds = None
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
-        cc_set_hostname.handle("cc_set_hostname", cfg, cc, LOG, [])
+        cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         contents = util.load_file("/etc/hostname")
         self.assertEqual("blah.yahoo.com", contents.strip())
 
@@ -61,7 +61,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         ds = None
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
-        cc_set_hostname.handle("cc_set_hostname", cfg, cc, LOG, [])
+        cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         contents = util.load_file("/etc/sysconfig/network", decode=False)
         n_cfg = ConfigObj(BytesIO(contents))
         self.assertEqual({"HOSTNAME": "blah"}, dict(n_cfg))
@@ -74,7 +74,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         ds = None
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
-        cc_set_hostname.handle("cc_set_hostname", cfg, cc, LOG, [])
+        cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         contents = util.load_file("/etc/sysconfig/network", decode=False)
         n_cfg = ConfigObj(BytesIO(contents))
         self.assertEqual({"HOSTNAME": "blah.blah.blah.yahoo.com"}, dict(n_cfg))
@@ -89,7 +89,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         ds = None
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
-        cc_set_hostname.handle("cc_set_hostname", cfg, cc, LOG, [])
+        cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         contents = util.load_file("/etc/hostname")
         self.assertEqual("blah", contents.strip())
 
@@ -103,7 +103,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         ds = None
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
-        cc_set_hostname.handle("cc_set_hostname", cfg, cc, LOG, [])
+        cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         contents = util.load_file(distro.hostname_conf_fn)
         self.assertEqual("blah", contents.strip())
 
@@ -126,7 +126,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         paths = helpers.Paths({"cloud_dir": self.tmp})
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         for c in [cfg1, cfg2]:
-            cc_set_hostname.handle("cc_set_hostname", c, cc, LOG, [])
+            cc_set_hostname.handle("cc_set_hostname", c, cc, [])
             print("\n", m_subp.call_args_list)
             if c["prefer_fqdn_over_hostname"]:
                 assert [
@@ -164,19 +164,19 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
         cc_set_hostname.handle(
-            "cc_set_hostname", {"hostname": "hostname1.me.com"}, cc, LOG, []
+            "cc_set_hostname", {"hostname": "hostname1.me.com"}, cc, []
         )
         contents = util.load_file("/etc/hostname")
         self.assertEqual("hostname1", contents.strip())
         cc_set_hostname.handle(
-            "cc_set_hostname", {"hostname": "hostname1.me.com"}, cc, LOG, []
+            "cc_set_hostname", {"hostname": "hostname1.me.com"}, cc, []
         )
         self.assertIn(
             "DEBUG: No hostname changes. Skipping set-hostname\n",
             self.logs.getvalue(),
         )
         cc_set_hostname.handle(
-            "cc_set_hostname", {"hostname": "hostname2.me.com"}, cc, LOG, []
+            "cc_set_hostname", {"hostname": "hostname2.me.com"}, cc, []
         )
         contents = util.load_file("/etc/hostname")
         self.assertEqual("hostname2", contents.strip())
@@ -198,7 +198,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
 
         util.write_file("/etc/hostname", "")
-        cc_set_hostname.handle("cc_set_hostname", {}, cc, LOG, [])
+        cc_set_hostname.handle("cc_set_hostname", {}, cc, [])
         contents = util.load_file("/etc/hostname")
         self.assertEqual("", contents.strip())
 
@@ -216,7 +216,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         # user-provided localhost should not be ignored
         util.write_file("/etc/hostname", "")
         cc_set_hostname.handle(
-            "cc_set_hostname", {"hostname": "localhost"}, cc, LOG, []
+            "cc_set_hostname", {"hostname": "localhost"}, cc, []
         )
         contents = util.load_file("/etc/hostname")
         self.assertEqual("localhost", contents.strip())
@@ -235,7 +235,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         with self.assertRaises(cc_set_hostname.SetHostnameError) as ctx_mgr:
             cc_set_hostname.handle(
-                "somename", {"hostname": "hostname1.me.com"}, cc, LOG, []
+                "somename", {"hostname": "hostname1.me.com"}, cc, []
             )
         self.assertEqual(
             "Failed to set the hostname to hostname1.me.com (hostname1):"
@@ -255,7 +255,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         prev_fn = Path(cc.get_cpath("data")) / "set-hostname"
         prev_fn.touch()
-        cc_set_hostname.handle("cc_set_hostname", cfg, cc, LOG, [])
+        cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         contents = util.load_file("/etc/hostname")
         self.assertEqual("blah", contents.strip())
 

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -118,7 +118,6 @@ def get_chpasswd_calls(cfg, cloud, log):
                 "IGNORED",
                 cfg=cfg,
                 cloud=cloud,
-                log=log,
                 args=[],
             )
     assert chpasswd.call_count > 0
@@ -132,7 +131,7 @@ class TestSetPasswordsHandle:
     def test_handle_on_empty_config(self, m_subp, caplog):
         """handle logs that no password has changed when config is empty."""
         cloud = get_cloud()
-        setpass.handle("IGNORED", cfg={}, cloud=cloud, log=LOG, args=[])
+        setpass.handle("IGNORED", cfg={}, cloud=cloud, args=[])
         assert (
             "Leaving SSH config 'PasswordAuthentication' unchanged. "
             "ssh_pwauth=None"
@@ -155,7 +154,7 @@ class TestSetPasswordsHandle:
         ]
         cfg = {"chpasswd": {"list": valid_hashed_pwds}}
         with mock.patch.object(setpass.Distro, "chpasswd") as chpasswd:
-            setpass.handle("IGNORED", cfg=cfg, cloud=cloud, log=LOG, args=[])
+            setpass.handle("IGNORED", cfg=cfg, cloud=cloud, args=[])
         assert "Handling input for chpasswd as list." in caplog.text
         assert "Setting hashed password for ['root', 'ubuntu']" in caplog.text
 
@@ -181,7 +180,7 @@ class TestSetPasswordsHandle:
         ]
         cfg = {"chpasswd": {"users": valid_hashed_pwds}}
         with mock.patch.object(setpass.Distro, "chpasswd") as chpasswd:
-            setpass.handle("IGNORED", cfg=cfg, cloud=cloud, log=LOG, args=[])
+            setpass.handle("IGNORED", cfg=cfg, cloud=cloud, args=[])
         assert "Handling input for chpasswd as list." not in caplog.text
         assert "Setting hashed password for ['root', 'ubuntu']" in caplog.text
         first_arg = chpasswd.call_args[0]
@@ -228,7 +227,7 @@ class TestSetPasswordsHandle:
         with mock.patch.object(
             cloud.distro, "uses_systemd", return_value=False
         ):
-            setpass.handle("IGNORED", cfg=cfg, cloud=cloud, log=LOG, args=[])
+            setpass.handle("IGNORED", cfg=cfg, cloud=cloud, args=[])
         assert [
             mock.call(
                 ["pw", "usermod", "ubuntu", "-h", "0"],
@@ -272,7 +271,7 @@ class TestSetPasswordsHandle:
         cfg = {"chpasswd": user_cfg}
 
         with mock.patch.object(setpass.Distro, "chpasswd") as chpasswd:
-            setpass.handle("IGNORED", cfg=cfg, cloud=cloud, log=LOG, args=[])
+            setpass.handle("IGNORED", cfg=cfg, cloud=cloud, args=[])
         dbg_text = "Handling input for chpasswd as list."
         if "list" in cfg["chpasswd"]:
             assert dbg_text in caplog.text
@@ -511,7 +510,7 @@ class TestExpire:
         mocker.patch.object(cloud.distro, "chpasswd")
         m_expire = mocker.patch.object(cloud.distro, "expire_passwd")
 
-        setpass.handle("IGNORED", cfg=cfg, cloud=cloud, log=LOG, args=[])
+        setpass.handle("IGNORED", cfg=cfg, cloud=cloud, args=[])
 
         if bool(cfg["chpasswd"]["expire"]):
             assert m_expire.call_args_list == [
@@ -537,7 +536,7 @@ class TestExpire:
         mocker.patch.object(cloud.distro, "chpasswd")
         m_expire = mocker.patch.object(cloud.distro, "expire_passwd")
 
-        setpass.handle("IGNORED", cfg=cfg, cloud=cloud, log=LOG, args=[])
+        setpass.handle("IGNORED", cfg=cfg, cloud=cloud, args=[])
 
         if bool(cfg["chpasswd"]["expire"]):
             assert m_expire.call_args_list == [

--- a/tests/unittests/config/test_cc_snap.py
+++ b/tests/unittests/config/test_cc_snap.py
@@ -329,7 +329,7 @@ class TestHandle:
         cfg = {
             "snap": {"assertions": [SYSTEM_USER_ASSERTION, ACCOUNT_ASSERTION]}
         }
-        handle("snap", cfg=cfg, cloud=fake_cloud, log=mock.Mock(), args=None)
+        handle("snap", cfg=cfg, cloud=fake_cloud, args=None)
         content = "\n".join(cfg["snap"]["assertions"])
         util.write_file(compare_file, content.encode("utf-8"))
         assert util.load_file(compare_file) == util.load_file(assert_file)

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -114,7 +114,7 @@ class TestHandleSsh:
         m_nug.return_value = ([], {})
         cc_ssh.PUBLISH_HOST_KEYS = False
         cloud = get_cloud(distro="ubuntu", metadata={"public-keys": keys})
-        cc_ssh.handle("name", cfg, cloud, LOG, None)
+        cc_ssh.handle("name", cfg, cloud, None)
         options = ssh_util.DISABLE_USER_OPTS.replace("$USER", "NONE")
         options = options.replace("$DISABLE_USER", "root")
         m_glob.assert_called_once_with("/etc/ssh/ssh_host_*key*")
@@ -145,7 +145,7 @@ class TestHandleSsh:
         m_path_exists.return_value = True
         m_nug.return_value = ({user: {"default": user}}, {})
         cloud = get_cloud(distro="ubuntu", metadata={"public-keys": keys})
-        cc_ssh.handle("name", cfg, cloud, LOG, None)
+        cc_ssh.handle("name", cfg, cloud, None)
 
         options = ssh_util.DISABLE_USER_OPTS.replace("$USER", user)
         options = options.replace("$DISABLE_USER", "root")
@@ -196,7 +196,7 @@ class TestHandleSsh:
         cloud = get_cloud(distro="ubuntu", metadata={"public-keys": keys})
         if mock_get_public_ssh_keys:
             cloud.get_public_ssh_keys = mock.Mock(return_value=keys)
-        cc_ssh.handle("name", cfg, cloud, LOG, None)
+        cc_ssh.handle("name", cfg, cloud, None)
 
         if empty_opts:
             options = ""
@@ -279,7 +279,7 @@ class TestHandleSsh:
                     ]
                 )
             ]
-        cc_ssh.handle("name", cfg, cloud, LOG, None)
+        cc_ssh.handle("name", cfg, cloud, None)
         assert (
             expected_calls == cloud.datasource.publish_host_keys.call_args_list
         )
@@ -363,7 +363,7 @@ class TestHandleSsh:
         with mock.patch(
             MODPATH + "ssh_util.parse_ssh_config", return_value=[]
         ):
-            cc_ssh.handle("name", cfg, get_cloud(distro="ubuntu"), LOG, None)
+            cc_ssh.handle("name", cfg, get_cloud(distro="ubuntu"), None)
 
         # Check that all expected output has been done.
         for call_ in expected_calls:
@@ -410,7 +410,7 @@ class TestHandleSsh:
         with mock.patch(
             MODPATH + "ssh_util.parse_ssh_config", return_value=[]
         ):
-            cc_ssh.handle("name", cfg, get_cloud("ubuntu"), LOG, None)
+            cc_ssh.handle("name", cfg, get_cloud("ubuntu"), None)
         assert [] == m_write_file.call_args_list
         expected_log_msgs = [
             f'Skipping {reason} ssh_keys entry: "{key_type}_private"',

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -74,5 +74,5 @@ class TestHandleSshImportIDs:
         """Skip config without ssh_import_id"""
         m_which.return_value = None
         cloud = get_cloud("ubuntu")
-        cc_ssh_import_id.handle("name", cfg, cloud, LOG, [])
+        cc_ssh_import_id.handle("name", cfg, cloud, [])
         assert log in caplog.text

--- a/tests/unittests/config/test_cc_timezone.py
+++ b/tests/unittests/config/test_cc_timezone.py
@@ -40,7 +40,7 @@ class TestTimezone(t_help.FilesystemMockingTestCase):
             "/usr/share/zoneinfo/%s" % cfg["timezone"], dummy_contents
         )
 
-        cc_timezone.handle("cc_timezone", cfg, cc, LOG, [])
+        cc_timezone.handle("cc_timezone", cfg, cc, [])
 
         contents = util.load_file("/etc/sysconfig/clock", decode=False)
         n_cfg = ConfigObj(BytesIO(contents))

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -804,7 +804,7 @@ class TestHandle:
         caplog,
     ):
         """Non-Pro schemas and instance."""
-        handle("nomatter", cfg=cfg, cloud=cloud, log=None, args=None)
+        handle("nomatter", cfg=cfg, cloud=cloud, args=None)
         for record_tuple in log_record_tuples:
             assert record_tuple in caplog.record_tuples
         if maybe_install_call_args_list is not None:
@@ -936,7 +936,7 @@ class TestHandle:
             m_auto_attach.side_effect = auto_attach_side_effect
 
         with expectation:
-            handle("nomatter", cfg=cfg, cloud=cloud, log=None, args=None)
+            handle("nomatter", cfg=cfg, cloud=cloud, args=None)
 
         for record_tuple in log_record_tuples:
             assert record_tuple in caplog.record_tuples
@@ -981,7 +981,7 @@ class TestHandle:
         enable or disable ua auto-attach.
         """
         m_should_auto_attach.return_value = is_pro
-        handle("nomatter", cfg=cfg, cloud=self.cloud, log=None, args=None)
+        handle("nomatter", cfg=cfg, cloud=self.cloud, args=None)
         assert not m_attach.call_args_list
 
     @pytest.mark.parametrize(
@@ -1012,7 +1012,7 @@ class TestHandle:
         self, m_configure_ua, cfg, handle_kwargs, match
     ):
         with pytest.raises(RuntimeError, match=match):
-            handle("nomatter", cfg=cfg, log=mock.Mock(), **handle_kwargs)
+            handle("nomatter", cfg=cfg, **handle_kwargs)
         assert 0 == m_configure_ua.call_count
 
     @pytest.mark.parametrize(
@@ -1035,7 +1035,6 @@ class TestHandle:
             handle(
                 "nomatter",
                 cfg=cfg,
-                log=mock.Mock(),
                 cloud=self.cloud,
                 args=None,
             )
@@ -1062,7 +1061,6 @@ class TestHandle:
             handle(
                 "nomatter",
                 cfg=cfg,
-                log=mock.Mock(),
                 cloud=self.cloud,
                 args=None,
             )
@@ -1084,7 +1082,6 @@ class TestHandle:
             handle(
                 "nomatter",
                 cfg=cfg,
-                log=mock.Mock(),
                 cloud=self.cloud,
                 args=None,
             )

--- a/tests/unittests/config/test_cc_ubuntu_autoinstall.py
+++ b/tests/unittests/config/test_cc_ubuntu_autoinstall.py
@@ -116,7 +116,7 @@ class TestHandleAutoinstall:
     ):
         subp.return_value = snap_list, ""
         cloud = get_cloud(distro="ubuntu")
-        cc_ubuntu_autoinstall.handle("name", cfg, cloud, LOG, None)
+        cc_ubuntu_autoinstall.handle("name", cfg, cloud, None)
         assert subp_calls == subp.call_args_list
         for log in logs:
             assert log in caplog.text

--- a/tests/unittests/config/test_cc_ubuntu_drivers.py
+++ b/tests/unittests/config/test_cc_ubuntu_drivers.py
@@ -88,7 +88,7 @@ class TestUbuntuDrivers:
         debconf_file = tdir.join("nvidia.template")
         m_tmp.return_value = tdir
         myCloud = mock.MagicMock()
-        drivers.handle("ubuntu_drivers", new_config, myCloud, None, None)
+        drivers.handle("ubuntu_drivers", new_config, myCloud, None)
         assert [
             mock.call(drivers.X_LOADTEMPLATEFILE, debconf_file)
         ] == m_debconf.DebconfCommunicator().__enter__().command.call_args_list
@@ -122,7 +122,7 @@ class TestUbuntuDrivers:
         )
 
         with pytest.raises(Exception):
-            drivers.handle("ubuntu_drivers", cfg_accepted, myCloud, None, None)
+            drivers.handle("ubuntu_drivers", cfg_accepted, myCloud, None)
         assert [
             mock.call(drivers.X_LOADTEMPLATEFILE, debconf_file)
         ] == m_debconf.DebconfCommunicator().__enter__().command.call_args_list
@@ -185,19 +185,19 @@ class TestUbuntuDrivers:
     ):
         """Helper to reduce repetition when testing negative cases"""
         myCloud = mock.MagicMock()
-        drivers.handle("ubuntu_drivers", config, myCloud, None, None)
+        drivers.handle("ubuntu_drivers", config, myCloud, None)
         assert 0 == myCloud.distro.install_packages.call_count
         assert 0 == m_subp.call_count
 
     @mock.patch(MPATH + "install_drivers")
+    @mock.patch(MPATH + "LOG")
     def test_handle_no_drivers_does_nothing(
-        self, m_install_drivers, m_debconf, cfg_accepted, install_gpgpu
+        self, m_log, m_install_drivers, m_debconf, cfg_accepted, install_gpgpu
     ):
         """If no 'drivers' key in the config, nothing should be done."""
         myCloud = mock.MagicMock()
-        myLog = mock.MagicMock()
-        drivers.handle("ubuntu_drivers", {"foo": "bzr"}, myCloud, myLog, None)
-        assert "Skipping module named" in myLog.debug.call_args_list[0][0][0]
+        drivers.handle("ubuntu_drivers", {"foo": "bzr"}, myCloud, None)
+        assert "Skipping module named" in m_log.debug.call_args_list[0][0][0]
         assert 0 == m_install_drivers.call_count
 
     @mock.patch(M_TMP_PATH)
@@ -267,7 +267,7 @@ class TestUbuntuDrivers:
         )
 
         with pytest.raises(Exception):
-            drivers.handle("ubuntu_drivers", cfg_accepted, myCloud, None, None)
+            drivers.handle("ubuntu_drivers", cfg_accepted, myCloud, None)
         assert [
             mock.call(drivers.X_LOADTEMPLATEFILE, debconf_file)
         ] == m_debconf.DebconfCommunicator().__enter__().command.call_args_list
@@ -304,9 +304,7 @@ class TestUbuntuDrivers:
             "drivers": {"nvidia": {"license-accepted": True, "version": None}}
         }
         with pytest.raises(AttributeError):
-            drivers.handle(
-                "ubuntu_drivers", version_none_cfg, myCloud, None, None
-            )
+            drivers.handle("ubuntu_drivers", version_none_cfg, myCloud, None)
         assert (
             0 == m_debconf.DebconfCommunicator.__enter__().command.call_count
         )
@@ -335,7 +333,7 @@ class TestUbuntuDriversWithVersion:
         version_none_cfg = {
             "drivers": {"nvidia": {"license-accepted": True, "version": None}}
         }
-        drivers.handle("ubuntu_drivers", version_none_cfg, myCloud, None, None)
+        drivers.handle("ubuntu_drivers", version_none_cfg, myCloud, None)
         assert [
             mock.call(drivers.X_LOADTEMPLATEFILE, debconf_file)
         ] == m_debconf.DebconfCommunicator().__enter__().command.call_args_list
@@ -349,20 +347,19 @@ class TestUbuntuDriversNotRun:
     @mock.patch(MPATH + "HAS_DEBCONF", True)
     @mock.patch(M_TMP_PATH)
     @mock.patch(MPATH + "install_drivers")
+    @mock.patch(MPATH + "LOG")
     def test_no_cfg_drivers_does_nothing(
         self,
+        m_log,
         m_install_drivers,
         m_tmp,
         m_debconf,
         tmpdir,
     ):
         m_tmp.return_value = tmpdir
-        m_log = mock.MagicMock()
         myCloud = mock.MagicMock()
         version_none_cfg = {}
-        drivers.handle(
-            "ubuntu_drivers", version_none_cfg, myCloud, m_log, None
-        )
+        drivers.handle("ubuntu_drivers", version_none_cfg, myCloud, None)
         assert 0 == m_install_drivers.call_count
         assert (
             mock.call(
@@ -375,20 +372,19 @@ class TestUbuntuDriversNotRun:
     @mock.patch(MPATH + "HAS_DEBCONF", False)
     @mock.patch(M_TMP_PATH)
     @mock.patch(MPATH + "install_drivers")
+    @mock.patch(MPATH + "LOG")
     def test_has_not_debconf_does_nothing(
         self,
+        m_log,
         m_install_drivers,
         m_tmp,
         m_debconf,
         tmpdir,
     ):
         m_tmp.return_value = tmpdir
-        m_log = mock.MagicMock()
         myCloud = mock.MagicMock()
         version_none_cfg = {"drivers": {"nvidia": {"license-accepted": True}}}
-        drivers.handle(
-            "ubuntu_drivers", version_none_cfg, myCloud, m_log, None
-        )
+        drivers.handle("ubuntu_drivers", version_none_cfg, myCloud, None)
         assert 0 == m_install_drivers.call_count
         assert (
             mock.call(

--- a/tests/unittests/config/test_cc_update_etc_hosts.py
+++ b/tests/unittests/config/test_cc_update_etc_hosts.py
@@ -44,7 +44,7 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
         ds = None
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
-        cc_update_etc_hosts.handle("test", cfg, cc, LOG, [])
+        cc_update_etc_hosts.handle("test", cfg, cc, [])
         contents = util.load_file("%s/etc/hosts" % self.tmp)
         if "127.0.1.1\tcloud-init.test.us\tcloud-init" not in contents:
             self.assertIsNone("No entry for 127.0.1.1 in etc/hosts")
@@ -67,7 +67,7 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
         ds = None
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
-        cc_update_etc_hosts.handle("test", cfg, cc, LOG, [])
+        cc_update_etc_hosts.handle("test", cfg, cc, [])
         contents = util.load_file("%s/etc/hosts" % self.tmp)
         if "127.0.1.1 cloud-init.test.us cloud-init" not in contents:
             self.assertIsNone("No entry for 127.0.1.1 in etc/hosts")

--- a/tests/unittests/config/test_cc_users_groups.py
+++ b/tests/unittests/config/test_cc_users_groups.py
@@ -42,7 +42,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro="ubuntu", sys_cfg=sys_cfg, metadata=metadata
         )
-        cc_users_groups.handle("modulename", cfg, cloud, None, None)
+        cc_users_groups.handle("modulename", cfg, cloud, None)
         m_user.assert_not_called()
         m_group.assert_not_called()
 
@@ -62,7 +62,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro="ubuntu", sys_cfg=sys_cfg, metadata=metadata
         )
-        cc_users_groups.handle("modulename", cfg, cloud, None, None)
+        cc_users_groups.handle("modulename", cfg, cloud, None)
         self.assertCountEqual(
             m_user.call_args_list,
             [
@@ -107,7 +107,7 @@ class TestHandleUsersGroups(CiTestCase):
             cloud = self.tmp_cloud(
                 distro="freebsd", sys_cfg=sys_cfg, metadata=metadata
             )
-        cc_users_groups.handle("modulename", cfg, cloud, None, None)
+        cc_users_groups.handle("modulename", cfg, cloud, None)
         self.assertCountEqual(
             m_fbsd_user.call_args_list,
             [
@@ -142,7 +142,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro="ubuntu", sys_cfg=sys_cfg, metadata=metadata
         )
-        cc_users_groups.handle("modulename", cfg, cloud, None, None)
+        cc_users_groups.handle("modulename", cfg, cloud, None)
         self.assertCountEqual(
             m_user.call_args_list,
             [
@@ -183,7 +183,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro="ubuntu", sys_cfg=sys_cfg, metadata=metadata
         )
-        cc_users_groups.handle("modulename", cfg, cloud, None, None)
+        cc_users_groups.handle("modulename", cfg, cloud, None)
         self.assertCountEqual(
             m_user.call_args_list,
             [
@@ -216,7 +216,7 @@ class TestHandleUsersGroups(CiTestCase):
         }
         cloud = self.tmp_cloud(distro="ubuntu", sys_cfg={}, metadata={})
         with self.assertRaises(ValueError) as context_manager:
-            cc_users_groups.handle("modulename", cfg, cloud, None, None)
+            cc_users_groups.handle("modulename", cfg, cloud, None)
         m_group.assert_not_called()
         self.assertEqual(
             "Not creating user me2. Key(s) ssh_import_id cannot be provided"
@@ -246,7 +246,7 @@ class TestHandleUsersGroups(CiTestCase):
             distro="ubuntu", sys_cfg=sys_cfg, metadata=metadata
         )
         with self.assertRaises(ValueError) as context_manager:
-            cc_users_groups.handle("modulename", cfg, cloud, None, None)
+            cc_users_groups.handle("modulename", cfg, cloud, None)
         m_group.assert_not_called()
         self.assertEqual(
             "Not creating user me2. Invalid value of ssh_redirect_user:"
@@ -270,7 +270,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro="ubuntu", sys_cfg=sys_cfg, metadata=metadata
         )
-        cc_users_groups.handle("modulename", cfg, cloud, None, None)
+        cc_users_groups.handle("modulename", cfg, cloud, None)
         self.assertCountEqual(
             m_user.call_args_list,
             [
@@ -296,7 +296,7 @@ class TestHandleUsersGroups(CiTestCase):
         cloud = self.tmp_cloud(
             distro="ubuntu", sys_cfg=sys_cfg, metadata=metadata
         )
-        cc_users_groups.handle("modulename", cfg, cloud, None, None)
+        cc_users_groups.handle("modulename", cfg, cloud, None)
         m_user.assert_called_once_with("me2", default=False)
         m_group.assert_not_called()
         self.assertEqual(

--- a/tests/unittests/config/test_cc_wireguard.py
+++ b/tests/unittests/config/test_cc_wireguard.py
@@ -209,9 +209,7 @@ class TestWireGuard(CiTestCase):
     def test_handle_no_config(self, m_maybe_install_wireguard_packages):
         """When no wireguard configuration is provided, nothing happens."""
         cfg = {}
-        cc_wireguard.handle(
-            "wg", cfg=cfg, cloud=None, log=self.logger, args=None
-        )
+        cc_wireguard.handle("wg", cfg=cfg, cloud=None, args=None)
         self.assertIn(
             "DEBUG: Skipping module named wg, no 'wireguard'"
             " configuration found",

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -160,7 +160,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
             ]
         }
         cc = self.tmp_cloud("ubuntu")
-        handle("ignored", cfg, cc, LOG, [])
+        handle("ignored", cfg, cc, [])
         assert content == util.load_file(file_path)
         self.assertNotIn(
             "Unknown encoding type text/plain", self.logs.getvalue()
@@ -171,7 +171,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
         file_path = "/tmp/deferred.file"
         config = {"write_files": [{"path": file_path, "defer": True}]}
         cc = self.tmp_cloud("ubuntu")
-        handle("cc_write_file", config, cc, LOG, [])
+        handle("cc_write_file", config, cc, [])
         with self.assertRaises(FileNotFoundError):
             util.load_file(file_path)
 

--- a/tests/unittests/config/test_cc_write_files_deferred.py
+++ b/tests/unittests/config/test_cc_write_files_deferred.py
@@ -44,7 +44,7 @@ class TestWriteFilesDeferred(FilesystemMockingTestCase):
             ]
         }
         cc = self.tmp_cloud("ubuntu")
-        handle("cc_write_files_deferred", config, cc, LOG, [])
+        handle("cc_write_files_deferred", config, cc, [])
         self.assertEqual(util.load_file("/tmp/deferred.file"), expected)
         with self.assertRaises(FileNotFoundError):
             util.load_file("/tmp/not_deferred.file")

--- a/tests/unittests/config/test_cc_yum_add_repo.py
+++ b/tests/unittests/config/test_cc_yum_add_repo.py
@@ -41,7 +41,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
             },
         }
         self.patchUtils(self.tmp)
-        cc_yum_add_repo.handle("yum_add_repo", cfg, None, LOG, [])
+        cc_yum_add_repo.handle("yum_add_repo", cfg, None, [])
         self.assertRaises(
             IOError, util.load_file, "/etc/yum.repos.d/epel_testing.repo"
         )
@@ -61,7 +61,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         }
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
-        cc_yum_add_repo.handle("yum_add_repo", cfg, None, LOG, [])
+        cc_yum_add_repo.handle("yum_add_repo", cfg, None, [])
         contents = util.load_file("/etc/yum.repos.d/epel-testing.repo")
         parser = configparser.ConfigParser()
         parser.read_string(contents)
@@ -101,7 +101,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
             }
         }
         self.patchUtils(self.tmp)
-        cc_yum_add_repo.handle("yum_add_repo", cfg, None, LOG, [])
+        cc_yum_add_repo.handle("yum_add_repo", cfg, None, [])
         contents = util.load_file("/etc/yum.repos.d/puppetlabs-products.repo")
         parser = configparser.ConfigParser()
         parser.read_string(contents)

--- a/tests/unittests/config/test_cc_zypper_add_repo.py
+++ b/tests/unittests/config/test_cc_zypper_add_repo.py
@@ -162,7 +162,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         os.makedirs("%s/etc/zypp/repos.d" % root_d)
         helpers.populate_dir(root_d, {self.zypp_conf: "# Zypp config\n"})
         self.reRoot(root_d)
-        cc_zypper_add_repo.handle("zypper_add_repo", cfg, None, LOG, [])
+        cc_zypper_add_repo.handle("zypper_add_repo", cfg, None, [])
         cfg_out = os.path.join(root_d, self.zypp_conf)
         contents = util.load_file(cfg_out)
         expected = [


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
refactor: stop passing log to cc_* handlers

Use the module level Log instances instead of passing log instances
to the cc_* handlers
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
