### PR TITLE
tests: avoid leaks to underlying file-system for /etc/cloud/clean.d

### DIFF
--- a/tests/unittests/cmd/test_clean.py
+++ b/tests/unittests/cmd/test_clean.py
@@ -123,12 +123,15 @@ class TestClean:
         symlink = clean_paths.cloud_dir.join("mylink")
         sym_link(dir1.strpath, symlink.strpath)
 
-        retcode = wrap_and_call(
-            "cloudinit.cmd.clean",
-            {"Init": {"side_effect": init_class}},
-            clean.remove_artifacts,
-            remove_logs=False,
-        )
+        with mock.patch.object(
+            cloudinit.settings, "CLEAN_RUNPARTS_DIR", clean_paths.clean_dir
+        ):
+            retcode = wrap_and_call(
+                "cloudinit.cmd.clean",
+                {"Init": {"side_effect": init_class}},
+                clean.remove_artifacts,
+                remove_logs=False,
+            )
         assert 0 == retcode
         for path in (dir1, symlink):
             assert path.exists() is False, f"Unexpected {path} found"
@@ -146,12 +149,15 @@ class TestClean:
         for _dir in dirs:
             ensure_dir(_dir)
 
-        retcode = wrap_and_call(
-            "cloudinit.cmd.clean",
-            {"Init": {"side_effect": init_class}},
-            clean.remove_artifacts,
-            remove_logs=False,
-        )
+        with mock.patch.object(
+            cloudinit.settings, "CLEAN_RUNPARTS_DIR", clean_paths.clean_dir
+        ):
+            retcode = wrap_and_call(
+                "cloudinit.cmd.clean",
+                {"Init": {"side_effect": init_class}},
+                clean.remove_artifacts,
+                remove_logs=False,
+            )
         assert 0 == retcode
         for expected_dir in dirs[:2]:
             assert expected_dir.exists() is True, f"Missing {expected_dir}"
@@ -171,13 +177,16 @@ class TestClean:
         for _dir in dirs:
             ensure_dir(_dir)
 
-        retcode = wrap_and_call(
-            "cloudinit.cmd.clean",
-            {"Init": {"side_effect": init_class}},
-            clean.remove_artifacts,
-            remove_logs=False,
-            remove_seed=True,
-        )
+        with mock.patch.object(
+            cloudinit.settings, "CLEAN_RUNPARTS_DIR", clean_paths.clean_dir
+        ):
+            retcode = wrap_and_call(
+                "cloudinit.cmd.clean",
+                {"Init": {"side_effect": init_class}},
+                clean.remove_artifacts,
+                remove_logs=False,
+                remove_seed=True,
+            )
         assert 0 == retcode
         assert (
             clean_paths.cloud_dir.exists() is True


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: avoid leaks to underlying file-system for /etc/cloud/clean.d
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
# setup bogus script on test host which will exit non-zero
mkdir -p /etc/cloud/clean.d
cat > /etc/cloud/clean.d/1.sh <<EOF
#!/bin/bash
exit 1
EOF
chmod 755 /etc/cloud/clean.d/1.sh

# Run unittests and ensure no failure due to attempting to runparts on that /etc/cloud/clean.d directory
tox -e py3 tests/unittests/cmd/test_clean.py
```


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
