### PR TITLE
FreeBSD: Fix user account locking

### DIFF
--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -147,9 +147,9 @@ class Distro(cloudinit.distros.bsd.BSD):
 
     def lock_passwd(self, name):
         try:
-            subp.subp(["pw", "usermod", name, "-h", "-"])
+            subp.subp(["pw", "usermod", name, "-w", "no"])
         except Exception:
-            util.logexc(LOG, "Failed to lock user %s", name)
+            util.logexc(LOG, "Failed to lock password login for user %s", name)
             raise
 
     def apply_locale(self, locale, out_fn=None):


### PR DESCRIPTION
## Proposed Commit Message
```
FreeBSD: Fix user account locking

On Linux, we only disable login via Password authentication.
On FreeBSD, we were right out locking the account.
This was reported back when #93 was merged,
but back then I didn't understand that.

Newly created FreeBSD users can now login with with SSH keys.

LP: #1854594 (For real this time)
Fixes: #3507

Sponsored by: The FreeBSD Foundation
```

## Additional Context

#93

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
