### PR TITLE
Force OpenStack When It Is Only Datasource in datasource_list

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -992,37 +992,6 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             **kwargs,
         )
 
-    @property
-    def is_virtual(self) -> Optional[bool]:
-        """Detect if running on a virtual machine or bare metal.
-
-        If the detection fails, it returns None.
-        """
-        if not uses_systemd():
-            # For non systemd systems the method should be
-            # implemented in the distro class.
-            LOG.warning("is_virtual should be implemented on distro class")
-            return None
-
-        try:
-            detect_virt_path = subp.which("systemd-detect-virt")
-            if detect_virt_path:
-                out, _ = subp.subp(
-                    [detect_virt_path], capture=True, rcs=[0, 1]
-                )
-
-                return not out.strip() == "none"
-            else:
-                err_msg = "detection binary not found"
-        except subp.ProcessExecutionError as e:
-            err_msg = str(e)
-
-        LOG.warning(
-            "Failed to detect virtualization with systemd-detect-virt: %s",
-            err_msg,
-        )
-        return None
-
 
 def _apply_hostname_transformations_to_url(url: str, transformations: list):
     """

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -6,9 +6,7 @@
 
 import os
 import re
-from functools import lru_cache
 from io import StringIO
-from typing import Optional
 
 import cloudinit.distros.bsd
 from cloudinit import log as logging
@@ -194,40 +192,5 @@ class Distro(cloudinit.distros.bsd.BSD):
             freq=PER_INSTANCE,
         )
 
-    @lru_cache()
-    def is_container(self) -> bool:
-        """return whether we're running in a container.
-        Cached, because it's unlikely to change."""
-        jailed, _ = subp.subp(["sysctl", "-n", "security.jail.jailed"])
-        if jailed.strip() == "0":
-            return False
-        return True
 
-    @lru_cache()
-    def virtual(self) -> str:
-        """return the kind of virtualisation system we're running under.
-        Cached, because it's unlikely to change."""
-        if self.is_container():
-            return "jail"
-        # map FreeBSD's kern.vm_guest to systemd-detect-virt, just like we do
-        # in ds-identify
-        VM_GUEST_TO_SYSTEMD = {
-            "hv": "microsoft",
-            "vbox": "oracle",
-            "generic": "vm-other",
-        }
-        vm, _ = subp.subp(["sysctl", "-n", "kern.vm_guest"])
-        vm = vm.strip()
-        if vm in VM_GUEST_TO_SYSTEMD:
-            return VM_GUEST_TO_SYSTEMD[vm]
-        return vm
-
-    @property
-    def is_virtual(self) -> Optional[bool]:
-        """Detect if running on a virtual machine or bare metal.
-
-        This can fail on some platforms, so the signature is Optional[bool]
-        """
-        if self.virtual() == "none":
-            return False
-        return True
+# vi: ts=4 expandtab

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -280,22 +280,6 @@ def read_metadata_service(base_url, ssl_details=None, timeout=5, retries=5):
     return reader.read_v2()
 
 
