### PR TITLE
Ubuntu/focal 23.2.x

### DIFF
--- a/debian/apport-general-hook.py
+++ b/debian/apport-general-hook.py
@@ -2,9 +2,10 @@
 
 import json
 import logging
+from typing import Dict
 
 
-def _get_azure_data(ds_data) -> dict[str, str]:
+def _get_azure_data(ds_data) -> Dict[str, str]:
     compute = ds_data.get("meta_data", {}).get("imds", {}).get("compute")
     if not compute:
         return {}
@@ -21,7 +22,7 @@ def _get_azure_data(ds_data) -> dict[str, str]:
     return azure_data
 
 
-def _get_ec2_data(ds_data) -> dict[str, str]:
+def _get_ec2_data(ds_data) -> Dict[str, str]:
     document = (
         ds_data.get("dynamic", {}).get("instance-identity", {}).get("document")
     )

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-cloud-init (23.2.1-0ubuntu0~20.04.2) UNRELEASED; urgency=medium
+cloud-init (23.2.1-0ubuntu0~20.04.2) focal; urgency=medium
 
   * d/apport-general-hook: correct type hints on Dict for py3.8
     (LP: #2025376)
 
- -- Chad Smith <chad.smith@canonical.com>  Thu, 29 Jun 2023 09:35:37 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 29 Jun 2023 09:41:13 -0600
 
 cloud-init (23.2.1-0ubuntu0~20.04.1) focal; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (23.2.1-0ubuntu0~20.04.2) UNRELEASED; urgency=medium
+
+  * d/apport-general-hook: correct type hints on Dict for py3.8
+    (LP: #2025376)
+
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 29 Jun 2023 09:35:37 -0600
+
 cloud-init (23.2.1-0ubuntu0~20.04.1) focal; urgency=medium
 
   * Upstream snapshot based on 23.2.1. (LP: #2025180).


### PR DESCRIPTION
## do no squash merge. review as individual SRU upload (test pkg build, lint etc)

Update cloud-init's apport general hooks for focal to ensure we don't hit type annotations issues.

LP: #2025376

## Proposed Commit Message
```
    d/apport-general-hook: correct type hints on Dict for py3.8
    
    Focal's python3.8 traces on type hints of the format:
     dict[str, str].
    
    Instead, from typing import Dict

    LP: #2025376
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
