### PR TITLE
Fix logger, use instance rather than module function

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -67,7 +67,7 @@ FREQ_SHORT_NAMES = {
     "once": PER_ONCE,
 }
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 # Used for when a logger may not be active

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -21,7 +21,7 @@ _OPEN_ISCSI_INTERFACE_FILE = "/run/initramfs/open-iscsi.interface"
 
 KERNEL_CMDLINE_NETWORK_CONFIG_DISABLED = "disabled"
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 
 class InitramfsNetworkConfigSource(metaclass=abc.ABCMeta):

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -21,6 +21,8 @@ _OPEN_ISCSI_INTERFACE_FILE = "/run/initramfs/open-iscsi.interface"
 
 KERNEL_CMDLINE_NETWORK_CONFIG_DISABLED = "disabled"
 
+LOG = logging.getLogger()
+
 
 class InitramfsNetworkConfigSource(metaclass=abc.ABCMeta):
     """ABC for net config sources that read config written by initramfses"""
@@ -258,7 +260,7 @@ def _b64dgz(data):
     try:
         blob = base64.b64decode(data)
     except (TypeError, ValueError):
-        logging.error(
+        LOG.error(
             "Expected base64 encoded kernel commandline parameter"
             " network-config. Ignoring network-config=%s.",
             data,

--- a/cloudinit/netinfo.py
+++ b/cloudinit/netinfo.py
@@ -18,7 +18,7 @@ from cloudinit import subp, util
 from cloudinit.net.network_state import net_prefix_to_ipv4_mask
 from cloudinit.simpletable import SimpleTable
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 # Example netdev format:
 # {'eth0': {'hwaddr': '00:16:3e:16:db:54',

--- a/cloudinit/warnings.py
+++ b/cloudinit/warnings.py
@@ -7,7 +7,7 @@ from cloudinit import helpers
 from cloudinit import log as logging
 from cloudinit import util
 
-LOG = logging.getLogger()
+LOG = logging.getLogger(__name__)
 
 WARNINGS = {
     "non_ec2_md": """


### PR DESCRIPTION
```
Fix logger calls

Use Logger instance rather than module function.
Add missing logger names.
```
