### PR TITLE
fix schema integration test regressions: invalid header and expected output from schema --system CLI

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1491,6 +1491,19 @@ def handle_schema_args(name, args):
                 sys_exit=True,
             )
             return  # Helps typing
+
+        # Prefer raw user-data.txt when processed cloud-config is empty and
+        # raw user-data.txt is not because processed cloud-config.txt will
+        # not be written in cases where user-data header is not supported.
+        try:
+            if os.stat(userdata_file).st_size == 0:
+                raw_userdata_file = paths.get_ipath("userdata_raw")
+                if os.stat(raw_userdata_file).st_size:
+                    userdata_file = raw_userdata_file
+        except FileNotFoundError:
+            # Error handling on absent userdata_file below
+            pass
+
         config_files = (("user-data", userdata_file),)
         supplemental_config_files = (
             ("vendor-data", paths.get_ipath("vendor_cloud_config")),

--- a/tests/integration_tests/cmd/test_schema.py
+++ b/tests/integration_tests/cmd/test_schema.py
@@ -70,6 +70,6 @@ class TestSchemaDeprecations:
             # D3: Default: ``false``. Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
 
 
-            Valid cloud-config: /root/user-data"""  # noqa: E501
+            Valid schema /root/user-data"""  # noqa: E501
         )
         assert expected_output in annotated_result.stdout

--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -42,7 +42,7 @@ def test_valid_userdata(client: IntegrationInstance):
     """
     result = client.execute("cloud-init schema --system")
     assert result.ok
-    assert "Valid cloud-config: user-data" in result.stdout.strip()
+    assert "Valid schema user-data" in result.stdout.strip()
     result = client.execute("cloud-init status --long")
     if not result.ok:
         raise AssertionError(


### PR DESCRIPTION
# rebase merge separate commits


## Proposed Commit Message
```
*  tests: fix schema test expected cli output Valid schema <type>

*   fix(schema cli): check raw userdata when processed cloud-config empty

    The processed userdata file /var/lib/cloud/instance/cloud-config.txt
    will be empty when invalid user-data headers are declared.
    
    When cloud-init schema --system finds an empty
    /var/lib/cloud/instance/cloud-config.txt prefer to validate a
    non-empty unprocessed raw userdata file at
    /var/lib/cloud/instance/user-data.txt.
    
    This allows the CLI to provide actionable error messages about
    unsupported header declarations in raw userdata.
```

## Additional Context
<!-- If relevant -->
Fix [Jenkins job]( integration test failures:

-  commit 1: one behavioral regression in `cloud-init schema --system` not reporting invalid user-data header types https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-azure/335/testReport/junit/tests.integration_tests.modules/test_cli/test_invalid_userdata/
- commit 2: fix test regression. integration test expecting wrong successful output from cloud-init schema --system https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-azure/335/testReport/junit/tests.integration_tests.modules/test_cli/test_valid_userdata/
- https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-lunar-gce/177/testReport/junit/tests.integration_tests.cmd.test_schema/TestSchemaDeprecations/test_schema_deprecations/


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
./tools/run-container --package ubuntu/jammy
CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init*bddeb.deb CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily .tox/integration-tests/bin/pytest tests/integration_tests/modules/test_cli.py
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
