### PR TITLE
cc_ntp: Sync up with current FreeBSD ntp.conf

### DIFF
--- a/templates/ntp.conf.freebsd.tmpl
+++ b/templates/ntp.conf.freebsd.tmpl
@@ -22,12 +22,13 @@
 tos minclock 3 maxclock 6
 
 #
-# The following pool statement will give you a random set of NTP servers
-# geographically close to you.  A single pool statement adds multiple
-# servers from the pool, according to the tos minclock/maxclock targets.
+# The following pool statements will give you a random set of IPv4 and IPv6
+# NTP servers geographically close to you.  A single pool statement adds
+# multiple servers from the pool, according to the tos minclock/maxclock
+# targets.
 # See http://www.pool.ntp.org/ for details.  Note, pool.ntp.org encourages
 # users with a static IP and good upstream NTP servers to add a server
-# to the pool. See http://www.pool.ntp.org/join.html if you are interested.
+# to the pool.  See http://www.pool.ntp.org/join.html if you are interested.
 #
 # The option `iburst' is used for faster initial synchronization.
 #


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ntp: Sync up with current FreeBSD ntp.conf

ref: https://reviews.freebsd.org/D39954

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
