### PR TITLE
Sc 1452 persist run combined cloud config json

### DIFF
--- a/cloudinit/analyze/__main__.py
+++ b/cloudinit/analyze/__main__.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import IO
 
 from cloudinit.analyze import dump, show
-from cloudinit.util import json_dumps
+from cloudinit.atomic_helper import json_dumps
 
 
 def get_parser(parser=None):

--- a/cloudinit/analyze/dump.py
+++ b/cloudinit/analyze/dump.py
@@ -4,7 +4,7 @@ import calendar
 import sys
 from datetime import datetime
 
-from cloudinit import subp, util
+from cloudinit import atomic_helper, subp
 
 stage_to_description = {
     "finished": "finished running cloud-init",
@@ -174,7 +174,7 @@ def main():
     else:
         cisource = sys.stdin
 
-    return util.json_dumps(dump_events(cisource))
+    return atomic_helper.json_dumps(dump_events(cisource))
 
 
 if __name__ == "__main__":

--- a/cloudinit/atomic_helper.py
+++ b/cloudinit/atomic_helper.py
@@ -5,9 +5,28 @@ import logging
 import os
 import stat
 import tempfile
+from base64 import b64decode, b64encode
 
 _DEF_PERMS = 0o644
 LOG = logging.getLogger(__name__)
+
+
+def b64d(source):
+    # Base64 decode some data, accepting bytes or unicode/str, and returning
+    # str/unicode if the result is utf-8 compatible, otherwise returning bytes.
+    decoded = b64decode(source)
+    try:
+        return decoded.decode("utf-8")
+    except UnicodeDecodeError:
+        return decoded
+
+
+def b64e(source):
+    # Base64 encode some data, accepting bytes or unicode/str, and returning
+    # str/unicode if the result is utf-8 compatible, otherwise returning bytes.
+    if not isinstance(source, bytes):
+        source = source.encode("utf-8")
+    return b64encode(source).decode("utf-8")
 
 
 def write_file(
@@ -46,14 +65,30 @@ def write_file(
         raise e
 
 
+def json_serialize_default(_obj):
+    """Handler for types which aren't json serializable."""
+    try:
+        return "ci-b64:{0}".format(b64e(_obj))
+    except AttributeError:
+        return "Warning: redacted unserializable type {0}".format(type(_obj))
+
+
+def json_dumps(data):
+    """Return data in nicely formatted json."""
+    return json.dumps(
+        data,
+        indent=1,
+        sort_keys=True,
+        separators=(",", ": "),
+        default=json_serialize_default,
+    )
+
+
 def write_json(filename, data, mode=_DEF_PERMS):
     # dump json representation of data to file filename.
     return write_file(
         filename,
-        json.dumps(data, indent=1, sort_keys=True) + "\n",
+        json_dumps(data) + "\n",
         omode="w",
         mode=mode,
     )
-
-
-# vi: ts=4 expandtab

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -20,7 +20,7 @@ import os
 import sys
 from errno import EACCES
 
-from cloudinit import log, util
+from cloudinit import atomic_helper, log, util
 from cloudinit.cmd.devel import addLogHandlerCLI, read_cfg_paths
 from cloudinit.handlers.jinja_template import (
     convert_jinja_instance_data,
@@ -315,7 +315,7 @@ def handle_args(name, args):
             return 1
         response = "\n".join(sorted(response.keys()))
     if not isinstance(response, str):
-        response = util.json_dumps(response)
+        response = atomic_helper.json_dumps(response)
     print(response)
     return 0
 

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -8,6 +8,7 @@ from typing import Optional, Type
 
 from cloudinit import handlers
 from cloudinit import log as logging
+from cloudinit.atomic_helper import b64d, json_dumps
 from cloudinit.helpers import Paths
 from cloudinit.settings import PER_ALWAYS
 from cloudinit.templater import (
@@ -15,7 +16,7 @@ from cloudinit.templater import (
     detect_template,
     render_string,
 )
-from cloudinit.util import b64d, json_dumps, load_file, load_json
+from cloudinit.util import load_file, load_json
 
 JUndefinedError: Type[Exception]
 try:

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -346,6 +346,7 @@ class Paths(persistence.CloudInitPickleMixin):
             # security-sensitive key values are present in this root-readable
             # file
             "instance_data_sensitive": "instance-data-sensitive.json",
+            "combined_cloud_config": "combined-cloud-config.json",
             "instance_id": ".instance-id",
             "manual_clean_marker": "manual-clean",
             "obj_pkl": "obj.pkl",
@@ -382,6 +383,10 @@ class Paths(persistence.CloudInitPickleMixin):
             self.lookups[
                 "instance_data_sensitive"
             ] = "instance-data-sensitive.json"
+        if "combined_cloud_config" not in self.lookups:
+            self.lookups[
+                "combined_cloud_config"
+            ] = "combined-cloud-config.json"
 
     # get_ipath_cur: get the current instance path for an item
     def get_ipath_cur(self, name=None):

--- a/cloudinit/sources/DataSourceExoscale.py
+++ b/cloudinit/sources/DataSourceExoscale.py
@@ -3,7 +3,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from cloudinit import dmi, helpers
+from cloudinit import atomic_helper, dmi, helpers
 from cloudinit import log as logging
 from cloudinit import sources, url_helper, util
 from cloudinit.sources.helpers import ec2
@@ -286,6 +286,6 @@ if __name__ == "__main__":
         url_retries=args.retries,
     )
 
-    print(util.json_dumps(data))
+    print(atomic_helper.json_dumps(data))
 
 # vi: ts=4 expandtab

--- a/cloudinit/sources/DataSourceIBMCloud.py
+++ b/cloudinit/sources/DataSourceIBMCloud.py
@@ -96,6 +96,7 @@ import base64
 import json
 import os
 
+from cloudinit import atomic_helper
 from cloudinit import log as logging
 from cloudinit import sources, subp, util
 from cloudinit.sources.helpers import openstack
@@ -423,6 +424,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Query IBM Cloud Metadata")
     args = parser.parse_args()
     data = read_md()
-    print(util.json_dumps(data))
+    print(atomic_helper.json_dumps(data))
 
 # vi: ts=4 expandtab

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -23,6 +23,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.connection import HTTPConnection
 from urllib3.connectionpool import HTTPConnectionPool
 
+from cloudinit import atomic_helper
 from cloudinit import log as logging
 from cloudinit import sources, subp, url_helper, util
 from cloudinit.net import find_fallback_nic
@@ -471,6 +472,8 @@ if __name__ == "__main__":
     description = """Query LXD metadata and emit a JSON object."""
     parser = argparse.ArgumentParser(description=description)
     parser.parse_args()
-    print(util.json_dumps(read_metadata(metadata_keys=MetaDataKeys.ALL)))
+    print(
+        atomic_helper.json_dumps(read_metadata(metadata_keys=MetaDataKeys.ALL))
+    )
 
 # vi: ts=4 expandtab

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -19,6 +19,7 @@ import pwd
 import re
 import string
 
+from cloudinit import atomic_helper
 from cloudinit import log as logging
 from cloudinit import net, sources, subp, util
 
@@ -486,7 +487,7 @@ def read_context_disk_dir(source_dir, distro, asuser=None):
         )
         if encoding == "base64":
             try:
-                results["userdata"] = util.b64d(results["userdata"])
+                results["userdata"] = atomic_helper.b64d(results["userdata"])
             except TypeError:
                 LOG.warning("Failed base64 decoding of userdata")
 

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -18,7 +18,7 @@ import ipaddress
 from collections import namedtuple
 from typing import Optional, Tuple
 
-from cloudinit import dmi
+from cloudinit import atomic_helper, dmi
 from cloudinit import log as logging
 from cloudinit import net, sources, util
 from cloudinit.distros.networking import NetworkConfig
@@ -403,7 +403,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=description)
     parser.parse_args()
     print(
-        util.json_dumps(
+        atomic_helper.json_dumps(
             {
                 "read_opc_metadata": read_opc_metadata(),
                 "_is_platform_viable": _is_platform_viable(),

--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -32,7 +32,7 @@ import socket
 
 import serial
 
-from cloudinit import dmi
+from cloudinit import atomic_helper, dmi
 from cloudinit import log as logging
 from cloudinit import sources, subp, util
 from cloudinit.event import EventScope, EventType
@@ -419,7 +419,7 @@ class JoyentMetadataClient:
         if not frame_data.get("payload", None):
             LOG.debug("No value found.")
             return None
-        value = util.b64d(frame_data["payload"])
+        value = atomic_helper.b64d(frame_data["payload"])
         LOG.debug('Value "%s" found.', value)
         return value
 

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -73,7 +73,7 @@ import time
 
 import netifaces
 
-from cloudinit import dmi
+from cloudinit import atomic_helper, dmi
 from cloudinit import log as logging
 from cloudinit import net, sources, util
 from cloudinit.sources.helpers.vmware.imc import guestcust_util
@@ -418,10 +418,10 @@ def decode(key, enc_type, data):
     raw_data = None
     if enc_type in ["gzip+base64", "gz+b64"]:
         LOG.debug("Decoding %s format %s", enc_type, key)
-        raw_data = util.decomp_gzip(util.b64d(data))
+        raw_data = util.decomp_gzip(atomic_helper.b64d(data))
     elif enc_type in ["base64", "b64"]:
         LOG.debug("Decoding %s format %s", enc_type, key)
-        raw_data = util.b64d(data)
+        raw_data = atomic_helper.b64d(data)
     else:
         LOG.debug("Plain-text data %s", key)
         raw_data = data
@@ -977,7 +977,7 @@ def main():
     }
     host_info = wait_on_network(metadata)
     metadata = util.mergemanydict([metadata, host_info])
-    print(util.json_dumps(metadata))
+    print(atomic_helper.json_dumps(metadata))
 
 
 if __name__ == "__main__":

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -262,7 +262,9 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
     # N-tuple of keypaths or keynames redact from instance-data.json for
     # non-root users
     sensitive_metadata_keys: Tuple[str, ...] = (
+        "combined_cloud_config",
         "merged_cfg",
+        "merged_system_cfg",
         "security-credentials",
         "userdata",
         "user-data",
@@ -478,7 +480,14 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         instance_data["ds"]["_doc"] = EXPERIMENTAL_TEXT
         # Add merged cloud.cfg and sys info for jinja templates and cli query
         instance_data["merged_cfg"] = copy.deepcopy(self.sys_cfg)
-        instance_data["merged_cfg"]["_doc"] = (
+        instance_data["merged_cfg"][
+            "_doc"
+        ] = "DEPRECATED: Use merged_system_config. Will be dropped from 24.1"
+        # Deprecate merged_cfg to a more specific key name merged_system_cfg
+        instance_data["merged_system_cfg"] = copy.deepcopy(
+            instance_data["merged_cfg"]
+        )
+        instance_data["merged_system_cfg"]["_doc"] = (
             "Merged cloud-init system config from /etc/cloud/cloud.cfg and"
             " /etc/cloud/cloud.cfg.d/"
         )

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -18,7 +18,7 @@ from collections import namedtuple
 from enum import Enum, unique
 from typing import Any, Dict, List, Optional, Tuple
 
-from cloudinit import dmi, importer
+from cloudinit import atomic_helper, dmi, importer
 from cloudinit import log as logging
 from cloudinit import net, type_utils
 from cloudinit import user_data as ud
@@ -495,7 +495,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         instance_data.update(self._get_standardized_metadata(instance_data))
         try:
             # Process content base64encoding unserializable values
-            content = util.json_dumps(instance_data)
+            content = atomic_helper.json_dumps(instance_data)
             # Strip base64: prefix and set base64_encoded_keys list.
             processed_data = process_instance_metadata(
                 json.loads(content),

--- a/cloudinit/sources/helpers/vmware/imc/config_passwd.py
+++ b/cloudinit/sources/helpers/vmware/imc/config_passwd.py
@@ -9,7 +9,7 @@
 import logging
 import os
 
-from cloudinit import subp, util
+from cloudinit import atomic_helper, subp
 
 LOG = logging.getLogger(__name__)
 
@@ -30,7 +30,7 @@ class PasswordConfigurator:
         """
         LOG.info("Starting password configuration")
         if passwd:
-            passwd = util.b64d(passwd)
+            passwd = atomic_helper.b64d(passwd)
         allRootUsers = []
         for line in open("/etc/passwd", "r"):
             if line.split(":")[2] == "0":

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -10,8 +10,14 @@ import sys
 from collections import namedtuple
 from typing import Dict, Iterable, List, Optional, Set
 
-from cloudinit.atomic_helper import write_json
-from cloudinit import cloud, distros, handlers, helpers, importer
+from cloudinit import (
+    atomic_helper,
+    cloud,
+    distros,
+    handlers,
+    helpers,
+    importer,
+)
 from cloudinit import log as logging
 from cloudinit import net, sources, type_utils, util
 from cloudinit.event import EventScope, EventType, userdata_to_events
@@ -716,7 +722,7 @@ class Init:
             " vendordata and userdata. The combined_cloud_config represents"
             " the aggregated desired configuration acted upon by cloud-init."
         )
-        write_json(
+        atomic_helper.write_json(
             self.paths.get_runpath("combined_cloud_config"),
             combined_cloud_cfg,
             mode=0o600,

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -507,7 +507,7 @@ class Init:
             )
         # This data may be a list, convert it to a string if so
         if isinstance(data, list):
-            data = util.json_dumps(data)
+            data = atomic_helper.json_dumps(data)
         self._store_rawdata(data, datasource)
 
     def _store_processeddata(self, processed_data, datasource):

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -10,6 +10,7 @@ import sys
 from collections import namedtuple
 from typing import Dict, Iterable, List, Optional, Set
 
+from cloudinit.atomic_helper import write_json
 from cloudinit import cloud, distros, handlers, helpers, importer
 from cloudinit import log as logging
 from cloudinit import net, sources, type_utils, util
@@ -708,6 +709,18 @@ class Init:
         # references to the previous config, distro, paths
         # objects before the load of the userdata happened,
         # this is expected.
+        combined_cloud_cfg = copy.deepcopy(self.cfg)
+        combined_cloud_cfg["_doc"] = (
+            "Aggregated cloud-config created by merging merged_system_cfg"
+            " (/etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d), metadata,"
+            " vendordata and userdata. The combined_cloud_config represents"
+            " the aggregated desired configuration acted upon by cloud-init."
+        )
+        write_json(
+            self.paths.get_runpath("combined_cloud_config"),
+            combined_cloud_cfg,
+            mode=0o600,
+        )
 
     def _consume_vendordata(self, vendor_source, frequency=PER_INSTANCE):
         """

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -32,7 +32,6 @@ import string
 import subprocess
 import sys
 import time
-from base64 import b64decode, b64encode
 from collections import deque, namedtuple
 from contextlib import suppress
 from errno import EACCES, ENOENT
@@ -136,24 +135,6 @@ def encode_text(text, encoding="utf-8"):
     if isinstance(text, bytes):
         return text
     return text.encode(encoding)
-
-
-def b64d(source):
-    # Base64 decode some data, accepting bytes or unicode/str, and returning
-    # str/unicode if the result is utf-8 compatible, otherwise returning bytes.
-    decoded = b64decode(source)
-    try:
-        return decoded.decode("utf-8")
-    except UnicodeDecodeError:
-        return decoded
-
-
-def b64e(source):
-    # Base64 encode some data, accepting bytes or unicode/str, and returning
-    # str/unicode if the result is utf-8 compatible, otherwise returning bytes.
-    if not isinstance(source, bytes):
-        source = source.encode("utf-8")
-    return b64encode(source).decode("utf-8")
 
 
 def fully_decoded_payload(part):
@@ -1845,25 +1826,6 @@ def load_json(text, root_types=(dict,)):
             % (expected_types, type(decoded))
         )
     return decoded
-
-
-def json_serialize_default(_obj):
-    """Handler for types which aren't json serializable."""
-    try:
-        return "ci-b64:{0}".format(b64e(_obj))
-    except AttributeError:
-        return "Warning: redacted unserializable type {0}".format(type(_obj))
-
-
-def json_dumps(data):
-    """Return data in nicely formatted json."""
-    return json.dumps(
-        data,
-        indent=1,
-        sort_keys=True,
-        separators=(",", ": "),
-        default=json_serialize_default,
-    )
 
 
 def get_non_exist_parent_dir(path):

--- a/tests/integration_tests/modules/test_jinja_templating.py
+++ b/tests/integration_tests/modules/test_jinja_templating.py
@@ -17,7 +17,7 @@ USER_DATA = """\
 #cloud-config
 runcmd:
   - echo {{v1.local_hostname}} > /var/tmp/runcmd_output
-  - echo {{merged_cfg._doc}} >> /var/tmp/runcmd_output
+  - echo {{merged_system_cfg._doc}} >> /var/tmp/runcmd_output
   - echo {{v1['local-hostname']}} >> /var/tmp/runcmd_output
 """
 
@@ -52,7 +52,7 @@ def test_substitution_in_etc_cloud(client: IntegrationInstance):
     new_cloud_part = (
         "## template: jinja\n"
         "bootcmd:\n"
-        " - echo {{merged_cfg._doc}} > /var/tmp/bootcmd_output\n"
+        " - echo '{{merged_system_cfg._doc}}' > /var/tmp/bootcmd_output\n"
     )
     client.write_to_file(
         "/etc/cloud/cloud.cfg.d/50-jinja-test.cfg", new_cloud_part

--- a/tests/unittests/cmd/test_cloud_id.py
+++ b/tests/unittests/cmd/test_cloud_id.py
@@ -4,7 +4,7 @@
 
 import pytest
 
-from cloudinit import util
+from cloudinit import atomic_helper
 from cloudinit.cmd import cloud_id, status
 from cloudinit.helpers import Paths
 from tests.unittests.helpers import mock
@@ -189,7 +189,7 @@ class TestCloudId:
             '{"v1": {"cloud_name": "unknown", "region": "dfw",'
             ' "platform": "openstack", "public_ssh_keys": []}}',
         )
-        expected = util.json_dumps(
+        expected = atomic_helper.json_dumps(
             {
                 "cloud_id": "openstack",
                 "cloud_name": "unknown",

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -11,10 +11,11 @@ from textwrap import dedent
 
 import pytest
 
+from cloudinit.atomic_helper import b64e
 from cloudinit.cmd import query
 from cloudinit.helpers import Paths
 from cloudinit.sources import REDACT_SENSITIVE_VALUE
-from cloudinit.util import b64e, write_file
+from cloudinit.util import write_file
 from tests.unittests.helpers import mock
 
 M_PATH = "cloudinit.cmd.query."

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -326,7 +326,7 @@ class TestQuery:
             with mock.patch("os.getuid", return_value=0):
                 assert 0 == query.handle_args("anyname", args)
         expected = (
-            '{\n "my-var": "it worked",\n '
+            '{\n "combined_cloud_config": null,\n "my-var": "it worked",\n '
             '"userdata": "instance_link_ud",\n '
             '"vendordata": "instance_link_vd"\n}\n'
         )
@@ -358,7 +358,7 @@ class TestQuery:
                 m_getuid.return_value = 0
                 assert 0 == query.handle_args("anyname", args)
         expected = (
-            '{\n "my-var": "it worked",\n '
+            '{\n "combined_cloud_config": null,\n "my-var": "it worked",\n '
             '"userdata": "ud",\n "vendordata": "vd"\n}\n'
         )
         out, _err = capsys.readouterr()
@@ -382,7 +382,9 @@ class TestQuery:
             m_getuid.return_value = 100
             assert 0 == query.handle_args("anyname", args)
         expected = (
-            '{\n "my-var": "it worked",\n "userdata": "<%s> file:ud",\n'
+            '{\n "combined_cloud_config": "<redacted for non-root user> file:'
+            '/run/cloud-init/combined-cloud-config.json",\n "my-var":'
+            ' "it worked",\n "userdata": "<%s> file:ud",\n'
             ' "vendordata": "<%s> file:vd"\n}\n'
             % (REDACT_SENSITIVE_VALUE, REDACT_SENSITIVE_VALUE)
         )
@@ -460,6 +462,7 @@ class TestQuery:
         expected = dedent(
             """\
             {
+             "combined_cloud_config": "<redacted for non-root user> %s",
              "top": "gun",
              "userdata": "<redacted for non-root user> file:ud",
              "v1": {
@@ -473,6 +476,7 @@ class TestQuery:
              "vendordata": "<redacted for non-root user> file:vd"
             }
         """
+            % "file:/run/cloud-init/combined-cloud-config.json"
         )
         args = self.Args(
             debug=False,
@@ -499,7 +503,10 @@ class TestQuery:
             '{"v1": {"v1_1": "val1.1"}, "v2": {"v2_2": "val2.2"},'
             ' "top": "gun"}'
         )
-        expected = "top\nuserdata\nv1\nv1_1\nv2\nv2_2\nvendordata\n"
+        expected = (
+            "combined_cloud_config\ntop\nuserdata\nv1\nv1_1\nv2\nv2_2\n"
+            "vendordata\n"
+        )
         args = self.Args(
             debug=False,
             dump_all=False,

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -14,7 +14,7 @@ from io import BytesIO
 
 import pytest
 
-from cloudinit import subp, util
+from cloudinit import atomic_helper, subp, util
 from cloudinit.config import cc_seed_random
 from cloudinit.config.schema import (
     SchemaValidationError,
@@ -120,7 +120,7 @@ class TestRandomSeed(TestCase):
         self.assertEqual("big-toe", contents)
 
     def test_append_random_base64(self):
-        data = util.b64e("bubbles")
+        data = atomic_helper.b64e("bubbles")
         cfg = {
             "random_seed": {
                 "file": self._seed_file,
@@ -133,7 +133,7 @@ class TestRandomSeed(TestCase):
         self.assertEqual("bubbles", contents)
 
     def test_append_random_b64(self):
-        data = util.b64e("kit-kat")
+        data = atomic_helper.b64e("kit-kat")
         cfg = {
             "random_seed": {
                 "file": self._seed_file,

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -46,6 +46,7 @@ FS_FUNCS = {
     ],
     atomic_helper: [
         ("write_file", 1),
+        ("write_json", 1),
     ],
 }
 

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -12,6 +12,7 @@ import pytest
 import requests
 
 from cloudinit import distros, dmi, helpers, subp, url_helper
+from cloudinit.atomic_helper import b64e, json_dumps
 from cloudinit.net import dhcp
 from cloudinit.reporting.handlers import HyperVKvpReportingHandler
 from cloudinit.sources import UNSET
@@ -19,14 +20,7 @@ from cloudinit.sources import DataSourceAzure as dsaz
 from cloudinit.sources import InvalidMetaDataException
 from cloudinit.sources.azure import errors, identity, imds
 from cloudinit.sources.helpers import netlink
-from cloudinit.util import (
-    MountFailedError,
-    b64e,
-    json_dumps,
-    load_file,
-    load_json,
-    write_file,
-)
+from cloudinit.util import MountFailedError, load_file, load_json, write_file
 from tests.unittests.helpers import (
     CiTestCase,
     ExitStack,

--- a/tests/unittests/sources/test_init.py
+++ b/tests/unittests/sources/test_init.py
@@ -399,7 +399,8 @@ class TestDataSource(CiTestCase):
         expected = {
             "base64_encoded_keys": [],
             "merged_cfg": REDACT_SENSITIVE_VALUE,
-            "sensitive_keys": ["merged_cfg"],
+            "merged_system_cfg": REDACT_SENSITIVE_VALUE,
+            "sensitive_keys": ["merged_cfg", "merged_system_cfg"],
             "sys_info": sys_info,
             "v1": {
                 "_beta_keys": ["subplatform"],
@@ -468,7 +469,9 @@ class TestDataSource(CiTestCase):
         )
         self.assertCountEqual(
             (
+                "combined_cloud_config",
                 "merged_cfg",
+                "merged_system_cfg",
                 "security-credentials",
                 "userdata",
                 "user-data",
@@ -501,11 +504,13 @@ class TestDataSource(CiTestCase):
         expected = {
             "base64_encoded_keys": [],
             "merged_cfg": REDACT_SENSITIVE_VALUE,
+            "merged_system_cfg": REDACT_SENSITIVE_VALUE,
             "sensitive_keys": [
                 "ds/meta_data/VENDOR-DAta",
                 "ds/meta_data/some/security-credentials",
                 "ds/meta_data/someother/nested/userData",
                 "merged_cfg",
+                "merged_system_cfg",
             ],
             "sys_info": sys_info,
             "v1": {
@@ -591,7 +596,9 @@ class TestDataSource(CiTestCase):
 
         self.assertCountEqual(
             (
+                "combined_cloud_config",
                 "merged_cfg",
+                "merged_system_cfg",
                 "security-credentials",
                 "userdata",
                 "user-data",
@@ -616,6 +623,13 @@ class TestDataSource(CiTestCase):
             "base64_encoded_keys": [],
             "merged_cfg": {
                 "_doc": (
+                    "DEPRECATED: Use merged_system_config. Will be dropped "
+                    "from 24.1"
+                ),
+                "datasource": {"_undef": {"key1": False}},
+            },
+            "merged_system_cfg": {
+                "_doc": (
                     "Merged cloud-init system config from "
                     "/etc/cloud/cloud.cfg and /etc/cloud/cloud.cfg.d/"
                 ),
@@ -624,6 +638,7 @@ class TestDataSource(CiTestCase):
             "sensitive_keys": [
                 "ds/meta_data/some/security-credentials",
                 "merged_cfg",
+                "merged_system_cfg",
             ],
             "sys_info": sys_info,
             "v1": {

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -6,7 +6,7 @@ import unittest
 
 import pytest
 
-from cloudinit import helpers, util
+from cloudinit import atomic_helper, helpers, util
 from cloudinit.sources import DataSourceOpenNebula as ds
 from tests.unittests.helpers import CiTestCase, mock, populate_dir
 
@@ -198,7 +198,7 @@ class TestOpenNebulaDataSource(CiTestCase):
             self.assertEqual(USER_DATA, results["userdata"])
 
     def test_user_data_encoding_required_for_decode(self):
-        b64userdata = util.b64e(USER_DATA)
+        b64userdata = atomic_helper.b64e(USER_DATA)
         for k in ("USER_DATA", "USERDATA"):
             my_d = os.path.join(self.tmp, k)
             populate_context_dir(my_d, {k: b64userdata})
@@ -211,7 +211,11 @@ class TestOpenNebulaDataSource(CiTestCase):
         for k in ("USER_DATA", "USERDATA"):
             my_d = os.path.join(self.tmp, k)
             populate_context_dir(
-                my_d, {k: util.b64e(USER_DATA), "USERDATA_ENCODING": "base64"}
+                my_d,
+                {
+                    k: atomic_helper.b64e(USER_DATA),
+                    "USERDATA_ENCODING": "base64",
+                },
             )
             results = ds.read_context_disk_dir(my_d, mock.Mock())
 

--- a/tests/unittests/sources/test_smartos.py
+++ b/tests/unittests/sources/test_smartos.py
@@ -26,6 +26,7 @@ from binascii import crc32
 import serial
 
 from cloudinit import helpers as c_helpers
+from cloudinit.atomic_helper import b64e
 from cloudinit.event import EventScope, EventType
 from cloudinit.sources import DataSourceSmartOS
 from cloudinit.sources.DataSourceSmartOS import SERIAL_DEVICE, SMARTOS_ENV_KVM
@@ -37,7 +38,7 @@ from cloudinit.sources.DataSourceSmartOS import (
     identify_file,
 )
 from cloudinit.subp import ProcessExecutionError, subp, which
-from cloudinit.util import b64e, write_file
+from cloudinit.util import write_file
 from tests.unittests.helpers import (
     CiTestCase,
     FilesystemMockingTestCase,

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 
 import pytest
 
-from cloudinit import handlers, helpers, util
+from cloudinit import atomic_helper, handlers, helpers, util
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.handlers.cloud_config import CloudConfigPartHandler
 from cloudinit.handlers.jinja_template import (
@@ -109,7 +109,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         # Create required instance data json file
         instance_json = os.path.join(self.run_dir, INSTANCE_DATA_FILE)
         instance_data = {"topkey": "echo himom"}
-        util.write_file(instance_json, util.json_dumps(instance_data))
+        util.write_file(instance_json, atomic_helper.json_dumps(instance_data))
         h = JinjaTemplatePartHandler(self.paths, sub_handlers=[script_handler])
         with mock.patch.object(script_handler, "handle_part") as m_part:
             # ctype with leading '!' not in handlers.CONTENT_SIGNALS
@@ -134,7 +134,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         # Create required instance-data.json file
         instance_json = os.path.join(self.run_dir, INSTANCE_DATA_FILE)
         instance_data = {"topkey": {"sub": "runcmd: [echo hi]"}}
-        util.write_file(instance_json, util.json_dumps(instance_data))
+        util.write_file(instance_json, atomic_helper.json_dumps(instance_data))
         h = JinjaTemplatePartHandler(
             self.paths, sub_handlers=[cloudcfg_handler]
         )
@@ -185,7 +185,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         """If instance-data is unreadable, raise an error from handle_part."""
         script_handler = ShellScriptPartHandler(self.paths)
         instance_json = os.path.join(self.run_dir, INSTANCE_DATA_FILE)
-        util.write_file(instance_json, util.json_dumps({}))
+        util.write_file(instance_json, atomic_helper.json_dumps({}))
         h = JinjaTemplatePartHandler(self.paths, sub_handlers=[script_handler])
         with mock.patch(self.mpath + "load_file") as m_load:
             with self.assertRaises(JinjaLoadError) as context_manager:
@@ -215,7 +215,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         script_handler = ShellScriptPartHandler(self.paths)
         instance_json = os.path.join(self.run_dir, INSTANCE_DATA_FILE)
         instance_data = {"topkey": {"subkey": "echo himom"}}
-        util.write_file(instance_json, util.json_dumps(instance_data))
+        util.write_file(instance_json, atomic_helper.json_dumps(instance_data))
         h = JinjaTemplatePartHandler(self.paths, sub_handlers=[script_handler])
         h.handle_part(
             data="data",
@@ -246,7 +246,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         script_handler = ShellScriptPartHandler(self.paths)
         instance_json = os.path.join(self.run_dir, INSTANCE_DATA_FILE)
         instance_data = {"topkey": {"subkey": "echo himom"}}
-        util.write_file(instance_json, util.json_dumps(instance_data))
+        util.write_file(instance_json, atomic_helper.json_dumps(instance_data))
         h = JinjaTemplatePartHandler(self.paths, sub_handlers=[script_handler])
         h.handle_part(
             data="data",

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from textwrap import dedent
 from uuid import uuid4
 
-from cloudinit import safeyaml, subp, util
+from cloudinit import atomic_helper, safeyaml, subp, util
 from cloudinit.sources import DataSourceIBMCloud as ds_ibm
 from cloudinit.sources import DataSourceOracle as ds_oracle
 from cloudinit.sources import DataSourceSmartOS as ds_smartos
@@ -1003,7 +1003,7 @@ def _print_run_output(rc, out, err, cfg, files):
                 "-- err --",
                 str(err),
                 "-- cfg --",
-                util.json_dumps(cfg),
+                atomic_helper.json_dumps(cfg),
             ]
         )
     )

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -22,7 +22,7 @@ from urllib.parse import urlparse
 import pytest
 import yaml
 
-from cloudinit import features, importer, subp, url_helper, util
+from cloudinit import atomic_helper, features, importer, subp, url_helper, util
 from cloudinit.helpers import Paths
 from cloudinit.sources import DataSourceHostname
 from cloudinit.subp import SubpResult
@@ -1327,19 +1327,22 @@ class TestGetVariant:
 class TestJsonDumps(CiTestCase):
     def test_is_str(self):
         """json_dumps should return a string."""
-        self.assertTrue(isinstance(util.json_dumps({"abc": "123"}), str))
+        self.assertTrue(
+            isinstance(atomic_helper.json_dumps({"abc": "123"}), str)
+        )
 
     def test_utf8(self):
         smiley = "\\ud83d\\ude03"
         self.assertEqual(
-            {"smiley": smiley}, json.loads(util.json_dumps({"smiley": smiley}))
+            {"smiley": smiley},
+            json.loads(atomic_helper.json_dumps({"smiley": smiley})),
         )
 
     def test_non_utf8(self):
         blob = b"\xba\x03Qx-#y\xea"
         self.assertEqual(
             {"blob": "ci-b64:" + base64.b64encode(blob).decode("utf-8")},
-            json.loads(util.json_dumps({"blob": blob})),
+            json.loads(atomic_helper.json_dumps({"blob": blob})),
         )
 
 


### PR DESCRIPTION
## Proposed Commit Message
```
instance-data: write /run/cloud-init/merged-cloud-config.json

Persist the merged_cloud_config key as a new file to aid in
discovery or provided configuration settings.

The file /run/cloud-init/merged-cloud-config.json represents the
full configuration presented to cloud-init which layers config
settings in the following priority order:
1. default config: cloudinit.settings.CFG_BUILTIN
2. merged_system_cfg: config from file-system /etc/cloud and
    /etc/cloud.cfg.d
3. cloud-specific metadata
4. cloud-specific vendor-data, vendor-data2
5. cloud-specific user-data
    
Configuration keys present in earlier sources are overridden by
keys in later sources.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
