### PR TITLE
schema: read_cfg_paths call init.fetch to lookup /v/l/c/instance

### DIFF
--- a/cloudinit/cmd/devel/__init__.py
+++ b/cloudinit/cmd/devel/__init__.py
@@ -17,9 +17,17 @@ def addLogHandlerCLI(logger, log_level):
     return logger
 
 
-def read_cfg_paths() -> Paths:
-    """Return a Paths object based on the system configuration on disk."""
+def read_cfg_paths(fetch_existing_datasource: str = "") -> Paths:
+    """Return a Paths object based on the system configuration on disk.
+
+    :param fetch_existing_datasource: String one of check or trust. Whether to
+        load the pickled datasource before returning Paths. This is necessary
+        when using instance paths via Paths.get_ipath method which are only
+        known from the instance-id metadata in the detected datasource.
+    """
     init = Init(ds_deps=[])
+    if fetch_existing_datasource:
+        init.fetch(existing=fetch_existing_datasource)
     init.read_cfg()
     return init.paths
 

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1264,7 +1264,7 @@ def handle_schema_args(name, args):
     if args.docs:
         print(load_doc(args.docs))
         return
-    paths = read_cfg_paths()
+    paths = read_cfg_paths(fetch_existing_datasource="trust")
     if args.instance_data:
         instance_data_path = args.instance_data
     elif os.getuid() != 0:

--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -58,7 +58,10 @@ def test_invalid_userdata(client: IntegrationInstance):
     result = client.execute("cloud-init schema --system")
     assert not result.ok
     assert "Cloud config schema errors" in result.stderr
-    assert 'needs to begin with "#cloud-config"' in result.stderr
+    assert (
+        "Expected first line to be one of: #!, ## template: jinja,"
+        " #cloud-boothook, #cloud-config" in result.stderr
+    )
     result = client.execute("cloud-init status --long")
     if not result.ok:
         raise AssertionError(

--- a/tests/unittests/cmd/devel/test_init.py
+++ b/tests/unittests/cmd/devel/test_init.py
@@ -1,0 +1,29 @@
+from unittest import mock
+
+from cloudinit import stages
+from cloudinit.cmd.devel import read_cfg_paths
+from tests.unittests.util import TEST_INSTANCE_ID, FakeDataSource
+
+
+class TestReadCfgPaths:
+    def test_read_cfg_paths_fetches_cached_datasource(self, tmpdir):
+        init = stages.Init()
+        init._cfg = {
+            "system_info": {
+                "distro": "ubuntu",
+                "paths": {"cloud_dir": tmpdir, "run_dir": tmpdir},
+            }
+        }
+        with mock.patch("cloudinit.cmd.devel.Init") as m_init:
+            with mock.patch.object(init, "_restore_from_cache") as restore:
+                restore.return_value = FakeDataSource(paths=init.paths)
+                with mock.patch(
+                    "cloudinit.util.read_conf_from_cmdline", return_value={}
+                ):
+                    m_init.return_value = init
+                    paths = read_cfg_paths()
+                    assert paths.get_ipath() is None
+                    paths = read_cfg_paths(fetch_existing_datasource="trust")
+        assert (
+            paths.get_ipath() == f"/var/lib/cloud/instances/{TEST_INSTANCE_ID}"
+        )

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -2060,3 +2060,6 @@ apt_reboot_if_required: Default: ``false``. Deprecated in version 22.2.\
             expected_err.format(cfg_file=user_data_fn, id_path=id_path) == err
         )
         assert "deprec" not in caplog.text
+        assert read_cfg_paths.call_args_list == [
+            mock.call(fetch_existing_datasource="trust")
+        ]


### PR DESCRIPTION
## Proposed Commit Message
```
Fix cloud-init schema --system being unable to find merged
userdata stored at /var/lib/cloud/instance/cloud_config.txt.

commit e9d1d3a regressed cloud-init schema --system by dropping
a call to fetch existing cached datasource information before
calling Init.paths.get_ipath.

Init.paths.get_ipath only has visibility to merged cloud config in
/var/lib/cloud/<instance_id>/cloud-config.txt after fetching the
existing cached datasource which provides instance-id from metadata
in order to determine the unique instance-id which represents
the full path to the cloud-config.txt.

To support reuse of read_cfg_paths helper function, add an optional
parameter fetch_existing_datasource which indicates whether reading
the existing datasource is necessary for this helper function.

cloud-init schema --system calls read_cfg_paths providing
fetch_existing_datasource="trust" prior to calls to
paths.get_ipath().
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
make deb
CLOUD_INIT_OS_IMAGE=lunar CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_23.1-98-g689cd92a7-1~bddeb_all.deb tox -e integration-tests tests/integration_tests/modules/test_cli.py
# Assert test_valid_userdata and test_invalid_userdata succeed
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
