### PR TITLE
fix(cmdline): fix cmdline parsing with MAC containing cc:

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1166,7 +1166,8 @@ def read_cc_from_cmdline(cmdline=None):
     if cmdline is None:
         cmdline = get_cmdline()
 
-    tag_begin = "cc:"
+    cmdline = f" {cmdline}"
+    tag_begin = " cc:"
     tag_end = "end_cc"
     begin_l = len(tag_begin)
     end_l = len(tag_end)

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1457,6 +1457,19 @@ class TestReadCcFromCmdline:
                 "cc:runcmd%3A%20%5B%20%5B%20ls%2C%20-l%20%5D%20%5D end_cc",
                 {"ssh_import_id": ["smoser"], "runcmd": [["ls", "-l"]]},
             ),
+            # Parse cmdlines that contain an IPv6 with cc: in different
+            # positions
+            ("BOOTIF=aa:bb:cc:dd bar", None),
+            ("BOOTIF=aa:bb:cc:dd cc: end_cc bar", None),
+            ("BOOTIF=aa:bb:cc:dd cc: ssh_pwauth: true", {"ssh_pwauth": True}),
+            (
+                "BOOTIF=aa:bb:cc:dd cc: ssh_pwauth: true end_cc",
+                {"ssh_pwauth": True},
+            ),
+            (
+                "cc: ssh_pwauth: true end_cc BOOTIF=aa:bb:cc:dd",
+                {"ssh_pwauth": True},
+            ),
         ],
     )
     def test_read_conf_from_cmdline_config(self, expected_cfg, cmdline):


### PR DESCRIPTION
## Rebase and merge please

## Additional Context
<!-- If relevant -->
Follow up of https://github.com/canonical/cloud-init/pull/4477

The chances of ds-idenfy being affected by this issue are very small, as it searches for the presence of `cc:` and `datasource_list` and if so parses the array following `datasource_list`. See, https://github.com/canonical/cloud-init/blob/14b76c4448e817570699421b27e234d60cf40bbb/tools/ds-identify#L591

I think this change is sufficient as cloud-configs contained in kernel cmdline are expected to be fairly simple, and even if a `cc:` would be needed within a `cc: end_cc`, then that `cc:` could be url-encoded bypassing this problem.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
