### PR TITLE
azure/errors: introduce reportable errors

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -27,7 +27,7 @@ from cloudinit.net.dhcp import (
 )
 from cloudinit.net.ephemeral import EphemeralDHCPv4
 from cloudinit.reporting import events
-from cloudinit.sources.azure import imds
+from cloudinit.sources.azure import errors, imds
 from cloudinit.sources.helpers import netlink
 from cloudinit.sources.helpers.azure import (
     DEFAULT_WIRESERVER_ENDPOINT,
@@ -730,11 +730,12 @@ class DataSourceAzure(sources.DataSource):
                 msg="Crawl of metadata service",
                 func=self.crawl_metadata,
             )
-        except Exception as e:
-            report_diagnostic_event(
-                "Could not crawl Azure metadata: %s" % e, logger_func=LOG.error
-            )
-            self._report_failure()
+        except errors.ReportableError as error:
+            self._report_failure(error)
+            return False
+        except Exception as error:
+            reportable_error = errors.ReportableErrorUnhandledException(error)
+            self._report_failure(reportable_error)
             return False
         finally:
             self._teardown_ephemeral_networking()
@@ -1179,12 +1180,17 @@ class DataSourceAzure(sources.DataSource):
         return reprovision_data
 
     @azure_ds_telemetry_reporter
-    def _report_failure(self) -> bool:
+    def _report_failure(self, error: errors.ReportableError) -> bool:
         """Tells the Azure fabric that provisioning has failed.
 
         @param description: A description of the error encountered.
         @return: The success status of sending the failure signal.
         """
+        report_diagnostic_event(
+            f"Azure datasource failure occurred: {error.as_description()}",
+            logger_func=LOG.error,
+        )
+
         if self._is_ephemeral_networking_up():
             try:
                 report_diagnostic_event(
@@ -1192,7 +1198,9 @@ class DataSourceAzure(sources.DataSource):
                     "to report failure to Azure",
                     logger_func=LOG.debug,
                 )
