### PR TITLE
Ubuntu/devel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloud-init (23.3-0ubuntu2) UNRELEASED; urgency=medium
+
+  * d/control: add python3-apt as Recommends to read APT config from apt_pkg
+
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 28 Sep 2023 13:57:45 -0600
+
 cloud-init (23.3-0ubuntu1) mantic; urgency=medium
 
   * d/po/templates.pot: refresh with debconf-updatepo

--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,7 @@ Depends: cloud-guest-utils | cloud-utils,
          python3-serial,
          ${misc:Depends},
          ${python3:Depends}
-Recommends: eatmydata, gdisk, gnupg, software-properties-common
+Recommends: eatmydata, gdisk, gnupg, python3-apt, software-properties-common
 Suggests: openssh-server, ssh-import-id
 Description: initialization and customization tool for cloud instances
  Cloud-init is the industry standard multi-distribution method for


### PR DESCRIPTION
## do not squash merge
Queue Recommends dependency on python3-apt for apt_pkg module since cc_apt_configure uses it for some operations.
Cloud-init falls back to `apt-config dump` command when python module not present.

When this PR is merged, I will reflect it to Focal/Jammy/Lunar branches

## Proposed commit messages
```
update changelog
```
```
    d/contol: add python3-apt to Recommends
    
    cc_apt_configure will use apt_pkg from this deb if present to
    read apt configuration for Dir::Etc::sourceparts/sourcelist values.
    
    When absent, rely on the command apt-config dump.
```

## Additional Context


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
