### PR TITLE
Added support for Akamai Connected Cloud (formerly Linode)

### DIFF
--- a/cloudinit/sources/DataSourceAkamai.py
+++ b/cloudinit/sources/DataSourceAkamai.py
@@ -336,12 +336,16 @@ class DataSourceAkamai(sources.DataSource):
                         local_instance_id,
                     )
                     break
+        else:
+            # even if we failed to reach the metadata service this loop, we
+            # still have the locally-available metadata (namely the instance id
+            # and cloud name), and by accepting just that we ensure that
+            # cloud-init won't run on our next boot
+            LOG.warning(
+                "Failed to contact metadata service, falling back to local "
+                "metadata only."
+            )
 
-        # even if we failed to reach the metadata service in the loop above, we
-        # still have the locally-available metadata (namely the instance id and
-        # cloud name), and by accepting just that we ensure that cloud-init
-        # won't run on our next boot; as such, regardless of the outcome of the
-        # loop above, we should return True here
         return True
 
     def check_instance_id(self, sys_cfg) -> bool:

--- a/cloudinit/sources/DataSourceAkamai.py
+++ b/cloudinit/sources/DataSourceAkamai.py
@@ -330,18 +330,12 @@ class DataSourceAkamai(sources.DataSource):
                         local_instance_id,
                     )
                     break
-        else:
-            # TODO: This was suggested in code review, however I'm not sure that
-            # we want it; in the event that the above loop doesn't break, we most
-            # likely failed to retrieve metadata via IPv4 _or_ IPv6.  This could
-            # mean that the service is down, and the Linode will still boot, but
-            # cloud-init will probably re-run on the next boot since it didn't get
-            # a cached instance id.  This needs to be tested, but as-written before
-            # this else block was added if all requests failed then the linode would
-            # still see the local metadata (namely the instance-id set above) and
-            # would not reprovision itself on reboot
-            return False
 
+        # even if we failed to reach the metadata service in the loop above, we
+        # still have the locally-available metadata (namely the instance id and
+        # cloud name), and by accepting just that we ensure that cloud-init won't
+        # run on our next boot; as such, regardless of the outcome of the loop
+        # above, we should return True here
         return True
 
     def check_instance_id(self, sys_cfg) -> bool:

