### PR TITLE
Specify build-system for pep517 [SC-1492]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 79
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Specify build-system for pep517

Make it clear to various packaging frontends that we're using
setuptools as our backend.
```

## Test Steps
I created 3 separate builds:
`python setup.py sdist`
`python -m build` without pyproject.toml changes
`python -m build` with pyproject.toml changes

All three builds contained exactly the same contents