### PR TITLE
Pytestify apt config test modules

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -562,7 +562,11 @@ def add_apt_sources(
         ent = srcdict[filename]
         LOG.debug("adding source/key '%s'", ent)
         if "filename" not in ent:
-            ent["filename"] = filename
+            if target and filename.startswith(target):
+                # Strip target path prefix from filename
+                ent["filename"] = filename[len(target) :]
+            else:
+                ent["filename"] = filename
 
         if "source" in ent and "$KEY_FILE" in ent["source"]:
             key_file = add_apt_key(ent, target, hardened=True)

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -3,21 +3,33 @@
 """ test_handler_apt_configure_sources_list
 Test templating of sources list
 """
-import os
-import shutil
-import tempfile
-from unittest import mock
+import stat
 
-from cloudinit import subp, templater, util
+import pytest
+
+from cloudinit import subp, util
 from cloudinit.config import cc_apt_configure
-from cloudinit.distros.debian import Distro
-from tests.unittests import helpers as t_help
 from tests.unittests.util import get_cloud
+
+EXAMPLE_TMPL = """\
+## template:jinja
+## Note, this file is written by cloud-init on first boot of an instance
+## modifications made here will not survive a re-bundle.
+## if you wish to make changes you can:
+## a.) add 'apt_preserve_sources_list: true' to /etc/cloud/cloud.cfg
+##     or do the same in user-data
+## b.) add sources in /etc/apt/sources.list.d
+## c.) make changes to template file /etc/cloud/templates/sources.list.tmpl
+
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+deb {{mirror}} {{codename}} main restricted
+deb-src {{mirror}} {{codename}} main restricted
+"""
 
 YAML_TEXT_CUSTOM_SL = """
 apt_mirror: http://archive.ubuntu.com/ubuntu/
 apt_custom_sources_list: |
-    ## template:jinja
     ## Note, this file is written by cloud-init on first boot of an instance
     ## modifications made here will not survive a re-bundle.
     ## if you wish to make changes you can:
@@ -28,8 +40,8 @@ apt_custom_sources_list: |
 
     # See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
     # newer versions of the distribution.
-    deb {{mirror}} {{codename}} main restricted
-    deb-src {{mirror}} {{codename}} main restricted
+    deb $MIRROR $RELEASE main restricted
+    deb-src $MIRROR $RELEASE main restricted
     # FIND_SOMETHING_SPECIAL
 """
 
@@ -45,31 +57,26 @@ EXPECTED_CONVERTED_CONTENT = """## Note, this file is written by cloud-init on f
 # newer versions of the distribution.
 deb http://archive.ubuntu.com/ubuntu/ fakerelease main restricted
 deb-src http://archive.ubuntu.com/ubuntu/ fakerelease main restricted
-# FIND_SOMETHING_SPECIAL
 """  # noqa: E501
 
 
-class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
+@pytest.mark.usefixtures("fake_filesystem")
+class TestAptSourceConfigSourceList:
     """TestAptSourceConfigSourceList
     Main Class to test sources list rendering
     """
 
-    def setUp(self):
-        super(TestAptSourceConfigSourceList, self).setUp()
-        self.subp = subp.subp
-        self.new_root = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self.new_root)
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        self.subp = mocker.patch.object(
+            subp, "subp", return_value=("PPID   PID", "")
+        )
+        lsb = mocker.patch("cloudinit.util.lsb_release")
+        lsb.return_value = {"codename": "fakerelease"}
+        m_arch = mocker.patch("cloudinit.util.get_dpkg_architecture")
+        m_arch.return_value = "amd64"
 
-        rpatcher = mock.patch("cloudinit.util.lsb_release")
-        get_rel = rpatcher.start()
-        get_rel.return_value = {"codename": "fakerelease"}
-        self.addCleanup(rpatcher.stop)
-        apatcher = mock.patch("cloudinit.util.get_dpkg_architecture")
-        get_arch = apatcher.start()
-        get_arch.return_value = "amd64"
-        self.addCleanup(apatcher.stop)
-
-    def apt_source_list(self, distro, mirror, mirrorcheck=None):
+    def apt_source_list(self, distro, mirror, tmpdir, mirrorcheck=None):
         """apt_source_list
         Test rendering of a source.list from template for a given distro
         """
