### PR TITLE
Test fix warning error codes

### DIFF
--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -61,16 +61,18 @@ def test_invalid_userdata(client: IntegrationInstance):
     """
     result = client.execute("cloud-init schema --system")
     assert not result.ok
+    assert (
+        2 == result.return_code
+    ), f"Unexpected exit code {result.return_code}"
     assert "Cloud config schema errors" in result.stderr
     assert (
         "Expected first line to be one of: #!, ## template: jinja,"
         " #cloud-boothook, #cloud-config" in result.stderr
     )
     result = client.execute("cloud-init status --long")
-    if not result.ok:
-        raise AssertionError(
-            f"Unexpected error from cloud-init status: {result}"
-        )
+    assert (
+        2 == result.return_code
+    ), f"Unexpected exit code {result.return_code}"
 
 
 @pytest.mark.user_data(INVALID_USER_DATA_SCHEMA)
@@ -80,7 +82,9 @@ def test_invalid_userdata_schema(client: IntegrationInstance):
     PR #1175
     """
     result = client.execute("cloud-init status --long")
-    assert result.ok
+    assert (
+        2 == result.return_code
+    ), f"Unexpected exit code {result.return_code}"
     log = client.read_from_file("/var/log/cloud-init.log")
     warning = (
         "[WARNING]: Invalid cloud-config provided: Please run "


### PR DESCRIPTION
## rebase and merge

```
tests: fix integration test expectations of exit 2 on schema warning

Commit 70acb7f2a introduced exit code 2 for schema warnings.
Update cli integration tests to expect return_code == 2 on invalid
schema.
```

## Additional Context

Failed jenkins job: https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-lxd_container/102/


## Test Steps
```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_OS_IMAGE=jammy tox -e integration-tests  tests/integration_tests/modules/test_cli.py
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly
