### PR TITLE
tests: reboot client to assert x-shellscript-per-boot is triggered

### DIFF
--- a/tests/integration_tests/test_multi_part_user_data_handling.py
+++ b/tests/integration_tests/test_multi_part_user_data_handling.py
@@ -85,6 +85,15 @@ def test_per_freq(client: IntegrationInstance):
     assert client.execute(cmd).ok
     cmd = "test -f /tmp/test_per_freq_once"
     assert client.execute(cmd).ok
+    client.restart()
+    # Assert Always is run per boot
+    cmd = "test -f /tmp/test_per_freq_always"
+    assert client.execute(cmd).ok
+    # Assert no per instance/once execution across reboot
+    cmd = "test -f /tmp/test_per_freq_instance"
+    assert client.execute(cmd).failed
+    cmd = "test -f /tmp/test_per_freq_once"
+    assert client.execute(cmd).failed
 
 
 RE_EXPECTED_SCHEMA_STDERR = (


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: reboot client to assert x-shellscript-per-boot is triggered

Improve assertions across reboot to prove per-always is run and
per-once per-instance are not run across typical reboot.
```

## Additional Context
Additional assertions to prove that cloud-init runs x-shellscript-per-always every reboot to assert that https://github.com/canonical/cloud-init/issues/4197 is not a cloud-init prob.


## Test Steps
```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_OS_IMAGE=kinetic .tox/integration-tests/bin/pytest tests/integration_tests/test_shell_script_by_frequency.py
```
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
