### PR TITLE
azure/errors: include http code in reason for IMDS failure

### DIFF
--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -136,7 +136,7 @@ class ReportableErrorImdsUrlError(ReportableError):
         elif isinstance(exception.cause, requests.ReadTimeout):
             reason = "read timeout querying IMDS"
         elif exception.code:
-            reason = "http error querying IMDS"
+            reason = f"http error {exception.code} querying IMDS"
         else:
             reason = "unexpected error querying IMDS"
 

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -160,9 +160,16 @@ def test_dhcp_interface_not_found():
         (
             UrlError(
                 Exception(),
+                code=404,
+            ),
+            "http error 404 querying IMDS",
+        ),
+        (
+            UrlError(
+                Exception(),
                 code=500,
             ),
-            "http error querying IMDS",
+            "http error 500 querying IMDS",
         ),
         (
             UrlError(


### PR DESCRIPTION
Include the failing code in the reason to make it more prominent.