### PR TITLE
Prevent from wrongly interpreting cc: in a BOOTIF=mac  as config yaml

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1166,7 +1166,7 @@ def read_cc_from_cmdline(cmdline=None):
     if cmdline is None:
         cmdline = get_cmdline()
 
-    tag_begin = "cc:"
+    tag_begin = " cc:"
     tag_end = "end_cc"
     begin_l = len(tag_begin)
     end_l = len(tag_end)


### PR DESCRIPTION

When a mac address contains cc, such as
```
01:02:03:04:cc:f4
```

and when the kernel command line is
```
.... BOOTIF=01:02:03:04:cc:f4 ...
```

then cloudinit will wrongly think that 
```
f4 ...
```
are a cloudinit config yaml, then the yaml parser fails.

Normally this will not have a problem, but if the kernel command line embeds an important cloudinit instruction such as runcmd, then it will not be run, such as
```
... ds=nocloud cc: datasource_list: [NoCloud] end_cc cc: runcmd: [[echo,a]] end_cc BOOTIF=01:02:03:04:cc:f4
```

I have tested on a real UEFI PXE booted liveos.

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
