### PR TITLE
Bump pycloudlib to 1!5.1.0

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib==1!3.0.2
+pycloudlib==1!5.1.0
 
 # Await pytest > 7.3.2. Breaking change in `testpaths` treatment forced
 # test/unittests/conftest.py to be loaded by our integration-tests tox env

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -96,7 +96,7 @@ class IntegrationCloud(ABC):
                 raise
 
     def _perform_launch(
-        self, *, wait=True, launch_kwargs, **kwargs
+        self, *, launch_kwargs, wait=True, **kwargs
     ) -> BaseInstance:
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
         self._maybe_wait(pycloudlib_instance, wait)
@@ -197,7 +197,7 @@ class Ec2Cloud(IntegrationCloud):
         )
 
     def _perform_launch(
-        self, *, wait=True, launch_kwargs, **kwargs
+        self, *, launch_kwargs, wait=True, **kwargs
     ) -> EC2Instance:
         """Use a dual-stack VPC for cloud-init integration testing."""
         if "vpc" not in launch_kwargs:
@@ -305,7 +305,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
             subp(command.split())
 
     def _perform_launch(
-        self, *, wait=True, launch_kwargs, **kwargs
+        self, *, launch_kwargs, wait=True, **kwargs
     ) -> LXDInstance:
         instance_kwargs = deepcopy(launch_kwargs)
         instance_kwargs["inst_type"] = instance_kwargs.pop(

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -21,6 +21,7 @@ from pycloudlib import (
     Openstack,
 )
 from pycloudlib.cloud import BaseCloud, ImageType
+from pycloudlib.ec2.instance import EC2Instance
 from pycloudlib.lxd.cloud import _BaseLXD
 from pycloudlib.lxd.instance import BaseInstance, LXDInstance
 
@@ -86,13 +87,25 @@ class IntegrationCloud(ABC):
             CURRENT_RELEASE.series, **kwargs
         )
 
-    def _perform_launch(self, launch_kwargs, **kwargs) -> BaseInstance:
+    def _maybe_wait(self, pycloudlib_instance, wait):
+        if wait:
+            try:
+                pycloudlib_instance.wait()
+            except Exception:
+                pycloudlib_instance.delete()
+                raise
+
+    def _perform_launch(
+        self, *, wait=True, launch_kwargs, **kwargs
+    ) -> BaseInstance:
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
+        self._maybe_wait(pycloudlib_instance, wait)
         return pycloudlib_instance
 
     def launch(
         self,
         user_data=None,
+        wait=True,
         launch_kwargs=None,
         settings=integration_settings,
         **kwargs,
@@ -129,10 +142,12 @@ class IntegrationCloud(ABC):
         )
 
         with emit_dots_on_travis():
-            pycloudlib_instance = self._perform_launch(launch_kwargs, **kwargs)
+            pycloudlib_instance = self._perform_launch(
+                wait=wait, launch_kwargs=launch_kwargs, **kwargs
+            )
         log.info("Launched instance: %s", pycloudlib_instance)
         instance = self.get_instance(pycloudlib_instance, settings)
-        if launch_kwargs.get("wait", True):
+        if wait:
             # If we aren't waiting, we can't rely on command execution here
             log.info(
                 "cloud-init version: %s",
@@ -149,7 +164,7 @@ class IntegrationCloud(ABC):
         return IntegrationInstance(self, cloud_instance, settings)
 
     def destroy(self):
-        pass
+        self.cloud_instance.clean()
 
     def snapshot(self, instance):
         return self.cloud_instance.snapshot(instance, clean=True)
@@ -181,7 +196,9 @@ class Ec2Cloud(IntegrationCloud):
             image_type=self._image_type, **kwargs
         )
 
-    def _perform_launch(self, launch_kwargs, **kwargs):
+    def _perform_launch(
+        self, *, wait=True, launch_kwargs, **kwargs
+    ) -> EC2Instance:
         """Use a dual-stack VPC for cloud-init integration testing."""
         if "vpc" not in launch_kwargs:
             launch_kwargs["vpc"] = self.cloud_instance.get_or_create_vpc(
@@ -196,6 +213,7 @@ class Ec2Cloud(IntegrationCloud):
             launch_kwargs["MetadataOptions"] = {"HttpProtocolIpv6": "enabled"}
 
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
+        self._maybe_wait(pycloudlib_instance, wait)
         return pycloudlib_instance
 
 
@@ -267,7 +285,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
                 "/etc/cloud/templates",
             ),
         ]
-        for (n, (source_path, target_path)) in enumerate(mounts):
+        for n, (source_path, target_path) in enumerate(mounts):
             format_variables = {
                 "name": instance.name,
                 "source_path": os.path.realpath(source_path),
@@ -286,12 +304,13 @@ class _LxdIntegrationCloud(IntegrationCloud):
             ).format(**format_variables)
             subp(command.split())
 
-    def _perform_launch(self, launch_kwargs, **kwargs):
+    def _perform_launch(
+        self, *, wait=True, launch_kwargs, **kwargs
+    ) -> LXDInstance:
         instance_kwargs = deepcopy(launch_kwargs)
         instance_kwargs["inst_type"] = instance_kwargs.pop(
             "instance_type", None
         )
-        wait = instance_kwargs.pop("wait", True)
         release = instance_kwargs.pop("image_id")
 
         try:

--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -28,14 +28,14 @@ def test_wait_when_no_datasource(session_cloud: IntegrationCloud, setup_image):
     LP: #1966085
     """
     with session_cloud.launch(
+        wait=False,
         launch_kwargs={
             # On Jammy and above, we detect the LXD datasource using a
             # socket available to the container. This prevents the socket
             # from being exposed in the container, causing datasource detection
             # to fail. ds-identify will then have failed to detect a datasource
             "config_dict": {"security.devlxd": False},
-            "wait": False,  # to prevent cloud-init status --wait
-        }
+        },
     ) as client:
         # We know this will be an LXD instance due to our pytest mark
         client.instance.execute_via_ssh = False  # pyright: ignore

--- a/tests/integration_tests/modules/test_power_state_change.py
+++ b/tests/integration_tests/modules/test_power_state_change.py
@@ -74,7 +74,7 @@ class TestPowerChange:
             user_data=USER_DATA.format(
                 delay=delay, mode=mode, timeout=timeout, condition="true"
             ),
-            launch_kwargs={"wait": False},
+            wait=False,
         ) as instance:
             if mode == "reboot":
                 _detect_reboot(instance)

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -112,6 +112,7 @@ def test_lxd_datasource_kernel_override_nocloud_net(
     _key, _, url_val = seed_url.partition("=")
     source = get_validated_source(session_cloud)
     with session_cloud.launch(
+        wait=False,  # to prevent cloud-init status --wait
         launch_kwargs={
             # On Jammy and above, we detect the LXD datasource using a
             # socket available to the container. This prevents the socket
@@ -119,8 +120,7 @@ def test_lxd_datasource_kernel_override_nocloud_net(
             # This allows us to wait for detection in 'init' stage with
             # DataSourceNoCloudNet.
             "config_dict": {"security.devlxd": False},
-            "wait": False,  # to prevent cloud-init status --wait
-        }
+        },
     ) as client:
         # We know this will be an LXD instance due to our pytest mark
         client.instance.execute_via_ssh = False  # pyright: ignore


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Bump pycloudlib to 1!5.1.0

1!5.0.0 removed 'wait' on launch along with a cloud 'clean' method, so
update our integration testing code appropriately.
```

## Additional Context
Required by #4324

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
