### PR TITLE
Remove the crypt dependency

### DIFF
--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -2,9 +2,10 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import crypt
 import os
 import platform
+
+from passlib.hash import bcrypt
 
 import cloudinit.distros.bsd
 from cloudinit import log as logging
@@ -90,8 +91,7 @@ class NetBSD(cloudinit.distros.bsd.BSD):
         if hashed:
             hashed_pw = passwd
         else:
-            method = crypt.METHOD_BLOWFISH  # pylint: disable=E1101
-            hashed_pw = crypt.crypt(passwd, crypt.mksalt(method))
+            hashed_pw = bcrypt.hash(passwd)
 
         try:
             subp.subp(["usermod", "-p", hashed_pw, user])

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -5,7 +5,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import base64
-import crypt
 import os
 import os.path
 import re
@@ -15,6 +14,8 @@ from enum import Enum
 from pathlib import Path
 from time import sleep, time
 from typing import Any, Dict, List, Optional
+
+import passlib
 
 from cloudinit import log as logging
 from cloudinit import net, sources, ssh_util, subp, util
@@ -1764,8 +1765,8 @@ def read_azure_ovf(contents):
     return (md, ud, cfg)
 
 
-def encrypt_pass(password, salt_id="$6$"):
-    return crypt.crypt(password, salt_id + util.rand_str(strlen=16))
+def encrypt_pass(password):
+    return passlib.hash.sha512_crypt.encrypt(password)
 
 
 @azure_ds_telemetry_reporter

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1766,7 +1766,7 @@ def read_azure_ovf(contents):
 
 
 def encrypt_pass(password):
-    return passlib.hash.sha512_crypt.encrypt(password)
+    return passlib.hash.sha512_crypt.hash(password)
 
 
 @azure_ds_telemetry_reporter

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -425,8 +425,8 @@ syslog_fix_perms: syslog:root
 #   expire: True
 # ssh_pwauth: [ True, False, "" or "unchanged" ]
 #
-# Hashed passwords can be generated in multiple ways, example with python3:
-# python3 -c 'import crypt,getpass; print(crypt.crypt(getpass.getpass(), crypt.mksalt(crypt.METHOD_SHA512)))'
+# Hashed passwords can be generated in multiple ways, example with python3 and the passlib module:
+# python3 -c 'import passlib.hash;print(passlib.hash.sha512_crypt.hash("password"))'
 # Newer versions of 'mkpasswd' will also work: mkpasswd -m sha-512 password
 #
 # So, a simple working example to allow login via ssh, and not expire

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -10,4 +10,3 @@ pycloudlib==1!3.0.2
 pytest<=7.3.1
 
 packaging
-passlib

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -10,3 +10,4 @@ pycloudlib==1!3.0.2
 pytest<=7.3.1
 
 packaging
+passlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,3 +38,6 @@ jsonschema
 # runtime and merge that information into the metadata and repersist that to
 # disk.
 netifaces>=0.10.4
+
+# passlib to replace crypt.crypt
+passlib

