### PR TITLE
integration tests: Fix cgroup parsing

### DIFF
--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -29,5 +29,9 @@ def test_gpg_no_tty(client: IntegrationInstance):
         "Imported key 'E4D304DF' from keyserver 'keyserver.ubuntu.com'",
     ]
     verify_ordered_items_in_text(to_verify, log)
-    result = client.execute("systemctl status cloud-config.service")
-    assert "CGroup" not in result.stdout
+    processes_in_cgroup = int(
+        client.execute(
+            "systemd-cgls -u cloud-config.service 2>/dev/null | wc -l"
+        ).stdout
+    )
+    assert processes_in_cgroup < 2


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
integration tests: Fix cgroup parsing

It's possible to still have cgroup output for cloud-config.service
even if there are no spawned processes. Instead, use systemd-cgls
to list the cgroup and ensure there are isn't more than 1 line of
output.
```

## Additional Context
Fixes https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-ec2/291/testReport/tests.integration_tests.bugs/test_lp1813396/test_gpg_no_tty/

where `systemctl status` output looks like:
```
    ● cloud-config.service - Apply the settings specified in cloud-config
         Loaded: loaded (/lib/systemd/system/cloud-config.service; enabled; vendor preset: enabled)
         Active: active (exited) since Fri 2023-09-01 01:06:13 UTC; 3s ago
        Process: 802 ExecStart=/usr/bin/cloud-init modules --mode=config (code=exited, status=0/SUCCESS)
       Main PID: 802 (code=exited, status=0/SUCCESS)
          Tasks: 0 (limit: 1096)
         Memory: 301.8M
         CGroup: /system.slice/cloud-config.service
```

