### PR TITLE
apt: kill dirmngr/gpg-agent without gpgconf dependency

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -12,6 +12,7 @@ import glob
 import os
 import pathlib
 import re
+import signal
 from textwrap import dedent
 
 from cloudinit import gpg
@@ -245,23 +246,17 @@ def apply_apt(cfg, cloud, target):
     # GH: 4344 - stop gpg-agent/dirmgr daemons spawned by gpg key imports.
     # Daemons spawned by cloud-config.service on systemd v253 report (running)
     gpg_process_out, _err = subp.subp(
-        ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+        ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
         target=target,
         capture=True,
         rcs=[0, 1],
     )
-    gpg_pids = re.findall(r"(?P<pid>\d+).*homedir \/root", gpg_process_out)
-    if len(gpg_pids) <= 2:
-        if gpg_pids:
-            LOG.debug("Killing gpg-agent and dirmngr pids: %s", gpg_pids)
-        for gpg_pid in gpg_pids:
-            os.kill(int(gpg_pid))
-    else:
-        LOG.debug(
-            "Leaving all gpg-agent and dirmngr daemons running. Greater than 2"
-            " active daemons present: %s",
-            gpg_process_out,
-        )
+    gpg_pids = re.findall(r"(?P<ppid>\d+)\s+(?P<pid>\d+)", gpg_process_out)
+    root_gpg_pids = [int(pid[1]) for pid in gpg_pids if pid[0] == "1"]
+    if root_gpg_pids:
+        LOG.debug("Killing gpg-agent and dirmngr pids: %s", root_gpg_pids)
+    for gpg_pid in root_gpg_pids:
+        os.kill(gpg_pid, signal.SIGKILL)
 
 
 def debconf_set_selections(selections, target=None):

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -6,7 +6,10 @@ Ensure gpg is called with no tty flag.
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_ordered_items_in_text
+from tests.integration_tests.util import (
+    verify_clean_log,
+    verify_ordered_items_in_text,
+)
 
 USER_DATA = """\
 #cloud-config
@@ -29,6 +32,7 @@ def test_gpg_no_tty(client: IntegrationInstance):
         "Imported key 'E4D304DF' from keyserver 'keyserver.ubuntu.com'",
     ]
     verify_ordered_items_in_text(to_verify, log)
+    verify_clean_log(log)
     processes_in_cgroup = int(
         client.execute(
             "systemd-cgls -u cloud-config.service 2>/dev/null | wc -l"

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -122,13 +122,13 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
     def test_apt_v1_source_list_debian(self):
         """Test rendering of a source.list from template for debian"""
         with mock.patch.object(
-            subp, "subp", return_value=("PID", "")
+            subp, "subp", return_value=("PPID   PID", "")
         ) as mocksubp:
             self.apt_source_list(
                 "debian", "http://httpredir.debian.org/debian"
             )
         mocksubp.assert_called_once_with(
-            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
             rcs=[0, 1],
@@ -137,11 +137,11 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
     def test_apt_v1_source_list_ubuntu(self):
         """Test rendering of a source.list from template for ubuntu"""
         with mock.patch.object(
-            subp, "subp", return_value=("PID", "")
+            subp, "subp", return_value=("PPID   PID", "")
         ) as mocksubp:
             self.apt_source_list("ubuntu", "http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
             rcs=[0, 1],
@@ -163,7 +163,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
             with mock.patch.object(
-                subp, "subp", return_value=("PID", "")
+                subp, "subp", return_value=("PPID   PID", "")
             ) as mocksubp:
                 self.apt_source_list(
                     "debian",
@@ -176,7 +176,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://httpredir.debian.org/debian")
         mocksubp.assert_called_once_with(
-            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
             rcs=[0, 1],
@@ -188,7 +188,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
             with mock.patch.object(
-                subp, "subp", return_value=("PID", "")
+                subp, "subp", return_value=("PPID   PID", "")
             ) as mocksubp:
                 self.apt_source_list(
                     "ubuntu",
@@ -201,7 +201,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
             rcs=[0, 1],
@@ -215,7 +215,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         # the second mock restores the original subp
         with mock.patch.object(util, "write_file") as mockwrite:
             with mock.patch.object(
-                subp, "subp", return_value=("PID", "")
+                subp, "subp", return_value=("PPID   PID", "")
             ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
@@ -226,7 +226,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             "/etc/apt/sources.list", EXPECTED_CONVERTED_CONTENT, mode=420
         )
         mocksubp.assert_called_once_with(
-            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
             rcs=[0, 1],

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -121,20 +121,30 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
     def test_apt_v1_source_list_debian(self):
         """Test rendering of a source.list from template for debian"""
-        with mock.patch.object(subp, "subp") as mocksubp:
+        with mock.patch.object(
+            subp, "subp", return_value=("PID", "")
+        ) as mocksubp:
             self.apt_source_list(
                 "debian", "http://httpredir.debian.org/debian"
             )
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_source_list_ubuntu(self):
         """Test rendering of a source.list from template for ubuntu"""
-        with mock.patch.object(subp, "subp") as mocksubp:
+        with mock.patch.object(
+            subp, "subp", return_value=("PID", "")
+        ) as mocksubp:
             self.apt_source_list("ubuntu", "http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     @staticmethod
@@ -152,7 +162,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         with mock.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PID", "")
+            ) as mocksubp:
                 self.apt_source_list(
                     "debian",
                     [
@@ -164,7 +176,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://httpredir.debian.org/debian")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_srcl_ubuntu_mirrorfail(self):
@@ -172,7 +187,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         with mock.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PID", "")
+            ) as mocksubp:
                 self.apt_source_list(
                     "ubuntu",
                     [
@@ -184,7 +201,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_srcl_custom(self):
@@ -194,7 +214,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
         # the second mock restores the original subp
         with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PID", "")
+            ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
@@ -204,7 +226,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             "/etc/apt/sources.list", EXPECTED_CONVERTED_CONTENT, mode=420
         )
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
 

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -126,7 +126,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
                 mock.patch(cfg_func, return_value=(cfg_on_empty, "test"))
             )
             mock_subp = stack.enter_context(
-                mock.patch.object(subp, "subp", return_value=("PID", ""))
+                mock.patch.object(subp, "subp", return_value=("PPID  PID", ""))
             )
             cc_apt_configure.handle("test", cfg, mycloud, None)
 
@@ -240,7 +240,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
         with mock.patch.object(util, "write_file") as mockwrite:
             with mock.patch.object(
-                subp, "subp", return_value=("PID", "")
+                subp, "subp", return_value=("PPID   PID", "")
             ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
@@ -254,7 +254,7 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         ]
         mockwrite.assert_has_calls(calls)
         mocksubp.assert_called_once_with(
-            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
             rcs=[0, 1],

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -125,7 +125,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             mock_shouldcfg = stack.enter_context(
                 mock.patch(cfg_func, return_value=(cfg_on_empty, "test"))
             )
-            mock_subp = stack.enter_context(mock.patch.object(subp, "subp"))
+            mock_subp = stack.enter_context(
+                mock.patch.object(subp, "subp", return_value=("PID", ""))
+            )
             cc_apt_configure.handle("test", cfg, mycloud, None)
 
             return (
@@ -237,7 +239,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mycloud = get_cloud()
 
         with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PID", "")
+            ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
@@ -250,7 +254,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         ]
         mockwrite.assert_has_calls(calls)
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "pid,args", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
 

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -9,6 +9,7 @@ import os
 import pathlib
 import re
 import shutil
+import signal
 import tempfile
 from unittest import mock
 from unittest.mock import call
@@ -75,7 +76,7 @@ class TestAptSourceConfig(TestCase):
         get_arch.return_value = "amd64"
         self.addCleanup(apatcher.stop)
         subp_patcher = mock.patch.object(
-            subp, "subp", return_value=("PID", "")
+            subp, "subp", return_value=("PPID   PID", "")
         )
         self.m_subp = subp_patcher.start()
         self.addCleanup(subp_patcher.stop)
@@ -568,12 +569,24 @@ class TestAptSourceConfig(TestCase):
         """Test specification of a keyid without source"""
         cfg = {"keyid": "03683F77", "filename": self.aptlistfile}
         cfg = self.wrapv1conf([cfg])
-
+        SAMPLE_GPG_AGENT_DIRMNGR_PIDS = """\
+   PPID     PID
+      1    1057
+      1    1095
+   1511    2493
+   1511    2509
+"""
         with mock.patch.object(
-            subp, "subp", side_effect=[("fakekey 1212", ""), ("PID", "")]
+            subp,
+            "subp",
+            side_effect=[
+                ("fakekey 1212", ""),
+                (SAMPLE_GPG_AGENT_DIRMNGR_PIDS, ""),
+            ],
         ):
             with mock.patch.object(cc_apt_configure, "apt_key") as mockobj:
-                cc_apt_configure.handle("test", cfg, self.cloud, None)
+                with mock.patch.object(cc_apt_configure.os, "kill") as m_kill:
+                    cc_apt_configure.handle("test", cfg, self.cloud, None)
 
         calls = (
             call(
@@ -584,6 +597,10 @@ class TestAptSourceConfig(TestCase):
             ),
         )
         mockobj.assert_has_calls(calls, any_order=True)
+        self.assertEqual(
+            ([call(1057, signal.SIGKILL), call(1095, signal.SIGKILL)]),
+            m_kill.call_args_list,
+        )
 
         # filename should be ignored on key only
         self.assertFalse(os.path.isfile(self.aptlistfile))
@@ -663,7 +680,7 @@ class TestAptSourceConfig(TestCase):
                     [
                         "ps",
                         "-o",
-                        "pid,args",
+                        "ppid,pid",
                         "-C",
                         "dirmngr",
                         "-C",
@@ -695,7 +712,7 @@ class TestAptSourceConfig(TestCase):
         cfg = self.wrapv1conf([cfg1, cfg2, cfg3])
 
         with mock.patch.object(
-            subp, "subp", return_value=("PID", "")
+            subp, "subp", return_value=("PPID   PID", "")
         ) as mockobj:
             cc_apt_configure.handle("test", cfg, self.cloud, None)
         calls = [


### PR DESCRIPTION
## Proposed Commit Message

```
Upstream commit 842d0452 introduced a dependency on gpgconf
utility without a strict Depends: clause in debian/control.

While gnupg is in Recommends for cloud-init, some images
like Ubuntu minimal will not install the package Recommends
to keep images smaller.

To avoid adding a hard Requires dependency on gpgconf, use os.kill
directly to stop any dirmngr and gpg-agent when spawned by
cloud-config's root ppid due to apt-related user-data.

NOOP If no gpg-agent or dirmngr processes are spawned by PPID 1.

LP: #2034273
```

## Additional Context
<!-- If relevant -->
As this represents a regression in behavior for Ubuntu minimal images and possibly Debian images without gpgconf, this is going to require a hotfix release of 23.3.1

## Test Steps
```
# Generate local deb from this branch
./tools/run-container --package ubuntu/mantic

# test using local deb
CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_23.3-11-gce9b83b2-1~bddeb_all.deb CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_OS_IMAGE=mantic .tox/integration-tests/bin/pytest  tests/integration_tests/bugs/test_lp1813396.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
