### PR TITLE
Kernel Commandline: Fix 4271

### DIFF
--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -66,7 +66,7 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance) -> str:
     "ds_str, configured",
     (
         (
-            "ds=nocloud;s=http://my-url/",
+            "ds=nocloud;s=http://my-url/;h=hostname",
             "DataSourceNoCloud [seed=None][dsmode=net]",
         ),
         ("ci.ds=openstack", "DataSourceOpenStack"),

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1742,8 +1742,8 @@ read_config() {
         key=${tok%%=*}
         val=${tok#*=}
 
-        # discard anything after delimiter
-        val=${val%;*}
+        # discard anything after the first delimiter
+        val=${val%%;*}
         case "$key" in
             ds) _rc_dsname="$val";;
             ci.ds) _rc_dsname="$val";;


### PR DESCRIPTION
```
Fix NoCloud kernel commandline key parsing

Currently >2 keys in NoCloud datasource are not
supported. Previously 250280 attempted to correct
no keys being supported, however that fix was only
partial since more than one key breaks datasource
detection.

Additionally add test coverage.

Fixes GH-4271
```