### PR TITLE
Ubuntu/lunar: Revert behavior, allow user login after cloud-init stage

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 cloud-init (23.3-0ubuntu0~23.04.1) UNRELEASED; urgency=medium
 
+  * d/p/do-not-block-user-login.patch:
+    - Revert behavior, allow user login after cloud-init stage (LP: #2039505)
   * d/control: add python3-apt as Recommends to read APT config from apt_pkg
   * d/cloud-init.maintscript: Remove the unused hook-network-manager
     conffile. (LP: #2027861)
@@ -13,7 +15,7 @@ cloud-init (23.3-0ubuntu0~23.04.1) UNRELEASED; urgency=medium
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/23.3/ChangeLog
 
- -- Chad Smith <chad.smith@canonical.com>  Wed, 04 Oct 2023 06:53:10 -0600
+ -- Brett Holman <brett.holman@canonical.com>  Wed, 18 Oct 2023 12:13:10 -0600
 
 cloud-init (23.2.2-0ubuntu0~23.04.1) lunar; urgency=medium
 

--- a/debian/patches/do-not-block-user-login.patch
+++ b/debian/patches/do-not-block-user-login.patch
@@ -1,0 +1,28 @@
+Description: Do not block user login
+Author: Brett Holman <brett.holman@canonical.com>
+Origin: other
+Bug: https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2039505
+Last-Update: 2023-10-16
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+
+--- a/systemd/cloud-config.service.tmpl
++++ b/systemd/cloud-config.service.tmpl
+@@ -3,7 +3,6 @@
+ Description=Apply the settings specified in cloud-config
+ After=network-online.target cloud-config.target
+ After=snapd.seeded.service
+-Before=systemd-user-sessions.service
+ Wants=network-online.target cloud-config.target
+ {% if variant == "rhel" %}
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+--- a/systemd/cloud-init.service.tmpl
++++ b/systemd/cloud-init.service.tmpl
+@@ -38,6 +38,7 @@
+ Before=shutdown.target
+ Conflicts=shutdown.target
+ {% endif %}
++Before=systemd-user-sessions.service
+ {% if variant == "rhel" %}
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 retain-old-groups.patch
+do-not-block-user-login.patch


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
summary: no more than 70 characters

A description of what the change being made is and why it is being
made, if the summary line is insufficient.  The blank line above is
required. This should be wrapped at 72 characters, but otherwise has
no particular length requirements.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
