### PR TITLE
Move DigitalOcean before ConfigDrive datasource in default list

### DIFF
--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -22,10 +22,10 @@ RUN_CLOUD_CONFIG = "/run/cloud-init/cloud.cfg"
 CFG_BUILTIN = {
     "datasource_list": [
         "NoCloud",
+        "DigitalOcean",
         "ConfigDrive",
         "LXD",
         "OpenNebula",
-        "DigitalOcean",
         "Azure",
         "AltCloud",
         "OVF",

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -124,8 +124,8 @@ DS_MAYBE=2
 DI_DSNAME=""
 # this has to match the builtin list in cloud-init, it is what will
 # be searched if there is no setting found in config.
-DI_DSLIST_DEFAULT="MAAS ConfigDrive NoCloud AltCloud Azure Bigstep \
-CloudSigma CloudStack DigitalOcean Vultr AliYun Ec2 GCE OpenNebula OpenStack \
+DI_DSLIST_DEFAULT="MAAS DigitalOcean ConfigDrive NoCloud AltCloud Azure \
+Bigstep CloudSigma CloudStack Vultr AliYun Ec2 GCE OpenNebula OpenStack \
 OVF SmartOS Scaleway Hetzner IBMCloud Oracle Exoscale RbxCloud UpCloud VMware \
 LXD NWCS"
 DI_DSLIST=""


### PR DESCRIPTION
## Proposed Commit Message

```
Move DigitalOcean before ConfigDrive datasource in default list

DigitalOcean originally used the ConfigDrive data source before they
wrote and submitted their own DigitalOcean datasource. However it
appears that DO instances are still provided with a ConfigDrive ISO
upon boot - this means that unless the datasource_list is tailored
to specify "DigitalOcean" before "ConfigDrive" or to not mention
"ConfigDrive" at all then ConfigDrive will incorrectly be used.

If no datasource_list is specified in /etc/cloud.cfg or
/etc/cloud.cfg.d/* then the default datasource list is used which
defines ConfigDrive before DigitalOcean - this PR changes the order
of those 2 datasources in the default list.

Note: from searching online it seems that various documents on
DigitalOcean's website, as well as 3rd party article, still only mention
using the ConfigDrive datasource - this makes no sense as the
DigitalOcean datasource has existed since 2014!
```

## Additional Context

## Test Steps

## Checklist:

 - [ x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ x ] I have updated or added any unit tests accordingly
 - [ x ] I have updated or added any documentation accordingly
