### PR TITLE
tools/read-version refactors and unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ import setuptools
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
+# Python-path here is a little unpredictable as setup.py could be run
+# from a directory other than the root of the repo, so ensure we can find
+# our utils
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 # isort: off
 from setup_utils import (  # noqa: E402

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,20 @@ import setuptools
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
 
+sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
+# isort: off
+from setup_utils import (  # noqa: E402
+    get_version,
+    in_virtualenv,
+    is_f,
+    is_generator,
+    pkg_config_read,
+    read_requires,
+)
+
+# isort: on
+del sys.path[0]
+
 # pylint: disable=W0402
 try:
     from setuptools.errors import DistutilsError
@@ -31,65 +45,6 @@ except ImportError:
 RENDERED_TMPD_PREFIX = "RENDERED_TEMPD"
 VARIANT = None
 PREFIX = None
-
-
-def is_f(p):
-    return os.path.isfile(p)
-
-
-def is_generator(p):
-    return "-generator" in p
-
-
-def pkg_config_read(library, var):
-    fallbacks = {
-        "systemd": {
-            "systemdsystemconfdir": "/etc/systemd/system",
-            "systemdsystemunitdir": "/lib/systemd/system",
-            "systemdsystemgeneratordir": "/lib/systemd/system-generators",
-        },
-        "udev": {
-            "udevdir": "/lib/udev",
-        },
-    }
-    cmd = ["pkg-config", "--variable=%s" % var, library]
-    try:
-        path = subprocess.check_output(cmd).decode("utf-8")
-        path = path.strip()
-    except Exception:
-        path = fallbacks[library][var]
-    if path.startswith("/"):
-        path = path[1:]
-
-    return path
-
-
-def in_virtualenv():
-    try:
-        if sys.real_prefix == sys.prefix:
-            return False
-        else:
-            return True
-    except AttributeError:
-        return False
-
-
-def get_version():
-    cmd = [sys.executable, "tools/read-version"]
-    ver = subprocess.check_output(cmd)
-    version = ver.decode("utf-8").strip()
-    # read-version can spit out something like 22.4-15-g7f97aee24
-    # which is invalid under PEP440. If we replace the first - with a +
-    # that should give us a valid version.
-    if "-" in version:
-        version = version.replace("-", "+", 1)
-    return version
-
-
-def read_requires():
-    cmd = [sys.executable, "tools/read-dependencies"]
-    deps = subprocess.check_output(cmd)
-    return deps.decode("utf-8").splitlines()
 
 
 def render_tmpl(template, mode=None):

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -1,0 +1,64 @@
+import os
+import subprocess
+import sys
+from typing import List
+
+
+def is_f(p: str) -> bool:
+    return os.path.isfile(p)
+
+
+def is_generator(p: str) -> bool:
+    return "-generator" in p
+
+
+def pkg_config_read(library: str, var: str) -> str:
+    fallbacks = {
+        "systemd": {
+            "systemdsystemconfdir": "/etc/systemd/system",
+            "systemdsystemunitdir": "/lib/systemd/system",
+            "systemdsystemgeneratordir": "/lib/systemd/system-generators",
+        },
+        "udev": {
+            "udevdir": "/lib/udev",
+        },
+    }
+    cmd = ["pkg-config", f"--variable={var}", library]
+    try:
+        path = subprocess.check_output(cmd).decode("utf-8")
+        path = path.strip()
+    except Exception:
+        path = fallbacks[library][var]
+    if path.startswith("/"):
+        path = path[1:]
+
+    return path
+
+
+def in_virtualenv() -> bool:
+    # TODO: sys.real_prefix doesn't exist on any currently supported
+    # version of python. This function can never return True
+    try:
+        return sys.real_prefix != sys.prefix
+    except AttributeError:
+        return False
+
+
+def version_to_pep440(version: str) -> str:
+    # read-version can spit out something like 22.4-15-g7f97aee24
+    # which is invalid under PEP 440. If we replace the first - with a +
+    # that should give us a valid version.
+    return version.replace("-", "+", 1)
+
+
+def get_version() -> str:
+    cmd = [sys.executable, "tools/read-version"]
+    ver = subprocess.check_output(cmd)
+    version = ver.decode("utf-8").strip()
+    return version_to_pep440(version)
+
+
+def read_requires() -> List[str]:
+    cmd = [sys.executable, "tools/read-dependencies"]
+    deps = subprocess.check_output(cmd)
+    return deps.decode("utf-8").splitlines()

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,6 @@ pytest<=7.3.1
 
 pytest-cov
 pytest-mock
-
-# Only really needed on older versions of python
 setuptools
 jsonschema
 responses

--- a/tools/read-version
+++ b/tools/read-version
@@ -1,13 +1,16 @@
 #!/usr/bin/env python3
 
-import os
+# This script has tests. Run pytest on the tools directory if you make changes
+
 import json
+import os
 import re
 import subprocess
 import sys
+from shutil import which
 
-_tdir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, _tdir)
+repo_base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, repo_base_dir)
 
 from cloudinit import version as ci_version  # noqa: E402
 
