### PR TITLE
integration tests: fix mount indentation

### DIFF
--- a/tests/integration_tests/modules/test_disk_setup.py
+++ b/tests/integration_tests/modules/test_disk_setup.py
@@ -191,7 +191,7 @@ class TestPartProbeAvailability:
             UPDATED_PARTPROBE_USERDATA,
         )
         client.execute(
-            "sed -i 's/write_files/write_files\\n -  mounts/' "
+            "sed -i 's/write_files$/write_files\\n  - mounts/' "
             "/etc/cloud/cloud.cfg"
         )
 


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
integration tests: fix mount indentation

A previous attempt didn't quite get it right.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_vm/316/testReport/junit/tests.integration_tests.modules.test_disk_setup/TestPartProbeAvailability/test_disk_setup_when_mounted/
