### PR TITLE
check whether old version is empty in postinst

### DIFF
--- a/debian/cloud-init.postinst
+++ b/debian/cloud-init.postinst
@@ -230,6 +230,10 @@ disable_network_config_on_upgrade() {
         # this is a fresh system not one that has been booted.
         return 0
     fi
+    if [ -z $oldver ];then
+        # if the previous cloudinit was installed by source instead of a deb pkg, oldver would be empty
+        return 0
+    fi
     if dpkg --compare-versions "$oldver" le "$last_without_net"; then
         echo "dpkg upgrade from $oldver" > /var/lib/cloud/data/upgraded-network
     fi

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -76,6 +76,7 @@ jordimassaguerpla
 jqueuniet
 jsf9k
 jshen28
+jinkkkang
 kadiron
 kaiwalyakoparkar
 kallioli


### PR DESCRIPTION
## check whether old version is empty in postinst
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: check whether old version is empty in postinst

The /var/lib/cloud/data/upgraded-network file touched after apt install cloudinit in
instance of cloud-init installed by source instead of deb pkg, add check  to determine whether the old version is empty during installation

LP: #2012044
```
