### PR TITLE
[bionic] patch: Retain old groups in default user template

### DIFF
--- a/debian/patches/retain-old-groups.patch
+++ b/debian/patches/retain-old-groups.patch
@@ -1,0 +1,14 @@
+diff --git a/config/cloud.cfg.tmpl b/config/cloud.cfg.tmpl
+index e496c62c3..a4a4671a6 100644
+--- a/config/cloud.cfg.tmpl
++++ b/config/cloud.cfg.tmpl
+@@ -206,7 +206,7 @@ system_info:
+      name: ubuntu
+      lock_passwd: True
+      gecos: Ubuntu
+-     groups: [adm, cdrom, dip, lxd, sudo]
++     groups: [adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video]
+      sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+      shell: /bin/bash
+ {# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
+


### PR DESCRIPTION
```
patch: Retain old groups in default user template
```

## Additional Context
I just merged https://github.com/canonical/cloud-init/pull/4258, for which this patch retains old behavior.

https://bugs.launchpad.net/ubuntu/+source/ubiquity/+bug/1923363
