### PR TITLE
Standardise module names in cloud.cfg.tmpl to only use underscore

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -412,13 +412,13 @@ def _should_auto_attach(ua_section: dict) -> bool:
 def _attach(ua_section: dict):
     token = ua_section.get("token")
     if not token:
-        msg = "`ubuntu-advantage.token` required in non-Pro Ubuntu instances."
+        msg = "`ubuntu_advantage.token` required in non-Pro Ubuntu instances."
         LOG.error(msg)
         raise RuntimeError(msg)
     enable_beta = ua_section.get("enable_beta")
     if enable_beta:
         LOG.debug(
-            "Ignoring `ubuntu-advantage.enable_beta` services in UA attach:"
+            "Ignoring `ubuntu_advantage.enable_beta` services in UA attach:"
             " %s",
             ", ".join(enable_beta),
         )

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -1,5 +1,4 @@
 ## template:jinja
-
 # The top level settings are used as module
 # and base configuration.
 {% set is_bsd = variant in ["dragonfly", "freebsd", "netbsd", "openbsd"] %}
@@ -89,7 +88,7 @@ cloud_init_modules:
  - seed_random
 {% endif %}
  - bootcmd
- - write-files
+ - write_files
 {% if variant not in ["netbsd", "openbsd"] %}
  - growpart
  - resizefs
@@ -106,11 +105,11 @@ cloud_init_modules:
 {% endif %}
 {% if not variant.endswith("bsd") %}
 {% if variant not in ["photon"] %}
- - ca-certs
+ - ca_certs
 {% endif %}
  - rsyslog
 {% endif %}
- - users-groups
+ - users_groups
  - ssh
 
 # The modules that run in the 'config' stage
@@ -125,7 +124,7 @@ cloud_config_modules:
  - ubuntu_autoinstall
 {% endif %}
 {% if variant not in ["photon"] %}
- - ssh-import-id
+ - ssh_import_id
 {% if not is_rhel %}
  - keyboard
 {% endif %}
@@ -139,25 +138,25 @@ cloud_config_modules:
 {% if variant not in ["mariner", "photon"] %}
  - spacewalk
 {% endif %}
- - yum-add-repo
+ - yum_add_repo
 {% endif %}
 {% if variant in ["ubuntu", "unknown", "debian"] %}
- - grub-dpkg
- - apt-pipelining
- - apt-configure
+ - grub_dpkg
+ - apt_pipelining
+ - apt_configure
 {% endif %}
 {% if variant in ["ubuntu"] %}
- - ubuntu-advantage
+ - ubuntu_advantage
 {% endif %}
 {% if variant in ["suse"] %}
- - zypper-add-repo
+ - zypper_add_repo
 {% endif %}
 {% if variant in ["alpine"] %}
- - apk-configure
+ - apk_configure
 {% endif %}
  - ntp
  - timezone
- - disable-ec2-metadata
+ - disable_ec2_metadata
  - runcmd
 {% if variant in ["ubuntu", "unknown", "debian"] %}
  - byobu
@@ -165,16 +164,16 @@ cloud_config_modules:
 
 # The modules that run in the 'final' stage
 cloud_final_modules:
- - package-update-upgrade-install
+ - package_update_upgrade_install
 {% if variant in ["ubuntu", "unknown", "debian"] %}
  - fan
  - landscape
  - lxd
 {% endif %}
 {% if variant in ["ubuntu", "unknown"] %}
- - ubuntu-drivers
+ - ubuntu_drivers
 {% endif %}
- - write-files-deferred
+ - write_files_deferred
  - puppet
  - chef
  - ansible
@@ -183,17 +182,17 @@ cloud_final_modules:
  - reset_rmc
  - refresh_rmc_and_interface
  - rightscale_userdata
- - scripts-vendor
- - scripts-per-once
- - scripts-per-boot
- - scripts-per-instance
- - scripts-user
- - ssh-authkey-fingerprints
- - keys-to-console
- - install-hotplug
- - phone-home
- - final-message
- - power-state-change
+ - scripts_vendor
+ - scripts_per_once
+ - scripts_per_boot
+ - scripts_per_instance
+ - scripts_user
+ - ssh_authkey_fingerprints
+ - keys_to_console
+ - install_hotplug
+ - phone_home
+ - final_message
+ - power_state_change
 
 # System and/or distro specific settings
 # (not accessible to handlers/transforms)

--- a/tests/integration_tests/modules/test_ca_certs.py
+++ b/tests/integration_tests/modules/test_ca_certs.py
@@ -103,11 +103,11 @@ class TestCaCerts:
         verify_clean_log(log, ignore_deprecations=False)
 
         expected_inactive = {
-            "apt-pipelining",
+            "apt_pipelining",
             "ansible",
             "bootcmd",
             "chef",
-            "disable-ec2-metadata",
+            "disable_ec2_metadata",
             "disk_setup",
             "fan",
             "keyboard",
@@ -115,22 +115,22 @@ class TestCaCerts:
             "lxd",
             "mcollective",
             "ntp",
-            "package-update-upgrade-install",
-            "phone-home",
-            "power-state-change",
+            "package_update_upgrade_install",
+            "phone_home",
+            "power_state_change",
             "puppet",
             "rsyslog",
             "runcmd",
-            "salt-minion",
+            "salt_minion",
             "snap",
             "timezone",
             "ubuntu_autoinstall",
-            "ubuntu-advantage",
-            "ubuntu-drivers",
+            "ubuntu_advantage",
+            "ubuntu_drivers",
             "update_etc_hosts",
             "wireguard",
-            "write-files",
-            "write-files-deferred",
+            "write_files",
+            "write_files_deferred",
         }
 
         # Remove modules that run independent from user-data
