### PR TITLE
azure: report failure to host if ephemeral DHCP was on a secondary NIC

### DIFF
--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -8,7 +8,7 @@ import logging
 import traceback
 from datetime import datetime
 from io import StringIO
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 import requests
 
@@ -105,6 +105,25 @@ class ReportableErrorDhcpLease(ReportableError):
 
         self.supporting_data["duration"] = duration
         self.supporting_data["interface"] = interface
+
+
+class ReportableErrorDhcpOnNonPrimaryInterface(ReportableError):
+    def __init__(
+        self,
+        *,
+        interface: Optional[str],
+        driver: Optional[str],
+        router: Optional[str],
+        static_routes: Optional[List[Tuple[str, str]]],
+        lease: Dict[str, Any],
+    ) -> None:
+        super().__init__("failure to find primary DHCP interface")
+
+        self.supporting_data["interface"] = interface
+        self.supporting_data["driver"] = driver
+        self.supporting_data["router"] = router
+        self.supporting_data["static_routes"] = static_routes
+        self.supporting_data["lease"] = lease
 
 
 class ReportableErrorImdsUrlError(ReportableError):

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3918,7 +3918,11 @@ class TestProvisioning:
         # Verify DHCP is setup twice.
         assert self.mock_wrapping_setup_ephemeral_networking.mock_calls == [
             mock.call(timeout_minutes=20),
-            mock.call(iface="ethAttached1", timeout_minutes=20),
+            mock.call(
+                iface="ethAttached1",
+                timeout_minutes=20,
+                report_failure_if_not_primary=False,
+            ),
         ]
         assert self.mock_net_dhcp_maybe_perform_dhcp_discovery.mock_calls == [
             mock.call(
@@ -4066,7 +4070,11 @@ class TestProvisioning:
         # Verify DHCP is setup twice.
         assert self.mock_wrapping_setup_ephemeral_networking.mock_calls == [
             mock.call(timeout_minutes=20),
-            mock.call(iface="ethAttached1", timeout_minutes=20),
+            mock.call(
+                iface="ethAttached1",
+                timeout_minutes=20,
+                report_failure_if_not_primary=False,
+            ),
         ]
         assert self.mock_net_dhcp_maybe_perform_dhcp_discovery.mock_calls == [
             mock.call(


### PR DESCRIPTION
Azure requires the use of the primary interface to query IMDS and report ready to wireserver.  If we determine that the interface is not the primary interface, report the failure to the host.

The exception is when iterating over hotplugged NICs in the Savable PPS scenario.  In this case the secondary may be enumerated first and we would expect a failure.