### PR TITLE
Log PPID for better debugging

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -82,10 +82,21 @@ def print_exc(msg=""):
     sys.stderr.write("\n")
 
 
+def log_ppid():
+    if util.is_Linux():
+        ppid = os.getppid()
+        LOG.info(
+            "PID [%s] started cloud-init using: %s",
+            ppid,
+            os.path.realpath(f"/proc/{ppid}/exe"),
+        )
+
+
 def welcome(action, msg=None):
     if not msg:
         msg = welcome_format(action)
     util.multi_log("%s\n" % (msg), console=False, stderr=True, log=LOG)
+    log_ppid()
     return msg
 
 


### PR DESCRIPTION
```
Log PPID for easier debugging

It is unusual on Linux for cloud-init to be started
by any process besides PID 1. To ease debugging, log
parent process PID and executable.

Note: current implementation only supports Linux 
```

This would ideally be implemented in the distro base class for cleaner cross-distro support, but the distro object isn't yet instantiated as early as we want for this message, and I'd rather not refactor that right now. 

Sample logs:
```
grep -i pid ./cloud-init.log
2023-08-30 17:38:18,306 - main.py[INFO]: PID [1] started cloud-init using: /usr/lib/systemd/systemd
2023-08-30 17:38:19,086 - main.py[INFO]: PID [1] started cloud-init using: /usr/lib/systemd/systemd
2023-08-30 17:38:27,027 - main.py[INFO]: PID [1] started cloud-init using: /usr/lib/systemd/systemd
2023-08-30 17:38:27,786 - main.py[INFO]: PID [1] started cloud-init using: /usr/lib/systemd/systemd
```


This log is expected to be useful anytime the process starting cloud-init would be valuable to know, since anything besides PID 1 as a PPID is unlikely to be a well-tested or easily supported environment on Linux.


Example use case: https://github.com/canonical/cloud-init/issues/4359