### PR TITLE
setup: fix generation of init templates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -167,10 +167,14 @@ for a in sys.argv:
 INITSYS_FILES = {
     "sysvinit": [f for f in glob("sysvinit/redhat/*") if is_f(f)],
     "sysvinit_freebsd": [
-        render_tmpl(f) for f in glob("sysvinit/freebsd/*") if is_f(f)
+        render_tmpl(f, mode=0o755)
+        for f in glob("sysvinit/freebsd/*")
+        if is_f(f)
     ],
     "sysvinit_netbsd": [
-        render_tmpl(f) for f in glob("sysvinit/netbsd/*") if is_f(f)
+        render_tmpl(f, mode=0o755)
+        for f in glob("sysvinit/netbsd/*")
+        if is_f(f)
     ],
     "sysvinit_deb": [f for f in glob("sysvinit/debian/*") if is_f(f)],
     "sysvinit_openrc": [f for f in glob("sysvinit/gentoo/*") if is_f(f)],

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,10 @@ def render_tmpl(template, mode=None):
     topdir = os.path.dirname(sys.argv[0])
     tmpd = tempfile.mkdtemp(dir=topdir, prefix=RENDERED_TMPD_PREFIX)
     atexit.register(shutil.rmtree, tmpd)
-    bname = os.path.basename(template).rstrip(tmpl_ext)
+    bname = os.path.basename(template)
+    ename, ext = os.path.splitext(bname)
+    if ext == tmpl_ext:
+        bname = ename
     fpath = os.path.join(tmpd, bname)
     cmd_variant = []
     cmd_prefix = []


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
setup: fix generation of init templates

if an init file ends in any of the letters [tmpl] these will be stripped
in addition to the .tmpl extension.

This is documented behaviour of the str.rstrip() method.
This PR fixes it by using os.path.splitext() (rather than
str.removesuffix which is only available in python 3.9+)

Since BSD sysvinit scripts are now rendered as template,
we need to fix an oversight from #4182 and pass the mode.

Sponsored by: The FreeBSD Foundation
```

## Additional Context

https://github.com/canonical/cloud-init/pull/4182

## Test Steps

successfully tested on Hetzner

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
