### PR TITLE
Pro enable fix and shift to using pro command instead of ua

### DIFF
--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -233,7 +233,7 @@ def set_ua_config(ua_config: Any = None):
         subp_kwargs: dict = {}
         if value is None:
             LOG.debug("Disabling UA config for %s", key)
-            config_cmd = ["ua", "config", "unset", key]
+            config_cmd = ["pro", "config", "unset", key]
         else:
             redacted_key_value = f"{key}=REDACTED"
             LOG.debug("Enabling UA config %s", redacted_key_value)
@@ -241,7 +241,7 @@ def set_ua_config(ua_config: Any = None):
                 key_value = f"{key}={re.escape(value)}"
             else:
                 key_value = f"{key}={value}"
-            config_cmd = ["ua", "config", "set", key_value]
+            config_cmd = ["pro", "config", "set", key_value]
             subp_kwargs = {"logstring": config_cmd[:-1] + [redacted_key_value]}
         try:
             subp.subp(config_cmd, **subp_kwargs)
@@ -280,9 +280,9 @@ def configure_ua(token, enable=None):
 
     # Perform attach
     if enable:
-        attach_cmd = ["ua", "attach", "--no-auto-enable", token]
+        attach_cmd = ["pro", "attach", "--no-auto-enable", token]
     else:
-        attach_cmd = ["ua", "attach", token]
+        attach_cmd = ["pro", "attach", token]
     redacted_cmd = attach_cmd[:-1] + [REDACTED]
     LOG.debug("Attaching to Ubuntu Advantage. %s", " ".join(redacted_cmd))
     try:
@@ -297,7 +297,7 @@ def configure_ua(token, enable=None):
     # Enable services
     if not enable:
         return
-    cmd = ["ua", "enable", "--assume-yes", "--format", "json"] + enable
+    cmd = ["pro", "enable", "--assume-yes", "--format", "json"] + enable
     try:
         enable_stdout, _ = subp.subp(cmd, capture=True, rcs={0, 1})
     except subp.ProcessExecutionError as e:
@@ -360,7 +360,7 @@ def configure_ua(token, enable=None):
 
 def maybe_install_ua_tools(cloud: Cloud):
     """Install ubuntu-advantage-tools if not present."""
-    if subp.which("ua"):
+    if subp.which("pro"):
         return
     try:
         cloud.distro.update_package_sources()

--- a/cloudinit/config/cc_ubuntu_advantage.py
+++ b/cloudinit/config/cc_ubuntu_advantage.py
@@ -297,7 +297,7 @@ def configure_ua(token, enable=None):
     # Enable services
     if not enable:
         return
-    cmd = ["ua", "enable", "--assume-yes", "--format", "json", "--"] + enable
+    cmd = ["ua", "enable", "--assume-yes", "--format", "json"] + enable
     try:
         enable_stdout, _ = subp.subp(cmd, capture=True, rcs={0, 1})
     except subp.ProcessExecutionError as e:

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -144,7 +144,6 @@ class TestConfigureUA:
                             "--assume-yes",
                             "--format",
                             "json",
-                            "--",
                             "fips",
                         ],
                         capture=True,
@@ -182,7 +181,6 @@ class TestConfigureUA:
                             "--assume-yes",
                             "--format",
                             "json",
-                            "--",
                             "fips",
                         ],
                         capture=True,
@@ -271,7 +269,6 @@ class TestConfigureUA:
                 "--assume-yes",
                 "--format",
                 "json",
-                "--",
                 "livepatch",
             ]
             if cmd == fail_cmds and capture:
@@ -303,7 +300,6 @@ class TestConfigureUA:
                     "--assume-yes",
                     "--format",
                     "json",
-                    "--",
                     "livepatch",
                 ],
                 capture=True,
@@ -326,7 +322,6 @@ class TestConfigureUA:
                 "--assume-yes",
                 "--format",
                 "json",
