### PR TITLE
DS VMware: add i386 arch dir to deployPkg plugin search path

### DIFF
--- a/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
@@ -614,6 +614,7 @@ def is_cust_plugin_available():
         "/usr/lib64/open-vm-tools",
         "/usr/lib/x86_64-linux-gnu/open-vm-tools",
         "/usr/lib/aarch64-linux-gnu/open-vm-tools",
+        "/usr/lib/i386-linux-gnu/open-vm-tools",
     )
     cust_plugin = "libdeployPkgPlugin.so"
     for path in search_paths:

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -832,6 +832,21 @@ class TestDsIdentify(DsIdentifyBase):
             cust64, RC_FOUND, dslist=[cust64.get("ds"), DS_NONE]
         )
 
+    def test_vmware_on_vmware_open_vm_tools_i386_linux_gnu(self):
+        """VMware is identified when open-vm-tools installed in
+        /usr/lib/i386-linux-gnu."""
+        cust64 = copy.deepcopy(VALID_CFG["VMware-vmware-customization"])
+        p32 = "usr/lib/vmware-tools/plugins/vmsvc/libdeployPkgPlugin.so"
+        i386 = (
+            "usr/lib/i386-linux-gnu/open-vm-tools/plugins/vmsvc/"
+            "libdeployPkgPlugin.so"
+        )
+        cust64["files"][i386] = cust64["files"][p32]
+        del cust64["files"][p32]
+        return self._check_via_dict(
+            cust64, RC_FOUND, dslist=[cust64.get("ds"), DS_NONE]
+        )
+
     def test_vmware_envvar_no_data(self):
         """VMware: envvar transport no data"""
         self._test_ds_not_found("VMware-EnvVar-NoData")

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -931,14 +931,16 @@ vmware_guest_customization() {
 
     # we have to have the plugin to do vmware customization
     local found="" pkg="" pre="${PATH_ROOT}/usr/lib"
-    local x86="x86_64-linux-gnu" aarch="aarch64-linux-gnu"
+    local x86="x86_64-linux-gnu" aarch="aarch64-linux-gnu" i386="i386-linux-gnu"
     local ppath="plugins/vmsvc/libdeployPkgPlugin.so"
     for pkg in vmware-tools open-vm-tools; do
         if [ -f "$pre/$pkg/$ppath" -o -f "${pre}64/$pkg/$ppath" ]; then
             found="$pkg"; break;
         fi
         # search in multiarch dir
-        if [ -f "$pre/$x86/$pkg/$ppath" -o -f "$pre/$aarch/$pkg/$ppath" ]; then
+        if [ -f "$pre/$x86/$pkg/$ppath" ] || \
+           [ -f "$pre/$aarch/$pkg/$ppath" ] || \
+           [ -f "$pre/$i386/$pkg/$ppath" ]; then
             found="$pkg"; break;
         fi
     done


### PR DESCRIPTION
## Proposed Commit Message
DS VMware: add i386 arch dir to deployPkg plugin search path

See details in https://bugs.launchpad.net/cloud-init/+bug/1944946, path of open-vm-tools libdeployPkgPlugin.so is now multi-arch compliant. For Debian12 32-bit, the path is /usr/lib/i386-linux-gnu/open-vm-tools/plugins/vmsvc/libdeployPkgPlugin.so. This change is to add  i386-linux-gnu path to search pathes.

Fixes GH-4253

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
