### PR TITLE
cloud.cfg.tmpl: reinstate ca_certs entry

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -99,7 +99,7 @@ cloud_init_modules:
  - resolv_conf
 {% endif %}
 {% if not is_bsd or variant not in ["photon"] %}
- - ca-certs
+ - ca_certs
 {% endif %}
  - rsyslog
  - users_groups


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cloud.cfg.tmpl: reinstate ca_certs entry

The change from "ca-certs" to "ca_certs" in PR #4128 was accidentally reverted by PR #4119.

This PR reinstates the original change.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
