### PR TITLE
Bring back flake8 for python 3.6

### DIFF
--- a/tools/run-lint
+++ b/tools/run-lint
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# This file runs flake8 for compatibility's sake. As soon as we move off python 3.6, this should be changed to use ruff.
+
 CR="
 "
 pycheck_dirs=( "cloudinit/" "tests/" "tools/"  "setup.py" )
@@ -11,7 +13,7 @@ else
    files=( "$@" )
 fi
 
-cmd=( "python3" -m "ruff" "${files[@]}" )
+cmd=( "python3" -m "flake8" "${files[@]}" )
 
 echo "Running: " "${cmd[@]}" 1>&2
 exec "${cmd[@]}"

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ isort==5.10.1
 mypy==0.950
 pylint==2.13.9
 pytest==7.0.1
-ruff==0.0.282
+ruff==0.0.285
 types-jsonschema==4.4.2
 types-oauthlib==3.1.6
 types-passlib==1.7.7.12


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Bring back flake8 for python 3.6

Ruff is incompatible with python 3.6. Since we still support 3.6,
bring back the option to run flake8 from the Makefile.

Also bump ruff version to bring flake8 parity.

Fixes GH-4339
```

Note, that this doesn't bring flake8 back to github actions or tox. It is simply for compatibility reasons.