### PR TITLE
azure/errors: treat traceback_base64 as string

### DIFF
--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -87,7 +87,7 @@ class ReportableErrorUnhandledException(ReportableError):
                 type(exception), exception, exception.__traceback__
             )
         )
-        trace_base64 = base64.b64encode(trace.encode("utf-8"))
+        trace_base64 = base64.b64encode(trace.encode("utf-8")).decode("utf-8")
 
         self.supporting_data["exception"] = repr(exception)
         self.supporting_data["traceback_base64"] = trace_base64

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -126,12 +126,14 @@ def test_unhandled_exception():
         source_error = exception
 
     error = errors.ReportableErrorUnhandledException(source_error)
-    trace = base64.b64decode(error.supporting_data["traceback_base64"]).decode(
-        "utf-8"
-    )
 
-    quoted_value = quote_csv_value(f"exception={source_error!r}")
-    assert f"|{quoted_value}|" in error.as_description()
+    traceback_base64 = error.supporting_data["traceback_base64"]
+    assert isinstance(traceback_base64, str)
+
+    trace = base64.b64decode(traceback_base64).decode("utf-8")
     assert trace.startswith("Traceback")
     assert "raise ValueError" in trace
     assert trace.endswith("ValueError: my value error\n")
+
+    quoted_value = quote_csv_value(f"exception={source_error!r}")
+    assert f"|{quoted_value}|" in error.as_description()


### PR DESCRIPTION
Save a few characters by decoding it as utf-8 string rather than using the bytes representation.