### PR TITLE
LXD moved from linuxcontainers.org to Canonical

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,7 +19,7 @@ jobs:
           to have signed the Contributor License Agreement (CLA).
           Please sign the CLA by following our
           contribution guide at:
-            https://cloudinit.readthedocs.io/en/latest/topics/contributing.html
+            https://cloudinit.readthedocs.io/en/latest/development/contributing.html
 
           Thanks,
           Your friendly cloud-init upstream

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -78,7 +78,7 @@ jobs:
           sudo adduser $USER lxd
           # Jammy GH Action runners have docker installed, which edits iptables
           # in a way that is incompatible with lxd.
-          # https://linuxcontainers.org/lxd/docs/master/howto/network_bridge_firewalld/#prevent-issues-with-lxd-and-docker
+          # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
           sudo iptables -I DOCKER-USER -j ACCEPT
           sudo lxd init --auto
       - name: Run integration Tests

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -462,7 +462,7 @@ def maybe_cleanup_default(
     By removing any that lxd-init created, we simply leave the add/attach
     code intact.
 
-    https://github.com/lxc/lxd/issues/4649"""
+    https://github.com/canonical/lxd/issues/4649"""
     if net_name != _DEFAULT_NETWORK_NAME or not did_init:
         return
 

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1678,7 +1678,7 @@
             },
             "preseed": {
               "type": "string",
-              "description": "Opaque LXD preseed YAML config passed via stdin to the command: lxd init --preseed. See: https://linuxcontainers.org/lxd/docs/master/preseed/ or lxd init --dump for viable config. Can not be combined with either ``lxd.init`` or ``lxd.bridge``."
+              "description": "Opaque LXD preseed YAML config passed via stdin to the command: lxd init --preseed. See: https://documentation.ubuntu.com/lxd/en/latest/howto/initialize/#non-interactive-configuration or lxd init --dump for viable config. Can not be combined with either ``lxd.init`` or ``lxd.bridge``."
             }
           }
         }

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -5,7 +5,7 @@ Notes:
  * Older LXD images may not have updates for cloud-init so NoCloud may
    still be detected on those images.
  * Detect LXD datasource when /dev/lxd/sock is an active socket file.
