### PR TITLE
Standardize kernel commandline disable

### DIFF
--- a/systemd/cloud-init-hotplugd.service
+++ b/systemd/cloud-init-hotplugd.service
@@ -13,6 +13,8 @@
 Description=cloud-init hotplug hook daemon
 After=cloud-init-hotplugd.socket
 Requires=cloud-init-hotplugd.socket
+ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ConditionKernelCommandLine=!cloud-init=disabled
 
 [Service]
 Type=simple

--- a/systemd/cloud-init-hotplugd.socket
+++ b/systemd/cloud-init-hotplugd.socket
@@ -5,8 +5,6 @@
 # Known bug with an enforcing SELinux policy: LP: #1936229
 [Unit]
 Description=cloud-init hotplug hook socket
-ConditionPathExists=!/etc/cloud/cloud-init.disabled
-ConditionKernelCommandLine=!cloud-init=disabled
 
 [Socket]
 ListenFIFO=/run/cloud-init/hook-hotplug-cmd

--- a/systemd/cloud-init-hotplugd.socket
+++ b/systemd/cloud-init-hotplugd.socket
@@ -5,6 +5,8 @@
 # Known bug with an enforcing SELinux policy: LP: #1936229
 [Unit]
 Description=cloud-init hotplug hook socket
+ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ConditionKernelCommandLine=!cloud-init=disabled
 
 [Socket]
 ListenFIFO=/run/cloud-init/hook-hotplug-cmd

--- a/sysvinit/debian/cloud-config
+++ b/sysvinit/debian/cloud-config
@@ -45,6 +45,11 @@ fi
 case "$1" in
 start)
 	log_daemon_msg "Starting $DESC" "$NAME"
+	if grep 'cloud-init=disabled' /proc/cmdline; then
+			log_daemon_msg "$NAME is disabled via /proc/cmdline."
+			exit 0
+	fi
+
 	$DAEMON ${DAEMON_ARGS}
 	case "$?" in
 		0|1) log_end_msg 0 ;;

--- a/sysvinit/debian/cloud-config
+++ b/sysvinit/debian/cloud-config
@@ -45,7 +45,7 @@ fi
 case "$1" in
 start)
 	log_daemon_msg "Starting $DESC" "$NAME"
-	if grep 'cloud-init=disabled' /proc/cmdline; then
+	if grep -q 'cloud-init=disabled' /proc/cmdline; then
 			log_daemon_msg "$NAME is disabled via /proc/cmdline."
 			exit 0
 	fi

--- a/sysvinit/debian/cloud-config
+++ b/sysvinit/debian/cloud-config
@@ -46,8 +46,11 @@ case "$1" in
 start)
 	log_daemon_msg "Starting $DESC" "$NAME"
 	if grep -q 'cloud-init=disabled' /proc/cmdline; then
-			log_daemon_msg "$NAME is disabled via /proc/cmdline."
-			exit 0
+		log_daemon_msg "$NAME is disabled via /proc/cmdline."
+		exit 0
+	elif test -e /etc/cloud/cloud-init.disabled; then
+		log_daemon_msg "$NAME is disabled via cloud-init.disabled file"
+		exit 0
 	fi
 
 	$DAEMON ${DAEMON_ARGS}

--- a/sysvinit/debian/cloud-final
+++ b/sysvinit/debian/cloud-final
@@ -47,7 +47,7 @@ fi
 case "$1" in
 start)
 	log_daemon_msg "Starting $DESC" "$NAME"
-	if grep 'cloud-init=disabled' /proc/cmdline; then
+	if grep -q 'cloud-init=disabled' /proc/cmdline; then
 			log_daemon_msg "$NAME is disabled via /proc/cmdline."
 			exit 0
 	fi

--- a/sysvinit/debian/cloud-final
+++ b/sysvinit/debian/cloud-final
@@ -47,6 +47,11 @@ fi
 case "$1" in
 start)
 	log_daemon_msg "Starting $DESC" "$NAME"
+	if grep 'cloud-init=disabled' /proc/cmdline; then
+			log_daemon_msg "$NAME is disabled via /proc/cmdline."
+			exit 0
+	fi
+
 	$DAEMON ${DAEMON_ARGS}
 	case "$?" in
 		0|1) log_end_msg 0 ;;

