### PR TITLE
drop systemd order After=snapd.seeded.service from cloud-config.service

### DIFF
--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -15,7 +15,7 @@ from cloudinit import safeyaml, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema, get_meta_doc
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_INSTANCE, PER_ONCE
 
 LOG = logging.getLogger(__name__)
 
@@ -210,6 +210,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             f" '{type(lxd_cfg).__name__}'"
         )
 
+    cloud.run("snap-seeded", util.wait_for_snap_seeded, [], freq=PER_ONCE)
     # Grab the configuration
     init_cfg = lxd_cfg.get("init", {})
     preseed_str = lxd_cfg.get("preseed", "")

--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -17,7 +17,7 @@ from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema, get_meta_doc
 from cloudinit.distros import ALL_DISTROS
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_INSTANCE, PER_ONCE
 
 # The schema definition for each cloud-config module is a strict contract for
 # describing supported configuration parameters for each cloud-config section.
@@ -85,6 +85,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         )
         return
 
+    cloud.run("snap-seeded", util.wait_for_snap_seeded, [], freq=PER_ONCE)
     out_fn = os.path.join(cloud.get_ipath("scripts"), "runcmd")
     cmd = cfg["runcmd"]
     try:

--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -13,7 +13,7 @@ from cloudinit import subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema, get_meta_doc
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_INSTANCE, PER_ONCE
 from cloudinit.subp import prepend_base_command
 
 distros = ["ubuntu"]
@@ -192,7 +192,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             "Skipping module named %s, no 'snap' key in configuration", name
         )
         return
