### PR TITLE
Ensure get_features() grabs all features

### DIFF
--- a/cloudinit/features.py
+++ b/cloudinit/features.py
@@ -86,5 +86,5 @@ def get_features() -> Dict[str, bool]:
     return {
         k: getattr(sys.modules["cloudinit.features"], k)
         for k in sys.modules["cloudinit.features"].__dict__.keys()
-        if re.match(r"^[_A-Z]+$", k)
+        if re.match(r"^[_A-Z0-9]+$", k)
     }

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -465,6 +465,17 @@ c: 4
             init_tmp.paths.get_ipath("cloud_config"), "", 0o600
         )
 
+    # Since features are intended to be overridden downstream, mock them
+    # all here so new feature flags don't require a new change to this
+    # unit test.
+    @mock.patch.multiple(
+        "cloudinit.features",
+        ERROR_ON_USER_DATA_FAILURE=True,
+        ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES=True,
+        EXPIRE_APPLIES_TO_HASHED_USERS=False,
+        NETPLAN_CONFIG_ROOT_READ_ONLY=True,
+        NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH=False,
+    )
     def test_shellscript(self, init_tmp, tmpdir, caplog):
         """Raw text starting #!/bin/sh is treated as script."""
         script = "#!/bin/sh\necho hello\n"
@@ -490,9 +501,10 @@ c: 4
         expected = {
             "features": {
                 "ERROR_ON_USER_DATA_FAILURE": True,
-                "EXPIRE_APPLIES_TO_HASHED_USERS": True,
+                "ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES": True,
+                "EXPIRE_APPLIES_TO_HASHED_USERS": False,
                 "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
-                "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": True,
+                "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": False,
             },
             "system_info": {
                 "default_user": {"name": "ubuntu"},
@@ -503,11 +515,14 @@ c: 4
                 },
             },
         }
-        assert expected == util.load_json(
+
+        loaded_json = util.load_json(
             util.load_file(
                 init_tmp.paths.get_runpath("instance_data_sensitive")
             )
         )
+        assert expected == loaded_json
+
         expected["_doc"] = stages.COMBINED_CLOUD_CONFIG_DOC
         assert expected == util.load_json(
             util.load_file(init_tmp.paths.get_runpath("combined_cloud_config"))

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -1,5 +1,4 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-# pylint: disable=no-member,no-name-in-module
 """
 This file is for testing the feature flag functionality itself,
 NOT for testing any individual feature flag
@@ -10,21 +9,22 @@ from cloudinit import features
 
 
 class TestGetFeatures:
-    """default pytest-xdist behavior may fail due to these tests"""
-
     def test_feature_without_override(self):
-        assert {
-            "ERROR_ON_USER_DATA_FAILURE": True,
-            "EXPIRE_APPLIES_TO_HASHED_USERS": True,
-            "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
-            "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": True,
-        } == features.get_features()
-        with mock.patch.object(
-            features, "NETPLAN_CONFIG_ROOT_READ_ONLY", False
+        # Since features are intended to be overridden downstream, mock them
+        # all here so new feature flags don't require a new change to this
+        # unit test.
+        with mock.patch.multiple(
+            "cloudinit.features",
+            ERROR_ON_USER_DATA_FAILURE=True,
+            ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES=True,
+            EXPIRE_APPLIES_TO_HASHED_USERS=False,
+            NETPLAN_CONFIG_ROOT_READ_ONLY=True,
+            NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH=False,
         ):
             assert {
                 "ERROR_ON_USER_DATA_FAILURE": True,
-                "EXPIRE_APPLIES_TO_HASHED_USERS": True,
-                "NETPLAN_CONFIG_ROOT_READ_ONLY": False,
-                "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": True,
+                "ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES": True,
+                "EXPIRE_APPLIES_TO_HASHED_USERS": False,
+                "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
+                "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": False,
             } == features.get_features()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Ensure get_features() grabs all features

It was previously ignoring keys with numbers in them.

Additionally, update tests so that they don't have to be patched
downstream any time we add a new feature flag. Since the whole point
of the feature flags is to create overrides, that seems like a lot
of needless churn.
```

## Additional Context
Will replace https://github.com/canonical/cloud-init/pull/4279 if accepted.

I more-or-less duplicated the mocking code and comment. If we find we need it in more places, it should probably be refactored into a common fixture then, but for now I'm ok with 2.