### PR TITLE
net: Document use of `ip route append` to add routes

### DIFF
--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -197,6 +197,14 @@ class EphemeralIPv4Network:
             via_arg = []
             if gateway != "0.0.0.0":
                 via_arg = ["via", gateway]
+
+            # Use "append" rather than "add" since the DHCP server may provide
+            # rfc3442 classless static routes with multiple routes to the same
+            # subnet via different routers or local interface addresses.
+            #
+            # In this scenario, `ip r add` fails.
+            #
+            # RHBZ: #2003231
             subp.subp(
                 ["ip", "-4", "route", "append", net_address]
                 + via_arg

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -198,7 +198,7 @@ class EphemeralIPv4Network:
             if gateway != "0.0.0.0":
                 via_arg = ["via", gateway]
             subp.subp(
-                ["ip", "-4", "route", "append", net_address]
+                ["ip", "-4", "route", "add", net_address]
                 + via_arg
                 + ["dev", self.interface],
                 capture=True,

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -198,7 +198,7 @@ class EphemeralIPv4Network:
             if gateway != "0.0.0.0":
                 via_arg = ["via", gateway]
             subp.subp(
-                ["ip", "-4", "route", "add", net_address]
+                ["ip", "-4", "route", "append", net_address]
                 + via_arg
                 + ["dev", self.interface],
                 capture=True,

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -864,7 +864,7 @@ class TestEphemeralIPV4Network(CiTestCase):
         """
 
         def side_effect(args, **kwargs):
-            if args[3] == "append" and args[4] == "3.3.3.3/32":
+            if args[3] == "add" and args[4] == "3.3.3.3/32":
                 raise subp.ProcessExecutionError("oh no!")
 
         m_subp.side_effect = side_effect
@@ -1167,7 +1167,7 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "ip",
                     "-4",
                     "route",
-                    "append",
+                    "add",
                     "192.168.2.1/32",
                     "dev",
                     "eth0",
@@ -1179,7 +1179,7 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "ip",
                     "-4",
                     "route",
-                    "append",
+                    "add",
                     "169.254.169.254/32",
                     "via",
                     "192.168.2.1",
@@ -1193,7 +1193,7 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "ip",
                     "-4",
                     "route",
-                    "append",
+                    "add",
                     "0.0.0.0/0",
                     "via",
                     "192.168.2.1",

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -864,7 +864,7 @@ class TestEphemeralIPV4Network(CiTestCase):
         """
 
         def side_effect(args, **kwargs):
-            if args[3] == "add" and args[4] == "3.3.3.3/32":
+            if args[3] == "append" and args[4] == "3.3.3.3/32":
                 raise subp.ProcessExecutionError("oh no!")
 
         m_subp.side_effect = side_effect
@@ -1167,7 +1167,7 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "ip",
                     "-4",
                     "route",
-                    "add",
+                    "append",
                     "192.168.2.1/32",
                     "dev",
                     "eth0",
@@ -1179,7 +1179,7 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "ip",
                     "-4",
                     "route",
-                    "add",
+                    "append",
                     "169.254.169.254/32",
                     "via",
                     "192.168.2.1",
@@ -1193,7 +1193,7 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "ip",
                     "-4",
                     "route",
-                    "add",
+                    "append",
                     "0.0.0.0/0",
                     "via",
                     "192.168.2.1",


### PR DESCRIPTION
```
net: Document use of `ip route append` to add routes
```

**Update**
I am changing this PR to document the reason that the current code is needed for better context. 