### PR TITLE
Update kernel commandline docs (SC-1457)

### DIFF
--- a/doc/rtd/development/datasource_creation.rst
+++ b/doc/rtd/development/datasource_creation.rst
@@ -3,7 +3,7 @@
 Datasource creation
 *******************
 
-There are multiple ways to provide `user data`, `meta data`, and
+There are multiple ways to provide `user data`, `metadata`, and
 `vendor data`, and each cloud solution prefers its own way. A datasource
 abstract class was internally created to allow for a single way to access the
 different cloud systems methods, providing this data through the typical usage

--- a/doc/rtd/development/datasource_creation.rst
+++ b/doc/rtd/development/datasource_creation.rst
@@ -1,0 +1,89 @@
+.. _datasource_creation:
+
+Datasource creation
+*******************
+
+Since there are multiple ways to provide `user data`, `meta data`, and
+`vendor data` (each cloud solution seems to prefer its own way), a datasource
+abstract class was internally created to allow for a single way to access the
+different cloud systems methods, providing this data through the typical usage
+of subclasses. See :file:`cloud-init/sources/__init__.py` as a starting
+point for understanding the datastructures used.
+
+The datasource objects have a few touch points with ``cloud-init``. If you
+are interested in adding a new datasource for your cloud platform you will
+need to take care of the following items:
+
+Identify a mechanism for positive identification of the platform
+================================================================
+
+It is good practice for a cloud platform to positively identify itself to
+the guest. This allows the guest to make educated decisions based on the
+platform on which it is running. On the x86 and arm64 architectures, many
+clouds identify themselves through DMI data. For example, Oracle's public
+cloud provides the string ``'OracleCloud.com'`` in the DMI chassis-asset
+field.
+
+``Cloud-init``-enabled images produce a log file with details about the
+platform. Reading through this log in :file:`/run/cloud-init/ds-identify.log`
+may provide the information needed to uniquely identify the platform.
+If the log is not present, you can generate it by running from source
+:file:`./tools/ds-identify` or the installed location
+:file:`/usr/lib/cloud-init/ds-identify`.
+
+The mechanism used to identify the platform will be required for the
+``ds-identify`` and datasource module sections below.
+
+Add datasource module cloudinit/sources/DataSource<CloudPlatform>.py
+====================================================================
+
+It is suggested that you start by copying one of the simpler datasources
+such as ``DataSourceHetzner``.
+
+Add tests for datasource module
+===============================
+
+Add a new file with some tests for the module to
+:file:`cloudinit/sources/test_<yourplatform>.py`. For example, see
+:file:`cloudinit/sources/tests/test_oracle.py`
+
+Update ``ds-identify``
+======================
+
+In ``systemd`` systems, ``ds-identify`` is used to detect which datasource
+should be enabled, or if ``cloud-init`` should run at all. You'll need to
+make changes to :file:`tools/ds-identify`.
+
+Add tests for ``ds-identify``
+=============================
+
+Add relevant tests in a new class to
+:file:`tests/unittests/test_ds_identify.py`. You can use ``TestOracle`` as
+an example.
+
+Add your datasource name to the built-in list of datasources
+============================================================
+
+Add your datasource module name to the end of the ``datasource_list``
+entry in :file:`cloudinit/settings.py`.
+
+Add your cloud platform to apport collection prompts
+====================================================
+
+Update the list of cloud platforms in :file:`cloudinit/apport.py`. This list
+will be provided to the user who invokes :command:`ubuntu-bug cloud-init`.
+
+Enable datasource by default in Ubuntu packaging branches
+=========================================================
+
+Ubuntu packaging branches contain a template file,
+:file:`debian/cloud-init.templates`, which ultimately sets the default
+``datasource_list`` when installed via package. This file needs updating when
+the commit gets into a package.
+
+Add documentation for your datasource
+=====================================
+
+You should add a new file in :file:`doc/datasources/<cloudplatform>.rst`.
+
+.. _make-mime: https://cloudinit.readthedocs.io/en/latest/explanation/instancedata.html#storage-locations

--- a/doc/rtd/development/datasource_creation.rst
+++ b/doc/rtd/development/datasource_creation.rst
@@ -37,7 +37,7 @@ The mechanism used to identify the platform will be required for the
 Add datasource module cloudinit/sources/DataSource<CloudPlatform>.py
 ====================================================================
 
-It is suggested that you start by copying one of the simpler datasources
+We suggest you start by copying one of the simpler datasources
 such as ``DataSourceHetzner``.
 
 Add tests for datasource module

--- a/doc/rtd/development/datasource_creation.rst
+++ b/doc/rtd/development/datasource_creation.rst
@@ -5,14 +5,13 @@ Datasource creation
 
 There are multiple ways to provide `user data`, `metadata`, and
 `vendor data`, and each cloud solution prefers its own way. A datasource
-abstract class was internally created to allow for a single way to access the
-different cloud systems methods, providing this data through the typical usage
-of subclasses. See :file:`cloud-init/sources/__init__.py` as a starting
-point for understanding the datastructures used.
+abstract base class defines a single interface to interact with the different
+clouds. Each cloud implementation must inherit from this base class to use this
+shared functionality and interface. See :file:`cloud-init/sources/__init__.py`
+to see this class.
 
-The datasource objects have a few touch points with ``cloud-init``. If you
-are interested in adding a new datasource for your cloud platform you will
-need to take care of the following items:
+If you are interested in adding a new datasource for your cloud platform you
+will need to do all of the following:
 
 Identify a mechanism for positive identification of the platform
 ================================================================
@@ -20,7 +19,7 @@ Identify a mechanism for positive identification of the platform
 It is good practice for a cloud platform to positively identify itself to
 the guest. This allows the guest to make educated decisions based on the
 platform on which it is running. On the x86 and arm64 architectures, many
-clouds identify themselves through DMI data. For example, Oracle's public
+clouds identify themselves through `DMI`_ data. For example, Oracle's public
 cloud provides the string ``'OracleCloud.com'`` in the DMI chassis-asset
 field.
 
@@ -87,3 +86,4 @@ Add documentation for your datasource
 You should add a new file in :file:`doc/datasources/<cloudplatform>.rst`.
 
 .. _make-mime: https://cloudinit.readthedocs.io/en/latest/explanation/instancedata.html#storage-locations
+.. _DMI: https://www.dmtf.org/sites/default/files/standards/documents/DSP0005.pdf

--- a/doc/rtd/development/datasource_creation.rst
+++ b/doc/rtd/development/datasource_creation.rst
@@ -4,7 +4,7 @@ Datasource creation
 *******************
 
 Since there are multiple ways to provide `user data`, `meta data`, and
