### PR TITLE
Remove mount NTFS error message

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1592,6 +1592,7 @@ def can_dev_be_reformatted(devpath, preserve_ntfs):
                 count_files,
                 mtype="ntfs",
                 update_env_for_mount={"LANG": "C"},
+                log_error=False,
             )
         except util.MountFailedError as e:
             evt.description = "cannot mount ntfs"

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1884,7 +1884,12 @@ def mounts():
 
 
 def mount_cb(
-    device, callback, data=None, mtype=None, update_env_for_mount=None
+    device,
+    callback,
+    data=None,
+    mtype=None,
+    update_env_for_mount=None,
+    log_error=True,
 ):
     """
     Mount the device, call method 'callback' passing the directory
@@ -1944,15 +1949,16 @@ def mount_cb(
                     mountpoint = tmpd
                     break
                 except (IOError, OSError) as exc:
-                    LOG.debug(
-                        "Failed to mount device: '%s' with type: '%s' "
-                        "using mount command: '%s', "
-                        "which caused exception: %s",
-                        device,
-                        mtype,
-                        " ".join(mountcmd),
-                        exc,
-                    )
+                    if log_error:
+                        LOG.debug(
+                            "Failed to mount device: '%s' with type: '%s' "
+                            "using mount command: '%s', "
+                            "which caused exception: %s",
+                            device,
+                            mtype,
+                            " ".join(mountcmd),
+                            exc,
+                        )
                     failure_reason = exc
             if not mountpoint:
                 raise MountFailedError(

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2287,7 +2287,9 @@ class TestCanDevBeReformatted(CiTestCase):
             # return sorted by partition number
             return sorted(ret, key=lambda d: d[0])
 
-        def mount_cb(device, callback, mtype, update_env_for_mount):
+        def mount_cb(
+            device, callback, mtype, update_env_for_mount, log_error=False
+        ):
             self.assertEqual("ntfs", mtype)
             self.assertEqual("C", update_env_for_mount.get("LANG"))
             p = self.tmp_dir()

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1583,7 +1583,7 @@ class TestMountCb:
         callback = mock.Mock(autospec=True)
         with pytest.raises(Exception):
             util.mount_cb(
-                "/dev/sda1",
+                "/dev/fake0",
                 callback,
                 mtype="ntfs",
                 update_env_for_mount={"LANG": "C"},

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1571,26 +1571,6 @@ class TestMountCb:
             mock.call(mock.ANY, mock.sentinel.data)
         ] == callback.call_args_list
 
-    @mock.patch(M_PATH + "subp.subp")
-    def test_mount_cb_does_not_log(self, m_subp, caplog):
-        log_msg = (
-            "Failed to mount device: '/dev/fake0' with type: "
-            "'ntfs' using mount command:"
-        )
-        m_subp.side_effect = subp.ProcessExecutionError(
-            "", "unknown filesystem type 'ntfs'"
-        )
-        callback = mock.Mock(autospec=True)
-        with pytest.raises(Exception):
-            util.mount_cb(
-                "/dev/fake0",
-                callback,
-                mtype="ntfs",
-                update_env_for_mount={"LANG": "C"},
-                log_error=False,
-            )
-        assert log_msg not in caplog.text
-
     @pytest.mark.parametrize("log_error", [True, False])
     @mock.patch(M_PATH + "subp.subp")
     def test_mount_cb_log(self, m_subp, log_error, caplog):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1591,8 +1591,9 @@ class TestMountCb:
             )
         assert log_msg not in caplog.text
 
+    @pytest.mark.parametrize("log_error", [True, False])
     @mock.patch(M_PATH + "subp.subp")
-    def test_mount_cb_does_log(self, m_subp, caplog):
+    def test_mount_cb_log(self, m_subp, log_error, caplog):
         log_msg = (
             "Failed to mount device: '/dev/fake0' with type: "
             "'ntfs' using mount command:"
@@ -1607,9 +1608,12 @@ class TestMountCb:
                 callback,
                 mtype="ntfs",
                 update_env_for_mount={"LANG": "C"},
-                log_error=True,
+                log_error=log_error,
             )
-        assert log_msg in caplog.text
+        if log_error:
+            assert log_msg in caplog.text
+        else:
+            assert log_msg not in caplog.text
 
 
 @mock.patch(M_PATH + "write_file")
@@ -2086,7 +2090,6 @@ class TestMountinfoParsing(helpers.ResourceUsingTestCase):
             self.assertEqual(expected, util.parse_mount_info("/", lines))
 
     def test_precise_ext4_root(self):
-
         lines = helpers.readResource("mountinfo_precise_ext4.txt").splitlines()
 
         expected = ("/dev/mapper/vg0-root", "ext4", "/")
@@ -2529,7 +2532,6 @@ class TestEncode(helpers.TestCase):
 
 
 class TestProcessExecutionError(helpers.TestCase):
-
     template = (
         "{description}\n"
         "Command: {cmd}\n"
@@ -2840,7 +2842,6 @@ class TestHuman2Bytes:
                 util.human2bytes(test_i)
 
     def test_ibibytes2bytes(self):
-
         assert util.human2bytes("0.5GiB") == 536870912
         assert util.human2bytes("100MiB") == 104857600
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1574,7 +1574,7 @@ class TestMountCb:
     @mock.patch(M_PATH + "subp.subp")
     def test_mount_cb_does_not_log(self, m_subp, caplog):
         log_msg = (
-            "Failed to mount device: '/dev/sda1' with type: "
+            "Failed to mount device: '/dev/fake0' with type: "
             "'ntfs' using mount command:"
         )
         m_subp.side_effect = subp.ProcessExecutionError(
@@ -1594,7 +1594,7 @@ class TestMountCb:
     @mock.patch(M_PATH + "subp.subp")
     def test_mount_cb_does_log(self, m_subp, caplog):
         log_msg = (
-            "Failed to mount device: '/dev/sda1' with type: "
+            "Failed to mount device: '/dev/fake0' with type: "
             "'ntfs' using mount command:"
         )
         m_subp.side_effect = subp.ProcessExecutionError(
@@ -1603,7 +1603,7 @@ class TestMountCb:
         callback = mock.Mock(autospec=True)
         with pytest.raises(Exception):
             util.mount_cb(
-                "/dev/sda1",
+                "/dev/fake0",
                 callback,
                 mtype="ntfs",
                 update_env_for_mount={"LANG": "C"},


### PR DESCRIPTION
Provide an option to suppress error logging from _mount_cb_ as some errors can be expected error and handled appropriately by DataSources. For example: failure to mount NTFS volumes on VMs that do not have NTFS drivers.
