### PR TITLE
Python 3.12 has been released. Require CI tests to pass.

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,7 +11,7 @@ jobs:
   unittests:
     strategy:
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
         toxenv: [ py3 ]
         experimental: [false]
         include:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -11,13 +11,10 @@ jobs:
   unittests:
     strategy:
       matrix:
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
         toxenv: [ py3 ]
         experimental: [false]
         include:
-          - python-version: "3.12-dev"
-            toxenv: py3
-            experimental: true
           - python-version: "3.6"
             toxenv: lowest-supported
             experimental: false


### PR DESCRIPTION
```
Make Python 3.12 CI test non-experimental

Python 3.12 is released upstream. Require it.
```
