### PR TITLE
ds-identify/CloudStack: return $DS_MAYBE if vm is running on vmware/xen

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1463,6 +1463,7 @@ VALID_CFG = {
     },
     "IBMCloud-metadata": {
         "ds": "IBMCloud",
+        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             MOCK_VIRT_IS_XEN,
             {"name": "is_ibm_provisioning", "ret": shell_false},
@@ -1529,6 +1530,7 @@ VALID_CFG = {
     },
     "IBMCloud-nodisks": {
         "ds": "IBMCloud",
+        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             MOCK_VIRT_IS_XEN,
             {"name": "is_ibm_provisioning", "ret": shell_false},
@@ -1615,6 +1617,7 @@ VALID_CFG = {
     },
     "VMware-NoValidTransports": {
         "ds": "VMware",
+        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             MOCK_VIRT_IS_VMWARE,
         ],
@@ -1637,6 +1640,7 @@ VALID_CFG = {
     },
     "VMware-EnvVar-NoData": {
         "ds": "VMware",
+        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             {
                 "name": "vmware_has_envvar_vmx_guestinfo",
@@ -1746,6 +1750,7 @@ VALID_CFG = {
     },
     "VMware-GuestInfo-NoData": {
         "ds": "VMware",
+        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             {
                 "name": "vmware_has_rpctool",

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -155,6 +155,7 @@ vteratipally
 Vultaire
 waveform80
 WebSpider
+weizhouapache
 Wind-net
 wmousa
 wschoot

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -739,6 +739,9 @@ probe_floppy() {
 dscheck_CloudStack() {
     is_container && return ${DS_NOT_FOUND}
     dmi_product_name_matches "CloudStack*" && return $DS_FOUND
+    if [ "$DI_VIRT" = "vmware" ] || [ "$DI_VIRT" = "xen" ]; then
+        return $DS_MAYBE
+    fi
     return $DS_NOT_FOUND
 }
 


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: ds-identify/CloudStack: return $DS_MAYBE if vm is running on vmware/xen
```

Currently, ds-identify determines if CloudStack is supported by checking dmi product name. It works fine on KVM, as the VM has the following system information
```
System Information
	Manufacturer: Apache Software Foundation
	Product Name: CloudStack KVM Hypervisor
```

However, it does not work on VMware or XenServer/XCP-ng. For example, on VMware, the system information is
```
System Information
        Manufacturer: VMware, Inc.
        Product Name: VMware Virtual Platform
        Version: None
```

Therefore, return $DS_MAYBE instead of $DS_NOT_FOUND if vm is running on vmware/xen.

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
