### PR TITLE
Ansible complete the examples and doc

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -39,6 +39,7 @@ meta: MetaSchema = {
         dedent(
             """\
             ansible:
+              package_name: ansible-core
               install_method: distro
               pull:
                 url: "https://github.com/holmanb/vmboot.git"

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -136,6 +136,7 @@ vorlonofportland
 vteratipally
 Vultaire
 WebSpider
+Wind-net
 wschoot
 wynnfeng
 xiachen-rh


### PR DESCRIPTION
The code examples provided for cloud-init with the cc-ansible.py module are not accurate. The "package_name" parameter is mandatory and must be included in the example code. To improve the usability of these examples, they should be updated to include all necessary parameters and reflect the current best practices for using cc-ansible with cloud-init.