### PR TITLE
integration test: allow pro service warnings

### DIFF
--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -112,7 +112,8 @@ def get_services_status(client: IntegrationInstance) -> dict:
     assert status_resp.ok
     status = json.loads(status_resp.stdout)
     return {
-        svc["name"]: svc["status"] == "enabled" for svc in status["services"]
+        svc["name"]: svc["status"] in ["enabled", "warning"]
+        for svc in status["services"]
     }
 
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
integration test: allow pro service warnings

Even if pro is giving us warnings, that is showing that cloud-init
enabled things correctly.
```

## Additional Context
An integration test is failing due to livepatch warning that a kernel is not supported. While this may be a problem, it should be caught elseware and is not a problem in cloud-init.
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-ec2/306/testReport/tests.integration_tests.modules.test_ubuntu_advantage/TestUbuntuAdvantagePro/test_custom_services/