--- a/tests/integration_tests/bugs/test_gh671.py
+++ b/tests/integration_tests/bugs/test_gh671.py
@@ -5,8 +5,7 @@ through the Azure API that a change in the default password overwrites
 the old password
 """
 
-import crypt
-
+import passlib.hash
 import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
@@ -18,9 +17,7 @@ NEW_PASSWORD = "DoIM33tTheComplexityRequirementsNow!??"
 
 def _check_password(instance, unhashed_password):
     shadow_password = instance.execute("getent shadow ubuntu").split(":")[1]
-    salt = shadow_password.rsplit("$", 1)[0]
-    hashed_password = crypt.crypt(unhashed_password, salt)
-    assert shadow_password == hashed_password
+    assert passlib.hash.sha512_crypt.verify(unhashed_password, shadow_password)
 
 
 @pytest.mark.skipif(PLATFORM != "azure", reason="Test is Azure specific")

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -188,7 +188,6 @@ class IntegrationInstance:
             local_path=integration_settings.CLOUD_INIT_SOURCE,
             remote_path=remote_path,
         )
-        assert self.execute("apt-get install -qy python3-passlib").ok
         assert self.execute("dpkg -i {path}".format(path=remote_path)).ok
 
     @retry(tries=30, delay=1)

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -188,9 +188,7 @@ class IntegrationInstance:
             local_path=integration_settings.CLOUD_INIT_SOURCE,
             remote_path=remote_path,
         )
-        assert self.execute(
-            "apt install -y --allow-downgrades {path}".format(path=remote_path)
-        ).ok
+        assert self.execute("dpkg -i {path}".format(path=remote_path)).ok
 
     @retry(tries=30, delay=1)
     def upgrade_cloud_init(self):

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -188,6 +188,7 @@ class IntegrationInstance:
             local_path=integration_settings.CLOUD_INIT_SOURCE,
             remote_path=remote_path,
         )
+        assert self.execute("apt-get install -qy python3-passlib").ok
         assert self.execute("dpkg -i {path}".format(path=remote_path)).ok
 
     @retry(tries=30, delay=1)

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -188,7 +188,9 @@ class IntegrationInstance:
             local_path=integration_settings.CLOUD_INIT_SOURCE,
             remote_path=remote_path,
         )
-        assert self.execute("dpkg -i {path}".format(path=remote_path)).ok
+        assert self.execute(
+            "apt install -y --allow-downgrades {path}".format(path=remote_path)
+        ).ok
 
     @retry(tries=30, delay=1)
     def upgrade_cloud_init(self):

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1,13 +1,13 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import copy
-import crypt
 import json
 import os
 import stat
 import xml.etree.ElementTree as ET
 from pathlib import Path
 
+import passlib.hash
 import pytest
 import requests
 
@@ -1561,10 +1561,10 @@ scbus-1 on xpt0 bus 0
         # passwd is crypt formated string $id$salt$encrypted
         # encrypting plaintext with salt value of everything up to final '$'
         # should equal that after the '$'
-        pos = defuser["hashed_passwd"].rfind("$") + 1
-        self.assertEqual(
-            defuser["hashed_passwd"],
-            crypt.crypt("mypass", defuser["hashed_passwd"][0:pos]),
+        self.assertTrue(
+            passlib.hash.sha512_crypt.verify(
+                "mypass", defuser["hashed_passwd"]
+            )
         )
 
         assert dsrc.cfg["ssh_pwauth"] is True

--- a/tox.ini
+++ b/tox.ini
@@ -30,10 +30,12 @@ pylint==2.13.9
 pytest==7.0.1
 types-jsonschema==4.4.2
 types-oauthlib==3.1.6
+types-passlib==1.7.7.12
 types-PyYAML==6.0.4
 types-requests==2.27.8
 types-setuptools==57.4.9
 typing-extensions==4.1.1
+
 
 [files]
 schema = cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -68,8 +70,9 @@ deps =
     mypy=={[format_deps]mypy}
     pytest=={[format_deps]pytest}
     types-jsonschema=={[format_deps]types-jsonschema}
-    types-oauthlib=={[format_deps]types-oauthlib}
+    types-passlib=={[format_deps]types-passlib}
     types-pyyaml=={[format_deps]types-PyYAML}
+    types-oauthlib=={[format_deps]types-oauthlib}
     types-requests=={[format_deps]types-requests}
     types-setuptools=={[format_deps]types-setuptools}
     typing-extensions=={[format_deps]typing-extensions}
@@ -87,6 +90,7 @@ deps =
     pytest=={[format_deps]pytest}
     types-jsonschema=={[format_deps]types-jsonschema}
     types-oauthlib=={[format_deps]types-oauthlib}
+    types-passlib=={[format_deps]types-passlib}
     types-pyyaml=={[format_deps]types-PyYAML}
     types-requests=={[format_deps]types-requests}
     types-setuptools=={[format_deps]types-setuptools}


### PR DESCRIPTION
crypt is deprecated in Python 3.11 and will be removed in 3.13. This uses the passlib module to replace it. passlib is a pure-Python package.

See: https://passlib.readthedocs.io