@@ -78,69 +85,65 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
 
         if isinstance(mirror, list):
             cfg = {"apt_mirror_search": mirror}
+            expected = EXPECTED_CONVERTED_CONTENT.replace(
+                "http://archive.ubuntu.com/ubuntu/", mirror[-1]
+            )
         else:
             cfg = {"apt_mirror": mirror}
+            expected = EXPECTED_CONVERTED_CONTENT.replace(
+                "http://archive.ubuntu.com/ubuntu/", mirror
+            )
 
         mycloud = get_cloud(distro)
+        tmpl_file = f"/etc/cloud/templates/sources.list.{distro}.tmpl"
+        util.write_file(tmpl_file, EXAMPLE_TMPL)
 
-        with mock.patch.object(util, "write_file") as mockwf:
-            with mock.patch.object(
-                util, "load_file", return_value="faketmpl"
-            ) as mocklf:
-                with mock.patch.object(
-                    os.path, "isfile", return_value=True
-                ) as mockisfile:
-                    with mock.patch.object(
-                        templater, "render_string", return_value="fake"
-                    ) as mockrnd:
-                        with mock.patch.object(util, "rename"):
-                            cc_apt_configure.handle("test", cfg, mycloud, None)
+        cc_apt_configure.handle("test", cfg, mycloud, None)
+        sources_file = tmpdir.join("/etc/apt/sources.list")
+        assert expected == sources_file.read()
+        assert 0o644 == stat.S_IMODE(sources_file.stat().mode)
 
