### PR TITLE
WIP: Snap package regression

### DIFF
--- a/cloudinit/config/cc_puppet.py
+++ b/cloudinit/config/cc_puppet.py
@@ -240,7 +240,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             if package_name is None:  # conf has no package_nam
                 for puppet_name in PUPPET_PACKAGE_NAMES:
                     try:
-                        cloud.distro.install_packages((puppet_name, version))
+                        cloud.distro.install_packages([(puppet_name, version)])
                         package_name = puppet_name
                         break
                     except subp.ProcessExecutionError:

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -183,6 +183,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                             )
             elif isinstance(entry, str):
                 generic_packages.add(entry)
+            elif isinstance(entry, tuple) and len(entry) == 2:
+                generic_packages.add(entry)
             else:
                 raise ValueError(
                     "Invalid 'packages' yaml specification. "

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -185,6 +185,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 generic_packages.add(entry)
             elif isinstance(entry, tuple) and len(entry) == 2:
                 generic_packages.add(entry)
+            elif isinstance(entry, list) and len(entry) == 2:
+                generic_packages.add(tuple(entry))
             else:
                 raise ValueError(
                     "Invalid 'packages' yaml specification. "

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -190,6 +190,15 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                     "Invalid 'packages' yaml specification. "
                     "Check schema definition."
                 )
+        for package_manager in packages_by_manager:
+            if package_manager not in getattr(self, "package_managers", []):
+                LOG.error(
+                    "Cannot install packages '%s' under '%s' as it is not a "
+                    "supported package manager for '%s'.",
+                    packages_by_manager[package_manager],
+                    package_manager,
+                    self.osfamily,
+                )
         return dict(packages_by_manager), generic_packages
 
     def install_packages(self, pkglist):

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -70,8 +70,12 @@ class Distro(distros.Distro):
         util.write_file(out_fn, "\n".join(lines), 0o644)
 
     def install_packages(self, pkglist):
+        (
+            _packages_by_manager,  # not yet supported
+            generic_packages,
+        ) = self._extract_package_by_manager(pkglist)
         self.update_package_sources()
-        self.package_command("add", pkgs=pkglist)
+        self.package_command("add", pkgs=generic_packages)
 
     def _write_hostname(self, hostname, filename):
         conf = None
@@ -171,7 +175,7 @@ class Distro(distros.Distro):
         if command == "upgrade":
             cmd.extend(["--update-cache", "--available"])
 
-        pkglist = util.expand_package_list("%s-%s", pkgs)
+        pkglist = sorted(util.expand_package_list("%s-%s", pkgs))
         cmd.extend(pkglist)
 
         # Allow the output of this to flow outwards (ie not be captured)

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -58,8 +58,12 @@ class Distro(distros.Distro):
         subp.subp(["localectl", "set-locale", locale], capture=False)
 
     def install_packages(self, pkglist):
+        (
+            _packages_by_manager,  # not yet supported
+            generic_packages,
+        ) = self._extract_package_by_manager(pkglist)
         self.update_package_sources()
-        self.package_command("", pkgs=pkglist)
+        self.package_command("", pkgs=generic_packages)
 
     def _get_renderer(self) -> Renderer:
         try:
@@ -185,7 +189,7 @@ class Distro(distros.Distro):
         if command:
             cmd.append(command)
 
-        pkglist = util.expand_package_list("%s-%s", pkgs)
+        pkglist = sorted(util.expand_package_list("%s-%s", pkgs))
         cmd.extend(pkglist)
 
         # Allow the output of this to flow outwards (ie not be captured)

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -97,8 +97,12 @@ class BSD(distros.Distro):
         return nconf
 
     def install_packages(self, pkglist):
+        (
+            _packages_by_manager,  # not yet supported
+            generic_packages,
+        ) = self._extract_package_by_manager(pkglist)
         self.update_package_sources()
-        self.package_command("install", pkgs=pkglist)
+        self.package_command("install", pkgs=generic_packages)
 
     def _get_pkg_cmd_environ(self):
         """Return environment vars used in *BSD package_command operations"""
@@ -126,7 +130,7 @@ class BSD(distros.Distro):
         elif args and isinstance(args, list):
             cmd.extend(args)
 
-        pkglist = util.expand_package_list("%s-%s", pkgs)
+        pkglist = sorted(util.expand_package_list("%s-%s", pkgs))
         cmd.extend(pkglist)
 
         # Allow the output of this to flow outwards (ie not be captured)

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -57,8 +57,12 @@ class Distro(distros.Distro):
         )
 
     def install_packages(self, pkglist):
