### PR TITLE
dmi: support OpenBSD native reading 

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -19,17 +19,17 @@ from tests.unittests.helpers import (
 )
 
 UNAME_MYSYS = (
-    "Linux bart 4.4.0-62-generic #83-Ubuntu "
-    "SMP Wed Jan 18 14:10:15 UTC 2017 x86_64 GNU/Linux"
+    "Linux 4.4.0-62-generic #83-Ubuntu SMP Wed Jan 18 14:10:15 UTC 2017 x86_64"
 )
 UNAME_PPC64EL = (
-    "Linux diamond 4.4.0-83-generic #106-Ubuntu SMP "
+    "Linux 4.4.0-83-generic #106-Ubuntu SMP "
     "Mon Jun 26 17:53:54 UTC 2017 "
-    "ppc64le ppc64le ppc64le GNU/Linux"
+    "ppc64le ppc64le ppc64le"
 )
 UNAME_FREEBSD = (
-    "FreeBSD fbsd12-1 12.1-RELEASE-p10 FreeBSD 12.1-RELEASE-p10 GENERIC  amd64"
+    "FreeBSD 12.1-RELEASE-p10 FreeBSD 12.1-RELEASE-p10 GENERIC  amd64"
 )
+UNAME_OPENBSD = "OpenBSD GENERIC.MP#1397 amd64"
 
 BLKID_EFI_ROOT = """
 DEVNAME=/dev/sda1
@@ -246,6 +246,7 @@ MOCK_VIRT_IS_VM_OTHER = {"name": "detect_virt", "RET": "vm-other", "ret": 0}
 MOCK_VIRT_IS_XEN = {"name": "detect_virt", "RET": "xen", "ret": 0}
 MOCK_UNAME_IS_PPC64 = {"name": "uname", "out": UNAME_PPC64EL, "ret": 0}
 MOCK_UNAME_IS_FREEBSD = {"name": "uname", "out": UNAME_FREEBSD, "ret": 0}
+MOCK_UNAME_IS_OPENBSD = {"name": "uname", "out": UNAME_OPENBSD, "ret": 0}
 
 shell_true = 0
 shell_false = 1
@@ -434,11 +435,8 @@ class TestDsIdentify(DsIdentifyBase):
             "KERNEL_CMDLINE",
             "VIRT",
             "UNAME_KERNEL_NAME",
-            "UNAME_KERNEL_RELEASE",
             "UNAME_KERNEL_VERSION",
             "UNAME_MACHINE",
-            "UNAME_NODENAME",
-            "UNAME_OPERATING_SYSTEM",
             "DSNAME",
             "DSLIST",
             "MODE",
@@ -1062,6 +1060,7 @@ class TestBSDNoSys(DsIdentifyBase):
     """Test *BSD code paths
 
     FreeBSD doesn't have /sys so we use kenv(1) here.
+    OpenBSD uses sysctl(8).
     Other BSD systems fallback to dmidecode(8).
     BSDs also doesn't have systemd-detect-virt(8), so we use sysctl(8) to query
     kern.vm_guest, and optionally map it"""
@@ -1072,6 +1071,13 @@ class TestBSDNoSys(DsIdentifyBase):
         This will be used on FreeBSD systems.
         """
         self._test_ds_found("Hetzner-kenv")