-`vendor data` (each cloud solution seems to prefer its own way), a datasource
+`vendor data`, and each cloud solution prefers its own way. A datasource
 abstract class was internally created to allow for a single way to access the
 different cloud systems methods, providing this data through the typical usage
 of subclasses. See :file:`cloud-init/sources/__init__.py` as a starting

--- a/doc/rtd/development/datasource_creation.rst
+++ b/doc/rtd/development/datasource_creation.rst
@@ -3,7 +3,7 @@
 Datasource creation
 *******************
 
-Since there are multiple ways to provide `user data`, `meta data`, and
+There are multiple ways to provide `user data`, `meta data`, and
 `vendor data`, and each cloud solution prefers its own way. A datasource
 abstract class was internally created to allow for a single way to access the
 different cloud systems methods, providing this data through the typical usage

--- a/doc/rtd/development/index.rst
+++ b/doc/rtd/development/index.rst
@@ -16,6 +16,7 @@ Contributing
 
    contributing.rst
    module_creation.rst
+   datasource_creation.rst
    code_review.rst
    dir_layout.rst
 

--- a/doc/rtd/explanation/boot.rst
+++ b/doc/rtd/explanation/boot.rst
@@ -17,7 +17,7 @@ stages to boot:
 
 Generator
 =========
-When booting under systemd, a generator will run that determines if
+When booting under ``systemd``, a generator will run that determines if
 cloud-init.target should be included in the boot goals. ``ds-identify``
 runs at this stage.
 

--- a/doc/rtd/explanation/boot.rst
+++ b/doc/rtd/explanation/boot.rst
@@ -7,36 +7,11 @@ To be able to provide the functionality that it does, ``cloud-init`` must be
 integrated into the boot in a fairly controlled way. There are five
 stages to boot:
 
-1. Generator
-2. Local
-3. Network
-4. Config
-5. Final
+1. Local
+2. Network
+3. Config
+4. Final
 
-.. _boot-Generator:
-
-Generator
-=========
-
-# TODO: This entire stage is really just an implementation detail of systemd
-# systems - as long as we document how to disable cloud-init somewhere else
-# I think we can probably remove this information - unless we think it is
-# somehow actionable for the average user?
-
-When booting under ``systemd``, a `generator`_ will run that determines if
-``cloud-init.target`` should be included in the boot goals. By default, this
-generator will enable ``cloud-init``. It will not enable ``cloud-init``
-if either:
-
-- The file :file:`/etc/cloud/cloud-init.disabled` exists, or
-- The kernel command line as found in :file:`/proc/cmdline` contains
-  ``cloud-init=disabled``. When running in a container, the kernel command
-  line is not honored, but ``cloud-init`` will read an environment
-  variable named ``KERNEL_CMDLINE`` in its place.
-
-.. note::
-   These mechanisms for disabling ``cloud-init`` at runtime currently only
-   exist in ``systemd``.
 
 .. _boot-Local:
 

--- a/doc/rtd/explanation/boot.rst
+++ b/doc/rtd/explanation/boot.rst
@@ -18,6 +18,11 @@ stages to boot:
 Generator
 =========
 
+# TODO: This entire stage is really just an implementation detail of systemd
+# systems - as long as we document how to disable cloud-init somewhere else
+# I think we can probably remove this information - unless we think it is
+# somehow actionable for the average user?
+
 When booting under ``systemd``, a `generator`_ will run that determines if
 ``cloud-init.target`` should be included in the boot goals. By default, this
 generator will enable ``cloud-init``. It will not enable ``cloud-init``

--- a/doc/rtd/explanation/boot.rst
+++ b/doc/rtd/explanation/boot.rst
@@ -7,11 +7,19 @@ To be able to provide the functionality that it does, ``cloud-init`` must be
 integrated into the boot in a fairly controlled way. There are five
 stages to boot:
 
-1. Local
-2. Network
-3. Config
-4. Final
+1. Generator
+2. Local
+3. Network
+4. Config
+5. Final
 
+.. _boot-Generator:
+
+Generator
+=========
+When booting under systemd, a generator will run that determines if
+cloud-init.target should be included in the boot goals. ``ds-identify``
+runs at this stage.
 
 .. _boot-Local:
 

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -6,6 +6,8 @@ User data formats
 User data that will be acted upon by ``cloud-init`` must be in one of the
 following types.
 
+.. _user_data_cloud_config:
+
 Cloud config data
 =================
 

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -6,7 +6,7 @@ User data formats
 User data that will be acted upon by ``cloud-init`` must be in one of the
 following types.
 
-.. _user_data_cloud_config:
+.. _user_data_formats-cloud_config:
 
 Cloud config data
 =================

--- a/doc/rtd/explanation/index.rst
+++ b/doc/rtd/explanation/index.rst
@@ -18,3 +18,4 @@ knowledge and become better at using and configuring ``cloud-init``.
    vendordata.rst
    security.rst
    analyze.rst
+   kernel-cmdline.rst

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -36,8 +36,8 @@ Then, when the datasource runs, it will find that config already available.
 # TODO: document cloud-init=disabled (also, does this work on non-systemd)
 
 
-# TODO: Since cloud-config-url in the commandline tells ds-identify that this
-# is MASS, this belongs in MAAS-specific documentation
+# TODO: make this not-maas-specific example
+# TODO: add a test for this behavior
 So, to be able to configure the MAAS datasource by controlling the
 kernel command line from outside the image, you can append:
 

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -9,12 +9,12 @@ resort, since this method supports only a subset of the
 do not support injecting kernel commandline arguments without modifying
 the bootloader.
 
-Despite the limitations of using the kernel commandline, cloud-init supports
+Despite the limitations of using the kernel command line, cloud-init supports
 some use-cases.
 
-Note that this page describes kernel commandline behavior that applies
+Note that this page describes kernel command line behavior that applies
 to all clouds. To provide a local configuration with an image using kernel
-commandline, see :ref:`datasource NoCloud<datasource_nocloud>` which provides
+command line, see :ref:`datasource NoCloud<datasource_nocloud>` which provides
 more configuration options.
 
 .. _kernel_datasource_override:

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -5,9 +5,9 @@ Kernel command line
 
 Providing configuration data via the kernel command line is somewhat of a last
 resort, since this method supports only a subset of the
-:ref:`cloud config<user_data_formats-cloud_config>` format, and many datasources
-do not support injecting kernel commandline arguments without modifying
-the bootloader.
+:ref:`cloud config<user_data_formats-cloud_config>` format, and many
+datasources do not support injecting kernel commandline arguments without
+modifying the bootloader.
 
 Despite the limitations of using the kernel command line, cloud-init supports
 some use-cases.
