### PR TITLE
Adding contributors for DataSourceAkamai

### DIFF
--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -1,4 +1,5 @@
 aciba90
+acourdavAkamai
 ader1990
 adobley
 ajmyyra
@@ -36,6 +37,7 @@ dbungert
 ddymko
 dermotbradley
 dhensby
+dorthu
 eandersson
 eb3095
 ederst
@@ -57,6 +59,7 @@ ITJamie
 ixjhuang
 izzyleung
 j5awry
+jamesottinger
 Jehops
 jf
 Jille


### PR DESCRIPTION
I signed the Canonical CLA on behalf of Akamai; this change adds myself and two ICs from Akamai who are associated with my organization to the github-cli-signers file to allow them to contribute on the organization's behalf.