### PR TITLE
Enhanced Jinja Templating Feedback and Error Handling (SC-1603)

### DIFF
--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -11,6 +11,7 @@ import sys
 
 from cloudinit.cmd.devel import addLogHandlerCLI, read_cfg_paths
 from cloudinit.handlers.jinja_template import (
+    CustomParsedJinjaException,
     JinjaLoadError,
     NotJinjaError,
     render_jinja_payload_from_file,
@@ -99,6 +100,14 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
         LOG.error(
             "Cannot render from instance data due to exception: %s", repr(e)
         )
+        return 1
+    except CustomParsedJinjaException as e:
+        error_msg = "Failed to render user-data file '{file_path}' due to jinja parsing error: {error}".format(
+            file_path=user_data_path,
+            error=str(e),
+        )
+        LOG.error(error_msg)
+        sys.stderr.write(error_msg + "\n")
         return 1
     if not rendered_payload:
         LOG.error("Unable to render user-data file: %s", user_data_path)

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -11,8 +11,8 @@ import sys
 
 from cloudinit.cmd.devel import addLogHandlerCLI, read_cfg_paths
 from cloudinit.handlers.jinja_template import (
-    CustomParsedJinjaException,
     JinjaLoadError,
+    JinjaSyntaxParsingException,
     NotJinjaError,
     render_jinja_payload_from_file,
 )
@@ -101,7 +101,7 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
             "Cannot render from instance data due to exception: %s", repr(e)
         )
         return 1
-    except CustomParsedJinjaException as e:
+    except JinjaSyntaxParsingException as e:
         error_msg = (
             "Failed to render user-data file '{file_path}' "
             "due to jinja parsing error: {error}".format(
@@ -110,7 +110,7 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
             )
         )
         LOG.error(error_msg)
-        sys.stderr.write(error_msg + "\n")
+        # sys.stderr.write(error_msg + "\n")
         return 1
     if not rendered_payload:
         LOG.error("Unable to render user-data file: %s", user_data_path)

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -102,9 +102,12 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
         )
         return 1
     except CustomParsedJinjaException as e:
-        error_msg = "Failed to render user-data file '{file_path}' due to jinja parsing error: {error}".format(
-            file_path=user_data_path,
-            error=str(e),
+        error_msg = (
+            "Failed to render user-data file '{file_path}' "
+            "due to jinja parsing error: {error}".format(
+                file_path=user_data_path,
+                error=str(e),
+            )
         )
         LOG.error(error_msg)
         sys.stderr.write(error_msg + "\n")

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -278,12 +278,19 @@ def handle_args(name, args):
         return 1
     if args.format:
         payload = "## template: jinja\n{fmt}".format(fmt=args.format)
-        rendered_payload = render_jinja_payload(
-            payload=payload,
-            payload_fn="query commandline",
-            instance_data=instance_data,
-            debug=True if args.debug else False,
-        )
+        try:
+            rendered_payload = render_jinja_payload(
+                payload=payload,
+                payload_fn="query commandline",
+                instance_data=instance_data,
+                debug=True if args.debug else False,
+            )
+        except Exception as e:
+            error_msg = "Failed to render templated data due to jinja parsing error: {error}".format(
+                error=str(e),
+            )
+            print(error_msg)
+            return 1
         if rendered_payload:
             print(rendered_payload)
             return 0

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -286,8 +286,11 @@ def handle_args(name, args):
                 debug=True if args.debug else False,
             )
         except Exception as e:
-            error_msg = "Failed to render templated data due to jinja parsing error: {error}".format(
-                error=str(e),
+            error_msg = (
+                "Failed to render templated data due to jinja parsing error: "
+                "{error}".format(
+                    error=str(e),
+                )
             )
             print(error_msg)
             return 1

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -29,6 +29,7 @@ from cloudinit.handlers.jinja_template import (
     render_jinja_payload,
 )
 from cloudinit.sources import REDACT_SENSITIVE_VALUE
+from cloudinit.templater import JinjaSyntaxParsingException
 
 NAME = "query"
 LOG = logging.getLogger(__name__)
@@ -285,14 +286,12 @@ def handle_args(name, args):
                 instance_data=instance_data,
                 debug=True if args.debug else False,
             )
