### PR TITLE
subp: add a log when skipping a file for execution for lack of exe permission

### DIFF
--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -405,6 +405,13 @@ def runparts(dirp, skip_no_exist=True, exe_prefix=None):
             except ProcessExecutionError as e:
                 LOG.debug(e)
                 failed.append(exe_name)
+        else:
+            LOG.warning(
+                "skipping %s as its not executable "
+                "or the underlying file system is mounted without "
+                "executable permissions.",
+                exe_path,
+            )
 
     if failed and attempted:
         raise RuntimeError(


### PR DESCRIPTION
Sometimes a script may itself have executable permission but the underlying
file system on which the script is located may have been mounted with 'noexec'
mount option. On those cases is_exe() would return false and the file would
be silently skipped. Add a warning log when a file is being skipped so that
it can be noticed and provides useful information while debugging issues.

