### PR TITLE
Ubuntu/focal

### DIFF
--- a/debian/apport-general-hook.py
+++ b/debian/apport-general-hook.py
@@ -1,0 +1,99 @@
+"""General Apport hook for all reports that are using cloud-init."""
+
+import json
+import logging
+
+
+def _get_azure_data(ds_data) -> dict[str, str]:
+    compute = ds_data.get("meta_data", {}).get("imds", {}).get("compute")
+    if not compute:
+        return {}
+    name_to_report_map = {
+        "publisher": "ImagePublisher",
+        "offer": "ImageOffer",
+        "sku": "ImageSKU",
+        "version": "ImageVersion",
+        "vmSize": "VMSize",
+    }
+    azure_data = {}
+    for src_key, report_key_name in name_to_report_map.items():
+        azure_data[report_key_name] = compute[src_key]
+    return azure_data
+
+
+def _get_ec2_data(ds_data) -> dict[str, str]:
+    document = (
+        ds_data.get("dynamic", {}).get("instance-identity", {}).get("document")
+    )
+    if not document:
+        return {}
+    wanted_keys = {
+        "architecture",
+        "billingProducts",
+        "imageId",
+        "instanceType",
+        "region",
+    }
+    return {
+        key: value for key, value in document.items() if key in wanted_keys
+    }
+
+
+PLATFORM_SPECIFIC_INFO = {"azure": _get_azure_data, "ec2": _get_ec2_data}
+
+
+def add_datasource_specific_info(report, platform: str, ds_data) -> None:
+    """Add datasoure specific information from the ds dictionary.
+
+    ds_data contains the "ds" entry from data from
+    /run/cloud/instance-data.json.
+    """
+    platform_info = PLATFORM_SPECIFIC_INFO.get(platform)
+    if not platform_info:
+        return
+    retrieved_data = platform_info(ds_data)
+    for key, value in retrieved_data.items():
+        if not value:
+            continue
+        report[platform.capitalize() + key.capitalize()] = value
+
+
+def add_info(report, ui) -> None:
+    """Entry point for Apport.
+
+    Add a subset of non-sensitive cloud-init data from
+    /run/cloud/instance-data.json that will be helpful for debugging.
+    """
+    try:
+        with open("/run/cloud-init/instance-data.json", "r") as fopen:
+            instance_data = json.load(fopen)
+    except FileNotFoundError:
+        logging.getLogger().warning(
+            "cloud-init run data not found on system. "
+            "Unable to add cloud-specific data."
+        )
+        return
+
+    v1 = instance_data.get("v1")
+    if not v1:
+        logging.getLogger().warning(
+            "instance-data.json lacks 'v1' metadata. Present keys: %s",
+            sorted(instance_data.keys()),
+        )
+        return
+
+    for key, report_key in {
+        "cloud_id": "CloudID",
+        "cloud_name": "CloudName",
+        "machine": "CloudArchitecture",
+        "platform": "CloudPlatform",
+        "region": "CloudRegion",
+        "subplatform": "CloudSubPlatform",
+    }.items():
+        value = v1.get(key)
+        if value:
+            report[report_key] = value
+
+    add_datasource_specific_info(
+        report, v1["platform"], instance_data.get("ds")
+    )

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 cloud-init (23.1-0ubuntu1~20.04.1) UNRELEASED; urgency=medium
 
+  * d/apport-general-hook.py: Add general apport hook to append cloud type,
+    image and instance size information to bug reports (LP: #1724623)
   * d/cloud-init.preinst: Oracle to remove vestigial /etc/cloud.cloud.cfg.d/
     99-disable-network-config.cfg because system config is now honored before
     datasource config (LP: #1956788)

--- a/debian/rules
+++ b/debian/rules
@@ -23,5 +23,6 @@ override_dh_auto_install:
 	install -D -m 0644 ./tools/21-cloudinit.conf debian/cloud-init/etc/rsyslog.d/21-cloudinit.conf
 	install -D ./tools/Z99-cloud-locale-test.sh debian/cloud-init/etc/profile.d/Z99-cloud-locale-test.sh
 	install -D ./tools/Z99-cloudinit-warnings.sh debian/cloud-init/etc/profile.d/Z99-cloudinit-warnings.sh
+	install -m 0644 -D debian/apport-general-hook.py debian/cloud-init/usr/share/apport/general-hooks/cloud-init.py
 	install -m 0644 -D debian/apport-launcher.py debian/cloud-init/usr/share/apport/package-hooks/cloud-init.py
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -11,6 +11,7 @@ andrewbogott
 andrewlukoshko
 antonyc
 aswinrajamannar
+bdrung
 beantaxi
 beezly
 berolinux


### PR DESCRIPTION
## do not squash merge
Reflecting @bdrung's #2020 to all `ubuntu/*` downstream branches we support 

```
    Add Apport general hook
    
    Apport 2.25.0-0ubuntu1 removed the buggy `add_cloud_info` from the
    ubuntu general hook. Add an Apport general hook that reads
    `/run/cloud-init/instance-data.json` if present.
    
    LP: #1724623
    Thanks for the initial version: John Chittum
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
