### PR TITLE
Add new datasource for TencentCloud CVM

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -55,6 +55,7 @@ KNOWN_CLOUD_NAMES = [
     "SAP Converged Cloud",
     "Scaleway",
     "SmartOS",
+    "TencentCloud",
     "UpCloud",
     "VMware",
     "Vultr",

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -48,6 +48,7 @@ CFG_BUILTIN = {
         "UpCloud",
         "VMware",
         "NWCS",
+        "TencentCloud",
         # At the end to act as a 'catch' when none of the above work...
         "None",
     ],

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -38,6 +38,7 @@ class CloudNames:
     ZSTACK = "zstack"
     E24CLOUD = "e24cloud"
     OUTSCALE = "outscale"
+    TENCENTCLOUD = "tencentcloud"
     # UNKNOWN indicates no positive id.  If strict_id is 'warn' or 'false',
     # then an attempt at the Ec2 Metadata service will be made.
     UNKNOWN = "unknown"
@@ -52,7 +53,11 @@ def skip_404_tag_errors(exception):
 
 
 # Cloud platforms that support IMDSv2 style metadata server
-IDMSV2_SUPPORTED_CLOUD_PLATFORMS = [CloudNames.AWS, CloudNames.ALIYUN]
+IDMSV2_SUPPORTED_CLOUD_PLATFORMS = [
+    CloudNames.AWS,
+    CloudNames.ALIYUN,
+    CloudNames.TENCENTCLOUD,
+]
 
 
 class DataSourceEc2(sources.DataSource):
@@ -781,6 +786,11 @@ def identify_aliyun(data):
         return CloudNames.ALIYUN
 
 
+def identify_tencentcloud(data):
+    if data["product_name"] == "Tencent Cloud CVM":
+        return CloudNames.TENCENTCLOUD
+
+
 def identify_aws(data):
     # data is a dictionary returned by _collect_platform_data.
     if data["uuid"].startswith("ec2") and (
@@ -824,6 +834,7 @@ def identify_platform():
         identify_e24cloud,
         identify_outscale,
         identify_aliyun,
+        identify_tencentcloud,
         lambda x: CloudNames.UNKNOWN,
     )
     for checker in checks:

--- a/cloudinit/sources/DataSourceTencentCloud.py
+++ b/cloudinit/sources/DataSourceTencentCloud.py
@@ -1,0 +1,268 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import json
+import os
+import traceback
+
+from cloudinit import dmi
+from cloudinit import log as logging
+from cloudinit import sources, ssh_util, util
+from cloudinit.sources import DataSourceEc2 as EC2
+from cloudinit.sources import DataSourceHostname
+
+TENCENTCLOUD_PRODUCT = "Tencent Cloud CVM"
+LOG = logging.getLogger(__name__)
+
+
+class DataSourceTencentCloud(EC2.DataSourceEc2):
+
+    metadata_urls = ["http://169.254.0.23", "http://metadata.tencentyun.com"]
+
+    # The minimum supported metadata_version from the ec2 metadata apis
+    min_metadata_version = "2017-09-19"
+    extended_metadata_versions: list[str] = []
+
+    def __init__(self, sys_cfg, distro, paths):
+        super(DataSourceTencentCloud, self).__init__(sys_cfg, distro, paths)
+        self.seed_dir = os.path.join(paths.seed_dir, "TencentCloud")
+
+    def set_config_mod_always(self, mod_name):
+        self.set_mod_always(mod_name, "cloud_config_modules")
+
+    def set_mod_always(self, mod_name, stage):
+        modules = self.sys_cfg.get(stage, [])
+        new_modules = []
+        for mod in modules:
+            if mod == mod_name:
+                new_modules.append([mod_name, "always"])
+            else:
+                new_modules.append(mod)
+        self.cfg[stage] = new_modules
+
+    def add_config_mod_always(self, mod_name):
+        modules = self.sys_cfg.get("cloud_config_modules", [])
+        modules.append([mod_name, "always"])
+        self.cfg["cloud_config_modules"] = modules
+
+    def check_item_change(self, item, value):
+        if not value and item != "ssh_key":
+            return False
+        changed = False
+        d_item = {}
+        item_path = "/var/lib/cloud/tencentcloud.item"
+        try:
+            if os.path.exists(item_path):
+                with open(item_path, "r") as f:
+                    d_item = json.load(f)
+                if d_item.get(item) != value:
+                    changed = True
+            else:
+                changed = True
+            if changed:
+                d_item[item] = value
+                with open(item_path, "w") as f:
+                    json.dump(d_item, f)
+        except Exception as e:
+            LOG.debug(str(e))
+            LOG.debug(traceback.format_exc())
+            changed = True
+        LOG.debug("%s changed %s", item, changed)
+        return changed
+
+    def del_authorized_keys(self, old_entries, keys):
+        to_del = []
+        for i in range(0, len(old_entries)):
+            ent = old_entries[i]
+            if not ent.valid():
+                continue
+            # Replace those with the same base64
+            for k in keys:
+                if k.base64 == ent.base64:
+                    # Replace it with our better one
+                    ent = k
+                    to_del.append(k)
+            old_entries[i] = ent
+
+        # Now format them back to strings...
+        lines = [str(b) for b in old_entries if b not in to_del]
+
+        # Ensure it ends with a newline
+        lines.append("")
+        return ("\n".join(lines), len(to_del) > 0)
+
+    def del_user_keys(self, keys, username, options=None):
+        # Make sure the users .ssh dir is setup accordingly
+        (ssh_dir, pwent) = ssh_util.users_ssh_info(username)
+        if not os.path.isdir(ssh_dir):
+            util.ensure_dir(ssh_dir, mode=0o700)
+            util.chownbyid(ssh_dir, pwent.pw_uid, pwent.pw_gid)
+
+        # Turn the 'update' keys given into actual entries
+        parser = ssh_util.AuthKeyLineParser()
+        key_entries = []
+        for k in keys:
+            key_entries.append(parser.parse(str(k), options=options))
+
+        # Extract the old and make the new
+        (auth_key_fn, auth_key_entries) = ssh_util.extract_authorized_keys(
+            username
+        )
+        with util.SeLinuxGuard(ssh_dir, recursive=True):
+            content, to_del = self.del_authorized_keys(
+                auth_key_entries, key_entries
+            )
+            if to_del:
+                util.ensure_dir(os.path.dirname(auth_key_fn), mode=0o700)
+                util.write_file(auth_key_fn, content, mode=0o600)
+                util.chownbyid(auth_key_fn, pwent.pw_uid, pwent.pw_gid)
+
+    def get_data(self):
+        self.get_network_metadata = True
+        data = super(DataSourceTencentCloud, self).get_data()
+        self.cfg = {
+            "runcmd": self.metadata.get("runcmd", []),
+            "manage_etc_hosts": "template",
+            "ntp": self.metadata.get("ntp", {}),
+            "unverified_modules": ["ntp"],
+            "users": [],
+        }
+        # password
+        passwd = self.metadata.get("password")
+        if passwd is not None:
+            self.cfg["ssh_pwauth"] = (True,)
+            self.cfg["chpasswd"] = {"expire": False, "list": [passwd]}
+            ch_passwd = self.check_item_change("passwd", passwd)
+            if ch_passwd:
+                self.set_config_mod_always("set-passwords")
+        # hostname
+        hostname = self.get_hostname()
+        if hostname is None:
+            self.cfg["preserve_hostname"] = True
+        ch_hostname = self.check_item_change("hostname", hostname)
+        if ch_hostname:
+            self.add_config_mod_always("set-hostname")
+            self.add_config_mod_always("update_hostname")
+            self.add_config_mod_always("update_etc_hosts")
+            self.set_config_mod_always("runcmd")
+        # ssh key
+        ubuntu = self.distro.name == "ubuntu"
+        username = "ubuntu" if ubuntu else "root"
+        # disassociated_keys
+        # delet key from authorized_keys
+        disassociated_ssh_keys = self.get_disassociated_public_ssh_keys()
+        ch_disassociated_ssh_key = self.check_item_change(
+            "disassociated_ssh_key", disassociated_ssh_keys
+        )
+        if ch_disassociated_ssh_key:
+            self.del_user_keys(disassociated_ssh_keys, username)
+        # public_keys
+        # append key to authorized_keys
+        ssh_key = self.get_public_ssh_keys()
+        ch_ssh_key = self.check_item_change("ssh_key", ssh_key)
+        if ch_ssh_key:
+            self.add_config_mod_always("users-groups")
+            self.set_config_mod_always("set-passwords")
+            if ssh_key:
+                self.cfg["ssh_pwauth"] = False
+                users = parse_users_config(
+                    self.metadata.get("public-keys", {})
+                )
+                self.cfg["users"].extend(users)
+            else:
+                self.cfg["ssh_pwauth"] = True
+                self.cfg["users"].append(
+                    {
+                        "name": username,
+                        "lock_passwd": False,
+                    }
+                )
+
+        return data
+
+    def get_config_obj(self):
+        return self.cfg
+
+    def get_hostname(self, fqdn=False, resolve_ip=False, metadata_only=False):
+        hostname = self.metadata.get("hostname")
+        is_default = False
+        if hostname is None:
+            hostname = "localhost.localdomain"
+            is_default = True
+        return DataSourceHostname(hostname, is_default)
+
+    def get_public_ssh_keys(self):
+        return parse_public_keys(self.metadata.get("public-keys", {}))
+
+    def get_disassociated_public_ssh_keys(self):
+        return parse_public_keys(
+            self.metadata.get("disassociated-public-keys", {})
+        )
+
+    def _get_cloud_name(self):
+        return "TencentCloud"
+
+    @property
+    def cloud_platform(self):
+        """
+        todo:
+        1, 通过DMI数据判断是否腾讯云平台。DMI数据：/sys/class/dmi/id/product_name
+        2, 添加EC2.Platforms.TENCENTCLOUD
+        """
+        return "TencentCloud"
+
+
+def _is_tencentcloud():
+    return dmi.read_dmi_data("system-product-name") == TENCENTCLOUD_PRODUCT
+
+
+def parse_public_keys(public_keys):
+    keys = []
+    for _key_id, key_body in public_keys.items():
+        if isinstance(key_body, str):
+            keys.append(key_body.strip())
+        elif isinstance(key_body, list):
+            keys.extend(key_body)
+        elif isinstance(key_body, dict):
+            key = key_body.get("openssh-key", [])
+            if isinstance(key, str):
+                keys.append(key.strip())
+            elif isinstance(key, list):
+                keys.extend(key)
+    return keys
+
+
+def clean_authorized_keys(user_name):
+    if user_name == "root":
+        ssh_key_path = "/root/.ssh/authorized_keys"
+    else:
+        ssh_key_path = "/home/%s/.ssh/authorized_keys" % user_name
+    if os.path.exists(ssh_key_path):
+        os.remove(ssh_key_path)
+
+
+def parse_users_config(public_keys):
+    users = {}
+    for _k_id, k_body in public_keys.items():
+        if isinstance(k_body, dict):
+            name = k_body["user"]
+            if users.get(name):
+                users[name]["ssh_authorized_keys"].append(
+                    k_body.get("openssh-key", "")
+                )
+            else:
+                users[name] = {
+                    "name": name,
+                    "ssh_authorized_keys": [k_body.get("openssh-key", "")],
+                }
+    return [t for _, t in users.items()]
+
+
+# Used to match classes to dependencies
+datasources = [
+    (DataSourceTencentCloud, (sources.DEP_FILESYSTEM, sources.DEP_NETWORK)),
+]
+
+
+# Return a list of data sources that match this set of dependencies
+def get_datasource_list(depends):
+    return sources.list_from_depends(depends, datasources)

--- a/cloudinit/sources/DataSourceTencentCloud.py
+++ b/cloudinit/sources/DataSourceTencentCloud.py
@@ -65,7 +65,6 @@ class DataSourceTencentCloud(EC2.DataSourceEc2):
                     json.dump(d_item, f)
         except Exception as e:
             LOG.debug(str(e))
-            LOG.debug(traceback.format_exc())
             changed = True
         LOG.debug("%s changed %s", item, changed)
         return changed

--- a/cloudinit/sources/DataSourceTencentCloud.py
+++ b/cloudinit/sources/DataSourceTencentCloud.py
@@ -3,6 +3,7 @@
 import json
 import os
 import traceback
+from typing import List
 
 from cloudinit import dmi
 from cloudinit import log as logging
@@ -20,7 +21,7 @@ class DataSourceTencentCloud(EC2.DataSourceEc2):
 
     # The minimum supported metadata_version from the ec2 metadata apis
     min_metadata_version = "2017-09-19"
-    extended_metadata_versions: list[str] = []
+    extended_metadata_versions: List[str] = []
 
     def __init__(self, sys_cfg, distro, paths):
         super(DataSourceTencentCloud, self).__init__(sys_cfg, distro, paths)

--- a/cloudinit/sources/DataSourceTencentCloud.py
+++ b/cloudinit/sources/DataSourceTencentCloud.py
@@ -145,8 +145,7 @@ class DataSourceTencentCloud(EC2.DataSourceEc2):
             self.add_config_mod_always("update_etc_hosts")
             self.set_config_mod_always("runcmd")
         # ssh key
-        ubuntu = self.distro.name == "ubuntu"
-        username = "ubuntu" if ubuntu else "root"
+        username = "root"
         # disassociated_keys
         # delet key from authorized_keys
         disassociated_ssh_keys = self.get_disassociated_public_ssh_keys()
@@ -199,15 +198,6 @@ class DataSourceTencentCloud(EC2.DataSourceEc2):
         )
 
     def _get_cloud_name(self):
