### PR TITLE
Add 'peers' and 'allow' directives in cc_ntp

### DIFF
--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -282,11 +282,24 @@ meta: MetaSchema = {
                  {% for server in servers -%}
                  server {{server}} iburst
                  {% endfor %}
+                 {% if peers -%}# peers{% endif %}
+                 {% for peer in peers -%}
+                 peer {{peer}}
+                 {% endfor %}
+                 {% if allow -%}# allow{% endif %}
+                 {% for cidr in allow -%}
+                 allow {{cidr}}
+                 {% endfor %}
           pools: [0.int.pool.ntp.org, 1.int.pool.ntp.org, ntp.myorg.org]
           servers:
             - ntp.server.local
             - ntp.ubuntu.com
-            - 192.168.23.2"""
+            - 192.168.23.2
+          allow:
+            - 192.168.23.0/32
+          peers:
+            - km001
+            - km002"""
         ),
     ],
     "frequency": PER_INSTANCE,
@@ -425,6 +438,8 @@ def write_ntp_config_template(
     service_name=None,
     servers=None,
     pools=None,
+    allow=None,
+    peers=None,
     path=None,
     template_fn=None,
     template=None,
@@ -437,6 +452,10 @@ def write_ntp_config_template(
     list.
     @param pools: A list of strings specifying ntp pools. Defaults to empty
     list.
+    @param allow: A list of strings specifying a network/CIDR. Defaults to
+    empty list.
+    @param peers: A list nodes that should peer with each other. Defaults to
+    empty list.
     @param path: A string to specify where to write the rendered template.
     @param template_fn: A string to specify the template source file.
     @param template: A string specifying the contents of the template. This
@@ -450,6 +469,10 @@ def write_ntp_config_template(
         servers = []
     if not pools:
         pools = []
+    if not allow:
+        allow = []
+    if not peers:
+        peers = []
 
     if len(servers) == 0 and len(pools) == 0 and distro_name == "cos":
         return
@@ -474,7 +497,12 @@ def write_ntp_config_template(
     if not template_fn and not template:
         raise ValueError("Not template_fn or template provided")
 
-    params = {"servers": servers, "pools": pools}
+    params = {
+        "servers": servers,
+        "pools": pools,
+        "allow": allow,
+        "peers": peers,
+    }
     if template:
         tfile = temp_utils.mkstemp(prefix="template_name-", suffix=".tmpl")
         template_fn = tfile[1]  # filepath is second item in tuple
@@ -596,11 +624,18 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             )
             raise RuntimeError(msg)
 
+    LOG.debug("service_name: %s", ntp_client_config.get("service_name"))
+    LOG.debug("servers: %s", ntp_cfg.get("servers", []))
+    LOG.debug("pools: %s", ntp_cfg.get("pools", []))
+    LOG.debug("allow: %s", ntp_cfg.get("allow", []))
+    LOG.debug("peers: %s", ntp_cfg.get("peers", []))
     write_ntp_config_template(
         cloud.distro.name,
         service_name=ntp_client_config.get("service_name"),
         servers=ntp_cfg.get("servers", []),
         pools=ntp_cfg.get("pools", []),
+        allow=ntp_cfg.get("allow", []),
+        peers=ntp_cfg.get("peers", []),
         path=ntp_client_config.get("confpath"),
         template_fn=template_fn,
         template=ntp_client_config.get("template"),

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1846,6 +1846,23 @@
               "uniqueItems": true,
               "description": "List of ntp servers. If both pools and servers are\nempty, 4 default pool servers will be provided with\nthe format ``{0-3}.{distro}.pool.ntp.org``."
             },
+            "peers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "hostname"
+              },
+              "uniqueItems": true,
+              "description": "List of ntp peers."
+            },
+            "allow": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true,
+              "description": "List of CIDRs to allow"
+            },
             "ntp_client": {
               "type": "string",
               "default": "auto",

--- a/templates/chrony.conf.alpine.tmpl
+++ b/templates/chrony.conf.alpine.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # This directive specifies the location of the file containing ID/key pairs for
 # NTP authentication.

--- a/templates/chrony.conf.centos.tmpl
+++ b/templates/chrony.conf.centos.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.cos.tmpl
+++ b/templates/chrony.conf.cos.tmpl
@@ -12,6 +12,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # This directive specify the file into which chronyd will store the rate
 # information.

--- a/templates/chrony.conf.debian.tmpl
+++ b/templates/chrony.conf.debian.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # This directive specify the location of the file containing ID/key pairs for
 # NTP authentication.

--- a/templates/chrony.conf.fedora.tmpl
+++ b/templates/chrony.conf.fedora.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.freebsd.tmpl
+++ b/templates/chrony.conf.freebsd.tmpl
@@ -42,6 +42,12 @@ server {{server}} iburst
 pool {{pool}} iburst
 {% endfor %}
 
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 #######################################################################
 ### AVOIDING POTENTIALLY BOGUS CHANGES TO YOUR CLOCK
 #

--- a/templates/chrony.conf.opensuse-leap.tmpl
+++ b/templates/chrony.conf.opensuse-leap.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.opensuse-microos.tmpl
+++ b/templates/chrony.conf.opensuse-microos.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.opensuse-tumbleweed.tmpl
+++ b/templates/chrony.conf.opensuse-tumbleweed.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.opensuse.tmpl
+++ b/templates/chrony.conf.opensuse.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.photon.tmpl
+++ b/templates/chrony.conf.photon.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.rhel.tmpl
+++ b/templates/chrony.conf.rhel.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.sle-micro.tmpl
+++ b/templates/chrony.conf.sle-micro.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.sle_hpc.tmpl
+++ b/templates/chrony.conf.sle_hpc.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.sles.tmpl
+++ b/templates/chrony.conf.sles.tmpl
@@ -11,6 +11,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # Record the rate at which the system clock gains/losses time.
 driftfile /var/lib/chrony/drift

--- a/templates/chrony.conf.ubuntu.tmpl
+++ b/templates/chrony.conf.ubuntu.tmpl
@@ -15,6 +15,12 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
 
 # This directive specify the location of the file containing ID/key pairs for
 # NTP authentication.

--- a/templates/ntp.conf.alpine.tmpl
+++ b/templates/ntp.conf.alpine.tmpl
@@ -8,3 +8,6 @@
 {% for server in servers -%}
 server {{server}}
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}

