### PR TITLE
.gitignore: extend coverage pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist
 __pycache__
 .tox
 .coverage
+.coverage.*
 .python-version
 doc/rtd_html
 parts


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
.gitignore: extend coverage pattern

apply more ignorance.

Sponsored by: FreeBSD Foundation
```

## Additional Context
This now ignore stuff like

```
meena@76ix ~/s/c/cloud-init (freebsd/cc_rsyslogd)> git status
On branch freebsd/cc_rsyslogd
Your branch is up to date with 'meena/freebsd/cc_rsyslogd'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	.coverage.76ix.155619.066231
	.coverage.76ix.155619.278789
	.coverage.76ix.155651.132853
	.coverage.76ix.155651.886957
	.coverage.76ix.155774.532336
	.coverage.76ix.155774.848850
	.coverage.76ix.155775.241306
	.coverage.76ix.155775.885948
	.coverage.76ix.155776.720099
	.coverage.76ix.155776.820759

nothing added to commit but untracked files present (use "git add" to track)
meena@76ix ~/s/c/cloud-init (freebsd/cc_rsyslogd)> 
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
