### PR TITLE
cc_mounts: Use fallocate to create swapfile on btrfs

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -321,9 +321,7 @@ def create_swapfile(fname: str, size: str) -> None:
         subp.subp(["truncate", "-s", "0", fname])
         subp.subp(["chattr", "+C", fname])
 
-    if (
-        fstype == "xfs" and util.kernel_version() < (4, 18)
-    ) or fstype == "btrfs":
+    if fstype == "xfs" and util.kernel_version() < (4, 18):
         create_swap(fname, size, "dd")
     else:
         try:

--- a/tests/unittests/config/test_cc_mounts.py
+++ b/tests/unittests/config/test_cc_mounts.py
@@ -307,13 +307,7 @@ class TestSwapFileCreation(test_helpers.FilesystemMockingTestCase):
                 mock.call(["truncate", "-s", "0", self.swap_path]),
                 mock.call(["chattr", "+C", self.swap_path]),
                 mock.call(
-                    [
-                        "dd",
-                        "if=/dev/zero",
-                        "of=" + self.swap_path,
-                        "bs=1M",
-                        "count=0",
-                    ],
+                    ["fallocate", "-l", "0M", self.swap_path],
                     capture=True,
                 ),
                 mock.call(["mkswap", self.swap_path]),


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_mounts: Use fallocate to create swapfile on btrfs

Swapfile works fine with fallocate on btrfs.
Btrfs official document also use fallocate instead of dd.

See https://btrfs.readthedocs.io/en/latest/Swapfile.html
```
## Additional Context
https://btrfs.readthedocs.io/en/latest/Swapfile.html

## Test Steps
```
tox -- tests/unittests/config/test_cc_mounts.py::TestSwapFileCreation::test_swap_creation_method_btrfs
tests/unittests/config/test_cc_mounts.py::TestSwapFileCreation::test_swap_creation_method_btrfs PASSED [100%]
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