--- a/cloudinit/sources/DataSourceAkamai.py
+++ b/cloudinit/sources/DataSourceAkamai.py
@@ -1,0 +1,372 @@
+import binascii
+import json
+from base64 import b64decode
+from contextlib import suppress as noop
+from enum import Enum
+from typing import Any, Dict, List, Tuple, Union
+
+from cloudinit import log as logging
+from cloudinit import sources, url_helper, util
+from cloudinit.net import find_fallback_nic, get_interfaces_by_mac
+from cloudinit.net.ephemeral import EphemeralIPNetwork
+from cloudinit.sources.helpers.akamai import (
+    get_dmi_config,
+    get_local_instance_id,
+    is_on_akamai,
+)
+
+LOG = logging.getLogger(__name__)
+
+
+BUILTIN_DS_CONFIG = {
+    "base_urls": {
+        "ipv4": "http://169.254.169.254",
+        "ipv6": "http://[fd00:a9fe:a9fe::1]",
+    },
+    "paths": {
+        "token": "/v1/token",
+        "metadata": "/v1/instance",
+        "userdata": "/v1/user-data",
+    },
+    # configures the behavior of the datasource
+    "allow_local_stage": True,
+    "allow_init_stage": True,
+    "allow_dhcp": True,
+    "allow_ipv4": True,
+    "allow_ipv6": True,
+    # mac address prefixes for interfaces that we would prefer to use for
+    # local-stage initialization
+    "preferred_mac_prefixes": [
+        "f2:3",
+    ],
+}
+
+
+class MetadataAvailabilityResult(Enum):
+    """
+    Used to indicate how this instance should behave based on the availability
+    of metadata to it
+    """
+
+    not_available = 0
+    available = 1
+    defer = 2
+
+
+class DataSourceAkamai(sources.DataSource):
+
+    dsname = "Akamai"
+    local_stage = False
+
+    def __init__(self, sys_cfg, distro, paths):
+        LOG.debug("Setting up Akamai DataSource")
+        sources.DataSource.__init__(self, sys_cfg, distro, paths)
+        self.metadata = dict()
+
+        # build our config
+        self.ds_cfg = util.mergemanydict(
+            [
+                get_dmi_config(),
+                util.get_cfg_by_path(
+                    sys_cfg,
+                    ["datasource", "Akamai"],
+                    {},
+                ),
+                BUILTIN_DS_CONFIG,
+            ],
+        )
+
+    def _build_url(self, path_name: str, use_v6: bool = False) -> str:
+        """
+        Looks up the path for a given name and returns a full url for it.  If
+        use_v6 is passed in, the IPv6 base url is used; otherwise the IPv4 url
+        is used unless IPv4 is not allowed in ds_cfg
+        """
+        if path_name not in self.ds_cfg["paths"]:
+            raise ValueError("Unknown path name {}".format(path_name))
+
+        version_key = "ipv4"
+        if use_v6 or not self.ds_cfg["allow_ipv4"]:
+            version_key = "ipv6"
+
+        base_url = self.ds_cfg["base_urls"][version_key]
+        path = self.ds_cfg["paths"][path_name]
+
+        return "{}{}".format(base_url, path)
+
+    def _should_fetch_data(self) -> MetadataAvailabilityResult:
+        """
+        Returns True if we should fetch metadata right now, otherwise false
+        """
+        if (
+            not self.ds_cfg["allow_ipv4"] and not self.ds_cfg["allow_ipv6"]
+        ) or (
+            not self.ds_cfg["allow_local_stage"]
+            and not self.ds_cfg["allow_init_stage"]
+        ):
+            # if we're not allowed to fetch data, we shouldn't try
+            LOG.info("Configuration prohibits fetching metadata.")
+            return MetadataAvailabilityResult.not_available
+
+        if self.local_stage:
+            return self._should_fetch_data_local()
+        else:
+            return self._should_fetch_data_network()
+
+    def _should_fetch_data_local(self) -> MetadataAvailabilityResult:
+        """
+        Returns True if data should be fetched at the local stage (before
+        networking is available), or False otherwise
+        """
+        if not self.ds_cfg["allow_local_stage"]:
+            # if this stage is explicitly disabled, don't attempt to fetch here
+            LOG.info("Configuration prohibits local stage setup")
+            return MetadataAvailabilityResult.defer
+
+        if not self.ds_cfg["allow_dhcp"] and not self.ds_cfg["allow_ipv6"]:
+            # without dhcp, we can't fetch during the local stage over IPv4.  If we're
+            # not allowed to use IPv6 either, then we can't init during this stage
+            LOG.info(
+                "Configuration does not allow for ephemeral network setup."
+            )
+            return MetadataAvailabilityResult.defer
+
+        return MetadataAvailabilityResult.available
+
+    def _should_fetch_data_network(self) -> MetadataAvailabilityResult:
+        """
+        Returns True if data should be fetched during the init stage, or False
+        otherwise
+        """
+        if not self.ds_cfg["allow_init_stage"]:
+            # if this stage is explicitly disabled, don't attempt to fetch here
+            LOG.info("Configuration does not allow for init stage setup")
+            return MetadataAvailabilityResult.defer
+
+        return MetadataAvailabilityResult.available
+
+    def _get_network_context_managers(
+        self,
+    ) -> List[Tuple[Union[Any, EphemeralIPNetwork], bool]]:
+        """
+        Returns a list of context managers which should be tried when setting
+        up a network context.  If we're running in init mode, this return a
+        noop since networking should already be configured.
+        """
+        network_context_managers: List[
+            Tuple[Union[Any, EphemeralIPNetwork], bool]
+        ] = []
+        if self.local_stage:
+            # at this stage, networking isn't up yet.  To support that, we need
+            # an ephemeral network
+
+            # find the first interface that isn't lo or a vlan interface
+            interfaces = get_interfaces_by_mac()
+            interface = None
+            preferred_prefixes = self.ds_cfg["preferred_mac_prefixes"]
+            for mac, inf in interfaces.items():
+                # try to match on the preferred mac prefixes
+                if any(
+                    [mac.startswith(prefix) for prefix in preferred_prefixes]
+                ):
+                    interface = inf
+                    break
+
+            if interface is None:
+                LOG.warning(
+                    "Failed to find default interface, attempting DHCP on "
+                    "fallback interface"
+                )
+                interface = find_fallback_nic()
+
+            network_context_managers = []
+
+            if self.ds_cfg["allow_ipv6"]:
+                network_context_managers.append(
+                    (
+                        EphemeralIPNetwork(
+                            self.distro,
+                            interface,
+                            ipv4=False,
+                            ipv6=True,
+                        ),
+                        True,
+                    ),
+                )
+
+            if self.ds_cfg["allow_ipv4"] and self.ds_cfg["allow_dhcp"]:
+                network_context_managers.append(
+                    (
+                        EphemeralIPNetwork(
+                            self.distro,
+                            interface,
+                            ipv4=True,
+                        ),
+                        False,
+                    )
+                )
+        else:
+            if self.ds_cfg["allow_ipv6"]:
+                network_context_managers.append(
+                    (
+                        noop(),
+                        True,
+                    ),
+                )
+
+            if self.ds_cfg["allow_ipv4"]:
+                network_context_managers.append(
+                    (
+                        noop(),
+                        False,
+                    ),
+                )
+
+        return network_context_managers
+
+    def _make_requests(self, use_v6: bool = False) -> bool:
+        """
+        Runs through the sequence of requests necessary to retrieve our
+        metadata and user data, creating a token for use in doing so
+        """
+        try:
+            # retrieve a token for future requests
+            token_response = url_helper.readurl(
+                self._build_url("token", use_v6=use_v6),
+                request_method="PUT",
+                timeout=30,
+                sec_between=2,
+                retries=4,
+                headers={
+                    "Metadata-Token-Expiry-Seconds": "300",
+                },
+            )
+            if token_response.code != 200:
+                LOG.info(
+                    f"Fetching token returned {token_response.code}; "
+                    "not fetching data"
+                )
+                return True
+
+            token = str(token_response)
+
+            # fetch general metadata
+            metadata = url_helper.readurl(
+                self._build_url("metadata", use_v6=use_v6),
+                timeout=30,
+                sec_between=2,
+                retries=2,
+                headers={
+                    "Accept": "application/json",
+                    "Metadata-Token": token,
+                },
+            )
+            self.metadata = json.loads(str(metadata))
+
+            # fetch user data
+            userdata = url_helper.readurl(
+                self._build_url("userdata", use_v6=use_v6),
+                timeout=30,
+                sec_between=2,
+                retries=2,
+                headers={
+                    "Metadata-Token": token,
+                },
+            )
+            self.userdata_raw = str(userdata)  # type: ignore
+            try:
+                self.userdata_raw = b64decode(self.userdata_raw).decode()  # type: ignore
+            except binascii.Error as e:
+                LOG.warning(f"Failed to base64 decode userdata due to {e}")
+        except url_helper.UrlError as e:
+            # we failed to retrieve data with an exception; log the error and return
+            # false, indicating that we should retry using a different network if
+            # possible
+            LOG.warning(
+                f"Failed to retrieve metadata using IPv{'6' if use_v6 else '4'} due to {e}"
+            )
+            return False
+
+        return True
+
+    def _get_data(self) -> bool:
+        """
+        Overrides _get_data in the DataSource class to actually retrieve data
+        """
+        LOG.debug("Getting data from Akamai DataSource")
+
+        if not is_on_akamai():
+            LOG.info("Not running on Akamai, not running.")
+            return False
+
+        local_instance_id = get_local_instance_id()
+        self.metadata = {
+            "instance-id": local_instance_id,
+        }
+        availability = self._should_fetch_data()
+
+        if availability != MetadataAvailabilityResult.available:
+            if availability == MetadataAvailabilityResult.not_available:
+                LOG.info(
+                    "Metadata is not available, returning local data only."
+                )
+                return True
+
+            LOG.info(
+                "Configured not to fetch data at this stage; waiting for "
+                "a later stage."
+            )
+            return False
+
+        network_context_managers = self._get_network_context_managers()
+        for manager, use_v6 in network_context_managers:
+            with manager as m:
+                done = self._make_requests(use_v6=use_v6)
+                if done:
+                    # fix up some field names
+                    self.metadata["instance-id"] = self.metadata.get(
+                        "id",
+                        local_instance_id,
+                    )
+                    break
+
+        return True
+
+    def check_instance_id(self, sys_cfg) -> bool:
+        """
+        A local-only check to see if the instance id matches the id we see on
+        the system
+        """
+        return sources.instance_id_matches_system_uuid(
+            self.get_instance_id(), "system-serial-number"
+        )
+
+
+class DataSourceAkamaiLocal(DataSourceAkamai):
+    """
+    A subclass of DataSourceAkamai that runs the same functions, but during the
+    init-local stage.  This allows configuring networking via cloud-init, as
+    networking hasn't been configured yet.
+    """
+
+    local_stage = True
+
+
+datasources = [
+    # run in init-local if possible
+    (DataSourceAkamaiLocal, (sources.DEP_FILESYSTEM,)),
+    # if not, run in init
+    (
+        DataSourceAkamai,
+        (
+            sources.DEP_FILESYSTEM,
+            sources.DEP_NETWORK,
+        ),
+    ),
+]
+
+
+# cloudinit/sources/__init__.py will look for and call this when deciding if
+# we're a valid DataSource for the stage its running
+def get_datasource_list(depends) -> List[sources.DataSource]:
+    return sources.list_from_depends(depends, datasources)

