### PR TITLE
BSD: simplify finding MBR partitions

### DIFF
--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -305,14 +305,7 @@ def device_part_info(devpath):
         # FreeBSD doesn't know of sysfs so just get everything we need from
         # the device, like /dev/vtbd0p2.
         fpart = "/dev/" + util.find_freebsd_part(devpath)
-        m = re.search("^(/dev/.+)p([0-9])$", fpart)
-        if m:
-            return m.group(1), m.group(2)
-
-        # alternatively, we could be dealing with MBR slices,
-        # or we're on DragonFly
-        fslice = "/dev/" + util.find_dragonflybsd_part(devpath)
-        m = re.search("^(/dev/.+)s([0-9])$", fslice)
+        m = re.search("^(/dev/.+)sp([0-9]+[a-z]*)$", fpart)
         if m:
             return m.group(1), m.group(2)
 

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -305,9 +305,12 @@ def device_part_info(devpath):
         # FreeBSD doesn't know of sysfs so just get everything we need from
         # the device, like /dev/vtbd0p2.
         fpart = "/dev/" + util.find_freebsd_part(devpath)
-        m = re.search("^(/dev/.+)[sp]([0-9]+[a-z]*)$", fpart)
+        # Handle both GPT partions and MBR slices with partitions
+        m = re.search(
+            r"^(?P<dev>/dev/.+)[sp](?P<part_slice>\d+[a-z]*)$", fpart
+        )
         if m:
-            return m.group(1), m.group(2)
+            return m["dev"], m["part_slice"]
 
     if not os.path.exists(syspath):
         raise ValueError("%s had no syspath (%s)" % (devpath, syspath))

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -305,7 +305,7 @@ def device_part_info(devpath):
         # FreeBSD doesn't know of sysfs so just get everything we need from
         # the device, like /dev/vtbd0p2.
         fpart = "/dev/" + util.find_freebsd_part(devpath)
-        m = re.search("^(/dev/.+)sp([0-9]+[a-z]*)$", fpart)
+        m = re.search("^(/dev/.+)[sp]([0-9]+[a-z]*)$", fpart)
         if m:
             return m.group(1), m.group(2)
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -365,7 +365,7 @@ def uniq_merge(*lists):
 
 
 def clean_filename(fn):
-    for (k, v) in FN_REPLACEMENTS.items():
+    for k, v in FN_REPLACEMENTS.items():
         fn = fn.replace(k, v)
     removals = []
     for k in fn:
@@ -767,7 +767,6 @@ def fixup_output(cfg, mode):
 #   value then output input will not be closed (useful for debugging).
 #
 def redirect_output(outfmt, errfmt, o_out=None, o_err=None):
-
     if is_true(os.environ.get("_CLOUD_INIT_SAVE_STDOUT")):
         LOG.debug("Not redirecting output due to _CLOUD_INIT_SAVE_STDOUT")
         return
@@ -1264,7 +1263,7 @@ def is_resolvable(url) -> bool:
                     iname, None, 0, 0, socket.SOCK_STREAM, socket.AI_CANONNAME
                 )
                 badresults[iname] = []
-                for (_fam, _stype, _proto, cname, sockaddr) in result:
+                for _fam, _stype, _proto, cname, sockaddr in result:
                     badresults[iname].append("%s: %s" % (cname, sockaddr[0]))
                     badips.add(sockaddr[0])
             except (socket.gaierror, socket.error):
@@ -2566,7 +2565,9 @@ def parse_mtab(path):
 
 def find_freebsd_part(fs):
     splitted = fs.split("/")
-    if len(splitted) == 3:
+    if len(splitted) == 1:
+        return splitted[0]
+    elif len(splitted) == 3:
         return splitted[2]
     elif splitted[2] in ["label", "gpt", "ufs"]:
         target_label = fs[5:]
@@ -2579,14 +2580,6 @@ def find_freebsd_part(fs):
         return str(part)
     else:
         LOG.warning("Unexpected input in find_freebsd_part: %s", fs)
-
-
-def find_dragonflybsd_part(fs):
-    splitted = fs.split("/")
-    if len(splitted) == 3 and splitted[1] == "dev":
-        return splitted[2]
-    else:
-        LOG.warning("Unexpected input in find_dragonflybsd_part: %s", fs)
 
 
 def get_path_dev_freebsd(path, mnt_list):

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -610,6 +610,35 @@ class Bunch:
         self.__dict__.update(kwds)
 
 
+class TestDevicePartInfo:
+    @pytest.mark.parametrize(
+        "devpath, is_BSD, expected, raised_exception",
+        (
+            pytest.param(
+                "/dev/vtbd0p2",
+                True,
+                ("/dev/vtbd0", "2"),
+                does_not_raise(),
+                id="gpt_partition",
+            ),
+            pytest.param(
+                "/dev/vbd0s3a",
+                True,
+                ("/dev/vbd0", "3a"),
+                does_not_raise(),
+                id="bsd_mbr_slice_and_partition",
+            ),
+        ),
+    )
+    @mock.patch("cloudinit.util.is_BSD")
+    def test_device_part_into(
+        self, m_is_BSD, is_BSD, devpath, expected, raised_exception
+    ):
+        m_is_BSD.return_value = is_BSD
+        with raised_exception:
+            assert expected == cc_growpart.device_part_info(devpath)
+
+
 class TestGrowpartSchema:
     @pytest.mark.parametrize(
         "config, expectation",

--- a/tests/unittests/distros/test_dragonflybsd.py
+++ b/tests/unittests/distros/test_dragonflybsd.py
@@ -1,12 +1,11 @@
-#!/usr/bin/env python3
-
+# This file is part of cloud-init. See LICENSE file for license information.
 
 import cloudinit.util
 from tests.unittests.helpers import mock
 
 
 def test_find_dragonflybsd_part():
-    assert cloudinit.util.find_dragonflybsd_part("/dev/vbd0s3") == "vbd0s3"
+    assert cloudinit.util.find_freebsd_part("/dev/vbd0s3") == "vbd0s3"
 
 
 @mock.patch("cloudinit.util.is_DragonFlyBSD")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
BSD: simplify finding MBR partitions

by removing duplicate code.

Sponsored by: The FreeBSD Foundation

Co-authored-by: Alberto Contreras <aciba90@gmail.com>
Co-authored-by: Chad Smith <chad.smith@canonical.com>

Fixes: #2168 
```

## Additional Context
Fixes: #2168 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
