### PR TITLE
test-requirements: add pytest-antilru plugin to manage lru caches

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,9 @@ pytest
 pytest-cov
 pytest-mock
 
+# Clear lru caches on every test
+pytest-antilru
+
 # Only really needed on older versions of python
 setuptools
 jsonschema

--- a/tox.ini
+++ b/tox.ini
@@ -191,6 +191,7 @@ deps =
     netifaces==0.10.4
     # test-requirements
     pytest==3.3.2
+    pytest-antilru==1.1.1
     pytest-cov==2.5.1
     pytest-mock==1.7.1
     # Needed by pytest and default causes failures


### PR DESCRIPTION
lru caches may be populated on module loads and not cleared for tests (or between tests).

Ensure all tests run with a clean cache with pytest-antilru.  It wraps lru_cache() to track each user and clear them for each test.