### PR TITLE
azure/imds: ensure new errors are logged immediately when retrying

### DIFF
--- a/cloudinit/sources/azure/imds.py
+++ b/cloudinit/sources/azure/imds.py
@@ -83,12 +83,16 @@ class ReadUrlRetryHandler:
 
         # Always log if error does not match previous.
         if exception.code is not None:
+            # This is an HTTP response with failing code, log if different.
             if self._last_error != exception.code:
                 log = True
                 self._last_error = exception.code
         elif (
+            # No previous error to match against.
             self._last_error is None
+            # Previous error is exception code (int).
             or not isinstance(self._last_error, type)
+            # Previous error is different class.
             or not isinstance(exception.cause, self._last_error)
         ):
             log = True

--- a/tests/unittests/sources/azure/test_imds.py
+++ b/tests/unittests/sources/azure/test_imds.py
@@ -129,6 +129,9 @@ class TestFetchMetadataWithApiFallback:
     fallback_url = (
         "http://169.254.169.254/metadata/instance?api-version=2019-06-01"
     )
+
+    # Early versions of responses do not appreciate the parameters...
+    base_url = "http://169.254.169.254/metadata/instance"
     headers = {"Metadata": "true"}
     timeout = 30
 
@@ -143,7 +146,7 @@ class TestFetchMetadataWithApiFallback:
         fake_md = {"foo": {"bar": []}}
         responses.add(
             method=responses.GET,
-            url=self.default_url,
+            url=self.base_url,
             json=fake_md,
             status=200,
         )
@@ -187,7 +190,7 @@ class TestFetchMetadataWithApiFallback:
         fake_md = {"foo": {"bar": []}}
         responses.add(
             method=responses.GET,
-            url=self.default_url,
+            url=self.base_url,
             status=400,
         )
         responses.add(
@@ -281,7 +284,7 @@ class TestFetchMetadataWithApiFallback:
         responses_add_errors([error] * error_count, self.default_url)
         responses.add(
             method=responses.GET,
-            url=self.default_url,
+            url=self.base_url,
             json=fake_md,
             status=200,
         )
@@ -340,7 +343,7 @@ class TestFetchMetadataWithApiFallback:
         fake_md = {"foo": {"bar": []}}
         responses.add(
             method=responses.GET,
-            url=self.default_url,
+            url=self.base_url,
             status=400,
         )
         responses.add(
@@ -499,7 +502,7 @@ class TestFetchMetadataWithApiFallback:
     ):
         responses.add(
             method=responses.GET,
-            url=self.default_url,
+            url=self.base_url,
             status=error,
         )
 
@@ -548,7 +551,7 @@ class TestFetchMetadataWithApiFallback:
     ):
         responses.add(
             method=responses.GET,
-            url=self.default_url,
+            url=self.base_url,
             body=body,
         )
 
@@ -598,7 +601,7 @@ class TestFetchMetadataWithApiFallback:
         responses_add_errors(errors, self.default_url)
         responses.add(
             method=responses.GET,
-            url=self.default_url,
+            url=self.base_url,
             json=fake_md,
         )
 

--- a/tests/unittests/sources/azure/test_imds.py
+++ b/tests/unittests/sources/azure/test_imds.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 import requests
+import responses
 
 from cloudinit.sources.azure import imds
 from cloudinit.url_helper import UrlError, readurl
@@ -22,6 +23,16 @@ class StringMatch:
 
     def __eq__(self, other) -> bool:
         return bool(re.match("^" + self.regex + "$", other))
+
+    def __repr__(self) -> str:
+        return repr(self.regex)
+
+
+@pytest.fixture(autouse=True)
+def caplog(caplog):
+    # Ensure caplog is set to debug.
+    caplog.set_level(logging.DEBUG)
+    yield caplog
 
 
 @pytest.fixture
@@ -67,6 +78,49 @@ def fake_http_error_for_code(status_code: int):
     )
 
 
