### PR TITLE
feat(ds-identify): Don't run unnecessary systemd-detect-virt

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -317,7 +317,7 @@ class DsIdentifyBase(CiTestCase):
         data = copy.deepcopy(VALID_CFG[name])
 
         return self._check_via_dict(
-            data, RC_FOUND, dslist=[data.pop("ds"), DS_NONE], **data
+            data, RC_FOUND, dslist=[data.pop("ds"), DS_NONE]
         )
 
     def _test_ds_not_found(self, name):

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -3,11 +3,11 @@
 import copy
 import os
 from collections import namedtuple
+from logging import getLogger
 from pathlib import Path
+from tempfile import mkdtemp
 from textwrap import dedent
 from uuid import uuid4
-from logging import getLogger
-from tempfile import mkdtemp
 
 import pytest
 
@@ -115,12 +115,24 @@ MOCK_VIRT_IS_KVM_ENV = {"name": "detect_virt_env", "RET": "vm:kvm", "ret": 0}
 # passed `hv_passthrough` which causes systemd < v.251 to misinterpret CPU
 # as "qemu" instead of "kvm"
 MOCK_VIRT_IS_KVM_QEMU = {"name": "detect_virt", "RET": "qemu", "ret": 0}
-MOCK_VIRT_IS_KVM_QEMU_ENV = {"name": "detect_virt_env", "RET": "vm:qemu", "ret": 0}
+MOCK_VIRT_IS_KVM_QEMU_ENV = {
+    "name": "detect_virt_env",
+    "RET": "vm:qemu",
+    "ret": 0,
+}
 MOCK_VIRT_IS_VMWARE = {"name": "detect_virt", "RET": "vmware", "ret": 0}
-MOCK_VIRT_IS_VMWARE_ENV = {"name": "detect_virt_env", "RET": "vm:vmware", "ret": 0}
+MOCK_VIRT_IS_VMWARE_ENV = {
+    "name": "detect_virt_env",
+    "RET": "vm:vmware",
+    "ret": 0,
+}
 # currenty' SmartOS hypervisor "bhyve" is unknown by systemd-detect-virt.
 MOCK_VIRT_IS_VM_OTHER = {"name": "detect_virt", "RET": "vm-other", "ret": 0}
-MOCK_VIRT_IS_VM_OTHER_ENV = {"name": "detect_virt_env", "RET": "vm:vm-other", "ret": 0}
+MOCK_VIRT_IS_VM_OTHER_ENV = {
+    "name": "detect_virt_env",
+    "RET": "vm:vm-other",
+    "ret": 0,
+}
 MOCK_VIRT_IS_XEN = {"name": "detect_virt", "RET": "xen", "ret": 0}
 MOCK_VIRT_IS_XEN_ENV = {"name": "detect_virt_env", "RET": "vm:xen", "ret": 0}
 MOCK_VIRT_IS_WSL = {"name": "detect_virt", "RET": "wsl", "ret": 0}
@@ -210,9 +222,10 @@ class DsIdentifyBase(CiTestCase):
             # Don't mock when SYSTEMD_VIRTUALIZATION would be set to a value.
             # When no virtualization is detected, the call path would currently
             # fall back to calling systemd-detect-virt, which we currently mock
-            # out at the function call to `detectdir = _virt()`. Continue mocking
-            # that code path. One day when systemd 250 is no longer supported
-            # we can simplify this code and not mock `detect_virt()` at all.
+            # out at the function call to `detectdir = _virt()`. Continue
+            # mocking that code path. One day when systemd 250 is no longer
+            # supported we can simplify this code and not mock `detect_virt()`
+            # at all.
             if "detect_virt_env" == data["name"] and "none" != data["RET"]:
                 return ""
             ddata.update(data)
@@ -483,7 +496,10 @@ class TestDsIdentify(DsIdentifyBase):
         self._test_ds_found("GCE")
 
     def test_gce_by_product_name_env(self):
