### PR TITLE
Add documentation label automatically

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+Documentation:
+- doc/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,2 +1,2 @@
-Documentation:
+documentation:
 - doc/*

--- a/.github/workflows/doc-autolabel.yml
+++ b/.github/workflows/doc-autolabel.yml
@@ -1,0 +1,12 @@
+name: Label documentation changes automatically
+on:
+- pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4


### PR DESCRIPTION
```
Add documentation label automatically
```

## Additional Context
All bugs with this label assigned can be viewed at the following url: https://github.com/canonical/cloud-init/labels/Documentation

## Test
See test [here](https://github.com/holmanb/cloud-init/pull/49).