-        except Exception as e:
-            error_msg = (
+        except JinjaSyntaxParsingException as e:
+            LOG.error(
                 "Failed to render templated data due to jinja parsing error: "
-                "{error}".format(
-                    error=str(e),
-                )
+                "{error}",
+                str(e),
             )
-            print(error_msg)
             return 1
         if rendered_payload:
             print(rendered_payload)

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -767,8 +767,8 @@ def _get_config_type_and_rendered_userdata(
         header declared ## template: jinja.
     """
     from cloudinit.handlers.jinja_template import (
-        CustomParsedJinjaException,
         JinjaLoadError,
+        JinjaSyntaxParsingException,
         NotJinjaError,
         render_jinja_payload_from_file,
     )
@@ -790,7 +790,7 @@ def _get_config_type_and_rendered_userdata(
                     )
                 ]
             ) from e
-        except CustomParsedJinjaException as e:
+        except JinjaSyntaxParsingException as e:
             error(
                 "Failed to render templated cloud-config due to jinja parsing "
                 "error: " + str(e),

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -767,6 +767,7 @@ def _get_config_type_and_rendered_userdata(
         header declared ## template: jinja.
     """
     from cloudinit.handlers.jinja_template import (
+        CustomParsedJinjaException,
         JinjaLoadError,
         NotJinjaError,
         render_jinja_payload_from_file,
@@ -789,6 +790,12 @@ def _get_config_type_and_rendered_userdata(
                     )
                 ]
             ) from e
+        except CustomParsedJinjaException as e:
+            error(
+                "Failed to render templated cloud-config due to jinja parsing error: "
+                + str(e),
+                sys_exit=True,
+            )
         except JinjaLoadError as e:
             error(str(e), sys_exit=True)
         schema_position = "format-l2.c1"

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -792,8 +792,8 @@ def _get_config_type_and_rendered_userdata(
             ) from e
         except CustomParsedJinjaException as e:
             error(
-                "Failed to render templated cloud-config due to jinja parsing error: "
-                + str(e),
+                "Failed to render templated cloud-config due to jinja parsing "
+                "error: " + str(e),
                 sys_exit=True,
             )
         except JinjaLoadError as e:

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -122,7 +122,9 @@ def run_part(mod, data, filename, payload, frequency, headers):
             mod.handle_part(data, content_type, filename, payload)
         else:
             raise ValueError("Unknown module version %s" % (mod_ver))
-    except Exception:
+    except Exception as e:
+        print("[a-dubs] e: %s" % e)
+        LOG.warning(str(e))
         util.logexc(
             LOG,
             "Failed calling handler %s (%s, %s, %s) with frequency %s",

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -122,9 +122,7 @@ def run_part(mod, data, filename, payload, frequency, headers):
             mod.handle_part(data, content_type, filename, payload)
         else:
             raise ValueError("Unknown module version %s" % (mod_ver))
-    except Exception as e:
-        print("[a-dubs] e: %s" % e)
-        LOG.warning(str(e))
+    except Exception:
         util.logexc(
             LOG,
             "Failed calling handler %s (%s, %s, %s) with frequency %s",

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -61,9 +61,9 @@ class JinjaTemplatePartHandler(handlers.Handler):
             )
         except CustomParsedJinjaException as e:
             LOG.warning(
-                "Failed to render templated cloud-config file due to jinja parsing error: {e}".format(
-                    e=str(e),
-                )
+                "Failed to render templated cloud-config file due to jinja "
+                "parsing error: %s",
+                str(e),
             )
             return
 
@@ -146,8 +146,6 @@ def render_jinja_payload(payload, payload_fn, instance_data, debug=False):
         )
     try:
         rendered_payload = render_string(payload, instance_jinja_vars)
-    # except CustomParsedJinjaException as custom_raised_jinja_error:
-    #     LOG.error("Failed to parse jinja template: %s", str(custom_raised_jinja_error))
     except (TypeError, JUndefinedError) as e:
         LOG.warning("Ignoring jinja template for %s: %s", payload_fn, str(e))
         return None

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -13,7 +13,7 @@ from cloudinit.helpers import Paths
 from cloudinit.settings import PER_ALWAYS
 from cloudinit.templater import (
     MISSING_JINJA_PREFIX,
-    CustomParsedJinjaException,
+    JinjaSyntaxParsingException,
     detect_template,
     render_string,
 )
@@ -59,10 +59,10 @@ class JinjaTemplatePartHandler(handlers.Handler):
             rendered_payload = render_jinja_payload_from_file(
                 payload, filename, jinja_json_file
             )
-        except CustomParsedJinjaException as e:
+        except JinjaSyntaxParsingException as e:
             LOG.warning(
-                "Failed to render templated cloud-config file due to jinja "
-                "parsing error: %s",
+                "Ignoring jinja template for %s. Failed to render due to jinja parsing error: %s",
+                filename,
                 str(e),
             )
             return

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -110,18 +110,21 @@ def detect_template(text):
         # keep_trailing_newline is in jinja2 2.7+, not 2.6
         add = "\n" if content.endswith("\n") else ""
         try:
-            result = JTemplate(
-                content,
-                undefined=UndefinedJinjaVariable,
-                trim_blocks=True,
-                extensions=["jinja2.ext.do"],
-            ).render(**params) + add
+            result = (
+                JTemplate(
+                    content,
+                    undefined=UndefinedJinjaVariable,
+                    trim_blocks=True,
+                    extensions=["jinja2.ext.do"],
+                ).render(**params)
+                + add
+            )
             return result
 
         except Exception as JTemplateError:
             # if the error is a syntax one, we know this next line will fail
             # we want to get the traceback and error message it throws
-            try:  
+            try:
                 jinja_env = Environment(
                     loader=BaseLoader(),
                     autoescape=False,
@@ -129,10 +132,10 @@ def detect_template(text):
                     trim_blocks=True,
                     extensions=["jinja2.ext.do"],
                 )
-                template = jinja_env.parse(content)
-                # if we get here, then the previous line didn't fail, so we just need to re-raise the original error
+                jinja_env.parse(content)
+                # if we get here, then the previous line didn't fail,
+                # so we just need to re-raise the original error
                 raise JTemplateError
-            # TODO: check other exception types
             except Exception as useful_jinja_error:
                 try:
                     tb = "".join(
@@ -142,19 +145,30 @@ def detect_template(text):
                         r'File "<unknown>", line (\d+)', tb
                     )
                     line_number_of_error = int(line_number_matches[0])
-                except: # if we couldn't parse the traceback for some reason, just re-raise the original error
-                    raise JTemplateError
-                # adjust line number for the fact that the jinja header has been removed from the content
-                if len(re.findall("##( )?template:( )?jinja", content.split("\n")[0].strip().lower())) == 0:
+                # if we couldn't parse the traceback for some reason,
+                # just re-raise the original error
+                except Exception:
+                    raise JTemplateError from useful_jinja_error
+                # adjust line number to adjust for the jinja header having been
+                # removed from the content
+                if (
+                    len(
+                        re.findall(
+                            "##( )?template:( )?jinja",
+                            content.split("\n")[0].strip().lower(),
+                        )
+                    )
+                    == 0
+                ):
                     line_number_of_error += 1
                 raise CustomParsedJinjaException(
                     "{e} on line {line_no}".format(
                         e=useful_jinja_error,
                         line_no=line_number_of_error,
                     )
-                )
+                ) from useful_jinja_error
 
