### PR TITLE
doc: fix instructions on how to disable cloud-init from kernel commadline

### DIFF
--- a/doc/rtd/howto/disable_cloud_init.rst
+++ b/doc/rtd/howto/disable_cloud_init.rst
@@ -31,7 +31,7 @@ Example (using GRUB2 with Ubuntu):
 
 .. code-block::
 
-    $ echo 'GRUB_CMDLINE_LINUX=cloud-init.disabled' >> /etc/default/grub
+    $ echo 'GRUB_CMDLINE_LINUX="cloud-init=disabled"' >> /etc/default/grub
     $ grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg
 
 .. note::


### PR DESCRIPTION

There was a typo in the instruction on disabling cloud-init from the kernel command line. The actual command is:
#echo 'GRUB_CMDLINE_LINUX="cloud-init=disabled"' >> /etc/default/grub

Instead of
#echo 'GRUB_CMDLINE_LINUX=cloud-init.disabled' >> /etc/default/grub

Fix it.

