### PR TITLE
Add logging setup fixture

### DIFF
--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from cloudinit import atomic_helper, util
+from cloudinit import atomic_helper, log, util
 from tests.hypothesis import HAS_HYPOTHESIS
 from tests.unittests.helpers import retarget_many_wrapper
 
@@ -75,6 +75,8 @@ def disable_dns_lookup(request):
     ):
         yield
 
+
+log.configure_root_logger()
 
 PYTEST_VERSION_TUPLE = tuple(map(int, pytest.__version__.split(".")))
 

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -87,7 +87,6 @@ class TestCLI:
             return "SomeDatasource", ["an error"]
 
         myargs = FakeArgs(("ignored_name", myaction), True, "bogusmode")
-        log.configure_root_logger()
         cli.status_wrapper("init", myargs, data_d, link_d)
         # No errors reported in status
         status_v1 = m_json.call_args_list[1][0][1]["v1"]


### PR DESCRIPTION
```
tests: Add logging fix

Prior to 6bbbfbbb03, cloud-init's logger was initialized during module
load in cloudinit/log.py and cloudinit/cmd/main.py. Running individual
unittests exposes that many tests assume logging to be configured
automatically as it was before. Configure automatically in conftest.py.
```


Without this fix running various individual test files, such as test_schema.py, causes failures due to unconfigured logging:
```
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_schema_emits_warning_on_missing_jsonschema - AssertionError: assert 'Ignoring schema validation. jsonschema is not present' in ''
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[schema0-config0-Deprecated cloud-config provided:\na-b: <desc> Deprecated in version 22.1.-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[schema1-config1-Deprecated cloud-config provided:\nx: <desc> Deprecated in version 22.1.-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[schema2-config2-Deprecated cloud-config provided:\nx: <desc> Deprecated in version 22.1. <dep desc>-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[schema3-config3-Deprecated cloud-config provided:\nx: <desc> Deprecated in version 22.1.-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[schema4-config4-Deprecated cloud-config provided:\nx: <desc> Deprecated in version 22.1.-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[schema6-config6-Deprecated cloud-config provided:\nx: <desc> Deprecated in version 32.3.-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[schema7-config7-Deprecated cloud-config provided:\nx:  Deprecated in version 27.2.-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[schema8-config8-Deprecated cloud-config provided:\na-b: <desc> Deprecated in version 27.2.-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
FAILED tests/unittests/config/test_schema.py::TestValidateCloudConfigSchema::test_validateconfig_logs_deprecations[deprecated_pattern_property_without_description-True] - AttributeError: 'Logger' object has no attribute 'deprecated'
================================================================== 10 failed, 269 passed, 1 skipped, 177 warnings in 2.68s ===================================================================
```
after the fix:
```
tests/unittests/config/test_schema.py ................................................................................................................................................ [ 51%]
...................................................................................................................................s....                                               [100%]
```

