### PR TITLE
feat(disk_setup) add timeout

### DIFF
--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -131,6 +131,13 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
                 LOG.warning("Invalid disk definition for %s", disk)
                 continue
 
+            if definition.get("timeout"):
+                tmout = int(definition.get("timeout", "0"))
+                missing = util.wait_for_files(
+                    [disk], maxwait=tmout, naplen=0.1
+                )
+                if len(missing) > 0:
+                    LOG.warning("Timeout expired waiting for %s", disk)
             try:
                 LOG.debug("Creating new partition table/disk")
                 util.log_time(

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1261,6 +1261,11 @@
                   "type": "boolean",
                   "default": false,
                   "description": "Controls whether this module tries to be safe about writing partition tables or not. If ``overwrite: false`` is set, the device will be checked for a partition table and for a file system and if either is found, the operation will be skipped. If ``overwrite: true`` is set, no checks will be performed. Using ``overwrite: true`` is **dangerous** and can lead to data loss, so double check that the correct device has been specified if using this option. Default: ``false``"
+                },
+                "timeout": {
+                  "type": "integer",
+                  "default": 0,
+                  "description": "Seconds to wait for a disk to appear. If omitted, no wait is performed. This is useful if a cloud provider has late or inconsistent disk attachments and you need a delay."
                 }
               }
             }

--- a/doc/examples/cloud-config-disk-setup.txt
+++ b/doc/examples/cloud-config-disk-setup.txt
@@ -98,6 +98,7 @@ disk_setup:
 #       table_type: 'mbr'
 #       layout: <LAYOUT|BOOL>
 #       overwrite: <BOOL>
+#       timeout: <INT>
 #
 # Where:
 #   <DEVICE>: The name of the device. 'ephemeralX' and 'swap' are special
@@ -159,6 +160,11 @@ disk_setup:
 #               'true' is cowboy mode. There are no checks and things are
 #                   done blindly. USE with caution, you can do things you
 #                   really, really don't want to do.
+#
+#   timeout=<INT>: Seconds to wait for a disk to appear. If omitted, no wait
+#               is performed. This is useful if a cloud provider has late or
+#               inconsistent disk attachments and you need a delay.
+#
 #
 #
 # fs_setup: Setup the filesystem

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -54,6 +54,7 @@ einsibjarni
 emmanuelthome
 eslerm
 esposem
+flokli
 frantisekz
 GabrielNagy
 garzdin


### PR DESCRIPTION

## Proposed Commit Message
```
In a cloud environment, sometimes disks will attach while cloud-init is running and get missed. This adds a configurable timeout to wait for those disks.

Fixes GH-3386
LP: #1832645
```

## Additional Context
This is https://github.com/canonical/cloud-init/pull/710 resurrected.
Fixes #3386.

## Test Steps
Tested with the following cloud-config file on azure:

```yaml
disk_setup:
  /dev/disk/by-lun/10:
    layout: false
    timeout: 60

fs_setup:
 - filesystem: ext4
   partition: auto
   device: /dev/disk/by-lun/10
   label: jenkins

mounts:
 - ["/dev/disk/by-label/jenkins", "/var/lib/jenkins"]
```

I used a `azurerm_virtual_machine_data_disk_attachment` terraform resource, which attaches the disk halfway during bootup, due to https://github.com/hashicorp/terraform-provider-azurerm/issues/6117, but this should also work with setting a reasonably large timeout and manually attaching the disk (at that lun)


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