@@ -140,8 +140,8 @@ class TestCaCerts:
             expected_inactive.discard("ntp")
         elif class_client.settings.PLATFORM == "lxd_vm":
             if class_client.settings.OS_IMAGE == "bionic":
-                expected_inactive.discard("write-files")
-                expected_inactive.discard("write-files-deferred")
+                expected_inactive.discard("write_files")
+                expected_inactive.discard("write_files_deferred")
 
         diff = expected_inactive.symmetric_difference(
             get_inactive_modules(log)

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -225,7 +225,6 @@ class TestCombined:
         verify_clean_log(log, ignore_deprecations=False)
         requested_modules = {
             "apt_configure",
-            "apt_pipelining",
             "byobu",
             "final_message",
             "locale",

--- a/tests/integration_tests/modules/test_disk_setup.py
+++ b/tests/integration_tests/modules/test_disk_setup.py
@@ -191,7 +191,7 @@ class TestPartProbeAvailability:
             UPDATED_PARTPROBE_USERDATA,
         )
         client.execute(
-            "sed -i 's/write-files/write-files\\n - mounts/' "
+            "sed -i 's/write_files/write_files\\n - mounts/' "
             "/etc/cloud/cloud.cfg"
         )
 

--- a/tests/integration_tests/modules/test_frequency_override.py
+++ b/tests/integration_tests/modules/test_frequency_override.py
@@ -13,21 +13,21 @@ runcmd:
 def test_frequency_override(client: IntegrationInstance):
     # Some pre-checks
     assert (
-        "running config-scripts-user with frequency once-per-instance"
+        "running config-scripts_user with frequency once-per-instance"
         in client.read_from_file("/var/log/cloud-init.log")
     )
     assert client.read_from_file("/var/tmp/hi").strip().count("hi") == 1
 
-    # Change frequency of scripts-user to always
+    # Change frequency of scripts_user to always
     config = client.read_from_file("/etc/cloud/cloud.cfg")
-    new_config = config.replace("- scripts-user", "- [ scripts-user, always ]")
+    new_config = config.replace("- scripts_user", "- [ scripts_user, always ]")
     client.write_to_file("/etc/cloud/cloud.cfg", new_config)
 
     client.restart()
 
     # Ensure the script was run again
     assert (
-        "running config-scripts-user with frequency always"
+        "running config-scripts_user with frequency always"
         in client.read_from_file("/var/log/cloud-init.log")
     )
     assert client.read_from_file("/var/tmp/hi").strip().count("hi") == 2

--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -84,10 +84,10 @@ class TestPowerChange:
             log = instance.read_from_file("/var/log/cloud-init.log")
             assert _can_connect(instance)
         lines_to_check = [
-            "Running module power-state-change",
+            "Running module power_state_change",
             expected,
             "running 'init-local'",
-            "config-power-state-change already ran",
+            "config-power_state_change already ran",
         ]
         verify_ordered_items_in_text(lines_to_check, log)
 

--- a/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
+++ b/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
@@ -36,7 +36,7 @@ class TestSshAuthkeyFingerprints:
     def test_ssh_authkey_fingerprints_disable(self, client):
         cloudinit_output = client.read_from_file("/var/log/cloud-init.log")
         assert (
-            "Skipping module named ssh-authkey-fingerprints, "
+            "Skipping module named ssh_authkey_fingerprints, "
             "logging of SSH fingerprints disabled" in cloudinit_output
         )
 

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -42,7 +42,7 @@ class TestMain(FilesystemMockingTestCase):
                     "permissions": 0o755,
                 },
             ],
-            "cloud_init_modules": ["write-files", "runcmd"],
+            "cloud_init_modules": ["write_files", "runcmd"],
         }
         cloud_cfg = safeyaml.dumps(self.cfg)
         ensure_dir(os.path.join(self.new_root, "etc", "cloud"))

--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -32,13 +32,13 @@ class TestNoConfig(FilesystemMockingTestCase):
     def setUp(self):
         super(TestNoConfig, self).setUp()
         self.add_patch(CC_APK + "._write_repositories_file", "m_write_repos")
-        self.name = "apk-configure"
+        self.name = "apk_configure"
         self.cloud_init = None
         self.args = []
 
     def test_no_config(self):
         """
-        Test that nothing is done if no apk-configure
+        Test that nothing is done if no apk_configure
         configuration is provided.
         """
         config = util.get_builtin_cfg()
