### PR TITLE
tests/net: fix TestGetInterfaces' mock coverage for get_master

### DIFF
--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -7880,6 +7880,7 @@ class TestGetInterfaces(CiTestCase):
             "eth1": "aa:aa:aa:aa:aa:01",
             "tun0": None,
         },
+        "masters": {},
         "drivers": {
             "enp0s1": "virtio_net",
             "enp0s2": "e1000",
@@ -7907,6 +7908,9 @@ class TestGetInterfaces(CiTestCase):
     def _se_get_interface_mac(self, name):
         return self.data["macs"][name]
 
+    def _se_get_master(self, name):
+        return self.data["masters"].get(name)
+
     def _se_is_bridge(self, name):
         return name in self.data["bridges"]
 
@@ -7928,6 +7932,7 @@ class TestGetInterfaces(CiTestCase):
         mocks = (
             "get_devicelist",
             "get_interface_mac",
+            "get_master",
             "is_bridge",
             "interface_has_own_mac",
             "is_vlan",


### PR DESCRIPTION
get_master() was checking against system's sysfs which may cause failures when the mocked interface conflicted with real one.