### PR TITLE
net/dhcp: catch dhclient failures and raise NoDHCPLeaseError

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -168,7 +168,17 @@ def dhcp_discovery(dhclient_cmd_path, interface, dhcp_log_func=None):
         util.write_file(file_name, interface_dhclient_content)
         cmd.append("-cf")
         cmd.append(file_name)
-    out, err = subp.subp(cmd, capture=True)
+
+    try:
+        out, err = subp.subp(cmd, capture=True)
+    except subp.ProcessExecutionError as error:
+        LOG.debug(
+            "dhclient exited with code: %s stderr: %r stdout: %r",
+            error.exit_code,
+            error.stderr,
+            error.stdout,
+        )
+        raise NoDHCPLeaseError from error
 
     # Wait for pid file and lease file to appear, and for the process
     # named by the pid file to daemonize (have pid 1 as its parent). If we


### PR DESCRIPTION
Some variants of dhclient will exit with non-zero codes on lease failure. For example, on RHEL 8.7:
```
[cpatterson@test-rhel87 ~]$ sudo /usr/sbin/dhclient -1 -v -lf /tmp/my.lease -pf /tmp/my.pid bridge2nowhere -sf /bin/true
Internet Systems Consortium DHCP Client 4.3.6
Copyright 2004-2017 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/bridge2nowhere/42:ef:d5:38:1d:19
Sending on   LPF/bridge2nowhere/42:ef:d5:38:1d:19
Sending on   Socket/fallback
Created duid "\000\004E<\225X\232\304J\337\243\026T\324\243O\270\177".
DHCPDISCOVER on bridge2nowhere to 255.255.255.255 port 67 interval 4 (xid=0x777bc142)
DHCPDISCOVER on bridge2nowhere to 255.255.255.255 port 67 interval 7 (xid=0x777bc142)
DHCPDISCOVER on bridge2nowhere to 255.255.255.255 port 67 interval 13 (xid=0x777bc142)
DHCPDISCOVER on bridge2nowhere to 255.255.255.255 port 67 interval 6 (xid=0x777bc142)
No DHCPOFFERS received.
Unable to obtain a lease on first try.  Exiting.

[cpatterson@test-rhel87 ~]$ echo $?
2
```

This results in an unhandled subp.ProcessExecutionError exception. Catch these failures and re-raise as NoDHCPLeaseError.
