### PR TITLE
[enhancement]: Add shellcheck to CI

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -94,6 +94,22 @@ jobs:
         run: |
           tox
 
+  shell-lint:
+    name: Shell Lint
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.0
+
+      - name: Install ShellCheck
+        run: |
+          sudo apt-get update
+          sudo apt install shellcheck
+
+      - name: Run ShellCheck
+        run: |
+          shellcheck ./tools/ds-identify
+
   check-cla-signers:
     runs-on: ubuntu-22.04
     steps:

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -590,8 +590,8 @@ read_datasource_list() {
     case "$DI_KERNEL_CMDLINE" in
         *cc:*datasource_list*)
             t=${DI_KERNEL_CMDLINE##*datasource_list}
-            t=${t%%"$cb"*}
-            t=${t##*"$ob"}
+            t=${t%%"${cb}"*}
+            t=${t##*"${ob}"}
             parse_yaml_array "$t"
             dslist=${_RET}
             ;;

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -869,7 +869,7 @@ dscheck_NoCloud() {
 
 is_ds_enabled() {
     local name="$1" pad=" ${DI_DSLIST} "
-    [ "${pad#* "$name" }" != "${pad}" ]
+    [ "${pad#* "${name}" }" != "${pad}" ]
 }
 
 check_configdrive_v2() {

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1137,7 +1137,7 @@ ec2_read_strict_setting() {
     # 4. kernel command line
     case " ${DI_KERNEL_CMDLINE} " in
         *\ $key=*\ )
-            val=${DI_KERNEL_CMDLINE##*"$key"=}
+            val=${DI_KERNEL_CMDLINE##*"${key}"=}
             val=${val%% *};
             _RET=${val:-$default}
             return 0

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -330,8 +330,8 @@ read_fs_info_linux() {
     [ -n "$dev" -a "$ftype" = "iso9660" ] &&
         isodevs="${isodevs},${dev}=$label"
 
-    DI_FS_LABELS="${labels%${delim}}"
-    DI_FS_UUIDS="${uuids%${delim}}"
+    DI_FS_LABELS="${labels%"${delim}"}"
+    DI_FS_UUIDS="${uuids%"${delim}"}"
     DI_ISO9660_DEVS="${isodevs#,}"
 }
 
@@ -381,7 +381,7 @@ read_fs_info_freebsd() {
         labels="${labels}${label}${delim}"
     done
 
-    DI_FS_LABELS="${labels%${delim}}"
+    DI_FS_LABELS="${labels%"${delim}"}"
     DI_ISO9660_DEVS="${isodevs#,}"
 }
 
@@ -462,7 +462,7 @@ is_container() {
 }
 
 is_socket_file() {
-    [ -S $1 ] && return 0 || return 1
+    [ -S "$1" ] && return 0 || return 1
 }
 
 read_kernel_cmdline() {
@@ -590,8 +590,8 @@ read_datasource_list() {
     case "$DI_KERNEL_CMDLINE" in
         *cc:*datasource_list*)
             t=${DI_KERNEL_CMDLINE##*datasource_list}
-            t=${t%%$cb*}
-            t=${t##*$ob}
+            t=${t%%"$cb"*}
+            t=${t##*"$ob"}
             parse_yaml_array "$t"
             dslist=${_RET}
             ;;
@@ -687,7 +687,7 @@ nocase_equal() {
     local delim="-delim-"
     # shellcheck disable=2018,2019
     out=$(echo "$1${delim}$2" | tr A-Z a-z)
-    [ "${out#*${delim}}" = "${out%${delim}*}" ]
+    [ "${out#*"${delim}"}" = "${out%"${delim}"*}" ]
 }
 
 check_seed_dir() {
@@ -713,7 +713,7 @@ check_writable_seed_dir() {
     # over the top of /var/lib/cloud, but the mount might not be done yet.
     local wdir="/writable/system-data"
     [ -d "${PATH_ROOT}$wdir" ] || return 1
-    local sdir="${PATH_ROOT}$wdir${PATH_VAR_LIB_CLOUD#${PATH_ROOT}}"
+    local sdir="${PATH_ROOT}$wdir${PATH_VAR_LIB_CLOUD#"${PATH_ROOT}"}"
     local PATH_VAR_LIB_CLOUD="$sdir"
     check_seed_dir "$@"
 }
@@ -869,7 +869,7 @@ dscheck_NoCloud() {
 
 is_ds_enabled() {
     local name="$1" pad=" ${DI_DSLIST} "
-    [ "${pad#* $name }" != "${pad}" ]
+    [ "${pad#* "$name" }" != "${pad}" ]
 }
 
 check_configdrive_v2() {
@@ -1009,27 +1009,17 @@ vmware_guestinfo_ovfenv_err() {
 }
 
 vmware_guestinfo_metadata() {
-    if [ "${1:-}" = "err" ]; then
-      vmware_guestinfo_err "metadata"
-    else
-      vmware_guestinfo "metadata"
-    fi
+    vmware_guestinfo "metadata"
 }
 
 vmware_guestinfo_userdata() {
-    if [ "${1:-}" = "err" ]; then
-      vmware_guestinfo_err "userdata"
-    else
-      vmware_guestinfo "userdata"
-    fi
+
+    vmware_guestinfo "userdata"
 }
 
 vmware_guestinfo_vendordata() {
-    if [ "${1:-}" = "err" ]; then
-      vmware_guestinfo_err "vendordata"
-    else
-      vmware_guestinfo "vendordata"
-    fi
+
+    vmware_guestinfo "vendordata"
 }
 
 ovf_vmware_transport_guestinfo() {
@@ -1088,7 +1078,7 @@ is_cdrom_ovf() {
 has_ovf_cdrom() {
     # DI_ISO9660_DEVS is <device>=label,<device>=label2
     # like /dev/sr0=OVF-TRANSPORT,/dev/other=with spaces
-    if [ "${DI_ISO9660_DEVS#${UNAVAILABLE}:}" = "${DI_ISO9660_DEVS}" ]; then
+    if [ "${DI_ISO9660_DEVS#"${UNAVAILABLE}":}" = "${DI_ISO9660_DEVS}" ]; then
         local oifs="$IFS"
         # shellcheck disable=2086
         { IFS=","; set -- ${DI_ISO9660_DEVS}; IFS="$oifs"; }
@@ -1147,7 +1137,7 @@ ec2_read_strict_setting() {
     # 4. kernel command line
     case " ${DI_KERNEL_CMDLINE} " in
         *\ $key=*\ )
-            val=${DI_KERNEL_CMDLINE##*$key=}
+            val=${DI_KERNEL_CMDLINE##*"$key"=}
             val=${val%% *};
             _RET=${val:-$default}
             return 0
@@ -1665,7 +1655,7 @@ _read_config() {
     local keyname="${1:-_unset}"
     local line="" hash="#" key="" val=""
     while read line; do
-        line=${line%%${hash}*}
+        line=${line%%"${hash}"*}
         key="${line%%:*}"
 
         # no : in the line.


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

Add shellcheck to CI


Fixes GH- #4453  

## Additional Context

@TheRealFalcon 

After finding bug in the systemd-generator script, I have added shellcheck for ds-identify script and system-generator script can be integrated later on in the CI. 
Please review my PR. Any changes suggested by the maintainers are welcome!

## Test Steps

![Screenshot from 2023-10-05 01-06-04](https://github.com/canonical/cloud-init/assets/96782675/6f8631cf-c2cc-43a1-a818-c872970fdaa5)


## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
