### PR TITLE
Revert "net: allow dhcp6 configuration from generate_fallback_configu…

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -571,12 +571,7 @@ def generate_fallback_config(config_driver=None):
         match = {
             "macaddress": read_sys_net_safe(target_name, "address").lower()
         }
-    cfg = {
-        "dhcp4": True,
-        "dhcp6": True,
-        "set-name": target_name,
-        "match": match,
-    }
+    cfg = {"dhcp4": True, "set-name": target_name, "match": match}
     if config_driver:
         driver = device_driver(target_name)
         if driver:

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -261,7 +261,6 @@ class TestGenerateFallbackConfig(CiTestCase):
                 "eth1": {
                     "match": {"macaddress": mac},
                     "dhcp4": True,
-                    "dhcp6": True,
                     "set-name": "eth1",
                 }
             },
@@ -279,7 +278,6 @@ class TestGenerateFallbackConfig(CiTestCase):
                 "eth0": {
                     "match": {"macaddress": mac},
                     "dhcp4": True,
-                    "dhcp6": True,
                     "set-name": "eth0",
                 }
             },
@@ -295,7 +293,6 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "eth0": {
                     "dhcp4": True,
-                    "dhcp6": True,
                     "match": {"macaddress": mac},
                     "set-name": "eth0",
                 }
@@ -362,7 +359,6 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "ens3": {
                     "dhcp4": True,
-                    "dhcp6": True,
                     "match": {"name": "ens3"},
                     "set-name": "ens3",
                 }

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4287,7 +4287,6 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "eth0": {
                     "dhcp4": True,
-                    "dhcp6": True,
                     "set-name": "eth0",
                     "match": {
                         "macaddress": "00:11:22:33:44:55",
@@ -4372,9 +4371,6 @@ iface lo inet loopback
 
 auto eth0
 iface eth0 inet dhcp
-
-# control-alias eth0
-iface eth0 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -4464,9 +4460,6 @@ iface lo inet loopback
 
 auto eth1
 iface eth1 inet dhcp
-
-# control-alias eth1
-iface eth1 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -4690,9 +4683,7 @@ class TestRhelSysConfigRendering(CiTestCase):
 #
 BOOTPROTO=dhcp
 DEVICE=eth1000
-DHCPV6C=yes
 HWADDR=07-1c-c6-75-a4-be
-IPV6INIT=yes
 NM_CONTROLLED=no
 ONBOOT=yes
 TYPE=Ethernet
@@ -5603,8 +5594,7 @@ class TestOpenSuseSysConfigRendering(CiTestCase):
             expected_content = """
 # Created by cloud-init automatically, do not edit.
 #
-BOOTPROTO=dhcp
-DHCLIENT6_MODE=managed
+BOOTPROTO=dhcp4
 LLADDR=07-1c-c6-75-a4-be
 STARTMODE=auto
 """.lstrip()
@@ -5986,10 +5976,6 @@ class TestNetworkManagerRendering(CiTestCase):
                 method=auto
                 may-fail=false
 
-                [ipv6]
-                method=auto
-                may-fail=false
-
                 """
                 ),
             },
@@ -6254,9 +6240,6 @@ iface lo inet loopback
 
 auto eth1000
 iface eth1000 inet dhcp
-
-# control-alias eth1000
-iface eth1000 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -6316,7 +6299,6 @@ class TestNetplanNetRendering:
                   ethernets:
                     eth1000:
                       dhcp4: true
-                      dhcp6: true
                       match:
                         macaddress: 07-1c-c6-75-a4-be
                       set-name: eth1000
@@ -7816,7 +7798,7 @@ class TestNetworkdNetRendering(CiTestCase):
             Name=eth1000
             MACAddress=07-1c-c6-75-a4-be
             [Network]
-            DHCP=yes"""
+            DHCP=ipv4"""
         ).rstrip(" ")
 
         expected = self.create_conf_dict(expected.splitlines())


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Revert "net: allow dhcp6 configuration from generate_fallback_configu…
…ration() (#4474)"

This reverts commit 518047aea93d502aefae808921b11d0cfe2e7fd9.

This commit could cause issues in bringing up the network, especially
because in non-netplan NetworkManager environments, may-fail=false .
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type
- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
