### PR TITLE
ci(linkcheck): fix invalid ternary operator

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   linkcheck:
     runs-on: ubuntu-22.04
-    continue-on-error:${{ github.event_name == 'workflow_dispatch' && github.event.inputs.failOnError == 'true' ? false : true }}
+    continue-on-error: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.failOnError == 'true') }}
 
     steps:
       - name: Checkout Repository
@@ -32,10 +32,10 @@ jobs:
       - name: Run Sphinx linkcheck
         run: tox -e linkcheck | tee output.txt
 
-      - name: Check for broken links below threshold 6
+      - name: Check for broken links below threshold
         run: |
           broken_count=$(grep -c "broken" output.txt)
-          if [[ $broken_count -ge 3 ]]; then
+          if [[ $broken_count -ge 5 ]]; then
             echo "Too many broken links detected: $broken_count"
             exit 1
           else


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
ci(linkcheck): fix invalid ternary operator
```

## Additional Context
<!-- If relevant -->

I am not sure why `github.event_name == 'workflow_dispatch' && github.event.inputs.failOnError` is needed at all, but the JS-sh ternary operator (x ? y : z) it not a valid [action expression](https://docs.github.com/en/actions/learn-github-actions/expressions), as shown in https://github.com/canonical/cloud-init/actions/runs/6429056328.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
