### PR TITLE
delete DSA support

### DIFF
--- a/cloudinit/config/cc_keys_to_console.py
+++ b/cloudinit/config/cc_keys_to_console.py
@@ -36,8 +36,8 @@ meta: MetaSchema = {
         " ``ssh_fp_console_blacklist`` config key can be used. By default,"
         " all types of keys will have their fingerprints written to console."
         " To avoid host keys of a key type being written to console the"
-        "``ssh_key_console_blacklist`` config key can be used. By default,"
-        " ``ssh-dss`` host keys are not written to console."
+        "``ssh_key_console_blacklist`` config key can be used. By default"
+        " all supported host keys are written to console."
     ),
     "distros": distros,
     "examples": [
@@ -51,7 +51,7 @@ meta: MetaSchema = {
         dedent(
             """\
             # Do not print certain ssh key types to console
-            ssh_key_console_blacklist: [dsa, ssh-dss]
+            ssh_key_console_blacklist: [rsa]
             """
         ),
         dedent(
@@ -99,7 +99,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         cfg, "ssh_fp_console_blacklist", []
     )
     key_blacklist = util.get_cfg_option_list(
-        cfg, "ssh_key_console_blacklist", ["ssh-dss"]
+        cfg, "ssh_key_console_blacklist", []
     )
 
     try:

--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -21,7 +21,6 @@ from cloudinit.settings import PER_INSTANCE
 frequency = PER_INSTANCE
 
 POST_LIST_ALL = [
-    "pub_key_dsa",
     "pub_key_rsa",
     "pub_key_ecdsa",
     "pub_key_ed25519",
@@ -36,7 +35,6 @@ If the post url contains the string ``$INSTANCE_ID`` it will be replaced with
 the id of the current instance. Either all data can be posted or a list of
 keys to post. Available keys are:
 
-    - ``pub_key_dsa``
     - ``pub_key_rsa``
     - ``pub_key_ecdsa``
     - ``pub_key_ed25519``
@@ -57,7 +55,7 @@ Data is sent as ``x-www-form-urlencoded`` arguments.
     Accept: */*
     Content-Type: application/x-www-form-urlencoded
 
-    pub_key_dsa=dsa_contents&pub_key_rsa=rsa_contents&pub_key_ecdsa=ecdsa_contents&pub_key_ed25519=ed25519_contents&instance_id=i-87018aed&hostname=myhost&fqdn=myhost.internal
+    pub_key_rsa=rsa_contents&pub_key_ecdsa=ecdsa_contents&pub_key_ed25519=ed25519_contents&instance_id=i-87018aed&hostname=myhost&fqdn=myhost.internal
 """
 
 meta: MetaSchema = {
@@ -80,7 +78,6 @@ meta: MetaSchema = {
             phone_home:
                 url: http://example.com/$INSTANCE_ID/
                 post:
-                    - pub_key_dsa
                     - pub_key_rsa
                     - pub_key_ecdsa
                     - pub_key_ed25519
@@ -103,7 +100,7 @@ LOG = logging.getLogger(__name__)
 #
 # phone_home:
 #  url: http://my.foo.bar/$INSTANCE_ID/
-#  post: [ pub_key_dsa, pub_key_rsa, pub_key_ecdsa, instance_id, hostname,
+#  post: [ pub_key_rsa, pub_key_ecdsa, instance_id, hostname,
 #          fqdn ]
 #
 
@@ -152,7 +149,6 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     }
 
     pubkeys = {
-        "pub_key_dsa": "/etc/ssh/ssh_host_dsa_key.pub",
         "pub_key_rsa": "/etc/ssh/ssh_host_rsa_key.pub",
         "pub_key_ecdsa": "/etc/ssh/ssh_host_ecdsa_key.pub",
         "pub_key_ed25519": "/etc/ssh/ssh_host_ed25519_key.pub",

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -43,7 +43,6 @@ login options can be manually specified with ``disable_root_opts``.
 
 Supported public key types for the ``ssh_authorized_keys`` are:
 
-    - dsa
     - rsa
     - ecdsa
     - ed25519
@@ -71,7 +70,7 @@ Supported public key types for the ``ssh_authorized_keys`` are:
     `OpenSSH`_ source, where the sigonly keys are removed. Please see
     ``ssh_util`` for more information.
 
-    ``dsa``, ``rsa``, ``ecdsa`` and ``ed25519`` are added for legacy,
+    ``rsa``, ``ecdsa`` and ``ed25519`` are added for legacy,
     as they are valid public keys in some old distros. They can possibly
     be removed in the future when support for the older distros are dropped
 
@@ -104,7 +103,6 @@ system (i.e. if ``ssh_deletekeys`` was false), no key will be generated.
 Supported host key types for the ``ssh_keys`` and the ``ssh_genkeytypes``
 config flags are:
 
-    - dsa
     - ecdsa
     - ed25519
     - rsa
@@ -141,19 +139,11 @@ meta: MetaSchema = {
               rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAGEAoPRhIfLvedSDKw7Xd ...
               rsa_certificate: |
                 ssh-rsa-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQt ...
-              dsa_private: |
-                -----BEGIN DSA PRIVATE KEY-----
-                MIIBxwIBAAJhAKD0YSHy73nUgysO13XsJmd4fHiFyQ+00R7VVu2iV9Qco
-                ...
-                -----END DSA PRIVATE KEY-----
-              dsa_public: ssh-dsa AAAAB3NzaC1yc2EAAAABIwAAAGEAoPRhIfLvedSDKw7Xd ...
-              dsa_certificate: |
-                ssh-dsa-cert-v01@openssh.com AAAAIHNzaC1lZDI1NTE5LWNlcnQt ...
             ssh_authorized_keys:
               - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAGEA3FSyQwBI6Z+nCSjUU ...
               - ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA3I7VUf2l5gSn5uavROsc5HRDpZ ...
             ssh_deletekeys: true
-            ssh_genkeytypes: [rsa, dsa, ecdsa, ed25519]
+            ssh_genkeytypes: [rsa, ecdsa, ed25519]
             disable_root: true
             disable_root_opts: no-port-forwarding,no-agent-forwarding,no-X11-forwarding
             allow_public_ssh_keys: true
@@ -170,7 +160,7 @@ meta: MetaSchema = {
 __doc__ = get_meta_doc(meta)
 LOG = logging.getLogger(__name__)
 
-GENERATE_KEY_NAMES = ["rsa", "dsa", "ecdsa", "ed25519"]
+GENERATE_KEY_NAMES = ["rsa", "ecdsa", "ed25519"]
 FIPS_UNSUPPORTED_KEY_NAMES = ["dsa", "ed25519"]
 
 pattern_unsupported_config_keys = re.compile(

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2011,7 +2011,6 @@
                   "items": {
                     "type": "string",
                     "enum": [
-                      "pub_key_dsa",
                       "pub_key_rsa",
                       "pub_key_ecdsa",
                       "pub_key_ed25519",
@@ -2811,7 +2810,7 @@
           "description": "A dictionary entries for the public and private host keys of each desired key type. Entries in the ``ssh_keys`` config dict should have keys in the format ``<key type>_private``, ``<key type>_public``, and, optionally, ``<key type>_certificate``, e.g. ``rsa_private: <key>``, ``rsa_public: <key>``, and ``rsa_certificate: <key>``. Not all key types have to be specified, ones left unspecified will not be used. If this config option is used, then separate keys will not be automatically generated. In order to specify multiline private host keys and certificates, use yaml multiline syntax.",
           "additionalProperties": false,
           "patternProperties": {
-            "^(dsa|ecdsa|ed25519|rsa)_(public|private|certificate)$": {
+            "^(ecdsa|ed25519|rsa)_(public|private|certificate)$": {
               "label": "<key_type>",
               "type": "string"
             }
@@ -2832,9 +2831,8 @@
         },
         "ssh_genkeytypes": {
           "type": "array",
-          "description": "The SSH key types to generate. Default: ``[rsa, dsa, ecdsa, ed25519]``",
+          "description": "The SSH key types to generate. Default: ``[rsa, ecdsa, ed25519]``",
           "default": [
-            "dsa",
             "ecdsa",
             "ed25519",
             "rsa"
@@ -2843,7 +2841,6 @@
           "items": {
             "type": "string",
             "enum": [
-              "dsa",
               "ecdsa",
               "ed25519",
               "rsa"

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1459,9 +1459,7 @@
         },
         "ssh_key_console_blacklist": {
           "type": "array",
-          "default": [
-            "ssh-dss"
-          ],
+          "default": [],
           "description": "Avoid printing matching SSH key types to the system console.",
           "items": {
             "type": "string"
@@ -2878,7 +2876,7 @@
             },
             "blacklist": {
               "type": "array",
-              "description": "The SSH key types to ignore when publishing. Default: ``[dsa]``",
+              "description": "The SSH key types to ignore when publishing. Default: ``[]`` to publish all SSH key types",
               "items": {
                 "type": "string"
               }

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -27,14 +27,13 @@ DEF_SSHD_CFG = "/etc/ssh/sshd_config"
 # refer to the keytype struct of OpenSSH in the same file, to see
 # if the position of the sigonly flag has been moved.
 #
-# dsa, rsa, ecdsa and ed25519 are added for legacy, as they are valid
+# rsa, ecdsa and ed25519 are added for legacy, as they are valid
 # public keys in some old distros. They can possibly be removed
 # in the future when support for the older distros is dropped
 #
 # When updating the list, also update the _is_printable_key list in
 # cloudinit/config/cc_ssh_authkey_fingerprints.py
 VALID_KEY_TYPES = (
-    "dsa",
     "rsa",
     "ecdsa",
     "ed25519",
@@ -48,8 +47,6 @@ VALID_KEY_TYPES = (
     "sk-ecdsa-sha2-nistp256@openssh.com",
     "sk-ssh-ed25519-cert-v01@openssh.com",
     "sk-ssh-ed25519@openssh.com",
-    "ssh-dss-cert-v01@openssh.com",
-    "ssh-dss",
     "ssh-ed25519-cert-v01@openssh.com",
     "ssh-ed25519",
     "ssh-rsa-cert-v01@openssh.com",
@@ -106,7 +103,7 @@ class AuthKeyLineParser:
      (because of the size of the public key encoding) up to a limit of 8 kilo-
      bytes, which permits DSA keys up to 8 kilobits and RSA keys up to 16
      kilobits.  You don't want to type them in; instead, copy the
-     identity.pub, id_dsa.pub, or the id_rsa.pub file and edit it.
+     identity.pub or the id_rsa.pub file and edit it.
 
      sshd enforces a minimum RSA key modulus size for protocol 1 and protocol
      2 keys of 768 bits.

--- a/doc/examples/cloud-config-ssh-keys.txt
+++ b/doc/examples/cloud-config-ssh-keys.txt
@@ -9,7 +9,7 @@ ssh_authorized_keys:
 # Send pre-generated SSH private keys to the server
 # If these are present, they will be written to /etc/ssh and
 # new random keys will not be generated
-#  in addition to 'rsa' and 'dsa' as shown below, 'ecdsa' is also supported
+#  in addition to 'rsa' as shown below, 'ecdsa' is also supported
 ssh_keys:
   rsa_private: |
     -----BEGIN RSA PRIVATE KEY-----
@@ -26,22 +26,6 @@ ssh_keys:
     -----END RSA PRIVATE KEY-----
 
   rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAGEAoPRhIfLvedSDKw7XdewmZ3h8eIXJD7TRHtVW7aJX1ByifYtlL/HVzJ09nilCl+MSFrpbFnqjxyL8Rr/DSf7QcY/BrGUQbZn2Kc22PemAWthxHO18QJvWPocKJtlsDNi3 smoser@localhost
-
-  dsa_private: |
-    -----BEGIN DSA PRIVATE KEY-----
-    MIIBuwIBAAKBgQDP2HLu7pTExL89USyM0264RCyWX/CMLmukxX0Jdbm29ax8FBJT
-    pLrO8TIXVY5rPAJm1dTHnpuyJhOvU9G7M8tPUABtzSJh4GVSHlwaCfycwcpLv9TX
-    DgWIpSj+6EiHCyaRlB1/CBp9RiaB+10QcFbm+lapuET+/Au6vSDp9IRtlQIVAIMR
-    8KucvUYbOEI+yv+5LW9u3z/BAoGBAI0q6JP+JvJmwZFaeCMMVxXUbqiSko/P1lsa
-    LNNBHZ5/8MOUIm8rB2FC6ziidfueJpqTMqeQmSAlEBCwnwreUnGfRrKoJpyPNENY
-    d15MG6N5J+z81sEcHFeprryZ+D3Ge9VjPq3Tf3NhKKwCDQ0240aPezbnjPeFm4mH
-    bYxxcZ9GAoGAXmLIFSQgiAPu459rCKxT46tHJtM0QfnNiEnQLbFluefZ/yiI4DI3
-    8UzTCOXLhUA7ybmZha+D/csj15Y9/BNFuO7unzVhikCQV9DTeXX46pG4s1o23JKC
-    /QaYWNMZ7kTRv+wWow9MhGiVdML4ZN4XnifuO5krqAybngIy66PMEoQCFEIsKKWv
-    99iziAH0KBMVbxy03Trz
-    -----END DSA PRIVATE KEY-----
-
-  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAM/Ycu7ulMTEvz1RLIzTbrhELJZf8Iwua6TFfQl1ubb1rHwUElOkus7xMhdVjms8AmbV1Meem7ImE69T0bszy09QAG3NImHgZVIeXBoJ/JzByku/1NcOBYilKP7oSIcLJpGUHX8IGn1GJoH7XRBwVub6Vqm4RP78C7q9IOn0hG2VAAAAFQCDEfCrnL1GGzhCPsr/uS1vbt8/wQAAAIEAjSrok/4m8mbBkVp4IwxXFdRuqJKSj8/WWxos00Ednn/ww5QibysHYULrOKJ1+54mmpMyp5CZICUQELCfCt5ScZ9GsqgmnI80Q1h3Xkwbo3kn7PzWwRwcV6muvJn4PcZ71WM+rdN/c2EorAINDTbjRo97NueM94WbiYdtjHFxn0YAAACAXmLIFSQgiAPu459rCKxT46tHJtM0QfnNiEnQLbFluefZ/yiI4DI38UzTCOXLhUA7ybmZha+D/csj15Y9/BNFuO7unzVhikCQV9DTeXX46pG4s1o23JKC/QaYWNMZ7kTRv+wWow9MhGiVdML4ZN4XnifuO5krqAybngIy66PMEoQ= smoser@localhost
 
 # By default, the fingerprints of the authorized keys for the users
 # cloud-init adds are printed to the console. Setting

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -65,7 +65,7 @@ ssh_authorized_keys:
 # Send pre-generated ssh private keys to the server
 # If these are present, they will be written to /etc/ssh and
 # new random keys will not be generated
-#  in addition to 'rsa' and 'dsa' as shown below, 'ecdsa' is also supported
+#  in addition to 'rsa' as shown below, 'ecdsa' is also supported
 ssh_keys:
   rsa_private: |
     -----BEGIN RSA PRIVATE KEY-----
@@ -82,23 +82,6 @@ ssh_keys:
     -----END RSA PRIVATE KEY-----
 
   rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAGEAoPRhIfLvedSDKw7XdewmZ3h8eIXJD7TRHtVW7aJX1ByifYtlL/HVzJ09nilCl+MSFrpbFnqjxyL8Rr/DSf7QcY/BrGUQbZn2Kc22PemAWthxHO18QJvWPocKJtlsDNi3 smoser@localhost
-
-  dsa_private: |
-    -----BEGIN DSA PRIVATE KEY-----
-    MIIBuwIBAAKBgQDP2HLu7pTExL89USyM0264RCyWX/CMLmukxX0Jdbm29ax8FBJT
-    pLrO8TIXVY5rPAJm1dTHnpuyJhOvU9G7M8tPUABtzSJh4GVSHlwaCfycwcpLv9TX
-    DgWIpSj+6EiHCyaRlB1/CBp9RiaB+10QcFbm+lapuET+/Au6vSDp9IRtlQIVAIMR
-    8KucvUYbOEI+yv+5LW9u3z/BAoGBAI0q6JP+JvJmwZFaeCMMVxXUbqiSko/P1lsa
-    LNNBHZ5/8MOUIm8rB2FC6ziidfueJpqTMqeQmSAlEBCwnwreUnGfRrKoJpyPNENY
-    d15MG6N5J+z81sEcHFeprryZ+D3Ge9VjPq3Tf3NhKKwCDQ0240aPezbnjPeFm4mH
-    bYxxcZ9GAoGAXmLIFSQgiAPu459rCKxT46tHJtM0QfnNiEnQLbFluefZ/yiI4DI3
-    8UzTCOXLhUA7ybmZha+D/csj15Y9/BNFuO7unzVhikCQV9DTeXX46pG4s1o23JKC
-    /QaYWNMZ7kTRv+wWow9MhGiVdML4ZN4XnifuO5krqAybngIy66PMEoQCFEIsKKWv
-    99iziAH0KBMVbxy03Trz
-    -----END DSA PRIVATE KEY-----
-
-  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAM/Ycu7ulMTEvz1RLIzTbrhELJZf8Iwua6TFfQl1ubb1rHwUElOkus7xMhdVjms8AmbV1Meem7ImE69T0bszy09QAG3NImHgZVIeXBoJ/JzByku/1NcOBYilKP7oSIcLJpGUHX8IGn1GJoH7XRBwVub6Vqm4RP78C7q9IOn0hG2VAAAAFQCDEfCrnL1GGzhCPsr/uS1vbt8/wQAAAIEAjSrok/4m8mbBkVp4IwxXFdRuqJKSj8/WWxos00Ednn/ww5QibysHYULrOKJ1+54mmpMyp5CZICUQELCfCt5ScZ9GsqgmnI80Q1h3Xkwbo3kn7PzWwRwcV6muvJn4PcZ71WM+rdN/c2EorAINDTbjRo97NueM94WbiYdtjHFxn0YAAACAXmLIFSQgiAPu459rCKxT46tHJtM0QfnNiEnQLbFluefZ/yiI4DI38UzTCOXLhUA7ybmZha+D/csj15Y9/BNFuO7unzVhikCQV9DTeXX46pG4s1o23JKC/QaYWNMZ7kTRv+wWow9MhGiVdML4ZN4XnifuO5krqAybngIy66PMEoQ= smoser@localhost
-
 
 # remove access to the ec2 metadata service early in boot via null route
 #  the null route can be removed (by root) with:
@@ -360,7 +343,7 @@ output:
 #
 phone_home:
   url: http://my.example.com/$INSTANCE_ID/
-  post: [ pub_key_dsa, pub_key_rsa, pub_key_ecdsa, instance_id ]
+  post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]
 
 # timezone: set the timezone for this instance
 # the value of 'timezone' must exist in /usr/share/zoneinfo
@@ -454,7 +437,7 @@ manual_cache_clean: False
 #    boolean indicating if existing ssh keys should be deleted on a
 #    per-instance basis.  On a public image, this should absolutely be set
 #    to 'True'
-# ssh_genkeytypes: ['rsa', 'dsa', 'ecdsa']
+# ssh_genkeytypes: ['rsa', 'ecdsa']
 #    a list of the ssh key types that should be generated
 #    These are passed to 'ssh-keygen -t'
 

--- a/tests/data/merge_sources/expected9.yaml
+++ b/tests/data/merge_sources/expected9.yaml
@@ -2,4 +2,4 @@
 
 phone_home:
  url: http://my.example.com/$INSTANCE_ID/$BLAH_BLAH
- post: [ pub_key_dsa, pub_key_rsa, pub_key_ecdsa, instance_id ]
+ post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]

--- a/tests/data/merge_sources/source9-1.yaml
+++ b/tests/data/merge_sources/source9-1.yaml
@@ -2,4 +2,4 @@
 
 phone_home:
  url: http://my.example.com/$INSTANCE_ID/
- post: [ pub_key_dsa, pub_key_rsa, pub_key_ecdsa, instance_id ]
+ post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]

--- a/tests/integration_tests/modules/test_keys_to_console.py
+++ b/tests/integration_tests/modules/test_keys_to_console.py
@@ -40,7 +40,7 @@ users:
 class TestKeysToConsoleBlacklist:
     """Test that the blacklist options work as expected."""
 
-    @pytest.mark.parametrize("key_type", ["DSA", "ECDSA"])
+    @pytest.mark.parametrize("key_type", ["ECDSA"])
     def test_excluded_keys(self, class_client, key_type):
         syslog = class_client.read_from_file("/var/log/syslog")
         assert "({})".format(key_type) not in syslog
@@ -73,7 +73,7 @@ class TestAllKeysToConsoleBlacklist:
 class TestKeysToConsoleDisabled:
     """Test that output can be fully disabled."""
 
-    @pytest.mark.parametrize("key_type", ["DSA", "ECDSA", "ED25519", "RSA"])
+    @pytest.mark.parametrize("key_type", ["ECDSA", "ED25519", "RSA"])
     def test_keys_excluded(self, class_client, key_type):
         syslog = class_client.read_from_file("/var/log/syslog")
         assert "({})".format(key_type) not in syslog

--- a/tests/integration_tests/modules/test_keys_to_console.py
+++ b/tests/integration_tests/modules/test_keys_to_console.py
@@ -11,13 +11,13 @@ from tests.integration_tests.util import get_console_log
 
 BLACKLIST_USER_DATA = """\
 #cloud-config
-ssh_fp_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
-ssh_key_console_blacklist: [ssh-dss, ssh-dsa, ecdsa-sha2-nistp256]
+ssh_fp_console_blacklist: [ecdsa-sha2-nistp256]
+ssh_key_console_blacklist: [ecdsa-sha2-nistp256]
 """
 
 BLACKLIST_ALL_KEYS_USER_DATA = """\
 #cloud-config
-ssh_fp_console_blacklist: [ssh-dsa, ssh-ecdsa, ssh-ed25519, ssh-rsa, ssh-dss, ecdsa-sha2-nistp256]
+ssh_fp_console_blacklist: [ssh-ecdsa, ssh-ed25519, ssh-rsa, ecdsa-sha2-nistp256]
 """  # noqa: E501
 
 DISABLED_USER_DATA = """\

--- a/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
+++ b/tests/integration_tests/modules/test_ssh_auth_key_fingerprints.py
@@ -49,7 +49,6 @@ class TestSshAuthkeyFingerprints:
 
         assert re.search(r"256 SHA256:.*(ECDSA)", syslog_output) is not None
         assert re.search(r"256 SHA256:.*(ED25519)", syslog_output) is not None
-        assert re.search(r"1024 SHA256:.*(DSA)", syslog_output) is None
         assert re.search(r"2048 SHA256:.*(RSA)", syslog_output) is None
 
 

--- a/tests/integration_tests/modules/test_ssh_generate.py
+++ b/tests/integration_tests/modules/test_ssh_generate.py
@@ -25,8 +25,6 @@ class TestSshKeysGenerate:
     @pytest.mark.parametrize(
         "ssh_key_path",
         (
-            "/etc/ssh/ssh_host_dsa_key.pub",
-            "/etc/ssh/ssh_host_dsa_key",
             "/etc/ssh/ssh_host_rsa_key.pub",
             "/etc/ssh/ssh_host_rsa_key",
         ),

--- a/tests/integration_tests/modules/test_ssh_keys_provided.py
+++ b/tests/integration_tests/modules/test_ssh_keys_provided.py
@@ -47,20 +47,6 @@ ssh_keys:
     -----END RSA PRIVATE KEY-----
   rsa_public: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97N root@xenial-lxd
   rsa_certificate: ssh-rsa-cert-v01@openssh.com AAAAHHNzaC1yc2EtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgMpgBP4Phn3L8I7Vqh7lmHKcOfIokEvSEbHDw83Y3JloAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgTLnZOtrxPl+fSvJfKDjoOLY0HB2eOjy2s2/2N6d9X9SGZ4+XnyVeNPjfBXw4IyXoqxhfIF16Azfk022iejgjiYssoUxH31M60OfqJhxo16dWEXdkKP1nac06VOt1zS5yEeooyvEuMJEJSsv3VR/7GKhMX3TVhEz5moLmVP3bIAvvoXio8X4urVC1R819QjDC86nlxwNks/GKPRi/IHO5tjJ72Eke7KNsm/vxHgkdX4vZaHNKhfdb/pavFXN5eoUaofz3hxw5oL/u2epI/pXyUhDp8Tb5wO6slykzcIlGCSd0YeO1TnljvViRx0uSxIy97NAAAAAAAAAAAAAAACAAAACnhlbmlhbC1seGQAAAAAAAAAAF+vVEIAAAAAYY83bgAAAAAAAAAAAAAAAAAAADMAAAALc3NoLWVkMjU1MTkAAAAgz4SlDwbq53ZrRsnS6ISdwxgFDRpnEX44K8jFmLpI9NAAAABTAAAAC3NzaC1lZDI1NTE5AAAAQMWpiRWKNMFvRX0g6OQOELMqDhtNBpkIN92IyO25qiY2oDSd1NyVme6XnGDFt8CS7z5NufV04doP4aacLOBbQww= root@xenial-lxd
-  dsa_private: |
-    -----BEGIN DSA PRIVATE KEY-----
-    MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXrhOVAfzZ6+jklP
-    55mzvC7jO53PWWC31hq10xBoWdev0WtcNF9Tv+4bAa1263y51Rqo4GI7xx+xic1d
-    mLqqfYijBT9k48J/1tV0cs1Wjs6FP/IJTD/kYVC930JjYQMi722lBnUxsQIVAL7i
-    z3fTGKTvSzvW0wQlwnYpS2QFAoGANp+KdyS9V93HgxGQEN1rlj/TSv/a3EVdCKtE
-    nQf55aPHxDAVDVw5JtRh4pZbbRV4oGRPc9KOdjo5BU28vSM3Lmhkb+UaaDXwHkgI
-    nK193o74DKjADWZxuLyyiKHiMOhxozoxDfjWxs8nz6uqvSW0pr521EwIY6RajbED
-    nZ2a3GkCgYEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pf
-    Q2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2E
-    wExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkICFA5kVUcW
-    nCPOXEQsayANi8+Cb7BH
-    -----END DSA PRIVATE KEY-----
-  dsa_public: ssh-dss AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4RZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM7nc9ZYLfWGrXTEGhZ16/Ra1w0X1O/7hsBrXbrfLnVGqjgYjvHH7GJzV2Yuqp9iKMFP2Tjwn/W1XRyzVaOzoU/8glMP+RhUL3fQmNhAyLvbaUGdTGxAAAAFQC+4s930xik70s71tMEJcJ2KUtkBQAAAIA2n4p3JL1X3ceDEZAQ3WuWP9NK/9rcRV0Iq0SdB/nlo8fEMBUNXDkm1GHillttFXigZE9z0o52OjkFTby9IzcuaGRv5RpoNfAeSAicrX3ejvgMqMANZnG4vLKIoeIw6HGjOjEN+NbGzyfPq6q9JbSmvnbUTAhjpFqNsQOdnZrcaQAAAIEAyoUomNRB6bmpsIfzt8zdtqLP5umIj2uhr9MVPL8/QdbxmJ72Z7pfQ2z1B7QAdIBGOlqJXtlau7ABhWK29Efe+99ObyTSSdDc6RCDeAwUmBAiPRQhDH2EwExw3doDSCUb28L1B50wBzQ8mC3KXp6C7IkBXWspb16DLHUHFSI8bkI= root@xenial-lxd
   ed25519_private: |
     -----BEGIN OPENSSH PRIVATE KEY-----
     b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW
@@ -87,16 +73,6 @@ class TestSshKeysProvided:
     @pytest.mark.parametrize(
         "config_path,expected_out",
         (
-            (
-                "/etc/ssh/ssh_host_dsa_key.pub",
-                "AAAAB3NzaC1kc3MAAACBAPkWy1zbchVIN7qTgM0/yyY8q4R"
-                "ZS8cNM4ZpeuE5UB/Nnr6OSU/nmbO8LuM",
-            ),
-            (
-                "/etc/ssh/ssh_host_dsa_key",
-                "MIIBuwIBAAKBgQD5Fstc23IVSDe6k4DNP8smPKuEWUvHDTOGaXr"
-                "hOVAfzZ6+jklP",
-            ),
             (
                 "/etc/ssh/ssh_host_rsa_key.pub",
                 "AAAAB3NzaC1yc2EAAAADAQABAAABAQC0/Ho+o3eJISydO2JvIgT"

--- a/tests/unittests/config/test_cc_phone_home.py
+++ b/tests/unittests/config/test_cc_phone_home.py
@@ -29,10 +29,9 @@ class TestPhoneHome:
         assert m_readurl.call_args == mock.call(
             "myurl",
             data={
-                "pub_key_dsa": "0",
-                "pub_key_rsa": "1",
-                "pub_key_ecdsa": "2",
-                "pub_key_ed25519": "3",
+                "pub_key_rsa": "0",
+                "pub_key_ecdsa": "1",
+                "pub_key_ed25519": "2",
                 "instance_id": "iid-datasource-none",
                 "hostname": "hostname",
                 "fqdn": "hostname",
@@ -98,11 +97,11 @@ class TestPhoneHomeSchema:
         "config",
         [
             # phone_home definition with url
-            {"phone_home": {"post": ["pub_key_dsa"]}},
+            {"phone_home": {"post": ["pub_key_rsa"]}},
             # post using string other than "all"
-            {"phone_home": {"url": "test_url", "post": "pub_key_dsa"}},
+            {"phone_home": {"url": "test_url", "post": "pub_key_rsa"}},
             # post using list with misspelled entry
-            {"phone_home": {"url": "test_url", "post": ["pub_kye_dsa"]}},
+            {"phone_home": {"url": "test_url", "post": ["pub_kye_rsa"]}},
         ],
     )
     @skipUnlessJsonSchema()

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -28,7 +28,6 @@ KEY_NAMES_NO_DSA = [
 @pytest.fixture(scope="function")
 def publish_hostkey_test_setup(tmpdir):
     test_hostkeys = {
-        "dsa": ("ssh-dss", "AAAAB3NzaC1kc3MAAACB"),
         "ecdsa": ("ecdsa-sha2-nistp256", "AAAAE2VjZ"),
         "ed25519": ("ssh-ed25519", "AAAAC3NzaC1lZDI"),
         "rsa": ("ssh-rsa", "AAAAB3NzaC1yc2EAAA"),
@@ -128,7 +127,6 @@ class TestHandleSsh:
         if not m_fips():
             expected_calls = [
                 mock.call("/etc/ssh/ssh_host_rsa_key"),
-                mock.call("/etc/ssh/ssh_host_dsa_key"),
                 mock.call("/etc/ssh/ssh_host_ecdsa_key"),
                 mock.call("/etc/ssh/ssh_host_ed25519_key"),
             ]
@@ -490,10 +488,6 @@ class TestSshSchema:
         "config, error_msg",
         (
             ({"ssh_authorized_keys": ["key1", "key2"]}, None),
-            (
-                {"ssh_keys": {"dsa_private": "key1", "rsa_public": "key2"}},
-                None,
-            ),
             (
                 {"ssh_keys": {"rsa_a": "key"}},
                 "'rsa_a' does not match any of the regexes",

--- a/tests/unittests/config/test_cc_ssh.py
+++ b/tests/unittests/config/test_cc_ssh.py
@@ -20,9 +20,6 @@ from tests.unittests.util import get_cloud
 LOG = logging.getLogger(__name__)
 
 MODPATH = "cloudinit.config.cc_ssh."
-KEY_NAMES_NO_DSA = [
-    name for name in cc_ssh.GENERATE_KEY_NAMES if name not in "dsa"
-]
 
 
 @pytest.fixture(scope="function")
@@ -131,7 +128,7 @@ class TestHandleSsh:
                 mock.call("/etc/ssh/ssh_host_ed25519_key"),
             ]
         else:
-            # Enabled fips doesn't generate dsa or ed25519
+            # Enabled fips doesn't generate ed25519
             expected_calls = [
                 mock.call("/etc/ssh/ssh_host_rsa_key"),
                 mock.call("/etc/ssh/ssh_host_ecdsa_key"),
@@ -226,10 +223,10 @@ class TestHandleSsh:
     @pytest.mark.parametrize(
         "cfg, expected_key_types",
         [
-            pytest.param({}, KEY_NAMES_NO_DSA, id="default"),
+            pytest.param({}, cc_ssh.GENERATE_KEY_NAMES, id="default"),
             pytest.param(
                 {"ssh_publish_hostkeys": {"enabled": True}},
-                KEY_NAMES_NO_DSA,
+                cc_ssh.GENERATE_KEY_NAMES,
                 id="config_enable",
             ),
             pytest.param(

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -58,18 +58,6 @@ def mock_getpwnam(users, username):
 # the testdata for OpenSSH, and their private keys are available
 # https://github.com/openssh/openssh-portable/tree/master/regress/unittests/sshkey/testdata
 VALID_CONTENT = {
-    "dsa": (
-        "AAAAB3NzaC1kc3MAAACBAIrjOQSlSea19bExXBMBKBvcLhBoVvNBjCppNzllipF"
-        "W4jgIOMcNanULRrZGjkOKat6MWJNetSbV1E6IOFDQ16rQgsh/OvYU9XhzM8seLa"
-        "A21VszZuhIV7/2DE3vxu7B54zVzueG1O1Deq6goQCRGWBUnqO2yluJiG4HzrnDa"
-        "jzRAAAAFQDMPO96qXd4F5A+5b2f2MO7SpVomQAAAIBpC3K2zIbDLqBBs1fn7rsv"
-        "KcJvwihdlVjG7UXsDB76P2GNqVG+IlYPpJZ8TO/B/fzTMtrdXp9pSm9OY1+BgN4"
-        "REsZ2WNcvfgY33aWaEM+ieCcQigvxrNAF2FTVcbUIIxAn6SmHuQSWrLSfdHc8H7"
-        "hsrgeUPPdzjBD/cv2ZmqwZ1AAAAIAplIsScrJut5wJMgyK1JG0Kbw9JYQpLe95P"
-        "obB069g8+mYR8U0fysmTEdR44mMu0VNU5E5OhTYoTGfXrVrkR134LqFM2zpVVbE"
-        "JNDnIqDHxTkc6LY2vu8Y2pQ3/bVnllZZOda2oD5HQ7ovygQa6CH+fbaZHbdDUX/"
-        "5z7u2rVAlDw=="
-    ),
     "ecdsa": (
         "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBITrGBB3cgJ"
         "J7fPxvtMW9H3oRisNpJ3OAslxZeyP7I0A9BPAW0RQIwHVtVnM7zrp4nI+JLZov/"
@@ -179,35 +167,6 @@ VALID_CONTENT = {
     "sk-ssh-ed25519@openssh.com": (
         "AAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY29tAAAAICFo/k5LU8863u66YC9"
         "eUO2170QduohPURkQnbLa/dczAAAABHNzaDo="
-    ),
-    "ssh-dss-cert-v01@openssh.com": (
-        "AAAAHHNzaC1kc3MtY2VydC12MDFAb3BlbnNzaC5jb20AAAAgdTlbNU9Hn9Qng3F"
-        "HxwH971bxCIoq1ern/QWFFDWXgmYAAACBAPqS600VGwdPAQC/p3f0uGyrLVql0c"
-        "Fn1zYd/JGvtabKnIYjLaYprje/NcjwI3CZFJiz4Dp3S8kLs+X5/1DMn/Tg1Y4D4"
-        "yLB+6vCtHcJF7rVBFhvw/KZwc7G54ez3khyOtsg82fzpyOc8/mq+/+C5TMKO7DD"
-        "jMF0k5emWKCsa3ZfAAAAFQCjA/+dKkMu4/CWjJPtfl7YNaStNQAAAIEA7uX1BVV"
-        "tJKjLmWrpw62+l/xSXA5rr7MHBuWjiCYV3VHBfXJaQDyRDtGuEJKDwdzqYgacpG"
-        "ApGWL/cuBtJ9nShsUl6GRG0Ra03g+Hx9VR5LviJBsjAVB4qVgciU1NGga0Bt2Le"
-        "cd1X4EGQRBzVXeuOpiqGM6jP/I2yDMs0Pboet0AAACBAOdXpyfmobEBaOqZAuvg"
-        "j1P0uhjG2P31Ufurv22FWPBU3A9qrkxbOXwE0LwvjCvrsQV/lrYhJz/tiys40Ve"
-        "ahulWZE5SAHMXGIf95LiLSgaXMjko7joot+LK84ltLymwZ4QMnYjnZSSclf1Uuy"
-        "QMcUtb34+I0u9Ycnyhp2mSFsQtAAAAAAAAAAYAAAACAAAABmp1bGl1cwAAABIAA"
-        "AAFaG9zdDEAAAAFaG9zdDIAAAAANowB8AAAAABNHmBwAAAAAAAAAAAAAAAAAAAA"
-        "MwAAAAtzc2gtZWQyNTUxOQAAACBThupGO0X+FLQhbz8CoKPwc7V3JNsQuGtlsgN"
-        "+F7SMGQAAAFMAAAALc3NoLWVkMjU1MTkAAABAh/z1LIdNL1b66tQ8t9DY9BTB3B"
-        "QKpTKmc7ezyFKLwl96yaIniZwD9Ticdbe/8i/Li3uCFE3EAt8NAIv9zff8Bg=="
-    ),
-    "ssh-dss": (
-        "AAAAB3NzaC1kc3MAAACBAPqS600VGwdPAQC/p3f0uGyrLVql0cFn1zYd/JGvtab"
-        "KnIYjLaYprje/NcjwI3CZFJiz4Dp3S8kLs+X5/1DMn/Tg1Y4D4yLB+6vCtHcJF7"
-        "rVBFhvw/KZwc7G54ez3khyOtsg82fzpyOc8/mq+/+C5TMKO7DDjMF0k5emWKCsa"
-        "3ZfAAAAFQCjA/+dKkMu4/CWjJPtfl7YNaStNQAAAIEA7uX1BVVtJKjLmWrpw62+"
-        "l/xSXA5rr7MHBuWjiCYV3VHBfXJaQDyRDtGuEJKDwdzqYgacpGApGWL/cuBtJ9n"
-        "ShsUl6GRG0Ra03g+Hx9VR5LviJBsjAVB4qVgciU1NGga0Bt2Lecd1X4EGQRBzVX"
-        "euOpiqGM6jP/I2yDMs0Pboet0AAACBAOdXpyfmobEBaOqZAuvgj1P0uhjG2P31U"
-        "furv22FWPBU3A9qrkxbOXwE0LwvjCvrsQV/lrYhJz/tiys40VeahulWZE5SAHMX"
-        "GIf95LiLSgaXMjko7joot+LK84ltLymwZ4QMnYjnZSSclf1UuyQMcUtb34+I0u9"
-        "Ycnyhp2mSFsQt"
     ),
     "ssh-ed25519-cert-v01@openssh.com": (
         "AAAAIHNzaC1lZDI1NTE5LWNlcnQtdjAxQG9wZW5zc2guY29tAAAAIIxzuxl4z3u"
@@ -398,7 +357,7 @@ class TestUpdateAuthorizedKeys:
         """new entries with the same base64 should replace old."""
         orig_entries = [
             " ".join(("rsa", VALID_CONTENT["rsa"], "orig_comment1")),
-            " ".join(("dsa", VALID_CONTENT["dsa"], "orig_comment2")),
+            " ".join(("ecdsa", VALID_CONTENT["ecdsa"], "orig_comment2")),
         ]
 
         expected = "\n".join([new_entries[0], orig_entries[1]]) + "\n"
@@ -852,9 +811,9 @@ class TestMultipleSshAuthorizedKeysFile:
             home, "authorized_keys", "rsa", keys
         )
 
-        # /tmp/home/bobby/.ssh/user_keys = dsa
+        # /tmp/home/bobby/.ssh/user_keys = ed25519
         user_keys = self.create_user_authorized_file(
-            home, "user_keys", "dsa", keys
+            home, "user_keys", "ed25519", keys
         )
 
         # /tmp/sshd_config
@@ -920,9 +879,9 @@ class TestMultipleSshAuthorizedKeysFile:
             home, "authorized_keys", "rsa", keys
         )
 
-        # /tmp/home/bobby/.ssh/user_keys = dsa
+        # /tmp/home/bobby/.ssh/user_keys = ed25519
         user_keys = self.create_user_authorized_file(
-            home, "user_keys", "dsa", keys
+            home, "user_keys", "ed25519", keys
         )
 
         authorized_keys_global = self.create_global_authorized_file(
@@ -1153,9 +1112,9 @@ class TestMultipleSshAuthorizedKeysFile:
         self.create_user_authorized_file(
             home_bobby, "authorized_keys2", "rsa", keys
         )
-        # /tmp/home/bobby/.ssh/user_keys3 = dsa
+        # /tmp/home/bobby/.ssh/user_keys3 = ed25519
         user_keys = self.create_user_authorized_file(
-            home_bobby, "user_keys3", "dsa", keys
+            home_bobby, "user_keys3", "ed25519", keys
         )
 
         # /tmp/home/suzie/.ssh/authorized_keys2 = rsa
@@ -1233,9 +1192,9 @@ class TestMultipleSshAuthorizedKeysFile:
         authorized_keys = self.create_user_authorized_file(
             home_bobby, "authorized_keys2", "rsa", keys
         )
-        # /tmp/home/bobby/.ssh/user_keys3 = dsa
+        # /tmp/home/bobby/.ssh/user_keys3 = ecdsa
         user_keys = self.create_user_authorized_file(
-            home_bobby, "user_keys3", "dsa", keys
+            home_bobby, "user_keys3", "ecdsa", keys
         )
 
         # /tmp/home/badguy/home/bobby = ""
@@ -1326,10 +1285,10 @@ class TestMultipleSshAuthorizedKeysFile:
         authorized_keys = self.create_user_authorized_file(
             home_bobby, "authorized_keys", "rsa", keys
         )
-        # /tmp/etc/ssh/userkeys/bobby = dsa
+        # /tmp/etc/ssh/userkeys/bobby = ecdsa
         # assume here that we can bypass userkeys, despite permissions
         self.create_global_authorized_file(
-            "etc/ssh/userkeys/bobby", "dsa", keys, tmpdir
+            "etc/ssh/userkeys/bobby", "ecdsa", keys, tmpdir
         )
 
         # /tmp/home/badguy/.ssh/authorized_keys = ssh-xmss@openssh.com
@@ -1419,10 +1378,10 @@ class TestMultipleSshAuthorizedKeysFile:
         self.create_user_authorized_file(
             home_bobby, "authorized_keys", "rsa", keys
         )
-        # /tmp/etc/ssh/userkeys/bobby = dsa
+        # /tmp/etc/ssh/userkeys/bobby = ed25519
         # assume here that we can bypass userkeys, despite permissions
         authorized_keys = self.create_global_authorized_file(
-            "etc/ssh/userkeys/bobby", "dsa", keys, tmpdir
+            "etc/ssh/userkeys/bobby", "ed25519", keys, tmpdir
         )
 
         # /tmp/home/badguy/.ssh/authorized_keys = ssh-xmss@openssh.com

--- a/tools/mock-meta.py
+++ b/tools/mock-meta.py
@@ -179,8 +179,6 @@ def get_ssh_keys():
 
     # Nice helper to add in the 'running' users key (if they have one)
     key_pth = os.path.expanduser("~/.ssh/id_rsa.pub")
-    if not os.path.isfile(key_pth):
-        key_pth = os.path.expanduser("~/.ssh/id_dsa.pub")
 
     if os.path.isfile(key_pth):
         with open(key_pth, "rb") as fh:


### PR DESCRIPTION
## Proposed Commit Message
OpenSSH 7.0 and greater similarly disable the ssh-dss (DSA) public key algorithm. It too is weak and we recommend against its use. 
refer:https://www.openssh.com/legacy.html

However, cloud-init still generates the DSA key.  It is recommended that cloud-init disable dsa