+        (
+            _packages_by_manager,  # not yet supported
+            generic_packages,
+        ) = self._extract_package_by_manager(pkglist)
         self.update_package_sources()
-        self.package_command("", pkgs=pkglist)
+        self.package_command("", pkgs=generic_packages)
 
     def _write_network(self, settings):
         entries = net_util.translate_network(settings)
@@ -242,7 +246,7 @@ class Distro(distros.Distro):
             if command:
                 cmd.append(command)
 
-            pkglist = util.expand_package_list("%s-%s", pkgs)
+            pkglist = sorted(util.expand_package_list("%s-%s", pkgs))
             cmd.extend(pkglist)
 
         # Allow the output of this to flow outwards (ie not be captured)

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -68,8 +68,12 @@ class Distro(distros.Distro):
         rhutil.update_sysconfig_file(out_fn, locale_cfg)
 
     def install_packages(self, pkglist):
+        (
+            _packages_by_manager,  # not yet supported
+            generic_packages,
+        ) = self._extract_package_by_manager(pkglist)
         self.package_command(
-            "install", args="--auto-agree-with-licenses", pkgs=pkglist
+            "install", args="--auto-agree-with-licenses", pkgs=generic_packages
         )
 
     def package_command(self, command, args=None, pkgs=None):
@@ -122,7 +126,7 @@ class Distro(distros.Distro):
         elif args and isinstance(args, list):
             cmd.extend(args)
 
-        pkglist = util.expand_package_list("%s-%s", pkgs)
+        pkglist = sorted(util.expand_package_list("%s-%s", pkgs))
         cmd.extend(pkglist)
 
         # Allow the output of this to flow outwards (ie not be captured)

--- a/cloudinit/distros/photon.py
+++ b/cloudinit/distros/photon.py
@@ -83,8 +83,11 @@ class Distro(distros.Distro):
         self.exec_cmd(cmd)
 
     def install_packages(self, pkglist):
-        # self.update_package_sources()
-        self.package_command("install", pkgs=pkglist)
+        (
+            _packages_by_manager,  # not yet supported
+            generic_packages,
+        ) = self._extract_package_by_manager(pkglist)
+        self.package_command("install", pkgs=generic_packages)
 
     def _write_hostname(self, hostname, filename):
         if filename and filename.endswith("/previous-hostname"):
@@ -145,7 +148,7 @@ class Distro(distros.Distro):
 
         cmd.append(command)
 
-        pkglist = util.expand_package_list("%s-%s", pkgs)
+        pkglist = sorted(util.expand_package_list("%s-%s", pkgs))
         cmd.extend(pkglist)
 
         ret, _out, err = self.exec_cmd(cmd)

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -56,7 +56,11 @@ class Distro(distros.Distro):
         cfg["ssh_svcname"] = "sshd"
 
     def install_packages(self, pkglist):
-        self.package_command("install", pkgs=pkglist)
+        (
+            _packages_by_manager,  # not yet supported
+            generic_packages,
+        ) = self._extract_package_by_manager(pkglist)
+        self.package_command("install", pkgs=generic_packages)
 
     def get_locale(self):
         """Return the default locale if set, else use system locale"""
@@ -195,7 +199,7 @@ class Distro(distros.Distro):
 
         cmd.append(command)
 
