### PR TITLE
Fix pip-managed ansible on pip < 23.0.1

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -136,32 +136,13 @@ class AnsiblePullPip(AnsiblePull):
                 import pip  # noqa: F401
             except ImportError:
                 self.distro.install_packages(self.distro.pip_package_name)
-
-            pip_version_output = self.do_as(
-                [
-                    sys.executable,
-                    "-m",
-                    "pip",
-                    "--version",
-                ]
-            ).stdout
-            pip_version = pip_version_output.split()
-
-            if 2 > len(pip_version):
-                LOG.warning(
-                    "Error parsing pip version string: %s", pip_version_output
-                )
-            version = Version.from_str(pip_version[1])
             cmd = [
                 sys.executable,
                 "-m",
                 "pip",
                 "install",
+                "--break-system-packages",
             ]
-
-            # see pip commit e6deb9b87c18cdd27a9ba27cb7e0670ffb81d45e
-            if version >= Version(23, 0, 1):
-                cmd.append("--break-system-packages")
             if self.run_user:
                 cmd.append("--user")
             self.do_as([*cmd, "--upgrade", "pip"])

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -3,6 +3,7 @@ import abc
 import os
 import re
 import sys
+import sysconfig
 from copy import deepcopy
 from logging import getLogger
 from textwrap import dedent
@@ -141,8 +142,11 @@ class AnsiblePullPip(AnsiblePull):
                 "-m",
                 "pip",
                 "install",
-                "--break-system-packages",
             ]
+            if os.path.join(
+                sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED"
+            ):
+                cmd.append("--break-system-packages")
             if self.run_user:
                 cmd.append("--user")
             self.do_as([*cmd, "--upgrade", "pip"])

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -143,8 +143,10 @@ class AnsiblePullPip(AnsiblePull):
                 "pip",
                 "install",
             ]
-            if os.path.join(
-                sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED"
+            if os.path.exists(
+                os.path.join(
+                    sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED"
+                )
             ):
                 cmd.append("--break-system-packages")
             if self.run_user:

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -136,13 +136,32 @@ class AnsiblePullPip(AnsiblePull):
                 import pip  # noqa: F401
             except ImportError:
                 self.distro.install_packages(self.distro.pip_package_name)
+
+            pip_version_output = self.do_as(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "--version",
+                ]
+            ).stdout
+            pip_version = pip_version_output.split()
+
+            if 2 > len(pip_version):
+                LOG.warning(
+                    "Error parsing pip version string: %s", pip_version_output
+                )
+            version = Version.from_str(pip_version[1])
             cmd = [
                 sys.executable,
                 "-m",
                 "pip",
                 "install",
-                "--break-system-packages",
             ]
+
+            # see pip commit e6deb9b87c18cdd27a9ba27cb7e0670ffb81d45e
+            if version >= Version(23, 0, 1):
+                cmd.append("--break-system-packages")
             if self.run_user:
                 cmd.append("--user")
             self.do_as([*cmd, "--upgrade", "pip"])

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 from unittest import mock
 
-from cloudinit import cloud, distros, helpers, subp
+from cloudinit import cloud, distros, helpers
 from cloudinit.sources import DataSource, DataSourceHostname
 from cloudinit.sources.DataSourceNone import DataSourceNone
 
@@ -153,7 +153,7 @@ class MockDistro(distros.Distro):
         return (True, "yay")
 
     def do_as(self, command, args=None, **kwargs):
-        return subp.SubpResult("pip 23.0.1 from /usr/lib/python3/dist-packages/pip (python 3.11)", "stderr")
+        return ("stdout", "stderr")
 
 
 TEST_INSTANCE_ID = "i-testing"

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -1,7 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 from unittest import mock
 
-from cloudinit import cloud, distros, helpers
+from cloudinit import cloud, distros, helpers, subp
 from cloudinit.sources import DataSource, DataSourceHostname
 from cloudinit.sources.DataSourceNone import DataSourceNone
 
@@ -153,7 +153,7 @@ class MockDistro(distros.Distro):
         return (True, "yay")
 
     def do_as(self, command, args=None, **kwargs):
-        return ("stdout", "stderr")
+        return subp.SubpResult("pip 23.0.1 from /usr/lib/python3/dist-packages/pip (python 3.11)", "stderr")
 
 
 TEST_INSTANCE_ID = "i-testing"


### PR DESCRIPTION
```
Fix pip-managed ansible on pip < 23.0.1

Commit b417b218 broke pip-managed ansible with
pip < 23.0.1 and fixed pip-managed ansible with
pip >= 23.0.1. Gate change by pip version to
correctly operate on both versions.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_vm/303/testReport/junit/tests.integration_tests.modules/test_ansible/test_ansible_controller/