-    if text.find("\n") != -1:  
+    if text.find("\n") != -1:
         ident, rest = text.split("\n", 1)  # remove the first line
     else:
         ident = text

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -304,6 +304,7 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
     """Read a yaml config with optional template, and convert to dict"""
     # Avoid circular import
     from cloudinit.handlers.jinja_template import (
+        CustomParsedJinjaException,
         JinjaLoadError,
         NotJinjaError,
         render_jinja_payload_from_file,
@@ -330,6 +331,11 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
                 instance_data_file,
                 fname,
             )
+        except CustomParsedJinjaException as e:
+            error_msg = "Failed to render user-data file '{file_path}' due to jinja parsing error: {error}".format(
+                file_path=fname, error=str(e)
+            )
+            LOG.warning(error_msg)
         except NotJinjaError:
             # A log isn't appropriate here as we generally expect most
             # cloud.cfgs to not be templated. The other path is logged

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -332,8 +332,11 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
                 fname,
             )
         except CustomParsedJinjaException as e:
-            error_msg = "Failed to render user-data file '{file_path}' due to jinja parsing error: {error}".format(
-                file_path=fname, error=str(e)
+            error_msg = (
+                "Failed to render user-data file '{file_path}' "
+                "due to jinja parsing error: {error}".format(
+                    file_path=fname, error=str(e)
+                )
             )
             LOG.warning(error_msg)
         except NotJinjaError:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -304,8 +304,8 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
     """Read a yaml config with optional template, and convert to dict"""
     # Avoid circular import
     from cloudinit.handlers.jinja_template import (
-        CustomParsedJinjaException,
         JinjaLoadError,
+        JinjaSyntaxParsingException,
         NotJinjaError,
         render_jinja_payload_from_file,
     )
@@ -331,14 +331,13 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
                 instance_data_file,
                 fname,
             )
