### PR TITLE
Revert "ds-identify/CloudStack: $DS_MAYBE if vm running on vmware/xen…

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1637,7 +1637,6 @@ VALID_CFG = {
     },
     "IBMCloud-metadata": {
         "ds": "IBMCloud",
-        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             MOCK_VIRT_IS_XEN,
             {"name": "is_ibm_provisioning", "ret": shell_false},
@@ -1704,7 +1703,6 @@ VALID_CFG = {
     },
     "IBMCloud-nodisks": {
         "ds": "IBMCloud",
-        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             MOCK_VIRT_IS_XEN,
             {"name": "is_ibm_provisioning", "ret": shell_false},
@@ -1791,7 +1789,6 @@ VALID_CFG = {
     },
     "VMware-NoValidTransports": {
         "ds": "VMware",
-        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             MOCK_VIRT_IS_VMWARE,
         ],
@@ -1819,7 +1816,6 @@ VALID_CFG = {
     },
     "VMware-EnvVar-NoData": {
         "ds": "VMware",
-        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             {
                 "name": "vmware_has_envvar_vmx_guestinfo",
@@ -1929,7 +1925,6 @@ VALID_CFG = {
     },
     "VMware-GuestInfo-NoData-Rpctool": {
         "ds": "VMware",
-        "policy_dmi": POLICY_FOUND_ONLY,
         "mocks": [
             {
                 "name": "vmware_has_rpctool",

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -739,9 +739,6 @@ probe_floppy() {
 dscheck_CloudStack() {
     is_container && return ${DS_NOT_FOUND}
     dmi_product_name_matches "CloudStack*" && return $DS_FOUND
-    if [ "$DI_VIRT" = "vmware" ] || [ "$DI_VIRT" = "xen" ]; then
-        return $DS_MAYBE
-    fi
     return $DS_NOT_FOUND
 }
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Revert "ds-identify/CloudStack: $DS_MAYBE if vm running on
 vmware/xen (#4281)"

This reverts commit 7949bb3de352dc40c62c38a0534722b24b7eed22
but keeps the CLA signature.

Fixes GH-4501
LP: #2039453
```

## Additional Context
https://github.com/canonical/cloud-init/issues/4501
