### PR TITLE
ubuntu/focal: Gcp drop disable network activation focal (SC-1440)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -12,18 +12,18 @@ cloud-init (23.1-0ubuntu0~20.04.2) UNRELEASED; urgency=medium
 
  -- James Falcon <james.falcon@canonical.com>  Wed, 29 Mar 2023 10:37:59 -0500
 
-cloud-init (23.1-0ubuntu0~20.04.1) focal; urgency=medium
+cloud-init (23.1.1-0ubuntu0~20.04.1) focal; urgency=medium
 
   * d/patches/retain-netplan-world-readable.patch:
     - Retain original world-readable perms of /etc/netplan/50-cloud-init.yaml.
       Lunar made the config root read-only.
   * refresh patches:
     + debian/patches/expire-on-hashed-users.patch
-  * Upstream snapshot based on 23.1. (LP: #2008230).
+  * Upstream snapshot based on 23.1.1. (LP: #2008230).
     List of changes from upstream can be found at
-    https://raw.githubusercontent.com/canonical/cloud-init/23.1/ChangeLog
+    https://raw.githubusercontent.com/canonical/cloud-init/23.1.1/ChangeLog
 
- -- Alberto Contreras <alberto.contreras@canonical.com>  Fri, 24 Feb 2023 12:51:43 +0100
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Fri, 03 Mar 2023 09:48:54 +0100
 
 cloud-init (22.4.2-0ubuntu0~20.04.2) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,16 +1,19 @@
-cloud-init (23.1-0ubuntu0~20.04.2) UNRELEASED; urgency=medium
+cloud-init (23.1.2-0ubuntu0~20.04.2) UNRELEASED; urgency=medium
 
   * d/apport-general-hook.py: Add general apport hook to append cloud type,
     image and instance size information to bug reports (LP: #1724623)
   * d/cloud-init.preinst: Oracle to remove vestigial /etc/cloud.cloud.cfg.d/
     99-disable-network-config.cfg because system config is now honored before
     datasource config (LP: #1956788)
+  * d/cloud-init.preinst: Clean up vestigial
+    /etc/cloud/cloud.cfg.d/99-disable-network-activation.cfg on GCE instances
+    after fix in upstream google-guest-agent.
   * Refresh patches against upstream/main:
     - d/p/expire-on-hashed-users.patch
     - d/p/retain-netplan-world-readable.patch
   * Upstream snapshot based on upstream/main at d7bdba6f.
 
- -- James Falcon <james.falcon@canonical.com>  Wed, 29 Mar 2023 10:37:59 -0500
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Fri, 14 Apr 2023 11:44:48 +0200
 
 cloud-init (23.1.1-0ubuntu0~20.04.1) focal; urgency=medium
 

--- a/debian/cloud-init.preinst
+++ b/debian/cloud-init.preinst
@@ -188,6 +188,14 @@ cleanup_oci_network_lp1956788() {
    rm -f /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
 }
 
+cleanup_gce_disable_network_activation_sc1440() {
+   # Remove vestigial /etc/cloud/cloud.cfg.d/99-disable-network-activation.cfg
+   # from GCE images now that google-guest-agent includes
+   # https://github.com/GoogleCloudPlatform/guest-agent/commit/8c36e064abebb814dc56647e8db43f261deb9a63
+   grep DataSourceGCE /var/lib/cloud/instance/datasource > /dev/null 2>&1 || return 0
+   rm -f /etc/cloud/cloud.cfg.d/99-disable-network-activation.cfg
+}
+
 case "$1" in
     install|upgrade)
         if dpkg --compare-versions "$2" le "0.5.11-0ubuntu1"; then
@@ -232,6 +240,7 @@ case "$1" in
 
       cleanup_lp1552999 "$oldver"
       cleanup_oci_network_lp1956788
+      cleanup_gce_disable_network_activation_sc1440
 
 esac
 


### PR DESCRIPTION
# do not squash

## Test steps

```bash
tar -cvaf ../cloud-init_23.1.1.orig.tar.xz .

build-package # or: debuild -d -S -nc 

sbuild --dist focal ../out/cloud-init_23.1.1-0ubuntu0~20.04.1.dsc

CLOUD_INIT_PLATFORM=gce CLOUD_INIT_CLOUD_INIT_SOURCE=$(ls cloud-init_*.deb) CLOUD_INIT_OS_IMAGE=focal tox -e integration-tests -- tests/integration_tests/modules/test_combined.py
```

## Additional context
SC-1440
https://github.com/canonical/cloud-init/pull/2117#issuecomment-1508151851