-def detect_openstack(accept_oracle=False):
-    """Return True when a potential OpenStack platform is detected."""
-    if not util.is_x86():
-        return True  # Non-Intel cpus don't properly report dmi product names
-    product_name = dmi.read_dmi_data("system-product-name")
-    if product_name in VALID_DMI_PRODUCT_NAMES:
-        return True
-    elif dmi.read_dmi_data("chassis-asset-tag") in VALID_DMI_ASSET_TAGS:
-        return True
-    elif accept_oracle and oracle._is_platform_viable():
-        return True
-    elif util.get_proc_env(1).get("product_name") == DMI_PRODUCT_NOVA:
-        return True
-    return False
-
-
 # Used to match classes to dependencies
 datasources = [
     (DataSourceOpenStackLocal, (sources.DEP_FILESYSTEM,)),

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -73,7 +73,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
         mstr = "%s [%s,ver=%s]" % (root, self.dsmode, self.version)
         return mstr
 
-    def wait_for_metadata_service(self, max_wait=None, timeout=None):
+    def wait_for_metadata_service(self):
         urls = self.ds_cfg.get("metadata_urls", DEF_MD_URLS)
         filtered = [x for x in urls if util.is_resolvable_url(x)]
         if set(filtered) != set(urls):
@@ -90,23 +90,16 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
         md_urls = []
         url2base = {}
         for url in urls:
-            # Wait for a specific openstack metadata url
             md_url = url_helper.combine_url(url, "openstack")
             md_urls.append(md_url)
             url2base[md_url] = url
 
         url_params = self.get_url_params()
-        if max_wait is None:
-            max_wait = url_params.max_wait_seconds
-
-        if timeout is None:
-            timeout = url_params.timeout_seconds
-
         start_time = time.time()
         avail_url, _response = url_helper.wait_for_url(
             urls=md_urls,
-            max_wait=max_wait,
-            timeout=timeout,
+            max_wait=url_params.max_wait_seconds,
+            timeout=url_params.timeout_seconds,
             connect_synchronously=False,
         )
         if avail_url:
@@ -158,6 +151,8 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             format is invalid or disabled.
         """
         oracle_considered = "Oracle" in self.sys_cfg.get("datasource_list")
+        if not detect_openstack(accept_oracle=not oracle_considered):
+            return False
 
         if self.perform_dhcp_setup:  # Setup networking in init-local stage.
             try:
@@ -165,15 +160,6 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
                     self.fallback_interface,
                     tmp_dir=self.distro.get_tmp_exec_path(),
                 ):
-                    if not self.detect_openstack(
-                        accept_oracle=not oracle_considered
-                    ):
-                        LOG.debug(
-                            "OpenStack datasource not running"
-                            " on OpenStack (dhcp)"
-                        )
-                        return False
-
                     results = util.log_time(
                         logfunc=LOG.debug,
                         msg="Crawl of metadata service",
@@ -183,13 +169,6 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
                 util.logexc(LOG, str(e))
                 return False
         else:
-            if not self.detect_openstack(accept_oracle=not oracle_considered):
-                LOG.debug(
-                    "OpenStack datasource not running"
-                    " on OpenStack (non-dhcp)"
-                )
-                return False
-
             try:
                 results = self._crawl_metadata()
             except sources.InvalidMetaDataException as e:
@@ -268,30 +247,6 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             raise sources.InvalidMetaDataException(msg) from e
         return result
 
-    def detect_openstack(self, accept_oracle=False):
-        """Return True when a potential OpenStack platform is detected."""
-        if not util.is_x86():
-            # Non-Intel cpus don't properly report dmi product names
-            return True
-
-        product_name = dmi.read_dmi_data("system-product-name")
-        if product_name in VALID_DMI_PRODUCT_NAMES:
-            return True
-        elif dmi.read_dmi_data("chassis-asset-tag") in VALID_DMI_ASSET_TAGS:
-            return True
-        elif accept_oracle and oracle._is_platform_viable():
-            return True
-        elif util.get_proc_env(1).get("product_name") == DMI_PRODUCT_NOVA:
-            return True
-        # On bare metal hardware, the product name is not set like
-        # in a virtual OpenStack vm. We check if the system is virtual
-        # and if the openstack specific metadata service has been found.
-        elif not self.distro.is_virtual and self.wait_for_metadata_service(
-            max_wait=15, timeout=5
-        ):
-            return True
-        return False
-
 
 class DataSourceOpenStackLocal(DataSourceOpenStack):
     """Run in init-local using a dhcp discovery prior to metadata crawl.
@@ -310,6 +265,22 @@ def read_metadata_service(base_url, ssl_details=None, timeout=5, retries=5):
         base_url, ssl_details=ssl_details, timeout=timeout, retries=retries
     )
     return reader.read_v2()
+
+
+def detect_openstack(accept_oracle=False):
+    """Return True when a potential OpenStack platform is detected."""
+    if not util.is_x86():
+        return True  # Non-Intel cpus don't properly report dmi product names
+    product_name = dmi.read_dmi_data("system-product-name")
+    if product_name in VALID_DMI_PRODUCT_NAMES:
+        return True
+    elif dmi.read_dmi_data("chassis-asset-tag") in VALID_DMI_ASSET_TAGS:
+        return True
+    elif accept_oracle and oracle._is_platform_viable():
+        return True
+    elif util.get_proc_env(1).get("product_name") == DMI_PRODUCT_NOVA:
+        return True
+    return False
 
 
 # Used to match classes to dependencies

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -325,8 +325,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         """Overrides runtime datasource detection"""
         if self.override_ds_detect() or self.ds_detect():
             LOG.debug("Machine is running on %s.", self)
-            self._get_data()
-            return True
+            return self._get_data()
 
         LOG.debug("Datasource type %s is not detected.", self)
         return False

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -323,12 +323,14 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
     def _check_and_get_data(self):
         """Overrides runtime datasource detection"""
-        if self.override_ds_detect() or self.ds_detect():
+        if self.override_ds_detect():
+            LOG.debug("Machine is configured to run on single datasource %s.", self)
+        elif self.ds_detect():
             LOG.debug("Machine is running on %s.", self)
-            return self._get_data()
-
-        LOG.debug("Datasource type %s is not detected.", self)
-        return False
+        else:
+            LOG.debug("Datasource type %s is not detected.", self)
+            return False
+        return self._get_data()
 
     def _get_standardized_metadata(self, instance_data):
         """Return a dictionary of standardized metadata keys."""

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -394,7 +394,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         Minimally, the datasource should return a boolean True on success.
         """
         self._dirty_cache = True
-        return_value = self._get_data()
+        return_value = self._check_and_get_data()
         if not return_value:
             return return_value
         self.persist_instance_data()

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -324,7 +324,9 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def _check_and_get_data(self):
         """Overrides runtime datasource detection"""
         if self.override_ds_detect():
-            LOG.debug("Machine is configured to run on single datasource %s.", self)
+            LOG.debug(
+                "Machine is configured to run on single datasource %s.", self
+            )
         elif self.ds_detect():
             LOG.debug("Machine is running on %s.", self)
         else:

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -317,18 +317,18 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         - TODO: commandline argument is used (ci.ds=OpenStack)
         """
         return self.sys_cfg.get("datasource_list", []) in (
-            [self.dslist],
-            [self.dslist, "None"],
+            [self.dsname],
+            [self.dsname, "None"],
         )
 
     def _check_and_get_data(self):
         """Overrides runtime datasource detection"""
