### PR TITLE
instance-data: add system-info and features to combined-cloud-config

### DIFF
--- a/cloudinit/features.py
+++ b/cloudinit/features.py
@@ -14,6 +14,9 @@ the flag and intended lifetime.
 Tests are required for new feature flags, and tests must verify
 all valid states of a flag, not just the default state.
 """
+import re
+import sys
+from typing import Dict
 
 ERROR_ON_USER_DATA_FAILURE = True
 """
@@ -76,3 +79,12 @@ separators.
 
 (This flag can be removed when Jammy is no longer supported.)
 """
+
+
+def get_features() -> Dict[str, bool]:
+    """Return a dict of applicable features/overrides and their values."""
+    return {
+        k: getattr(sys.modules["cloudinit.features"], k)
+        for k in sys.modules["cloudinit.features"].__dict__.keys()
+        if re.match(r"^[_A-Z]+$", k)
+    }

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -482,7 +482,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         instance_data["merged_cfg"] = copy.deepcopy(self.sys_cfg)
         instance_data["merged_cfg"][
             "_doc"
-        ] = "DEPRECATED: Use merged_system_config. Will be dropped from 24.1"
+        ] = "DEPRECATED: Use merged_system_cfg. Will be dropped from 24.1"
         # Deprecate merged_cfg to a more specific key name merged_system_cfg
         instance_data["merged_system_cfg"] = copy.deepcopy(
             instance_data["merged_cfg"]

--- a/doc/rtd/explanation/instancedata.rst
+++ b/doc/rtd/explanation/instancedata.rst
@@ -163,6 +163,9 @@ Storage locations
   standardised keys, sensitive keys redacted.
 * :file:`/run/cloud-init/instance-data-sensitive.json`: root-readable
   unredacted JSON blob.
+* :file:`/run/cloud-init/combined-cloud-config.json`: root-readable
+  unredacted JSON blob. Any meta-data, vendor-data and user-data overrides
+  are applied to the :file:`/run/cloud-init/combined-cloud-config.json` config values.
 
 :file:`instance-data.json` top level keys
 -----------------------------------------
@@ -174,6 +177,13 @@ A list of forward-slash delimited key paths into the :file:`instance-data.json`
 object whose value is base64encoded for JSON compatibility. Values at these
 paths should be decoded to get the original value.
 
+``features``
+^^^^^^^^^^^^
+
+A dictionary of feature name and boolean value pairs. A value of ``True`` means
+the feature is enabled.
+
+
 ``sensitive_keys``
 ^^^^^^^^^^^^^^^^^^
 
@@ -184,11 +194,22 @@ non-root users.
 
 ``merged_cfg``
 ^^^^^^^^^^^^^^
+Deprecated use ``merged_system_cfg`` instead.
+
+``merged_system_cfg``
+^^^^^^^^^^^^^^^^^^^^^
 
 Merged ``cloud-init`` :ref:`base_config_reference` from
 :file:`/etc/cloud/cloud.cfg` and :file:`/etc/cloud/cloud-cfg.d`. Values under
 this key could contain sensitive information such as passwords, so it is
 included in the ``sensitive-keys`` list which is only readable by root.
+
+.. note::
+   ``merged_system_cfg`` represents only the merged config from the underlying
+   filesystem. These values can be overridden by meta-data, vendor-data or
+   user-data. The fully merged cloud-config provided to a machine
+   which accounts for any supplemental overrides is the file
+   :file:`/run/cloud-init/combined-cloud-config.json`.
 
 ``ds``
 ^^^^^^
@@ -205,6 +226,14 @@ is currently **experimental** and expected to change slightly in the upcoming
 
 Information about the underlying OS, Python, architecture and kernel. This
 represents the data collected by ``cloudinit.util.system_info``.
+
+``system_info``
+^^^^^^^^^^^^^^^
+
+This is a cloud-init configuration key present in :file:`/etc/cloud/cloud.cfg`
+which describes cloud-init's configured `default_user`, `distro`, `network`
+renderes, and `paths` that cloud-init will use. Not to be confused with the
+underlying host ``sys_info`` key above.
 
 ``v1``
 ^^^^^^

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import pytest
 
 import cloudinit.config
+from cloudinit.features import get_features
 from cloudinit.util import is_true
 from tests.integration_tests.decorators import retry
 from tests.integration_tests.instances import IntegrationInstance
@@ -312,6 +313,18 @@ class TestCombined:
         assert v1_data["distro_release"] == CURRENT_RELEASE.series
         assert v1_data["machine"] == "x86_64"
         assert re.match(r"3.\d+\.\d+", v1_data["python_version"])
+
+    @pytest.mark.skipif(not IS_UBUNTU, reason="Testing default_user ubuntu")
+    def test_combined_cloud_config_json(
+        self, class_client: IntegrationInstance
+    ):
+        client = class_client
+        combined_json = client.read_from_file(
+            "/run/cloud-init/combined-cloud-config.json"
+        )
+        data = json.loads(combined_json)
+        assert data["features"] == get_features()
+        assert data["system_info"]["default_user"]["name"] == "ubuntu"
 
     @pytest.mark.skipif(
         PLATFORM != "lxd_container",

--- a/tests/unittests/sources/test_init.py
+++ b/tests/unittests/sources/test_init.py
@@ -623,7 +623,7 @@ class TestDataSource(CiTestCase):
             "base64_encoded_keys": [],
             "merged_cfg": {
                 "_doc": (
-                    "DEPRECATED: Use merged_system_config. Will be dropped "
+                    "DEPRECATED: Use merged_system_cfg. Will be dropped "
                     "from 24.1"
                 ),
                 "datasource": {"_undef": {"key1": False}},

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -1,0 +1,30 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+# pylint: disable=no-member,no-name-in-module
+"""
+This file is for testing the feature flag functionality itself,
+NOT for testing any individual feature flag
+"""
+from unittest import mock
+
+from cloudinit import features
+
+
+class TestGetFeatures:
+    """default pytest-xdist behavior may fail due to these tests"""
+
+    def test_feature_without_override(self):
+        assert {
+            "ERROR_ON_USER_DATA_FAILURE": True,
+            "EXPIRE_APPLIES_TO_HASHED_USERS": True,
+            "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
+            "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": True,
+        } == features.get_features()
+        with mock.patch.object(
+            features, "NETPLAN_CONFIG_ROOT_READ_ONLY", False
+        ):
+            assert {
+                "ERROR_ON_USER_DATA_FAILURE": True,
+                "EXPIRE_APPLIES_TO_HASHED_USERS": True,
+                "NETPLAN_CONFIG_ROOT_READ_ONLY": False,
+                "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": True,
+            } == features.get_features()


### PR DESCRIPTION
```
instance-data: add system-info and features to combined-cloud-config

Some snap environments (subiquity live installer) have different
versions of cloudinit within the snap environment than is installed
on the host system. Invoking cloudinit.stages.Init().read_cfg on an
older version of cloudinit potentially breaks when the host environment
has a newer version of cloud-init because the obj.pkl can not be
deserialized on an older version of cloud-init.

To avoid having to invoke cloudinit.stages.Init().read_cfg() to get
system_info and default_user config, provide this config in:
 - /run/cloud-init/combined-cloud-config.json and
 - /run/cloud-init/instance-data-sensitive.json:merged_system_cfg key

Add a system_info key in combined-cloud-config.json as seen in
/etc/cloud/cloud.cfg*.

Also add a util.get_features function which will seed the "features"
key in combined-cloud-config.json. This also prevents the need for
importing cloudinit.features to read that value or overridden feature
values.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly