### PR TITLE
network-manager: generate ipv6 stateful dhcp config at par with sysconfig

### DIFF
--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -72,7 +72,7 @@ class NMConnection:
             "dhcp6": "auto",
             "ipv6_slaac": "auto",
             "ipv6_dhcpv6-stateless": "auto",
-            "ipv6_dhcpv6-stateful": "auto",
+            "ipv6_dhcpv6-stateful": "dhcp",
             "dhcp4": "auto",
             "dhcp": "auto",
         }


### PR DESCRIPTION
The sysconfig renderer sets the following in the ifcfg file for IPV6 stateful DHCP configuration:

 BOOTPROTO = "dhcp"
 DHCPV6C = True
 IPV6INIT = True
 IPV6_AUTOCONF = False

This should result in
  [ipv6]
  method=dhcp

in the network manager generated keyfile since DHCPV6C is set and IPV6_AUTOCONF is not set. Unfortunately the network manager renderer deviates from this and generates:
  [ipv6]
  method=auto

keyfile setting. This change fixes this deviation and sets the IPV6 dhcp stateful configuration in alignment with sysconfig renderer.

RHBZ: 2207716