-        if self.override_ds_detect() or self.detect_datasource():
-            LOG.debug(f"Machine is running on {self}.")
+        if self.override_ds_detect() or self.ds_detect():
+            LOG.debug("Machine is running on %s.", self)
             self._get_data()
             return True
 
-        LOG.debug(f"Datasource type {self} is not detected.")
+        LOG.debug("Datasource type %s is not detected.", self)
         return False
 
     def _get_standardized_metadata(self, instance_data):

--- a/doc/examples/cloud-config-datasources.txt
+++ b/doc/examples/cloud-config-datasources.txt
@@ -16,11 +16,6 @@ datasource:
      - http://169.254.169.254:80
      - http://instance-data:8773
 
-  OpenStack:
-    # The default list of metadata services to check for OpenStack.
-    metadata_urls:
-     - http://169.254.169.254
-
   MAAS:
     timeout : 50
     max_wait : 120

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -221,60 +221,6 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
             ["pw", "usermod", "myuser", "-p", "01-Jan-1970"]
         )
 
-    @mock.patch("cloudinit.distros.uses_systemd")
-    @mock.patch(
-        "cloudinit.distros.subp.which",
-    )
-    @mock.patch(
-        "cloudinit.distros.subp.subp",
-    )
-    def test_virtualization_detected(self, m_subp, m_which, m_uses_systemd):
-        m_uses_systemd.return_value = True
-        m_which.return_value = "/usr/bin/systemd-detect-virt"
-        m_subp.return_value = ("kvm", None)
-
-        cls = distros.fetch("ubuntu")
-        d = cls("ubuntu", {}, None)
-        self.assertTrue(d.is_virtual)
-
-    @mock.patch("cloudinit.distros.uses_systemd")
-    @mock.patch(
-        "cloudinit.distros.subp.subp",
-    )
-    def test_virtualization_not_detected(self, m_subp, m_uses_systemd):
-        m_uses_systemd.return_value = True
-        m_subp.return_value = ("none", None)
-
-        cls = distros.fetch("ubuntu")
-        d = cls("ubuntu", {}, None)
-        self.assertFalse(d.is_virtual)
-
-    @mock.patch("cloudinit.distros.uses_systemd")
-    def test_virtualization_unknown(self, m_uses_systemd):
-        m_uses_systemd.return_value = True
-
-        from cloudinit.subp import ProcessExecutionError
-
-        cls = distros.fetch("ubuntu")
-        d = cls("ubuntu", {}, None)
-        with mock.patch(
-            "cloudinit.distros.subp.which",
-            return_value=None,
-        ):
-            self.assertIsNone(
-                d.is_virtual,
-                "Reflect unknown state when detection"
-                " binary cannot be found",
-            )
-
-        with mock.patch(
-            "cloudinit.distros.subp.subp",
-            side_effect=ProcessExecutionError(),
-        ):
-            self.assertIsNone(
-                d.is_virtual, "Reflect unknown state on ProcessExecutionError"
-            )
-
 
 class TestGetPackageMirrors:
     def return_first(self, mlist):

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -305,7 +305,8 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         self.assertIsNone(ds_os.version)
-        self.assertTrue(ds_os.get_data())
+        with mock.patch.object(ds_os, "ds_detect", return_value=True):
+            self.assertTrue(ds_os.get_data())
         self.assertEqual(2, ds_os.version)
         md = dict(ds_os.metadata)
         md.pop("instance-id", None)
@@ -382,9 +383,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         self.assertIsNone(ds_os.version)
-        with test_helpers.mock.patch.object(
-            ds_os, "ds_detect"
-        ) as m_detect_os:
+        with test_helpers.mock.patch.object(ds_os, "ds_detect") as m_detect_os:
             m_detect_os.return_value = True
             found = ds_os.get_data()
         self.assertFalse(found)
@@ -413,7 +412,8 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             "timeout": 0,
         }
         self.assertIsNone(ds_os.version)
-        self.assertFalse(ds_os.get_data())
+        with mock.patch.object(ds_os, "ds_detect", return_value=True):
+            self.assertFalse(ds_os.get_data())
         self.assertIsNone(ds_os.version)
 
     def test_network_config_disabled_by_datasource_config(self):
@@ -488,9 +488,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             "timeout": 0,
         }
         self.assertIsNone(ds_os.version)
-        with test_helpers.mock.patch.object(
-            ds_os, "ds_detect"
-        ) as m_detect_os:
+        with test_helpers.mock.patch.object(ds_os, "ds_detect") as m_detect_os:
             m_detect_os.return_value = True
             found = ds_os.get_data()
         self.assertFalse(found)
@@ -598,9 +596,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
     @test_helpers.mock.patch(MOCK_PATH + "util.get_proc_env")
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_not_ds_detect_intel_x86_ec2(
-        self, m_dmi, m_proc_env, m_is_x86
-    ):
+    def test_not_ds_detect_intel_x86_ec2(self, m_dmi, m_proc_env, m_is_x86):
         """Return False on EC2 platforms."""
         m_is_x86.return_value = True
         # No product_name in proc/1/environ