@@ -17,25 +20,6 @@ def tiny_p(cmd):
     return subprocess.check_output(
         cmd, stderr=stderr, stdin=None, universal_newlines=True
     )
-
-
-def which(program):
-    # Return path of program for execution if found in path
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    _fpath, _ = os.path.split(program)
-    if _fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ.get("PATH", "").split(os.pathsep):
-            path = path.strip('"')
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-    return None
 
 
 def is_gitdir(path):
@@ -51,7 +35,7 @@ def is_gitdir(path):
     return False
 
 
-def get_version_details(version, version_long):
+def get_version_details(version, version_long, is_release_branch_ci):
     release = None
     extra = None
     commit = None
@@ -82,67 +66,71 @@ def get_version_details(version, version_long):
     }
 
 
-use_long = "--long" in sys.argv or os.environ.get("CI_RV_LONG")
-use_tags = "--tags" in sys.argv or os.environ.get("CI_RV_TAGS")
-output_json = "--json" in sys.argv
+def get_version_from_git(
+    src_version, major_minor_version, use_tags, is_release_branch_ci
+):
+    if is_gitdir(repo_base_dir) and which("git") and not is_release_branch_ci:
+        branch_name = tiny_p(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+        ).strip()
+        if branch_name.startswith(f"upstream/{major_minor_version}"):
+            version = src_version
+            version_long = ""
+        else:
+            flags = ["--tags"] if use_tags else []
+            cmd = [
+                "git",
+                "describe",
+                branch_name,
+                "--abbrev=8",
+            ] + flags
 