-        except CustomParsedJinjaException as e:
-            error_msg = (
-                "Failed to render user-data file '{file_path}' "
-                "due to jinja parsing error: {error}".format(
-                    file_path=fname, error=str(e)
-                )
+        except JinjaSyntaxParsingException as e:
+            LOG.warning(
+                "Failed to render user-data file '%s' "
+                "due to jinja parsing error: %s",
+                fname,
+                str(e),
             )
-            LOG.warning(error_msg)
         except NotJinjaError:
             # A log isn't appropriate here as we generally expect most
             # cloud.cfgs to not be templated. The other path is logged

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -149,7 +149,6 @@ class TestRender:
         render.render_template(user_data, instance_data, False)
         assert "Unable to render user-data file" in caplog.text
 
-    # test that error with "Failed to render template" is logged when jinja syntax error in user data file
     @skipUnlessJinja()
     def test_invalid_jinja_syntax(self, caplog, tmpdir):
         user_data = tmpdir.join("user-data")
@@ -157,4 +156,7 @@ class TestRender:
         instance_data = tmpdir.join("instance-data")
         write_file(instance_data, '{"my-var": "jinja worked"}')
         assert render.render_template(user_data, instance_data, True) == 1
-        assert "due to jinja parsing error: unexpected '}' on line 2" in caplog.text
+        assert (
+            "due to jinja parsing error: unexpected '}' on line 2"
+            in caplog.text
+        )

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -148,3 +148,13 @@ class TestRender:
         write_file(instance_data, '{"my-var": "jinja worked"}')
         render.render_template(user_data, instance_data, False)
         assert "Unable to render user-data file" in caplog.text
+
+    # test that error with "Failed to render template" is logged when jinja syntax error in user data file
+    @skipUnlessJinja()
+    def test_invalid_jinja_syntax(self, caplog, tmpdir):
+        user_data = tmpdir.join("user-data")
+        write_file(user_data, "##template: jinja\nrendering: {{ my_var } }")
+        instance_data = tmpdir.join("instance-data")
+        write_file(instance_data, '{"my-var": "jinja worked"}')
+        assert render.render_template(user_data, instance_data, True) == 1
+        assert "due to jinja parsing error: unexpected '}' on line 2" in caplog.text

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -817,6 +817,34 @@ class TestValidateCloudConfigFile:
         with pytest.raises(SchemaValidationError, match=error_msg):
             validate_cloudconfig_file(cloud_config_file, schema, annotate)
 
+    @pytest.mark.parametrize("annotate", (True, False))
+    def test_validateconfig_file_raises_enhanced_jinja_error(
+        self, annotate, tmpdir, mocker, capsys
+    ):
+        """ """
+        mocker.patch("os.path.exists", return_value=True)
+        mocker.patch(
+            "cloudinit.util.load_file",
+            return_value='## template: jinja\n{"a": "{{c}}"',  # missing }
+        )
+        mocker.patch(
+            "cloudinit.handlers.jinja_template.load_file",
+            return_value='{"c": "d"}',
+        )
+        config_file = tmpdir.join("my.yaml")
+        config_file.write("## template: jinja\na:b\nc:{{ d } }")
+        with pytest.raises(SystemExit) as context_manager:
+            validate_cloudconfig_file(config_file.strpath, {}, annotate)
+        assert 1 == context_manager.value.code
+
+        _out, err = capsys.readouterr()
+        expected = (
+            "Error:\n"
+            "Failed to render templated cloud-config due to jinja parsing "
+            "error: unexpected '}' on line 3\n"
+        )
+        assert expected == err
+
 
 class TestSchemaDocMarkdown:
     """Tests for get_meta_doc."""

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -167,3 +167,15 @@ class TestTemplates(test_helpers.CiTestCase):
             ).strip(),
             expected_result,
         )
+    # give invalid jinja that has a `} }` and catch the error
+    def test_jinja_invalid_syntax(self):
+        """ Make sure invalid jinja syntax is caught """
+        jinja_template = (
+            "{% set r = [] %} {% set input = [1,2,3] %} "
+            "{% for i in input % } {% do r.append(i) %} {% endfor %} {{r}}"
+        )
+        self.assertRaises(
+            templater.CustomParsedJinjaException, 
+            templater.render_string, 
+            self.add_header("jinja", jinja_template), {},
+        )

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -167,15 +167,17 @@ class TestTemplates(test_helpers.CiTestCase):
             ).strip(),
             expected_result,
         )
+
     # give invalid jinja that has a `} }` and catch the error
     def test_jinja_invalid_syntax(self):
