### PR TITLE
ubuntu/devel: Remove pep8 dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,6 @@
 cloud-init (23.1.1-0ubuntu3) UNRELEASED; urgency=medium
 
+  * d/control: Remove pep8 dependency. It is no longer used.
   * Upstream snapshot based on upstream/main at d6ac22e1.
     - Bugs fixed in this snapshot: (LP: #2011783, #2008888)
 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,6 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends: debhelper-compat (= 13),
                dh-python,
                iproute2,
-               pep8,
                po-debconf,
                python3,
                python3-configobj,


### PR DESCRIPTION
It is no longer used and no longer exists in mantic.