### PR TITLE
net: purge blacklist_drivers across net and azure

### DIFF
--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -1,7 +1,6 @@
 import abc
 import logging
 import os
-from typing import List, Optional
 
 from cloudinit import net, subp, util
 from cloudinit.distros.parsers import ifconfig
@@ -23,9 +22,6 @@ class Networking(metaclass=abc.ABCMeta):
     Hierarchy" in CONTRIBUTING.rst for full details.
     """
 
-    def __init__(self):
-        self.blacklist_drivers: Optional[List[str]] = None
-
     def _get_current_rename_info(self) -> dict:
         return net._get_current_rename_info()
 
@@ -45,15 +41,11 @@ class Networking(metaclass=abc.ABCMeta):
     def extract_physdevs(self, netcfg: NetworkConfig) -> list:
         return net.extract_physdevs(netcfg)
 
-    def find_fallback_nic(self, *, blacklist_drivers=None):
-        return net.find_fallback_nic(blacklist_drivers=blacklist_drivers)
+    def find_fallback_nic(self):
+        return net.find_fallback_nic()
 
-    def generate_fallback_config(
-        self, *, blacklist_drivers=None, config_driver: bool = False
-    ):
-        return net.generate_fallback_config(
-            blacklist_drivers=blacklist_drivers, config_driver=config_driver
-        )
+    def generate_fallback_config(self, *, config_driver: bool = False):
+        return net.generate_fallback_config(config_driver=config_driver)
 
     def get_devicelist(self) -> list:
         return net.get_devicelist()
@@ -73,9 +65,7 @@ class Networking(metaclass=abc.ABCMeta):
         return net.get_interfaces()
 
     def get_interfaces_by_mac(self) -> dict:
-        return net.get_interfaces_by_mac(
-            blacklist_drivers=self.blacklist_drivers
-        )
+        return net.get_interfaces_by_mac()
 
     def get_master(self, devname: DeviceName):
         return net.get_master(devname)

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -675,7 +675,7 @@ class NetworkStateInterpreter(metaclass=CommandHandlerMeta):
           eno1:
             match:
               macaddress: 00:11:22:33:44:55
-              driver: hv_netsvc
+              driver: hv_netvsc
             wakeonlan: true
             dhcp4: true
             dhcp6: false

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -482,13 +482,27 @@ class TestNetFindCandidateNics:
             operstate="testing",
         )
         self.create_fake_interface(
-            name="blacklistedDriverIgnored",
-            driver="bad",
+            name="hv",
+            driver="hv_netvsc",
+            address="00:11:22:00:00:f0",
+        )
+        self.create_fake_interface(
+            name="hv_vf_mlx4",
+            driver="mlx4_core",
+            address="00:11:22:00:00:f0",
+        )
+        self.create_fake_interface(
+            name="hv_vf_mlx5",
+            driver="mlx5_core",
+            address="00:11:22:00:00:f0",
+        )
+        self.create_fake_interface(
+            name="hv_vf_mana",
+            driver="mana",
+            address="00:11:22:00:00:f0",
         )
 
-        assert (
-            net.find_candidate_nics_on_linux(blacklist_drivers=["bad"]) == []
-        )
+        assert net.find_candidate_nics_on_linux() == ["hv"]
 
     def test_carrier_preferred(self):
         self.create_fake_interface(name="eth0", carrier=False, dormant=True)

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -804,7 +804,7 @@ class TestNetworkConfig:
                 "type": "physical",
                 "name": "eth0",
                 "mac_address": "00:11:22:33:44:55",
-                "params": {"driver": "hv_netsvc"},
+                "params": {"driver": "hv_netvsc"},
                 "subnets": [{"type": "dhcp"}],
             }
         ],
@@ -2004,14 +2004,9 @@ scbus-1 on xpt0 bus 0
         distro = distro_cls("ubuntu", {}, self.paths)
         dsrc = self._get_ds(data, distro=distro)
         dsrc.get_data()
-        self.assertEqual(
-            distro.networking.blacklist_drivers, dsaz.BLACKLIST_DRIVERS
-        )
 
         distro.networking.get_interfaces_by_mac()
-        m_net_get_interfaces.assert_called_with(
-            blacklist_drivers=dsaz.BLACKLIST_DRIVERS
-        )
+        m_net_get_interfaces.assert_called_with()
 
     @mock.patch(
         "cloudinit.sources.helpers.azure.OpenSSLManager.parse_certificates"

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4045,7 +4045,7 @@ class TestGenerateFallbackConfig(CiTestCase):
                 "dormant": False,
                 "operstate": "down",
                 "address": "00:11:22:33:44:55",
-                "device/driver": "hv_netsvc",
+                "device/driver": "hv_netvsc",
                 "device/device": "0x3",
                 "name_assign_type": "4",
             },
@@ -4078,7 +4078,7 @@ class TestGenerateFallbackConfig(CiTestCase):
                     "set-name": "eth0",
                     "match": {
                         "macaddress": "00:11:22:33:44:55",
-                        "driver": "hv_netsvc",
+                        "driver": "hv_netvsc",
                     },
                 }
             },
@@ -4099,7 +4099,7 @@ class TestGenerateFallbackConfig(CiTestCase):
                 "dormant": False,
                 "operstate": "down",
                 "address": "00:11:22:33:44:55",
-                "device/driver": "hv_netsvc",
+                "device/driver": "hv_netvsc",
                 "device/device": "0x3",
                 "name_assign_type": "4",
                 "addr_assign_type": "0",
@@ -4164,7 +4164,7 @@ iface eth0 inet dhcp
         expected_rule = [
             'SUBSYSTEM=="net"',
             'ACTION=="add"',
-            'DRIVERS=="hv_netsvc"',
+            'DRIVERS=="hv_netvsc"',
             'ATTR{address}=="00:11:22:33:44:55"',
             'NAME="eth0"',
         ]
@@ -4173,7 +4173,7 @@ iface eth0 inet dhcp
     @mock.patch("cloudinit.net.sys_dev_path")
     @mock.patch("cloudinit.net.read_sys_net")
     @mock.patch("cloudinit.net.get_devicelist")
-    def test_device_driver_blacklist(
+    def test_hv_netvsc_vf_filter(
         self, mock_get_devicelist, mock_read_sys_net, mock_sys_dev_path
     ):
         devices = {
@@ -4183,7 +4183,7 @@ iface eth0 inet dhcp
                 "dormant": False,
                 "operstate": "down",
                 "address": "00:11:22:33:44:55",
-                "device/driver": "hv_netsvc",
+                "device/driver": "hv_netvsc",
                 "device/device": "0x3",
                 "name_assign_type": "4",
                 "addr_assign_type": "0",
@@ -4195,7 +4195,7 @@ iface eth0 inet dhcp
                 "carrier": False,
                 "dormant": False,
                 "operstate": "down",
-                "address": "00:11:22:33:44:56",
+                "address": "00:11:22:33:44:55",
                 "device/driver": "mlx4_core",
                 "device/device": "0x7",
                 "name_assign_type": "4",
@@ -4214,10 +4214,7 @@ iface eth0 inet dhcp
             dev_attrs=devices,
         )
 
-        blacklist = ["mlx4_core"]
-        network_cfg = net.generate_fallback_config(
-            blacklist_drivers=blacklist, config_driver=True
-        )
+        network_cfg = net.generate_fallback_config(config_driver=True)
         ns = network_state.parse_net_config_data(
             network_cfg, skip_broken=False
         )
@@ -4251,7 +4248,7 @@ iface eth1 inet dhcp
         expected_rule = [
             'SUBSYSTEM=="net"',
             'ACTION=="add"',
-            'DRIVERS=="hv_netsvc"',
+            'DRIVERS=="hv_netvsc"',
             'ATTR{address}=="00:11:22:33:44:55"',
             'NAME="eth1"',
         ]
@@ -4278,7 +4275,7 @@ iface eth1 inet dhcp
                 "dormant": False,
                 "operstate": "down",
                 "address": "00:11:22:33:44:55",
-                "device/driver": "hv_netsvc",
+                "device/driver": "hv_netvsc",
                 "device/device": "0x3",
                 "name_assign_type": False,
             },
@@ -4327,7 +4324,7 @@ iface eth1 inet dhcp
                 "dormant": False,
                 "operstate": "down",
                 "address": "00:11:22:33:44:55",
-                "device/driver": "hv_netsvc",
+                "device/driver": "hv_netvsc",
                 "device/device": "0x3",
                 "name_assign_type": False,
             },
@@ -5252,7 +5249,7 @@ USERCTL=no
                 "dormant": False,
                 "operstate": "down",
                 "address": "CF:D6:AF:48:E8:80",
-                "device/driver": "hv_netsvc",
+                "device/driver": "hv_netvsc",
                 "device/device": "0x3",
                 "name_assign_type": "4",
                 "addr_assign_type": "0",
@@ -8490,14 +8487,14 @@ class TestRenameInterfaces(CiTestCase):
     @mock.patch("cloudinit.subp.subp")
     def test_rename_duplicate_macs(self, mock_subp):
         renames = [
-            ("00:11:22:33:44:55", "eth0", "hv_netsvc", "0x3"),
+            ("00:11:22:33:44:55", "eth0", "hv_netvsc", "0x3"),
             ("00:11:22:33:44:55", "vf1", "mlx4_core", "0x5"),
         ]
         current_info = {
             "eth0": {
                 "downable": True,
                 "device_id": "0x3",
-                "driver": "hv_netsvc",
+                "driver": "hv_netvsc",
                 "mac": "00:11:22:33:44:55",
                 "name": "eth0",
                 "up": False,
@@ -8524,14 +8521,14 @@ class TestRenameInterfaces(CiTestCase):
     @mock.patch("cloudinit.subp.subp")
     def test_rename_duplicate_macs_driver_no_devid(self, mock_subp):
         renames = [
-            ("00:11:22:33:44:55", "eth0", "hv_netsvc", None),
+            ("00:11:22:33:44:55", "eth0", "hv_netvsc", None),
             ("00:11:22:33:44:55", "vf1", "mlx4_core", None),
         ]
         current_info = {
             "eth0": {
                 "downable": True,
                 "device_id": "0x3",
-                "driver": "hv_netsvc",
+                "driver": "hv_netvsc",
                 "mac": "00:11:22:33:44:55",
                 "name": "eth0",
                 "up": False,
@@ -8558,7 +8555,7 @@ class TestRenameInterfaces(CiTestCase):
     @mock.patch("cloudinit.subp.subp")
     def test_rename_multi_mac_dups(self, mock_subp):
         renames = [
-            ("00:11:22:33:44:55", "eth0", "hv_netsvc", "0x3"),
+            ("00:11:22:33:44:55", "eth0", "hv_netvsc", "0x3"),
             ("00:11:22:33:44:55", "vf1", "mlx4_core", "0x5"),
             ("00:11:22:33:44:55", "vf2", "mlx4_core", "0x7"),
         ]
@@ -8566,7 +8563,7 @@ class TestRenameInterfaces(CiTestCase):
             "eth0": {
                 "downable": True,
                 "device_id": "0x3",
-                "driver": "hv_netsvc",
+                "driver": "hv_netvsc",
                 "mac": "00:11:22:33:44:55",
                 "name": "eth0",
                 "up": False,

--- a/tests/unittests/test_upgrade.py
+++ b/tests/unittests/test_upgrade.py
@@ -64,10 +64,6 @@ class TestUpgrade:
         """We always expect to have ``.networking`` on ``Distro`` objects."""
         assert previous_obj_pkl.distro.networking is not None
 
-    def test_blacklist_drivers_set_on_networking(self, previous_obj_pkl):
-        """We always expect Networking.blacklist_drivers to be initialised."""
-        assert previous_obj_pkl.distro.networking.blacklist_drivers is None
-
     def test_paths_has_run_dir_attribute(self, previous_obj_pkl):
         assert previous_obj_pkl.paths.run_dir is not None
 


### PR DESCRIPTION
    It was only used by Hyper-V which now has a filtering
    mechanism that does not require the use of a denylist.

    This exposed some issues with tests misspelling "hv_netvsc"
    and using unmatched mac addresses. This fixes those to work
    with the current filter that does not rely on the driver name.