-        """ Make sure invalid jinja syntax is caught """
+        """Make sure invalid jinja syntax is caught"""
         jinja_template = (
             "{% set r = [] %} {% set input = [1,2,3] %} "
             "{% for i in input % } {% do r.append(i) %} {% endfor %} {{r}}"
         )
         self.assertRaises(
-            templater.CustomParsedJinjaException, 
-            templater.render_string, 
-            self.add_header("jinja", jinja_template), {},
+            templater.CustomParsedJinjaException,
+            templater.render_string,
+            self.add_header("jinja", jinja_template),
+            {},
         )

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -176,7 +176,7 @@ class TestTemplates(test_helpers.CiTestCase):
             "{% for i in input % } {% do r.append(i) %} {% endfor %} {{r}}"
         )
         self.assertRaises(
-            templater.CustomParsedJinjaException,
+            templater.JinjaSyntaxParsingException,
             templater.render_string,
             self.add_header("jinja", jinja_template),
             {},

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -466,7 +466,7 @@ class TestUtil:
         ) in caplog.text
 
     @skipUnlessJinja()
-    def test_read_conf_with_failed_template(self, mocker, caplog):
+    def test_read_conf_with_failed_config_json(self, mocker, caplog):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
             "cloudinit.util.load_file",
@@ -481,7 +481,7 @@ class TestUtil:
         assert conf == {}
 
     @skipUnlessJinja()
-    def test_read_conf_with_failed_vars(self, mocker, caplog):
+    def test_read_conf_with_failed_instance_data_json(self, mocker, caplog):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
             "cloudinit.util.load_file",

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -500,8 +500,8 @@ class TestUtil:
         [
             '{"a": "{{c} } }"',
             '{"a": "{{c} } "',
-            '{% if c %} C is present {% else % } C is NOT present {% endif %}',
-        ]
+            "{% if c %} C is present {% else % } C is NOT present {% endif %}",
+        ],
     )
     @skipUnlessJinja()
     def test_read_conf_with_config_invalid_jinja_syntax(
@@ -510,7 +510,7 @@ class TestUtil:
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
             "cloudinit.util.load_file",
-            return_value='## template: jinja\n' + template,
+            return_value="## template: jinja\n" + template,
         )
         mocker.patch(
             "cloudinit.handlers.jinja_template.load_file",


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
feat(jinja): better jinja feedback and error catching

When an error is encountered while trying to parse a jinja template, the traceback is automatically parsed to get the specific error and the line number that caused this error, and then this information is turned into a user-friendly single-line error message. 

The cloud-init runtime will log these error messages when jinja syntax errors are encountered in the cloud-config file. For the query, render, and schema commands, the nasty traceback is caught and a single line error message is given to the user instead.

Fixes GH-4360
```

## Additional Context

### Cloud-config w/ Invalid Jinja used:
```yaml
## template: jinja
#cloud-config
runcmd:
  - echo 'Hello, World!' > /var/tmp/hello-world.txt
{% if v1.cloud_name == "unknown" % }
  - echo "True: cloud name is unknown" > /var/tmp/jinja.txt
{% else %}
  - echo "False: cloud name is not unknown. Cloud name is: {{ v1.cloud_name }}" > /var/tmp/jinja.txt
{% endif %}
``` 
The error is in line 5 with the accidental whitespace at the end of the line: `% }`


### Cloud-init-output.log
```
Failed to render user-data file 'cc.yaml' due to jinja parsing error: unexpected '}' on line 5
...
2023-10-16 13:33:12,667 - jinja_template.py[WARNING]: Failed to render templated cloud-config file due to jinja parsing error: unexpected '}' on line 5
```

### Query Command
```shell
root@dev:~# cloud-init query -f "$(cat cc.yaml)"
Failed to render templated data due to jinja parsing error: unexpected '}' on line 5
```

### Render Command
```shell
root@dev:~# cloud-init devel render cc.yaml
Failed to render user-data file 'cc.yaml' due to jinja parsing error: unexpected '}' on line 5
```

### Schema Command
```shell
root@dev:~# cloud-init schema -c cc.yaml
Error:
Failed to render templated cloud-config due to jinja parsing error: unexpected '}' on line 5
```


## Test Steps
Clone this branch locally, copy the example cloud-config file and launch a container with that cloud-config file. Run the 4 commands given above and make sure the output is as expected. 


## PR Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly


## To-Do's Before Taking PR out of Draft:
- [x] Add unit tests:
  - [x] query
  - [x] render
  - [x] schema
  - [x] templating
- [x] Tox passes locally
- [x] Add test instructions to PR