### PR TITLE
vmware: Fall back to vmtoolsd if vmware-rpctool errs

### DIFF
--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -8,6 +8,11 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+"""Cloud-Init DataSource for OVF
+
+This module provides a cloud-init datasource for OVF data.
+"""
+
 import base64
 import os
 import re
@@ -20,7 +25,6 @@ LOG = logging.getLogger(__name__)
 
 
 class DataSourceOVF(sources.DataSource):
-
     dsname = "OVF"
 
     def __init__(self, sys_cfg, distro, paths):
@@ -142,7 +146,7 @@ def read_ovf_environment(contents, read_network=False):
     cfg_props = ["password"]
     md_props = ["seedfrom", "local-hostname", "public-keys", "instance-id"]
     network_props = ["network-config"]
-    for (prop, val) in props.items():
+    for prop, val in props.items():
         if prop == "hostname":
             prop = "local-hostname"
         if prop in md_props:
@@ -220,10 +224,9 @@ def maybe_cdrom_device(devname):
 # Transport functions are called with no arguments and return
 # either None (indicating not present) or string content of an ovf-env.xml
 def transport_iso9660(require_iso=True):
-
     # Go through mounts to see if it was already mounted
     mounts = util.mounts()
-    for (dev, info) in mounts.items():
+    for dev, info in mounts.items():
         fstype = info["fstype"]
         if fstype != "iso9660" and require_iso:
             continue
@@ -258,22 +261,85 @@ def transport_iso9660(require_iso=True):
     return None
 
 
+def exec_vmware_rpctool(rpctool, arg):
+    cmd = [rpctool, arg]
+    (stdout, stderr) = subp.subp(cmd)
+    return (cmd, stdout, stderr)
+
+
+def exec_vmtoolsd(rpctool, arg):
+    cmd = [rpctool, "--cmd", arg]
+    (stdout, stderr) = subp.subp(cmd)
+    return (cmd, stdout, stderr)
+
+
 def transport_vmware_guestinfo():
-    rpctool = "vmware-rpctool"
-    not_found = None
-    if not subp.which(rpctool):
-        return not_found
-    cmd = [rpctool, "info-get guestinfo.ovfEnv"]
+    rpctool, rpctool_fn = None, None
+    vmtoolsd = subp.which("vmtoolsd")
+    vmware_rpctool = subp.which("vmware-rpctool")
+
+    # Default to using vmware-rpctool if it is available.
+    if vmware_rpctool:
+        rpctool, rpctool_fn = vmware_rpctool, exec_vmware_rpctool
+        LOG.debug("discovered vmware-rpctool: %s", vmware_rpctool)
+
+    if vmtoolsd:
+        # Default to using vmtoolsd if it is available and vmware-rpctool is
+        # not.
+        if not vmware_rpctool:
+            rpctool, rpctool_fn = vmtoolsd, exec_vmtoolsd
+        LOG.debug("discovered vmtoolsd: %s", vmtoolsd)
+
+    # If neither vmware-rpctool nor vmtoolsd are available, then nothing can
+    # be done.
+    if not rpctool:
+        LOG.debug("no rpctool discovered")
+        return None
+
+    def query_guestinfo(rpctool, rpctool_fn):
+        LOG.info("query guestinfo.ovfEnv with %s", rpctool)
+        try:
+            cmd, stdout, _ = rpctool_fn(rpctool, "info-get guestinfo.ovfEnv")
+            if stdout:
+                return stdout
+            LOG.debug("cmd %s exited 0 with empty stdout", cmd)
+            return None
+        except subp.ProcessExecutionError as error:
+            if error.exit_code != 1:
+                LOG.warning("%s exited with code %d", rpctool, error.exit_code)
+            raise error
+
     try:
-        out, _err = subp.subp(cmd)
-        if out:
-            return out
-        LOG.debug("cmd %s exited 0 with empty stdout: %s", cmd, out)
-    except subp.ProcessExecutionError as e:
-        if e.exit_code != 1:
-            LOG.warning("%s exited with code %d", rpctool, e.exit_code)
-            LOG.debug(e)
-    return not_found
+        # The first attempt to query guestinfo could occur via either
+        # vmware-rpctool *or* vmtoolsd.
+        return query_guestinfo(rpctool, rpctool_fn)
+    except subp.ProcessExecutionError as error:
+        # The second attempt to query guestinfo can only occur with
+        # vmtoolsd.
+
+        # If the first attempt at getting the data was with vmtoolsd, then
+        # no second attempt is made.
+        if vmtoolsd and rpctool == vmtoolsd:
+            # The fallback failed, log the error.
+            util.logexc(
+                LOG, "vmtoolsd failed to get guestinfo.ovfEnv: %s", error
+            )
+            return None
+
+        if not vmtoolsd:
+            LOG.info("vmtoolsd fallback option not present")
+            return None
+
+        try:
+            LOG.info("fallback to vmtoolsd")
+            return query_guestinfo(vmtoolsd, exec_vmtoolsd)
+        except subp.ProcessExecutionError as error:
+            # The fallback failed, log the error.
+            util.logexc(
+                LOG, "vmtoolsd failed to get guestinfo.ovfEnv: %s", error
+            )
+
+    return None
 
 
 def find_child(node, filter_func):
@@ -287,7 +353,6 @@ def find_child(node, filter_func):
 
 
 def get_properties(contents):
-
     dom = minidom.parseString(contents)
     if dom.documentElement.localName != "Environment":
         raise XmlError("No Environment Node")

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -89,7 +89,6 @@ DATA_ACCESS_METHOD_ENVVAR = "envvar"
 DATA_ACCESS_METHOD_GUESTINFO = "guestinfo"
 DATA_ACCESS_METHOD_IMC = "imc"
 
-VMWARE_RPCTOOL = which("vmware-rpctool")
 REDACT = "redact"
 CLEANUP_GUESTINFO = "cleanup-guestinfo"
 VMX_GUESTINFO = "VMX_GUESTINFO"
