### PR TITLE
gce: improve ephemeral fallback NIC selection (CPC-2578)

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -399,9 +399,7 @@ def is_disabled_cfg(cfg):
     return cfg.get("config") == "disabled"
 
 
-def find_candidate_nics(
-    default_primary_interface: Optional[str] = None,
-) -> List[str]:
+def find_candidate_nics() -> List[str]:
     """Get the list of network interfaces viable for networking.
 
     @return List of interfaces, sorted naturally.
@@ -411,7 +409,7 @@ def find_candidate_nics(
     elif util.is_NetBSD() or util.is_OpenBSD():
         return find_candidate_nics_on_netbsd_or_openbsd()
     else:
-        return find_candidate_nics_on_linux(default_primary_interface)
+        return find_candidate_nics_on_linux()
 
 
 def find_fallback_nic() -> Optional[str]:
@@ -471,9 +469,7 @@ def find_fallback_nic_on_freebsd() -> Optional[str]:
     return None
 
 
-def find_candidate_nics_on_linux(
-    default_primary_interface: Optional[str] = None,
-) -> List[str]:
+def find_candidate_nics_on_linux() -> List[str]:
     """Get the names of the candidate network devices on Linux.
 
     @return List of sorted interfaces.
@@ -535,14 +531,12 @@ def find_candidate_nics_on_linux(
     # 2. Remaining connected interfaces, naturally sorted.
     # 3. DEFAULT_PRIMARY_INTERFACE, if possibly connected.
     # 4. Remaining possibly connected interfaces, naturally sorted.
-    if not default_primary_interface:
-        default_primary_interface = DEFAULT_PRIMARY_INTERFACE
     sorted_interfaces = []
     for interfaces in [connected, possibly_connected]:
         interfaces = sorted(interfaces, key=natural_sort_key)
-        if default_primary_interface in interfaces:
-            interfaces.remove(default_primary_interface)
-            interfaces.insert(0, default_primary_interface)
+        if DEFAULT_PRIMARY_INTERFACE in interfaces:
+            interfaces.remove(DEFAULT_PRIMARY_INTERFACE)
+            interfaces.insert(0, DEFAULT_PRIMARY_INTERFACE)
         sorted_interfaces += interfaces
 
     return sorted_interfaces
@@ -670,7 +664,7 @@ def _get_current_rename_info(check_downable=True):
          }}
     """
     cur_info = {}
-    for name, mac, driver, device_id in get_interfaces():
+    for (name, mac, driver, device_id) in get_interfaces():
         cur_info[name] = {
             "downable": None,
             "device_id": device_id,
@@ -703,6 +697,7 @@ def _get_current_rename_info(check_downable=True):
 def _rename_interfaces(
     renames, strict_present=True, strict_busy=True, current_info=None
 ):
+
     if not len(renames):
         LOG.debug("no interfaces to rename")
         return
@@ -998,6 +993,7 @@ def get_interfaces_by_mac_on_linux() -> dict:
         # TODO: move this format to openstack
         ib_mac = get_ib_interface_hwaddr(name, True)
         if ib_mac:
+
             # If an Ethernet mac address happens to collide with a few bits in
             # an IB GUID, prefer the ethernet address.
             #

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -115,11 +115,11 @@ class DataSourceGCE(sources.DataSource):
                                     "url_params": url_params,
                                 },
                             )
-                        except Exception:
+                        except Exception as e:
                             LOG.debug(
-                                "Error fetching IMD with candidate NIC %s",
+                                "Error fetching IMD with candidate NIC %s: %s",
                                 candidate_nic,
-                                exc_info=True,
+                                e,
                             )
                             continue
                 except NoDHCPLeaseError:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
gce: improve ephemeral fallback NIC selection (CPC-2578)

While setting up the ephemeral network config for fetching the IMD at init-local timeframe on multi-NIC instances, fulfilling:

- All NICs without carrier flag or more than one NIC with carrier flag
- systemd's predictable interface names is enabled

net.find_fallback_nic could select a NIC that is not the primary NIC, leaving the instance without access to the network, as on GCE, only the primary NIC can talk to the IMDS.

At this point in time, there is yet not access to
{instance,vendor,user}-data. Thus, it is tricky to dynamically inject a breadcrum pointing to the primary NIC.

Two actions have been taken to fix this situation:

1. Substitute eth0 with ens4 as the default primary NIC candidate on Linux systems.
2. Try through the list of candidate NICs and use the first that can reach the IMDS.

Note that none of these changes do change cloud-init's behavior as:

(1) only applies to instances with more than one NIC. (2) will eventually find the correct NIC as opposed to leaving the instance without network (previous behavior).
```

## Additional Context
<!-- If relevant -->
[SF: #00359767](https://bootstack.canonical.com/cases/00359767)
[CPC-2578](https://warthogs.atlassian.net/browse/CPC-2578)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

1. Create instance on GCE with two NICs.
2. Ideally, the secondary instance should have a `ensXpY` name, but I wasn't able to achieve this situation (I do not have access to the machine type facing this situation). To have a similar situation, change the [DataSourceGCE.py::DEFAULT_PRIMARY_NIC](https://github.com/canonical/cloud-init/compare/main...aciba90:gce-multinic?expand=1#diff-da4370ff1bd47f364de530e8738ac0906b2664145bbeb23f1344543dbc6909f3R29) to the secondary NIC name on your instance (ens5 in my case).
3. `cloud-init clean --logs --reboot`
4. Verify the instance is reachable.

Log example: https://pastebin.canonical.com/p/7W3td2VttZ/

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly


[CPC-2578]: https://warthogs.atlassian.net/browse/CPC-2578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