### PR TITLE
Move disable checks out of systemd generator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ render-template:
 # Our generator is a shell script. Make it easy to measure the
 # generator. This should be monitored for performance regressions
 benchmark-generator: FILE=$(GENERATOR_F).tmpl
+benchmark-generator: VARIANT="benchmark"
 benchmark-generator: export ITER=$(NUM_ITER)
 benchmark-generator: render-template
 	$(BENCHMARK) $(GENERATOR_F)

--- a/doc/rtd/howto/disable_cloud_init.rst
+++ b/doc/rtd/howto/disable_cloud_init.rst
@@ -6,7 +6,7 @@ How to disable cloud-init
 One may wish to disable cloud-init to ensure that it doesn't do anything on
 subsequent boots. Some parts of cloud-init may run once per boot otherwise.
 
-There are two cross-platform methods of disabling ``cloud-init``.
+There are three cross-platform methods of disabling ``cloud-init``.
 
 Method 1: text file
 ====================
@@ -34,6 +34,15 @@ Example (using GRUB2 with Ubuntu):
     $ echo 'GRUB_CMDLINE_LINUX="cloud-init=disabled"' >> /etc/default/grub
     $ grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg
 
-.. note::
-   When running in containers, ``cloud-init`` will read an environment
-   variable named ``KERNEL_CMDLINE`` in place of a kernel commandline.
+Method 3: environment variable
+==============================
+
+To disable cloud-init, pass the environment variable
+``KERNEL_CMDLINE=cloud-init=disabled`` into each of cloud-init's
+processes.
+
+Example (using systemd):
+
+.. code-block::
+
+    $ echo "DefaultEnvironment=KERNEL_CMDLINE=cloud-init=disabled" >> /etc/systemd/system.conf

--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -5,10 +5,9 @@ After=network-online.target cloud-config.target
 After=snapd.seeded.service
 Before=systemd-user-sessions.service
 Wants=network-online.target cloud-config.target
