### PR TITLE
Don't require passlib dependency

### DIFF
--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -2,14 +2,37 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import functools
 import os
 import platform
-
-from passlib.hash import bcrypt
 
 import cloudinit.distros.bsd
 from cloudinit import log as logging
 from cloudinit import subp, util
+
+try:
+    import crypt
+
+    blowfish_hash = functools.partial(
+        crypt.crypt,
+        salt=crypt.mksalt(crypt.METHOD_BLOWFISH),  # pylint: disable=E1101
+    )
+except ImportError:
+    try:
+        from passlib.hash import bcrypt
+
+        blowfish_hash = bcrypt.hash
+    except ImportError:
+
+        def blowfish_hash(_):
+            """Raise when called so that importing this module doesn't throw
+            ImportError when this module is not used. In this case, crypt
+            and passlib are not needed.
+            """
+            raise ImportError(
+                "crypt and passlib not found, missing dependency"
+            )
+
 
 LOG = logging.getLogger(__name__)
 
@@ -91,7 +114,7 @@ class NetBSD(cloudinit.distros.bsd.BSD):
         if hashed:
             hashed_pw = passwd
         else:
-            hashed_pw = bcrypt.hash(passwd)
+            hashed_pw = blowfish_hash(passwd)
 
         try:
             subp.subp(["usermod", "-p", hashed_pw, user])

--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -13,9 +13,10 @@ from cloudinit import subp, util
 try:
     import crypt
 
+    salt = crypt.METHOD_BLOWFISH  # pylint: disable=E1101
     blowfish_hash = functools.partial(
         crypt.crypt,
-        salt=crypt.mksalt(crypt.METHOD_BLOWFISH),  # pylint: disable=E1101
+        salt=crypt.mksalt(salt),
     )
 except ImportError:
     try:

--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -19,7 +19,7 @@ try:
         crypt.crypt,
         salt=crypt.mksalt(salt),
     )
-except ImportError:
+except (ImportError, AttributeError):
     try:
         from passlib.hash import bcrypt
 

--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -5,6 +5,7 @@
 import functools
 import os
 import platform
+from typing import Any
 
 import cloudinit.distros.bsd
 from cloudinit import log as logging
@@ -14,7 +15,7 @@ try:
     import crypt
 
     salt = crypt.METHOD_BLOWFISH  # pylint: disable=E1101
