### PR TITLE
analyze: fix (unexpected) timestamp parsing

### DIFF
--- a/tests/unittests/analyze/test_dump.py
+++ b/tests/unittests/analyze/test_dump.py
@@ -11,7 +11,7 @@ from cloudinit.analyze.dump import (
     parse_timestamp,
 )
 from cloudinit.subp import which
-from cloudinit.util import write_file
+from cloudinit.util import is_Linux, write_file
 from tests.unittests.helpers import mock, skipIf
 
 
@@ -44,7 +44,11 @@ class TestParseTimestamp:
         assert float(dt.strftime("%s.%f")) == parse_timestamp(journal_stamp)
 
     @skipIf(not which("date"), "'date' command not available.")
-    @pytest.mark.allow_subp_for("date")
+    @skipIf(
+        not is_Linux() and not which("gdate"),
+        "'GNU date' command not available.",
+    )
+    @pytest.mark.allow_subp_for("date", "gdate")
     def test_parse_unexpected_timestamp_format_with_date_command(self):
         """Dump sends unexpected timestamp formats to date for processing."""
         new_fmt = "%H:%M %m/%d %Y"


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
analyze: fix (unexpected) timestamp parsing

In case of very unexpected timestamps, we pass them on to date.
Unfortunately, only GNU date is able to perform this level of deduction
(guess work).

Rework the code and tests to look for GNU date on non-Linux platforms.
Only fail, and loudly! if GNU date cannot be found.

This patch (partially)

fixes GH-4333

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