--- a/cloudinit/sources/helpers/akamai.py
+++ b/cloudinit/sources/helpers/akamai.py
@@ -1,0 +1,54 @@
+import re
+from typing import Any, Dict, Optional, Union
+
+from cloudinit import dmi
+
+# dmi data can override
+DMI_OVERRIDE_MAP = {
+    "als": "allow_local_stage",
+    "ais": "allow_init_stage",
+    "dhcp": "allow_dhcp",
+    "v4": "allow_ipv4",
+    "v6": "allow_ipv6",
+    "pmp": "preferred_mac_prefixes",
+}
+
+
+def get_dmi_config() -> Dict[str, Union[bool, str]]:
+    """
+    Parses flags from dmi data and updates self.ds_cfg accordingly
+    """
+    dmi_flags = dmi.read_dmi_data("baseboard-serial-number")
+    ret: Dict[str, Any] = {}
+
+    if not dmi_flags:
+        return ret
+
+    # parse the value into individual flags, then set them in our config
+    # based on the short name lookup table
+    for key, value, _ in re.findall(r"([a-z0-9]+)=(.*?)(;|$)", dmi_flags):
+        if key in DMI_OVERRIDE_MAP:
+            if value in "01":
+                value = bool(int(value))
+            elif key == "pmp":
+                value = value.split(",")
+            ret[DMI_OVERRIDE_MAP[key]] = value
+
+    return ret
+
+
+def is_on_akamai() -> bool:
+    """
+    Reads the BIOS vendor from dmi data to determine if we are running in the
+    Akamai Connected Cloud.
+    """
+    vendor = dmi.read_dmi_data("bios-vendor")
+    return vendor in ("Linode", "Akamai")
+
+
+def get_local_instance_id() -> Optional[str]:
+    """
+    Returns the instance id read from dmi data without requiring the metadata
+    service to be reachable
+    """
+    return dmi.read_dmi_data("system-serial-number")