@@ -621,9 +617,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
         m_proc_env.assert_called_with(1)
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_ds_detect_intel_product_name_compute(
-        self, m_dmi, m_is_x86
-    ):
+    def test_ds_detect_intel_product_name_compute(self, m_dmi, m_is_x86):
         """Return True on OpenStack compute and nova instances."""
         m_is_x86.return_value = True
         openstack_product_names = ["OpenStack Nova", "OpenStack Compute"]
@@ -656,9 +650,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_ds_detect_sapccloud_chassis_asset_tag(
-        self, m_dmi, m_is_x86
-    ):
+    def test_ds_detect_sapccloud_chassis_asset_tag(self, m_dmi, m_is_x86):
         """Return True on OpenStack reporting SAP CCloud VM asset-tag."""
         m_is_x86.return_value = True
 
@@ -676,9 +668,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_ds_detect_huaweicloud_chassis_asset_tag(
-        self, m_dmi, m_is_x86
-    ):
+    def test_ds_detect_huaweicloud_chassis_asset_tag(self, m_dmi, m_is_x86):
         """Return True on OpenStack reporting Huawei Cloud VM asset-tag."""
         m_is_x86.return_value = True
 
@@ -696,9 +686,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_ds_detect_oraclecloud_chassis_asset_tag(
-        self, m_dmi, m_is_x86
-    ):
+    def test_ds_detect_oraclecloud_chassis_asset_tag(self, m_dmi, m_is_x86):
         """Return True on OpenStack reporting Oracle cloud asset-tag."""
         m_is_x86.return_value = True
 
@@ -755,9 +743,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
     @test_helpers.mock.patch(MOCK_PATH + "util.get_proc_env")
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_ds_detect_by_proc_1_environ(
-        self, m_dmi, m_proc_env, m_is_x86
-    ):
+    def test_ds_detect_by_proc_1_environ(self, m_dmi, m_proc_env, m_is_x86):
         """Return True when nova product_name specified in /proc/1/environ."""
         m_is_x86.return_value = True
         # Nova product_name in proc/1/environ

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -301,7 +301,6 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             responses_mock=self.responses,
         )
         distro = mock.MagicMock(spec=Distro)
-        distro.is_virtual = False
         ds_os = ds.DataSourceOpenStack(
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
@@ -351,7 +350,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
 
         self.assertIsNone(ds_os_local.version)
         with test_helpers.mock.patch.object(
-            ds_os_local, "detect_openstack"
+            ds_os_local, "ds_detect"
         ) as m_detect_os:
             m_detect_os.return_value = True
             found = ds_os_local.get_data()
@@ -384,7 +383,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         )
         self.assertIsNone(ds_os.version)
         with test_helpers.mock.patch.object(
-            ds_os, "detect_openstack"
+            ds_os, "ds_detect"
         ) as m_detect_os:
             m_detect_os.return_value = True
             found = ds_os.get_data()
@@ -490,7 +489,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         }
         self.assertIsNone(ds_os.version)
         with test_helpers.mock.patch.object(
-            ds_os, "detect_openstack"
+            ds_os, "ds_detect"
         ) as m_detect_os:
             m_detect_os.return_value = True
             found = ds_os.get_data()
@@ -589,51 +588,17 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
             settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
 
-    def test_detect_openstack_non_intel_x86(self, m_is_x86):
+    def test_ds_detect_non_intel_x86(self, m_is_x86):
         """Return True on non-intel platforms because dmi isn't conclusive."""
         m_is_x86.return_value = False
         self.assertTrue(
-            self._fake_ds().detect_openstack(),
-            "Expected detect_openstack == True",
+            self._fake_ds().ds_detect(),
+            "Expected ds_detect == True",
         )
