### PR TITLE
lxd: Retry if the server isn't ready

### DIFF
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -301,16 +301,16 @@ def _do_request(
     session: requests.Session, url: str, do_raise: bool = True
 ) -> requests.Response:
     for retries in range(29, 0, -1):
-    ....
-    LOG.warning(
-        "[GET] [HTTP:%d] %s, retrying %d more time(s)", response.status_code, url, retries
         response = session.get(url)
         if 500 == response.status_code:
             # retry every 0.1 seconds for 3 seconds in the case of 500 error
             # tis evil, but it also works around a bug
             time.sleep(0.1)
             LOG.warning(
-                "[GET] [HTTP:%d] %s, retrying", response.status_code, url
+                "[GET] [HTTP:%d] %s, retrying %d more time(s)",
+                response.status_code,
+                url,
+                retries,
             )
         else:
             break

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -11,6 +11,7 @@ Notes:
 import os
 import socket
 import stat
+import time
 from enum import Flag, auto
 from json.decoder import JSONDecodeError
 from typing import Any, Dict, List, Optional, Union, cast
@@ -299,7 +300,17 @@ def _get_json_response(
 def _do_request(
     session: requests.Session, url: str, do_raise: bool = True
 ) -> requests.Response:
-    response = session.get(url)
+    for _ in range(30):
+        response = session.get(url)
+        if 500 == response.status_code:
+            # retry every 0.1 seconds for 3 seconds in the case of 500 error
+            # tis evil, but it also works around a bug
+            time.sleep(0.1)
+            LOG.warning(
+                "[GET] [HTTP:%d] %s, retrying", response.status_code, url
+            )
+        else:
+            break
     LOG.debug("[GET] [HTTP:%d] %s", response.status_code, url)
     if do_raise and not response.ok:
         raise sources.InvalidMetaDataException(

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -300,7 +300,7 @@ def _get_json_response(
 def _do_request(
     session: requests.Session, url: str, do_raise: bool = True
 ) -> requests.Response:
-    for retries in range(29, 0, -1):
+    for retries in range(30, 0, -1):
         response = session.get(url)
         if 500 == response.status_code:
             # retry every 0.1 seconds for 3 seconds in the case of 500 error

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -300,7 +300,10 @@ def _get_json_response(
 def _do_request(
     session: requests.Session, url: str, do_raise: bool = True
 ) -> requests.Response:
-    for _ in range(30):
+    for retries in range(29, 0, -1):
+    ....
+    LOG.warning(
+        "[GET] [HTTP:%d] %s, retrying %d more time(s)", response.status_code, url, retries
         response = session.get(url)
         if 500 == response.status_code:
             # retry every 0.1 seconds for 3 seconds in the case of 500 error

--- a/tests/unittests/sources/test_lxd.py
+++ b/tests/unittests/sources/test_lxd.py
@@ -733,5 +733,6 @@ class TestReadMetadata:
             )
             lxd._do_request(m, "http://agua/")
 
-            # assert that the first 200 code is the final retry
+            # assert that 30 iterations or the first 200 code is the final
+            # attempt, whichever comes first
             assert min(len(return_codes), 30) == m.get.call_count

--- a/tests/unittests/sources/test_lxd.py
+++ b/tests/unittests/sources/test_lxd.py
@@ -731,8 +731,12 @@ class TestReadMetadata:
                     ]
                 )
             )
-            lxd._do_request(m, "http://agua/")
+            resp = lxd._do_request(m, "http://agua/")
 
             # assert that 30 iterations or the first 200 code is the final
             # attempt, whichever comes first
             assert min(len(return_codes), 30) == m.get.call_count
+            if len(return_codes) < 31:
+                assert 200 == resp.status_code
+            else:
+                assert 500 == resp.status_code

--- a/tests/unittests/sources/test_lxd.py
+++ b/tests/unittests/sources/test_lxd.py
@@ -712,7 +712,7 @@ class TestReadMetadata:
             five_hundreds = []
 
             # generate a couple of longer ones to assert timeout condition
-            for i in range(33):
+            for _ in range(33):
                 five_hundreds.append(500)
                 yield [*five_hundreds, 200]
 


### PR DESCRIPTION
```
lxd: Retry if the server isn't ready
```

## Additional Context
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/sources/__init__.py", line 946, in find_source
    if s.update_metadata_if_supported(
  File "/usr/lib/python3/dist-packages/cloudinit/sources/__init__.py", line 828, in update_metadata_if_supported
    result = self.get_data()
  File "/usr/lib/python3/dist-packages/cloudinit/sources/__init__.py", line 373, in get_data
    return_value = self._get_data()
  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceLXD.py", line 193, in _get_data
    self._crawled_metadata = util.log_time(
  File "/usr/lib/python3/dist-packages/cloudinit/util.py", line 2680, in log_time
    ret = func(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceLXD.py", line 428, in read_metadata
    return _MetaDataReader(api_version=api_version)(
  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceLXD.py", line 384, in __call__
    md["meta-data"] = _do_request(session, md_route).text
  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceLXD.py", line 297, in _do_request
    raise sources.InvalidMetaDataException(
cloudinit.sources.InvalidMetaDataException: Invalid HTTP response [500] from http://lxd/1.0/meta-data: internal server error
```

## Test Logs
```
2023-02-17 23:25:24,815 - __init__.py[DEBUG]: Update datasource metadata and network config due to events: boot-new-instance
2023-02-17 23:25:25,039 - DataSourceLXD.py[WARNING]: [GET] [HTTP:500] http://lxd/1.0/meta-data, retrying
2023-02-17 23:25:25,143 - DataSourceLXD.py[WARNING]: [GET] [HTTP:500] http://lxd/1.0/meta-data, retrying
2023-02-17 23:25:25,179 - DataSourceLXD.py[DEBUG]: [GET] [HTTP:200] http://lxd/1.0/meta-data
2023-02-17 23:25:25,229 - DataSourceLXD.py[DEBUG]: [GET] [HTTP:200] http://lxd/1.0/config
2023-02-17 23:25:25,269 - DataSourceLXD.py[DEBUG]: [GET] [HTTP:200] http://lxd/1.0/config/cloud-init.user-data
2023-02-17 23:25:25,359 - DataSourceLXD.py[DEBUG]: [GET] [HTTP:200] http://lxd/1.0/devices
```