### PR TITLE
test: unpin pytest

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -3,11 +3,11 @@
 #
 pycloudlib==1!5.6.0
 
-# Await pytest > 7.3.2. Breaking change in `testpaths` treatment forced
+# Avoid breaking change in `testpaths` treatment forced
 # test/unittests/conftest.py to be loaded by our integration-tests tox env
 # resulting in an unmet dependency issue:
 # https://github.com/pytest-dev/pytest/issues/11104
-pytest<=7.3.1
+pytest!=7.3.2
 
 packaging
 passlib

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,10 @@
 # Needed generally in tests
 
-# Await pytest > 7.3.2. Breaking change in `testpaths` treatment forced
+# Avoid breaking change in `testpaths` treatment forced
 # test/unittests/conftest.py to be loaded by our integration-tests tox env
 # resulting in an unmet dependency issue:
 # https://github.com/pytest-dev/pytest/issues/11104
-pytest<=7.3.1
+pytest!=7.3.2
 
 pytest-cov
 pytest-mock

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -210,8 +210,11 @@ def parse_pip_requirements(requirements_path):
             dep = line.split(";")[0]
 
             # remove version requirements
-            if re.search("[>=.<]+", dep):
-                dep_names.append(re.split(r"[>=.<]+", dep)[0].strip())
+            version_comparison = re.compile(r"[~!>=.<]+")
+            if version_comparison.search(dep):
+                dep_names.append(
+                    version_comparison.split(dep)[0].strip()
+                )
             else:
                 dep_names.append(dep)
     return dep_names


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
test: unpin pytest

After https://github.com/pytest-dev/pytest/pull/11125 being
included in pytest==7.4, pytest can be unpinned.
```

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/pull/4184
https://github.com/pytest-dev/pytest/issues/11104
https://github.com/pytest-dev/pytest/pull/11125#issuecomment-1600235619

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
tox -re integration-tests -- --collect-only tests/integration_tests/
```

With pytest==7.3.2 the following traceback appeared:

```
ImportError while loading conftest '/home/aciba/canonical/cloud-init/tests/unittests/conftest.py'.                                                                                                                 
tests/unittests/conftest.py:11: in <module>                                                                                                                                                                        
    from tests.unittests.helpers import retarget_many_wrapper                                                                                                                                                      
tests/unittests/helpers.py:21: in <module>                                                                                                                                                                         
    import responses                                                                                                                                                                                               
E   ModuleNotFoundError: No module named 'responses'                                                                                                                                                               
ERROR: InvocationError for command '/home/aciba/canonical/cloud-init/.tox/integration-tests/bin/python -m pytest -vv --log-cli-level=INFO --durations 10 --collect-only tests/integration_tests' (exited with code 
4) 
```

With this change no traceback appears.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
