### PR TITLE
tests: apt support for deb822 format .sources files on mantic

### DIFF
--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -166,12 +166,22 @@ class TestApt:
         Ported from
         tests/cloud_tests/testcases/modules/apt_configure_sources_ppa.py
         """
-        ppa_path_contents = class_client.read_from_file(
-            "/etc/apt/sources.list.d/"
-            "simplestreams-dev-ubuntu-trunk-{}.list".format(
-                CURRENT_RELEASE.series
+        if CURRENT_RELEASE.series < "mantic":
+            ppa_path_contents = class_client.read_from_file(
+                "/etc/apt/sources.list.d/"
+                "simplestreams-dev-ubuntu-trunk-{}.list".format(
+                    CURRENT_RELEASE.series
+                )
             )
-        )
+        else:
+            # deb822 support present on mantic and later
+            ppa_path_contents = class_client.read_from_file(
+                "/etc/apt/sources.list.d/"
+                "simplestreams-dev-ubuntu-trunk-{}.sources".format(
+                    CURRENT_RELEASE.series
+                )
+            )
+
         assert (
             "://ppa.launchpad.net/simplestreams-dev/trunk/ubuntu"
             in ppa_path_contents


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->
[Failing Jenkins job showcasing the error](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-lxd_container/lastSuccessfulBuild/testReport/junit/tests.integration_tests.modules.test_apt/TestApt/test_ppa_source/)
## Test Steps

```
# Assert mantic and non-mantic work
for RELEASE in kinetic mantic; do
    CLOUD_INIT_OS_IMAGE=$RELEASE tox -e  integration-tests tests/integration_tests/modules/test_apt.py::TestApt::test_ppa_source
done
```
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
