### PR TITLE
Tests proposed install disregard apt policy

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -165,7 +165,9 @@ class IntegrationInstance:
             "/etc/apt/sources.list.d/proposed.list"
         ).ok
         assert self.execute("apt-get update -q").ok
-        assert self.execute("apt-get install -qy cloud-init").ok
+        assert self.execute(
+            "apt-get install -qy cloud-init -t=$(lsb_release -sc)-proposed"
+        ).ok
 
     @retry(tries=30, delay=1)
     def install_ppa(self):


### PR DESCRIPTION
## Proposed Commit Message
```
    tests: proposed should invoke apt-get install -t=<release>-proposed
    
    Specify apt-get install -t=$RELEASE-proposed to ensure installing
    proposed package regardless of default apt policy priority
    
    Ubuntu Lunar priority of -proposed pocket is 100 instead of 500
    so cloud-init CLOUD_INIT_SOURCE=PROPOSED does not actually install
    from lunar-proposed.
```

## Additional Context
<!-- If relevant -->
Lunar apt policy of -proposed shows up at priority 100 instead of 500, resulting in no cloud-init installed from -proposed

## Test Steps
```
# Test without this PR will fail as cloud-init is from lunar-updates, with patch, will install from lunar-proposed.
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED CLOUD_INIT_OS_IMAGE=lunar tox -e integration-tests tests/integration_tests/test_kernel_commandline_match.py::test_lxd_datasource_kernel_override_nocloud_net
```
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
