### PR TITLE
Ubuntu/lunar fix daily recipe

### DIFF
--- a/debian/patches/retain-old-groups.patch
+++ b/debian/patches/retain-old-groups.patch
@@ -7,12 +7,12 @@ Last-Update: 2023-07-24
 This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 --- a/config/cloud.cfg.tmpl
 +++ b/config/cloud.cfg.tmpl
-@@ -206,7 +206,7 @@ system_info:
-      name: ubuntu
-      lock_passwd: True
-      gecos: Ubuntu
--     groups: [adm, cdrom, dip, lxd, sudo]
-+     groups: [adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video]
-      sudo: ["ALL=(ALL) NOPASSWD:ALL"]
-      shell: /bin/bash
- {# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
+@@ -17,7 +17,7 @@
+                   "photon": "wheel",
+                   "openmandriva": "wheel, users, systemd-journal",
+                   "suse": "cdrom, users",
+-                  "ubuntu": "adm, cdrom, dip, lxd, sudo",
++                  "ubuntu": "adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video",
+                   "unknown": "adm, cdrom, dip, lxd, sudo"}) %}
+ {% set shells = ({"alpine": "/bin/ash", "dragonfly": "/bin/sh",
+                   "freebsd": "/bin/tcsh", "netbsd": "/bin/sh",


### PR DESCRIPTION
## do not squash merge
## Proposed Commit Message
```
refresh patches against upstream/main
    
Commit cda82fe4cc warranted downstream patch refresh to
fix daily recipe builds against main.

patches:
debian/patches/retain-old-groups.patch
```


## Additional Context
original daily recipe build failure log: https://launchpadlibrarian.net/683385837/buildlog.txt.gz

Once approved: I'll apply the same changeset to jammy and focal branches:

- [ ] jammy
- [ ] focal

## Test Steps
To replicate daily build recipe failure:
```
git fetch upstream
git checkout -B upstream/main main
# checkout the packaging directory from ubuntu/lunar which contains the quilt patch that no longer applies
git checkout upstream/ubuntu/lunar -- debian 
quilt push -a   # see the quilt apply failure
```

To create the fix following [process docs](https://github.com/canonical/uss-tableflip/blob/main/doc/ubuntu_release_process.md)
```
quilt push -f
quilt edit config/cloud.cfg.tmpl   
# fix groups definition on line 20 to reflect the previous list of group names: "adm, audio, cdrom, dialout, dip, floppy, lxd, netdev, plugdev, sudo, video"
quilt refresh
git diff > my.patch
git checkout upstream/ubuntu/lunar  -B ubuntu/lunar
git apply my.patch
```

To ensure daily recipe will build
```
git checkout upstream/main -B main
git checkout ubuntu/lunar -- debian   # get your local debian dir with updated patch file
quilt push -a # expect success on quilt apply
```

One can also check that local ubuntu/X branch will build using new_upstream_snapshot.py
````
git checkout ubuntu/lunar
new_upstream_snapshot.py
quilt push -a
quilt pop -a
````


<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
