### PR TITLE
Do not generate dsa and ed25519 key types when crypto FIPS mode is enabled

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1578,6 +1578,18 @@ def get_cmdline():
     return _get_cmdline()
 
 
+def fips_enabled() -> bool:
+    fips_proc = "/proc/sys/crypto/fips_enabled"
+    try:
+        contents = load_file(fips_proc).strip()
+        return contents == "1"
+    except (IOError, OSError):
+        # for BSD systems and Linux systems where the proc entry is not
+        # available, we assume FIPS is disabled to retain the old behavior
+        # for now.
+        return False
+
+
 def pipe_in_out(in_fh, out_fh, chunk_size=1024, chunk_cb=None):
     bytes_piped = 0
     while True:


### PR DESCRIPTION
DSA and ED25519 key types are not supported when FIPS is enabled in crypto. Check if FIPS has been enabled on the system and if so, do not generate those key types. Presently the check is only available on Linux systems.

Test Steps:
Steps to Reproduce:
Manual:
1. Boot into an RHEL-9.1 system with fips enabled
2. Try to clean and init cloud-init again
$sudo cloud-init clean
$sudo cloud-init init

LP: 2017761
RHBZ: 2187164
