### PR TITLE
fix(runpath): On *BSD, create /run is not ephemeral

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -326,6 +326,9 @@ system_info:
   paths:
     cloud_dir: /var/lib/cloud/
     templates_dir: /etc/cloud/templates/
+{% elif is_bsd %}
+  paths:
+    run_dir: /var/run/
 {% endif %}
 {% if variant == "debian" %}
   package_mirrors:

--- a/sysvinit/freebsd/cloudinitlocal.tmpl
+++ b/sysvinit/freebsd/cloudinitlocal.tmpl
@@ -4,7 +4,7 @@
 # PROVIDE: cloudinitlocal
 {#
 ``cloudinitlocal`` purposefully does not depend on ``dsidentify``.
-That makes it easy for image builders to create images without ``dsidentify``.
+That makes it easy for image builders to disable ``dsidentify``.
 #}
 # REQUIRE: ldconfig mountcritlocal
 # BEFORE:  NETWORKING cloudinit cloudconfig cloudfinal

--- a/sysvinit/netbsd/cloudconfig.tmpl
+++ b/sysvinit/netbsd/cloudconfig.tmpl
@@ -11,9 +11,10 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
-    test -e {{prefix}}/etc/cloud/cloud-init.disabled \
-      && warn "cloud-init disabled by cloud-init.disabled file" \
-      && exit 0
+    if test -e {{prefix}}/etc/cloud/cloud-init.disabled ; then
+       warn "cloud-init disabled by cloud-init.disabled file"
+       exit 0
+    fi
     {{prefix}}/bin/cloud-init modules --mode config
 }
 

--- a/sysvinit/netbsd/cloudfinal.tmpl
+++ b/sysvinit/netbsd/cloudfinal.tmpl
@@ -10,9 +10,10 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
-    test -e {{prefix}}/etc/cloud/cloud-init.disabled \
-      && warn "cloud-init disabled by cloud-init.disabled file" \
-      && exit 0
+    if test -e {{prefix}}/etc/cloud/cloud-init.disabled ; then
+       warn "cloud-init disabled by cloud-init.disabled file"
+       exit 0
+    fi
     {{prefix}}/bin/cloud-init modules --mode final
 }
 

--- a/sysvinit/netbsd/cloudinit.tmpl
+++ b/sysvinit/netbsd/cloudinit.tmpl
@@ -10,9 +10,10 @@ name="cloudinit"
 start_cmd="start_cloud_init"
 start_cloud_init()
 {
-    test -e {{prefix}}/etc/cloud/cloud-init.disabled \
-      && warn "cloud-init disabled by cloud-init.disabled file" \
-      && exit 0
+    if test -e {{prefix}}/etc/cloud/cloud-init.disabled ; then
+       warn "cloud-init disabled by cloud-init.disabled file"
+       exit 0
+    fi
     {{prefix}}/bin/cloud-init init
 }
 

--- a/sysvinit/netbsd/cloudinitlocal.tmpl
+++ b/sysvinit/netbsd/cloudinitlocal.tmpl
@@ -16,9 +16,10 @@ name="cloudinitlocal"
 start_cmd="start_cloud_init_local"
 start_cloud_init_local()
 {
-    test -e {{prefix}}/etc/cloud/cloud-init.disabled \
-      && warn "cloud-init disabled by cloud-init.disabled file" \
-      && exit 0
+    if test -e {{prefix}}/etc/cloud/cloud-init.disabled; then
+       warn "cloud-init disabled by cloud-init.disabled file"
+       exit 0
+    fi
     {{prefix}}/bin/cloud-init init -l
 }
 

