### PR TITLE
subp: Fix spurious test failure on FreeBSD

### DIFF
--- a/tests/unittests/test_subp.py
+++ b/tests/unittests/test_subp.py
@@ -16,7 +16,6 @@ BOGUS_COMMAND = "this-is-not-expected-to-be-a-program-name"
 
 
 class TestPrependBaseCommands(CiTestCase):
-
     with_logs = True
 
     def test_prepend_base_command_errors_on_neither_string_nor_list(self):
@@ -239,6 +238,7 @@ class TestSubp(CiTestCase):
             capture=True,
             combine_capture=True,
             decode=False,
+            env={"LANG": "C"},
             data=data,
         )
         self.assertEqual(b"", err)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
subp: Fix spurious test failure on FreeBSD

Fix a test failure that only seemed to occur when running the full test
suite. Probably due to something not being cleaned up properly.

This adds an env={"LANG": "C"} to simplify the test execution, and makes
the failure go away.

Sponsored by: The FreeBSD Foundation

Fixes: GH-4354
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
