### PR TITLE
Inspect systemd state for cloud-init status

### DIFF
--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -224,9 +224,8 @@ def _get_systemd_status() -> Optional[UXAppStatus]:
             states["UnitFileState"].startswith("enabled")
             or states["UnitFileState"] == "static"
         ):
-            # Service is not set to run, so don't determine state
-            # based on this service
-            continue
+            # Individual services should not get disabled
+            return UXAppStatus.ERROR
         if (
             states["ActiveState"] == "active"
             and states["SubState"] == "exited"

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -15,7 +15,7 @@ import sys
 from time import gmtime, sleep, strftime
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
-from cloudinit import safeyaml
+from cloudinit import safeyaml, subp
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.distros import uses_systemd
 from cloudinit.helpers import Paths
@@ -196,6 +196,54 @@ def get_bootstatus(disable_file, paths) -> Tuple[UXAppBootStatusCode, str]:
     return (bootstatus_code, reason)
 
 
+def _get_systemd_status() -> Optional[UXAppStatus]:
+    """Get status from systemd.
+
+    Using systemd, we can get more fine-grained status of the
+    individual unit. Determine if we're still
+    running or if there's an error we haven't otherwise detected
+    """
+    for service in [
+        "cloud-final.service",
+        "cloud-config.service",
+        "cloud-init.service",
+        "cloud-init-local.service",
+    ]:
+        stdout = subp.subp(
+            [
+                "systemctl",
+                "show",
+                "--property=ActiveState,UnitFileState,SubState",
+                service,
+            ],
+        ).stdout
+        states = dict(
+            [[x.strip() for x in r.split("=")] for r in stdout.splitlines()]
+        )
+        if not (
+            states["UnitFileState"].startswith("enabled")
+            or states["UnitFileState"] == "static"
+        ):
+            # Service is not set to run, so don't determine state
+            # based on this service
+            continue
+        if (
+            states["ActiveState"] == "active"
+            and states["SubState"] == "exited"
+        ):
+            # Service exited normally, nothing interesting from systemd
+            continue
+        if states["ActiveState"] == "failed" or states["SubState"] == "failed":
+            # We have an error
+            return UXAppStatus.ERROR
+        # If we made it here, our unit is enabled and it hasn't exited
+        # normally or exited with failure, so it is still running.
+        return UXAppStatus.RUNNING
+    # All services exited normally or aren't enabled, so don't report
+    # any particular status based on systemd.
+    return None
+
+
 def get_status_details(paths: Optional[Paths] = None) -> StatusDetails:
     """Return a dict with status, details and errors.
 
@@ -251,6 +299,14 @@ def get_status_details(paths: Optional[Paths] = None) -> StatusDetails:
         description = "\n".join(errors)
     elif status == UXAppStatus.NOT_RUN and latest_event > 0:
         status = UXAppStatus.DONE
+    if uses_systemd() and status not in (
+        UXAppStatus.NOT_RUN,
+        UXAppStatus.DISABLED,
+    ):
+        systemd_status = _get_systemd_status()
+        if systemd_status:
+            status = systemd_status
+
     last_update = (
         strftime("%a, %d %b %Y %H:%M:%S %z", gmtime(latest_event))
         if latest_event

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -683,12 +683,12 @@ class TestSystemdStatusDetails:
             ("deactivating", "enabled-runtime", "any", UXAppStatus.RUNNING),
             ("failed", "static", "failed", UXAppStatus.ERROR),
             # Try previous combinations again with "not enabled" states
-            ("activating", "linked", "start", None),
-            ("active", "linked-runtime", "exited", None),
-            ("inactive", "masked", "dead", None),
-            ("reloading", "masked-runtime", "start", None),
-            ("deactivating", "disabled", "any", None),
-            ("failed", "invalid", "failed", None),
+            ("activating", "linked", "start", UXAppStatus.ERROR),
+            ("active", "linked-runtime", "exited", UXAppStatus.ERROR),
+            ("inactive", "masked", "dead", UXAppStatus.ERROR),
+            ("reloading", "masked-runtime", "start", UXAppStatus.ERROR),
+            ("deactivating", "disabled", "any", UXAppStatus.ERROR),
+            ("failed", "invalid", "failed", UXAppStatus.ERROR),
         ],
     )
     def test_get_systemd_status(

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -11,6 +11,8 @@ import pytest
 
 from cloudinit.atomic_helper import write_json
 from cloudinit.cmd import status
+from cloudinit.cmd.status import UXAppStatus, _get_systemd_status
+from cloudinit.subp import SubpResult
 from cloudinit.util import ensure_file
 from tests.unittests.helpers import wrap_and_call
 
@@ -58,8 +60,14 @@ class TestStatus:
             "Cloud-init enabled by systemd cloud-init-generator",
         ),
     )
+    @mock.patch(f"{M_PATH}_get_systemd_status", return_value=None)
     def test_get_status_details_ds_none(
-        self, m_get_boot_status, m_p_exists, m_load_json, tmpdir
+        self,
+        m_get_systemd_status,
+        m_get_boot_status,
+        m_p_exists,
+        m_load_json,
+        tmpdir,
     ):
         paths = mock.Mock()
         paths.run_dir = str(tmpdir)
@@ -487,8 +495,10 @@ class TestStatus:
         ],
     )
     @mock.patch(M_PATH + "read_cfg_paths")
+    @mock.patch(f"{M_PATH}_get_systemd_status", return_value=None)
     def test_status_output(
         self,
+        m_get_systemd_status,
         m_read_cfg_paths,
         ensured_file: Optional[Callable],
         bootstatus: status.UXAppBootStatusCode,
@@ -526,8 +536,9 @@ class TestStatus:
             assert out == expected_status
 
     @mock.patch(M_PATH + "read_cfg_paths")
+    @mock.patch(f"{M_PATH}_get_systemd_status", return_value=None)
     def test_status_wait_blocks_until_done(
-        self, m_read_cfg_paths, config: Config, capsys
+        self, m_get_systemd_status, m_read_cfg_paths, config: Config, capsys
     ):
         """Specifying wait will poll every 1/4 second until done state."""
         m_read_cfg_paths.return_value = config.paths
@@ -576,8 +587,9 @@ class TestStatus:
         assert out == "....\nstatus: done\n"
 
     @mock.patch(M_PATH + "read_cfg_paths")
+    @mock.patch(f"{M_PATH}_get_systemd_status", return_value=None)
     def test_status_wait_blocks_until_error(
-        self, m_read_cfg_paths, config: Config, capsys
+        self, m_get_systemd_status, m_read_cfg_paths, config: Config, capsys
     ):
         """Specifying wait will poll every 1/4 second until error state."""
         m_read_cfg_paths.return_value = config.paths
@@ -628,7 +640,10 @@ class TestStatus:
         assert out == "....\nstatus: error\n"
 
     @mock.patch(M_PATH + "read_cfg_paths")
-    def test_status_main(self, m_read_cfg_paths, config: Config, capsys):
+    @mock.patch(f"{M_PATH}_get_systemd_status", return_value=None)
+    def test_status_main(
+        self, m_get_systemd_status, m_read_cfg_paths, config: Config, capsys
+    ):
         """status.main can be run as a standalone script."""
         m_read_cfg_paths.return_value = config.paths
         write_json(
@@ -649,4 +664,43 @@ class TestStatus:
         assert out == "status: running\n"
 
 
-# vi: ts=4 expandtab syntax=python
+class TestSystemdStatusDetails:
+    @pytest.mark.parametrize(
+        ["active_state", "unit_file_state", "sub_state", "status"],
+        [
+            # To cut down on the combination of states, I'm grouping
+            # enabled, enabled-runtime, and static into an "enabled" state
+            # and everything else functionally disabled.
+            # Additionally, SubStates are undocumented and may mean something
+            # different depending on the ActiveState they are mapped too.
+            # Because of this I'm only testing SubState combinations seen
+            # in real-world testing (or using "any" string if we dont care).
+            ("activating", "enabled", "start", UXAppStatus.RUNNING),
+            ("active", "enabled-runtime", "exited", None),
+            # Dead doesn't mean exited here. It means not run yet.
+            ("inactive", "static", "dead", UXAppStatus.RUNNING),
+            ("reloading", "enabled", "start", UXAppStatus.RUNNING),
+            ("deactivating", "enabled-runtime", "any", UXAppStatus.RUNNING),
+            ("failed", "static", "failed", UXAppStatus.ERROR),
+            # Try previous combinations again with "not enabled" states
+            ("activating", "linked", "start", None),
+            ("active", "linked-runtime", "exited", None),
+            ("inactive", "masked", "dead", None),
+            ("reloading", "masked-runtime", "start", None),
+            ("deactivating", "disabled", "any", None),
+            ("failed", "invalid", "failed", None),
+        ],
+    )
+    def test_get_systemd_status(
+        self, active_state, unit_file_state, sub_state, status
+    ):
+        with mock.patch(
+            f"{M_PATH}subp.subp",
+            return_value=SubpResult(
+                f"ActiveState={active_state}\n"
+                f"UnitFileState={unit_file_state}\n"
+                f"SubState={sub_state}",
+                stderr=None,
+            ),
+        ):
+            assert _get_systemd_status() == status


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Inspect systemd state for cloud-init status

Relying solely on status.json and result.json can result in reporting
error before cloud-init has fully completed. Using systemd state can
give us more correct info.

Fixes GH-3769
```

## Additional Context
#3769
