### PR TITLE
Ubuntu/focal 23.3.x

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+23.3.3
+ - Fix pip-managed ansible on pip < 23.0.1 (#4403)
+
 23.3.2
  - Revert "ds-identify/CloudStack: $DS_MAYBE if vm running on vmware/xen (#4281)"
    (#4511) (LP: #2039453)

--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -3,6 +3,7 @@ import abc
 import os
 import re
 import sys
+import sysconfig
 from copy import deepcopy
 from logging import getLogger
 from textwrap import dedent
@@ -141,8 +142,13 @@ class AnsiblePullPip(AnsiblePull):
                 "-m",
                 "pip",
                 "install",
-                "--break-system-packages",
             ]
+            if os.path.exists(
+                os.path.join(
+                    sysconfig.get_path("stdlib"), "EXTERNALLY-MANAGED"
+                )
+            ):
+                cmd.append("--break-system-packages")
             if self.run_user:
                 cmd.append("--user")
             self.do_as([*cmd, "--upgrade", "pip"])

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "23.3.2"
+__VERSION__ = "23.3.3"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (23.3.3-0ubuntu0~20.04.1) UNRELEASED; urgency=medium
+
+  * Upstream snapshot based on 23.3.3. (LP: #2040291).
+    List of changes from upstream can be found at
+    https://raw.githubusercontent.com/canonical/cloud-init/23.3.3/ChangeLog
+
+ -- James Falcon <james.falcon@canonical.com>  Tue, 24 Oct 2023 10:59:25 -0500
+
 cloud-init (23.3.2-0ubuntu0~20.04.1) focal; urgency=medium
 
   * d/p/do-not-block-user-login.patch:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-cloud-init (23.3.3-0ubuntu0~20.04.1) UNRELEASED; urgency=medium
+cloud-init (23.3.3-0ubuntu0~20.04.1) focal; urgency=medium
 
   * Upstream snapshot based on 23.3.3. (LP: #2040291).
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/23.3.3/ChangeLog
 
- -- James Falcon <james.falcon@canonical.com>  Tue, 24 Oct 2023 10:59:25 -0500
+ -- James Falcon <james.falcon@canonical.com>  Tue, 24 Oct 2023 10:59:56 -0500
 
 cloud-init (23.3.2-0ubuntu0~20.04.1) focal; urgency=medium
 


### PR DESCRIPTION
new_upstream_snapshot.py -c 23.3.3 -b 2040291

I popped off the quilt refresh as it isn't necessary and adds noise to the hotfix