@@ -56,7 +56,7 @@ class TestConfig(FilesystemMockingTestCase):
         for dirname in ["tmp", "etc/apk"]:
             util.ensure_dir(os.path.join(self.new_root, dirname))
         self.paths = helpers.Paths({"templates_dir": self.new_root})
-        self.name = "apk-configure"
+        self.name = "apk_configure"
         self.cloud = cloud.Cloud(None, self.paths, None, None, None)
         self.args = []
 

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -24,7 +24,7 @@ from tests.unittests.util import get_cloud
 class TestNoConfig(unittest.TestCase):
     def setUp(self):
         super(TestNoConfig, self).setUp()
-        self.name = "ca-certs"
+        self.name = "ca_certs"
         self.cloud_init = None
         self.args = []
 
@@ -50,7 +50,7 @@ class TestNoConfig(unittest.TestCase):
 class TestConfig(TestCase):
     def setUp(self):
         super(TestConfig, self).setUp()
-        self.name = "ca-certs"
+        self.name = "ca_certs"
         self.paths = None
         self.args = []
 

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -751,7 +751,7 @@ class TestHandle:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Ignoring `ubuntu-advantage.enable_beta` services in"
+                        "Ignoring `ubuntu_advantage.enable_beta` services in"
                         " UA attach: realtime-kernel",
                     )
                 ],
@@ -1075,7 +1075,7 @@ class TestHandle:
         with pytest.raises(
             RuntimeError,
             match=re.escape(
-                "`ubuntu-advantage.token` required in non-Pro Ubuntu"
+                "`ubuntu_advantage.token` required in non-Pro Ubuntu"
                 " instances."
             ),
         ):
@@ -1087,7 +1087,7 @@ class TestHandle:
             )
         assert [] == m_subp.call_args_list
         assert (
-            "`ubuntu-advantage.token` required in non-Pro Ubuntu"
+            "`ubuntu_advantage.token` required in non-Pro Ubuntu"
             " instances.\n"
         ) in caplog.text
 
@@ -1175,7 +1175,7 @@ class TestAttach:
         with pytest.raises(
             RuntimeError,
             match=(
-                "`ubuntu-advantage.token` required in non-Pro Ubuntu"
+                "`ubuntu_advantage.token` required in non-Pro Ubuntu"
                 " instances."
             ),
         ):

--- a/tests/unittests/runs/test_merge_run.py
+++ b/tests/unittests/runs/test_merge_run.py
@@ -21,7 +21,7 @@ class TestMergeRun(helpers.FilesystemMockingTestCase):
         self.replicateTestRoot("simple_ubuntu", new_root)
         cfg = {
             "datasource_list": ["None"],
-            "cloud_init_modules": ["write-files"],
+            "cloud_init_modules": ["write_files"],
             "system_info": {"paths": {"run_dir": new_root}},
         }
         ud = helpers.readResource("user_data.1.txt")
@@ -54,7 +54,7 @@ class TestMergeRun(helpers.FilesystemMockingTestCase):
         (which_ran, failures) = mods.run_section("cloud_init_modules")
         self.assertTrue(len(failures) == 0)
         self.assertTrue(os.path.exists("/etc/blah.ini"))
-        self.assertIn("write-files", which_ran)
+        self.assertIn("write_files", which_ran)
         contents = util.load_file("/etc/blah.ini")
         self.assertEqual(contents, "blah")
 

--- a/tests/unittests/runs/test_simple_run.py
+++ b/tests/unittests/runs/test_simple_run.py
@@ -34,7 +34,7 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
                     "permissions": 0o755,
                 },
             ],
-            "cloud_init_modules": ["write-files", "spacewalk", "runcmd"],
+            "cloud_init_modules": ["write_files", "spacewalk", "runcmd"],
         }
         cloud_cfg = safeyaml.dumps(self.cfg)
         util.ensure_dir(os.path.join(self.new_root, "etc", "cloud"))
@@ -79,11 +79,11 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
         (which_ran, failures) = mods.run_section("cloud_init_modules")
         self.assertTrue(len(failures) == 0)
         self.assertTrue(os.path.exists("/etc/blah.ini"))
-        self.assertIn("write-files", which_ran)
+        self.assertIn("write_files", which_ran)
         contents = util.load_file("/etc/blah.ini")
         self.assertEqual(contents, "blah")
         self.assertNotIn(
-            "Skipping modules ['write-files'] because they are not verified on"
+            "Skipping modules ['write_files'] because they are not verified on"
             " distro 'ubuntu'",
             self.logs.getvalue(),
         )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cloud.cfg.tmpl: standardise on underscores for module names

Some module names in cloud.cfg.tmpl use minus signs, others use
underscores. Standardise on only using underscores for module names
as this aligns with modules using underscores, rather than minus
signs for the names of their settings.

Also remove the blank line created at the top of the resultant
cloud.cfg file - strictly speaking it may not be valid to start a
YAML file with a blank line.

## Additional Context

## Test Steps

## Checklist:

 - [ x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ x ] I have updated or added any unit tests accordingly
 - [ x ] I have updated or added any documentation accordingly
