### PR TITLE
FreeBSD fix parsing of mount and mount options

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2638,6 +2638,8 @@ def parse_mount(path, get_mnt_opts=False):
     )
 
     path_elements = [e for e in path.split("/") if e]
+    devpth = None
+    mount_point = None
     match_mount_point = None
     match_mount_point_elements = None
     for line in mountoutput.splitlines():
@@ -2686,19 +2688,20 @@ def parse_mount(path, get_mnt_opts=False):
         # continue finding the real device like '/dev/da0'.
         # this is only valid for non zfs file systems as a zpool
         # can have gpt labels as disk.
-        devm = re.search("^(/dev/.+)p([0-9])$", devpth)
-        if not devm and is_FreeBSD() and fs_type != "zfs":
+        devm = re.search("^(/dev/.+)[sp]([0-9])$", devpth)
+        if not devm and is_FreeBSD() and fs_type not in ["zfs", "nfs"]:
             devpth = get_freebsd_devpth(path)
 
         if match_mount_point == path:
             break
 
-    if get_mnt_opts:
-        if devpth and fs_type and match_mount_point and mount_options:
-            return (devpth, fs_type, match_mount_point, mount_options)
-    else:
-        if devpth and fs_type and match_mount_point:
-            return (devpth, fs_type, match_mount_point)
+    if path in mount_point:
+        if get_mnt_opts:
+            if devpth and fs_type and match_mount_point and mount_options:
+                return (devpth, fs_type, match_mount_point, mount_options)
+        else:
+            if devpth and fs_type and match_mount_point:
+                return (devpth, fs_type, match_mount_point)
     return None
 
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2695,7 +2695,7 @@ def parse_mount(path, get_mnt_opts=False):
         if match_mount_point == path:
             break
 
-    if path in mount_point:
+    if mount_point and path in mount_point:
         if get_mnt_opts:
             if devpth and fs_type and match_mount_point and mount_options:
                 return (devpth, fs_type, match_mount_point, mount_options)

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2200,7 +2200,7 @@ class TestMountinfoParsing(helpers.ResourceUsingTestCase):
         self.assertEqual(("/dev/mapper/vg00-lv_root", "ext4", "/"), ret)
         # this one exists in mount_parse_ext.txt
         ret = util.parse_mount("/sys/kernel/debug")
-        self.assertIsNone(ret)
+        self.assertEqual(("none", "debugfs", "/sys/kernel/debug"), ret)
         # this one does not even exist in mount_parse_ext.txt
         ret = util.parse_mount("/not/existing/mount")
         self.assertIsNone(ret)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
FreeBSD fix parsing of mount and mount options

The regular expressions used to parse BSD mount(8) are both
overly complicated and limited.

- Combine the two regular expressions into one
- clarify regular expressions with named groups
- add parsing of mount options
- Attempt to extract mount-parent sub-path finding code from  parse_mount_info()
- Failing that, duplicate it in parse_mount()

This leaves parse_mtab() as only mount info provider without options parsing, for now.

Sponsored by: The FreeBSD Foundation
```

## Additional Context

a hopefully better fix for #2143 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
