### PR TITLE
setup.py: use pkg-config for udev/rules path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,10 @@ def pkg_config_read(library, var):
             "systemdsystemconfdir": "/etc/systemd/system",
             "systemdsystemunitdir": "/lib/systemd/system",
             "systemdsystemgeneratordir": "/lib/systemd/system-generators",
-        }
+        },
+        "udev": {
+            "udevdir": "/lib/udev",
+        },
     }
     cmd = ["pkg-config", "--variable=%s" % var, library]
     try:
@@ -307,14 +310,11 @@ data_files = [
     ),
 ]
 if not platform.system().endswith("BSD"):
-
-    RULES_PATH = LIB
-    if os.path.isfile("/etc/redhat-release"):
-        RULES_PATH = "/usr/lib"
+    RULES_PATH = pkg_config_read("udev", "udevdir")
 
     data_files.extend(
         [
-            (RULES_PATH + "/udev/rules.d", [f for f in glob("udev/*.rules")]),
+            (RULES_PATH + "/rules.d", [f for f in glob("udev/*.rules")]),
             (
                 ETC + "/systemd/system/sshd-keygen@.service.d/",
                 ["systemd/disable-sshd-keygen-if-cloud-init-active.conf"],

--- a/setup.py
+++ b/setup.py
@@ -311,6 +311,8 @@ data_files = [
 ]
 if not platform.system().endswith("BSD"):
     RULES_PATH = pkg_config_read("udev", "udevdir")
+    if not in_virtualenv():
+        RULES_PATH = "/" + RULES_PATH
 
     data_files.extend(
         [

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -33,6 +33,7 @@ cjp256
 Conan-Kudo
 cvstealth
 dankenigsberg
+dankm
 david-caro
 dbungert
 ddymko


### PR DESCRIPTION
Distributions other than RHEL also use /usr/lib/udev for the rules path. Instead of hardcoding the udev rules path for RedHat, check pkg-config for the proper location.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
setup.py: use pkg-config for udev/rules path

Distributions other than RHEL also use /usr/lib/udev for the rules
path. Instead of hardcoding the udev rules path for RedHat, check
pkg-config for the proper location.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
