### PR TITLE
azure: Check for stale pps data from IMDS

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -661,6 +661,15 @@ class DataSourceAzure(sources.DataSource):
             # fetch metadata again as it has changed after reprovisioning
             imds_md = self.get_metadata_from_imds(report_failure=True)
 
+            # validate imds pps metadata
+            imds_ppstype = self._ppstype_from_imds(imds_md)
+            if imds_ppstype != PPSType.NONE.value:
+                self._report_failure(
+                    errors.ReportableErrorImdsInvalidMetadata(
+                        key="extended.compute.ppsType", value=imds_ppstype
+                    )
+                )
+
         # Report errors if IMDS network configuration is missing data.
         self.validate_imds_network_metadata(imds_md=imds_md)
 

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -663,7 +663,7 @@ class DataSourceAzure(sources.DataSource):
 
             # validate imds pps metadata
             imds_ppstype = self._ppstype_from_imds(imds_md)
-            if imds_ppstype != PPSType.NONE.value:
+            if imds_ppstype is not None and imds_ppstype != PPSType.NONE.value:
                 self._report_failure(
                     errors.ReportableErrorImdsInvalidMetadata(
                         key="extended.compute.ppsType", value=imds_ppstype

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -663,7 +663,7 @@ class DataSourceAzure(sources.DataSource):
 
             # validate imds pps metadata
             imds_ppstype = self._ppstype_from_imds(imds_md)
-            if imds_ppstype is not None and imds_ppstype != PPSType.NONE.value:
+            if imds_ppstype not in (None, PPSType.NONE.value):
                 self._report_failure(
                     errors.ReportableErrorImdsInvalidMetadata(
                         key="extended.compute.ppsType", value=imds_ppstype

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -170,3 +170,11 @@ class ReportableErrorUnhandledException(ReportableError):
 
         self.supporting_data["exception"] = repr(exception)
         self.supporting_data["traceback_base64"] = trace_base64
+
+
+class ReportableErrorImdsInvalidMetadata(ReportableError):
+    def __init__(self, *, key: str, value: Any) -> None:
+        super().__init__(f"invalid IMDS metadata for key={key}")
+
+        self.supporting_data["key"] = key
+        self.supporting_data["value"] = repr(value)

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -225,3 +225,13 @@ def test_unhandled_exception():
 
     quoted_value = quote_csv_value(f"exception={source_error!r}")
     assert f"|{quoted_value}|" in error.as_encoded_report()
+
+
+def test_imds_invalid_metadata():
+    key = "compute"
+    value = "Running"
+    error = errors.ReportableErrorImdsInvalidMetadata(key=key, value=value)
+
+    assert error.reason == "invalid IMDS metadata for key=compute"
+    assert error.supporting_data["key"] == key
+    assert error.supporting_data["value"] == repr(value)

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3824,7 +3824,6 @@ class TestProvisioning:
         ]
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 1
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
         assert self.mock_kvp_report_failure_to_host.mock_calls == [

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import copy
+import datetime
 import json
 import os
 import stat
@@ -271,6 +272,14 @@ def mock_sleep():
 def mock_subp_subp():
     with mock.patch(MOCKPATH + "subp.subp", side_effect=[]) as m:
         yield m
+
+
+@pytest.fixture
+def mock_timestamp():
+    timestamp = datetime.datetime.utcnow()
+    with mock.patch.object(errors, "datetime", autospec=True) as m:
+        m.utcnow.return_value = timestamp
+        yield timestamp
 
 
 @pytest.fixture
@@ -3628,6 +3637,7 @@ class TestProvisioning:
         mock_netlink,
         mock_readurl,
         mock_subp_subp,
+        mock_timestamp,
         mock_util_ensure_dir,
         mock_util_find_devs_with,
         mock_util_load_file,
@@ -3656,6 +3666,7 @@ class TestProvisioning:
         self.mock_netlink = mock_netlink
         self.mock_readurl = mock_readurl
         self.mock_subp_subp = mock_subp_subp
+        self.mock_timestmp = mock_timestamp
         self.mock_util_ensure_dir = mock_util_ensure_dir
         self.mock_util_find_devs_with = mock_util_find_devs_with
         self.mock_util_load_file = mock_util_load_file
@@ -3759,13 +3770,79 @@ class TestProvisioning:
         assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 0
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
-    def test_running_pps(self):
-        self.imds_md["extended"]["compute"]["ppsType"] = "Running"
+    @pytest.mark.parametrize("pps_type", ["Savable", "Running"])
+    def test_stale_pps(self, pps_type):
+        imds_md_source = copy.deepcopy(self.imds_md)
+        imds_md_source["extended"]["compute"]["ppsType"] = pps_type
 
         nl_sock = mock.MagicMock()
         self.mock_netlink.create_bound_netlink_socket.return_value = nl_sock
         self.mock_readurl.side_effect = [
-            mock.MagicMock(contents=json.dumps(self.imds_md).encode()),
+            mock.MagicMock(contents=json.dumps(imds_md_source).encode()),
+            mock.MagicMock(contents=construct_ovf_env().encode()),
+            mock.MagicMock(contents=json.dumps(imds_md_source).encode()),
+        ]
+        self.mock_azure_get_metadata_from_fabric.return_value = []
+
+        self.azure_ds._check_and_get_data()
+
+        assert self.mock_readurl.mock_calls == [
+            mock.call(
+                "http://169.254.169.254/metadata/instance?"
+                "api-version=2021-08-01&extended=true",
+                exception_cb=mock.ANY,
+                headers={"Metadata": "true"},
+                infinite=True,
+                log_req_resp=True,
+                timeout=30,
+            ),
+            mock.call(
+                "http://169.254.169.254/metadata/reprovisiondata?"
+                "api-version=2019-06-01",
+                exception_cb=mock.ANY,
+                headers={"Metadata": "true"},
+                log_req_resp=False,
+                infinite=True,
+                timeout=30,
+            ),
+            mock.call(
+                "http://169.254.169.254/metadata/instance?"
+                "api-version=2021-08-01&extended=true",
+                exception_cb=mock.ANY,
+                headers={"Metadata": "true"},
+                infinite=True,
+                log_req_resp=True,
+                timeout=30,
+            ),
+        ]
+
+        # Verify DMI usage.
+        assert self.mock_dmi_read_dmi_data.mock_calls == [
+            mock.call("chassis-asset-tag"),
+            mock.call("system-uuid"),
+            mock.call("system-uuid"),
+        ]
+
+        # Verify reports via KVP.
+        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 1
+        assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
+
+        assert self.mock_kvp_report_failure_to_host.mock_calls == [
+            mock.call(
+                errors.ReportableErrorImdsInvalidMetadata(
+                    key="extended.compute.ppsType", value=pps_type
+                ),
+            ),
+        ]
+
+    def test_running_pps(self):
+        imds_md_source = copy.deepcopy(self.imds_md)
+        imds_md_source["extended"]["compute"]["ppsType"] = "Running"
+
+        nl_sock = mock.MagicMock()
+        self.mock_netlink.create_bound_netlink_socket.return_value = nl_sock
+        self.mock_readurl.side_effect = [
+            mock.MagicMock(contents=json.dumps(imds_md_source).encode()),
             mock.MagicMock(contents=construct_ovf_env().encode()),
             mock.MagicMock(contents=json.dumps(self.imds_md).encode()),
         ]
@@ -3868,7 +3945,8 @@ class TestProvisioning:
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
     def test_savable_pps(self):
-        self.imds_md["extended"]["compute"]["ppsType"] = "Savable"
+        imds_md_source = copy.deepcopy(self.imds_md)
+        imds_md_source["extended"]["compute"]["ppsType"] = "Savable"
 
         nl_sock = mock.MagicMock()
         self.mock_netlink.create_bound_netlink_socket.return_value = nl_sock
@@ -3877,7 +3955,7 @@ class TestProvisioning:
             "ethAttached1"
         )
         self.mock_readurl.side_effect = [
-            mock.MagicMock(contents=json.dumps(self.imds_md).encode()),
+            mock.MagicMock(contents=json.dumps(imds_md_source).encode()),
             mock.MagicMock(contents=construct_ovf_env().encode()),
             mock.MagicMock(contents=json.dumps(self.imds_md).encode()),
         ]
@@ -4006,7 +4084,8 @@ class TestProvisioning:
         ],
     )
     def test_savable_pps_early_unplug(self, fabric_side_effect):
-        self.imds_md["extended"]["compute"]["ppsType"] = "Savable"
+        imds_md_source = copy.deepcopy(self.imds_md)
+        imds_md_source["extended"]["compute"]["ppsType"] = "Savable"
 
         nl_sock = mock.MagicMock()
         self.mock_netlink.create_bound_netlink_socket.return_value = nl_sock
@@ -4015,7 +4094,7 @@ class TestProvisioning:
             "ethAttached1"
         )
         self.mock_readurl.side_effect = [
-            mock.MagicMock(contents=json.dumps(self.imds_md).encode()),
+            mock.MagicMock(contents=json.dumps(imds_md_source).encode()),
             mock.MagicMock(contents=construct_ovf_env().encode()),
             mock.MagicMock(contents=json.dumps(self.imds_md).encode()),
         ]
