### PR TITLE
Fix cloud-init for Python 3.13

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -58,7 +58,7 @@ try:
     )
 except (ImportError, AttributeError):
     try:
-        import passlib
+        import passlib.hash
 
         blowfish_hash = passlib.hash.sha512_crypt.hash
     except ImportError:


### PR DESCRIPTION
## Commit
Use the commit message

## Additional Context
Without this change, CI unittests [failed on Python 3.13](https://github.com/canonical/cloud-init/actions/runs/7103603744/job/19336679815). With this change, [tests succeed](https://github.com/canonical/cloud-init/actions/runs/7106053767/job/19344642252?pr=4567).


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