-
+    cloud.run("snap-seeded", util.wait_for_snap_seeded, [], freq=PER_ONCE)
     add_assertions(
         cfgin.get("assertions", []),
         os.path.join(cloud.paths.get_ipath_cur(), "snapd.assertions"),

--- a/cloudinit/config/cc_ubuntu_autoinstall.py
+++ b/cloudinit/config/cc_ubuntu_autoinstall.py
@@ -6,6 +6,7 @@ import logging
 import re
 from textwrap import dedent
 
+from cloudinit import util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import (
@@ -83,6 +84,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         )
         return
 
+    cloud.run("snap-seeded", util.wait_for_snap_seeded, [], freq=PER_ONCE)
     snap_list, _ = subp(["snap", "list"])
     installer_present = None
     for snap_name in LIVE_INSTALLER_SNAPS:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3093,6 +3093,14 @@ def wait_for_files(flist, maxwait, naplen=0.5, log_pre=""):
     return need
 
 
+def wait_for_snap_seeded():
+    """Helper to wait on completion of snap seeding."""
+    if not subp.which("snap"):
+        LOG.debug("Skipping snap wait, no snap command present")
+        return
+    subp.subp(["snap", "wait", "system", "seed.loaded"])
+
+
 def mount_is_read_write(mount_point):
     """Check whether the given mount point is mounted rw"""
     result = get_mount_info(mount_point, get_mnt_opts=True)

--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -2,7 +2,6 @@
 [Unit]
 Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
-After=snapd.seeded.service
 Before=systemd-user-sessions.service
 Wants=network-online.target cloud-config.target
 ConditionPathExists=!/etc/cloud/cloud-init.disabled

--- a/tests/unittests/config/test_cc_snap.py
+++ b/tests/unittests/config/test_cc_snap.py
@@ -319,8 +319,11 @@ class TestSnapSchema:
 
 
 class TestHandle:
+    @mock.patch("cloudinit.util.wait_for_snap_seeded")
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_handle_adds_assertions(self, m_subp, fake_cloud, tmpdir):
+    def test_handle_adds_assertions(
+        self, m_subp, wait_for_snap_seeded, fake_cloud, tmpdir
+    ):
         """Any configured snap assertions are provided to add_assertions."""
         assert_file = os.path.join(
             fake_cloud.paths.get_ipath_cur(), "snapd.assertions"
@@ -333,3 +336,4 @@ class TestHandle:
         content = "\n".join(cfg["snap"]["assertions"])
         util.write_file(compare_file, content.encode("utf-8"))
         assert util.load_file(compare_file) == util.load_file(assert_file)
+        wait_for_snap_seeded.assert_called_once_with()

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -32,7 +32,9 @@ def get_cloud(
         myds.metadata.update(metadata)
     if paths:
         paths.datasource = myds
-    return cloud.Cloud(myds, paths, sys_cfg, mydist, None)
+    return cloud.Cloud(
+        myds, paths, sys_cfg, mydist, runners=helpers.Runners(paths)
+    )
 
 
 def abstract_to_concrete(abclass):


### PR DESCRIPTION
For review and discussion.  Having a strict systemd ordering `After=snapd.seeded.service` declared for `cloud-config.service` was defined to give cloud-config.service certainty that everything snap has already been set up in case any optional cloud-config modules in cloudinit.config.cc_* needed to rely on snap tooling to be present.

In practice this strict ordering always adds around a 10 second delay while cloud-config.service waits for snapd.seeded.service to complete its attestation, installation and setup yet the snaps seeded are not critical to the default functionality the cloud-init is configuring.

 In practice, there are only a few modules that absolutely require snaps to be seeded because they may be interacting with snapd itself, those modules are:
- cc_lxd
- cc_ubuntu_autoinstall
- cc_snaps
- cc_runcmd (in case option runcmd scripts reference snaps or snap tools)


This PR provides a common `util.wait_for_snap_seeded` which invokes `snap wait system seed.loaded` can be called from any config module that relies on snap setup being complete. This means that the default case for cloud-image installs should no longer have to wait on snaps being seeded to finish initial user configuration and bringing up SSH  and can therefore unblock earlier remote access and login to the system during boot. Each module will attempt to call wait_for_snap_seeded through the semaphore-based cloud.run method to prevent this function from being called more than once by other modules.


## boottime comparisons

TLDR: default launch without runcmd/lxd/autoinstall gets a big reduction in time to SSH/login (~4 seconds) by cloud-config.service not waiting on snap.seeded.service.   Overall boot time via systemd analyze is unchanged as we still have to wait for snap.seeded.service somewhere before mulit-user-.target. When runcmd/lxd/autoinstall needs to snap wait system seed.service, overall boot time is still comparable but time-to-SSH/login still blocks on snaps being seeded.


<details>
   <summary>ppa:cloud-init-dev/daily vs daily+ThisPR with no applicable user-data (default launch case)</summary>

Things to note between run #1 (daily image)  vs run #2 (daily image + this PR)
* slightly faster boot time  time for systemd-analyze  (15.580s vs  14.076s)
* despite slightly longer snapd.seeded.service in run2 around <> ( 3.775s vs 4.277s)
* systemd-user-sessions.service still after cloud-config.service but starts earlier during boot: ( @11.978s vs @5.853s)
* comparable time cost of modules-config boot stage from cloud-init analyze show (00.26000 vs 00.47200)
* run2: no dependency on After=snapd.seeded.service for cloud-config.service crit-chain
* neither run invokes snap wait system seed.loaded because empty user-data doesn't depend on snaps
```
Formatting '/tmp/pycl-qemu-examples-1019-152637/mantic-server-cloudimg-amd64-0/inst.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=10737418240 backing_file=/srv/pycloudlib/mantic/20231014/mantic-server-cloudimg-amd64.img backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
--- Launching control daily image /srv/pycloudlib/mantic/20231014/mantic-server-cloudimg-amd64.img ---
--- dpkg -l cloud-init  ---
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version                                      Architecture Description
+++-==============-============================================-============-=========================================================
ii  cloud-init     99.daily-202310191631-9a401b4a~ubuntu23.10.1 all          initialization and customization tool for cloud instances
--- cloud-init status --wait --long  ---

status: done
boot_status_code: enabled-by-generator
last_update: Thu, 19 Oct 2023 21:27:08 +0000
detail:
DataSourceNoCloud [seed=/dev/vda][dsmode=net]
--- systemd-analyze  ---
Startup finished in 2.882s (kernel) + 12.698s (userspace) = 15.580s 
graphical.target reached after 12.444s in userspace.
--- systemd-analyze blame  ---
3.775s snapd.seeded.service
2.059s cloud-init.service
1.709s snapd.apparmor.service
1.476s cloud-init-local.service
1.461s systemd-networkd-wait-online.service
1.134s pollinate.service
1.003s systemd-resolved.service
 938ms systemd-binfmt.service
 934ms systemd-timesyncd.service
 854ms snapd.service
 749ms dev-sda1.device
 544ms apport.service
 441ms apparmor.service
 437ms cloud-config.service
 385ms udisks2.service
 319ms snap.lxd.activate.service
 316ms polkit.service
 267ms rsyslog.service
 245ms cloud-final.service
 238ms ModemManager.service
 222ms systemd-logind.service
 199ms grub-common.service
 175ms systemd-machine-id-commit.service
 153ms lvm2-monitor.service
 137ms multipathd.service
 115ms dev-hugepages.mount
 115ms dev-mqueue.mount
 114ms sys-kernel-debug.mount
 114ms sys-kernel-tracing.mount
 108ms keyboard-setup.service
 107ms e2scrub_reap.service
 104ms kmod-static-nodes.service
 102ms systemd-journald.service
 100ms systemd-udev-trigger.service
  95ms dbus.service
  94ms modprobe@configfs.service
  92ms modprobe@dm_mod.service
  92ms user@1000.service
  91ms modprobe@drm.service
  78ms systemd-udevd.service
  76ms modprobe@efi_pstore.service
  66ms systemd-sysusers.service
  63ms systemd-journal-flush.service
  62ms modprobe@fuse.service
  61ms systemd-tmpfiles-setup-dev.service
  59ms systemd-fsck@dev-disk-by\x2dlabel-UEFI.service
  56ms systemd-tmpfiles-setup.service
  55ms systemd-fsck-root.service
  54ms systemd-fsck@dev-disk-by\x2dlabel-BOOT.service
  53ms ssh.service
  52ms systemd-random-seed.service
  49ms systemd-modules-load.service
  46ms grub-initrd-fallback.service
  44ms modprobe@loop.service
  42ms ufw.service
  41ms systemd-networkd.service
  41ms systemd-sysctl.service
  39ms systemd-timedated.service
  37ms systemd-remount-fs.service
  36ms boot.mount
  29ms finalrd.service
  27ms plymouth-read-write.service
  23ms console-setup.service
  23ms snap-core22-864.mount
  16ms systemd-update-utmp.service
  13ms boot-efi.mount
  13ms plymouth-quit.service
  11ms snap-snapd-20290.mount
  10ms snap-lxd-25945.mount
   8ms systemd-update-utmp-runlevel.service
   8ms snapd.socket
   7ms user-runtime-dir@1000.service
   7ms proc-sys-fs-binfmt_misc.mount
   6ms snap.mount
   4ms sys-kernel-config.mount
   3ms sys-fs-fuse-connections.mount
   3ms setvtrgb.service
   3ms systemd-user-sessions.service
   1ms plymouth-quit-wait.service
   9us blk-availability.service
--- systemd-analyze critical-chain systemd-user-sessions.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

systemd-user-sessions.service +3ms
└─cloud-config.service @11.978s +437ms
  └─snapd.seeded.service @8.190s +3.775s
    └─snapd.service @7.327s +854ms
      └─basic.target @7.238s
        └─sockets.target @7.238s
          └─snap.lxd.user-daemon.unix.socket @9.634s
            └─sysinit.target @7.219s
              └─cloud-init.service @5.158s +2.059s
                └─systemd-networkd-wait-online.service @3.681s +1.461s
                  └─systemd-networkd.service @3.633s +41ms
                    └─network-pre.target @3.625s
                      └─cloud-init-local.service @2.148s +1.476s
                        └─systemd-remount-fs.service @647ms +37ms
                          └─systemd-fsck-root.service @590ms +55ms
                            └─systemd-journald.socket @495ms
                              └─system.slice @470ms
                                └─-.slice @470ms
--- systemd-analyze critical-chain cloud-config.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

cloud-config.service +437ms
└─snapd.seeded.service @8.190s +3.775s
  └─snapd.service @7.327s +854ms
    └─basic.target @7.238s
      └─sockets.target @7.238s
        └─snap.lxd.user-daemon.unix.socket @9.634s
          └─sysinit.target @7.219s
            └─cloud-init.service @5.158s +2.059s
              └─systemd-networkd-wait-online.service @3.681s +1.461s
                └─systemd-networkd.service @3.633s +41ms
                  └─network-pre.target @3.625s
                    └─cloud-init-local.service @2.148s +1.476s
                      └─systemd-remount-fs.service @647ms +37ms
                        └─systemd-fsck-root.service @590ms +55ms
                          └─systemd-journald.socket @495ms
                            └─system.slice @470ms
                              └─-.slice @470ms
--- systemd-analyze critical-chain snapd.seeded.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

snapd.seeded.service +3.775s
└─snapd.service @7.327s +854ms
  └─basic.target @7.238s
    └─sockets.target @7.238s
      └─snap.lxd.user-daemon.unix.socket @9.634s
        └─sysinit.target @7.219s
          └─cloud-init.service @5.158s +2.059s
            └─systemd-networkd-wait-online.service @3.681s +1.461s
              └─systemd-networkd.service @3.633s +41ms
                └─network-pre.target @3.625s
                  └─cloud-init-local.service @2.148s +1.476s
                    └─systemd-remount-fs.service @647ms +37ms
                      └─systemd-fsck-root.service @590ms +55ms
                        └─systemd-journald.socket @495ms
                          └─system.slice @470ms
                            └─-.slice @470ms
--- cloud-init analyze show  ---
(Reading database ... 65535 files and directories currently installed.)
Preparing to unpack .../cloud-init_mantic_nosnapseeded~bddeb.deb ...
Unpacking cloud-init (23.3-93-g5f557f79-1~bddeb) over (99.daily-202310191631-9a401b4a~ubuntu23.10.1) ...
Setting up cloud-init (23.3-93-g5f557f79-1~bddeb) ...
Processing triggers for rsyslog (8.2306.0-2ubuntu2) ...
Processing triggers for man-db (2.11.2-3) ...
Formatting '/tmp/pycl-qemu-examples-1019-152637/mantic-server-cloudimg-amd64-1/inst.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=10737418240 backing_file=/home/csmith/src/pycloudlib/mantic-server-cloudimg-amd64.img1 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
-- Boot Record 01 --
The total time elapsed since completing an event is printed after the "@" character.
The time the event takes is printed after the "+" character.

Starting stage: init-local
|`->no cache found @00.00200s +00.00000s
|`->found local data from DataSourceNoCloud @00.01600s +00.45500s
Finished stage: (init-local) 00.81400 seconds

Starting stage: init-network
|`->restored from cache with run check: DataSourceNoCloud [seed=/dev/vda][dsmode=net] @02.54100s +00.00100s
|`->setting up datasource @02.57000s +00.00000s
|`->reading and applying user-data @02.57700s +00.00200s
|`->reading and applying vendor-data @02.57900s +00.00000s
|`->reading and applying vendor-data2 @02.57900s +00.00000s
|`->activating datasource @02.59000s +00.00100s
|`->config-migrator ran successfully @02.61100s +00.00000s
|`->config-seed_random ran successfully @02.61100s +00.00000s
|`->config-bootcmd ran successfully @02.61100s +00.00100s
|`->config-growpart ran successfully @02.61200s +00.66400s
|`->config-resizefs ran successfully @03.27600s +00.24400s
|`->config-mounts ran successfully @03.52000s +00.00100s
|`->config-set_hostname ran successfully @03.52100s +00.00500s
|`->config-update_hostname ran successfully @03.52600s +00.00100s
|`->config-users_groups ran successfully @03.52700s +00.33500s
|`->config-ssh ran successfully @03.86200s +00.55200s
Finished stage: (init-network) 01.88000 seconds

Starting stage: modules-config
|`->config-ssh_import_id ran successfully @09.39700s +00.00100s
|`->config-locale ran successfully @09.39800s +00.00000s
|`->config-set_passwords ran successfully @09.39800s +00.00100s
|`->config-grub_dpkg ran successfully @09.39900s +00.20900s
|`->config-apt_configure ran successfully @09.60800s +00.02500s
|`->config-byobu ran successfully @09.63300s +00.00000s
Finished stage: (modules-config) 00.26000 seconds

Starting stage: modules-final
|`->config-reset_rmc ran successfully @09.87200s +00.00100s
|`->config-rightscale_userdata ran successfully @09.87300s +00.00100s
|`->config-scripts_vendor ran successfully @09.87400s +00.00000s
|`->config-scripts_per_once ran successfully @09.87400s +00.00000s
|`->config-scripts_per_boot ran successfully @09.87400s +00.00000s
|`->config-scripts_per_instance ran successfully @09.87400s +00.00100s
|`->config-scripts_user ran successfully @09.87500s +00.00000s
|`->config-ssh_authkey_fingerprints ran successfully @09.87500s +00.00400s
|`->config-keys_to_console ran successfully @09.87900s +00.02400s
|`->config-install_hotplug ran successfully @09.90300s +00.00000s
|`->config-final_message ran successfully @09.90300s +00.00400s
Finished stage: (modules-final) 00.06900 seconds

Total Time: 3.02300 seconds

1 boot records analyzed
--- egrep 'snap.*wait' /var/log/cloud-init.log  ---

--- Launching modified daily image /srv/pycloudlib/mantic/20231014/mantic-server-cloudimg-amd64.img with cloud-init_mantic_nosnapseeded~bddeb.deb ---
--- dpkg -l cloud-init  ---
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version                   Architecture Description
+++-==============-=========================-============-=================================
ii  cloud-init     23.3-93-g5f557f79-1~bddeb all          Init scripts for cloud instances
--- cloud-init status --wait --long  ---

status: done
boot_status_code: enabled-by-generator
last_update: Thu, 19 Oct 2023 21:27:45 +0000
detail:
DataSourceNoCloud [seed=/dev/vda][dsmode=net]
--- systemd-analyze  ---
Startup finished in 2.805s (kernel) + 11.270s (userspace) = 14.076s 
graphical.target reached after 10.993s in userspace.
--- systemd-analyze blame  ---
4.277s snapd.seeded.service
1.730s snapd.apparmor.service
1.370s cloud-init-local.service
1.321s cloud-config.service
1.260s cloud-init.service
1.077s systemd-networkd-wait-online.service
 994ms systemd-resolved.service
 935ms systemd-timesyncd.service
 913ms systemd-binfmt.service
 819ms pollinate.service
 776ms snapd.service
 739ms apport.service
 669ms dev-sda1.device
 379ms udisks2.service
 368ms apparmor.service
 328ms polkit.service
 277ms snap.lxd.activate.service
 276ms rsyslog.service
 255ms cloud-final.service
 176ms systemd-logind.service
 164ms ModemManager.service
 132ms grub-common.service
 120ms dev-hugepages.mount
 119ms dev-mqueue.mount
 119ms sys-kernel-debug.mount
 117ms sys-kernel-tracing.mount
 112ms keyboard-setup.service
 109ms systemd-journald.service
 108ms user@1000.service
 107ms kmod-static-nodes.service
 102ms lvm2-monitor.service
 101ms multipathd.service
  98ms e2scrub_reap.service
  97ms modprobe@configfs.service
  97ms systemd-udev-trigger.service
  87ms dbus.service
  84ms systemd-machine-id-commit.service
  81ms modprobe@dm_mod.service
  80ms modprobe@drm.service
  79ms modprobe@efi_pstore.service
  67ms modprobe@fuse.service
  56ms systemd-udevd.service
  55ms systemd-fsck@dev-disk-by\x2dlabel-UEFI.service
  52ms systemd-journal-flush.service
  51ms systemd-fsck-root.service
  50ms systemd-modules-load.service
  49ms systemd-sysusers.service
  45ms systemd-timedated.service
  43ms modprobe@loop.service
  43ms ssh.service
  42ms systemd-fsck@dev-disk-by\x2dlabel-BOOT.service
  39ms boot.mount
  38ms grub-initrd-fallback.service
  37ms systemd-networkd.service
  37ms systemd-tmpfiles-setup-dev.service
  36ms systemd-random-seed.service
  34ms plymouth-read-write.service
  29ms console-setup.service
  29ms systemd-remount-fs.service
  29ms finalrd.service
  28ms systemd-tmpfiles-setup.service
  25ms systemd-sysctl.service
  23ms sys-kernel-config.mount
  19ms sys-fs-fuse-connections.mount
  16ms systemd-update-utmp.service
  15ms boot-efi.mount
  13ms plymouth-quit.service
  13ms snap-core22-864.mount
  12ms snap-lxd-25945.mount
  12ms snap-snapd-20290.mount
  10ms ufw.service
  10ms snapd.socket
   8ms systemd-update-utmp-runlevel.service
   7ms user-runtime-dir@1000.service
   6ms snap.mount
   5ms proc-sys-fs-binfmt_misc.mount
   4ms plymouth-quit-wait.service
   3ms setvtrgb.service
   3ms systemd-user-sessions.service
  10us blk-availability.service
--- systemd-analyze critical-chain systemd-user-sessions.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

systemd-user-sessions.service +3ms
└─cloud-config.service @5.853s +1.321s
  └─basic.target @5.851s
    └─sockets.target @5.851s
      └─snap.lxd.daemon.unix.socket @7.939s
        └─sysinit.target @5.825s
          └─cloud-init.service @4.562s +1.260s
            └─systemd-networkd-wait-online.service @3.470s +1.077s
              └─systemd-networkd.service @3.426s +37ms
                └─network-pre.target @3.416s
                  └─cloud-init-local.service @2.045s +1.370s
                    └─systemd-remount-fs.service @605ms +29ms
                      └─systemd-fsck-root.service @553ms +51ms
                        └─systemd-journald.socket @456ms
                          └─-.mount @431ms
                            └─-.slice @431ms
--- systemd-analyze critical-chain cloud-config.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

cloud-config.service +1.321s
└─basic.target @5.851s
  └─sockets.target @5.851s
    └─snap.lxd.daemon.unix.socket @7.939s
      └─sysinit.target @5.825s
        └─cloud-init.service @4.562s +1.260s
          └─systemd-networkd-wait-online.service @3.470s +1.077s
            └─systemd-networkd.service @3.426s +37ms
              └─network-pre.target @3.416s
                └─cloud-init-local.service @2.045s +1.370s
                  └─systemd-remount-fs.service @605ms +29ms
                    └─systemd-fsck-root.service @553ms +51ms
                      └─systemd-journald.socket @456ms
                        └─-.mount @431ms
                          └─-.slice @431ms
--- systemd-analyze critical-chain snapd.seeded.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

snapd.seeded.service +4.277s
└─snapd.service @5.931s +776ms
  └─basic.target @5.851s
    └─sockets.target @5.851s
      └─snap.lxd.daemon.unix.socket @7.939s
        └─sysinit.target @5.825s
          └─cloud-init.service @4.562s +1.260s
            └─systemd-networkd-wait-online.service @3.470s +1.077s
              └─systemd-networkd.service @3.426s +37ms
                └─network-pre.target @3.416s
                  └─cloud-init-local.service @2.045s +1.370s
                    └─systemd-remount-fs.service @605ms +29ms
                      └─systemd-fsck-root.service @553ms +51ms
                        └─systemd-journald.socket @456ms
                          └─-.mount @431ms
                            └─-.slice @431ms
--- cloud-init analyze show  ---
-- Boot Record 01 --
The total time elapsed since completing an event is printed after the "@" character.
The time the event takes is printed after the "+" character.

Starting stage: init-local
|`->no cache found @00.00200s +00.00000s
|`->found local data from DataSourceNoCloud @00.00700s +00.45800s
Finished stage: (init-local) 00.80500 seconds

Starting stage: init-network
|`->restored from cache with run check: DataSourceNoCloud [seed=/dev/vda][dsmode=net] @02.15000s +00.00100s
|`->setting up datasource @02.18000s +00.00000s
|`->reading and applying user-data @02.18400s +00.00100s
|`->reading and applying vendor-data @02.18500s +00.00000s
|`->reading and applying vendor-data2 @02.18500s +00.00000s
|`->activating datasource @02.19700s +00.00000s
|`->config-migrator ran successfully @02.21900s +00.00000s
|`->config-seed_random ran successfully @02.21900s +00.00100s
|`->config-bootcmd ran successfully @02.22000s +00.00000s
|`->config-growpart ran successfully @02.22000s +00.53800s
|`->config-resizefs ran successfully @02.75800s +00.10900s
|`->config-mounts ran successfully @02.86700s +00.00100s
|`->config-set_hostname ran successfully @02.86800s +00.00400s
|`->config-update_hostname ran successfully @02.87200s +00.00100s
|`->config-users_groups ran successfully @02.87300s +00.12400s
|`->config-ssh ran successfully @02.99700s +00.22800s
Finished stage: (init-network) 01.08300 seconds

Starting stage: modules-config
|`->config-ssh_import_id ran successfully @04.13100s +00.00000s
|`->config-locale ran successfully @04.13100s +00.00100s
|`->config-set_passwords ran successfully @04.13200s +00.00300s
|`->config-grub_dpkg ran successfully @04.13500s +00.38600s
|`->config-apt_configure ran successfully @04.52100s +00.03200s
|`->config-byobu ran successfully @04.55400s +00.00000s
Finished stage: (modules-config) 00.47200 seconds

Starting stage: modules-final
|`->config-reset_rmc ran successfully @08.64900s +00.00100s
|`->config-rightscale_userdata ran successfully @08.65000s +00.00000s
|`->config-scripts_vendor ran successfully @08.65000s +00.00100s
|`->config-scripts_per_once ran successfully @08.65100s +00.00000s
|`->config-scripts_per_boot ran successfully @08.65100s +00.00000s
|`->config-scripts_per_instance ran successfully @08.65100s +00.00000s
|`->config-scripts_user ran successfully @08.65100s +00.00100s
|`->config-ssh_authkey_fingerprints ran successfully @08.65200s +00.00400s
|`->config-keys_to_console ran successfully @08.65600s +00.02300s
|`->config-install_hotplug ran successfully @08.67900s +00.00100s
|`->config-final_message ran successfully @08.68000s +00.00300s
Finished stage: (modules-final) 00.06900 seconds

Total Time: 2.42900 seconds

1 boot records analyzed
--- egrep 'snap.*wait' /var/log/cloud-init.log  ---


```
</details>


<details>
 <summary> ppa:cloud-init-dev/daily vs daily+ThisPR with applicable runcmd/autoinstall user-data (to trigger manual snap wait)</summary>

Things to note between run #1 (daily image)  vs run #2 (daily image + this PR)
* slightly longer boot time for systemd-analyze  ( 15.092s vs  16.068s)
* systemd-user-sessions.service still after cloud-config.service but starts earlier during boot: ( @11.437s vs @8.067s)
* much longer time cost of modules-config boot stage because of `snap wait system seed.loaded`  from cloud-init analyze show (00.29800 vs 03.66600)
* run2: no dependency on After=snapd.seeded.service for cloud-config.service crit-chain
* snap wait system seed.loaded only invoked once my cloud-init despite runcmd and autoinstall modules both active
```
Formatting '/tmp/pycl-qemu-examples-1019-154020/mantic-server-cloudimg-amd64-0/inst.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=10737418240 backing_file=/srv/pycloudlib/mantic/20231014/mantic-server-cloudimg-amd64.img backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
--- Launching control daily image /srv/pycloudlib/mantic/20231014/mantic-server-cloudimg-amd64.img ---
--- dpkg -l cloud-init  ---
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version                                      Architecture Description
+++-==============-============================================-============-=========================================================
ii  cloud-init     99.daily-202310191631-9a401b4a~ubuntu23.10.1 all          initialization and customization tool for cloud instances
--- cloud-init status --wait --long  ---

status: done
boot_status_code: enabled-by-generator
last_update: Thu, 19 Oct 2023 21:40:51 +0000
detail:
DataSourceNoCloud [seed=/dev/vda][dsmode=net]
--- systemd-analyze  ---
Startup finished in 2.851s (kernel) + 12.240s (userspace) = 15.092s 
graphical.target reached after 11.954s in userspace.
--- systemd-analyze blame  ---
4.158s snapd.seeded.service
1.738s snapd.apparmor.service
1.516s cloud-init.service
1.505s systemd-networkd-wait-online.service
1.383s cloud-init-local.service
1.144s pollinate.service
1.002s systemd-resolved.service
 940ms systemd-timesyncd.service
 921ms systemd-binfmt.service
 694ms dev-sda1.device
 673ms snapd.service
 656ms apport.service
 489ms cloud-config.service
 374ms apparmor.service
 312ms udisks2.service
 284ms snap.lxd.activate.service
 280ms cloud-final.service
 268ms polkit.service
 247ms ModemManager.service
 228ms rsyslog.service
 129ms grub-common.service
 129ms dev-hugepages.mount
 128ms dev-mqueue.mount
 127ms sys-kernel-debug.mount
 127ms systemd-logind.service
 126ms sys-kernel-tracing.mount
 122ms user@1000.service
 120ms keyboard-setup.service
 117ms systemd-journald.service
 115ms kmod-static-nodes.service
 111ms lvm2-monitor.service
 107ms modprobe@configfs.service
 101ms modprobe@dm_mod.service
  94ms systemd-udev-trigger.service
  93ms modprobe@drm.service
  91ms multipathd.service
  88ms systemd-machine-id-commit.service
  85ms e2scrub_reap.service
  78ms modprobe@efi_pstore.service
  78ms dbus.service
  73ms modprobe@fuse.service
  66ms modprobe@loop.service
  57ms systemd-udevd.service
  49ms grub-initrd-fallback.service
  48ms systemd-sysusers.service
  47ms systemd-fsck@dev-disk-by\x2dlabel-UEFI.service
  47ms systemd-fsck@dev-disk-by\x2dlabel-BOOT.service
  45ms systemd-fsck-root.service
  40ms systemd-timedated.service
  37ms systemd-networkd.service
  37ms systemd-journal-flush.service
  37ms ssh.service
  37ms systemd-tmpfiles-setup-dev.service
  37ms systemd-remount-fs.service
  35ms boot.mount
  35ms plymouth-read-write.service
  33ms console-setup.service
  31ms systemd-tmpfiles-setup.service
  30ms systemd-modules-load.service
  30ms systemd-random-seed.service
  30ms finalrd.service
  29ms ufw.service
  24ms sys-fs-fuse-connections.mount
  23ms sys-kernel-config.mount
  23ms systemd-sysctl.service
  16ms boot-efi.mount
  14ms snapd.socket
  14ms systemd-update-utmp.service
  13ms plymouth-quit.service
  12ms snap-core22-864.mount
  11ms snap-lxd-25945.mount
  11ms snap-snapd-20290.mount
   8ms systemd-update-utmp-runlevel.service
   8ms user-runtime-dir@1000.service
   5ms proc-sys-fs-binfmt_misc.mount
   4ms snap.mount
   3ms setvtrgb.service
   3ms systemd-user-sessions.service
   1ms plymouth-quit-wait.service
  11us blk-availability.service
--- systemd-analyze critical-chain systemd-user-sessions.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

systemd-user-sessions.service +3ms
└─cloud-config.service @11.437s +489ms
  └─snapd.seeded.service @7.264s +4.158s
    └─snapd.service @6.581s +673ms
      └─basic.target @6.513s
        └─sockets.target @6.513s
          └─snap.lxd.user-daemon.unix.socket @8.293s
            └─sysinit.target @6.483s
              └─cloud-init.service @4.964s +1.516s
                └─systemd-networkd-wait-online.service @3.444s +1.505s
                  └─systemd-networkd.service @3.400s +37ms
                    └─network-pre.target @3.391s
                      └─cloud-init-local.service @2.007s +1.383s
                        └─systemd-remount-fs.service @576ms +37ms
                          └─systemd-fsck-root.service @529ms +45ms
                            └─systemd-journald.socket @418ms
                              └─system.slice @393ms
                                └─-.slice @393ms
--- systemd-analyze critical-chain cloud-config.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

cloud-config.service +489ms
└─snapd.seeded.service @7.264s +4.158s
  └─snapd.service @6.581s +673ms
    └─basic.target @6.513s
      └─sockets.target @6.513s
        └─snap.lxd.user-daemon.unix.socket @8.293s
          └─sysinit.target @6.483s
            └─cloud-init.service @4.964s +1.516s
              └─systemd-networkd-wait-online.service @3.444s +1.505s
                └─systemd-networkd.service @3.400s +37ms
                  └─network-pre.target @3.391s
                    └─cloud-init-local.service @2.007s +1.383s
                      └─systemd-remount-fs.service @576ms +37ms
                        └─systemd-fsck-root.service @529ms +45ms
                          └─systemd-journald.socket @418ms
                            └─system.slice @393ms
                              └─-.slice @393ms
--- systemd-analyze critical-chain snapd.seeded.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

snapd.seeded.service +4.158s
└─snapd.service @6.581s +673ms
  └─basic.target @6.513s
    └─sockets.target @6.513s
      └─snap.lxd.user-daemon.unix.socket @8.293s
        └─sysinit.target @6.483s
          └─cloud-init.service @4.964s +1.516s
            └─systemd-networkd-wait-online.service @3.444s +1.505s
              └─systemd-networkd.service @3.400s +37ms
                └─network-pre.target @3.391s
                  └─cloud-init-local.service @2.007s +1.383s
                    └─systemd-remount-fs.service @576ms +37ms
                      └─systemd-fsck-root.service @529ms +45ms
                        └─systemd-journald.socket @418ms
                          └─system.slice @393ms
                            └─-.slice @393ms
--- cloud-init analyze show  ---
(Reading database ... 65535 files and directories currently installed.)
Preparing to unpack .../cloud-init_mantic_nosnapseeded~bddeb.deb ...
Unpacking cloud-init (23.3-93-g5f557f79-1~bddeb) over (99.daily-202310191631-9a401b4a~ubuntu23.10.1) ...
Setting up cloud-init (23.3-93-g5f557f79-1~bddeb) ...
Processing triggers for rsyslog (8.2306.0-2ubuntu2) ...
Processing triggers for man-db (2.11.2-3) ...
Formatting '/tmp/pycl-qemu-examples-1019-154020/mantic-server-cloudimg-amd64-1/inst.qcow2', fmt=qcow2 cluster_size=65536 extended_l2=off compression_type=zlib size=10737418240 backing_file=/home/csmith/src/pycloudlib/mantic-server-cloudimg-amd64.img1 backing_fmt=qcow2 lazy_refcounts=off refcount_bits=16
-- Boot Record 01 --
The total time elapsed since completing an event is printed after the "@" character.
The time the event takes is printed after the "+" character.

Starting stage: init-local
|`->no cache found @00.00200s +00.00000s
|`->found local data from DataSourceNoCloud @00.00700s +00.47400s
Finished stage: (init-local) 00.82900 seconds

Starting stage: init-network
|`->restored from cache with run check: DataSourceNoCloud [seed=/dev/vda][dsmode=net] @02.59800s +00.00500s
|`->setting up datasource @02.62700s +00.00000s
|`->reading and applying user-data @02.63400s +00.00200s
|`->reading and applying vendor-data @02.63600s +00.00000s
|`->reading and applying vendor-data2 @02.63600s +00.00000s
|`->activating datasource @02.64800s +00.00000s
|`->config-migrator ran successfully @02.66900s +00.00000s
|`->config-seed_random ran successfully @02.66900s +00.00100s
|`->config-bootcmd ran successfully @02.67000s +00.00000s
|`->config-growpart ran successfully @02.67100s +00.54900s
|`->config-resizefs ran successfully @03.22000s +00.10100s
|`->config-mounts ran successfully @03.32200s +00.00100s
|`->config-set_hostname ran successfully @03.32300s +00.00400s
|`->config-update_hostname ran successfully @03.32700s +00.00000s
|`->config-users_groups ran successfully @03.32800s +00.09900s
|`->config-ssh ran successfully @03.42700s +00.49500s
Finished stage: (init-network) 01.33200 seconds

Starting stage: modules-config
|`->config-ubuntu_autoinstall ran successfully @09.12200s +00.03200s
|`->config-ssh_import_id ran successfully @09.15400s +00.00100s
|`->config-locale ran successfully @09.15600s +00.00000s
|`->config-set_passwords ran successfully @09.15600s +00.00000s
|`->config-grub_dpkg ran successfully @09.15600s +00.20500s
|`->config-apt_configure ran successfully @09.36100s +00.02700s
|`->config-runcmd ran successfully @09.38800s +00.00100s
|`->config-byobu ran successfully @09.38900s +00.00000s
Finished stage: (modules-config) 00.29800 seconds

Starting stage: modules-final
|`->config-reset_rmc ran successfully @09.66400s +00.00100s
|`->config-rightscale_userdata ran successfully @09.66500s +00.00100s
|`->config-scripts_vendor ran successfully @09.66600s +00.00000s
|`->config-scripts_per_once ran successfully @09.66600s +00.00000s
|`->config-scripts_per_boot ran successfully @09.66600s +00.00000s
|`->config-scripts_per_instance ran successfully @09.66600s +00.00100s
|`->config-scripts_user ran successfully @09.66700s +00.00000s
|`->config-ssh_authkey_fingerprints ran successfully @09.66800s +00.00400s
|`->config-keys_to_console ran successfully @09.67200s +00.02300s
|`->config-install_hotplug ran successfully @09.69500s +00.00100s
|`->config-final_message ran successfully @09.69600s +00.00300s
Finished stage: (modules-final) 00.09800 seconds

Total Time: 2.55700 seconds

1 boot records analyzed
--- egrep 'snap.*wait' /var/log/cloud-init.log  ---

--- Launching modified daily image /srv/pycloudlib/mantic/20231014/mantic-server-cloudimg-amd64.img with cloud-init_mantic_nosnapseeded~bddeb.deb ---
--- dpkg -l cloud-init  ---
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version                   Architecture Description
+++-==============-=========================-============-=================================
ii  cloud-init     23.3-93-g5f557f79-1~bddeb all          Init scripts for cloud instances
--- cloud-init status --wait --long  ---

status: done
boot_status_code: enabled-by-generator
last_update: Thu, 19 Oct 2023 21:41:32 +0000
detail:
DataSourceNoCloud [seed=/dev/vda][dsmode=net]
--- systemd-analyze  ---
Startup finished in 2.859s (kernel) + 13.208s (userspace) = 16.068s 
graphical.target reached after 12.670s in userspace.
--- systemd-analyze blame  ---
4.568s cloud-config.service
3.148s snapd.seeded.service
2.051s cloud-init.service
1.970s systemd-networkd-wait-online.service
1.894s snapd.apparmor.service
1.684s cloud-init-local.service
1.302s pollinate.service
1.005s snapd.service
 981ms systemd-resolved.service
 935ms apport.service
 917ms systemd-binfmt.service
 914ms dev-sda1.device
 910ms systemd-timesyncd.service
 527ms cloud-final.service
 492ms apparmor.service
 392ms udisks2.service
 370ms polkit.service
 352ms ModemManager.service
 348ms snap.lxd.activate.service
 324ms rsyslog.service
 187ms systemd-logind.service
 180ms systemd-machine-id-commit.service
 172ms grub-common.service
 161ms multipathd.service
 149ms dev-hugepages.mount
 147ms dev-mqueue.mount
 146ms user@1000.service
 142ms sys-kernel-debug.mount
 137ms sys-kernel-tracing.mount
 131ms e2scrub_reap.service
 130ms systemd-journald.service
 128ms keyboard-setup.service
 124ms dbus.service
 112ms kmod-static-nodes.service
 111ms lvm2-monitor.service
  97ms systemd-sysusers.service
  94ms modprobe@configfs.service
  93ms modprobe@dm_mod.service
  86ms modprobe@drm.service
  85ms systemd-journal-flush.service
  82ms systemd-udevd.service
  80ms modprobe@efi_pstore.service
  78ms systemd-udev-trigger.service
  70ms systemd-fsck@dev-disk-by\x2dlabel-UEFI.service
  68ms systemd-random-seed.service
  68ms modprobe@fuse.service
  67ms systemd-modules-load.service
  62ms systemd-fsck-root.service
  60ms systemd-tmpfiles-setup.service
  60ms modprobe@loop.service
  58ms systemd-tmpfiles-setup-dev.service
  54ms grub-initrd-fallback.service
  48ms systemd-fsck@dev-disk-by\x2dlabel-BOOT.service
  47ms systemd-sysctl.service
  41ms finalrd.service
  41ms systemd-networkd.service
  41ms systemd-timedated.service
  40ms plymouth-read-write.service
  40ms console-setup.service
  39ms ufw.service
  39ms boot.mount
  38ms ssh.service
  30ms systemd-remount-fs.service
  25ms boot-efi.mount
  21ms systemd-update-utmp.service
  18ms snap-snapd-20290.mount
  17ms sys-kernel-config.mount
  17ms sys-fs-fuse-connections.mount
  14ms plymouth-quit.service
  12ms snap-core22-864.mount
  11ms proc-sys-fs-binfmt_misc.mount
  11ms snap-lxd-25945.mount
  10ms snapd.socket
   8ms user-runtime-dir@1000.service
   6ms snap.mount
   4ms systemd-update-utmp-runlevel.service
   4ms setvtrgb.service
   3ms systemd-user-sessions.service
   2ms plymouth-quit-wait.service
  10us blk-availability.service
--- systemd-analyze critical-chain systemd-user-sessions.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

systemd-user-sessions.service +3ms
└─cloud-config.service @8.067s +4.568s
  └─basic.target @8.065s
    └─sockets.target @8.064s
      └─snap.lxd.daemon.unix.socket @10.663s
        └─sysinit.target @8.037s
          └─cloud-init.service @5.984s +2.051s
            └─systemd-networkd-wait-online.service @4.000s +1.970s
              └─systemd-networkd.service @3.952s +41ms
                └─network-pre.target @3.944s
                  └─cloud-init-local.service @2.259s +1.684s
                    └─systemd-remount-fs.service @716ms +30ms
                      └─systemd-fsck-root.service @643ms +62ms
                        └─systemd-journald.socket @502ms
                          └─system.slice @477ms
                            └─-.slice @477ms
--- systemd-analyze critical-chain cloud-config.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

cloud-config.service +4.568s
└─basic.target @8.065s
  └─sockets.target @8.064s
    └─snap.lxd.daemon.unix.socket @10.663s
      └─sysinit.target @8.037s
        └─cloud-init.service @5.984s +2.051s
          └─systemd-networkd-wait-online.service @4.000s +1.970s
            └─systemd-networkd.service @3.952s +41ms
              └─network-pre.target @3.944s
                └─cloud-init-local.service @2.259s +1.684s
                  └─systemd-remount-fs.service @716ms +30ms
                    └─systemd-fsck-root.service @643ms +62ms
                      └─systemd-journald.socket @502ms
                        └─system.slice @477ms
                          └─-.slice @477ms
--- systemd-analyze critical-chain snapd.seeded.service  ---
The time when unit became active or started is printed after the "@" character.
The time the unit took to start is printed after the "+" character.

snapd.seeded.service +3.148s
└─snapd.service @8.166s +1.005s
  └─basic.target @8.065s
    └─sockets.target @8.064s
      └─snap.lxd.daemon.unix.socket @10.663s
        └─sysinit.target @8.037s
          └─cloud-init.service @5.984s +2.051s
            └─systemd-networkd-wait-online.service @4.000s +1.970s
              └─systemd-networkd.service @3.952s +41ms
                └─network-pre.target @3.944s
                  └─cloud-init-local.service @2.259s +1.684s
                    └─systemd-remount-fs.service @716ms +30ms
                      └─systemd-fsck-root.service @643ms +62ms
                        └─systemd-journald.socket @502ms
                          └─system.slice @477ms
                            └─-.slice @477ms
--- cloud-init analyze show  ---
-- Boot Record 01 --
The total time elapsed since completing an event is printed after the "@" character.
The time the event takes is printed after the "+" character.

Starting stage: init-local
|`->no cache found @00.00400s +00.00000s
|`->found local data from DataSourceNoCloud @00.01800s +00.44700s
Finished stage: (init-local) 00.87100 seconds

Starting stage: init-network
|`->restored from cache with run check: DataSourceNoCloud [seed=/dev/vda][dsmode=net] @03.14800s +00.00100s
|`->setting up datasource @03.18100s +00.00000s
|`->reading and applying user-data @03.18500s +00.00100s
|`->reading and applying vendor-data @03.18600s +00.00000s
|`->reading and applying vendor-data2 @03.18600s +00.00000s
|`->activating datasource @03.19900s +00.00100s
|`->config-migrator ran successfully @03.22200s +00.00000s
|`->config-seed_random ran successfully @03.22200s +00.00000s
|`->config-bootcmd ran successfully @03.22200s +00.00100s
|`->config-growpart ran successfully @03.22300s +00.68900s
|`->config-resizefs ran successfully @03.91200s +00.20100s
|`->config-mounts ran successfully @04.11400s +00.00200s
|`->config-set_hostname ran successfully @04.11600s +00.00800s
|`->config-update_hostname ran successfully @04.12400s +00.00100s
|`->config-users_groups ran successfully @04.12500s +00.32900s
|`->config-ssh ran successfully @04.45400s +00.53100s
Finished stage: (init-network) 01.84500 seconds

Starting stage: modules-config
|`->config-ubuntu_autoinstall ran successfully @06.02300s +03.35600s
|`->config-ssh_import_id ran successfully @09.37900s +00.00000s
|`->config-locale ran successfully @09.37900s +00.00100s
|`->config-set_passwords ran successfully @09.38000s +00.00000s
|`->config-grub_dpkg ran successfully @09.38000s +00.19700s
|`->config-apt_configure ran successfully @09.57700s +00.02700s
|`->config-runcmd ran successfully @09.60400s +00.00000s
|`->config-byobu ran successfully @09.60400s +00.00000s
Finished stage: (modules-config) 03.66600 seconds

Starting stage: modules-final
|`->config-reset_rmc ran successfully @09.95200s +00.00500s
|`->config-rightscale_userdata ran successfully @09.95700s +00.00100s
|`->config-scripts_vendor ran successfully @09.95800s +00.00000s
|`->config-scripts_per_once ran successfully @09.95800s +00.00000s
|`->config-scripts_per_boot ran successfully @09.95800s +00.00000s
|`->config-scripts_per_instance ran successfully @09.95800s +00.00100s
|`->config-scripts_user ran successfully @09.95900s +00.00000s
|`->config-ssh_authkey_fingerprints ran successfully @09.96000s +00.01200s
|`->config-keys_to_console ran successfully @09.97200s +00.07600s
|`->config-install_hotplug ran successfully @10.04800s +00.00100s
|`->config-final_message ran successfully @10.05300s +00.00500s
Finished stage: (modules-final) 00.18100 seconds

Total Time: 6.56300 seconds

1 boot records analyzed
--- egrep 'snap.*wait' /var/log/cloud-init.log  ---
2023-10-19 21:41:28,055 - subp.py[DEBUG]: Running command ['snap', 'wait', 'system', 'seed.loaded'] with allowed return codes [0] (shell=False, capture=True)

```
</details>

TODO:
- boot time comparisons before/after changeset with and without snap-dependent user-data 
- integration test coverage


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
    drop systemd order After=snapd.seeded.service from cloud-config.service
    
    Dropping a hard ordering dependency `After=snapd.seeded.service`
    allows cloud-config.service to proceed with cloud-config module setup
    earlier in initial boot allowing for faster time to SSH to an instance booting.
    Instead, config modules which rely on snap setup now directly call
    "snap system wait seed.loaded" if user-data requires that snaps are
    present and seeded.

    The modules cc_snap, cc_lxd, cc_ubuntu_autoinstall and cc_runcmd
    are the only modules that may strictly rely on snaps being seeded
    during initial boot.
    
    Add`util.wait_for_snap_seeded` and a semaphore runner to limit to
    frequency PER_ONCE which calls snap wait system seed.loaded only
    one time and will NOOP when multiple cloud-config modules attempt
    to wait on snaps.
    
    Add this helper to each affected cloud-config module: snap, lxd,
    ubuntu_autoinstall and runcmd.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
