### PR TITLE
BSD: remove datasource_list from cloud.cfg template

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -54,11 +54,6 @@ preserve_hostname: false
 
 # If you use datasource_list array, keep array items in a single line.
 # If you use multi line array, ds-identify script won't read array items.
-{% if variant.endswith("bsd") %}
-# This should not be required, but leave it in place until the real cause of
-# not finding -any- datasources is resolved.
-datasource_list: ['NoCloud', 'ConfigDrive', 'Azure', 'OpenStack', 'Ec2']
-{% endif %}
 # Example datasource config
 # datasource:
 #    Ec2:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
BSD: remove datasource_list from cloud.cfg template

This limited list was put into place, because in the past, something
wasn't working right. Whatever it was, seems to be resolved. Removing it
means BSDs have the same chance on all clouds like other distros do.

People can always create images that customize the selection, but the
out of box experience should be that cloud-init works as advertised on
all supported distros and all available clouds.

Sponsored by: The FreeBSD Foundation
```

## Additional Context
Found while testing my last change on Hetzner.
ds-identify identifies Hetzner, but cloud-init did not.
Because it wasn't in the list of options.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
