### PR TITLE
Fix 

### DIFF
--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -183,9 +183,22 @@ class TestCollectLogs:
                 subp(cmd)  # Pass through tar cmd so we can check output
             return SubpResult(expected_subp[cmd_tuple], "")
 
+        def fake_subprocess_call(cmd, stdout=None, stderr=None):
+            cmd_tuple = tuple(cmd)
+            if cmd_tuple not in expected_subp:
+                raise AssertionError(
+                    "Unexpected command provided to subprocess: {0}".format(
+                        cmd
+                    )
+                )
+            stdout.write(expected_subp[cmd_tuple])
+
         fake_stderr = mock.MagicMock()
 
         mocker.patch(M_PATH + "subp", side_effect=fake_subp)
+        mocker.patch(
+            M_PATH + "subprocess.call", side_effect=fake_subprocess_call
+        )
         mocker.patch(M_PATH + "sys.stderr", fake_stderr)
         mocker.patch(M_PATH + "CLOUDINIT_LOGS", [log1, log2])
         mocker.patch(M_PATH + "CLOUDINIT_RUN_DIR", run_dir)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
```
fix: added mock to stop leaking journalctl that slows down unit test

In test_logs.py, test_collect_logs_includes_optional_userdata() would leak the
journalctl subprocess call because it did not mock subprocess.call() like
test_collect_logs_creates_tarfile() does. This would cause the unit test to
take a long time to run because it was calling the actual journalctl command.

Fixes GH-4536 (GitHub Issue number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
