### PR TITLE
integration tests: don't clean when KEEP_* flags true

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -169,7 +169,13 @@ class IntegrationCloud(ABC):
         return IntegrationInstance(self, cloud_instance, settings)
 
     def destroy(self):
-        self.cloud_instance.clean()
+        if self.settings.KEEP_IMAGE or self.settings.KEEP_INSTANCE:
+            log.info(
+                "NOT cleaning cloud instance because KEEP_IMAGE or "
+                "KEEP_INSTANCE is True"
+            )
+        else:
+            self.cloud_instance.clean()
 
     def snapshot(self, instance):
         return self.cloud_instance.snapshot(instance, clean=True)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
integration tests: don't clean when KEEP_* flags true

When bumping to pycloudlib version 1!5.0.0, we gained the ability to
clean anything created by the Cloud instance, not just the Instance
instance. This commit ensures we don't do this when KEEP_ settings
are true.
```
