### PR TITLE
Maas disregard initramfs

### DIFF
--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -44,6 +44,7 @@ DEFAULT_LOCAL = [
     Hetzner.DataSourceHetzner,
     IBMCloud.DataSourceIBMCloud,
     LXD.DataSourceLXD,
+    MAAS.DataSourceMAAS,
     NoCloud.DataSourceNoCloud,
     OpenNebula.DataSourceOpenNebula,
     Oracle.DataSourceOracle,

--- a/tests/unittests/sources/test_maas.py
+++ b/tests/unittests/sources/test_maas.py
@@ -1,26 +1,18 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import os
-import shutil
-import tempfile
 from copy import copy
 from unittest import mock
 
+import pytest
 import yaml
 
 from cloudinit import url_helper
 from cloudinit.sources import DataSourceMAAS
-from tests.unittests.helpers import CiTestCase, populate_dir
+from tests.unittests.helpers import populate_dir
 
 
-class TestMAASDataSource(CiTestCase):
-    def setUp(self):
-        super(TestMAASDataSource, self).setUp()
-        # Make a temp directoy for tests to use.
-        self.tmp = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self.tmp)
-
-    def test_seed_dir_valid(self):
+class TestMAASDataSource:
+    def test_seed_dir_valid(self, tmpdir):
         """Verify a valid seeddir is read as such."""
 
         userdata = b"valid01-userdata"
@@ -31,20 +23,20 @@ class TestMAASDataSource(CiTestCase):
             "public-keys": "ssh-rsa AAAAB3Nz...aC1yc2E= keyname",
         }
 
-        my_d = os.path.join(self.tmp, "valid")
+        my_d = tmpdir.join("valid").strpath
         populate_dir(my_d, data)
 
         ud, md, vd = DataSourceMAAS.read_maas_seed_dir(my_d)
 
-        self.assertEqual(userdata, ud)
+        assert userdata == ud
         for key in ("instance-id", "local-hostname"):
-            self.assertEqual(data["meta-data/" + key], md[key])
+            assert data["meta-data/" + key] == md[key]
 
         # verify that 'userdata' is not returned as part of the metadata
-        self.assertFalse(("user-data" in md))
-        self.assertIsNone(vd)
+        assert "user-data" not in md
+        assert vd is None
 
-    def test_seed_dir_valid_extra(self):
+    def test_seed_dir_valid_extra(self, tmpdir):
         """Verify extra files do not affect seed_dir validity."""
 
         userdata = b"valid-extra-userdata"
@@ -55,19 +47,19 @@ class TestMAASDataSource(CiTestCase):
             "foo": "bar",
         }
 
-        my_d = os.path.join(self.tmp, "valid_extra")
+        my_d = tmpdir.join("valid_extra").strpath
         populate_dir(my_d, data)
 
         ud, md, _vd = DataSourceMAAS.read_maas_seed_dir(my_d)
 
-        self.assertEqual(userdata, ud)
+        assert userdata == ud
         for key in ("instance-id", "local-hostname"):
-            self.assertEqual(data["meta-data/" + key], md[key])
+            assert data["meta-data/" + key] == md[key]
 
         # additional files should not just appear as keys in metadata atm
-        self.assertFalse(("foo" in md))
+        assert "foo" not in md
 
-    def test_seed_dir_invalid(self):
+    def test_seed_dir_invalid(self, tmpdir):
         """Verify that invalid seed_dir raises MAASSeedDirMalformed."""
 
         valid = {
@@ -76,47 +68,37 @@ class TestMAASDataSource(CiTestCase):
             "user-data": "",
         }
 
-        my_based = os.path.join(self.tmp, "valid_extra")
+        my_based = tmpdir.join("valid_extra").strpath
 
         # missing 'userdata' file
         my_d = "%s-01" % my_based
         invalid_data = copy(valid)
         del invalid_data["local-hostname"]
         populate_dir(my_d, invalid_data)
-        self.assertRaises(
-            DataSourceMAAS.MAASSeedDirMalformed,
-            DataSourceMAAS.read_maas_seed_dir,
-            my_d,
-        )
+        with pytest.raises(DataSourceMAAS.MAASSeedDirMalformed):
+            DataSourceMAAS.read_maas_seed_dir(my_d)
 
         # missing 'instance-id'
         my_d = "%s-02" % my_based
         invalid_data = copy(valid)
         del invalid_data["instance-id"]
         populate_dir(my_d, invalid_data)
-        self.assertRaises(
-            DataSourceMAAS.MAASSeedDirMalformed,
-            DataSourceMAAS.read_maas_seed_dir,
-            my_d,
-        )
+        with pytest.raises(DataSourceMAAS.MAASSeedDirMalformed):
+            DataSourceMAAS.read_maas_seed_dir(my_d)
 
-    def test_seed_dir_none(self):
+    def test_seed_dir_none(self, tmpdir):
         """Verify that empty seed_dir raises MAASSeedDirNone."""
 
