### PR TITLE
update ntp custom config documentation #4166

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1903,7 +1903,7 @@
                 },
                 "template": {
                   "type": "string",
-                  "description": "Inline template allowing users to customize their `ntp_client` configuration with the use of the Jinja templating engine. The template should start with '## template:jinja'. Within the template, you can utilize the following parameters:\n- servers: A list of strings, each specifying an NTP server. When defined, entries will be rendered as 'server [server_name] iburst'. Defaults to an empty list.\n- pools: A list of strings, each specifying an NTP pool. When defined, entries will be rendered as 'pool [pool_name] iburst'. Defaults to an empty list.\n- allow: A list of strings, each specifying a network or CIDR. When defined, entries will be rendered as 'allow [CIDR]'. Defaults to an empty list.\n- peers: A list of nodes that should peer with each other. When defined, entries will be rendered as 'peer [peer_name]'. Defaults to an empty list.\nFor more information on Jinja templates and syntax, refer to the official documentation: [Jinja Template Documentation](https://jinja.palletsprojects.com/en/2.9.x/templates/)"
+                  "description": "Inline template allowing users to customize their ``ntp_client`` configuration with the use of the Jinja templating engine.\nThe template content should start with ``## template:jinja``.\nWithin the template, you can utilize any of the following ntp module config keys: ``servers``, ``pools``, ``allow``, and ``peers``.\nEach cc_ntp schema config key and expected value type is defined above."
                 }
               }
             }

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1903,7 +1903,7 @@
                 },
                 "template": {
                   "type": "string",
-                  "description": "Inline template allowing users to define their\nown ``ntp_client`` configuration template.\nThe value must start with '## template:jinja'\nto enable use of templating support.\n"
+                  "description": "Inline template allowing users to customize their `ntp_client` configuration with the use of the Jinja templating engine. The template should start with '## template:jinja'. Within the template, you can utilize the following parameters:\n- servers: A list of strings, each specifying an NTP server. When defined, entries will be rendered as 'server [server_name] iburst'. Defaults to an empty list.\n- pools: A list of strings, each specifying an NTP pool. When defined, entries will be rendered as 'pool [pool_name] iburst'. Defaults to an empty list.\n- allow: A list of strings, each specifying a network or CIDR. When defined, entries will be rendered as 'allow [CIDR]'. Defaults to an empty list.\n- peers: A list of nodes that should peer with each other. When defined, entries will be rendered as 'peer [peer_name]'. Defaults to an empty list.\nFor more information on Jinja templates and syntax, refer to the official documentation: [Jinja Template Documentation](https://jinja.palletsprojects.com/en/2.9.x/templates/)"
                 }
               }
             }

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -103,6 +103,7 @@ Mazorius
 megian
 michaelrommel
 mitechie
+MjMoshiri
 mxwebdev
 nazunalika
 netcho


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: Update template parameter descriptions in docs #4166 

Enhanced the clarity and detail of template parameter descriptions in cloud-init documentation. 
Specifically, parameters related to the `ntp_client` configuration have been revisited.


Fixes GH-4166
```

## Additional Context
<!-- If relevant -->


## Checklist:
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly (Not required for this documentation update)
 - [x] I have updated or added any documentation accordingly