-                "--",
             ]
             if cmd[: len(fail_cmd)] == fail_cmd and capture:
                 response = {
@@ -375,7 +370,6 @@ class TestConfigureUA:
                     "--assume-yes",
                     "--format",
                     "json",
-                    "--",
                     "esm",
                     "cc",
                     "fips",

--- a/tests/unittests/config/test_cc_ubuntu_advantage.py
+++ b/tests/unittests/config/test_cc_ubuntu_advantage.py
@@ -70,7 +70,7 @@ def fake_uaclient(mocker):
 @mock.patch(f"{MPATH}.subp.subp")
 class TestConfigureUA:
     def test_configure_ua_attach_error(self, m_subp):
-        """Errors from ua attach command are raised."""
+        """Errors from pro attach command are raised."""
         m_subp.side_effect = subp.ProcessExecutionError(
             "Invalid token SomeToken"
         )
@@ -85,13 +85,13 @@ class TestConfigureUA:
     @pytest.mark.parametrize(
         "kwargs, call_args_list, log_record_tuples",
         [
-            # When token is provided, attach the machine to ua using the token.
+            # When token is provided, attach to pro using the token.
             pytest.param(
                 {"token": "SomeToken"},
                 [
                     mock.call(
-                        ["ua", "attach", "SomeToken"],
-                        logstring=["ua", "attach", "REDACTED"],
+                        ["pro", "attach", "SomeToken"],
+                        logstring=["pro", "attach", "REDACTED"],
                         rcs={0, 2},
                     )
                 ],
@@ -99,7 +99,7 @@ class TestConfigureUA:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Attaching to Ubuntu Advantage. ua attach REDACTED",
+                        "Attaching to Ubuntu Advantage. pro attach REDACTED",
                     )
                 ],
                 id="with_token",
@@ -109,8 +109,8 @@ class TestConfigureUA:
                 {"token": "SomeToken", "enable": []},
                 [
                     mock.call(
-                        ["ua", "attach", "SomeToken"],
-                        logstring=["ua", "attach", "REDACTED"],
+                        ["pro", "attach", "SomeToken"],
+                        logstring=["pro", "attach", "REDACTED"],
                         rcs={0, 2},
                     )
                 ],
@@ -118,7 +118,7 @@ class TestConfigureUA:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Attaching to Ubuntu Advantage. ua attach REDACTED",
+                        "Attaching to Ubuntu Advantage. pro attach REDACTED",
                     )
                 ],
                 id="with_empty_services",
