### PR TITLE
macs: ignore duplicate MAC for devs with driver driver qmi_wwan

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1040,7 +1040,7 @@ def get_interfaces_by_mac_on_linux(blacklist_drivers=None) -> dict:
             # cloud-init happens to enumerate network interfaces before drivers
             # have fully initialized the leader/subordinate relationships for
             # those devices or switches.
-            if driver == "mscc_felix" or driver == "fsl_enetc":
+            if driver in ("fsl_enetc", "mscc_felix", "qmi_wwan"):
                 LOG.debug(
                     "Ignoring duplicate macs from '%s' and '%s' due to "
                     "driver '%s'.",

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -11,6 +11,7 @@ andrewbogott
 andrewlukoshko
 antonyc
 aswinrajamannar
+bdrung
 beantaxi
 beezly
 berolinux


### PR DESCRIPTION
## Proposed Commit Message
```
    macs: ignore duplicate MAC for devs with driver driver qmi_wwan
    
    Another physical modem which has duplicate MAC addresses.
    Cloud-init needs to ignore the subordinate devices which are
    associated with the qmi_wwan driver.

    Fixes network rendering for the following modems:
    Quectel EG25
    Quectel RM510Q-GLHA
    Sierra Wireless MC7455

    LP: #2008888
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
