### PR TITLE
get an container shell with tox -e boot

### DIFF
--- a/tests/integration_tests/test_utility.py
+++ b/tests/integration_tests/test_utility.py
@@ -1,0 +1,13 @@
+import logging
+
+import pytest
+
+LOG = logging.getLogger("integration_testing.test_utility")
+
+
+class TestUtilities:
+    @pytest.mark.instance_name("boot")
+    def test_boot(self, client):
+        """Boot an instance. That's all it does."""
+        assert client.execute("whoami").ok
+        LOG.info('Instance name "boot" started')

--- a/tox.ini
+++ b/tox.ini
@@ -261,6 +261,32 @@ deps =
     -r{toxinidir}/integration-requirements.txt
 passenv = CLOUD_INIT_* PYCLOUDLIB_* SSH_AUTH_SOCK OS_*
 
+[testenv:boot]
+# If a user has lxd installed, this makes it possible to get an instance shell
+# in just three commands:
+#
+# $ git clone https://github.com/canonical/cloud-init.git
+# $ cd cloud-init
+# $ tox -e boot
+# root@boot:~#
+#
+# Uses "boot" instance name for simplicity. Subsequent runs get new machine.
+commands =
+	# Tox execution stops when when command fails. Ignore failures.
+	{envpython} -c 'import os; os.system("lxc rm -f boot")'
+	{envpython} -m pytest -vv \
+		--log-cli-level=INFO \
+		--durations 10 \
+		{posargs:tests/integration_tests/test_utility.py::TestUtilities::test_boot}
+	lxc shell boot
+deps =
+    -r{toxinidir}/integration-requirements.txt
+passenv = CLOUD_INIT_* PYCLOUDLIB_* SSH_AUTH_SOCK OS_*
+setenv =
+    KEEP_INSTANCE = True
+    CLOUD_INIT_SOURCE = IN_PLACE
+whitelist_externals = lxc
+
 [testenv:integration-tests-ci]
 commands = {[testenv:integration-tests]commands}
 deps = {[testenv:integration-tests]deps}


### PR DESCRIPTION
```
tox: add boot environment

Uses test infrastructure to start an lxc container
from current directory.
```

User / dev tool improvement. There is nothing novel here, just a bit of glue for nicer UX. I assume most devs have their own magic to do effectively this quickly, no reason not to give it to users. It would be trivial to add a dedicated user/meta/vendor filepath to source as well.

## Test Steps
```bash
$ git clone https://github.com/canonical/cloud-init.git
$ cd cloud-init
$ tox -e boot
root@boot:~#
```