### PR TITLE
Systemd_locale_conf filename parameter gets overridden

### DIFF
--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -75,7 +75,6 @@ class Distro(distros.Distro):
         if self.uses_systemd():
             if not out_fn:
                 out_fn = self.systemd_locale_conf_fn
-            out_fn = self.systemd_locale_conf_fn
         else:
             if not out_fn:
                 out_fn = self.locale_conf_fn

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -118,6 +118,7 @@ Oursin
 outscale-mdr
 phunyguy
 qubidt
+r00ta
 RedKrieg
 renanrodrigo
 rhansen


### PR DESCRIPTION
## Proposed Commit Message
Fix override of systemd_locale_conf in RHEL distro

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
