### PR TITLE
Integration tests fix stray file test

### DIFF
--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -47,4 +47,3 @@ def test_wait_when_no_datasource(session_cloud: IntegrationCloud, setup_image):
         status_out = wait_for_cloud_init(client).stdout.strip()
         assert "status: disabled" in status_out
         assert client.execute("cloud-init status --wait").ok
-        assert client.execute("test -f /cmdline-userdata-success").ok


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Integration tests fix stray file test

test regression introduced by 0e374f83
```

## Additional Context
<!-- If relevant -->
unhappy jenkins: 
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_container/lastSuccessfulBuild/testReport/tests.integration_tests.cmd/test_status/test_wait_when_no_datasource/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests tests/integration_tests/cmd/test_status.py::test_wait_when_no_datasource
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
