### PR TITLE
Enable SUSE distros for ca handling

### DIFF
--- a/cloudinit/config/cc_ca_certs.py
+++ b/cloudinit/config/cc_ca_certs.py
@@ -32,7 +32,24 @@ DISTRO_OVERRIDES = {
         "ca_cert_config": None,
         "ca_cert_update_cmd": ["update-ca-trust"],
     },
+    "opensuse": {
+        "ca_cert_path": "/etc/pki/trust/",
+        "ca_cert_local_path": "/usr/share/pki/trust/",
+        "ca_cert_filename": "anchors/cloud-init-ca-cert-{cert_index}.crt",
+        "ca_cert_config": None,
+        "ca_cert_update_cmd": ["update-ca-certificates"],
+    },
 }
+
+for distro in (
+    "opensuse-microos",
+    "opensuse-tumbleweed",
+    "opensuse-leap",
+    "sle_hpc",
+    "sle-micro",
+    "sles",
+):
+    DISTRO_OVERRIDES[distro] = DISTRO_OVERRIDES["opensuse"]
 
 MODULE_DESCRIPTION = """\
 This module adds CA certificates to the system's CA store and updates any
@@ -48,7 +65,19 @@ configuration option ``remove_defaults``.
     Alpine Linux requires the ca-certificates package to be installed in
     order to provide the ``update-ca-certificates`` command.
 """
-distros = ["alpine", "debian", "rhel", "ubuntu"]
+distros = [
+    "alpine",
+    "debian",
+    "rhel",
+    "opensuse",
+    "opensuse-microos",
+    "opensuse-tumbleweed",
+    "opensuse-leap",
+    "sle_hpc",
+    "sle-micro",
+    "sles",
+    "ubuntu",
+]
 
 meta: MetaSchema = {
     "id": "cc_ca_certs",

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -311,6 +311,7 @@ class TestRemoveDefaultCaCerts(TestCase):
                 "cloud_dir": tmpdir,
             }
         )
+        self.add_patch("cloudinit.config.cc_ca_certs.os.stat", "m_stat")
 
     def test_commands(self):
         ca_certs_content = "# line1\nline2\nline3\n"
@@ -318,6 +319,7 @@ class TestRemoveDefaultCaCerts(TestCase):
             "# line1\n# Modified by cloud-init to deselect certs due to"
             " user-data\n!line2\n!line3\n"
         )
+        self.m_stat.return_value.st_size = 1
 
         for distro_name in cc_ca_certs.distros:
             conf = cc_ca_certs._distro_ca_certs_configs(distro_name)


### PR DESCRIPTION
- Enable SUSE based distros to be supported for CA handling
- Do not let the test bleed through to the underlying system where the test is run

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Enable SUSE based distros to be supported for CA handling

CA handling in he configuration module was previously not supported for SUSE based distros. Enable this functionality
by creating the necessary configuration settings.

Secondly update the test such thta it does not bleed through to the test system
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