--- a/sysvinit/debian/cloud-final
+++ b/sysvinit/debian/cloud-final
@@ -48,8 +48,11 @@ case "$1" in
 start)
 	log_daemon_msg "Starting $DESC" "$NAME"
 	if grep -q 'cloud-init=disabled' /proc/cmdline; then
-			log_daemon_msg "$NAME is disabled via /proc/cmdline."
-			exit 0
+		log_daemon_msg "$NAME is disabled via /proc/cmdline."
+		exit 0
+	elif test -e /etc/cloud/cloud-init.disabled; then
+		log_daemon_msg "$NAME is disabled via cloud-init.disabled."
+		exit 0
 	fi
 
 	$DAEMON ${DAEMON_ARGS}

--- a/sysvinit/debian/cloud-init
+++ b/sysvinit/debian/cloud-init
@@ -46,8 +46,11 @@ case "$1" in
     start)
 	log_daemon_msg "Starting $DESC" "$NAME"
 	if grep -q 'cloud-init=disabled' /proc/cmdline; then
-			log_daemon_msg "$NAME is disabled via /proc/cmdline."
-			exit 0
+		log_daemon_msg "$NAME is disabled via /proc/cmdline."
+		exit 0
+	elif test -e /etc/cloud/cloud-init.disabled; then
+		log_daemon_msg "$NAME is disabled via cloud-init.disabled file."
+		exit 0
 	fi
 
 	$DAEMON ${DAEMON_ARGS}

--- a/sysvinit/debian/cloud-init
+++ b/sysvinit/debian/cloud-init
@@ -45,7 +45,7 @@ fi
 case "$1" in
     start)
 	log_daemon_msg "Starting $DESC" "$NAME"
-	if grep 'cloud-init=disabled' /proc/cmdline; then
+	if grep -q 'cloud-init=disabled' /proc/cmdline; then
 			log_daemon_msg "$NAME is disabled via /proc/cmdline."
 			exit 0
 	fi

--- a/sysvinit/debian/cloud-init
+++ b/sysvinit/debian/cloud-init
@@ -45,6 +45,11 @@ fi
 case "$1" in
     start)
 	log_daemon_msg "Starting $DESC" "$NAME"
+	if grep 'cloud-init=disabled' /proc/cmdline; then
+			log_daemon_msg "$NAME is disabled via /proc/cmdline."
+			exit 0
+	fi
+
 	$DAEMON ${DAEMON_ARGS}
 	case "$?" in
 	    0|1) log_end_msg 0 ;;

--- a/sysvinit/debian/cloud-init-local
+++ b/sysvinit/debian/cloud-init-local
@@ -44,7 +44,7 @@ fi
 case "$1" in
 start)
 	log_daemon_msg "Starting $DESC" "$NAME"
-	if grep 'cloud-init=disabled' /proc/cmdline; then
+	if grep -q 'cloud-init=disabled' /proc/cmdline; then
 		log_daemon_msg "$NAME is disabled via /proc/cmdline."
 		exit 0
 	fi

--- a/sysvinit/debian/cloud-init-local
+++ b/sysvinit/debian/cloud-init-local
@@ -44,6 +44,10 @@ fi
 case "$1" in
 start)
 	log_daemon_msg "Starting $DESC" "$NAME"
+	if grep 'cloud-init=disabled' /proc/cmdline; then
+		log_daemon_msg "$NAME is disabled via /proc/cmdline."
+		exit 0
+	fi
 	$DAEMON ${DAEMON_ARGS}
 	case "$?" in
 		0|1) log_end_msg 0 ;;

--- a/sysvinit/debian/cloud-init-local
+++ b/sysvinit/debian/cloud-init-local
@@ -47,6 +47,9 @@ start)
 	if grep -q 'cloud-init=disabled' /proc/cmdline; then
 		log_daemon_msg "$NAME is disabled via /proc/cmdline."
 		exit 0
+	elif test -e /etc/cloud/cloud-init.disabled; then
+		log_daemon_msg "$NAME is disabled via cloud-init.disabled"
+		exit 0
 	fi
 	$DAEMON ${DAEMON_ARGS}
 	case "$?" in

