### PR TITLE
boothook: allow stdout/stderr to emit to cloud-init-output.log

### DIFF
--- a/cloudinit/handlers/boot_hook.py
+++ b/cloudinit/handlers/boot_hook.py
@@ -47,7 +47,8 @@ class BootHookPartHandler(handlers.Handler):
             env = os.environ.copy()
             if self.instance_id is not None:
                 env["INSTANCE_ID"] = str(self.instance_id)
-            subp.subp([filepath], env=env)
+            LOG.debug("Executing boothook")
+            subp.subp([filepath], env=env, capture=False)
         except subp.ProcessExecutionError:
             util.logexc(LOG, "Boothooks script %s execution error", filepath)
         except Exception:

--- a/tests/integration_tests/modules/test_boothook.py
+++ b/tests/integration_tests/modules/test_boothook.py
@@ -1,0 +1,39 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+import re
+
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+USER_DATA = """\
+#cloud-boothook
+#!/bin/sh
+# Error below will generate stderr
+BOOTHOOK/0
+echo BOOTHOOKstdout
+echo "BOOTHOOK: $INSTANCE_ID: is called every boot." >> /boothook.txt
+"""
+
+
+@pytest.mark.user_data(USER_DATA)
+def test_boothook_header_runs_part_per_instance(client: IntegrationInstance):
+    """Test boothook handling creates a script that runs per-boot.
+    Streams stderr and stdout are directed to /var/log/cloud-init-output.log.
+    """
+    instance_id = client.instance.execute("cloud-init query instance-id")
+    RE_BOOTHOOK = f"BOOTHOOK: {instance_id}: is called every boot"
+    log = client.read_from_file("/var/log/cloud-init.log")
+    verify_clean_log(log)
+    output = client.read_from_file("/boothook.txt")
+    assert 1 == len(re.findall(RE_BOOTHOOK, output))
+    client.restart()
+    output = client.read_from_file("/boothook.txt")
+    assert 2 == len(re.findall(RE_BOOTHOOK, output))
+    output_log = client.read_from_file("/var/log/cloud-init-output.log")
+    expected_msgs = [
+        "BOOTHOOKstdout",
+        "boothooks/part-001: 3: BOOTHOOK/0: not found",
+    ]
+    for msg in expected_msgs:
+        assert msg in output_log

--- a/tests/integration_tests/test_multi_part_user_data_handling.py
+++ b/tests/integration_tests/test_multi_part_user_data_handling.py
@@ -63,6 +63,18 @@ CLOUD_CONFIG_FILES = [
 ]
 MIME_WITH_ERRORS = create_mime_message(CLOUD_CONFIG_FILES)[0].as_string()
 
+CLOUD_CONFIG_ARCHIVE = """
+#cloud-config-archive
+- type: 'text/cloud-boothook'
+  content: |
+    #!/bin/sh
+    echo "BOOTHOOK: $(date -R): this is called every boot." | tee /run/boothook.txt
+- type: 'text/cloud-config'
+  content: |
+    bootcmd:
+     - [sh, -c, 'echo "BOOTCMD: $(date -R): $INSTANCE_ID" | tee /run/bootcmd.txt']
+"""  # noqa: E501
+
 
 @pytest.mark.ci
 @pytest.mark.user_data(USER_DATA)
@@ -132,3 +144,17 @@ def test_mime_with_error_parts(client: IntegrationInstance):
     assert (
         "Failed at merging in cloud config part from cfg-invalid.yaml" in log
     )
+
+
+@pytest.mark.ci
+@pytest.mark.user_data(CLOUD_CONFIG_ARCHIVE)
+def test_cloud_config_archive_boot_hook_logging(client: IntegrationInstance):
+    """
+    boot-hook and bootcmd scripts run per boot and log to cloud-init-outout.log
+    """
+    cmd = "cloud-init schema --system"
+    assert "Valid schema user-data" in client.execute(cmd).stdout
+    client.restart()
+    log = client.read_from_file("/var/log/cloud-init-output.log")
+    assert 2 == len(re.findall("BOOTHOOK:.*", log))
+    assert 2 == len(re.findall("BOOTCMD:.*", log))


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
boothook: allow stdout/stderr to emit to cloud-init-output.log

Fixes GH-3016
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
./tools/run-container --package ubuntu/mantic
CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init.*bddeb_all.deb CLOUD_INIT_OS_IMAGE=mantic tox -e integration-tests tests/integration_tests/test_multi_part_user_data_handling.py::test_cloud_config_archive_boot_hook_logging
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
