### PR TITLE
Install gnupg if gpg not found

### DIFF
--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -71,6 +71,7 @@ class TestAptSourceConfigSourceList:
         self.subp = mocker.patch.object(
             subp, "subp", return_value=("PPID   PID", "")
         )
+        mocker.patch("cloudinit.config.cc_apt_configure._ensure_gpg")
         lsb = mocker.patch("cloudinit.util.lsb_release")
         lsb.return_value = {"codename": "fakerelease"}
         m_arch = mocker.patch("cloudinit.util.get_dpkg_architecture")

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -88,6 +88,7 @@ class TestAptSourceConfigSourceList:
         lsb.return_value = {"codename": "fakerel"}
         m_arch = mocker.patch("cloudinit.util.get_dpkg_architecture")
         m_arch.return_value = "amd64"
+        mocker.patch("cloudinit.config.cc_apt_configure._ensure_gpg")
 
     @pytest.mark.parametrize(
         "distro,template_present",

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -77,6 +77,7 @@ class TestAptSourceConfig:
             "cloudinit.util.get_dpkg_architecture", return_value="amd64"
         )
         mocker.patch.object(subp, "subp", return_value=("PPID   PID", ""))
+        mocker.patch("cloudinit.config.cc_apt_configure._ensure_gpg")
 
     def _get_default_params(self):
         """get_default_params
@@ -351,16 +352,17 @@ class TestAptSourceConfig:
         Test specification of a source + keyid
         """
         cfg = self.wrapv1conf(cfg)
+        cloud = get_cloud()
 
         with mock.patch.object(cc_apt_configure, "add_apt_key") as mockobj:
-            cc_apt_configure.handle("test", cfg, get_cloud(), [])
+            cc_apt_configure.handle("test", cfg, cloud, [])
 
         # check if it added the right number of keys
         calls = []
         sources = cfg["apt"]["sources"]
         for src in sources:
             print(sources[src])
-            calls.append(call(sources[src], None))
+            calls.append(call(sources[src], cloud, None))
 
         mockobj.assert_has_calls(calls, any_order=True)
 
@@ -473,16 +475,17 @@ class TestAptSourceConfig:
         Test specification of a source + key
         """
         cfg = self.wrapv1conf([cfg])
+        cloud = get_cloud()
 
         with mock.patch.object(cc_apt_configure, "add_apt_key") as mockobj:
-            cc_apt_configure.handle("test", cfg, get_cloud(), [])
+            cc_apt_configure.handle("test", cfg, cloud, [])
 
         # check if it added the right amount of keys
         sources = cfg["apt"]["sources"]
         calls = []
         for src in sources:
             print(sources[src])
-            calls.append(call(sources[src], None))
+            calls.append(call(sources[src], cloud, None))
 
         mockobj.assert_has_calls(calls, any_order=True)
 

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -55,6 +55,7 @@ class TestAptSourceConfig:
             f"{M_PATH}util.lsb_release",
             return_value=MOCK_LSB_RELEASE_DATA.copy(),
         )
+        mocker.patch(f"{M_PATH}_ensure_gpg")
         self.aptlistfile = tmpdir.join("src1.list").strpath
         self.aptlistfile2 = tmpdir.join("src2.list").strpath
         self.aptlistfile3 = tmpdir.join("src3.list").strpath
@@ -269,9 +270,9 @@ class TestAptSourceConfig:
         calls = []
         for key in cfg:
             if is_hardened is not None:
-                calls.append(call(cfg[key], hardened=is_hardened))
+                calls.append(call(cfg[key], None, hardened=is_hardened))
             else:
-                calls.append(call(cfg[key], tmpdir.strpath))
+                calls.append(call(cfg[key], None, tmpdir.strpath))
 
         mockobj.assert_has_calls(calls, any_order=True)
 
@@ -736,7 +737,7 @@ class TestAptSourceConfig:
 
         expected = sorted([npre + suff for opre, npre, suff in files])
         # create files
-        for (opre, _npre, suff) in files:
+        for opre, _npre, suff in files:
             fpath = os.path.join(apt_lists_d, opre + suff)
             util.write_file(fpath, content=fpath)
 
@@ -1285,7 +1286,7 @@ deb http://ubuntu.com/ubuntu/ xenial-proposed main"""
         }
 
         with mock.patch.object(cc_apt_configure, "add_apt_key_raw") as mockadd:
-            cc_apt_configure.add_mirror_keys(cfg, tmpdir.strpath)
+            cc_apt_configure.add_mirror_keys(cfg, None, tmpdir.strpath)
         calls = [
             mock.call("fakekey_primary", "primary", hardened=False),
             mock.call("fakekey_security", "security", hardened=False),


### PR DESCRIPTION
Note that this still hasn't been broken in the latest mantic images, so I can't actually confirm that the fix works other than manually uninstalling packages and re-running cloud-init.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Install gnupg if gpg not found

Ubuntu recommends gnupg in its packaging but does not require it, and
minimal images will no longer contain gnupg. Given that gpg is only
used for apt key handling, rather than having a hard requirement,
this commit installs gnupg if no gpg binary is found.

Fixes GH-4410
```

## Additional Context
https://github.com/canonical/cloud-init/issues/4410
