### PR TITLE
tests: can't match MAC for LXD container veth due to netplan 0.106

### DIFF
--- a/tests/integration_tests/bugs/test_gh626.py
+++ b/tests/integration_tests/bugs/test_gh626.py
@@ -3,12 +3,11 @@
 Ensure if wakeonlan is specified in the network config that it is rendered
 in the /etc/network/interfaces or netplan config.
 """
-
 import pytest
 import yaml
 
 from tests.integration_tests import random_mac_address
-from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.integration_settings import PLATFORM
 
 MAC_ADDRESS = random_mac_address()
@@ -19,9 +18,18 @@ ethernets:
     dhcp4: true
     wakeonlan: true
     match:
-      macaddress: {}
-""".format(
-    MAC_ADDRESS
+      {match_clause}
+"""
+
+# On netplan 0.106 and above, netplan emits mac address matches as
+# PermanentMACAdddress on networkd systems. This match clause will
+# not match LXD's veth devices which results in no IPv4 address
+# being allocated via DHCP. As a result, we match container by NIC name.
+NETWORK_CONFIG_CONTAINER = NETWORK_CONFIG.format(match_clause="name: eth0")
+
+# Match LXD VM by MAC just to assert plumbing is working by MAC
+NETWORK_CONFIG_VM = NETWORK_CONFIG.format(
+    match_clause=f"macaddress: {MAC_ADDRESS}"
 )
 
 EXPECTED_ENI_END = """\
@@ -33,14 +41,22 @@ iface eth0 inet dhcp
     PLATFORM not in ["lxd_container", "lxd_vm"],
     reason="Test requires custom networking provided by LXD",
 )
-@pytest.mark.lxd_config_dict(
-    {
-        "user.network-config": NETWORK_CONFIG,
-        "volatile.eth0.hwaddr": MAC_ADDRESS,
-    }
-)
-def test_wakeonlan(client: IntegrationInstance):
-    netplan_cfg = client.execute("cat /etc/netplan/50-cloud-init.yaml")
-    netplan_yaml = yaml.safe_load(netplan_cfg)
-    assert "wakeonlan" in netplan_yaml["network"]["ethernets"]["eth0"]
-    assert netplan_yaml["network"]["ethernets"]["eth0"]["wakeonlan"] is True
+def test_wakeonlan(session_cloud: IntegrationCloud):
+    if PLATFORM == "lxd_vm":
+        config_dict = {
+            "user.network-config": NETWORK_CONFIG_VM,
+            "volatile.eth0.hwaddr": MAC_ADDRESS,
+        }
+    else:
+        config_dict = {"user.network-config": NETWORK_CONFIG_CONTAINER}
+    with session_cloud.launch(
+        launch_kwargs={
+            "config_dict": config_dict,
+        }
+    ) as client:
+        netplan_cfg = client.execute("cat /etc/netplan/50-cloud-init.yaml")
+        netplan_yaml = yaml.safe_load(netplan_cfg)
+        assert "wakeonlan" in netplan_yaml["network"]["ethernets"]["eth0"]
+        assert (
+            netplan_yaml["network"]["ethernets"]["eth0"]["wakeonlan"] is True
+        )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: can't match MAC for LXD container veth due to netplan 0.106

netplan 0.106 introduced PermanentMACAddress matching for networkd
configuration. LXD containers us veth interfaces which cannot
be matched by PermanentMACAddress.

Fix test_wakeonlan to prefer match by macadddress in network-config
for lxd_vm platform and prefer match by name on lxd_container.

Leave both test types in place to validate netplan plumbing for
both cases.
```

## Additional Context
<!-- If relevant -->
Jenkins failure (lunar and mantic both affected)
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-lunar-lxd_container/lastSuccessfulBuild/testReport/junit/tests.integration_tests.bugs/test_gh626/test_wakeonlan/


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
