### PR TITLE
status: treat SubState=running and MainPID=0 as service exited

### DIFF
--- a/tests/integration_tests/modules/test_puppet.py
+++ b/tests/integration_tests/modules/test_puppet.py
@@ -38,7 +38,7 @@ puppet:
 
 @pytest.mark.user_data
 @pytest.mark.user_data(EXEC_DATA)
-def test_pupet_exec(client: IntegrationInstance):
+def test_puppet_exec(client: IntegrationInstance):
     """Basic test that puppet gets installed and runs."""
     log = client.read_from_file("/var/log/cloud-init.log")
     assert "Running command ['puppet', 'agent', '--noop']" in log


### PR DESCRIPTION
b## Proposed Commit Message
```
status: treat SubState=running and MainPID=0 as service exited

Avoid cloud-init status --wait blocking indefinitely on systemd
status SubState=running and MainPID=0 condition for cloud-init
systemd services.

When daemons are spawned by a systemd unit
in the unified heirarchy, long-lived processes or daemons launched by
the systemd unit will be tracked in the CGroup/slice.
As long as spawned daemons of processes live, the systemd tooling will
report the parent systemd unit as SubState=running instead of
SubState=exited.

This affected Ubuntu across the 23.04 -> 23.10 release boundary
because a long-term patch to ignore cgroup status was dropped at
systemd 252.5 which last existed in Ubuntu 23.04 (Lunar).

Cloud-init status --wait checks MainPID == 0 when SubState=running
as a secondary indicator the the executing process of the boot
stage has completed despite any forked daemons.

Additionally fix typo in puppet integration test name.

Fixes GH-4373
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
# Make pkg from this branch
./tools/run-container --package ubuntu/mantic
# Run puppet integration test and expect it to pass with the deb built from this branch
CLOUD_INIT_OS_IMAGE=mantic CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_23.2-109-g259cb588-1~bddeb_all.deb tox -e integration-tests ./tests/integration_tests/modules/test_puppet.py
```


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