--- a/sysvinit/netbsd/dsidentify.tmpl
+++ b/sysvinit/netbsd/dsidentify.tmpl
@@ -11,9 +11,10 @@ name="dsidentify"
 start_cmd="start_dsidentify"
 start_dsidentify()
 {
-    test -e {{prefix}}/etc/cloud/cloud-init.disabled \
-      && warn "cloud-init disabled by cloud-init.disabled file" \
-      && exit 0
+    if test -e {{prefix}}/etc/cloud/cloud-init.disabled ; then
+      warn "cloud-init disabled by cloud-init.disabled file"
+      exit 0
+    fi
     {{prefix}}/lib/cloud-init/ds-identify
 }
 

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -18,16 +18,14 @@ from tests.unittests.helpers import (
     populate_dir_with_ts,
 )
 
-UNAME_MYSYS = (
-    "Linux 4.4.0-62-generic #83-Ubuntu SMP Wed Jan 18 14:10:15 UTC 2017 x86_64"
-)
+UNAME_MYSYS = "Linux #83-Ubuntu SMP Wed Jan 18 14:10:15 UTC 2017 x86_64"
 UNAME_PPC64EL = (
-    "Linux 4.4.0-83-generic #106-Ubuntu SMP "
-    "Mon Jun 26 17:53:54 UTC 2017 "
+    "Linux #106-Ubuntu SMP mon Jun 26 17:53:54 UTC 2017 "
     "ppc64le ppc64le ppc64le"
 )
 UNAME_FREEBSD = (
-    "FreeBSD 12.1-RELEASE-p10 FreeBSD 12.1-RELEASE-p10 GENERIC  amd64"
+    "FreeBSD FreeBSD 14.0-RELEASE-p3 releng/14.0-n265398-20fae1e1699"
+    "GENERIC-MMCCAM amd64"
 )
 UNAME_OPENBSD = "OpenBSD GENERIC.MP#1397 amd64"
 
@@ -340,7 +338,17 @@ class DsIdentifyBase(CiTestCase):
             },
         ]
 
-        written = [d["name"] for d in mocks]
+        uname = "Linux"
+        runpath = "run"
+        written = []
+        for d in mocks:
+            written.append(d["name"])
+            if d["name"] == "uname":
+                uname = d["out"].split(" ")[0]
+        # set runpath so that BSDs use /var/run rather than /run
+        if uname != "Linux":
+            runpath = "var/run"
+
         for data in mocks:
             mocklines.append(write_mock(data))
         for d in default_mocks:
@@ -363,7 +371,7 @@ class DsIdentifyBase(CiTestCase):
             err = e.stderr
 
         cfg = None
-        cfg_out = os.path.join(rootd, "run/cloud-init/cloud.cfg")
+        cfg_out = os.path.join(rootd, runpath, "cloud-init/cloud.cfg")
         if os.path.exists(cfg_out):
             contents = util.load_file(cfg_out)
             try:

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -68,7 +68,6 @@ DI_DISABLED="disabled"
 DI_DEBUG_LEVEL="${DEBUG_LEVEL:-1}"
 
 PATH_ROOT=${PATH_ROOT:-""}
-PATH_RUN=${PATH_RUN:-"${PATH_ROOT}/run"}
 PATH_SYS_CLASS_DMI_ID=${PATH_SYS_CLASS_DMI_ID:-${PATH_ROOT}/sys/class/dmi/id}
 PATH_SYS_HYPERVISOR=${PATH_SYS_HYPERVISOR:-${PATH_ROOT}/sys/hypervisor}
 PATH_SYS_CLASS_BLOCK=${PATH_SYS_CLASS_BLOCK:-${PATH_ROOT}/sys/class/block}
@@ -82,11 +81,17 @@ PATH_PROC_UPTIME=${PATH_PROC_UPTIME:-${PATH_ROOT}/proc/uptime}
 PATH_ETC_CLOUD="${PATH_ETC_CLOUD:-${PATH_ROOT}/etc/cloud}"
 PATH_ETC_CI_CFG="${PATH_ETC_CI_CFG:-${PATH_ETC_CLOUD}/cloud.cfg}"
 PATH_ETC_CI_CFG_D="${PATH_ETC_CI_CFG_D:-${PATH_ETC_CI_CFG}.d}"
