### PR TITLE
Remove Testing dropdown

### DIFF
--- a/doc/rtd/development/testing.rst
+++ b/doc/rtd/development/testing.rst
@@ -3,12 +3,6 @@
 Testing
 *******
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   integration_tests.rst
-
 ``Cloud-init`` has both unit tests and integration tests. Unit tests can
 be found at :file:`tests/unittests`. Integration tests can be found at
 :file:`tests/integration_tests`. Documentation specifically for integration

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -117,6 +117,7 @@ RedKrieg
 renanrodrigo
 rhansen
 riedel
+rishitashaw
 rmhsawyer
 rongz609
 s-makin


### PR DESCRIPTION
**Summary: Remove duplicate Integration testing button**

Removes the duplicate Integration testing button from the documentation. This simplifies the documentation and improves the hierarchy under Development.

_Fixes GH- #4242_


## Additional Context

* The duplicate button was originally created as a way to provide a separate entry point for the integration tests from the Development section of the documentation. However, this is no longer necessary, as the integration tests can now be accessed from the main menu.
* Removing the duplicate button will make the documentation simpler and easier to navigate.

## Test Steps

* To verify that the duplicate button has been removed, open the documentation and navigate to the Development section. The Integration testing button should now only appear once.

## Checklist

* My code follows the process laid out in the documentation: https://cloudinit.readthedocs.io/en/latest/development/contributing.html.
* I have updated the code accordingly.