-        return "TencentCloud"
-
-    @property
-    def cloud_platform(self):
-        """
-        todo:
-        1, 通过DMI数据判断是否腾讯云平台。DMI数据：/sys/class/dmi/id/product_name
-        2, 添加EC2.Platforms.TENCENTCLOUD
-        """
         return "TencentCloud"
 
 

--- a/cloudinit/sources/DataSourceTencentCloud.py
+++ b/cloudinit/sources/DataSourceTencentCloud.py
@@ -2,7 +2,6 @@
 
 import json
 import os
-import traceback
 from typing import List
 
 from cloudinit import dmi

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ elif os.path.isfile("/etc/system-release-cpe"):
     with open("/etc/system-release-cpe") as f:
         cpe_data = f.read().rstrip().split(":")
 
-        if cpe_data[1] == "\o":  # noqa: W605
+        if cpe_data[1] == "/o":  # noqa: W605
             # URI formatted CPE
             inc = 0
         else:

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ elif os.path.isfile("/etc/system-release-cpe"):
     with open("/etc/system-release-cpe") as f:
         cpe_data = f.read().rstrip().split(":")
 
-        if cpe_data[1] == "/o":  # noqa: W605
+        if cpe_data[1] == "\o":  # noqa: W605
             # URI formatted CPE
             inc = 0
         else:

