### PR TITLE
Fix linux-specific call on BSD.

### DIFF
--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from cloudinit import distros, helpers
 from cloudinit import log as logging
-from cloudinit import net, subp, util
+from cloudinit import net, subp, temp_utils, util
 from cloudinit.distros import bsd_utils
 from cloudinit.distros.networking import BSDNetworking
 
@@ -138,3 +138,6 @@ class BSD(distros.Distro):
     def chpasswd(self, plist_in: list, hashed: bool):
         for name, password in plist_in:
             self.set_passwd(name, password, hashed=hashed)
+
+    def get_tmp_exec_path(self) -> str:
+        return temp_utils.get_tmp_ancestor(needs_exe=True)


### PR DESCRIPTION
```
Fix linux-specific call on BSDs.

util.get_mount_info() which is called from the
distro base class is linux-specific
```

## Additional Context
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/cloudinit/sources/__init__.py", line 946, in find_source
    if s.update_metadata_if_supported(
  File "/usr/local/lib/python3.9/site-packages/cloudinit/sources/__init__.py", line 828, in update_metadata_if_supported
    result = self.get_data()
  File "/usr/local/lib/python3.9/site-packages/cloudinit/sources/__init__.py", line 373, in get_data
    return_value = self._get_data()
  File "/usr/local/lib/python3.9/site-packages/cloudinit/sources/DataSourceOpenStack.py", line 161, in _get_data
    tmp_dir=self.distro.get_tmp_exec_path(),
  File "/usr/local/lib/python3.9/site-packages/cloudinit/distros/__init__.py", line 961, in get_tmp_exec_path
    if not util.has_mount_opt(tmp_dir, "noexec"):
  File "/usr/local/lib/python3.9/site-packages/cloudinit/util.py", line 2650, in has_mount_opt
    *_, mnt_opts = get_mount_info(path, get_mnt_opts=True)
TypeError: cannot unpack non-iterable NoneType object
```

Traceback doesn't occur after this change.