--- a/cloudinit/sources/helpers/akamai.py
+++ b/cloudinit/sources/helpers/akamai.py
@@ -42,7 +42,7 @@ def is_on_akamai() -> bool:
     Reads the BIOS vendor from dmi data to determine if we are running in the
     Akamai Connected Cloud.
     """
-    vendor = dmi.read_dmi_data("bios-vendor")
+    vendor = dmi.read_dmi_data("system-manufacturer")
     return vendor in ("Linode", "Akamai")
 
 

--- a/doc/rtd/reference/availability.rst
+++ b/doc/rtd/reference/availability.rst
@@ -61,6 +61,7 @@ environments in the public cloud:
 - Vultr
 - Zadara Edge Cloud Platform
 - 3DS Outscale
+- Akamai
 
 Additionally, ``cloud-init`` is supported on these private clouds:
 

--- a/doc/rtd/reference/datasource_dsname_map.rst
+++ b/doc/rtd/reference/datasource_dsname_map.rst
@@ -51,3 +51,4 @@ mapping between datasource module names and ``dsname`` in the table below.
     DataSourceExoscale.py, Exoscale
     DataSourceAliYun.py, AliYun
     DataSourceNWCS.py, NWCS
+    DataSourceAkamai.py, Akamai

--- a/doc/rtd/reference/datasources.rst
+++ b/doc/rtd/reference/datasources.rst
@@ -38,6 +38,7 @@ The following is a list of documentation for each supported datasource:
 .. toctree::
    :titlesonly:
 
+   datasources/akamai.rst
    datasources/aliyun.rst
    datasources/altcloud.rst
    datasources/ec2.rst

--- a/doc/rtd/reference/datasources/akamai.rst
+++ b/doc/rtd/reference/datasources/akamai.rst
@@ -1,0 +1,82 @@
+.. _datasource_akamai:
+
+Akamai
+******
+
+The Akamai datasource provides an interface to consume metadata on the `Akamai
+Connected Cloud`_.  This service is available at ``169.254.169.254`` and 
+``fd00:a9fe:a9fe::1`` from within the instance.
+
+.. _Akamai Connected Cloud: https://linode.com
+
+
+Configuration
+=============
+
+The Akamai datasource supports the following configuration, although in normal
+use no changes to the defaults should be necessary: ::
+
+ datasource:
+   Akamai:
+     base_urls:
+       ipv4: http://169.254.169.254
+       ipv6: http://[fd00:a9fe:a9fe::1]
+     paths:
+         token: /v1/token
+         metadata: /v1/instance
+         userdata: /v1/user-data
+     allow_local_stage: True
+     allow_init_stage: True
+     allow_dhcp: True
+     allow_ipv4: True
+     allow_ipv6: True
+     preferred_mac_prefixes:
+     - f2:3
+
+* ``base_urls``
+
+  The URLs used to access the metadata service over IPv4 and IPv6 respectively.
+
+* ``paths``
+
+  The paths used to reach specific endpoints within the service.
+
+* ``allow_local_stage``
+
+  Allows this datasource to fetch data during the local stage.  This can be
+  disabled if your image does not want ephemeral networking used.
+
+* ``allow_init_stage``
+
+  Allows this datasource to fetch data during the init stage, once networking
+  is online.
+
+* ``allow_dhcp``
+
+  Allows this datasource to use dhcp to find an IPv4 address to fetch metadata
+  with during the local stage.
+
+* ``allow_ipv4``
+
+  Allow the use of IPv4 when fetching metadata during any stage.
+
+* ``allow_ipv6``
+
+  Allows the use of IPv6 when fetching metadata during any stage.
+
+* ``preferred_mac_prefixes``
+
+  A list of MAC Address prefixes that will be preferred when selecting an
+  interface to use for ephemeral networking.  This is ignored during the init
+  stage.
+
+Configuration Overrides
+^^^^^^^^^^^^^^^^^^^^^^^
+
+In some circumstances, the Akamai platform may send configurations overrides to
+instances via dmi data to prevent certain behavior that may not be supported
+based on the instance's region or configuration.  For example, if deploying an
+instance in a region that does not yet support metadata, both the local and
+init stages will be disabled, preventing cloud-init from attempting to fetch
+metadata.  Configuration overrides sent this way will appears in the
+``baseboard-serial-number`` field.

--- a/doc/rtd/reference/datasources/akamai.rst
+++ b/doc/rtd/reference/datasources/akamai.rst
@@ -4,7 +4,7 @@ Akamai
 ******
 
 The Akamai datasource provides an interface to consume metadata on the `Akamai
-Connected Cloud`_.  This service is available at ``169.254.169.254`` and 
+Connected Cloud`_.  This service is available at ``169.254.169.254`` and
 ``fd00:a9fe:a9fe::1`` from within the instance.
 
 .. _Akamai Connected Cloud: https://linode.com

--- a/tests/unittests/sources/helpers/test_akamai.py
+++ b/tests/unittests/sources/helpers/test_akamai.py
@@ -55,7 +55,7 @@ class TestAkamaiHelper:
             result == expected_result
         ), f"Unexpected result parsing dmi config '{dmi_config}'!"
         assert [
-            mock.call("baseboard-serial-number") 
+            mock.call("baseboard-serial-number")
         ] == read_dmi_data.call_args_list
 
     @pytest.mark.parametrize(

--- a/tests/unittests/sources/helpers/test_akamai.py
+++ b/tests/unittests/sources/helpers/test_akamai.py
@@ -54,7 +54,9 @@ class TestAkamaiHelper:
         assert (
             result == expected_result
         ), f"Unexpected result parsing dmi config '{dmi_config}'!"
-        assert read_dmi_data.called_with("baseboard-serial-number")
+        assert [
+            mock.call("baseboard-serial-number") 
+        ] == read_dmi_data.call_args_list
 
     @pytest.mark.parametrize(
         "dmi_data,expected_result",

--- a/tests/unittests/sources/helpers/test_akamai.py
+++ b/tests/unittests/sources/helpers/test_akamai.py
@@ -1,0 +1,82 @@
+from typing import Any, Dict
+
+import pytest
+
+from cloudinit.sources.helpers.akamai import get_dmi_config, is_on_akamai
+from tests.unittests.helpers import mock
+
+
+class TestAkamaiHelper:
+    """
+    Test for the Akamai helper functions
+    """
+
+    @pytest.mark.parametrize(
+        "dmi_config,expected_result",
+        (
+            # no content
+            ("", {}),
+            # stage control flags
+            (
+                "als=0;ais=0",
+                {"allow_local_stage": False, "allow_init_stage": False},
+            ),
+            # networking flags
+            (
+                "v4=0;v6=0;dhcp=0",
+                {
+                    "allow_ipv4": False,
+                    "allow_ipv6": False,
+                    "allow_dhcp": False,
+                },
+            ),
+            # interface prefix overrides
+            ("pmp=ab:cd:", {"preferred_mac_prefixes": ["ab:cd:"]}),
+            (
+                "pmp=ab:cd:,12:34:",
+                {"preferred_mac_prefixes": ["ab:cd:", "12:34:"]},
+            ),
+            # unrecognized data
+            ("unrecognized", {}),
+            (",;", {}),
+        ),
+    )
+    @mock.patch("cloudinit.dmi.read_dmi_data")
+    def test_get_dmi_config(
+        self, read_dmi_data, dmi_config: str, expected_result: Dict[str, Any]
+    ):
+        """
+        Tests that dmi-based configuration overrides parse as expected
+        """
+        read_dmi_data.return_value = dmi_config
+        result = get_dmi_config()
+
+        assert (
+            result == expected_result
+        ), f"Unexpected result parsing dmi config '{dmi_config}'!"
+        assert read_dmi_data.called_with("baseboard-serial-number")
+
+    @pytest.mark.parametrize(
+        "dmi_data,expected_result",
+        (
+            ("Akamai", True),
+            ("Linode", True),
+            ("GCE", False),
+            ("EC2", False),
+            ("", False),
+        ),
+    )
+    @mock.patch("cloudinit.dmi.read_dmi_data")
+    def test_is_on_akamai(
+        self, read_dmi_data, dmi_data: str, expected_result: bool
+    ):
+        """
+        Tests that is_on_akamai correctly detects if we are on Akama's platform
+        """
+        read_dmi_data.return_value = dmi_data
+        result = is_on_akamai()
+
+        assert (
+            result == expected_result
+        ), f"Unexpected result checking if '{dmi_data}' is Akamai"
+        assert read_dmi_data.called_with("bios-vendor")

--- a/tests/unittests/sources/helpers/test_akamai.py
+++ b/tests/unittests/sources/helpers/test_akamai.py
@@ -81,4 +81,6 @@ class TestAkamaiHelper:
         assert (
             result == expected_result
         ), f"Unexpected result checking if '{dmi_data}' is Akamai"
-        assert read_dmi_data.called_with("bios-vendor")
+        assert [
+            mock.call("system-manufacturer")
+        ] == read_dmi_data.call_args_list

--- a/tests/unittests/sources/test_akamai.py
+++ b/tests/unittests/sources/test_akamai.py
@@ -99,71 +99,71 @@ class TestDataSourceAkamai:
         "local_stage,ds_cfg,expected_result",
         (
             # normal config
-            (True, {}, MetadataAvailabilityResult.available),
-            (False, {}, MetadataAvailabilityResult.available),
+            (True, {}, MetadataAvailabilityResult.AVAILABLE),
+            (False, {}, MetadataAvailabilityResult.AVAILABLE),
             # disable dhcp
             (
                 True,
                 {"allow_dhcp": False},
-                MetadataAvailabilityResult.available,
+                MetadataAvailabilityResult.AVAILABLE,
             ),
             (
                 True,
                 {"allow_dhcp": False, "allow_ipv6": False},
-                MetadataAvailabilityResult.defer,
+                MetadataAvailabilityResult.DEFER,
             ),
             (
                 False,
                 {"allow_dhcp": False},
-                MetadataAvailabilityResult.available,
+                MetadataAvailabilityResult.AVAILABLE,
             ),
             (
                 False,
                 {"allow_dhcp": False, "allow_ipv6": False},
-                MetadataAvailabilityResult.available,
+                MetadataAvailabilityResult.AVAILABLE,
             ),
             # disable stages
             (
                 True,
                 {"allow_local_stage": False},
-                MetadataAvailabilityResult.defer,
+                MetadataAvailabilityResult.DEFER,
             ),
             (
                 False,
                 {"allow_local_stage": False},
-                MetadataAvailabilityResult.available,
+                MetadataAvailabilityResult.AVAILABLE,
             ),
             (
                 True,
                 {"allow_init_stage": False},
-                MetadataAvailabilityResult.available,
+                MetadataAvailabilityResult.AVAILABLE,
             ),
             (
                 False,
                 {"allow_init_stage": False},
-                MetadataAvailabilityResult.defer,
+                MetadataAvailabilityResult.DEFER,
             ),
             # disable all network types
             (
                 True,
                 {"allow_ipv4": False, "allow_ipv6": False},
-                MetadataAvailabilityResult.not_available,
+                MetadataAvailabilityResult.NOT_AVAILABLE,
             ),
             (
                 False,
                 {"allow_ipv4": False, "allow_ipv6": False},
-                MetadataAvailabilityResult.not_available,
+                MetadataAvailabilityResult.NOT_AVAILABLE,
             ),
             # disable all stages
             (
                 True,
                 {"allow_local_stage": False, "allow_init_stage": False},
-                MetadataAvailabilityResult.not_available,
+                MetadataAvailabilityResult.NOT_AVAILABLE,
             ),
             (
                 False,
                 {"allow_local_stage": False, "allow_init_stage": False},
-                MetadataAvailabilityResult.not_available,
+                MetadataAvailabilityResult.NOT_AVAILABLE,
             ),
         ),
     )
@@ -268,7 +268,7 @@ class TestDataSourceAkamai:
         ),
     )
     @mock.patch("cloudinit.url_helper.readurl")
-    def test_make_requests(self, readurl, use_v6: bool):
+    def test_fetch_metadata(self, readurl, use_v6: bool):
         """
         Tests that making requests sends the expected requests in the expected
         order
