### PR TITLE
drop unused kwarg

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -42,7 +42,7 @@ class NoDHCPLeaseMissingDhclientError(NoDHCPLeaseError):
     """Raised when unable to find dhclient."""
 
 
-def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None, tmp_dir=None):
+def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None):
     """Perform dhcp discovery if nic valid and dhclient command exists.
 
     If the nic is invalid or undiscoverable or dhclient command is not found,
@@ -51,7 +51,6 @@ def maybe_perform_dhcp_discovery(nic=None, dhcp_log_func=None, tmp_dir=None):
     @param nic: Name of the network interface we want to run dhclient on.
     @param dhcp_log_func: A callable accepting the dhclient output and error
         streams.
-    @param tmp_dir: Tmp dir with exec permissions.
     @return: A list of dicts representing dhcp options for each lease obtained
         from the dhclient discovery if run, otherwise an empty list is
         returned.

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -315,14 +315,12 @@ class EphemeralDHCPv4:
         iface=None,
         connectivity_url_data: Optional[Dict[str, Any]] = None,
         dhcp_log_func=None,
-        tmp_dir=None,
     ):
         self.iface = iface
         self._ephipv4 = None
         self.lease = None
         self.dhcp_log_func = dhcp_log_func
         self.connectivity_url_data = connectivity_url_data
-        self.tmp_dir = tmp_dir
 
     def __enter__(self):
         """Setup sandboxed dhcp context, unless connectivity_url can already be
@@ -424,23 +422,19 @@ class EphemeralIPNetwork:
         interface,
         ipv6: bool = False,
         ipv4: bool = True,
-        tmp_dir=None,
     ):
         self.interface = interface
         self.ipv4 = ipv4
         self.ipv6 = ipv6
         self.stack = contextlib.ExitStack()
         self.state_msg: str = ""
-        self.tmp_dir = tmp_dir
 
     def __enter__(self):
         # ipv6 dualstack might succeed when dhcp4 fails
         # therefore catch exception unless only v4 is used
         try:
             if self.ipv4:
