### PR TITLE
[WIP] Feature/imds parallelization

### DIFF
--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -17,7 +17,7 @@ from cloudinit.sources import DataSourceHostname
 
 LOG = logging.getLogger(__name__)
 
-MD_V1_URL = "http://metadata.google.internal/computeMetadata/v1/"
+MD_V1_URL = "http://metadata.google.internal/computeMetadata/v1"
 BUILTIN_DS_CONFIG = {"metadata_url": MD_V1_URL}
 REQUIRED_FIELDS = ("instance-id", "availability-zone", "local-hostname")
 GUEST_ATTRIBUTES_URL = (
@@ -282,23 +282,21 @@ def read_md(address=None, url_params=None, platform_check=True):
         return ret
 
     # url_map: (our-key, path, required, is_text, is_recursive)
-#    url_map = [
-#        ("instance-id", ("instance/id",), True, True, False),
-#        ("availability-zone", ("instance/zone",), True, True, False),
-#        ("local-hostname", ("instance/hostname",), True, True, False),
-#        ("instance-data", ("instance/attributes",), False, False, True),
-#        ("project-data", ("project/attributes",), False, False, True),
-#    ]
+    #    url_map = [
+    #        ("instance-id", ("instance/id",), True, True, False),
+    #        ("availability-zone", ("instance/zone",), True, True, False),
+    #        ("local-hostname", ("instance/hostname",), True, True, False),
+    #        ("instance-data", ("instance/attributes",), False, False, True),
+    #        ("project-data", ("project/attributes",), False, False, True),
+    #    ]
     url_map = {
         "instance": {
             "id": ("instance-id", True),
             "zone": ("availability-zone", True),
             "hostname": ("local-hostname", True),
-            "attributes": ("instance-data", False)
+            "attributes": ("instance-data", False),
         },
-        "project": {
-            "attributes": ("project-data", False)
-        }
+        "project": {"attributes": ("project-data", False)},
     }
     metadata_fetcher = GoogleMetadataFetcher(
         address, url_params.num_retries, url_params.sec_between_retries
@@ -311,28 +309,33 @@ def read_md(address=None, url_params=None, platform_check=True):
         value = json_data.get(top_level_key)
         for second_level_key in url_map[top_level_key]:
             (mkey, required) = url_map[top_level_key][second_level_key]
+            new_value = None
             if value is not None and second_level_key in value:
                 new_value = value[second_level_key]
                 md[mkey] = new_value
-            if required and value is None:
+            if required and new_value is None:
                 msg = "required key %s returned nothing. not GCE"
                 ret["reason"] = msg % mkey
                 return ret
 
-#    for (mkey, paths, required, is_text, is_recursive) in url_map:
-#        value = None
-#        for path in paths:
-#            new_value = metadata_fetcher.get_value(path, is_text, is_recursive)
-#            if new_value is not None:
-#                value = new_value
-#        if required and value is None:
-#            msg = "required key %s returned nothing. not GCE"
-#            ret["reason"] = msg % mkey
-#            return ret
-#        md[mkey] = value
+    #    for (mkey, paths, required, is_text, is_recursive) in url_map:
+    #        value = None
+    #        for path in paths:
+    #            new_value = metadata_fetcher.get_value(path, is_text, is_recursive)
+    #            if new_value is not None:
+    #                value = new_value
+    #        if required and value is None:
+    #            msg = "required key %s returned nothing. not GCE"
+    #            ret["reason"] = msg % mkey
+    #            return ret
+    #        md[mkey] = value
 
-    instance_data = md.get("instance-data", {}) #json.loads(md["instance-data"] or "{}")
-    project_data = md.get("project-data", {}) #json.loads(md["project-data"] or "{}")
+    instance_data = md.get(
+        "instance-data", {}
+    )  # json.loads(md["instance-data"] or "{}")
+    project_data = md.get(
+        "project-data", {}
+    )  # json.loads(md["project-data"] or "{}")
     valid_keys = [instance_data.get("sshKeys"), instance_data.get("ssh-keys")]
     block_project = instance_data.get("block-project-ssh-keys", "").lower()
     if block_project != "true" and not instance_data.get("sshKeys"):

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -24,6 +24,7 @@ bmhughes
 brianphaley
 CalvoM
 candlerb
+catmsred
 cawamata
 cclauss
 chifac08


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
perf!: refactor GCE IMDS query to pull all data

In order to improve boot speed, I am looking into parallelizing the IMDS
queries using GCE as my test environment.  This required a refactor of the
structure of how the results of the query are coming back (since we are
sending only one call to the IMDS and then parsing the resulting structures).

This PR is a work in progress -- when testing my changes I came across
several tox tests failing because of JSON parsing errors on bytestrings.
I am trying to understand the expected format of IMDS responses so I can
correctly construct them for the tests/ensure that my JSON parsing is
correctly allocated between actual code and mocks.

Currently failing tests are: 
tests/unittests/sources/test_gce.py::TestDataSourceGCE::test_metadata
tests/unittests/sources/test_gce.py::TestDataSourceGCE::test_missing_required_keys_return_false
tests/unittests/sources/test_gce.py::TestDataSourceGCE::test_no_ssh_keys_metadata
tests/unittests/sources/test_gce.py::TestDataSourceGCE::test_only_last_part_of_zone_used_for_availability_zone
```

## Test Steps
All the tests are failing on the same error as follows:

```
____________________________________________________ TestDataSourceGCE.test_metadata ____________________________________________________

self = <tests.unittests.sources.test_gce.TestDataSourceGCE testMethod=test_metadata>

    def test_metadata(self):
        # UnicodeDecodeError if set to ds.userdata instead of userdata_raw
        meta = GCE_META.copy()
        meta["instance"]["attributes"] = { "user-data": b"/bin/echo \xff\n" }
    
        self._set_mock_metadata()
>       self.ds.get_data()

meta       = {'instance': {'attributes': {'user-data': b'/bin/echo \xff\n'},
              'hostname': 'server.project-foo.local',
              'id': '123',
              'zone': 'foo/bar'}}
self       = <tests.unittests.sources.test_gce.TestDataSourceGCE testMethod=test_metadata>

tests/unittests/sources/test_gce.py:158: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cloudinit/sources/__init__.py:442: in get_data
    return_value = self._check_and_get_data()
        self       = <cloudinit.sources.DataSourceGCE.DataSourceGCE object at 0x7fbd6c311b90>
cloudinit/sources/__init__.py:374: in _check_and_get_data
    return self._get_data()
        self       = <cloudinit.sources.DataSourceGCE.DataSourceGCE object at 0x7fbd6c311b90>
cloudinit/sources/DataSourceGCE.py:136: in _get_data
    ret = util.log_time(
        self       = <cloudinit.sources.DataSourceGCE.DataSourceGCE object at 0x7fbd6c311b90>
        url_params = URLParams(max_wait_seconds=-1, timeout_seconds=10, num_retries=5, sec_between_retries=1)
cloudinit/util.py:2821: in log_time
    ret = func(*args, **kwargs)
        args       = []
        delta      = 0.0005643367767333984
        func       = <function read_md at 0x7fbd80af23e0>
        get_uptime = False
        kwargs     = {'address': 'http://metadata.google.internal/computeMetadata/v1/',
 'url_params': URLParams(max_wait_seconds=-1, timeout_seconds=10, num_retries=5, sec_between_retries=1)}
        logfunc    = <bound method Logger.debug of <Logger cloudinit.sources.DataSourceGCE (NOTSET)>>
        msg        = 'Crawl of GCE metadata service'
        start      = 1691157759.1573243
        tmsg       = ' took 0.001 seconds'
        udelta     = None
        ustart     = None
cloudinit/sources/DataSourceGCE.py:308: in read_md
    string_data = metadata_fetcher.get_value("", False, True)
        address    = 'http://metadata.google.internal/computeMetadata/v1/'
        md         = {}
        metadata_fetcher = <cloudinit.sources.DataSourceGCE.GoogleMetadataFetcher object at 0x7fbd6c310310>
        platform_check = True
        ret        = {'meta-data': None,
 'platform_reports_gce': True,
 'reason': None,
 'success': False,
 'user-data': None}
        url_map    = {'instance': {'attributes': ('instance-data', False),
              'hostname': ('local-hostname', True),
              'id': ('instance-id', True),
              'zone': ('availability-zone', True)},
 'project': {'attributes': ('project-data', False)}}
        url_params = URLParams(max_wait_seconds=-1, timeout_seconds=10, num_retries=5, sec_between_retries=1)
cloudinit/sources/DataSourceGCE.py:44: in get_value
    resp = url_helper.readurl(
        is_recursive = True
        is_text    = False
        path       = ''
        self       = <cloudinit.sources.DataSourceGCE.GoogleMetadataFetcher object at 0x7fbd6c310310>
        url        = 'http://metadata.google.internal/computeMetadata/v1//?recursive=True'
        value      = None
cloudinit/url_helper.py:317: in readurl
    r = sess.request(**req_args)
        _cb        = <function readurl.<locals>._cb at 0x7fbd6c446160>
        allow_redirects = True
        check_status = True
        data       = None
        def_headers = {'Metadata-Flavor': 'Google', 'User-Agent': 'Cloud-Init/23.2.2'}
        exception_cb = None
        excps      = []
        filtered_req_args = {'allow_redirects': True,
 'headers': {'Metadata-Flavor': 'Google', 'User-Agent': 'Cloud-Init/23.2.2'},
 'method': 'GET',
 'stream': False,
 'url': 'http://metadata.google.internal/computeMetadata/v1//?recursive=True'}
        headers    = {'Metadata-Flavor': 'Google', 'User-Agent': 'Cloud-Init/23.2.2'}
        headers_cb = <function readurl.<locals>._cb at 0x7fbd6c446160>
        headers_redact = []
        i          = 0
        infinite   = False
        k          = 'headers'
        log_req_resp = True
        manual_tries = 6
        req_args   = {'allow_redirects': True,
 'headers': {'Metadata-Flavor': 'Google', 'User-Agent': 'Cloud-Init/23.2.2'},
 'method': 'GET',
 'stream': False,
 'url': 'http://metadata.google.internal/computeMetadata/v1//?recursive=True'}
        request_method = 'GET'
        retries    = 5
        sec_between = 1
        sess       = <requests.sessions.Session object at 0x7fbd6c31fd50>
        session    = <requests.sessions.Session object at 0x7fbd6c31fd50>
        ssl_details = None
        stream     = False
        timeout    = None
        url        = 'http://metadata.google.internal/computeMetadata/v1//?recursive=True'
        v          = {'Metadata-Flavor': 'Google', 'User-Agent': 'Cloud-Init/23.2.2'}
.tox/py3/lib/python3.11/site-packages/requests/sessions.py:589: in request
    resp = self.send(prep, **send_kwargs)
        allow_redirects = True
        auth       = None
        cert       = None
        cookies    = None
        data       = None
        files      = None
        headers    = {'Metadata-Flavor': 'Google', 'User-Agent': 'Cloud-Init/23.2.2'}
        hooks      = None
        json       = None
        method     = 'GET'
        params     = None
        prep       = <PreparedRequest [GET]>
        proxies    = {}
        req        = <Request [GET]>
        self       = <requests.sessions.Session object at 0x7fbd6c31fd50>
        send_kwargs = {'allow_redirects': True,
 'cert': None,
 'proxies': OrderedDict(),
 'stream': False,
 'timeout': None,
 'verify': True}
        settings   = {'cert': None, 'proxies': OrderedDict(), 'stream': False, 'verify': True}
        stream     = False
        timeout    = None
        url        = 'http://metadata.google.internal/computeMetadata/v1//?recursive=True'
        verify     = None
.tox/py3/lib/python3.11/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
        adapter    = <requests.adapters.HTTPAdapter object at 0x7fbd6c31c7d0>
        allow_redirects = True
        hooks      = {'response': []}
        kwargs     = {'cert': None,
 'proxies': OrderedDict(),
 'stream': False,
 'timeout': None,
 'verify': True}
        request    = <PreparedRequest [GET]>
        self       = <requests.sessions.Session object at 0x7fbd6c31fd50>
        start      = 1691157759.1578164
        stream     = False
.tox/py3/lib/python3.11/site-packages/responses/__init__.py:1127: in send
    return self._on_request(adapter, request, **kwargs)
        adapter    = <requests.adapters.HTTPAdapter object at 0x7fbd6c31c7d0>
        args       = ()
        kwargs     = {'cert': None,
 'proxies': OrderedDict(),
 'stream': False,
 'timeout': None,
 'verify': True}
        request    = <PreparedRequest [GET]>
        self       = <tests.unittests.helpers.CiRequestsMock object at 0x7fbd6c310390>
.tox/py3/lib/python3.11/site-packages/responses/__init__.py:1064: in _on_request
    request, match.get_response(request)
        adapter    = <requests.adapters.HTTPAdapter object at 0x7fbd6c31c7d0>
        kwargs     = {'cert': None,
 'proxies': OrderedDict(),
 'stream': False,
 'timeout': None,
 'verify': True}
        match      = <responses.CallbackResponse object at 0x7fbd6c3118d0>
        match_failed_reasons = []
        request    = <PreparedRequest [GET]>
        request_url = 'http://metadata.google.internal/computeMetadata/v1//?recursive=True'
        resp_callback = None
        retries    = None
        self       = <tests.unittests.helpers.CiRequestsMock object at 0x7fbd6c310390>
.tox/py3/lib/python3.11/site-packages/responses/__init__.py:633: in get_response
    result = self.callback(request)
        headers    = HTTPHeaderDict({'Content-Type': 'text/plain'})
        request    = <PreparedRequest [GET]>
        self       = <responses.CallbackResponse object at 0x7fbd6c3118d0>
tests/unittests/sources/test_gce.py:136: in _request_callback
    response = json.dumps(decode_gce_meta)
        _decode_obj = <function TestDataSourceGCE._set_mock_metadata.<locals>._decode_obj at 0x7fbd6c45ccc0>
        check_headers = None
        decode_gce_meta = {'instance': {'attributes': {'user-data': b'/bin/echo \xff\n'},
              'hostname': 'server.project-foo.local',
              'id': '123',
              'zone': 'foo/bar'}}
        gce_meta   = {'instance': {'attributes': {'user-data': b'/bin/echo \xff\n'},
              'hostname': 'server.project-foo.local',
              'id': '123',
              'zone': 'foo/bar'}}
        path       = ''
        recursive  = True
        request    = <PreparedRequest [GET]>
        self       = <tests.unittests.sources.test_gce.TestDataSourceGCE testMethod=test_metadata>
        url_path   = '/computeMetadata/v1//'
/usr/lib/python3.11/json/__init__.py:231: in dumps
    return _default_encoder.encode(obj)
        allow_nan  = True
        check_circular = True
        cls        = None
        default    = None
        ensure_ascii = True
        indent     = None
        kw         = {}
        obj        = {'instance': {'attributes': {'user-data': b'/bin/echo \xff\n'},
              'hostname': 'server.project-foo.local',
              'id': '123',
              'zone': 'foo/bar'}}
        separators = None
        skipkeys   = False
        sort_keys  = False
/usr/lib/python3.11/json/encoder.py:200: in encode
    chunks = self.iterencode(o, _one_shot=True)
        o          = {'instance': {'attributes': {'user-data': b'/bin/echo \xff\n'},
              'hostname': 'server.project-foo.local',
              'id': '123',
              'zone': 'foo/bar'}}
        self       = <json.encoder.JSONEncoder object at 0x7fbd841215d0>
/usr/lib/python3.11/json/encoder.py:258: in iterencode
    return _iterencode(o, 0)
        _encoder   = <built-in function encode_basestring_ascii>
        _iterencode = <_json.Encoder object at 0x7fbd7f89cfa0>
        _one_shot  = True
        floatstr   = <function JSONEncoder.iterencode.<locals>.floatstr at 0x7fbd6c444ae0>
        markers    = {140451540746816: {'instance': {'attributes': {'user-data': b'/bin/echo \xff\n'},
                                'hostname': 'server.project-foo.local',
                                'id': '123',
                                'zone': 'foo/bar'}},
 140451540815296: {'user-data': b'/bin/echo \xff\n'},
 140451881481344: b'/bin/echo \xff\n',
 140451881552640: {'attributes': {'user-data': b'/bin/echo \xff\n'},
                   'hostname': 'server.project-foo.local',
                   'id': '123',
                   'zone': 'foo/bar'}}
        o          = {'instance': {'attributes': {'user-data': b'/bin/echo \xff\n'},
              'hostname': 'server.project-foo.local',
              'id': '123',
              'zone': 'foo/bar'}}
        self       = <json.encoder.JSONEncoder object at 0x7fbd841215d0>
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <json.encoder.JSONEncoder object at 0x7fbd841215d0>, o = b'/bin/echo \xff\n'

    def default(self, o):
        """Implement this method in a subclass such that it returns
        a serializable object for ``o``, or calls the base implementation
        (to raise a ``TypeError``).
    
        For example, to support arbitrary iterators, you could
        implement default like this::
    
            def default(self, o):
                try:
                    iterable = iter(o)
                except TypeError:
                    pass
                else:
                    return list(iterable)
                # Let the base class default method raise the TypeError
                return JSONEncoder.default(self, o)
    
        """
>       raise TypeError(f'Object of type {o.__class__.__name__} '
                        f'is not JSON serializable')
E       TypeError: Object of type bytes is not JSON serializable

o          = b'/bin/echo \xff\n'
self       = <json.encoder.JSONEncoder object at 0x7fbd841215d0>

/usr/lib/python3.11/json/encoder.py:180: TypeError
```

For these tests, there are instance attributes of user-data that is a bytestring eg
`meta["instance"]["attributes"] = { "user-data": b"/bin/echo \xff\n" }` which is the
problematic change.  Originally this line would have been:
`meta["instance/attributes/user-data"] = b"/bin/echo \xff\n"` but that has been
change for the mock due the fact taht requesting the entire dataset in one
query should return a larger JSON object.  I'm not sure how the mock should
be structured and whether we would expect proper JSON (no bytestring),
bytestring for userdata in the JSON object, or the entire JSON object stringified
as a bytestring.  Any insight into these structures would be appreciated, thanks!

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
