### PR TITLE
net/sysconfig: enable sysconfig renderer if network manager has ifcfg-rh plugin

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import copy
+import glob
 import io
 import os
 import re
@@ -1050,7 +1051,25 @@ def _supported_vlan_names(rdev, vid):
 def available(target=None):
     if not util.system_info()["variant"] in KNOWN_DISTROS:
         return False
+    if available_sysconfig(target):
+        return True
+    if available_nm_ifcfg_rh(target):
+        return True
+    return False
 
+
+def available_nm_ifcfg_rh(target=None):
+    # The ifcfg-rh plugin of NetworkManager is installed.
+    # NetworkManager can handle the ifcfg files.
+    return glob.glob(
+        subp.target_path(
+            target,
+            "usr/lib*/NetworkManager/*/libnm-settings-plugin-ifcfg-rh.so",
+        )
+    )
+
+
+def available_sysconfig(target=None):
     expected = ["ifup", "ifdown"]
     search = ["/sbin", "/usr/sbin"]
     for p in expected:


### PR DESCRIPTION
Some distributions like RHEL does not have ifup and ifdown scripts that traditionally handled ifcfg-eth* files. Instead RHEL uses network manager with ifcfg-rh plugin to handle ifcfg scripts. Therefore, the sysconfig should check for the existence of ifcfg-rh plugin in addition to checking for the existence of ifup and ifdown scripts in order to determine if it can handle ifcfg files. If either the plugin or ifup/ifdown scripts are present, sysconfig renderer can be enabled.

fixes: https://github.com/canonical/cloud-init/issues/4131
RHBZ: 2194050