### PR TITLE
fix: Move cloud-final.service after time-sync.target

### DIFF
--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -1,7 +1,7 @@
 ## template:jinja
 [Unit]
 Description=Execute cloud user/final scripts
-After=network-online.target cloud-config.service rc-local.service
+After=network-online.target time-sync.target cloud-config.service rc-local.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 After=multi-user.target
 Before=apt-daily.service


### PR DESCRIPTION
## Proposed Commit Message
```
fix: Move cloud-final.service after time-sync.target

The cloud-final service (which may include apt or HTTPS operations
requiring certificate verification) must run after the clock has been
synchronized. Otherwise, systems lacking an RTC (notably the Raspberry
Pi) risk hitting the certificates that are valid "in the future" because
their clock is wrong.

This change was tested on Ubuntu mantic (23.10) server images on a
Raspberry Pi both connected to a LAN, and disconnected from a LAN. In
both cases, start-up time was not affected significantly, and
cloud-final started after time-sync had finished (successfully or
otherwise).

Fixes #3928
LP: #1951639
```

## Checklist
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type
- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
