### PR TITLE
Schema annotate nested sequence and dict

### DIFF
--- a/cloudinit/cmd/devel/__init__.py
+++ b/cloudinit/cmd/devel/__init__.py
@@ -24,6 +24,8 @@ def read_cfg_paths(fetch_existing_datasource: str = "") -> Paths:
         load the pickled datasource before returning Paths. This is necessary
         when using instance paths via Paths.get_ipath method which are only
         known from the instance-id metadata in the detected datasource.
+
+    :raises: DataSourceNotFoundException when no datasource cache exists.
     """
     init = Init(ds_deps=[])
     if fetch_existing_datasource:

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -19,6 +19,7 @@ import yaml
 from cloudinit import importer, safeyaml
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.handlers import INCLUSION_TYPES_MAP, type_from_starts_with
+from cloudinit.sources import DataSourceNotFoundException
 from cloudinit.util import error, get_modules_from_dir, load_file
 
 try:
@@ -1372,7 +1373,14 @@ def handle_schema_args(name, args):
     if args.docs:
         print(load_doc(args.docs))
         return
-    paths = read_cfg_paths(fetch_existing_datasource="trust")
+    try:
+        paths = read_cfg_paths(fetch_existing_datasource="trust")
+    except DataSourceNotFoundException:
+        paths = read_cfg_paths()
+        print(
+            "WARNING: datasource not detected, using default"
+            " instance-data/user-data paths."
+        )
     if args.instance_data:
         instance_data_path = args.instance_data
     elif os.getuid() != 0:

--- a/tests/unittests/test_safeyaml.py
+++ b/tests/unittests/test_safeyaml.py
@@ -46,7 +46,7 @@ class TestLoadWithMarks:
             pytest.param(
                 b"{a: [a1, a2], b: [b3]}",
                 {"a": ["a1", "a2"], "b": ["b3"]},
-                {"a": 1, "a.0": 1, "a.1": 1, "b": 1},
+                {"a": 1, "a.0": 1, "a.1": 1, "b": 1, "b.0": 1},
                 id="dict_of_lists_oneline",
             ),
             pytest.param(
@@ -65,11 +65,42 @@ class TestLoadWithMarks:
                 b"a:\n- a1\n- a2\nb:\n- b3",
                 {"a": ["a1", "a2"], "b": ["b3"]},
                 {"a": 1, "a.0": 2, "a.1": 3, "b": 4, "b.0": 5},
-                id="separate_dicts_nestes_lists",
+                id="separate_dicts_nested_lists",
+            ),
+            pytest.param(
+                b"a:\n- {a1: 1}\n- {a2: 2}\n",
+                {"a": [{"a1": 1}, {"a2": 2}]},
+                {"a": 1, "a.0": 2, "a.0.a1": 2, "a.1": 3, "a.1.a2": 3},
+                id="list_of_dict_items",
+            ),
+            pytest.param(
+                b"a:\n- x: ['i', 'ii']\n",
+                {"a": [{"x": ["i", "ii"]}]},
+                {"a": 1, "a.0": 2, "a.0.x": 2, "a.0.x.0": 2, "a.0.x.1": 2},
+                id="list_of_dict_items_with_nested_lists",
+            ),
+            pytest.param(
+                b"a:\n- x: [['i', 'ii']]\n- y: ['iii', 'iv']\n",
+                {"a": [{"x": [["i", "ii"]]}, {"y": ["iii", "iv"]}]},
+                {
+                    "a": 1,
+                    "a.0": 2,
+                    "a.0.x": 2,
+                    "a.0.x.0": 2,
+                    "a.0.x.0.0": 2,
+                    "a.0.x.0.1": 2,
+                    "a.1": 3,
+                    "a.1.y": 3,
+                    "a.1.y.0": 3,
+                    "a.1.y.1": 3,
+                },
+                id="list_of_dict_items_with_nested_lists_of_lists",
             ),
         ),
     )
     def test_schema_marks_preserved(
         self, source_yaml, loaded_yaml, schemamarks
     ):
-        assert (loaded_yaml, schemamarks) == load_with_marks(source_yaml)
+        (processed_yaml, yaml_marks) = load_with_marks(source_yaml)
+        assert loaded_yaml == processed_yaml
+        assert schemamarks == yaml_marks


### PR DESCRIPTION
## rebase merge, not a squash merge

Fix schema annotation handling and schema marks for nested sequences and maps.

<!-- Include a proposed commit message because all PRs are squash merged -->

```
    schema: handle nested dicts and lists in schema marks and annotation
    
    YAML schema processing of sequences will process the root node and
    then leaf-first processing of children. This adds complexity for nested
    maps and sequences that may live under intermediate parents below the
    root because those parents have not yet been processed.
    
    Refactor safeyaml schemamark handling to cope with depth-first
    processing of nested mappings and sequences.
    
    Make SchemaPathMarks a class instead of namedtuple to allow for
    operator overloading of equality and contains operators.
    
    Add helper private functions to correct the parentage of
    schema marks during construct_sequence and construct_mapping calls
    when the newly schema mark happens to be a parent of children
    stored in schemamarks_by_line.

---
schema: support cloud-init schema in early boot or in dev environ

Add DataSouceNotFoundException handling in cloudinit schema
subcommand which prints a warning when no datsource cache is
present.

Allows developers to run the schema subcommand directly from
the repository with:
 PYTHONPATH=. python3 -m cloudinit.cmd.main schema -c <your_yaml>
```

## Additional Context

## Test Steps
```
cat > invalid_nested.yaml <<EOF
#cloud-config
packages:
- apta: [bogus]
EOF

PYTHONPATH=. python3 -m cloudinit.cmd.main schema --annotate -c invalid_nested.yaml
# 1. expect trace back on datasource not found when on main
# 2. cherry-pick the first commit from this PR, to allow for development run of cloud-init schema --annotate
#      - expect Traceback on KeyError: 'packages.0' becuase schema 
# 3. with both commits from this PR:
$ PYTHONPATH=. python3 -m cloudinit.cmd.main schema --annotate -c invalid_nested.yaml
#cloud-config
packages:
- apta: [bogus]		# E1,E2

# Errors: -------------
# E1: {'apta': ['bogus']} is not of type 'array'
# E2: {'apta': ['bogus']} is not valid under any of the given schemas

```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