+REQUESTS_CONNECTION_ERROR = requests.ConnectionError("Fake connection error")
+
+REQUESTS_TIMEOUT_ERROR = requests.Timeout("Fake connection timeout")
+
+
+def responses_add_errors(errors, url):
+    def callback_connection_error(request):
+        raise REQUESTS_CONNECTION_ERROR
+
+    def callback_timeout(request):
+        raise REQUESTS_TIMEOUT_ERROR
+
+    for error in errors:
+        if isinstance(error, int):
+            responses.add(
+                method=responses.GET,
+                url=url,
+                status=error,
+            )
+        elif error == REQUESTS_CONNECTION_ERROR:
+            responses.add_callback(
+                method=responses.GET,
+                url=url,
+                callback=callback_connection_error,
+            )
+        elif error == REQUESTS_TIMEOUT_ERROR:
+            responses.add_callback(
+                method=responses.GET,
+                url=url,
+                callback=callback_timeout,
+            )
+        else:
+            assert False
+
+
+def regex_for_http_error(error):
+    if isinstance(error, int):
+        return f".*{error!s}.*"
+
+    # Returns 'Fake connection error' or 'Fake connection timeout'
+    return f".*{error!s}.*"
+
+
 class TestFetchMetadataWithApiFallback:
     default_url = (
         "http://169.254.169.254/metadata/instance?"
@@ -79,17 +133,20 @@ class TestFetchMetadataWithApiFallback:
     timeout = 30
 
     @pytest.mark.parametrize("retry_deadline", [0.0, 1.0, 60.0])
+    @responses.activate
     def test_basic(
         self,
         caplog,
-        mock_requests_session_request,
         retry_deadline,
         wrapped_readurl,
     ):
         fake_md = {"foo": {"bar": []}}
-        mock_requests_session_request.side_effect = [
-            mock.Mock(content=json.dumps(fake_md)),
-        ]
+        responses.add(
+            method=responses.GET,
+            url=self.default_url,
+            json=fake_md,
+            status=200,
+        )
 
         md = imds.fetch_metadata_with_api_fallback(
             retry_deadline=retry_deadline
@@ -120,18 +177,25 @@ class TestFetchMetadataWithApiFallback:
         ]
 
     @pytest.mark.parametrize("retry_deadline", [0.0, 1.0, 60.0])
+    @responses.activate
     def test_basic_fallback(
         self,
         caplog,
-        mock_requests_session_request,
         retry_deadline,
         wrapped_readurl,
     ):
         fake_md = {"foo": {"bar": []}}
-        mock_requests_session_request.side_effect = [
-            UrlError("No IMDS version", code=400),
-            mock.Mock(content=json.dumps(fake_md)),
-        ]
+        responses.add(
+            method=responses.GET,
+            url=self.default_url,
+            status=400,
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.fallback_url,
+            json=fake_md,
+            status=200,
+        )
 
         md = imds.fetch_metadata_with_api_fallback(
             retry_deadline=retry_deadline
@@ -165,8 +229,15 @@ class TestFetchMetadataWithApiFallback:
             ),
             (
                 LOG_PATH,
+                logging.INFO,
+                StringMatch("Polling IMDS failed attempt 1 with.*400.*"),
+            ),
+            (
+                LOG_PATH,
                 logging.WARNING,
-                "Failed to fetch metadata from IMDS: No IMDS version",
+                StringMatch(
+                    "Failed to fetch metadata from IMDS:.*400 Client Error.*"
+                ),
             ),
             (
                 LOG_PATH,
@@ -181,44 +252,52 @@ class TestFetchMetadataWithApiFallback:
             (
                 "cloudinit.url_helper",
                 logging.DEBUG,
-                StringMatch("Read from.*"),
+                f"Read from {self.fallback_url} (200, 20b) after 1 attempts",
             ),
         ]
 
     @pytest.mark.parametrize(
         "error",
         [
-            fake_http_error_for_code(404),
-            fake_http_error_for_code(410),
-            fake_http_error_for_code(429),
-            fake_http_error_for_code(500),
-            requests.ConnectionError("Fake connection error"),
-            requests.Timeout("Fake connection timeout"),
+            404,
+            410,
+            429,
+            500,
+            REQUESTS_CONNECTION_ERROR,
+            REQUESTS_TIMEOUT_ERROR,
         ],
     )
-    @pytest.mark.parametrize("max_attempts,retry_deadline", [(2, 1.0)])
+    @pytest.mark.parametrize("error_count,retry_deadline", [(1, 2.0)])
+    @responses.activate
     def test_will_retry_errors(
         self,
         caplog,
-        max_attempts,
         retry_deadline,
-        mock_requests_session_request,
         mock_url_helper_time_sleep,
         error,
+        error_count,
     ):
         fake_md = {"foo": {"bar": []}}
-        mock_requests_session_request.side_effect = [
-            error,
-            mock.Mock(content=json.dumps(fake_md)),
-        ]
+        responses_add_errors([error] * error_count, self.default_url)
+        responses.add(
+            method=responses.GET,
+            url=self.default_url,
+            json=fake_md,
+            status=200,
+        )
 
         md = imds.fetch_metadata_with_api_fallback(
             retry_deadline=retry_deadline
         )
 
         assert md == fake_md
-        assert len(mock_requests_session_request.mock_calls) == max_attempts
-        assert mock_url_helper_time_sleep.mock_calls == [mock.call(1)]
+        assert (
+            mock_url_helper_time_sleep.mock_calls
+            == [mock.call(1)] * error_count
+        )
+        assert responses.assert_call_count(self.default_url, error_count + 1)
+
+        error_regex = regex_for_http_error(error)
         assert caplog.record_tuples == [
             (
                 "cloudinit.url_helper",
@@ -229,8 +308,8 @@ class TestFetchMetadataWithApiFallback:
                 LOG_PATH,
                 logging.INFO,
                 StringMatch(
-                    "Polling IMDS failed attempt 1 with exception:"
-                    f".*{error!s}.*"
+                    "Polling IMDS failed attempt 1 with exception: "
+                    f"{error_regex}"
                 ),
             ),
             (
@@ -251,28 +330,38 @@ class TestFetchMetadataWithApiFallback:
         ]
 
     @pytest.mark.parametrize("retry_deadline", [3.0, 30.0])
+    @responses.activate
     def test_will_retry_errors_on_fallback(
         self,
         caplog,
         retry_deadline,
-        mock_requests_session_request,
         mock_url_helper_time_sleep,
     ):
-        error = fake_http_error_for_code(400)
         fake_md = {"foo": {"bar": []}}
-        mock_requests_session_request.side_effect = [
-            error,
-            fake_http_error_for_code(429),
-            mock.Mock(content=json.dumps(fake_md)),
-        ]
-        max_attempts = len(mock_requests_session_request.side_effect)
+        responses.add(
+            method=responses.GET,
+            url=self.default_url,
+            status=400,
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.fallback_url,
+            status=429,
+        )
+        responses.add(
+            method=responses.GET,
+            url=self.fallback_url,
+            json=fake_md,
+            status=200,
+        )
 
         md = imds.fetch_metadata_with_api_fallback(
             retry_deadline=retry_deadline
         )
 
         assert md == fake_md
-        assert len(mock_requests_session_request.mock_calls) == max_attempts
+        assert responses.assert_call_count(self.default_url, 1)
+        assert responses.assert_call_count(self.fallback_url, 2)
         assert mock_url_helper_time_sleep.mock_calls == [mock.call(1)]
         assert caplog.record_tuples == [
             (
@@ -284,14 +373,14 @@ class TestFetchMetadataWithApiFallback:
                 LOG_PATH,
                 logging.INFO,
                 StringMatch(
-                    "Polling IMDS failed attempt 1 with exception:"
-                    f".*{error!s}.*"
+                    "Polling IMDS failed attempt 1 with exception:.*400.*"
                 ),
             ),
             (
                 LOG_PATH,
                 logging.WARNING,
-                "Failed to fetch metadata from IMDS: fake error",
+                "Failed to fetch metadata from IMDS: 400 Client Error: "
+                f"Bad Request for url: {self.default_url}",
             ),
             (
                 LOG_PATH,
@@ -307,8 +396,7 @@ class TestFetchMetadataWithApiFallback:
                 LOG_PATH,
                 logging.INFO,
                 StringMatch(
-                    "Polling IMDS failed attempt 1 with exception:"
-                    f".*{error!s}.*"
+                    "Polling IMDS failed attempt 1 with exception:.*429.*"
                 ),
             ),
             (
@@ -331,46 +419,46 @@ class TestFetchMetadataWithApiFallback:
     @pytest.mark.parametrize(
         "error",
         [
-            fake_http_error_for_code(404),
-            fake_http_error_for_code(410),
-            fake_http_error_for_code(429),
-            fake_http_error_for_code(500),
-            requests.ConnectionError("Fake connection error"),
-            requests.Timeout("Fake connection timeout"),
+            404,
+            410,
+            429,
+            500,
+            REQUESTS_CONNECTION_ERROR,
+            REQUESTS_TIMEOUT_ERROR,
         ],
     )
     @pytest.mark.parametrize(
-        "max_attempts,retry_deadline", [(1, 0.0), (2, 1.0), (301, 300.0)]
+        "error_count,retry_deadline", [(1, 0.0), (2, 1.0), (301, 300.0)]
     )
+    @responses.activate
     def test_retry_until_failure(
         self,
         error,
-        max_attempts,
+        error_count,
         retry_deadline,
         caplog,
-        mock_requests_session_request,
         mock_url_helper_time_sleep,
     ):
-        mock_requests_session_request.side_effect = error
+        responses_add_errors([error] * error_count, self.default_url)
 
         with pytest.raises(UrlError) as exc_info:
             imds.fetch_metadata_with_api_fallback(
                 retry_deadline=retry_deadline
             )
 
-        assert exc_info.value.cause == error
+        error_regex = regex_for_http_error(error)
+        assert re.search(error_regex, str(exc_info.value.cause))
 
         # Connection errors max out at 11 attempts.
-        max_attempts = (
+        error_count = (
             11
-            if isinstance(error, requests.ConnectionError)
-            and max_attempts > 11
-            else max_attempts
+            if error == REQUESTS_CONNECTION_ERROR and error_count > 11
+            else error_count
         )
-        assert len(mock_requests_session_request.mock_calls) == (max_attempts)
         assert mock_url_helper_time_sleep.mock_calls == [mock.call(1)] * (
-            max_attempts - 1
+            error_count - 1
         )
+        assert responses.assert_call_count(self.default_url, error_count)
 
         logs = [x for x in caplog.record_tuples if x[0] == LOG_PATH]
         assert logs == [
@@ -379,47 +467,50 @@ class TestFetchMetadataWithApiFallback:
                 logging.INFO,
                 StringMatch(
                     f"Polling IMDS failed attempt {i} with exception:"
-                    f".*{error!s}.*"
+                    f"{error_regex}"
                 ),
             )
-            for i in range(1, max_attempts + 1)
+            for i in range(1, error_count + 1)
         ] + [
             (
                 LOG_PATH,
                 logging.WARNING,
-                f"Failed to fetch metadata from IMDS: {error!s}",
+                StringMatch(
+                    f"Failed to fetch metadata from IMDS: {error_regex}",
+                ),
             )
         ]
 
     @pytest.mark.parametrize(
         "error",
         [
-            fake_http_error_for_code(403),
-            fake_http_error_for_code(501),
+            403,
+            501,
         ],
     )
     @pytest.mark.parametrize("retry_deadline", [0.0, 1.0, 60.0])
+    @responses.activate
     def test_will_not_retry_errors(
         self,
         error,
         retry_deadline,
         caplog,
-        mock_requests_session_request,
         mock_url_helper_time_sleep,
     ):
-        fake_md = {"foo": {"bar": []}}
-        mock_requests_session_request.side_effect = [
-            error,
-            mock.Mock(content=json.dumps(fake_md)),
-        ]
+        responses.add(
+            method=responses.GET,
+            url=self.default_url,
+            status=error,
+        )
 
         with pytest.raises(UrlError) as exc_info:
             imds.fetch_metadata_with_api_fallback(
                 retry_deadline=retry_deadline
             )
 
-        assert exc_info.value.cause == error
-        assert len(mock_requests_session_request.mock_calls) == 1
+        error_regex = regex_for_http_error(error)
+        assert re.search(error_regex, str(exc_info.value.cause))
+        assert responses.assert_call_count(self.default_url, 1)
         assert mock_url_helper_time_sleep.mock_calls == []
 
         assert caplog.record_tuples == [
@@ -433,27 +524,33 @@ class TestFetchMetadataWithApiFallback:
                 logging.INFO,
                 StringMatch(
                     "Polling IMDS failed attempt 1 with exception:"
-                    f".*{error!s}.*"
+                    f".*{error_regex}"
                 ),
             ),
             (
                 LOG_PATH,
                 logging.WARNING,
-                f"Failed to fetch metadata from IMDS: {error!s}",
+                StringMatch(
+                    f"Failed to fetch metadata from IMDS: {error_regex!s}"
+                ),
             ),
         ]
 
+    @pytest.mark.parametrize("body", ["", "invalid", "<tag></tag>"])
     @pytest.mark.parametrize("retry_deadline", [0.0, 1.0, 60.0])
+    @responses.activate
     def test_non_json_repsonse(
         self,
+        body,
         retry_deadline,
         caplog,
-        mock_requests_session_request,
         wrapped_readurl,
     ):
-        mock_requests_session_request.side_effect = [
-            mock.Mock(content=b"bad data")
-        ]
+        responses.add(
+            method=responses.GET,
+            url=self.default_url,
+            body=body,
+        )
 
         with pytest.raises(ValueError):
             imds.fetch_metadata_with_api_fallback(
@@ -481,45 +578,46 @@ class TestFetchMetadataWithApiFallback:
             )
         ]
 
-    def test_logs_unique_errors(
+    @responses.activate
+    def test_logs_all_errors(
         self,
         caplog,
-        mock_requests_session_request,
         mock_url_helper_time_sleep,
     ):
         fake_md = {"foo": {"bar": []}}
-        fake_errors = [
-            fake_http_error_for_code(404),
-            fake_http_error_for_code(410),
-            fake_http_error_for_code(429),
-            fake_http_error_for_code(500),
-            requests.ConnectionError("Fake connection error"),
-            requests.Timeout("Fake connection timeout"),
-        ]
-        attempts = len(fake_errors) + 1
-        mock_requests_session_request.side_effect = fake_errors + [
-            mock.Mock(content=json.dumps(fake_md))
-        ]
+
+        errors = (
+            [404] * 10
+            + [410] * 10
+            + [429] * 10
+            + [500] * 10
+            + [REQUESTS_CONNECTION_ERROR] * 10
+            + [REQUESTS_TIMEOUT_ERROR] * 10
+        )
+
+        responses_add_errors(errors, self.default_url)
+        responses.add(
+            method=responses.GET,
+            url=self.default_url,
+            json=fake_md,
+        )
 
         md = imds.fetch_metadata_with_api_fallback(retry_deadline=300)
 
         assert md == fake_md
-        assert len(mock_requests_session_request.mock_calls) == attempts
         assert mock_url_helper_time_sleep.mock_calls == [mock.call(1)] * (
-            attempts - 1
+            len(errors)
         )
 
+        expected_logs = [
+            StringMatch(
+                f"Polling IMDS failed attempt {i} with exception:"
+                f"{regex_for_http_error(error)}"
+            )
+            for i, error in enumerate(errors, start=1)
+        ]
         logs = [t[2] for t in caplog.record_tuples if "Polling IMDS" in t[2]]
-        assert all(
-            [
-                logs[i]
-                == StringMatch(
-                    f"Polling IMDS failed attempt {i+1} with exception:"
-                    f".*{error!s}.*"
-                )
-                for i, error in enumerate(fake_errors)
-            ]
-        )
+        assert logs == expected_logs
 
 
 class TestFetchReprovisionData:
@@ -725,3 +823,45 @@ class TestFetchReprovisionData:
                 f"{exc_info.value!r}",
             ),
         ]
+
+    @responses.activate
+    def test_logs_unique_errors(
+        self,
+        caplog,
+        mock_url_helper_time_sleep,
+    ):
+        content = b"ovf content"
+
+        errors = (
+            [404] * 10
+            + [410] * 10
+            + [429] * 10
+            + [404] * 10
+            + [410] * 10
+            + [429] * 10
+        )
+
+        responses_add_errors(errors, self.url)
+        responses.add(
+            method=responses.GET,
+            url=self.url,
+            body=content,
+        )
+
+        ovf = imds.fetch_reprovision_data()
+
+        assert ovf == content
+        assert mock_url_helper_time_sleep.mock_calls == [mock.call(1)] * (
+            len(errors)
+        )
+
+        backoff_logs = [
+            StringMatch(
+                f"Polling IMDS failed attempt {i} with exception:"
+                f"{regex_for_http_error(error)}"
+            )
+            for i, error in enumerate(errors, start=1)
+            if i == 1 or math.log2(i).is_integer() or (i - 1) % 10 == 0
+        ]
+        logs = [t[2] for t in caplog.record_tuples if "Polling IMDS" in t[2]]
+        assert logs == backoff_logs


### PR DESCRIPTION
When retrying to fetch metadata from IMDS there is a backoff for logging to avoid flooding the logs.  In the current implementation we have to wait until the next backoff log to see the transition.

Always log when the current error does not match the previous one.