@@ -146,7 +145,8 @@ class DataSourceVMware(sources.DataSource):
 
         self.cfg = {}
         self.data_access_method = None
-        self.vmware_rpctool = VMWARE_RPCTOOL
+        self.rpctool = None
+        self.rpctool_fn = None
 
         # A list includes all possible data transports, each tuple represents
         # one data transport type. This datasource will try to get data from
@@ -237,7 +237,7 @@ class DataSourceVMware(sources.DataSource):
 
         # Reflect any possible local IPv4 or IPv6 addresses in the guest
         # info.
-        advertise_local_ip_addrs(host_info)
+        advertise_local_ip_addrs(host_info, self.rpctool, self.rpctool_fn)
 
         # Ensure the metadata gets updated with information about the
         # host, including the network interfaces, default IP addresses,
@@ -313,7 +313,9 @@ class DataSourceVMware(sources.DataSource):
             keys_to_redact = self.metadata[CLEANUP_GUESTINFO]
 
         if self.data_access_method == DATA_ACCESS_METHOD_GUESTINFO:
-            guestinfo_redact_keys(keys_to_redact, self.vmware_rpctool)
+            guestinfo_redact_keys(
+                keys_to_redact, self.rpctool, self.rpctool_fn
+            )
 
     def get_envvar_data_fn(self):
         """
@@ -331,13 +333,77 @@ class DataSourceVMware(sources.DataSource):
         """
         check to see if there is data via the guestinfo transport
         """
-        md, ud, vd = None, None, None
-        if self.vmware_rpctool:
-            md = guestinfo("metadata", self.vmware_rpctool)
-            ud = guestinfo("userdata", self.vmware_rpctool)
-            vd = guestinfo("vendordata", self.vmware_rpctool)
 
-        return (md, ud, vd)
+        vmtoolsd = which("vmtoolsd")
+        vmware_rpctool = which("vmware-rpctool")
+
+        # Default to using vmware-rpctool if it is available.
+        if vmware_rpctool:
+            self.rpctool = vmware_rpctool
+            self.rpctool_fn = exec_vmware_rpctool
+            LOG.debug("discovered vmware-rpctool: %s", vmware_rpctool)
+
+        if vmtoolsd:
+            # Default to using vmtoolsd if it is available and vmware-rpctool
+            # is not.
+            if not vmware_rpctool:
+                self.rpctool = vmtoolsd
+                self.rpctool_fn = exec_vmtoolsd
+            LOG.debug("discovered vmtoolsd: %s", vmtoolsd)
+
+        # If neither vmware-rpctool nor vmtoolsd are available, then nothing
+        # can be done.
+        if not self.rpctool:
+            LOG.debug("no rpctool discovered")
+            return (None, None, None)
+
+        def query_guestinfo(rpctool, rpctool_fn):
+            md, ud, vd = None, None, None
+            LOG.info("query guestinfo with %s", rpctool)
+            md = guestinfo("metadata", rpctool, rpctool_fn)
+            ud = guestinfo("userdata", rpctool, rpctool_fn)
+            vd = guestinfo("vendordata", rpctool, rpctool_fn)
+            return md, ud, vd
+
+        try:
+            # The first attempt to query guestinfo could occur via either
+            # vmware-rpctool *or* vmtoolsd.
+            return query_guestinfo(self.rpctool, self.rpctool_fn)
+        except Exception as error:
+            util.logexc(
+                LOG,
+                "Failed to query guestinfo with %s: %s",
+                self.rpctool,
+                error,
+            )
+
+            # The second attempt to query guestinfo can only occur with
+            # vmtoolsd.
+
+            # If the first attempt at getting the data was with vmtoolsd, then
+            # no second attempt is made.
+            if vmtoolsd and self.rpctool == vmtoolsd:
+                return (None, None, None)
+
+            if not vmtoolsd:
+                LOG.info("vmtoolsd fallback option not present")
+                return (None, None, None)
+
+            LOG.info("fallback to vmtoolsd")
+            self.rpctool = vmtoolsd
+            self.rpctool_fn = exec_vmtoolsd
+
+            try:
+                return query_guestinfo(self.rpctool, self.rpctool_fn)
+            except Exception:
+                util.logexc(
+                    LOG,
+                    "Failed to query guestinfo with %s: %s",
+                    self.rpctool,
+                    error,
+                )
+
+                return (None, None, None)
 
     def get_imc_data_fn(self):
         """
@@ -447,25 +513,25 @@ def get_none_if_empty_val(val):
     return val
 
 
-def advertise_local_ip_addrs(host_info):
+def advertise_local_ip_addrs(host_info, rpctool, rpctool_fn):
     """
     advertise_local_ip_addrs gets the local IP address information from
     the provided host_info map and sets the addresses in the guestinfo
     namespace
     """
-    if not host_info:
+    if not host_info or not rpctool or not rpctool_fn:
         return
 
     # Reflect any possible local IPv4 or IPv6 addresses in the guest
     # info.
     local_ipv4 = host_info.get(LOCAL_IPV4)
     if local_ipv4:
-        guestinfo_set_value(LOCAL_IPV4, local_ipv4)
+        guestinfo_set_value(LOCAL_IPV4, local_ipv4, rpctool, rpctool_fn)
         LOG.info("advertised local ipv4 address %s in guestinfo", local_ipv4)
 
     local_ipv6 = host_info.get(LOCAL_IPV6)
     if local_ipv6:
-        guestinfo_set_value(LOCAL_IPV6, local_ipv6)
+        guestinfo_set_value(LOCAL_IPV6, local_ipv6, rpctool, rpctool_fn)
         LOG.info("advertised local ipv6 address %s in guestinfo", local_ipv6)
 
 
