### PR TITLE
Fix NoCloud Delimited Args

### DIFF
--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -14,6 +14,20 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
     Ironic, for example, it will succeed.
     """
     client = c
+
+    # The final output in /etc/default/grub should be:
+    #
+    # GRUB_CMDLINE_LINUX="'ds=nocloud;s=http://my-url/'"
+    #
+    # That ensures that the kernel commandline passed into
+    # /boot/efi/EFI/ubuntu/grub.cfg will be properly single-quoted
+    #
+    # Example:
+    #
+    # linux /boot/vmlinuz-5.15.0-1030-kvm ro 'ds=nocloud;s=http://my-url/'
+    #
+    # Not doing this will result in a semicolon-delimited ds argument
+    # terminating the kernel arguments prematurely.
     client.execute(
         'printf "GRUB_CMDLINE_LINUX=\\\"" >> /etc/default/grub'
     )

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -15,9 +15,10 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
     """
     client = c
     client.execute(
-        "sed --in-place "
-        "'s/^.*GRUB_CMDLINE_LINUX=.*$/GRUB_CMDLINE_LINUX=\"" + ds_str + '"/g'
-        "' /etc/default/grub"
+        "sed --in-place /GRUB_CMDLINE_LINUX=/d /etc/default/grub"
+    )
+    client.execute(
+        "echo \"GRUB_CMDLINE_LINUX='" + ds_str + "'\" >> /etc/default/grub"
     )
 
     # We should probably include non-systemd distros at some point. This should

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -36,7 +36,7 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
 @pytest.mark.parametrize(
     "ds_str, configured",
     (
-        ("ds=nocloud", "DataSourceNoCloud"),
+        ("ds=nocloud;s=http://my-url/", "DataSourceNoCloud"),
         ("ci.ds=openstack", "DataSourceOpenStack"),
     ),
 )

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -14,9 +14,17 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
     Ironic, for example, it will succeed.
     """
     client = c
-    client.execute("sed --in-place /GRUB_CMDLINE_LINUX=/d /etc/default/grub")
     client.execute(
-        "echo \"GRUB_CMDLINE_LINUX='" + ds_str + "'\" >> /etc/default/grub"
+        'printf "GRUB_CMDLINE_LINUX=\\\"" >> /etc/default/grub'
+    )
+    client.execute(
+        "printf \"'\" >> /etc/default/grub"
+    )
+    client.execute(
+        f"printf '{ds_str}' >> /etc/default/grub"
+    )
+    client.execute(
+        "printf \"'\\\"\" >> /etc/default/grub"
     )
 
     # We should probably include non-systemd distros at some point. This should

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -14,9 +14,7 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
     Ironic, for example, it will succeed.
     """
     client = c
-    client.execute(
-        "sed --in-place /GRUB_CMDLINE_LINUX=/d /etc/default/grub"
-    )
+    client.execute("sed --in-place /GRUB_CMDLINE_LINUX=/d /etc/default/grub")
     client.execute(
         "echo \"GRUB_CMDLINE_LINUX='" + ds_str + "'\" >> /etc/default/grub"
     )

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -28,18 +28,10 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
     #
     # Not doing this will result in a semicolon-delimited ds argument
     # terminating the kernel arguments prematurely.
-    client.execute(
-        'printf "GRUB_CMDLINE_LINUX=\\\"" >> /etc/default/grub'
-    )
-    client.execute(
-        "printf \"'\" >> /etc/default/grub"
-    )
-    client.execute(
-        f"printf '{ds_str}' >> /etc/default/grub"
-    )
-    client.execute(
-        "printf \"'\\\"\" >> /etc/default/grub"
-    )
+    client.execute('printf "GRUB_CMDLINE_LINUX=\\"" >> /etc/default/grub')
+    client.execute('printf "\'" >> /etc/default/grub')
+    client.execute(f"printf '{ds_str}' >> /etc/default/grub")
+    client.execute('printf "\'\\"" >> /etc/default/grub')
 
     # We should probably include non-systemd distros at some point. This should
     # most likely be as simple as updating the output path for grub-mkconfig

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1739,6 +1739,9 @@ read_config() {
     for tok in ${DI_KERNEL_CMDLINE}; do
         key=${tok%%=*}
         val=${tok#*=}
+
+        # discard anything after delimiter
+        val=$(echo $val | cut -f1 -d ';')
         case "$key" in
             ds) _rc_dsname="$val";;
             ci.ds) _rc_dsname="$val";;

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1741,7 +1741,7 @@ read_config() {
         val=${tok#*=}
 
         # discard anything after delimiter
-        val=$(echo $val | cut -f1 -d ';')
+        val=${val%;*}
         case "$key" in
             ds) _rc_dsname="$val";;
             ci.ds) _rc_dsname="$val";;


