### PR TITLE
Ubuntu/kinetic oci 99 disable network config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (23.1-0ubuntu1~22.10.1) UNRELEASED; urgency=medium
+
+  * d/cloud-init.preinst: Oracle to remove vestigial /etc/cloud.cloud.cfg.d/
+    99-disable-network-config.cfg because system config is now honored before
+    datasource config (LP: #1956788)
+
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Thu, 09 Mar 2023 11:49:48 +0100
+
 cloud-init (23.1-0ubuntu0~22.10.1) kinetic; urgency=medium
 
   * d/patches/retain-netplan-world-readable.patch:

--- a/debian/cloud-init.preinst
+++ b/debian/cloud-init.preinst
@@ -181,6 +181,13 @@ cleanup_lp1552999() {
         "$hdir/cloud-init-local.service" "$hdir/cloud-init.service"
 }
 
+cleanup_oci_network_lp1956788() {
+   # Remove vestigial /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+   # from Oracle now that datasource honors system cfg above datasource cfg.
+   grep DataSourceOracle /var/lib/cloud/instance/datasource > /dev/null 2>&1 || return 0
+   rm -f /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+}
+
 case "$1" in
     install|upgrade)
         if dpkg --compare-versions "$2" le "0.5.11-0ubuntu1"; then
@@ -224,6 +231,8 @@ case "$1" in
       fi
 
       cleanup_lp1552999 "$oldver"
+      cleanup_oci_network_lp1956788
+
 esac
 
 #DEBHELPER#


### PR DESCRIPTION
## DO NOT SQUASH

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
d/cloud-init.preinst: drop 99-disable-network-config.cfg in Oracle instances
```

## Additional Context
<!-- If relevant -->
https://warthogs.atlassian.net/browse/SC-1414
https://bugs.launchpad.net/cloud-init/+bug/1956788