### PR TITLE
tools: fix run-container builds for rockylinux/8 git hash mismatch

### DIFF
--- a/tools/read-version
+++ b/tools/read-version
@@ -88,6 +88,7 @@ if is_gitdir(_tdir) and which("git") and not is_release_branch_ci:
             "git",
             "describe",
             branch_name,
+            "--abbrev=8",
         ] + flags
 
         try:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
tools: fix run-container builds for rockylinux/8 git hash mismatch

When building untagged commits from tip of main, brpm uses git describe to create a versioned subdirectory.

For untagged commite, limit git describe hash to 8 characters to align with the expected hash length of 8 that rpmbuild expects.

This avoids missing file errors during %prep stage resulting in the following type or build error:
  + cd cloud-init-23.2-15-g95364bbf7 /var/tmp/rpm-tmp.S7mQ7Y: line 40: cd: cloud-init-23.2-15-g95364bbf7 : No such file or directory
```

## Additional Context
<!-- If relevant -->


## Test Steps
See failure on tip of main:
```
# See failure on tip of main 
./tools/run-container --source-package --unittest --package --artifacts=./srpm/ rockylinux/8
cloudinit.subp.ProcessExecutionError: Unexpected error while running command.
Command: ['rpmbuild', '-ba', '/tmp/rpmbuildda995r7s/rpmbuild/SPECS/cloud-init.spec']
Exit code: 1
Reason: -
Stdout: Executing(%prep): /bin/sh -e /var/tmp/rpm-tmp.S7mQ7Y
        
        
        RPM build errors:
Stderr: + umask 022
        + cd /tmp/rpmbuildda995r7s/rpmbuild/BUILD
        + cd /tmp/rpmbuildda995r7s/rpmbuild/BUILD
        + rm -rf cloud-init-23.2-15-g95364bbf7
        + /usr/bin/gzip -dc /tmp/rpmbuildda995r7s/rpmbuild/SOURCES/cloud-init-23.2-15-g95364bbf7.tar.gz
        + /usr/bin/tar -xof -
        + STATUS=0
        + '[' 0 -ne 0 ']'
        + cd cloud-init-23.2-15-g95364bbf7
        /var/tmp/rpm-tmp.S7mQ7Y: line 40: cd: cloud-init-23.2-15-g95364bbf7: No such file or directory
        error: Bad exit status from /var/tmp/rpm-tmp.S7mQ7Y (%prep)
            Bad exit status from /var/tmp/rpm-tmp.S7mQ7Y (%prep)
failed: ./packages/brpm --distro=redhat ret=1
there were 1 errors.
  binary package

# success with this branch 
./tools/run-container --source-package --unittest --package --artifacts=./srpm/ rockylinux/8
```
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
