### PR TITLE
ubuntu/kinetic: gce drop disable network activation kinetic (SC-1440)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+23.1.1
+ - source: Force OpenStack when it is only option (#2045)
+ - sources/azure: fix regressions in IMDS behavior (#2041)
+   [Chris Patterson]
+
 23.1
  - Support transactional-updates for SUSE based distros (#1997)
    [Robert Schweikert]

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,16 +8,16 @@ cloud-init (23.1-0ubuntu1~22.10.1) UNRELEASED; urgency=medium
 
  -- Alberto Contreras <alberto.contreras@canonical.com>  Thu, 09 Mar 2023 11:49:48 +0100
 
-cloud-init (23.1-0ubuntu0~22.10.1) kinetic; urgency=medium
+cloud-init (23.1.1-0ubuntu0~22.10.1) kinetic; urgency=medium
 
   * d/patches/retain-netplan-world-readable.patch:
     - Retain original world-readable perms of /etc/netplan/50-cloud-init.yaml.
       Lunar made the config root read-only.
-  * Upstream snapshot based on 23.1. (LP: #2008230).
+  * Upstream snapshot based on 23.1.1. (LP: #2008230).
     List of changes from upstream can be found at
-    https://raw.githubusercontent.com/canonical/cloud-init/23.1/ChangeLog
+    https://raw.githubusercontent.com/canonical/cloud-init/23.1.1/ChangeLog
 
- -- Chad Smith <chad.smith@canonical.com>  Thu, 23 Feb 2023 22:37:55 -0700
+ -- James Falcon <james.falcon@canonical.com>  Thu, 02 Mar 2023 12:02:34 -0600
 
 cloud-init (22.4.2-0ubuntu0~22.10.1) kinetic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,15 @@
-cloud-init (23.1-0ubuntu1~22.10.1) UNRELEASED; urgency=medium
+cloud-init (23.1.1-0ubuntu1~22.10.2) UNRELEASED; urgency=medium
 
   * d/apport-general-hook.py: Add general apport hook to append cloud type,
     image and instance size information to bug reports (LP: #1724623)
   * d/cloud-init.preinst: Oracle to remove vestigial /etc/cloud.cloud.cfg.d/
     99-disable-network-config.cfg because system config is now honored before
     datasource config (LP: #1956788)
+  * d/cloud-init.preinst: Clean up vestigial
+    /etc/cloud/cloud.cfg.d/99-disable-network-activation.cfg on GCE instances
+    after fix in upstream google-guest-agent.
 
- -- Alberto Contreras <alberto.contreras@canonical.com>  Thu, 09 Mar 2023 11:49:48 +0100
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Mon, 03 Apr 2023 13:39:38 +0200
 
 cloud-init (23.1.1-0ubuntu0~22.10.1) kinetic; urgency=medium
 

--- a/debian/cloud-init.preinst
+++ b/debian/cloud-init.preinst
@@ -188,6 +188,14 @@ cleanup_oci_network_lp1956788() {
    rm -f /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
 }
 
+cleanup_gce_disable_network_activation_sc1440() {
+   # Remove vestigial /etc/cloud/cloud.cfg.d/99-disable-network-activation.cfg
+   # from GCE images now that google-guest-agent includes
+   # https://github.com/GoogleCloudPlatform/guest-agent/commit/8c36e064abebb814dc56647e8db43f261deb9a63
+   grep DataSourceGCE /var/lib/cloud/instance/datasource > /dev/null 2>&1 || return 0
+   rm -f /etc/cloud/cloud.cfg.d/99-disable-network-activation.cfg
+}
+
 case "$1" in
     install|upgrade)
         if dpkg --compare-versions "$2" le "0.5.11-0ubuntu1"; then
@@ -232,6 +240,7 @@ case "$1" in
 
       cleanup_lp1552999 "$oldver"
       cleanup_oci_network_lp1956788
+      cleanup_gce_disable_network_activation_sc1440
 
 esac
 


### PR DESCRIPTION
# do not squash

## Test steps

```bash
build-package
sbuild
CLOUD_INIT_PLATFORM=gce CLOUD_INIT_CLOUD_INIT_SOURCE=$(ls cloud-init_*.deb) tox -e integration-tests -- tests/integration_tests/modules/test_combined.py
```

