### PR TITLE
azure/imds: increase read-timeout to 30s

### DIFF
--- a/cloudinit/sources/azure/imds.py
+++ b/cloudinit/sources/azure/imds.py
@@ -94,7 +94,7 @@ def _fetch_url(
     *,
     retry_deadline: float,
     log_response: bool = True,
-    timeout: int = 2,
+    timeout: int = 30,
 ) -> bytes:
     """Fetch URL from IMDS.
 
@@ -194,7 +194,7 @@ def fetch_reprovision_data() -> bytes:
         headers={"Metadata": "true"},
         infinite=True,
         log_req_resp=False,
-        timeout=2,
+        timeout=30,
     )
 
     report_diagnostic_event(

--- a/tests/unittests/sources/azure/test_imds.py
+++ b/tests/unittests/sources/azure/test_imds.py
@@ -76,7 +76,7 @@ class TestFetchMetadataWithApiFallback:
         "http://169.254.169.254/metadata/instance?api-version=2019-06-01"
     )
     headers = {"Metadata": "true"}
-    timeout = 2
+    timeout = 30
 
     @pytest.mark.parametrize("retry_deadline", [0.0, 1.0, 60.0])
     def test_basic(
@@ -488,7 +488,7 @@ class TestFetchReprovisionData:
         "reprovisiondata?api-version=2019-06-01"
     )
     headers = {"Metadata": "true"}
-    timeout = 2
+    timeout = 30
 
     def test_basic(
         self,

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3660,7 +3660,7 @@ class TestProvisioning:
             mock.call(
                 "http://169.254.169.254/metadata/instance?"
                 "api-version=2021-08-01&extended=true",
-                timeout=2,
+                timeout=30,
                 headers={"Metadata": "true"},
                 exception_cb=mock.ANY,
                 infinite=True,
@@ -3737,7 +3737,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/reprovisiondata?"
@@ -3746,7 +3746,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 log_req_resp=False,
                 infinite=True,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/instance?"
@@ -3755,7 +3755,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
         ]
 
@@ -3850,7 +3850,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/instance?"
@@ -3859,7 +3859,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/reprovisiondata?"
@@ -3868,7 +3868,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 log_req_resp=False,
                 infinite=True,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/instance?"
@@ -3877,7 +3877,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
         ]
 
@@ -4010,7 +4010,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/instance?"
@@ -4019,7 +4019,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/reprovisiondata?"
@@ -4028,7 +4028,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=False,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/instance?"
@@ -4037,7 +4037,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
         ]
 
@@ -4124,7 +4124,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/reprovisiondata?"
@@ -4133,7 +4133,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=False,
-                timeout=2,
+                timeout=30,
             ),
             mock.call(
                 "http://169.254.169.254/metadata/instance?"
@@ -4142,7 +4142,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
         ]
 
@@ -4249,7 +4249,7 @@ class TestProvisioning:
                 headers={"Metadata": "true"},
                 infinite=True,
                 log_req_resp=True,
-                timeout=2,
+                timeout=30,
             ),
         ]
 


### PR DESCRIPTION
When fetching metadata or reprovisiondata, allow up to 30 seconds for a read timeout.  For cases where a read request is delayed, this would eliminate extra follow-up request(s).
