### PR TITLE
Add templates for GitHub Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -4,18 +4,18 @@ about: Submit a bug report
 labels: bug, new
 ---
 
-<!--
-Thanks for taking the time to improve cloud-init!
-
-Please include the following in your bug report:
-
-1. Your cloud provider
-2. Any appropriate cloud-init configuration you can provide us with
-3. cloud-init logs:
-  Run `sudo cloud-init collect-logs`. Add `--include-userdata` if
-  there is no sensitive information in your user data.
-
-Include a minimal, reproducible example (<https://stackoverflow.com/help/minimal-reproducible-example>), if possible.
--->
-
 # Bug report
+<!-- bug description explaining unmet expectation or use-case -->
+
+## Steps to reproduce the problem
+<!--Provide any applicable user-data, config, commandline or procedure to reproduce this problem -->
+
+## Environment details
+- Cloud-init version:
+- Operating System Distribution:
+- Cloud provider, platform or installer type:
+
+## cloud-init logs
+<!--
+Please provide either the applicable excerpt of /var/log/cloud-init.log representing the failure or attach cloud-init-logs.tar.gz obtained by running `sudo cloud-init collect-logs`. Add `--include-userdata` if there is no sensitive information in your user data.
+-->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -10,10 +10,10 @@ Thanks for taking the time to improve cloud-init!
 Please include the following in your bug report:
 
 1. Your cloud provider
-2. Any appropriate cloud-init configuration you can provide us
+2. Any appropriate cloud-init configuration you can provide us with
 3. cloud-init logs:
   Run `sudo cloud-init collect-logs`. Add `--include-userdata` if
-  there is no sensitive information in your userdata.
+  there is no sensitive information in your user data.
 
 Include a minimal, reproducible example (<https://stackoverflow.com/help/minimal-reproducible-example>), if possible.
 -->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,21 @@
+---
+name: Bug
+about: Submit a bug report
+labels: bug, new
+---
+
+<!--
+Thanks for taking the time to improve cloud-init!
+
+Please include the following in your bug report:
+
+1. Your cloud provider
+2. Any appropriate cloud-init configuration you can provide us
+3. cloud-init logs:
+  Run `sudo cloud-init collect-logs`. Add `--include-userdata` if
+  there is no sensitive information in your userdata.
+
+Include a minimal, reproducible example (<https://stackoverflow.com/help/minimal-reproducible-example>), if possible.
+-->
+
+# Bug report

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
-  - name: "Getting Help"
+  - name: "Get Help"
     about: "Links to documentation and community support"
     url: "https://cloudinit.readthedocs.io/en/latest/#project-and-community"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: "Getting Help"
+    about: "Links to documentation and community support"
+    url: "https://cloudinit.readthedocs.io/en/latest/#project-and-community"

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,8 @@
+---
+name: Documentation
+about: Report a problem with the documentation
+title: "[docs]: "
+labels: documentation, new
+---
+
+# Documentation

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -5,4 +5,5 @@ title: "[docs]: "
 labels: documentation, new
 ---
 
-# Documentation
+# Documentation request
+<!-- Please include affected doc URL, command line utility or tool -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,6 +1,6 @@
 ---
 name: Documentation
-about: Report a problem with the documentation
+about: Give feedback, make a suggestion/requeset, or report a problem with the documentation
 title: "[docs]: "
 labels: documentation, new
 ---

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,6 +1,6 @@
 ---
 name: Documentation
-about: Give feedback, make a suggestion/requeset, or report a problem with the documentation
+about: Give feedback, make a suggestion/request, or report a problem with the documentation
 title: "[docs]: "
 labels: documentation, new
 ---

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,9 @@
+---
+name: Enhancement
+about: Functionality to improve cloud-init
+title: "[enhancement]: "
+labels: enhancement, new
+---
+
+# Enhancement
+

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ If you need additional help consider reaching out with one of the following opti
 
 - Ask a question in the [``#cloud-init`` IRC channel on Libera](https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init)
 - Search the cloud-init [mailing list archive](https://lists.launchpad.net/cloud-init/)
-- Better yet, join the [cloud-init mailing list](https://launchpad.net/~cloud-init) and participate
+* Follow announcements or ask a question on [Discourse](https://discourse.ubuntu.com/c/server/cloud-init/)
+- Join the [cloud-init mailing list](https://launchpad.net/~cloud-init) and participate
 - Find a bug? [Report bugs on GitHub Issues](https://github.com/canonical/cloud-init/issues)
 
 ## Distribution and cloud support

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you need additional help consider reaching out with one of the following opti
 
 - Ask a question in the [``#cloud-init`` IRC channel on Libera](https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init)
 - Search the cloud-init [mailing list archive](https://lists.launchpad.net/cloud-init/)
-* Follow announcements or ask a question on [Discourse](https://discourse.ubuntu.com/c/server/cloud-init/)
+* Follow announcements or ask a question on [the cloud-init Discourse forum](https://discourse.ubuntu.com/c/server/cloud-init/)
 - Join the [cloud-init mailing list](https://launchpad.net/~cloud-init) and participate
 - Find a bug? [Report bugs on GitHub Issues](https://github.com/canonical/cloud-init/issues)
 

--- a/doc/rtd/index.rst
+++ b/doc/rtd/index.rst
@@ -72,7 +72,7 @@ projects, contributions, suggestions, fixes and constructive feedback.
 
 * Read our `Code of Conduct`_
 * Ask questions in the ``#cloud-init`` `IRC channel on Libera`_
-* Follow announcements or ask a question on `Discourse`_
+* Follow announcements or ask a question on `the cloud-init Discourse forum`_
 * Join the `cloud-init mailing list`_
 * :ref:`Contribute on GitHub<contributing>`
 * `Release schedule`_
@@ -91,7 +91,7 @@ projects, contributions, suggestions, fixes and constructive feedback.
 .. LINKS
 .. _Code of Conduct: https://ubuntu.com/community/code-of-conduct
 .. _IRC channel on Libera: https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init
-.. _Discourse: https://discourse.ubuntu.com/c/server/cloud-init/
+.. _the cloud-init Discourse forum: https://discourse.ubuntu.com/c/server/cloud-init/
 .. _cloud-init mailing list: https://launchpad.net/~cloud-init
 .. _mailing list archive: https://lists.launchpad.net/cloud-init/
 .. _Release schedule: https://discourse.ubuntu.com/t/cloud-init-release-schedule/32244

--- a/doc/rtd/index.rst
+++ b/doc/rtd/index.rst
@@ -72,6 +72,7 @@ projects, contributions, suggestions, fixes and constructive feedback.
 
 * Read our `Code of Conduct`_
 * Ask questions in the ``#cloud-init`` `IRC channel on Libera`_
+* Follow announcements or ask a question on `Discourse`_
 * Join the `cloud-init mailing list`_
 * :ref:`Contribute on GitHub<contributing>`
 * `Release schedule`_
@@ -90,6 +91,7 @@ projects, contributions, suggestions, fixes and constructive feedback.
 .. LINKS
 .. _Code of Conduct: https://ubuntu.com/community/code-of-conduct
 .. _IRC channel on Libera: https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init
+.. _Discourse: https://discourse.ubuntu.com/c/server/cloud-init/
 .. _cloud-init mailing list: https://launchpad.net/~cloud-init
 .. _mailing list archive: https://lists.launchpad.net/cloud-init/
 .. _Release schedule: https://discourse.ubuntu.com/t/cloud-init-release-schedule/32244


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add templates for GitHub Issues
```

I tried it on a private repo first, and he's what the `New Issue` page looks like:
![image](https://github.com/canonical/cloud-init/assets/153674/34742627-1ccc-407e-a899-9d242876ad58)

The Security Policy page takes the user to our [SECURITY.md](https://github.com/canonical/cloud-init/blob/main/SECURITY.md)

GitHub does allow for [full web forms for issues](https://docs.github.com/assets/cb-80507/mw-1440/images/help/repository/sample-issue-form.webp) these days, but I think that might be overkill for our project. 