-        """GCE identifies itself with product_name. Uses SYSTEMD_VIRTUALIZATION"""
+        """GCE identifies itself with product_name.
+
+        Uses SYSTEMD_VIRTUALIZATION
+        """
         self._test_ds_found("GCE_ENV")
 
     def test_gce_by_serial(self):
@@ -1444,12 +1460,19 @@ VALID_CFG = {
         "mocks": [{"name": "is_socket_file", "ret": 1}, MOCK_VIRT_IS_KVM_QEMU],
         "no_mocks": ["dscheck_LXD"],  # Don't default mock dscheck_LXD
     },
-    "LXD-kvm-qemu-kernel-gt-5.10-env": {  # LXD host > 5.10 kvm launch virt==qemu
+    # LXD host > 5.10 kvm launch virt==qemu
+    "LXD-kvm-qemu-kernel-gt-5.10-env": {
         "ds": "LXD",
         "files": {P_BOARD_NAME: "LXD\n"},
         # /dev/lxd/sock does not exist and KVM virt-type
-        "mocks": [{"name": "is_socket_file", "ret": 1}, MOCK_VIRT_IS_KVM_QEMU_ENV],
-        "no_mocks": ["dscheck_LXD", "detect_virt"],  # Don't default mock dscheck_LXD
+        "mocks": [
+            {"name": "is_socket_file", "ret": 1},
+            MOCK_VIRT_IS_KVM_QEMU_ENV,
+        ],
+        "no_mocks": [
+            "dscheck_LXD",
+            "detect_virt",
+        ],  # Don't default mock dscheck_LXD
     },
     "LXD": {
         "ds": "LXD",

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -123,6 +123,7 @@ DS_FOUND=0
 DS_NOT_FOUND=1
 DS_MAYBE=2
 
+DI_SYSTEMD_VIRTUALIZATION=${SYSTEMD_VIRTUALIZATION:-}
 DI_DSNAME=""
 # this has to match the builtin list in cloud-init, it is what will
 # be searched if there is no setting found in config.
@@ -437,8 +438,9 @@ cached() {
 detect_virt() {
     local virt="${UNAVAILABLE}" r="" out=""
     if [ -d /run/systemd ]; then
-        if [ -n "$SYSTEMD_VIRTUALIZATION" ]; then
-            virt=${SYSTEMD_VIRTUALIZATION#*:}
+        if [ -n "$DI_SYSTEMD_VIRTUALIZATION" ]; then
+            virt=${DI_SYSTEMD_VIRTUALIZATION#*:}
+            debug 2 "detected $virt via env variable SYSTEMD_VIRTUALIZATION"
         else
             # required for compatibility with systemd version <251
             out=$(systemd-detect-virt 2>&1)
@@ -446,6 +448,7 @@ detect_virt() {
             if [ $r -eq 0 ] || { [ $r -ne 0 ] && [ "$out" = "none" ]; }; then
                 virt="$out"
             fi
+            debug 2 "detected $virt via ds-identify"
         fi
     elif command -v virt-what >/dev/null 2>&1; then
         # Map virt-what's names to those systemd-detect-virt that
@@ -480,7 +483,7 @@ detect_virt() {
             case "$out" in
                 hv) virt="microsoft" ;;
                 vbox) virt="oracle" ;;
-                generic) "vm-other";;
+                generic) virt="vm-other";;
                 *) virt="$out"
             esac
         }

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -437,10 +437,15 @@ cached() {
 detect_virt() {
     local virt="${UNAVAILABLE}" r="" out=""
     if [ -d /run/systemd ]; then
-        out=$(systemd-detect-virt 2>&1)
-        r=$?
-        if [ $r -eq 0 ] || { [ $r -ne 0 ] && [ "$out" = "none" ]; }; then
-            virt="$out"
+        if [ -n "$SYSTEMD_VIRTUALIZATION" ]; then
+            virt=${SYSTEMD_VIRTUALIZATION#*:}
+        else
+            # required for compatibility with systemd version <251
+            out=$(systemd-detect-virt 2>&1)
+            r=$?
+            if [ $r -eq 0 ] || { [ $r -ne 0 ] && [ "$out" = "none" ]; }; then
+                virt="$out"
+            fi
         fi
     elif command -v virt-what >/dev/null 2>&1; then
         # Map virt-what's names to those systemd-detect-virt that


### PR DESCRIPTION
## Additional Context
```
feat(ds-identify): Don't run unnecessary systemd-detect-virt

Running systemd-detect-virt is expensive and, on systemd >=251,
it is unnecessary.

The environment variable SYSTEMD_VIRTUALIZATION contains the
virtualization type that we currently manually get from
systemd-detect-virt.

https://www.freedesktop.org/software/systemd/man/latest/systemd.generator.html#Environment
```

## Test Steps

#### shell stuff
```bash
$ /bin/sh -c 'VALUE="container:lxc";echo ${VALUE#*:}'
lxc
```

#### this branch: focal (systemd 245)
```console
# cat /run/cloud-init/ds-identify.log 
[up 0.50s] ds-identify 
policy loaded: mode=search report=false found=all maybe=all notfound=disabled
/etc/cloud/cloud.cfg.d/90_dpkg.cfg set datasource_list: [ NoCloud, ConfigDrive, OpenNebula, DigitalOcean, Azure, AltCloud, OVF, MAAS, GCE, OpenStack, CloudSigma, SmartOS, Bigstep, Scaleway, AliYun, Ec2, CloudStack, Hetzner, IBMCloud, Oracle, Exoscale, RbxCloud, UpCloud, VMware, Vultr, LXD, NWCS, Akamai, None ]
DMI_PRODUCT_NAME=MS-7B79
DMI_SYS_VENDOR=Micro-Star International Co., Ltd.
DMI_PRODUCT_SERIAL=unavailable
DMI_PRODUCT_UUID=unavailable
PID_1_PRODUCT_NAME=unavailable
DMI_CHASSIS_ASSET_TAG=To be filled by O.E.M.
DMI_BOARD_NAME=X470 GAMING PLUS (MS-7B79)
FS_LABELS=unavailable:container
ISO9660_DEVS=unavailable:container
KERNEL_CMDLINE=/sbin/init 
VIRT=lxc
UNAME_KERNEL_NAME=Linux
UNAME_KERNEL_RELEASE=6.2.0-37-generic
UNAME_KERNEL_VERSION=#38-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct 30 21:04:52 UTC 2023
UNAME_MACHINE=x86_64
UNAME_NODENAME=me
UNAME_OPERATING_SYSTEM=GNU/Linux
DSNAME=
DSLIST=NoCloud ConfigDrive OpenNebula DigitalOcean Azure AltCloud OVF MAAS GCE OpenStack CloudSigma SmartOS Bigstep Scaleway AliYun Ec2 CloudStack Hetzner IBMCloud Oracle Exoscale RbxCloud UpCloud VMware Vultr LXD NWCS Akamai None
MODE=search
ON_FOUND=all
ON_MAYBE=all
ON_NOTFOUND=disabled
pid=47 ppid=27
is_container=true
check for 'NoCloud' returned found
is_ds_enabled(IBMCloud) = true.
is_ds_enabled(IBMCloud) = true.
Found single datasource: NoCloud
[up 0.53s] returning 0
```

#### this branch: mantic (systemd 253)
```console
# cat /run/cloud-init/ds-identify.log 
[up 0.43s] ds-identify 
policy loaded: mode=search report=false found=all maybe=all notfound=disabled
/etc/cloud/cloud.cfg.d/90_dpkg.cfg set datasource_list: [ NoCloud, ConfigDrive, OpenNebula, DigitalOcean, Azure, AltCloud, OVF, MAAS, GCE, OpenStack, CloudSigma, SmartOS, Bigstep, Scaleway, AliYun, Ec2, CloudStack, Hetzner, IBMCloud, Oracle, Exoscale, RbxCloud, UpCloud, VMware, Vultr, LXD, NWCS, Akamai, None ]
DMI_PRODUCT_NAME=MS-7B79
DMI_SYS_VENDOR=Micro-Star International Co., Ltd.
DMI_PRODUCT_SERIAL=unavailable
DMI_PRODUCT_UUID=unavailable
PID_1_PRODUCT_NAME=unavailable
DMI_CHASSIS_ASSET_TAG=To be filled by O.E.M.
DMI_BOARD_NAME=X470 GAMING PLUS (MS-7B79)
FS_LABELS=unavailable:container
ISO9660_DEVS=unavailable:container
KERNEL_CMDLINE=/sbin/init 
VIRT=lxc
UNAME_KERNEL_NAME=Linux
UNAME_KERNEL_RELEASE=6.2.0-37-generic
UNAME_KERNEL_VERSION=#38-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct 30 21:04:52 UTC 2023
UNAME_MACHINE=x86_64
UNAME_NODENAME=me
UNAME_OPERATING_SYSTEM=GNU/Linux
DSNAME=
DSLIST=NoCloud ConfigDrive OpenNebula DigitalOcean Azure AltCloud OVF MAAS GCE OpenStack CloudSigma SmartOS Bigstep Scaleway AliYun Ec2 CloudStack Hetzner IBMCloud Oracle Exoscale RbxCloud UpCloud VMware Vultr LXD NWCS Akamai None
MODE=search
ON_FOUND=all
ON_MAYBE=all
ON_NOTFOUND=disabled
pid=47 ppid=29
is_container=true
is_ds_enabled(IBMCloud) = true.
is_ds_enabled(IBMCloud) = true.
No ds found [mode=search, notfound=disabled]. Disabled cloud-init [1]
[up 0.47s] returning 1
```

#### compared to main branch: mantic (systemd 253)
```console
# cat /run/cloud-init/ds-identify.log 
[up 0.48s] ds-identify 
policy loaded: mode=search report=false found=all maybe=all notfound=disabled
/etc/cloud/cloud.cfg.d/90_dpkg.cfg set datasource_list: [ NoCloud, ConfigDrive, OpenNebula, DigitalOcean, Azure, AltCloud, OVF, MAAS, GCE, OpenStack, CloudSigma, SmartOS, Bigstep, Scaleway, AliYun, Ec2, CloudStack, Hetzner, IBMCloud, Oracle, Exoscale, RbxCloud, UpCloud, VMware, Vultr, LXD, NWCS, Akamai, None ]
DMI_PRODUCT_NAME=MS-7B79
DMI_SYS_VENDOR=Micro-Star International Co., Ltd.
DMI_PRODUCT_SERIAL=unavailable
DMI_PRODUCT_UUID=unavailable
PID_1_PRODUCT_NAME=unavailable
DMI_CHASSIS_ASSET_TAG=To be filled by O.E.M.
DMI_BOARD_NAME=X470 GAMING PLUS (MS-7B79)
FS_LABELS=unavailable:container
ISO9660_DEVS=unavailable:container
KERNEL_CMDLINE=/sbin/init 
VIRT=lxc
UNAME_KERNEL_NAME=Linux
UNAME_KERNEL_RELEASE=6.2.0-37-generic
UNAME_KERNEL_VERSION=#38-Ubuntu SMP PREEMPT_DYNAMIC Mon Oct 30 21:04:52 UTC 2023
UNAME_MACHINE=x86_64
UNAME_NODENAME=me
UNAME_OPERATING_SYSTEM=GNU/Linux
DSNAME=
DSLIST=NoCloud ConfigDrive OpenNebula DigitalOcean Azure AltCloud OVF MAAS GCE OpenStack CloudSigma SmartOS Bigstep Scaleway AliYun Ec2 CloudStack Hetzner IBMCloud Oracle Exoscale RbxCloud UpCloud VMware Vultr LXD NWCS Akamai None
MODE=search
ON_FOUND=all
ON_MAYBE=all
ON_NOTFOUND=disabled
pid=46 ppid=29
is_container=true
is_ds_enabled(IBMCloud) = true.
is_ds_enabled(IBMCloud) = true.
No ds found [mode=search, notfound=disabled]. Disabled cloud-init [1]
[up 0.52s] returning 1
```
## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
