### PR TITLE
docs: Correct some bootcmd example wording

### DIFF
--- a/doc/examples/cloud-config-boot-cmds.txt
+++ b/doc/examples/cloud-config-boot-cmds.txt
@@ -5,7 +5,7 @@
 # This is very similar to runcmd, but commands run very early
 # in the boot process, only slightly after a 'boothook' would run.
 # - bootcmd will run on every boot
-# - INSTANCE_ID variable will be set to the current instance id
+# - INSTANCE_ID variable will be set to the current instance ID
 # - 'cloud-init-per' command can be used to make bootcmd run exactly once
 bootcmd:
   - echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts

--- a/doc/examples/cloud-config-boot-cmds.txt
+++ b/doc/examples/cloud-config-boot-cmds.txt
@@ -2,14 +2,11 @@
 
 # boot commands
 # default: none
-# this is very similar to runcmd, but commands run very early
+# This is very similar to runcmd, but commands run very early
 # in the boot process, only slightly after a 'boothook' would run.
-# bootcmd should really only be used for things that could not be
-# done later in the boot process.  bootcmd is very much like
-# boothook, but possibly with more friendly.
 # - bootcmd will run on every boot
-# - the INSTANCE_ID variable will be set to the current instance id.
-# - you can use 'cloud-init-per' command to help only run once
+# - INSTANCE_ID variable will be set to the current instance id
+# - 'cloud-init-per' command can be used to make bootcmd run exactly once
 bootcmd:
   - echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts
   - [ cloud-init-per, once, mymkfs, mkfs, /dev/vdb ]

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -134,7 +134,7 @@ runcmd:
 # This is very similar to runcmd above, but commands run very early
 # in the boot process, only slightly after a 'boothook' would run.
 #  - bootcmd will run on every boot
-#  - INSTANCE_ID variable will be set to the current instance id
+#  - INSTANCE_ID variable will be set to the current instance ID
 #  - 'cloud-init-per' command can be used to make bootcmd run exactly once
 bootcmd:
  - echo 192.168.1.130 us.archive.ubuntu.com > /etc/hosts

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -131,14 +131,11 @@ runcmd:
 
 # boot commands
 # default: none
-# this is very similar to runcmd above, but commands run very early
+# This is very similar to runcmd above, but commands run very early
 # in the boot process, only slightly after a 'boothook' would run.
-# bootcmd should really only be used for things that could not be
-# done later in the boot process.  bootcmd is very much like
-# boothook, but possibly with more friendly.
-#  * bootcmd will run on every boot
-#  * the INSTANCE_ID variable will be set to the current instance id.
-#  * you can use 'cloud-init-per' command to help only run once
+#  - bootcmd will run on every boot
+#  - INSTANCE_ID variable will be set to the current instance id
+#  - 'cloud-init-per' command can be used to make bootcmd run exactly once
 bootcmd:
  - echo 192.168.1.130 us.archive.ubuntu.com > /etc/hosts
  - [ cloud-init-per, once, mymkfs, mkfs, /dev/vdb ]


### PR DESCRIPTION
A user initially found the poor wording of `but possibly with more friendly.`, and I added a few other minor changes to fix up the wording. I don't think we need the extra boothook comparisons or explanation here as boothooks are very rarely used anymore.