### PR TITLE
testing: Clear all LRU caches after each test

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,11 +7,23 @@ Any imports that are performed at the top-level here must be installed wherever
 any of these tests run: that is to say, they must be listed in
 ``integration-requirements.txt`` and in ``test-requirements.txt``.
 """
+# If we don't import this early, lru_cache may get applied before we have the
+# chance to patch. This is also too early for the pytest-antilru plugin
+# to work.
+from tests.unittests.early_patches import get_cached_functions  # noqa: E402
 from unittest import mock
 
 import pytest
 
 from cloudinit import helpers, subp, util
+
+
+@pytest.fixture(autouse=True, scope="function")
+def cleanup_lru_cache():
+    yield
+
+    for func in get_cached_functions():
+        func.cache_clear()
 
 
 class _FixtureUtils:

--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,10 @@ any of these tests run: that is to say, they must be listed in
 # If we don't import this early, lru_cache may get applied before we have the
 # chance to patch. This is also too early for the pytest-antilru plugin
 # to work.
+# isort: off
 from tests.unittests.early_patches import get_cached_functions  # noqa: E402
+
+# isort: on
 from unittest import mock
 
 import pytest

--- a/tests/unittests/early_patches.py
+++ b/tests/unittests/early_patches.py
@@ -1,0 +1,20 @@
+import functools
+
+old_lru_cache = functools.lru_cache
+cached_functions = []
+
+
+def wrapped_lru_cache(*args, **kwargs):
+    def wrapper(func):
+        new_func = old_lru_cache(*args, **kwargs)(func)
+        cached_functions.append(new_func)
+        return new_func
+
+    return wrapper
+
+
+def get_cached_functions():
+    return cached_functions
+
+
+functools.lru_cache = wrapped_lru_cache

--- a/tests/unittests/early_patches.py
+++ b/tests/unittests/early_patches.py
@@ -7,7 +7,12 @@ cached_functions = []
 def wrapped_lru_cache(*args, **kwargs):
     def wrapper(func):
         new_func = old_lru_cache(*args, **kwargs)(func)
-        cached_functions.append(new_func)
+
+        # Without this check, we'll also store stdlib functions with @lru_cache
+        if "cloudinit" in func.__module__:
+            # Imports only happen once, so we don't need to worry about
+            # duplicates here
+            cached_functions.append(new_func)
         return new_func
 
     return wrapper

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -407,6 +407,11 @@ class TestRenderJinjaPayload(CiTestCase):
 
 
 class TestShellScriptByFrequencyHandlers:
+    @pytest.fixture(autouse=True)
+    def common_mocks(self):
+        with mock.patch("cloudinit.stages.Init._read_cfg", return_value={}):
+            yield
+
     def do_test_frequency(self, frequency):
         ci_paths = read_cfg_paths()
         scripts_dir = ci_paths.get_cpath("scripts")

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -178,8 +178,9 @@ class TestCLI:
             "schema",
         ],
     )
+    @mock.patch("cloudinit.stages.Init._read_cfg", return_value={})
     def test_conditional_subcommands_from_entry_point_sys_argv(
-        self, subcommand, capsys, mock_get_user_data_file, tmpdir
+        self, m_read_cfg, subcommand, capsys, mock_get_user_data_file, tmpdir
     ):
         """Subcommands from entry-point are properly parsed from sys.argv."""
         expected_error = f"usage: cloud-init {subcommand}"
@@ -224,7 +225,8 @@ class TestCLI:
         for subcommand in expected_subcommands:
             assert subcommand in err
 
-    def test_wb_schema_subcommand_parser(self, capsys):
+    @mock.patch("cloudinit.stages.Init._read_cfg", return_value={})
+    def test_wb_schema_subcommand_parser(self, m_read_cfg, capsys):
         """The subcommand cloud-init schema calls the correct subparser."""
         exit_code = self._call_main(["cloud-init", "schema"])
         _out, err = capsys.readouterr()
@@ -283,7 +285,10 @@ class TestCLI:
             ),
         ],
     )
-    def test_wb_schema_subcommand(self, args, expected_doc_sections, is_error):
+    @mock.patch("cloudinit.stages.Init._read_cfg", return_value={})
+    def test_wb_schema_subcommand(
+        self, m_read_cfg, args, expected_doc_sections, is_error
+    ):
         """Validate that doc content has correct values."""
 
         # Note: patchStdoutAndStderr() is convenient for reducing boilerplate,

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -483,13 +483,16 @@ class TestInit:
         self.init.is_new_instance = mock.Mock(return_value=False)
         return net_cfg
 
+    @mock.patch("cloudinit.util._get_cmdline", return_value="")
     @mock.patch("cloudinit.net.get_interfaces_by_mac")
     @mock.patch("cloudinit.distros.ubuntu.Distro")
     @mock.patch.dict(
         sources.DataSource.default_update_events,
         {EventScope.NETWORK: {EventType.BOOT_NEW_INSTANCE, EventType.BOOT}},
     )
-    def test_apply_network_allowed_when_default_boot(self, m_ubuntu, m_macs):
+    def test_apply_network_allowed_when_default_boot(
+        self, m_ubuntu, m_macs, m_get_cmdline
+    ):
         """Apply network if datasource permits BOOT event."""
         net_cfg = self._apply_network_setup(m_macs)
 
@@ -522,6 +525,7 @@ class TestInit:
             "network update allowed" in caplog.text
         )
 
+    @mock.patch("cloudinit.util._get_cmdline", return_value="")
     @mock.patch("cloudinit.net.get_interfaces_by_mac")
     @mock.patch("cloudinit.distros.ubuntu.Distro")
     @mock.patch.dict(
@@ -529,7 +533,7 @@ class TestInit:
         {EventScope.NETWORK: {EventType.BOOT_NEW_INSTANCE}},
     )
     def test_apply_network_allowed_with_userdata_overrides(
-        self, m_ubuntu, m_macs
+        self, m_ubuntu, m_macs, m_get_cmdline
     ):
         """Apply network if userdata overrides default config"""
         net_cfg = self._apply_network_setup(m_macs)

--- a/tox.ini
+++ b/tox.ini
@@ -287,7 +287,6 @@ ignore=E203,W503
 exclude = .venv,.tox,dist,doc,*egg,.git,build,tools
 per-file-ignores =
     cloudinit/cmd/main.py:E402
-    tests/conftest.py:E402
 
 [pytest]
 # TODO: s/--strict/--strict-markers/ once pytest version is high enough

--- a/tox.ini
+++ b/tox.ini
@@ -287,6 +287,7 @@ ignore=E203,W503
 exclude = .venv,.tox,dist,doc,*egg,.git,build,tools
 per-file-ignores =
     cloudinit/cmd/main.py:E402
+    tests/conftest.py:E402
 
 [pytest]
 # TODO: s/--strict/--strict-markers/ once pytest version is high enough


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
testing: Clear all LRU caches after each test

Some unit tests were missing necessary mocks because a previous test
had mocked the behavior and mock stuck around because of an LRU cache.
This means that if tests got run out of a specific order, they would
fail due to missing mocks. Because of this, a new autouse fixture was
added to automatically clear any lru cache after every test.

Additionally, updated unit tests accordingly so that they have the
necessary mocks, and convert `test_create_users.py` to pytest as
I was getting some transient errors from it.
```

## Additional Context
Been hidden forever, but started surfacing in #4237