### PR TITLE
systemd: Block login until config stage completes

### DIFF
--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -3,6 +3,7 @@
 Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
 After=snapd.seeded.service
+Before=systemd-user-sessions.service
 Wants=network-online.target cloud-config.target
 {% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -38,7 +38,6 @@ Conflicts=shutdown.target
 Before=shutdown.target
 Conflicts=shutdown.target
 {% endif %}
-Before=systemd-user-sessions.service
 {% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled


### PR DESCRIPTION
```
systemd: Block login until config stage completes

LP: #2013403
```

## Additional Context
Discovered on riscv64, cc_set_passwords runs in cloud config stage, but tty access blocked by cloud init stage. This means that a user may be able to try logging in prior to the user account being configured.

## Test Steps

download the ubuntu riscv unmatched image, install riscv qemu dependencies, then: 
```
qemu-system-riscv64 \
    -machine virt \
    -cpu rv64 \
    -m 1G \
    -device virtio-blk-device,drive=hd \
    -drive file=lunar-preinstalled-server-riscv64+unmatched.img,if=none,id=hd \
    -device virtio-net-device,netdev=net \
    -netdev user,id=net,hostfwd=tcp::2222-:22 \
    -bios /usr/lib/riscv64-linux-gnu/opensbi/generic/fw_jump.elf \
    -kernel /usr/lib/u-boot/qemu-riscv64_smode/uboot.elf \
    -object rng-random,filename=/dev/urandom,id=rng \
    -device virtio-rng-device,rng=rng \
    -append "root=LABEL=rootfs console=ttyS0" \
    -nographic
```

The prompt becomes available prior to cloud-init configuring the user.