### PR TITLE
integration test fix for deb822 format on azure platform

### DIFF
--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -315,7 +315,7 @@ class TestDefaults:
             get_feature_flag_value(class_client, "APT_DEB822_SOURCE_LIST_FILE")
         )
         if class_client.settings.PLATFORM == "azure":
-            sec_url = "deb http://azure.archive.ubuntu.com/ubuntu/"
+            sec_url = "http://azure.archive.ubuntu.com/ubuntu/"
         else:
             sec_url = "http://security.ubuntu.com/ubuntu"
         if feature_deb822:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
integration test fix for deb822 URI format
```

## Additional Context
Jenkins failures exhibiting this test failure
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-azure/320/testReport/tests.integration_tests.modules.test_apt_functionality/TestDefaults/test_security/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