--- a/templates/chrony.conf.OpenCloudOS.tmpl
+++ b/templates/chrony.conf.OpenCloudOS.tmpl
@@ -1,0 +1,45 @@
+## template:jinja
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+{% if pools %}# pools
+{% endif %}
+{% for pool in pools -%}
+pool {{pool}} iburst
+{% endfor %}
+{%- if servers %}# servers
+{% endif %}
+{% for server in servers -%}
+server {{server}} iburst
+{% endfor %}
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/templates/chrony.conf.TencentOS.tmpl
+++ b/templates/chrony.conf.TencentOS.tmpl
@@ -1,0 +1,45 @@
+## template:jinja
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+{% if pools %}# pools
+{% endif %}
+{% for pool in pools -%}
+pool {{pool}} iburst
+{% endfor %}
+{%- if servers %}# servers
+{% endif %}
+{% for server in servers -%}
+server {{server}} iburst
+{% endfor %}
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/templates/hosts.OpenCloudOS.tmpl
+++ b/templates/hosts.OpenCloudOS.tmpl
@@ -1,0 +1,24 @@
+## template:jinja
+{#
+This file /etc/cloud/templates/hosts.redhat.tmpl is only utilized
+if enabled in cloud-config.  Specifically, in order to enable it
+you need to add the following to config:
+  manage_etc_hosts: True
+-#}
+# Your system has configured 'manage_etc_hosts' as True.
+# As a result, if you wish for changes to this file to persist
+# then you will need to either
+# a.) make changes to the master file in /etc/cloud/templates/hosts.redhat.tmpl
+# b.) change or remove the value of 'manage_etc_hosts' in
+#     /etc/cloud/cloud.cfg or cloud-config from user-data
+# 
+# The following lines are desirable for IPv4 capable hosts
+127.0.0.1 {{fqdn}} {{hostname}}
+127.0.0.1 localhost.localdomain localhost
+127.0.0.1 localhost4.localdomain4 localhost4
+
+# The following lines are desirable for IPv6 capable hosts
+::1 {{fqdn}} {{hostname}}
+::1 localhost.localdomain localhost
+::1 localhost6.localdomain6 localhost6
+

--- a/templates/hosts.TencentOS.tmpl
+++ b/templates/hosts.TencentOS.tmpl
@@ -1,0 +1,24 @@
+## template:jinja
+{#
+This file /etc/cloud/templates/hosts.redhat.tmpl is only utilized
+if enabled in cloud-config.  Specifically, in order to enable it
+you need to add the following to config:
+  manage_etc_hosts: True
+-#}
+# Your system has configured 'manage_etc_hosts' as True.
+# As a result, if you wish for changes to this file to persist
+# then you will need to either
+# a.) make changes to the master file in /etc/cloud/templates/hosts.redhat.tmpl
+# b.) change or remove the value of 'manage_etc_hosts' in
+#     /etc/cloud/cloud.cfg or cloud-config from user-data
+# 
+# The following lines are desirable for IPv4 capable hosts
+127.0.0.1 {{fqdn}} {{hostname}}
+127.0.0.1 localhost.localdomain localhost
+127.0.0.1 localhost4.localdomain4 localhost4
+
+# The following lines are desirable for IPv6 capable hosts
+::1 {{fqdn}} {{hostname}}
+::1 localhost.localdomain localhost
+::1 localhost6.localdomain6 localhost6
+

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -29,6 +29,7 @@ from cloudinit.sources import DataSourceOVF as OVF
 from cloudinit.sources import DataSourceRbxCloud as RbxCloud
 from cloudinit.sources import DataSourceScaleway as Scaleway
 from cloudinit.sources import DataSourceSmartOS as SmartOS
+from cloudinit.sources import DataSourceTencentCloud as TencentCloud
 from cloudinit.sources import DataSourceUpCloud as UpCloud
 from cloudinit.sources import DataSourceVMware as VMware
 from cloudinit.sources import DataSourceVultr as Vultr
@@ -71,6 +72,7 @@ DEFAULT_NETWORK = [
     NoCloud.DataSourceNoCloudNet,
     OpenStack.DataSourceOpenStack,
     OVF.DataSourceOVFNet,
+    TencentCloud.DataSourceTencentCloud,
     UpCloud.DataSourceUpCloud,
     VMware.DataSourceVMware,
 ]

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -1198,6 +1198,16 @@ class TesIdentifyPlatform(test_helpers.CiTestCase):
         self.assertEqual(ec2.CloudNames.ALIYUN, ec2.identify_platform())
 
     @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
+    def test_identify_tencentcloud(self, m_collect):
+        """tencentcloud should be identified if product name equals to
+        Tencent Cloud CVM
+        """
+        m_collect.return_value = self.collmock(
+            product_name="Tencent Cloud CVM"
+        )
+        self.assertEqual(ec2.CloudNames.TENCENTCLOUD, ec2.identify_platform())
+
+    @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
     def test_identify_zstack(self, m_collect):
         """zstack should be identified if chassis-asset-tag
         ends in .zstack.io

--- a/tests/unittests/sources/test_tencentcloud.py
+++ b/tests/unittests/sources/test_tencentcloud.py
@@ -1,0 +1,291 @@
+import functools
+import os
+from unittest import mock
+
+import responses
+
+from cloudinit import helpers
+from cloudinit.sources import DataSourceTencentCloud as TencentCloud
+from cloudinit.sources.DataSourceEc2 import convert_ec2_metadata_network_config
+from tests.unittests import helpers as test_helpers
+
+DEFAULT_METADATA = {
+    "instance-id": "tencentcloud-test-vm-00",
+    "eipv4": "10.0.0.1",
+    "hostname": "test-hostname",
+    "image-id": "m-test",
+    "launch-index": "0",
+    "mac": "00:16:3e:00:00:00",
+    "network-type": "vpc",
+    "private-ipv4": "192.168.0.1",
+    "serial-number": "test-string",
+    "vpc-cidr-block": "192.168.0.0/16",
+    "vpc-id": "test-vpc",
+    "vswitch-id": "test-vpc",
+    "vswitch-cidr-block": "192.168.0.0/16",
+    "zone-id": "test-zone-1",
+    "ntp-conf": {
+        "ntp_servers": [
+            "ntp1.tencent.com",
+            "ntp2.tencent.com",
+            "ntp3.tencent.com",
+        ]
+    },
+    "source-address": [
+        "https://cloud.tencent.com/",
+    ],
+    "public-keys": {
+        "key-pair-1": {"user": "root", "openssh-key": "ssh-rsa AAAAB3..."},
+        "key-pair-2": {"user": "root", "openssh-key": "ssh-rsa AAAAB3..."},
+    },
+}
+
+DEFAULT_USERDATA = """\
+#cloud-config
+
+hostname: localhost"""
+
+
+class TestTencentCloudDatasource(test_helpers.ResponsesTestCase):
+    def setUp(self):
+        super(TestTencentCloudDatasource, self).setUp()
+        cfg = {"datasource": {"TencentCloud": {"timeout": "1", "max_wait": "1"}}}
+        distro = {}
+        paths = helpers.Paths({"run_dir": self.tmp_dir()})
+        self.ds = TencentCloud.DataSourceTencentCloud(cfg, distro, paths)
+        self.metadata_address = self.ds.metadata_urls[0]
+
+    @property
+    def default_metadata(self):
+        return DEFAULT_METADATA
+    
+    @property
+    def default_userdata(self):
+        return DEFAULT_USERDATA
+    
+    @property
+    def metadata_url(self):
+        return (
+            os.path.join(
+                self.metadata_address,
+                self.ds.min_metadata_version,
+                "meta-data",
+            )
+            + "/"
+        )
+
+    @property
+    def userdata_url(self):
+        return os.path.join(
+            self.metadata_address, self.ds.min_metadata_version, "user-data"
+        )
+
+    # EC2 provides an instance-identity document which must return 404 here
+    # for this test to pass.
+    @property
+    def default_identity(self):
+        return {}
+
+    @property
+    def identity_url(self):
+        return os.path.join(
+            self.metadata_address,
+            self.ds.min_metadata_version,
+            "dynamic",
+            "instance-identity",
+        )
+
+    @property
+    def token_url(self):
+        return os.path.join(
+            self.metadata_address,
+            "latest",
+            "api",
+            "token",
+        )
+
+    def register_mock_metaserver(self, base_url, data):
+        def register_helper(register, base_url, body):
+            if isinstance(body, str):
+                register(base_url, body)
+            elif isinstance(body, list):
+                register(base_url.rstrip("/"), "\n".join(body) + "\n")
+            elif isinstance(body, dict):
+                if not body:
+                    register(
+                        base_url.rstrip("/") + "/", "not found", status=404
+                    )
+                vals = []
+                for k, v in body.items():
+                    if isinstance(v, (str, list)):
+                        suffix = k.rstrip("/")
+                    else:
+                        suffix = k.rstrip("/") + "/"
+                    vals.append(suffix)
+                    url = base_url.rstrip("/") + "/" + suffix
+                    register_helper(register, url, v)
+                register(base_url, "\n".join(vals) + "\n")
+
+        register = functools.partial(self.responses.add, responses.GET)
+        register_helper(register, base_url, data)
+
+    def register_default_server(self):
+        self.register_mock_metaserver(self.metadata_url, self.default_metadata)
+        self.register_mock_metaserver(self.userdata_url, self.default_userdata)
+        self.register_mock_metaserver(self.identity_url, self.default_identity)
+        self.responses.add(responses.PUT, self.token_url, "API-TOKEN")
+
+    def _test_get_data(self):
+        self.assertEqual(self.ds.metadata, self.default_metadata)
+        self.assertEqual(
+            self.ds.userdata_raw, self.default_userdata.encode("utf8")
+        )
+    
+    def _test_get_sshkey(self):
+        pub_keys = [
+            v["openssh-key"]
+            for (_, v) in self.default_metadata["public-keys"].items()
+        ]
+        self.assertEqual(self.ds.get_public_ssh_keys(), pub_keys)
+
+    def _test_get_iid(self):
+        self.assertEqual(
+            self.default_metadata["instance-id"], self.ds.get_instance_id()
+        )
+
+    def _test_host_name(self):
+        self.assertEqual(
+            self.default_metadata["hostname"], self.ds.get_hostname().hostname
+        )
+
+    # @mock.patch("cloudinit.sources.DataSourceEc2.util.is_resolvable")
+    # @mock.patch("cloudinit.sources.DataSourceTencentCloud._is_tencentcloud")
+    # def test_with_mock_server(self, m_is_tencentcloud, m_resolv):
+    #     m_is_tencentcloud.return_value = True
+    #     self.register_default_server()
+    #     ret = self.ds.get_data()
+    #     self.assertEqual(True, ret)
+    #     self.assertEqual(1, m_is_tencentcloud.call_count)
+    #     self._test_get_data()
+    #     self._test_get_sshkey()
+    #     self._test_get_iid()
+    #     self._test_host_name()
+    #     self.assertEqual("tencentcloud", self.ds.cloud_name)
+    #     self.assertEqual("ec2", self.ds.platform)
+    #     self.assertEqual(
+    #         "metadata (http://100.100.100.200)", self.ds.subplatform
+    #     )
+
+    # @mock.patch("cloudinit.sources.DataSourceTencentCloud._is_tencentcloud")
+    # def test_returns_false_when_not_on_tencentcloud(self, m_is_tencentcloud):
+    #     """If is_tencentcloud returns false, then get_data should return False."""
+    #     m_is_tencentcloud.return_value = False
+    #     self.register_default_server()
+    #     ret = self.ds.get_data()
+    #     self.assertEqual(1, m_is_tencentcloud.call_count)
+    #     self.assertEqual(False, ret)
+
+    def test_parse_public_keys(self):
+        public_keys = {}
+        self.assertEqual(TencentCloud.parse_public_keys(public_keys), [])
+
+        public_keys = {"key-pair-0": "ssh-key-0"}
+        self.assertEqual(
+            TencentCloud.parse_public_keys(public_keys), [public_keys["key-pair-0"]]
+        )
+
+        public_keys = {"key-pair-0": "ssh-key-0", "key-pair-1": "ssh-key-1"}
+        self.assertEqual(
+            set(TencentCloud.parse_public_keys(public_keys)),
+            set([public_keys["key-pair-0"], public_keys["key-pair-1"]]),
+        )
+
+        public_keys = {"key-pair-0": ["ssh-key-0", "ssh-key-1"]}
+        self.assertEqual(
+            TencentCloud.parse_public_keys(public_keys), public_keys["key-pair-0"]
+        )
+
+        public_keys = {"key-pair-0": {"openssh-key": []}}
+        self.assertEqual(TencentCloud.parse_public_keys(public_keys), [])
+
+        public_keys = {"key-pair-0": {"openssh-key": "ssh-key-0"}}
+        self.assertEqual(
+            TencentCloud.parse_public_keys(public_keys),
+            [public_keys["key-pair-0"]["openssh-key"]],
+        )
+
+        public_keys = {
+            "key-pair-0": {"openssh-key": ["ssh-key-0", "ssh-key-1"]}
+        }
+        self.assertEqual(
+            TencentCloud.parse_public_keys(public_keys),
+            public_keys["key-pair-0"]["openssh-key"],
+        )
+
+    def test_route_metric_calculated_without_device_number(self):
+        """Test that route-metric code works without `device-number`
+
+        `device-number` is part of EC2 metadata, but not supported on aliyun.
+        Attempting to access it will raise a KeyError.
+
+        LP: #1917875
+        """
+        netcfg = convert_ec2_metadata_network_config(
+            {
+                "interfaces": {
+                    "macs": {
+                        "06:17:04:d7:26:09": {
+                            "interface-id": "eni-e44ef49e",
+                        },
+                        "06:17:04:d7:26:08": {
+                            "interface-id": "eni-e44ef49f",
+                        },
+                    }
+                }
+            },
+            macs_to_nics={
+                "06:17:04:d7:26:09": "eth0",
+                "06:17:04:d7:26:08": "eth1",
+            },
+        )
+
+        met0 = netcfg["ethernets"]["eth0"]["dhcp4-overrides"]["route-metric"]
+        met1 = netcfg["ethernets"]["eth1"]["dhcp4-overrides"]["route-metric"]
+
+        # route-metric numbers should be 100 apart
+        assert 100 == abs(met0 - met1)
+
+
+class TestIsTencentCloud(test_helpers.CiTestCase):
+    TENCENTCLOUD_PRODUCT = "Tencent Cloud CVM"
+    read_dmi_data_expected = [mock.call("system-product-name")]
+
+    @mock.patch("cloudinit.sources.DataSourceTencentCloud.dmi.read_dmi_data")
+    def test_true_on_tencentcloud_product(self, m_read_dmi_data):
+        """Should return true if the dmi product data has expected value."""
+        m_read_dmi_data.return_value = self.TENCENTCLOUD_PRODUCT
+        ret = TencentCloud._is_tencentcloud()
+        self.assertEqual(
+            self.read_dmi_data_expected, m_read_dmi_data.call_args_list
+        )
+        self.assertEqual(True, ret)
+
+    @mock.patch("cloudinit.sources.DataSourceTencentCloud.dmi.read_dmi_data")
+    def test_false_on_empty_string(self, m_read_dmi_data):
+        """Should return false on empty value returned."""
+        m_read_dmi_data.return_value = ""
+        ret = TencentCloud._is_tencentcloud()
+        self.assertEqual(
+            self.read_dmi_data_expected, m_read_dmi_data.call_args_list
+        )
+        self.assertEqual(False, ret)
+
+    @mock.patch("cloudinit.sources.DataSourceTencentCloud.dmi.read_dmi_data")
+    def test_false_on_unknown_string(self, m_read_dmi_data):
+        """Should return false on an unrelated string."""
+        m_read_dmi_data.return_value = "cubs win"
+        ret = TencentCloud._is_tencentcloud()
+        self.assertEqual(
+            self.read_dmi_data_expected, m_read_dmi_data.call_args_list
+        )
+        self.assertEqual(False, ret)

--- a/tests/unittests/sources/test_tencentcloud.py
+++ b/tests/unittests/sources/test_tencentcloud.py
@@ -49,7 +49,9 @@ hostname: localhost"""
 class TestTencentCloudDatasource(test_helpers.ResponsesTestCase):
     def setUp(self):
         super(TestTencentCloudDatasource, self).setUp()
-        cfg = {"datasource": {"TencentCloud": {"timeout": "1", "max_wait": "1"}}}
+        cfg = {
+            "datasource": {"TencentCloud": {"timeout": "1", "max_wait": "1"}}
+        }
         distro = {}
         paths = helpers.Paths({"run_dir": self.tmp_dir()})
         self.ds = TencentCloud.DataSourceTencentCloud(cfg, distro, paths)
@@ -58,11 +60,11 @@ class TestTencentCloudDatasource(test_helpers.ResponsesTestCase):
     @property
     def default_metadata(self):
         return DEFAULT_METADATA
-    
+
     @property
     def default_userdata(self):
         return DEFAULT_USERDATA
-    
+
     @property
     def metadata_url(self):
         return (
@@ -140,7 +142,7 @@ class TestTencentCloudDatasource(test_helpers.ResponsesTestCase):
         self.assertEqual(
             self.ds.userdata_raw, self.default_userdata.encode("utf8")
         )
-    
+
     def _test_get_sshkey(self):
         pub_keys = [
             v["openssh-key"]
@@ -158,40 +160,14 @@ class TestTencentCloudDatasource(test_helpers.ResponsesTestCase):
             self.default_metadata["hostname"], self.ds.get_hostname().hostname
         )
 
-    # @mock.patch("cloudinit.sources.DataSourceEc2.util.is_resolvable")
-    # @mock.patch("cloudinit.sources.DataSourceTencentCloud._is_tencentcloud")
-    # def test_with_mock_server(self, m_is_tencentcloud, m_resolv):
-    #     m_is_tencentcloud.return_value = True
-    #     self.register_default_server()
-    #     ret = self.ds.get_data()
-    #     self.assertEqual(True, ret)
-    #     self.assertEqual(1, m_is_tencentcloud.call_count)
-    #     self._test_get_data()
-    #     self._test_get_sshkey()
-    #     self._test_get_iid()
-    #     self._test_host_name()
-    #     self.assertEqual("tencentcloud", self.ds.cloud_name)
-    #     self.assertEqual("ec2", self.ds.platform)
-    #     self.assertEqual(
-    #         "metadata (http://100.100.100.200)", self.ds.subplatform
-    #     )
-
-    # @mock.patch("cloudinit.sources.DataSourceTencentCloud._is_tencentcloud")
-    # def test_returns_false_when_not_on_tencentcloud(self, m_is_tencentcloud):
-    #     """If is_tencentcloud returns false, then get_data should return False."""
-    #     m_is_tencentcloud.return_value = False
-    #     self.register_default_server()
-    #     ret = self.ds.get_data()
-    #     self.assertEqual(1, m_is_tencentcloud.call_count)
-    #     self.assertEqual(False, ret)
-
     def test_parse_public_keys(self):
         public_keys = {}
         self.assertEqual(TencentCloud.parse_public_keys(public_keys), [])
 
         public_keys = {"key-pair-0": "ssh-key-0"}
         self.assertEqual(
-            TencentCloud.parse_public_keys(public_keys), [public_keys["key-pair-0"]]
+            TencentCloud.parse_public_keys(public_keys),
+            [public_keys["key-pair-0"]],
         )
 
         public_keys = {"key-pair-0": "ssh-key-0", "key-pair-1": "ssh-key-1"}
@@ -202,7 +178,8 @@ class TestTencentCloudDatasource(test_helpers.ResponsesTestCase):
 
         public_keys = {"key-pair-0": ["ssh-key-0", "ssh-key-1"]}
         self.assertEqual(
-            TencentCloud.parse_public_keys(public_keys), public_keys["key-pair-0"]
+            TencentCloud.parse_public_keys(public_keys),
+            public_keys["key-pair-0"],
         )
 
         public_keys = {"key-pair-0": {"openssh-key": []}}
@@ -223,13 +200,6 @@ class TestTencentCloudDatasource(test_helpers.ResponsesTestCase):
         )
 
     def test_route_metric_calculated_without_device_number(self):
-        """Test that route-metric code works without `device-number`
-
-        `device-number` is part of EC2 metadata, but not supported on aliyun.
-        Attempting to access it will raise a KeyError.
-
-        LP: #1917875
-        """
         netcfg = convert_ec2_metadata_network_config(
             {
                 "interfaces": {

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -595,6 +595,10 @@ class TestDsIdentify(DsIdentifyBase):
         )
         self.assertIn("check for 'OpenStack' returned maybe", err)
 
+    def test_tencentcloud_identified(self):
+        """Test that TencentCloud is identified by product id."""
+        self._test_ds_found("TencentCloud")
+
     def test_default_ovf_is_found(self):
         """OVF is identified found when ovf/ovf-env.xml seed file exists."""
         self._test_ds_found("OVF-seed")
@@ -1585,6 +1589,10 @@ VALID_CFG = {
             {"name": "blkid", "ret": 2, "out": ""},
         ],
         "files": {ds_smartos.METADATA_SOCKFILE: "would be a socket\n"},
+    },
+    "TencentCloud": {
+        "ds": "TencentCloud",
+        "files": {P_PRODUCT_NAME: "Tencent Cloud CVM\n"},
     },
     "Ec2-ZStack": {
         "ds": "Ec2",

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -127,7 +127,7 @@ DI_DSNAME=""
 DI_DSLIST_DEFAULT="MAAS ConfigDrive NoCloud AltCloud Azure Bigstep \
 CloudSigma CloudStack DigitalOcean Vultr AliYun Ec2 GCE OpenNebula OpenStack \
 OVF SmartOS Scaleway Hetzner IBMCloud Oracle Exoscale RbxCloud UpCloud VMware \
-LXD NWCS"
+LXD NWCS TencentCloud"
 DI_DSLIST=""
 DI_MODE=""
 DI_ON_FOUND=""
@@ -1354,6 +1354,14 @@ dscheck_Oracle() {
     local asset_tag="OracleCloud.com"
     dmi_chassis_asset_tag_matches "${asset_tag}" && return ${DS_FOUND}
     return ${DS_NOT_FOUND}
+}
+
+dscheck_TencentCloud() {
+    check_seed_dir "TencentCloud" meta-data user-data && return ${DS_FOUND}
+    if dmi_product_name_matches "Tencent Cloud CVM"; then
+        return $DS_FOUND
+    fi
+    return $DS_NOT_FOUND
 }
 
 is_ibm_provisioning() {


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Add new datasource for TencentCloud CVM 

Support TencentCloud. This datasource inherits from EC2 and add it to ensure cloud-init acts normally on TencentOS and OpencloudOS
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
