### PR TITLE
upstream gentoo patch

### DIFF
--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -218,7 +218,7 @@ class Distro(distros.Distro):
         distros.set_etc_timezone(tz=tz, tz_file=self._find_tz_file(tz))
 
     def package_command(self, command, args=None, pkgs=None):
-        cmd = list("emerge")
+        cmd = ["emerge"]
         # Redirect output
         cmd.append("--quiet")
 


### PR DESCRIPTION
```
Upstream gentoo patch

https://launchpadlibrarian.net/394553826/0001-Fix-Gentoo-package-installation-command.patch

Fixes GH-3260
```

## Additional Context
I thought this was already fixed, but apparently not. Fixes #3260.