-        pkglist = util.expand_package_list("%s-%s", pkgs)
+        pkglist = sorted(util.expand_package_list("%s-%s", pkgs))
         cmd.extend(pkglist)
 
         # Allow the output of this to flow outwards (ie not be captured)

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2499,6 +2499,8 @@ def is_partition(device):
 
 def expand_package_list(version_fmt, pkgs):
     # we will accept tuples, lists of tuples, or just plain lists
+    if isinstance(pkgs, set):
+        pkgs = [p for p in pkgs]
     if not isinstance(pkgs, list):
         pkgs = [pkgs]
 
@@ -2507,8 +2509,7 @@ def expand_package_list(version_fmt, pkgs):
         if isinstance(pkg, str):
             pkglist.append(pkg)
             continue
-
-        if isinstance(pkg, (tuple, list)):
+        elif isinstance(pkg, (tuple, list)):
             if len(pkg) < 1 or len(pkg) > 2:
                 raise RuntimeError("Invalid package & version tuple.")
 
@@ -2517,7 +2518,6 @@ def expand_package_list(version_fmt, pkgs):
                 continue
 
             pkglist.append(pkg[0])
-
         else:
             raise RuntimeError("Invalid package type.")
 

--- a/tests/integration_tests/modules/test_package_update_upgrade_install.py
+++ b/tests/integration_tests/modules/test_package_update_upgrade_install.py
@@ -10,7 +10,22 @@ import re
 
 import pytest
 
