### PR TITLE
Add deprecation log during init of DataSourceDigitalOcean

### DIFF
--- a/cloudinit/sources/DataSourceDigitalOcean.py
+++ b/cloudinit/sources/DataSourceDigitalOcean.py
@@ -40,15 +40,24 @@ class DataSourceDigitalOcean(sources.DataSource):
                 BUILTIN_DS_CONFIG,
             ]
         )
-        LOG.warning(
-            "DataSourceDigitalOcean is deprecated in favour of DataSourceConfigDrive."
-        )
+        self._deprecate()
         self.metadata_address = self.ds_cfg["metadata_url"]
         self.retries = self.ds_cfg.get("retries", MD_RETRIES)
         self.timeout = self.ds_cfg.get("timeout", MD_TIMEOUT)
         self.use_ip4LL = self.ds_cfg.get("use_ip4LL", MD_USE_IPV4LL)
         self.wait_retry = self.ds_cfg.get("wait_retry", MD_WAIT_RETRY)
         self._network_config = None
+
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+        self._deprecate()
+
+    def _deprecate(self):
+        util.deprecate(
+            deprecated="DataSourceDigitalOcean",
+            deprecated_version="23.2",
+            extra_message="Deprecated in favour of DataSourceConfigDrive.",
+        )
 
     def _get_sysinfo(self):
         return do_helper.read_sysinfo()

--- a/cloudinit/sources/DataSourceDigitalOcean.py
+++ b/cloudinit/sources/DataSourceDigitalOcean.py
@@ -40,6 +40,9 @@ class DataSourceDigitalOcean(sources.DataSource):
                 BUILTIN_DS_CONFIG,
             ]
         )
+        LOG.warning(
+            "DataSourceDigitalOcean is deprecated in favour of DataSourceConfigDrive."
+        )
         self.metadata_address = self.ds_cfg["metadata_url"]
         self.retries = self.ds_cfg.get("retries", MD_RETRIES)
         self.timeout = self.ds_cfg.get("timeout", MD_TIMEOUT)

--- a/doc/rtd/reference/datasources/digitalocean.rst
+++ b/doc/rtd/reference/datasources/digitalocean.rst
@@ -2,6 +2,9 @@
 
 DigitalOcean
 ************
+.. warning::
+    Deprecated in version 23.2. Use ``DataSourceConfigDrive`` instead.
+
 
 The `DigitalOcean`_ datasource consumes the content served from DigitalOcean's
 metadata service. This metadata service serves information about the

--- a/tests/unittests/sources/test_digitalocean.py
+++ b/tests/unittests/sources/test_digitalocean.py
@@ -140,6 +140,8 @@ def _mock_dmi():
 
 
 class TestDataSourceDigitalOcean(CiTestCase):
+    with_logs = True
+
     """
     Test reading the meta-data
     """
@@ -163,6 +165,15 @@ class TestDataSourceDigitalOcean(CiTestCase):
         ds = self.get_ds(get_sysinfo=None)
         self.assertEqual(False, ds.get_data())
         self.assertTrue(m_read_sysinfo.called)
+
+    @mock.patch("cloudinit.sources.helpers.digitalocean.read_metadata")
+    def test_deprecation_log(self, mock_readmd):
+        ds = self.get_ds()
+        self.assertTrue(ds.get_data())
+        self.assertIn(
+            "WARNING: DataSourceDigitalOcean is deprecated in favour of DataSourceConfigDrive.",
+            self.logs.getvalue(),
+        )
 
     @mock.patch("cloudinit.sources.helpers.digitalocean.read_metadata")
     def test_metadata(self, mock_readmd):

--- a/tests/unittests/sources/test_digitalocean.py
+++ b/tests/unittests/sources/test_digitalocean.py
@@ -187,12 +187,16 @@ class TestDataSourceDigitalOcean(CiTestCase):
                 mock.call(
                     deprecated="DataSourceDigitalOcean",
                     deprecated_version="23.2",
-                    extra_message="Deprecated in favour of DataSourceConfigDrive.",
+                    extra_message=(
+                        "Deprecated in favour of DataSourceConfigDrive."
+                    ),
                 ),
                 mock.call(
                     deprecated="DataSourceDigitalOcean",
                     deprecated_version="23.2",
-                    extra_message="Deprecated in favour of DataSourceConfigDrive.",
+                    extra_message=(
+                        "Deprecated in favour of DataSourceConfigDrive."
+                    ),
                 ),
             ]
         )

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -145,6 +145,7 @@ tnt-dev
 tomponline
 tsanghan
 tSU-RooT
+tyb-truth
 tylerschultz
 vorlonofportland
 vteratipally


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Add deprecation log during init of DataSourceDigitalOcean
This PR adds a log warning of deprecation when DataSourceDigitalOcean is initialized. The DigitalOcean data source is not maintained and currently overridden in official DigitalOcean images with DataSourceConfigDrive.

Fixes GH-4172
```

Resolves https://github.com/canonical/cloud-init/issues/4172.

## Additional Context
More context: https://github.com/canonical/cloud-init/pull/4130#issuecomment-1573884030

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
