### PR TITLE
Fix pip-managed ansible

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -136,7 +136,13 @@ class AnsiblePullPip(AnsiblePull):
                 import pip  # noqa: F401
             except ImportError:
                 self.distro.install_packages(self.distro.pip_package_name)
-            cmd = [sys.executable, "-m", "pip", "install"]
+            cmd = [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "--break-system-packages",
+            ]
             if self.run_user:
                 cmd.append("--user")
             self.do_as([*cmd, "--upgrade", "pip"])


### PR DESCRIPTION
```
Fix pip-managed ansible

PEP 668 disallows installing packages via pip outside of virtual
environments, to avoid breaking due to conflicting system packages.

Ansible is unlikely to be installed in the base system, and if it is and
the user still chooses to use `install_method: pip`, that would be an
invalid configuration.

This flag exists to allow users to bootstrap ansible to run as a
controller. The alternative solution would be to require virtual
environments, however this is often packaged as a separate dependency,
which further complicates bootstrap. Allow installing ansible outside of
virtual environments via pip's --break-system-packages.

Fixes GH-4244
```

fixes https://github.com/canonical/cloud-init/issues/4244

## Test
```
tox -re integration-tests -- tests/integration_tests/modules/test_ansible.py
```