### PR TITLE
sources: do not override datasource detection if None is in list

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -352,10 +352,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 self,
             )
             return True
-        elif self.sys_cfg.get("datasource_list", []) in (
-            [self.dsname],
-            [self.dsname, "None"],
-        ):
+        elif self.sys_cfg.get("datasource_list", []) == [self.dsname]:
             LOG.debug(
                 "Machine is configured to run on single datasource %s.", self
             )


### PR DESCRIPTION
    Users with datasource_list = [Azure, None] started failing to boot
    properly outside of Azure with the changes to override datasource detection.

    If the fallback "None" is included in the datasource_list, do not treat
    the system as configured with a single datasource.

    If users want to force a single datasource regardless of detection,
    they can do so by removing None from the list.