### PR DESCRIPTION
```
Fix NoCloud kernel commandline semi-colon args.

This was broken in 612b4de892d on systemd systems.
Add an integration test for this codepath.
```

## Additional Context
This codepath was already tested without ds-identify, ensure that this works with ds-identify too. 

Successful test run:
```
tests/integration_tests/test_kernel_commandline_match.py::test_lxd_datasource_kernel_override[ds=nocloud;s=http://my-url/-DataSourceNoCloud] 
---------------------------------------------- live log setup ----------------------------------------------
2023-04-07 21:17:44 INFO      integration_testing:clouds.py:70 Settings:
CLOUD_INIT_SOURCE=./cloud-init_all.deb
COLLECT_LOGS=ON_ERROR
EXISTING_INSTANCE_ID=None
INSTANCE_TYPE=None
KEEP_IMAGE=False
KEEP_INSTANCE=True
LOCAL_LOG_PATH=/tmp/cloud_init_test_logs
OS_IMAGE=focal
PLATFORM=lxd_vm
RUN_UNSTABLE=False
2023-04-07 21:17:44 INFO      integration_testing:conftest.py:118 Setting up environment for lxd_vm
2023-04-07 21:17:44 INFO      integration_testing:clouds.py:124 Launching instance with launch_kwargs:
image_id=ubuntu-daily:e21003e15e88a5ef939aa6e9105965078bc645363a47f45430d82e679eba85f4
user_data=None
2023-04-07 21:18:43 INFO      pycloudlib.instance:instance.py:468 _wait_for_execute to complete
2023-04-07 21:18:43 WARNING   pycloudlib.instance:instance.py:405 The specified key (/home/holmanb/.ssh/id_rsa) requires a passphrase. If you have not added this key to a running SSH agent, you will see failures to connect after a long timeout.
2023-04-07 21:18:48 WARNING   pycloudlib.instance:instance.py:405 The specified key (/home/holmanb/.ssh/id_rsa) requires a passphrase. If you have not added this key to a running SSH agent, you will see failures to connect after a long timeout.
2023-04-07 21:18:50 WARNING   pycloudlib.instance:instance.py:405 The specified key (/home/holmanb/.ssh/id_rsa) requires a passphrase. If you have not added this key to a running SSH agent, you will see failures to connect after a long timeout.
2023-04-07 21:18:51 WARNING   pycloudlib.instance:instance.py:405 The specified key (/home/holmanb/.ssh/id_rsa) requires a passphrase. If you have not added this key to a running SSH agent, you will see failures to connect after a long timeout.
2023-04-07 21:18:53 WARNING   pycloudlib.instance:instance.py:405 The specified key (/home/holmanb/.ssh/id_rsa) requires a passphrase. If you have not added this key to a running SSH agent, you will see failures to connect after a long timeout.
2023-04-07 21:18:53 INFO      paramiko.transport:transport.py:1873 Connected (version 2.0, client OpenSSH_8.2p1)
2023-04-07 21:18:54 INFO      paramiko.transport:transport.py:1873 Authentication (publickey) successful!
2023-04-07 21:18:59 INFO      pycloudlib.instance:instance.py:489 _wait_for_cloudinit to complete
2023-04-07 21:18:59 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'command -v systemctl'
2023-04-07 21:19:11 INFO      pycloudlib.instance:instance.py:244 executing: cloud-init status --wait --long
2023-04-07 21:19:11 INFO      integration_testing:clouds.py:133 Launched instance: LXDInstance(name=cloudinit-0407-211746gy6itu11)
2023-04-07 21:19:11 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'cloud-init --version'
2023-04-07 21:19:12 INFO      integration_testing:clouds.py:137 cloud-init version: /usr/bin/cloud-init 22.4.2-0ubuntu0~20.04.2
2023-04-07 21:19:12 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
2023-04-07 21:19:12 INFO      integration_testing:clouds.py:143 image serial: 20230215
2023-04-07 21:19:12 INFO      integration_testing:instances.py:181 Installing deb package
2023-04-07 21:19:12 INFO      paramiko.transport.sftp:sftp.py:169 [chan 17] Opened sftp connection (server version 3)
2023-04-07 21:19:12 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'mv /var/tmp/6c32878d-6753-45ce-b946-4481ae30dbbe.tmp /var/tmp/cloud-init_all.deb'
2023-04-07 21:19:12 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'dpkg -i /var/tmp/cloud-init_all.deb'
2023-04-07 21:19:17 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'cloud-init -v'
2023-04-07 21:19:18 INFO      integration_testing:instances.py:148 Installed cloud-init version: 23.1-56-g908e528d0-1~bddeb
2023-04-07 21:19:18 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'sudo cloud-init clean --logs'
2023-04-07 21:19:18 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'sudo rm -rf /var/log/syslog'
2023-04-07 21:19:18 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'sudo cloud-init clean --logs'
2023-04-07 21:19:19 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'sudo rm -rf /var/log/syslog'
2023-04-07 21:19:19 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'sudo cloud-init clean --logs'
2023-04-07 21:19:20 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'sudo rm -rf /var/log/syslog'
2023-04-07 21:22:00 INFO      integration_testing:instances.py:124 Created new image: local:cloudinit-0407-211746gy6itu11-snapshot
2023-04-07 21:22:01 INFO      integration_testing:conftest.py:124 Done with environment setup
2023-04-07 21:22:01 INFO      integration_testing:clouds.py:124 Launching instance with launch_kwargs:
image_id=local:cloudinit-0407-211746gy6itu11-snapshot
user_data=None
execute_via_ssh=False
2023-04-07 21:23:06 INFO      pycloudlib.instance:instance.py:468 _wait_for_execute to complete
2023-04-07 21:23:06 INFO      pycloudlib.instance:instance.py:489 _wait_for_cloudinit to complete
2023-04-07 21:23:06 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'command -v systemctl'
2023-04-07 21:23:24 INFO      pycloudlib.instance:instance.py:244 executing: cloud-init status --wait --long
2023-04-07 21:23:25 INFO      integration_testing:clouds.py:133 Launched instance: LXDInstance(name=cloudinit-0407-212201bzuw5ny8)
2023-04-07 21:23:25 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'cloud-init --version'
2023-04-07 21:23:26 INFO      integration_testing:clouds.py:137 cloud-init version: /usr/bin/cloud-init 23.1-56-g908e528d0-1~bddeb
2023-04-07 21:23:26 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'grep serial /etc/cloud/build.info'
2023-04-07 21:23:26 INFO      integration_testing:clouds.py:143 image serial: 20230215
---------------------------------------------- live log call -----------------------------------------------
2023-04-07 21:23:26 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'sed --in-place /GRUB_CMDLINE_LINUX=/d /etc/default/grub'
2023-04-07 21:23:26 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'echo "GRUB_CMDLINE_LINUX='"'"'ds=nocloud;s=http://my-url/'"'"'" >> /etc/default/grub'
2023-04-07 21:23:26 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg'
2023-04-07 21:23:31 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'cloud-init clean --logs'
2023-04-07 21:23:53 INFO      pycloudlib.instance:instance.py:468 _wait_for_execute to complete
2023-04-07 21:23:54 INFO      pycloudlib.instance:instance.py:489 _wait_for_cloudinit to complete
2023-04-07 21:23:54 INFO      pycloudlib.instance:instance.py:244 executing: sh -c 'command -v systemctl'
2023-04-07 21:24:11 INFO      pycloudlib.instance:instance.py:244 executing: cloud-init status --wait --long
2023-04-07 21:24:12 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'cloud-init status --wait'
2023-04-07 21:24:13 INFO      pycloudlib.instance:instance.py:244 executing: sudo -- sh -c 'cat /var/log/cloud-init.log'
PASSED                                                                                               [100%]
-------------------------------------------- live log teardown ---------------------------------------------
2023-04-07 21:24:13 INFO      integration_testing:instances.py:213 Keeping Instance, public ip: 10.237.65.49
2023-04-07 21:24:13 INFO      integration_testing:clouds.py:166 Deleting snapshot image created for this testrun: local:cloudinit-0407-211746gy6itu11-snapshot


============================================= warnings summary =============================================
.tox/integration-tests/lib/python3.11/site-packages/_pytest/config/__init__.py:1242
  /home/holmanb/cloud-init/.tox/integration-tests/lib/python3.11/site-packages/_pytest/config/__init__.py:1242: PytestRemovedIn8Warning: The --strict option is deprecated, use --strict-markers instead.
    self.issue_config_time_warning(

.tox/integration-tests/lib/python3.11/site-packages/pyparsing.py:108
  /home/holmanb/cloud-init/.tox/integration-tests/lib/python3.11/site-packages/pyparsing.py:108: DeprecationWarning: module 'sre_constants' is deprecated
    import sre_constants

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== slowest 10 durations ===========================================
343.37s setup    tests/integration_tests/test_kernel_commandline_match.py::test_lxd_datasource_kernel_override[ds=nocloud;s=http://my-url/-DataSourceNoCloud]
47.00s call     tests/integration_tests/test_kernel_commandline_match.py::test_lxd_datasource_kernel_override[ds=nocloud;s=http://my-url/-DataSourceNoCloud]
0.36s teardown tests/integration_tests/test_kernel_commandline_match.py::test_lxd_datasource_kernel_override[ds=nocloud;s=http://my-url/-DataSourceNoCloud]
================================ 1 passed, 2 warnings in 390.76s (0:06:30) =================================
_________________________________________________ summary __________________________________________________
  integration-tests: commands succeeded
  congratulations :)
```