### PR TITLE
cc_rsyslog: Refactor for better multi-platform support

### DIFF
--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -1,8 +1,10 @@
 # Copyright (C) 2009-2010 Canonical Ltd.
 # Copyright (C) 2012 Hewlett-Packard Development Company, L.P.
+# Copyright (C) 2023 FreeBSD Foundation
 #
 # Author: Scott Moser <scott.moser@canonical.com>
 # Author: Juerg Haefliger <juerg.haefliger@hp.com>
+# Author: Mina Galić <FreeBSD@igalic.co>
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -83,13 +83,6 @@ DISTRO_OVERRIDES = {
         "config_dir": "/usr/local/etc/rsyslog.d",
         "packages": ["sysutils/rsyslog"],
     },
-    # this one is only necessary because of
-    # https://github.com/canonical/cloud-init/issues/4118
-    "dragonfly": {
-        "config_dir": "/usr/local/etc/rsyslog.d",
-        "check_exe": "rsyslogd",
-        "packages": ["sysutils/rsyslog"],
-    },
     "openbsd": {
         "config_dir": "/usr/local/etc/rsyslog.d",
         "packages": ["sysutils/rsyslog"],
@@ -119,7 +112,7 @@ def distro_default_rsyslog_config(distro: Distro):
     """
     dcfg = DISTRO_OVERRIDES
     cfg = copy.copy(RSYSLOG_CONFIG)
-    if distro.name in dcfg:
+    if distro.osfamily in dcfg:
         cfg = util.mergemanydict([cfg, dcfg[distro.name]], reverse=True)
     return cfg
 

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -32,9 +32,9 @@ convenience it can be specified as key value pairs in ``remotes``.
 This module can install rsyslog if it's not installed.
 
 .. note::
-On BSD cloud-init will attempt to disable and stop the base system syslogd.
-This might not work in the first run.
-We recommend creating images with ``service syslogd disable``.
+    On BSD cloud-init will attempt to disable and stop the base system syslogd.
+    This might not work in the first run on all systems.
+    We recommend creating images with ``service syslogd disable``.
 """
 
 meta: MetaSchema = {

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -81,7 +81,6 @@ RSYSLOG_CONFIG = {
 DISTRO_OVERRIDES = {
     "freebsd": {
         "config_dir": "/usr/local/etc/rsyslog.d",
-        "packages": ["sysutils/rsyslog"],
     },
     "openbsd": {
         "config_dir": "/usr/local/etc/rsyslog.d",
@@ -171,6 +170,8 @@ def load_config(cfg: dict, distro: Distro) -> dict:
             default_config["service_reload_command"],
             (str, list),
         ),
+        ("check_exe", default_config["check_exe"], str),
+        ("packages", default_config["packages"], list),
     )
 
     for key, default, vtypes in fillup:

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -29,10 +29,12 @@ This module configures remote system logging using rsyslog.
 Configuration for remote servers can be specified in ``configs``, but for
 convenience it can be specified as key value pairs in ``remotes``.
 
-This module can install rsyslog if it's not installed, and on BSD
-will attempt to disable and stop the base system syslog daemon.
-This might not work in the first run. We recommend creating images with
-``service syslogd disable``d.
+This module can install rsyslog if it's not installed.
+
+.. note::
+On BSD cloud-init will attempt to disable and stop the base system syslogd.
+This might not work in the first run.
+We recommend creating images with ``service syslogd disable``.
 """
 
 meta: MetaSchema = {

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -10,6 +10,7 @@
 
 """Rsyslog: Configure system logging via rsyslog"""
 
+import contextlib
 import copy
 import os
 import re
@@ -378,16 +379,15 @@ def disable_and_stop_bsd_base_syslog(cloud: Cloud) -> None:
     cloud.distro.manage_service("disable", "syslogd")
     cloud.distro.reload_init()
 
-    try:
+    with contextlib.suppress(subp.ProcessExecutionError):
         # for some inexplicable reason we're running after syslogd,
-        # try to stop it:
+        # try to stop it, ignoring failures, only log the fact that
+        # syslog is running, which it shouldn't be.
         cloud.distro.manage_service("onestop", "syslogd")
         LOG.error(
             "syslogd is running before cloud-init! "
             "Please report this as bug to the porters!"
         )
-    except subp.ProcessExecutionError:
-        pass
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -376,8 +376,7 @@ def disable_and_stop_bsd_base_syslog(cloud: Cloud) -> None:
     except subp.ProcessExecutionError:
         # we're running before syslogd, make sure to tell rc(8) to reload its
         # config, so it won't start syslogd
-        if cloud.distro.osfamily == "freebsd":
-            cloud.distro.reload_rc()
+        cloud.distro.reload_init()
         # Either way, we're done here
         return
 

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -82,12 +82,13 @@ RSYSLOG_CONFIG = {
     "remotes": {},
     "configs": {},
     "check_exe": "rsyslogd",
-    "packages": ["rsyslog"],
+    "packages": [],
 }
 
 DISTRO_OVERRIDES = {
     "freebsd": {
         "config_dir": "/usr/local/etc/rsyslog.d",
+        "packages": ["rsyslog"],
     },
     "openbsd": {
         "config_dir": "/usr/local/etc/rsyslog.d",

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -157,7 +157,7 @@ def load_config(cfg: dict, distro: Distro) -> dict:
     Raise a `ValueError` if some top level entry has an incorrect type.
     """
     mycfg = cfg.get("rsyslog", {})
-    default_config = distro_default_rsyslog_config(distro)
+    distro_config = distro_default_rsyslog_config(distro)
 
     if isinstance(cfg.get("rsyslog"), list):
         util.deprecate(
@@ -172,16 +172,16 @@ def load_config(cfg: dict, distro: Distro) -> dict:
 
     fillup: tuple = (
         ("configs", [], list),
-        ("config_dir", default_config["config_dir"], str),
-        ("config_filename", default_config["config_filename"], str),
-        ("remotes", default_config["remotes"], dict),
+        ("config_dir", distro_config["config_dir"], str),
+        ("config_filename", distro_config["config_filename"], str),
+        ("remotes", distro_config["remotes"], dict),
         (
             "service_reload_command",
-            default_config["service_reload_command"],
+            distro_config["service_reload_command"],
             (str, list),
         ),
-        ("check_exe", default_config["check_exe"], str),
-        ("packages", default_config["packages"], list),
+        ("check_exe", distro_config["check_exe"], str),
+        ("packages", distro_config["packages"], list),
     )
 
     for key, default, vtypes in fillup:

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -30,10 +30,9 @@ This module configures remote system logging using rsyslog.
 Configuration for remote servers can be specified in ``configs``, but for
 convenience it can be specified as key value pairs in ``remotes``.
 
-This module can install rsyslog ``packages`` (Default: ``["rsyslog"]``) if
-``check_exe`` (Default: ``"rsyslogd"``) cannot be found.
-On many systems, this may not work, because networking isn't up yet.
-That's why ``install_rsyslog`` defaults to ``False``.
+This module can install rsyslog if not already present on the system using the
+``install_rsyslog``, ``packages``, and ``check_exe`` options. Installation
+may not work on systems where this module runs before networking is up.
 
 .. note::
     On BSD cloud-init will attempt to disable and stop the base system syslogd.

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -71,6 +71,15 @@ meta: MetaSchema = {
                 service_reload_command: [your, syslog, restart, command]
             """
         ),
+        dedent(
+            """\
+            # default (no) configuration with package installation on FreeBSD
+            rsyslog:
+                config_dir: /usr/local/etc/rsyslog.d
+                check_exe: "rsyslogd"
+                packages: ["rsyslogd"]
+            """
+        ),
     ],
     "activate_by_schema_keys": ["rsyslog"],
 }

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2384,6 +2384,11 @@
               },
               "uniqueItems": true,
               "description": "List of packages needed to be installed for rsyslog."
+            },
+            "install_rsyslog": {
+              "default": false,
+              "description": "Install rsyslog. Default: ``false``",
+              "type": "boolean"
             }
           }
         }

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2372,6 +2372,18 @@
                   }
                 }
               ]
+            },
+            "check_exe": {
+              "type": "string",
+              "description": "The executable name for the rsyslog daemon.\nFor example, ``rsyslogd``, or ``/opt/sbin/rsyslogd`` if the rsyslog binary is in an unusual path."
+            },
+            "packages": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "uniqueItems": true,
+              "description": "List of packages needed to be installed for rsyslog."
             }
           }
         }

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2373,9 +2373,14 @@
                 }
               ]
             },
+            "install_rsyslog": {
+              "default": false,
+              "description": "Install rsyslog. Default: ``false``",
+              "type": "boolean"
+            },
             "check_exe": {
               "type": "string",
-              "description": "The executable name for the rsyslog daemon.\nFor example, ``rsyslogd``, or ``/opt/sbin/rsyslogd`` if the rsyslog binary is in an unusual path."
+              "description": "The executable name for the rsyslog daemon.\nFor example, ``rsyslogd``, or ``/opt/sbin/rsyslogd`` if the rsyslog binary is in an unusual path. This is only used if ``install_rsyslog`` is ``true``. Default: ``rsyslogd``"
             },
             "packages": {
               "type": "array",
@@ -2383,12 +2388,7 @@
                 "type": "string"
               },
               "uniqueItems": true,
-              "description": "List of packages needed to be installed for rsyslog."
-            },
-            "install_rsyslog": {
-              "default": false,
-              "description": "Install rsyslog. Default: ``false``",
-              "type": "boolean"
+              "description": "List of packages needed to be installed for rsyslog. This is only used if ``install_rsyslog`` is ``true``. Default: ``[rsyslog]``"
             }
           }
         }

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -35,6 +35,7 @@ class BSD(distros.Distro):
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         cfg["ssh_svcname"] = "sshd"
+        cfg["rsyslog_svcname"] = "rsyslogd"
         self.osfamily = platform.system().lower()
 
     def _read_system_hostname(self):

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -37,18 +37,19 @@ class Distro(cloudinit.distros.bsd.BSD):
     prefer_fqdn = True  # See rc.conf(5) in FreeBSD
     home_dir = "/usr/home"
 
-    @staticmethod
-    def reload_rc() -> None:
+    @classmethod
+    def reload_init(cls, rcs=None):
+        """
+        Tell rc to reload its configuration
+        Note that this only works while we're still in the process of booting.
+        May raise ProcessExecutionError
+        """
         rc_pid = os.environ.get("RC_PID")
         if rc_pid is None:
             LOG.warning("Unable to reload rc(8): no RC_PID in Environment")
             return
 
-        try:
-            subp.subp(["kill", "-SIGALRM", rc_pid])
-        except subp.ProcessExecutionError as e:
-            LOG.warning("Failed to reload rc(8): %s", e)
-        return
+        return subp.subp(["kill", "-SIGALRM", rc_pid], capture=True, rcs=rcs)
 
     @classmethod
     def manage_service(

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -103,12 +103,10 @@ cloud_init_modules:
 {% if variant in ["alpine", "photon"] %}
  - resolv_conf
 {% endif %}
-{% if not variant.endswith("bsd") %}
-{% if variant not in ["photon"] %}
- - ca_certs
+{% if not is_bsd or variant not in ["photon"] %}
+ - ca-certs
 {% endif %}
  - rsyslog
-{% endif %}
  - users_groups
  - ssh
 

--- a/tests/unittests/config/test_cc_rsyslog.py
+++ b/tests/unittests/config/test_cc_rsyslog.py
@@ -36,7 +36,7 @@ class TestLoadConfig(TestCase):
             "configs": [],
             "remotes": {},
             "check_exe": "rsyslogd",
-            "packages": ["rsyslog"],
+            "packages": [],
         }
         self.bsdcfg = {
             "config_filename": "20-cloud-config.conf",

--- a/tests/unittests/config/test_cc_rsyslog.py
+++ b/tests/unittests/config/test_cc_rsyslog.py
@@ -11,9 +11,6 @@ import pytest
 
 from cloudinit import util
 from cloudinit.config.cc_rsyslog import (
-    DEF_DIR,
-    DEF_FILENAME,
-    DEF_RELOAD,
     apply_rsyslog_changes,
     load_config,
     parse_remotes_line,
@@ -31,9 +28,9 @@ class TestLoadConfig(TestCase):
     def setUp(self):
         super(TestLoadConfig, self).setUp()
         self.basecfg = {
-            "config_filename": DEF_FILENAME,
-            "config_dir": DEF_DIR,
-            "service_reload_command": DEF_RELOAD,
+            "config_filename": "20-cloud-config.conf",
+            "config_dir": "/etc/rsyslog.d",
+            "service_reload_command": "auto",
             "configs": [],
             "remotes": {},
         }
@@ -291,6 +288,3 @@ class TestInvalidKeyType:
         else:
             with pytest.raises(ValueError, match=re.escape(error_msg)):
                 callable_()
-
-
-# vi: ts=4 expandtab

--- a/tests/unittests/config/test_cc_rsyslog.py
+++ b/tests/unittests/config/test_cc_rsyslog.py
@@ -36,7 +36,8 @@ class TestLoadConfig(TestCase):
             "configs": [],
             "remotes": {},
             "check_exe": "rsyslogd",
-            "packages": [],
+            "packages": ["rsyslog"],
+            "install_rsyslog": False,
         }
         self.bsdcfg = {
             "config_filename": "20-cloud-config.conf",
@@ -46,6 +47,7 @@ class TestLoadConfig(TestCase):
             "remotes": {},
             "check_exe": "rsyslogd",
             "packages": ["rsyslog"],
+            "install_rsyslog": False,
         }
 
     def test_legacy_full(self, distro=None):

--- a/tests/unittests/config/test_cc_rsyslog.py
+++ b/tests/unittests/config/test_cc_rsyslog.py
@@ -35,6 +35,8 @@ class TestLoadConfig(TestCase):
             "service_reload_command": "auto",
             "configs": [],
             "remotes": {},
+            "check_exe": "rsyslogd",
+            "packages": ["rsyslog"],
         }
         self.bsdcfg = {
             "config_filename": "20-cloud-config.conf",
@@ -42,6 +44,8 @@ class TestLoadConfig(TestCase):
             "service_reload_command": "auto",
             "configs": [],
             "remotes": {},
+            "check_exe": "rsyslogd",
+            "packages": ["rsyslog"],
         }
 
     def test_legacy_full(self, distro=None):

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -21,7 +21,10 @@ def get_cloud(
     paths = paths or helpers.Paths({})
     sys_cfg = sys_cfg or {}
     cls = distros.fetch(distro) if distro else MockDistro
-    mydist = cls(distro, sys_cfg, paths)
+    # *BSD calls platform.system to determine osfamilies
+    osfamily = distro.lower() if distro else "ubuntu"
+    with mock.patch("platform.system", return_value=osfamily):
+        mydist = cls(distro, sys_cfg, paths)
     if mocked_distro:
         mydist = mock.MagicMock(wraps=mydist)
     myds = DataSourceTesting(sys_cfg, mydist, paths)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_rsyslog: Refactor for better multi-platform support

- remove Hash key redirection
- copy basic multi-distro config from cc_ntp
- add optional installation
- enable and start services
- on BSD: disable Base system syslog

Co-Authored-by: Chad Smith <chad.smith@canonical.com>
Co-Authored-by: James Falcon <james.falcon@canonical.com>
Sponsored by: The FreeBSD Foundation

Fixes: #3250, #4118
LP: #1798055
```

## Additional Context
Fixes: #3250, #4118
LP: #1798055

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
