### PR TITLE
resolv_conf: Allow > 3 nameservers

### DIFF
--- a/cloudinit/distros/parsers/resolv_conf.py
+++ b/cloudinit/distros/parsers/resolv_conf.py
@@ -87,14 +87,6 @@ class ResolvConf:
         new_ns = util.uniq_list(new_ns)
         if len(new_ns) == len(current_ns):
             return current_ns
-        if len(current_ns) >= 3:
-            LOG.warning(
-                "ignoring nameserver %r: adding would "
-                "exceed the maximum of "
-                "'3' name servers (see resolv.conf(5))",
-                ns,
-            )
-            return current_ns[:3]
         self._remove_option("nameserver")
         for n in new_ns:
             self._contents.append(("option", ["nameserver", n, ""]))

--- a/tests/unittests/distros/test_resolv.py
+++ b/tests/unittests/distros/test_resolv.py
@@ -30,16 +30,22 @@ class TestResolvHelper(TestCase):
 
     def test_nameservers(self):
         rp = resolv_conf.ResolvConf(BASE_RESOLVE)
+
+        # Start with two nameservers that already appear in the configuration.
         self.assertIn("10.15.44.14", rp.nameservers)
         self.assertIn("10.15.30.92", rp.nameservers)
+
+        # Add a third nameserver and verify it appears in the resolv.conf.
         rp.add_nameserver("10.2")
         self.assertIn("10.2", rp.nameservers)
         self.assertIn("nameserver 10.2", str(rp))
-        self.assertNotIn("10.3", rp.nameservers)
         self.assertEqual(len(rp.nameservers), 3)
-        rp.add_nameserver("10.2")
+
+        # Add a fourth nameserver and verify it appears in the resolv.conf.
         rp.add_nameserver("10.3")
-        self.assertNotIn("10.3", rp.nameservers)
+        self.assertIn("10.3", rp.nameservers)
+        self.assertIn("nameserver 10.3", str(rp))
+        self.assertEqual(len(rp.nameservers), 4)
 
     def test_search_domains(self):
         rp = resolv_conf.ResolvConf(BASE_RESOLVE)

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -82,6 +82,7 @@ lucasmoura
 lucendio
 lungj
 magnetikonline
+major
 mal
 mamercad
 ManassehZhou


### PR DESCRIPTION
Systems running systemd-resolved or dnsmasq can utlize more than three namervers. Older systems will just use the first three and ignore the rest.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
resolv_conf: Allow > 3 nameservers

Systems running systemd-resolved or dnsmasq can utlize more than three
namervers. Older systems will just use the first three and ignore the
rest.

Signed-off-by: Major Hayden <major@redhat.com>
```

## Additional Context
[Red Hat Bugzilla #2068529](https://bugzilla.redhat.com/show_bug.cgi?id=2068529)

## Test Steps
Launch a cloud instance when > 3 nameservers are configured. All of the provided nameservers should be configured on the systems. Older systems without systemd-resolved/NetworkManager/dnsmasq will just use the first three provided while newer systems will use all the servers provided.

## Checklist:
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
