### PR TITLE
tests: write to /var/spool/rsyslog to adhere to apparmor profile

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -60,7 +60,7 @@ rsyslog:
       content: |
         module(load="imtcp")
         input(type="imtcp" port="514")
-        $template RemoteLogs,"/var/tmp/rsyslog.log"
+        $template RemoteLogs,"/var/spool/rsyslog/cloudinit.log"
         *.* ?RemoteLogs
         & ~
   remotes:
@@ -175,7 +175,9 @@ class TestCombined:
     def test_rsyslog(self, class_client: IntegrationInstance):
         """Test rsyslog is configured correctly."""
         client = class_client
-        assert "My test log" in client.read_from_file("/var/tmp/rsyslog.log")
+        assert "My test log" in client.read_from_file(
+            "/var/spool/rsyslog/cloudinit.log"
+        )
 
     def test_runcmd(self, class_client: IntegrationInstance):
         """Test runcmd works as expected"""


### PR DESCRIPTION


## Proposed Commit Message

```
tests: write to /var/spool/rsyslog to adhere to apparmor profile

AppArmor is active on 23.04. It prevents writing to /var/tmp.
Integration tests now write to /var/spool/rsyslog/cloudinit.log to
assert working config.
```

## Additional Context
<!-- If relevant -->
- 23.04 enabled rsyslog apparmor profile. This profile doesn't allow for file writes to /var/tmp/
https://git.launchpad.net/ubuntu/+source/rsyslog/commit/?id=449cc82460d0b3209751c8a96450f02a5a3b85b3
- Fix Lunar jenkins failed runs like https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-lunar-azure/lastSuccessfulBuild/testReport/tests.integration_tests.modules.test_combined/TestCombined/test_rsyslog/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_OS_IMAGE=lunar tox -e integration-tests tests/integration_tests/modules/test_combined.py::TestCombined::test_rsyslog`

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
