### PR TITLE
sources/azure: report failures to host via kvp

### DIFF
--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -347,6 +347,21 @@ class HyperVKvpReportingHandler(ReportingHandler):
                 break
         return result_array
 
+    def write_key(self, key: str, value: str) -> None:
+        """Write KVP key-value.
+
+        Values will be truncated as needed.
+        """
+        if len(value) >= self.HV_KVP_AZURE_MAX_VALUE_SIZE:
+            value = value[0 : self.HV_KVP_AZURE_MAX_VALUE_SIZE - 1]
+
+        data = [self._encode_kvp_item(key, value)]
+
+        try:
+            self._append_kvp_item(data)
+        except (OSError, IOError):
+            LOG.warning("failed posting kvp=%s value=%s", key, value)
+
     def _encode_event(self, event):
         """
         encode the event into kvp data bytes.

--- a/tests/unittests/reporting/test_reporting_hyperv.py
+++ b/tests/unittests/reporting/test_reporting_hyperv.py
@@ -347,3 +347,18 @@ class TextKvpReporter(CiTestCase):
         self.assertNotEqual(
             kvps[0]["key"], kvps[1]["key"], "duplicate keys for KVP entries"
         )
+
+    def test_write_key(self):
+        reporter = HyperVKvpReportingHandler(kvp_file_path=self.tmp_file_path)
+        reporter.write_key("test-key", "test-value")
+        assert list(reporter._iterate_kvps(0)) == [
+            {"key": "test-key", "value": "test-value"}
+        ]
+
+    def test_write_key_truncates(self):
+        reporter = HyperVKvpReportingHandler(kvp_file_path=self.tmp_file_path)
+
+        value = "A" * 2000
+        reporter.write_key("test-key", value)
+
+        assert len(list(reporter._iterate_kvps(0))[0]["value"]) == 1023


### PR DESCRIPTION
Azure can report provisioning failures via the Wireserver health endpoint.  However, in the event of networking failures or Wireserver issues, this report cannot be made and the VM will result in an OS provisioning timeout and a generic error is presented to the user.

Report the failure via KVP using the "PROVISIONING_REPORT" key so that the host can relay the provisioning error report to the user when the VM fails to provision.

The format used is subject to change and/or removal.