-src_version = ci_version.version_string()
-# upstream/MM.NN.x tracks our patch level releases so ignore trailing '.x'
-major_minor_version = ".".join(src_version.split(".")[:2])
-version_long = ""
-
-# If we're performing CI for a new release branch (which our tooling creates
-# with an "upstream/" prefix), then we don't want to enforce strict version
-# matching because we know it will fail.
-github_ci_release_br = bool(
-    os.environ.get("GITHUB_HEAD_REF", "").startswith(
-        f"upstream/{major_minor_version}"
-    )
-)
-travis_ci_release_br = bool(
-    os.environ.get("TRAVIS_PULL_REQUEST_BRANCH", "").startswith("upstream/")
-)
-is_release_branch_ci = bool(github_ci_release_br or travis_ci_release_br)
-
-if is_gitdir(_tdir) and which("git") and not is_release_branch_ci:
-    # This cmd can be simplified to ["git", "branch", "--show-current"]
-    # after bionic EOL.
-    branch_name = tiny_p(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
-    if branch_name.startswith(f"upstream/{major_minor_version}"):
-        version = src_version
-        version_long = ""
-    else:
-
-        flags = []
-        if use_tags:
-            flags = ["--tags"]
-        cmd = [
-            "git",
-            "describe",
-            branch_name,
-            "--abbrev=8",
-        ] + flags
-
-        try:
-            version = tiny_p(cmd).strip()
-            version_long = tiny_p(cmd + ["--long"]).strip()
-        except subprocess.CalledProcessError as e:
-            if "No tags can describe" in e.stderr:
-                print(f"{cmd} found no tags. Using cloudinit.verison.py ")
+            try:
+                version = tiny_p(cmd).strip()
+                version_long = tiny_p(cmd + ["--long"]).strip()
+            except subprocess.CalledProcessError as e:
+                if "No tags can describe" not in e.stderr:
+                    raise
                 version = src_version
                 version_long = ""
-            else:
-                raise
-else:
-    version = src_version
-    version_long = ""
+    else:
+        version = src_version
+        version_long = ""
+    return version, version_long
 
 
-details = get_version_details(version, version_long)
+def main(use_tags: bool = False, output_json: bool = False):
+    src_version = ci_version.version_string()
+    # upstream/MM.NN.x tracks our patch level releases so ignore trailing '.x'
+    major_minor_version = ".".join(src_version.split(".")[:2])
 
-if output_json:
-    sys.stdout.write(json.dumps(details, indent=1) + "\n")
-else:
+    # If we're performing CI for a new release branch (which our tooling
+    # creates with an "upstream/" prefix), then we don't want to enforce
+    # strict version matching because we know it will fail.
+    github_ci_release_br = bool(
+        os.environ.get("GITHUB_HEAD_REF", "").startswith(
+            f"upstream/{major_minor_version}"
+        )
+    )
+    travis_ci_release_br = bool(
+        os.environ.get("TRAVIS_PULL_REQUEST_BRANCH", "").startswith(
+            "upstream/"
+        )
+    )
+    is_release_branch_ci = github_ci_release_br or travis_ci_release_br
+
+    version, version_long = get_version_from_git(
+        src_version=src_version,
+        major_minor_version=major_minor_version,
+        use_tags=use_tags,
+        is_release_branch_ci=is_release_branch_ci,
+    )
+
+    details = get_version_details(version, version_long, is_release_branch_ci)
+
+    if output_json:
+        return json.dumps(details, indent=1)
+
     output = ""
     if details["release"]:
         output += details["release"]
@@ -150,6 +138,11 @@ else:
         output += details["extra"]
     if not output:
         output = src_version
-    sys.stdout.write(output + "\n")
+    return output
 
-sys.exit(0)
+
+if __name__ == "__main__":
+    arg_use_tags = "--tags" in sys.argv or bool(os.environ.get("CI_RV_TAGS"))
+    arg_output_json = "--json" in sys.argv
+    output = main(arg_use_tags, arg_output_json)
+    sys.stdout.write(output + "\n")

--- a/tools/read-version
+++ b/tools/read-version
@@ -145,4 +145,4 @@ if __name__ == "__main__":
     arg_use_tags = "--tags" in sys.argv or bool(os.environ.get("CI_RV_TAGS"))
     arg_output_json = "--json" in sys.argv
     output = main(arg_use_tags, arg_output_json)
-    sys.stdout.write(output + "\n")
+    print(output)

--- a/tools/test_tools.py
+++ b/tools/test_tools.py
@@ -1,0 +1,85 @@
+import pathlib
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from unittest import mock
+
+import pytest
+import setuptools
+
+from setup_utils import version_to_pep440
+
+validate_version = setuptools.dist.Distribution._validate_version  # type: ignore  # noqa: E501
+
+# Since read-version has a '-' and no .py extension, we have to do this
+# to import it
+spec = spec_from_loader(
+    "read-version",
+    SourceFileLoader(
+        "read-version",
+        str(pathlib.Path(__file__).absolute().parent / "read-version"),
+    ),
+)
+if not spec:
+    pytest.fail("Could not import read-version")
+read_version = module_from_spec(spec)
+if not spec.loader:
+    pytest.fail("Could not import read-version")
+spec.loader.exec_module(read_version)
+
+
+def assert_valid_version(version):
+    response = validate_version(version)
+    if isinstance(response, setuptools.sic):
+        pytest.fail(f"{version} is not PEP 440 compliant")
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        (("23.2", "23.2"), "23.2"),
+        (("23.2", "23.2-0-gcdc24d864"), "23.2-0-gcdc24d86"),
+        (("23.2.1", "23.2.1"), "23.2.1"),
+        (("23.2.1", "23.2.1-0-gcda472559"), "23.2.1-0-gcda47255"),
+        (
+            ("23.2-65-g392346ccd", "23.2-65-g392346ccd"),
+            "23.2-65-g392346cc",
+        ),
+        (
+            ("23.2.1-65-g392346ccd", "23.2.1-65-g392346ccd"),
+            "23.2.1-65-g392346cc",
+        ),
+        (
+            (
+                "cloud-init-23.1.1-2.el8-2-g285d8d80",
+                "cloud-init-23.1.1-2.el8-2-g285d8d80",
+            ),
+            "23.1.1-2-g285d8d80",
+        ),  # RH tags
+        (
+            (
+                "21.1-19-gbad84ad4-0ubuntu1_16.04.4+esm1",
+                "21.1-19-gbad84ad4-0ubuntu1_16.04.4+esm1",
+            ),
+            "21.1-19-gbad84ad4",
+        ),
+        (("0.3.4ubuntu6", "0.3.4ubuntu6"), "0.3.4"),
+        (("noparse", "noparse"), "10.2.1"),
+    ],
+)
+@mock.patch.object(
+    read_version.ci_version, "version_string", return_value="10.2.1"
+)
+class TestReadVersion:
+    def test_tag_parsing(self, _m_package_version, version, expected):
+        """Ensure that we can parse most tags.
+
+        If  we cannot parse the tag, fallback to package version.
+        """
+        with mock.patch.object(
+            read_version, "get_version_from_git", return_value=version
+        ):
+            out = read_version.main()
+        assert out == expected
+
+        # Also ensure it passes setuptools PEP 440 check
+        assert_valid_version(version_to_pep440(out))

