### PR TITLE
cc_ssh: support multiple hostcertificates (SC-1425)

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -211,6 +211,7 @@ def handle(
 
     if "ssh_keys" in cfg:
         # if there are keys and/or certificates in cloud-config, use them
+        cert_config = []
         for (key, val) in cfg["ssh_keys"].items():
             if key not in CONFIG_KEY_TO_FILE:
                 if pattern_unsupported_config_keys.match(key):
@@ -224,8 +225,10 @@ def handle(
             util.write_file(tgt_fn, val, tgt_perms)
             # set server to present the most recently identified certificate
             if "_certificate" in key:
-                cert_config = {"HostCertificate": tgt_fn}
-                ssh_util.update_ssh_config(cert_config)
+                cert_config.append(("HostCertificate", str(tgt_fn)))
+
+        if cert_config:
+            ssh_util.append_ssh_config(cert_config)
 
         for private_type, public_type in PRIV_TO_PUB.items():
             if (

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -577,7 +577,7 @@ def update_ssh_config(updates, fname=DEF_SSHD_CFG):
     if changed:
         util.write_file(
             fname,
-            "\n".join(map(str, lines)) + "\n",
+            "\n".join([str(line) for line in lines]) + "\n",
             preserve_mode=True,
         )
     return len(changed) != 0

--- a/tests/integration_tests/modules/test_ssh_keys_provided.py
+++ b/tests/integration_tests/modules/test_ssh_keys_provided.py
@@ -70,6 +70,7 @@ ssh_keys:
     1M6G15dqjQ2XkNVOEnb5AAAAD3Jvb3RAeGVuaWFsLWx4ZAECAwQFBg==
     -----END OPENSSH PRIVATE KEY-----
   ed25519_public: ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5 root@xenial-lxd
+  ed25519_certificate: ssh-ed25519-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIAGbMtat76PmaoqQ7B2lDvhnzE47psvMvmnPhz6f423ZAAAAINudAZSu4vjZpVWzId5pXmZg1M6G15dqjQ2XkNVOEnb5AAAAAAAAAAAAAAACAAAAA2x4ZAAAAAAAAAAAY+0LHAAAAABlzO1rAAAAAAAAAAAAAAAAAAABFwAAAAdzc2gtcnNhAAAAAwEAAQAAAQEAtPx6PqN3iSEsnTtibyIEy52Tra8T5fn0ryXyg46Di2NBwdnjo8trNv9jenfV/UhmePl58lXjT43wV8OCMl6KsYXyBdegM35NNtono4I4mLLKFMR99TOtDn6iYcaNenVhF3ZCj9Z2nNOlTrdc0uchHqKMrxLjCRCUrL91Uf+xioTF901YRM+ZqC5lT92yAL76F4qPF+Lq1QtUfNfUIwwvOp5ccDZLPxij0YvyBzubYye9hJHuyjbJv78R4JHV+L2WhzSoX3W/6WrxVzeXqFGqH894ccOaC/7tnqSP6V8lIQ6fE2+cDurJcpM3CJRgkndGHjtU55Y71YkcdLksSMvezQAAARQAAAAMcnNhLXNoYTItNTEyAAABAC8VDdaBkdt9jRW2Wh7A54rtbWyoafEtA8rud9UHgq3fSLFvWMBBe19/MJZXs+xWkdvSuG49ZeaEWi7ZO3SQaUbmXp2L5CH6TNnok3yo5QL2h01gP6+ydn98cA8lktvZt/+ihSqXpeSAg6S755W0zqlaeT5iyopSmNt4/wLh8FvgXR+TrAEe2EEXcPcLEXrBrPkjoLZ8j/pzLFJHHmlme/JcHPGMB7ksGG9nKr6ZViB3VPshdxP4iqpORv4Ro+UBUaS1AoHe0mZsccr7gKg7Xe6lhqHT2Fwlkk9B1zsWWUTjWU4TeG9FrJCjSAGCHLdHUszhCOsQHOOf9aR2095mbI8= root@xenial-lxd
   ecdsa_private: |
     -----BEGIN EC PRIVATE KEY-----
     MHcCAQEEIDuK+QFc1wmyJY8uDqQVa1qHte30Rk/fdLxGIBkwJAyOoAoGCCqGSM49
@@ -138,7 +139,11 @@ class TestSshKeysProvided:
         assert expected_out in out
 
     @pytest.mark.parametrize(
-        "expected_out", ("HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub")
+        "expected_out",
+        (
+            "HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub",
+            "HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub",
+        ),
     )
     def test_sshd_config(self, expected_out, class_client):
         if ImageSpecification.from_os_image().release in {"bionic"}:

--- a/tests/integration_tests/modules/test_ssh_keys_provided.py
+++ b/tests/integration_tests/modules/test_ssh_keys_provided.py
@@ -138,17 +138,15 @@ class TestSshKeysProvided:
         out = class_client.read_from_file(config_path).strip()
         assert expected_out in out
 
-    @pytest.mark.parametrize(
-        "expected_out",
-        (
+    def test_sshd_config(self, class_client):
+        expected_certs = (
             "HostCertificate /etc/ssh/ssh_host_rsa_key-cert.pub",
             "HostCertificate /etc/ssh/ssh_host_ed25519_key-cert.pub",
-        ),
-    )
-    def test_sshd_config(self, expected_out, class_client):
+        )
         if ImageSpecification.from_os_image().release in {"bionic"}:
             sshd_config_path = "/etc/ssh/sshd_config"
         else:
             sshd_config_path = "/etc/ssh/sshd_config.d/50-cloud-init.conf"
         sshd_config = class_client.read_from_file(sshd_config_path).strip()
-        assert expected_out in sshd_config
+        for expected_cert in expected_certs:
+            assert expected_cert in sshd_config

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -311,6 +311,7 @@ class TestHandleSsh:
         cfg = {"ssh_keys": {}}
 
         expected_calls = []
+        cert_content = ""
         for key_type in cc_ssh.GENERATE_KEY_NAMES:
             private_name = "{}_private".format(key_type)
             public_name = "{}_public".format(key_type)
@@ -342,14 +343,20 @@ class TestHandleSsh:
                         cert_value,
                         0o644,
                     ),
-                    mock.call(
-                        sshd_conf_fname,
-                        "HostCertificate /etc/ssh/ssh_host_{}_key-cert.pub"
-                        "\n".format(key_type),
-                        preserve_mode=True,
-                    ),
                 ]
             )
+            cert_content += (
+                f"HostCertificate /etc/ssh/ssh_host_{key_type}_key-cert.pub\n"
+            )
+
+        expected_calls.append(
+            mock.call(
+                sshd_conf_fname,
+                cert_content,
+                omode="ab",
+                preserve_mode=True,
+            )
+        )
 
         # Run the handler.
         m_nug.return_value = ([], {})


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ssh: support multiple hostcertificates

LP: #1999164
```

## Additional Context
<!-- If relevant -->
https://bugs.launchpad.net/cloud-init/+bug/1999164

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
CLOUD_INIT_KEEP_INSTANCE=true tox -e integration-tests -- tests/integration_tests/modules/test_ssh_keys_provided.py::TestSshKeysProvided

# within the instance:
$ systemctl status ssh
$ sshd -T | grep -i hostcertificate
hostcertificate /etc/ssh/ssh_host_ed25519_key-cert.pub
hostcertificate /etc/ssh/ssh_host_rsa_key-cert.pub
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
