### PR TITLE
Fix test_tools.py collection

### DIFF
--- a/tools/test_tools.py
+++ b/tools/test_tools.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 import setuptools
 
+
 from setup_utils import version_to_pep440
 
 try:
@@ -14,7 +15,8 @@ try:
 except AttributeError:
     pytest.skip(
         "Unable to import necessary setuptools utilities. "
-        "Version is likely too old."
+        "Version is likely too old.",
+        allow_module_level=True,
     )
 
 # Since read-version has a '-' and no .py extension, we have to do this

--- a/tox.ini
+++ b/tox.ini
@@ -267,7 +267,7 @@ commands = {envpython} -m pytest -vv \
 	{posargs:tests/integration_tests}
 deps =
     -r{toxinidir}/integration-requirements.txt
-passenv = 
+passenv =
     CLOUD_INIT_*
     PYCLOUDLIB_*
     SSH_AUTH_SOCK
@@ -276,7 +276,7 @@ passenv =
 [testenv:integration-tests-ci]
 commands = {[testenv:integration-tests]commands}
 deps = {[testenv:integration-tests]deps}
-passenv = 
+passenv =
     CLOUD_INIT_*
     SSH_AUTH_SOCK
     OS_*
@@ -290,7 +290,7 @@ setenv =
 allowlist_externals = sh
 commands = sh -c "{envpython} -m pytest --log-cli-level=INFO -vv {posargs:tests/integration_tests/none} || [ $? -eq 1 ]"
 deps = {[testenv:integration-tests]deps}
-passenv = 
+passenv =
     *_proxy
     CLOUD_INIT_*
     PYCLOUDLIB_*
@@ -311,7 +311,7 @@ per-file-ignores =
 
 [pytest]
 # TODO: s/--strict/--strict-markers/ once pytest version is high enough
-testpaths = tests/unittests tools
+testpaths = tools tests/unittests
 addopts = --strict
 log_format = %(asctime)s %(levelname)-9s %(name)s:%(filename)s:%(lineno)d %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix test_tools.py collection

When required setuptools functions are not available, we skip running
the module. Doing this requires specifying `allow_module_level=True`,
which we were not doing before.
```
