### PR TITLE
fixes 3355

### DIFF
--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -60,7 +60,7 @@ Filesystem
 
 A filesystem path starting with ``/`` or ``file://`` that points to a directory
 containing files: ``user-data``, ``meta-data``, and (optionally)
-``vendor-data``
+``vendor-data`` (a trailing ``/`` is required)
 
 HTTP server
 -----------


### PR DESCRIPTION
```
Clarify directory syntax for nocloud local filesystem.

Fixes GH-3355
```

## Additional Context
fixes https://github.com/canonical/cloud-init/issues/3355