--- a/sysvinit/freebsd/cloudconfig
+++ b/sysvinit/freebsd/cloudconfig
@@ -18,7 +18,7 @@ start_cmd="cloudconfig_start"
 cloudconfig_start()
 {
 	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-      || -e /etc/cloud/cloud-init.disabled \
+      || test -e /etc/cloud/cloud-init.disabled \
       && exit 0
 	echo "${command} starting"
 	${command} modules --mode config

--- a/sysvinit/freebsd/cloudconfig
+++ b/sysvinit/freebsd/cloudconfig
@@ -17,6 +17,7 @@ start_cmd="cloudconfig_start"
 
 cloudconfig_start()
 {
+	kenv -q kernel_options | grep 'cloud-init=disabled' && exit 0
 	echo "${command} starting"
 	${command} modules --mode config
 }

--- a/sysvinit/freebsd/cloudconfig
+++ b/sysvinit/freebsd/cloudconfig
@@ -18,8 +18,8 @@ start_cmd="cloudconfig_start"
 cloudconfig_start()
 {
 	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-      || test -e /etc/cloud/cloud-init.disabled \
-      && exit 0
+		|| test -e /etc/cloud/cloud-init.disabled \
+		&& exit 0
 	echo "${command} starting"
 	${command} modules --mode config
 }

--- a/sysvinit/freebsd/cloudconfig
+++ b/sysvinit/freebsd/cloudconfig
@@ -17,7 +17,9 @@ start_cmd="cloudconfig_start"
 
 cloudconfig_start()
 {
-	kenv -q kernel_options | grep -q 'cloud-init=disabled' && exit 0
+	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
+      || -e /etc/cloud/cloud-init.disabled \
+      && exit 0
 	echo "${command} starting"
 	${command} modules --mode config
 }

--- a/sysvinit/freebsd/cloudconfig
+++ b/sysvinit/freebsd/cloudconfig
@@ -17,7 +17,7 @@ start_cmd="cloudconfig_start"
 
 cloudconfig_start()
 {
-	kenv -q kernel_options | grep 'cloud-init=disabled' && exit 0
+	kenv -q kernel_options | grep -q 'cloud-init=disabled' && exit 0
 	echo "${command} starting"
 	${command} modules --mode config
 }

--- a/sysvinit/freebsd/cloudconfig
+++ b/sysvinit/freebsd/cloudconfig
@@ -17,11 +17,14 @@ start_cmd="cloudconfig_start"
 
 cloudconfig_start()
 {
-	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-		|| test -e /etc/cloud/cloud-init.disabled \
-		&& exit 0
-	echo "${command} starting"
-	${command} modules --mode config
+    echo "${command} starting"
+    if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
+        warn "cloud-init is disabled via kernel_options."
+    elif test -e /etc/cloud/cloud-init.disabled; then
+        warn "cloud-init is disabled via cloud-init.disabled file."
+    else
+        ${command} modules --mode config
+    fi
 }
 
 load_rc_config 'cloudinit'

--- a/sysvinit/freebsd/cloudfinal
+++ b/sysvinit/freebsd/cloudfinal
@@ -17,11 +17,14 @@ start_cmd="cloudfinal_start"
 
 cloudfinal_start()
 {
-	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-		|| test -e /etc/cloud/cloud-init.disabled
-		&& exit 0
 	echo -n "${command} starting"
-	${command} modules --mode final
+    if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
+        warn "cloud-init is disabled via kernel_options."
+    elif test -e /etc/cloud/cloud-init.disabled; then
+        warn "cloud-init is disabled via cloud-init.disabled file."
+    else
+        ${command} modules --mode final
+    fi
 }
 
 load_rc_config 'cloudinit'

--- a/sysvinit/freebsd/cloudfinal
+++ b/sysvinit/freebsd/cloudfinal
@@ -18,8 +18,8 @@ start_cmd="cloudfinal_start"
 cloudfinal_start()
 {
 	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-      || test -e /etc/cloud/cloud-init.disabled
-      && exit 0
+		|| test -e /etc/cloud/cloud-init.disabled
+		&& exit 0
 	echo -n "${command} starting"
 	${command} modules --mode final
 }

--- a/sysvinit/freebsd/cloudfinal
+++ b/sysvinit/freebsd/cloudfinal
@@ -17,6 +17,7 @@ start_cmd="cloudfinal_start"
 
 cloudfinal_start()
 {
+	kenv -q kernel_options | grep 'cloud-init=disabled' && exit 0
 	echo -n "${command} starting"
 	${command} modules --mode final
 }

--- a/sysvinit/freebsd/cloudfinal
+++ b/sysvinit/freebsd/cloudfinal
@@ -17,7 +17,7 @@ start_cmd="cloudfinal_start"
 
 cloudfinal_start()
 {
-	kenv -q kernel_options | grep 'cloud-init=disabled' && exit 0
+	kenv -q kernel_options | grep -q 'cloud-init=disabled' && exit 0
 	echo -n "${command} starting"
 	${command} modules --mode final
 }

--- a/sysvinit/freebsd/cloudfinal
+++ b/sysvinit/freebsd/cloudfinal
@@ -17,7 +17,9 @@ start_cmd="cloudfinal_start"
 
 cloudfinal_start()
 {
-	kenv -q kernel_options | grep -q 'cloud-init=disabled' && exit 0
+	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
+      || -e /etc/cloud/cloud-init.disabled
+      && exit 0
 	echo -n "${command} starting"
 	${command} modules --mode final
 }

--- a/sysvinit/freebsd/cloudfinal
+++ b/sysvinit/freebsd/cloudfinal
@@ -18,7 +18,7 @@ start_cmd="cloudfinal_start"
 cloudfinal_start()
 {
 	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-      || -e /etc/cloud/cloud-init.disabled
+      || test -e /etc/cloud/cloud-init.disabled
       && exit 0
 	echo -n "${command} starting"
 	${command} modules --mode final

--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -17,6 +17,7 @@ start_cmd="cloudinit_start"
 
 cloudinit_start()
 {
+	kenv -q kernel_options | grep 'cloud-init=disabled' && exit 0
 	echo -n "${command} starting"
 	${command} init
 }

--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -18,8 +18,8 @@ start_cmd="cloudinit_start"
 cloudinit_start()
 {
 	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-      || test -e /etc/cloud/cloud-init.disabled \
-      && exit 0
+		|| test -e /etc/cloud/cloud-init.disabled \
+		&& exit 0
 	echo -n "${command} starting"
 	${command} init
 }

--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -17,7 +17,7 @@ start_cmd="cloudinit_start"
 
 cloudinit_start()
 {
-	kenv -q kernel_options | grep 'cloud-init=disabled' && exit 0
+	kenv -q kernel_options | grep -q 'cloud-init=disabled' && exit 0
 	echo -n "${command} starting"
 	${command} init
 }

--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -17,7 +17,9 @@ start_cmd="cloudinit_start"
 
 cloudinit_start()
 {
-	kenv -q kernel_options | grep -q 'cloud-init=disabled' && exit 0
+	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
+      || -e /etc/cloud/cloud-init.disabled \
+      && exit 0
 	echo -n "${command} starting"
 	${command} init
 }

--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -17,11 +17,14 @@ start_cmd="cloudinit_start"
 
 cloudinit_start()
 {
-	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-		|| test -e /etc/cloud/cloud-init.disabled \
-		&& exit 0
-	echo -n "${command} starting"
-	${command} init
+    echo -n "${command} starting"
+    if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
+        warn "cloud-init is disabled via kernel_options."
+    elif test -e /etc/cloud/cloud-init.disabled; then
+        warn "cloud-init is disabled via cloud-init.disabled file."
+    else
+        ${command} init
+    fi
 }
 
 load_rc_config 'cloudinit'

--- a/sysvinit/freebsd/cloudinit
+++ b/sysvinit/freebsd/cloudinit
@@ -18,7 +18,7 @@ start_cmd="cloudinit_start"
 cloudinit_start()
 {
 	kenv -q kernel_options | grep -q 'cloud-init=disabled' \
-      || -e /etc/cloud/cloud-init.disabled \
+      || test -e /etc/cloud/cloud-init.disabled \
       && exit 0
 	echo -n "${command} starting"
 	${command} init

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -18,9 +18,9 @@ start_cmd="cloudlocal_start"
 cloudlocal_start()
 {
 	echo -n "${command} starting"
-	if kenv -q kernel_options | grep -q 'cloud-init=disabled';
+	if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
 		warn "cloud-init is disabled via kernel_options."
-	elif test -e /etc/cloud/cloud-init.disabled;
+	elif test -e /etc/cloud/cloud-init.disabled; then
 		warn "cloud-init is disabled via cloud-init.disabled file."
 	else
 		${command} init --local

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -17,13 +17,13 @@ start_cmd="cloudlocal_start"
 
 cloudlocal_start()
 {
-	echo -n "${command} starting"
-	if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
-		warn "cloud-init is disabled via kernel_options."
+    echo -n "${command} starting"
+    if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
+        warn "cloud-init is disabled via kernel_options."
 	elif test -e /etc/cloud/cloud-init.disabled; then
-		warn "cloud-init is disabled via cloud-init.disabled file."
+        warn "cloud-init is disabled via cloud-init.disabled file."
 	else
-		${command} init --local
+        ${command} init --local
 	fi
 }
 

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -18,8 +18,8 @@ start_cmd="cloudlocal_start"
 cloudlocal_start()
 {
 	echo -n "${command} starting"
-	if kenv -q kernel_options | grep 'cloud-init=disabled'; then
-		echo "cloud-init is disabled via /proc/cmdline."
+	if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
+		echo "cloud-init is disabled via kernel_options."
 		exit 0
 	fi
 

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -18,12 +18,13 @@ start_cmd="cloudlocal_start"
 cloudlocal_start()
 {
 	echo -n "${command} starting"
-	if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
+	if kenv -q kernel_options | grep -q 'cloud-init=disabled';
 		warn "cloud-init is disabled via kernel_options."
-		exit 0
+	elif test -e /etc/cloud/cloud-init.disabled;
+		warn "cloud-init is disabled via cloud-init.disabled file."
+	else
+		${command} init --local
 	fi
-
-	${command} init --local
 }
 
 load_rc_config 'cloudinit'

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -18,6 +18,11 @@ start_cmd="cloudlocal_start"
 cloudlocal_start()
 {
 	echo -n "${command} starting"
+	if kenv -q kernel_options | grep 'cloud-init=disabled'; then
+		echo "cloud-init is disabled via /proc/cmdline."
+		exit 0
+	fi
+
 	${command} init --local
 }
 

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -20,11 +20,11 @@ cloudlocal_start()
     echo -n "${command} starting"
     if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
         warn "cloud-init is disabled via kernel_options."
-	elif test -e /etc/cloud/cloud-init.disabled; then
+    elif test -e /etc/cloud/cloud-init.disabled; then
         warn "cloud-init is disabled via cloud-init.disabled file."
-	else
+    else
         ${command} init --local
-	fi
+    fi
 }
 
 load_rc_config 'cloudinit'

--- a/sysvinit/freebsd/cloudinitlocal
+++ b/sysvinit/freebsd/cloudinitlocal
@@ -19,7 +19,7 @@ cloudlocal_start()
 {
 	echo -n "${command} starting"
 	if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
-		echo "cloud-init is disabled via kernel_options."
+		warn "cloud-init is disabled via kernel_options."
 		exit 0
 	fi
 

--- a/sysvinit/gentoo/cloud-config
+++ b/sysvinit/gentoo/cloud-config
@@ -8,7 +8,10 @@ depend() {
 }
 
 start() {
-  grep -q 'cloud-init=disabled' /proc/cmdline && exit 0
+  grep -q 'cloud-init=disabled' /proc/cmdline \
+    && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
+    && exit 0
+
   cloud-init modules --mode config
   eend 0
 }

--- a/sysvinit/gentoo/cloud-config
+++ b/sysvinit/gentoo/cloud-config
@@ -8,6 +8,7 @@ depend() {
 }
 
 start() {
+  grep 'cloud-init=disabled' /proc/cmdline && exit 0
   cloud-init modules --mode config
   eend 0
 }

--- a/sysvinit/gentoo/cloud-config
+++ b/sysvinit/gentoo/cloud-config
@@ -8,7 +8,7 @@ depend() {
 }
 
 start() {
-  grep 'cloud-init=disabled' /proc/cmdline && exit 0
+  grep -q 'cloud-init=disabled' /proc/cmdline && exit 0
   cloud-init modules --mode config
   eend 0
 }

--- a/sysvinit/gentoo/cloud-config
+++ b/sysvinit/gentoo/cloud-config
@@ -9,6 +9,7 @@ depend() {
 
 start() {
   grep -q 'cloud-init=disabled' /proc/cmdline \
+    || -e /etc/cloud/cloud-init.disabled \
     && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
     && exit 0
 

--- a/sysvinit/gentoo/cloud-config
+++ b/sysvinit/gentoo/cloud-config
@@ -8,11 +8,12 @@ depend() {
 }
 
 start() {
-  grep -q 'cloud-init=disabled' /proc/cmdline \
-    || -e /etc/cloud/cloud-init.disabled \
-    && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
-    && exit 0
-
-  cloud-init modules --mode config
+  if grep -q 'cloud-init=disabled' /proc/cmdline;
+    ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
+  elif test -e /etc/cloud/cloud-init.disabled;
+    ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
+  else
+    cloud-init modules --mode config
+  fi
   eend 0
 }

--- a/sysvinit/gentoo/cloud-config
+++ b/sysvinit/gentoo/cloud-config
@@ -8,9 +8,9 @@ depend() {
 }
 
 start() {
-  if grep -q 'cloud-init=disabled' /proc/cmdline;
+  if grep -q 'cloud-init=disabled' /proc/cmdline; then
     ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
-  elif test -e /etc/cloud/cloud-init.disabled;
+  elif test -e /etc/cloud/cloud-init.disabled; then
     ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
   else
     cloud-init modules --mode config

--- a/sysvinit/gentoo/cloud-final
+++ b/sysvinit/gentoo/cloud-final
@@ -6,7 +6,9 @@ depend() {
 }
 
 start() {
-  grep -q 'cloud-init=disabled' /proc/cmdline && exit 0
+  grep -q 'cloud-init=disabled' /proc/cmdline \
+    && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
+    && exit 0
   cloud-init modules --mode final
   eend 0
 }

--- a/sysvinit/gentoo/cloud-final
+++ b/sysvinit/gentoo/cloud-final
@@ -7,6 +7,7 @@ depend() {
 
 start() {
   grep -q 'cloud-init=disabled' /proc/cmdline \
+    || -e /etc/cloud/cloud-init.disabled \
     && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
     && exit 0
   cloud-init modules --mode final

--- a/sysvinit/gentoo/cloud-final
+++ b/sysvinit/gentoo/cloud-final
@@ -6,6 +6,7 @@ depend() {
 }
 
 start() {
+  grep 'cloud-init=disabled' /proc/cmdline && exit 0
   cloud-init modules --mode final
   eend 0
 }

--- a/sysvinit/gentoo/cloud-final
+++ b/sysvinit/gentoo/cloud-final
@@ -6,9 +6,9 @@ depend() {
 }
 
 start() {
-  if grep -q 'cloud-init=disabled' /proc/cmdline;
+  if grep -q 'cloud-init=disabled' /proc/cmdline; then
     ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
-  elif test -e /etc/cloud/cloud-init.disabled;
+  elif test -e /etc/cloud/cloud-init.disabled; then
     ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
   else
     cloud-init modules --mode final

--- a/sysvinit/gentoo/cloud-final
+++ b/sysvinit/gentoo/cloud-final
@@ -6,10 +6,12 @@ depend() {
 }
 
 start() {
-  grep -q 'cloud-init=disabled' /proc/cmdline \
-    || -e /etc/cloud/cloud-init.disabled \
-    && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
-    && exit 0
-  cloud-init modules --mode final
+  if grep -q 'cloud-init=disabled' /proc/cmdline;
+    ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
+  elif test -e /etc/cloud/cloud-init.disabled;
+    ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
+  else
+    cloud-init modules --mode final
+  fi
   eend 0
 }

--- a/sysvinit/gentoo/cloud-final
+++ b/sysvinit/gentoo/cloud-final
@@ -6,7 +6,7 @@ depend() {
 }
 
 start() {
-  grep 'cloud-init=disabled' /proc/cmdline && exit 0
+  grep -q 'cloud-init=disabled' /proc/cmdline && exit 0
   cloud-init modules --mode final
   eend 0
 }

--- a/sysvinit/gentoo/cloud-init
+++ b/sysvinit/gentoo/cloud-init
@@ -9,6 +9,7 @@ depend() {
 
 start() {
   grep -q 'cloud-init=disabled' /proc/cmdline \
+    || -e /etc/cloud/cloud-init.disabled \
     && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
     && exit 0
   cloud-init init

--- a/sysvinit/gentoo/cloud-init
+++ b/sysvinit/gentoo/cloud-init
@@ -8,9 +8,9 @@ depend() {
 }
 
 start() {
-  if grep -q 'cloud-init=disabled' /proc/cmdline;
+  if grep -q 'cloud-init=disabled' /proc/cmdline; then
     ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
-  elif test -e /etc/cloud/cloud-init.disabled;
+  elif test -e /etc/cloud/cloud-init.disabled; then
     ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
   else
     cloud-init init

--- a/sysvinit/gentoo/cloud-init
+++ b/sysvinit/gentoo/cloud-init
@@ -8,6 +8,7 @@ depend() {
 }
 
 start() {
+  grep 'cloud-init=disabled' /proc/cmdline && exit 0
   cloud-init init
   eend 0
 }

--- a/sysvinit/gentoo/cloud-init
+++ b/sysvinit/gentoo/cloud-init
@@ -8,10 +8,12 @@ depend() {
 }
 
 start() {
-  grep -q 'cloud-init=disabled' /proc/cmdline \
-    || -e /etc/cloud/cloud-init.disabled \
-    && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
-    && exit 0
-  cloud-init init
+  if grep -q 'cloud-init=disabled' /proc/cmdline;
+    ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
+  elif test -e /etc/cloud/cloud-init.disabled;
+    ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
+  else
+    cloud-init init
+  fi
   eend 0
 }

--- a/sysvinit/gentoo/cloud-init
+++ b/sysvinit/gentoo/cloud-init
@@ -8,7 +8,9 @@ depend() {
 }
 
 start() {
-  grep -q 'cloud-init=disabled' /proc/cmdline && exit 0
+  grep -q 'cloud-init=disabled' /proc/cmdline \
+    && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
+    && exit 0
   cloud-init init
   eend 0
 }

--- a/sysvinit/gentoo/cloud-init
+++ b/sysvinit/gentoo/cloud-init
@@ -8,7 +8,7 @@ depend() {
 }
 
 start() {
-  grep 'cloud-init=disabled' /proc/cmdline && exit 0
+  grep -q 'cloud-init=disabled' /proc/cmdline && exit 0
   cloud-init init
   eend 0
 }

--- a/sysvinit/gentoo/cloud-init-local
+++ b/sysvinit/gentoo/cloud-init-local
@@ -8,6 +8,7 @@ depend() {
 }
 
 start() {
+  grep 'cloud-init=disabled' /proc/cmdline && exit 0
   cloud-init init --local
   eend 0
 }

--- a/sysvinit/gentoo/cloud-init-local
+++ b/sysvinit/gentoo/cloud-init-local
@@ -8,10 +8,13 @@ depend() {
 }
 
 start() {
-  grep -q 'cloud-init=disabled' /proc/cmdline \
-    || -e /etc/cloud/cloud-init.disabled \
-    && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
-    && exit 0
-  cloud-init init --local
+  if grep -q 'cloud-init=disabled' /proc/cmdline;
+    ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
+  elif test -e /etc/cloud/cloud-init.disabled;
+    ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
+  else
+    cloud-init init --local
+  fi
+
   eend 0
 }

--- a/sysvinit/gentoo/cloud-init-local
+++ b/sysvinit/gentoo/cloud-init-local
@@ -8,7 +8,7 @@ depend() {
 }
 
 start() {
-  grep 'cloud-init=disabled' /proc/cmdline && exit 0
+  grep -q 'cloud-init=disabled' /proc/cmdline && exit 0
   cloud-init init --local
   eend 0
 }

--- a/sysvinit/gentoo/cloud-init-local
+++ b/sysvinit/gentoo/cloud-init-local
@@ -8,9 +8,9 @@ depend() {
 }
 
 start() {
-  if grep -q 'cloud-init=disabled' /proc/cmdline;
+  if grep -q 'cloud-init=disabled' /proc/cmdline; then
     ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
-  elif test -e /etc/cloud/cloud-init.disabled;
+  elif test -e /etc/cloud/cloud-init.disabled; then
     ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
   else
     cloud-init init --local

--- a/sysvinit/gentoo/cloud-init-local
+++ b/sysvinit/gentoo/cloud-init-local
@@ -9,6 +9,7 @@ depend() {
 
 start() {
   grep -q 'cloud-init=disabled' /proc/cmdline \
+    || -e /etc/cloud/cloud-init.disabled \
     && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
     && exit 0
   cloud-init init --local

--- a/sysvinit/gentoo/cloud-init-local
+++ b/sysvinit/gentoo/cloud-init-local
@@ -8,7 +8,9 @@ depend() {
 }
 
 start() {
-  grep -q 'cloud-init=disabled' /proc/cmdline && exit 0
+  grep -q 'cloud-init=disabled' /proc/cmdline \
+    && ewarn "$RC_SVCNAME is disabled via /proc/cmdline." \
+    && exit 0
   cloud-init init --local
   eend 0
 }

--- a/sysvinit/netbsd/cloudconfig
+++ b/sysvinit/netbsd/cloudconfig
@@ -10,6 +10,7 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
+    test -e /etc/cloud/cloud-init.disabled && exit 0
     /usr/pkg/bin/cloud-init modules --mode config
 }
 

--- a/sysvinit/netbsd/cloudconfig
+++ b/sysvinit/netbsd/cloudconfig
@@ -10,7 +10,9 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
-    test -e /etc/cloud/cloud-init.disabled && exit 0
+    test -e /etc/cloud/cloud-init.disabled \
+      && warn "cloud-init disabled by cloud-init.disabled file" \
+      && exit 0
     /usr/pkg/bin/cloud-init modules --mode config
 }
 

--- a/sysvinit/netbsd/cloudfinal
+++ b/sysvinit/netbsd/cloudfinal
@@ -9,6 +9,7 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
+    test -e /etc/cloud/cloud-init.disabled && exit 0
     /usr/pkg/bin/cloud-init modules --mode final
 }
 

--- a/sysvinit/netbsd/cloudfinal
+++ b/sysvinit/netbsd/cloudfinal
@@ -9,7 +9,9 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
-    test -e /etc/cloud/cloud-init.disabled && exit 0
+    test -e /etc/cloud/cloud-init.disabled \
+      && warn "cloud-init disabled by cloud-init.disabled file" \
+      && exit 0
     /usr/pkg/bin/cloud-init modules --mode final
 }
 

--- a/sysvinit/netbsd/cloudinit
+++ b/sysvinit/netbsd/cloudinit
@@ -9,7 +9,9 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
-    test -e /etc/cloud/cloud-init.disabled && exit 0
+    test -e /etc/cloud/cloud-init.disabled \
+      && warn "cloud-init disabled by cloud-init.disabled file" \
+      && exit 0
     /usr/pkg/bin/cloud-init init
 }
 

--- a/sysvinit/netbsd/cloudinit
+++ b/sysvinit/netbsd/cloudinit
@@ -9,6 +9,7 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
+    test -e /etc/cloud/cloud-init.disabled && exit 0
     /usr/pkg/bin/cloud-init init
 }
 

--- a/sysvinit/netbsd/cloudinitlocal
+++ b/sysvinit/netbsd/cloudinitlocal
@@ -11,6 +11,9 @@ name="cloudinitlocal"
 start_cmd="start_cloud_init_local"
 start_cloud_init_local()
 {
+    test -e /etc/cloud/cloud-init.disabled \
+      && warn "cloud-init disabled by cloud-init.disabled file" \
+      && exit 0
     /usr/pkg/bin/cloud-init init -l
 }
 


### PR DESCRIPTION
```
Standardize disabling cloud-init on non-systemd

Some distros support disabling cloud-init using the 
kernel argument cloud-init=disabled. Standardize it
across non-systemd distros. Skip NetBSD, which
doesn't appear to support passing external
arguments to the kernel.

Add support for disabling cloud-init using
/etc/cloud/cloud-init.disabled to non-systemd
distros.
```

## Additional Context
Support disabling cloud-init via kernel commandline using `cloud-init=disabled`

Note: suse and rhel shouldn't need these changes per #2115 and #2114

Docs to follow in another PR.