### PR TITLE
Overhaul module reference page

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -26,8 +26,7 @@ MODULE_DESCRIPTION = """\
 This module handles most configuration for SSH and both host and authorized SSH
 keys.
 
-Authorized Keys
-^^^^^^^^^^^^^^^
+**Authorized keys**
 
 Authorized keys are a list of public SSH keys that are allowed to connect to
 a user account on a system. They are stored in `.ssh/authorized_keys` in that
@@ -36,8 +35,8 @@ account's home directory. Authorized keys for the default user defined in
 should be specified as a list of public keys.
 
 .. note::
-    see the ``cc_set_passwords`` module documentation to enable/disable SSH
-    password authentication
+    See the ``cc_set_passwords`` module documentation to enable/disable SSH
+    password authentication.
 
 Root login can be enabled/disabled using the ``disable_root`` config key. Root
 login options can be manually specified with ``disable_root_opts``.
@@ -78,8 +77,7 @@ Supported public key types for the ``ssh_authorized_keys`` are:
 
 .. _OpenSSH: https://github.com/openssh/openssh-portable/blob/master/sshkey.c
 
-Host Keys
-^^^^^^^^^
+**Host keys**
 
 Host keys are for authenticating a specific instance. Many images have default
 host SSH keys, which can be removed using ``ssh_deletekeys``.
@@ -90,9 +88,9 @@ When host keys are generated the output of the ssh-keygen command(s) can be
 displayed on the console using the ``ssh_quiet_keygen`` configuration key.
 
 .. note::
-    when specifying private host keys in cloud-config, care should be taken to
+    When specifying private host keys in cloud-config, care should be taken to
     ensure that the communication between the data source and the instance is
-    secure
+    secure.
 
 
 If no host keys are specified using ``ssh_keys``, then keys will be generated

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -88,7 +88,8 @@ SCHEMA_DOC_TMPL = """
 SCHEMA_PROPERTY_HEADER = ""
 SCHEMA_PROPERTY_TMPL = "{prefix}* **{prop_name}:** ({prop_type}){description}"
 SCHEMA_LIST_ITEM_TMPL = (
-   "{prefix}* Each object in **{prop_name}** list supports the following keys:"
+    "{prefix}* Each object in **{prop_name}** list supports "
+    "the following keys:"
 )
 SCHEMA_EXAMPLES_HEADER = ""
 SCHEMA_EXAMPLES_SPACER_TEMPLATE = "\n   # --- Example{example_count} ---\n\n"
@@ -485,7 +486,7 @@ def validate_cloudconfig_metaschema(validator, schema: dict, throw=True):
                 ]
             ) from err
         LOG.warning(
-            """Meta-schema validation failed, attempting to validate config 
+            """Meta-schema validation failed, attempting to validate config
             anyway: {err}"""
         )
 
@@ -596,7 +597,7 @@ class _Annotator:
 
     def _build_errors_by_line(self, schema_problems: SchemaProblems):
         errors_by_line = defaultdict(list)
-        for (path, msg) in schema_problems:
+        for path, msg in schema_problems:
             match = re.match(r"format-l(?P<line>\d+)\.c(?P<col>\d+).*", path)
             if match:
                 line, col = match.groups()
@@ -842,7 +843,7 @@ def validate_cloudconfig_file(
         else:
             cloudconfig = safeyaml.load(content)
             marks = {}
-    except (yaml.YAMLError) as e:
+    except yaml.YAMLError as e:
         line = column = 1
         mark = None
         if hasattr(e, "context_mark") and getattr(e, "context_mark"):
@@ -1160,7 +1161,9 @@ def _get_examples(meta: MetaSchema) -> str:
         return ""
     rst_content = SCHEMA_EXAMPLES_HEADER
     for count, example in enumerate(examples, 1):
-        rst_content += SCHEMA_EXAMPLES_SPACER_TEMPLATE.format(example_count=count)
+        rst_content += SCHEMA_EXAMPLES_SPACER_TEMPLATE.format(
+            example_count=count
+        )
         indented_lines = textwrap.indent(example, "   ").split("\n")
         rst_content += "\n".join(indented_lines)
     return rst_content
@@ -1217,21 +1220,27 @@ def get_meta_doc(meta: MetaSchema, schema: Optional[dict] = None) -> str:
     meta_copy["property_header"] = ""
     meta_copy["prefix6"] = "      "
     meta_copy["prefix3"] = "   "
-    meta_copy["description"] = textwrap.indent(meta_copy["description"], "      ")
+    meta_copy["description"] = textwrap.indent(
+        meta_copy["description"], "      "
+    )
     defs = schema.get("$defs", {})
     if defs.get(meta["id"]):
         schema = defs.get(meta["id"], {})
         schema = cast(dict, schema)
     try:
-        meta_copy["property_doc"] = _get_property_doc(schema, defs=defs, prefix="      ")
+        meta_copy["property_doc"] = _get_property_doc(
+            schema, defs=defs, prefix="      "
+        )
     except AttributeError:
         LOG.warning("Unable to render property_doc due to invalid schema")
         meta_copy["property_doc"] = ""
     if not meta_copy["property_doc"]:
-        meta_copy["property_doc"] = f"      No schema definitions for this module"
+        meta_copy[
+            "property_doc"
+        ] = "      No schema definitions for this module"
     meta_copy["examples"] = textwrap.indent(_get_examples(meta), "      ")
     if not meta_copy["examples"]:
-        meta_copy["examples"] = f"         No examples for this module"
+        meta_copy["examples"] = "         No examples for this module"
     meta_copy["distros"] = ", ".join(meta["distros"])
     # Need an underbar of the same length as the name
     meta_copy["title_underbar"] = re.sub(r".", "-", meta["name"])
@@ -1240,6 +1249,7 @@ def get_meta_doc(meta: MetaSchema, schema: Optional[dict] = None) -> str:
     )
     template = SCHEMA_DOC_TMPL.format(**meta_copy)
     return template
+
 
 def get_modules() -> dict:
     configs_dir = os.path.dirname(os.path.abspath(__file__))

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -486,8 +486,9 @@ def validate_cloudconfig_metaschema(validator, schema: dict, throw=True):
                 ]
             ) from err
         LOG.warning(
-            """Meta-schema validation failed, attempting to validate config
-            anyway: {err}"""
+            "Meta-schema validation failed, attempting to validate config "
+            "anyway: %s",
+            err,
         )
 
 

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1221,7 +1221,7 @@ def get_meta_doc(meta: MetaSchema, schema: Optional[dict] = None) -> str:
     meta_copy["prefix6"] = "      "
     meta_copy["prefix3"] = "   "
     meta_copy["description"] = textwrap.indent(
-        meta_copy["description"], "      "
+        cast(str, meta_copy["description"]), "      "
     )
     defs = schema.get("$defs", {})
     if defs.get(meta["id"]):

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -182,11 +182,11 @@ class SchemaValidationError(ValueError):
 
         self.schema_errors = handle_problems(
             schema_errors,
-            prefix=f"Cloud config schema errors: ",
+            prefix="Cloud config schema errors: ",
         )
         self.schema_deprecations = handle_problems(
             schema_deprecations,
-            prefix=f"Cloud config schema deprecations: ",
+            prefix="Cloud config schema deprecations: ",
         )
         super().__init__(message)
 
@@ -485,7 +485,7 @@ def validate_cloudconfig_metaschema(validator, schema: dict, throw=True):
                 ]
             ) from err
         LOG.warning(
-            f"""Meta-schema validation failed, attempting to validate config 
+            """Meta-schema validation failed, attempting to validate config 
             anyway: {err}"""
         )
 

