### PR TITLE
landscape: use landscape-config utility

### DIFF
--- a/cloudinit/config/cc_landscape.py
+++ b/cloudinit/config/cc_landscape.py
@@ -153,7 +153,6 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     )
     subp.subp(["landscape-config", "--silent"] + cmd_params)
     util.write_file(LS_DEFAULT_FILE, "RUN=1\n")
-    cloud.distro.manage_service("restart", "landscape-client")
 
 
 def merge_together(objs):

--- a/cloudinit/config/cc_landscape.py
+++ b/cloudinit/config/cc_landscape.py
@@ -9,8 +9,6 @@
 """install and configure landscape client"""
 
 import logging
-import os
-from io import BytesIO
 from textwrap import dedent
 
 from configobj import ConfigObj
@@ -72,6 +70,7 @@ meta: MetaSchema = {
             # To discover additional supported client keys, run
             # man landscape-config.
             landscape:
+                install_source: distro
                 client:
                     url: "https://landscape.canonical.com/message-system"
                     ping_url: "http://landscape.canonical.com/ping"
@@ -119,7 +118,20 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         )
     if not ls_cloudcfg:
         return
-
+    install_src = ls_cloudcfg.pop("install_source", "distro")
+    if not any([install_src == "distro", install_src.startswith("ppa:")]):
+        raise RuntimeError(
+            "Invalid 'landscape.install_source' config value %s."
+            "Expected either 'distro' or 'ppa:*'."
+        )
+    if install_src.startswith("ppa:"):
+        try:
+            subp.subp(["add-apt-repository", install_src])
+        except Exception as e:
+            raise RuntimeError(
+                "Unable to add-apt-repository to install landscape-client: %s"
+                % e
+            ) from e
     cloud.distro.install_packages(("landscape-client",))
 
     # Later order config values override earlier values
@@ -128,14 +140,11 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         LSC_CLIENT_CFG_FILE,
         ls_cloudcfg,
     ]
-    merged = merge_together(merge_data)
-    contents = BytesIO()
-    merged.write(contents)
-
-    util.ensure_dir(os.path.dirname(LSC_CLIENT_CFG_FILE))
-    util.write_file(LSC_CLIENT_CFG_FILE, contents.getvalue())
-    LOG.debug("Wrote landscape config file to %s", LSC_CLIENT_CFG_FILE)
-
+    cmd_params = [
+        f"--{k.replace('_', '-')}=\"{v}\""
+        for k, v in sorted(merge_together(merge_data)["client"].items())
+    ]
+    subp.subp(["landscape-config", "--silent"] + cmd_params)
     util.write_file(LS_DEFAULT_FILE, "RUN=1\n")
     subp.subp(["service", "landscape-client", "restart"])
 

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1480,6 +1480,11 @@
           ],
           "additionalProperties": false,
           "properties": {
+            "install_source": {
+              "type": "string",
+              "pattern": "^(distro|ppa:.+)$",
+              "description": "Whether to install landscape-client deb package from the 'distro' default repositories or a custom 'ppa:YOUR_PPA'. Default: 'distro'"
+            },
             "client": {
               "type": "object",
               "additionalProperties": true,

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1480,14 +1480,13 @@
           ],
           "additionalProperties": false,
           "properties": {
-            "install_source": {
-              "type": "string",
-              "pattern": "^(distro|ppa:.+)$",
-              "description": "Whether to install landscape-client deb package from the 'distro' default repositories or a custom 'ppa:YOUR_PPA'. Default: 'distro'"
-            },
             "client": {
               "type": "object",
               "additionalProperties": true,
+              "required": [
+                "account_name",
+                "computer_title"
+              ],
               "properties": {
                 "url": {
                   "type": "string",

--- a/tests/unittests/config/test_cc_landscape.py
+++ b/tests/unittests/config/test_cc_landscape.py
@@ -24,7 +24,6 @@ class TestLandscape:
         cfg = {"landscape": {}}
         cc_landscape.handle("notimportant", cfg, mycloud, None)
         assert mycloud.distro.install_packages.called is False
-        assert mycloud.distro.manage_service.called is False
 
     def test_handler_error_on_invalid_landscape_type(self, m_subp):
         """Raise an error when landscape configuraiton option is invalid."""
@@ -75,9 +74,6 @@ class TestLandscape:
                 ]
             ),
         ] == m_subp.call_args_list
-        mycloud.distro.manage_service.assert_called_once_with(
-            "restart", "landscape-client"
-        )
 
     def test_handler_installs_client_from_ppa_and_supports_overrides(
         self, m_subp, tmpdir
@@ -126,9 +122,6 @@ class TestLandscape:
             ("landscape-client",)
         )
         assert expected_calls == m_subp.call_args_list
-        mycloud.distro.manage_service.assert_called_once_with(
-            "restart", "landscape-client"
-        )
         assert "RUN=1\n" == default_fn.read()
 
     def test_handler_writes_merged_client_config_file_with_defaults(
@@ -173,9 +166,6 @@ class TestLandscape:
             None,
         )
         assert expected_calls == m_subp.call_args_list
-        mycloud.distro.manage_service.assert_called_once_with(
-            "restart", "landscape-client"
-        )
 
     def test_handler_writes_merged_provided_cloudconfig_with_defaults(
         self, m_subp, tmpdir
@@ -219,9 +209,6 @@ class TestLandscape:
             None,
         )
         assert expected_calls == m_subp.call_args_list
-        mycloud.distro.manage_service.assert_called_once_with(
-            "restart", "landscape-client"
-        )
 
 
 class TestLandscapeSchema:

--- a/tests/unittests/config/test_cc_landscape.py
+++ b/tests/unittests/config/test_cc_landscape.py
@@ -24,6 +24,7 @@ class TestLandscape:
         cfg = {"landscape": {}}
         cc_landscape.handle("notimportant", cfg, mycloud, None)
         assert mycloud.distro.install_packages.called is False
+        assert mycloud.distro.manage_service.called is False
 
     def test_handler_error_on_invalid_landscape_type(self, m_subp):
         """Raise an error when landscape configuraiton option is invalid."""
@@ -63,14 +64,20 @@ class TestLandscape:
                 [
                     "landscape-config",
                     "--silent",
-                    "--data-path=/var/lib/landscape/client",
-                    "--log-level=info",
-                    "--ping-url=http://landscape.canonical.com/ping",
-                    "--url=https://landscape.canonical.com/message-system",
+                    "--data-path",
+                    "/var/lib/landscape/client",
+                    "--log-level",
+                    "info",
+                    "--ping-url",
+                    "http://landscape.canonical.com/ping",
+                    "--url",
+                    "https://landscape.canonical.com/message-system",
                 ]
             ),
-            mock.call(["service", "landscape-client", "restart"]),
         ] == m_subp.call_args_list