@@ -88,8 +88,8 @@ Then, have the following content at that url:
 .. note::
 
    Since ``cloud-config-url=`` is so generic, in order to avoid false
-   positives, only :ref:`cloud config<user_data_cloud_config>` user data
-   starting with ``#cloud-config`` is supported.
+   positives, only :ref:`cloud config<user_data_formats-cloud_config>` user
+   data starting with ``#cloud-config`` is supported.
 
 
 .. note::

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -32,6 +32,8 @@ If that file exists already, it will not be overwritten, and the
 
 Then, when the datasource runs, it will find that config already available.
 
+# TODO say something about datasource detection override
+
 So, to be able to configure the MAAS datasource by controlling the
 kernel command line from outside the image, you can append:
 
@@ -61,6 +63,7 @@ Then, have the following content at that url:
    Since ``cloud-config-url=`` is so generic, in order to avoid false
    positives, ``cloud-init`` requires the content to start with
    ``#cloud-config`` for it to be considered.
+
 
 .. note::
 

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -32,7 +32,8 @@ If that file exists already, it will not be overwritten, and the
 
 Then, when the datasource runs, it will find that config already available.
 
-# TODO say something about datasource detection override
+# TODO: say something about datasource detection override
+# TODO: document cloud-init=disabled (also, does this work on non-systemd)
 
 So, to be able to configure the MAAS datasource by controlling the
 kernel command line from outside the image, you can append:

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -35,6 +35,9 @@ Then, when the datasource runs, it will find that config already available.
 # TODO: say something about datasource detection override
 # TODO: document cloud-init=disabled (also, does this work on non-systemd)
 
+
+# TODO: Since cloud-config-url in the commandline tells ds-identify that this
+# is MASS, this belongs in MAAS-specific documentation
 So, to be able to configure the MAAS datasource by controlling the
 kernel command line from outside the image, you can append:
 

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -90,6 +90,6 @@ Then, have the following content at that url:
 
 .. note::
 
-   The ``cloud-config-url=`` is un-authed http GET, and may contain
+   The ``cloud-config-url=`` is unencrypted http GET, and may contain
    credentials. Care must be taken to ensure this data is only
-   transferred via trusted channels.
+   transferred via trusted channels (i.e., within a closed system).

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -4,7 +4,7 @@ Kernel command line
 *******************
 
 In order to allow an ephemeral, or otherwise pristine image to receive some
-configuration, ``cloud-init`` will read a URL directed by the kernel command
+configuration, ``cloud-init`` can read a URL directed by the kernel command
 line and proceed as if its data had previously existed.
 
 This allows for configuring a metadata service, or some other data.
@@ -14,9 +14,9 @@ This allows for configuring a metadata service, or some other data.
    as it requires knowing in advance the correct command line or modifying
    the boot loader to append data.
 
-For example, when :command:`cloud-init init --local` runs, it will check to
-see if ``cloud-config-url`` appears in key/value fashion in the kernel command
-line, as in:
+When :ref:`the local stage<boot-Local>` runs, it will check to see if
+``cloud-config-url`` appears in key/value fashion in the kernel command line,
+such as:
 
 .. code-block:: text
 
@@ -27,19 +27,16 @@ starts with ``#cloud-config``, it will store that data to the local filesystem
 in a static filename :file:`/etc/cloud/cloud.cfg.d/91_kernel_cmdline_url.cfg`,
 and consider it as part of the config from that point forward.
 
-If that file exists already, it will not be overwritten, and the
-``cloud-config-url`` parameter is completely ignored.
+.. note::
+   If :file:`/etc/cloud/cloud.cfg.d/91_kernel_cmdline_url.cfg` already exists,
+   cloud-init will not overwrite the file, and the ``cloud-config-url``
+   parameter is completely ignored.
 
-Then, when the datasource runs, it will find that config already available.
 
 # TODO: say something about datasource detection override
-# TODO: document cloud-init=disabled (also, does this work on non-systemd)
 
-
-# TODO: make this not-maas-specific example
-# TODO: add a test for this behavior
-So, to be able to configure the MAAS datasource by controlling the
-kernel command line from outside the image, you can append:
+This is useful, for example, to be able to configure the MAAS datasource by
+controlling the kernel command line from outside the image, you can append:
 
 .. code-block:: text
 
@@ -71,4 +68,6 @@ Then, have the following content at that url:
 
 .. note::
 
-   The ``cloud-config-url=`` is un-authed http GET, and contains credentials.
+   The ``cloud-config-url=`` is un-authed http GET, and may contain
+   credentials. Care must be taken to ensure this data is only
+   transferred via trusted channels.

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -5,7 +5,7 @@ Kernel command line
 
 Providing configuration data via the kernel command line is somewhat of a last
 resort, since this method supports only a subset of the
-:ref:`cloud config<user_data_cloud_config>` format, and many datasources
+:ref:`cloud config<user_data_formats-cloud_config>` format, and many datasources
 do not support injecting kernel commandline arguments without modifying
 the bootloader.
 

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -69,5 +69,3 @@ Then, have the following content at that url:
 .. note::
 
    The ``cloud-config-url=`` is un-authed http GET, and contains credentials.
-   It could be set up to be randomly generated and also to check the source
-   address in order to be more secure.

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -4,9 +4,13 @@ Kernel command line
 *******************
 
 Providing configuration data via the kernel command line is somewhat of a last
-resort, as it often requires modifying the boot loader to work. Despite the
-limitations of using the kernel commandline, cloud-init supports some
-use-cases.
+resort, since this method supports only a subset of the
+:ref:`cloud config<user_data_cloud_config>` format, and many datasources
+do not support injecting kernel commandline arguments without modifying
+the bootloader.
+
+Despite the limitations of using the kernel commandline, cloud-init supports
+some use-cases.
 
 Note that this page describes kernel commandline behavior that applies
 to all clouds. To provide a local configuration with an image using kernel
@@ -84,8 +88,8 @@ Then, have the following content at that url:
 .. note::
 
    Since ``cloud-config-url=`` is so generic, in order to avoid false
-   positives, ``cloud-init`` requires the content to start with
-   ``#cloud-config`` for it to be considered.
+   positives, only :ref:`cloud config<user_data_cloud_config>` user data
+   starting with ``#cloud-config`` is supported.
 
 
 .. note::

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -4,10 +4,10 @@ Kernel command line
 *******************
 
 Providing configuration data via the kernel command line is somewhat of a last