-        my_d = os.path.join(self.tmp, "valid_empty")
-        self.assertRaises(
-            DataSourceMAAS.MAASSeedDirNone,
-            DataSourceMAAS.read_maas_seed_dir,
-            my_d,
-        )
+        my_d = tmpdir.join("valid_extra").strpath
+        with pytest.raises(DataSourceMAAS.MAASSeedDirNone):
+            DataSourceMAAS.read_maas_seed_dir(my_d)
 
-    def test_seed_dir_missing(self):
+    def test_seed_dir_missing(self, tmpdir):
         """Verify that missing seed_dir raises MAASSeedDirNone."""
-        self.assertRaises(
-            DataSourceMAAS.MAASSeedDirNone,
-            DataSourceMAAS.read_maas_seed_dir,
-            os.path.join(self.tmp, "nonexistantdirectory"),
-        )
+        with pytest.raises(DataSourceMAAS.MAASSeedDirNone):
+            DataSourceMAAS.read_maas_seed_dir(
+                tmpdir.join("doesnotexist").strpath
+            )
 
     def mock_read_maas_seed_url(self, data, seed, version="19991231"):
         """mock up readurl to appear as a web server at seed has provided data.
@@ -141,7 +123,7 @@ class TestMAASDataSource(CiTestCase):
             mock_readurl.side_effect = my_readurl
             return DataSourceMAAS.read_maas_seed_url(seed, version=version)
 
-    def test_seed_url_valid(self):
+    def test_seed_url_valid(self, tmpdir):
         """Verify that valid seed_url is read as such."""
         valid = {
             "meta-data/instance-id": "i-instanceid",
@@ -154,14 +136,12 @@ class TestMAASDataSource(CiTestCase):
         my_ver = "1999-99-99"
         ud, md, vd = self.mock_read_maas_seed_url(valid, my_seed, my_ver)
 
-        self.assertEqual(valid["meta-data/instance-id"], md["instance-id"])
-        self.assertEqual(
-            valid["meta-data/local-hostname"], md["local-hostname"]
-        )
-        self.assertEqual(valid["meta-data/public-keys"], md["public-keys"])
-        self.assertEqual(valid["user-data"], ud)
+        assert valid["meta-data/instance-id"] == md["instance-id"]
+        assert valid["meta-data/local-hostname"] == md["local-hostname"]
+        assert valid["meta-data/public-keys"] == md["public-keys"]
+        assert valid["user-data"] == ud
         # vendor-data is yaml, which decodes a string
-        self.assertEqual(valid["meta-data/vendor-data"].decode(), vd)
+        assert valid["meta-data/vendor-data"].decode() == vd
 
     def test_seed_url_vendor_data_dict(self):
         expected_vd = {"key1": "value1"}
@@ -174,12 +154,12 @@ class TestMAASDataSource(CiTestCase):
             valid, "http://example.com/foo"
         )
 
-        self.assertEqual(valid["meta-data/instance-id"], md["instance-id"])
-        self.assertEqual(expected_vd, vd)
+        assert valid["meta-data/instance-id"] == md["instance-id"]
+        assert expected_vd == vd
 
 
 @mock.patch("cloudinit.sources.DataSourceMAAS.url_helper.OauthUrlHelper")
-class TestGetOauthHelper(CiTestCase):
+class TestGetOauthHelper:
     base_cfg = {
         "consumer_key": "FAKE_CONSUMER_KEY",
         "token_key": "FAKE_TOKEN_KEY",
@@ -200,7 +180,7 @@ class TestGetOauthHelper(CiTestCase):
         m_helper.assert_has_calls([mock.call(**self.base_cfg)])
 
 
-class TestGetIdHash(CiTestCase):
+class TestGetIdHash:
     v1_cfg = {
         "consumer_key": "CKEY",
         "token_key": "TKEY",
@@ -213,7 +193,7 @@ class TestGetIdHash(CiTestCase):
     def test_v1_expected(self):
         """Test v1 id generated as expected working behavior from config."""
         result = DataSourceMAAS.get_id_from_ds_cfg(self.v1_cfg.copy())
-        self.assertEqual(self.v1_id, result)
+        assert self.v1_id == result
 
     def test_v1_extra_fields_are_ignored(self):
         """Test v1 id ignores unused entries in config."""
@@ -221,4 +201,4 @@ class TestGetIdHash(CiTestCase):
         cfg["consumer_secret"] = "BOO"
         cfg["unrelated"] = "HI MOM"
         result = DataSourceMAAS.get_id_from_ds_cfg(cfg)
-        self.assertEqual(self.v1_id, result)
+        assert self.v1_id == result


### PR DESCRIPTION
```
Make MAAS a local data source

The existing datasource works for ephemeral deployments
(booting over the network). When adapted to run during 
local timeframe, the initramfs brings up the initial
networking.

However, when the system boots from disk initramfs doesn’t bring
up the networking, which means that cloud-init will try to get
the metadata before network is actually up.

The motivation for this change is to support network configuration
for non-Ubuntu operating systems.
```

## Additional Context
https://warthogs.atlassian.net/browse/MAASENG-2140
