### PR TITLE
openstack/static: honor the DNS servers associated with a network

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -642,6 +642,14 @@ def convert_net_json(network_json=None, known_macs=None):
                     }
                 )
 
+            dns_nameservers = [
+                service["address"]
+                for service in network.get("services", [])
+                if service.get("type") == "dns"
+            ]
+            if dns_nameservers:
+                subnet["dns_nameservers"] = dns_nameservers
+
             # Enable accept_ra for stateful and legacy ipv6_dhcp types
             if network["type"] in ["ipv6_dhcpv6-stateful", "ipv6_dhcp"]:
                 cfg.update({"accept-ra": True})

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -60,3 +60,62 @@ class TestConvertNetJson(test_helpers.CiTestCase):
                     network_json=net_json, known_macs=macs
                 ),
             )
+
+    def test_subnet_dns(self):
+        """Verify the different known physical types are handled."""
+        # network_data.json example from
+        # https://docs.openstack.org/nova/latest/user/metadata.html
+        mac0 = "fa:16:3e:9c:bf:3d"
+        net_json = {
+            "links": [
+                {
+                    "ethernet_mac_address": mac0,
+                    "id": "tapcd9f6d46-4a",
+                    "mtu": None,
+                    "type": "phy",
+                    "vif_id": "cd9f6d46-4a3a-43ab-a466-994af9db96fc",
+                }
+            ],
+            "networks": [
+                {
+                    "id": "network0",
+                    "link": "tapcd9f6d46-4a",
+                    "network_id": "99e88329-f20d-4741-9593-25bf07847b16",
+                    "type": "ipv4",
+                    "ip_address": "192.168.123.5",
+                    "netmask": "255.255.255.0",
+                    "services": [{"type": "dns", "address": "192.168.123.1"}],
+                }
+            ],
+        }
+        macs = {mac0: "eth0"}
+
+        expected = {
+            "version": 1,
+            "config": [
+                {
+                    "mac_address": "fa:16:3e:9c:bf:3d",
+                    "mtu": None,
+                    "name": "eth0",
+                    "subnets": [
+                        {
+                            "type": "static",
+                            "address": "192.168.123.5",
+                            "netmask": "255.255.255.0",
+                            "ipv4": True,
+                            "dns_nameservers": ["192.168.123.1"],
+                        }
+                    ],
+                    "type": "physical",
+                }
+            ],
+        }
+
+        for t in openstack.KNOWN_PHYSICAL_TYPES:
+            net_json["links"][0]["type"] = t
+            self.assertEqual(
+                expected,
+                openstack.convert_net_json(
+                    network_json=net_json, known_macs=macs
+                ),
+            )


### PR DESCRIPTION
The `network_data.json` allows the definition of the DNS through the `services` list at the network level.

See:
- https://opendev.org/openstack/nova/src/commit/700db274c613d6f8f30e5cdc3462beaeb0fda456/nova/tests/unit/network/test_network_info.py#L979-L980
- https://opendev.org/openstack/metalsmith/src/commit/f98dfa61c1d7475b81c20dabbf2c74198c38c793/metalsmith/test/test_network_metadata.py#L52-L90
- https://opendev.org/openstack/nova/commit/4b333b989dfc778a8b61db4a1b8552e988a10471
