### PR TITLE
tox.ini: set -vvvv --showlocals for pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -141,6 +141,7 @@ commands =
 deps =
     -r{toxinidir}/test-requirements.txt
 commands = {envpython} -m pytest \
+            -vvvv --showlocals \
             --durations 10 \
             -m "not hypothesis_slow" \
             {posargs:--cov=cloudinit --cov-branch tests/unittests}


### PR DESCRIPTION
Test failures may have truncated assertions using `...` in some output.

Increase verbosity and print locals to help with triaging failures caught in CI, particularly as some environments may not be readily testable locally.