### PR TITLE
openstack: set max_wait to 120

### DIFF
--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -50,6 +50,9 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
     # Whether we want to get network configuration from the metadata service.
     perform_dhcp_setup = False
 
+    # wait for metadata service by default, some network backends need it
+    url_max_wait = 120
+
     supported_update_events = {
         EventScope.NETWORK: {
             EventType.BOOT_NEW_INSTANCE,

--- a/doc/rtd/reference/datasources/openstack.rst
+++ b/doc/rtd/reference/datasources/openstack.rst
@@ -49,7 +49,7 @@ The maximum amount of clock time (in seconds) that should be spent searching
 ``metadata_urls``. A value less than zero will result in only one request
 being made, to the first in the list.
 
-Default: -1
+Default: 120
 
 ``timeout``
 -----------


### PR DESCRIPTION
with OpenStack Neutron using OVN as a backend (default for some releases already) there's no more guarantee that dhcp/metadata will be ready by the time the VM starts, so we better add some default max_wait for OpenStack data source too.

closes #3989

## Proposed Commit Message
openstack: set max_wait to 120

```
with OpenStack Neutron using OVN as a backend (which is default for some releases already) there's no more guarantee that dhcp/metadata will be ready by the time the VM starts, so we better add some default max_wait for OpenStack data source too.

Fixes GH-3989
LP: #1979049
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