-resort, since this method supports only a subset of the
-:ref:`cloud config<user_data_formats-cloud_config>` format, and many
-datasources do not support injecting kernel commandline arguments without
-modifying the bootloader.
+resort, since this method only supports
+:ref:`cloud config<user_data_formats-cloud_config>` starting with
+`#cloud-config`, and many datasources do not support injecting kernel
+command line arguments without modifying the bootloader.
 
 Despite the limitations of using the kernel command line, cloud-init supports
 some use-cases.
@@ -38,9 +38,6 @@ configuration, ``cloud-init`` can read a URL directed by the kernel command
 line and proceed as if its data had previously existed.
 
 This allows for configuring a metadata service, or some other data.
-
-This method is different from the standard way that most datasources receive
-configuration.
 
 When :ref:`the local stage<boot-Local>` runs, it will check to see if
 ``cloud-config-url`` appears in key/value fashion in the kernel command line,

--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -3,16 +3,40 @@
 Kernel command line
 *******************
 
+Providing configuration data via the kernel command line is somewhat of a last
+resort, as it often requires modifying the boot loader to work. Despite the
+limitations of using the kernel commandline, cloud-init supports some
+use-cases.
+
+Note that this page describes kernel commandline behavior that applies
+to all clouds. To provide a local configuration with an image using kernel
+commandline, see :ref:`datasource NoCloud<datasource_nocloud>` which provides
+more configuration options.
+
+.. _kernel_datasource_override:
+
+Datasource discovery override
+=============================
+
+During boot, cloud-init must identify which datasource it is running on
+(OpenStack, AWS, Azure, GCP, etc). This discovery step can be optionally
+overriden by specifying the datasource name, such as:
+
+.. code-block:: text
+
+   root=/dev/sda ro ds=openstack
+
+Kernel cloud-config-url configuration
+=====================================
+
 In order to allow an ephemeral, or otherwise pristine image to receive some
 configuration, ``cloud-init`` can read a URL directed by the kernel command
 line and proceed as if its data had previously existed.
 
 This allows for configuring a metadata service, or some other data.
 
-.. note::
-   Usage of the kernel command line is somewhat of a last resort,
-   as it requires knowing in advance the correct command line or modifying
-   the boot loader to append data.
+This method is different from the standard way that most datasources receive
+configuration.
 
 When :ref:`the local stage<boot-Local>` runs, it will check to see if
 ``cloud-config-url`` appears in key/value fashion in the kernel command line,
@@ -32,8 +56,6 @@ and consider it as part of the config from that point forward.
    cloud-init will not overwrite the file, and the ``cloud-config-url``
    parameter is completely ignored.
 
-
-# TODO: say something about datasource detection override
 
 This is useful, for example, to be able to configure the MAAS datasource by
 controlling the kernel command line from outside the image, you can append:

--- a/doc/rtd/howto/disable_cloud_init.rst
+++ b/doc/rtd/howto/disable_cloud_init.rst
@@ -1,7 +1,10 @@
 .. _disable-Cloud_init:
 
-Disable cloud-init
-******************
+How to disable cloud-init
+*************************
+
+One may wish to disable cloud-init to ensure that it doesn't do anything on
+subsequent boots. Some parts of cloud-init may run once per boot otherwise.
 
 There are two cross-platform methods of disabling ``cloud-init``.
 

--- a/doc/rtd/howto/disable_cloud_init.rst
+++ b/doc/rtd/howto/disable_cloud_init.rst
@@ -7,6 +7,7 @@ There are two cross-platform methods of disabling ``cloud-init``.
 
 Method 1: text file
 ====================
+
 To disable cloud-init, create the empty file
 :file:`/etc/cloud/cloud-init.disabled`. During boot the operating system's init
 system will check for the existence of this file. If it exists, cloud-init will

--- a/doc/rtd/howto/disable_cloud_init.rst
+++ b/doc/rtd/howto/disable_cloud_init.rst
@@ -1,0 +1,34 @@
+.. _disable-Cloud_init:
+
+Disable cloud-init
+******************
+
+There are two cross-platform methods of disabling ``cloud-init``.
+
+Method 1: text file
+====================
+To disable cloud-init, create the empty file
+:file:`/etc/cloud/cloud-init.disabled`. During boot the operating system's init
+system will check for the existence of this file. If it exists, cloud-init will
+not be started.
+
+Example:
+
+.. code-block::
+
+    $ touch /etc/cloud/cloud-init.disabled
+
+Method 2: kernel commandline
+============================
+To disable cloud-init, add ``cloud-init=disabled`` to the kernel commandline.
+
+Example (using GRUB2 with Ubuntu):
+
+.. code-block::
+
+    $ echo 'GRUB_CMDLINE_LINUX=cloud-init.disabled' >> /etc/default/grub
+    $ grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg
+
+.. note::
+   When running in containers, ``cloud-init`` will read an environment
+   variable named ``KERNEL_CMDLINE`` in place of a kernel commandline.

--- a/doc/rtd/howto/disable_cloud_init.rst
+++ b/doc/rtd/howto/disable_cloud_init.rst
@@ -21,6 +21,7 @@ Example:
 
 Method 2: kernel commandline
 ============================
+
 To disable cloud-init, add ``cloud-init=disabled`` to the kernel commandline.
 
 Example (using GRUB2 with Ubuntu):

--- a/doc/rtd/howto/index.rst
+++ b/doc/rtd/howto/index.rst
@@ -20,4 +20,5 @@ How do I...?
 
    Test cloud-init locally before deploying <predeploy_testing.rst>
    Change how often a module runs <module_run_frequency.rst>
+   Disable cloud-init <disable_cloud_init.rst>
    Report a bug <bugs.rst>

--- a/doc/rtd/reference/base_config_reference.rst
+++ b/doc/rtd/reference/base_config_reference.rst
@@ -215,6 +215,8 @@ instance.
 Prioritised list of python packages to search when finding a datasource.
 Automatically includes ``cloudinit.sources``.
 
+.. _base_config_datasource_list:
+
 ``datasource_list``
 ^^^^^^^^^^^^^^^^^^^
 

--- a/doc/rtd/reference/base_config_reference.rst
+++ b/doc/rtd/reference/base_config_reference.rst
@@ -229,8 +229,8 @@ are two primary use cases for modifying the ``datasource_list``:
    type than would typically be prioritised.
 
 If ``datasource_list`` has only a single entry (or a single entry + ``None``),
-:ref:`cloud-init's generator script<boot-Generator>` will automatically assume
-and use this datasource without attempting detection.
+`cloud-init` will automatically assume and use this datasource without
+attempting detection.
 
 ``vendor_data``/``vendor_data2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/rtd/reference/datasource_dsname_map.rst
