### PR TITLE
net: fix ipv6_dhcpv6_stateful configuration for rhel

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -439,10 +439,11 @@ class Renderer(renderer.Renderer):
                 elif (
                     flavor == "rhel" and subnet_type == "ipv6_dhcpv6-stateful"
                 ):
-                    iface_cfg["BOOTPROTO"] = "dhcp"
+                    iface_cfg["BOOTPROTO"] = "none"
                     iface_cfg["DHCPV6C"] = True
                     iface_cfg["IPV6INIT"] = True
                     iface_cfg["IPV6_AUTOCONF"] = False
+                    iface_cfg["IPV6_FAILURE_FATAL"] = True
                 else:
                     iface_cfg["IPV6INIT"] = True
                     # Configure network settings using DHCPv6

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -2091,11 +2091,12 @@ NETWORK_CONFIGS = {
         "expected_sysconfig_rhel": {
             "ifcfg-iface0": textwrap.dedent(
                 """\
-            BOOTPROTO=dhcp
+            BOOTPROTO=none
             DEVICE=iface0
             DHCPV6C=yes
             IPV6INIT=yes
             IPV6_AUTOCONF=no
+            IPV6_FAILURE_FATAL=yes
             IPV6_FORCE_ACCEPT_RA=yes
             DEVICE=iface0
             NM_CONTROLLED=no


### PR DESCRIPTION
When network type is ipv6_dhcpv6-stateful, cloud-init seems to enable dhcp for both ipv4 and ipv6. Network manager prefers dhcp over ipv4 and hence dhcp6 is not used to obtain the IP address. This is incorrect. For ipv6_dhcpv6-stateful networks, we should set:

```
ipv4.method = disabled // disables all ipv4 dhcp
ipv6.method = dhcp
ipv6.may-fail = no // dhcp6 must succeed.
```
For ifcfg files (sysconfig renderer), the corresponding changes should be:
```
BOOTPROTO = none // instead of dhcp so that dhcp4 is disabled. 
IPV6_FAILURE_FATAL = yes // so that dhcp6 should succeed.
```
This patch fixes this. This patch has been tested by Red Hat QE and it seems to fix the above issue.

RHBZ: 2227767
fixes: f550c8765ca03d ("Adding BOOTPROTO = dhcp to render sysconfig dhcp6 stateful on RHEL (#685)")
