### PR TITLE
test: use a mantic-compatible tz in t/i/m/test_combined.py

### DIFF
--- a/cloudinit/config/cc_timezone.py
+++ b/cloudinit/config/cc_timezone.py
@@ -17,7 +17,8 @@ from cloudinit.distros import ALL_DISTROS
 from cloudinit.settings import PER_INSTANCE
 
 MODULE_DESCRIPTION = """\
-Sets the system timezone based on the value provided.
+Sets the system `timezone <https://www.iana.org/time-zones>`_ based on the
+value provided.
 """
 
 meta: MetaSchema = {

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -78,7 +78,7 @@ snap:
 ssh_import_id:
   - lp:smoser
 
-timezone: US/Aleutian
+timezone: Europe/Madrid
 """
 
 
@@ -207,7 +207,7 @@ class TestCombined:
         timezone_output = client.execute(
             'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
         )
-        assert timezone_output.strip() == "HDT"
+        assert timezone_output.strip() == "CET"
 
     def test_no_problems(self, class_client: IntegrationInstance):
         """Test no errors, warnings, deprecations, tracebacks or


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
test: use a mantic-compatible tz in t/i/m/test_combined.py
```

## Additional Context
<!-- If relevant -->
In Debian testing and Ubuntu Mantic+, some legacy timezones under `/usr/share/timezone` have been moved from `tzdata` to `tzdata-legacy`.

Per [cc_timezone](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#timezone) and https://github.com/canonical/cloud-init/issues/3761#issuecomment-1545387654, non-present timezones are historically treated as config errors. So, update the integration test to include a timezone compatible across the board.

Fixes: 
- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests.modules.test_combined/TestCombined/test_timezone/
- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests.modules.test_combined/TestCombined/test_no_problems/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
series='mantic lunar jammy focal bionic'

for s in $series; do
        CLOUD_INIT_OS_IMAGE=$s tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined::test_timezone tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems
done

```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