+++ b/doc/rtd/reference/datasource_dsname_map.rst
@@ -3,10 +3,11 @@
 Datasource dsname
 *****************
 
-Each datasource has an attribute called ``dsname``, which may be used in the
+Each datasource has an attribute called dsname. This may be used in the
 kernel commandline to
-:ref:`override datasource detection<kernel_datasource_override>` using a
-case-insensitive match with the following mapping:
+:ref:`override datasource detection<kernel_datasource_override>`. The
+``dsname`` on the kernel command line may be a case-insensitive match. See the
+mapping between datasource module names and ``dsname`` in the table below.
 
 
 ..
@@ -17,9 +18,8 @@ case-insensitive match with the following mapping:
        | awk -F '[/:"]' '{print $3 ", " $5}'
 
 
-.. csv-table::
+.. csv-table:: Datasource module -> dsname
    :align: left
-   :header: "Datasource", "dsname"
 
     DataSourceRbxCloud.py, RbxCloud
     DataSourceConfigDrive.py, ConfigDrive

--- a/doc/rtd/reference/datasource_dsname_map.rst
+++ b/doc/rtd/reference/datasource_dsname_map.rst
@@ -1,0 +1,51 @@
+.. _datasource_dsname:
+
+Datasource dsname
+*****************
+
+Each datasource has an attribute called ``dsname``, which may be used in the
+kernel commandline to
+:ref:`override datasource detection<kernel_datasource_override>` using a
+case-insensitive match with the following mapping:
+
+
+..
+    generate the following map with the following one-liner:
+
+    find cloudinit/sources -name 'DataSource*.py' \
+       | xargs grep 'dsname =' \
+       | awk -F '[/:"]' '{print $3 ", " $5}'
+
+
+.. csv-table::
+   :align: left
+   :header: "Datasource", "dsname"
+
+    DataSourceRbxCloud.py, RbxCloud
+    DataSourceConfigDrive.py, ConfigDrive
+    DataSourceNoCloud.py, NoCloud
+    DataSourceVultr.py, Vultr
+    DataSourceEc2.py, Ec2
+    DataSourceOracle.py, Oracle
+    DataSourceMAAS.py, MAAS
+    DataSourceDigitalOcean.py, DigitalOcean
+    DataSourceNone.py, None
+    DataSourceSmartOS.py, Joyent
+    DataSourceHetzner.py, Hetzner
+    DataSourceLXD.py, LXD
+    DataSourceOpenNebula.py, OpenNebula
+    DataSourceAzure.py, Azure
+    DataSourceGCE.py, GCE
+    DataSourceScaleway.py, Scaleway
+    DataSourceAltCloud.py, AltCloud
+    DataSourceCloudSigma.py, CloudSigma
+    DataSourceBigstep.py, Bigstep
+    DataSourceIBMCloud.py, IBMCloud
+    DataSourceOVF.py, OVF
+    DataSourceUpCloud.py, UpCloud
+    DataSourceOpenStack.py, OpenStack
+    DataSourceVMware.py, VMware
+    DataSourceCloudStack.py, CloudStack
+    DataSourceExoscale.py, Exoscale
+    DataSourceAliYun.py, AliYun
+    DataSourceNWCS.py, NWCS

--- a/doc/rtd/reference/datasource_dsname_map.rst
+++ b/doc/rtd/reference/datasource_dsname_map.rst
@@ -14,13 +14,15 @@ mapping between datasource module names and ``dsname`` in the table below.
     generate the following map with the following one-liner:
 
     find cloudinit/sources -name 'DataSource*.py' \
-       | xargs grep 'dsname =' \
-       | awk -F '[/:"]' '{print $3 ", " $5}'
+    |  xargs grep 'dsname =' \
+    | awk -F '[/:"]' 'BEGIN { print "**Datasource Module**, **dsname**" }\
+      {print $3 ", " $5}'
 
 
-.. csv-table:: Datasource module -> dsname
+.. csv-table::
    :align: left
 
+    **Datasource Module**, **dsname**
     DataSourceRbxCloud.py, RbxCloud
     DataSourceConfigDrive.py, ConfigDrive
     DataSourceNoCloud.py, NoCloud

--- a/doc/rtd/reference/datasources.rst
+++ b/doc/rtd/reference/datasources.rst
@@ -3,25 +3,35 @@
 Datasources
 ***********
 
-# todo fix links
-Datasources are sources of configuration data for ``cloud-init``. This data
-comes in the form of `user data`, `meta data`, and `vendor data`, which are
-combined together into a single configuration.
+Datasources are sources of configuration data for ``cloud-init`` that typically
+come from the user (i.e., user data) or come from the cloud that created the
+configuration drive (i.e., metadata). Typical user data includes files,
+YAML, and shell scripts whereas typical metadata includes server name,
+instance id, display name, and other cloud specific details.
 
-To view this data, run ``sudo cloud-init query -a`` or check one of the files
-that at instancedata-Using_
+Any metadata processed by ``cloud-init``'s datasources is persisted as
+:file:`/run/cloud-init/instance-data.json`. ``Cloud-init`` provides tooling to
+quickly introspect some of that data. See :ref:`instance_metadata` for more
+information.
 
-TODO: the following belongs in dev docs
+How to configure which datasource to use
+========================================
 
-Since there are multiple ways to provide this data (each cloud solution seems
-to prefer its own way), a datasource abstract class was internally created to
-allow for a single way to access the different cloud systems methods, providing
-this data through the typical usage of subclasses.
+By default ``cloud-init`` should automatically determine which datasource it is
+running on. Therefore, in most cases, users of ``cloud-init`` should not
+have to configure ``cloud-init`` to specify which datasource cloud-init is
+running on; ``cloud-init`` should "figure it out".
 
-Source
-======
+There are exceptions, however, when the :ref:`datasource does not
+identify<datasource_ironic>` itself to ``cloud-init``.
 
-The following is a list of documents for each supported datasource:
+- mention datasource_list in /etc/cloud/cloud.cfg.d/
+- mention kernel commandline (include a map of datasource <-> dsname)
+
+Datasources:
+============
+
+The following is a list of documentation for each supported datasource:
 
 .. toctree::
    :titlesonly:
@@ -53,94 +63,3 @@ The following is a list of documents for each supported datasource:
    datasources/vultr.rst
    datasources/zstack.rst
 
