### PR TITLE
azure: report failure to eject as error instead of debug

### DIFF
--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -794,7 +794,7 @@ class WALinuxAgentShim:
         except Exception as e:
             report_diagnostic_event(
                 "Failed ejecting the provisioning iso: %s" % e,
-                logger_func=LOG.debug,
+                logger_func=LOG.error,
             )
 
     @azure_ds_telemetry_reporter


### PR DESCRIPTION
I recently noticed some images do not include `eject` and this failure is lost in the debug messages.  Raising it to error to improve visibility of the error.

Given that the media may contain the plain-text admin password, we strongly prefer to eject it as soon as possible from within the VM.  If the media is not ejected by the client, the host will do so with some delay when cloud-init reports ready/failure to WireServer.