### PR TITLE
apt: install software-properties-common when absent but needed

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -520,9 +520,13 @@ def _ensure_dependencies(cfg, aa_repo_match, cloud):
     missing_packages = []
     required_cmds = set()
     if util.is_false(cfg.get("preserve_sources_list", False)):
-        for key in ("primary", "security"):
-            if cfg.get(key):  # If either key set, we'll add_mirror_keys
-                required_cmds.add("gpg")
+        for mirror_key in ("primary", "security"):
+            if cfg.get(mirror_key):
+                # Include gpg when mirror_key non-empty list and any item
+                # defines key or keyid.
+                for mirror_item in cfg[mirror_key]:
+                    if {"key", "keyid"}.intersection(mirror_item):
+                        required_cmds.add("gpg")
     apt_sources_dict = cfg.get("sources", {})
     for ent in apt_sources_dict.values():
         if {"key", "keyid"}.intersection(ent):

--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -437,4 +437,4 @@ apt:
 def test_install_missing_deps(client: IntegrationInstance):
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
-    assert "install software-properties-common gnupg" in log
+    assert "install gnupg software-properties-common" in log

--- a/tests/integration_tests/modules/test_apt.py
+++ b/tests/integration_tests/modules/test_apt.py
@@ -8,6 +8,7 @@ from cloudinit.config import cc_apt_configure
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
+from tests.integration_tests.util import verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -412,3 +413,28 @@ def test_apt_proxy(client: IntegrationInstance):
     assert 'Acquire::http::Proxy "http://squid.internal:3128";' in out
     assert 'Acquire::ftp::Proxy "ftp://squid.internal:3128";' in out
     assert 'Acquire::https::Proxy "https://squid.internal:3128";' in out
+
+
+INSTALL_ANY_MISSING_RECOMMENDED_DEPENDENCIES = """\
+#cloud-config
+bootcmd:
+    - apt-get remove gpg -y
+apt:
+  sources:
+    test_keyserver:
+      keyid: 110E21D8B0E2A1F0243AF6820856F197B892ACEA
+      keyserver: keyserver.ubuntu.com
+      source: "deb http://ppa.launchpad.net/canonical-kernel-team/ppa/ubuntu $RELEASE main"
+    test_ppa:
+      keyid: 441614D8
+      keyserver: keyserver.ubuntu.com
+      source: "ppa:simplestreams-dev/trunk"
+"""  # noqa: E501
+
+
+@pytest.mark.skipif(not IS_UBUNTU, reason="Apt usage")
+@pytest.mark.user_data(INSTALL_ANY_MISSING_RECOMMENDED_DEPENDENCIES)
+def test_install_missing_deps(client: IntegrationInstance):
+    log = client.read_from_file("/var/log/cloud-init.log")
+    verify_clean_log(log)
+    assert "install software-properties-common gnupg" in log

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -71,7 +71,7 @@ class TestAptSourceConfigSourceList:
         self.subp = mocker.patch.object(
             subp, "subp", return_value=("PPID   PID", "")
         )
-        mocker.patch("cloudinit.config.cc_apt_configure._ensure_gpg")
+        mocker.patch("cloudinit.config.cc_apt_configure._ensure_dependencies")
         lsb = mocker.patch("cloudinit.util.lsb_release")
         lsb.return_value = {"codename": "fakerelease"}
         m_arch = mocker.patch("cloudinit.util.get_dpkg_architecture")

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -88,7 +88,7 @@ class TestAptSourceConfigSourceList:
         lsb.return_value = {"codename": "fakerel"}
         m_arch = mocker.patch("cloudinit.util.get_dpkg_architecture")
         m_arch.return_value = "amd64"
-        mocker.patch("cloudinit.config.cc_apt_configure._ensure_gpg")
+        mocker.patch("cloudinit.config.cc_apt_configure._ensure_dependencies")
 
     @pytest.mark.parametrize(
         "distro,template_present",

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -77,7 +77,7 @@ class TestAptSourceConfig:
             "cloudinit.util.get_dpkg_architecture", return_value="amd64"
         )
         mocker.patch.object(subp, "subp", return_value=("PPID   PID", ""))
-        mocker.patch("cloudinit.config.cc_apt_configure._ensure_gpg")
+        mocker.patch("cloudinit.config.cc_apt_configure._ensure_dependencies")
 
     def _get_default_params(self):
         """get_default_params

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -55,7 +55,7 @@ class TestAptSourceConfig:
             f"{M_PATH}util.lsb_release",
             return_value=MOCK_LSB_RELEASE_DATA.copy(),
         )
-        mocker.patch(f"{M_PATH}_ensure_gpg")
+        mocker.patch(f"{M_PATH}_ensure_dependencies")
         self.aptlistfile = tmpdir.join("src1.list").strpath
         self.aptlistfile2 = tmpdir.join("src2.list").strpath
         self.aptlistfile3 = tmpdir.join("src3.list").strpath


### PR DESCRIPTION
## Proposed Commit Message
```
apt: install software-properties-common when absent but needed

When optional user-data contains APT sources configuration that warrants source repo setup, cloud-init calls add-apt-repository which is packaged in software-properties common.

The software-properties-common package is defined as a Recommends: in debian/control, and some minimal images do not install recommended packages.

When minimal images do not have software-properties-common installed, cloud-init will install this package on first boot only when required by optional apt sources user-data.

The gnupg package is another optional/recommended package that willl be installed is specific apt user-data config requires gpg interaction.

Refactor _ensure_gpg to _ensure_dependencies to only attempt to install missing dependencies once in mininmal image cases where user-data requires both gpg and add-apt-repository commands and the image includes neither gnupg nor software-properties-common.
```

## Additional Context
Ubuntu mantic minimal daily builds do not install Recommends: packages. We need to assert that images without these packages (gnupg, software-properties-common) can 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