-How to configure datasource
-===========================
-- mention that by default cloud-init should automatically determine which datasource it is running on
-- however, in some cases, the datasource does not identify itself to cloud-init
-- mention datasource_list in /etc/cloud/cloud.cfg.d/
-- mention kernel commandline (include a map of datasource <-> dsname)
-
-
-# TODO: everything below this line belongs in a dev doc
-
-Datasource creation
-===================
-
-The datasource objects have a few touch points with ``cloud-init``. If you
-are interested in adding a new datasource for your cloud platform you will
-need to take care of the following items:
-
-Identify a mechanism for positive identification of the platform
-----------------------------------------------------------------
-
-It is good practice for a cloud platform to positively identify itself to
-the guest. This allows the guest to make educated decisions based on the
-platform on which it is running. On the x86 and arm64 architectures, many
-clouds identify themselves through DMI data. For example, Oracle's public
-cloud provides the string ``'OracleCloud.com'`` in the DMI chassis-asset
-field.
-
-``Cloud-init``-enabled images produce a log file with details about the
-platform. Reading through this log in :file:`/run/cloud-init/ds-identify.log`
-may provide the information needed to uniquely identify the platform.
-If the log is not present, you can generate it by running from source
-:file:`./tools/ds-identify` or the installed location
-:file:`/usr/lib/cloud-init/ds-identify`.
-
-The mechanism used to identify the platform will be required for the
-``ds-identify`` and datasource module sections below.
-
-# Todo: the following line is broken in upstream docs, lets fix it now
-Add datasource module :file:`cloudinit/sources/DataSource<CloudPlatform>.py`
-----------------------------------------------------------------------------
-
-It is suggested that you start by copying one of the simpler datasources
-such as ``DataSourceHetzner``.
-
-Add tests for datasource module
--------------------------------
-
-Add a new file with some tests for the module to
-:file:`cloudinit/sources/test_<yourplatform>.py`. For example, see
-:file:`cloudinit/sources/tests/test_oracle.py`
-
-Update ``ds-identify``
-----------------------
-
-In ``systemd`` systems, ``ds-identify`` is used to detect which datasource
-should be enabled, or if ``cloud-init`` should run at all. You'll need to
-make changes to :file:`tools/ds-identify`.
-
-Add tests for ``ds-identify``
------------------------------
-
-Add relevant tests in a new class to
-:file:`tests/unittests/test_ds_identify.py`. You can use ``TestOracle`` as
-an example.
-
-Add your datasource name to the built-in list of datasources
-------------------------------------------------------------
-
-Add your datasource module name to the end of the ``datasource_list``
-entry in :file:`cloudinit/settings.py`.
-
-Add your cloud platform to apport collection prompts
-----------------------------------------------------
-
-Update the list of cloud platforms in :file:`cloudinit/apport.py`. This list
-will be provided to the user who invokes :command:`ubuntu-bug cloud-init`.
-
-Enable datasource by default in Ubuntu packaging branches
----------------------------------------------------------
-
-Ubuntu packaging branches contain a template file,
-:file:`debian/cloud-init.templates`, which ultimately sets the default
-``datasource_list`` when installed via package. This file needs updating when
-the commit gets into a package.
-
-Add documentation for your datasource
--------------------------------------
-
-You should add a new file in :file:`doc/datasources/<cloudplatform>.rst`.
-
-.. _make-mime: https://cloudinit.readthedocs.io/en/latest/explanation/instancedata.html#storage-locations

--- a/doc/rtd/reference/datasources.rst
+++ b/doc/rtd/reference/datasources.rst
@@ -3,24 +3,23 @@
 Datasources
 ***********
 
-Datasources are sources of configuration data for ``cloud-init`` that typically
-come from the user (i.e., user data) or come from the cloud that created the
-configuration drive (i.e., metadata). Typical user data includes files,
-YAML, and shell scripts whereas typical metadata includes server name,
-instance id, display name, and other cloud specific details.
+# todo fix links
+Datasources are sources of configuration data for ``cloud-init``. This data
+comes in the form of `user data`, `meta data`, and `vendor data`, which are
+combined together into a single configuration.
+
+To view this data, run ``sudo cloud-init query -a`` or check one of the files
+that at instancedata-Using_
+
+TODO: the following belongs in dev docs
 
 Since there are multiple ways to provide this data (each cloud solution seems
 to prefer its own way), a datasource abstract class was internally created to
 allow for a single way to access the different cloud systems methods, providing
 this data through the typical usage of subclasses.
 
-Any metadata processed by ``cloud-init``'s datasources is persisted as
-:file:`/run/cloud-init/instance-data.json`. ``Cloud-init`` provides tooling to
-quickly introspect some of that data. See :ref:`instance_metadata` for more
-information.
-
-Known sources
-=============
+Source
+======
 
 The following is a list of documents for each supported datasource:
 
@@ -54,6 +53,16 @@ The following is a list of documents for each supported datasource:
    datasources/vultr.rst
    datasources/zstack.rst
 
+How to configure datasource
+===========================
+- mention that by default cloud-init should automatically determine which datasource it is running on
+- however, in some cases, the datasource does not identify itself to cloud-init
+- mention datasource_list in /etc/cloud/cloud.cfg.d/
+- mention kernel commandline (include a map of datasource <-> dsname)
+
+
+# TODO: everything below this line belongs in a dev doc
+
 Datasource creation
 ===================
 
@@ -81,6 +90,7 @@ If the log is not present, you can generate it by running from source
 The mechanism used to identify the platform will be required for the
 ``ds-identify`` and datasource module sections below.
 
+# Todo: the following line is broken in upstream docs, lets fix it now
 Add datasource module :file:`cloudinit/sources/DataSource<CloudPlatform>.py`
 ----------------------------------------------------------------------------
 
@@ -132,3 +142,5 @@ Add documentation for your datasource
 -------------------------------------
 
 You should add a new file in :file:`doc/datasources/<cloudplatform>.rst`.
+
+.. _make-mime: https://cloudinit.readthedocs.io/en/latest/explanation/instancedata.html#storage-locations

