### PR TITLE
Fix test_dhclient_exits_with_error

### DIFF
--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -353,7 +353,10 @@ class TestDHCPDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.find_fallback_nic", return_value="eth9")
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
-    def test_dhclient_exits_with_error(self, m_subp, m_remove, m_fallback):
+    @mock.patch("cloudinit.net.dhcp.subp.which")
+    def test_dhclient_exits_with_error(
+        self, m_which, m_subp, m_remove, m_fallback
+    ):
         """Log and do nothing when nic is absent and no fallback is found."""
         m_subp.side_effect = [
             ("", ""),


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix test_dhclient_exits_with_error

Test was missing a mock of subp.which. This was missed because dhclient
is installed on machines it was tested on.
```

## Additional Context
https://launchpadlibrarian.net/658725650/buildlog_ubuntu-kinetic-amd64.cloud-init_23.1.daily-202303301232-c82ace92~ubuntu22.10.1_BUILDING.txt.gz

