### PR TITLE
bug(schema): do not write network-config when instance dir absent

### DIFF
--- a/tests/integration_tests/datasources/test_none.py
+++ b/tests/integration_tests/datasources/test_none.py
@@ -1,0 +1,83 @@
+"""DataSourceNone integration tests on LXD."""
+import json
+
+from pycloudlib.lxd.instance import LXDInstance
+
+from tests.integration_tests.decorators import retry
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log
+
+DS_NONE_BASE_CFG = """\
+datasource_list: [None]
+datasource:
+  None:
+    metadata:
+      instance-id: my-iid-uuid
+    userdata_raw: |
+      #cloud-config
+      runcmd:
+      - touch /var/tmp/success-with-datasource-none
+"""
+
+
+@retry(tries=30, delay=1)
+def wait_for_cloud_init_status_file(instance: LXDInstance):
+    """Wait for a non-empty status.json indicating cloud-init has started.
+
+    We don't wait for cloud-init to complete in this scenario as the failure
+    path on some images leaves us with cloud-init status blocking
+    indefinitely in the "running" state.
+    """
+    status_file = instance.read_from_file("/run/cloud-init/status.json")
+    assert len(status_file)
+
+
+def test_datasource_none_discovery(client: IntegrationInstance):
+    """Integration test for #4635.
+
+    Test that DataSourceNone detection (used by live installers) doesn't
+    generate errors or warnings.
+    """
+    log = client.read_from_file("/var/log/cloud-init.log")
+    verify_clean_log(log)
+    # Limit datasource detection to DataSourceNone.
+    client.write_to_file(
+        "/etc/cloud/cloud.cfg.d/99-force-dsnone.cfg", DS_NONE_BASE_CFG
+    )
+    if client.settings.PLATFORM in ["lxd_container"]:
+        # DataSourceNone provides no network_config.
+        # To avoid changing network config from platform desired net cfg
+        # to fallback config, copy out the rendered network config
+        # to /etc/cloud/cloud.cfg.d/99-orig-net.cfg so it is
+        # setup by the DataSourceNone case as well.
+        # Otherwise (LXD specifically) we'll have network torn down due
+        # to virtual NICs present which results in not network being
+        # brought up when we emit fallback config which attempts to
+        # match on PermanentMACAddress. LP:#2022947
+        client.execute(
+            "cp /etc/netplan/50-cloud-init.yaml"
+            " /etc/cloud/cloud.cfg.d/99-orig-net.cfg"
+        )
+    client.execute("cloud-init clean --logs --reboot")
+    wait_for_cloud_init_status_file(client)
+    status = json.loads(client.execute("cloud-init status --format=json"))
+    assert [] == status["errors"]
+    expected_warnings = [
+        "Used fallback datasource",
+        "Falling back to a hard restart of systemd-networkd.service",
+    ]
+    unexpected_warnings = []
+    for current_warning in status["recoverable_errors"].get("WARNING", []):
+        if [w for w in expected_warnings if w in current_warning]:
+            # Found a matching expected_warning substring in current_warning
+            continue
+        unexpected_warnings.append(current_warning)
+
+    if unexpected_warnings:
+        raise AssertionError(
+            f"Unexpected recoverable errors: {list(unexpected_warnings)}"
+        )
+    client.execute("cloud-init status --wait")
+    log = client.read_from_file("/var/log/cloud-init.log")
+    verify_clean_log(log)
+    assert client.execute("test -f /var/tmp/success-with-datasource-none").ok

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -55,7 +55,7 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
             "Found unexpected errors: %s" % "\n".join(error_logs)
         )
 
-    warning_count = log.count("WARN")
+    warning_count = log.count("[WARNING]")
     expected_warnings = 0
     traceback_count = log.count("Traceback")
     expected_tracebacks = 0
@@ -74,6 +74,11 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         # and enabling it
         warning_texts.append(
             "canonical-livepatch returned error when checking status"
+        )
+    if "found network data from DataSourceNone" in log:
+        warning_texts.append("Used fallback datasource")
+        warning_texts.append(
+            "Falling back to a hard restart of systemd-networkd.service"
         )
     if "oracle" in log:
         # LP: #1842752

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -21,7 +21,7 @@ from urllib.parse import urlsplit, urlunsplit
 import responses
 
 import cloudinit
-from cloudinit import cloud, distros
+from cloudinit import atomic_helper, cloud, distros
 from cloudinit import helpers as ch
 from cloudinit import subp, util
 from cloudinit.config.schema import (
@@ -292,6 +292,9 @@ class FilesystemMockingTestCase(ResourceUsingTestCase):
                 ("del_file", 1),
                 ("sym_link", -1),
                 ("copy", -1),
+            ],
+            atomic_helper: [
+                ("write_json", 1),
             ],
         }
         for (mod, funcs) in patch_funcs.items():

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -10,7 +10,7 @@ import pytest
 from cloudinit import sources, stages
 from cloudinit.event import EventScope, EventType
 from cloudinit.sources import NetworkConfigSource
-from cloudinit.util import write_file
+from cloudinit.util import sym_link, write_file
 from tests.unittests.helpers import mock
 from tests.unittests.util import TEST_INSTANCE_ID, FakeDataSource
 
@@ -28,7 +28,8 @@ class TestInit:
                 "paths": {"cloud_dir": self.tmpdir, "run_dir": self.tmpdir},
             }
         }