--- a/doc/rtd/reference/datasources.rst
+++ b/doc/rtd/reference/datasources.rst
@@ -23,10 +23,10 @@ have to configure ``cloud-init`` to specify which datasource cloud-init is
 running on; ``cloud-init`` should "figure it out".
 
 There are exceptions, however, when the :ref:`datasource does not
-identify<datasource_ironic>` itself to ``cloud-init``.
-
-- mention datasource_list in /etc/cloud/cloud.cfg.d/
-- mention kernel commandline (include a map of datasource <-> dsname)
+identify<datasource_ironic>` itself to ``cloud-init``. For these
+exceptions, one can override datasource detection either by configuring a
+single datasource in the :ref:`datasource_list<base_config_datasource_list>`,
+or by using :ref:`kernel commandline arguments<kernel_datasource_override>`.
 
 Datasources:
 ============

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -21,6 +21,7 @@ be used. For this method to work, the filesystem volume must be labeled
 
 Method 2: Local filesystem, kernel commandline or SMBIOS
 --------------------------------------------------------
+
 Configuration files can be provided on the local filesystem without a label
 using kernel commandline arguments or SMBIOS serial number to tell cloud-init
 where on the filesystem to look.

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -55,8 +55,9 @@ A filesystem path starting with ``/`` or ``file://`` that points to a directory
 containing files: ``user-data``, ``meta-data``, and (optionally)
 ``vendor-data``
 
-Http server
+HTTP server
 -----------
+
 An ``http`` or ``https`` url (a trailing ``/`` is required)
 
 

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -32,6 +32,7 @@ Alternatively, one can provide metadata via the kernel command line or SMBIOS
 
 Method 3: Custom webserver: kernel commandline or SMBIOS
 --------------------------------------------------------
+
 In a similar fashion, configuration files can be provided to cloud-init using a
 custom webserver at a URL dictated by kernel commandline arguments or SMBIOS
 serial number. This argument might look like: ::

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -6,21 +6,21 @@ NoCloud
 The data source ``NoCloud`` is a flexible datasource that can be used in
 multiple different ways. With NoCloud, the user can provide user data and
 metadata to the instance without running a network service (or even without
-having a network at all). It is also possible to use a custom webserver to 
+having a network at all). Alternatively, one may use a custom webserver to
 provide configurations.
 
 Configuration Methods:
 ======================
 
-Local filesystem: labeled filesystem
--------------------------------------
+Method 1: Local filesystem, labeled filesystem
+----------------------------------------------
 To provide cloud-init configurations from the local filesystem, a labeled
 `vfat`_ or `iso9660`_ filesystem containing user data and metadata may
 be used. For this method to work, the filesystem volume must be labeled
 ``CIDATA``.
 
-Local filesystem: kernel commandline or SMBIOS
-----------------------------------------------
+Method 2: Local filesystem, kernel commandline or SMBIOS
+--------------------------------------------------------
 Configuration files can be provided on the local filesystem without a label
 using kernel commandline arguments or SMBIOS serial number to tell cloud-init
 where on the filesystem to look.
@@ -30,8 +30,8 @@ Alternatively, one can provide metadata via the kernel command line or SMBIOS
 
   ds=nocloud s=file://path/to/directory/;h=node-42
 
-Custom webserver: kernel commandline or SMBIOS
-----------------------------------------------
+Method 3: Custom webserver: kernel commandline or SMBIOS
+--------------------------------------------------------
 In a similar fashion, configuration files can be provided to cloud-init using a
 custom webserver at a URL dictated by kernel commandline arguments or SMBIOS
 serial number. This argument might look like: ::
@@ -49,10 +49,15 @@ The permitted keys are:
 
 A valid ``seedfrom`` values consist of:
 
-Filesystem: a filesystem path starting with ``/`` or ``file://`` that points to
-            a directory containing files: ``user-data``, ``meta-data``, and
-            (optionally) ``vendor-data``
-Http server: an ``http`` or ``https`` url (a trailing ``/`` is required).
+Filesystem
+----------
+A filesystem path starting with ``/`` or ``file://`` that points to a directory
+containing files: ``user-data``, ``meta-data``, and (optionally)
+``vendor-data``
+
+Http server
+-----------
+An ``http`` or ``https`` url (a trailing ``/`` is required)
 
 
 File formats

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -51,6 +51,7 @@ A valid ``seedfrom`` value consists of:
 
 Filesystem
 ----------
+
 A filesystem path starting with ``/`` or ``file://`` that points to a directory
 containing files: ``user-data``, ``meta-data``, and (optionally)
 ``vendor-data``

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -83,8 +83,9 @@ You may also optionally provide a vendor data file adhering to
   /vendor-data
 
 
-DMI-Specific Kernel Commandline
+DMI-specific kernel commandline
 ===============================
+
 Cloud-init performs variable expansion of the ``seedfrom`` URL for any DMI
 kernel variables present in :file:`/sys/class/dmi/id` (kenv on FreeBSD).
 Your ``seedfrom`` URL can contain variable names of the format

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -17,7 +17,7 @@ Method 1: Local filesystem, labeled filesystem
 
 To provide cloud-init configurations from the local filesystem, a labeled
 `vfat`_ or `iso9660`_ filesystem containing user data and metadata may
-be used. For this method to work, the filesystem volume must be labeled
+be used. For this method to work, the filesystem volume must be labelled
 ``CIDATA``.
 
 Method 2: Local filesystem, kernel commandline or SMBIOS

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -16,9 +16,7 @@ Alternatively, you can provide metadata via the kernel command line or SMBIOS
 
   ds=nocloud[;key=val;key=val]
 
-or, ::
-
-  ds=nocloud-net[;key=val;key=val]
+  # TODO: Document future changes here
 
 Permitted keys
 ==============
@@ -29,10 +27,17 @@ The permitted keys are:
 * ``i`` or ``instance-id``
 * ``s`` or ``seedfrom``
 
-With ``ds=nocloud``, the ``seedfrom`` value must start with ``/`` or
-``file://``.  With ``ds=nocloud-net``, the ``seedfrom`` value must start
-with ``http://`` or ``https://`` and end with a trailing ``/``.
+Valid ``seedfrom`` values consist of:
 
+Filesystem: begins with ``/`` or ``file://``
+Http server: begins with ``http://`` or ``https://`` and ends
+    with a trailing ``/``.
+
+# TODO: Document future changes here
+# TODO: Why is the dmi stuff higher on the page than file formats? reorder?
+
+DMI-Specific Kernel Commandline
+===============================
 Cloud-init performs variable expansion of the ``seedfrom`` URL for any DMI
 kernel variables present in :file:`/sys/class/dmi/id` (kenv on FreeBSD).
 Your ``seedfrom`` URL can contain variable names of the format

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -14,6 +14,7 @@ Configuration Methods:
 
 Method 1: Local filesystem, labeled filesystem
 ----------------------------------------------
+
 To provide cloud-init configurations from the local filesystem, a labeled
 `vfat`_ or `iso9660`_ filesystem containing user data and metadata may
 be used. For this method to work, the filesystem volume must be labeled

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -47,7 +47,7 @@ The permitted keys are:
 * ``i`` or ``instance-id``
 * ``s`` or ``seedfrom``
 
-A valid ``seedfrom`` values consist of:
+A valid ``seedfrom`` value consists of:
 
 Filesystem
 ----------

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -62,7 +62,7 @@ containing files: ``user-data``, ``meta-data``, and (optionally)
 HTTP server
 -----------
 
-An ``http`` or ``https`` url (a trailing ``/`` is required)
+An ``http`` or ``https`` URL (a trailing ``/`` is required)
 
 
 File formats

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -71,7 +71,7 @@ same base URL: ::
 
 Both files must be present for it to be considered a valid seed ISO.
 
-Basically, ``user-data`` is simply :ref:`user data<user_data_formats>` and
+The ``user-data`` file uses :ref:`user data format<user_data_formats>` and
 ``meta-data`` is a YAML-formatted file representing what you'd find in the EC2
 metadata service.
 

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -5,8 +5,6 @@ OpenStack
 
 This datasource supports reading data from the `OpenStack Metadata Service`_.
 
-# TODO: document d1ffbea556a061 and its implications for openstack baremetal
-
 Discovery
 =========
 
@@ -126,5 +124,36 @@ different metadata path, :file:`/vendor_data2.json`.
 path; if found, settings are applied after (and, hence, overriding) the
 settings from static vendor data. Both sets of vendor data can be overridden
 by user data.
+
+.. _datasource_ironic:
+
+OpenStack Ironic Bare Metal
+===========================
+During boot, cloud-init typically has to identify which platform it is running
+on. Since OpenStack Ironic bare metal doesn't provide a method for cloud-init
+to discover that it is running on Ironic, extra user configuration is required.
+
+Cloud-init provides two method to do this:
+
+Method 1:
+---------
+Explicitly set ``datasource_list`` to only ``openstack``, such as:
+
+.. code-block:: yaml
+
+   datasource_list: ["openstack"]
+
+Method 2:
+---------
+Set the kernel commandline to configure
+:ref:`datasource override <kernel_datasource_override>`.
+
+Example using Ubuntu + GRUB2:
+
+.. code-block::
+
+    $ echo 'ds=openstack' >> /etc/default/grub
+    $ grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg
+
 
 .. _OpenStack Metadata Service: https://docs.openstack.org/nova/latest/admin/metadata-service.html

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -145,6 +145,7 @@ Explicitly set ``datasource_list`` to only ``openstack``, such as:
 
 Method 2:
 ---------
+
 Set the kernel commandline to configure
 :ref:`datasource override <kernel_datasource_override>`.
 

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -133,7 +133,7 @@ During boot, cloud-init typically has to identify which platform it is running
 on. Since OpenStack Ironic bare metal doesn't provide a method for cloud-init
 to discover that it is running on Ironic, extra user configuration is required.
 
-Cloud-init provides two method to do this:
+Cloud-init provides two methods to do this:
 
 Method 1:
 ---------

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -5,6 +5,8 @@ OpenStack
 
 This datasource supports reading data from the `OpenStack Metadata Service`_.
 
+# TODO: document d1ffbea556a061 and its implications for openstack baremetal
+
 Discovery
 =========
 

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -137,6 +137,7 @@ Cloud-init provides two methods to do this:
 
 Method 1:
 ---------
+
 Explicitly set ``datasource_list`` to only ``openstack``, such as:
 
 .. code-block:: yaml

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -136,8 +136,8 @@ to discover that it is running on Ironic, extra user configuration is required.
 
 Cloud-init provides two methods to do this:
 
-Method 1:
----------
+Method 1: Configuration file
+----------------------------
 
 Explicitly set ``datasource_list`` to only ``openstack``, such as:
 
@@ -145,8 +145,8 @@ Explicitly set ``datasource_list`` to only ``openstack``, such as:
 
    datasource_list: ["openstack"]
 
-Method 2:
----------
+Method 2: Kernel command line
+-----------------------------
 
 Set the kernel commandline to configure
 :ref:`datasource override <kernel_datasource_override>`.

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -130,7 +130,7 @@ by user data.
 OpenStack Ironic Bare Metal
 ===========================
 During boot, cloud-init typically has to identify which platform it is running
-on. Since OpenStack Ironic bare metal doesn't provide a method for cloud-init
+on. Since OpenStack Ironic Bare Metal doesn't provide a method for cloud-init
 to discover that it is running on Ironic, extra user configuration is required.
 
 Cloud-init provides two methods to do this:

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -129,6 +129,7 @@ by user data.
 
 OpenStack Ironic Bare Metal
 ===========================
+
 During boot, cloud-init typically has to identify which platform it is running
 on. Since OpenStack Ironic Bare Metal doesn't provide a method for cloud-init
 to discover that it is running on Ironic, extra user configuration is required.

--- a/doc/rtd/reference/index.rst
+++ b/doc/rtd/reference/index.rst
@@ -19,3 +19,4 @@ matrices and so on.
    datasources.rst
    network-config.rst
    base_config_reference.rst
+   datasource_dsname_map.rst


### PR DESCRIPTION
```
Update kernel commandline docs

