### PR TITLE
net: Fix DHCPv4 not enabled on SUSE in some cases

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -429,7 +429,7 @@ class Renderer(renderer.Renderer):
             if subnet_type == "dhcp6" or subnet_type == "ipv6_dhcpv6-stateful":
                 if flavor == "suse":
                     # User wants dhcp for both protocols
-                    if iface_cfg["BOOTPROTO"] == "dhcp4":
+                    if iface_cfg["BOOTPROTO"] in ("dhcp4", "dhcp"):
                         iface_cfg["BOOTPROTO"] = "dhcp"
                     else:
                         # Only IPv6 is DHCP, IPv4 may be static
@@ -450,7 +450,7 @@ class Renderer(renderer.Renderer):
             elif subnet_type == "ipv6_dhcpv6-stateless":
                 if flavor == "suse":
                     # User wants dhcp for both protocols
-                    if iface_cfg["BOOTPROTO"] == "dhcp4":
+                    if iface_cfg["BOOTPROTO"] in ("dhcp4", "dhcp"):
                         iface_cfg["BOOTPROTO"] = "dhcp"
                     else:
                         # Only IPv6 is DHCP, IPv4 may be static
@@ -468,7 +468,7 @@ class Renderer(renderer.Renderer):
             elif subnet_type == "ipv6_slaac":
                 if flavor == "suse":
                     # User wants dhcp for both protocols
-                    if iface_cfg["BOOTPROTO"] == "dhcp4":
+                    if iface_cfg["BOOTPROTO"] in ("dhcp4", "dhcp"):
                         iface_cfg["BOOTPROTO"] = "dhcp"
                     else:
                         # Only IPv6 is DHCP, IPv4 may be static
@@ -484,7 +484,7 @@ class Renderer(renderer.Renderer):
                 if flavor == "suse":
                     # If dhcp6 is already specified the user wants dhcp
                     # for both protocols
-                    if bootproto_in != "dhcp6":
+                    if bootproto_in not in ("dhcp6", "dhcp"):
                         # Only IPv4 is DHCP, IPv6 may be static
                         iface_cfg["BOOTPROTO"] = "dhcp4"
             elif subnet_type in ["static", "static6"]:

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -481,7 +481,7 @@ class Renderer(renderer.Renderer):
             elif subnet_type in ["dhcp4", "dhcp"]:
                 bootproto_in = iface_cfg["BOOTPROTO"]
                 iface_cfg["BOOTPROTO"] = "dhcp"
-                if flavor == "suse" and subnet_type == "dhcp4":
+                if flavor == "suse":
                     # If dhcp6 is already specified the user wants dhcp
                     # for both protocols
                     if bootproto_in != "dhcp6":

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -988,6 +988,58 @@ iface eth1 inet static
 """.lstrip()
 
 NETWORK_CONFIGS = {
+    "small_v1_suse_dhcp6": {
+        "expected_sysconfig_opensuse": {
+            "ifcfg-eth1": textwrap.dedent(
+                """\
+                BOOTPROTO=static
+                LLADDR=cf:d6:af:48:e8:80
+                STARTMODE=auto"""
+            ),
+            "ifcfg-eth99": textwrap.dedent(
+                """\
+                BOOTPROTO=dhcp
+                DHCLIENT6_MODE=managed
+                LLADDR=c0:d6:9f:2c:e8:80
+                IPADDR=192.168.21.3
+                NETMASK=255.255.255.0
+                STARTMODE=auto"""
+            ),
+        },
+        "yaml": textwrap.dedent(
+            """
+            version: 1
+            config:
+                # Physical interfaces.
+                - type: physical
+                  name: eth99
+                  mac_address: c0:d6:9f:2c:e8:80
+                  subnets:
+                      - type: dhcp4
+                      - type: dhcp6
+                      - type: static
+                        address: 192.168.21.3/24
+                        dns_nameservers:
+                          - 8.8.8.8
+                          - 8.8.4.4
+                        dns_search: barley.maas sach.maas
+                        routes:
+                          - gateway: 65.61.151.37
+                            netmask: 0.0.0.0
+                            network: 0.0.0.0
+                            metric: 10000
+                - type: physical
+                  name: eth1
+                  mac_address: cf:d6:af:48:e8:80
+                - type: nameserver
+                  address:
+                    - 1.2.3.4
+                    - 5.6.7.8
+                  search:
+                    - wark.maas
+        """
+        ),
+    },
     "small_v1": {
         "expected_networkd_eth99": textwrap.dedent(
             """\
@@ -5803,6 +5855,12 @@ STARTMODE=auto
 
     def test_small_config_v1(self):
         entry = NETWORK_CONFIGS["small_v1"]
+        found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        self._compare_files_to_expected(entry[self.expected_name], found)
+        self._assert_headers(found)
+
+    def test_small_config_v1_suse(self):
+        entry = NETWORK_CONFIGS["small_v1_suse_dhcp6"]
         found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
         self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -2538,7 +2538,7 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
             ),
             "ifcfg-eth5": textwrap.dedent(
                 """\
-                BOOTPROTO=dhcp
+                BOOTPROTO=dhcp4
                 LLADDR=98:bb:9f:2c:e8:8a
                 STARTMODE=manual"""
             ),
@@ -5750,7 +5750,7 @@ STARTMODE=auto
         expected = """\
 # Created by cloud-init automatically, do not edit.
 #
-BOOTPROTO=dhcp
+BOOTPROTO=dhcp4
 STARTMODE=auto
 """
         self.assertEqual(expected, found[nspath + "ifcfg-eth0"])


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
net: Fix DHCPv4 not enabled on SUSE in some cases
```

## Additional Context

Fix follow issue:

```
#cloud-config
datasource_list: [NoCloud]
network:
  version: 1
  config:
    - type: physical
      name: eth0
      mac_address: 56:00:04:a2:c5:f0
      subnets:
        - type: dhcp
        - type: ipv6_dhcpv6-stateful
```

cloud-init devel net-convert -p test.cfg -k yaml -d out -O sysconfig -D opensuse
cat out/etc/sysconfig/network/ifcfg-eth0

```
# Created by cloud-init automatically, do not edit.
#
BOOTPROTO=dhcp6         # this shuold be dhcp
DHCLIENT6_MODE=managed
LLADDR=56:00:04:a2:c5:f0
STARTMODE=auto
```


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type
- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