@@ -128,9 +128,9 @@ class TestConfigureUA:
                 {"token": "SomeToken", "enable": ["fips"]},
                 [
                     mock.call(
-                        ["ua", "attach", "--no-auto-enable", "SomeToken"],
+                        ["pro", "attach", "--no-auto-enable", "SomeToken"],
                         logstring=[
-                            "ua",
+                            "pro",
                             "attach",
                             "--no-auto-enable",
                             "REDACTED",
@@ -139,7 +139,7 @@ class TestConfigureUA:
                     ),
                     mock.call(
                         [
-                            "ua",
+                            "pro",
                             "enable",
                             "--assume-yes",
                             "--format",
@@ -154,7 +154,7 @@ class TestConfigureUA:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Attaching to Ubuntu Advantage. ua attach"
+                        "Attaching to Ubuntu Advantage. pro attach"
                         " --no-auto-enable REDACTED",
                     )
                 ],
@@ -165,9 +165,9 @@ class TestConfigureUA:
                 {"token": "SomeToken", "enable": "fips"},
                 [
                     mock.call(
-                        ["ua", "attach", "--no-auto-enable", "SomeToken"],
+                        ["pro", "attach", "--no-auto-enable", "SomeToken"],
                         logstring=[
-                            "ua",
+                            "pro",
                             "attach",
                             "--no-auto-enable",
                             "REDACTED",
@@ -176,7 +176,7 @@ class TestConfigureUA:
                     ),
                     mock.call(
                         [
-                            "ua",
+                            "pro",
                             "enable",
                             "--assume-yes",
                             "--format",
@@ -191,7 +191,7 @@ class TestConfigureUA:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Attaching to Ubuntu Advantage. ua attach"
+                        "Attaching to Ubuntu Advantage. pro attach"
                         " --no-auto-enable REDACTED",
                     ),
                     (
@@ -208,8 +208,8 @@ class TestConfigureUA:
                 {"token": "SomeToken", "enable": {"deffo": "wont work"}},
                 [
                     mock.call(
-                        ["ua", "attach", "SomeToken"],
-                        logstring=["ua", "attach", "REDACTED"],
+                        ["pro", "attach", "SomeToken"],
+                        logstring=["pro", "attach", "REDACTED"],
                         rcs={0, 2},
                     )
                 ],
@@ -217,7 +217,7 @@ class TestConfigureUA:
                     (
                         MPATH,
                         logging.DEBUG,
-                        "Attaching to Ubuntu Advantage. ua attach REDACTED",
+                        "Attaching to Ubuntu Advantage. pro attach REDACTED",
                     ),
                     (
                         MPATH,
@@ -241,20 +241,20 @@ class TestConfigureUA:
             assert record_tuple in caplog.record_tuples
 
     def test_configure_ua_already_attached(self, m_subp, caplog):
-        """ua is already attached to an subscription"""
+        """pro is already attached to an subscription"""
         m_subp.rcs = 2
         configure_ua(token="SomeToken")
         assert m_subp.call_args_list == [
             mock.call(
-                ["ua", "attach", "SomeToken"],
-                logstring=["ua", "attach", "REDACTED"],
+                ["pro", "attach", "SomeToken"],
+                logstring=["pro", "attach", "REDACTED"],
                 rcs={0, 2},
             )
         ]
         assert (
             MPATH,
             logging.DEBUG,
-            "Attaching to Ubuntu Advantage. ua attach REDACTED",
+            "Attaching to Ubuntu Advantage. pro attach REDACTED",
         ) in caplog.record_tuples
 
     def test_configure_ua_attach_on_service_enabled(
@@ -264,7 +264,7 @@ class TestConfigureUA:
 
         def fake_subp(cmd, capture=None, rcs=None, logstring=None):
             fail_cmds = [
-                "ua",
+                "pro",
                 "enable",
                 "--assume-yes",
                 "--format",
@@ -289,13 +289,13 @@ class TestConfigureUA:
         configure_ua(token="SomeToken", enable=["livepatch"])
         assert m_subp.call_args_list == [
             mock.call(
-                ["ua", "attach", "--no-auto-enable", "SomeToken"],
-                logstring=["ua", "attach", "--no-auto-enable", "REDACTED"],
+                ["pro", "attach", "--no-auto-enable", "SomeToken"],
+                logstring=["pro", "attach", "--no-auto-enable", "REDACTED"],
                 rcs={0, 2},
             ),
             mock.call(
                 [
-                    "ua",
+                    "pro",
                     "enable",
                     "--assume-yes",
                     "--format",
@@ -317,7 +317,7 @@ class TestConfigureUA:
 
         def fake_subp(cmd, capture=None, rcs=None, logstring=None):
             fail_cmd = [
-                "ua",
+                "pro",
                 "enable",
                 "--assume-yes",
                 "--format",
@@ -359,13 +359,13 @@ class TestConfigureUA:
             )
         assert m_subp.call_args_list == [
             mock.call(
-                ["ua", "attach", "--no-auto-enable", "SomeToken"],
-                logstring=["ua", "attach", "--no-auto-enable", "REDACTED"],
+                ["pro", "attach", "--no-auto-enable", "SomeToken"],
+                logstring=["pro", "attach", "--no-auto-enable", "REDACTED"],
                 rcs={0, 2},
             ),
             mock.call(
                 [
-                    "ua",
+                    "pro",
                     "enable",
                     "--assume-yes",
                     "--format",
@@ -398,7 +398,7 @@ class TestConfigureUA:
 
     def test_ua_enable_unexpected_error_codes(self, m_subp):
         def fake_subp(cmd, capture=None, **kwargs):
-            if cmd[:2] == ["ua", "enable"] and capture:
+            if cmd[:2] == ["pro", "enable"] and capture:
                 raise subp.ProcessExecutionError(exit_code=255)
             return subp.SubpResult(json.dumps({"errors": []}), "")
 
@@ -412,7 +412,7 @@ class TestConfigureUA:
 
     def test_ua_enable_non_json_response(self, m_subp):
         def fake_subp(cmd, capture=None, **kwargs):
-            if cmd[:2] == ["ua", "enable"] and capture:
+            if cmd[:2] == ["pro", "enable"] and capture:
                 return subp.SubpResult("I dream to be a Json", "")
             return subp.SubpResult(json.dumps({"errors": []}), "")
 
@@ -967,7 +967,7 @@ class TestHandle:
         is_pro,
     ):
         """Checks that attach is not called in the case where we want only to
-        enable or disable ua auto-attach.
+        enable or disable pro auto-attach.
         """
         m_should_auto_attach.return_value = is_pro
         handle("nomatter", cfg=cfg, cloud=self.cloud, args=None)
@@ -1030,7 +1030,7 @@ class TestHandle:
 
     @mock.patch(f"{MPATH}.subp.subp")
     def test_ua_config_error_invalid_url(self, m_subp, caplog):
-        """Errors from ua config command are raised."""
+        """Errors from pro config command are raised."""
         cfg = {
             "ubuntu_advantage": {
                 "token": "SomeToken",
@@ -1289,8 +1289,8 @@ class TestSetUAConfig:
         ]:
             assert (
                 mock.call(
-                    ["ua", "config", "set", ua_arg],
-                    logstring=["ua", "config", "set", redacted_arg],
+                    ["pro", "config", "set", ua_arg],
+                    logstring=["pro", "config", "set", redacted_arg],
                 )
                 in m_subp.call_args_list
             )
@@ -1306,15 +1306,15 @@ class TestSetUAConfig:
         }
         set_ua_config(ua_config)
         for call in [
-            mock.call(["ua", "config", "unset", "http_proxy"]),
+            mock.call(["pro", "config", "unset", "http_proxy"]),
             mock.call(
                 [
-                    "ua",
+                    "pro",
                     "config",
                     "set",
                     "https_proxy=https://user:pass@some-proxy:8088",
                 ],
-                logstring=["ua", "config", "set", "https_proxy=REDACTED"],
+                logstring=["pro", "config", "set", "https_proxy=REDACTED"],
             ),
         ]:
             assert call in m_subp.call_args_list
@@ -1348,8 +1348,8 @@ class TestSetUAConfig:
         set_ua_config(ua_config)
         assert [
             mock.call(
-                ["ua", "config", "set", "asdf=qwer"],
-                logstring=["ua", "config", "set", "asdf=REDACTED"],
+                ["pro", "config", "set", "asdf=qwer"],
+                logstring=["pro", "config", "set", "asdf=REDACTED"],
             )
         ] == m_subp.call_args_list
         assert "qwer" not in caplog.text


### PR DESCRIPTION
## keep as separate commits as there are two distinct changes to preseve

1. fix ua enable to avoid passing `--` to the command line  (this wasn't caught in integration tests as the tests were inadvertently skipped in jenkins.
2. Shift cloud-init from invoking `ua` on the command line to using the preferred `pro` name for the command to align with branding.

Fixes# 
 ## Proposed Commit Message(s)
<!-- Include a proposed commit message because all PRs are squash merged -->

```
*     ua: shift CLI command from ua to pro for all interactions
    
    Because the Ubuntu advantage is branded pro, the command-line utility
    is also named 'pro' for which an alias of 'ua' exists. Eventually,
    ua will likely be deprecated, so shift away from calling ua in favor of
    pro.

 *   pro: avoid double-dash when enabling inviddual services on CLI
    
    When ubuntu_advantage: enable: [] lists individual services,
    cloud-init invokes the pro CLI incorrectly by providing a
    double-dash '--' which the command-line parsing doesn't like.
    
    Dropping the '--' avoids tracebacks such as:
    
    Stderr: usage: pro enable <service> [<service>] [flags]
            the following arguments are required: service
    
    Fixes GH-4491
```

## Additional Context
<!-- If relevant -->
We also need a server-jenkins-jobs PR to ensure CLOUD_INIT_UA_TOKEN is provided to our integration tests to avoid skipping this test in the future.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
# build the package
./tools/run-container --package ubuntu/jammy
# test it
CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_*deb  CLOUD_INIT_UA_TOKEN=YOUR_TOKEN  CLOUD_INIT_OS_IMAGE=jammy tox -e integration-tests tests/integration_tests/modules/test_ubuntu_advantage.py::TestUbuntuAdvantage::test_idempotency
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
