### PR TITLE
feat(akamai): add akamai to settings.py and apport.py

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -29,6 +29,7 @@ except ImportError:
 KNOWN_CLOUD_NAMES = [
     "AliYun",
     "AltCloud",
+    "Akamai",
     "Amazon - Ec2",
     "Azure",
     "Bigstep",

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -48,6 +48,7 @@ CFG_BUILTIN = {
         "UpCloud",
         "VMware",
         "NWCS",
+        "Akamai",
         # At the end to act as a 'catch' when none of the above work...
         "None",
     ],

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from cloudinit import importer, settings, sources, type_utils
 from cloudinit.sources import DataSource
+from cloudinit.sources import DataSourceAkamai as Akamai
 from cloudinit.sources import DataSourceAliYun as AliYun
 from cloudinit.sources import DataSourceAltCloud as AltCloud
 from cloudinit.sources import DataSourceAzure as Azure
@@ -56,6 +57,7 @@ DEFAULT_LOCAL = [
     UpCloud.DataSourceUpCloudLocal,
     VMware.DataSourceVMware,
     NWCS.DataSourceNWCS,
+    Akamai.DataSourceAkamaiLocal,
 ]
 
 DEFAULT_NETWORK = [
@@ -72,6 +74,7 @@ DEFAULT_NETWORK = [
     OpenStack.DataSourceOpenStack,
     OVF.DataSourceOVFNet,
     UpCloud.DataSourceUpCloud,
+    Akamai.DataSourceAkamai,
     VMware.DataSourceVMware,
 ]
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
fix(akamai): add akamai ds to settings.py and apport.py

Fixes GH-4362
```

## Additional Context
<!-- If relevant -->
Adding some missing things from https://github.com/canonical/cloud-init/pull/4167

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
