### PR TITLE
net/dhcp: add udhcpc support

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -112,14 +112,18 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     resolve_conf_fn = "/etc/resolv.conf"
 
     osfamily: str
-    dhcp_client_priority = [dhcp.IscDhclient, dhcp.Dhcpcd]
+    dhcp_client_priority = [dhcp.IscDhclient, dhcp.Dhcpcd, dhcp.Udhcpc]
 
     def __init__(self, name, cfg, paths):
         self._paths = paths
         self._cfg = cfg
         self.name = name
         self.networking: Networking = self.networking_cls()
-        self.dhcp_client_priority = [dhcp.IscDhclient, dhcp.Dhcpcd]
+        self.dhcp_client_priority = [
+            dhcp.IscDhclient,
+            dhcp.Dhcpcd,
+            dhcp.Udhcpc,
+        ]
         self.net_ops = iproute2.Iproute2
 
     def _unpickle(self, ci_pkl_version: int) -> None:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -67,6 +67,7 @@ jacobsalmela
 jamesottinger
 Jehops
 jf
+jfroche
 Jille
 JohnKepplers
 johnsonshi


### PR DESCRIPTION
## Proposed Commit Message

```
The currently used dhcp client, dhclient, is coming from the unmaintained package,
`isc-dhcp-client` (refer https://www.isc.org/dhcp/) which ended support in 2022.

This change introduce support for the dhcp client, udhcpc, from the busybox project.
Busybox advantages are that it is available across many distributions and comes with
lightweight executables.
```

## Additional Context

Already discussed in #2125 

## Test Steps


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