-PATH_RUN_CI="${PATH_RUN_CI:-${PATH_RUN}/cloud-init}"
-PATH_RUN_CI_CFG=${PATH_RUN_CI_CFG:-${PATH_RUN_CI}/cloud.cfg}
-PATH_RUN_DI_RESULT=${PATH_RUN_DI_RESULT:-${PATH_RUN_CI}/.ds-identify.result}
 
-DI_LOG="${DI_LOG:-${PATH_RUN_CI}/ds-identify.log}"
+# Declare global here, so they can be overwritten from the outside.
+# if not overwritten from the outside, we'll populate them with system default
+# paths, once we have determined the system we're running on.
+# This is done in set_run_path(), which must run after read_uname_info().
+PATH_RUN="${PATH_RUN:-}"
+PATH_RUN_CI="${PATH_RUN_CI:-}"
+PATH_RUN_CI_CFG="${PATH_RUN_CI_CFG:-}"
+PATH_RUN_DI_RESULT="${PATH_RUN_DI_RESULT:-}"
+
+DI_LOG="${DI_LOG:-}"
 _DI_LOGGED=""
 
 # set DI_MAIN='noop' in environment to source this file with no main called.
@@ -153,6 +158,8 @@ debug() {
     local lvl="$1"
     shift
     [ "$lvl" -gt "${DI_DEBUG_LEVEL}" ] && return
+
+    [ "$DI_LOG" = "" ] && DI_LOG="stderr"
 
     if [ "$_DI_LOGGED" != "$DI_LOG" ]; then
         # first time here, open file descriptor for append
@@ -1579,6 +1586,7 @@ collect_info() {
 }
 
 print_info() {
+    read_uname_info
     collect_info
     _print_info
 }
@@ -1835,12 +1843,25 @@ read_uptime() {
     return
 }
 
+set_run_path() {
+    if [ "$DI_UNAME_KERNEL_NAME" != "Linux" ]; then
+        PATH_RUN=${PATH_RUN:-"${PATH_ROOT}/var/run"}
+    else
+        PATH_RUN=${PATH_RUN:-"${PATH_ROOT}/run"}
+    fi
+
+    PATH_RUN_CI="${PATH_RUN_CI:-${PATH_RUN}/cloud-init}"
+    PATH_RUN_CI_CFG=${PATH_RUN_CI_CFG:-${PATH_RUN_CI}/cloud.cfg}
+    PATH_RUN_DI_RESULT=${PATH_RUN_DI_RESULT:-${PATH_RUN_CI}/.ds-identify.result}
+
+    DI_LOG="${DI_LOG:-${PATH_RUN_CI}/ds-identify.log}"
+}
+
 _main() {
     local dscheck_fn="" ret_dis=1 ret_en=0
 
     read_uptime
     debug 1 "[up ${_RET}s]" "ds-identify $*"
-    read_uname_info
     read_virt
     read_kernel_cmdline
     if is_disabled; then
@@ -1963,6 +1984,9 @@ _main() {
 main() {
     local ret=""
     ensure_sane_path
+    read_uname_info
+    set_run_path
+
     [ -d "$PATH_RUN_CI" ] || mkdir -p "$PATH_RUN_CI"
     if [ "${1:+$1}" != "--force" ] && [ -f "$PATH_RUN_CI_CFG" ] &&
         [ -f "$PATH_RUN_DI_RESULT" ]; then


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(runpath): On *BSD, /run is not ephemeral

On *BSD, `/run` is not ephemeral, but the way cloud-init behaves, it
expects it to be. To fix this, we ds-identify's RUN_* initialization after
figuring out which OS we run on.
For the Python we set the config to the expected directories.

Add and fix tests to ensure this behavior is correct and consistent.

Sponsored by: The FreeBSD Foundation
Fixes GH-4180
Fixes GH-4231
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
