### PR TITLE
Fix Python 3.12 unit test failures

### DIFF
--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -802,7 +802,7 @@ class TestEphemeralDhcpNoNetworkSetup(ResponsesTestCase):
         ) as lease:
             self.assertEqual(fake_lease, lease)
         # Ensure that dhcp discovery occurs
-        m_dhcp.called_once_with()
+        m_dhcp.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -854,64 +854,66 @@ class TestBlkid(CiTestCase):
         )
 
 
-@mock.patch("cloudinit.subp.which")
-@mock.patch("cloudinit.subp.subp")
+@mock.patch("cloudinit.util.subp.which")
+@mock.patch("cloudinit.util.subp.subp")
 class TestUdevadmSettle(CiTestCase):
-    def test_with_no_params(self, m_which, m_subp):
+    def test_with_no_params(self, m_subp, m_which):
         """called with no parameters."""
         m_which.side_effect = lambda m: m in ("udevadm",)
         util.udevadm_settle()
-        m_subp.called_once_with(mock.call(["udevadm", "settle"]))
+        m_subp.assert_called_once_with(["udevadm", "settle"])
 
-    def test_udevadm_not_present(self, m_which, m_subp):
+    def test_udevadm_not_present(self, m_subp, m_which):
         """where udevadm program does not exist should not invoke subp."""
         m_which.side_effect = lambda m: m in ("",)
         util.udevadm_settle()
-        m_subp.called_once_with(["which", "udevadm"])
+        m_which.assert_called_once_with("udevadm")
+        m_subp.assert_not_called()
 
-    def test_with_exists_and_not_exists(self, m_which, m_subp):
+    def test_with_exists_and_not_exists(self, m_subp, m_which):
         """with exists=file where file does not exist should invoke subp."""
         m_which.side_effect = lambda m: m in ("udevadm",)
         mydev = self.tmp_path("mydev")
         util.udevadm_settle(exists=mydev)
-        m_subp.called_once_with(
+        m_subp.assert_called_once_with(
             ["udevadm", "settle", "--exit-if-exists=%s" % mydev]
         )
 
-    def test_with_exists_and_file_exists(self, m_which, m_subp):
+    def test_with_exists_and_file_exists(self, m_subp, m_which):
         """with exists=file where file does exist should only invoke subp
         once for 'which' call."""
         m_which.side_effect = lambda m: m in ("udevadm",)
         mydev = self.tmp_path("mydev")
         util.write_file(mydev, "foo\n")
         util.udevadm_settle(exists=mydev)
-        m_subp.called_once_with(["which", "udevadm"])
+        m_which.assert_called_once_with("udevadm")
+        m_subp.assert_not_called()
 
-    def test_with_timeout_int(self, m_which, m_subp):
+    def test_with_timeout_int(self, m_subp, m_which):
         """timeout can be an integer."""
         m_which.side_effect = lambda m: m in ("udevadm",)
         timeout = 9
         util.udevadm_settle(timeout=timeout)
-        m_subp.called_once_with(
+        m_subp.assert_called_once_with(
             ["udevadm", "settle", "--timeout=%s" % timeout]
         )
 
-    def test_with_timeout_string(self, m_which, m_subp):
+    def test_with_timeout_string(self, m_subp, m_which):
         """timeout can be a string."""
         m_which.side_effect = lambda m: m in ("udevadm",)
         timeout = "555"
         util.udevadm_settle(timeout=timeout)
-        m_subp.called_once_with(
+        m_subp.assert_called_once_with(
             ["udevadm", "settle", "--timeout=%s" % timeout]
         )
 
-    def test_with_exists_and_timeout(self, m_which, m_subp):
+    def test_with_exists_and_timeout(self, m_subp, m_which):
         """test call with both exists and timeout."""
         m_which.side_effect = lambda m: m in ("udevadm",)
         mydev = self.tmp_path("mydev")
         timeout = "3"
-        util.udevadm_settle(exists=mydev)
-        m_subp.called_once_with(
+        util.udevadm_settle(exists=mydev, timeout=timeout)
+        m_subp.assert_called_once_with(
             [
                 "udevadm",
                 "settle",
@@ -920,7 +922,7 @@ class TestUdevadmSettle(CiTestCase):
             ]
         )
 
-    def test_subp_exception_raises_to_caller(self, m_which, m_subp):
+    def test_subp_exception_raises_to_caller(self, m_subp, m_which):
         m_which.side_effect = lambda m: m in ("udevadm",)
         m_subp.side_effect = subp.ProcessExecutionError("BOOM")
         self.assertRaises(subp.ProcessExecutionError, util.udevadm_settle)


### PR DESCRIPTION
Oof. We had a number of unit tests not actually checking anything.

Still having problems with `test_url_helper.py` (it's 3.12 specific), but figured I'd at least get this much up.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix Python 3.12 unit test failures
```