-                self.stack.enter_context(
-                    EphemeralDHCPv4(self.interface, tmp_dir=self.tmp_dir)
-                )
+                self.stack.enter_context(EphemeralDHCPv4(self.interface))
             if self.ipv6:
                 self.stack.enter_context(EphemeralIPv6Network(self.interface))
         # v6 link local might be usable

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -360,9 +360,7 @@ class EphemeralDHCPv4:
         """
         if self.lease:
             return self.lease
-        leases = maybe_perform_dhcp_discovery(
-            self.iface, self.dhcp_log_func
-        )
+        leases = maybe_perform_dhcp_discovery(self.iface, self.dhcp_log_func)
         if not leases:
             raise NoDHCPLeaseError()
         self.lease = leases[-1]

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -361,7 +361,7 @@ class EphemeralDHCPv4:
         if self.lease:
             return self.lease
         leases = maybe_perform_dhcp_discovery(
-            self.iface, self.dhcp_log_func, self.tmp_dir
+            self.iface, self.dhcp_log_func
         )
         if not leases:
             raise NoDHCPLeaseError()

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -402,7 +402,6 @@ class DataSourceAzure(sources.DataSource):
         self._ephemeral_dhcp_ctx = EphemeralDHCPv4(
             iface=iface,
             dhcp_log_func=dhcp_log_cb,
-            tmp_dir=self.distro.get_tmp_exec_path(),
         )
 
         lease = None

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -134,7 +134,6 @@ class DataSourceEc2(sources.DataSource):
                     self.fallback_interface,
                     ipv4=True,
                     ipv6=True,
-                    tmp_dir=self.distro.get_tmp_exec_path(),
                 ) as netw:
                     state_msg = f" {netw.state_msg}" if netw.state_msg else ""
                     self._crawled_metadata = util.log_time(

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -85,7 +85,6 @@ class DataSourceGCE(sources.DataSource):
         if self.perform_dhcp_setup:
             network_context = EphemeralDHCPv4(
                 self.fallback_interface,
-                tmp_dir=self.distro.get_tmp_exec_path(),
             )
         with network_context:
             ret = util.log_time(

--- a/cloudinit/sources/DataSourceHetzner.py
+++ b/cloudinit/sources/DataSourceHetzner.py
@@ -61,7 +61,6 @@ class DataSourceHetzner(sources.DataSource):
                 connectivity_url_data={
                     "url": BASE_URL_V1 + "/metadata/instance-id",
                 },
-                tmp_dir=self.distro.get_tmp_exec_path(),
             ):
                 md = hc_helper.read_metadata(
                     self.metadata_address,

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -161,10 +161,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
 
         if self.perform_dhcp_setup:  # Setup networking in init-local stage.
             try:
-                with EphemeralDHCPv4(
-                    self.fallback_interface,
-                    tmp_dir=self.distro.get_tmp_exec_path(),
-                ):
+                with EphemeralDHCPv4(self.fallback_interface):
                     if not self.detect_openstack(
                         accept_oracle=not oracle_considered
                     ):

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -156,7 +156,6 @@ class DataSourceOracle(sources.DataSource):
                 "url": METADATA_PATTERN.format(version=2, path="instance"),
                 "headers": V2_HEADERS,
             },
-            tmp_dir=self.distro.get_tmp_exec_path(),
         )
         fetch_primary_nic = not self._is_iscsi_root()
         fetch_secondary_nics = self.ds_cfg.get(

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -210,10 +210,7 @@ class DataSourceScaleway(sources.DataSource):
         if self._fallback_interface is None:
             self._fallback_interface = net.find_fallback_nic()
         try:
-            with EphemeralDHCPv4(
-                self._fallback_interface,
-                tmp_dir=self.distro.get_tmp_exec_path(),
-            ):
+            with EphemeralDHCPv4(self._fallback_interface):
                 util.log_time(
                     logfunc=LOG.debug,
                     msg="Crawl of metadata service",

--- a/cloudinit/sources/DataSourceUpCloud.py
+++ b/cloudinit/sources/DataSourceUpCloud.py
@@ -71,9 +71,7 @@ class DataSourceUpCloud(sources.DataSource):
                 LOG.debug("Finding a fallback NIC")
                 nic = cloudnet.find_fallback_nic()
                 LOG.debug("Discovering metadata via DHCP interface %s", nic)
-                with EphemeralDHCPv4(
-                    nic, tmp_dir=self.distro.get_tmp_exec_path()
-                ):
+                with EphemeralDHCPv4(nic):
                     md = util.log_time(
                         logfunc=LOG.debug,
                         msg="Reading from metadata service",

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -26,9 +26,7 @@ def get_metadata(url, timeout, retries, sec_between, agent, tmp_dir=None):
     for iface in get_interface_list():
         try:
             with EphemeralDHCPv4(
-                iface=iface,
-                connectivity_url_data={"url": url},
-                tmp_dir=tmp_dir,
+                iface=iface, connectivity_url_data={"url": url}
             ):
                 # Check for the metadata route, skip if not there
                 if not check_route(url):

--- a/tests/unittests/net/test_ephemeral.py
+++ b/tests/unittests/net/test_ephemeral.py
@@ -22,22 +22,16 @@ class TestEphemeralIPNetwork:
         m_exit_stack,
         ipv4,
         ipv6,
-        tmpdir,
     ):
         interface = object()
-        tmp_dir = str(tmpdir)
-        with EphemeralIPNetwork(
-            interface, ipv4=ipv4, ipv6=ipv6, tmp_dir=tmp_dir
-        ):
+        with EphemeralIPNetwork(interface, ipv4=ipv4, ipv6=ipv6):
             pass
         expected_call_args_list = []
         if ipv4:
             expected_call_args_list.append(
                 mock.call(m_ephemeral_dhcp_v4.return_value)
             )
-            assert [
-                mock.call(interface, tmp_dir=tmp_dir)
-            ] == m_ephemeral_dhcp_v4.call_args_list
+            assert [mock.call(interface)] == m_ephemeral_dhcp_v4.call_args_list
         else:
             assert [] == m_ephemeral_dhcp_v4.call_args_list
         if ipv6:

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3723,7 +3723,6 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             )
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
@@ -3806,12 +3805,10 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
@@ -3921,12 +3918,10 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call(
                 "ethAttached1",
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
@@ -4072,12 +4067,10 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call(
                 "ethAttached1",
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             ),
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"
@@ -4170,7 +4163,6 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             ),
         ]
 
@@ -4235,7 +4227,6 @@ class TestProvisioning:
             mock.call(
                 None,
                 dsaz.dhcp_log_cb,
-                self.azure_ds.distro.get_tmp_exec_path(),
             )
         ]
         assert self.azure_ds._wireserver_endpoint == "10.11.12.13"

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3406,7 +3406,6 @@ class TestEphemeralNetworking:
             mock.call(
                 iface=iface,
                 dhcp_log_func=dsaz.dhcp_log_cb,
-                tmp_dir=azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call().obtain_lease(),
         ]
@@ -3433,7 +3432,6 @@ class TestEphemeralNetworking:
             mock.call(
                 iface=iface,
                 dhcp_log_func=dsaz.dhcp_log_cb,
-                tmp_dir=azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call().obtain_lease(),
         ]
@@ -3476,7 +3474,6 @@ class TestEphemeralNetworking:
             mock.call(
                 iface=None,
                 dhcp_log_func=dsaz.dhcp_log_cb,
-                tmp_dir=azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call().obtain_lease(),
             mock.call().obtain_lease(),
@@ -3511,7 +3508,6 @@ class TestEphemeralNetworking:
             mock.call(
                 iface=None,
                 dhcp_log_func=dsaz.dhcp_log_cb,
-                tmp_dir=azure_ds.distro.get_tmp_exec_path(),
             ),
             mock.call().obtain_lease(),
             mock.call().obtain_lease(),
@@ -3550,7 +3546,6 @@ class TestEphemeralNetworking:
                 mock.call(
                     iface=None,
                     dhcp_log_func=dsaz.dhcp_log_cb,
-                    tmp_dir=azure_ds.distro.get_tmp_exec_path(),
                 ),
             ]
             + [mock.call().obtain_lease()] * 11

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -879,7 +879,7 @@ class TestEc2(test_helpers.ResponsesTestCase):
 
         ret = ds.get_data()
         self.assertTrue(ret)
-        m_dhcp.assert_called_once_with("eth9", None, mock.ANY)
+        m_dhcp.assert_called_once_with("eth9", None)
         m_net4.assert_called_once_with(
             broadcast="192.168.2.255",
             interface="eth9",

--- a/tests/unittests/sources/test_hetzner.py
+++ b/tests/unittests/sources/test_hetzner.py
@@ -114,7 +114,6 @@ class TestDataSourceHetzner(CiTestCase):
             connectivity_url_data={
                 "url": "http://169.254.169.254/hetzner/v1/metadata/instance-id"
             },
-            tmp_dir=mock.ANY,
         )
 
         self.assertTrue(m_readmd.called)

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -367,7 +367,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         self.assertEqual(VENDOR_DATA, ds_os_local.vendordata_pure)
         self.assertEqual(VENDOR_DATA2, ds_os_local.vendordata2_pure)
         self.assertIsNone(ds_os_local.vendordata_raw)
-        m_dhcp.assert_called_with("eth9", None, mock.ANY)
+        m_dhcp.assert_called_with("eth9", None)
 
     def test_bad_datasource_meta(self):
         os_files = copy.deepcopy(OS_FILES)

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -987,7 +987,6 @@ class TestNonIscsiRoot_GetDataBehaviour:
                     "headers": {"Authorization": "Bearer Oracle"},
                     "url": "http://169.254.169.254/opc/v2/instance/",
                 },
-                tmp_dir=oracle_ds.distro.get_tmp_exec_path(),
             )
         ] == m_EphemeralDHCPv4.call_args_list
 
@@ -1030,7 +1029,6 @@ class TestNonIscsiRoot_GetDataBehaviour:
                     "headers": {"Authorization": "Bearer Oracle"},
                     "url": "http://169.254.169.254/opc/v2/instance/",
                 },
-                tmp_dir=oracle_ds.distro.get_tmp_exec_path(),
             )
         ] == m_EphemeralDHCPv4.call_args_list
 

--- a/tests/unittests/sources/test_upcloud.py
+++ b/tests/unittests/sources/test_upcloud.py
@@ -242,7 +242,7 @@ class TestUpCloudNetworkSetup(CiTestCase):
         self.assertTrue(ret)
 
         self.assertTrue(m_dhcp.called)
-        m_dhcp.assert_called_with("eth1", None, mock.ANY)
+        m_dhcp.assert_called_with("eth1", None)
 
         m_net.assert_called_once_with(
             broadcast="10.6.3.255",


### PR DESCRIPTION
```
dhcp: Cleanup unused kwarg.

Usage was dropped in de7851b93c5a2d4658.
```

## Additional Context
Pick up a couple of bits missed in https://github.com/canonical/cloud-init/pull/1715