+
+    def test_dmi_sysctl(self):
+        """Test that sysctl(8) works on systems which don't have /sys
+
+        This will be used on OpenBSD systems.
+        """
+        self._test_ds_found("Hetzner-sysctl")
 
     def test_dmi_dmidecode(self):
         """Test that dmidecode(8) works on systems which don't have /sys
@@ -1616,6 +1622,13 @@ VALID_CFG = {
             {"name": "get_kenv_field", "ret": 0, "RET": "Hetzner"},
         ],
     },
+    "Hetzner-sysctl": {
+        "ds": "Hetzner",
+        "mocks": [
+            MOCK_UNAME_IS_OPENBSD,
+            {"name": "get_sysctl_field", "ret": 0, "RET": "Hetzner"},
+        ],
+    },
     "Hetzner-dmidecode": {
         "ds": "Hetzner",
         "mocks": [{"name": "dmi_decode", "ret": 0, "RET": "Hetzner"}],
@@ -1766,10 +1779,7 @@ VALID_CFG = {
             {
                 "name": "uname",
                 "ret": 0,
-                "out": (
-                    "Linux d43da87a-daca-60e8-e6d4-d2ed372662a3 4.3.0 "
-                    "BrandZ virtual linux x86_64 GNU/Linux"
-                ),
+                "out": ("Linux BrandZ virtual linux x86_64"),
             },
             {"name": "blkid", "ret": 2, "out": ""},
         ],

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -210,6 +210,27 @@ get_kenv_field() {
     _RET="$val"
 }
 
+get_sysctl_field() {
+    local sys_field="$1" sysctl_field="" val=""
+    command -v sysctl >/dev/null 2>&1 || {
+        warn "No sysctl program. Cannot read $sys_field."
+        return 1
+    }
+    case "$sys_field" in
+        chassis_vendor) sysctl_field='hw.vendor';;
+        chassis_serial) sysctl_field='hw.type';;
+        chassis_version) sysctl_field='hw.uuid';;
+        sys_vendor) sysctl_field='hw.vendor';;
+        product_name) sysctl_field='hw.product';;
+        product_serial) sysctl_field='hw.uuid';;
+        product_uuid) sysctl_field='hw.uuid';;
+        *) error "Unknown field $sys_field. Cannot call sysctl."
+           return 1;;
+    esac
+    val=$(sysctl -nq "$sysctl_field" 2>/dev/null) || return 1
+    _RET="$val"
+}
+
 dmi_decode() {
     local sys_field="$1" dmi_field="" val=""
     command -v dmidecode >/dev/null 2>&1 || {
@@ -234,6 +255,9 @@ get_dmi_field() {
 
     if [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" -o "$DI_UNAME_KERNEL_NAME" = "Dragonfly" ]; then
         get_kenv_field "$1" || _RET="$ERROR"
+        return $?
+    elif [ "$DI_UNAME_KERNEL_NAME" = "OpenBSD" ]; then
+        get_sysctl_field "$1" || _RET="$ERROR"
         return $?
     fi
 
@@ -521,11 +545,8 @@ read_uname_info() {
     # uname is tricky to parse as it outputs always in a given order
     # independent of option order. kernel-version is known to have spaces.
     # 1   -s kernel-name
-    # 2   -n nodename
-    # 3   -r kernel-release
-    # 4.. -v kernel-version(whitespace)
-    # N-2 -m machine
-    # N-1 -o operating-system
+    # 2.. -v kernel-version(whitespace)
+    # N-1 -m machine
     cached "${DI_UNAME_CMD_OUT}" && return
     local out="${1:-}" ret=0 buf=""
     if [ -z "$out" ]; then

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -110,11 +110,8 @@ DI_VIRT=""
 DI_PID_1_PRODUCT_NAME=""
 
 DI_UNAME_KERNEL_NAME=""
-DI_UNAME_KERNEL_RELEASE=""
 DI_UNAME_KERNEL_VERSION=""
 DI_UNAME_MACHINE=""
-DI_UNAME_NODENAME=""
-DI_UNAME_OPERATING_SYSTEM=""
 DI_UNAME_CMD_OUT=""
 
 DS_FOUND=0
@@ -235,7 +232,7 @@ dmi_decode() {
 get_dmi_field() {
     _RET="$UNAVAILABLE"
 
-    if [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" ]; then
+    if [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" -o "$DI_UNAME_KERNEL_NAME" = "Dragonfly" ]; then
         get_kenv_field "$1" || _RET="$ERROR"
         return $?
     fi
@@ -393,7 +390,7 @@ read_fs_info() {
     # - DI_ISO9660_DEVS
     # - DI_FS_UUIDS
 
-    if [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" ]; then
+    if [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" -o "$DI_UNAME_KERNEL_NAME" = "Dragonfly" ]; then
         read_fs_info_freebsd
         return $?
     else
@@ -414,7 +411,7 @@ detect_virt() {
         if [ $r -eq 0 ] || { [ $r -ne 0 ] && [ "$out" = "none" ]; }; then
             virt="$out"
         fi
-    elif [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" ]; then
+    elif [ "$DI_UNAME_KERNEL_NAME" = "FreeBSD" -o "$DI_UNAME_KERNEL_NAME" = "Dragonfly" ]; then
         # Map FreeBSD's vm_guest names to those systemd-detect-virt that
         # don't match up. See
         # https://github.com/freebsd/freebsd/blob/master/sys/kern/subr_param.c#L144-L160
@@ -532,25 +529,22 @@ read_uname_info() {
     cached "${DI_UNAME_CMD_OUT}" && return
     local out="${1:-}" ret=0 buf=""
     if [ -z "$out" ]; then
-        out=$(uname -snrvmo) || {
+        out=$(uname -svm) || {
             ret=$?
-            error "failed reading uname with 'uname -snrvmo'"
+            error "failed reading uname with 'uname -svm'"
             return $ret
         }
     fi
     # shellcheck disable=2086
     set -- $out
     DI_UNAME_KERNEL_NAME="$1"
-    DI_UNAME_NODENAME="$2"
-    DI_UNAME_KERNEL_RELEASE="$3"
-    shift 3
-    while [ $# -gt 2 ]; do
+    shift
+    while [ $# -gt 1 ]; do
         buf="$buf $1"
         shift
     done
     DI_UNAME_KERNEL_VERSION="${buf# }"
     DI_UNAME_MACHINE="$1"
-    DI_UNAME_OPERATING_SYSTEM="$2"
     DI_UNAME_CMD_OUT="$out"
     return 0
 }
@@ -1573,8 +1567,7 @@ _print_info() {
     vars="DMI_PRODUCT_NAME DMI_SYS_VENDOR DMI_PRODUCT_SERIAL"
     vars="$vars DMI_PRODUCT_UUID PID_1_PRODUCT_NAME DMI_CHASSIS_ASSET_TAG"
     vars="$vars DMI_BOARD_NAME FS_LABELS ISO9660_DEVS KERNEL_CMDLINE VIRT"
-    vars="$vars UNAME_KERNEL_NAME UNAME_KERNEL_RELEASE UNAME_KERNEL_VERSION"
-    vars="$vars UNAME_MACHINE UNAME_NODENAME UNAME_OPERATING_SYSTEM"
+    vars="$vars UNAME_KERNEL_NAME UNAME_KERNEL_VERSION UNAME_MACHINE"
     vars="$vars DSNAME DSLIST"
     vars="$vars MODE ON_FOUND ON_MAYBE ON_NOTFOUND"
     for v in ${vars}; do


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: add support for OpenBSD's native dmi reading

OpenBSD's sysctl provides the most important DMI data in
its `hw` hierarchy. Switch ds-identify and cloudinit.dmi to using it.

This means we can get rid of the dmidecode dependency, which
requires setting `kern.allowkmem=1` and a reboot before usage.

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
