### PR TITLE
network_manager: add a method for ipv6 static IP configuration

### DIFF
--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -69,6 +69,7 @@ class NMConnection:
 
         method_map = {
             "static": "manual",
+            "static6": "manual",
             "dhcp6": "auto",
             "ipv6_slaac": "auto",
             "ipv6_dhcpv6-stateless": "auto",


### PR DESCRIPTION
The static IP configuration for IPv6 in the method_map is missing for network manager renderer. This is causing cloud-init to generate a keyfile with IPv6 method as "auto" instead of "manual". This fixes this issue.

fixes: https://github.com/canonical/cloud-init/issues/4126
RHBZ: 2196284

