### PR TITLE
collect-logs fix memory usage (SC-1590)

### DIFF
--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -144,23 +144,22 @@ def _copytree_rundir_ignore_files(curdir, files):
 
 def _write_command_output_to_file(cmd, filename, msg, verbosity):
     """Helper which runs a command and writes output or error to filename."""
-    output = ""
+    ensure_dir(os.path.dirname(filename))
     try:
-        ensure_dir(os.path.dirname(filename))
         output = subp(cmd)[0]
-        write_file(filename, output)
     except ProcessExecutionError as e:
         write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)
     else:
+        write_file(filename, output)
         _debug("collected %s\n" % msg, 1, verbosity)
         return output
 
 
 def _stream_command_output_to_file(cmd, filename, msg, verbosity):
     """Helper which runs a command and writes output or error to filename."""
+    ensure_dir(os.path.dirname(filename))
     try:
-        ensure_dir(os.path.dirname(filename))
         with open(filename, "w") as f:
             subprocess.call(cmd, stdout=f, stderr=f)
     except ProcessExecutionError as e:

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -152,7 +152,6 @@ def _write_command_output_to_file(cmd, filename, msg, verbosity):
     except ProcessExecutionError as e:
         write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)
-        return str(e)
     else:
         _debug("collected %s\n" % msg, 1, verbosity)
         return output

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -150,11 +150,13 @@ def _write_command_output_to_file(cmd, filename, msg, verbosity, return_output=F
         with open(filename, "w") as f:
             if return_output:
                 output = subp(cmd)[0]
+                f.write(output)
             else:
-                subp(cmd)
+                f.write(subp(cmd)[0])
     except ProcessExecutionError as e:
-        write_file(filename, str(e))
+        write_file(filename, output:=str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)
+        return output
     else:
         _debug("collected %s\n" % msg, 1, verbosity)
         return output

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -146,7 +146,7 @@ def _write_command_output_to_file(cmd, filename, msg, verbosity):
     """Helper which runs a command and writes output or error to filename."""
     ensure_dir(os.path.dirname(filename))
     try:
-        output = subp(cmd)[0]
+        output = subp(cmd).stdout
     except ProcessExecutionError as e:
         write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)
@@ -162,7 +162,7 @@ def _stream_command_output_to_file(cmd, filename, msg, verbosity):
     try:
         with open(filename, "w") as f:
             subprocess.call(cmd, stdout=f, stderr=f)
-    except ProcessExecutionError as e:
+    except OSError as e:
         write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)
     else:
@@ -211,7 +211,6 @@ def collect_logs(tarfile, include_userdata: bool, verbosity=0):
         return 1
     tarfile = os.path.abspath(tarfile)
     log_dir = datetime.utcnow().date().strftime("cloud-init-logs-%Y-%m-%d")
-    # def _write_command_output_to_file(cmd, filename, msg, verbosity):
     with tempdir(dir="/tmp") as tmp_dir:
         log_dir = os.path.join(tmp_dir, log_dir)
         version = _write_command_output_to_file(

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -152,9 +152,9 @@ def _write_command_output_to_file(cmd, filename, msg, verbosity):
         # f.write(output)
         write_file(filename, output)
     except ProcessExecutionError as e:
-        write_file(filename, output := str(e))
+        write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)
-        return output
+        return str(e)
     else:
         _debug("collected %s\n" % msg, 1, verbosity)
         return output
@@ -167,7 +167,7 @@ def _stream_command_output_to_file(cmd, filename, msg, verbosity):
         with open(filename, "w") as f:
             subprocess.call(cmd, stdout=f, stderr=f)
     except ProcessExecutionError as e:
-        # write_file(filename, str(e))
+        write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)
     else:
         _debug("collected %s\n" % msg, 1, verbosity)

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -19,6 +19,7 @@ from cloudinit.helpers import Paths
 from cloudinit.subp import ProcessExecutionError, subp
 from cloudinit.temp_utils import tempdir
 from cloudinit.util import chdir, copy, ensure_dir, write_file
+import subprocess
 
 CLOUDINIT_LOGS = ["/var/log/cloud-init.log", "/var/log/cloud-init-output.log"]
 CLOUDINIT_RUN_DIR = "/run/cloud-init"
@@ -141,17 +142,22 @@ def _copytree_rundir_ignore_files(curdir, files):
     return ignored_files
 
 
