### PR TITLE
cc_mounts: Fix swapfile not works on btrfs

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -317,6 +317,10 @@ def create_swapfile(fname: str, size: str) -> None:
 
     fstype = util.get_mount_info(swap_dir)[1]
 
+    if fstype == "btrfs":
+        subp.subp(["truncate", "-s", "0", fname])
+        subp.subp(["chattr", "+C", fname])
+
     if (
         fstype == "xfs" and util.kernel_version() < (4, 18)
     ) or fstype == "btrfs":

--- a/tests/unittests/config/test_cc_mounts.py
+++ b/tests/unittests/config/test_cc_mounts.py
@@ -304,6 +304,8 @@ class TestSwapFileCreation(test_helpers.FilesystemMockingTestCase):
         cc_mounts.handle(None, self.cc, self.mock_cloud, [])
         self.m_subp_subp.assert_has_calls(
             [
+                mock.call(["truncate", "-s", "0", self.swap_path]),
+                mock.call(["chattr", "+C", self.swap_path]),
                 mock.call(
                     [
                         "dd",

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -18,6 +18,7 @@ bdrung
 beantaxi
 beezly
 berolinux
+bin456789
 bipinbachhao
 BirknerAlex
 bmhughes


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_mounts: Fix swapfile not works on btrfs

To make a swapfile works on btrfs
We need to create an empty file, add "no copy-on-write" attribute
before turn it into swapfile

Fixes GH-3713
LP: #1884127
```

## Additional Context
https://btrfs.readthedocs.io/en/latest/Swapfile.html

## Test Steps
    tox  -- tests/unittests/config/test_cc_mounts.py::TestSwapFileCreation::test_swap_creation_method_btrfs
    tests/unittests/config/test_cc_mounts.py::TestSwapFileCreation::test_swap_creation_method_btrfs PASSED [100%]

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly

