### PR TITLE
Support Ephemeral Networking for BSD

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -18,6 +18,7 @@ import urllib.parse
 from io import StringIO
 from typing import Any, Mapping, MutableMapping, Optional, Type
 
+import cloudinit.net.netops.iproute2 as iproute2
 from cloudinit import importer
 from cloudinit import log as logging
 from cloudinit import (
@@ -104,6 +105,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     # This is used by self.shutdown_command(), and can be overridden in
     # subclasses
     shutdown_options_map = {"halt": "-H", "poweroff": "-P", "reboot": "-r"}
+    net_ops = iproute2.Iproute2
 
     _ci_pkl_version = 1
     prefer_fqdn = False
@@ -118,6 +120,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         self.name = name
         self.networking: Networking = self.networking_cls()
         self.dhcp_client_priority = [dhcp.IscDhclient, dhcp.Dhcpcd]
+        self.net_ops = iproute2.Iproute2
 
     def _unpickle(self, ci_pkl_version: int) -> None:
         """Perform deserialization fixes for Distro."""
@@ -997,6 +1000,26 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             ],
             **kwargs,
         )
+
+    @staticmethod
+    def build_dhclient_cmd(
+        path: str,
+        lease_file: str,
+        pid_file: str,
+        interface: str,
+        config_file: str,
+    ) -> list:
+        return [
+            path,
+            "-1",
+            "-v",
+            "-lf",
+            lease_file,
+            "-pf",
+            pid_file,
+            "-sf",
+            "/bin/true",
+        ] + (["-cf", config_file, interface] if config_file else [interface])
 
 
 def _apply_hostname_transformations_to_url(url: str, transformations: list):

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -1,6 +1,7 @@
 import platform
 from typing import List, Optional
 
+import cloudinit.net.netops.bsd_netops as bsd_netops
 from cloudinit import distros, helpers
 from cloudinit import log as logging
 from cloudinit import net, subp, util
@@ -27,6 +28,7 @@ class BSD(distros.Distro):
     # There is no update/upgrade on OpenBSD
     pkg_cmd_update_prefix: Optional[List[str]] = None
     pkg_cmd_upgrade_prefix: Optional[List[str]] = None
+    net_ops = bsd_netops.BsdNetOps  # type: ignore
 
     def __init__(self, name, cfg, paths):
         super().__init__(name, cfg, paths)
@@ -36,6 +38,7 @@ class BSD(distros.Distro):
         self._runner = helpers.Runners(paths)
         cfg["ssh_svcname"] = "sshd"
         self.osfamily = platform.system().lower()
+        self.net_ops = bsd_netops
 
     def _read_system_hostname(self):
         sys_hostname = self._read_hostname(self.hostname_conf_fn)

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -203,6 +203,6 @@ class Distro(cloudinit.distros.bsd.BSD):
         interface: str,
         config_file: str,
     ) -> list:
-        return ["-l", lease_file, "-p", pid_file] + (
+        return [path, "-l", lease_file, "-p", pid_file] + (
             ["-c", config_file, interface] if config_file else [interface]
         )

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -194,3 +194,15 @@ class Distro(cloudinit.distros.bsd.BSD):
             ["update"],
             freq=PER_INSTANCE,
         )
+
+    @staticmethod
+    def build_dhclient_cmd(
+        path: str,
+        lease_file: str,
+        pid_file: str,
+        interface: str,
+        config_file: str,
+    ) -> list:
+        return ["-l", lease_file, "-p", pid_file] + (
+            ["-c", config_file, interface] if config_file else [interface]
+        )

--- a/cloudinit/net/netops/__init__.py
+++ b/cloudinit/net/netops/__init__.py
@@ -1,0 +1,47 @@
+from typing import Optional
+
+
+class NetOps:
+    @staticmethod
+    def link_up(interface: str):
+        pass
+
+    @staticmethod
+    def link_down(interface: str):
+        pass
+
+    @staticmethod
+    def add_route(
+        interface: str,
+        route: str,
+        *,
+        gateway: Optional[str] = None,
+        source_address: Optional[str] = None
+    ):
+        pass
+
+    @staticmethod
+    def append_route(interface: str, address: str, gateway: str):
+        pass
+
+    @staticmethod
+    def del_route(
+        interface: str,
+        address: str,
+        *,
+        gateway: Optional[str] = None,
+        source_address: Optional[str] = None
+    ):
+        pass
+
+    @staticmethod
+    def get_default_route() -> str:
+        pass
+
+    @staticmethod
+    def add_addr(interface: str, address: str, broadcast: str):
+        pass
+
+    @staticmethod
+    def del_addr(interface: str, address: str):
+        pass

