### PR TITLE
cc_ssh_import_id: Extend support to FreeBSD

### DIFF
--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -19,7 +19,7 @@ from cloudinit.distros import ug_util
 from cloudinit.settings import PER_INSTANCE
 
 # https://launchpad.net/ssh-import-id
-distros = ["alpine", "cos", "debian", "ubuntu"]
+distros = ["alpine", "cos", "debian", "freebsd", "ubuntu"]
 
 SSH_IMPORT_ID_BINARY = "ssh-import-id"
 MODULE_DESCRIPTION = """\
@@ -54,7 +54,6 @@ LOG = logging.getLogger(__name__)
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
-
     if not is_key_in_nested_dict(cfg, "ssh_import_id"):
         LOG.debug(
             "Skipping module named ssh_import_id, no 'ssh_import_id'"
@@ -81,7 +80,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # import for cloudinit created users
     (users, _groups) = ug_util.normalize_users_groups(cfg, cloud.distro)
     elist = []
-    for (user, user_cfg) in users.items():
+    for user, user_cfg in users.items():
         import_ids = []
         if user_cfg["default"]:
             import_ids = util.get_cfg_option_list(cfg, "ssh_import_id", [])
@@ -117,7 +116,6 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
 
 def import_ssh_ids(ids, user):
-
     if not (user and ids):
         LOG.debug("empty user(%s) or ids(%s). not importing", user, ids)
         return

--- a/tools/build-on-freebsd
+++ b/tools/build-on-freebsd
@@ -28,8 +28,9 @@ pkgs="
     $py_prefix-jsonpointer
     $py_prefix-jsonschema
     $py_prefix-oauthlib
-    $py_prefix-requests
     $py_prefix-pyserial
+    $py_prefix-requests
+    $py_prefix-ssh-import-id
     $py_prefix-yaml
     sudo
 "


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
cc_ssh_import_id: Extend support to FreeBSD

The module was already enabled in cloud.cfg, but it doesn't officially
state that FreeBSD is supported.
Any platform that has a ssh-import-id package is supported, so add the
dependency and declare FreeBSD supported.

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
