### PR TITLE
cc_ubuntu_advantage: do not rely on uaclient.messages module

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -334,16 +334,9 @@ def configure_ua(token, enable=None):
     # related. We can distinguish them by checking if `service` is non-null
     # or null respectively.
 
-    # pylint: disable=import-error
-    from uaclient.messages import ALREADY_ENABLED
-
-    # pylint: enable=import-error
-
-    UA_MC_ALREADY_ENABLED = ALREADY_ENABLED.name
-
     enable_errors: List[dict] = []
     for err in enable_resp.get("errors", []):
-        if err["message_code"] == UA_MC_ALREADY_ENABLED:
+        if err["message_code"] == "service-already-enabled":
             LOG.debug("Service `%s` already enabled.", err["service"])
             continue
         enable_errors.append(err)

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -142,6 +142,19 @@ class TestUbuntuAdvantage:
         verify_clean_log(log)
         assert is_attached(client)
 
+        # Assert service-already-enabled handling for esm-infra.
+        # First totally destroy ubuntu-advantage-tools data and state.
+        # This is a hack but results in a system that thinks it
+        # is detached even though esm-infra is still enabled.
+        # When cloud-init runs again, it will successfully re-attach
+        # and then notice that esm-infra is already enabled.
+        client.execute("rm -rf /var/lib/ubuntu-advantage")
+        assert client.execute("cloud-init clean --logs").ok
+        client.restart()
+        log = client.read_from_file("/var/log/cloud-init.log")
+        verify_clean_log(log)
+        assert "Service `esm-infra` already enabled" in log
+
 
 def maybe_install_cloud_init(session_cloud: IntegrationCloud):
     source = get_validated_source(session_cloud)

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -148,7 +148,7 @@ def maybe_install_cloud_init(session_cloud: IntegrationCloud):
 
     launch_kwargs = {
         "image_id": session_cloud.cloud_instance.daily_image(
-            CURRENT_RELEASE.image_id, image_type=ImageType.PRO
+            CURRENT_RELEASE.series, image_type=ImageType.PRO
         )
     }
 

--- a/tests/integration_tests/releases.py
+++ b/tests/integration_tests/releases.py
@@ -53,6 +53,21 @@ class Release:
     def __repr__(self):
         return f"Release({self.os}, {self.version})"
 
+    def __eq__(self, other: object):
+        if not isinstance(other, Release):
+            return False
+        if all(
+            [
+                self.os == other.os,
+                self.series == other.series,
+                self.version == other.version,
+            ]
+        ):
+            if self.image_id and other.image_id:
+                return self.image_id == other.image_id
+            return True  # If either image_id is None then ignore it
+        return False
+
     def __lt__(self, other: "Release"):
         if self.os != other.os:
             raise ValueError(f"{self.os} cannot be compared to {other.os}!")

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -69,6 +69,12 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         "WARNING]: Could not match supplied host pattern, ignoring:",
     ]
     traceback_texts = []
+    if "install canonical-livepatch" in log:
+        # Ubuntu Pro Client emits a warning in between installing livepatch
+        # and enabling it
+        warning_texts.append(
+            "canonical-livepatch returned error when checking status"
+        )
     if "oracle" in log:
         # LP: #1842752
         lease_exists_text = "Stderr: RTNETLINK answers: File exists"

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -65,11 +65,6 @@ def fake_uaclient(mocker):
     )
     sys.modules["uaclient.api.exceptions"] = _exceptions
 
-    # Messages
-    m_messages = mock.Mock()
-    m_messages.ALREADY_ENABLED.name = "service-already-enabled"
-    sys.modules["uaclient.messages"] = m_messages
-
 
 @pytest.mark.usefixtures("fake_uaclient")
 @mock.patch(f"{MPATH}.subp.subp")

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -114,6 +114,7 @@ nmeyerhans
 olivierlemasle
 omBratteng
 onitake
+orndorffgrant
 Oursin
 outscale-mdr
 phunyguy


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ubuntu_advantage: do not rely on uaclient.messages module

Importing a uaclient module that is not under "uaclient.api" is not
supported and likely to break in the future.

The expected message_codes are defined as part of the API of `pro enable
--format=json` and won't change, so we don't lose anything by hardcoding
the value.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
No functional change. The ubuntu_advantage `enable` and `enable_beta` options should still work.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
