### PR TITLE
Ubuntu/devel

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+23.3.1
+ - apt: kill dirmngr/gpg-agent without gpgconf dependency (LP: #2034273)
+ - integration tests: Fix cgroup parsing (#4402)
+
 23.3
  - Bump pycloudlib to 1!5.1.0 for ec2 mantic daily image support (#4390)
  - Fix cc_keyboard in mantic (LP: #2030788)

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "23.3"
+__VERSION__ = "23.3.1"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cloud-init (23.3.1-0ubuntu1) UNRELEASED; urgency=medium
+
+  * New upstream bug fix release based on 23.3.1.
+    List of changes from upstream can be found at
+    https://raw.githubusercontent.com/canonical/cloud-init/23.3.1/ChangeLog
+    - Bugs fixed in this snapshot: (LP: #2034273)
+
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 05 Sep 2023 17:03:54 -0600
+
 cloud-init (23.3-0ubuntu1) mantic; urgency=medium
 
   * d/po/templates.pot: refresh with debconf-updatepo

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,11 @@
-cloud-init (23.3.1-0ubuntu1) UNRELEASED; urgency=medium
+cloud-init (23.3.1-0ubuntu1) mantic; urgency=medium
 
   * New upstream bug fix release based on 23.3.1.
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/23.3.1/ChangeLog
     - Bugs fixed in this snapshot: (LP: #2034273)
 
- -- Chad Smith <chad.smith@canonical.com>  Tue, 05 Sep 2023 17:03:54 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 05 Sep 2023 17:03:59 -0600
 
 cloud-init (23.3-0ubuntu1) mantic; urgency=medium
 

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -6,7 +6,10 @@ Ensure gpg is called with no tty flag.
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_ordered_items_in_text
+from tests.integration_tests.util import (
+    verify_clean_log,
+    verify_ordered_items_in_text,
+)
 
 USER_DATA = """\
 #cloud-config
@@ -29,5 +32,10 @@ def test_gpg_no_tty(client: IntegrationInstance):
         "Imported key 'E4D304DF' from keyserver 'keyserver.ubuntu.com'",
     ]
     verify_ordered_items_in_text(to_verify, log)
-    result = client.execute("systemctl status cloud-config.service")
-    assert "CGroup" not in result.stdout
+    verify_clean_log(log)
+    processes_in_cgroup = int(
+        client.execute(
+            "systemd-cgls -u cloud-config.service 2>/dev/null | wc -l"
+        ).stdout
+    )
+    assert processes_in_cgroup < 2

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -121,20 +121,30 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
     def test_apt_v1_source_list_debian(self):
         """Test rendering of a source.list from template for debian"""
-        with mock.patch.object(subp, "subp") as mocksubp:
+        with mock.patch.object(
+            subp, "subp", return_value=("PPID   PID", "")
+        ) as mocksubp:
             self.apt_source_list(
                 "debian", "http://httpredir.debian.org/debian"
             )
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_source_list_ubuntu(self):
         """Test rendering of a source.list from template for ubuntu"""
-        with mock.patch.object(subp, "subp") as mocksubp:
+        with mock.patch.object(
+            subp, "subp", return_value=("PPID   PID", "")
+        ) as mocksubp:
             self.apt_source_list("ubuntu", "http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     @staticmethod
@@ -152,7 +162,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         with mock.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 self.apt_source_list(
                     "debian",
                     [
@@ -164,7 +176,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://httpredir.debian.org/debian")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_srcl_ubuntu_mirrorfail(self):
@@ -172,7 +187,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         with mock.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 self.apt_source_list(
                     "ubuntu",
                     [
@@ -184,7 +201,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_srcl_custom(self):
@@ -194,7 +214,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
         # the second mock restores the original subp
         with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
@@ -204,7 +226,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             "/etc/apt/sources.list", EXPECTED_CONVERTED_CONTENT, mode=420
         )
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
 

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -125,7 +125,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             mock_shouldcfg = stack.enter_context(
                 mock.patch(cfg_func, return_value=(cfg_on_empty, "test"))
             )
-            mock_subp = stack.enter_context(mock.patch.object(subp, "subp"))
+            mock_subp = stack.enter_context(
+                mock.patch.object(subp, "subp", return_value=("PPID  PID", ""))
+            )
             cc_apt_configure.handle("test", cfg, mycloud, None)
 
             return (
@@ -237,7 +239,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mycloud = get_cloud()
 
         with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
@@ -250,7 +254,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         ]
         mockwrite.assert_has_calls(calls)
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
 


### PR DESCRIPTION
## do not squash merge

New upstream snapshot to avoid dependency on gpgconf fix LP: #2034273.


## procedure to create branch
```

git clone git@github.com:canonical/cloud-init.git -o upstream
cd cloud-init
git fetch upstream --tags
git checkout upstream/ubuntu/devel -B ubuntu/devel
new_upstream_snapshot.py -c 23.3.1
```

## Additional Context
<!-- If relevant -->
Looking to avoid direct dependency on gpgconf as that's not ideal. this was originally by daily builds of ubuntu-minimal breaking on mantic when cloud-init 23.3 was published to mantic.

While this fix avoids cloud-init dependency on `gpgconf` package, we may also need some sort of fix for ubuntu-minimal to ensure that gpg package is still installed in ubuntu-minimal per @philroche's Merge proposal https://code.launchpad.net/~philroche/ubuntu-seeds/+git/ubuntu/+merge/450569.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
# build this package
$ build-package
$ sbuild --dist=mantic  --arch=amd64  --arch-all ../out/*dsc

# test with this package
CLOUD_INIT_CLOUD_INIT_SOURCE=../out/cloud-init*deb CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_OS_IMAGE=mantic tox -e integration-tests tests/integration_tests/bugs/test_lp1813396.py
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
