### PR TITLE
azure/imds: retry on 429 errors for reprovisiondata

### DIFF
--- a/cloudinit/sources/azure/imds.py
+++ b/cloudinit/sources/azure/imds.py
@@ -185,6 +185,7 @@ def fetch_reprovision_data() -> bytes:
         retry_codes=(
             404,
             410,
+            429,
         ),
         retry_deadline=None,
     )

--- a/tests/unittests/sources/azure/test_imds.py
+++ b/tests/unittests/sources/azure/test_imds.py
@@ -533,6 +533,7 @@ class TestFetchReprovisionData:
         [
             fake_http_error_for_code(404),
             fake_http_error_for_code(410),
+            fake_http_error_for_code(429),
         ],
     )
     @pytest.mark.parametrize("failures", [1, 5, 100, 1000])
@@ -591,6 +592,7 @@ class TestFetchReprovisionData:
         [
             fake_http_error_for_code(404),
             fake_http_error_for_code(410),
+            fake_http_error_for_code(429),
         ],
     )
     @pytest.mark.parametrize("failures", [1, 5, 100, 1000])


### PR DESCRIPTION
Allow retries for 429 when fetching reprovisiondata. 429 is used when exceeding rate-limits and is currently retried for fetching instance metadata.

A tight retry-loop was observed on older versions of cloud-init where we had a series of short (2 second) read timeouts.  We expect this had triggered the rate-limiting due to max concurrent connections (from IMDS' perspective). Then _poll_imds() then entered a tight retry loop, spamming the logs until connections were allowed to resume.

The standard sleep between readurl() retries should be an adequate backoff if 429 is observed.