### PR TITLE
Ubuntu/jammy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (23.2-0ubuntu0~22.04.2) UNRELEASED; urgency=medium
+
+  * Refresh patches against upstream/main
+    - d/p/retain-netplan-world-readable.patch
+
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 21 Jul 2023 21:56:16 -0600
+
 cloud-init (23.2-0ubuntu0~22.04.1) jammy; urgency=medium
 
   * d/control: Remove pep8 dependency. It is no longer used.

--- a/debian/patches/retain-netplan-world-readable.patch
+++ b/debian/patches/retain-netplan-world-readable.patch
@@ -8,7 +8,7 @@ Last-Update: 2023-01-09
 ---
 This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 --- a/cloudinit/features.py
-+++ b/cloudinit/features.py
++++ cloud-init/cloudinit/features.py
 @@ -59,7 +59,7 @@ only non-hashed passwords were expired.
  (This flag can be removed after Jammy is no longer supported.)
  """
@@ -120,3 +120,40 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  
  
  class TestNetCfgDistroPhoton(TestNetCfgDistroBase):
+--- a/tests/unittests/test_data.py
++++ b/tests/unittests/test_data.py
+@@ -490,8 +490,8 @@ c: 4
+         expected = {
+             "features": {
+                 "ERROR_ON_USER_DATA_FAILURE": True,
+-                "EXPIRE_APPLIES_TO_HASHED_USERS": True,
+-                "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
++                "EXPIRE_APPLIES_TO_HASHED_USERS": False,
++                "NETPLAN_CONFIG_ROOT_READ_ONLY": False,
+                 "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": True,
+             },
+             "system_info": {
+--- a/tests/unittests/test_features.py
++++ b/tests/unittests/test_features.py
+@@ -15,16 +15,16 @@ class TestGetFeatures:
+     def test_feature_without_override(self):
+         assert {
+             "ERROR_ON_USER_DATA_FAILURE": True,
+-            "EXPIRE_APPLIES_TO_HASHED_USERS": True,
+-            "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
++            "EXPIRE_APPLIES_TO_HASHED_USERS": False,
++            "NETPLAN_CONFIG_ROOT_READ_ONLY": False,
+             "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": True,
+         } == features.get_features()
+         with mock.patch.object(
+-            features, "NETPLAN_CONFIG_ROOT_READ_ONLY", False
++            features, "NETPLAN_CONFIG_ROOT_READ_ONLY", True
+         ):
+             assert {
+                 "ERROR_ON_USER_DATA_FAILURE": True,
+-                "EXPIRE_APPLIES_TO_HASHED_USERS": True,
+-                "NETPLAN_CONFIG_ROOT_READ_ONLY": False,
++                "EXPIRE_APPLIES_TO_HASHED_USERS": False,
++                "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
+                 "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": True,
+             } == features.get_features()


### PR DESCRIPTION
Fix daily jammy build recipes due to feature drift in unit tests
do not squash merge. push separate commits to upstream/ubuntu/jammy  when reviewed




## Additional Context
Daily recipe builds failing on jammy  due to quilt apply debian/patch/series
https://launchpadlibrarian.net/678153853/buildlog_ubuntu-jammy-amd64.cloud-init_23.2.daily-202307201631-392346cc~ubuntu22.04.1_BUILDING.txt.gz


## Test Steps
```
git checkout main
git merge upstream/ubuntu/jammy
quilt push -a
tox -e py3 # expect failures in test_data and test_features for the features that are set False ROOT_READ_ONLY and HASHED_USERS
quilt pop -a


# See fix
git reset --hard upstream/main
git merge blackboxsw/ubuntu/jammy
quilt push -a 
tox -e py3 # expect success
quilt pop -a
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
