### PR TITLE
NoCloud: Use seedfrom protocol to determine mode

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -280,24 +280,23 @@ def load_cmdline_data(fill, cmdline=None):
         ("ds=nocloud-net", sources.DSMODE_NETWORK),
     ]
     for idstr, dsmode in pairs:
-        if parse_cmdline_data(idstr, fill, cmdline):
+        if not parse_cmdline_data(idstr, fill, cmdline):
+            continue
+        if "dsmode" in fill:
             # if dsmode was explicitly in the command line, then
             # prefer it to the dsmode based on seedfrom type
-            if "dsmode" not in fill and fill["seedfrom"]:
-                seedfrom = fill["seedfrom"]
-                if seedfrom.startswith("http://") or seedfrom.startswith(
-                    "https://"
-                ):
-                    fill["dsmode"] = sources.DSMODE_NETWORK
-                elif seedfrom.startswith("file://") or seedfrom.startswith(
-                    "/"
-                ):
-                    fill["dsmode"] = sources.DSMODE_LOCAL
-            elif "dsmode" not in fill:
-                # this path only gets hit if no seedfrom arg is provided
-                fill["dsmode"] = dsmode
-
             return True
+
+        seedfrom = fill.get("seedfrom")
+        if seedfrom:
+            if seedfrom.startswith(("http://", "https://")):
+                fill["dsmode"] = sources.DSMODE_NETWORK
+            elif seedfrom.startswith(("file://", "/")):
+                fill["dsmode"] = sources.DSMODE_LOCAL
+        else:
+            fill["dsmode"] = dsmode
+
+        return True
     return False
 
 

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -282,9 +282,21 @@ def load_cmdline_data(fill, cmdline=None):
     for idstr, dsmode in pairs:
         if parse_cmdline_data(idstr, fill, cmdline):
             # if dsmode was explicitly in the command line, then
-            # prefer it to the dsmode based on the command line id
-            if "dsmode" not in fill:
+            # prefer it to the dsmode based on seedfrom type
+            if "dsmode" not in fill and fill["seedfrom"]:
+                seedfrom = fill["seedfrom"]
+                if seedfrom.startswith("http://") or seedfrom.startswith(
+                    "https://"
+                ):
+                    fill["dsmode"] = sources.DSMODE_NETWORK
+                elif seedfrom.startswith("file://") or seedfrom.startswith(
+                    "/"
+                ):
+                    fill["dsmode"] = sources.DSMODE_LOCAL
+            elif "dsmode" not in fill:
+                # this path only gets hit if no seedfrom arg is provided
                 fill["dsmode"] = dsmode
+
             return True
     return False
 

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -49,7 +49,10 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
 @pytest.mark.parametrize(
     "ds_str, configured",
     (
-        ("ds=nocloud;s=http://my-url/", "DataSourceNoCloud"),
+        (
+            "ds=nocloud;s=http://my-url/",
+            "DataSourceNoCloud [seed=None][dsmode=net]",
+        ),
         ("ci.ds=openstack", "DataSourceOpenStack"),
     ),
 )


### PR DESCRIPTION
```
NoCloud: Use seedfrom protocol to determine mode

Historically ds=nocloud-net was a required argument
for the user to pass in to tell cloud-init which mode
to use. This argument, however, is redundant when a
seedfrom argument is passed. Allow the mode to be
automatically determined, so that the user need not
pass a mode configuration to achieve desired behavior.
```

## Additional Context
[context](https://github.com/canonical/cloud-init/pull/2093#issuecomment-1490989378)