@@ -288,7 +288,7 @@ class TestDataSourceAkamai:
         host = "[fd00:a9fe:a9fe::1]" if use_v6 else "169.254.169.254"
 
         ds = self._get_datasource()
-        ds._make_requests(use_v6=use_v6)
+        ds._fetch_metadata(use_v6=use_v6)
 
         assert readurl.call_count == 3
         assert ds.metadata == {"id": 123}

--- a/tests/unittests/sources/test_akamai.py
+++ b/tests/unittests/sources/test_akamai.py
@@ -32,12 +32,17 @@ class TestDataSourceAkamai:
             }
         }
 
-        if local:
-            ds: Union[
-                DataSourceAkamai, DataSourceAkamaiLocal
-            ] = DataSourceAkamaiLocal(sys_cfg, None, None)
-        else:
-            ds = DataSourceAkamai(sys_cfg, None, None)
+        # patch read_dmi_data, even when not in a container
+        with mock.patch(
+            "cloudinit.dmi.read_dmi_data",
+            return_value="",
+        ):
+            if local:
+                ds: Union[
+                    DataSourceAkamai, DataSourceAkamaiLocal
+                ] = DataSourceAkamaiLocal(sys_cfg, None, None)
+            else:
+                ds = DataSourceAkamai(sys_cfg, None, None)
 
         return ds
 
