### PR TITLE
read-version: fallback to get_version when git describe fails

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -2,7 +2,7 @@ doc8
 furo
 m2r2
 pyyaml
-sphinx
+sphinx==7.1.2
 sphinx-design
 sphinx-copybutton
 sphinx-notfound-page

--- a/tools/read-version
+++ b/tools/read-version
@@ -89,7 +89,12 @@ def get_version_from_git(
                 version = tiny_p(cmd).strip()
                 version_long = tiny_p(cmd + ["--long"]).strip()
             except subprocess.CalledProcessError as e:
-                if "No tags can describe" not in e.stderr:
+                if not any(
+                    [
+                        "No tags can describe" in e.stderr,
+                        "cannot describe anything" in e.stderr,
+                    ]
+                ):
                     raise
                 version = src_version
                 version_long = ""


### PR DESCRIPTION
## Proposed Commit Message
```
read-version: fallback to get_version when git describe fails

Annotated git tags are not present in shallow git clones. In shallow
clones, git describe may fail with exit 128 with one of the following
errors:
 - No tags can describe <hash>
 - No names found, cannot describe anything

If either message is present, fallback to
cloudinit.version.version_string.

This fixes readthedocs CI builds which may use git clone --depth 1 in
Annotated git tags are not present in shallow git clones. In shallow
clones, git describe may fail with exit 128 with one of the following
errors:
 - No tags can describe <hash>
 - No names found, cannot describe anything

If either message is present, fallback to
cloudinit.version.version_string.

Also pin sphinx=7.1.2 as the release 7.2.0 on  August 17 dropped the
extension setup_js_tag_helper used by our sphinx builds.

This fixes readthedocs CI builds which may use git clone --depth 1 in
the doc build process.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
