### PR TITLE
net: refactor hyper-v VF filtering and apply to get_interfaces()

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1127,13 +1127,14 @@ def get_interfaces(
 
     # Last-pass filter(s) which need the full device list to perform properly.
     if filter_hyperv_vf_with_synthetic:
-        filter_hyperv_vf_with_synthetic_interface(ret)
+        filter_hyperv_vf_with_synthetic_interface(filtered_logger, ret)
 
     return ret
 
 
 def filter_hyperv_vf_with_synthetic_interface(
-    interfaces: List[Tuple[str, str, str, str]]
+    filtered_logger: Callable[..., None],
+    interfaces: List[Tuple[str, str, str, str]],
 ) -> None:
     """Filter Hyper-V SR-IOV/VFs when used with synthetic hv_netvsc.
 
@@ -1164,7 +1165,7 @@ def filter_hyperv_vf_with_synthetic_interface(
 
     for interface in interfaces_to_remove:
         name, mac, driver, _ = interface
-        LOG.debug(
+        filtered_logger(
             "Ignoring %r VF interface with driver %r due to "
             "synthetic hv_netvsc interface %r with mac address %r.",
             name,

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1144,15 +1144,13 @@ def filter_hyperv_vf_with_synthetic_interface(
     process.  The [perhaps-yet-to-be-enslaved] VF should never be directly
     configured, so we filter interfaces that duplicate any hv_netvsc mac
     address, as this the most reliable indicator that it is meant to be
-    paired (and configured only through hv_netvsc).
+    subordinate to the synthetic interface.
 
-    The driver will be mlx4_core, mlx5_core, or mana.  However, given that
+    VF drivers will be mlx4_core, mlx5_core, or mana.  However, given that
     this list of drivers has changed over time and mana's dependency on
-    hv_netvsc is expected to be removed in the future, we will simply
-    filter any interface that matches hv_netvsc mac.  If there's no matching
-    hv_netvsc interface, future mana interfaces will remain unfiltered.
-    Similarly, this does not affect mlx4/5 instances outside of Hyper-V
-    usage as this filter only affects scenarios where hv_netvsc is present.
+    hv_netvsc is expected to be removed in the future, we no longer rely
+    on these names. Note that this will not affect mlx4/5 instances outside
+    of Hyper-V, as it only affects environments where hv_netvsc is present.
     """
     hv_netvsc_mac_to_name = {
         i[1]: i[0] for i in interfaces if i[2] == "hv_netvsc"


### PR DESCRIPTION
    Azure is introducing a new VF ("MANA") that will initially behave
    similarly to mlx4/5 but cannot be denylisted in the same manner.
    This is because the synthetic interface (hv_netvsc) will no longer
    be required to function in the future which means we must
    intelligently filter the VFs out instead of relying solely on the
    driver name.

    - Isolate filtering logic for Hyper-V's SR-IOV/VFs when used
      with synthetic hv_netvsc interfaces.

    - Move the filter up to get_interfaces() from
      get_interfaces_by_mac_on_linux() to increase coverage of the
      filter. With this in place, we should be able to purge the
      "blacklist_drivers" across the codebase as it will no longer be
      necessary unless there are other paths to be considered.