--- a/cloudinit/net/netops/bsd_netops.py
+++ b/cloudinit/net/netops/bsd_netops.py
@@ -1,0 +1,49 @@
+from typing import Optional
+
+import cloudinit.net.netops as netops
+
+
+class BsdNetOps(netops.NetOps):
+    @staticmethod
+    def link_up(interface: str):
+        pass
+
+    @staticmethod
+    def link_down(interface: str):
+        pass
+
+    @staticmethod
+    def add_route(
+        interface: str,
+        route: str,
+        *,
+        gateway: Optional[str] = None,
+        source_address: Optional[str] = None
+    ):
+        pass
+
+    @staticmethod
+    def append_route(interface: str, address: str, gateway: str):
+        pass
+
+    @staticmethod
+    def del_route(
+        interface: str,
+        address: str,
+        *,
+        gateway: Optional[str] = None,
+        source_address: Optional[str] = None
+    ):
+        pass
+
+    @staticmethod
+    def get_default_route() -> str:
+        pass
+
+    @staticmethod
+    def add_addr(interface: str, address: str, broadcast: str):
+        pass
+
+    @staticmethod
+    def del_addr(interface: str, address: str):
+        pass

--- a/cloudinit/net/netops/iproute2.py
+++ b/cloudinit/net/netops/iproute2.py
@@ -1,0 +1,93 @@
+from typing import Optional
+
+import cloudinit.net.netops as netops
+from cloudinit import subp
+
+
+class Iproute2(netops.NetOps):
+    @staticmethod
+    def link_up(interface: str, family: Optional[str] = None):
+        subp.subp(
+            ["ip"]
+            + (["-family", family] if family else [])
+            + ["link", "set", "dev", interface, "up"]
+        )
+
+    @staticmethod
+    def link_down(interface: str, family: Optional[str] = None):
+        subp.subp(
+            ["ip"]
+            + (["-family", family] if family else [])
+            + ["link", "set", "dev", interface, "down"]
+        )
+
+    @staticmethod
+    def add_route(
+        interface: str,
+        route: str,
+        *,
+        gateway: Optional[str] = None,
+        source_address: Optional[str] = None,
+    ):
+        subp.subp(
+            ["ip", "-4", "route", "add", route]
+            + (["via", gateway] if gateway and gateway != "0.0.0.0" else [])
+            + [
+                "dev",
+                interface,
+            ]
+            + (["src", source_address] if source_address else []),
+        )
+
+    @staticmethod
+    def append_route(interface: str, address: str, gateway: str):
+        subp.subp(
+            ["ip", "-4", "route", "append", address]
+            + (["via", gateway] if gateway and gateway != "0.0.0.0" else [])
+            + ["dev", interface]
+        )
+
+    @staticmethod
+    def del_route(
+        interface: str,
+        address: str,
+        *,
+        gateway: Optional[str] = None,
+        source_address: Optional[str] = None,
+    ):
+        subp.subp(
+            ["ip", "-4", "route", "del", address]
+            + (["via", gateway] if gateway and gateway != "0.0.0.0" else [])
+            + ["dev", interface]
+            + (["src", source_address] if source_address else [])
+        )
+
+    @staticmethod
+    def get_default_route() -> str:
+        return subp.subp(
+            ["ip", "route", "show", "0.0.0.0/0"],
+        ).stdout
+
+    @staticmethod
+    def add_addr(interface: str, address: str, broadcast: str):
+        subp.subp(
+            [
+                "ip",
+                "-family",
+                "inet",
+                "addr",
+                "add",
+                address,
+                "broadcast",
+                broadcast,
+                "dev",
+                interface,
+            ],
+            update_env={"LANG": "C"},
+        )
+
+    @staticmethod
+    def del_addr(interface: str, address: str):
+        subp.subp(
+            ["ip", "-family", "inet", "addr", "del", address, "dev", interface]
+        )

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -311,6 +311,7 @@ class DataSourceScaleway(sources.DataSource):
         if not self.has_ipv4:
             try:
                 with EphemeralIPv6Network(
+                    self.distro,
                     self._fallback_interface,
                 ):
                     util.log_time(

--- a/tests/unittests/net/test_ephemeral.py
+++ b/tests/unittests/net/test_ephemeral.py
@@ -43,7 +43,7 @@ class TestEphemeralIPNetwork:
                 mock.call(m_ephemeral_ip_v6_network.return_value)
             )
             assert [
-                mock.call(interface)
+                mock.call(distro, interface)
             ] == m_ephemeral_ip_v6_network.call_args_list
         else:
             assert [] == m_ephemeral_ip_v6_network.call_args_list

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -18,6 +18,7 @@ from cloudinit.net.ephemeral import EphemeralIPv4Network, EphemeralIPv6Network
 from cloudinit.subp import ProcessExecutionError
 from cloudinit.util import ensure_file, write_file
 from tests.unittests.helpers import CiTestCase, ResponsesTestCase
