### PR TITLE
Ubuntu/devel: Remove unused NetworkManager hook

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloud-init (23.3~3gebd7b2b6-0ubuntu2) UNRELEASED; urgency=medium
+
+  * d/cloud-init.maintscript: Remove the unused hook-network-manager conffile
+
+ -- Brett Holman <brett.holman@canonical.com>  Tue, 25 Jul 2023 16:03:57 -0600
+
 cloud-init (23.3~3gebd7b2b6-0ubuntu1) mantic; urgency=medium
 
   * Upstream snapshot based on upstream/main at ebd7b2b6.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-cloud-init (23.3~3gebd7b2b6-0ubuntu2) UNRELEASED; urgency=medium
+cloud-init (23.3~3gebd7b2b6-0ubuntu3) UNRELEASED; urgency=medium
 
   * d/cloud-init.maintscript: Remove the unused hook-network-manager conffile
+  * d/control: Add python3-passlib as needed for testing
 
- -- Brett Holman <brett.holman@canonical.com>  Tue, 25 Jul 2023 16:03:57 -0600
+ -- Brett Holman <brett.holman@canonical.com>  Tue, 25 Jul 2023 16:06:32 -0600
 
 cloud-init (23.3~3gebd7b2b6-0ubuntu1) mantic; urgency=medium
 

--- a/debian/cloud-init.maintscript
+++ b/debian/cloud-init.maintscript
@@ -6,3 +6,4 @@ rm_conffile /etc/init/cloud-init-local.conf 0.7.9-243-ge74d775-0ubuntu2~
 rm_conffile /etc/init/cloud-init-nonet.conf 0.7.9-243-ge74d775-0ubuntu2~
 rm_conffile /etc/init/cloud-init.conf 0.7.9-243-ge74d775-0ubuntu2~
 rm_conffile /etc/init/cloud-log-shutdown.conf 0.7.9-243-ge74d775-0ubuntu2~
+rm_conffile /etc/NetworkManager/dispatcher.d/hook-network-manager 23.2.1-0ubuntu0~

--- a/debian/control
+++ b/debian/control
@@ -22,7 +22,9 @@ Build-Depends: debhelper-compat (= 13),
                python3-serial,
                python3-setuptools,
                python3-yaml,
-               python3-responses
+               python3-responses,
+               python3-passlib
+XS-Python-Version: all
 Vcs-Browser: https://github.com/canonical/cloud-init/tree/ubuntu/devel
 Vcs-Git: https://github.com/canonical/cloud-init -b ubuntu/devel
 Standards-Version: 4.5.0


### PR DESCRIPTION
```
Remove unused NetworkManager hook

Silence warnings on old installs during upgrade.
This file was removed in 23.2.1-0ubuntu0 and the
upgrade path issue discovered in 23.2.1-0ubuntu0.

LP: #2027861
```