### PR TITLE
ensure do clean network

### DIFF
--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -374,12 +374,8 @@ class EphemeralDHCPv4:
             )
         if self.connectivity_url_data:
             kwargs["connectivity_url_data"] = self.connectivity_url_data
-        try:
-            ephipv4 = EphemeralIPv4Network(**kwargs)
-            ephipv4.__enter__()
-            self._ephipv4 = ephipv4
-        except subp.ProcessExecutionError:
-            ephipv4.__exit__(None, None, None)
+        self._ephipv4 = EphemeralIPv4Network(**kwargs)
+        self._ephipv4.__enter__()
         return self.lease
 
     def extract_dhcp_options_mapping(self, nmap):

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -379,7 +379,7 @@ class EphemeralDHCPv4:
             ephipv4.__enter__()
             self._ephipv4 = ephipv4
         except subp.ProcessExecutionError:
-            ephipv4.__exit__()
+            ephipv4.__exit__(None, None, None)
         return self.lease
 
     def extract_dhcp_options_mapping(self, nmap):

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -374,8 +374,12 @@ class EphemeralDHCPv4:
             )
         if self.connectivity_url_data:
             kwargs["connectivity_url_data"] = self.connectivity_url_data
-        self._ephipv4 = EphemeralIPv4Network(**kwargs)
-        self._ephipv4.__enter__()
+        try:
+            ephipv4 = EphemeralIPv4Network(**kwargs)
+            ephipv4.__enter__()
+            self._ephipv4 = ephipv4
+        except subp.ProcessExecutionError:
+            ephipv4.__exit__(None, None, None)
         return self.lease
 
     def extract_dhcp_options_mapping(self, nmap):

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -378,8 +378,14 @@ class EphemeralDHCPv4:
             ephipv4 = EphemeralIPv4Network(**kwargs)
             ephipv4.__enter__()
             self._ephipv4 = ephipv4
-        except Exception:
+        except subp.ProcessExecutionError:
+            LOG.error(
+                "Error bringing up EphemeralIPv4Network. "
+                "Datasource setup cannot continue"
+            )
             ephipv4.__exit__(None, None, None)
+            raise
+
         return self.lease
 
     def extract_dhcp_options_mapping(self, nmap):

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -84,23 +84,32 @@ class EphemeralIPv4Network:
                 )
                 return
 
-        self._bringup_device()
+        try:
+            self._bringup_device()
 
-        # rfc3442 requires us to ignore the router config *if* classless static
-        # routes are provided.
-        #
-        # https://tools.ietf.org/html/rfc3442
-        #
-        # If the DHCP server returns both a Classless Static Routes option and
-        # a Router option, the DHCP client MUST ignore the Router option.
-        #
-        # Similarly, if the DHCP server returns both a Classless Static Routes
-        # option and a Static Routes option, the DHCP client MUST ignore the
-        # Static Routes option.
-        if self.static_routes:
-            self._bringup_static_routes()
-        elif self.router:
-            self._bringup_router()
+            # rfc3442 requires us to ignore the router config *if*
+            # classless static routes are provided.
+            #
+            # https://tools.ietf.org/html/rfc3442
+            #
+            # If the DHCP server returns both a Classless Static Routes
+            # option and a Router option, the DHCP client MUST ignore
+            # the Router option.
+            #
+            # Similarly, if the DHCP server returns both a Classless
+            # Static Routes option and a Static Routes option, the DHCP
+            # client MUST ignore the Static Routes option.
+            if self.static_routes:
+                self._bringup_static_routes()
+            elif self.router:
+                self._bringup_router()
+        except subp.ProcessExecutionError:
+            LOG.error(
+                "Error bringing up EphemeralIPv4Network. "
+                "Datasource setup cannot continue"
+            )
+            self.__exit__(None, None, None)
+            raise
 
     def __exit__(self, excp_type, excp_value, excp_traceback):
         """Teardown anything we set up."""
@@ -374,18 +383,9 @@ class EphemeralDHCPv4:
             )
         if self.connectivity_url_data:
             kwargs["connectivity_url_data"] = self.connectivity_url_data
-        try:
-            ephipv4 = EphemeralIPv4Network(**kwargs)
-            ephipv4.__enter__()
-            self._ephipv4 = ephipv4
-        except subp.ProcessExecutionError:
-            LOG.error(
-                "Error bringing up EphemeralIPv4Network. "
-                "Datasource setup cannot continue"
-            )
-            ephipv4.__exit__(None, None, None)
-            raise
-
+        ephipv4 = EphemeralIPv4Network(**kwargs)
+        ephipv4.__enter__()
+        self._ephipv4 = ephipv4
         return self.lease
 
     def extract_dhcp_options_mapping(self, nmap):

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -374,9 +374,12 @@ class EphemeralDHCPv4:
             )
         if self.connectivity_url_data:
             kwargs["connectivity_url_data"] = self.connectivity_url_data
