### PR TITLE
Upstream opensuse route code

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -173,7 +173,12 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         renderer = render_cls(config=self.renderer_configs.get(name))
         return renderer
 
-    def _write_network_state(self, network_state, renderer: Renderer):
+    def _write_network_state(
+        self,
+        network_state,
+        renderer: Renderer,
+        netconfig: Optional[dict] = None,
+    ):
         renderer.render_network_state(network_state)
 
     def _find_tz_file(self, tz):
@@ -286,7 +291,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             )
 
         network_state = parse_net_config_data(netconfig, renderer=renderer)
-        self._write_network_state(network_state, renderer)
+        self._write_network_state(network_state, renderer, netconfig=netconfig)
 
         # Now try to bring them up
         if bring_up:

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -10,6 +10,7 @@
 
 import logging
 import os
+from contextlib import suppress
 from typing import Optional
 
 from cloudinit import distros, helpers, subp, util
@@ -402,7 +403,10 @@ class Distro(distros.Distro):
                 for device_name in devices:
                     config_routes = ""
                     device_config = devices[device_name]
-                    try:
+                    # the parser expects another level of nesting
+                    # which should be there in case it's properly
+                    # formatted; if not we may get an exception on items()
+                    with suppress(AttributeError):
                         gateways = [
                             v
                             for k, v in device_config.items()
@@ -421,8 +425,3 @@ class Distro(distros.Distro):
                                 )
                             )
                             util.write_file(route_file, config_routes)
-                    except Exception:
-                        # the parser above expects another level of nesting
-                        # which should be there in case it's properly
-                        # formatted; if not we may get an exception on items()
-                        pass

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -286,10 +286,14 @@ class Distro(distros.Distro):
         return self._preferred_ntp_clients
 
     def _write_network_state(
-        self, network_state, renderer: Renderer, netconfig: Optional[dict]
+        self,
+        network_state,
+        renderer: Renderer,
+        netconfig: Optional[dict] = None,
     ):
         super()._write_network_state(network_state, renderer)
-        netconfig_ver = (netconfig or {}).get("version")
+        netconfig = netconfig or {}
+        netconfig_ver = netconfig.get("version")
         if netconfig_ver == 1:
             self._write_routes_v1(netconfig)
         elif netconfig_ver == 2:
@@ -299,7 +303,7 @@ class Distro(distros.Distro):
                 "unsupported or missing netconfig version, not writing routes"
             )
 
-    def _write_routes_v1(self, netconfig):
+    def _write_routes_v1(self, netconfig: dict):
         """Write route files, not part of the standard distro interface"""
         # Due to the implementation of the sysconfig renderer default routes
         # are setup in ifcfg-* files. But this does not work on SLES or
@@ -360,10 +364,10 @@ class Distro(distros.Distro):
                         continue
                     config_routes += " ".join([dest, gateway, "-", "-\n"])
             if config_routes:
-                route_file = "/etc/sysconfig/network/ifroute-%s" % if_name
+                route_file = f"/etc/sysconfig/network/ifroute-{if_name}"
                 util.write_file(route_file, config_routes)
 
-    def _render_route_string(self, netconfig_route):
+    def _render_route_string(self, netconfig_route: dict):
         route_to = netconfig_route.get("to", None)
         route_via = netconfig_route.get("via", None)
         route_metric = netconfig_route.get("metric", None)
@@ -380,7 +384,7 @@ class Distro(distros.Distro):
 
         return route_string
 
-    def _write_routes_v2(self, netconfig):
+    def _write_routes_v2(self, netconfig: dict):
         for device_type in netconfig:
             if device_type == "version":
                 continue
@@ -418,7 +422,7 @@ class Distro(distros.Distro):
                             )
                             util.write_file(route_file, config_routes)
                     except Exception:
-                        # the parser above epxects another level of nesting
+                        # the parser above expects another level of nesting
                         # which should be there in case it's properly
                         # formatted; if not we may get an exception on items()
                         pass

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -10,10 +10,13 @@
 
 import logging
 import os
+from typing import Optional
 
 from cloudinit import distros, helpers, subp, util
 from cloudinit.distros import rhel_util as rhutil
 from cloudinit.distros.parsers.hostname import HostnameConf
+from cloudinit.net import ipv4_mask_to_net_prefix
+from cloudinit.net.renderer import Renderer
 from cloudinit.settings import PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
@@ -281,3 +284,141 @@ class Distro(distros.Distro):
                 ]
 
         return self._preferred_ntp_clients
