### PR TITLE
launching salt-minion in masterless mode

### DIFF
--- a/cloudinit/config/cc_salt_minion.py
+++ b/cloudinit/config/cc_salt_minion.py
@@ -159,5 +159,5 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         # Note: see https://docs.saltproject.io/en/latest/topics/tutorials/quickstart.html
         subp.subp(["salt-call", "--local", "state.apply"], capture=False)
 
-    cloud.distro.manage_service("restart" if minion_daemon else "stop", const.srv_name)
     cloud.distro.manage_service("enable" if minion_daemon else "disable", const.srv_name)
+    cloud.distro.manage_service("restart" if minion_daemon else "stop", const.srv_name)

--- a/cloudinit/config/cc_salt_minion.py
+++ b/cloudinit/config/cc_salt_minion.py
@@ -156,14 +156,15 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if minion_data and minion_data.get("file_client") == "local":
         minion_daemon = False
 
-        # if salt-minion was configured as masterless, we should not run
-        # salt-minion as a daemon
-        # Note: see https://docs.saltproject.io/en/latest/topics/tutorials/quickstart.html
-        subp.subp(["salt-call", "--local", "state.apply"], capture=False)
-
     cloud.distro.manage_service(
         "enable" if minion_daemon else "disable", const.srv_name
     )
     cloud.distro.manage_service(
         "restart" if minion_daemon else "stop", const.srv_name
     )
+
+    if not minion_daemon:
+        # if salt-minion was configured as masterless, we should not run
+        # salt-minion as a daemon
+        # Note: see https://docs.saltproject.io/en/latest/topics/tutorials/quickstart.html
+        subp.subp(["salt-call", "--local", "state.apply"], capture=False)

--- a/cloudinit/config/cc_salt_minion.py
+++ b/cloudinit/config/cc_salt_minion.py
@@ -161,5 +161,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         # Note: see https://docs.saltproject.io/en/latest/topics/tutorials/quickstart.html
         subp.subp(["salt-call", "--local", "state.apply"], capture=False)
 
-    cloud.distro.manage_service("enable" if minion_daemon else "disable", const.srv_name)
-    cloud.distro.manage_service("restart" if minion_daemon else "stop", const.srv_name)
+    cloud.distro.manage_service(
+        "enable" if minion_daemon else "disable", const.srv_name
+    )
+    cloud.distro.manage_service(
+        "restart" if minion_daemon else "stop", const.srv_name
+    )

--- a/cloudinit/config/cc_salt_minion.py
+++ b/cloudinit/config/cc_salt_minion.py
@@ -122,6 +122,8 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # Ensure we can configure files at the right dir
     util.ensure_dir(const.conf_dir)
 
+    minion_data = None
+
     # ... and then update the salt configuration
     if "conf" in s_cfg:
         # Add all sections from the conf object to minion config file
@@ -151,7 +153,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     minion_daemon = True
 
-    if "file_client" in minion_data and minion_data["file_client"] == "local":
+    if minion_data and minion_data.get("file_client") == "local":
         minion_daemon = False
 
         # if salt-minion was configured as masterless, we should not run

--- a/tests/unittests/config/test_salt_minion.py
+++ b/tests/unittests/config/test_salt_minion.py
@@ -1,12 +1,23 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+from unittest import mock
+
 import pytest
 
+from cloudinit.config import cc_salt_minion
 from cloudinit.config.schema import (
     SchemaValidationError,
     get_schema,
     validate_cloudconfig_schema,
 )
 from tests.unittests.helpers import skipUnlessJsonSchema
+from tests.unittests.util import get_cloud
+
+
+@pytest.fixture(autouse=True)
+def common_mocks(mocker):
+    mocker.patch("cloudinit.util.ensure_dir")
+    mocker.patch("cloudinit.safeyaml.dumps")
+    mocker.patch("cloudinit.util.write_file")
 
 
 @skipUnlessJsonSchema()
@@ -31,3 +42,45 @@ class TestSaltMinionSchema:
         else:
             with pytest.raises(SchemaValidationError, match=error_msg):
                 validate_cloudconfig_schema(config, get_schema(), strict=True)
+
+
+class TestDaemonInstall:
+    def test_daemon_install(self, mocker):
+        m_subp = mocker.patch("cloudinit.subp.subp")
+        m_manage = mocker.patch(
+            "tests.unittests.util.MockDistro.manage_service"
+        )
+        cc_salt_minion.handle(
+            name="name", cfg={"salt_minion": {}}, cloud=get_cloud(), args=[]
+        )
+        assert m_manage.call_args_list == [
+            mock.call("enable", "salt-minion"),
+            mock.call("restart", "salt-minion"),
+        ]
+        m_subp.assert_not_called()
+
+    def test_file_client_local(self, mocker):
+        m_subp = mocker.patch("cloudinit.subp.subp")
+        m_manage = mocker.patch(
+            "tests.unittests.util.MockDistro.manage_service"
+        )
+        cc_salt_minion.handle(
+            name="name",
+            cfg={
+                "salt_minion": {
+                    "conf": {
+                        "file_client": "local",
+                    }
+                }
+            },
+            cloud=get_cloud(),
+            args=[],
+        )
+        assert m_manage.call_args_list == [
+            mock.call("disable", "salt-minion"),
+            mock.call("stop", "salt-minion"),
+        ]
+
+        m_subp.assert_called_once_with(
+            ["salt-call", "--local", "state.apply"], capture=False
+        )

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -152,6 +152,12 @@ class MockDistro(distros.Distro):
     def do_as(self, command, args=None, **kwargs):
         return ("stdout", "stderr")
 
+    @classmethod
+    def manage_service(
+        cls, action: str, service: str, *extra_args: str, rcs=None
+    ):
+        pass
+
 
 TEST_INSTANCE_ID = "i-testing"
 

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -152,12 +152,6 @@ class MockDistro(distros.Distro):
     def do_as(self, command, args=None, **kwargs):
         return ("stdout", "stderr")
 
-    @classmethod
-    def manage_service(
-        cls, action: str, service: str, *extra_args: str, rcs=None
-    ):
-        pass
-
 
 TEST_INSTANCE_ID = "i-testing"
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -38,6 +38,7 @@ david-caro
 dbungert
 ddymko
 dermotbradley
+dhalturin
 dhensby
 dorthu
 eandersson
@@ -157,4 +158,3 @@ yawkat
 zhan9san
 zhuzaifangxuele
 zykovd
-dhalturin

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -157,3 +157,4 @@ yawkat
 zhan9san
 zhuzaifangxuele
 zykovd
+dhalturin


### PR DESCRIPTION
## Proposed Commit Message
Launching salt-minion in masterless mode

```
If the minion is launched in masterless mode, then it should not be launched as a daemon.
```

## Additional Context
For more - https://docs.saltproject.io/en/latest/topics/tutorials/quickstart.html

## Test Steps
For testing and reproduce, you can run cloud-init with the following config:
```
#cloud-config
salt_minion:
  conf:
    file_client: local
    fileserver_backend:
     - gitfs
    gitfs_remotes:
     - https://github.com/foo/bar
```
Without a fix, salt-minion will not run correctly in this case.
This fix allows you to run salt-minion both in daemon mode and in masterless mode.

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
