### PR TITLE
tests: avoid leaks into host system checking of ovs-vsctl cmd

### DIFF
--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4291,11 +4291,16 @@ class TestGenerateFallbackConfig(CiTestCase):
         }
         self.assertEqual(expected, network_cfg)
 
+    @mock.patch("cloudinit.net.openvswitch_is_installed", return_value=False)
     @mock.patch("cloudinit.net.sys_dev_path")
     @mock.patch("cloudinit.net.read_sys_net")
     @mock.patch("cloudinit.net.get_devicelist")
     def test_device_driver(
-        self, mock_get_devicelist, mock_read_sys_net, mock_sys_dev_path
+        self,
+        mock_get_devicelist,
+        mock_read_sys_net,
+        mock_sys_dev_path,
+        _ovs_is_installed,
     ):
         devices = {
             "eth0": {
@@ -4375,11 +4380,16 @@ iface eth0 inet dhcp
         ]
         self.assertEqual(", ".join(expected_rule) + "\n", contents.lstrip())
 
+    @mock.patch("cloudinit.net.openvswitch_is_installed", return_value=False)
     @mock.patch("cloudinit.net.sys_dev_path")
     @mock.patch("cloudinit.net.read_sys_net")
     @mock.patch("cloudinit.net.get_devicelist")
     def test_hv_netvsc_vf_filter(
-        self, mock_get_devicelist, mock_read_sys_net, mock_sys_dev_path
+        self,
+        mock_get_devicelist,
+        mock_read_sys_net,
+        mock_sys_dev_path,
+        _ovs_installed,
     ):
         devices = {
             "eth1": {
@@ -6556,6 +6566,7 @@ class TestNetplanNetRendering:
     )
     @mock.patch("cloudinit.net.util.get_cmdline", return_value="root=myroot")
     @mock.patch("cloudinit.net.netplan._clean_default")
+    @mock.patch("cloudinit.net.openvswitch_is_installed", return_value=False)
     @mock.patch("cloudinit.net.sys_dev_path")
     @mock.patch("cloudinit.net.read_sys_net")
     @mock.patch("cloudinit.net.get_devicelist")
@@ -6564,6 +6575,7 @@ class TestNetplanNetRendering:
         mock_get_devicelist,
         mock_read_sys_net,
         mock_sys_dev_path,
+        _openvswitch_is_installed,
         mock_clean_default,
         m_get_cmdline,
         m_renderer_features,


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
tests: avoid leaks into host system checking of ovs-vsctl cmd

Mock out the `which` checks for presence of ovs-vsctl cmd on system. This prevents test leaks which eventually call subp ovs-vsctl commands.
```

## Additional Context
<!-- If relevant -->


## Test Steps
```
# install openvswitch-switch
sudo apt install openvswitch-switch
# Run failing unit tests:
tox -e py3 tests/unittests/test_net.py



FAILED tests/unittests/test_net.py::TestGenerateFallbackConfig::test_device_driver - RuntimeError: called subp. set self.allowed_subp=True to allow
FAILED tests/unittests/test_net.py::TestGenerateFallbackConfig::test_hv_netvsc_vf_filter - RuntimeError: called subp. set self.allowed_subp=True to allow
FAILED tests/unittests/test_net.py::TestNetplanNetRendering::test_render[default_generation] - AssertionError: Unexpectedly used subp.subp
============================================= 3 failed, 4777 passed, 4 skipped, 1 deselected, 1 xfailed, 271 warnings in 68.30s (0:01:08) ====
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
