### PR TITLE
cmd/clean: fix tests on non-Linux platforms

### DIFF
--- a/tests/unittests/cmd/test_clean.py
+++ b/tests/unittests/cmd/test_clean.py
@@ -77,7 +77,7 @@ class TestClean:
         ensure_dir(clean_paths.clean_dir)
         assert artifact_file.exists() is False, f"Unexpected {artifact_file}"
         clean_script = clean_paths.clean_dir.join("1.sh")
-        clean_script.write(f"#!/bin/bash\ntouch {artifact_file}\n")
+        clean_script.write(f"#!/bin/sh\ntouch {artifact_file}\n")
         clean_script.chmod(mode=0o755)
         with mock.patch.object(
             cloudinit.settings, "CLEAN_RUNPARTS_DIR", clean_paths.clean_dir


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cmd/clean: fix tests on non-Linux platforms

change clean_script to use `#!/bin/sh` which is guaranteed to exist on
pretty much any Unix (like) system, unlike `/bin/bash`, which could be
anywhere in the PATH.

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