--- a/templates/ntp.conf.debian.tmpl
+++ b/templates/ntp.conf.debian.tmpl
@@ -29,6 +29,9 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 
 # Access control configuration; see /usr/share/doc/ntp-doc/html/accopt.html for
 # details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>

--- a/templates/ntp.conf.fedora.tmpl
+++ b/templates/ntp.conf.fedora.tmpl
@@ -30,6 +30,9 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 
 #broadcast 192.168.1.255 autokey	# broadcast server
 #broadcastclient			# broadcast client

--- a/templates/ntp.conf.freebsd.tmpl
+++ b/templates/ntp.conf.freebsd.tmpl
@@ -36,6 +36,9 @@ tos minclock 3 maxclock 6
 {% for pool in pools -%}
 pool {{pool}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 
 #
 # To configure a specific server, such as an organization-wide local

--- a/templates/ntp.conf.opensuse.tmpl
+++ b/templates/ntp.conf.opensuse.tmpl
@@ -42,6 +42,9 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 
 # Access control configuration; see /usr/share/doc/packages/ntp/html/accopt.html for
 # details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>

--- a/templates/ntp.conf.photon.tmpl
+++ b/templates/ntp.conf.photon.tmpl
@@ -31,6 +31,9 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 
 #broadcast 192.168.1.255 autokey	# broadcast server
 #broadcastclient			# broadcast client

--- a/templates/ntp.conf.rhel.tmpl
+++ b/templates/ntp.conf.rhel.tmpl
@@ -31,6 +31,9 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 
 #broadcast 192.168.1.255 autokey	# broadcast server
 #broadcastclient			# broadcast client

--- a/templates/ntp.conf.sles.tmpl
+++ b/templates/ntp.conf.sles.tmpl
@@ -42,6 +42,9 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 
 # Access control configuration; see /usr/share/doc/packages/ntp/html/accopt.html for
 # details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>

--- a/templates/ntp.conf.ubuntu.tmpl
+++ b/templates/ntp.conf.ubuntu.tmpl
@@ -27,6 +27,9 @@ pool {{pool}} iburst
 {% for server in servers -%}
 server {{server}} iburst
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 
 # Use Ubuntu's ntp server as a fallback.
 # pool ntp.ubuntu.com

--- a/templates/ntpd.conf.openbsd.tmpl
+++ b/templates/ntpd.conf.openbsd.tmpl
@@ -12,6 +12,9 @@ servers {{pool}}
 {% for server in servers -%}# servers
 server {{server}}
 {% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
 sensor *
 
 constraint from "9.9.9.9"              # quad9 v4 without DNS

--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -830,6 +830,17 @@ class TestNTPSchema:
                 "ntp.pools: 123 is not of type 'array'.*"
                 "ntp.servers: 'non-array' is not of type 'array'",
             ),
+            (
+                {
+                    "ntp": {
+                        "peers": [123],
+                        "allow": ["www.example.com", None],
+                    }
+                },
+                "Cloud config schema errors: "
+                "ntp.allow.1: None is not of type 'string',*"
+                ", ntp.peers.0: 123 is not of type 'string'",
+            ),
         ),
     )
     @skipUnlessJsonSchema()

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -61,6 +61,7 @@ ITJamie
 ixjhuang
 izzyleung
 j5awry
+jacobsalmela
 jamesottinger
 Jehops
 jf


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Adds the 'peer' and 'allow' directives to the NTP template.  This also adds additional debug logging for these settings.
```

## Additional Context

When deploying NTP servers and peers in a complex system, these additional settings enable the hostnames and IP ranges to be dynamically set in the config file.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Set a `peers` or `allow` directive in the template and run the NTP module.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
