### PR TITLE
update grub-dpkg docs

### DIFF
--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -22,7 +22,7 @@ from cloudinit.subp import ProcessExecutionError
 MODULE_DESCRIPTION = """\
 Configure which device is used as the target for grub installation. This module
 can be enabled/disabled using the ``enabled`` config key in the ``grub_dpkg``
-config dict. This module automatically selects a disk with ``grub-probe`` if no
+config dict. This module automatically selects a disk using ``grub-probe`` if no
 installation device is specified.
 
 The value which is placed into the debconf database is in the format which the

--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -22,8 +22,8 @@ from cloudinit.subp import ProcessExecutionError
 MODULE_DESCRIPTION = """\
 Configure which device is used as the target for grub installation. This module
 can be enabled/disabled using the ``enabled`` config key in the ``grub_dpkg``
-config dict. This module automatically selects a disk using ``grub-probe`` if no
-installation device is specified.
+config dict. This module automatically selects a disk using ``grub-probe`` if
+no installation device is specified.
 
 The value which is placed into the debconf database is in the format which the
 grub postinstall script expects. Normally, this is a /dev/disk/by-id/ value,

--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -22,9 +22,8 @@ from cloudinit.subp import ProcessExecutionError
 MODULE_DESCRIPTION = """\
 Configure which device is used as the target for grub installation. This module
 can be enabled/disabled using the ``enabled`` config key in the ``grub_dpkg``
-config dict. The global config key ``grub-dpkg`` is an alias for ``grub_dpkg``.
-If no installation device is specified this module will execute grub-probe to
-determine which disk the /boot directory is associated with.
+config dict. This module automatically selects a disk with ``grub-probe`` if no
+installation device is specified.
 
 The value which is placed into the debconf database is in the format which the
 grub postinstall script expects. Normally, this is a /dev/disk/by-id/ value,

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1343,7 +1343,7 @@
               "description": "Device to use as target for grub installation. If unspecified, ``grub-probe`` of ``/boot`` will be used to find the device"
             },
             "grub-pc/install_devices_empty": {
-              "description": "Sets values for ``grub-pc/install_devices_empty``. If unspecified, will be set to ``true`` if ``grub-pc/install_devices`` is empty, otherwise ``false``.",
+              "description": "Sets values for ``grub-pc/install_devices_empty``. If unspecified, will be set to ``true`` if ``grub-pc/install_devices`` is empty, otherwise ``false``",
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1360,6 +1360,7 @@
         },
         "grub-dpkg": {
           "type": "object",
+          "description": "An alias for ``grub_dpkg``",
           "deprecated": true,
           "deprecated_version": "22.2",
           "deprecated_description": "Use ``grub_dpkg`` instead."

--- a/tests/unittests/config/test_cc_grub_dpkg.py
+++ b/tests/unittests/config/test_cc_grub_dpkg.py
@@ -235,8 +235,8 @@ class TestGrubDpkgSchema:
                 pytest.raises(
                     SchemaValidationError,
                     match=(
-                        "Cloud config schema deprecations: grub-dpkg:"
-                        "  Deprecated in version 22.2. Use "
+                        "Cloud config schema deprecations: grub-dpkg: An alias"
+                        " for ``grub_dpkg`` Deprecated in version 22.2. Use "
                         "``grub_dpkg`` instead."
                     ),
                 ),


### PR DESCRIPTION
```
config: Update grub-dpkg docs
```

## Additional Context
We should always describe config key metadata in the appropriate schema field rather than in the module description.
