### PR TITLE
cc_mounts: xfs is a Linux only FS

### DIFF
--- a/tests/unittests/config/test_cc_mounts.py
+++ b/tests/unittests/config/test_cc_mounts.py
@@ -340,7 +340,6 @@ class TestSwapFileCreation(test_helpers.FilesystemMockingTestCase):
 
 
 class TestFstabHandling(test_helpers.FilesystemMockingTestCase):
-
     swap_path = "/dev/sdb1"
 
     def setUp(self):
@@ -504,13 +503,17 @@ class TestCreateSwapfile:
     @pytest.mark.parametrize("fstype", ("xfs", "btrfs", "ext4", "other"))
     @mock.patch(M_PATH + "util.get_mount_info")
     @mock.patch(M_PATH + "subp.subp")
-    def test_happy_path(self, m_subp, m_get_mount_info, fstype, tmpdir):
+    @mock.patch(M_PATH + "util.kernel_version")
+    def test_happy_path(
+        self, m_kernel_version, m_subp, m_get_mount_info, fstype, tmpdir
+    ):
         swap_file = tmpdir.join("swap-file")
         fname = str(swap_file)
 
         # Some of the calls to subp.subp should create the swap file; this
         # roughly approximates that
         m_subp.side_effect = lambda *args, **kwargs: swap_file.write("")
+        m_kernel_version.return_value = (4, 31)
 
         m_get_mount_info.return_value = (mock.ANY, fstype)
 
@@ -629,6 +632,3 @@ class TestMountsSchema:
         else:
             with pytest.raises(SchemaValidationError, match=error_msg):
                 validate_cloudconfig_schema(config, get_schema(), strict=True)
-
-
-# vi: ts=4 expandtab


### PR DESCRIPTION
## Proposed Commit Message
```
cc_mounts: xfs is a Linux only FS

reflect this in the test, by mocking the kernel_version every time.

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
run unittests on FreeBSD
apply this patch
see one less (if only slightly different) failure
(baby steps.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
