### PR TITLE
test: provide puppet agent --onetime to avoid blocking daemon

### DIFF
--- a/tests/integration_tests/modules/test_puppet.py
+++ b/tests/integration_tests/modules/test_puppet.py
@@ -32,13 +32,13 @@ puppet:
   install: true
   install_type: packages
   exec: true
-  exec_args: ['--noop']
+  exec_args: ['--noop', '--onetime']
 """
 
 
 @pytest.mark.user_data
 @pytest.mark.user_data(EXEC_DATA)
-def test_pupet_exec(client: IntegrationInstance):
+def test_puppet_exec(client: IntegrationInstance):
     """Basic test that puppet gets installed and runs."""
     log = client.read_from_file("/var/log/cloud-init.log")
-    assert "Running command ['puppet', 'agent', '--noop']" in log
+    assert "Running command ['puppet', 'agent', '--noop', '--onetime']" in log


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
test: provide puppet agent --onetime to avoid blocking daemon

test_puppet invokes puppet agent --noop which spawns puppet agent as a daemon which lives after cloud-final.service exits. Systemd v253 will report SubState=running in this case which indefinitely blocks cloud-init status --wait.

Avoid leaving that daemon around by passing --onetime which will force the puppet agent to exit once it has run.
```

## Additional Context
<!-- If relevant -->
Jenkins job hitting 10 hour timeout on `cloud-init status --wait` due to puppet agent as background process not exiting
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-lxd_container/50/console

## Test Steps
```
# make sure the integration test doesn't block indefinitely on cloud-init status --wait
CLOUD_INIT_OS_IMAGE=mantic tox -e integration-tests tests/integration_tests/modules/test_puppet.py
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