-                report_failure_to_fabric(endpoint=self._wireserver_endpoint)
+                report_failure_to_fabric(
+                    endpoint=self._wireserver_endpoint, error=error
+                )
                 return True
             except Exception as e:
                 report_diagnostic_event(
@@ -1212,7 +1220,9 @@ class DataSourceAzure(sources.DataSource):
             except NoDHCPLeaseError:
                 # Reporting failure will fail, but it will emit telemetry.
                 pass
-            report_failure_to_fabric(endpoint=self._wireserver_endpoint)
+            report_failure_to_fabric(
+                endpoint=self._wireserver_endpoint, error=error
+            )
             return True
         except Exception as e:
             report_diagnostic_event(

--- a/cloudinit/sources/azure/dmi.py
+++ b/cloudinit/sources/azure/dmi.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2023 Microsoft Corporation.
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import logging
+from typing import Optional
+
+from cloudinit import dmi
+
+LOG = logging.getLogger(__name__)
+
+
+def query_vm_id() -> Optional[str]:
+    system_uuid = dmi.read_dmi_data("system-uuid")
+    LOG.debug("Read product uuid: %s", system_uuid)
+    if not system_uuid:
+        return None
+
+    system_uuid = system_uuid.lower()
+    parts = system_uuid.split("-")
+
+    # Swap endianess for first three parts.
+    for i in [0, 1, 2]:
+        try:
+            parts[i] = bytearray.fromhex(parts[i])[::-1].hex()
+        except ValueError as error:
+            LOG.error(
+                "Failed to parse product uuid %r due to error: %r",
+                system_uuid,
+                error,
+            )
+            return None
+
+    vm_id = "-".join(parts)
+    LOG.debug("Azure VM identifier: %s", vm_id)
+    return vm_id

--- a/cloudinit/sources/azure/dmi.py
+++ b/cloudinit/sources/azure/dmi.py
@@ -19,7 +19,7 @@ def query_vm_id() -> Optional[str]:
     system_uuid = system_uuid.lower()
     parts = system_uuid.split("-")
 
-    # Swap endianess for first three parts.
+    # Swap endianness for first three parts.
     for i in [0, 1, 2]:
         try:
             parts[i] = bytearray.fromhex(parts[i])[::-1].hex()

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -26,7 +26,6 @@ class ReportableError(Exception):
         timestamp: Optional[datetime] = None,
     ) -> None:
         self.documentation_url = "https://aka.ms/linuxprovisioningerror"
-        self.error = "PROVISIONING_FAILED_CLOUDINIT"
         self.reason = reason
 
         if supporting_data:
@@ -42,19 +41,18 @@ class ReportableError(Exception):
     def as_description(
         self, *, delimiter: str = "|", quotechar: str = "'"
     ) -> str:
-        error = [
-            f"error={self.error}",
+        vm_id = query_vm_id()
+
+        data = [
             f"reason={self.reason}",
             f"agent=Cloud-Init/{version.version_string()}",
-            f"documentation_url={self.documentation_url}",
-            f"timestamp={self.timestamp.isoformat()}",
         ]
-
-        vm_id = query_vm_id()
-        if vm_id:
-            error.append(f"vm_id={vm_id}")
-
-        data = error + [f"{k}={v}" for k, v in self.supporting_data.items()]
+        data += [f"{k}={v}" for k, v in self.supporting_data.items()]
+        data += [
+            f"vm_id={vm_id}",
+            f"timestamp={self.timestamp.isoformat()}",
+            f"documentation_url={self.documentation_url}",
+        ]
 
         with StringIO() as io:
             csv.writer(

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -10,7 +10,9 @@ from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, Optional
 
-from cloudinit import dmi, version
+from cloudinit import version
+
+from .dmi import query_vm_id
 
 LOG = logging.getLogger(__name__)
 
@@ -48,10 +50,9 @@ class ReportableError(Exception):
             f"timestamp={self.timestamp.isoformat()}",
         ]
 
-        system_uuid = dmi.read_dmi_data("system-uuid")
-        if system_uuid:
-            system_uuid = system_uuid.lower()
-            error.append(f"vm_id={system_uuid}")
+        vm_id = query_vm_id()
+        if vm_id:
+            error.append(f"vm_id={vm_id}")
 
         data = error + [f"{k}={v}" for k, v in self.supporting_data.items()]
 

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -1,0 +1,95 @@
+# Copyright (C) 2022 Microsoft Corporation.
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import base64
+import csv
+import logging
+import traceback
+from datetime import datetime
+from io import StringIO
+from typing import Any, Dict, Optional
+
+from cloudinit import dmi, version
+
+LOG = logging.getLogger(__name__)
+
+
+class ReportableError(Exception):
+    def __init__(
+        self,
+        reason: str,
+        *,
+        supporting_data: Optional[Dict[str, Any]] = None,
+        timestamp: Optional[datetime] = None,
+    ) -> None:
+        self.documentation_url = "https://aka.ms/linuxprovisioningerror"
+        self.error = "PROVISIONING_FAILED_CLOUDINIT"
+        self.reason = reason
+
+        if supporting_data:
+            self.supporting_data = supporting_data
+        else:
+            self.supporting_data = {}
+
+        if timestamp:
+            self.timestamp = timestamp
+        else:
+            self.timestamp = datetime.utcnow()
+
+    def as_description(
+        self, *, delimiter: str = "|", quotechar: str = "'"
+    ) -> str:
+        error = [
+            f"error={self.error}",
+            f"reason={self.reason}",
+            f"agent=Cloud-Init/{version.version_string()}",
+            f"documentation_url={self.documentation_url}",
+            f"timestamp={self.timestamp.isoformat()}",
+        ]
+
+        system_uuid = dmi.read_dmi_data("system-uuid")
+        if system_uuid:
+            system_uuid = system_uuid.lower()
+            error.append(f"vm_id={system_uuid}")
+
+        data = error + [f"{k}={v}" for k, v in self.supporting_data.items()]
+
+        with StringIO() as io:
+            csv.writer(
+                io,
+                delimiter=delimiter,
+                quotechar=quotechar,
+                quoting=csv.QUOTE_MINIMAL,
+            ).writerow(data)
+
+            # strip trailing \r\n
+            csv_data = io.getvalue()[:-2]
+
+        return f"PROVISIONING_ERROR: {csv_data}"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, ReportableError)
+            and self.timestamp == other.timestamp
+            and self.reason == other.reason
+            and self.supporting_data == other.supporting_data
+        )
+
+    def __repr__(self) -> str:
+        return self.as_description()
+
+
+class ReportableErrorUnhandledException(ReportableError):
+    def __init__(self, exception: Exception) -> None:
+        super().__init__("unhandled exception")
+
+        trace = "".join(
+            traceback.format_exception(
+                type(exception), exception, exception.__traceback__
+            )
+        )
+        trace_base64 = base64.b64encode(trace.encode("utf-8"))
+
+        self.supporting_data["exception"] = repr(exception)
+        self.supporting_data["traceback_base64"] = trace_base64

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -20,6 +20,7 @@ from xml.sax.saxutils import escape
 from cloudinit import distros, dmi, subp, temp_utils, url_helper, util, version
 from cloudinit.reporting import events
 from cloudinit.settings import CFG_BUILTIN
