### PR TITLE
fix(packages/brpm): correct syntax error and typo

### DIFF
--- a/packages/brpm
+++ b/packages/brpm
@@ -44,7 +44,7 @@ def run_helper(helper, args=None, strip=True):
 
 
 def read_dependencies(distro):
-    """Returns the Python package depedencies from requirements.txt files.
+    """Returns the Python package dependencies from requirements.txt files.
 
     @returns a tuple of (build_deps, run_deps, test_deps)
     """
@@ -169,7 +169,7 @@ def main():
         util.write_file(spec_fn, contents)
         print("Created spec file at %r" % (spec_fn))
         for p in args.patches:
-            util.copy(p, os.path.abspath(os.path.join(topdir, 'SOURCES', os.path.basename(p)))_
+            util.copy(p, os.path.abspath(os.path.join(topdir, 'SOURCES', os.path.basename(p))))
 
         # Now build it!
         print("Running 'rpmbuild' in %r" % (topdir))

--- a/packages/redhat/cloud-init.spec.in
+++ b/packages/redhat/cloud-init.spec.in
@@ -184,7 +184,7 @@ fi
 %{_bindir}/cloud-id*
 
 # Docs
-%doc LICENSE ChangeLog TODO.rst requirements.txt
+%doc LICENSE ChangeLog requirements.txt
 %doc %{_defaultdocdir}/cloud-init/*
 
 # Configs


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(copr): Multiple fixes to allow COPR builds

Correct syntax error and typo in packages/brpm and remove unneeded
TODO.rst reference from packages/redhat/cloud-init.spec.in.
```

## Additional Context
<!-- If relevant -->
Successful build with these additional two commits: https://copr.fedorainfracloud.org/coprs/g/cloud-init/el-testing/build/6726068/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`bash -x ./tools/run-container --source-package --unittest --artifacts=./srpm/ rockylinux/8`

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
