### PR TITLE
Fix deprecated log

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -41,6 +41,7 @@ from cloudinit.log import (
     setup_logging,
     reset_logging,
     configure_root_logger,
+    DEPRECATED,
 )
 from cloudinit.reporting import events
 from cloudinit.settings import PER_INSTANCE, PER_ALWAYS, PER_ONCE, CLOUD_CONFIG
@@ -220,11 +221,17 @@ def attempt_cmdline_url(path, network=True, cmdline=None) -> Tuple[int, str]:
                 is_cloud_cfg = False
             if is_cloud_cfg:
                 if cmdline_name == "url":
-                    util.deprecate(
-                        deprecated="The kernel command line key `url`",
-                        deprecated_version="22.3",
-                        extra_message=" Please use `cloud-config-url` "
-                        "kernel command line parameter instead",
+                    return (
+                        DEPRECATED,
+                        str(
+                            util.deprecate(
+                                deprecated="The kernel command line key `url`",
+                                deprecated_version="22.3",
+                                extra_message=" Please use `cloud-config-url` "
+                                "kernel command line parameter instead",
+                                return_log=True,
+                            ),
+                        ),
                     )
             else:
                 if cmdline_name == "cloud-config-url":

--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -22,6 +22,7 @@ from contextlib import suppress
 from typing import DefaultDict
 
 DEFAULT_LOG_FORMAT = "%(asctime)s - %(filename)s[%(levelname)s]: %(message)s"
+DEPRECATED = 35
 
 
 def setup_basic_logging(level=logging.DEBUG, formatter=None):
@@ -50,7 +51,7 @@ def flush_loggers(root):
     flush_loggers(root.parent)
 
 
-def define_deprecation_logger(lvl=35):
+def define_deprecation_logger(lvl=DEPRECATED):
     logging.addLevelName(lvl, "DEPRECATED")
 
     def deprecated(self, message, *args, **kwargs):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3236,6 +3236,7 @@ def deprecate(
     deprecated_version: str,
     extra_message: Optional[str] = None,
     schedule: int = 5,
+    return_log: bool = False,
 ):
     """Mark a "thing" as deprecated. Deduplicated deprecations are
     logged.
@@ -3252,6 +3253,8 @@ def deprecate(
     @param schedule: Manually set the deprecation schedule. Defaults to
         5 years. Leave a comment explaining your reason for deviation if
         setting this value.
+    @param return_log: Return log text rather than logging it. Useful for
+        running prior to logging setup.
 
     Note: uses keyword-only arguments to improve legibility
     """
@@ -3261,13 +3264,15 @@ def deprecate(
     dedup = hash(deprecated + message + deprecated_version + str(schedule))
     version = Version.from_str(deprecated_version)
     version_removed = Version(version.major + schedule, version.minor)
+    deprecate_msg = (
+        f"{deprecated} is deprecated in "
+        f"{deprecated_version} and scheduled to be removed in "
+        f"{version_removed}. {message}"
+    ).rstrip()
+    if return_log:
+        return deprecate_msg
     if dedup not in deprecate._log:  # type: ignore
         deprecate._log.add(dedup)  # type: ignore
-        deprecate_msg = (
-            f"{deprecated} is deprecated in "
-            f"{deprecated_version} and scheduled to be removed in "
-            f"{version_removed}. {message}"
-        ).rstrip()
         if hasattr(LOG, "deprecated"):
             LOG.deprecated(deprecate_msg)  # type: ignore
         else:


### PR DESCRIPTION
```
main: Don't call logging too early

A deprecate log was called before logging was set up. Fix it.
```
