### PR TITLE
SC-1603-jinja-enhancements

### DIFF
--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -11,8 +11,8 @@ import sys
 
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.handlers.jinja_template import (
-    CustomParsedJinjaException,
     JinjaLoadError,
+    JinjaSyntaxParsingException,
     NotJinjaError,
     render_jinja_payload_from_file,
 )
@@ -100,7 +100,7 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
             "Cannot render from instance data due to exception: %s", repr(e)
         )
         return 1
-    except CustomParsedJinjaException as e:
+    except JinjaSyntaxParsingException as e:
         error_msg = (
             "Failed to render user-data file '{file_path}' "
             "due to jinja parsing error: {error}".format(
@@ -109,7 +109,7 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
             )
         )
         LOG.error(error_msg)
-        sys.stderr.write(error_msg + "\n")
+        # sys.stderr.write(error_msg + "\n")
         return 1
     if not rendered_payload:
         LOG.error("Unable to render user-data file: %s", user_data_path)

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -101,9 +101,12 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
         )
         return 1
     except CustomParsedJinjaException as e:
-        error_msg = "Failed to render user-data file '{file_path}' due to jinja parsing error: {error}".format(
-            file_path=user_data_path,
-            error=str(e),
+        error_msg = (
+            "Failed to render user-data file '{file_path}' "
+            "due to jinja parsing error: {error}".format(
+                file_path=user_data_path,
+                error=str(e),
+            )
         )
         LOG.error(error_msg)
         sys.stderr.write(error_msg + "\n")

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -11,6 +11,7 @@ import sys
 
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.handlers.jinja_template import (
+    CustomParsedJinjaException,
     JinjaLoadError,
     NotJinjaError,
     render_jinja_payload_from_file,
@@ -98,6 +99,14 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
         LOG.error(
             "Cannot render from instance data due to exception: %s", repr(e)
         )
+        return 1
+    except CustomParsedJinjaException as e:
+        error_msg = "Failed to render user-data file '{file_path}' due to jinja parsing error: {error}".format(
+            file_path=user_data_path,
+            error=str(e),
+        )
+        LOG.error(error_msg)
+        sys.stderr.write(error_msg + "\n")
         return 1
     if not rendered_payload:
         LOG.error("Unable to render user-data file: %s", user_data_path)

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -101,15 +101,11 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
         )
         return 1
     except JinjaSyntaxParsingException as e:
-        error_msg = (
-            "Failed to render user-data file '{file_path}' "
-            "due to jinja parsing error: {error}".format(
-                file_path=user_data_path,
-                error=str(e),
-            )
+        LOG.error(
+            "Failed to render templated user-data file '%s'. %s",
+            user_data_path,
+            str(e),
         )
-        LOG.error(error_msg)
-        # sys.stderr.write(error_msg + "\n")
         return 1
     if not rendered_payload:
         LOG.error("Unable to render user-data file: %s", user_data_path)

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -277,12 +277,19 @@ def handle_args(name, args):
         return 1
     if args.format:
         payload = "## template: jinja\n{fmt}".format(fmt=args.format)
-        rendered_payload = render_jinja_payload(
-            payload=payload,
-            payload_fn="query commandline",
-            instance_data=instance_data,
-            debug=True if args.debug else False,
-        )
+        try:
+            rendered_payload = render_jinja_payload(
+                payload=payload,
+                payload_fn="query commandline",
+                instance_data=instance_data,
+                debug=True if args.debug else False,
+            )
+        except Exception as e:
+            error_msg = "Failed to render templated data due to jinja parsing error: {error}".format(
+                error=str(e),
+            )
+            print(error_msg)
+            return 1
         if rendered_payload:
             print(rendered_payload)
             return 0

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -285,8 +285,11 @@ def handle_args(name, args):
                 debug=True if args.debug else False,
             )
         except Exception as e:
-            error_msg = "Failed to render templated data due to jinja parsing error: {error}".format(
-                error=str(e),
+            error_msg = (
+                "Failed to render templated data due to jinja parsing error: "
+                "{error}".format(
+                    error=str(e),
+                )
             )
             print(error_msg)
             return 1

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -29,6 +29,7 @@ from cloudinit.handlers.jinja_template import (
     render_jinja_payload,
 )
 from cloudinit.sources import REDACT_SENSITIVE_VALUE
+from cloudinit.templater import JinjaSyntaxParsingException
 
 NAME = "query"
 LOG = logging.getLogger(__name__)
@@ -284,14 +285,12 @@ def handle_args(name, args):
                 instance_data=instance_data,
                 debug=True if args.debug else False,
             )
-        except Exception as e:
-            error_msg = (
+        except JinjaSyntaxParsingException as e:
+            LOG.error(
                 "Failed to render templated data due to jinja parsing error: "
-                "{error}".format(
-                    error=str(e),
-                )
+                "{error}",
+                str(e),
             )
-            print(error_msg)
             return 1
         if rendered_payload:
             print(rendered_payload)

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -34,6 +34,7 @@ from cloudinit.templater import JinjaSyntaxParsingException
 NAME = "query"
 LOG = logging.getLogger(__name__)
 
+
 def get_parser(parser=None):
     """Build or extend an arg parser for query utility.
 
@@ -289,7 +290,6 @@ def handle_args(name, args):
                 "Failed to render templated data. %s",
                 str(e),
             )
-            print("Failed to render templated data. {}".format(str(e)))
             return 1
         if rendered_payload:
             print(rendered_payload)

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -34,7 +34,6 @@ from cloudinit.templater import JinjaSyntaxParsingException
 NAME = "query"
 LOG = logging.getLogger(__name__)
 
-
 def get_parser(parser=None):
     """Build or extend an arg parser for query utility.
 
@@ -287,10 +286,10 @@ def handle_args(name, args):
             )
         except JinjaSyntaxParsingException as e:
             LOG.error(
-                "Failed to render templated data due to jinja parsing error: "
-                "{error}",
+                "Failed to render templated data. %s",
                 str(e),
             )
+            print("Failed to render templated data. {}".format(str(e)))
             return 1
         if rendered_payload:
             print(rendered_payload)

--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -96,6 +96,10 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             stderr=True,
             log=LOG,
         )
