### PR TITLE
schema: do not manipulate draft4 metaschema on jsonschema 2.6.0

### DIFF
--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -51,6 +51,7 @@ from tests.unittests.helpers import (
     mock,
     skipUnlessHypothesisJsonSchema,
     skipUnlessJsonSchema,
+    skipUnlessJsonSchemaVersionGreaterThan,
 )
 from tests.unittests.util import FakeDataSource
 
@@ -422,7 +423,7 @@ class TestValidateCloudConfigSchema:
             context_mgr.value
         )
 
-    @skipUnlessJsonSchema()
+    @skipUnlessJsonSchemaVersionGreaterThan(version=(3, 0, 0))
     def test_validateconfig_strict_metaschema_do_not_raise_exception(
         self, caplog
     ):
@@ -1770,7 +1771,7 @@ class TestStrictMetaschema:
             else:
                 logging.warning("module %s has no schema definition", name)
 
-    @skipUnlessJsonSchema()
+    @skipUnlessJsonSchemaVersionGreaterThan(version=(3, 0, 0))
     def test_validate_bad_module(self):
         """Throw exception by default, don't throw if throw=False
 

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -491,9 +491,23 @@ try:
     import jsonschema
 
     assert jsonschema  # avoid pyflakes error F401: import unused
+    _jsonschema_version = tuple(
+        int(part) for part in jsonschema.__version__.split(".")  # type: ignore
+    )
     _missing_jsonschema_dep = False
 except ImportError:
     _missing_jsonschema_dep = True
+    _jsonschema_version = (0, 0, 0)
+
+
+def skipUnlessJsonSchemaVersionGreaterThan(version=(0, 0, 0)):
+    return skipIf(
+        _jsonschema_version <= version,
+        reason=(
+            f"python3-jsonschema {_jsonschema_version} not greater than"
+            f" {version}"
+        ),
+    )
 
 
 def skipUnlessJsonSchema():


### PR DESCRIPTION
## Proposed Commit Message
```
    schema: do not manipulate draft4 metaschema for jsonschema 2.6.0
    
    Only set additionalProperties = False in unittest
    draft4 schema definition because cloud-init globally
    registers its draft4 extensions as the primary validator
    for any draft4 schemas in the python process.
    
    This affects solutions such as subiquity and
    ubuntu-desktop-installer which invoke jsonschema.validate
    in the same process at runtime just after calling
    cloudinit.schema.get_jsonschema_validator.
    
    The resulting Tracebacks are seen as something like:
     jsonschema.exceptions.SchemaError:
     {'$ref': '#/definitions/ref_id'} is not valid under any of the
     given schema
    
    Background:
    cloud-init needs to extend draft4 schema to better
    validate and warn 'deprecated' properties in draft4-based
    cloud-init schema definitions. Our unittests also attempt
    to strictly validate any meta schema definitions for the
    cc_* config modules.
    
    To accomplish strict meta schema validation cloud-init makes
    a copy of the draft4 meta schema and adds an
    'additionalProperties' = True to that schema to raise specific
    errors and catch typos in cc_ module schema definitions.
    
    Given that cloud-init at runtime extends and registers
    a draft4 schema validator, any external consumers
    of jsonschema.validate with draft4-base schemas are
    exposed to cloud-init's validator extentions so let's
    limit our risk exposure.
    
    For python 2.6.0, we cannot specify make draft4 schema
    strict because any "$ref" keys are not yet resolved
    to their actual #/defintions/<id> values so the traceback above
    will always be generated in 'strict' mode for complex schemas.
    
    This does not affect jsonschema 3.0+ which appears to resolve
    schema $refs values before schema validation.
```

## Additional Context
<!-- If relevant -->
python3-jsonschema 2.6.0 in ubuntu-desktop-installer causing probs for cloud-init/curtin https://github.com/canonical/ubuntu-desktop-installer/issues/1714


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
