### PR TITLE
Ubuntu/devel

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -1177,9 +1177,9 @@ def parse_cmdline() -> str:
     Passing by command line overrides runtime datasource detection
     """
     cmdline = util.get_cmdline()
-    ds_parse_0 = re.search(r"ds=([a-zA-Z]+)(\s|$|;)", cmdline)
-    ds_parse_1 = re.search(r"ci\.ds=([a-zA-Z]+)(\s|$|;)", cmdline)
-    ds_parse_2 = re.search(r"ci\.datasource=([a-zA-Z]+)(\s|$|;)", cmdline)
+    ds_parse_0 = re.search(r"ds=([^\s;]+)", cmdline)
+    ds_parse_1 = re.search(r"ci\.ds=([^\s;]+)", cmdline)
+    ds_parse_2 = re.search(r"ci\.datasource=([^\s;]+)", cmdline)
     ds = ds_parse_0 or ds_parse_1 or ds_parse_2
     deprecated = ds_parse_1 or ds_parse_2
     if deprecated:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloud-init (23.2-0ubuntu2) mantic; urgency=medium
+
+  * yep 
+
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 27 Jun 2023 06:23:45 -0600
+
 cloud-init (23.2-0ubuntu1) mantic; urgency=medium
 
   * d/control: Remove pep8 dependency. It is no longer used.

--- a/tests/data/kernel_cmdline_match/meta-data
+++ b/tests/data/kernel_cmdline_match/meta-data
@@ -1,0 +1,1 @@
+instance=id: dfa16c21-4b25-4767-b94c-f98f5d73736d

--- a/tests/data/kernel_cmdline_match/user-data
+++ b/tests/data/kernel_cmdline_match/user-data
@@ -1,0 +1,3 @@
+#cloud-config
+runcmd:
+- touch /cmdline-userdata-success

--- a/tests/data/kernel_cmdline_match/vendor-data
+++ b/tests/data/kernel_cmdline_match/vendor-data
@@ -1,0 +1,2 @@
+#cloud-config
+{}

--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -1,33 +1,11 @@
 """Tests for `cloud-init status`"""
-from time import sleep
-
 import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, JAMMY
-
-
-# We're implementing our own here in case cloud-init status --wait
-# isn't working correctly (LP: #1966085)
-def _wait_for_cloud_init(client: IntegrationInstance):
-    last_exception = None
-    for _ in range(30):
-        try:
-            result = client.execute("cloud-init status")
-            if (
-                result
-                and result.ok
-                and ("running" not in result or "not run" not in result)
-            ):
-                return result
-        except Exception as e:
-            last_exception = e
-        sleep(1)
-    raise Exception(
-        "cloud-init status did not return successfully."
-    ) from last_exception
+from tests.integration_tests.util import wait_for_cloud_init
 
 
 def _remove_nocloud_dir_and_reboot(client: IntegrationInstance):
@@ -66,6 +44,7 @@ def test_wait_when_no_datasource(session_cloud: IntegrationCloud, setup_image):
         # Jammy and above will use LXD datasource by default
         if CURRENT_RELEASE < JAMMY:
             _remove_nocloud_dir_and_reboot(client)
-        status_out = _wait_for_cloud_init(client).stdout.strip()
+        status_out = wait_for_cloud_init(client).stdout.strip()
         assert "status: disabled" in status_out
         assert client.execute("cloud-init status --wait").ok
+        assert client.execute("test -f /cmdline-userdata-success").ok

--- a/tests/unittests/sources/test___init__.py
+++ b/tests/unittests/sources/test___init__.py
@@ -4,42 +4,44 @@ from cloudinit import sources
 from cloudinit.sources import DataSourceOpenStack as ds
 from tests.unittests.helpers import mock
 
+openstack_ds_name = ds.DataSourceOpenStack.dsname.lower()
+
 
 @pytest.mark.parametrize(
-    "m_cmdline",
+    "m_cmdline, expected_ds",
     (
         # test ci.ds=
-        "aosiejfoij ci.ds=OpenStack ",
-        "ci.ds=OpenStack",
-        "aosiejfoij ci.ds=OpenStack blah",
-        "aosiejfoij ci.ds=OpenStack faljskebflk",
-        "ci.ds=OpenStack;",
-        "ci.ds=openstack;",
+        ("aosiejfoij ci.ds=OpenStack ", openstack_ds_name),
+        ("ci.ds=OpenStack", openstack_ds_name),
+        ("aosiejfoij ci.ds=OpenStack blah", openstack_ds_name),
+        ("aosiejfoij ci.ds=OpenStack faljskebflk", openstack_ds_name),
+        ("ci.ds=OpenStack;", openstack_ds_name),
+        ("ci.ds=openstack;", openstack_ds_name),
         # test ci.datasource=
-        "aosiejfoij ci.datasource=OpenStack ",
-        "ci.datasource=OpenStack",
-        "aosiejfoij ci.datasource=OpenStack blah",
-        "aosiejfoij ci.datasource=OpenStack faljskebflk",
-        "ci.datasource=OpenStack;",
-        "ci.datasource=openstack;",
+        ("aosiejfoij ci.datasource=OpenStack ", openstack_ds_name),
+        ("ci.datasource=OpenStack", openstack_ds_name),
+        ("aosiejfoij ci.datasource=OpenStack blah", openstack_ds_name),
+        ("aosiejfoij ci.datasource=OpenStack faljskebflk", openstack_ds_name),
+        ("ci.datasource=OpenStack;", openstack_ds_name),
+        ("ci.datasource=openstack;", openstack_ds_name),
         # weird whitespace
-        "ci.datasource=OpenStack\n",
-        "ci.datasource=OpenStack\t",
-        "ci.datasource=OpenStack\r",
-        "ci.datasource=OpenStack\v",
-        "ci.ds=OpenStack\n",
-        "ci.ds=OpenStack\t",
-        "ci.ds=OpenStack\r",
-        "ci.ds=OpenStack\v",
+        ("ci.datasource=OpenStack\n", openstack_ds_name),
+        ("ci.datasource=OpenStack\t", openstack_ds_name),
+        ("ci.datasource=OpenStack\r", openstack_ds_name),
+        ("ci.datasource=OpenStack\v", openstack_ds_name),
+        ("ci.ds=OpenStack\n", openstack_ds_name),
+        ("ci.ds=OpenStack\t", openstack_ds_name),
+        ("ci.ds=OpenStack\r", openstack_ds_name),
+        ("ci.ds=OpenStack\v", openstack_ds_name),
+        ("ci.ds=nocloud-net\v", "nocloud-net"),
     ),
 )
-def test_ds_detect_kernel_commandline(m_cmdline):
+def test_ds_detect_kernel_commandline(m_cmdline, expected_ds):
     """check commandline match"""
     with mock.patch(
         "cloudinit.util.get_cmdline",
         return_value=m_cmdline,
     ):
         assert (
-            ds.DataSourceOpenStack.dsname.lower()
-            == sources.parse_cmdline().lower()
+            expected_ds == sources.parse_cmdline().lower()
         ), f"could not parse [{m_cmdline}]"


### PR DESCRIPTION
## do not squash merge
Queue Recommends dependency on python3-apt for apt_pkg module since cc_apt_configure uses it for some operations.
Cloud-init falls back to `apt-config dump` command when python module not present.

When this PR is merged, I will reflect it to Focal/Jammy/Lunar branches

## Proposed commit messages
```
update changelog
```
```
    d/contol: add python3-apt to Recommends
    
    cc_apt_configure will use apt_pkg from this deb if present to
    read apt configuration for Dir::Etc::sourceparts/sourcelist values.
    
    When absent, rely on the command apt-config dump.
```


## Additional Context


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
