### PR TITLE
23.3.x

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+23.3.1
+ - apt: kill dirmngr/gpg-agent without gpgconf dependency (LP: #2034273)
+ - integration tests: Fix cgroup parsing (#4402)
+
 23.3
  - Bump pycloudlib to 1!5.1.0 for ec2 mantic daily image support (#4390)
  - Fix cc_keyboard in mantic (LP: #2030788)

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "23.3"
+__VERSION__ = "23.3.1"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -29,5 +29,9 @@ def test_gpg_no_tty(client: IntegrationInstance):
         "Imported key 'E4D304DF' from keyserver 'keyserver.ubuntu.com'",
     ]
     verify_ordered_items_in_text(to_verify, log)
-    result = client.execute("systemctl status cloud-config.service")
-    assert "CGroup" not in result.stdout
+    processes_in_cgroup = int(
+        client.execute(
+            "systemd-cgls -u cloud-config.service 2>/dev/null | wc -l"
+        ).stdout
+    )
+    assert processes_in_cgroup < 2

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -6,7 +6,10 @@ Ensure gpg is called with no tty flag.
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_ordered_items_in_text
+from tests.integration_tests.util import (
+    verify_clean_log,
+    verify_ordered_items_in_text,
+)
 
 USER_DATA = """\
 #cloud-config
@@ -29,6 +32,7 @@ def test_gpg_no_tty(client: IntegrationInstance):
         "Imported key 'E4D304DF' from keyserver 'keyserver.ubuntu.com'",
     ]
     verify_ordered_items_in_text(to_verify, log)
+    verify_clean_log(log)
     processes_in_cgroup = int(
         client.execute(
             "systemd-cgls -u cloud-config.service 2>/dev/null | wc -l"

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -121,20 +121,30 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
     def test_apt_v1_source_list_debian(self):
         """Test rendering of a source.list from template for debian"""
-        with mock.patch.object(subp, "subp") as mocksubp:
+        with mock.patch.object(
+            subp, "subp", return_value=("PPID   PID", "")
+        ) as mocksubp:
             self.apt_source_list(
                 "debian", "http://httpredir.debian.org/debian"
             )
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_source_list_ubuntu(self):
         """Test rendering of a source.list from template for ubuntu"""
-        with mock.patch.object(subp, "subp") as mocksubp:
+        with mock.patch.object(
+            subp, "subp", return_value=("PPID   PID", "")
+        ) as mocksubp:
             self.apt_source_list("ubuntu", "http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     @staticmethod
@@ -152,7 +162,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         with mock.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 self.apt_source_list(
                     "debian",
                     [
@@ -164,7 +176,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://httpredir.debian.org/debian")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_srcl_ubuntu_mirrorfail(self):
@@ -172,7 +187,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         with mock.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 self.apt_source_list(
                     "ubuntu",
                     [
@@ -184,7 +201,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_srcl_custom(self):
@@ -194,7 +214,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
         # the second mock restores the original subp
         with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
@@ -204,7 +226,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             "/etc/apt/sources.list", EXPECTED_CONVERTED_CONTENT, mode=420
         )
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
 

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -125,7 +125,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             mock_shouldcfg = stack.enter_context(
                 mock.patch(cfg_func, return_value=(cfg_on_empty, "test"))
             )
-            mock_subp = stack.enter_context(mock.patch.object(subp, "subp"))
+            mock_subp = stack.enter_context(
+                mock.patch.object(subp, "subp", return_value=("PPID  PID", ""))
+            )
             cc_apt_configure.handle("test", cfg, mycloud, None)
 
             return (
@@ -237,7 +239,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mycloud = get_cloud()
 
         with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
@@ -250,7 +254,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         ]
         mockwrite.assert_has_calls(calls)
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
 


### PR DESCRIPTION
## do not squash merge

Create upstream hotfix branch upstream/23.3.x


Branch created with a cherry-pick of two functional commits

git cherry-pick 60b50dd4ffcf2da67d22cc842a9008f9e39d89f9   # integration test fix to ease subsequent cherry-pick
git cherry-pick f6bb5530276f896087b60bce11d11c1f9e662e7d    # Fix for kill gpg-agent/dirmngr when apt/keyid provided
git log 23.3..HEAD # Add this dedented output to ChangeLog

Fixes LP: #2034273
## Additional Context
<!-- If relevant -->
Avoid dependence on gpgconf package/command: https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2034273


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
