### PR TITLE
Apt tests and docs

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -594,6 +594,11 @@ def get_apt_cfg() -> Dict[str, str]:
     output unparsable.
     """
     try:
+        # python3-apt package is only a Recommends: not a strict Requires:
+        # in debian/control. Prefer the apt_pkg python module for APT
+        # interaction due to 7 ms performance improvement above subp.
+        # Given that debian/buntu images may not contain python3-apt
+        # fallback to subp if the image lacks this dependency.
         import apt_pkg  # type: ignore
 
         apt_pkg.init_config()

--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -433,9 +433,15 @@ apt:
 """  # noqa: E501
 
 
+RE_GPG_SW_PROPERTIES_INSTALLED = (
+    r"install"
+    r" (gnupg software-properties-common|software-properties-common gnupg)"
+)
+
+
 @pytest.mark.skipif(not IS_UBUNTU, reason="Apt usage")
 @pytest.mark.user_data(INSTALL_ANY_MISSING_RECOMMENDED_DEPENDENCIES)
 def test_install_missing_deps(client: IntegrationInstance):
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
-    assert "install gnupg software-properties-common" in log
+    assert re.search(RE_GPG_SW_PROPERTIES_INSTALLED, log)


### PR DESCRIPTION
## Please rebase merge of separate commits

## Proposed Commit Message(s)

```
*     tests: apt re.search to match alternative ordering of installed pkgs
    
    Given that different versions of python may order set items
    differrently, update log matching for logs containing either:
     install gnupg software-properties-common
       - or -
     install software-properties-common gnupg


*     apt: doc apt_pkg performance improvement over subp apt-config dump

```

## Additional Context
<!-- If relevant -->
1. Fixes failing jenkins tests due to different sort order of packages installed https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-ec2/lastSuccessfulBuild/testReport/
2. Documents the reason we have an apt_pkg ImportError fallback to a less performant subp(apt-config dump) in response to review comments on https://github.com/canonical/cloud-init/pull/4472

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly
