### PR TITLE
Log deprecated Python features

### DIFF
--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -90,6 +90,11 @@ class NetBSD(cloudinit.distros.bsd.BSD):
         if hashed:
             hashed_pw = passwd
         else:
+            util.deprecate_python(
+                deprecated="Standard library module 'crypt'",
+                deprecated_version="3.11",
+                removed_version="3.13",
+            )
             method = crypt.METHOD_BLOWFISH  # pylint: disable=E1101
             hashed_pw = crypt.crypt(passwd, crypt.mksalt(method))
 
@@ -136,6 +141,3 @@ class NetBSD(cloudinit.distros.bsd.BSD):
 
 class Distro(NetBSD):
     pass
-
-
-# vi: ts=4 expandtab

--- a/cloudinit/distros/parsers/sys_conf.py
+++ b/cloudinit/distros/parsers/sys_conf.py
@@ -17,6 +17,8 @@ from io import StringIO
 # bash scripts...
 import configobj
 
+from cloudinit import util
+
 # See: http://pubs.opengroup.org/onlinepubs/000095399/basedefs/xbd_chap08.html
 # or look at the 'param_expand()' function in the subst.c file in the bash
 # source tarball...
@@ -93,6 +95,11 @@ class SysConf(configobj.ConfigObj):
                                 lambda x: self._get_single_quote(x) % x
                             )  # noqa: E731
                     else:
+                        util.deprecate_python(
+                            deprecated="Standard library module 'pipes'",
+                            deprecated_version="3.11",
+                            removed_version="3.13",
+                        )
                         quot_func = pipes.quote
         if not quot_func:
             return value
@@ -111,6 +118,3 @@ class SysConf(configobj.ConfigObj):
             val,
             cmnt,
         )
-
-
-# vi: ts=4 expandtab

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1744,6 +1744,7 @@ def read_azure_ovf(contents):
 
 
 def encrypt_pass(password, salt_id="$6$"):
+    util.deprecate_python("")
     return crypt.crypt(password, salt_id + util.rand_str(strlen=16))
 
 

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1744,7 +1744,11 @@ def read_azure_ovf(contents):
 
 
 def encrypt_pass(password, salt_id="$6$"):
-    util.deprecate_python("")
+    util.deprecate_python(
+        deprecated="Standard library module 'crypt'",
+        deprecated_version="3.11",
+        removed_version="3.13",
+    )
     return crypt.crypt(password, salt_id + util.rand_str(strlen=16))
 
 

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -87,3 +87,21 @@ class TestDeprecatedLogs:
             schedule=6,
         )
         assert 2 == len(caplog.records)
+
+    def test_python_log_deduplication(self, caplog):
+        ci_logging.defineDeprecationLogger()
+        util.deprecate_python(
+            deprecated="Python stuff",
+            deprecated_version="3.2",
+        )
+        util.deprecate_python(
+            deprecated="Python stuff",
+            deprecated_version="3.2",
+        )
+        assert 1 == len(caplog.records)
+        print(caplog.records)
+        print(caplog.records[0])
+        assert (
+            "Python stuff was deprecated in Python 3.2 and will be removed in "
+            "a future version of Python. Please file a bug report."
+        ) in caplog.text


### PR DESCRIPTION
```
Log deprecated Python features
      
- Add deduplicating Python deprecation utility
- Only log for versions of Python which have features that have been deprecated
- Also fix bug in deprecate_call()
```

## Additional Context
Fixing all of these issues would be better than just logging them, but this is better than nothing - this makes Python deprecated features discoverable for future maintenance, and a minor nuisance for those that are affected until they are resolved.