+from tests.unittests.util import MockDistro
 
 
 class TestSysDevPath(CiTestCase):
@@ -769,7 +770,7 @@ class TestEphemeralIPV4Network(CiTestCase):
             params = copy.deepcopy(required_params)
             params[key] = None
             with self.assertRaises(ValueError) as context_manager:
-                EphemeralIPv4Network(**params)
+                EphemeralIPv4Network(MockDistro(), **params)
             error = context_manager.exception
             self.assertIn("Cannot init network on", str(error))
             self.assertEqual(0, m_subp.call_count)
@@ -785,7 +786,7 @@ class TestEphemeralIPV4Network(CiTestCase):
         for error_val in invalid_masks:
             params["prefix_or_mask"] = error_val
             with self.assertRaises(ValueError) as context_manager:
-                with EphemeralIPv4Network(**params):
+                with EphemeralIPv4Network(MockDistro(), **params):
                     pass
             error = context_manager.exception
             self.assertIn(
@@ -809,12 +810,10 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
                 update_env={"LANG": "C"},
             ),
             mock.call(
                 ["ip", "-family", "inet", "link", "set", "dev", "eth0", "up"],
-                capture=True,
             ),
         ]
         expected_teardown_calls = [
@@ -829,7 +828,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "eth0",
                     "down",
                 ],
-                capture=True,
             ),
             mock.call(
                 [
@@ -842,7 +840,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
         ]
         params = {
@@ -851,7 +848,7 @@ class TestEphemeralIPV4Network(CiTestCase):
             "prefix_or_mask": "255.255.255.0",
             "broadcast": "192.168.2.255",
         }
-        with EphemeralIPv4Network(**params):
+        with EphemeralIPv4Network(MockDistro(), **params):
             self.assertEqual(expected_setup_calls, m_subp.call_args_list)
         m_subp.assert_has_calls(expected_teardown_calls)
 
@@ -864,13 +861,14 @@ class TestEphemeralIPV4Network(CiTestCase):
         """
 
         def side_effect(args, **kwargs):
-            if args[3] == "append" and args[4] == "3.3.3.3/32":
+            if "append" in args and "3.3.3.3/32" in args:
                 raise subp.ProcessExecutionError("oh no!")
 
         m_subp.side_effect = side_effect
 
         with pytest.raises(subp.ProcessExecutionError):
             with EphemeralIPv4Network(
+                MockDistro(),
                 interface="eth0",
                 ip="1.1.1.1",
                 prefix_or_mask="255.255.255.0",
@@ -895,7 +893,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
             mock.call(
                 [
@@ -908,7 +905,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "eth0",
                     "down",
                 ],
-                capture=True,
             ),
             mock.call(
                 [
@@ -921,7 +917,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
         ]
         for teardown in expected_teardown_calls:
@@ -941,7 +936,7 @@ class TestEphemeralIPV4Network(CiTestCase):
             "connectivity_url_data": {"url": "http://example.org/index.html"},
         }
 
-        with EphemeralIPv4Network(**params):
+        with EphemeralIPv4Network(MockDistro(), **params):
             self.assertEqual(
                 [mock.call(url="http://example.org/index.html", timeout=5)],
                 m_readurl.call_args_list,
@@ -977,11 +972,10 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
                 update_env={"LANG": "C"},
             )
         ]
-        with EphemeralIPv4Network(**params):
+        with EphemeralIPv4Network(MockDistro(), **params):
             pass
         self.assertEqual(expected_calls, m_subp.call_args_list)
         self.assertIn(
@@ -999,7 +993,7 @@ class TestEphemeralIPV4Network(CiTestCase):
         }
         for prefix_val in ["24", 16]:  # prefix can be int or string
             params["prefix_or_mask"] = prefix_val
-            with EphemeralIPv4Network(**params):
+            with EphemeralIPv4Network(MockDistro(), **params):
                 pass
         m_subp.assert_has_calls(
             [
@@ -1016,7 +1010,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                         "dev",
                         "eth0",
                     ],
-                    capture=True,
                     update_env={"LANG": "C"},
                 )
             ]
@@ -1036,7 +1029,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                         "dev",
                         "eth0",
                     ],
-                    capture=True,
                     update_env={"LANG": "C"},
                 )
             ]
@@ -1051,7 +1043,8 @@ class TestEphemeralIPV4Network(CiTestCase):
             "broadcast": "192.168.2.255",
             "router": "192.168.2.1",
         }
-        m_subp.return_value = "", ""  # Empty response from ip route gw check
+        # Empty response from ip route gw check
+        m_subp.return_value = subp.SubpResult("", "")
         expected_setup_calls = [
             mock.call(
                 [
@@ -1066,14 +1059,12 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
                 update_env={"LANG": "C"},
             ),
             mock.call(
                 ["ip", "-family", "inet", "link", "set", "dev", "eth0", "up"],
-                capture=True,
             ),
-            mock.call(["ip", "route", "show", "0.0.0.0/0"], capture=True),
+            mock.call(["ip", "route", "show", "0.0.0.0/0"]),
             mock.call(
                 [
                     "ip",
@@ -1086,7 +1077,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "src",
                     "192.168.2.2",
                 ],
-                capture=True,
             ),
             mock.call(
                 [
@@ -1100,13 +1090,11 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
         ]
         expected_teardown_calls = [
             mock.call(
                 ["ip", "-4", "route", "del", "default", "dev", "eth0"],
-                capture=True,
             ),
             mock.call(
                 [
@@ -1120,11 +1108,10 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "src",
                     "192.168.2.2",
                 ],
-                capture=True,
             ),
         ]
 
-        with EphemeralIPv4Network(**params):
+        with EphemeralIPv4Network(MockDistro(), **params):
             self.assertEqual(expected_setup_calls, m_subp.call_args_list)
         m_subp.assert_has_calls(expected_teardown_calls)
 
@@ -1155,12 +1142,10 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
                 update_env={"LANG": "C"},
             ),
             mock.call(
                 ["ip", "-family", "inet", "link", "set", "dev", "eth0", "up"],
-                capture=True,
             ),
             mock.call(
                 [
@@ -1172,7 +1157,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
             mock.call(
                 [
@@ -1186,7 +1170,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
             mock.call(
                 [
@@ -1200,7 +1183,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
         ]
         expected_teardown_calls = [
@@ -1216,7 +1198,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
             mock.call(
                 [
@@ -1230,11 +1211,9 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
             mock.call(
                 ["ip", "-4", "route", "del", "192.168.2.1/32", "dev", "eth0"],
-                capture=True,
             ),
             mock.call(
                 [
@@ -1247,7 +1226,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "eth0",
                     "down",
                 ],
-                capture=True,
             ),
             mock.call(
                 [
@@ -1260,10 +1238,9 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                capture=True,
             ),
         ]
-        with EphemeralIPv4Network(**params):
+        with EphemeralIPv4Network(MockDistro(), **params):
             self.assertEqual(expected_setup_calls, m_subp.call_args_list)
         m_subp.assert_has_calls(expected_setup_calls + expected_teardown_calls)
 
@@ -1276,10 +1253,9 @@ class TestEphemeralIPV6Network:
         expected_setup_calls = [
             mock.call(
                 ["ip", "link", "set", "dev", "eth0", "up"],
-                capture=False,
             ),
         ]
-        with EphemeralIPv6Network(interface="eth0"):
+        with EphemeralIPv6Network(MockDistro(), interface="eth0"):
             assert expected_setup_calls == m_subp.call_args_list
 
 

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3072,6 +3072,7 @@ class TestAzureDataSourcePreprovisioning(CiTestCase):
         self.assertTrue(len(dsa._poll_imds()) > 0)
         self.assertEqual(m_dhcp.call_count, 1)
         m_net.assert_any_call(
+            dsa.distro,
             broadcast="192.168.2.255",
             interface="eth9",
             ip="192.168.2.9",
@@ -3106,6 +3107,7 @@ class TestAzureDataSourcePreprovisioning(CiTestCase):
         self.assertEqual(cfg["system_info"]["default_user"]["name"], username)
         self.assertEqual(m_dhcp.call_count, 1)
         m_net.assert_any_call(
+            dsa.distro,
             broadcast="192.168.2.255",
             interface="eth9",
             ip="192.168.2.9",

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -881,6 +881,7 @@ class TestEc2(test_helpers.ResponsesTestCase):
         self.assertTrue(ret)
         m_dhcp.assert_called_once_with(ds.distro, "eth9", None)
         m_net4.assert_called_once_with(
+            ds.distro,
             broadcast="192.168.2.255",
             interface="eth9",
             ip="192.168.2.9",

--- a/tests/unittests/sources/test_upcloud.py
+++ b/tests/unittests/sources/test_upcloud.py
@@ -245,6 +245,7 @@ class TestUpCloudNetworkSetup(CiTestCase):
         m_dhcp.assert_called_with(ds.distro, "eth1", None)
 
         m_net.assert_called_once_with(
+            ds.distro,
             broadcast="10.6.3.255",
             interface="eth1",
             ip="10.6.3.27",


### PR DESCRIPTION
```
Support ephemeral network for BSDs

Currently ephemeral.py uses hardcoded iproute2
calls to setup ephemeral networking, which is
incompatible with BSDs. Refactor to support
pluggable network interface operations.
```

## Additional Context
Blocked by https://github.com/canonical/cloud-init/pull/2130 ~~and https://github.com/canonical/cloud-init/pull/2122 ([context](https://github.com/canonical/cloud-init/pull/2122#pullrequestreview-1389048745))~~.