### PR TITLE
tests/sources: patch util.get_cmdline() for datasource tests

### DIFF
--- a/tests/unittests/sources/conftest.py
+++ b/tests/unittests/sources/conftest.py
@@ -1,0 +1,9 @@
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def mock_util_get_cmdline():
+    with mock.patch("cloudinit.util.get_cmdline", return_value="") as m:
+        yield m


### PR DESCRIPTION
Recent changes to override_ds_detect() triggers a call to get_cmdline(), which invokes subp.subp() for various container checks.  This causes tests to fail when running a specific test module instead of the full set.  This is because test_smartos.py on module load will trigger these calls and the lru_cache() will retain the results.  So if the module does not load, the tests will fail.

Patch util.get_cmdline() for all data source tests to avoid this behavior.