### PR TITLE
net/network_manager: do not set "may-fail" to False for both ipv4 and ipv6

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -571,7 +571,12 @@ def generate_fallback_config(config_driver=None):
         match = {
             "macaddress": read_sys_net_safe(target_name, "address").lower()
         }
-    cfg = {"dhcp4": True, "set-name": target_name, "match": match}
+    cfg = {
+        "dhcp4": True,
+        "dhcp6": True,
+        "set-name": target_name,
+        "match": match,
+    }
     if config_driver:
         driver = device_driver(target_name)
         if driver:

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -261,6 +261,7 @@ class TestGenerateFallbackConfig(CiTestCase):
                 "eth1": {
                     "match": {"macaddress": mac},
                     "dhcp4": True,
+                    "dhcp6": True,
                     "set-name": "eth1",
                 }
             },
@@ -278,6 +279,7 @@ class TestGenerateFallbackConfig(CiTestCase):
                 "eth0": {
                     "match": {"macaddress": mac},
                     "dhcp4": True,
+                    "dhcp6": True,
                     "set-name": "eth0",
                 }
             },
@@ -293,6 +295,7 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "eth0": {
                     "dhcp4": True,
+                    "dhcp6": True,
                     "match": {"macaddress": mac},
                     "set-name": "eth0",
                 }
@@ -359,6 +362,7 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "ens3": {
                     "dhcp4": True,
+                    "dhcp6": True,
                     "match": {"name": "ens3"},
                     "set-name": "ens3",
                 }

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1477,11 +1477,11 @@ NETWORK_CONFIGS = {
 
                 [ipv4]
                 method=auto
-                may-fail=false
+                may-fail=true
 
                 [ipv6]
                 method=auto
-                may-fail=false
+                may-fail=true
 
                 """
             ),
@@ -1650,11 +1650,11 @@ NETWORK_CONFIGS = {
 
                 [ipv6]
                 method=auto
-                may-fail=false
+                may-fail=true
 
                 [ipv4]
                 method=auto
-                may-fail=false
+                may-fail=true
 
                 """
             ),

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4339,6 +4339,7 @@ class TestGenerateFallbackConfig(CiTestCase):
             "ethernets": {
                 "eth0": {
                     "dhcp4": True,
+                    "dhcp6": True,
                     "set-name": "eth0",
                     "match": {
                         "macaddress": "00:11:22:33:44:55",
@@ -4423,6 +4424,9 @@ iface lo inet loopback
 
 auto eth0
 iface eth0 inet dhcp
+
+# control-alias eth0
+iface eth0 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -4512,6 +4516,9 @@ iface lo inet loopback
 
 auto eth1
 iface eth1 inet dhcp
+
+# control-alias eth1
+iface eth1 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -4735,7 +4742,9 @@ class TestRhelSysConfigRendering(CiTestCase):
 #
 BOOTPROTO=dhcp
 DEVICE=eth1000
+DHCPV6C=yes
 HWADDR=07-1c-c6-75-a4-be
+IPV6INIT=yes
 NM_CONTROLLED=no
 ONBOOT=yes
 TYPE=Ethernet
@@ -5646,7 +5655,8 @@ class TestOpenSuseSysConfigRendering(CiTestCase):
             expected_content = """
 # Created by cloud-init automatically, do not edit.
 #
-BOOTPROTO=dhcp4
+BOOTPROTO=dhcp
+DHCLIENT6_MODE=managed
 LLADDR=07-1c-c6-75-a4-be
 STARTMODE=auto
 """.lstrip()
@@ -6032,7 +6042,11 @@ class TestNetworkManagerRendering(CiTestCase):
 
                 [ipv4]
                 method=auto
-                may-fail=false
+                may-fail=true
+
+                [ipv6]
+                method=auto
+                may-fail=true
 
                 """
                 ),
@@ -6298,6 +6312,9 @@ iface lo inet loopback
 
 auto eth1000
 iface eth1000 inet dhcp
+
+# control-alias eth1000
+iface eth1000 inet6 dhcp
 """
         self.assertEqual(expected.lstrip(), contents.lstrip())
 
@@ -6357,6 +6374,7 @@ class TestNetplanNetRendering:
                   ethernets:
                     eth1000:
                       dhcp4: true
+                      dhcp6: true
                       match:
                         macaddress: 07-1c-c6-75-a4-be
                       set-name: eth1000
@@ -7856,7 +7874,7 @@ class TestNetworkdNetRendering(CiTestCase):
             Name=eth1000
             MACAddress=07-1c-c6-75-a4-be
             [Network]
-            DHCP=ipv4"""
+            DHCP=yes"""
         ).rstrip(" ")
 
         expected = self.create_conf_dict(expected.splitlines())


### PR DESCRIPTION
Please see discussions in https://github.com/canonical/cloud-init/pull/4474 .

The second patch unreverts the revert https://github.com/TheRealFalcon/cloud-init/commit/21e6dfb8298835e93e5a11e6185574e611a1f44b .

The first change tries to the fix the issue due to which the above reversal was made. 

```
   If "may-fail" is set to False in the Network Manager keyfile for both ipv4
    and ipv6, it essentially means both ipv4 and ipv6 network initialization must
    succeed for the overall network configuration to succeed. This means, for
    environments where only ipv4 or ipv6 is available but not both and we need to
    configure both ipv4 and ipv6 options, the overall network configuration will
    fail. This is not what we want. When both ipv4 and ipv6 are configured,
    it is enough for the overall configuration to succeed if any one succeeds.
    Therefore, set "may-fail" to True for both ipv4 and ipv6 if and only if both
    ipv4 and ipv6 are configured in the Network Manager keyfile and "may-fail" is
    set to False for both. If both ipv4 and ipv6 are configured in the keyfile
    and if for any of them "may-fail" is already set to True, then do nothing.
    All other cases remain same as before.
```
