### PR TITLE
Update build-on-openbsd dependencies

### DIFF
--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -33,6 +33,7 @@ chrislalos
 ciprianbadescu
 citrus-it
 cjp256
+CodeBleu
 Conan-Kudo
 cvstealth
 dankenigsberg

--- a/tools/build-on-openbsd
+++ b/tools/build-on-openbsd
@@ -10,13 +10,14 @@ pkgs="
    py3-configobj
    py3-jinja2
    py3-jsonschema
+   py3-netifaces
    py3-oauthlib
    py3-requests
    py3-setuptools
    py3-yaml
    sudo--
 "
-[ -f "$depschecked" ] || pkg_add ${pkgs} || fail "install packages"
+[ -f "$depschecked" ] || pkg_add "${pkgs}" || fail "install packages"
 
 touch $depschecked
 


### PR DESCRIPTION

fix: Update build-on-openbsd dependencies

    * script would fail will needing to do work with python netifaces
      module.
    * linting: SC2806 -  Double quote to prevent globbing and word
      splitting.
