### PR TITLE
Fix permissions issue

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -220,25 +220,12 @@ class Init:
         self._initialize_filesystem()
 
     def _initialize_filesystem(self):
-        mode = 0o640
-        fmode = None
-
         util.ensure_dirs(self._initial_subdirs())
         log_file = util.get_cfg_option_str(self.cfg, "def_log_file")
         if log_file:
             # At this point the log file should have already been created
-            # in the setup_logging function of log.py
-
-            try:
-                fmode = util.get_permissions(log_file)
-            except OSError:
-                pass
-
-            # if existing file mode fmode is stricter, do not change it.
-            if fmode and util.compare_permission(fmode, mode) < 0:
-                mode = fmode
-
-            util.ensure_file(log_file, mode, preserve_mode=False)
+            # in the setupLogging function of log.py
+            util.ensure_file(log_file, mode=0o640, preserve_mode=False)
             perms = self.cfg.get("syslog_fix_perms")
             if not perms:
                 perms = {}

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2143,29 +2143,6 @@ def safe_int(possible_int):
         return None
 
 
-def compare_permission(mode1, mode2):
-    """Compare two file modes in octal.
-
-    If mode1 is less restrictive than mode2 return 1
-    If mode1 is more restrictive than mode2 return -1
-    If mode1 is same as mode2, return 0
-
-    The comparison starts from the permission of the
-    set of users in "others" and then works up to the
-    permission of "user" set.
-    """
-    # Convert modes to octal and reverse the last 3 digits
-    # so 0o640 would be become 0o046
-    mode1_oct = oct(mode1)[2:].rjust(3, "0")
-    mode2_oct = oct(mode2)[2:].rjust(3, "0")
-    m1 = int(mode1_oct[:-3] + mode1_oct[-3:][::-1], 8)
-    m2 = int(mode2_oct[:-3] + mode2_oct[-3:][::-1], 8)
-
-    # Then do a traditional cmp()
-    # https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons
-    return (m1 > m2) - (m1 < m2)
-
-
 def chmod(path, mode):
     real_mode = safe_int(mode)
     if path and real_mode:

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -622,22 +622,13 @@ class TestInit_InitializeFilesystem:
         # Assert we create it 0o640  by default if it doesn't already exist
         assert 0o640 == stat.S_IMODE(log_file.stat().mode)
 
-    @pytest.mark.parametrize(
-        "set_perms,expected_perms",
-        [
-            (0o640, 0o640),
-            (0o606, 0o640),
-            (0o600, 0o600),
-        ],
-    )
-    def test_existing_file_permissions(
-        self, init, tmpdir, set_perms, expected_perms
-    ):
+    def test_existing_file_permissions(self, init, tmpdir):
         """Test file permissions are set as expected.
 
-        CIS Hardening requires 640 permissions. If the file has looser
-        permissions, then hard code 640. If the file has tighter
-        permissions, then leave them as they are
+        CIS Hardening requires 640 permissions. These permissions are
+        currently hardcoded on every boot, but if there's ever a reason
+        to change this, we need to then ensure that they
+        are *not* set every boot.
 
         See https://bugs.launchpad.net/cloud-init/+bug/1900837.
         """
@@ -645,9 +636,9 @@ class TestInit_InitializeFilesystem:
         log_file.ensure()
         # Use a mode that will never be made the default so this test will
         # always be valid
-        log_file.chmod(set_perms)
+        log_file.chmod(0o606)
         init._cfg = {"def_log_file": str(log_file)}
 
         init._initialize_filesystem()
 
-        assert expected_perms == stat.S_IMODE(log_file.stat().mode)
+        assert 0o640 == stat.S_IMODE(log_file.stat().mode)

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -3150,30 +3150,6 @@ class TestHashBuffer:
             )
 
 
-class TestComparePermissions:
-    @pytest.mark.parametrize(
-        "perm1,perm2,expected",
-        [
-            (0o777, 0o777, 0),
-            (0o000, 0o000, 0),
-            (0o421, 0o421, 0),
-            (0o1640, 0o1640, 0),
-            (0o1407, 0o1600, 1),
-            (0o1600, 0o1407, -1),
-            (0o407, 0o600, 1),
-            (0o600, 0o407, -1),
-            (0o007, 0o700, 1),
-            (0o700, 0o007, -1),
-            (0o077, 0o100, 1),
-            (0o644, 0o640, 1),
-            (0o640, 0o600, 1),
-            (0o600, 0o400, 1),
-        ],
-    )
-    def test_compare_permissions(self, perm1, perm2, expected):
-        assert util.compare_permission(perm1, perm2) == expected
-
-
 class TestMaybeB64Decode:
     """Test the maybe_b64decode helper function."""
 


### PR DESCRIPTION
## Additional Context
Since cloud-init still redacts sensitive information from `/var/log/cloud-init.log`, there is no way to expose a secure system (no CVE). However, https://github.com/canonical/cloud-init/pull/4250 weakens our mitigation of restricting logs by allowing more permissive log permissions. Revert that commit and implement the behavior it was trying to introduce.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
