### PR TITLE
apport: only prompt for cloud_name when instance-data.json is absent

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -107,7 +107,11 @@ def attach_cloud_info(report, ui=None):
     When we have valid _get_instance_data, apport/generic-hooks/cloud_init.py
     provides CloudName, CloudID, CloudPlatform and CloudSubPlatform.
 
-    In absence of instance-data.json, prompt for the cloud below.
+    Apport/generic-hooks are delivered by cloud-init's downstream branches
+    ubuntu/(devel|kinetic|jammy|focal|bionic) so they will not be represented
+    in upstream main.
+
+    In absence of viable instance-data.json format, prompt for the cloud below.
     """
 
     if ui:
@@ -116,7 +120,7 @@ def attach_cloud_info(report, ui=None):
             with open(paths.get_runpath("instance_data")) as file:
                 instance_data = json.load(file)
                 assert instance_data.get("v1", {}).get("cloud_name")
-                return
+                return  # Valid instance-data means generic-hooks will report
         except (IOError, json.decoder.JSONDecodeError, AssertionError):
             pass
 

--- a/tests/unittests/test_apport.py
+++ b/tests/unittests/test_apport.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from tests.unittests.helpers import mock
@@ -5,24 +7,74 @@ from tests.unittests.helpers import mock
 M_PATH = "cloudinit.apport."
 
 
+@pytest.fixture()
+def apport(request, mocker, paths):
+    """Mock apport.hookutils before importing cloudinit.apport.
+
+    This avoids our optional import dependency on apport, providing tests with
+    mocked apport.hookutils function call counts.
+    """
+    m_hookutils = mock.Mock()
+    mocker.patch.dict("sys.modules", {"apport.hookutils": m_hookutils})
+    mocker.patch(M_PATH + "read_cfg_paths", return_value=paths)
+    from cloudinit import apport
+
+    yield apport
+
+
 class TestApport:
-    def test_attach_user_data(self, mocker, tmpdir):
-        m_hookutils = mock.Mock()
-        mocker.patch.dict("sys.modules", {"apport.hookutils": m_hookutils})
-        user_data_file = tmpdir.join("instance", "user-data.txt")
-        mocker.patch(
-            M_PATH + "_get_user_data_file", return_value=user_data_file
-        )
+    @pytest.mark.parametrize(
+        "instance_data,choice_idx,expected_report",
+        (
+            pytest.param(
+                '{"v1": {"cloud_name": "mycloud"}}',
+                None,
+                {},
+                id="v1_cloud_name_exists",
+            ),
+            pytest.param(
+                '{"v1": {"cloud_id": "invalid"}}',
+                1,
+                {"CloudName": "Azure"},
+                id="v1_no_cloud_name_present",
+            ),
+            pytest.param("{}", 0, {"CloudName": "AliYun"}, id="no_v1_key"),
+            pytest.param(
+                "{", 22, {"CloudName": "Oracle"}, id="not_valid_json"
+            ),
+        ),
+    )
+    def test_attach_cloud_info(
+        self, instance_data, choice_idx, expected_report, apport, paths
+    ):
+        """Prompt for cloud name when instance-data.json is not-json/absent."""
 
-        from cloudinit import apport
+        instance_data_file = paths.get_runpath("instance_data")
+        if instance_data is None:
+            assert not os.path.exists(instance_data_file)
+        else:
+            with open(instance_data_file, "w") as stream:
+                stream.write(instance_data)
+        ui = mock.Mock()
+        ui.yesno.return_value = True
+        ui.choice.return_value = (choice_idx, "")
+        report = {}
+        apport.attach_cloud_info(report, ui)
+        if choice_idx is not None:
+            assert ui.choice.call_count == 1
+            assert report["CloudName"] == apport.KNOWN_CLOUD_NAMES[choice_idx]
+        else:
+            assert ui.choice.call_count == 0
 
+    def test_attach_user_data(self, apport, paths):
+        user_data_file = paths.get_ipath_cur("userdata_raw")
         ui = mock.Mock()
         ui.yesno.return_value = True
         report = object()
         apport.attach_user_data(report, ui)
         assert [
             mock.call(report, user_data_file, "user_data.txt"),
-        ] == m_hookutils.attach_file.call_args_list
+        ] == apport.attach_file.call_args_list
         assert [
             mock.call(
                 report,
@@ -35,7 +87,7 @@ class TestApport:
                 "/etc/cloud/cloud.cfg.d/99-installer.cfg",
                 "InstallerCloudCfg",
             ),
-        ] == m_hookutils.attach_file_if_exists.call_args_list
+        ] == apport.attach_file_if_exists.call_args_list
 
     @pytest.mark.parametrize(
         "report,tags",
@@ -52,9 +104,8 @@ class TestApport:
             ),
         ),
     )
-    def test_add_bug_tags_assigns_proper_tags(self, report, tags):
+    def test_add_bug_tags_assigns_proper_tags(self, report, tags, apport):
         """Tags are assigned based on non-empty project report key values."""
-        from cloudinit import apport
 
         apport.add_bug_tags(report)
         assert report.get("Tags", "") == tags


### PR DESCRIPTION
Do not prompt for CloudName when instance-data.json exists.

When instance-data.json exists, general-hooks/cloud_init.py will add the following fields to bug reports:
   CloudName, CloudID, CloudPlatform and CloudSubplatform.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Do not prompt for CloudName when instance-data.json exists.

When instance-data.json exists, general-hooks/cloud_init.py will add the
following fields to bug reports:
   CloudName, CloudID, CloudPlatform and CloudSubplatform.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
