### PR TITLE
schema: emit network schema warnings in logs schema --system validates network

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -417,7 +417,7 @@
     "anyOf_type_route": {
       "type": "object",
       "additionalProperties": false,
-      "anyOf": [
+      "oneOf": [
         {
           "required": [
             "network",
@@ -566,13 +566,20 @@
       }
     }
   },
-  "required": [
-    "network"
-  ],
-  "properties": {
-    "network": {
+  "oneOf": [
+    {
       "$ref": "#/$defs/network_config_version1"
+    },
+    {
+      "required": [
+        "network"
+      ],
+      "properties": {
+        "network": {
+          "$ref": "#/$defs/network_config_version1"
+        }
+      },
+      "additionalProperties": false
     }
-  },
-  "additionalProperties": false
+  ]
 }

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -347,6 +347,7 @@ class Paths(persistence.CloudInitPickleMixin):
             # file
             "instance_data_sensitive": "instance-data-sensitive.json",
             "combined_cloud_config": "combined-cloud-config.json",
+            "network_config": "network-config.json",
             "instance_id": ".instance-id",
             "manual_clean_marker": "manual-clean",
             "obj_pkl": "obj.pkl",

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -934,6 +934,22 @@ class Init:
         )
 
     def _apply_netcfg_names(self, netcfg):
+        ncfg_instance_path = self.paths.get_ipath_cur("network_config")
+        network_link = self.paths.get_runpath("network_config")
+        if not self._network_already_configured():
+            if os.path.exists(ncfg_instance_path):
+                if netcfg != util.load_json(
+                    util.load_file(ncfg_instance_path)
+                ):
+                    atomic_helper.write_json(
+                        ncfg_instance_path, netcfg, mode=0o600
+                    )
+            else:
+                atomic_helper.write_json(
+                    ncfg_instance_path, netcfg, mode=0o600
+                )
+        if not os.path.islink(network_link):
+            util.sym_link(ncfg_instance_path, network_link)
         try:
             LOG.debug("applying net config names for %s", netcfg)
             self.distro.networking.apply_network_config_names(netcfg)
@@ -956,6 +972,8 @@ class Init:
         Find the config, determine whether to apply it, apply it via
         the distro, and optionally bring it up
         """
+        from cloudinit.config.schema import validate_cloudconfig_schema
+
         netcfg, src = self._find_networking_config()
         if netcfg is None:
             LOG.info("network config is disabled by %s", src)
@@ -991,6 +1009,15 @@ class Init:
 
         # refresh netcfg after update
         netcfg, src = self._find_networking_config()
+
+        if netcfg and netcfg.get("version") == 1:
+            validate_cloudconfig_schema(
+                config=netcfg,
+                schema_type="network-config",
+                strict=False,
+                log_details=True,
+                log_deprecations=True,
+            )
 
         # ensure all physical devices in config are present
         self.distro.networking.wait_for_physdevs(netcfg)

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -307,6 +307,9 @@ Validate cloud-config files using jsonschema.
 * :command:`-h, --help`: Show this help message and exit.
 * :command:`-c CONFIG_FILE, --config-file CONFIG_FILE`: Path of the
   cloud-config YAML file to validate.
+* :command:`-t SCHEMA_TYPE, --schema-type SCHEMA_TYPE`: The schema type to
+  validate --config-file against. One of: cloud-config, network-config.
+  Default: cloud-config.
 * :command:`--system`: Validate the system cloud-config user data.
 * :command:`-d DOCS [cc_module ...], --docs DOCS [cc_module ...]`:
   Print schema module

--- a/doc/rtd/reference/network-config.rst
+++ b/doc/rtd/reference/network-config.rst
@@ -16,6 +16,12 @@ precedence; each item overriding the previous.
 - **Kernel command line**: ``ip=`` or
   ``network-config=<Base64 encoded YAML config string>``
 
+Cloud-init will write out the following files representing the network-config
+processed:
+
+- :file:`/run/cloud-init/network-config.json`: world-readable JSON containing
+  the selected source network-config JSON used by cloud-init network renderers.
+
 User data cannot change an instance's network configuration. In the absence
 of network configuration in any of the above sources, ``cloud-init`` will
 write out a network configuration that will issue a DHCP request on a "first"

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -327,6 +327,27 @@ class TestCombined:
         assert data["system_info"]["default_user"]["name"] == "ubuntu"
 
     @pytest.mark.skipif(
+        PLATFORM not in ("lxd_vm", "lxd_container"),
+        reason="Test is LXD specific",
+    )
+    def test_network_config_json(self, class_client: IntegrationInstance):
+        client = class_client
+        network_json = client.read_from_file(
+            "/run/cloud-init/network-config.json"
+        )
+        devname = "eth0" if PLATFORM == "lxd_container" else "enp5s0"
+        assert {
+            "config": [
+                {
+                    "name": devname,
+                    "subnets": [{"control": "auto", "type": "dhcp"}],
+                    "type": "physical",
+                }
+            ],
+            "version": 1,
+        } == json.loads(network_json)
+
+    @pytest.mark.skipif(
         PLATFORM != "lxd_container",
         reason="Test is LXD container specific",
     )

--- a/tests/unittests/config/test_cc_apt_pipelining.py
+++ b/tests/unittests/config/test_cc_apt_pipelining.py
@@ -2,6 +2,8 @@
 
 """Tests cc_apt_pipelining handler"""
 
+import re
+
 import pytest
 
 import cloudinit.config.cc_apt_pipelining as cc_apt_pipelining
@@ -45,9 +47,12 @@ class TestAptPipelining:
             # Invalid schemas
             (
                 {"apt_pipelining": "bogus"},
-                "Cloud config schema errors: apt_pipelining: 'bogus' is not of"
-                " type 'integer', apt_pipelining: 'bogus' is not valid under"
-                " any of the given schemas",
+                re.escape(
+                    "Cloud config schema errors: apt_pipelining: 'bogus' is"
+                    " not of type 'boolean', apt_pipelining: 'bogus' is not"
+                    " of type 'integer', apt_pipelining: 'bogus' is not one"
+                    " of ['none', 'unchanged', 'os']"
+                ),
             ),
         ),
     )

--- a/tests/unittests/config/test_cc_bootcmd.py
+++ b/tests/unittests/config/test_cc_bootcmd.py
@@ -145,10 +145,8 @@ class TestBootCMDSchema:
                     ]
                 },
                 "Cloud config schema errors: bootcmd.1: 20 is not of type"
-                " 'array', bootcmd.1: 20 is not valid under any of the given"
-                " schemas, bootcmd.3: {'a': 'n'} is not of type 'array',"
-                " bootcmd.3: {'a': 'n'} is not valid under any of the given"
-                " schemas",
+                " 'array', bootcmd.1: 20 is not of type 'string', bootcmd.3:"
+                " {'a': 'n'} is not of type 'array'",
             ),
         ),
     )

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -446,7 +446,7 @@ class TestCACertsSchema:
         ]
         for warning in expected_warnings:
             assert warning in caplog.text
-            assert "DEPRECAT" in caplog.text
+            assert "deprecat" in caplog.text
         assert 1 == update_ca_certs.call_count
 
     @mock.patch.object(cc_ca_certs, "update_ca_certs")

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -678,9 +678,8 @@ class TestGrowpartSchema:
                 {"growpart": {"mode": "false"}},
                 pytest.raises(
                     SchemaValidationError,
-                    match=(
-                        "growpart.mode: 'false' is not valid under any of the"
-                        " given schemas"
+                    match=re.escape(
+                        "growpart.mode: 'false' is not one of [False"
                     ),
                 ),
             ),
@@ -688,9 +687,8 @@ class TestGrowpartSchema:
                 {"growpart": {"mode": "a"}},
                 pytest.raises(
                     SchemaValidationError,
-                    match=(
-                        "growpart.mode: 'a' is not valid under any of the"
-                        " given schemas"
+                    match=re.escape(
+                        "growpart.mode: 'a' is not one of ['auto',"
                     ),
                 ),
             ),

--- a/tests/unittests/config/test_cc_mounts.py
+++ b/tests/unittests/config/test_cc_mounts.py
@@ -612,13 +612,16 @@ class TestMountsSchema:
             ({"swap": {"size": "1.5MB"}}, "swap.size:"),
             (
                 {"swap": {"maxsize": "1.5MT"}},
-                "swap.maxsize: '1.5MT' is not valid",
+                re.escape("swap.maxsize: '1.5MT' does not match '^([0-9]+)?"),
             ),
             (
                 {"swap": {"maxsize": "..5T"}},
-                "swap.maxsize: '..5T' is not valid",
+                re.escape("swap.maxsize: '..5T' does not match '^([0-9]+)?"),
             ),
-            ({"swap": {"size": "K"}}, "swap.size: 'K' is not valid"),
+            (
+                {"swap": {"size": "K"}},
+                "swap.size: 'K' is not of type 'integer'",
+            ),
         ],
     )
     @test_helpers.skipUnlessJsonSchema()

--- a/tests/unittests/config/test_cc_update_etc_hosts.py
+++ b/tests/unittests/config/test_cc_update_etc_hosts.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import shutil
 
 import pytest
@@ -98,9 +99,9 @@ class TestUpdateEtcHosts:
                 {"manage_etc_hosts": "templatey"},
                 pytest.raises(
                     SchemaValidationError,
-                    match=(
-                        "manage_etc_hosts: 'templatey' is not valid under any"
-                        " of the given schemas"
+                    match=re.escape(
+                        "manage_etc_hosts: 'templatey' is not one of"
+                        " ['template']",
                     ),
                 ),
             ),

--- a/tests/unittests/config/test_cc_users_groups.py
+++ b/tests/unittests/config/test_cc_users_groups.py
@@ -337,7 +337,10 @@ class TestUsersGroupsSchema:
                 {"users": [{"name": "bbsw", "garbage-key": None}]},
                 pytest.raises(
                     SchemaValidationError,
-                    match="is not valid under any of the given schemas",
+                    match=(
+                        "users.0: {'name': 'bbsw', 'garbage-key': None} is"
+                        " not of type 'string'"
+                    ),
                 ),
                 True,
             ),
@@ -407,7 +410,9 @@ class TestUsersGroupsSchema:
                 {"user": ["no_list_allowed"]},
                 pytest.raises(
                     SchemaValidationError,
-                    match=re.escape("user: ['no_list_allowed'] is not valid "),
+                    match=re.escape(
+                        "user: ['no_list_allowed'] is not of type 'string'"
+                    ),
                 ),
                 True,
             ),
@@ -425,7 +430,10 @@ class TestUsersGroupsSchema:
                 },
                 pytest.raises(
                     SchemaValidationError,
-                    match="errors: users.0: {'inactive': True",
+                    match=(
+                        "errors: users.0.inactive: True is not of type"
+                        " 'string'"
+                    ),
                 ),
                 True,
             ),
@@ -491,10 +499,7 @@ class TestUsersGroupsSchema:
                 {"users": [{"name": "a", "expiredate": "2038,1,19"}]},
                 pytest.raises(
                     SchemaValidationError,
-                    match=(
-                        "users.0: {'name': 'a', 'expiredate': '2038,1,19'}"
-                        " is not valid under any of the given schemas"
-                    ),
+                    match=("users.0.expiredate: '2038,1,19' is not a 'date'"),
                 ),
                 True,
             ),

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -112,8 +112,11 @@ class TestVersionedSchemas:
         (
             ({}, None),
             ({"version": "v1"}, None),
-            ({"version": "v2"}, "is not valid"),
-            ({"version": "v1", "final_message": -1}, "is not valid"),
+            ({"version": "v2"}, "is not one of ['v1']"),
+            (
+                {"version": "v1", "final_message": -1},
+                "is not of type 'string'",
+            ),
             ({"version": "v1", "final_message": "some msg"}, None),
         ),
     )

--- a/tests/unittests/reporting/test_reporting.py
+++ b/tests/unittests/reporting/test_reporting.py
@@ -2,6 +2,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import re
 from unittest import mock
 
 import pytest
@@ -537,10 +538,19 @@ class TestReportingSchema:
             ({"reporting": "a"}, "'a' is not of type 'object'"),
             ({"reporting": {"a": "b"}}, "'b' is not of type 'object'"),
             # BAD: invalid type
-            ({"reporting": {"a": {"type": "b"}}}, "not valid"),
+            (
+                {"reporting": {"a": {"type": "b"}}},
+                re.escape("'b' is not one of ['log']"),
+            ),
             # BAD: invalid additional properties
-            ({"reporting": {"a": {"type": "print", "a": "b"}}}, "not valid"),
-            ({"reporting": {"a": {"type": "log", "a": "b"}}}, "not valid"),
+            (
+                {"reporting": {"a": {"type": "print", "a": "b"}}},
+                "'a' was unexpected",
+            ),
+            (
+                {"reporting": {"a": {"type": "log", "a": "b"}}},
+                "'a' was unexpected",
+            ),
             (
                 {
                     "reporting": {
@@ -551,14 +561,26 @@ class TestReportingSchema:
                         }
                     }
                 },
-                "not valid",
+                "'a' was unexpected",
             ),
-            ({"reporting": {"a": {"type": "hyperv", "a": "b"}}}, "not valid"),
+            (
+                {"reporting": {"a": {"type": "hyperv", "a": "b"}}},
+                "'a' was unexpected",
+            ),
             # BAD: missing required properties
-            ({"reporting": {"a": {"level": "FATAL"}}}, "not valid"),
-            ({"reporting": {"a": {"endpoint": "http://a"}}}, "not valid"),
-            ({"reporting": {"a": {"kvp_file_path": "/a/b"}}}, "not valid"),
-            ({"reporting": {"a": {"type": "webhook"}}}, "not valid"),
+            ({"reporting": {"a": {"level": "FATAL"}}}, "'type' is a required"),
+            (
+                {"reporting": {"a": {"endpoint": "http://a"}}},
+                "'type' is a required",
+            ),
+            (
+                {"reporting": {"a": {"kvp_file_path": "/a/b"}}},
+                "'endpoint' is a required",
+            ),
+            (
+                {"reporting": {"a": {"type": "webhook"}}},
+                "'endpoint' is a required",
+            ),
         ],
     )
     def test_schema_validation(self, config, error_msg):


### PR DESCRIPTION
## intended as separate commits for rebase merge

Wire network warnings to schema logs
Write /run/cloud-init/network-config.json reflecting cloud-init's source network-config

Add the following to the cloud-init schema sub command:
 - cloud-init schema --system now validates network-config
 - new cloud-init schema --config-type param accepts "network-config" when testing config files for development

## Proposed Commit Messages

```
*     schema: network-config optional network key. Use route def uses oneOf
    
    network-config schema now permits optional top-level network key.
    
    We should generally be using oneOf declarations in JSON schema.
    Fix anyOf_type_route schema definition.
    
    Update route definition to oneOf from anyOf requiring either
    'network' or 'destrination' key, combined with a 'gateway' key.

* schema: add cloud_init_deepest_matches for best_match error message
    
    Plug cloud_init_deppest_matches into any oneOf subschema calculation
    for most likely schema error match.
    
    This function will prefer the deepest match into the json_schema path
    with the exception that it prefers error messages for the matching
    subschema error for any instance containing a 'type' key.
    
    This means, when the subschema defines a required type: key. The
    cloud_init_deepest_match will raise the matching errors for the
    specific subschema containing the matching type: XXX over any
    other errors.
    
    Also drop unhelpful shema validation errors:
      'blah' is not valid under any of the given schemas.
    
    This is replaced with specific validation errors for each unmatched subschema.

* network: warn invalid cfg and expose /run/cloud-init/network-config
    
    When reading netcfg from the environment, validate version 1 against
    known JSON network-config schema and warnings on invalid schema.
    
    Persist the processed network-config at
    /run/cloud-init/network-config.json.
schema: add network-config support to schema subcommand
    
    By default, cloud-init schema command will look for processed network
    config at /run/cloud-init/network-config.json and report any
    schema validation errors on the commandline.
    
    To suport this feature:
    - return False when validate_cloudconfig_file does not validate a
      file
    - skip valdation on either empty network-config schema or network
      version 2
    - add a new --schema-type param to schema subcommand to allow for
      providing source network-config YAML files and validate as
      network-config instead of cloud-config
    - Add schema_type parameter to validate_cloudconfig_file allowing for
      plumbing 'network-config' type to schema validation call-sites
    
    Additionally, drop unnecessary jsonschema.ValidationError imports
    as that is already done at the module level.

```

## Additional Context
<!-- If relevant -->

## Test Steps
```
./tools/run-container --package ubuntu/mantic
CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=mantic CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_23.3-58-g4cee036f-1~bddeb_all.deb .tox/integration-tests/bin/pytest tests/integration_tests/modules/test_combined.py::TestCombined::test_network_config_json
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