@@ -213,7 +218,7 @@ class TestDataSourceAkamai:
             ),
         ),
     )
-    @mock.patch("cloudinit.net.get_interfaces_by_mac")
+    @mock.patch("cloudinit.sources.DataSourceAkamai.get_interfaces_by_mac")
     def test_get_network_context_managers(
         self,
         get_interfaces_by_mac,

--- a/tests/unittests/sources/test_akamai.py
+++ b/tests/unittests/sources/test_akamai.py
@@ -1,0 +1,322 @@
+from contextlib import suppress
+from typing import Any, Dict, List, Tuple, Union
+
+import pytest
+
+from cloudinit.sources.DataSourceAkamai import (
+    DataSourceAkamai,
+    DataSourceAkamaiLocal,
+    MetadataAvailabilityResult,
+)
+from tests.unittests.helpers import mock
+
+
+class TestDataSourceAkamai:
+    """
+    Test cases for DataSourceAkamai
+    """
+
+    def _get_datasource(
+        self, ds_cfg: Dict[str, Any] = None, local: bool = False
+    ) -> Union[DataSourceAkamai, DataSourceAkamaiLocal]:
+        """
+        Creates a test DataSource configured as provided
+        """
+        if ds_cfg is None:
+            ds_cfg = {}
+
+        # set up our system config with the config provided here
+        sys_cfg = {
+            "datasource": {
+                "Akamai": ds_cfg,
+            }
+        }
+
+        if local:
+            ds: Union[
+                DataSourceAkamai, DataSourceAkamaiLocal
+            ] = DataSourceAkamaiLocal(sys_cfg, None, None)
+        else:
+            ds = DataSourceAkamai(sys_cfg, None, None)
+
+        return ds
+
+    @pytest.mark.parametrize(
+        "path_name,use_v6,ds_cfg,expected_url",
+        (
+            # normal paths
+            ("token", False, {}, "http://169.254.169.254/v1/token"),
+            ("metadata", False, {}, "http://169.254.169.254/v1/instance"),
+            ("userdata", False, {}, "http://169.254.169.254/v1/user-data"),
+            # normal paths, force v6
+            ("metadata", True, {}, "http://[fd00:a9fe:a9fe::1]/v1/instance"),
+            ("token", True, {}, "http://[fd00:a9fe:a9fe::1]/v1/token"),
+            ("userdata", True, {}, "http://[fd00:a9fe:a9fe::1]/v1/user-data"),
+            # overrides
+            (
+                "token",
+                False,
+                {"allow_ipv4": False},
+                "http://[fd00:a9fe:a9fe::1]/v1/token",
+            ),
+            (
+                "token",
+                False,
+                {"paths": {"token": "/changed"}},
+                "http://169.254.169.254/changed",
+            ),
+            (
+                "token",
+                False,
+                {"base_urls": {"ipv4": "http://12.34.56.78"}},
+                "http://12.34.56.78/v1/token",
+            ),
+        ),
+    )
+    def test_build_url(
+        self,
+        path_name: str,
+        use_v6: bool,
+        ds_cfg: Dict[str, Any],
+        expected_url: str,
+    ):
+        """
+        Tests that _build_url returns the expected URLs for various
+        configurations
+        """
+        ds = self._get_datasource(ds_cfg=ds_cfg)
+        result = ds._build_url(path_name, use_v6=use_v6)
+        assert (
+            result == expected_url
+        ), f"Unexpected URL {result} for {path_name}"
+
+    @pytest.mark.parametrize(
+        "local_stage,ds_cfg,expected_result",
+        (
+            # normal config
+            (True, {}, MetadataAvailabilityResult.available),
+            (False, {}, MetadataAvailabilityResult.available),
+            # disable dhcp
+            (
+                True,
+                {"allow_dhcp": False},
+                MetadataAvailabilityResult.available,
+            ),
+            (
+                True,
+                {"allow_dhcp": False, "allow_ipv6": False},
+                MetadataAvailabilityResult.defer,
+            ),
+            (
+                False,
+                {"allow_dhcp": False},
+                MetadataAvailabilityResult.available,
+            ),
+            (
+                False,
+                {"allow_dhcp": False, "allow_ipv6": False},
+                MetadataAvailabilityResult.available,
+            ),
+            # disable stages
+            (
+                True,
+                {"allow_local_stage": False},
+                MetadataAvailabilityResult.defer,
+            ),
+            (
+                False,
+                {"allow_local_stage": False},
+                MetadataAvailabilityResult.available,
+            ),
+            (
+                True,
+                {"allow_init_stage": False},
+                MetadataAvailabilityResult.available,
+            ),
+            (
+                False,
+                {"allow_init_stage": False},
+                MetadataAvailabilityResult.defer,
+            ),
+            # disable all network types
+            (
+                True,
+                {"allow_ipv4": False, "allow_ipv6": False},
+                MetadataAvailabilityResult.not_available,
+            ),
+            (
+                False,
+                {"allow_ipv4": False, "allow_ipv6": False},
+                MetadataAvailabilityResult.not_available,
+            ),
+            # disable all stages
+            (
+                True,
+                {"allow_local_stage": False, "allow_init_stage": False},
+                MetadataAvailabilityResult.not_available,
+            ),
+            (
+                False,
+                {"allow_local_stage": False, "allow_init_stage": False},
+                MetadataAvailabilityResult.not_available,
+            ),
+        ),
+    )
+    def test_should_fetch_data(
+        self, local_stage: bool, ds_cfg: Dict[str, Any], expected_result: bool
+    ):
+        """
+        Tests if _should_fetch_data returns the expected values based on the
+        configuration of the DataSource
+        """
+        ds = self._get_datasource(ds_cfg=ds_cfg, local=local_stage)
+        result = ds._should_fetch_data()
+
+        assert (
+            result == expected_result
+        ), f"Unexpected result '{result}' for should fetch data!"
+
+    @pytest.mark.parametrize(
+        "local_stage,ds_cfg,expected_manager_config,expected_interface",
+        (
+            # local stage - these use context managers
+            (
+                True,
+                {},
+                [((False, True), True), ((True, False), False)],
+                "eth0",
+            ),
+            (True, {"allow_ipv4": False}, [((False, True), True)], "eth0"),
+            (True, {"allow_ipv6": False}, [((True, False), False)], "eth0"),
+            (True, {"allow_ipv4": False, "allow_ipv6": False}, [], "eth0"),
+            (
+                True,
+                {"preferred_mac_prefixes": ["12:34:"]},
+                [((False, True), True), ((True, False), False)],
+                "eth1",
+            ),
+            # init stage - these use the noop suppress
+            (False, {}, [(None, True), (None, False)], "eth0"),
+            (False, {"allow_ipv4": False}, [(None, True)], "eth0"),
+            (False, {"allow_ipv6": False}, [(None, False)], "eth0"),
+            (
+                False,
+                {"allow_ipv4": False, "allow_ipv6": False},
+                [],
+                "eth0",
+            ),
+            (
+                False,
+                {"preferred_mac_prefixes": ["12:34:"]},
+                [(None, True), (None, False)],
+                "eth1",
+            ),
+        ),
+    )
+    @mock.patch("cloudinit.net.get_interfaces_by_mac")
+    def test_get_network_context_managers(
+        self,
+        get_interfaces_by_mac,
+        local_stage: bool,
+        ds_cfg: Dict[str, Any],
+        expected_manager_config: List[Tuple[Tuple[bool, bool], bool]],
+        expected_interface: str,
+    ):
+        """
+        Tests that _get_network_context_managers returns the expected set of
+        context managers
+        """
+        ds = self._get_datasource(ds_cfg=ds_cfg, local=local_stage)
+
+        # set up fake mac addresses for our interfaces
+        get_interfaces_by_mac.return_value = {
+            "f2:3a:bc:de:f0:12": "eth0",
+            "12:34:56:78:90:ab": "eth1",
+        }
+
+        result = ds._get_network_context_managers()
+
+        assert len(result) == len(
+            expected_manager_config
+        ), f"Expected {len(expected_manager_config)}, got {result}"
+
+        # make sure the results are what we expected
+        for rx, ex in zip(result, expected_manager_config):
+            r, rv6 = rx
+            e, ev6 = ex
+            if e is None:
+                assert isinstance(
+                    r, suppress
+                ), f"Expected contextlib.suppress, got {r}"
+                assert rv6 == ev6
+            else:
+                ipv4, ipv6 = e
+                assert r.ipv4 == ipv4, f"Expected {r} to support ipv4"
+                assert r.ipv6 == ipv6, f"Expected {r} to support ipv6"
+                assert rv6 == ev6
+
+    @pytest.mark.parametrize(
+        "use_v6",
+        (
+            False,
+            True,
+        ),
+    )
+    @mock.patch("cloudinit.url_helper.readurl")
+    def test_make_requests(self, readurl, use_v6: bool):
+        """
+        Tests that making requests sends the expected requests in the expected
+        order
+        """
+        # the responses, in the order we expect the calls
+        readurl.side_effect = [
+            # to PUT /v1/token
+            mock.MagicMock(code=200, __str__=lambda _: "test-token"),
+            # to GET /v1/instance; truncated for brevity
+            '{"id": 123}',
+            # to GET /v1/user-data
+            "",
+        ]
+
+        # if we're asked to force using v6, we should see the hostname of the
+        # urls change
+        host = "[fd00:a9fe:a9fe::1]" if use_v6 else "169.254.169.254"
+
+        ds = self._get_datasource()
+        ds._make_requests(use_v6=use_v6)
+
+        assert readurl.call_count == 3
+        assert ds.metadata == {"id": 123}
+        assert ds.userdata_raw == ""
+
+        assert readurl.mock_calls == [
+            mock.call(
+                f"http://{host}/v1/token",
+                request_method="PUT",
+                timeout=30,
+                sec_between=2,
+                retries=4,
+                headers={
+                    "Metadata-Token-Expiry-Seconds": "300",
+                },
+            ),
+            mock.call(
+                f"http://{host}/v1/instance",
+                timeout=30,
+                sec_between=2,
+                retries=2,
+                headers={
+                    "Accept": "application/json",
+                    "Metadata-Token": "test-token",
+                },
+            ),
+            mock.call(
+                f"http://{host}/v1/user-data",
+                timeout=30,
+                sec_between=2,
+                retries=2,
+                headers={
+                    "Metadata-Token": "test-token",
+                },
+            ),
+        ]

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -257,6 +257,7 @@ class DsIdentifyBase(CiTestCase):
     def _check_via_dict(self, data, rc, dslist=None, **kwargs):
         ret = self._call_via_dict(data, **kwargs)
         good = False
+        print(f"I am looking for {rc}, got {ret}")
         try:
             self.assertEqual(rc, ret.rc)
             if dslist is not None:
@@ -873,6 +874,27 @@ class TestDsIdentify(DsIdentifyBase):
         self._test_ds_found("VMware-GuestInfo-Vendordata")
 
 
+class TestAkamai(DsIdentifyBase):
+    def test_found_by_sys_vendor(self):
+        """ds-identify finds Akamai by system-manufacturer dmi field"""
+        self._test_ds_found("Akamai")
+
+    def test_found_by_sys_vendor_akamai(self):
+        """
+        ds-identify finds Akamai by system-manufacturer dmi field when set with
+        name "Akamai" (expected in the future)
+        """
+        cfg = copy.deepcopy(VALID_CFG["Akamai"])
+        cfg["mocks"][0]["RET"] = "Akamai"
+        self._check_via_dict(cfg, rc=RC_FOUND)
+
+    def test_not_found(self):
+        """ds-identify does not find Akamai by system-manufacturer field"""
+        cfg = copy.deepcopy(VALID_CFG["Akamai"])
+        cfg["mocks"][0]["RET"] = "Other"
+        self._check_via_dict(cfg, rc=RC_NOT_FOUND)
+
+
 class TestBSDNoSys(DsIdentifyBase):
     """Test *BSD code paths
 
@@ -1017,6 +1039,10 @@ def _print_run_output(rc, out, err, cfg, files):
 
 
 VALID_CFG = {
+    "Akamai": {
+        "ds": "Akamai",
+        "mocks": [{"name": "dmi_decode", "ret": 0, "RET": "Linode"}],
+    },
     "AliYun": {
         "ds": "AliYun",
         "files": {P_PRODUCT_NAME: "Alibaba Cloud ECS\n"},

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -257,7 +257,6 @@ class DsIdentifyBase(CiTestCase):
     def _check_via_dict(self, data, rc, dslist=None, **kwargs):
         ret = self._call_via_dict(data, **kwargs)
         good = False
-        print(f"I am looking for {rc}, got {ret}")
         try:
             self.assertEqual(rc, ret.rc)
             if dslist is not None:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -40,7 +40,7 @@ ddymko
 dermotbradley
 dhalturin
 dhensby
-dorthu
+Dorthu
 eandersson
 eb3095
 ederst

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -127,7 +127,7 @@ DI_DSNAME=""
 DI_DSLIST_DEFAULT="MAAS ConfigDrive NoCloud AltCloud Azure Bigstep \
 CloudSigma CloudStack DigitalOcean Vultr AliYun Ec2 GCE OpenNebula OpenStack \
 OVF SmartOS Scaleway Hetzner IBMCloud Oracle Exoscale RbxCloud UpCloud VMware \
-LXD NWCS"
+LXD NWCS Akamai"
 DI_DSLIST=""
 DI_MODE=""
 DI_ON_FOUND=""
@@ -751,6 +751,12 @@ dscheck_CloudSigma() {
     # http://paste.ubuntu.com/23624795/
     dmi_product_name_matches "CloudSigma" && return $DS_FOUND
     return $DS_NOT_FOUND
+}
+
+dscheck_Akamai() {
+    dmi_sys_vendor_is Linode && return ${DS_FOUND}
+    dmi_sys_vendor_is Akamai && return ${DS_FOUND}
+    return ${DS_NOT_FOUND}
 }
 
 check_config() {


### PR DESCRIPTION
## Proposed Commit Message

```
Added support for Akamai Connected Cloud (formerly Linode)

Added a DataSource for the Akamai cloud platform, enabling metadata
and user data retrieval and instance provisioning via cloud-init.
```

## Test Steps

Our metadata service is not yet publicly available, and as such this is being opened as a draft.  We have tested this in
our lab environment, and will work with you to get you access to the service when it becomes available in beta in the
near future.

## Checklist:

 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