-def _write_command_output_to_file(cmd, filename, msg, verbosity):
+def _write_command_output_to_file(cmd, filename, msg, verbosity, return_output=False):
     """Helper which runs a command and writes output or error to filename."""
+    output = None
     try:
-        out, _ = subp(cmd)
+        ensure_dir(os.path.dirname(filename))
+        with open(filename, "w") as f:
+            if return_output:
+                output = subp(cmd)[0]
+            else:
+                subp(cmd)
     except ProcessExecutionError as e:
         write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)
     else:
-        write_file(filename, out)
         _debug("collected %s\n" % msg, 1, verbosity)
-        return out
+        return output
 
 
 def _debug(msg, level, verbosity):
@@ -196,34 +202,38 @@ def collect_logs(tarfile, include_userdata: bool, verbosity=0):
         return 1
     tarfile = os.path.abspath(tarfile)
     log_dir = datetime.utcnow().date().strftime("cloud-init-logs-%Y-%m-%d")
+    # def _write_command_output_to_file(cmd, filename, msg, verbosity):
     with tempdir(dir="/tmp") as tmp_dir:
         log_dir = os.path.join(tmp_dir, log_dir)
         version = _write_command_output_to_file(
-            ["cloud-init", "--version"],
-            os.path.join(log_dir, "version"),
-            "cloud-init --version",
-            verbosity,
+            cmd=["cloud-init", "--version"],
+            filename=os.path.join(log_dir, "version"),
+            msg="cloud-init --version",
+            verbosity=verbosity,
+            return_output=True,
         )
         dpkg_ver = _write_command_output_to_file(
-            ["dpkg-query", "--show", "-f=${Version}\n", "cloud-init"],
-            os.path.join(log_dir, "dpkg-version"),
-            "dpkg version",
-            verbosity,
+            cmd=["dpkg-query", "--show", "-f=${Version}\n", "cloud-init"],
+            filename=os.path.join(log_dir, "dpkg-version"),
+            msg="dpkg version",
+            verbosity=verbosity,
+            return_output=True,
         )
         if not version:
             version = dpkg_ver if dpkg_ver else "not-available"
+        print("version: ", version)
         _debug("collected cloud-init version: %s\n" % version, 1, verbosity)
         _write_command_output_to_file(
-            ["dmesg"],
-            os.path.join(log_dir, "dmesg.txt"),
-            "dmesg output",
-            verbosity,
+            cmd=["dmesg"],
+            filename=os.path.join(log_dir, "dmesg.txt"),
+            msg="dmesg output",
+            verbosity=verbosity,
         )
         _write_command_output_to_file(
-            ["journalctl", "--boot=0", "-o", "short-precise"],
-            os.path.join(log_dir, "journal.txt"),
-            "systemd journal of current boot",
-            verbosity,
+            cmd=["journalctl", "--boot=0", "-o", "short-precise"],
+            filename=os.path.join(log_dir, "journal.txt"),
+            msg="systemd journal of current boot",
+            verbosity=verbosity,
         )
 
         for log in CLOUDINIT_LOGS:

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -148,8 +148,6 @@ def _write_command_output_to_file(cmd, filename, msg, verbosity):
     try:
         ensure_dir(os.path.dirname(filename))
         output = subp(cmd)[0]
