### PR TITLE
net/dhcp: add udhcpc support

### DIFF
--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -63,6 +63,7 @@ j5awry
 jamesottinger
 Jehops
 jf
+jfroche
 Jille
 JohnKepplers
 johnsonshi


### PR DESCRIPTION
The currently used dhcp client, dhclient, is coming from the unmaintained package, isc-dhcp-client (refer https://www.isc.org/dhcp/) which ended support in 2022.

This change introduce support for the dhcp client, udhcpc, from the busybox project. Busybox advantages are that it is available across many distributions and comes with lightweight executables.

It might be useful to rebase this PR once https://github.com/canonical/cloud-init/pull/2122 is merged.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
