### PR TITLE
pep-594: drop deprecated pipes module import

### DIFF
--- a/cloudinit/distros/parsers/sys_conf.py
+++ b/cloudinit/distros/parsers/sys_conf.py
@@ -4,8 +4,8 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import pipes
 import re
+import shlex
 from io import StringIO
 
 # This library is used to parse/write
@@ -82,7 +82,7 @@ class SysConf(configobj.ConfigObj):
                 if re.search(r"[\t\r\n ]", value):
                     if _contains_shell_variable(value):
                         # If it contains shell variables then we likely want to
-                        # leave it alone since the pipes.quote function likes
+                        # leave it alone since the shlex.quote function likes
                         # to use single quotes which won't get expanded...
                         if re.search(r"[\n\"']", value):
                             quot_func = (
@@ -93,7 +93,7 @@ class SysConf(configobj.ConfigObj):
                                 lambda x: self._get_single_quote(x) % x
                             )  # noqa: E731
                     else:
-                        quot_func = pipes.quote
+                        quot_func = shlex.quote
         if not quot_func:
             return value
         return quot_func(value)

--- a/tests/unittests/distros/test_sysconfig.py
+++ b/tests/unittests/distros/test_sysconfig.py
@@ -65,7 +65,7 @@ USEMD5=no"""
         conf["IPV6TO4_ROUTING"] = "blah \tblah"
         contents2 = str(conf).strip()
         # Should be requoted due to whitespace
-        self.assertRegex(contents2, r"IPV6TO4_ROUTING=[\']blah\s+blah[\']")
+        self.assertRegex(contents2, r"IPV6TO4_ROUTING='blah\s+blah'")
 
     def test_parse_no_adjust_shell(self):
         conf = SysConf("".splitlines())


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
pep-594: drop deprecated pipes module import

python3.11 will deprecated pipes module 3.13 will drop it from main.

cloud-init only used the undocumented pipes.quote function, which is actually only wrapper around shlex.quote[1].

Use shlex.quote instead.

[1] https://github.com/python/cpython/blob/3.11/Lib/pipes.py#L64-L66
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
