### PR TITLE
apt: fix cloud-init status --wait blocking on systemd v 253

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -242,6 +242,13 @@ def apply_apt(cfg, cloud, target):
             template_params=params,
             aa_repo_match=matcher,
         )
+    # GH: 4344 - stop gpg-agent/dirmgr daemons spawned by gpg key imports.
+    # Daemons spawned by cloud-config.service on systemd v253 report (running)
+    subp.subp(
+        ["gpgconf", "--kill", "all"],
+        target=target,
+        capture=True,
+    )
 
 
 def debconf_set_selections(selections, target=None):

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -29,3 +29,5 @@ def test_gpg_no_tty(client: IntegrationInstance):
         "Imported key 'E4D304DF' from keyserver 'keyserver.ubuntu.com'",
     ]
     verify_ordered_items_in_text(to_verify, log)
+    result = client.execute("systemctl status cloud-config.service")
+    assert "CGroup" not in result.stdout


### PR DESCRIPTION
## Proposed Commit Message

```
apt: fix cloud-init status --wait blocking on systemd v 253

When user-data defines apt: config to setup repos with GPG keyids,
GPG spawns a two background daemons gpg-agent and dirmngr for the
root user.

In systemd 253 and later, systemd will report the systemd
unit as SubState=running instead of SubState=exited. This results in
cloud-init status --wait blocking indefinitely despite the fact that
the cloud-config.service StatusErrno=0 and Result=success.

While the SubState=running doesn't block systemd proceeding to any
units/services declared `After=cloud-config.service` it does block
cloud-init status --wait which will affect external tools/utilities
which may be waiting for cloud-init to complete initial system
configuration.

Rather than altering cloud-init status --wait to observe the
conditions StatusErrno=0 and Result=success, it makes sense for
cc_apt_configure to teardown the gpg-agent and dirmngr daemon cleanly
with gpgconf --kill all as cloud-init shouldn't be leaving around the
daemons which can immediately be spawned automatically on demand by
any subsequent gpg invocation.

Fixes: GH-4344
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
./tools/run-container --package ubuntu/mantic
cp cloud-init_*ddeb_all.deb cloud-init-bddeb.deb
CLOUD_INIT_OS_IMAGE=mantic CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init-bddeb.deb tox -e integration-tests tests/integration_tests/bugs/test_lp1813396.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
