### PR TITLE
Revert allowing pro service warnings

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib==1!5.3.0
+pycloudlib==1!5.6.0
 
 # Await pytest > 7.3.2. Breaking change in `testpaths` treatment forced
 # test/unittests/conftest.py to be loaded by our integration-tests tox env

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -112,8 +112,7 @@ def get_services_status(client: IntegrationInstance) -> dict:
     assert status_resp.ok
     status = json.loads(status_resp.stdout)
     return {
-        svc["name"]: svc["status"] in ["enabled", "warning"]
-        for svc in status["services"]
+        svc["name"]: svc["status"] == "enabled" for svc in status["services"]
     }
 
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Revert allowing pro service warnings in tests

This reverts commit 67bb6aa3. Since pycloudlib has been updated to
no longer allow a failure of this type, we can be more stringent
in what we allow.

Additionally, bump pycloudlib version accordingly.
```

## Additional Context
https://github.com/canonical/pycloudlib/pull/320/files
