### PR TITLE
cc_ntp: Fix support for Rocky Linux

### DIFF
--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -202,6 +202,14 @@ DISTRO_CLIENT_CONFIG = {
             "service_name": "chronyd",
         },
     },
+    "rocky": {
+        "ntp": {
+            "service_name": "ntpd",
+        },
+        "chrony": {
+            "service_name": "chronyd",
+        },
+    },
     "sles": {
         "chrony": {
             "service_name": "chronyd",

--- a/templates/chrony.conf.rocky.tmpl
+++ b/templates/chrony.conf.rocky.tmpl
@@ -1,0 +1,51 @@
+## template:jinja
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+{% if pools %}# pools
+{% endif %}
+{% for pool in pools -%}
+pool {{pool}} iburst
+{% endfor %}
+{%- if servers %}# servers
+{% endif %}
+{% for server in servers -%}
+server {{server}} iburst
+{% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+{% for a in allow -%}
+allow {{a}}
+{% endfor %}
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -52,6 +52,7 @@ einsibjarni
 emmanuelthome
 eslerm
 esposem
+falencastro
 frantisekz
 GabrielNagy
 garzdin


### PR DESCRIPTION
This patch corrects support for Rocky Linux by the addition of a config template for chrony and passing the correct service name.

Adds "falencastro" to contributor list.

LP: #1885952