### PR TITLE
unittests: fix breakage in test_read_cfg_paths_fetches_cached_datasource

### DIFF
--- a/tests/unittests/cmd/devel/test_init.py
+++ b/tests/unittests/cmd/devel/test_init.py
@@ -19,7 +19,7 @@ class TestReadCfgPaths:
                 restore.return_value = FakeDataSource(paths=init.paths)
                 with mock.patch(
                     "cloudinit.util.read_conf_from_cmdline", return_value={}
-                ):
+                ), mock.patch("cloudinit.util.read_conf", return_value={}):
                     m_init.return_value = init
                     paths = read_cfg_paths()
                     assert paths.get_ipath() is None


### PR DESCRIPTION
Fix the following breakage in `tests/unittests/cmd/devel/test_init.py ::TestReadCfgPaths::test_read_cfg_paths_fetches_cached_datasource`:

`PermissionError: [Errno 13] Permission denied: '/run/cloud-init/cloud.cfg'`

```
    def load_file(fname, read_cb=None, quiet=False, decode=True):
        LOG.debug("Reading from %s (quiet=%s)", fname, quiet)
        ofh = io.BytesIO()
        try:
>           with open(fname, "rb") as ifh:
E           PermissionError: [Errno 13] Permission denied: '/run/cloud-init/cloud.cfg'

decode     = True
fname      = '/run/cloud-init/cloud.cfg'
ofh        = <_io.BytesIO object at 0xffff9683bf10>
quiet      = False
read_cb    = None

cloudinit/util.py:1564: PermissionError

```
