### PR TITLE
fix d/p/do-not-block-user-login.patch

### DIFF
--- a/debian/patches/do-not-block-user-login.patch
+++ b/debian/patches/do-not-block-user-login.patch
@@ -16,3 +16,13 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  Wants=network-online.target cloud-config.target
  ConditionPathExists=!/etc/cloud/cloud-init.disabled
  ConditionKernelCommandLine=!cloud-init=disabled
+--- a/systemd/cloud-init.service.tmpl
++++ b/systemd/cloud-init.service.tmpl
+@@ -38,6 +38,7 @@ Conflicts=shutdown.target
+ Before=shutdown.target
+ Conflicts=shutdown.target
+ {% endif %}
++Before=systemd-user-sessions.service
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+ ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled


### PR DESCRIPTION
## Proposed Commit Message
```
Commit f17b889d unintentionally redacted the second part of the changeset moving Before=systemd-user-sessions.service from cloud-config.service back into cloud-init.service.

Replace the dropped patchset.
```

## Testing
test that daily recipe builds will build effetively:
```
git checkout main
git merge blackboxsw/ubuntu/devel
quilt push -a; git diff; quilt pop -a
build-package
sbuild --dist=mantic --arch=amd64 --arch-all ../out/cloud-init_23*dsc
```

## additional context
Additional branches for:
* [focal](https://github.com/canonical/cloud-init/compare/ubuntu/focal...blackboxsw:cloud-init:ubuntu/focal)
* [jammy](https://github.com/canonical/cloud-init/compare/ubuntu/jammy...blackboxsw:cloud-init:ubuntu/jammy)
* [lunar](https://github.com/canonical/cloud-init/compare/ubuntu/lunar...blackboxsw:cloud-init:ubuntu/lunar)