### PR TITLE
sources/azure: move pps handling out of _poll_imds()

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -574,7 +574,7 @@ class DataSourceAzure(sources.DataSource):
 
             if pps_type == PPSType.RUNNING:
                 self._wait_for_pps_running_reuse()
-            if pps_type == PPSType.SAVABLE:
+            elif pps_type == PPSType.SAVABLE:
                 self._wait_for_pps_savable_reuse()
             elif pps_type == PPSType.OS_DISK:
                 self._wait_for_pps_os_disk_shutdown()

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -4,6 +4,7 @@ import copy
 import crypt
 import json
 import os
+import stat
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
@@ -1346,6 +1347,14 @@ scbus-1 on xpt0 bus 0
         poll_imds_func.return_value = ovfenv
         dsrc.crawl_metadata()
         self.assertEqual(2, self.m_fetch.call_count)
+
+    def test_waagent_d_has_0700_perms(self):
+        # we expect /var/lib/waagent to be created 0700
+        dsrc = self._get_ds({"ovfcontent": construct_ovf_env()})
+        ret = dsrc.get_data()
+        self.assertTrue(ret)
+        self.assertTrue(os.path.isdir(self.waagent_d))
+        self.assertEqual(stat.S_IMODE(os.stat(self.waagent_d).st_mode), 0o700)
 
     def test_network_config_set_from_imds(self):
         """Datasource.network_config returns IMDS network data."""

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -4008,7 +4008,7 @@ class TestProvisioning:
         # Verify no netlink operations for recovering PPS.
         assert self.mock_netlink.mock_calls == []
 
-        # Verify reported_ready marker not written and cleaned up.
+        # Verify reported_ready marker not written.
         assert self.wrapped_util_write_file.mock_calls == [
             mock.call(
                 filename=str(self.patched_data_dir_path / "ovf-env.xml"),


### PR DESCRIPTION
Pull out remaining PPS handling bits from _poll_imds() and add two explicit methods for the overloaded path:

- _wait_for_pps_running_reuse() for running PPS logic.

- _wait_for_pps_unknown_reuse() for unknown and recovery PPS logic.

For consistency:

- Rename _wait_for_all_nics_ready() -> _wait_for_pps_savable_reuse().

- Move reporting ready logic into _wait_for_pps_os_disk_shutdown().

Drop several impacted tests as coverage already exists in TestProvisioning, and update the rest to handle the +/- 1 DHCP attempt due to varying assumptions around PPS state and DHCP.