### PR TITLE
util.get_proc*: Fix tests on non-Linux systems

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3117,9 +3117,9 @@ def udevadm_settle(exists=None, timeout=None):
     return subp.subp(settle_cmd)
 
 
-def get_proc_ppid(pid):
+def get_proc_ppid_linux(pid):
     """
-    Return the parent pid of a process.
+    Return the parent pid of a process by parsing /proc/$pid/stat.
     """
     ppid = 0
     try:
@@ -3138,6 +3138,24 @@ def get_proc_ppid(pid):
     except IOError as e:
         LOG.warning("Failed to load /proc/%s/stat. %s", pid, e)
     return ppid
+
+
+def get_proc_ppid_ps(pid):
+    """
+    Return the parent pid of a process by checking ps
+    """
+    ppid, _ = subp.subp(["ps", "-oppid=", "-p", str(pid)])
+    return int(ppid.strip())
+
+
+def get_proc_ppid(pid):
+    """
+    Return the parent pid of a process.
+    """
+    if is_Linux():
+        return get_proc_ppid_linux(pid)
+    else:
+        return get_proc_ppid_ps(pid)
 
 
 def error(msg, rc=1, fmt="Error:\n{}", sys_exit=False):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -27,7 +27,7 @@ from cloudinit.helpers import Paths
 from cloudinit.sources import DataSourceHostname
 from cloudinit.subp import SubpResult
 from tests.unittests import helpers
-from tests.unittests.helpers import CiTestCase, skipUnlessJinja
+from tests.unittests.helpers import CiTestCase, skipIf, skipUnlessJinja
 
 LOG = logging.getLogger(__name__)
 M_PATH = "cloudinit.util."
@@ -2728,6 +2728,9 @@ class TestLoadShellContent(helpers.TestCase):
         )
 
 
+@skipIf(
+    not util.is_Linux(), "These tests don't make sense on non-Linux systems."
+)
 class TestGetProcEnv(helpers.TestCase):
     """test get_proc_env."""
 
@@ -2791,13 +2794,32 @@ class TestGetProcEnv(helpers.TestCase):
         self.assertEqual({}, util.get_proc_env(1))
         self.assertEqual(1, m_load_file.call_count)
 
-    def test_get_proc_ppid(self):
+
+class TestGetProcPpid(helpers.TestCase):
+    """test get_proc_ppid"""
+
+    @skipIf(not util.is_Linux(), "/proc/$pid/stat is not useful on not-Linux")
+    @mock.patch(M_PATH + "is_Linux")
+    def test_get_proc_ppid_linux(self, m_is_Linux):
         """get_proc_ppid returns correct parent pid value."""
+        m_is_Linux.return_value = True
         my_pid = os.getpid()
         my_ppid = os.getppid()
         self.assertEqual(my_ppid, util.get_proc_ppid(my_pid))
 
-    def test_get_proc_ppid_mocked(self):
+    @pytest.mark.allow_subp_for("ps")
+    @mock.patch(M_PATH + "is_Linux")
+    def test_get_proc_ppid_ps(self, m_is_Linux):
+        """get_proc_ppid returns correct parent pid value."""
+        m_is_Linux.return_value = False
+        my_pid = os.getpid()
+        my_ppid = os.getppid()
+        self.assertEqual(my_ppid, util.get_proc_ppid(my_pid))
+
+    @mock.patch(M_PATH + "is_Linux")
+    def test_get_proc_ppid_mocked(self, m_is_Linux):
+        m_is_Linux.return_value = True
+
         for ppid, proc_data in (
             (
                 0,


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
util.get_proc*: Fix tests on non-Linux systems

`/proc/$pid/environ` and `/proc/$pid/stat` don't exist on BSD.
procfs on BSDs is highly limited, and its use very discouraged.

While FreeBSD has procstat(1), which could reasonably read a process
environment, that use-case in the code is Linux specific and doesn't map
on FreeBSD.

Guard get_proc_env() tests with is_Linux().
The code already mostly uses this as a fallback, when all else fails.

implement get_proc_ppid() with `ps(1)`.
This should work on most platforms that have `ps(1)`.

Sponsored by: The FreeBSD Foundation

Fixes: GH-4332
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
