### PR TITLE
Work around no instance ip

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -202,7 +202,10 @@ class IntegrationInstance:
             return self._ip
         try:
             # in some cases that ssh is not used, an address is not assigned
-            if self.instance.execute_via_ssh:
+            if (
+                hasattr(self.instance, "execute_via_ssh")
+                and self.instance.execute_via_ssh
+            ):
                 self._ip = self.instance.ip
         except NotImplementedError:
             self._ip = "Unknown"

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -201,7 +201,9 @@ class IntegrationInstance:
         if self._ip:
             return self._ip
         try:
-            self._ip = self.instance.ip
+            # in some cases that ssh is not used, an address is not assigned
+            if self.instance.execute_via_ssh:
+                self._ip = self.instance.ip
         except NotImplementedError:
             self._ip = "Unknown"
         return self._ip


### PR DESCRIPTION
## Proposed Commit Message
Use commit message.



## Additional Context
[Some integration tests](https://github.com/canonical/cloud-init/blob/fd214a1243011275c5dffb92b481c235e4c7a1bf/tests/integration_tests/test_kernel_commandline_match.py#L75) expect the instance to never receive a network connection, such as with lxc which may use a console connection in these cases. This causes errors on traceback when attempting to print the ip, which is only done for convenience. In these cases just don't print the ip address.

Error during teardown:
```
================================================================================== short test summary info ===================================================================================
ERROR tests/integration_tests/test_kernel_commandline_match.py::test_lxd_disable_cloud_init_env - pycloudlib.errors.PycloudlibTimeoutError: Unable to determine IP address after 150 retries. exit:0 stdout: {
===================================================================== 1 passed, 2 warnings, 1 error in 551.31s (0:09:11) =====================================================================
ERROR: InvocationError for command /home/holmanb/cloud-init-d/.tox/integration-tests/bin/python -m pytest -vv --log-cli-level=INFO --durations 10 tests/integration_tests/test_kernel_commandline_match.py::test_lxd_disable_cloud_init_env (exited with code 1)
```