-{% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
-{% endif %}
+ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -7,10 +7,9 @@ After=multi-user.target
 Before=apt-daily.service
 {% endif %}
 Wants=network-online.target cloud-config.service
-{% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
-{% endif %}
+ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
 
 
 [Service]

--- a/systemd/cloud-init-generator.tmpl
+++ b/systemd/cloud-init-generator.tmpl
@@ -64,8 +64,12 @@ main() {
     ds=$?
     debug 1 "ds-identify rc=$ds"
 
-    if [ "$ds" = "1" ]; then
-        debug 1 "cloud-init is enabled but no datasource found, disabling"
+    if [ "$ds" = "1" -o "$ds" = "2" ]; then
+        if [ "$ds" = "1" ]; then
+            debug 1 "cloud-init is enabled but no datasource found, disabling"
+        else
+            debug 1 "cloud-init is disabled by kernel commandline or etc_file"
+        fi
         if [ -f "$link_path" ]; then
             if rm -f "$link_path"; then
                 debug 1 "disabled. removed existing $link_path"

--- a/systemd/cloud-init-generator.tmpl
+++ b/systemd/cloud-init-generator.tmpl
@@ -42,105 +42,47 @@ debug() {
     echo "$@" >> "$LOG"
 }
 
-etc_file() {
-    local pprefix="${1:-/etc/cloud/cloud-init.}"
-    _RET="unset"
-    [ -f "${pprefix}$ENABLE" ] && _RET="$ENABLE" && return 0
-    [ -f "${pprefix}$DISABLE" ] && _RET="$DISABLE" && return 0
-    return 0
-}
-
-read_proc_cmdline() {
-    # return /proc/cmdline for non-container, and /proc/1/cmdline for container
-    local ctname="systemd"
-    if [ -n "$CONTAINER" ] && ctname=$CONTAINER ||
-        systemd-detect-virt --container --quiet; then
-        if { _RET=$(tr '\0' ' ' < /proc/1/cmdline); } 2>/dev/null; then
-            _RET_MSG="container[$ctname]: pid 1 cmdline"
-            return
-        fi
-        _RET=""
-        _RET_MSG="container[$ctname]: pid 1 cmdline not available"
-        return 0
-    fi
-
-    _RET_MSG="/proc/cmdline"
-    read _RET < /proc/cmdline
-}
-
-kernel_cmdline() {
-    local cmdline="" tok=""
-    if [ -n "${KERNEL_CMDLINE+x}" ]; then
-        # use KERNEL_CMDLINE if present in environment even if empty
-        cmdline=${KERNEL_CMDLINE}
-        debug 1 "kernel command line from env KERNEL_CMDLINE: $cmdline"
-    else
-        read_proc_cmdline && cmdline="$_RET" &&
-                debug 1 "kernel command line ($_RET_MSG): $cmdline"
-    fi
-    _RET="unset"
-    cmdline=" $cmdline "
-    tok=${cmdline##* cloud-init=}
-    [ "$tok" = "$cmdline" ] && _RET="unset"
-    tok=${tok%% *}
-    [ "$tok" = "$ENABLE" -o "$tok" = "$DISABLE" ] && _RET="$tok"
-    return 0
-}
-
-default() {
-    _RET="$ENABLE"
-}
-
-check_for_datasource() {
-    local ds_rc=""
-    if [ ! -x "$dsidentify" ]; then
-        debug 1 "no ds-identify in $dsidentify"
-        return 0
-    fi
-    $dsidentify
-    ds_rc=$?
-    debug 1 "ds-identify rc=$ds_rc"
-    if [ "$ds_rc" = "0" ]; then
-        return 0
-    fi
-    return 1
-}
-
 main() {
     local normal_d="$1" early_d="$2" late_d="$3"
     local target_name="multi-user.target" gen_d="$early_d"
     local link_path="$gen_d/${target_name}.wants/${CLOUD_TARGET_NAME}"
-    local ds=""
+    local ds="" ret=""
 
     debug 1 "$0 normal=$normal_d early=$early_d late=$late_d"
     debug 2 "$0 $*"
 
-    local search result="error" ret=""
-    for search in kernel_cmdline etc_file default; do
-        if $search; then
-            debug 1 "$search found $_RET"
-            [ "$_RET" = "$ENABLE" -o "$_RET" = "$DISABLE" ] &&
-                result=$_RET && break
-        else
-            ret=$?
-            debug 0 "search $search returned $ret"
-        fi
-    done
+    # ds=found => enable
+    # ds=notfound => disable
+    # <any> => disable
+    debug 1 "checking for datasource"
 
-    # enable AND ds=found == enable
-    # enable AND ds=notfound == disable
-    # disable || <any> == disabled
-    if [ "$result" = "$ENABLE" ]; then
-        debug 1 "checking for datasource"
-        check_for_datasource
-        ds=$?
-        if [ "$ds" = "1" ]; then
-            debug 1 "cloud-init is enabled but no datasource found, disabling"
-            result="$DISABLE"
-        fi
+    if [ ! -x "$dsidentify" ]; then
+        debug 1 "no ds-identify in $dsidentify"
+        ds=0
     fi
+    $dsidentify
+    ds=$?
+    debug 1 "ds-identify rc=$ds"
 
-    if [ "$result" = "$ENABLE" ]; then
+    if [ "$ds" = "1" ]; then
+        debug 1 "cloud-init is enabled but no datasource found, disabling"
+        if [ -f "$link_path" ]; then
+            if rm -f "$link_path"; then
+                debug 1 "disabled. removed existing $link_path"
+            else
+                ret=$?
+                debug 0 "[$ret] disable failed, remove $link_path"
+            fi
+        else
+            debug 1 "already disabled: no change needed [no $link_path]"
+        fi
+        if [ -e "$RUN_ENABLED_FILE" ]; then
+            debug 1 "removing $RUN_ENABLED_FILE and creating $RUN_DISABLED_FILE"
+            rm -f "$RUN_ENABLED_FILE"
+        fi
+        : > "$RUN_DISABLED_FILE"
+
+    elif [ "$ds" = "0" ]; then
         if [ -e "$link_path" ]; then
                 debug 1 "already enabled: no change needed"
         else
@@ -159,22 +101,6 @@ main() {
             rm -f $RUN_DISABLED_FILE
         fi
         : > "$RUN_ENABLED_FILE"
-    elif [ "$result" = "$DISABLE" ]; then
-        if [ -f "$link_path" ]; then
-            if rm -f "$link_path"; then
-                debug 1 "disabled. removed existing $link_path"
-            else
-                ret=$?
-                debug 0 "[$ret] disable failed, remove $link_path"
-            fi
-        else
-            debug 1 "already disabled: no change needed [no $link_path]"
-        fi
-        if [ -e "$RUN_ENABLED_FILE" ]; then
-            debug 1 "removing $RUN_ENABLED_FILE and creating $RUN_DISABLED_FILE"
-            rm -f "$RUN_ENABLED_FILE"
-        fi
-        : > "$RUN_DISABLED_FILE"
     else
         debug 0 "unexpected result '$result' 'ds=$ds'"
         ret=3

--- a/systemd/cloud-init-generator.tmpl
+++ b/systemd/cloud-init-generator.tmpl
@@ -23,6 +23,8 @@ CLOUD_SYSTEM_TARGET="/lib/systemd/system/cloud-init.target"
 {% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora",
                   "miraclelinux", "openeuler", "OpenCloudOS", "openmandriva", "rhel", "rocky", "TencentOS", "virtuozzo"] %}
     dsidentify="/usr/libexec/cloud-init/ds-identify"
+{% elif variant == "benchmark" %}
+    dsidentify="/bin/true"
 {% else %}
     dsidentify="/usr/lib/cloud-init/ds-identify"
 {% endif %}

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -26,10 +26,9 @@ Before=sysinit.target
 Conflicts=shutdown.target
 {% endif %}
 RequiresMountsFor=/var/lib/cloud
-{% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
-{% endif %}
+ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -38,10 +38,9 @@ Conflicts=shutdown.target
 Before=shutdown.target
 Conflicts=shutdown.target
 {% endif %}
-{% if variant == "rhel" %}
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
-{% endif %}
+ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
 
 [Service]
 Type=oneshot

--- a/systemd/cloud-init.target
+++ b/systemd/cloud-init.target
@@ -10,3 +10,6 @@
 [Unit]
 Description=Cloud-init target
 After=multi-user.target
+ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ConditionKernelCommandLine=!cloud-init=disabled
+ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -164,16 +164,26 @@ class TestStatus:
     ):
         if ensured_file is not None:
             ensure_file(ensured_file(config))
-        (code, reason) = wrap_and_call(
-            M_NAME,
-            {
-                "uses_systemd": uses_systemd,
-                "get_cmdline": get_cmdline,
-            },
-            status.get_bootstatus,
-            config.disable_file,
-            config.paths,
-        )
+        with mock.patch(
+            f"{M_PATH}subp.subp",
+            return_value=SubpResult(
+                """\
+LANG=en_US.UTF-8
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
+""",
+                stderr=None,
+            ),
+        ):
+            code, reason = wrap_and_call(
+                M_NAME,
+                {
+                    "uses_systemd": uses_systemd,
+                    "get_cmdline": get_cmdline,
+                },
+                status.get_bootstatus,
+                config.disable_file,
+                config.paths,
+            )
         assert code == expected_bootstatus, failure_msg
         if isinstance(expected_reason, str):
             assert reason == expected_reason

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -330,6 +330,10 @@ class DsIdentifyBase(CiTestCase):
                 "err": "No dmidecode program. ERROR.",
             },
             {
+                "name": "is_disabled",
+                "ret": 1,
+            },
+            {
                 "name": "get_kenv_field",
                 "ret": 1,
                 "err": "No kenv program. ERROR.",

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1039,6 +1039,23 @@ has_ovf_cdrom() {
     return 1
 }
 
+is_disabled() {
+    if [ -f /etc/cloud/cloud-init.disabled ]; then
+        debug 1 "disabled by marker file /etc/cloud-init.disabled"
+        return 0
+    fi
+    if [ "${KERNEL_CMDLINE:-}" = "cloud-init=disabled" ]; then
+        debug 1 "disabled by KERNEL_CMDLINE environment variable"
+        return 0
+    fi
+    case "$DI_KERNEL_CMDLINE" in
+       *cloud-init=disabled*)
+            debug 1 "disabled by kernel command line cloud-init=disabled"
+            return 0
+    esac
+    return 1
+}
+
 dscheck_OVF() {
     check_seed_dir ovf ovf-env.xml && return "${DS_FOUND}"
 
@@ -1517,10 +1534,7 @@ dscheck_VMware() {
 }
 
 collect_info() {
-    read_uname_info
-    read_virt
     read_pid1_product_name
-    read_kernel_cmdline
     read_config
     read_datasource_list
     read_dmi_sys_vendor
@@ -1795,6 +1809,12 @@ _main() {
 
     read_uptime
     debug 1 "[up ${_RET}s]" "ds-identify $*"
+    read_uname_info
+    read_virt
+    read_kernel_cmdline
+    if is_disabled; then
+        return 2
+    fi
     collect_info
 
     if [ "$DI_LOG" = "stderr" ]; then

--- a/tools/render-cloudcfg
+++ b/tools/render-cloudcfg
@@ -15,6 +15,7 @@ def main():
         "alpine",
         "amazon",
         "arch",
+        "benchmark",
         "centos",
         "cloudlinux",
         "debian",


### PR DESCRIPTION
#### Please do not squash merge this PR.

The commits in this PR are written separately with the intent of being added to the git tree individually. 

<details>
<summary>Old squashed commit message</summary>

```
Move disable checks out of systemd generator

- Add environment variable check to unit conditionals
- Change unit conditionals from rhel-only to all distros
- Add unit conditionals to cloud-init target
- Makefile: Benchmark generator script
- generator: Remove redundant code
- generator: Eliminate variables, branches and functions
- docs: Describe environment variable disablement method
- cloud-init status: Fix bug in containers where
  disabling cloud-init with KERNEL_CMDLINE causes
  cloud-init status --wait to loop indefinitely
- Add integration test coverage for disablement


- KERNEL_CMDLINE environment variable is now checked on
  all platforms which may simplify testing and presents
  minimal risk of unintended use.
- Kernel cmdline, cloud-init.disabled, and KERNEL_CMDLINE
  environment variable now have higher precedence than
  ds-identify policy in all distros, not just RHEL. 

https://www.freedesktop.org/software/systemd/man/systemd.unit.html
https://www.freedesktop.org/software/systemd/man/systemd-analyze.html
```
<br>
</details>

Behavior changes:

## Additional Details
Motivations: eliminate redundant code, performance improvements (do less in systemd generator, which blocks all of boot), standardize behavior across distros

The current [cloud-init docs](https://cloudinit.readthedocs.io/en/latest/howto/disable_cloud_init.html) that describe how to disable cloud-init are incomplete, since [ds-identify policy](https://github.com/canonical/cloud-init/issues/4359#issuecomment-1699682165)  may take precedence over the disable file, the kernel commandline and environment variable arguments. This is not ideal, as ds-identify.cfg is an undocumented and less user-friendly user interface for a common user operation.

Assuming that we want cloud-init to behave as the docs describe (i.e.: `touch /etc/cloud/cloud-init.disabled` actually disables cloud-init), this PR fixes that discrepancy between docs and behavior.

## Performance Implications
As @blackboxsw mentioned out of band:

> having the disable in generator script timeframe may solve the case earlier than having systemd's ordering logic have to calculate and redact the cloud-init* boot stages from boot. Not sure if that matters in terms of boot time.

and some of my own thoughts:

> The current generator code may allow the systemd ordering solver to run sooner without cloud-init, but it also delays all of boot with checking kernel commandline and cloud-init.disabled file while the generator is running (in a shell script), so I think there are perf costs and benefits with this (potential) change.
>
> Where the benefit of the generator pruning out cloud-init only improves performance in the case that cloud-init isn't running (by skipping ds-identify), and the potential speed benefit is the case where cloud-init is not disabled (by eliminating a redundant `systemd-detect-virt` call, and kernel cmdline and file checking that could be done by systemd later, and potentially faster).

Benchmarking the systemd generator shows a 2-3x performance improvement. However, this appears negligible since `systemd-analyze critical-chain` shows identical times for both (below) - and some work does get shifted from the generator to systemd itself in this change (later in boot).

Generator Benchmark: this branch
```
# make benchmark-generator 
python3 ./tools/render-cloudcfg --variant="benchmark" ./systemd/cloud-init-generator.tmpl ./systemd/cloud-init-generator
./tools/benchmark.sh ./systemd/cloud-init-generator

real	0m0.210s
user	0m0.140s
sys	0m0.072s
root@cloudinit-0901-025531ijbm4hwd:~/cloud-init# make benchmark-generator 
python3 ./tools/render-cloudcfg --variant="benchmark" ./systemd/cloud-init-generator.tmpl ./systemd/cloud-init-generator
./tools/benchmark.sh ./systemd/cloud-init-generator

real	0m0.225s
user	0m0.162s
sys	0m0.068s
```

Generator Benchmark: tip of main with just benchmark commit applied (6cf53172a)
```
# make benchmark-generator 
python3 ./tools/render-cloudcfg --variant="benchmark" ./systemd/cloud-init-generator.tmpl ./systemd/cloud-init-generator
./tools/benchmark.sh ./systemd/cloud-init-generator

real	0m0.631s
user	0m0.361s
sys	0m0.268s
root@cloudinit-0901-025531ijbm4hwd:~/cloud-init# make benchmark-generator 
python3 ./tools/render-cloudcfg --variant="benchmark" ./systemd/cloud-init-generator.tmpl ./systemd/cloud-init-generator
./tools/benchmark.sh ./systemd/cloud-init-generator

real	0m0.710s
user	0m0.353s
sys	0m0.360s
``` 

#### systemd-analyze critical chain

*note: I think that the time is since systemd starts, but if a better methodology exists, feedback is welcome*  

with this change:
```
root@cloudinit-0901-025531ijbm4hwd:~# systemd-analyze critical-chain cloud-init-local.service
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

cloud-init-local.service +749ms
└─systemd-remount-fs.service @185ms +6ms
  └─systemd-journald.socket @176ms
    └─-.mount @147ms
      └─-.slice @147ms
```

from tip of main:
```
root@cloudinit-0901-025531ijbm4hwd:~# systemd-analyze critical-chain cloud-init-local.service 
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

cloud-init-local.service +749ms
└─systemd-remount-fs.service @185ms +6ms
  └─systemd-journald.socket @176ms
    └─-.mount @147ms
      └─-.slice @147ms
```

Since the root slice starts at 147ms for both tip of main and this branch, this change doesn't appear to provide a performance regression.

### Measuring with and without conditionals in .target

From a different (slower) machine (don't compare the times below with the times above), I compare this branch:
```
# systemd-analyze critical-chain cloud-init-local.service
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

cloud-init-local.service +884ms
└─systemd-journald.socket @299ms
  └─-.mount @219ms
    └─system.slice @219ms
      └─-.slice @219ms
```

against an otherwise identical branch that drops f310f9aa68e51636e3266c93b8152b53f6c6708d:
```
# systemd-analyze critical-chain cloud-init-local.service
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

cloud-init-local.service +1.098s
└─systemd-journald.socket @316ms
  └─-.mount @243ms
    └─system.slice @242ms
      └─-.slice @243ms
```

I'd be surprised if this conditional to the target is actually an optimization that would save 0.2 seconds, so I assume that the measurable difference due to the target conditional is within the noise - not something to be concerned about.

## Test Steps

Systemd environment conditional test:
```
arc~ systemd-analyze condition 'ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled' 
test.service: ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled succeeded.
Conditions succeeded.
arc~ export KERNEL_CMDLINE=cloud-init=disabled                                           
arc~ systemd-analyze condition 'ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled'
test.service: ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled failed.
Conditions failed.
```

Integration Tests:
```
tox -e integration-tests -- tests/integration_tests/test_kernel_commandline_match.py
```
