### PR TITLE
send dhcp-client-identifier with dhclient command for InfiniBand ports

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -167,6 +167,10 @@ def master_is_openvswitch(devname):
     return os.path.exists(ovs_path)
 
 
+def is_ib_interface(devname):
+    return read_sys_net_safe(devname, "type") == "32"
+
+
 @functools.lru_cache(maxsize=None)
 def openvswitch_is_installed() -> bool:
     """Return a bool indicating if Open vSwitch is installed in the system."""

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -14,8 +14,13 @@ from io import StringIO
 
 import configobj
 
-from cloudinit import subp, util
-from cloudinit.net import find_fallback_nic, get_devicelist
+from cloudinit import subp, temp_utils, util
+from cloudinit.net import (
+    find_fallback_nic,
+    get_devicelist,
+    get_interface_mac,
+    is_ib_interface,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -136,6 +141,9 @@ def dhcp_discovery(dhclient_cmd_path, interface, dhcp_log_func=None):
     # link up before attempting discovery. Since we are using -sf /bin/true,
     # we need to do that "link up" ourselves first.
     subp.subp(["ip", "link", "set", "dev", interface, "up"], capture=True)
+    # For INFINIBAND port the dhlient must be sent with dhcp-client-identifier.
+    # So here we are checking if the interface is INFINIBAND or not.
+    # If yes, we are generating the the client-id to be used with the dhclient
     cmd = [
         dhclient_cmd_path,
         "-1",
@@ -148,6 +156,18 @@ def dhcp_discovery(dhclient_cmd_path, interface, dhcp_log_func=None):
         "-sf",
         "/bin/true",
     ]
+    if is_ib_interface(interface):
+        dhcp_client_identifier = "20:%s" % get_interface_mac(interface)[36:]
+        interface_dhclient_content = (
+            'interface "%s" '
+            "{send dhcp-client-identifier %s;}"
+            % (interface, dhcp_client_identifier)
+        )
+        tmp_dir = temp_utils.get_tmp_ancestor(needs_exe=True)
+        file_name = os.path.join(tmp_dir, interface + "-dhclient.conf")
+        util.write_file(file_name, interface_dhclient_content)
+        cmd.append("-cf")
+        cmd.append(file_name)
     out, err = subp.subp(cmd, capture=True)
 
     # Wait for pid file and lease file to appear, and for the process

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -137,6 +137,7 @@ vteratipally
 Vultaire
 WebSpider
 Wind-net
+wmousa
 wschoot
 wynnfeng
 xiachen-rh


### PR DESCRIPTION
Sending dhclient command failed for InfiniBand ports because dhcp-client-identifier is not specified.

So, providing this patch to allow send dhcp-client-identifier hardware with the dhclient command for InfiniBand ports.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

LP: #NNNNNNN (replace with the appropriate bug reference or remove
this line entirely if there is no associated bug)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
