### PR TITLE
fix(cc_apt_configure): avoid unneeded call to apt-install

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -733,7 +733,8 @@ def _ensure_dependencies(cfg, aa_repo_match, cloud):
     for command in required_cmds:
         if not shutil.which(command):
             missing_packages.append(PACKAGE_DEPENDENCY_BY_COMMAND[command])
-    cloud.distro.install_packages(sorted(missing_packages))
+    if missing_packages:
+        cloud.distro.install_packages(sorted(missing_packages))
 
 
 def add_apt_key(ent, cloud, target=None, hardened=False, file_name=None):

--- a/tests/unittests/config/test_cc_apt_configure.py
+++ b/tests/unittests/config/test_cc_apt_configure.py
@@ -3,9 +3,11 @@
 """ Tests for cc_apt_configure module """
 
 import re
+from unittest import mock
 
 import pytest
 
+from cloudinit.config import cc_apt_configure
 from cloudinit.config.schema import (
     SchemaValidationError,
     get_schema,
@@ -197,3 +199,12 @@ class TestAPTConfigureSchema:
                 error_msg = error_msg.replace("primary", "security")
                 with pytest.raises(SchemaValidationError, match=error_msg):
                     validate_cloudconfig_schema(config, schema, strict=True)
+
+
+class TestAPTConfigure:
+    def test_ensure_dependencies_no_apt_install(self):
+        """Ensures no apt-install when the user-data does not contain
+        apt-sources entries."""
+        m_cloud = mock.Mock()
+        cc_apt_configure._ensure_dependencies({}, mock.Mock(), m_cloud)
+        assert [] == m_cloud.distro.install_packages.call_args_list

--- a/tests/unittests/config/test_cc_apt_configure.py
+++ b/tests/unittests/config/test_cc_apt_configure.py
@@ -3,7 +3,6 @@
 """ Tests for cc_apt_configure module """
 
 import re
-from unittest import mock
 
 import pytest
 
@@ -14,6 +13,7 @@ from cloudinit.config.schema import (
     validate_cloudconfig_schema,
 )
 from tests.unittests.helpers import skipUnlessJsonSchema
+from tests.unittests.util import get_cloud
 
 
 class TestAPTConfigureSchema:
@@ -201,10 +201,68 @@ class TestAPTConfigureSchema:
                     validate_cloudconfig_schema(config, schema, strict=True)
 
 
-class TestAPTConfigure:
-    def test_ensure_dependencies_no_apt_install(self):
-        """Ensures no apt-install when the user-data does not contain
-        apt-sources entries."""
-        m_cloud = mock.Mock()
-        cc_apt_configure._ensure_dependencies({}, mock.Mock(), m_cloud)
-        assert [] == m_cloud.distro.install_packages.call_args_list
+class TestEnsureDependencies:
+    @pytest.mark.parametrize(
+        "cfg, already_installed, expected_install",
+        (
+            pytest.param({}, [], [], id="empty_cfg_no_pkg_installs"),
+            pytest.param(
+                {"sources": {"s1": {"keyid": "haveit"}}},
+                ["gpg"],
+                [],
+                id="cfg_needs_gpg_no_installs_when_gpg_present",
+            ),
+            pytest.param(
+                {"sources": {"s1": {"keyid": "haveit"}}},
+                [],
+                ["gnupg"],
+                id="cfg_needs_gpg_installs_gnupg_when_absent",
+            ),
+            pytest.param(
+                {"primary": [{"keyid": "haveit"}]},
+                [],
+                ["gnupg"],
+                id="cfg_primary_needs_gpg_installs_gnupg_when_absent",
+            ),
+            pytest.param(
+                {"security": [{"keyid": "haveit"}]},
+                [],
+                ["gnupg"],
+                id="cfg_security_needs_gpg_installs_gnupg_when_absent",
+            ),
+            pytest.param(
+                {"sources": {"s1": {"source": "ppa:yep"}}},
+                ["add-apt-repository"],
+                [],
+                id="cfg_needs_sw_prop_common_when_present",
+            ),
+            pytest.param(
+                {"sources": {"s1": {"source": "ppa:yep"}}},
+                [],
+                ["software-properties-common"],
+                id="cfg_needs_sw_prop_common_when_add_apt_repo_absent",
+            ),
+        ),
+    )
+    def test_only_install_needed_packages(
+        self, cfg, already_installed, expected_install, mocker
+    ):
+        """Only invoke install_packages when package installs are necessary"""
+        mycloud = get_cloud("debian")
+        install_packages = mocker.patch.object(
+            mycloud.distro, "install_packages"
+        )
+        matcher = re.compile(cc_apt_configure.ADD_APT_REPO_MATCH).search
+
+        def fake_which(cmd):
+            if cmd in already_installed:
+                return "foundit"
+            return None
+
+        which = mocker.patch.object(cc_apt_configure.shutil, "which")
+        which.side_effect = fake_which
+        cc_apt_configure._ensure_dependencies(cfg, matcher, mycloud)
+        if expected_install:
+            install_packages.assert_called_once_with(expected_install)
+        else:
+            install_packages.assert_not_called()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
If no apt-sources config is given, then no apt dependencies are required to be installed.
This avoids unneeded calls to apt-update and apt-install.

The problem was introduced in 015543d304.
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/4441

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
lxc launch ubuntu-daily:devel mm
lxc shell mm

# without this patch the following happens while cc_apt_configure runs, and no package is installed:
$ grep -E 'apt-update|apt-install' /var/log/cloud-init.log
2023-10-17 14:50:41,775 - util.py[DEBUG]: apt-update [eatmydata apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet update] took 8.957 seconds
2023-10-17 14:50:42,142 - util.py[DEBUG]: apt-install [eatmydata apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet install] took 0.366 seconds

# with this patch no output expected
```

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
