### PR TITLE
Fix KeyError when handling users.0.uid in schema.py

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -605,7 +605,8 @@ class _Annotator:
                 errors_by_line[int(line)].append(msg)
             else:
                 col = None
-                errors_by_line[self._schemamarks[path]].append(msg)
+                if path in self._schemamarks:
+                    errors_by_line[self._schemamarks[path]].append(msg)
             if col is not None:
                 msg = "Line {line} column {col}: {msg}".format(
                     line=line, col=col, msg=msg


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Fix KeyError when executing `$ cloud-init schema -c ./ud.yaml --annotate` with a string uid.

The message "Changed in version 22.3. The use of the `string` type is deprecated.
Use an `integer` instead." was not handled for the `--annotate` argv. 
To handle it, now it checks if the `self._schemamarks` dict has the key 
before appending the message to `errors_by_line[self._schemamarks[path]]`.

Fixes GH-4305
```


