### PR TITLE
add local_hostname to cc_ntp for enhanced template logic

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1826,6 +1826,15 @@
           ],
           "additionalProperties": false,
           "properties": {
+            "local_hostname": {
+              "type": "string",
+              "items": {
+                "type": "string",
+                "format": "hostname"
+              },
+              "uniqueItems": true,
+              "description": "Local hostname to use for ntp. If not provided,\nthe system hostname will be used."
+            },
             "pools": {
               "type": "array",
               "items": {

--- a/templates/chrony.conf.alpine.tmpl
+++ b/templates/chrony.conf.alpine.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.centos.tmpl
+++ b/templates/chrony.conf.centos.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.cos.tmpl
+++ b/templates/chrony.conf.cos.tmpl
@@ -13,6 +13,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.debian.tmpl
+++ b/templates/chrony.conf.debian.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.fedora.tmpl
+++ b/templates/chrony.conf.fedora.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.freebsd.tmpl
+++ b/templates/chrony.conf.freebsd.tmpl
@@ -43,6 +43,9 @@ pool {{pool}} iburst
 {% endfor %}
 
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.opensuse-leap.tmpl
+++ b/templates/chrony.conf.opensuse-leap.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.opensuse-microos.tmpl
+++ b/templates/chrony.conf.opensuse-microos.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.opensuse-tumbleweed.tmpl
+++ b/templates/chrony.conf.opensuse-tumbleweed.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.opensuse.tmpl
+++ b/templates/chrony.conf.opensuse.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.photon.tmpl
+++ b/templates/chrony.conf.photon.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.rhel.tmpl
+++ b/templates/chrony.conf.rhel.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.sle-micro.tmpl
+++ b/templates/chrony.conf.sle-micro.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.sle_hpc.tmpl
+++ b/templates/chrony.conf.sle_hpc.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.sles.tmpl
+++ b/templates/chrony.conf.sles.tmpl
@@ -12,6 +12,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}

--- a/templates/chrony.conf.ubuntu.tmpl
+++ b/templates/chrony.conf.ubuntu.tmpl
@@ -16,6 +16,9 @@ pool {{pool}} iburst
 server {{server}} iburst
 {% endfor %}
 {% for peer in peers -%}
+{% if local_hostname == peer %}
+{# a host should not peer with itself #}
+{% else %}
 peer {{peer}}
 {% endfor %}
 {% for a in allow -%}


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Adds a simple `local_hostname` variable to the NTP module.  In complex configurations, it can be helpful to key off of the local_hostname as detected by the OS.  I suspect most users will never need it, but in complex and custom templates, it is helpful to have in place, so I did not include any template changes.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Run ntp module.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
