### PR TITLE
[jammy] patch: Retain old groups in default user template

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (23.2-0ubuntu0~22.04.1ubuntu2) UNRELEASED; urgency=medium
+
+  * d/patches/retain-old-groups.patch:
+    - Retain original groups in default group for ubuntu.
+      Mantic removed unneeded groups.
+
+ -- Brett Holman <brett.holman@canonical.com>  Thu, 20 Jul 2023 15:07:36 -0600
+
 cloud-init (23.2-0ubuntu0~22.04.1) jammy; urgency=medium
 
   * d/control: Remove pep8 dependency. It is no longer used.

--- a/debian/patches/retain-old-groups.patch
+++ b/debian/patches/retain-old-groups.patch
@@ -1,0 +1,13 @@
+diff --git a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
+index e496c62c3..a4a4671a6 100644
+--- a/config/cloud.cfg.tmpl
++++ b/config/cloud.cfg.tmpl
+@@ -206,7 +206,7 @@ system_info:
+      name: ubuntu
+      lock_passwd: True
+      gecos: Ubuntu
+-     groups: [adm, cdrom, dip, lxd, sudo]
++     groups: [adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video]
+      sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+      shell: /bin/bash
+ {# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}


### PR DESCRIPTION
```
patch: Retain old groups in default user template
```

## Additional Context
I just merged https://github.com/canonical/cloud-init/pull/4258, for which this patch retains old behavior.

https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/1923363
