### PR TITLE
netplan: ensure ethernets is first key when rendering v2 passthrough

### DIFF
--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -372,7 +372,7 @@ class Renderer(renderer.Renderer):
         """
         content = []
         content.append("network:\n    version: 2\n")
-        to_render = ['ethernets'] + [
+        to_render = ["ethernets"] + [
             sec for sec in config.keys()
             if sec not in ["ethernets", "version"]]
         for section in to_render:

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -48,10 +48,12 @@ def _get_params_dict_by_match(config, match):
 # workaround yaml dictionary key sorting when dumping
 def _render_section(name, section):
     if section:
-        dump = safeyaml.dumps({name: section},
-                              explicit_start=False,
-                              explicit_end=False,
-                              noalias=True)
+        dump = safeyaml.dumps(
+            {name: section},
+            explicit_start=False,
+            explicit_end=False,
+            noalias=True,
+        )
         txt = textwrap.indent(dump, " " * 4)
         return [txt]
     return []
@@ -365,16 +367,16 @@ class Renderer(renderer.Renderer):
             ) from last_exception
 
     def _render_passthrough(self, config):
-        """ Render netplan content as passthrough but ensure that
-            'ethernets' is the first key in the final netplan content. netplan
-            parser will fail if bond, bridges, vlans reference links which have
-            not be parsed.
+        """Render netplan content as passthrough but ensure that
+        'ethernets' is the first key in the final netplan content. netplan
+        parser will fail if bond, bridges, vlans reference links which have
+        not be parsed.
         """
         content = []
         content.append("network:\n    version: 2\n")
         to_render = ["ethernets"] + [
-            sec for sec in config.keys()
-            if sec not in ["ethernets", "version"]]
+            sec for sec in config.keys() if sec not in ["ethernets", "version"]
+        ]
         for section in to_render:
             content += _render_section(section, config[section])
         return "".join(content)

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -240,6 +240,7 @@ V2_TO_V2_NET_CFG_OUTPUT = """\
 # /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
 # network: {config: disabled}
 network:
+    version: 2
     ethernets:
         eth7:
             addresses:
@@ -247,7 +248,6 @@ network:
             gateway4: 192.168.1.254
         eth9:
             dhcp4: true
-    version: 2
 """
 
 
@@ -270,6 +270,7 @@ V2_PASSTHROUGH_NET_CFG_OUTPUT = """\
 # /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
 # network: {config: disabled}
 network:
+    version: 2
     ethernets:
         eth7:
             addresses:
@@ -279,7 +280,6 @@ network:
             -   metric: 100
                 to: default
                 via: 10.0.4.1
-    version: 2
 """
 
 

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -440,6 +440,23 @@ network:
 
 NETPLAN_BOND_GRAT_ARP = """
 network:
+    version: 2
+    ethernets:
+        ens3:
+            dhcp4: false
+            dhcp6: false
+            match:
+                macaddress: 52:54:00:ab:cd:ef
+        ens4:
+            dhcp4: false
+            dhcp6: false
+            match:
+                macaddress: 52:54:00:11:22:ff
+        ens5:
+            dhcp4: false
+            dhcp6: false
+            match:
+                macaddress: 52:54:00:99:11:99
     bonds:
         bond0:
             interfaces:
@@ -460,23 +477,6 @@ network:
             - ens5
             macaddress: 68:05:ca:64:d3:6e
             mtu: 9000
-    ethernets:
-        ens3:
-            dhcp4: false
-            dhcp6: false
-            match:
-                macaddress: 52:54:00:ab:cd:ef
-        ens4:
-            dhcp4: false
-            dhcp6: false
-            match:
-                macaddress: 52:54:00:11:22:ff
-        ens5:
-            dhcp4: false
-            dhcp6: false
-            match:
-                macaddress: 52:54:00:99:11:99
-    version: 2
 """
 
 NETPLAN_DHCP_FALSE = """
@@ -2126,11 +2126,11 @@ NETWORK_CONFIGS = {
         "expected_netplan": textwrap.dedent(
             """
             network:
+                version: 2
                 ethernets:
                     iface0:
                         dhcp4: true
                         wakeonlan: false
-                version: 2
         """
         ),
         "expected_sysconfig_opensuse": {
@@ -2201,11 +2201,11 @@ NETWORK_CONFIGS = {
         "expected_netplan": textwrap.dedent(
             """
             network:
+                version: 2
                 ethernets:
                     iface0:
                         dhcp4: true
                         wakeonlan: true
-                version: 2
         """
         ),
         "expected_sysconfig_opensuse": {
@@ -3316,6 +3316,17 @@ iface bond0 inet6 static
         "expected_netplan-v2": textwrap.dedent(
             """
          network:
+             version: 2
+             ethernets:
+                 eth0:
+                     match:
+                         driver: virtio_net
+                         macaddress: aa:bb:cc:dd:e8:00
+                 vf0:
+                     match:
+                         driver: e1000
+                         macaddress: aa:bb:cc:dd:e8:01
+                     set-name: vf0
              bonds:
                  bond0:
                      addresses:
@@ -3344,17 +3355,6 @@ iface bond0 inet6 static
                      -   metric: 10000
                          to: 3001:67c:15:8007::1/64
                          via: 3001:67c:15:8007::aac:40b2
-             ethernets:
-                 eth0:
-                     match:
-                         driver: virtio_net
-                         macaddress: aa:bb:cc:dd:e8:00
-                 vf0:
-                     match:
-                         driver: e1000
-                         macaddress: aa:bb:cc:dd:e8:01
-                     set-name: vf0
-             version: 2
         """
         ),
         "expected_sysconfig_opensuse": {


### PR DESCRIPTION
## Proposed Commit Message

```
netplan: ensure ethernets is first key when rendering v2 passthrough

Render netplan content as passthrough but ensure that 'ethernets' is the first
key in the final netplan content. netplan parser will fail if bonds, bridges,
and vlans reference links which have not be parsed

LP: #2040295
```

## Additional Context

`netplan generate` and/or `netplan apply` have had issues with referencing
interfaces that have yet to be parsed ( at least in focal and jammy); it may
be the case that newer netplan releases have resolved this issue.

## Test Steps

```
$ lxc launch ubuntu-daily:jammy j2
$ lxc exec j2 /bin/bash
cat >test.yaml <<EOF
network:
  version: 2
  ethernets:
    eth1-1:
      match:
        name: "eth1-1"
      dhcp4: true
    eth1-2:
      match:
        name: "eth1-2"
      dhcp4: true
  bridges:
    oobmgmt:
      addresses: [10.24.232.207/23]
      interfaces: []
EOF
$ cloud-init devel net-convert --network-data test.yaml -k yaml -d nplantest -D ubuntu -O netplan --debug
$ cat nplantest/etc/netplan/50-cloud-init.yaml
# This file is generated from information provided by the datasource.  Changes
# to it will not persist across an instance reboot.  To disable cloud-init's
# network configuration capabilities, write a file
# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
# network: {config: disabled}
network:
    bridges:
        oobmgmt:
            addresses:
            - 10.24.232.207/23
            interfaces: []
    ethernets:
        eth1-1:
            dhcp4: true
            match:
                name: eth1-1
        eth1-2:
            dhcp4: true
            match:
                name: eth1-2
    version: 2

```

## Checklist
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
