### PR TITLE
Test static routes and netplan 0.106

### DIFF
--- a/tests/integration_tests/bugs/test_gh626.py
+++ b/tests/integration_tests/bugs/test_gh626.py
@@ -25,6 +25,7 @@ ethernets:
 # PermanentMACAdddress on networkd systems. This match clause will
 # not match LXD's veth devices which results in no IPv4 address
 # being allocated via DHCP. As a result, we match container by NIC name.
+# LP: #2022947 represents this netplan behavior
 NETWORK_CONFIG_CONTAINER = NETWORK_CONFIG.format(match_clause="name: eth0")
 
 # Match LXD VM by MAC just to assert plumbing is working by MAC

--- a/tests/integration_tests/bugs/test_gh668.py
+++ b/tests/integration_tests/bugs/test_gh668.py
@@ -8,7 +8,7 @@ for all network configuration outputs.
 import pytest
 
 from tests.integration_tests import random_mac_address
-from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.integration_settings import PLATFORM
 
 DESTINATION_IP = "172.16.0.10"
@@ -24,26 +24,48 @@ ethernets:
     routes:
     - to: {}/32
       via: {}
-    match:
-      macaddress: {}
 """.format(
-    DESTINATION_IP, GATEWAY_IP, MAC_ADDRESS
+    DESTINATION_IP, GATEWAY_IP
 )
 
 EXPECTED_ROUTE = "{} via {}".format(DESTINATION_IP, GATEWAY_IP)
+
+
+NETWORK_CONFIG_VM = f"""\
+{NETWORK_CONFIG}
+    match:
+      macaddress: {MAC_ADDRESS}
+"""
+
+# On netplan 0.106 and above, netplan emits MAC address matches as
+# PermanentMACAdddress= on networkd systems. This match clause will
+# not match LXD's veth devices which results in no routes being brought up.
+# As a result, we match container by NIC name. Leave lxd_vm as MAC match.
+# LP: #2022947 represents this netplan behavior
+NETWORK_CONFIG_CONTAINER = f"""\
+{NETWORK_CONFIG}
+    match:
+      name: eth0
+"""
 
 
 @pytest.mark.skipif(
     PLATFORM not in ["lxd_container", "lxd_vm"],
     reason="Test requires custom networking provided by LXD",
 )
-@pytest.mark.lxd_config_dict(
-    {
-        "user.network-config": NETWORK_CONFIG,
-        "volatile.eth0.hwaddr": MAC_ADDRESS,
-    }
-)
-@pytest.mark.lxd_use_exec
-def test_static_route_to_host(client: IntegrationInstance):
-    route = client.execute("ip route | grep {}".format(DESTINATION_IP))
-    assert route.startswith(EXPECTED_ROUTE)
+def test_static_route_to_host(session_cloud: IntegrationCloud):
+    if PLATFORM == "lxd_vm":
+        config_dict = {
+            "user.network-config": NETWORK_CONFIG_VM,
+            "volatile.eth0.hwaddr": MAC_ADDRESS,
+        }
+    else:
+        config_dict = {"user.network-config": NETWORK_CONFIG_CONTAINER}
+    with session_cloud.launch(
+        launch_kwargs={
+            "execute_via_ssh": False,
+            "config_dict": config_dict,
+        }
+    ) as client:
+        route = client.execute("ip route | grep {}".format(DESTINATION_IP))
+        assert route.startswith(EXPECTED_ROUTE)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: fix lxd_container tests for route setup due to netplan 0.106

netplan 0.106 networkd match clause of PermanentMACAddress prevents
networkd from matching virtual network devices when setting up config.

Since LXD containers use virtual NICs, routes are not brought up.

Change test_gh668 to match by name: eth0 on lxd_container, retain
macaddress matching for lxd_vm.number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=lunar .tox/integration-tests/bin/pytest tests/integration_tests/bugs/test_gh668.py
```
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