@@ -507,30 +573,37 @@ def guestinfo_envvar_get_value(key):
     return handle_returned_guestinfo_val(key, os.environ.get(env_key, ""))
 
 
-def guestinfo(key, vmware_rpctool=VMWARE_RPCTOOL):
+def exec_vmware_rpctool(rpctool, arg):
+    (stdout, stderr) = subp([rpctool, arg])
+    return (stdout, stderr)
+
+
+def exec_vmtoolsd(rpctool, arg):
+    (stdout, stderr) = subp([rpctool, "--cmd", arg])
+    return (stdout, stderr)
+
+
+def guestinfo(key, rpctool, rpctool_fn):
     """
     guestinfo returns the guestinfo value for the provided key, decoding
     the value when required
     """
-    val = guestinfo_get_value(key, vmware_rpctool)
+    val = guestinfo_get_value(key, rpctool, rpctool_fn)
     if not val:
         return None
-    enc_type = guestinfo_get_value(key + ".encoding", vmware_rpctool)
+    enc_type = guestinfo_get_value(key + ".encoding", rpctool, rpctool_fn)
     return decode(get_guestinfo_key_name(key), enc_type, val)
 
 
-def guestinfo_get_value(key, vmware_rpctool=VMWARE_RPCTOOL):
+def guestinfo_get_value(key, rpctool, rpctool_fn):
     """
     Returns a guestinfo value for the specified key.
     """
     LOG.debug("Getting guestinfo value for key %s", key)
 
     try:
-        (stdout, stderr) = subp(
-            [
-                vmware_rpctool,
-                "info-get " + get_guestinfo_key_name(key),
-            ]
+        (stdout, stderr) = rpctool_fn(
+            rpctool, "info-get " + get_guestinfo_key_name(key)
         )
         if stderr == NOVAL:
             LOG.debug("No value found for key %s", key)
@@ -538,27 +611,35 @@ def guestinfo_get_value(key, vmware_rpctool=VMWARE_RPCTOOL):
             LOG.error("Failed to get guestinfo value for key %s", key)
         return handle_returned_guestinfo_val(key, stdout)
     except ProcessExecutionError as error:
+        # No matter the tool used to access the data, if NOVAL was returned on
+        # stderr, do not raise an exception.
         if error.stderr == NOVAL:
             LOG.debug("No value found for key %s", key)
         else:
+            # Any other result gets logged as an error, and if the tool was
+            # vmware-rpctool, then raise the exception so the caller can try
+            # again with vmtoolsd.
             util.logexc(
                 LOG,
                 "Failed to get guestinfo value for key %s: %s",
                 key,
                 error,
             )
-    except Exception:
+            raise error
+    except Exception as error:
         util.logexc(
             LOG,
             "Unexpected error while trying to get "
-            "guestinfo value for key %s",
+            "guestinfo value for key %s: %s",
             key,
+            error,
         )
+        raise error
 
     return None
 
 
-def guestinfo_set_value(key, value, vmware_rpctool=VMWARE_RPCTOOL):
+def guestinfo_set_value(key, value, rpctool, rpctool_fn):
     """
     Sets a guestinfo value for the specified key. Set value to an empty string
     to clear an existing guestinfo key.
@@ -574,14 +655,14 @@ def guestinfo_set_value(key, value, vmware_rpctool=VMWARE_RPCTOOL):
     LOG.debug("Setting guestinfo key=%s to value=%s", key, value)
 
     try:
-        subp(
-            [
-                vmware_rpctool,
-                "info-set %s %s" % (get_guestinfo_key_name(key), value),
-            ]
+        rpctool_fn(
+            rpctool, "info-set %s %s" % (get_guestinfo_key_name(key), value)
         )
         return True
     except ProcessExecutionError as error:
+        # Any error result gets logged as an error, and if the tool was
+        # vmware-rpctool, then raise the exception so the caller can try
+        # again with vmtoolsd.
         util.logexc(
             LOG,
             "Failed to set guestinfo key=%s to value=%s: %s",
@@ -601,7 +682,7 @@ def guestinfo_set_value(key, value, vmware_rpctool=VMWARE_RPCTOOL):
     return None
 
 
-def guestinfo_redact_keys(keys, vmware_rpctool=VMWARE_RPCTOOL):
+def guestinfo_redact_keys(keys, rpctool, rpctool_fn):
     """
     guestinfo_redact_keys redacts guestinfo of all of the keys in the given
     list. each key will have its value set to "---". Since the value is valid
@@ -615,11 +696,11 @@ def guestinfo_redact_keys(keys, vmware_rpctool=VMWARE_RPCTOOL):
         key_name = get_guestinfo_key_name(key)
         LOG.info("clearing %s", key_name)
         if not guestinfo_set_value(
-            key, GUESTINFO_EMPTY_YAML_VAL, vmware_rpctool
+            key, GUESTINFO_EMPTY_YAML_VAL, rpctool, rpctool_fn
         ):
             LOG.error("failed to clear %s", key_name)
         LOG.info("clearing %s.encoding", key_name)
-        if not guestinfo_set_value(key + ".encoding", "", vmware_rpctool):
+        if not guestinfo_set_value(key + ".encoding", "", rpctool, rpctool_fn):
             LOG.error("failed to clear %s.encoding", key_name)
 
 

--- a/doc/rtd/reference/datasources/ovf.rst
+++ b/doc/rtd/reference/datasources/ovf.rst
@@ -6,6 +6,33 @@ OVF
 The OVF datasource provides a datasource for reading data from an
 `Open Virtualization Format`_ ISO transport.
 
+Graceful rpctool fallback
+-------------------------
+
+The datasource initially attempts to use the program ``vmware-rpctool`` if it
+is available. However, if the program returns a non-zero exit code, then the
+datasource falls back to using the program ``vmtoolsd`` with the ``--cmd``
+argument.
+
+On some older versions of ESXi and open-vm-tools, the ``vmware-rpctool``
+program is much more performant than ``vmtoolsd``. While this gap was
+closed, it is not reasonable to expect the guest where cloud-init is running to
+know whether the underlying hypervisor has the patch.
+
+Additionally, vSphere VMs may have the following present in their VMX file:
+
+.. code-block:: ini
+
+   guest_rpc.rpci.auth.cmd.info-set = "TRUE"
+   guest_rpc.rpci.auth.cmd.info-get = "TRUE"
+
+The above configuration causes the ``vmware-rpctool`` command to return a
+non-zero exit code with the error message ``Permission denied``. If this should
+occur, the datasource falls back to using ``vmtoolsd``.
+
+Additional information
+----------------------
+
 For further information see a full working example in ``cloud-init``'s
 source code tree in :file:`doc/sources/ovf`.
 

--- a/doc/rtd/reference/datasources/vmware.rst
+++ b/doc/rtd/reference/datasources/vmware.rst
@@ -148,6 +148,30 @@ Features
 
 This section reviews several features available in this datasource.
 
+Graceful rpctool fallback
+-------------------------
+
+The datasource initially attempts to use the program ``vmware-rpctool`` if it
+is available. However, if the program returns a non-zero exit code, then the
+datasource falls back to using the program ``vmtoolsd`` with the ``--cmd``
+argument.
+
+On some older versions of ESXi and open-vm-tools, the ``vmware-rpctool``
+program is much more performant than ``vmtoolsd``. While this gap was
+closed, it is not reasonable to expect the guest where cloud-init is running to
+know whether the underlying hypervisor has the patch.
+
+Additionally, vSphere VMs may have the following present in their VMX file:
+
+.. code-block:: ini
+
+   guest_rpc.rpci.auth.cmd.info-set = "TRUE"
+   guest_rpc.rpci.auth.cmd.info-get = "TRUE"
+
+The above configuration causes the ``vmware-rpctool`` command to return a
+non-zero exit code with the error message ``Permission denied``. If this should
+occur, the datasource falls back to using ``vmtoolsd``.
+
 Instance data and lazy networks
 -------------------------------
 

--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -16,6 +16,7 @@ import pytest
 from cloudinit import dmi, helpers, safeyaml, settings, util
 from cloudinit.sources import DataSourceVMware
 from cloudinit.sources.helpers.vmware.imc import guestcust_util
+from cloudinit.subp import ProcessExecutionError
 from tests.unittests.helpers import (
     CiTestCase,
     FilesystemMockingTestCase,
@@ -100,7 +101,6 @@ class TestDataSourceVMware(CiTestCase):
 
     def test_no_data_access_method(self):
         ds = get_ds(self.tmp)
-        ds.vmware_rpctool = None
         with mock.patch(
             "cloudinit.sources.DataSourceVMware.is_vmware_platform",
             return_value=False,
@@ -252,7 +252,6 @@ class TestDataSourceVMwareEnvVars(FilesystemMockingTestCase):
 
     def assert_get_data_ok(self, m_fn, m_fn_call_count=6):
         ds = get_ds(self.tmp)
-        ds.vmware_rpctool = None
         ret = ds.get_data()
         self.assertTrue(ret)
         self.assertEqual(m_fn_call_count, m_fn.call_count)
@@ -381,7 +380,6 @@ class TestDataSourceVMwareGuestInfo(FilesystemMockingTestCase):
 
     def assert_get_data_ok(self, m_fn, m_fn_call_count=6):
         ds = get_ds(self.tmp)
-        ds.vmware_rpctool = "vmware-rpctool"
         ret = ds.get_data()
         self.assertTrue(ret)
         self.assertEqual(m_fn_call_count, m_fn.call_count)
@@ -400,7 +398,9 @@ class TestDataSourceVMwareGuestInfo(FilesystemMockingTestCase):
         self.assertEqual(system_type, PRODUCT_NAME)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_get_subplatform(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_subplatform(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         m_fn.side_effect = [VMW_METADATA_YAML, "", "", "", "", ""]
         ds = self.assert_get_data_ok(m_fn, m_fn_call_count=4)
         self.assertEqual(
@@ -413,17 +413,53 @@ class TestDataSourceVMwareGuestInfo(FilesystemMockingTestCase):
         )
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_get_data_userdata_only(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_metadata_with_vmware_rpctool(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
+        m_fn.side_effect = [VMW_METADATA_YAML, "", "", ""]
+        self.assert_get_data_ok(m_fn, m_fn_call_count=4)
+
+    @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
+    @mock.patch("cloudinit.sources.DataSourceVMware.exec_vmware_rpctool")
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_metadata_non_zero_exit_code_fallback_to_vmtoolsd(
+        self, m_which_fn, m_exec_vmware_rpctool_fn, m_fn
+    ):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
+        m_exec_vmware_rpctool_fn.side_effect = ProcessExecutionError(
+            exit_code=1
+        )
+        m_fn.side_effect = [VMW_METADATA_YAML, "", "", ""]
+        self.assert_get_data_ok(m_fn, m_fn_call_count=4)
+
+    @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
+    @mock.patch("cloudinit.sources.DataSourceVMware.exec_vmware_rpctool")
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_metadata_vmware_rpctool_not_found_fallback_to_vmtoolsd(
+        self, m_which_fn, m_exec_vmware_rpctool_fn, m_fn
+    ):
+        m_which_fn.side_effect = ["vmtoolsd", None]
+        m_fn.side_effect = [VMW_METADATA_YAML, "", "", ""]
+        self.assert_get_data_ok(m_fn, m_fn_call_count=4)
+
+    @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_userdata_only(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         m_fn.side_effect = ["", VMW_USERDATA_YAML, "", ""]
         self.assert_get_data_ok(m_fn, m_fn_call_count=4)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_get_data_vendordata_only(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_vendordata_only(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         m_fn.side_effect = ["", "", VMW_VENDORDATA_YAML, ""]
         self.assert_get_data_ok(m_fn, m_fn_call_count=4)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_metadata_single_ssh_key(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_metadata_single_ssh_key(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         metadata = DataSourceVMware.load_json_or_yaml(VMW_METADATA_YAML)
         metadata["public_keys"] = VMW_SINGLE_KEY
         metadata_yaml = safeyaml.dumps(metadata)
@@ -431,7 +467,9 @@ class TestDataSourceVMwareGuestInfo(FilesystemMockingTestCase):
         self.assert_metadata(metadata, m_fn, m_fn_call_count=4)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_metadata_multiple_ssh_keys(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_metadata_multiple_ssh_keys(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         metadata = DataSourceVMware.load_json_or_yaml(VMW_METADATA_YAML)
         metadata["public_keys"] = VMW_MULTIPLE_KEYS
         metadata_yaml = safeyaml.dumps(metadata)
@@ -439,19 +477,25 @@ class TestDataSourceVMwareGuestInfo(FilesystemMockingTestCase):
         self.assert_metadata(metadata, m_fn, m_fn_call_count=4)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_get_data_metadata_base64(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_metadata_base64(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         data = base64.b64encode(VMW_METADATA_YAML.encode("utf-8"))
         m_fn.side_effect = [data, "base64", "", ""]
         self.assert_get_data_ok(m_fn, m_fn_call_count=4)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_get_data_metadata_b64(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_metadata_b64(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         data = base64.b64encode(VMW_METADATA_YAML.encode("utf-8"))
         m_fn.side_effect = [data, "b64", "", ""]
         self.assert_get_data_ok(m_fn, m_fn_call_count=4)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_get_data_metadata_gzip_base64(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_metadata_gzip_base64(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         data = VMW_METADATA_YAML.encode("utf-8")
         data = gzip.compress(data)
         data = base64.b64encode(data)
@@ -459,7 +503,9 @@ class TestDataSourceVMwareGuestInfo(FilesystemMockingTestCase):
         self.assert_get_data_ok(m_fn, m_fn_call_count=4)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.guestinfo_get_value")
-    def test_get_data_metadata_gz_b64(self, m_fn):
+    @mock.patch("cloudinit.sources.DataSourceVMware.which")
+    def test_get_data_metadata_gz_b64(self, m_which_fn, m_fn):
+        m_which_fn.side_effect = ["vmtoolsd", "vmware-rpctool"]
         data = VMW_METADATA_YAML.encode("utf-8")
         data = gzip.compress(data)
         data = base64.b64encode(data)
@@ -494,7 +540,6 @@ class TestDataSourceVMwareGuestInfo_InvalidPlatform(FilesystemMockingTestCase):
 
         m_fn.side_effect = [VMW_METADATA_YAML, "", "", "", "", ""]
         ds = get_ds(self.tmp)
-        ds.vmware_rpctool = "vmware-rpctool"
         ret = ds.get_data()
         self.assertFalse(ret)
 
@@ -1217,7 +1262,6 @@ def get_ds(temp_dir):
     ds = DataSourceVMware.DataSourceVMware(
         settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": temp_dir})
     )
-    ds.vmware_rpctool = "vmware-rpctool"
     return ds
 
 

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1013,7 +1013,8 @@ class TestDsIdentify(DsIdentifyBase):
 
     def test_vmware_guestinfo_no_data(self):
         """VMware: guestinfo transport no data"""
-        self._test_ds_not_found("VMware-GuestInfo-NoData")
+        self._test_ds_not_found("VMware-GuestInfo-NoData-Rpctool")
+        self._test_ds_not_found("VMware-GuestInfo-NoData-Vmtoolsd")
 
     def test_vmware_guestinfo_no_virt_id(self):
         """VMware: guestinfo transport fails if no virt id"""
@@ -1800,6 +1801,11 @@ VALID_CFG = {
                 "ret": 0,
                 "out": "/usr/bin/vmware-rpctool",
             },
+            {
+                "name": "vmware_has_vmtoolsd",
+                "ret": 1,
+                "out": "/usr/bin/vmtoolsd",
+            },
         ],
         "files": {
             # Setup vmware customization enabled
@@ -1917,7 +1923,7 @@ VALID_CFG = {
             MOCK_VIRT_IS_VMWARE,
         ],
     },
-    "VMware-GuestInfo-NoData": {
+    "VMware-GuestInfo-NoData-Rpctool": {
         "ds": "VMware",
         "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
@@ -1927,15 +1933,49 @@ VALID_CFG = {
                 "out": "/usr/bin/vmware-rpctool",
             },
             {
-                "name": "vmware_rpctool_guestinfo_metadata",
+                "name": "vmware_has_vmtoolsd",
+                "ret": 1,
+                "out": "/usr/bin/vmtoolsd",
+            },
+            {
+                "name": "vmware_guestinfo_metadata",
                 "ret": 1,
             },
             {
-                "name": "vmware_rpctool_guestinfo_userdata",
+                "name": "vmware_guestinfo_userdata",
                 "ret": 1,
             },
             {
-                "name": "vmware_rpctool_guestinfo_vendordata",
+                "name": "vmware_guestinfo_vendordata",
+                "ret": 1,
+            },
+            MOCK_VIRT_IS_VMWARE,
+        ],
+    },
+    "VMware-GuestInfo-NoData-Vmtoolsd": {
+        "ds": "VMware",
+        "policy_dmi": POLICY_FOUND_ONLY,
+        "mocks": [
+            {
+                "name": "vmware_has_rpctool",
+                "ret": 1,
+                "out": "/usr/bin/vmware-rpctool",
+            },
+            {
+                "name": "vmware_has_vmtoolsd",
+                "ret": 0,
+                "out": "/usr/bin/vmtoolsd",
+            },
+            {
+                "name": "vmware_guestinfo_metadata",
+                "ret": 1,
+            },
+            {
+                "name": "vmware_guestinfo_userdata",
+                "ret": 1,
+            },
+            {
+                "name": "vmware_guestinfo_vendordata",
                 "ret": 1,
             },
             MOCK_VIRT_IS_VMWARE,
@@ -1950,16 +1990,16 @@ VALID_CFG = {
                 "out": "/usr/bin/vmware-rpctool",
             },
             {
-                "name": "vmware_rpctool_guestinfo_metadata",
+                "name": "vmware_guestinfo_metadata",
                 "ret": 0,
                 "out": "---",
             },
             {
-                "name": "vmware_rpctool_guestinfo_userdata",
+                "name": "vmware_guestinfo_userdata",
                 "ret": 1,
             },
             {
-                "name": "vmware_rpctool_guestinfo_vendordata",
+                "name": "vmware_guestinfo_vendordata",
                 "ret": 1,
             },
         ],
@@ -1969,20 +2009,25 @@ VALID_CFG = {
         "mocks": [
             {
                 "name": "vmware_has_rpctool",
-                "ret": 0,
+                "ret": 1,
                 "out": "/usr/bin/vmware-rpctool",
             },
             {
-                "name": "vmware_rpctool_guestinfo_metadata",
+                "name": "vmware_has_vmtoolsd",
+                "ret": 0,
+                "out": "/usr/bin/vmtoolsd",
+            },
+            {
+                "name": "vmware_guestinfo_metadata",
                 "ret": 0,
                 "out": "---",
             },
             {
-                "name": "vmware_rpctool_guestinfo_userdata",
+                "name": "vmware_guestinfo_userdata",
                 "ret": 1,
             },
             {
-                "name": "vmware_rpctool_guestinfo_vendordata",
+                "name": "vmware_guestinfo_vendordata",
                 "ret": 1,
             },
             MOCK_VIRT_IS_VMWARE,
@@ -1997,16 +2042,21 @@ VALID_CFG = {
                 "out": "/usr/bin/vmware-rpctool",
             },
             {
-                "name": "vmware_rpctool_guestinfo_metadata",
+                "name": "vmware_has_vmtoolsd",
+                "ret": 1,
+                "out": "/usr/bin/vmtoolsd",
+            },
+            {
+                "name": "vmware_guestinfo_metadata",
                 "ret": 1,
             },
             {
-                "name": "vmware_rpctool_guestinfo_userdata",
+                "name": "vmware_guestinfo_userdata",
                 "ret": 0,
                 "out": "---",
             },
             {
-                "name": "vmware_rpctool_guestinfo_vendordata",
+                "name": "vmware_guestinfo_vendordata",
                 "ret": 1,
             },
             MOCK_VIRT_IS_VMWARE,
@@ -2017,19 +2067,24 @@ VALID_CFG = {
         "mocks": [
             {
                 "name": "vmware_has_rpctool",
-                "ret": 0,
+                "ret": 1,
                 "out": "/usr/bin/vmware-rpctool",
             },
             {
-                "name": "vmware_rpctool_guestinfo_metadata",
+                "name": "vmware_has_vmtoolsd",
+                "ret": 0,
+                "out": "/usr/bin/vmtoolsd",
+            },
+            {
+                "name": "vmware_guestinfo_metadata",
                 "ret": 1,
             },
             {
-                "name": "vmware_rpctool_guestinfo_userdata",
+                "name": "vmware_guestinfo_userdata",
                 "ret": 1,
             },
             {
-                "name": "vmware_rpctool_guestinfo_vendordata",
+                "name": "vmware_guestinfo_vendordata",
                 "ret": 0,
                 "out": "---",
             },

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -972,14 +972,74 @@ vmware_guest_customization() {
     return 1
 }
 
+vmware_has_rpctool() {
+    command -v vmware-rpctool >/dev/null 2>&1
+}
+
+vmware_rpctool_guestinfo() {
+    vmware-rpctool "info-get guestinfo.${1}" 2>/dev/null | grep "[[:alnum:]]"
+}
+
+vmware_rpctool_guestinfo_err() {
+    vmware-rpctool "info-get guestinfo.${1}" 2>&1 | grep "[[:alnum:]]"
+}
+
+vmware_has_vmtoolsd() {
+    command -v vmtoolsd >/dev/null 2>&1
+}
+
+vmware_vmtoolsd_guestinfo() {
+    vmtoolsd --cmd "info-get guestinfo.${1}" 2>/dev/null | grep "[[:alnum:]]"
+}
+
+vmware_vmtoolsd_guestinfo_err() {
+    vmtoolsd --cmd "info-get guestinfo.${1}" 2>&1 | grep "[[:alnum:]]"
+}
+
+vmware_guestinfo() {
+    vmware_rpctool_guestinfo "${1}" || vmware_vmtoolsd_guestinfo "${1}"
+}
+
+vmware_guestinfo_err() {
+    vmware_rpctool_guestinfo_err "${1}" || vmware_vmtoolsd_guestinfo_err "${1}"
+}
+
+vmware_guestinfo_ovfenv_err() {
+    vmware_guestinfo_err "ovfEnv"
+}
+
+vmware_guestinfo_metadata() {
+    if [ "${1:-}" = "err" ]; then
+      vmware_guestinfo_err "metadata"
+    else
+      vmware_guestinfo "metadata"
+    fi
+}
+
+vmware_guestinfo_userdata() {
+    if [ "${1:-}" = "err" ]; then
+      vmware_guestinfo_err "userdata"
+    else
+      vmware_guestinfo "userdata"
+    fi
+}
+
+vmware_guestinfo_vendordata() {
+    if [ "${1:-}" = "err" ]; then
+      vmware_guestinfo_err "vendordata"
+    else
+      vmware_guestinfo "vendordata"
+    fi
+}
+
 ovf_vmware_transport_guestinfo() {
     [ "${DI_VIRT}" = "vmware" ] || return 1
-    command -v vmware-rpctool >/dev/null 2>&1 || return 1
+    vmware_has_rpctool || vmware_has_vmtoolsd || return 1
     local out="" ret=""
-    out=$(vmware-rpctool "info-get guestinfo.ovfEnv" 2>&1)
+    out=$(vmware_guestinfo_ovfenv_err)
     ret=$?
     if [ $ret -ne 0 ]; then
-        debug 1 "Running on vmware but rpctool query returned $ret: $out"
+        debug 1 "Running on vmware but query returned $ret: $out"
         return 1
     fi
     case "$out" in
@@ -1439,26 +1499,6 @@ vmware_has_envvar_vmx_guestinfo_vendordata() {
     [ -n "${VMX_GUESTINFO_VENDORDATA:-}" ]
 }
 
-vmware_has_rpctool() {
-    command -v vmware-rpctool >/dev/null 2>&1
-}
-
-vmware_rpctool_guestinfo() {
-    vmware-rpctool "info-get guestinfo.${1}" 2>/dev/null | grep "[[:alnum:]]"
-}
-
-vmware_rpctool_guestinfo_metadata() {
-    vmware_rpctool_guestinfo "metadata"
-}
-
-vmware_rpctool_guestinfo_userdata() {
-    vmware_rpctool_guestinfo "userdata"
-}
-
-vmware_rpctool_guestinfo_vendordata() {
-    vmware_rpctool_guestinfo "vendordata"
-}
-
 dscheck_VMware() {
     # Checks to see if there is valid data for the VMware datasource.
     # The data transports are checked in the following order:
@@ -1486,16 +1526,16 @@ dscheck_VMware() {
         return "${DS_NOT_FOUND}"
     fi
 
-    # Do not proceed if the vmware-rpctool command is not present.
-    if ! vmware_has_rpctool; then
+    # Do not proceed if neither the vmware-rpctool or vmtoolsd command exists.
+    if ! vmware_has_rpctool && ! vmware_has_vmtoolsd; then
         return "${DS_NOT_FOUND}"
     fi
 
     # Activate the VMware datasource only if any of the fields used
     # by the datasource are present in the guestinfo table.
-    if { vmware_rpctool_guestinfo_metadata || \
-         vmware_rpctool_guestinfo_userdata || \
-         vmware_rpctool_guestinfo_vendordata; } >/dev/null 2>&1; then
+    if { vmware_guestinfo_metadata || \
+         vmware_guestinfo_userdata || \
+         vmware_guestinfo_vendordata; } >/dev/null 2>&1; then
         return "${DS_FOUND}"
     fi
 


### PR DESCRIPTION
Addresses #4436

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
vmware: Fallback to vmtoolsd if rpctool errs

This patch udpates the ds-identify script and the
VMware datasource to fall back to using the
vmtoolsd program if vmware-rpctool errors.

Fixes GH-4436
```

## Additional Context

I validated the output and exit code for both commands:

```shell
$ vmtoolsd --cmd "info-get guestinfo.userdata.encoding"; echo $?
gzip+base64
0
```

```shell
$ vmware-rpctool "info-get guestinfo.userdata.encoding"; echo $?
gzip+base64
0
```

```shell
$ vmtoolsd --cmd "info-get guestinfo.userdata.enc"; echo $?
No value found
1
```

```shell
$ vmware-rpctool "info-get guestinfo.userdata.enc"; echo $?
No value found
1
```

## Test Steps

* Locally I verified the OVF datasource with:

    ```shell
    make clean_pyc && PYTHONPATH="$(pwd)" python3 -m pytest -v --log-level=DEBUG tests/unittests/sources/test_ovf.py 
    ```

* Locally I verified the VMware datasource with:

    ```shell
    make clean_pyc && PYTHONPATH="$(pwd)" python3 -m pytest -v --log-level=DEBUG tests/unittests/sources/test_vmware.py 
    ```

* Locally I verified `ds-identify` with:

    ```shell
    make clean_pyc && PYTHONPATH="$(pwd)" python3 -m pytest -v --log-level=DEBUG tests/unittests/test_ds_identify.py
    ```

* I also copied the modified `ds-identify`  and datasources to a VM and ran the following:

    ```shell
      sudo rm -f cloud-init*.log; sudo cloud-init clean; sudo cloud-init init
    ```

    Everything behaved as expected.


* I also replaced `/usr/bin/vmware-rpctool` with:

    ```shell
    #!/bin/sh

    exit 1
    ```

    And ran:

    ```shell
    sudo rm -f cloud-init*.log; sudo cloud-init clean; sudo cloud-init init
    ```

    And `/var/log/cloud-init.log` showed the expected behavior occurred:

    ```log
    2023-09-18 18:29:04,244 - util.py[WARNING]: Failed to get guestinfo value for key metadata: Unexpected error while running command.
    Command: ['/usr/bin/vmware-rpctool', 'info-get guestinfo.metadata']
    Exit code: 1
    Reason: -
    Stdout: 
    Stderr: 
    2023-09-18 18:29:04,244 - util.py[DEBUG]: Failed to get guestinfo value for key metadata: Unexpected error while running command.
    Command: ['/usr/bin/vmware-rpctool', 'info-get guestinfo.metadata']
    Exit code: 1
    Reason: -
    Stdout: 
    Stderr: 
    Traceback (most recent call last):
      File "/usr/lib/python3.11/site-packages/cloudinit/sources/DataSourceVMware.py", line 551, in guestinfo_get_value
        (stdout, stderr) = subp(args)
                          ^^^^^^^^^^
      File "/usr/lib/python3.11/site-packages/cloudinit/subp.py", line 335, in subp
        raise ProcessExecutionError(
    cloudinit.subp.ProcessExecutionError: Unexpected error while running command.
    Command: ['/usr/bin/vmware-rpctool', 'info-get guestinfo.metadata']
    Exit code: 1
    Reason: -
    Stdout: 
    Stderr: 
    2023-09-18 18:29:04,246 - DataSourceVMware.py[DEBUG]: Getting guestinfo value for key metadata with /usr/bin/vmtoolsd
    2023-09-18 18:29:04,246 - subp.py[DEBUG]: Running command ['/usr/bin/vmtoolsd', '--cmd', 'info-get guestinfo.metadata'] with allowed return codes [0] (shell=False, capture=True)
    2023-09-18 18:29:04,295 - DataSourceVMware.py[DEBUG]: Getting guestinfo value for key metadata.encoding with /usr/bin/vmtoolsd
    2023-09-18 18:29:04,295 - subp.py[DEBUG]: Running command ['/usr/bin/vmtoolsd', '--cmd', 'info-get guestinfo.metadata.encoding'] with allowed return codes [0] (shell=False, capture=True)
    2023-09-18 18:29:04,329 - DataSourceVMware.py[DEBUG]: Getting encoded data for key=guestinfo.metadata, enc=gzip+base64
    2023-09-18 18:29:04,330 - DataSourceVMware.py[DEBUG]: Decoding gzip+base64 format guestinfo.metadata
    2023-09-18 18:29:04,330 - DataSourceVMware.py[DEBUG]: Getting guestinfo value for key userdata with /usr/bin/vmtoolsd
    2023-09-18 18:29:04,330 - subp.py[DEBUG]: Running command ['/usr/bin/vmtoolsd', '--cmd', 'info-get guestinfo.userdata'] with allowed return codes [0] (shell=False, capture=True)
    2023-09-18 18:29:04,373 - DataSourceVMware.py[DEBUG]: Getting guestinfo value for key userdata.encoding with /usr/bin/vmtoolsd
    2023-09-18 18:29:04,373 - subp.py[DEBUG]: Running command ['/usr/bin/vmtoolsd', '--cmd', 'info-get guestinfo.userdata.encoding'] with allowed return codes [0] (shell=False, capture=True)
    2023-09-18 18:29:04,411 - DataSourceVMware.py[DEBUG]: Getting encoded data for key=guestinfo.userdata, enc=gzip+base64
    2023-09-18 18:29:04,411 - DataSourceVMware.py[DEBUG]: Decoding gzip+base64 format guestinfo.userdata
    2023-09-18 18:29:04,411 - DataSourceVMware.py[DEBUG]: Getting guestinfo value for key vendordata with /usr/bin/vmtoolsd
    ```

* With `/usr/bin/vmware-rpctool` still replaced, I validated `ds-identify` by running `sudo rm /var/run/cloud-init/.ds-identify.result /var/run/cloud-init/ds-identify.log` and then running `sudo /usr/lib/cloud-init/ds-identify`. The resulting log fail showed the VMware datasource was still detected:

    ```shell
    $ sudo stat /var/run/cloud-init/ds-identify.log 
      File: /var/run/cloud-init/ds-identify.log
      Size: 1360      	Blocks: 8          IO Block: 4096   regular file
    Device: 0,23	Inode: 2318        Links: 1
    Access: (0640/-rw-r-----)  Uid: (    0/    root)   Gid: (    0/    root)
    Access: 2023-09-18 19:54:51.286717602 +0000
    Modify: 2023-09-18 19:54:48.650490201 +0000
    Change: 2023-09-18 19:54:48.650490201 +0000
     Birth: 2023-09-18 19:54:48.498477087 +0000
    ```
    
    ```
    [up 1725229.52s] ds-identify 
    policy loaded: mode=search report=false found=all maybe=all notfound=disabled
    /etc/cloud/cloud.cfg set datasource_list: ['NoCloud', 'ConfigDrive', 'OpenStack', 'VMware', None]
    DMI_PRODUCT_NAME=VMware20,1
    DMI_SYS_VENDOR=VMware, Inc.
    DMI_PRODUCT_SERIAL=VMware-42 1a b5 b3 64 97 90 e6-35 7b d8 97 66 df c3 d0
    DMI_PRODUCT_UUID=b3b51a42-9764-e690-357b-d89766dfc3d0
    PID_1_PRODUCT_NAME=unavailable
    DMI_CHASSIS_ASSET_TAG=No Asset Tag
    DMI_BOARD_NAME=440BX Desktop Reference Platform
    FS_LABELS=
    ISO9660_DEVS=
    KERNEL_CMDLINE=BOOT_IMAGE=/boot/vmlinuz-6.1.10-10.ph5-esx root=PARTUUID=c724cded-cf33-4d1c-b510-59478c322f84 init=/lib/systemd/systemd rcupdate.rcu_expedited=1 rw systemd.show_status=0 quiet noreplace-smp cpu_init_udelay=0 net.ifnames=0 plymouth.enable=0 systemd.unified_cgroup_hierarchy=yes
    VIRT=vmware
    UNAME_KERNEL_NAME=Linux
    UNAME_KERNEL_RELEASE=6.1.10-10.ph5-esx
    UNAME_KERNEL_VERSION=#1-photon SMP Mon Apr 24 22:51:08 UTC 2023
    UNAME_MACHINE=x86_64
    UNAME_NODENAME=photon5-w-tpm
    UNAME_OPERATING_SYSTEM=GNU/Linux
    DSNAME=
    DSLIST=NoCloud ConfigDrive OpenStack VMware None
    MODE=search
    ON_FOUND=all
    ON_MAYBE=all
    ON_NOTFOUND=disabled
    pid=24540 ppid=24539
    is_container=false
    is_ds_enabled(IBMCloud) = false.
    is_ds_enabled(IBMCloud) = false.
    check for 'VMware' returned found
    Found single datasource: VMware
    [up 1725229.68s] returning 0
    ``` 

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->

 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
