### PR TITLE
chore: fix PR template rendering

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -27,11 +27,6 @@ setup, and teardown. Scripts used may be attached directly to this PR. -->
 ## Checklist
 <!-- Go over all the following points, and put an `x` in all the boxes
 that apply. -->
-- [ ] My code follows the process laid out in
-[the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
-- [ ] I have updated or added any
-[unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html)
-accordingly
-- [ ] I have updated or added any
-[documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html)
-accordingly
+- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
+- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
+- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
chore: fix PR template rendering

GH seems to not respect proper Markdown rendering rules, splitting lines
where it shouldn't. Revert to single lines to avoid the issue.
```

## Additional Context
<!-- If relevant -->
![image](https://github.com/canonical/cloud-init/assets/22963691/c95cbf4b-c189-4963-9736-67b15f9fad3a)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in
[the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any
[unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html)
accordingly
- [ ] I have updated or added any
[documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html)
accordingly
