### PR TITLE
integration-tests: pin pytest 7.3.1 to avoid adverse testpaths behavior

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -2,5 +2,11 @@
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
 pycloudlib==1!3.0.2
-pytest
+
+# Await pytest > 7.3.2. Breaking change in `testpaths` treatment forced
+# test/unittests/conftest.py to be loaded by our integration-tests tox env
+# resulting in an unmet dependency issue:
+# https://github.com/pytest-dev/pytest/issues/11104
+pytest<=7.3.1
+
 packaging

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,11 @@
 # Needed generally in tests
-pytest
+
+# Await pytest > 7.3.2. Breaking change in `testpaths` treatment forced
+# test/unittests/conftest.py to be loaded by our integration-tests tox env
+# resulting in an unmet dependency issue:
+# https://github.com/pytest-dev/pytest/issues/11104
+pytest<=7.3.1
+
 pytest-cov
 pytest-mock
 


### PR DESCRIPTION
pytest 7.3.2 changed treatment of `testpaths` config which forced test/unittest/conftest.py module load in our integration-tests toxenv. Upstream bug is tracking their planned revert/fix for this regression. Pin 7.3.1 in the meantime.

Fixes #4183

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->
Jenkins job failures: https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_container/lastSuccessfulBuild/console

## Test Steps
```
tox -re integration-test # should work without traceback in your local env
```
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
