### PR TITLE
Set Debian's default locale to be C.UTF-8

### DIFF
--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -54,14 +54,13 @@ class Distro(distros.Distro):
         # calls from repeatly happening (when they
         # should only happen say once per instance...)
         self.osfamily = "debian"
-        self.default_locale = "en_US.UTF-8"
+        self.default_locale = "C.UTF-8"
         self.system_locale = None
         self.apt = Apt.from_config(self._runner, cfg)
         self.package_managers: List[PackageManager] = [self.apt]
 
     def get_locale(self):
         """Return the default locale if set, else use default locale"""
-
         # read system locale value
         if not self.system_locale:
             self.system_locale = read_system_locale()
@@ -84,7 +83,20 @@ class Distro(distros.Distro):
         # Update system locale config with specified locale if needed
         distro_locale = self.get_locale()
         conf_fn_exists = os.path.exists(out_fn)
-        sys_locale_unset = False if self.system_locale else True
+        sys_locale_unset = not self.system_locale
+        if sys_locale_unset:
+            LOG.debug(
+                "System locale not found in %s. "
+                "Assuming system locale is %s based on hardcoded default",
+                LOCALE_CONF_FN,
+                self.default_locale,
+            )
+        else:
+            LOG.debug(
+                "System locale set to %s via %s",
+                self.system_locale,
+                LOCALE_CONF_FN,
+            )
         need_regen = (
             locale.lower() != distro_locale.lower()
             or not conf_fn_exists

--- a/tests/unittests/distros/test_debian.py
+++ b/tests/unittests/distros/test_debian.py
@@ -1,131 +1,106 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-from unittest import mock
+import pytest
+from cloudinit import util
+from tests.unittests.util import get_cloud
 
-from cloudinit import distros, util
-from tests.unittests.helpers import FilesystemMockingTestCase
+LOCALE_PATH = "/etc/default/locale"
 
 
-@mock.patch("cloudinit.distros.debian.subp.subp")
-class TestDebianApplyLocale(FilesystemMockingTestCase):
-    def setUp(self):
-        super(TestDebianApplyLocale, self).setUp()
-        self.new_root = self.tmp_dir()
-        self.patchOS(self.new_root)
-        self.patchUtils(self.new_root)
-        self.spath = self.tmp_path("etc/default/locale", self.new_root)
-        cls = distros.fetch("debian")
-        self.distro = cls("debian", {}, None)
+@pytest.mark.usefixtures("fake_filesystem")
+class TestDebianApplyLocale:
+    @pytest.fixture
+    def m_subp(self, mocker):
+        yield mocker.patch(
+            "cloudinit.distros.debian.subp.subp", return_value=(None, None)
+        )
 
-    def test_no_rerun(self, m_subp):
+    @pytest.fixture
+    def distro(self):
+        yield get_cloud(distro="debian").distro
+
+    def test_no_rerun(self, distro, m_subp):
         """If system has defined locale, no re-run is expected."""
-        m_subp.return_value = (None, None)
         locale = "en_US.UTF-8"
-        util.write_file(self.spath, "LANG=%s\n" % locale, omode="w")
-        self.distro.apply_locale(locale, out_fn=self.spath)
+        util.write_file(LOCALE_PATH, "LANG=%s\n" % locale, omode="w")
+        distro.apply_locale(locale, out_fn=LOCALE_PATH)
         m_subp.assert_not_called()
 
-    def test_no_regen_on_c_utf8(self, m_subp):
+    def test_no_regen_on_c_utf8(self, distro, m_subp):
         """If locale is set to C.UTF8, do not attempt to call locale-gen"""
         m_subp.return_value = (None, None)
         locale = "C.UTF-8"
-        util.write_file(self.spath, "LANG=%s\n" % "en_US.UTF-8", omode="w")
-        self.distro.apply_locale(locale, out_fn=self.spath)
-        self.assertEqual(
-            [
-                [
-                    "update-locale",
-                    "--locale-file=" + self.spath,
-                    "LANG=%s" % locale,
-                ]
-            ],
-            [p[0][0] for p in m_subp.call_args_list],
-        )
+        util.write_file(LOCALE_PATH, "LANG=%s\n" % "en_US.UTF-8", omode="w")
+        distro.apply_locale(locale, out_fn=LOCALE_PATH)
+        assert [
+            ["update-locale", f"--locale-file={LOCALE_PATH}", f"LANG={locale}"]
+        ] == [p[0][0] for p in m_subp.call_args_list]
 
-    def test_rerun_if_different(self, m_subp):
+    def test_rerun_if_different(self, distro, m_subp):
         """If system has different locale, locale-gen should be called."""
-        m_subp.return_value = (None, None)
         locale = "en_US.UTF-8"
-        util.write_file(self.spath, "LANG=fr_FR.UTF-8", omode="w")
-        self.distro.apply_locale(locale, out_fn=self.spath)
-        self.assertEqual(
+        util.write_file(LOCALE_PATH, "LANG=fr_FR.UTF-8", omode="w")
+        distro.apply_locale(locale, out_fn=LOCALE_PATH)
+        assert [
+            ["locale-gen", locale],
             [
-                ["locale-gen", locale],
-                [
-                    "update-locale",
-                    "--locale-file=" + self.spath,
-                    "LANG=%s" % locale,
-                ],
+                "update-locale",
+                f"--locale-file={LOCALE_PATH}",
+                f"LANG={locale}",
             ],
-            [p[0][0] for p in m_subp.call_args_list],
-        )
+        ] == [p[0][0] for p in m_subp.call_args_list]
 
-    def test_rerun_if_no_file(self, m_subp):
+    def test_rerun_if_no_file(self, distro, m_subp):
         """If system has no locale file, locale-gen should be called."""
-        m_subp.return_value = (None, None)
         locale = "en_US.UTF-8"
-        self.distro.apply_locale(locale, out_fn=self.spath)
-        self.assertEqual(
+        distro.apply_locale(locale, out_fn=LOCALE_PATH)
+        assert [
+            ["locale-gen", locale],
             [
-                ["locale-gen", locale],
-                [
-                    "update-locale",
-                    "--locale-file=" + self.spath,
-                    "LANG=%s" % locale,
-                ],
+                "update-locale",
+                f"--locale-file={LOCALE_PATH}",
+                f"LANG={locale}",
             ],
-            [p[0][0] for p in m_subp.call_args_list],
-        )
+        ] == [p[0][0] for p in m_subp.call_args_list]
 
-    def test_rerun_on_unset_system_locale(self, m_subp):
+    def test_rerun_on_unset_system_locale(self, distro, m_subp):
         """If system has unset locale, locale-gen should be called."""
-        m_subp.return_value = (None, None)
         locale = "en_US.UTF-8"
-        util.write_file(self.spath, "LANG=", omode="w")
-        self.distro.apply_locale(locale, out_fn=self.spath)
-        self.assertEqual(
+        util.write_file(LOCALE_PATH, "LANG=", omode="w")
+        distro.apply_locale(locale, out_fn=LOCALE_PATH)
+        assert [
+            ["locale-gen", locale],
             [
-                ["locale-gen", locale],
-                [
-                    "update-locale",
-                    "--locale-file=" + self.spath,
-                    "LANG=%s" % locale,
-                ],
+                "update-locale",
+                f"--locale-file={LOCALE_PATH}",
+                f"LANG={locale}",
             ],
-            [p[0][0] for p in m_subp.call_args_list],
-        )
+        ] == [p[0][0] for p in m_subp.call_args_list]
 
-    def test_rerun_on_mismatched_keys(self, m_subp):
+    def test_rerun_on_mismatched_keys(self, distro, m_subp):
         """If key is LC_ALL and system has only LANG, rerun is expected."""
-        m_subp.return_value = (None, None)
         locale = "en_US.UTF-8"
-        util.write_file(self.spath, "LANG=", omode="w")
-        self.distro.apply_locale(locale, out_fn=self.spath, keyname="LC_ALL")
-        self.assertEqual(
+        util.write_file(LOCALE_PATH, "LANG=", omode="w")
+        distro.apply_locale(locale, out_fn=LOCALE_PATH, keyname="LC_ALL")
+        assert [
+            ["locale-gen", locale],
             [
-                ["locale-gen", locale],
-                [
-                    "update-locale",
-                    "--locale-file=" + self.spath,
-                    "LC_ALL=%s" % locale,
-                ],
+                "update-locale",
+                f"--locale-file={LOCALE_PATH}",
+                f"LC_ALL={locale}",
             ],
-            [p[0][0] for p in m_subp.call_args_list],
-        )
+        ] == [p[0][0] for p in m_subp.call_args_list]
 
-    def test_falseish_locale_raises_valueerror(self, m_subp):
+    def test_falseish_locale_raises_valueerror(self, distro, m_subp):
         """locale as None or "" is invalid and should raise ValueError."""
 
-        with self.assertRaises(ValueError) as ctext_m:
-            self.distro.apply_locale(None)
+        with pytest.raises(
+            ValueError, match="Failed to provide locale value."
+        ):
+            distro.apply_locale(None)
             m_subp.assert_not_called()
 
-        self.assertEqual(
-            "Failed to provide locale value.", str(ctext_m.exception)
-        )
-
-        with self.assertRaises(ValueError) as ctext_m:
-            self.distro.apply_locale("")
+        with pytest.raises(
+            ValueError, match="Failed to provide locale value."
+        ):
+            distro.apply_locale("")
             m_subp.assert_not_called()
-        self.assertEqual(
-            "Failed to provide locale value.", str(ctext_m.exception)
-        )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Set Debian's default locale to be C.UTF-8

When no locale is found in /etc/default/locale, cloud-init was
defaulting to generating en_US.UTF-8. This can be an expensive operation
and isn't necessary. Instead, change the default to C.UTF-8 which
generally shouldn't require generation.

Also add some logging to make it more obvious where cloud-init is
getting the locale information from.

LP: #2038945
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