-        tmpdir.mkdir("instance")
+        tmpdir.mkdir("instance-uuid")
+        sym_link(tmpdir.join("instance-uuid"), tmpdir.join("instance"))
         self.init.datasource = FakeDataSource(paths=self.init.paths)
         self._real_is_new_instance = self.init.is_new_instance
         self.init.is_new_instance = mock.Mock(return_value=True)
@@ -393,9 +394,12 @@ class TestInit:
         assert caplog.records[0].levelname == "INFO"
         assert f"network config is disabled by {disable_file}" in caplog.text
 
+    @pytest.mark.parametrize("instance_dir_present", (True, False))
     @mock.patch("cloudinit.net.get_interfaces_by_mac")
     @mock.patch("cloudinit.distros.ubuntu.Distro")
-    def test_apply_network_on_new_instance(self, m_ubuntu, m_macs):
+    def test_apply_network_on_new_instance(
+        self, m_ubuntu, m_macs, instance_dir_present
+    ):
         """Call distro apply_network_config methods on is_new_instance."""
         net_cfg = {
             "version": 1,
@@ -415,20 +419,26 @@ class TestInit:
         m_macs.return_value = {"42:42:42:42:42:42": "eth9"}
 
         self.init._find_networking_config = fake_network_config
-
+        if not instance_dir_present:
+            self.tmpdir.join("instance").remove()
+            self.tmpdir.join("instance-uuid").remove()
         self.init.apply_network_config(True)
         networking = self.init.distro.networking
         networking.apply_network_config_names.assert_called_with(net_cfg)
         self.init.distro.apply_network_config.assert_called_with(
             net_cfg, bring_up=True
         )
-        assert net_cfg == json.loads(
-            self.tmpdir.join("instance/network-config.json").read()
-        )
-        assert net_cfg == json.loads(
-            self.tmpdir.join("network-config.json").read()
-        )
-        assert os.path.islink(self.tmpdir.join("network-config.json"))
+        if instance_dir_present:
+            assert net_cfg == json.loads(
+                self.tmpdir.join("network-config.json").read()
+            )
+            assert os.path.islink(self.tmpdir.join("network-config.json"))
+        else:
+            for path in (
+                "instance/network-config.json",
+                "network-config.json",
+            ):
+                assert not self.tmpdir.join(path).exists()
 
     @mock.patch("cloudinit.distros.ubuntu.Distro")
     def test_apply_network_on_same_instance_id(self, m_ubuntu, caplog):
@@ -526,12 +536,9 @@ class TestInit:
         self, m_ubuntu, m_macs, caplog
     ):
         """Don't apply network if datasource has no BOOT event."""
-        net_cfg = self._apply_network_setup(m_macs)
+        self._apply_network_setup(m_macs)
         self.init.apply_network_config(True)
         self.init.distro.apply_network_config.assert_not_called()
-        assert net_cfg == json.loads(
-            self.tmpdir.join("network-config.json").read()
-        )
         assert (
             "No network config applied. Neither a new instance nor datasource "
             "network update allowed" in caplog.text


### PR DESCRIPTION
## Proposed Commit Message
```
bug(schema): write network-config if instance dir present (#4635)

Only write /var/lib/cloud/instance/network-config.json once
datasource is detected. The /var/lib/clound/instance symlink is
created by Init.instancify after datasource detection is complete.

Move creation of /var/lib/cloud/instance/network-config.json into
it's own method _write_network_config_json. It will be called by
any call to apply_network_config.

apply_network_config is called in both Local and Network stages.

In Local stage, apply_network_config is used to either:
 - render the final network config of datasource detected in Local
 - in absence of Local datasource, render basic fallback DHCP on
   primary NIC to allow network to come up before detecting a
   Network datasource

For Network datasources, they will not have been discovered or
instancify'd in Local boot stage, so apply_network_config cannot
yet persist network-config.json.

Defer creation of network-config.json for Network datasources
until until the link /var/lib/cloud/instance exists and
apply_network_config is called in Network stage to render final
network config.

Fixes GH-4630
```

## Additional Context
This broke live-service autoinstall images in Noble which use DataSourceNone for configuration on first boot because Local boot stage tried to create /var/lib/cloud/instance/tmpasdffile when atomically writing network-config.json to a directory /var/lib/cloud/instance which didn't exist yet.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
# reproducer 
lxc launch ubuntu-daily/noble test-n
lxc exec test-n -- apt update
lxc exec test-n -- apt install cloud-init
lxc exec test-n -- cloud-init --version  | grep 23.4
# inject datasource None config
cat > 99-none.cfg <<EOF
datasource_list: [None]
datasource:
  None:
    metadata: 
       instance-id: my-id
    userdata_raw: "#cloud-config\nssh_import_id: [YOUR_LP_NAME]"
EOF
lxc file push 99-none.cfg test-n/etc/cloud/cloud.cfg.d/
lxc exec test-n -- cloud-init clean --logs --reboot
lxc exec test-n -- cloud-init status --wait --format=json
# expect to see Tracebacks w/ FileNotFound related to writing /var/lib/cloud/instance/*
```


```
# build local deb from this PR
./tools/run-container --package ubuntu/noble
lxc file push cloud-init*bddeb.deb test-n/
lxc exec test-n -- apt install /cloud-init*deb
lxc exec test-n -- cloud-init clean --logs --reboot
lxc exec test-n -- cloud-init status --wait --format=json
# confirm /var/lib/cloud/instance/network-config.json still exists for the Network detected datasource
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