-
-    def test_detect_openstack_bare_metal(self, m_is_x86):
-        """Return True if the distro is non-virtual."""
-        m_is_x86.return_value = True
-
-        distro = mock.MagicMock(spec=Distro)
-        distro.is_virtual = False
-
-        fake_ds = self._fake_ds()
-        fake_ds.distro = distro
-
-        self.assertFalse(
-            fake_ds.distro.is_virtual,
-            "Expected distro.is_virtual == False",
-        )
-
-        with test_helpers.mock.patch.object(
-            fake_ds, "wait_for_metadata_service"
-        ) as m_wait_for_metadata_service:
-            m_wait_for_metadata_service.return_value = True
-
-            self.assertTrue(
-                fake_ds.wait_for_metadata_service(),
-                "Expected wait_for_metadata_service == True",
-            )
-
-            self.assertTrue(
-                fake_ds.detect_openstack(), "Expected detect_openstack == True"
-            )
-
-            self.assertTrue(
-                m_wait_for_metadata_service.called,
-                "Expected wait_for_metadata_service to be called",
-            )
 
     @test_helpers.mock.patch(MOCK_PATH + "util.get_proc_env")
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_not_detect_openstack_intel_x86_ec2(
+    def test_not_ds_detect_intel_x86_ec2(
         self, m_dmi, m_proc_env, m_is_x86
     ):
         """Return False on EC2 platforms."""
@@ -650,13 +615,13 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertFalse(
-            self._fake_ds().detect_openstack(),
-            "Expected detect_openstack == False on EC2",
+            self._fake_ds().ds_detect(),
+            "Expected ds_detect == False on EC2",
         )
         m_proc_env.assert_called_with(1)
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_detect_openstack_intel_product_name_compute(
+    def test_ds_detect_intel_product_name_compute(
         self, m_dmi, m_is_x86
     ):
         """Return True on OpenStack compute and nova instances."""
@@ -666,12 +631,12 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
         for product_name in openstack_product_names:
             m_dmi.return_value = product_name
             self.assertTrue(
-                self._fake_ds().detect_openstack(),
-                "Failed to detect_openstack",
+                self._fake_ds().ds_detect(),
+                "Failed to ds_detect",
             )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_detect_openstack_opentelekomcloud_chassis_asset_tag(
+    def test_ds_detect_opentelekomcloud_chassis_asset_tag(
         self, m_dmi, m_is_x86
     ):
         """Return True on OpenStack reporting OpenTelekomCloud asset-tag."""
@@ -686,12 +651,12 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            self._fake_ds().detect_openstack(),
-            "Expected detect_openstack == True on OpenTelekomCloud",
+            self._fake_ds().ds_detect(),
+            "Expected ds_detect == True on OpenTelekomCloud",
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_detect_openstack_sapccloud_chassis_asset_tag(
+    def test_ds_detect_sapccloud_chassis_asset_tag(
         self, m_dmi, m_is_x86
     ):
         """Return True on OpenStack reporting SAP CCloud VM asset-tag."""
@@ -706,12 +671,12 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            self._fake_ds().detect_openstack(),
-            "Expected detect_openstack == True on SAP CCloud VM",
+            self._fake_ds().ds_detect(),
+            "Expected ds_detect == True on SAP CCloud VM",
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_detect_openstack_huaweicloud_chassis_asset_tag(
+    def test_ds_detect_huaweicloud_chassis_asset_tag(
         self, m_dmi, m_is_x86
     ):
         """Return True on OpenStack reporting Huawei Cloud VM asset-tag."""
@@ -726,12 +691,12 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_asset_tag_dmi_read
         self.assertTrue(
-            self._fake_ds().detect_openstack(),
-            "Expected detect_openstack == True on Huawei Cloud VM",
+            self._fake_ds().ds_detect(),
+            "Expected ds_detect == True on Huawei Cloud VM",
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_detect_openstack_oraclecloud_chassis_asset_tag(
+    def test_ds_detect_oraclecloud_chassis_asset_tag(
         self, m_dmi, m_is_x86
     ):
         """Return True on OpenStack reporting Oracle cloud asset-tag."""
@@ -745,16 +710,19 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
             assert False, "Unexpected dmi read of %s" % dmi_key
 
         m_dmi.side_effect = fake_dmi_read
+        ds = self._fake_ds()
+        ds.sys_cfg = {"datasource_list": ["Oracle"]}
         self.assertTrue(
-            self._fake_ds().detect_openstack(accept_oracle=True),
-            "Expected detect_openstack == True on OracleCloud.com",
+            ds.ds_detect(),
+            "Expected ds_detect == True on OracleCloud.com",
         )
+        ds.sys_cfg = {"datasource_list": []}
         self.assertFalse(
-            self._fake_ds().detect_openstack(accept_oracle=False),
-            "Expected detect_openstack == False.",
+            ds.ds_detect(),
+            "Expected ds_detect == False.",
         )
 
-    def _test_detect_openstack_nova_compute_chassis_asset_tag(
+    def _test_ds_detect_nova_compute_chassis_asset_tag(
         self, m_dmi, m_is_x86, chassis_tag
     ):
         """Return True on OpenStack reporting generic asset-tag."""
@@ -769,25 +737,25 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            self._fake_ds().detect_openstack(),
-            "Expected detect_openstack == True on Generic OpenStack Platform",
+            self._fake_ds().ds_detect(),
+            "Expected ds_detect == True on Generic OpenStack Platform",
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_detect_openstack_nova_chassis_asset_tag(self, m_dmi, m_is_x86):
-        self._test_detect_openstack_nova_compute_chassis_asset_tag(
+    def test_ds_detect_nova_chassis_asset_tag(self, m_dmi, m_is_x86):
+        self._test_ds_detect_nova_compute_chassis_asset_tag(
             m_dmi, m_is_x86, "OpenStack Nova"
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_detect_openstack_compute_chassis_asset_tag(self, m_dmi, m_is_x86):
-        self._test_detect_openstack_nova_compute_chassis_asset_tag(
+    def test_ds_detect_compute_chassis_asset_tag(self, m_dmi, m_is_x86):
+        self._test_ds_detect_nova_compute_chassis_asset_tag(
             m_dmi, m_is_x86, "OpenStack Compute"
         )
 
     @test_helpers.mock.patch(MOCK_PATH + "util.get_proc_env")
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
-    def test_detect_openstack_by_proc_1_environ(
+    def test_ds_detect_by_proc_1_environ(
         self, m_dmi, m_proc_env, m_is_x86
     ):
         """Return True when nova product_name specified in /proc/1/environ."""
@@ -807,8 +775,8 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            self._fake_ds().detect_openstack(),
-            "Expected detect_openstack == True on OpenTelekomCloud",
+            self._fake_ds().ds_detect(),
+            "Expected ds_detect == True on OpenTelekomCloud",
         )
         m_proc_env.assert_called_with(1)
 

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -14,6 +14,7 @@ import pytest
 import responses
 
 from cloudinit import helpers, settings, util
+from cloudinit.distros import Distro
 from cloudinit.sources import UNSET, BrokenMetadata
 from cloudinit.sources import DataSourceOpenStack as ds
 from cloudinit.sources import convert_vendordata
@@ -299,15 +300,13 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             OS_FILES,
             responses_mock=self.responses,
         )
+        distro = mock.MagicMock(spec=Distro)
+        distro.is_virtual = False
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         self.assertIsNone(ds_os.version)
-        mock_path = MOCK_PATH + "detect_openstack"
-        with test_helpers.mock.patch(mock_path) as m_detect_os:
-            m_detect_os.return_value = True
-            found = ds_os.get_data()
-        self.assertTrue(found)
+        self.assertTrue(ds_os.get_data())
         self.assertEqual(2, ds_os.version)
         md = dict(ds_os.metadata)
         md.pop("instance-id", None)
@@ -351,8 +350,9 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         ]
 
         self.assertIsNone(ds_os_local.version)
-        mock_path = MOCK_PATH + "detect_openstack"
-        with test_helpers.mock.patch(mock_path) as m_detect_os:
+        with test_helpers.mock.patch.object(
+            ds_os_local, "detect_openstack"
+        ) as m_detect_os:
             m_detect_os.return_value = True
             found = ds_os_local.get_data()
         self.assertTrue(found)
@@ -377,12 +377,15 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         _register_uris(
             self.VERSION, {}, {}, os_files, responses_mock=self.responses
         )
+        distro = mock.MagicMock(spec=Distro)
+        distro.is_virtual = True
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         self.assertIsNone(ds_os.version)
-        mock_path = MOCK_PATH + "detect_openstack"
-        with test_helpers.mock.patch(mock_path) as m_detect_os:
+        with test_helpers.mock.patch.object(
+            ds_os, "detect_openstack"
+        ) as m_detect_os:
             m_detect_os.return_value = True
             found = ds_os.get_data()
         self.assertFalse(found)
@@ -401,19 +404,17 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         _register_uris(
             self.VERSION, {}, {}, os_files, responses_mock=self.responses
         )
+        distro = mock.MagicMock(spec=Distro)
+        distro.is_virtual = True
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         ds_os.ds_cfg = {
             "max_wait": 0,
             "timeout": 0,
         }
         self.assertIsNone(ds_os.version)
-        mock_path = MOCK_PATH + "detect_openstack"
-        with test_helpers.mock.patch(mock_path) as m_detect_os:
-            m_detect_os.return_value = True
-            found = ds_os.get_data()
-        self.assertFalse(found)
+        self.assertFalse(ds_os.get_data())
         self.assertIsNone(ds_os.version)
 
     def test_network_config_disabled_by_datasource_config(self):
@@ -478,16 +479,19 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         _register_uris(
             self.VERSION, {}, {}, os_files, responses_mock=self.responses
         )
+        distro = mock.MagicMock(spec=Distro)
+        distro.is_virtual = True
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
         )
         ds_os.ds_cfg = {
             "max_wait": 0,
             "timeout": 0,
         }
         self.assertIsNone(ds_os.version)
-        mock_path = MOCK_PATH + "detect_openstack"
-        with test_helpers.mock.patch(mock_path) as m_detect_os:
+        with test_helpers.mock.patch.object(
+            ds_os, "detect_openstack"
+        ) as m_detect_os:
             m_detect_os.return_value = True
             found = ds_os.get_data()
         self.assertFalse(found)
@@ -575,12 +579,57 @@ class TestVendorDataLoading(test_helpers.TestCase):
 
 @test_helpers.mock.patch(MOCK_PATH + "util.is_x86")
 class TestDetectOpenStack(test_helpers.CiTestCase):
+    def setUp(self):
+        self.tmp = self.tmp_dir()
+
+    def _fake_ds(self) -> ds.DataSourceOpenStack:
+        distro = mock.MagicMock(spec=Distro)
+        distro.is_virtual = True
+        return ds.DataSourceOpenStack(
+            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
+        )
+
     def test_detect_openstack_non_intel_x86(self, m_is_x86):
         """Return True on non-intel platforms because dmi isn't conclusive."""
         m_is_x86.return_value = False
         self.assertTrue(
-            ds.detect_openstack(), "Expected detect_openstack == True"
+            self._fake_ds().detect_openstack(),
+            "Expected detect_openstack == True",
         )
+
+    def test_detect_openstack_bare_metal(self, m_is_x86):
+        """Return True if the distro is non-virtual."""
+        m_is_x86.return_value = True
+
+        distro = mock.MagicMock(spec=Distro)
+        distro.is_virtual = False
+
+        fake_ds = self._fake_ds()
+        fake_ds.distro = distro
+
+        self.assertFalse(
+            fake_ds.distro.is_virtual,
+            "Expected distro.is_virtual == False",
+        )
+
+        with test_helpers.mock.patch.object(
+            fake_ds, "wait_for_metadata_service"
+        ) as m_wait_for_metadata_service:
+            m_wait_for_metadata_service.return_value = True
+
+            self.assertTrue(
+                fake_ds.wait_for_metadata_service(),
+                "Expected wait_for_metadata_service == True",
+            )
+
+            self.assertTrue(
+                fake_ds.detect_openstack(), "Expected detect_openstack == True"
+            )
+
+            self.assertTrue(
+                m_wait_for_metadata_service.called,
+                "Expected wait_for_metadata_service to be called",
+            )
 
     @test_helpers.mock.patch(MOCK_PATH + "util.get_proc_env")
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
@@ -601,7 +650,8 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertFalse(
-            ds.detect_openstack(), "Expected detect_openstack == False on EC2"
+            self._fake_ds().detect_openstack(),
+            "Expected detect_openstack == False on EC2",
         )
         m_proc_env.assert_called_with(1)
 
@@ -616,7 +666,8 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
         for product_name in openstack_product_names:
             m_dmi.return_value = product_name
             self.assertTrue(
-                ds.detect_openstack(), "Failed to detect_openstack"
+                self._fake_ds().detect_openstack(),
+                "Failed to detect_openstack",
             )
 
     @test_helpers.mock.patch(MOCK_PATH + "dmi.read_dmi_data")
@@ -635,7 +686,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            ds.detect_openstack(),
+            self._fake_ds().detect_openstack(),
             "Expected detect_openstack == True on OpenTelekomCloud",
         )
 
@@ -655,7 +706,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            ds.detect_openstack(),
+            self._fake_ds().detect_openstack(),
             "Expected detect_openstack == True on SAP CCloud VM",
         )
 
@@ -675,7 +726,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_asset_tag_dmi_read
         self.assertTrue(
-            ds.detect_openstack(),
+            self._fake_ds().detect_openstack(),
             "Expected detect_openstack == True on Huawei Cloud VM",
         )
 
@@ -695,11 +746,11 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            ds.detect_openstack(accept_oracle=True),
+            self._fake_ds().detect_openstack(accept_oracle=True),
             "Expected detect_openstack == True on OracleCloud.com",
         )
         self.assertFalse(
-            ds.detect_openstack(accept_oracle=False),
+            self._fake_ds().detect_openstack(accept_oracle=False),
             "Expected detect_openstack == False.",
         )
 
@@ -718,7 +769,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            ds.detect_openstack(),
+            self._fake_ds().detect_openstack(),
             "Expected detect_openstack == True on Generic OpenStack Platform",
         )
 
@@ -756,7 +807,7 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
 
         m_dmi.side_effect = fake_dmi_read
         self.assertTrue(
-            ds.detect_openstack(),
+            self._fake_ds().detect_openstack(),
             "Expected detect_openstack == True on OpenTelekomCloud",
         )
         m_proc_env.assert_called_with(1)

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -950,7 +950,7 @@ class TestOracle(DsIdentifyBase):
         """Simple negative test of Oracle."""
         mycfg = copy.deepcopy(VALID_CFG["Oracle"])
         mycfg["files"][P_CHASSIS_ASSET_TAG] = "Not Oracle"
-        self._check_via_dict(mycfg, ds=["openstack", "none"], rc=RC_FOUND)
+        self._check_via_dict(mycfg, rc=RC_NOT_FOUND)
 
 
 def blkid_out(disks=None):
@@ -1056,7 +1056,6 @@ VALID_CFG = {
     "Ec2-brightbox-negative": {
         "ds": "Ec2",
         "files": {P_PRODUCT_SERIAL: "tricky-host.bobrightbox.com\n"},
-        "mocks": [MOCK_VIRT_IS_KVM],
     },
     "GCE": {
         "ds": "GCE",
@@ -1598,7 +1597,6 @@ VALID_CFG = {
     "Ec2-E24Cloud-negative": {
         "ds": "Ec2",
         "files": {P_SYS_VENDOR: "e24cloudyday\n"},
-        "mocks": [MOCK_VIRT_IS_KVM],
     },
     "VMware-NoValidTransports": {
         "ds": "VMware",
@@ -1757,7 +1755,6 @@ VALID_CFG = {
     "VMware-GuestInfo-NoVirtID": {
         "ds": "VMware",
         "mocks": [
-            MOCK_VIRT_IS_KVM,
             {
                 "name": "vmware_has_rpctool",
                 "ret": 0,
@@ -1863,7 +1860,6 @@ VALID_CFG = {
             P_PRODUCT_NAME: "3DS Outscale VM\n",
             P_SYS_VENDOR: "Not 3DS Outscale\n",
         },
-        "mocks": [MOCK_VIRT_IS_KVM],
     },
     "Ec2-Outscale-negative-productname": {
         "ds": "Ec2",
@@ -1871,7 +1867,6 @@ VALID_CFG = {
             P_PRODUCT_NAME: "Not 3DS Outscale VM\n",
             P_SYS_VENDOR: "3DS Outscale\n",
         },
-        "mocks": [MOCK_VIRT_IS_KVM],
     },
 }
 

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -1,5 +1,4 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-from typing import Optional
 from unittest import mock
 
 from cloudinit import cloud, distros, helpers
@@ -145,10 +144,6 @@ class MockDistro(distros.Distro):
 
     def package_command(self, command, args=None, pkgs=None):
         pass
-
-    @property
-    def is_virtual(self) -> Optional[bool]:
-        return True
 
     def update_package_sources(self):
         return (True, "yay")

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1262,13 +1262,6 @@ dscheck_OpenStack() {
         *) return ${DS_MAYBE};;
     esac
 
-    # If we are on bare metal, then we maybe are on a
-    # bare metal Ironic environment.
-    detect_virt
-    if [ "${_RET}" = "none" ]; then
-      return ${DS_MAYBE}
-    fi
-
     return ${DS_NOT_FOUND}
 }
 


### PR DESCRIPTION
```
source: Force OpenStack when it is only option

Running on OpenStack Ironic was broken in 1efa8a0a0,
which prevented a system configured to run on only
Openstack from actually running this ds. This change
also prevents the kernel commandline override from
working. This change was required to prevent
unnecessarily probing OpenStack on Ec2, and is
therefore still required. 

This commit reverts an earlier attempt[1][2] to
automatically detect OpenStack, due to regression
it caused. Additionally, this change allows a
system that defines a datasource list containing
only [OpenStack] or [OpenStack, None] to attempt
running on OpenStack, overriding ds_detect(). A
datasource list that defines [OpenStack, None]
still falls back to DataSourceNone if OpenStack
fails to reach the IMDS.

This change also lays groundwork for the following
future work:

1. Add support for other datasources
2. Also override datasource checking when the kernel
   command line defines a datasource. This work needs
   to be done manually to support non-systemd systems.

Besides forcing OpenStack to run when it is the only
datasource in the datasource list, this commit also:

[1] 0220295 (it breaks some use cases)
[2] 29faf66 (no longer used)

LP: #2008727
```

## Additional Context
It may be easier to review this commit-by-commit. The first two commits reverted 29faf66 and 0220295, respectively

### Sample Logs

Log snippet on non-openstack (last line is new):
```
2023-03-01 21:45:56,065 - __init__.py[DEBUG]: Seeing if we can get any data from <class 'cloudinit.sources.DataSourceNoCloud.DataSourceNoCloud'>
2023-03-01 21:45:56,066 - __init__.py[DEBUG]: Update datasource metadata and network config due to events: boot-new-instance
2023-03-01 21:45:56,066 - __init__.py[DEBUG]: Machine is running on DataSourceNoCloud [seed=None][dsmode=net].
```

Log snippet on lxd, with this config:
```
$ cat /etc/cloud/cloud.cfg.d/90_dpkg.cfg 
datasource_list: [ OpenStack ]
```

Forced OpenStack on non-openstack:
```
2023-03-02 05:12:34,084 - __init__.py[DEBUG]: Seeing if we can get any data from <class 'cloudinit.sources.DataSourceO
penStack.DataSourceOpenStackLocal'>
2023-03-02 05:12:34,084 - __init__.py[DEBUG]: Update datasource metadata and network config due to events: boot-new-in
stance
2023-03-02 05:12:34,084 - __init__.py[DEBUG]: Machine is configured to run on single datasource DataSourceOpenStackLocal [net,ver=None].
```

Forced OpenStack on OpenStack Ironic:
```
2023-03-02 12:10:13,375 - stages.py[DEBUG]: Using distro class <class 'cloudinit.distros.ubuntu.Distro'>
2023-03-02 12:10:13,375 - __init__.py[DEBUG]: Looking for data source in: ['OpenStack'], via packages ['', 'cloudinit.sources'] that matches dependencies ['FILESYSTEM', 'NETWORK']
2023-03-02 12:10:13,377 - __init__.py[DEBUG]: Searching for network data source in: ['DataSourceOpenStack']
2023-03-02 12:10:13,377 - handlers.py[DEBUG]: start: init-network/search-OpenStack: searching for network data from DataSourceOpenStack
2023-03-02 12:10:13,377 - handlers.py[DEBUG]: Queuing POST to http://169.254.169.254/reporting/cloud-init, data: {'name': 'init-network/search-OpenStack', 'description': 'searching for network data from DataSourceOpenStack', 'event_type': 'start', 'origin': 'cloudinit', 'timestamp': 1677759013.3775737}
2023-03-02 12:10:13,377 - __init__.py[DEBUG]: Seeing if we can get any data from <class 'cloudinit.sources.DataSourceOpenStack.DataSourceOpenStack'>
2023-03-02 12:10:13,377 - __init__.py[DEBUG]: Update datasource metadata and network config due to events: boot-new-instance
2023-03-02 12:10:13,377 - __init__.py[DEBUG]: Machine is configured to run on single datasource DataSourceOpenStack [net,ver=None].
```

ref: https://github.com/canonical/cloud-init/pull/1923