### PR TITLE
doc: improve datasource_creation.rst

### DIFF
--- a/doc/rtd/development/datasource_creation.rst
+++ b/doc/rtd/development/datasource_creation.rst
@@ -83,7 +83,10 @@ the commit gets into a package.
 Add documentation for your datasource
 =====================================
 
-You should add a new file in :file:`doc/datasources/<cloudplatform>.rst`.
+You should add a new file in
+:file:`doc/rtd/reference/datasources/<cloudplatform>.rst`
+and reference it in
+:file:`doc/rtd/reference/datasources.rst`
 
 .. _make-mime: https://cloudinit.readthedocs.io/en/latest/explanation/instancedata.html#storage-locations
 .. _DMI: https://www.dmtf.org/sites/default/files/standards/documents/DSP0005.pdf


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
doc: improve datasource_creation.rst

Clarify that the new datasource doc page has to be referenced in doc/rtd/reference/datasources.rst to be rendered.
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/4167#discussion_r1269203689

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
