### PR TITLE
sudoers not idempotent (SC-1589) 

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -860,6 +860,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         content += "\n"  # trailing newline
 
         self.ensure_sudo_dir(os.path.dirname(sudo_file))
+
         if not os.path.exists(sudo_file):
             contents = [
                 util.make_header(),
@@ -871,11 +872,14 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 util.logexc(LOG, "Failed to write sudoers file %s", sudo_file)
                 raise e
         else:
-            try:
-                util.append_file(sudo_file, content)
-            except IOError as e:
-                util.logexc(LOG, "Failed to append sudoers file %s", sudo_file)
-                raise e
+            if content not in util.load_file(sudo_file):
+                try:
+                    util.append_file(sudo_file, content)
+                except IOError as e:
+                    util.logexc(
+                        LOG, "Failed to append to sudoers file %s", sudo_file
+                    )
+                    raise e
 
     def create_group(self, name, members=None):
         group_add_cmd = ["groupadd", name]

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -123,7 +123,9 @@ def test_sudoers_includedir(client: IntegrationInstance):
     """
     client.execute("sed -i 's/#include/@include/g' /etc/sudoers")
 
-    sudoers_content_before = client.read_from_file("/etc/sudoers.d/90-cloud-init-users").splitlines()[1:]
+    sudoers_content_before = client.read_from_file(
+        "/etc/sudoers.d/90-cloud-init-users"
+    ).splitlines()[1:]
     sudoers = client.read_from_file("/etc/sudoers")
     if "@includedir /etc/sudoers.d" not in sudoers:
         client.execute("echo '@includedir /etc/sudoers.d' >> /etc/sudoers")
@@ -134,5 +136,7 @@ def test_sudoers_includedir(client: IntegrationInstance):
     assert "#includedir" not in sudoers
     assert sudoers.count("includedir /etc/sudoers.d") == 1
 
-    sudoers_content_after = client.read_from_file("/etc/sudoers.d/90-cloud-init-users").splitlines()[1:]
+    sudoers_content_after = client.read_from_file(
+        "/etc/sudoers.d/90-cloud-init-users"
+    ).splitlines()[1:]
     assert sudoers_content_before == sudoers_content_after

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -123,6 +123,7 @@ def test_sudoers_includedir(client: IntegrationInstance):
     """
     client.execute("sed -i 's/#include/@include/g' /etc/sudoers")
 
+    sudoers_content_before = client.read_from_file("/etc/sudoers.d/90-cloud-init-users").splitlines()[1:]
     sudoers = client.read_from_file("/etc/sudoers")
     if "@includedir /etc/sudoers.d" not in sudoers:
         client.execute("echo '@includedir /etc/sudoers.d' >> /etc/sudoers")
@@ -132,3 +133,6 @@ def test_sudoers_includedir(client: IntegrationInstance):
 
     assert "#includedir" not in sudoers
     assert sudoers.count("includedir /etc/sudoers.d") == 1
+
+    sudoers_content_after = client.read_from_file("/etc/sudoers.d/90-cloud-init-users").splitlines()[1:]
+    assert sudoers_content_before == sudoers_content_after

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -68,7 +68,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         d.write_sudo_rules("harlowja", rules)
         contents = util.load_file(d.ci_sudoers_fn)
-        return contents
+        return contents, cls, d
 
     def _count_in(self, lines_look_for, text_content):
         found_amount = 0
@@ -81,7 +81,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
 
     def test_sudoers_ensure_rules(self):
         rules = "ALL=(ALL:ALL) ALL"
-        contents = self._write_load_sudoers("harlowja", rules)
+        contents = self._write_load_sudoers("harlowja", rules)[0]
         expected = ["harlowja ALL=(ALL:ALL) ALL"]
         self.assertEqual(len(expected), self._count_in(expected, contents))
         not_expected = [
@@ -97,7 +97,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
             "B-ALL=(ALL:ALL) ALL",
             "C-ALL=(ALL:ALL) ALL",
         ]
-        contents = self._write_load_sudoers("harlowja", rules)
+        contents = self._write_load_sudoers("harlowja", rules)[0]
         expected = [
             "harlowja ALL=(ALL:ALL) ALL",
             "harlowja B-ALL=(ALL:ALL) ALL",
@@ -117,14 +117,8 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
             "B-ALL=(ALL:ALL) ALL",
             "C-ALL=(ALL:ALL) ALL",
         ]
-        cls = distros.fetch("ubuntu")
-        d = cls("ubuntu", {}, None)
-        os.makedirs(os.path.join(self.tmp, "etc"))
-        os.makedirs(os.path.join(self.tmp, "etc", "sudoers.d"))
-        self.patchOS(self.tmp)
-        self.patchUtils(self.tmp)
-        d.write_sudo_rules("harlowja", rules)
-        # do it again - should not create duplicate rules for same user
+        d = self._write_load_sudoers("harlowja", rules)[2]
+        # write to sudoers again - should not create duplicate rules
         d.write_sudo_rules("harlowja", rules)
         contents = util.load_file(d.ci_sudoers_fn)
         expected = [
@@ -132,7 +126,6 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
             "harlowja B-ALL=(ALL:ALL) ALL",
             "harlowja C-ALL=(ALL:ALL) ALL",
         ]
-        # if duplicates handled properly, there should be only 3 matching rules, not 6
         self.assertEqual(len(expected), self._count_in(expected, contents))
         not_expected = [
             "harlowja A",


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
full re-runs will no longer write duplicate rules to sudoers file

Rerunning cloud-init would always append sudoer rules to the
sudoers file without checking if the rules already existed first.
This is no longer the case - only unique rules not already found
in the sudoers file will be added to it.

Fixes GH-4048 
LP: #1998539
```

## Additional Context
This change maintains the current functionality of only adding rules to the sudoers file without checking for old rules that
should be removed.   
Adding functionality for doing so should probably be addressed in a future ticket. 
See issue #4048 for more context on the bug this ticket is addressing.

## Test Steps
### To replicate duplication bug: 
- Launch an LXD container using any cloud-init source that isnt this branch with the following cloud-config:
```
#cloud-config for SC-1589
groups:
  - admingroup: [root,sys]
  - cloud-users
users:
  - default
  - name: foobar
    gecos: Foo B. Bar
    primary_group: foobar
    groups: users
    expiredate: '2032-09-01'
    passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
  - name: barfoo
    gecos: Bar B. Foo
    sudo: ALL=(ALL) NOPASSWD:ALL
    groups: users, admin
    lock_passwd: true
  - name: fizzbuzz
    sudo: false
    shell: /bin/bash
```
- Shell into the container and run the following command to fully rerun cloud init:
```
cloud-init clean --logs; cloud-init init --local; cloud-init init; cloud-init modules --mode=config; cloud-init modules --mode=final; cloud-init status --wait --long;
```
- Look at the sudoers file to see the duplicate rules (`cat /etc/sudoers.d/90-cloud-init-users`) and it should look like:
```
# Created by cloud-init v. ________________________________________

# User rules for barfoo
barfoo ALL=(ALL) NOPASSWD:ALL

# User rules for ubuntu
ubuntu ALL=(ALL) NOPASSWD:ALL

# User rules for barfoo
barfoo ALL=(ALL) NOPASSWD:ALL

# User rules for ubuntu
ubuntu ALL=(ALL) NOPASSWD:ALL
```

### To see new changes that prevent duplication bug from occurring:
- Launch an LXD container using this branch as the source cloud-init with the same cloud-config from above
- Follow all the same steps from above but this time when you peek at the sudoers file, there should be no duplicate rules and it should look like:
```
# Created by cloud-init v. ________________________________________

# User rules for barfoo
barfoo ALL=(ALL) NOPASSWD:ALL

# User rules for ubuntu
ubuntu ALL=(ALL) NOPASSWD:ALL
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
