### PR TITLE
config/cc_resizefs: fix do_resize arguments

### DIFF
--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -299,14 +299,14 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             logfunc=LOG.debug,
             msg="backgrounded Resizing",
             func=do_resize,
-            args=(resize_cmd),
+            args=(resize_cmd,),
         )
     else:
         util.log_time(
             logfunc=LOG.debug,
             msg="Resizing",
             func=do_resize,
-            args=(resize_cmd),
+            args=(resize_cmd,),
         )
 
     action = "Resized"

--- a/tests/unittests/config/test_cc_resizefs.py
+++ b/tests/unittests/config/test_cc_resizefs.py
@@ -191,7 +191,7 @@ class TestResizefs(CiTestCase):
             handle("cc_resizefs", cfg, cloud=None, args=[])
             ret = dresize.call_args[0]
 
-        self.assertEqual(("zpool", "online", "-e", "vmzroot", disk), ret)
+        self.assertEqual((("zpool", "online", "-e", "vmzroot", disk),), ret)
 
     @mock.patch("cloudinit.util.is_container", return_value=False)
     @mock.patch("cloudinit.util.get_mount_info")
@@ -224,7 +224,7 @@ class TestResizefs(CiTestCase):
                 m_stat.side_effect = fake_stat
                 handle("cc_resizefs", cfg, cloud=None, args=[])
         self.assertEqual(
-            ("zpool", "online", "-e", "zroot", "/dev/" + disk),
+            (("zpool", "online", "-e", "zroot", "/dev/" + disk),),
             dresize.call_args[0],
         )
 


### PR DESCRIPTION
Anh pointed out that the daily PPA builds were crashing due to refactor: stop passing log instances to cc_* handlers (#2016).

When dropping the logger argument, the tuple became a list which then gets expanded in the call to do_resize() and crashes.

```
Traceback (most recent call last):

  File "/usr/lib/python3/dist-packages/cloudinit/config/modules.py", line 257, in _run_modules
    run_name, mod.handle, func_args, freq=freq
  File "/usr/lib/python3/dist-packages/cloudinit/cloud.py", line 67, in run
    return self._runners.run(name, functor, args, freq, clear_on_fail)
  File "/usr/lib/python3/dist-packages/cloudinit/helpers.py", line 172, in run
    results = functor(**args)
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_resizefs.py", line 309, in handle
    args=(resize_cmd),
  File "/usr/lib/python3/dist-packages/cloudinit/util.py", line 2722, in log_time
    ret = func(*args, **kwargs)

TypeError: do_resize() takes 1 positional argument but 2 were given
```

Restore args as a tuple.