-        # with open(filename, "w") as f:
-        # f.write(output)
         write_file(filename, output)
     except ProcessExecutionError as e:
         write_file(filename, str(e))

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -85,7 +85,7 @@ class TestCollectLogs:
             cmd_tuple = tuple(cmd)
             if cmd_tuple not in expected_subp:
                 raise AssertionError(
-                    "Unexpected command provided to fake subprocess.call(): {0}".format(
+                    "Unexpected command provided to subprocess: {0}".format(
                         cmd
                     )
                 )
@@ -216,7 +216,7 @@ class TestCollectLogs:
         m_getuid.return_value = 100
         output_file1 = tmpdir.join("test-output-file-1.txt")
         output_file2 = tmpdir.join("test-output-file-2.txt")
-        output_file3 = tmpdir.join("test-output-file-3.txt")
+        # output_file3 = tmpdir.join("test-output-file-3.txt")
         return_output1 = logs._write_command_output_to_file(
             filename=output_file1,
             cmd=["echo", test_str_1],
@@ -251,35 +251,6 @@ class TestCollectLogs:
         # f"Stderr: ls: cannot access '{dir}': No such file or directory"
         # assert expected_err_msg == return_output3
         # assert expected_err_msg == load_file(output_file3)
-
-    # def test_write_command_output_to_file_with_return_output(self, m_getuid, tmpdir):
-    #     # what does this do???
-    #     m_getuid.return_value = 100
-    #     output_file = tmpdir.join("test-output-file.txt")
-    #     return_output = logs._write_command_output_to_file(
-    #         filename=output_file,
-    #         cmd=["echo", "test"],
-    #         msg="",
-    #         verbosity=0,
-    #         return_output=True,
-    #     )
-
-    #     assert "test\n" == return_output
-    #     assert "test\n" == load_file(output_file)
-
-    # def test_write_command_output_to_file_without_return_output(self, m_getuid, tmpdir):
-    #     # what does this do???
-    #     m_getuid.return_value = 100
-    #     output_file = tmpdir.join("test-output-file.txt")
-    #     return_output = logs._write_command_output_to_file(
-    #         filename=output_file,
-    #         cmd=["echo", "test"],
-    #         msg="",
-    #         verbosity=0,
-    #         return_output=False,
-    #     )
-    #     assert "test\n" == load_file(output_file)
-    #     assert None == return_output
 
 
 class TestCollectInstallerLogs:

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -210,7 +210,6 @@ class TestCollectLogs:
         fake_stderr.write.assert_any_call("Wrote %s\n" % output_tarfile)
 
     def test_write_command_output_to_file(self, m_getuid, tmpdir):
-        # what does this do???
         m_getuid.return_value = 100
         test_str = "cloud-init? more like cloud-innit!"
         output_file1 = tmpdir.join("test-output-file-1.txt")
@@ -244,12 +243,12 @@ class TestCollectLogs:
         assert expected_stderr == load_file(output_file2)
 
     def test_stream_command_output_to_file(self, m_getuid, tmpdir):
+        m_getuid.return_value = 100
         test_str = "cloud-init, shmoud-init"
         expected_stderr = (
             "ls: cannot access '/this-directory-does-not-exist':"
             + " No such file or directory"
         )
-        m_getuid.return_value = 100
         output_file1 = tmpdir.join("test-output-file-1.txt")
         output_file2 = tmpdir.join("test-output-file-2.txt")
         logs._stream_command_output_to_file(
@@ -266,20 +265,7 @@ class TestCollectLogs:
         )
 
         assert test_str + "\n" == load_file(output_file1)
-
-        # no output should have been returned so this value should be None
-        # assert None == return_output2
         assert expected_stderr + "\n" == load_file(output_file2)
-
-        # expected_err_msg = "Unexpected error while running command.\n" + \
-        # f"Command: ['ls', '{dir}']\n" + \
-        # "Exit code: 2\n" + \
-        # "Reason: -\n" + \
-        # "Stdout: \n" + \
-        # f"Stderr: ls: cannot access '{dir}': No such file or directory"
-        # assert expected_err_msg == return_output3
-        # assert expected_err_msg == load_file(output_file3)
-
 
 class TestCollectInstallerLogs:
     @pytest.mark.parametrize(

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -195,6 +195,83 @@ class TestCollectLogs:
         fake_stderr.write.assert_any_call("Wrote %s\n" % output_tarfile)
 
 
+    def test_write_command_output_to_file(self, m_getuid, tmpdir):
+        # what does this do???
+        test_str_1 = "test #1"
+        test_str_2 = "test #2"
+        m_getuid.return_value = 100
+        output_file1 = tmpdir.join("test-output-file-1.txt")
+        output_file2 = tmpdir.join("test-output-file-2.txt")
+        output_file3 = tmpdir.join("test-output-file-3.txt")
+        return_output1 = logs._write_command_output_to_file(
+            filename=output_file1,
+            cmd=["echo", test_str_1],
+            msg="",
+            verbosity=1,
+            return_output=True,
+        )
+        return_output2 = logs._write_command_output_to_file(
+            filename=output_file2,
+            cmd=["echo", test_str_2],
+            msg="",
+            verbosity=1,
+            return_output=False,
+        )
+        return_output3 = logs._write_command_output_to_file(
+            filename=output_file3,
+            cmd=["ls", dir:="/this-directory-does-not-exist"],
+            msg="",
+            verbosity=1,
+            return_output=True,
+        )
+
+        assert test_str_1 + "\n" == return_output1
+        assert test_str_1 + "\n" == load_file(output_file1)
+
+        # no output should have been returned so this value should be None
+        assert None == return_output2
+        assert test_str_2 + "\n" == load_file(output_file2)
+
+        expected_err_msg = "Unexpected error while running command.\n" + \
+        f"Command: ['ls', '{dir}']\n" + \
+        "Exit code: 2\n" + \
+        "Reason: -\n" + \
+        "Stdout: \n" + \
+        f"Stderr: ls: cannot access '{dir}': No such file or directory" 
+        assert expected_err_msg == return_output3
+        assert expected_err_msg == load_file(output_file3)
+
+    # def test_write_command_output_to_file_with_return_output(self, m_getuid, tmpdir):
+    #     # what does this do???
+    #     m_getuid.return_value = 100
+    #     output_file = tmpdir.join("test-output-file.txt")
+    #     return_output = logs._write_command_output_to_file(
+    #         filename=output_file,
+    #         cmd=["echo", "test"],
+    #         msg="",
+    #         verbosity=0,
+    #         return_output=True,
+    #     )
+        
+    #     assert "test\n" == return_output
+    #     assert "test\n" == load_file(output_file)
+        
+
+    # def test_write_command_output_to_file_without_return_output(self, m_getuid, tmpdir):
+    #     # what does this do???
+    #     m_getuid.return_value = 100
+    #     output_file = tmpdir.join("test-output-file.txt")
+    #     return_output = logs._write_command_output_to_file(
+    #         filename=output_file,
+    #         cmd=["echo", "test"],
+    #         msg="",
+    #         verbosity=0,
+    #         return_output=False,
+    #     )
+    #     assert "test\n" == load_file(output_file)
+    #     assert None == return_output
+
+
 class TestCollectInstallerLogs:
     @pytest.mark.parametrize(
         "include_userdata, apport_files, apport_sensitive_files",

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -10,7 +10,7 @@ import pytest
 
 from cloudinit.cmd.devel import logs
 from cloudinit.cmd.devel.logs import ApportFile
-from cloudinit.subp import subp
+from cloudinit.subp import SubpResult, subp
 from cloudinit.util import ensure_dir, load_file, write_file
 from tests.unittests.helpers import mock
 
@@ -77,7 +77,7 @@ class TestCollectLogs:
                 )
             if cmd == ["tar", "czvf", output_tarfile, date_logdir]:
                 subp(cmd)  # Pass through tar cmd so we can check output
-            return expected_subp[cmd_tuple], ""
+            return SubpResult(expected_subp[cmd_tuple], "")
 
         # the new _stream_command_output_to_file function uses subprocess.call
         # instead of subp, so we need to mock that as well
@@ -181,7 +181,7 @@ class TestCollectLogs:
                 )
             if cmd == ["tar", "czvf", output_tarfile, date_logdir]:
                 subp(cmd)  # Pass through tar cmd so we can check output
-            return expected_subp[cmd_tuple], ""
+            return SubpResult(expected_subp[cmd_tuple], "")
 
         fake_stderr = mock.MagicMock()
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
collect-logs now streams certain outputs to avoid large memory usage

_stream_command_output_to_file() was added to mimic functionality of 
_write_command_output_to_file() except instead of reading the output 
of subprocess calls into memory, it streams the outputs directly to 
the target file. this new function is used when the output of a 
subprocess call does not need to be saved into a variable.

As far as usage goes, the main difference between the two functions
is that the stream function does not return result of the subprocess
call, while the write function does.

Fixes GH-3994
LP: #1980150 
```

## Additional Context
See GitHub issue #3994 for more context on the issue this PR seeks to address.

## Test Steps
See [comment below](https://github.com/canonical/cloud-init/pull/4289#issuecomment-1664636829) for testing results and instructions to replicate / test yourself.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly

## Things left to do:
- [x] update unit tests for _write_command_output_to_file() to test that stderr outputs correctly to file 
  - [x] make any changes (if necessary) to _write_command_output_to_file() so that it handles stderr output properly
- [x] update unit tests for _stream_command_output_to_file() to test that stderr outputs correctly to file
  - [x] make any changes (if necessary) to _stream_command_output_to_file() so that it handles stderr output properly