+
+    def _write_network_state(
+        self, network_state, renderer: Renderer, netconfig: Optional[dict]
+    ):
+        super()._write_network_state(network_state, renderer)
+        netconfig_ver = (netconfig or {}).get("version")
+        if netconfig_ver == 1:
+            self._write_routes_v1(netconfig)
+        elif netconfig_ver == 2:
+            self._write_routes_v2(netconfig)
+        else:
+            LOG.warning(
+                "unsupported or missing netconfig version, not writing routes"
+            )
+
+    def _write_routes_v1(self, netconfig):
+        """Write route files, not part of the standard distro interface"""
+        # Due to the implementation of the sysconfig renderer default routes
+        # are setup in ifcfg-* files. But this does not work on SLES or
+        # openSUSE https://bugs.launchpad.net/cloud-init/+bug/1812117
+        # this is a very hacky way to get around the problem until a real
+        # solution is found in the sysconfig renderer
+        device_configs = netconfig.get("config", [])
+        default_nets = ("::", "0.0.0.0")
+        for config in device_configs:
+            if_name = config.get("name")
+            subnets = config.get("subnets", [])
+            config_routes = ""
+            has_default_route = False
+            seen_default_gateway = None
+            for subnet in subnets:
+                # Render the default gateway if it is present
+                gateway = subnet.get("gateway")
+                if gateway:
+                    config_routes += " ".join(["default", gateway, "-", "-\n"])
+                    has_default_route = True
+                    if not seen_default_gateway:
+                        seen_default_gateway = gateway
+                # Render subnet routes
+                routes = subnet.get("routes", [])
+                for route in routes:
+                    dest = route.get("destination") or route.get("network")
+                    if not dest or dest in default_nets:
+                        dest = "default"
+                        if not has_default_route:
+                            has_default_route = True
+                    if dest != "default":
+                        netmask = route.get("netmask")
+                        if netmask:
+                            prefix = ipv4_mask_to_net_prefix(netmask)
+                            dest += "/" + str(prefix)
+                        if "/" not in dest:
+                            LOG.warning(
+                                'Skipping route; has no prefix "%s"', dest
+                            )
+                            continue
+                    gateway = route.get("gateway")
+                    if not gateway:
+                        LOG.warning('Missing gateway for "%s", skipping', dest)
+                        continue
+                    if (
+                        dest == "default"
+                        and has_default_route
+                        and gateway == seen_default_gateway
+                    ):
+                        dest_info = dest
+                        if gateway:
+                            dest_info = " ".join([dest, gateway, "-", "-"])
+                        LOG.warning(
+                            '%s already has default route, skipping "%s"',
+                            if_name,
+                            dest_info,
+                        )
+                        continue
+                    config_routes += " ".join([dest, gateway, "-", "-\n"])
+            if config_routes:
+                route_file = "/etc/sysconfig/network/ifroute-%s" % if_name
+                util.write_file(route_file, config_routes)
+
+    def _render_route_string(self, netconfig_route):
+        route_to = netconfig_route.get("to", None)
+        route_via = netconfig_route.get("via", None)
+        route_metric = netconfig_route.get("metric", None)
+        route_string = ""
+
+        if route_to and route_via:
+            route_string = " ".join([route_to, route_via, "-", "-"])
+            if route_metric:
+                route_string += " metric {}\n".format(route_metric)
+            else:
+                route_string += "\n"
+        else:
+            LOG.warning("invalid route definition, skipping route")
+
+        return route_string
+
+    def _write_routes_v2(self, netconfig):
+        for device_type in netconfig:
+            if device_type == "version":
+                continue
+
+            if device_type == "routes":
+                # global static routes
+                config_routes = ""
+                for route in netconfig["routes"]:
+                    config_routes += self._render_route_string(route)
+                if config_routes:
+                    route_file = "/etc/sysconfig/network/routes"
+                    util.write_file(route_file, config_routes)
+            else:
+                devices = netconfig[device_type]
+                for device_name in devices:
+                    config_routes = ""
+                    device_config = devices[device_name]
+                    try:
+                        gateways = [
+                            v
+                            for k, v in device_config.items()
+                            if "gateway" in k
+                        ]
+                        for gateway in gateways:
+                            config_routes += " ".join(
+                                ["default", gateway, "-", "-\n"]
+                            )
+                        for route in device_config.get("routes", []):
+                            config_routes += self._render_route_string(route)
+                        if config_routes:
+                            route_file = (
+                                "/etc/sysconfig/network/ifroute-{}".format(
+                                    device_name
+                                )
+                            )
+                            util.write_file(route_file, config_routes)
+                    except Exception:
+                        # the parser above epxects another level of nesting
+                        # which should be there in case it's properly
+                        # formatted; if not we may get an exception on items()
+                        pass


### PR DESCRIPTION
```
Upstream opensuse route code into _write_network_state()

https://build.opensuse.org/package/view_file/Cloud:Tools/cloud-init/cloud-init-write-routes.patch
```

## Additional Context

@rjschwei could you please review? I think that once this lands we can drop the patch in downstream opensuse.

Based on discussion with @rjschwei at cloud-init summit on August 10th, 2023.