+    except templater.JinjaSyntaxParsingException as e:
+        util.logexc(
+            LOG, "Failed to render templated final message: %s", str(e)
+        )
     except Exception:
         util.logexc(LOG, "Failed to render final message template")
 

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -818,8 +818,8 @@ def _get_config_type_and_rendered_userdata(
         header declared ## template: jinja.
     """
     from cloudinit.handlers.jinja_template import (
-        CustomParsedJinjaException,
         JinjaLoadError,
+        JinjaSyntaxParsingException,
         NotJinjaError,
         render_jinja_payload_from_file,
     )
@@ -841,7 +841,7 @@ def _get_config_type_and_rendered_userdata(
                     )
                 ]
             ) from e
-        except CustomParsedJinjaException as e:
+        except JinjaSyntaxParsingException as e:
             error(
                 "Failed to render templated cloud-config due to jinja parsing "
                 "error: " + str(e),

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -843,8 +843,8 @@ def _get_config_type_and_rendered_userdata(
             ) from e
         except CustomParsedJinjaException as e:
             error(
-                "Failed to render templated cloud-config due to jinja parsing error: "
-                + str(e),
+                "Failed to render templated cloud-config due to jinja parsing "
+                "error: " + str(e),
                 sys_exit=True,
             )
         except JinjaLoadError as e:

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -816,6 +816,8 @@ def _get_config_type_and_rendered_userdata(
     :return: UserDataTypeAndDecodedContent
     :raises: SchemaValidationError when non-jinja content found but
         header declared ## template: jinja.
+    :raises JinjaSyntaxParsingException when jinja syntax error found.
+    :raises JinjaLoadError when jinja template fails to load.
     """
     from cloudinit.handlers.jinja_template import (
         JinjaLoadError,
@@ -843,8 +845,7 @@ def _get_config_type_and_rendered_userdata(
             ) from e
         except JinjaSyntaxParsingException as e:
             error(
-                "Failed to render templated cloud-config due to jinja parsing "
-                "error: " + str(e),
+                "Failed to render templated user-data. " + str(e),
                 sys_exit=True,
             )
         except JinjaLoadError as e:

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -818,6 +818,7 @@ def _get_config_type_and_rendered_userdata(
         header declared ## template: jinja.
     """
     from cloudinit.handlers.jinja_template import (
+        CustomParsedJinjaException,
         JinjaLoadError,
         NotJinjaError,
         render_jinja_payload_from_file,
@@ -840,6 +841,12 @@ def _get_config_type_and_rendered_userdata(
                     )
                 ]
             ) from e
+        except CustomParsedJinjaException as e:
+            error(
+                "Failed to render templated cloud-config due to jinja parsing error: "
+                + str(e),
+                sys_exit=True,
+            )
         except JinjaLoadError as e:
             error(str(e), sys_exit=True)
         schema_position = "format-l2.c1"

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -122,7 +122,9 @@ def run_part(mod, data, filename, payload, frequency, headers):
             mod.handle_part(data, content_type, filename, payload)
         else:
             raise ValueError("Unknown module version %s" % (mod_ver))
-    except Exception:
+    except Exception as e:
+        print("[a-dubs] e: %s" % e)
+        LOG.warning(str(e))
         util.logexc(
             LOG,
             "Failed calling handler %s (%s, %s, %s) with frequency %s",

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -122,9 +122,7 @@ def run_part(mod, data, filename, payload, frequency, headers):
             mod.handle_part(data, content_type, filename, payload)
         else:
             raise ValueError("Unknown module version %s" % (mod_ver))
-    except Exception as e:
-        print("[a-dubs] e: %s" % e)
-        LOG.warning(str(e))
+    except Exception:
         util.logexc(
             LOG,
             "Failed calling handler %s (%s, %s, %s) with frequency %s",

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -61,7 +61,7 @@ class JinjaTemplatePartHandler(handlers.Handler):
             )
         except JinjaSyntaxParsingException as e:
             LOG.warning(
-                "Ignoring jinja template for %s. Failed to render due to jinja parsing error: %s",
+                "Ignoring jinja template for %s. Failed to render template. %s",
                 filename,
                 str(e),
             )

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -61,9 +61,9 @@ class JinjaTemplatePartHandler(handlers.Handler):
             )
         except CustomParsedJinjaException as e:
             LOG.warning(
-                "Failed to render templated cloud-config file due to jinja parsing error: {e}".format(
-                    e=str(e),
-                )
+                "Failed to render templated cloud-config file due to jinja "
+                "parsing error: %s",
+                str(e),
             )
             return
 
@@ -146,8 +146,6 @@ def render_jinja_payload(payload, payload_fn, instance_data, debug=False):
         )
     try:
         rendered_payload = render_string(payload, instance_jinja_vars)
-    # except CustomParsedJinjaException as custom_raised_jinja_error:
-    #     LOG.error("Failed to parse jinja template: %s", str(custom_raised_jinja_error))
     except (TypeError, JUndefinedError) as e:
         LOG.warning("Ignoring jinja template for %s: %s", payload_fn, str(e))
         return None

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -13,7 +13,7 @@ from cloudinit.helpers import Paths
 from cloudinit.settings import PER_ALWAYS
 from cloudinit.templater import (
     MISSING_JINJA_PREFIX,
-    CustomParsedJinjaException,
+    JinjaSyntaxParsingException,
     detect_template,
     render_string,
 )
@@ -59,10 +59,10 @@ class JinjaTemplatePartHandler(handlers.Handler):
             rendered_payload = render_jinja_payload_from_file(
                 payload, filename, jinja_json_file
             )
-        except CustomParsedJinjaException as e:
+        except JinjaSyntaxParsingException as e:
             LOG.warning(
-                "Failed to render templated cloud-config file due to jinja "
-                "parsing error: %s",
+                "Ignoring jinja template for %s. Failed to render due to jinja parsing error: %s",
+                filename,
                 str(e),
             )
             return

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -61,7 +61,8 @@ class JinjaTemplatePartHandler(handlers.Handler):
             )
         except JinjaSyntaxParsingException as e:
             LOG.warning(
-                "Ignoring jinja template for %s. Failed to render template. %s",
+                "Ignoring jinja template for %s. "
+                "Failed to render template. %s",
                 filename,
                 str(e),
             )

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -110,18 +110,21 @@ def detect_template(text):
         # keep_trailing_newline is in jinja2 2.7+, not 2.6
         add = "\n" if content.endswith("\n") else ""
         try:
-            result = JTemplate(
-                content,
-                undefined=UndefinedJinjaVariable,
-                trim_blocks=True,
-                extensions=["jinja2.ext.do"],
-            ).render(**params) + add
+            result = (
+                JTemplate(
+                    content,
+                    undefined=UndefinedJinjaVariable,
+                    trim_blocks=True,
+                    extensions=["jinja2.ext.do"],
+                ).render(**params)
+                + add
+            )
             return result
 
         except Exception as JTemplateError:
             # if the error is a syntax one, we know this next line will fail
             # we want to get the traceback and error message it throws
-            try:  
+            try:
                 jinja_env = Environment(
                     loader=BaseLoader(),
                     autoescape=False,
@@ -129,10 +132,10 @@ def detect_template(text):
                     trim_blocks=True,
                     extensions=["jinja2.ext.do"],
                 )
-                template = jinja_env.parse(content)
-                # if we get here, then the previous line didn't fail, so we just need to re-raise the original error
+                jinja_env.parse(content)
+                # if we get here, then the previous line didn't fail,
+                # so we just need to re-raise the original error
                 raise JTemplateError
-            # TODO: check other exception types
             except Exception as useful_jinja_error:
                 try:
                     tb = "".join(
@@ -142,19 +145,30 @@ def detect_template(text):
                         r'File "<unknown>", line (\d+)', tb
                     )
                     line_number_of_error = int(line_number_matches[0])
-                except: # if we couldn't parse the traceback for some reason, just re-raise the original error
-                    raise JTemplateError
-                # adjust line number for the fact that the jinja header has been removed from the content
-                if len(re.findall("##( )?template:( )?jinja", content.split("\n")[0].strip().lower())) == 0:
+                # if we couldn't parse the traceback for some reason,
+                # just re-raise the original error
+                except Exception:
+                    raise JTemplateError from useful_jinja_error
+                # adjust line number to adjust for the jinja header having been
+                # removed from the content
+                if (
+                    len(
+                        re.findall(
+                            "##( )?template:( )?jinja",
+                            content.split("\n")[0].strip().lower(),
+                        )
+                    )
+                    == 0
+                ):
                     line_number_of_error += 1
                 raise CustomParsedJinjaException(
                     "{e} on line {line_no}".format(
                         e=useful_jinja_error,
                         line_no=line_number_of_error,
                     )
-                )
+                ) from useful_jinja_error
 
-    if text.find("\n") != -1:  
+    if text.find("\n") != -1:
         ident, rest = text.split("\n", 1)  # remove the first line
     else:
         ident = text

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -16,7 +16,6 @@ import collections
 import logging
 import re
 import sys
-import traceback
 from typing import Any
 
 from jinja2 import TemplateSyntaxError
@@ -52,7 +51,6 @@ class JinjaSyntaxParsingException(Exception):
         "Unable to parse Jinja template due to syntax error: "
         "{syntax_error} on line {line_no}: {line_content}"
     )
-    pass
 
 
 # Mypy, and the PEP 484 ecosystem in general, does not support creating
@@ -151,8 +149,9 @@ def detect_template(text):
                         line_content=content.splitlines()[ln - 1].strip(),
                     )
                 ) from jtemplate_error
+            # re-raise original error if a syntax error could not be found
             except Exception:
-                raise jtemplate_error
+                raise jtemplate_error from jtemplate_error
 
     if text.find("\n") != -1:
         ident, rest = text.split("\n", 1)  # remove the first line

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -304,6 +304,7 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
     """Read a yaml config with optional template, and convert to dict"""
     # Avoid circular import
     from cloudinit.handlers.jinja_template import (
+        CustomParsedJinjaException,
         JinjaLoadError,
         NotJinjaError,
         render_jinja_payload_from_file,
@@ -330,6 +331,11 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
                 instance_data_file,
                 fname,
             )
+        except CustomParsedJinjaException as e:
+            error_msg = "Failed to render user-data file '{file_path}' due to jinja parsing error: {error}".format(
+                file_path=fname, error=str(e)
+            )
+            LOG.warning(error_msg)
         except NotJinjaError:
             # A log isn't appropriate here as we generally expect most
             # cloud.cfgs to not be templated. The other path is logged

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -332,8 +332,11 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
                 fname,
             )
         except CustomParsedJinjaException as e:
-            error_msg = "Failed to render user-data file '{file_path}' due to jinja parsing error: {error}".format(
-                file_path=fname, error=str(e)
+            error_msg = (
+                "Failed to render user-data file '{file_path}' "
+                "due to jinja parsing error: {error}".format(
+                    file_path=fname, error=str(e)
+                )
             )
             LOG.warning(error_msg)
         except NotJinjaError:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -333,8 +333,7 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
             )
         except JinjaSyntaxParsingException as e:
             LOG.warning(
-                "Failed to render user-data file '%s' "
-                "due to jinja parsing error: %s",
+                "Failed to render templated yaml config file '%s'. %s",
                 fname,
                 str(e),
             )

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -335,7 +335,7 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
             LOG.warning(
                 "Failed to render templated yaml config file '%s'. %s",
                 fname,
-                str(e),
+                e,
             )
         except NotJinjaError:
             # A log isn't appropriate here as we generally expect most

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -304,8 +304,8 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
     """Read a yaml config with optional template, and convert to dict"""
     # Avoid circular import
     from cloudinit.handlers.jinja_template import (
-        CustomParsedJinjaException,
         JinjaLoadError,
+        JinjaSyntaxParsingException,
         NotJinjaError,
         render_jinja_payload_from_file,
     )
@@ -331,14 +331,13 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
                 instance_data_file,
                 fname,
             )
-        except CustomParsedJinjaException as e:
-            error_msg = (
-                "Failed to render user-data file '{file_path}' "
-                "due to jinja parsing error: {error}".format(
-                    file_path=fname, error=str(e)
-                )
+        except JinjaSyntaxParsingException as e:
+            LOG.warning(
+                "Failed to render user-data file '%s' "
+                "due to jinja parsing error: %s",
+                fname,
+                str(e),
             )
-            LOG.warning(error_msg)
         except NotJinjaError:
             # A log isn't appropriate here as we generally expect most
             # cloud.cfgs to not be templated. The other path is logged

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -149,7 +149,6 @@ class TestRender:
         render.render_template(user_data, instance_data, False)
         assert "Unable to render user-data file" in caplog.text
 
-    # test that error with "Failed to render template" is logged when jinja syntax error in user data file
     @skipUnlessJinja()
     def test_invalid_jinja_syntax(self, caplog, tmpdir):
         user_data = tmpdir.join("user-data")
@@ -157,4 +156,7 @@ class TestRender:
         instance_data = tmpdir.join("instance-data")
         write_file(instance_data, '{"my-var": "jinja worked"}')
         assert render.render_template(user_data, instance_data, True) == 1
-        assert "due to jinja parsing error: unexpected '}' on line 2" in caplog.text
+        assert (
+            "due to jinja parsing error: unexpected '}' on line 2"
+            in caplog.text
+        )

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -158,9 +158,9 @@ class TestRender:
         write_file(instance_data, '{"my-var": "jinja worked"}')
         assert render.render_template(user_data, instance_data, True) == 1
         assert (
-            JinjaSyntaxParsingException.message_template.format(
+            JinjaSyntaxParsingException.format_error_message(
                 syntax_error="unexpected '}'",
-                line_no=2,
+                line_number=2,
                 line_content="rendering: {{ my_var } }",
             )
             in caplog.text

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -6,9 +6,9 @@ import pytest
 
 from cloudinit.cmd.devel import render
 from cloudinit.helpers import Paths
+from cloudinit.templater import JinjaSyntaxParsingException
 from cloudinit.util import ensure_dir, write_file
 from tests.unittests.helpers import mock, skipUnlessJinja
-from cloudinit.templater import JinjaSyntaxParsingException
 
 M_PATH = "cloudinit.cmd.devel.render."
 

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -8,6 +8,7 @@ from cloudinit.cmd.devel import render
 from cloudinit.helpers import Paths
 from cloudinit.util import ensure_dir, write_file
 from tests.unittests.helpers import mock, skipUnlessJinja
+from cloudinit.templater import JinjaSyntaxParsingException
 
 M_PATH = "cloudinit.cmd.devel.render."
 
@@ -157,6 +158,10 @@ class TestRender:
         write_file(instance_data, '{"my-var": "jinja worked"}')
         assert render.render_template(user_data, instance_data, True) == 1
         assert (
-            "due to jinja parsing error: unexpected '}' on line 2"
+            JinjaSyntaxParsingException.message_template.format(
+                syntax_error="unexpected '}'",
+                line_no=2,
+                line_content="rendering: {{ my_var } }",
+            )
             in caplog.text
         )

--- a/tests/unittests/cmd/devel/test_render.py
+++ b/tests/unittests/cmd/devel/test_render.py
@@ -148,3 +148,13 @@ class TestRender:
         write_file(instance_data, '{"my-var": "jinja worked"}')
         render.render_template(user_data, instance_data, False)
         assert "Unable to render user-data file" in caplog.text
+
+    # test that error with "Failed to render template" is logged when jinja syntax error in user data file
+    @skipUnlessJinja()
+    def test_invalid_jinja_syntax(self, caplog, tmpdir):
+        user_data = tmpdir.join("user-data")
+        write_file(user_data, "##template: jinja\nrendering: {{ my_var } }")
+        instance_data = tmpdir.join("instance-data")
+        write_file(instance_data, '{"my-var": "jinja worked"}')
+        assert render.render_template(user_data, instance_data, True) == 1
+        assert "due to jinja parsing error: unexpected '}' on line 2" in caplog.text

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -15,9 +15,9 @@ from cloudinit.atomic_helper import b64e
 from cloudinit.cmd import query
 from cloudinit.helpers import Paths
 from cloudinit.sources import REDACT_SENSITIVE_VALUE
+from cloudinit.templater import JinjaSyntaxParsingException
 from cloudinit.util import write_file
 from tests.unittests.helpers import mock
-from cloudinit.templater import JinjaSyntaxParsingException
 
 M_PATH = "cloudinit.cmd.query."
 
@@ -32,6 +32,7 @@ def _gzip_data(data):
 @pytest.fixture(autouse=True)
 def setup_mocks(mocker):
     mocker.patch("cloudinit.cmd.query.read_cfg_paths", return_value=Paths({}))
+
 
 class TestQuery:
     Args = namedtuple(
@@ -570,7 +571,7 @@ class TestQuery:
 
     @pytest.mark.parametrize(
         "header_included",
-        [ True, False ],
+        [True, False],
     )
     def test_handle_args_formats_jinja_successfully(
         self, caplog, tmpdir, capsys, header_included
@@ -584,7 +585,7 @@ class TestQuery:
         header = "## template: jinja\n" if header_included else ""
         format = header + "v1_1: {{ v1.v1_1 }}"
         expected = header + "v1_1: val1.1\n"
-        
+
         args = self.Args(
             debug=False,
             dump_all=False,
@@ -610,11 +611,11 @@ class TestQuery:
         )
         format = "v1_1: {{ v1.v1_1 } }"
         expected_error = (
-            "Failed to render templated data. " + 
-            JinjaSyntaxParsingException.message_template.format(
-                syntax_error="unexpected '}'", 
+            "Failed to render templated data. "
+            + JinjaSyntaxParsingException.message_template.format(
+                syntax_error="unexpected '}'",
                 line_no=2,
-                line_content="v1_1: {{ v1.v1_1 } }"
+                line_content="v1_1: {{ v1.v1_1 } }",
             )
         )
         args = self.Args(
@@ -630,6 +631,4 @@ class TestQuery:
         with mock.patch("os.getuid") as m_getuid:
             m_getuid.return_value = 100
             assert 1 == query.handle_args("anyname", args)
-        out, err = capsys.readouterr()
         assert expected_error in caplog.text
-        assert expected_error in err

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -567,3 +567,58 @@ class TestQuery:
             m_getuid.return_value = 100
             assert 1 == query.handle_args("anyname", args)
         assert expected_error in caplog.text
+
+    def test_handle_args_formats_jinja_successfully(
+        self, caplog, tmpdir, capsys
+    ):
+        """Raise an error when --list-keys and varname specify a non-list."""
+        instance_data = tmpdir.join("instance-data")
+        instance_data.write(
+            '{"v1": {"v1_1": "val1.1", "v1_2": "val1.2"}, "v2": '
+            '{"v2_2": "val2.2"}, "top": "gun"}'
+        )
+        format = "v1_1: {{ v1.v1_1 }}"
+        expected = "v1_1: val1.1\n"
+        args = self.Args(
+            debug=False,
+            dump_all=False,
+            format=format,
+            instance_data=instance_data.strpath,
+            list_keys=False,
+            user_data="ud",
+            vendor_data="vd",
+            varname=None,
+        )
+        with mock.patch("os.getuid") as m_getuid:
+            m_getuid.return_value = 100
+            assert 0 == query.handle_args("anyname", args)
+        out, _err = capsys.readouterr()
+        assert expected == out
+
+    def test_handle_args_invalid_jinja_exception(self, caplog, tmpdir, capsys):
+        """Raise an error when --list-keys and varname specify a non-list."""
+        instance_data = tmpdir.join("instance-data")
+        instance_data.write(
+            '{"v1": {"v1_1": "val1.1", "v1_2": "val1.2"}, "v2": '
+            '{"v2_2": "val2.2"}, "top": "gun"}'
+        )
+        format = "v1_1: {{ v1.v1_1 } }"
+        expected_error = (
+            "Failed to render templated data due to jinja "
+            "parsing error: unexpected '}' on line 2\n"
+        )
+        args = self.Args(
+            debug=False,
+            dump_all=False,
+            format=format,
+            instance_data=instance_data.strpath,
+            list_keys=False,
+            user_data="ud",
+            vendor_data="vd",
+            varname=None,
+        )
+        with mock.patch("os.getuid") as m_getuid:
+            m_getuid.return_value = 100
+            assert 1 == query.handle_args("anyname", args)
+        out, _err = capsys.readouterr()
+        assert expected_error == out

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -612,9 +612,9 @@ class TestQuery:
         format = "v1_1: {{ v1.v1_1 } }"
         expected_error = (
             "Failed to render templated data. "
-            + JinjaSyntaxParsingException.message_template.format(
+            + JinjaSyntaxParsingException.format_error_message(
                 syntax_error="unexpected '}'",
-                line_no=2,
+                line_number=2,
                 line_content="v1_1: {{ v1.v1_1 } }",
             )
         )

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -33,7 +33,6 @@ def _gzip_data(data):
 def setup_mocks(mocker):
     mocker.patch("cloudinit.cmd.query.read_cfg_paths", return_value=Paths({}))
 
-
 class TestQuery:
     Args = namedtuple(
         "Args",
@@ -634,36 +633,3 @@ class TestQuery:
         out, err = capsys.readouterr()
         assert expected_error in caplog.text
         assert expected_error in err
-        
-
-    # def test_handle_args_jinja_template_missing_header(self, caplog, tmpdir, capsys):
-    #     """Raise an error when --list-keys and varname specify a non-list."""
-    #     instance_data = tmpdir.join("instance-data")
-    #     instance_data.write(
-    #         '{"v1": {"v1_1": "val1.1", "v1_2": "val1.2"}, "v2": '
-    #         '{"v2_2": "val2.2"}, "top": "gun"}'
-    #     )
-    #     format = "v1_1: {{ v1.v1_1 }}"
-    #     expected_error = (
-    #         "Failed to render templated data. " + 
-    #         JinjaSyntaxParsingException.message_template.format(
-    #             syntax_error="unexpected '{'", 
-    #             line_no=2,
-    #             line_content="v1_1: {{ v1.v1_1 }}"
-    #         )
-    #     )
-    #     args = self.Args(
-    #         debug=False,
-    #         dump_all=False,
-    #         format=format,
-    #         instance_data=instance_data.strpath,
-    #         list_keys=False,
-    #         user_data="ud",
-    #         vendor_data="vd",
-    #         varname=None,
-    #     )
-    #     with mock.patch("os.getuid") as m_getuid:
-    #         m_getuid.return_value = 100
-    #         assert 1 == query.handle_args("anyname", args)
-    #     out, _err = capsys.readouterr()
-    #     assert expected_error == out

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -40,6 +40,7 @@ from cloudinit.distros import OSFAMILIES
 from cloudinit.safeyaml import load, load_with_marks
 from cloudinit.settings import FREQUENCIES
 from cloudinit.sources import DataSourceNotFoundException
+from cloudinit.templater import JinjaSyntaxParsingException
 from cloudinit.util import load_file, write_file
 from tests.hypothesis import given
 from tests.hypothesis_jsonschema import from_schema
@@ -52,8 +53,6 @@ from tests.unittests.helpers import (
     skipUnlessJsonSchema,
     skipUnlessJsonSchemaVersionGreaterThan,
 )
-from cloudinit.templater import JinjaSyntaxParsingException
-
 
 M_PATH = "cloudinit.config.schema."
 DEPRECATED_LOG_LEVEL = 35
@@ -853,12 +852,13 @@ class TestValidateCloudConfigFile:
         _out, err = capsys.readouterr()
         expected = (
             "Error:\n"
-            "Failed to render templated user-data. " + 
-            JinjaSyntaxParsingException.message_template.format(
-                syntax_error="unexpected '}'", 
+            "Failed to render templated user-data. "
+            + JinjaSyntaxParsingException.message_template.format(
+                syntax_error="unexpected '}'",
                 line_no=3,
                 line_content="c:{{ d } }",
-            ) + "\n"
+            )
+            + "\n"
         )
         assert expected == err
 

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -828,7 +828,7 @@ class TestValidateCloudConfigFile:
         )
 
     @pytest.mark.parametrize("annotate", (True, False))
-    def test_validateconfig_file_raises_enhanced_jinja_error(
+    def test_validateconfig_file_raises_jinja_syntax_error(
         self, annotate, tmpdir, mocker, capsys
     ):
         """ """
@@ -853,9 +853,9 @@ class TestValidateCloudConfigFile:
         expected = (
             "Error:\n"
             "Failed to render templated user-data. "
-            + JinjaSyntaxParsingException.message_template.format(
+            + JinjaSyntaxParsingException.format_error_message(
                 syntax_error="unexpected '}'",
-                line_no=3,
+                line_number=3,
                 line_content="c:{{ d } }",
             )
             + "\n"

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -853,12 +853,12 @@ class TestValidateCloudConfigFile:
         _out, err = capsys.readouterr()
         expected = (
             "Error:\n"
-            "Failed to render templated user-data: " + 
+            "Failed to render templated user-data. " + 
             JinjaSyntaxParsingException.message_template.format(
                 syntax_error="unexpected '}'", 
                 line_no=3,
                 line_content="c:{{ d } }",
-            )
+            ) + "\n"
         )
         assert expected == err
 

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import io
+import logging
 import os
 from collections import namedtuple
 
@@ -171,6 +172,45 @@ class TestCLI:
         ]
         for subcommand in expected_subcommands:
             assert subcommand in err
+
+    @pytest.mark.parametrize(
+        "subcommand,log_to_stderr,mocks",
+        (
+            ("init", False, [mock.patch("cloudinit.cmd.main.status_wrapper")]),
+            (
+                "modules",
+                False,
+                [mock.patch("cloudinit.cmd.main.status_wrapper")],
+            ),
+            (
+                "schema",
+                True,
+                [
+                    mock.patch(
+                        "cloudinit.stages.Init._read_cfg", return_value={}
+                    ),
+                    mock.patch("cloudinit.config.schema.handle_schema_args"),
+                ],
+            ),
+        ),
+    )
+    @mock.patch("cloudinit.cmd.main.setup_basic_logging")
+    def test_subcommands_log_to_stderr_via_setup_basic_logging(
+        self, setup_basic_logging, subcommand, log_to_stderr, mocks
+    ):
+        """setup_basic_logging is called for modules to use stderr
+
+        Subcommands with exception of 'init'  and 'modules' use
+        setup_basic_logging to direct logged errors to stderr.
+        """
+        with contextlib.ExitStack() as mockstack:
+            for mymock in mocks:
+                mockstack.enter_context(mymock)
+            self._call_main(["cloud-init", subcommand])
+        if log_to_stderr:
+            setup_basic_logging.assert_called_once_with(logging.WARNING)
+        else:
+            setup_basic_logging.assert_not_called()
 
     @pytest.mark.parametrize("subcommand", ["init", "modules"])
     @mock.patch("cloudinit.cmd.main.status_wrapper")

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -167,3 +167,15 @@ class TestTemplates(test_helpers.CiTestCase):
             ).strip(),
             expected_result,
         )
+    # give invalid jinja that has a `} }` and catch the error
+    def test_jinja_invalid_syntax(self):
+        """ Make sure invalid jinja syntax is caught """
+        jinja_template = (
+            "{% set r = [] %} {% set input = [1,2,3] %} "
+            "{% for i in input % } {% do r.append(i) %} {% endfor %} {{r}}"
+        )
+        self.assertRaises(
+            templater.CustomParsedJinjaException, 
+            templater.render_string, 
+            self.add_header("jinja", jinja_template), {},
+        )

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -168,7 +168,6 @@ class TestTemplates(test_helpers.CiTestCase):
             expected_result,
         )
 
-    # give invalid jinja that has a `} }` and catch the error
     def test_jinja_invalid_syntax(self):
         """Make sure invalid jinja syntax is caught"""
         jinja_template = (
@@ -181,3 +180,7 @@ class TestTemplates(test_helpers.CiTestCase):
             self.add_header("jinja", jinja_template),
             {},
         )
+        with self.assertRaises(templater.JinjaSyntaxParsingException) as cm:
+            templater.render_string(
+                self.add_header("jinja", jinja_template), {}
+            )

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -181,7 +181,11 @@ class TestTemplates(test_helpers.CiTestCase):
         (4, ("%}", "}}"), "unexpected '}'"),
         (6, ("%}", "}}"), "unexpected '}'"),
         (8, ("%}", "}}"), "unexpected '}'"),
-        (4, ("==", "="), "expected token 'end of statement block', got '='",),
+        (
+            4,
+            ("==", "="),
+            "expected token 'end of statement block', got '='",
+        ),
         (7, ("}}", "} }"), "unexpected '}'"),
     ),
 )
@@ -194,10 +198,10 @@ def test_jinja_syntax_parsing_exception(line_no, replace_tuple, syntax_error):
         "## template: jinja\n"
         "#cloud-config\n"
         "runcmd:\n"
-        "{% if v1.cloud_name == \"unknown\" %}\n"
-        "  - echo \"cloud name is unknown\"\n"
+        '{% if v1.cloud_name == "unknown" %}\n'
+        '  - echo "cloud name is unknown"\n'
         "{% else %}\n"
-        "  - echo \"False: cloud name is not unknown. {{ v1.cloud_name }}\"\n" 
+        '  - echo "False: cloud name is not unknown. {{ v1.cloud_name }}"\n'
         "{% endif %}\n"
     )
     # replace "%}" in line_no with "% }"

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -167,15 +167,17 @@ class TestTemplates(test_helpers.CiTestCase):
             ).strip(),
             expected_result,
         )
+
     # give invalid jinja that has a `} }` and catch the error
     def test_jinja_invalid_syntax(self):
-        """ Make sure invalid jinja syntax is caught """
+        """Make sure invalid jinja syntax is caught"""
         jinja_template = (
             "{% set r = [] %} {% set input = [1,2,3] %} "
             "{% for i in input % } {% do r.append(i) %} {% endfor %} {{r}}"
         )
         self.assertRaises(
-            templater.CustomParsedJinjaException, 
-            templater.render_string, 
-            self.add_header("jinja", jinja_template), {},
+            templater.CustomParsedJinjaException,
+            templater.render_string,
+            self.add_header("jinja", jinja_template),
+            {},
         )

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -176,7 +176,7 @@ class TestTemplates(test_helpers.CiTestCase):
             "{% for i in input % } {% do r.append(i) %} {% endfor %} {{r}}"
         )
         self.assertRaises(
-            templater.CustomParsedJinjaException,
+            templater.JinjaSyntaxParsingException,
             templater.render_string,
             self.add_header("jinja", jinja_template),
             {},

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -269,7 +269,7 @@ class TestJinjaSyntaxParsingException:
         assert error.lineno == line_no
         assert error.message == syntax_error
         assert (
-            error.source.splitlines()[line_no - 1]
+            error.source.splitlines()[line_no - 2]  # -2 because of header
             == jinja_template.splitlines()[line_no - 1]
         )
 
@@ -285,12 +285,21 @@ class TestJinjaSyntaxParsingException:
         )
         assert error_msg == expected_error_msg
 
-    def test_format_error_message_without_content_line(self):
+    @pytest.mark.parametrize(
+        "line_content",
+        (
+            "",
+            None,
+        ),
+    )
+    def test_format_error_message_without_content_line(self, line_content):
         expected_error_msg = (
             "Unable to parse Jinja template due to syntax error: "
             "unexpected '}' on line 4"
         )
         error_msg = JinjaSyntaxParsingException.format_error_message(
-            syntax_error="unexpected '}'", line_number=4, line_content=None
+            syntax_error="unexpected '}'",
+            line_number=4,
+            line_content=line_content,
         )
         assert error_msg == expected_error_msg

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -517,7 +517,10 @@ class TestUtil:
             return_value='{"c": "d"}',
         )
         conf = util.read_conf("cfg_path", instance_data_file="vars_path")
-        assert "Failed to render user-data file" in caplog.text
+        assert (
+            "Failed to render templated yaml config file 'cfg_path'"
+            in caplog.text
+        )
         assert conf == {}
 
     @mock.patch(

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -466,7 +466,7 @@ class TestUtil:
         ) in caplog.text
 
     @skipUnlessJinja()
-    def test_read_conf_with_failed_template(self, mocker, caplog):
+    def test_read_conf_with_failed_config_json(self, mocker, caplog):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
             "cloudinit.util.load_file",
@@ -481,7 +481,7 @@ class TestUtil:
         assert conf == {}
 
     @skipUnlessJinja()
-    def test_read_conf_with_failed_vars(self, mocker, caplog):
+    def test_read_conf_with_failed_instance_data_json(self, mocker, caplog):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
             "cloudinit.util.load_file",

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -500,8 +500,8 @@ class TestUtil:
         [
             '{"a": "{{c} } }"',
             '{"a": "{{c} } "',
-            '{% if c %} C is present {% else % } C is NOT present {% endif %}',
-        ]
+            "{% if c %} C is present {% else % } C is NOT present {% endif %}",
+        ],
     )
     @skipUnlessJinja()
     def test_read_conf_with_config_invalid_jinja_syntax(
@@ -510,7 +510,7 @@ class TestUtil:
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
             "cloudinit.util.load_file",
-            return_value='## template: jinja\n' + template,
+            return_value="## template: jinja\n" + template,
         )
         mocker.patch(
             "cloudinit.handlers.jinja_template.load_file",


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
feat(jinja): better jinja feedback and error catching

When an error is encountered while trying to parse a jinja template, the traceback is automatically parsed to get the specific error and the line number that caused this error, and then this information is turned into a user-friendly single-line error message. 

The cloud-init runtime will log these error messages when jinja syntax errors are encountered in the cloud-config file. For the query, render, and schema commands, the nasty traceback is caught and a single line error message is given to the user instead.

Fixes GH-4360
```

## PR Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/contributing.html)
 - [x] I have updated or added any unit tests accordingly
 - [x] I have updated or added any documentation accordingly

