### PR TITLE
Remove default membership in redundant groups

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -206,7 +206,7 @@ system_info:
      name: ubuntu
      lock_passwd: True
      gecos: Ubuntu
-     groups: [adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video]
+     groups: [adm, cdrom, dip, lxd, sudo]
      sudo: ["ALL=(ALL) NOPASSWD:ALL"]
      shell: /bin/bash
 {# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -146,4 +146,4 @@ users:
 #     shell: /bin/bash
 #     lock_passwd: True
 #     gecos: Ubuntu
-#     groups: [adm, audio, cdrom, dialout, floppy, video, plugdev, dip, netdev]
+#     groups: [adm, cdrom, dip, lxd, sudo]

--- a/doc/rtd/reference/base_config_reference.rst
+++ b/doc/rtd/reference/base_config_reference.rst
@@ -348,7 +348,7 @@ On an Ubuntu system, :file:`/etc/cloud/cloud.cfg` should look similar to:
         name: ubuntu
         lock_passwd: True
         gecos: Ubuntu
-        groups: [adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video]
+        groups: [adm, cdrom, dip, lxd, sudo]
         sudo: ["ALL=(ALL) NOPASSWD:ALL"]
         shell: /bin/bash
       network:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -150,6 +150,7 @@ tylerschultz
 vorlonofportland
 vteratipally
 Vultaire
+waveform80
 WebSpider
 Wind-net
 wmousa


### PR DESCRIPTION
## Proposed Commit Message
```
Remove default membership in redundant groups

The cloud-init template for Ubuntu currently includes membership in
numerous groups. Many of these are groups that were removed from the
default list over a decade ago on the desktop, and which are better
served by udev rules today. Specifically: audio, dialout, floppy,
netdev, plugdev, video.

LP: #1923363
```

## Additional Context
[LP: #1923363](https://bugs.launchpad.net/ubuntu/mantic/+source/user-setup/+bug/1923363)

## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly (n/a, no tests failed)
 - [x] I have updated or added any documentation accordingly