--- a/doc/rtd/reference/modules.rst
+++ b/doc/rtd/reference/modules.rst
@@ -17,7 +17,6 @@ deprecated keys may cause warnings in the logs. In the case that a
 key's expected value changes, the key will be marked ``changed`` with a
 date. A 5 year timeline may also be expected for changed keys.
 
-
 .. automodule:: cloudinit.config.cc_ansible
 .. automodule:: cloudinit.config.cc_apk_configure
 .. automodule:: cloudinit.config.cc_apt_configure

--- a/doc/rtd/static/css/custom.css
+++ b/doc/rtd/static/css/custom.css
@@ -2,7 +2,7 @@
 /** Should be 100 for all headers, 400 for normal text  **/
 
 h1, h2, h3, h4, h5, h6, .sidebar-tree .current-page>.reference, button, input, optgroup, select, textarea, th.head {
-    font-weight: 200;
+    font-weight: 300;
 }
 
 .toc-title {

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -252,7 +252,8 @@ class TestCLI:
                     "opensuse, opensuse-microos, opensuse-tumbleweed, "
                     "opensuse-leap, photon, rhel, rocky, sle_hpc, "
                     "sle-micro, sles, TencentOS, ubuntu, virtuozzo",
-                    " **resize_rootfs:** " "(``true``/``false``/``noblock``)",
+                    " **resize_rootfs:** ",
+                    "(``true``/``false``/``noblock``)",
                     "runcmd:\n             - [ ls, -l, / ]\n",
                 ],
                 False,

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -252,16 +252,15 @@ class TestCLI:
                     "opensuse, opensuse-microos, opensuse-tumbleweed, "
                     "opensuse-leap, photon, rhel, rocky, sle_hpc, "
                     "sle-micro, sles, TencentOS, ubuntu, virtuozzo",
-                    "**Config schema**:\n    **resize_rootfs:** "
-                    "(``true``/``false``/``noblock``)",
-                    "**Examples**::\n\n    runcmd:\n        - [ ls, -l, / ]\n",
+                    " **resize_rootfs:** " "(``true``/``false``/``noblock``)",
+                    "runcmd:\n             - [ ls, -l, / ]\n",
                 ],
                 False,
                 id="all_spot_check",
             ),
             pytest.param(
                 ["cc_runcmd"],
-                ["Runcmd\n------\n**Summary:** Run arbitrary commands"],
+                ["\nRuncmd\n------\n\nRun arbitrary commands\n"],
                 False,
                 id="single_spot_check",
             ),
@@ -271,8 +270,8 @@ class TestCLI:
                     "cc_resizefs",
                 ],
                 [
-                    "Runcmd\n------\n**Summary:** Run arbitrary commands",
-                    "Resizefs\n--------\n**Summary:** Resize filesystem",
+                    "\nRuncmd\n------\n\nRun arbitrary commands",
+                    "\nResizefs\n--------\n\nResize filesystem",
                 ],
                 False,
                 id="multiple_spot_check",
@@ -331,6 +330,3 @@ class TestCLI:
         assert "features" == parseargs.action[0]
         assert False is parseargs.debug
         assert False is parseargs.force
-
-
-# : ts=4 expandtab


### PR DESCRIPTION
```
Module reference page was previously long lists of descriptions that were hard to consume.
- Add tabs to split up sections within module reference
- Tab syncing is an option, but may not be helpful here so left it off by default
- Subheadings can't be used within tabs, so changed headers in cc_ssh module description
```