-        ephipv4 = EphemeralIPv4Network(**kwargs)
-        ephipv4.__enter__()
-        self._ephipv4 = ephipv4
+        try:
+            ephipv4 = EphemeralIPv4Network(**kwargs)
+            ephipv4.__enter__()
+            self._ephipv4 = ephipv4
+        except subp.ProcessExecutionError:
+            ephipv4.__exit__()
         return self.lease
 
     def extract_dhcp_options_mapping(self, nmap):

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -378,7 +378,7 @@ class EphemeralDHCPv4:
             ephipv4 = EphemeralIPv4Network(**kwargs)
             ephipv4.__enter__()
             self._ephipv4 = ephipv4
-        except subp.ProcessExecutionError:
+        except:
             ephipv4.__exit__(None, None, None)
         return self.lease
 

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -378,7 +378,7 @@ class EphemeralDHCPv4:
             ephipv4 = EphemeralIPv4Network(**kwargs)
             ephipv4.__enter__()
             self._ephipv4 = ephipv4
-        except:
+        except Exception:
             ephipv4.__exit__(None, None, None)
         return self.lease
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

I analyze the code and find that the following function is normally used to perform the cleanup operation:
https://github.com/canonical/cloud-init/blob/main/cloudinit/net/ephemeral.py#L332
```pycon 
    def __exit__(self, excp_type, excp_value, excp_traceback):
        """Teardown sandboxed dhcp context."""
        self.clean_network()

    def clean_network(self):
        """Exit _ephipv4 context to teardown of ip configuration performed."""
        if self.lease:
            self.lease = None
        if not self._ephipv4:
            return
        self._ephipv4.__exit__(None, None, None)
```


Therefore, if the following log exists:
subp.py[DEBUG]: Running command ['ip', '-family', 'inet', 'addr', 'add', 'x.x.x.x/18', 'broadcast', 'x.x.x.x', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)

the following logs should exist:
subp.py[DEBUG]: Running command ['ip', '-family', 'inet', 'addr', 'del', 'x.x.x.x/18', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)

（The IP address is omitted and replaced by x.x.x.x.）

But the current execution process doesn't seem to guarantee it.  If an exception may occur [here](https://github.com/canonical/cloud-init/blob/main/cloudinit/net/ephemeral.py#L378):
```pycon 
        ephipv4.__enter__()
        self._ephipv4 = ephipv4
```
then self._ephipv4 is NULL, and the previous clean process does not go to.

## Additional Context
<!-- If relevant -->
I use cloud-init 21.4.  After the execution of cloud-init is complete, a problem is found: eth0 is bound to the same IP address as bond0.

I check /var/log/cloud-init.log and find that it throw the exception cloudinit.subp.ProcessExecutionError: Unexpected error while running command. at the following code:
https://github.com/canonical/cloud-init/blob/21.4/cloudinit/net/__init__.py#L1159

The exact cause is not clear. It can only be reproduced in some environments, and it is inevitable, but it cannot be reproduced in other environments. It is not clear what factors are related to the environment.

However, I analyze the code and find that the following function is normally used to perform the cleanup operation:
https://github.com/canonical/cloud-init/blob/21.4/cloudinit/net/dhcp.py#L75

I check /var/log/cloud-init.log and find the following log information::
subp.py[DEBUG]: Running command ['ip', '-family', 'inet', 'addr', 'add', 'x.x.x.x/18', 'broadcast', 'x.x.x.x', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)

However, the following logs are not found:
subp.py[DEBUG]: Running command ['ip', '-family', 'inet', 'addr', 'del', 'x.x.x.x/18', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)

（The IP address is omitted and replaced by x.x.x.x.）

I analyzed the code and thought that an exception occurred here：
https://github.com/canonical/cloud-init/blob/21.4/cloudinit/net/dhcp.py#L116

so the following code was not executed:
https://github.com/canonical/cloud-init/blob/21.4/cloudinit/net/dhcp.py#L117

So self._ephipv4 is NULL, and the [clean_newwork ](https://github.com/canonical/cloud-init/blob/21.4/cloudinit/net/dhcp.py#L74)does not work well.

The following commit can fix this problem:
https://github.com/canonical/cloud-init/commit/0e25076b34fa995161b83996e866c0974cee431f

But I don't think it solves the problem of cleaning network when an exception occurs, it only solves the problem of command execution failure. This problem seems to exist even in the latest version.
