### PR TITLE
feat: Allow aliyun ds to fetch data in init-local

### DIFF
--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -36,6 +36,7 @@ from cloudinit.sources import DataSourceVultr as Vultr
 from tests.unittests import helpers as test_helpers
 
 DEFAULT_LOCAL = [
+    AliYun.DataSourceAliYunLocal,
     Azure.DataSourceAzure,
     CloudSigma.DataSourceCloudSigma,
     ConfigDrive.DataSourceConfigDrive,

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -85,6 +85,7 @@ kallioli
 klausenbusk
 KsenijaS
 landon912
+ld9379435
 licebmi
 linitio
 lkundrak


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
feat: Allow aliyun ds to fetch data in init-local

In Alibaba Cloud environment, cloud-init supports fetching data before the network services start.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly