### PR TITLE
azure/errors: introduce reportable errors

### DIFF
--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2022 Microsoft Corporation.
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import base64
+import csv
+import logging
+import traceback
+from datetime import datetime
+from io import StringIO
+from typing import Any, Dict, Optional
+
+from cloudinit import version
+from cloudinit.sources.azure import identity
+
+LOG = logging.getLogger(__name__)
+
+
+class ReportableError(Exception):
+    def __init__(
+        self,
+        reason: str,
+        *,
+        supporting_data: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.agent = f"Cloud-Init/{version.version_string()}"
+        self.documentation_url = "https://aka.ms/linuxprovisioningerror"
+        self.reason = reason
+
+        if supporting_data:
+            self.supporting_data = supporting_data
+        else:
+            self.supporting_data = {}
+
+        self.timestamp = datetime.utcnow()
+
+        try:
+            self.vm_id = identity.query_vm_id()
+        except Exception as id_error:
+            self.vm_id = f"failed to read vm id: {id_error!r}"
+
+    def as_description(
+        self, *, delimiter: str = "|", quotechar: str = "'"
+    ) -> str:
+        data = [
+            f"reason={self.reason}",
+            f"agent={self.agent}",
+        ]
+        data += [f"{k}={v}" for k, v in self.supporting_data.items()]
+        data += [
+            f"vm_id={self.vm_id}",
+            f"timestamp={self.timestamp.isoformat()}",
+            f"documentation_url={self.documentation_url}",
+        ]
+
+        with StringIO() as io:
+            csv.writer(
+                io,
+                delimiter=delimiter,
+                quotechar=quotechar,
+                quoting=csv.QUOTE_MINIMAL,
+            ).writerow(data)
+
+            # strip trailing \r\n
+            csv_data = io.getvalue().rstrip()
+
+        return f"PROVISIONING_ERROR: {csv_data}"
+
+    def __eq__(self, other) -> bool:
+        return (
+            isinstance(other, ReportableError)
+            and self.timestamp == other.timestamp
+            and self.reason == other.reason
+            and self.supporting_data == other.supporting_data
+        )
+
+    def __repr__(self) -> str:
+        return self.as_description()
+
+
+class ReportableErrorUnhandledException(ReportableError):
+    def __init__(self, exception: Exception) -> None:
+        super().__init__("unhandled exception")
+
+        trace = "".join(
+            traceback.format_exception(
+                type(exception), exception, exception.__traceback__
+            )
+        )
+        trace_base64 = base64.b64encode(trace.encode("utf-8"))
+
+        self.supporting_data["exception"] = repr(exception)
+        self.supporting_data["traceback_base64"] = trace_base64

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -12,13 +12,16 @@ from contextlib import contextmanager
 from datetime import datetime
 from errno import ENOENT
 from time import sleep, time
-from typing import Callable, List, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, List, Optional, TypeVar, Union
 from xml.etree import ElementTree
 from xml.sax.saxutils import escape
 
 from cloudinit import distros, subp, temp_utils, url_helper, util, version
 from cloudinit.reporting import events
 from cloudinit.settings import CFG_BUILTIN
+
+if TYPE_CHECKING:
+    from cloudinit.sources.azure import errors
 
 LOG = logging.getLogger(__name__)
 
@@ -41,12 +44,6 @@ azure_ds_reporter = events.ReportEventStack(
     name="azure-ds",
     description="initialize reporter for azure ds",
     reporting_enabled=True,
-)
-
-DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE = (
-    "The VM encountered an error during deployment. "
-    "Please visit https://aka.ms/linuxprovisioningerror "
-    "for more information on remediation."
 )
 
 T = TypeVar("T")
@@ -1024,9 +1021,9 @@ def get_metadata_from_fabric(
 
 
 @azure_ds_telemetry_reporter
-def report_failure_to_fabric(endpoint: str):
+def report_failure_to_fabric(endpoint: str, error: "errors.ReportableError"):
     shim = WALinuxAgentShim(endpoint=endpoint)
-    description = DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE
+    description = error.as_description()
     try:
         shim.register_with_azure_and_report_failure(description=description)
     finally:

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -1,0 +1,137 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import base64
+import datetime
+from unittest import mock
+
+import pytest
+
+from cloudinit import version
+from cloudinit.sources.azure import errors
+
+
+@pytest.fixture()
+def agent_string():
+    yield f"agent=Cloud-Init/{version.version_string()}"
+
+
+@pytest.fixture()
+def fake_utcnow():
+    timestamp = datetime.datetime.utcnow()
+    with mock.patch.object(errors, "datetime", autospec=True) as m:
+        m.utcnow.return_value = timestamp
+        yield timestamp
+
+
+@pytest.fixture()
+def fake_vm_id():
+    vm_id = "fake-vm-id"
+    with mock.patch.object(errors.identity, "query_vm_id", autospec=True) as m:
+        m.return_value = vm_id
+        yield vm_id
+
+
+def quote_csv_value(value: str) -> str:
+    """Match quoting behavior, if needed for given string."""
+    if any([x in value for x in ("\n", "\r", "'")]):
+        value = value.replace("'", "''")
+        value = f"'{value}'"
+
+    return value
+
+
+@pytest.mark.parametrize("reason", ["foo", "foo bar", "foo'bar"])
+@pytest.mark.parametrize(
+    "supporting_data",
+    [
+        {},
+        {
+            "foo": "bar",
+        },
+        {
+            "foo": "bar",
+            "count": 4,
+        },
+        {
+            "csvcheck": "",
+        },
+        {
+            "csvcheck": "trailingspace ",
+        },
+        {
+            "csvcheck": "\r\n",
+        },
+        {
+            "csvcheck": "\n",
+        },
+        {
+            "csvcheck": "\t",
+        },
+        {
+            "csvcheck": "x\nx",
+        },
+        {
+            "csvcheck": "x\rx",
+        },
+        {
+            "csvcheck": '"',
+        },
+        {
+            "csvcheck": '""',
+        },
+        {
+            "csvcheck": "'",
+        },
+        {
+            "csvcheck": "''",
+        },
+        {
+            "csvcheck": "xx'xx'xx",
+        },
+        {
+            "csvcheck": ",'|~!@#$%^&*()[]\\{}|;':\",./<>?x\nnew\r\nline",
+        },
+    ],
+)
+def test_reportable_errors(
+    fake_utcnow,
+    fake_vm_id,
+    reason,
+    supporting_data,
+):
+    error = errors.ReportableError(
+        reason=reason,
+        supporting_data=supporting_data,
+    )
+
+    data = [
+        "PROVISIONING_ERROR: " + quote_csv_value(f"reason={reason}"),
+        f"agent=Cloud-Init/{version.version_string()}",
+    ]
+    data += [quote_csv_value(f"{k}={v}") for k, v in supporting_data.items()]
+    data += [
+        f"vm_id={fake_vm_id}",
+        f"timestamp={fake_utcnow.isoformat()}",
+        "documentation_url=https://aka.ms/linuxprovisioningerror",
+    ]
+
+    assert error.as_description() == "|".join(data)
+
+
+def test_unhandled_exception():
+    source_error = None
+    try:
+        raise ValueError("my value error")
+    except Exception as exception:
+        source_error = exception
+
+    error = errors.ReportableErrorUnhandledException(source_error)
+    trace = base64.b64decode(error.supporting_data["traceback_base64"]).decode(
+        "utf-8"
+    )
+
+    quoted_value = quote_csv_value(f"exception={source_error!r}")
+    assert f"|{quoted_value}|" in error.as_description()
+    assert trace.startswith("Traceback")
+    assert "raise ValueError" in trace
+    assert trace.endswith("ValueError: my value error\n")

--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -11,6 +11,7 @@ import pytest
 import requests
 
 from cloudinit import url_helper
+from cloudinit.sources.azure import errors
 from cloudinit.sources.helpers import azure as azure_helper
 from cloudinit.sources.helpers.azure import WALinuxAgentShim as wa_shim
 from cloudinit.util import load_file
@@ -103,15 +104,6 @@ HEALTH_DETAIL_SUBSECTION_XML_TEMPLATE = dedent(
 
 HEALTH_REPORT_DESCRIPTION_TRIM_LEN = 512
 MOCKPATH = "cloudinit.sources.helpers.azure."
-
-
-@pytest.fixture
-def mock_dmi_read_dmi_data():
-    with mock.patch(
-        MOCKPATH + "dmi.read_dmi_data",
-        autospec=True,
-    ) as m:
-        yield m
 
 
 @pytest.fixture
@@ -1358,7 +1350,10 @@ class TestGetMetadataGoalStateXMLAndReportFailureToFabric(CiTestCase):
         )
 
     def test_success_calls_clean_up(self):
-        azure_helper.report_failure_to_fabric(endpoint="test_endpoint")
+        error = errors.ReportableError(reason="test")
+        azure_helper.report_failure_to_fabric(
+            endpoint="test_endpoint", error=error
+        )
         self.assertEqual(1, self.m_shim.return_value.clean_up.call_count)
 
     def test_failure_in_shim_report_failure_propagates_exc_and_calls_clean_up(
@@ -1371,24 +1366,29 @@ class TestGetMetadataGoalStateXMLAndReportFailureToFabric(CiTestCase):
             SentinelException,
             azure_helper.report_failure_to_fabric,
             "test_endpoint",
+            errors.ReportableError(reason="test"),
         )
         self.assertEqual(1, self.m_shim.return_value.clean_up.call_count)
 
     def test_report_failure_to_fabric_calls_shim_report_failure(
         self,
     ):
-        azure_helper.report_failure_to_fabric(endpoint="test_endpoint")
+        error = errors.ReportableError(reason="test")
+
+        azure_helper.report_failure_to_fabric(
+            endpoint="test_endpoint",
+            error=error,
+        )
         # default err message description should be shown to the user
         # if an empty description is passed in
         self.m_shim.return_value.register_with_azure_and_report_failure.assert_called_once_with(  # noqa: E501
-            description=(
-                azure_helper.DEFAULT_REPORT_FAILURE_USER_VISIBLE_MESSAGE
-            )
+            description=error.as_description(),
         )
 
     def test_instantiates_shim_with_kwargs(self):
         azure_helper.report_failure_to_fabric(
             endpoint="test_endpoint",
+            error=errors.ReportableError(reason="test"),
         )
         self.m_shim.assert_called_once_with(
             endpoint="test_endpoint",


### PR DESCRIPTION
When provisioning failures occur an Azure, a generic description is used in the report and ultimately returned to the user.  To improve the user experience, report details of the failure in a manner that is parsable, readable and succinct.  The current approach is to use csv with a custom delimiter ("|") and quote character ("'").  This format may change in the future.

Gracefully handle reportable errors thrown while crawling metadata and treat other exceptions as ReportableErrorUnhandledException.  Future work will introduce more reportable errors to handle the expected failure cases.