### PR TITLE
ec2: initialize get_instance_userdata return value to bytes

### DIFF
--- a/cloudinit/sources/helpers/ec2.py
+++ b/cloudinit/sources/helpers/ec2.py
@@ -152,7 +152,7 @@ def get_instance_userdata(
 ):
     ud_url = url_helper.combine_url(metadata_address, api_version)
     ud_url = url_helper.combine_url(ud_url, "user-data")
-    user_data = ""
+    user_data = b""
     try:
         if not exception_cb:
             # It is ok for userdata to not exist (thats why we are stopping if

--- a/tests/unittests/sources/helpers/test_ec2.py
+++ b/tests/unittests/sources/helpers/test_ec2.py
@@ -27,7 +27,7 @@ class TestEc2Util(helpers.ResponsesTestCase):
             status=404,
         )
         userdata = ec2.get_instance_userdata(self.VERSION, retries=0)
-        self.assertEqual("", userdata)
+        self.assertEqual(b"", userdata)
 
     def test_userdata_fetch_fail_server_dead(self):
         self.responses.add(
@@ -36,7 +36,7 @@ class TestEc2Util(helpers.ResponsesTestCase):
             status=500,
         )
         userdata = ec2.get_instance_userdata(self.VERSION, retries=0)
-        self.assertEqual("", userdata)
+        self.assertEqual(b"", userdata)
 
     def test_userdata_fetch_fail_server_not_found(self):
         self.responses.add(
@@ -45,7 +45,7 @@ class TestEc2Util(helpers.ResponsesTestCase):
             status=404,
         )
         userdata = ec2.get_instance_userdata(self.VERSION)
-        self.assertEqual("", userdata)
+        self.assertEqual(b"", userdata)
 
     def test_metadata_fetch_no_keys(self):
         base_url = "http://169.254.169.254/%s/meta-data/" % (self.VERSION)


### PR DESCRIPTION
https://github.com/canonical/cloud-init/pull/4276 uncovered an issue with the initialization of the return value for get_instance_userdata().  The return value was initialized with

`user_data = ""`

which is a str class.  It then calls `url_helper.read_file_or_url()`, which attempts to retrieve user-data content from IMDS. `read_file_or_url()` returns its results as a bytes object, which is then passed directly up to the caller.  In the event that `read_file_or_url()` does not successfully retrieve content (e.g. because it was given a `file://` path to a nonexistent file or an `http://` path that generates a 404 code), an exception is raised and `get_instance_userdata()` returns the string object initially stored in user_data.

Rather than make the caller cope with return data potentially encoded as either `bytes` or `str`, this commit changes the initialization of `user_data` to an empty bytes object, ensuring type consistency in `get_instance_userdata()`'s return value.

Fixes https://github.com/canonical/cloud-init/issues/4386

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
ec2: initialize get_instance_userdata return value to bytes

https://github.com/canonical/cloud-init/pull/4276 uncovered an issue
with the initialization of the return value for
get_instance_userdata().  The return value was initialized with

user_data = ""

which is a str class.  It then calls url_helper.read_file_or_url(),
which attempts to retrieve user-data content from IMDS.
read_file_or_url() returns its results as a bytes object, which is
then passed directly up to the caller.  In the event that
read_file_or_url() does not successfully retrieve
content (e.g. because it was given a file:// path to a nonexistent
file or an http:// path that generates a 404 code), an exception is
raised and get_instance_userdata() returns the string object initially
stored in user_data.

Rather than make the caller cope with return data potentially encoded
as either bytes or str, this commit changes the initialization of
user_data to an empty bytes object, ensuring type consistency in
get_instance_userdata()'s return value.

Fixes https://github.com/canonical/cloud-init/issues/4386

Signed-off-by: Noah Meyerhans <nmeyerha@amazon.com>
```

## Test Steps

Launch an instance with no userdata, such that the EC2 IMDS returns 404 for the `user-data` key.  Prior to the PR, cloud-init would generate an exception as documented in #4386. With this change, it should properly cope with that scenario and record a zero-length value for userdata.  This will create a zero-length file `/var/lib/cloud/instance/user-data.txt` as expected, etc.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