- * Info on dev-lxd API: https://linuxcontainers.org/lxd/docs/master/dev-lxd
+ * Info on dev-lxd API: https://documentation.ubuntu.com/lxd/en/latest/dev-lxd/
 """
 
 import os

--- a/doc/rtd/howto/predeploy_testing.rst
+++ b/doc/rtd/howto/predeploy_testing.rst
@@ -134,8 +134,8 @@ check out the :ref:`datasource_nocloud` page.
 
 
 .. _Multipass: https://multipass.run/
-.. _LXD: https://linuxcontainers.org/
+.. _LXD: https://ubuntu.com/lxd
 .. _QEMU: https://www.qemu.org/
-.. _Instance Configuration: https://linuxcontainers.org/lxd/docs/master/instances
-.. _Custom Network Configuration: https://linuxcontainers.org/lxd/docs/master/cloud-init
+.. _Instance Configuration: https://documentation.ubuntu.com/lxd/en/latest/instances/
+.. _Custom Network Configuration: https://documentation.ubuntu.com/lxd/en/latest/cloud-init/
 .. _cloud-utils: https://github.com/canonical/cloud-utils/

--- a/doc/rtd/reference/datasources/lxd.rst
+++ b/doc/rtd/reference/datasources/lxd.rst
@@ -111,4 +111,4 @@ DHCP configuration of ``eth1``:
     $ lxc config device add my-lxd eth1 nic name=eth1 nictype=bridged parent=my-bridge
     Device eth1 added to my-lxd
 
-.. _LXD socket device: https://linuxcontainers.org/lxd/docs/master/dev-lxd
+.. _LXD socket device: https://documentation.ubuntu.com/lxd/en/latest/dev-lxd/

--- a/doc/rtd/reference/network-config.rst
+++ b/doc/rtd/reference/network-config.rst
@@ -316,7 +316,7 @@ Example output:
    USERCTL=no
 
 
-.. _LXD: https://linuxcontainers.org/lxd/docs/master/cloud-init/#custom-network-configuration
+.. _LXD: https://documentation.ubuntu.com/lxd/en/latest/cloud-init/#how-to-specify-network-configuration-data
 .. _NetworkManager: https://networkmanager.dev
 .. _Netplan: https://netplan.io/
 .. _DigitalOcean JSON metadata: https://developers.digitalocean.com/documentation/metadata/

--- a/doc/rtd/tutorial/lxd.rst
+++ b/doc/rtd/tutorial/lxd.rst
@@ -171,5 +171,5 @@ Each module contains examples of how to use it.
 You can also head over to the :ref:`examples page<yaml_examples>` for
 examples of more common use cases.
 
-.. _LXD: https://linuxcontainers.org/lxd/
-.. _other installation options: https://linuxcontainers.org/lxd/getting-started-cli/#other-installation-options
+.. _LXD: https://ubuntu.com/lxd
+.. _other installation options: https://documentation.ubuntu.com/lxd/en/latest/installing/#other-installation-options

--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -205,7 +205,7 @@ def validate_preseed_storage_pools(client, preseed_cfg):
 
 def validate_preseed_projects(client: IntegrationInstance, preseed_cfg):
     # Support for projects by lxd init --preseed was added in lxd 4.12
-    # https://discuss.linuxcontainers.org/t/lxd-4-12-has-been-released/10424#projects-now-supported-by-lxd-init-dump-and-preseed-9
+    # https://github.com/canonical/lxd/releases/tag/lxd-4.12
     if CURRENT_RELEASE.series in ("bionic", "focal"):
         return
     for src_project in preseed_cfg.get("projects", []):
@@ -219,12 +219,12 @@ def validate_preseed_projects(client: IntegrationInstance, preseed_cfg):
         )
         project.pop("used_by", None)
 
-        # `features.storage.buckets` was introduced in lxd 5.5 . More info:
-        # https://discuss.linuxcontainers.org/t/lxd-5-5-has-been-released/14899
+        # `features.storage.buckets` was introduced in lxd 5.5. More info:
+        # https://github.com/canonical/lxd/releases/tag/lxd-5.5
         if "features.storage.buckets" in project["config"]:
             assert "true" == project["config"].pop("features.storage.buckets")
         # `features.networks.zones` was introduced in lxd 5.9. More info:
-        # https://discuss.linuxcontainers.org/t/lxd-5-9-has-been-released/
+        # https://github.com/canonical/lxd/releases/tag/lxd-5.9
         if "features.networks.zones" in project["config"]:
             assert "true" == project["config"].pop("features.networks.zones")
         assert project == src_project

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -127,6 +127,7 @@ scorpion44
 shaardie
 shell-skrimp
 shi2wei3
+simondeziel
 slingamn
 slyon
 smoser

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -7,8 +7,8 @@ akutz
 AlexBaranowski
 Aman306
 andgein
-andrewbogott
 andrew-lee-metaswitch
+andrewbogott
 andrewlukoshko
 ani-sinha
 antonyc
@@ -119,6 +119,7 @@ rhansen
 riedel
 rmhsawyer
 rongz609
+s-makin
 SadeghHayeri
 sarahwzadara
 sbraz
@@ -129,7 +130,6 @@ shi2wei3
 simondeziel
 slingamn
 slyon
-s-makin
 smoser
 SRv6d
 sshedi

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -7,8 +7,8 @@ akutz
 AlexBaranowski
 Aman306
 andgein
-andrew-lee-metaswitch
 andrewbogott
+andrew-lee-metaswitch
 andrewlukoshko
 ani-sinha
 antonyc
@@ -119,7 +119,6 @@ rhansen
 riedel
 rmhsawyer
 rongz609
-s-makin
 SadeghHayeri
 sarahwzadara
 sbraz
@@ -130,6 +129,7 @@ shi2wei3
 simondeziel
 slingamn
 slyon
+s-makin
 smoser
 SRv6d
 sshedi

--- a/tools/check-cla-signers
+++ b/tools/check-cla-signers
@@ -2,13 +2,14 @@
 
 set -eu
 set -o pipefail
+export LC_ALL="C.UTF-8"
 
 CLA_SIGNERS_FILE="tools/.github-cla-signers"
 
 sort -f "${CLA_SIGNERS_FILE}" -o "${CLA_SIGNERS_FILE}"
 
 if [[ -n "$(git status --porcelain -- ${CLA_SIGNERS_FILE})" ]]; then
-    echo "Please make sure that ${CLA_SIGNERS_FILE} is in alphabetical order."
+    echo "Please make sure that ${CLA_SIGNERS_FILE} is in alphabetical order. Make sure to set LC_ALL=\"${LC_ALL}\""
     git --no-pager diff "${CLA_SIGNERS_FILE}"
     exit 1
 fi

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -814,7 +814,7 @@ dscheck_MAAS() {
 }
 
 # LXD datasource requires active /dev/lxd/sock
-# https://linuxcontainers.org/lxd/docs/master/dev-lxd
+# https://documentation.ubuntu.com/lxd/en/latest/dev-lxd/
 dscheck_LXD() {
     if is_socket_file /dev/lxd/sock; then
         return ${DS_FOUND}


### PR DESCRIPTION
Update many links to LXD now that is under the Canonical umbrella (https://discourse.ubuntu.com/t/faq-lxd-has-been-moved-to-canonical/36709)