### PR TITLE
tests/vmware: fix test_no_data_access_method failure

### DIFF
--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -101,7 +101,11 @@ class TestDataSourceVMware(CiTestCase):
     def test_no_data_access_method(self):
         ds = get_ds(self.tmp)
         ds.vmware_rpctool = None
-        ret = ds.get_data()
+        with mock.patch(
+            "cloudinit.sources.DataSourceVMware.is_vmware_platform",
+            return_value=False,
+        ):
+            ret = ds.get_data()
         self.assertFalse(ret)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")


### PR DESCRIPTION
Patch is_vmware_platform to return False to avoid failure:

```
    def test_no_data_access_method(self):
        ds = get_ds(self.tmp)
        ds.vmware_rpctool = None
>       ret = ds._get_data()

tests/unittests/sources/test_vmware.py:104:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cloudinit/sources/DataSourceVMware.py:193: in _get_data
    if require_vmware_platform and not is_vmware_platform():
cloudinit/sources/DataSourceVMware.py:401: in is_vmware_platform
    system_type = dmi.read_dmi_data("system-product-name")
cloudinit/dmi.py:180: in read_dmi_data
    return _call_dmidecode(key, dmidecode_path)
cloudinit/dmi.py:130: in _call_dmidecode
    (result, _err) = subp.subp(cmd)

E       RuntimeError: called subp. set self.allowed_subp=True to allow
E        subp(['/usr/sbin/dmidecode', '--string', 'system-product-name'])

tests/unittests/helpers.py:176: RuntimeError
```

Bypassing is_vmware_platform() avoids the dmi reads.

