### PR TITLE
add comment explaining difference between sysconfig and NetworkManager renderer

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -853,6 +853,11 @@ class Renderer(renderer.Renderer):
         # If DNS server information is provided, configure
         # NetworkManager to not manage dns, so that /etc/resolv.conf
         # does not get clobbered.
+        # This is not required for NetworkManager renderer as it
+        # does not write /etc/resolv.conf directly. DNS information is
+        # written to the interface keyfile and NetworkManager is then
+        # responsible for using the DNS information from the keyfile,
+        # including managing /etc/resolv.conf.
         if network_state.dns_nameservers:
             content.set_section_keypair("main", "dns", "none")
 


### PR DESCRIPTION
It is not necessary for NetworkManager renderer to keep NM out of the loop from handling DNS. This is unlike sysconfig renderer where we explicitly add `dns=none` in `/etc/NetworkManager/conf.d/99-cloud-init.conf` NetworkManager configuration file in order to prevent NetworkManager from handling DNS and writing `/etc/resolv.conf`. This is because NetworkManager renderer writes DNS information in the interface keyfile and does not manipulate `/etc/resolv.conf` directly. NetworkManager reads this information from the keyfile and handles DNS, including managing `/etc/resolv.conf`. Sysconfig renderer on the other hand directly writes `/etc/resolv.conf` directly and hence we need to make sure NetworkManager is not overwriting the DNS data in `/etc/resolv.conf`.

Add a comment explaining the difference between the two renderers with regards to DNS handling. See also GH PR #4450.

