### PR TITLE
Export errors to status.json for use in cloud-init status (SC-1489)

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -494,7 +494,7 @@ def validate_cloudconfig_schema(
         )
         # This warning doesn't fit the standardized util.deprecated() utility
         # format, but it is a deprecation log, so log it directly.
-        LOG.deprecated(message)  # type: ignore
+        LOG.deprecated(message)
     if strict and (errors or deprecations):
         raise SchemaValidationError(errors, deprecations)
     if errors:

--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -9,13 +9,17 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import collections.abc
+import copy
 import io
+import json
 import logging
 import logging.config
 import logging.handlers
 import os
 import sys
 import time
+from collections import defaultdict
+from typing import Dict
 
 # Logging levels for easy access
 CRITICAL = logging.CRITICAL
@@ -130,6 +134,17 @@ def setupLogging(cfg=None):
         setupBasicLogging()
 
 
+class LogExporter(logging.StreamHandler):
+    holder = defaultdict(list)
+
+    def emit(self, record: logging.LogRecord):
+        if record.levelno > 29:
+            self.holder[record.levelname].append(record.getMessage())
+
+    def export_logs(self):
+        return copy.deepcopy(self.holder)
+
+
 def getLogger(name="cloudinit"):
     return logging.getLogger(name)
 
@@ -157,5 +172,3 @@ def resetLogging():
 
 
 resetLogging()
-
-# vi: ts=4 expandtab

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -9,7 +9,6 @@ import pytest
 
 from cloudinit import helpers
 from cloudinit.cmd import main as cli
-from cloudinit.util import load_file, load_json
 from tests.unittests import helpers as test_helpers
 
 mock = test_helpers.mock
@@ -62,14 +61,18 @@ class TestCLI:
             cli.status_wrapper(name, myargs, data_d, link_d)
         assert [] == my_action.call_args_list
 
-    def test_status_wrapper_init_local_writes_fresh_status_info(self, tmpdir):
+    @mock.patch("cloudinit.cmd.main.atomic_helper.write_json")
+    def test_status_wrapper_init_local_writes_fresh_status_info(
+        self,
+        m_json,
+        tmpdir,
+    ):
         """When running in init-local mode, status_wrapper writes status.json.
 
         Old status and results artifacts are also removed.
         """
         data_d = tmpdir.join("data")
         link_d = tmpdir.join("link")
-        status_link = link_d.join("status.json")
         # Write old artifacts which will be removed or updated.
         for _dir in data_d, link_d:
             test_helpers.populate_dir(
@@ -85,7 +88,7 @@ class TestCLI:
         myargs = FakeArgs(("ignored_name", myaction), True, "bogusmode")
         cli.status_wrapper("init", myargs, data_d, link_d)
         # No errors reported in status
-        status_v1 = load_json(load_file(status_link))["v1"]
+        status_v1 = m_json.call_args_list[1][0][1]["v1"]
         assert ["an error"] == status_v1["init-local"]["errors"]
         assert "SomeDatasource" == status_v1["datasource"]
         assert False is os.path.exists(
@@ -95,7 +98,10 @@ class TestCLI:
             link_d.join("result.json")
         ), "unexpected result.json link found"
 
-    def test_status_wrapper_init_local_honor_cloud_dir(self, mocker, tmpdir):
+    @mock.patch("cloudinit.cmd.main.atomic_helper.write_json")
+    def test_status_wrapper_init_local_honor_cloud_dir(
+        self, m_json, mocker, tmpdir
+    ):
         """When running in init-local mode, status_wrapper honors cloud_dir."""
         cloud_dir = tmpdir.join("cloud")
         paths = helpers.Paths({"cloud_dir": str(cloud_dir)})
@@ -111,8 +117,9 @@ class TestCLI:
 
         myargs = FakeArgs(("ignored_name", myaction), True, "bogusmode")
         cli.status_wrapper("init", myargs, link_d=link_d)  # No explicit data_d
+
         # Access cloud_dir directly
-        status_v1 = load_json(load_file(data_d.join("status.json")))["v1"]
+        status_v1 = m_json.call_args_list[1][0][1]["v1"]
         assert ["an_error"] == status_v1["init-local"]["errors"]
         assert "SomeDatasource" == status_v1["datasource"]
         assert False is os.path.exists(
@@ -326,6 +333,3 @@ class TestCLI:
         assert "features" == parseargs.action[0]
         assert False is parseargs.debug
         assert False is parseargs.force
-
-
-# : ts=4 expandtab


### PR DESCRIPTION
```
Export errors to status.json
```

## Additional Context
Clean run:
```
{
 "v1": {
  "datasource": "DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]",
  "init": {
   "errors": [],
   "exported_errors": {
    "critical": [],
    "deprecated": [],
    "error": [],
    "exception": [],
    "traceback": [],
    "warning": []
   },
   "finished": 1683277305.5818005,
   "start": 1683277304.527766
  },
  "init-local": {
   "errors": [],
   "exported_errors": {
    "critical": [],
    "deprecated": [],
    "error": [],
    "exception": [],
    "traceback": [],
    "warning": []
   },
   "finished": 1683277302.2842877,
   "start": 1683277301.8024473
  },
  "modules-config": {
   "errors": [],
   "exported_errors": {
    "critical": [],
    "deprecated": [],
    "error": [],
    "exception": [],
    "traceback": [],
    "warning": []
   },
   "finished": 1683277312.4656065,
   "start": 1683277311.7796779
  },
  "modules-final": {
   "errors": [],
   "exported_errors": {
    "critical": [],
    "deprecated": [],
    "error": [],
    "exception": [],
    "traceback": [],
    "warning": []
   },
   "finished": 1683277313.3603466,
   "start": 1683277313.0623832
  },
  "modules-init": {
   "errors": [],
   "finished": null,
   "start": null
  },
  "stage": null
 }
}
```

With example errors:
```
cat /run/cloud-init/status.json 
{
 "v1": {
  "datasource": "DataSourceNoCloud [seed=/var/lib/cloud/seed/nocloud-net][dsmode=net]",
  "init": {
   "errors": [],
   "exported_errors": {
    "critical": [
     "example cricial from init"
    ],
    "deprecated": [],
    "error": [],
    "exception": [],
    "traceback": [],
    "warning": []
   },
   "finished": 1683281505.1164653,
   "start": 1683281504.4399703
  },
  "init-local": {
   "errors": [],
   "exported_errors": {
    "critical": [],
    "deprecated": [],
    "error": [],
    "exception": [],
    "traceback": [],
    "warning": [
     "example warning from init-local"
    ]
   },
   "finished": 1683281501.8215854,
   "start": 1683281501.328478
  },
  "modules-config": {
   "errors": [],
   "exported_errors": {
    "critical": [],
    "deprecated": [],
    "error": [],
    "exception": [],
    "traceback": [],
    "warning": []
   },
   "finished": 1683281512.2618463,
   "start": 1683281511.6123438
  },
  "modules-final": {
   "errors": [],
   "exported_errors": {
    "critical": [],
    "deprecated": [],
    "error": [],
    "exception": [],
    "traceback": [],
    "warning": []
   },
   "finished": 1683281513.140139,
   "start": 1683281512.8469067
  },
  "modules-init": {
   "errors": [],
   "finished": null,
   "start": null
  },
  "stage": null
 }
}
```