### PR TITLE
ubuntu/focal:cherry pick netplan99-cannot-use-default.patch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 cloud-init (23.1.2-0ubuntu0~20.04.2) UNRELEASED; urgency=medium
 
+  * d/patches/netplan99-cannot-use-default.patch:
+    - Retain routes' definitions compatible with netplan 0.99 (Fixes: #4133)
   * d/apport-general-hook.py: Add general apport hook to append cloud type,
     image and instance size information to bug reports (LP: #1724623)
   * d/cloud-init.preinst: Oracle to remove vestigial /etc/cloud.cloud.cfg.d/

--- a/debian/patches/netplan99-cannot-use-default.patch
+++ b/debian/patches/netplan99-cannot-use-default.patch
@@ -1,0 +1,168 @@
+Description: Retain compatible route definition for netplan 0.99
+ focal contains netplan v0.99 which is not compatible
+ with Routes' definitions containing `to: default`. This patch
+ retains the previous way to define routes.
+Author: james.falcon@canonical.com
+Origin: backport
+Forwarded: not-needed
+Bug: https://github.com/canonical/cloud-init/issues/4133
+Last-Update: 2023-05-19
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/cloudinit/net/netplan.py
++++ b/cloudinit/net/netplan.py
+@@ -119,7 +119,7 @@ def _extract_addresses(config: dict, ent
+             if subnet.get("gateway"):
+                 new_route = {
+                     "via": subnet.get("gateway"),
+-                    "to": "default",
++                    "to": "::/0" if ":" in subnet["gateway"] else "0.0.0.0/0",
+                 }
+                 try:
+                     subnet_gateway = ipaddress.ip_address(subnet["gateway"])
+--- a/tests/unittests/test_net.py
++++ b/tests/unittests/test_net.py
+@@ -403,7 +403,7 @@ network:
+                 transmit-hash-policy: layer3+4
+                 up-delay: 0
+             routes:
+-            -   to: default
++            -   to: 0.0.0.0/0
+                 via: 10.101.11.254
+     vlans:
+         bond0.3502:
+@@ -2264,7 +2264,7 @@ pre-down route del -net 10.0.0.0/8 gw 11
+                             - sacchromyces.maas
+                             - brettanomyces.maas
+                         routes:
+-                        -   to: default
++                        -   to: 0.0.0.0/0
+                             via: 192.168.0.1
+         """
+         ).rstrip(" "),
+@@ -2993,7 +2993,7 @@ pre-down route del -net 10.0.0.0/8 gw 11
+                          transmit-hash-policy: layer3+4
+                          up-delay: 20
+                      routes:
+-                     -   to: default
++                     -   to: 0.0.0.0/0
+                          via: 192.168.0.1
+                      -   to: 10.1.3.0/24
+                          via: 192.168.0.3
+@@ -6047,9 +6047,9 @@ class TestNetplanNetRendering:
+                         macaddress: 00:11:22:33:44:55
+                       set-name: interface0
+                       routes:
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 192.168.23.1
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 11.0.0.1
+                 """,
+                 id="physical_gateway46",
+@@ -6086,9 +6086,9 @@ class TestNetplanNetRendering:
+                       - eth0
+                       - eth1
+                       routes:
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 192.168.23.1
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 11.0.0.1
+                     eth0: {}
+                     eth1: {}
+@@ -6125,9 +6125,9 @@ class TestNetplanNetRendering:
+                       interfaces:
+                       - eth0
+                       routes:
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 192.168.23.1
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 11.0.0.1
+                 """,
+                 id="bridge_gateway46",
+@@ -6161,9 +6161,9 @@ class TestNetplanNetRendering:
+                       id: 101
+                       link: eth0
+                       routes:
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 192.168.23.1
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 11.0.0.1
+                 """,
+                 id="vlan_gateway46",
+@@ -6212,7 +6212,7 @@ class TestNetplanNetRendering:
+                         - exemplary
+                       set-name: interface0
+                       routes:
+-                        - to: default
++                        - to: 0.0.0.0/0
+                           via: 192.168.23.1
+                 """,
+                 id="nameserver_gateway4",
+@@ -6247,7 +6247,7 @@ class TestNetplanNetRendering:
+                       match:
+                         macaddress: 00:11:22:33:44:55
+                       routes:
+-                      -   to: default
++                      -   to: 0.0.0.0/0
+                           via: 192.168.23.1
+                       -   to: 10.176.0.0/24
+                           via: 10.184.225.121
+@@ -6282,7 +6282,7 @@ class TestNetplanNetRendering:
+                       match:
+                         macaddress: 00:11:22:33:44:55
+                       routes:
+-                      -   to: default
++                      -   to: 0.0.0.0/0
+                           via: 192.168.23.1
+                       -   to: 192.167.225.122/24
+                           via: 192.168.23.1
+@@ -6318,10 +6318,10 @@ class TestNetplanNetRendering:
+                       match:
+                         macaddress: 00:11:22:33:44:55
+                       routes:
+-                      -   to: default
++                      -   to: 0.0.0.0/0
+                           via: 192.168.255.1
+                           on-link: true
+-                      -   to: default
++                      -   to: "::/0"
+                           via: 2001:ffff::1
+                           on-link: true
+                       set-name: interface0
+--- a/tests/unittests/distros/test_netconfig.py
++++ b/tests/unittests/distros/test_netconfig.py
+@@ -199,7 +199,7 @@ network:
+             addresses:
+             - 192.168.1.5/24
+             routes:
+-            -   to: default
++            -   to: 0.0.0.0/0
+                 via: 192.168.1.254
+         eth1:
+             dhcp4: true
+@@ -218,7 +218,7 @@ network:
+             addresses:
+             - 2607:f0d0:1002:0011::2/64
+             routes:
+-            -   to: default
++            -   to: ::/0
+                 via: 2607:f0d0:1002:0011::1
+         eth1:
+             dhcp4: true
+@@ -1057,7 +1057,7 @@ class TestNetCfgDistroArch(TestNetCfgDis
+                             addresses:
+                             - 192.168.1.5/24
+                             routes:
+-                            -   to: default
++                            -   to: 0.0.0.0/0
+                                 via: 192.168.1.254
+                         eth1:
+                             dhcp4: true

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 retain-apt-partner-pocket.patch
 expire-on-hashed-users.patch
 retain-netplan-world-readable.patch
+netplan99-cannot-use-default.patch


### PR DESCRIPTION
To stay consistent with #4135