### PR TITLE
Undocument nocloud-net

### DIFF
--- a/doc/examples/seed/README
+++ b/doc/examples/seed/README
@@ -3,11 +3,8 @@ This directory is an example of a 'seed' directory.
 
 copying these files inside an instance's
   /var/lib/cloud/seed/nocloud
-or
-  /var/lib/cloud/seed/nocloud-net
 
-will cause the 'DataSourceNoCloud' and 'DataSourceNoCloudNet' modules
-to enable and read the given data.
+will cause the 'DataSourceNoCloud' module to enable and read the given data.
 
 The directory must have both files.
 

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -39,7 +39,7 @@ In a similar fashion, configuration files can be provided to cloud-init using a
 custom webserver at a URL dictated by kernel commandline arguments or SMBIOS
 serial number. This argument might look like: ::
 
-  ds=nocloud-net;s=http://10.42.42.42/cloud-init/configs/
+  ds=nocloud;s=http://10.42.42.42/cloud-init/configs/
 
 .. note::
    When supplementing kernel parameters in GRUB's boot menu take care to single-quote this full value to avoid GRUB interpreting the semi-colon as a reserved word. See: `GRUB quoting`_
@@ -121,7 +121,7 @@ wanted.
 
 For example, you can pass this option to QEMU: ::
 
-  -smbios type=1,serial=ds=nocloud-net;s=http://10.10.0.1:8000/__dmi.chassis-serial-number__/
+  -smbios type=1,serial=ds=nocloud;s=http://10.10.0.1:8000/__dmi.chassis-serial-number__/
 
 This will cause NoCloud to fetch the full metadata from a URL based on
 YOUR_SERIAL_NUMBER as seen in :file:`/sys/class/dmi/id/chassis_serial_number`

--- a/doc/rtd/tutorial/qemu-script.sh
+++ b/doc/rtd/tutorial/qemu-script.sh
@@ -38,7 +38,7 @@ qemu-system-x86_64                                              \
     -m 512                                                      \
     -nographic                                                  \
     -hda jammy-server-cloudimg-amd64.img                        \
-    -smbios type=1,serial=ds='nocloud-net;s=http://10.0.2.2:8000/'
+    -smbios type=1,serial=ds='nocloud;s=http://10.0.2.2:8000/'
 
 echo -e "\nTo reuse the image and config files, start the python webserver and "
 echo -e "virtual machine from $(pwd), which contains these files:\n$(ls -1)\n"

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -208,7 +208,7 @@ take a few moments to complete.
         -m 512                                                      \
         -nographic                                                  \
         -hda jammy-server-cloudimg-amd64.img                        \
-        -smbios type=1,serial=ds='nocloud-net;s=http://10.0.2.2:8000/'
+        -smbios type=1,serial=ds='nocloud;s=http://10.0.2.2:8000/'
 
 .. note::
    If the output stopped scrolling but you don't see a prompt yet, press
@@ -228,7 +228,7 @@ boot Ubuntu, which already has ``cloud-init`` installed.
 
 The second line tells ``cloud-init`` where it can find user data, using the
 :ref:`NoCloud datasource<datasource_nocloud>`. During boot, ``cloud-init``
-checks the ``SMBIOS`` serial number for ``ds=nocloud-net``. If found,
+checks the ``SMBIOS`` serial number for ``ds=nocloud``. If found,
 ``cloud-init`` will use the specified URL to source its user data config files.
 
 In this case, we use the default gateway of the virtual machine (``10.0.2.2``)


### PR DESCRIPTION
```
Undocument nocloud-net

In f146fe cloud-init developed capability to
automatically determine nocloud mode. Remove
documentation related to nocloud-net since this
is no longer a necessary argument and may
confuse users during debugging.
```

Should probably deprecate use of this key too, to allow eventual code cleanup, but that can be a separate PR.