-    blowfish_hash = functools.partial(
+    blowfish_hash: Any = functools.partial(
         crypt.crypt,
         salt=crypt.mksalt(salt),
     )

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -5,6 +5,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import base64
+import functools
 import os
 import os.path
 import re
@@ -14,8 +15,6 @@ from enum import Enum
 from pathlib import Path
 from time import sleep, time
 from typing import Any, Dict, List, Optional
-
-import passlib
 
 from cloudinit import log as logging
 from cloudinit import net, sources, ssh_util, subp, util
@@ -47,6 +46,29 @@ from cloudinit.sources.helpers.azure import (
     report_failure_to_fabric,
 )
 from cloudinit.url_helper import UrlError
+
+try:
+    import crypt
+
+    blowfish_hash = functools.partial(
+        crypt.crypt, salt=f"$6${util.rand_str(strlen=16)}"
+    )
+except ImportError:
+    try:
+        import passlib
+
+        blowfish_hash = passlib.hash.sha512_crypt.hash
+    except ImportError:
+
+        def blowfish_hash(_):
+            """Raise when called so that importing this module doesn't throw
+            ImportError when ds_detect() returns false. In this case, crypt
+            and passlib are not needed.
+            """
+            raise ImportError(
+                "crypt and passlib not found, missing dependency"
+            )
+
 
 LOG = logging.getLogger(__name__)
 
@@ -1766,7 +1788,7 @@ def read_azure_ovf(contents):
 
 
 def encrypt_pass(password):
-    return passlib.hash.sha512_crypt.hash(password)
+    return blowfish_hash(password)
 
 
 @azure_ds_telemetry_reporter

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -50,7 +50,7 @@ from cloudinit.url_helper import UrlError
 try:
     import crypt
 
-    blowfish_hash = functools.partial(
+    blowfish_hash: Any = functools.partial(
         crypt.crypt, salt=f"$6${util.rand_str(strlen=16)}"
     )
 except ImportError:

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -53,7 +53,7 @@ try:
     blowfish_hash: Any = functools.partial(
         crypt.crypt, salt=f"$6${util.rand_str(strlen=16)}"
     )
-except ImportError:
+except (ImportError, AttributeError):
     try:
         import passlib
 

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -10,3 +10,4 @@ pycloudlib==1!3.0.2
 pytest<=7.3.1
 
 packaging
+passlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,3 @@ jsonschema
 # runtime and merge that information into the metadata and repersist that to
 # disk.
 netifaces>=0.10.4
-
-# passlib to replace crypt.crypt
-passlib

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,3 +13,4 @@ pytest-mock
 setuptools
 jsonschema
 responses
+passlib

--- a/tests/unittests/distros/test_netbsd.py
+++ b/tests/unittests/distros/test_netbsd.py
@@ -3,13 +3,16 @@ import unittest.mock as mock
 
 import pytest
 
-import cloudinit.distros.netbsd
+try:
+    # Blowfish not available in < 3.7, so this has never worked. Ignore failure
+    # to import with AttributeError. We need this module imported prior to
+    # patching the object, so we can't gate the version with pytest skipif.
+    import cloudinit.distros.netbsd
+except AttributeError:
+    pass
 
 
 @pytest.mark.parametrize("with_pkgin", (True, False))
-@pytest.mark.skipif(
-    sys.version_info < (3, 7, 0), reason="Blowfish not available in 3.6"
-)
 @mock.patch("cloudinit.distros.netbsd.os")
 def test_init(m_os, with_pkgin):
     print(with_pkgin)

--- a/tests/unittests/distros/test_netbsd.py
+++ b/tests/unittests/distros/test_netbsd.py
@@ -1,3 +1,4 @@
+import sys
 import unittest.mock as mock
 
 import pytest
@@ -6,6 +7,9 @@ import cloudinit.distros.netbsd
 
 
 @pytest.mark.parametrize("with_pkgin", (True, False))
+@pytest.mark.skipif(
+    sys.version_info < (3, 7, 0), reason="Blowfish not available in 3.6"
+)
 @mock.patch("cloudinit.distros.netbsd.os")
 def test_init(m_os, with_pkgin):
     print(with_pkgin)

--- a/tests/unittests/distros/test_netbsd.py
+++ b/tests/unittests/distros/test_netbsd.py
@@ -1,4 +1,3 @@
-import sys
 import unittest.mock as mock
 
 import pytest

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -4580,3 +4580,11 @@ class TestValidateIMDSMetadata:
         }
 
         assert azure_ds.validate_imds_network_metadata(imds_md) is False
+
+
+class TestDependencyFallback:
+    def test_dependency_fallback(self):
+        """Ensure that crypt/passlib import failover gets exercised on all
+        Python versions
+        """
+        assert dsaz.encrypt_pass("`")

--- a/tox.ini
+++ b/tox.ini
@@ -202,7 +202,7 @@ deps =
     # Needed by pytest and default causes failures
     attrs==17.4.0
     responses==0.5.1
-	passlib
+    passlib
 commands = {[testenv:py3]commands}
 
 [testenv:doc]

--- a/tox.ini
+++ b/tox.ini
@@ -202,6 +202,7 @@ deps =
     # Needed by pytest and default causes failures
     attrs==17.4.0
     responses==0.5.1
+	passlib
 commands = {[testenv:py3]commands}
 
 [testenv:doc]


### PR DESCRIPTION
```
Don't require passlib dependency

Thee crypt module suffices on old versions of Python.
Use it when available. 
```

TODO: tests