### PR TITLE
Remove logging of PPID path

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -80,11 +80,7 @@ def print_exc(msg=""):
 def log_ppid():
     if util.is_Linux():
         ppid = os.getppid()
-        LOG.info(
-            "PID [%s] started cloud-init using: %s",
-            ppid,
-            os.path.realpath(f"/proc/{ppid}/exe"),
-        )
+        LOG.info("PID [%s] started cloud-init.", ppid)
 
 
 def welcome(action, msg=None):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Remove logging of PPID path

Attempting to read /proc/1/exe is now causing permission denied errors.
Since we're only accessing the path to log it, and the ppid gives us
enough information, just stop logging it.

```

## Additional Context
Traceback in logs when starting cloud-init:
```
2023-10-10 15:05:42,002 - util.py[DEBUG]: Cloud-init v. 23.3.1 running 'init-local' at Tue, 10 Oct 2023 15:05:41 +0000. Up 1.77 seconds.
2023-10-10 15:05:42,003 - util.py[WARNING]: failed stage init-local
2023-10-10 15:05:42,003 - util.py[DEBUG]: failed stage init-local
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 776, in status_wrapper
    ret = functor(name, args)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 354, in main_init
    welcome(name, msg=w_msg)
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 94, in welcome
    log_ppid()
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 86, in log_ppid
    os.path.realpath(f"/proc/{ppid}/exe"),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 416, in realpath
  File "<frozen posixpath>", line 476, in _joinrealpath
PermissionError: [Errno 13] Permission denied: '/proc/1/exe'
2023-10-10 15:05:42,004 - atomic_helper.py[DEBUG]: Atomically writing to file /var/lib/cloud/data/status.json (via temporary file /var/lib/cloud/data/tmpad7wal7p) - w: [644] 532 bytes/chars
2023-10-10 15:05:42,005 - util.py[DEBUG]: Reading from /proc/uptime (quiet=False)
2023-10-10 15:05:42,005 - util.py[DEBUG]: Read 10 bytes from /proc/uptime
2023-10-10 15:05:42,005 - util.py[DEBUG]: cloud-init mode 'init' took 0.020 seconds (0.02)
2023-10-10 15:05:42,005 - handlers.py[DEBUG]: finish: init-local: SUCCESS: searching for local datasources
2023-10-10 15:05:42,292 - util.py[DEBUG]: Cloud-init v. 23.3.1 running 'init' at Tue, 10 Oct 2023 15:05:42 +0000. Up 2.06 seconds.
2023-10-10 15:05:42,292 - util.py[WARNING]: failed stage init
2023-10-10 15:05:42,292 - util.py[DEBUG]: failed stage init
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 776, in status_wrapper
    ret = functor(name, args)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 354, in main_init
    welcome(name, msg=w_msg)
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 94, in welcome
    log_ppid()
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 86, in log_ppid
    os.path.realpath(f"/proc/{ppid}/exe"),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen posixpath>", line 416, in realpath
  File "<frozen posixpath>", line 476, in _joinrealpath
PermissionError: [Errno 13] Permission denied: '/proc/1/exe'
```
