### PR TITLE
feat(apport): collect ubuntu-pro logs if keys present in cloud-config (SC-1439)

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -7,7 +7,6 @@
 import json
 import os
 
-from cloudinit import stages
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.cmd.devel.logs import (
     INSTALLER_APPORT_FILES,
@@ -158,21 +157,13 @@ def attach_installer_files(report, ui=None):
 
 def attach_ubuntu_pro_info(report, ui=None):
     """Attach ubuntu pro logs and tag if keys present in user-data."""
-    init = stages.Init()
-    has_up_key = init.cfg and (
-        "ubuntu_advantage" in init.cfg.keys()
-        or "ubuntu-advantage" in init.cfg.keys()
-    )
-    if not has_up_key:
-        return
-
     realpath = os.path.realpath("/var/log/ubuntu-advantage.log")
     attach_file_if_exists(report, realpath)
-
-    report.setdefault("Tags", "")
-    if report["Tags"]:
-        report["Tags"] += " "
-    report["Tags"] += "ubuntu-pro"
+    if os.path.exists(realpath):
+        report.setdefault("Tags", "")
+        if report["Tags"]:
+            report["Tags"] += " "
+        report["Tags"] += "ubuntu-pro"
 
 
 def attach_user_data(report, ui=None):

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -7,6 +7,7 @@
 import json
 import os
 
+from cloudinit import stages
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.cmd.devel.logs import (
     INSTALLER_APPORT_FILES,
@@ -155,6 +156,25 @@ def attach_installer_files(report, ui=None):
         attach_file_if_exists(report, realpath, apport_file.label)
 
 
+def attach_ubuntu_pro_info(report, ui=None):
+    """Attach ubuntu pro logs and tag if keys present in user-data."""
+    init = stages.Init()
+    has_up_key = init.cfg and (
+        "ubuntu_advantage" in init.cfg.keys()
+        or "ubuntu-advantage" in init.cfg.keys()
+    )
+    if not has_up_key:
+        return
+
+    realpath = os.path.realpath("/var/log/ubuntu-advantage.log")
+    attach_file_if_exists(report, realpath)
+
+    report.setdefault("Tags", "")
+    if report["Tags"]:
+        report["Tags"] += " "
+    report["Tags"] += "ubuntu-pro"
+
+
 def attach_user_data(report, ui=None):
     """Optionally provide user-data if desired."""
     if ui:
@@ -212,6 +232,7 @@ def add_info(report, ui):
     attach_cloud_info(report, ui)
     attach_user_data(report, ui)
     attach_installer_files(report, ui)
+    attach_ubuntu_pro_info(report, ui)
     add_bug_tags(report)
     return True
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
feat(apport): collect ubuntu-pro logs if keys present in cloud-config
```

## Additional Context
<!-- If relevant -->
https://warthogs.atlassian.net/browse/SC-1439

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