--- a/tools/test_tools.py
+++ b/tools/test_tools.py
@@ -29,7 +29,7 @@ spec.loader.exec_module(read_version)
 
 def assert_valid_version(version):
     response = validate_version(version)
-    if isinstance(response, setuptools.sic):
+    if isinstance(response, setuptools.sic):  # noqa: E1101
         pytest.fail(f"{version} is not PEP 440 compliant")
 
 

--- a/tools/test_tools.py
+++ b/tools/test_tools.py
@@ -8,7 +8,14 @@ import setuptools
 
 from setup_utils import version_to_pep440
 
-validate_version = setuptools.dist.Distribution._validate_version  # type: ignore  # noqa: E501
+try:
+    validate_version = setuptools.dist.Distribution._validate_version
+    setuptools.sic  # pylint: disable=no-member,pointless-statement
+except AttributeError:
+    pytest.skip(
+        "Unable to import necessary setuptools utilities. "
+        "Version is likely too old."
+    )
 
 # Since read-version has a '-' and no .py extension, we have to do this
 # to import it
@@ -29,7 +36,7 @@ spec.loader.exec_module(read_version)
 
 def assert_valid_version(version):
     response = validate_version(version)
-    if isinstance(response, setuptools.sic):  # noqa: E1101
+    if isinstance(response, setuptools.sic):  # pylint: disable=no-member
         pytest.fail(f"{version} is not PEP 440 compliant")
 
 

--- a/tools/test_tools.py
+++ b/tools/test_tools.py
@@ -9,7 +9,7 @@ import setuptools
 from setup_utils import version_to_pep440
 
 try:
-    validate_version = setuptools.dist.Distribution._validate_version
+    validate_version = setuptools.dist.Distribution._validate_version  # type: ignore  # noqa: E501
     setuptools.sic  # pylint: disable=no-member,pointless-statement
 except AttributeError:
     pytest.skip(

--- a/tox.ini
+++ b/tox.ini
@@ -195,6 +195,7 @@ deps =
     pytest==3.3.2
     pytest-cov==2.5.1
     pytest-mock==1.7.1
+    setuptools==44.0.0
     # Needed by pytest and default causes failures
     attrs==17.4.0
     responses==0.5.1

--- a/tox.ini
+++ b/tox.ini
@@ -290,7 +290,7 @@ per-file-ignores =
 
 [pytest]
 # TODO: s/--strict/--strict-markers/ once pytest version is high enough
-testpaths = tests/unittests
+testpaths = tests/unittests tools
 addopts = --strict
 log_format = %(asctime)s %(levelname)-9s %(name)s:%(filename)s:%(lineno)d %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tools/read-version refactors and unit tests

* Refactor script into importable functions
* Replace 'which' function with shutils
* Remove unused "use_long" option
* Add unit tests for read-version and add them to default pytest
* Move some utility functions out of setup.py so they can be imported
  and tested
```

