### PR TITLE
d/postinst: prefer yaml.safe_load. yaml.load requires Loader param

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 cloud-init (23.1.1-0ubuntu2) UNRELEASED; urgency=medium
 
+  * d/cloud-init.postinst: MAAS prefer yaml.safe_load over yaml.load
+    (LP: #2009746)
   * d/cloud-init.preinst: Oracle to remove vestigial /etc/cloud.cloud.cfg.d/
     99-disable-network-config.cfg because system config is now honored before
     datasource config (LP: #1956788)

--- a/debian/cloud-init.postinst
+++ b/debian/cloud-init.postinst
@@ -38,10 +38,10 @@ def update(src, cand):
 REMOVER = object
 if len(sys.argv) == 5:
    REMOVER = sys.argv[4]
-newcfg = yaml.load(newyaml)
+newcfg = yaml.safe_load(newyaml)
 
 with open(fname, "r") as fp:
-    cfg = yaml.load(fp)
+    cfg = yaml.safe_load(fp)
 if not cfg: cfg = {}
 
 cfg = update(cfg, newcfg)


### PR DESCRIPTION
## Proposed Commit Message
```
    d/postinst: prefer yaml.safe_load. yaml.load requires Loader param
    
    It's been deprecated for a while, Ubuntu 23.04 sync'd 6.0.1 which
    dropped support for an optional Loader parameter making it required.
    
    This broke dpkg-reconfigured cloud-init on MAAS Ubuntu 23.04 system
    deployments which now exit non-zero due to changed yaml.load
    call-signature.
    
    LP: #2009746
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
# reproduce failure

lxc launch ubuntu-daily:lunar dev-l
lxc exec dev-l -- cloud-init status --wait --long
# Setup MAAS debconf setting which triggers failure during reconfigure
cat > debconf.settings <<EOF
cloud-init cloud-init/maas-metadata-url string SOMETEXT
EOF
lxc file push debconf.settings dev-l/
lxc exec dev-l -- dpkg-reconfigure -cloud-init
echo $?

# build local package and install it in lxc container and re-run dpkg-reconfigure
build-package
sbuild --dist=lunar --arch=amd64  --arch-all ../out/cloud-init_*.dsc
lxc file push cloud-init*deb dev-l
lxc exec dev-l -- 'dpkg -i /cloud-init*deb'
lxc exec dev-l -- dpkg-reconfigure -cloud-init
echo $?

```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly