### PR TITLE
Ubuntu/lunar 23.3.x new_upstream_snapshot

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+23.3.1
+ - apt: kill dirmngr/gpg-agent without gpgconf dependency (LP: #2034273)
+ - integration tests: Fix cgroup parsing (#4402)
+
 23.3
  - Bump pycloudlib to 1!5.1.0 for ec2 mantic daily image support (#4390)
  - Fix cc_keyboard in mantic (LP: #2030788)

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "23.3"
+__VERSION__ = "23.3.1"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (23.3.1-0ubuntu1~23.04.1) UNRELEASED; urgency=medium
+cloud-init (23.3.1-0ubuntu1~23.04.1) lunar; urgency=medium
 
   * Upstream snapshot based on upstream/main at ee9078a7.
   * d/cloud-init.maintscript: Remove the unused hook-network-manager
@@ -13,7 +13,7 @@ cloud-init (23.3.1-0ubuntu1~23.04.1) UNRELEASED; urgency=medium
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/23.3.1/ChangeLog
 
- -- James Falcon <james.falcon@canonical.com>  Wed, 06 Sep 2023 11:26:18 -0500
+ -- James Falcon <james.falcon@canonical.com>  Wed, 06 Sep 2023 11:28:36 -0500
 
 cloud-init (23.2.2-0ubuntu0~23.04.1) lunar; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (23.3-0ubuntu0~23.04.1) UNRELEASED; urgency=medium
+cloud-init (23.3.1-0ubuntu1~23.04.1) UNRELEASED; urgency=medium
 
   * Upstream snapshot based on upstream/main at ee9078a7.
   * d/cloud-init.maintscript: Remove the unused hook-network-manager
@@ -9,11 +9,11 @@ cloud-init (23.3-0ubuntu0~23.04.1) UNRELEASED; urgency=medium
   * d/cloud-init.templates: enable Akamai by default.
     Add Akamai to the default templates to allow datasource discovery.
   * d/po/templates.pot: refresh with debconf-updatepo
-  * Upstream snapshot based on 23.3. (LP: #2033310).
+  * Upstream snapshot based on 23.3.1. (LP: #2033310).
     List of changes from upstream can be found at
-    https://raw.githubusercontent.com/canonical/cloud-init/23.3/ChangeLog
+    https://raw.githubusercontent.com/canonical/cloud-init/23.3.1/ChangeLog
 
- -- James Falcon <james.falcon@canonical.com>  Mon, 28 Aug 2023 14:57:55 -0500
+ -- James Falcon <james.falcon@canonical.com>  Wed, 06 Sep 2023 11:26:18 -0500
 
 cloud-init (23.2.2-0ubuntu0~23.04.1) lunar; urgency=medium
 

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -6,7 +6,10 @@ Ensure gpg is called with no tty flag.
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_ordered_items_in_text
+from tests.integration_tests.util import (
+    verify_clean_log,
+    verify_ordered_items_in_text,
+)
 
 USER_DATA = """\
 #cloud-config
@@ -29,5 +32,10 @@ def test_gpg_no_tty(client: IntegrationInstance):
         "Imported key 'E4D304DF' from keyserver 'keyserver.ubuntu.com'",
     ]
     verify_ordered_items_in_text(to_verify, log)
-    result = client.execute("systemctl status cloud-config.service")
-    assert "CGroup" not in result.stdout
+    verify_clean_log(log)
+    processes_in_cgroup = int(
+        client.execute(
+            "systemd-cgls -u cloud-config.service 2>/dev/null | wc -l"
+        ).stdout
+    )
+    assert processes_in_cgroup < 2

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -121,20 +121,30 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
     def test_apt_v1_source_list_debian(self):
         """Test rendering of a source.list from template for debian"""
-        with mock.patch.object(subp, "subp") as mocksubp:
+        with mock.patch.object(
+            subp, "subp", return_value=("PPID   PID", "")
+        ) as mocksubp:
             self.apt_source_list(
                 "debian", "http://httpredir.debian.org/debian"
             )
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_source_list_ubuntu(self):
         """Test rendering of a source.list from template for ubuntu"""
-        with mock.patch.object(subp, "subp") as mocksubp:
+        with mock.patch.object(
+            subp, "subp", return_value=("PPID   PID", "")
+        ) as mocksubp:
             self.apt_source_list("ubuntu", "http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     @staticmethod
@@ -152,7 +162,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         with mock.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 self.apt_source_list(
                     "debian",
                     [
@@ -164,7 +176,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://httpredir.debian.org/debian")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_srcl_ubuntu_mirrorfail(self):
@@ -172,7 +187,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         with mock.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
         ) as mockresolve:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 self.apt_source_list(
                     "ubuntu",
                     [
@@ -184,7 +201,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call("http://archive.ubuntu.com/ubuntu/")
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
     def test_apt_v1_srcl_custom(self):
@@ -194,7 +214,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
         # the second mock restores the original subp
         with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
@@ -204,7 +226,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             "/etc/apt/sources.list", EXPECTED_CONVERTED_CONTENT, mode=420
         )
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
 

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -125,7 +125,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             mock_shouldcfg = stack.enter_context(
                 mock.patch(cfg_func, return_value=(cfg_on_empty, "test"))
             )
-            mock_subp = stack.enter_context(mock.patch.object(subp, "subp"))
+            mock_subp = stack.enter_context(
+                mock.patch.object(subp, "subp", return_value=("PPID  PID", ""))
+            )
             cc_apt_configure.handle("test", cfg, mycloud, None)
 
             return (
@@ -237,7 +239,9 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         mycloud = get_cloud()
 
         with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(subp, "subp") as mocksubp:
+            with mock.patch.object(
+                subp, "subp", return_value=("PPID   PID", "")
+            ) as mocksubp:
                 with mock.patch.object(
                     Distro, "get_primary_arch", return_value="amd64"
                 ):
@@ -250,7 +254,10 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
         ]
         mockwrite.assert_has_calls(calls)
         mocksubp.assert_called_once_with(
-            ["gpgconf", "--kill", "all"], capture=True, target=None
+            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            capture=True,
+            target=None,
+            rcs=[0, 1],
         )
 
 


### PR DESCRIPTION
Ran `new_upstream_snapshot.py -b 2033310 -c 23.3.1`, then manually updated version number and removed old snapshot message in log.