### PR TITLE
Fix minor schema validation regression and fixup typing

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1231,6 +1231,7 @@ def handle_schema_args(name, args):
         error(
             ", ".join(error_type for error_type in error_types),
             fmt="Error: Invalid cloud-config schema: {}\n",
+            sys_exit=True,
         )
 
 

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1166,7 +1166,7 @@ def handle_schema_args(name, args):
         return
     if args.config_file:
         config_files = (("user-data", args.config_file),)
-    elif args.system:
+    else:
         if os.getuid() != 0:
             error(
                 "Unable to read system userdata or vendordata as non-root"
@@ -1176,13 +1176,19 @@ def handle_schema_args(name, args):
         init = Init(ds_deps=[])
         init.fetch(existing="trust")
         userdata_file = init.paths.get_ipath("cloud_config")
+        if not userdata_file:
+            error(
+                "Unable to obtain user data file. No instance data available",
+                sys_exit=True,
+            )
+            return  # Helps typing
         config_files = (("user-data", userdata_file),)
         vendor_config_files = (
             ("vendor-data", init.paths.get_ipath("vendor_cloud_config")),
             ("vendor2-data", init.paths.get_ipath("vendor2_cloud_config")),
         )
         for cfg_type, vendor_file in vendor_config_files:
-            if os.path.exists(vendor_file):
+            if vendor_file and os.path.exists(vendor_file):
                 config_files += ((cfg_type, vendor_file),)
     if not os.path.exists(config_files[0][1]):
         error(
@@ -1219,7 +1225,8 @@ def handle_schema_args(name, args):
             error(str(e), fmt=nested_output_prefix + "Error: {}\n")
             error_types.append(cfg_type)
         else:
-            print(f"{nested_output_prefix}Valid cloud-config: {cfg_type}")
+            cfg = cfg_file if args.config_file else cfg_type
+            print(f"{nested_output_prefix}Valid cloud-config: {cfg}")
     if error_types:
         error(
             ", ".join(error_type for error_type in error_types),

--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -41,7 +41,7 @@ def test_valid_userdata(client: IntegrationInstance):
     """
     result = client.execute("cloud-init schema --system")
     assert result.ok
-    assert "Valid cloud-config: system userdata" == result.stdout.strip()
+    assert "Valid cloud-config: user-data" in result.stdout.strip()
     result = client.execute("cloud-init status --long")
     if not result.ok:
         raise AssertionError(

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -1559,7 +1559,7 @@ class TestMain:
         with mock.patch("sys.argv", myargs):
             assert 0 == main(), "Expected 0 exit code"
         out, _err = capsys.readouterr()
-        assert "Valid cloud-config: user-data\n" == out
+        assert f"Valid cloud-config: {myyaml}\n" == out
 
     @mock.patch(M_PATH + "os.getuid", return_value=0)
     def test_main_validates_system_userdata_and_vendordata(
@@ -1763,7 +1763,7 @@ class TestHandleSchemaArgs:
                     # D3: DEPRECATED: Dropped after April 2027. Use ``package_reboot_if_required``. Default: ``false``
 
 
-                    Valid cloud-config: user-data
+                    Valid cloud-config: {cfg_file}
                     """  # noqa: E501
                 ),
             ),
@@ -1775,7 +1775,7 @@ class TestHandleSchemaArgs:
 apt_reboot_if_required: DEPRECATED: Dropped after April 2027. Use ``package_reboot_if_required``. Default: ``false``, \
 apt_update: DEPRECATED: Dropped after April 2027. Use ``package_update``. Default: ``false``, \
 apt_upgrade: DEPRECATED: Dropped after April 2027. Use ``package_upgrade``. Default: ``false``
-                    Valid cloud-config: user-data
+                    Valid cloud-config: {cfg_file}
                     """  # noqa: E501
                 ),
             ),


### PR DESCRIPTION
~~Changing to WIP as I just noticed https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-azure/192/testReport/junit/tests.integration_tests.modules/test_cli/test_valid_userdata/ , and this can probably also be rolled in here.~~

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix minor schema validation regression and fixup typing

When annotating a schema, we should print "Valid cloud-config" along
with the filename if a file has been used rather than just the config
type.
```

## Additional Context
Fixes https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-bionic-azure/192/testReport/junit/tests.integration_tests.cmd.test_schema/TestSchemaDeprecations/test_schema_deprecations/

Also, pyright was complaining because `config_files` could not be set, so I changed the `elif` to and `else` (we have a guard further up). Also, `get_ipath` can return `None`, so I added checks for that as well.
