### PR TITLE
ds-identify: FreeBSD fixes

### DIFF
--- a/sysvinit/freebsd/dsidentify.tmpl
+++ b/sysvinit/freebsd/dsidentify.tmpl
@@ -39,5 +39,6 @@ load_rc_config 'cloudinit'
 
 : ${cloudinit_enable="NO"}
 : ${cloudinit_dsidentify_enable="YES"}
+: ${dsidentify_env="PATH_DI_CONFIG={{ prefix }}/etc/cloud/ds-identify.cfg PATH_ETC_CLOUD={{ prefix }}/etc/cloud"}
 
 run_rc_command "$1"

--- a/sysvinit/freebsd/dsidentify.tmpl
+++ b/sysvinit/freebsd/dsidentify.tmpl
@@ -23,18 +23,21 @@ rcvar="cloudinit_enable"
 
 dsidentify_start()
 {
-    echo "${command} starting"
-    if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
-        warn "cloud-init is disabled via kernel_options."
-    elif test -e {{ prefix }}/etc/cloud-init.disabled; then
-        warn "cloud-init is disabled via cloud-init.disabled file."
-    else
-        ${command}
+    if checkyesno cloudinit_dsidentify_enable; then
+        echo "${command} starting"
+        if kenv -q kernel_options | grep -q 'cloud-init=disabled'; then
+            warn "cloud-init is disabled via kernel_options."
+        elif test -e {{ prefix }}/etc/cloud-init.disabled; then
+            warn "cloud-init is disabled via cloud-init.disabled file."
+        else
+            ${command}
+        fi
     fi
 }
 
 load_rc_config 'cloudinit'
 
 : ${cloudinit_enable="NO"}
+: ${cloudinit_dsidentify_enable="YES"}
 
 run_rc_command "$1"


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
ds-identify: Allow disable service and override environment

This PR allows disabling the ds-identify service on FreeBSD, without
having to delete the service file.
It also overrides two environment variables when running the service
to ensure that on FreeBSD, paths are where they are to be expected.

Fixes GH-4481
Sponsored by: The FreeBSD Foundation
Co-authored-by: Dave Cottlehuber <dch@skunkwerks.at>
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
