### PR TITLE
Added / fixed support for static routes on OpenBSD and FreeBSD

### DIFF
--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -17,6 +17,7 @@ class BSDRenderer(renderer.Renderer):
     resolv_conf_fn = "etc/resolv.conf"
     rc_conf_fn = "etc/rc.conf"
     interface_routes = ""
+    route_names = ""
 
     def get_rc_config_value(self, key):
         fn = subp.target_path(self.target, self.rc_conf_fn)

--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -16,6 +16,7 @@ LOG = logging.getLogger(__name__)
 class BSDRenderer(renderer.Renderer):
     resolv_conf_fn = "etc/resolv.conf"
     rc_conf_fn = "etc/rc.conf"
+    interface_routes = ""
 
     def get_rc_config_value(self, key):
         fn = subp.target_path(self.target, self.rc_conf_fn)

--- a/cloudinit/net/freebsd.py
+++ b/cloudinit/net/freebsd.py
@@ -77,7 +77,7 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
         else:
             route_name = "net%d" % self._route_cpt
             route_cmd = "-net %s -netmask %s %s" % (network, netmask, gateway)
-            self.set_rc_config_value("route_"+route_name, route_cmd)
+            self.set_rc_config_value("route_" + route_name, route_cmd)
             self.route_names = "%s %s" % (self.route_names, route_name)
             self.set_rc_config_value("static_routes", self.route_names.strip())
             self._route_cpt += 1

--- a/cloudinit/net/freebsd.py
+++ b/cloudinit/net/freebsd.py
@@ -75,10 +75,10 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
         elif network == "::":
             self.set_rc_config_value("ipv6_defaultrouter", gateway)
         else:
-            route_name = "net%d" % self._route_cpt
-            route_cmd = "-net %s -netmask %s %s" % (network, netmask, gateway)
+            route_name = f"net{self._route_cpt}"
+            route_cmd = f"-net {network} -netmask {netmask} {gateway}"
             self.set_rc_config_value("route_" + route_name, route_cmd)
-            self.route_names = "%s %s" % (self.route_names, route_name)
+            self.route_names = f"{self.route_names} {route_name}"
             self.set_rc_config_value("static_routes", self.route_names.strip())
             self._route_cpt += 1
 

--- a/cloudinit/net/freebsd.py
+++ b/cloudinit/net/freebsd.py
@@ -75,9 +75,11 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
         elif network == "::":
             self.set_rc_config_value("ipv6_defaultrouter", gateway)
         else:
-            route_name = "route_net%d" % self._route_cpt
-            route_cmd = "-route %s/%s %s" % (network, netmask, gateway)
-            self.set_rc_config_value(route_name, route_cmd)
+            route_name = "net%d" % self._route_cpt
+            route_cmd = "-net %s -netmask %s %s" % (network, netmask, gateway)
+            self.set_rc_config_value("route_"+route_name, route_cmd)
+            self.route_names = "%s %s" % (self.route_names, route_name)
+            self.set_rc_config_value("static_routes", self.route_names.strip())
             self._route_cpt += 1
 
 

--- a/cloudinit/net/openbsd.py
+++ b/cloudinit/net/openbsd.py
@@ -28,7 +28,7 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
                 mtu = v.get("mtu")
                 if mtu:
                     content += " mtu %d" % mtu
-                content += "\n"
+                content += "\n" + self.interface_routes
             util.write_file(fn, content)
 
     def start_services(self, run=False):
@@ -54,6 +54,8 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             fn = subp.target_path(self.target, if_file)
             content = gateway + "\n"
             util.write_file(fn, content)
+        else:
+            self.interface_routes = self.interface_routes + "!route add " + network + " -netmask " + netmask + " " + gateway + "\n"
 
 
 def available(target=None):

--- a/cloudinit/net/openbsd.py
+++ b/cloudinit/net/openbsd.py
@@ -55,8 +55,16 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             content = gateway + "\n"
             util.write_file(fn, content)
         else:
-            self.interface_routes = (self.interface_routes + "!route add "
-                + network + " -netmask " + netmask + " " + gateway + "\n")
+            self.interface_routes = (
+                self.interface_routes
+                + "!route add "
+                + network
+                + " -netmask "
+                + netmask
+                + " "
+                + gateway
+                + "\n"
+            )
 
 
 def available(target=None):

--- a/cloudinit/net/openbsd.py
+++ b/cloudinit/net/openbsd.py
@@ -55,8 +55,8 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             content = gateway + "\n"
             util.write_file(fn, content)
         else:
-            self.interface_routes = ( self.interface_routes + "!route add " +
-              network + " -netmask " + netmask + " " + gateway + "\n" )
+            self.interface_routes = (self.interface_routes + "!route add " + \
+              network + " -netmask " + netmask + " " + gateway + "\n")
 
 
 def available(target=None):

--- a/cloudinit/net/openbsd.py
+++ b/cloudinit/net/openbsd.py
@@ -55,8 +55,8 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             content = gateway + "\n"
             util.write_file(fn, content)
         else:
-            self.interface_routes = (self.interface_routes + "!route add " + \
-              network + " -netmask " + netmask + " " + gateway + "\n")
+            self.interface_routes = (self.interface_routes + "!route add "
+                + network + " -netmask " + netmask + " " + gateway + "\n")
 
 
 def available(target=None):

--- a/cloudinit/net/openbsd.py
+++ b/cloudinit/net/openbsd.py
@@ -55,7 +55,8 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             content = gateway + "\n"
             util.write_file(fn, content)
         else:
-            self.interface_routes = self.interface_routes + "!route add " + network + " -netmask " + netmask + " " + gateway + "\n"
+            self.interface_routes = ( self.interface_routes + "!route add " +
+              network + " -netmask " + netmask + " " + gateway + "\n" )
 
 
 def available(target=None):

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -72,6 +72,7 @@ jqueuniet
 jsf9k
 jshen28
 kallioli
+kadiron
 klausenbusk
 KsenijaS
 landon912

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -71,8 +71,8 @@ jordimassaguerpla
 jqueuniet
 jsf9k
 jshen28
-kallioli
 kadiron
+kallioli
 klausenbusk
 KsenijaS
 landon912


### PR DESCRIPTION
## Proposed Commit Message
OpenBSD: Added support for static routes
FreeBSD: Fixed creation of static routes
- Corrected syntax in usage of route(8)
- Added the needed space separated list of route names in the /etc/rc.conf-variable "static_routes"