-from tests.integration_tests.releases import IS_UBUNTU
+from tests.integration_tests.clouds import IntegrationCloud
+from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
+from tests.integration_tests.util import verify_clean_log
+
+HELLO_VERSIONS_BY_RELEASE = {
+    "mantic": "2.10-3",
+    "lunar": "2.10-3",
+    "jammy": "2.10-2ubuntu4",
+    "focal": "2.10-2ubuntu2",
+}
+
+VERSIONED_USER_DATA = """\
+#cloud-config
+packages:
+- [hello, {pkg_version}]
+"""
 
 USER_DATA = """\
 #cloud-config
@@ -83,3 +98,14 @@ class TestPackageUpdateUpgradeInstall:
         output = class_client.execute("snap list")
         assert "curl" in output
         assert "postman" in output
+
+
+@pytest.mark.skipif(not IS_UBUNTU, reason="Uses Apt")
+def test_versioned_packages_are_installed(session_cloud: IntegrationCloud):
+
+    pkg_version = HELLO_VERSIONS_BY_RELEASE[CURRENT_RELEASE.series]
+    with session_cloud.launch(
+        user_data=VERSIONED_USER_DATA.format(pkg_version=pkg_version)
+    ) as client:
+        verify_clean_log(client.read_from_file("/var/log/cloud-init.log"))
+        assert f"hello	{pkg_version}" == client.execute("dpkg-query -W hello")

--- a/tests/unittests/config/test_cc_puppet.py
+++ b/tests/unittests/config/test_cc_puppet.py
@@ -115,7 +115,7 @@ class TestPuppetHandle(CiTestCase):
         cfg = {"puppet": {}}
         cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(
-            [mock.call(("puppet-agent", None))],
+            [mock.call([("puppet-agent", None)])],
             self.cloud.distro.install_packages.call_args_list,
         )
 
@@ -127,7 +127,7 @@ class TestPuppetHandle(CiTestCase):
         cfg = {"puppet": {"install": True}}
         cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertIn(
-            [mock.call(("puppet-agent", None))],
+            [mock.call([("puppet-agent", None)])],
             self.cloud.distro.install_packages.call_args_list,
         )
 
@@ -236,7 +236,7 @@ class TestPuppetHandle(CiTestCase):
         cfg = {"puppet": {"version": "3.8"}}
         cc_puppet.handle("notimportant", cfg, self.cloud, None)
         self.assertEqual(
-            [mock.call(("puppet-agent", "3.8"))],
+            [mock.call([("puppet-agent", "3.8")])],
             self.cloud.distro.install_packages.call_args_list,
         )
 

--- a/tests/unittests/distros/test_init.py
+++ b/tests/unittests/distros/test_init.py
@@ -327,7 +327,9 @@ class TestInstall:
             mock.call(["ifconfig", "-a"]),
             mock.call(["pkg", "update"], env={"fake"}, capture=False),
             mock.call(
-                ["pkg", "install", "pkg1", "pkg3-ver3"], env={"fake"}, capture=False
+                ["pkg", "install", "pkg1", "pkg3-ver3"],
+                env={"fake"},
+                capture=False
             ),
         ] == m_subp.call_args_list
 

--- a/tests/unittests/distros/test_opensuse.py
+++ b/tests/unittests/distros/test_opensuse.py
@@ -48,8 +48,8 @@ class TestPackageCommands:
             "zypper",
             "--non-interactive",
             "update",
-            "python36",
             "gzip",
+            "python36",
         ]
         m_subp.assert_called_with(expected_cmd, capture=False)
 
@@ -92,8 +92,8 @@ class TestPackageCommands:
             "zypper",
             "--non-interactive",
             "update",
-            "python36",
             "gzip",
+            "python36",
         ]
         m_subp.assert_called_with(expected_cmd, capture=False)
 
@@ -118,8 +118,8 @@ class TestPackageCommands:
             "--non-interactive",
             "install",
             "--auto-agree-with-licenses",
-            "python36",
             "gzip",
+            "python36",
         ]
         m_subp.assert_called_with(expected_cmd, capture=False)
 
@@ -165,8 +165,8 @@ class TestPackageCommands:
             "--drop-if-no-change",
             "pkg",
             "update",
-            "python36",
             "gzip",
+            "python36",
         ]
         m_subp.assert_called_with(expected_cmd, capture=False)
 
@@ -212,8 +212,8 @@ class TestPackageCommands:
             "--drop-if-no-change",
             "pkg",
             "update",
-            "python36",
             "gzip",
+            "python36",
         ]
         m_subp.assert_called_with(expected_cmd, capture=False)
 
@@ -238,8 +238,8 @@ class TestPackageCommands:
             "pkg",
             "install",
             "--auto-agree-with-licenses",
-            "python36",
             "gzip",
+            "python36",
         ]
         m_subp.assert_called_with(expected_cmd, capture=False)
 


### PR DESCRIPTION
WIP: needs integration test validation/fix.

Three separate commits fixing 3 failure conditions:
1. Fix jenkins failures in puppet integration tests now that distro.install_packages no longer accepts tuples
2. Wire _extract_package_manager to support and Distro subclass with it's own install_packages method in order to extract any generic packages: provided in cloud-config (and error on unsupported package_managers)
3. fix regression in 226ba258 by allowing per-package versions to be supplied in generic packages cloud-config
 ```
packages:
 - [pkg, ver]
```

## Proposed Commit Messages
<!-- Include a proposed commit message because all PRs are squash merged -->

```
*     packages: fix generic versioned package installs allowed
    
    Fix regression in commit 226ba258.
    
    User-data containing packages: can define specific package versions
    to install by providing a two-item list containing the package name and
    package version such as the following:
    
    packages:
    - [hello, 2.10-3]
    
    Add integration test covering this use case for the hello package on
    various supported Ubuntu releases.
    
    Fixes GH-4461

*     distros: invoke _extract_package_by_manager in all install_packages
    
    Distro subclasses like alpine, arch, bsd, redhat, suse need to
    parse packages: from cloud-config to separate generic package
    install requests for package manager specific install requests.
    
    This allows the packages listed to be aggregated as an installable
    list of generic packages.
    
    Given that only debian and ubuntu currently define
    Distro.package_managers attribute, allow extract_package_by_manager
    to raise an error when packages: cloud-config requests specific
    package managers that aren't supported by that Distro class.
    
    Allow util.expand_package_list to handle the sets of generic_packages
    returned by _extract_package_manager for alpined, arch, bsd, redhat and
    suse.

*  puppet: provide versioned package_install as a tuple in a list
    
    Since distro.install_packages operates on iterables, a versioned
    package install request shoud be provided as a single tuple as a
    list item to avoid iterating on each item in the tuple separately.

```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
