### PR TITLE
fix doc lint: spellchecker tripped up

### DIFF
--- a/doc/rtd/explanation/kernel-cmdline.rst
+++ b/doc/rtd/explanation/kernel-cmdline.rst
@@ -24,7 +24,7 @@ Datasource discovery override
 
 During boot, cloud-init must identify which datasource it is running on
 (OpenStack, AWS, Azure, GCP, etc). This discovery step can be optionally
-overriden by specifying the datasource name, such as:
+overridden by specifying the datasource name, such as:
 
 .. code-block:: text
 


### PR DESCRIPTION
on a document i have not touched

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
fix doc lint: spellchecker tripped up

why wasn't this failing before?

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