+from cloudinit.sources.azure import errors
 
 LOG = logging.getLogger(__name__)
 
@@ -42,12 +43,6 @@ azure_ds_reporter = events.ReportEventStack(
     name="azure-ds",
     description="initialize reporter for azure ds",
     reporting_enabled=True,
-)
-
-DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE = (
-    "The VM encountered an error during deployment. "
-    "Please visit https://aka.ms/linuxprovisioningerror "
-    "for more information on remediation."
 )
 
 T = TypeVar("T")
@@ -1053,9 +1048,9 @@ def get_metadata_from_fabric(
 
 
 @azure_ds_telemetry_reporter
-def report_failure_to_fabric(endpoint: str):
+def report_failure_to_fabric(endpoint: str, error: errors.ReportableError):
     shim = WALinuxAgentShim(endpoint=endpoint)
-    description = DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE
+    description = error.as_description()
     try:
         shim.register_with_azure_and_report_failure(description=description)
     finally:

--- a/tests/unittests/sources/azure/test_dmi.py
+++ b/tests/unittests/sources/azure/test_dmi.py
@@ -1,0 +1,26 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+
+import pytest
+
+from cloudinit.sources.azure import dmi
+
+
+@pytest.mark.parametrize(
+    "product_uuid,vm_id",
+    [
+        (None, None),
+        (
+            "527c2691-029f-fe4c-b1f4-a4da7ebac2cf",
+            "91267c52-9f02-4cfe-b1f4-a4da7ebac2cf",
+        ),
+        (
+            "garbage-in-garbage-out",
+            None,
+        ),
+    ],
+)
+def test_query_vm_id(monkeypatch, product_uuid, vm_id):
+    monkeypatch.setattr(dmi.dmi, "read_dmi_data", lambda _: product_uuid)
+
+    assert dmi.query_vm_id() == vm_id

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -1,0 +1,141 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import base64
+import datetime
+from unittest import mock
+
+import pytest
+
+from cloudinit import version
+from cloudinit.sources.azure import errors
+
+
+@pytest.fixture(autouse=True)
+def mock_dmi_uuid():
+    uuid = "527c2691-029f-fe4c-b1f4-a4da7ebac2cf"
+    with mock.patch(
+        "cloudinit.sources.azure.errors.dmi.read_dmi_data", return_value=uuid
+    ) as m:
+        yield m
+
+
+@pytest.fixture()
+def agent_string():
+    yield f"agent=Cloud-Init/{version.version_string()}"
+
+
+@pytest.fixture()
+def id_string(mock_dmi_uuid):
+    yield f"vm_id={mock_dmi_uuid.return_value}"
+
+
+def quote_csv_value(value: str) -> str:
+    """Match quoting behavior, if needed for given string."""
+    if any([x in value for x in ("\n", "\r", "'")]):
+        value = value.replace("'", "''")
+        value = f"'{value}'"
+
+    return value
+
+
+@pytest.mark.parametrize("reason", ["foo", "foo bar", "foo'bar"])
+@pytest.mark.parametrize(
+    "supporting_data",
+    [
+        {},
+        {
+            "foo": "bar",
+        },
+        {
+            "foo": "bar",
+            "count": 4,
+        },
+        {
+            "csvcheck": "",
+        },
+        {
+            "csvcheck": "trailingspace ",
+        },
+        {
+            "csvcheck": "\r\n",
+        },
+        {
+            "csvcheck": "\n",
+        },
+        {
+            "csvcheck": "\t",
+        },
+        {
+            "csvcheck": "x\nx",
+        },
+        {
+            "csvcheck": "x\rx",
+        },
+        {
+            "csvcheck": '"',
+        },
+        {
+            "csvcheck": '""',
+        },
+        {
+            "csvcheck": "'",
+        },
+        {
+            "csvcheck": "''",
+        },
+        {
+            "csvcheck": "xx'xx'xx",
+        },
+        {
+            "csvcheck": ",'|~!@#$%^&*()[]\\{}|;':\",./<>?x\nnew\r\nline",
+        },
+    ],
+)
+def test_reportable_errors(
+    agent_string,
+    id_string,
+    reason,
+    supporting_data,
+):
+    timestamp = datetime.datetime.utcnow()
+
+    error = errors.ReportableError(
+        reason=reason,
+        supporting_data=supporting_data,
+        timestamp=timestamp,
+    )
+
+    description_parts = [
+        "PROVISIONING_ERROR: error=PROVISIONING_FAILED_CLOUDINIT",
+        quote_csv_value(f"reason={reason}"),
+        agent_string,
+        "documentation_url=https://aka.ms/linuxprovisioningerror",
+        f"timestamp={timestamp.isoformat()}",
+        id_string,
+    ]
+
+    if supporting_data:
+        description_parts.extend(
+            [quote_csv_value(f"{k}={v}") for k, v in supporting_data.items()]
+        )
+
+    assert error.as_description() == "|".join(description_parts)
+
+
+def test_unhandled_exception():
+    source_error = None
+    try:
+        raise ValueError("my value error")
+    except Exception as exception:
+        source_error = exception
+
+    error = errors.ReportableErrorUnhandledException(source_error)
+    trace = base64.b64decode(error.supporting_data["traceback_base64"]).decode(
+        "utf-8"
+    )
+
+    quoted_value = quote_csv_value(f"exception={source_error!r}")
+    assert f"|{quoted_value}|" in error.as_description()
+    assert trace.startswith("Traceback")
+    assert "raise ValueError" in trace
+    assert trace.endswith("ValueError: my value error\n")

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -95,23 +95,18 @@ def test_reportable_errors(
         timestamp=timestamp,
     )
 
-    description_parts = [
-        "PROVISIONING_ERROR: error=PROVISIONING_FAILED_CLOUDINIT",
-        quote_csv_value(f"reason={reason}"),
-        agent_string,
-        "documentation_url=https://aka.ms/linuxprovisioningerror",
+    data = [
+        f"PROVISIONING_ERROR: " + quote_csv_value(f"reason={reason}"),
+        f"agent=Cloud-Init/{version.version_string()}",
+    ]
+    data += [quote_csv_value(f"{k}={v}") for k, v in supporting_data.items()]
+    data += [
+        f"vm_id={vm_id}",
         f"timestamp={timestamp.isoformat()}",
+        "documentation_url=https://aka.ms/linuxprovisioningerror",
     ]
 
-    if vm_id:
-        description_parts.append(f"vm_id={vm_id}")
-
-    if supporting_data:
-        description_parts.extend(
-            [quote_csv_value(f"{k}={v}") for k, v in supporting_data.items()]
-        )
-
-    assert error.as_description() == "|".join(description_parts)
+    assert error.as_description() == "|".join(data)
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -96,7 +96,7 @@ def test_reportable_errors(
     )
 
     data = [
-        f"PROVISIONING_ERROR: " + quote_csv_value(f"reason={reason}"),
+        "PROVISIONING_ERROR: " + quote_csv_value(f"reason={reason}"),
         f"agent=Cloud-Init/{version.version_string()}",
     ]
     data += [quote_csv_value(f"{k}={v}") for k, v in supporting_data.items()]

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -16,6 +16,7 @@ from cloudinit.net import dhcp
 from cloudinit.sources import UNSET
 from cloudinit.sources import DataSourceAzure as dsaz
 from cloudinit.sources import InvalidMetaDataException
+from cloudinit.sources.azure import errors
 from cloudinit.sources.helpers import netlink
 from cloudinit.util import (
     MountFailedError,
@@ -1152,7 +1153,7 @@ scbus-1 on xpt0 bus 0
             m_crawl_metadata.side_effect = Exception
             dsrc.get_data()
             self.assertEqual(1, m_crawl_metadata.call_count)
-            m_report_failure.assert_called_once_with()
+            m_report_failure.assert_called_once_with(mock.ANY)
 
     def test_crawl_metadata_exc_should_log_could_not_crawl_msg(self):
         data = {}
@@ -1162,7 +1163,7 @@ scbus-1 on xpt0 bus 0
             dsrc.get_data()
             self.assertEqual(1, m_crawl_metadata.call_count)
             self.assertIn(
-                "Could not crawl Azure metadata", self.logs.getvalue()
+                "Azure datasource failure occurred:", self.logs.getvalue()
             )
 
     def test_basic_seed_dir(self):
@@ -1773,7 +1774,8 @@ scbus-1 on xpt0 bus 0
             # mock crawl metadata failure to cause report failure
             m_crawl_metadata.side_effect = Exception
 
-            self.assertTrue(dsrc._report_failure())
+            error = errors.ReportableError(reason="foo")
+            self.assertTrue(dsrc._report_failure(error))
             self.assertEqual(1, self.m_report_failure_to_fabric.call_count)
 
     def test_dsaz_report_failure_returns_false_and_does_not_propagate_exc(
@@ -1803,7 +1805,9 @@ scbus-1 on xpt0 bus 0
             # 1. Using cached ephemeral dhcp context to report failure to Azure
             # 2. Using new ephemeral dhcp to report failure to Azure
             self.m_report_failure_to_fabric.side_effect = Exception
-            self.assertFalse(dsrc._report_failure())
+
+            error = errors.ReportableError(reason="foo")
+            self.assertFalse(dsrc._report_failure(error))
             self.assertEqual(2, self.m_report_failure_to_fabric.call_count)
 
     def test_dsaz_report_failure(self):
@@ -1812,9 +1816,10 @@ scbus-1 on xpt0 bus 0
         with mock.patch.object(dsrc, "crawl_metadata") as m_crawl_metadata:
             m_crawl_metadata.side_effect = Exception
 
-            self.assertTrue(dsrc._report_failure())
+            error = errors.ReportableError(reason="foo")
+            self.assertTrue(dsrc._report_failure(error))
             self.m_report_failure_to_fabric.assert_called_once_with(
-                endpoint="168.63.129.16"
+                endpoint="168.63.129.16", error=error
             )
 
     def test_dsaz_report_failure_uses_cached_ephemeral_dhcp_ctx_lease(self):
@@ -1828,11 +1833,12 @@ scbus-1 on xpt0 bus 0
             # mock crawl metadata failure to cause report failure
             m_crawl_metadata.side_effect = Exception
 
-            self.assertTrue(dsrc._report_failure())
+            error = errors.ReportableError(reason="foo")
+            self.assertTrue(dsrc._report_failure(error))
 
             # ensure called with cached ephemeral dhcp lease option 245
             self.m_report_failure_to_fabric.assert_called_once_with(
-                endpoint="test-ep"
+                endpoint="test-ep", error=error
             )
 
     def test_dsaz_report_failure_no_net_uses_new_ephemeral_dhcp_lease(self):
@@ -1849,12 +1855,13 @@ scbus-1 on xpt0 bus 0
             }
             self.m_dhcp.return_value.obtain_lease.return_value = test_lease
 
-            self.assertTrue(dsrc._report_failure())
+            error = errors.ReportableError(reason="foo")
+            self.assertTrue(dsrc._report_failure(error))
 
             # ensure called with the newly discovered
             # ephemeral dhcp lease option 245
             self.m_report_failure_to_fabric.assert_called_once_with(
-                endpoint="1.2.3.4"
+                endpoint="1.2.3.4", error=error
             )
 
     def test_exception_fetching_fabric_data_doesnt_propagate(self):
@@ -4038,7 +4045,7 @@ class TestProvisioning:
         with mock.patch.object(self.azure_ds, "_report_failure") as m_report:
             self.azure_ds._get_data()
 
-        assert m_report.mock_calls == [mock.call()]
+        assert m_report.mock_calls == [mock.call(mock.ANY)]
 
         assert self.mock_wrapping_setup_ephemeral_networking.mock_calls == [
             mock.call(timeout_minutes=20),

--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -115,6 +115,12 @@ def mock_dmi_read_dmi_data():
         yield m
 
 
+@pytest.fixture(autouse=True)
+def mock_query_vm_id():
+    with mock.patch.object(errors, "query_vm_id", return_value=None) as m:
+        yield m
+
+
 @pytest.fixture
 def mock_readurl():
     with mock.patch(MOCKPATH + "url_helper.readurl", autospec=True) as m:


### PR DESCRIPTION
When provisioning failures occur an Azure, a generic description is used in the report and ultimately is returned to the user.  To improve the user experience, report details of the failure in a manner that is parsable, readable and succinct.  The current approach is to use csv with a custom delimiter ("|") and quote character ("'").  This format may change in the future.

Gracefully handle reportable errors thrown while crawling metadata and treat other exceptions as ReportableErrorUnhandledException.  Future work will introduce more reportable errors to handle the expected cases.

Note that not all reportable errors are guaranteed to be fatal and that and the datasource may recover after reporting a failure.  However, due to the use of a variable timeout for provisioning, there are cases we will report failure because of an issue likely to affect provisioning within a reasonable timeframe (e.g. DHCP is very delayed, IMDS metadata is unavailable, etc.).