### PR TITLE
Fix the missing mcopy argument

### DIFF
--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -171,7 +171,7 @@ sufficient disk by following the following example.
 
         .. code-block::
 
-           $ mcopy -oi seed.iso user-data meta-data
+           $ mcopy -oi seed.iso user-data meta-data ::
 
 3. Create a new qcow image to boot, backed by your original image:
 


### PR DESCRIPTION
## Proposed Commit Message

Fix the missing mcopy argument
```

## Additional Context

Mcopy's last argument is the destination, which was missing in the example.

## Test Steps

Run the command from the original file, check the vfat and see that it didn't work. Run the new command and see it works.

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
