### PR TITLE
doc: add missing semi-colon to nocloud cmdline docs

### DIFF
--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -30,7 +30,7 @@ where on the filesystem to look.
 Alternatively, one can provide metadata via the kernel command line or SMBIOS
 "serial number" option. This argument might look like: ::
 
-  ds=nocloud s=file://path/to/directory/;h=node-42
+  ds=nocloud;s=file://path/to/directory/;h=node-42
 
 Method 3: Custom webserver: kernel commandline or SMBIOS
 --------------------------------------------------------
@@ -39,7 +39,10 @@ In a similar fashion, configuration files can be provided to cloud-init using a
 custom webserver at a URL dictated by kernel commandline arguments or SMBIOS
 serial number. This argument might look like: ::
 
-  ds=nocloud s=http://10.42.42.42/cloud-init/configs/
+  ds=nocloud-net;s=http://10.42.42.42/cloud-init/configs/
+
+.. note::
+   When supplementing kernel parameters in Grub's boot menu take care to single-quote this full value to avoid Grub interpreting the semi-colon as a reserved word. See: `Grub Quoting`_
 
 Permitted keys
 ==============
@@ -256,3 +259,4 @@ Example config
 
 .. _iso9660: https://en.wikipedia.org/wiki/ISO_9660
 .. _vfat: https://en.wikipedia.org/wiki/File_Allocation_Table
+.. _Grub Quoting: https://www.gnu.org/software/grub/manual/grub/grub.html#Quoting

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -259,4 +259,4 @@ Example config
 
 .. _iso9660: https://en.wikipedia.org/wiki/ISO_9660
 .. _vfat: https://en.wikipedia.org/wiki/File_Allocation_Table
-.. _Grub Quoting: https://www.gnu.org/software/grub/manual/grub/grub.html#Quoting
+.. _GRUB quoting: https://www.gnu.org/software/grub/manual/grub/grub.html#Quoting

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -42,7 +42,7 @@ serial number. This argument might look like: ::
   ds=nocloud-net;s=http://10.42.42.42/cloud-init/configs/
 
 .. note::
-   When supplementing kernel parameters in Grub's boot menu take care to single-quote this full value to avoid Grub interpreting the semi-colon as a reserved word. See: `Grub Quoting`_
+   When supplementing kernel parameters in GRUB's boot menu take care to single-quote this full value to avoid GRUB interpreting the semi-colon as a reserved word. See: `GRUB quoting`_
 
 Permitted keys
 ==============


### PR DESCRIPTION
## Proposed Commit Message

```
doc: add missing semi-colon to nocloud cmdline docs

Co-authored-by: s-makin <sally.makin@canonical.com>
```

## Additional Context
tox -e doc
xdg-open doc/rtd_html/reference/datasources/nocloud.html

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