-        mockisfile.assert_any_call(
-            "/etc/cloud/templates/sources.list.%s.tmpl" % distro
-        )
-        mocklf.assert_any_call(
-            "/etc/cloud/templates/sources.list.%s.tmpl" % distro
-        )
-        mockrnd.assert_called_once_with(
-            "faketmpl",
-            {
-                "RELEASE": "fakerelease",
-                "PRIMARY": mirrorcheck,
-                "MIRROR": mirrorcheck,
-                "SECURITY": mirrorcheck,
-                "codename": "fakerelease",
-                "primary": mirrorcheck,
-                "mirror": mirrorcheck,
-                "security": mirrorcheck,
-            },
-        )
-        mockwf.assert_called_once_with(
-            "/etc/apt/sources.list", "fake", mode=0o644
-        )
-
-    def test_apt_v1_source_list_debian(self):
-        """Test rendering of a source.list from template for debian"""
-        with mock.patch.object(
-            subp, "subp", return_value=("PPID   PID", "")
-        ) as mocksubp:
-            self.apt_source_list(
-                "debian", "http://httpredir.debian.org/debian"
+    @pytest.mark.parametrize(
+        "distro,mirror",
+        (
+            (
+                "ubuntu",
+                "http://archive.ubuntu.com/ubuntu/",
+            ),
+            (
+                "debian",
+                "http://httpredir.debian.org/debian/",
+            ),
+        ),
+    )
+    def test_apt_v1_source_list_by_distro(self, distro, mirror, tmpdir):
+        """Test rendering of a source.list from template for each distro"""
+        mycloud = get_cloud(distro)
+        tmpl_file = f"/etc/cloud/templates/sources.list.{distro}.tmpl"
+        util.write_file(tmpl_file, EXAMPLE_TMPL)
+        cc_apt_configure.handle("test", {"apt_mirror": mirror}, mycloud, None)
+        sources_file = tmpdir.join("/etc/apt/sources.list")
+        assert (
+            EXPECTED_CONVERTED_CONTENT.replace(
+                "http://archive.ubuntu.com/ubuntu/", mirror
             )
-        mocksubp.assert_called_once_with(
+            == sources_file.read()
+        )
+        assert 0o644 == stat.S_IMODE(sources_file.stat().mode)
+
+        self.subp.assert_called_once_with(
             ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
             rcs=[0, 1],
         )
 
-    def test_apt_v1_source_list_ubuntu(self):
+    def test_apt_v1_source_list_ubuntu(self, tmpdir):
         """Test rendering of a source.list from template for ubuntu"""
-        with mock.patch.object(
-            subp, "subp", return_value=("PPID   PID", "")
-        ) as mocksubp:
-            self.apt_source_list("ubuntu", "http://archive.ubuntu.com/ubuntu/")
-        mocksubp.assert_called_once_with(
+        self.apt_source_list(
+            "ubuntu", "http://archive.ubuntu.com/ubuntu/", tmpdir
+        )
+        self.subp.assert_called_once_with(
             ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
@@ -157,75 +160,79 @@ class TestAptSourceConfigSourceList(t_help.FilesystemMockingTestCase):
             print("Faking SUCCESS for '%s'" % name)
             return True
 
-    def test_apt_v1_srcl_debian_mirrorfail(self):
-        """Test rendering of a source.list from template for debian"""
-        with mock.patch.object(
-            util, "is_resolvable", side_effect=self.myresolve
-        ) as mockresolve:
-            with mock.patch.object(
-                subp, "subp", return_value=("PPID   PID", "")
-            ) as mocksubp:
-                self.apt_source_list(
-                    "debian",
-                    [
-                        "http://does.not.exist",
-                        "http://httpredir.debian.org/debian",
-                    ],
-                    "http://httpredir.debian.org/debian",
-                )
-        mockresolve.assert_any_call("http://does.not.exist")
-        mockresolve.assert_any_call("http://httpredir.debian.org/debian")
-        mocksubp.assert_called_once_with(
-            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
-            capture=True,
-            target=None,
-            rcs=[0, 1],
-        )
-
-    def test_apt_v1_srcl_ubuntu_mirrorfail(self):
+    @pytest.mark.parametrize(
+        "distro,mirrorlist,mirrorcheck",
+        (
+            (
+                "ubuntu",
+                ["http://does.not.exist", "http://archive.ubuntu.com/ubuntu/"],
+                "http://archive.ubuntu.com/ubuntu/",
+            ),
+            (
+                "debian",
+                [
+                    "http://does.not.exist",
+                    "http://httpredir.debian.org/debian/",
+                ],
+                "http://httpredir.debian.org/debian/",
+            ),
+        ),
+    )
+    def test_apt_v1_srcl_distro_mirrorfail(
+        self, distro, mirrorlist, mirrorcheck, mocker, tmpdir
+    ):
         """Test rendering of a source.list from template for ubuntu"""
-        with mock.patch.object(
+        mycloud = get_cloud(distro)
+        tmpl_file = f"/etc/cloud/templates/sources.list.{distro}.tmpl"
+        util.write_file(tmpl_file, EXAMPLE_TMPL)
+
+        mockresolve = mocker.patch.object(
             util, "is_resolvable", side_effect=self.myresolve
-        ) as mockresolve:
-            with mock.patch.object(
-                subp, "subp", return_value=("PPID   PID", "")
-            ) as mocksubp:
-                self.apt_source_list(
-                    "ubuntu",
-                    [
-                        "http://does.not.exist",
-                        "http://archive.ubuntu.com/ubuntu/",
-                    ],
-                    "http://archive.ubuntu.com/ubuntu/",
-                )
+        )
+        cc_apt_configure.handle(
+            "test", {"apt_mirror_search": mirrorlist}, mycloud, None
+        )
+        sources_file = tmpdir.join("/etc/apt/sources.list")
+        assert (
+            EXPECTED_CONVERTED_CONTENT.replace(
+                "http://archive.ubuntu.com/ubuntu/", mirrorcheck
+            )
+            == sources_file.read()
+        )
+        assert 0o644 == stat.S_IMODE(sources_file.stat().mode)
+
         mockresolve.assert_any_call("http://does.not.exist")
-        mockresolve.assert_any_call("http://archive.ubuntu.com/ubuntu/")
-        mocksubp.assert_called_once_with(
+        mockresolve.assert_any_call(mirrorcheck)
+        self.subp.assert_called_once_with(
             ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,
             rcs=[0, 1],
         )
 
-    def test_apt_v1_srcl_custom(self):
+    @pytest.mark.parametrize(
+        "cfg,apt_file,expected",
+        (
+            pytest.param(
+                util.load_yaml(YAML_TEXT_CUSTOM_SL),
+                "/etc/apt/sources.list",
+                EXPECTED_CONVERTED_CONTENT + "# FIND_SOMETHING_SPECIAL\n",
+                id="sources_list_writes_list_file",
+            ),
+        ),
+    )
+    def test_apt_v1_srcl_custom(self, cfg, apt_file, expected, tmpdir):
         """Test rendering from a custom source.list template"""
-        cfg = util.load_yaml(YAML_TEXT_CUSTOM_SL)
-        mycloud = get_cloud()
+        mycloud = get_cloud("ubuntu")
+        tmpl_file = "/etc/cloud/templates/sources.list.ubuntu.tmpl"
+        util.write_file(tmpl_file, EXAMPLE_TMPL)
 
         # the second mock restores the original subp
-        with mock.patch.object(util, "write_file") as mockwrite:
-            with mock.patch.object(
-                subp, "subp", return_value=("PPID   PID", "")
-            ) as mocksubp:
-                with mock.patch.object(
-                    Distro, "get_primary_arch", return_value="amd64"
-                ):
-                    cc_apt_configure.handle("notimportant", cfg, mycloud, None)
-
-        mockwrite.assert_called_once_with(
-            "/etc/apt/sources.list", EXPECTED_CONVERTED_CONTENT, mode=420
-        )
-        mocksubp.assert_called_once_with(
+        cc_apt_configure.handle("notimportant", cfg, mycloud, None)
+        sources_file = tmpdir.join(apt_file)
+        assert expected == sources_file.read()
+        assert 0o644 == stat.S_IMODE(sources_file.stat().mode)
+        self.subp.assert_called_once_with(
             ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
             capture=True,
             target=None,

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -738,7 +738,6 @@ class TestAptSourceConfig:
         # create files
         for (opre, _npre, suff) in files:
             fpath = os.path.join(apt_lists_d, opre + suff)
-            print(fpath)
             util.write_file(fpath, content=fpath)
 
         cc_apt_configure.rename_apt_lists(mirrors, target.strpath, arch)


### PR DESCRIPTION
## Proposed Commit Message
```
tests: convert multiple cc_apt_configure tests to pytest

Adapt test_apt_configure_sources_list_v1.py,
test_apt_configure_sources_list_v3.py and test_apt_source_v3.py
to pytest

One functional change made for test support in cc_apt_configure.
    - add_apt_sources function only prepends target test_apt_source_v3.py path to filename
      if filename does not already start with target.
No production logic invokes add_apt_sources with target= param set.

For pytest conversion, the following procedure was followed:
- Make use of fake_filesystem fixture and avoid subclassing from FilesystemMockingTestCase
- Rector common EXAMPLE_TMPL, reusing it as a base test content/layout representation in
  YAML_TEXT_CUSTOM_SL.
 - use a common setup fixture in a class for typical mocks are needed for tests
 - use mocker instead of unittest.mock where possible
 - drop private _apt_source_list function and complex ExitStack in favor of common setup fixture


Now that we are actually writing tmpl files out and reading them directly instead of mocking out
all isfile, load_file and write_file calls, there are a couple of bugs in the testing of
EXPECTED_CONTENT_MIRROR_CONTENT and EXPECTED_PRIMSEC_CONTENT suites
represented because of the nested ExitStack mocking was mocking the wrong return values.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [X] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
