### PR TITLE
docs: Add feedback button to docs

### DIFF
--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -110,7 +110,8 @@ html_theme_options = {
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
 html_static_path = ["static"]
-html_css_files = ["css/custom.css"]
+html_css_files = ["css/custom.css", "css/github_issue_links.css"]
+html_js_files = ["js/github_issue_links.js"]
 
 html_extra_path = ["googleaf254801a5285c31.html"]
 

--- a/doc/rtd/static/css/github_issue_links.css
+++ b/doc/rtd/static/css/github_issue_links.css
@@ -1,0 +1,24 @@
+.github-issue-link-container {
+    padding-right: 0.5rem;
+}
+.github-issue-link {
+    font-size: var(--font-size--small);
+    font-weight: bold;
+    background-color: #DD4814;
+    padding: 13px 23px;
+    text-decoration: none;
+}
+.github-issue-link:link {
+    color: #FFFFFF;
+}
+.github-issue-link:visited {
+    color: #FFFFFF
+}
+.muted-link.github-issue-link:hover {
+    color: #FFFFFF;
+    text-decoration: underline;
+}
+.github-issue-link:active {
+    color: #FFFFFF;
+    text-decoration: underline;
+}

--- a/doc/rtd/static/js/github_issue_links.js
+++ b/doc/rtd/static/js/github_issue_links.js
@@ -6,7 +6,7 @@ window.onload = function () {
   link.href = (
     "https://github.com/canonical/cloud-init/issues/new?"
     + "assignees=&labels=documentation%2C+new&projects=&template=documentation.md&title=%5Bdocs%5D%3A+"
-    + "&body=# Documentation"
+    + "&body=%23 Documentation request"
     + "%0A%0A%0A%0A%0A"
     + "---"
     + "%0A"

--- a/doc/rtd/static/js/github_issue_links.js
+++ b/doc/rtd/static/js/github_issue_links.js
@@ -1,0 +1,23 @@
+window.onload = function () {
+  const link = document.createElement("a");
+  link.classList.add("muted-link");
+  link.classList.add("github-issue-link");
+  link.text = "Give feedback";
+  link.href = (
+    "https://github.com/canonical/cloud-init/issues/new?"
+    + "assignees=&labels=documentation%2C+new&projects=&template=documentation.md&title=%5Bdocs%5D%3A+"
+    + "&body=# Documentation"
+    + "%0A%0A%0A%0A%0A"
+    + "---"
+    + "%0A"
+    + `*Reported+from%3A+${location.href}*`
+  );
+  link.target = "_blank";
+
+  const div = document.createElement("div");
+  div.classList.add("github-issue-link-container");
+  div.append(link)
+
+  const container = document.querySelector(".article-container > .content-icon-container");
+  container.prepend(div);
+};


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
docs: Add feedback button to docs

Adds a "Give feedback" button to the docs that links to creating a new
documentation issue when clicked
```

## Additional Context
Docs page should now look like this: ![image](https://github.com/canonical/cloud-init/assets/153674/d063c617-1965-4785-aefd-ab26139239c2)

When clicked, we get a link to [create a new issue](https://github.com/canonical/cloud-init/issues/new?assignees=&labels=documentation%2C+new&projects=&template=documentation.md&title=%5Bdocs%5D%3A+&body=#%20Documentation%0A%0A%0A%0A%0A---%0A*Reported+from%3A+file:///home/james/cloud-init/doc/rtd_html/index.html)

The css and js code was boldly taken from the Ubuntu Pro documentation.