+        mycloud.distro.manage_service.assert_called_once_with(
+            "restart", "landscape-client"
+        )
 
     def test_handler_installs_client_from_ppa_and_supports_overrides(
         self, m_subp, tmpdir
@@ -92,13 +99,16 @@ class TestLandscape:
                 [
                     "landscape-config",
                     "--silent",
-                    "--data-path=/var/lib/data",
-                    "--log-level=info",
-                    "--ping-url=http://landscape.canonical.com/ping",
-                    "--url=https://landscape.canonical.com/message-system",
+                    "--data-path",
+                    "/var/lib/data",
+                    "--log-level",
+                    "info",
+                    "--ping-url",
+                    "http://landscape.canonical.com/ping",
+                    "--url",
+                    "https://landscape.canonical.com/message-system",
                 ]
             ),
-            mock.call(["service", "landscape-client", "restart"]),
         ]
         wrap_and_call(
             "cloudinit.config.cc_landscape",
@@ -116,6 +126,9 @@ class TestLandscape:
             ("landscape-client",)
         )
         assert expected_calls == m_subp.call_args_list
+        mycloud.distro.manage_service.assert_called_once_with(
+            "restart", "landscape-client"
+        )
         assert "RUN=1\n" == default_fn.read()
 
     def test_handler_writes_merged_client_config_file_with_defaults(
@@ -134,14 +147,18 @@ class TestLandscape:
                 [
                     "landscape-config",
                     "--silent",
-                    '--computer-title="My PC"',
-                    "--data-path=/var/lib/landscape/client",
-                    "--log-level=info",
-                    "--ping-url=http://landscape.canonical.com/ping",
-                    "--url=https://landscape.canonical.com/message-system",
+                    "--computer-title",
+                    "My PC",
+                    "--data-path",
+                    "/var/lib/landscape/client",
+                    "--log-level",
+                    "info",
+                    "--ping-url",
+                    "http://landscape.canonical.com/ping",
+                    "--url",
+                    "https://landscape.canonical.com/message-system",
                 ]
             ),
-            mock.call(["service", "landscape-client", "restart"]),
         ]
         wrap_and_call(
             "cloudinit.config.cc_landscape",
@@ -156,6 +173,9 @@ class TestLandscape:
             None,
         )
         assert expected_calls == m_subp.call_args_list
+        mycloud.distro.manage_service.assert_called_once_with(
+            "restart", "landscape-client"
+        )
 
     def test_handler_writes_merged_provided_cloudconfig_with_defaults(
         self, m_subp, tmpdir
@@ -173,14 +193,18 @@ class TestLandscape:
                 [
                     "landscape-config",
                     "--silent",
-                    '--computer-title="My" PC"',
-                    "--data-path=/var/lib/landscape/client",
-                    "--log-level=info",
-                    "--ping-url=http://landscape.canonical.com/ping",
-                    "--url=https://landscape.canonical.com/message-system",
+                    "--computer-title",
+                    'My" PC',
+                    "--data-path",
+                    "/var/lib/landscape/client",
+                    "--log-level",
+                    "info",
+                    "--ping-url",
+                    "http://landscape.canonical.com/ping",
+                    "--url",
+                    "https://landscape.canonical.com/message-system",
                 ]
             ),
-            mock.call(["service", "landscape-client", "restart"]),
         ]
         wrap_and_call(
             "cloudinit.config.cc_landscape",
@@ -195,6 +219,9 @@ class TestLandscape:
             None,
         )
         assert expected_calls == m_subp.call_args_list
+        mycloud.distro.manage_service.assert_called_once_with(
+            "restart", "landscape-client"
+        )
 
 
 class TestLandscapeSchema:

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -689,6 +689,7 @@ class TestCloudConfigExamples:
         schema["additionalProperties"] = False
         # Some module examples reference keys defined in multiple schemas
         supplemental_schemas = {
+            "cc_landscape": ["cc_apt_configure"],
             "cc_ubuntu_advantage": ["cc_power_state_change"],
             "cc_update_hostname": ["cc_set_hostname"],
             "cc_users_groups": ["cc_ssh_import_id"],


### PR DESCRIPTION
## Proposed Commit Message

```
landscape: use landscape-config to write configuration

Avoid writing directly to /etc/landscape/client.conf as formats
or config file location could change.
Invoke the `landscape-config` utility instead to persist landscape
client config options.

No longer restart landscape-client service because
landcape-config starts landscape-client with updated values.

Add doc examples for installing via PPA using apt: config.
```


## Additional Context

SC-1531

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