- describe kernel commandline override
- add OpenStack Ironic selection instructions
- describe datasource selection
- move datasource creation doc to dev section
- remove generator stage from boot stages
- document how to disable cloud-init in howtos
- fix missing kernel-cmdline.rst link
- update outdated security advice

Document the following commits:

 34e8c914df666c937e48f5d1c3add0bd47e4e7eb
 f146fe71733e72b94fad525b8cc9988b1405e760
 250280ada67995a8449b64027b879d01939d2729
 612b4de892d19333c33276d541fed99fd16d3998
 a60c0845806baff72c74603286d048efbafab664
 d1ffbea556a06105d1ade88b4143ad43f53692c4
 02202954c65a7a1cdb9b28703bd0af01edd0e091
```

## Additional Context
This documentation serves to document recent work in the following commits:

https://github.com/canonical/cloud-init/commit/34e8c914df666c937e48f5d1c3add0bd47e4e7eb https://github.com/canonical/cloud-init/commit/f146fe71733e72b94fad525b8cc9988b1405e760 https://github.com/canonical/cloud-init/commit/250280ada67995a8449b64027b879d01939d2729 https://github.com/canonical/cloud-init/commit/612b4de892d19333c33276d541fed99fd16d3998 https://github.com/canonical/cloud-init/commit/a60c0845806baff72c74603286d048efbafab664 https://github.com/canonical/cloud-init/commit/d1ffbea556a06105d1ade88b4143ad43f53692c4 https://github.com/canonical/cloud-init/commit/02202954c65a7a1cdb9b28703bd0af01edd0e091