### PR TITLE
Set default renderer as sysconfig for centos/rhel

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -372,9 +372,12 @@ system_info:
 {% elif variant in ["dragonfly"] %}
    network:
       renderers: ['freebsd']
-{% elif variant in ["fedora"] or is_rhel %}
+{% elif variant in ["fedora"] %}
    network:
       renderers: ['netplan', 'network-manager', 'networkd', 'sysconfig', 'eni']
+{% elif is_rhel %}
+   network:
+      renderers: ['sysconfig', 'eni', 'netplan', 'network-manager', 'networkd' ]
 {% elif variant == "openmandriva" %}
    network:
       renderers: ['network-manager', 'networkd']


### PR DESCRIPTION
Currently, network manager is disabled on c9s and therefore sysconfig is used as the primary renderer for network configuration. We do not want to change this for c9s even when network-manager renderer is re-enabled as it would mean a big behaviour change for cloud-init in the centos 9 stream.

This change bumps up the priority for sysconfig renderer so that it is used as the primary renderer on c9s and other downstream distributions derived from it. In the next major centos stream release, we may use network manager as the default renderer and make changes accordingly.

RHBZ:2209349
