### PR TITLE
Fix cloud-init for Python 3.13

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cloud-init (24.1~1g70e6f2e3-0ubuntu1) UNRELEASED; urgency=medium
+
+  * d/rules: explicitly tell pybuild to use distutils
+
+ -- Brett Holman <brett.holman@canonical.com>  Tue, 05 Dec 2023 13:23:42 -0600
+
 cloud-init (23.4-0ubuntu1) noble; urgency=medium
 
   * Upstream snapshot based on 23.4.

--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,7 @@
 include /usr/share/dpkg/pkg-info.mk
 
 INIT_SYSTEM ?= systemd
+export PYBUILD_SYSTEM = distutils
 export PYBUILD_INSTALL_ARGS=--init-system=$(INIT_SYSTEM)
 
 %:


### PR DESCRIPTION
## Additional Context
Without this change, CI unittests failed on Python 3.13. With this change, [tests succeed](https://github.com/canonical/cloud-init/actions/runs/7106053767/job/19344642252?pr=4567).


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
