### PR TITLE
lxd: install lxd from snap, not deb if absent in image

### DIFF
--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -216,6 +216,13 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     bridge_cfg = lxd_cfg.get("bridge", {})
     supplemental_schema_validation(init_cfg, bridge_cfg, preseed_str)
 
+    if not subp.which("lxd"):
+        try:
+            subp.subp(["snap", "install", "lxd"])
+        except subp.ProcessExecutionError as e:
+            raise RuntimeError(
+                "Failed to install lxd from snap: %s" % e
+            ) from e
     packages = get_required_packages(init_cfg, preseed_str)
     if len(packages):
         try:
@@ -496,9 +503,6 @@ def maybe_cleanup_default(
 def get_required_packages(init_cfg: dict, preseed_str: str) -> List[str]:
     """identify required packages for install"""
     packages = []
-    if not subp.which("lxd"):
-        packages.append("lxd")
-
     # binary for pool creation must be available for the requested backend:
     # zfs, lvcreate, mkfs.btrfs
     storage_drivers: List[str] = []


### PR DESCRIPTION
## Proposed Commit Message

```
When lxd: cloud-config is provided and lxd command is not present on the image, install lxd from snap instead of deb.

On Ubuntu Focal and later LXD is available as a snap, the transitional lxd deb package was no longer available for install as a deb package as of 22.04 (Jammy) and later.

All ubuntu cloud images contain LXD as snap within the base image manifest. So, this logic generally should not get triggered. But, errors in cloud images build process generated some images without LXD and that triggered the install_packages logic to fail in cloud-init integration tests.
```

## Additional Context
<!-- If relevant -->
Failing Jenkins builds of ec2 images which temporarily lacked lxd in snap seed.
```
01:57:46   '2023-07-15 06:54:44,336 - cc_lxd.py[WARNING]: failed to install packages '
01:57:46   "['lxd']: Unexpected error while running command.\n"
```
- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-azure/31/testReport/junit/tests.integration_tests.modules.test_lxd/TestLxdBridge/test_bridge/

- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-azure/31/testReport/junit/tests.integration_tests.modules.test_lxd/TestLxdBridge/test_binaries_installed_lxc_/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
CLOUD_INIT_OS_IMAGE=mantic CLOUD_INIT_PLATFORM=ec2 tox -e integration-tests tests/integration_tests/modules/test_lxd.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
