### PR TITLE
net: fix ipv6_dhcpv6_stateful/stateless/slaac configuration for rhel

### DIFF
--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -105,6 +105,14 @@ class NMConnection:
         if self.config[family]["method"] == "auto" and method == "manual":
             return
 
+        if (
+            subnet_type == "ipv6_dhcpv6-stateful"
+            or subnet_type == "ipv6_dhcpv6-stateless"
+            or subnet_type == "ipv6_slaac"
+        ):
+            # set ipv4 method to 'disabled' to align with sysconfig renderer.
+            self._set_default("ipv4", "method", "disabled")
+
         self.config[family]["method"] = method
         self._set_default(family, "may-fail", "false")
 
@@ -342,6 +350,7 @@ class Renderer(renderer.Renderer):
 
     def __init__(self, config=None):
         self.connections = {}
+        self.config = config
 
     def get_conn(self, con_id):
         return self.connections[con_id]

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -436,13 +436,13 @@ class Renderer(renderer.Renderer):
                         iface_cfg["BOOTPROTO"] = "dhcp6"
                     iface_cfg["DHCLIENT6_MODE"] = "managed"
                 # only if rhel AND dhcpv6 stateful
-                elif (
-                    flavor == "rhel" and subnet_type == "ipv6_dhcpv6-stateful"
+                elif flavor == "rhel" and (
+                    subnet_type == "ipv6_dhcpv6-stateful"
                 ):
-                    iface_cfg["BOOTPROTO"] = "dhcp"
                     iface_cfg["DHCPV6C"] = True
                     iface_cfg["IPV6INIT"] = True
                     iface_cfg["IPV6_AUTOCONF"] = False
+                    iface_cfg["IPV6_FAILURE_FATAL"] = True
                 else:
                     iface_cfg["IPV6INIT"] = True
                     # Configure network settings using DHCPv6

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1932,6 +1932,9 @@ NETWORK_CONFIGS = {
                 method=auto
                 may-fail=false
 
+                [ipv4]
+                method=disabled
+
                 """
             ),
         },
@@ -2044,6 +2047,9 @@ NETWORK_CONFIGS = {
                 method=auto
                 may-fail=false
 
+                [ipv4]
+                method=disabled
+
                 """
             ),
         },
@@ -2091,11 +2097,12 @@ NETWORK_CONFIGS = {
         "expected_sysconfig_rhel": {
             "ifcfg-iface0": textwrap.dedent(
                 """\
-            BOOTPROTO=dhcp
+            BOOTPROTO=none
             DEVICE=iface0
             DHCPV6C=yes
             IPV6INIT=yes
             IPV6_AUTOCONF=no
+            IPV6_FAILURE_FATAL=yes
             IPV6_FORCE_ACCEPT_RA=yes
             DEVICE=iface0
             NM_CONTROLLED=no


### PR DESCRIPTION
When network type is ipv6_dhcpv6-stateful/stateless/slaac, cloud-init seems to
enable dhcp for both ipv4 and ipv6. Network manager prefers dhcp over ipv4 and
hence dhcp6 is not used to obtain the IP address. This is incorrect.
For only ipv6_dhcpv6-stateful/stateless/slaac networks, we should set:
    `ipv4.method = disabled // disables all ipv4 dhcp`
    
For ifcfg files (sysconfig renderer), the corresponding changes should be:
    `BOOTPROTO = none // instead of dhcp so that dhcp4 is disabled.`

Additionally, for only ipv6_dhcpv6_stateful, we should set:
    `ipv6.may-fail = no // dhcp6 must succeed.`
    
which translates to the following ifcfg setting:
    `IPV6_FAILURE_FATAL = yes // so that dhcp6 should succeed.`
    
This patch fixes this for rhel. The patch has been tested by Red Hat QE.
    
RHBZ: 2046491
fixes: f550c8765ca03d3 ("Adding BOOTPROTO = dhcp to render sysconfig dhcp6 stateful on RHEL (#685)")