@@ -4135,10 +4214,11 @@ class TestProvisioning:
     @pytest.mark.parametrize("pps_type", ["Savable", "Running", "None"])
     def test_recovery_pps(self, pps_type):
         self.patched_reported_ready_marker_path.write_text("")
-        self.imds_md["extended"]["compute"]["ppsType"] = pps_type
+        imds_md_source = copy.deepcopy(self.imds_md)
+        imds_md_source["extended"]["compute"]["ppsType"] = pps_type
 
         self.mock_readurl.side_effect = [
-            mock.MagicMock(contents=json.dumps(self.imds_md).encode()),
+            mock.MagicMock(contents=json.dumps(imds_md_source).encode()),
             mock.MagicMock(contents=construct_ovf_env().encode()),
             mock.MagicMock(contents=json.dumps(self.imds_md).encode()),
         ]


### PR DESCRIPTION
## preferred commit message
```
azure: Check for stale pps data from IMDS

After reprovisioning, IMDS should return None value for PPS data
type.

Introduce a check to verify it IMDS is returning stale-PPS
data. In case of stale data, report the error to the host and allow
the VM to continue with provisioning. This is part of a larger effort
to improve error handling and error reporting during VM provisioning.
```

After reprovisioning, IMDS should return None value for PPS data type. This PR introduces a check to verify if IMDS is returning stale PPS data. In case of stale data, error will be reported to the host and VM will continue with provisioning.
This is a part of a large larg
