### PR TITLE
fix: fix issue with networkd online target

### DIFF
--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -8,7 +8,6 @@ Wants=cloud-init-local.service
 Wants=sshd-keygen.service
 Wants=sshd.service
 After=cloud-init-local.service
-After=systemd-networkd-wait-online.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 After=networking.service
 {% endif %}
@@ -26,6 +25,7 @@ After=wicked.service
 # would not be guaranteed at this point.
 After=dbus.service
 {% endif %}
+Before=systemd-networkd-wait-online.service
 Before=network-online.target
 Before=sshd-keygen.service
 Before=sshd.service


### PR DESCRIPTION
## Proposed Commit Message
fix: fix issue with networkd online target

```
fix: fix issue with networkd online target

This adds systemd-networkd-wait-online.service to the Before's of cloud-init.service to prevent boot hangs and unitfile failures when its in use.
```

## Additional Context
We are currently encountering this on select Ubuntu releases at Vultr.

## Test Steps
We made this change live on a system and in our custom package.

## Checklist
- [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [X] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [X] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
