### PR TITLE
fix(cli): fix parsing of argparse subcommands

### DIFF
--- a/bash_completion/cloud-init
+++ b/bash_completion/cloud-init
@@ -11,7 +11,7 @@ _cloudinit_complete()
     prev_word="${COMP_WORDS[COMP_CWORD-1]}"
 
     subcmds="analyze clean collect-logs devel features init modules query schema single status"
-    base_params="--help --file --version --debug --force"
+    base_params="--help --version --debug --force"
     case ${COMP_CWORD} in
         1)
             COMPREPLY=($(compgen -W "$base_params $subcmds" -- $cur_word))
@@ -34,10 +34,10 @@ _cloudinit_complete()
                     COMPREPLY=($(compgen -W "--help" -- $cur_word))
                     ;;
                 init)
-                    COMPREPLY=($(compgen -W "--help --local" -- $cur_word))
+                    COMPREPLY=($(compgen -W "--help --local --file" -- $cur_word))
                     ;;
                 modules)
-                    COMPREPLY=($(compgen -W "--help --mode" -- $cur_word))
+                    COMPREPLY=($(compgen -W "--help --mode --file" -- $cur_word))
                     ;;
 
                 query)
@@ -46,7 +46,7 @@ _cloudinit_complete()
                     COMPREPLY=($(compgen -W "--help --config-file --docs --annotate --system" -- $cur_word))
                     ;;
                 single)
-                    COMPREPLY=($(compgen -W "--help --name --frequency --report" -- $cur_word))
+                    COMPREPLY=($(compgen -W "--help --name --frequency --report --file" -- $cur_word))
                     ;;
                 status)
                     COMPREPLY=($(compgen -W "--help --long --wait" -- $cur_word))

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -863,14 +863,6 @@ def main(sysv_args=None):
         help="Show program's version number and exit.",
     )
     parser.add_argument(
-        "--file",
-        "-f",
-        action="append",
-        dest="files",
-        help="Use additional yaml configuration files.",
-        type=argparse.FileType("rb"),
-    )
-    parser.add_argument(
         "--debug",
         "-d",
         action="store_true",
@@ -903,6 +895,14 @@ def main(sysv_args=None):
         help="Start in local mode (default: %(default)s).",
         default=False,
     )
+    parser_init.add_argument(
+        "--file",
+        "-f",
+        action="append",
+        dest="files",
+        help="Use additional yaml configuration files.",
+        type=argparse.FileType("rb"),
+    )
     # This is used so that we can know which action is selected +
     # the functor to use to run this subcommand
     parser_init.set_defaults(action=("init", main_init))
@@ -918,6 +918,14 @@ def main(sysv_args=None):
         help="Module configuration name to use (default: %(default)s).",
         default="config",
         choices=("init", "config", "final"),
+    )
+    parser_mod.add_argument(
+        "--file",
+        "-f",
+        action="append",
+        dest="files",
+        help="Use additional yaml configuration files.",
+        type=argparse.FileType("rb"),
     )
     parser_mod.set_defaults(action=("modules", main_modules))
 
@@ -950,6 +958,14 @@ def main(sysv_args=None):
         nargs="*",
         metavar="argument",
         help="Any additional arguments to pass to this module.",
+    )
+    parser_single.add_argument(
+        "--file",
+        "-f",
+        action="append",
+        dest="files",
+        help="Use additional yaml configuration files.",
+        type=argparse.FileType("rb"),
     )
     parser_single.set_defaults(action=("single", main_single))
 
@@ -989,7 +1005,10 @@ def main(sysv_args=None):
 
     if sysv_args:
         # Only load subparsers if subcommand is specified to avoid load cost
-        subcommand = sysv_args[0]
+        subcommand = next(
+            (posarg for posarg in sysv_args if not posarg.startswith("-")),
+            None,
+        )
         if subcommand == "analyze":
             from cloudinit.analyze import get_parser as analyze_parser
 

--- a/doc/man/cloud-init.1
+++ b/doc/man/cloud-init.1
@@ -26,10 +26,6 @@ Show help message and exit.
 Show additional pre-action logging (default: False).
 
 .TP
-.B "-f <files>, --files <files>"
-Use additional YAML configuration files.
-
-.TP
 .B "--force"
 Force running even if no datasource is found (use at your own risk).
 

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -15,14 +15,12 @@ Example output:
 
 .. code-block::
 
-   usage: cloud-init [-h] [--version] [--file FILES] [--debug] [--force]
+   usage: cloud-init [-h] [--version] [--debug] [--force]
                                                                {init,modules,single,query,features,analyze,devel,collect-logs,clean,status,schema} ...
 
     options:
       -h, --help            show this help message and exit
       --version, -v         Show program's version number and exit.
-      --file FILES, -f FILES
-                            Use additional yaml configuration files.
       --debug, -d           Show additional pre-action logging (default: False).
       --force               Force running even if no datasource is found (use at your own risk).
 
@@ -173,6 +171,7 @@ due to semaphores in :file:`/var/lib/cloud/instance/sem/` and
 :file:`/var/lib/cloud/sem`.
 
 * :command:`--local`: Run *init-local* stage instead of *init*.
+* :command:`--file` : Use additional yaml configuration files.
 
 .. _cli_modules:
 
@@ -195,6 +194,7 @@ to semaphores in :file:`/var/lib/cloud/`.
 * :command:`--mode [init|config|final]`: Run ``modules:init``,
   ``modules:config`` or ``modules:final`` ``cloud-init`` stages.
   See :ref:`boot_stages` for more info.
+* :command:`--file` : Use additional yaml configuration files.
 
 .. _cli_query:
 
@@ -335,6 +335,7 @@ Attempt to run a single, named, cloud config module.
 * :command:`--frequency`: Module frequency for this run.
   One of (``always``|``once-per-instance``|``once``).
 * :command:`--report`: Enable reporting.
+* :command:`--file` : Use additional yaml configuration files.
 
 The following example re-runs the ``cc_set_hostname`` module ignoring the
 module default frequency of ``once-per-instance``:

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -166,6 +166,19 @@ class TestMain(FilesystemMockingTestCase):
         for log in expected_logs:
             self.assertIn(log, self.stderr.getvalue())
 
+    @mock.patch("cloudinit.cmd.clean.get_parser")
+    @mock.patch("cloudinit.cmd.clean.handle_clean_args")
+    @mock.patch("cloudinit.log.configure_root_logger")
+    def test_main_sys_argv(
+        self,
+        _m_configure_root_logger,
+        _m_handle_clean_args,
+        m_clean_get_parser,
+    ):
+        with mock.patch("sys.argv", ["cloudinit", "--debug", "clean"]):
+            main.main()
+        m_clean_get_parser.assert_called_once()
+
 
 class TestShouldBringUpInterfaces:
     @pytest.mark.parametrize(


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->


We are currently not parsing the subcommands correctly. 
This causes the high-level arguments to make parsing of subcommand be erroneous.
Fixes
LP: #2040325


## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
The steps listed in [this LP bug](https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2040325) are sufficient and well explained.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
