### PR TITLE
sources/Azure: Ignore system volume information folder while scanning for files in the ntfs resource disk

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1615,7 +1615,9 @@ def can_dev_be_reformatted(devpath, preserve_ntfs):
 
     @azure_ds_telemetry_reporter
     def count_files(mp):
-        ignored = set(["dataloss_warning_readme.txt"])
+        ignored = set(
+            ["dataloss_warning_readme.txt", "system volume information"]
+        )
         return len([f for f in os.listdir(mp) if f.lower() not in ignored])
 
     bmsg = "partition %s (%s) on device %s was ntfs formatted" % (

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2479,6 +2479,28 @@ class TestCanDevBeReformatted(CiTestCase):
         self.assertTrue(value)
         self.assertIn("safe for", msg.lower())
 
+    def test_one_partition_ntfs_empty_with_svi_file_is_true(self):
+        """1 mountable ntfs partition and only warn file can be formatted."""
+        bypath = self.patchup(
+            {
+                "/dev/sda": {
+                    "partitions": {
+                        "/dev/sda1": {
+                            "num": 1,
+                            "fs": "ntfs",
+                            "files": ["System Volume Information"],
+                        }
+                    }
+                }
+            }
+        )
+        self._domock_mount_cb(bypath)
+        value, msg = dsaz.can_dev_be_reformatted(
+            "/dev/sda", preserve_ntfs=False
+        )
+        self.assertTrue(value)
+        self.assertIn("safe for", msg.lower())
+
     def test_one_partition_through_realpath_is_true(self):
         """A symlink to a device with 1 ntfs partition can be formatted."""
         epath = "/dev/disk/cloud/azure_resource"


### PR DESCRIPTION
## Proposed Commit Message:
```
In VM SKUs with large ephemeral disk, the NTFS-formatted resource disk
might have the SVI (System Volume Information) folder present. This 
causes cloud-init to skip formatting the resource disk for these SKUs 
during VM stop/start. This PR adds the SVI folder to the list of files 
cloud-init should ignore when it attempts to check if there is any user 
data on the resource disk.
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
