### PR TITLE
Ubuntu/lunar: Fix removing the unused network manager hook

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,8 @@
 cloud-init (23.2-0ubuntu0~23.04.2) UNRELEASED; urgency=medium
 
   * Upstream snapshot based on upstream/main at ee9078a7.
-  * d/cloud-init.maintscript: Remove the unused hook-network-manager conffile
+  * d/cloud-init.maintscript: Remove the unused hook-network-manager
+    conffile. (LP: #2027861)
   * d/patches/retain-old-groups.patch:
     - Retain original groups in cloud.cfg.tmpl
   * d/control: Add python3-passlib as needed for testing

--- a/debian/cloud-init.maintscript
+++ b/debian/cloud-init.maintscript
@@ -6,4 +6,4 @@ rm_conffile /etc/init/cloud-init-local.conf 0.7.9-243-ge74d775-0ubuntu2~
 rm_conffile /etc/init/cloud-init-nonet.conf 0.7.9-243-ge74d775-0ubuntu2~
 rm_conffile /etc/init/cloud-init.conf 0.7.9-243-ge74d775-0ubuntu2~
 rm_conffile /etc/init/cloud-log-shutdown.conf 0.7.9-243-ge74d775-0ubuntu2~
-rm_conffile /etc/NetworkManager/dispatcher.d/hook-network-manager 23.2.1-0ubuntu0~
+rm_conffile /etc/NetworkManager/dispatcher.d/hook-network-manager 23.3-0ubuntu0~23.04.1~


### PR DESCRIPTION
DO NOT SQUASH

When publishing packaging changes to `ubuntu/devel`, I got sponsor feedback that our `rm_conffile` should target the version being prepared rather than any previous version (see the man page quoted in the commit message). Additionally, we should include the LP number for the change.

If this get's a +1, I'll push the same changes for focal and bionic.