### PR TITLE
cloud-config: after systemd ordering After=snapd.seeded.service

### DIFF
--- a/cloudinit/cloud.py
+++ b/cloudinit/cloud.py
@@ -57,6 +57,17 @@ class Cloud:
         return copy.deepcopy(self._cfg)
 
     def run(self, name, functor, args, freq=None, clear_on_fail=False):
+        """Run a function gated by a named semaphore for a desired frequency.
+
+        The typical case for this method would be to limit running of the
+        provided func to a single well-defined frequency:
+            PER_INSTANCE, PER_BOOT or PER_ONCE
+
+        The semaphore provides a gate that persists across cloud-init
+        boot stage boundaries so multiple modules can share this state
+        even if they happen to be run in different boot stages or across
+        reboots.
+        """
         return self._runners.run(name, functor, args, freq, clear_on_fail)
 
     def get_template_filename(self, name):

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -210,6 +210,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             f" '{type(lxd_cfg).__name__}'"
         )
 
+    util.wait_for_snap_seeded(cloud)
     # Grab the configuration
     init_cfg = lxd_cfg.get("init", {})
     preseed_str = lxd_cfg.get("preseed", "")

--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -191,7 +191,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             "Skipping module named %s, no 'snap' key in configuration", name
         )
         return
-
+    util.wait_for_snap_seeded(cloud)
     add_assertions(
         cfgin.get("assertions", []),
         os.path.join(cloud.paths.get_ipath_cur(), "snapd.assertions"),

--- a/cloudinit/config/cc_ubuntu_autoinstall.py
+++ b/cloudinit/config/cc_ubuntu_autoinstall.py
@@ -6,6 +6,7 @@ import logging
 import re
 from textwrap import dedent
 
+from cloudinit import util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import (
@@ -83,6 +84,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         )
         return
 
+    util.wait_for_snap_seeded(cloud)
     snap_list, _ = subp(["snap", "list"])
     installer_present = None
     for snap_name in LIVE_INSTALLER_SNAPS:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -65,7 +65,7 @@ from cloudinit import (
     url_helper,
     version,
 )
-from cloudinit.settings import CFG_BUILTIN
+from cloudinit.settings import CFG_BUILTIN, PER_ONCE
 
 _DNS_REDIRECT_IP = None
 LOG = logging.getLogger(__name__)
@@ -3092,6 +3092,18 @@ def wait_for_files(flist, maxwait, naplen=0.5, log_pre=""):
         "%sStill missing files after %s seconds: %s", log_pre, maxwait, need
     )
     return need
+
+
+def wait_for_snap_seeded(cloud):
+    """Helper to wait on completion of snap seeding."""
+
+    def callback():
+        if not subp.which("snap"):
+            LOG.debug("Skipping snap wait, no snap command present")
+            return
+        subp.subp(["snap", "wait", "system", "seed.loaded"])
+
+    cloud.run("snap-seeded", callback, [], freq=PER_ONCE)
 
 
 def mount_is_read_write(mount_point):

--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -2,7 +2,6 @@
 [Unit]
 Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
-After=snapd.seeded.service
 Before=systemd-user-sessions.service
 Wants=network-online.target cloud-config.target
 ConditionPathExists=!/etc/cloud/cloud-init.disabled

--- a/tests/unittests/config/test_cc_lxd.py
+++ b/tests/unittests/config/test_cc_lxd.py
@@ -11,6 +11,8 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
+from cloudinit.helpers import Paths
+from cloudinit.util import del_file
 from tests.unittests import helpers as t_help
 from tests.unittests.util import get_cloud
 
@@ -44,7 +46,9 @@ class TestLxd(t_help.CiTestCase):
     )
     def test_lxd_init(self, maybe_clean, which, subp, exists, system_info):
         system_info.return_value = {"uname": [0, 1, "mykernel"]}
-        cc = get_cloud(mocked_distro=True)
+        tmpdir = self.tmp_dir()
+        sem_file = f"{tmpdir}/sem/snap_seeded.once"
+        cc = get_cloud(mocked_distro=True, paths=Paths({"cloud_dir": tmpdir}))
         install = cc.distro.install_packages
 
         for backend, cmd, package in BACKEND_DEF:
@@ -84,21 +88,23 @@ class TestLxd(t_help.CiTestCase):
             if backend == "lvm":
                 self.assertEqual(
                     [
+                        mock.call(sem_file),
                         mock.call(
                             "/lib/modules/mykernel/"
                             "kernel/drivers/md/dm-thin-pool.ko"
-                        )
+                        ),
                     ],
                     exists.call_args_list,
                 )
             else:
-                self.assertEqual([], exists.call_args_list)
+                self.assertEqual([mock.call(sem_file)], exists.call_args_list)
+            del_file(sem_file)
 
     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
     @mock.patch("cloudinit.config.cc_lxd.subp")
     @mock.patch("cloudinit.config.cc_lxd.subp.which", return_value=False)
     def test_lxd_install(self, m_which, mock_subp, m_maybe_clean):
-        cc = get_cloud()
+        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
         cc.distro = mock.MagicMock()
         mock_subp.which.return_value = None
         cc_lxd.handle("cc_lxd", LXD_INIT_CFG, cc, [])
@@ -112,7 +118,7 @@ class TestLxd(t_help.CiTestCase):
     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
     @mock.patch("cloudinit.config.cc_lxd.subp")
     def test_no_init_does_nothing(self, mock_subp, m_maybe_clean):
-        cc = get_cloud()
+        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
         cc.distro = mock.MagicMock()
         cc_lxd.handle("cc_lxd", {"lxd": {}}, cc, [])
         self.assertFalse(cc.distro.install_packages.called)
@@ -122,16 +128,17 @@ class TestLxd(t_help.CiTestCase):
     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
     @mock.patch("cloudinit.config.cc_lxd.subp")
     def test_no_lxd_does_nothing(self, mock_subp, m_maybe_clean):
-        cc = get_cloud()
+        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
         cc.distro = mock.MagicMock()
         cc_lxd.handle("cc_lxd", {"package_update": True}, cc, [])
         self.assertFalse(cc.distro.install_packages.called)
         self.assertFalse(mock_subp.subp.called)
         self.assertFalse(m_maybe_clean.called)
 
+    @mock.patch("cloudinit.config.cc_lxd.util.wait_for_snap_seeded")
     @mock.patch("cloudinit.config.cc_lxd.subp")
-    def test_lxd_preseed(self, mock_subp):
-        cc = get_cloud()
+    def test_lxd_preseed(self, mock_subp, wait_for_snap_seeded):
+        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
         cc.distro = mock.MagicMock()
         cc_lxd.handle(
             "cc_lxd",
@@ -146,6 +153,7 @@ class TestLxd(t_help.CiTestCase):
             ],
             mock_subp.subp.call_args_list,
         )
+        wait_for_snap_seeded.assert_called_once_with(cc)
 
     def test_lxd_debconf_new_full(self):
         data = {

--- a/tests/unittests/config/test_cc_snap.py
+++ b/tests/unittests/config/test_cc_snap.py
@@ -293,8 +293,11 @@ class TestSnapSchema:
 
 
 class TestHandle:
+    @mock.patch("cloudinit.util.wait_for_snap_seeded")
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_handle_adds_assertions(self, m_subp, fake_cloud, tmpdir):
+    def test_handle_adds_assertions(
+        self, m_subp, wait_for_snap_seeded, fake_cloud, tmpdir
+    ):
         """Any configured snap assertions are provided to add_assertions."""
         assert_file = os.path.join(
             fake_cloud.paths.get_ipath_cur(), "snapd.assertions"
@@ -309,3 +312,4 @@ class TestHandle:
         assert util.load_text_file(compare_file) == util.load_text_file(
             assert_file
         )
+        wait_for_snap_seeded.assert_called_once_with(fake_cloud)

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -33,7 +33,9 @@ def get_cloud(
         myds.metadata.update(metadata)
     if paths:
         paths.datasource = myds
-    return cloud.Cloud(myds, paths, sys_cfg, mydist, None)
+    return cloud.Cloud(
+        myds, paths, sys_cfg, mydist, runners=helpers.Runners(paths)
+    )
 
 
 def abstract_to_concrete(abclass):


### PR DESCRIPTION
## Recreated from autoclosed https://github.com/canonical/cloud-init/pull/4535 now that we have some boot speed metrics. 

## Proposed Commit Message
```
feat(bootspeed): cloud-config.service drop After=snapd.seeded (#4687)

Historically cloud-config.service was declared the boot stage blocked
on After=snapd.seeded.service to allow for any config module to
potentially leverage snap utilities if present.

In practice, only the config modules cc_snap, cc_lxd,
cc_ubuntu_autoinstall and cc_runcmd are the modules that may strictly
rely on snaps being seeded during initial boot. So the systemd
ordering is not necessary in the majority of deployment cases.

Avoid a hard systemd ordering `After=snapd-seeded.service` in
cloud-config.service. Instead, directly call
`snap system wait seed.loaded` if user-data requires that snaps
are present and seeded.

Add a semaphore runner set limited to frequency PER_ONCE
which calls snap wait system seed.loaded one time to block
if any related cloud-config modules are active which may require
snap interaction.

Add this helper to each affected cloud-config module:
  snap, lxd and ubuntu_autoinstall

In runcmd, document the need for call: snap wait system seed.loaded
if the runcmd user-data requires snaps being present.

The runner will prevent cloud-init from making multiple
calls to snap wait even if user-data requires snappy interaction
is applicable for multiple config modules with a dependency on snaps.
```

## Additional Context
<!-- If relevant -->

boot speed improvements on GCP: https://github.com/canonical/cloud-init/pull/4535#issuecomment-1841008249

By instrumenting a [local test script for testing on QEMU](https://github.com/canonical/server-test-scripts/pull/201), I see negligible performance impacts when launching images with upgraded cloud-init and no user-data with this branch. 

When providing runcmd content in user-data I do see a 3 second degradation to boot time.


<details>
  <summary>Launch empty userdata: boot time to SSH delta: < 1 second diff </summary>

```
python3 qemu_performance.py -c cloud-init-drop-snapd-seeded.deb  -n 4 -c cloud-init-drop-snapd-seeded.deb | tee drop-strict-snap-seeded.log
------------------- Boot speed comparison ---------------------------
Boot image serial: 20231211
Cloud-init from: cloud-init-drop-snapd-seeded.deb
Source image: /srv/pycloudlib/noble/20231211/noble-server-cloudimg-amd64.img
Number of samples: 4
---------------------------------------------------------------------
```

```
--------------------- Performance Deltas Encountered ---------------------
| Delta type and service name        | Original avg/samples | New avg/samples
--------------------------------------------------------------------------
| ***         client_time_to_ssh       | 034.75: ['035.367', '034.398', '034.260', '034.967'] | 035.35: ['035.023', '035.677', '034.719', '035.963']
| ***         time_systemd_userspace   | 020.73: ['020.988', '020.234', '020.967', '020.713'] | 019.82: ['019.558', '019.998', '019.104', '020.612']
| ***DEGRADED cloud-config.service     | 001.15: ['001.078', '001.229', '001.143'] | 002.46: ['002.437', '002.454', '002.468', '002.464']
| ***IMPROVED init-network/config-ssh  | 001.30: ['002.076', '001.080', '000.634', '001.417'] | 001.04: ['001.228', '001.292', '000.931', '000.706']
------------------- Control image ---------------------------
| Avg    |  Max   |  Min   | Metric Name
------------------------------------------------------------------
| 034.75 | 035.37 | 034.26 | client_time_to_ssh
| 040.44 | 040.69 | 040.04 | client_time_to_cloudinit_done
| 003.90 | 003.93 | 003.88 | time_systemd_kernel
| 020.73 | 020.99 | 020.23 | time_systemd_userspace
| 006.33 | 006.46 | 006.23 | snapd.seeded.service
| 003.33 | 004.05 | 002.66 | cloud-init.service
| 002.69 | 002.70 | 002.68 | snapd.apparmor.service
| 002.10 | 002.12 | 002.08 | cloud-init-local.service
| 001.59 | 001.64 | 001.56 | dev-sda1.device
| 001.27 | 001.41 | 001.16 | pollinate.service
| 001.19 | 001.22 | 001.17 | snapd.service
| 001.36 | 001.86 | 001.17 | systemd-networkd-wait-online.service
| 001.11 | 001.14 | 001.08 | apport.service
| 001.12 | 001.12 | 001.12 | snap.lxd.activate.service
| 001.15 | 001.23 | 001.08 | cloud-config.service
| 001.30 | 002.08 | 000.63 | init-network/config-ssh
| 000.88 | 000.91 | 000.85 | init-network/config-growpart
| 000.53 | 000.53 | 000.52 | init-local/search-NoCloud
| 000.49 | 000.53 | 000.41 | modules-config/config-grub_dpkg
| 000.29 | 000.32 | 000.27 | init-network/config-resizefs
| 000.28 | 000.31 | 000.25 | init-network/config-users_groups
------------------- Updated cloud-init image ---------------------------
| Avg    |  Max   |  Min   | Metric Name
------------------------------------------------------------------
| 035.35 | 035.96 | 034.72 | client_time_to_ssh
| 039.61 | 040.41 | 039.17 | client_time_to_cloudinit_done
| 003.86 | 003.88 | 003.82 | time_systemd_kernel
| 019.82 | 020.61 | 019.10 | time_systemd_userspace
| 006.57 | 006.84 | 006.30 | snapd.seeded.service
| 003.04 | 003.37 | 002.67 | cloud-init.service
| 002.67 | 002.67 | 002.66 | snapd.apparmor.service
| 002.46 | 002.47 | 002.44 | cloud-config.service
| 002.10 | 002.10 | 002.08 | cloud-init-local.service
| 001.59 | 001.63 | 001.55 | dev-sda1.device
| 001.56 | 001.96 | 001.16 | systemd-networkd-wait-online.service
| 001.38 | 001.40 | 001.37 | snapd.service
| 001.28 | 001.35 | 001.18 | pollinate.service
| 001.19 | 001.23 | 001.14 | apport.service
| 001.13 | 001.18 | 001.07 | snap.lxd.activate.service
| 001.11 | 001.12 | 001.10 | user@1000.service
| 001.04 | 001.29 | 000.71 | init-network/config-ssh
| 000.86 | 000.91 | 000.81 | init-network/config-growpart
| 000.53 | 000.54 | 000.52 | init-local/search-NoCloud
| 000.47 | 000.50 | 000.46 | modules-config/config-grub_dpkg
| 000.27 | 000.29 | 000.24 | init-network/config-users_groups
| 000.30 | 000.31 | 000.28 | init-network/config-resizefs
```
</details>

<details>
  <summary>Launch runcmd in userdata: boot time to SSH delta: ~ 3 second diff </summary>

```
------------------- Boot speed comparison ---------------------------
Boot image serial: 20231211
Cloud-init from: cloud-init-drop-snapd-seeded.deb
Source image: /srv/pycloudlib/noble/20231211/noble-server-cloudimg-amd64.img
Number of samples: 4
---------------------------------------------------------------------


--------------------- Performance Deltas Encountered ---------------------
| Delta type and service name        | Original avg/samples | New avg/samples
--------------------------------------------------------------------------
| ***         client_time_to_ssh       | 034.58: ['033.666', '035.233', '034.777', '034.638'] | 038.20: ['037.362', '039.576', '038.053', '037.821']
| ***         time_systemd_userspace   | 020.42: ['019.875', '021.370', '020.485', '019.947'] | 018.97: ['018.361', '019.130', '018.829', '019.556']
| ***DEGRADED cloud-config.service     | 001.15: ['001.240', '001.000', '001.206'] | 006.99: ['006.719', '007.036', '007.055', '007.153']
| ***DEGRADED modules-config/config-runcmd | 000.00: ['000.001', '000.001', '000.002', '000.001'] | 004.60: ['004.369', '004.594', '004.699', '004.748']
------------------- Control image ---------------------------
| Avg    |  Max   |  Min   | Metric Name
------------------------------------------------------------------
| 034.58 | 035.23 | 033.67 | client_time_to_ssh
| 040.35 | 041.42 | 039.69 | client_time_to_cloudinit_done
| 003.88 | 003.91 | 003.86 | time_systemd_kernel
| 020.42 | 021.37 | 019.88 | time_systemd_userspace
| 006.27 | 006.40 | 006.17 | snapd.seeded.service
| 002.70 | 002.72 | 002.67 | snapd.apparmor.service
| 002.99 | 003.79 | 002.61 | cloud-init.service
| 002.10 | 002.12 | 002.09 | cloud-init-local.service
| 001.60 | 001.66 | 001.57 | dev-sda1.device
| 001.48 | 001.72 | 001.05 | systemd-networkd-wait-online.service
| 001.15 | 001.24 | 001.00 | cloud-config.service
| 001.25 | 001.36 | 001.17 | pollinate.service
| 001.25 | 001.40 | 001.17 | snapd.service
| 001.17 | 001.29 | 001.11 | apport.service
| 001.13 | 001.18 | 001.09 | snap.lxd.activate.service
| 001.07 | 001.07 | 001.07 | user@1000.service
| 000.85 | 000.88 | 000.80 | init-network/config-growpart
| 001.02 | 001.89 | 000.61 | init-network/config-ssh
| 000.53 | 000.54 | 000.50 | init-local/search-NoCloud
| 000.45 | 000.47 | 000.43 | modules-config/config-grub_dpkg
| 000.28 | 000.29 | 000.25 | init-network/config-users_groups
| 000.26 | 000.29 | 000.21 | init-network/config-resizefs
------------------- Updated cloud-init image ---------------------------
| Avg    |  Max   |  Min   | Metric Name
------------------------------------------------------------------
| 038.20 | 039.58 | 037.36 | client_time_to_ssh
| 038.84 | 039.97 | 037.93 | client_time_to_cloudinit_done
| 003.87 | 003.90 | 003.84 | time_systemd_kernel
| 018.97 | 019.56 | 018.36 | time_systemd_userspace
| 006.99 | 007.15 | 006.72 | cloud-config.service
| 005.27 | 005.35 | 005.22 | snapd.seeded.service
| 002.79 | 003.43 | 002.43 | cloud-init.service
| 002.71 | 002.75 | 002.68 | snapd.apparmor.service
| 002.12 | 002.14 | 002.11 | cloud-init-local.service
| 001.60 | 001.64 | 001.57 | dev-sda1.device
| 001.34 | 001.39 | 001.29 | snapd.service
| 001.24 | 001.29 | 001.18 | pollinate.service
| 001.17 | 001.20 | 001.13 | apport.service
| 001.63 | 002.02 | 001.06 | systemd-networkd-wait-online.service
| 001.52 | 001.52 | 001.52 | cloud-final.service
| 004.60 | 004.75 | 004.37 | modules-config/config-runcmd
| 000.83 | 001.47 | 000.43 | init-network/config-ssh
| 000.85 | 000.87 | 000.84 | init-network/config-growpart
| 000.53 | 000.54 | 000.53 | init-local/search-NoCloud
| 000.48 | 000.53 | 000.44 | modules-config/config-grub_dpkg
| 000.28 | 000.31 | 000.27 | init-network/config-resizefs
| 000.25 | 000.26 | 000.24 | init-network/config-users_groups
| 000.11 | 000.11 | 000.09 | modules-final/config-keys_to_console

```
</details>


The runcmd launches represent `cloud-config.service` boot costs because we are now explicitly calling `snap wait system seed.loaded` in the runcmd module to block for 4.3 seconds on snap seeding instead of relying on systemd unit ordering After=snapd.seeded.service in `cloud-config.service` config.  This user-facing cost is not percieved as more than a 0.5 second delay in time to SSH because systemd allows `cloud-config.service` to start earlier and run other cloud-config modules prior to hitting the block on runcmd. So more work is done before blocking on snap seeding, which saves us some of that cost of waiting on snap seeding directly in the runcmd module.

This testing does represent that we may want to avoid arbitrarily blocking on `snap seed.loaded` in runcmd as most user-data may not truly depend on seeded snaps being present. We could retain this blocking behavior on stable releases by always calling `snap wait systemd seed.loaded`. For latest devel release, we should document that if your runcmd relies on snaps being present, the runcmd should start with a call to `snap wait systemd seed.loaded`. So that this cost is an opt-in when snaps are necessary to the runcmd operations.

This PR will need a followup PR for downstream `ubuntu/(focal|jammy|lunar|mantic)` series branches to strictly revert this commit because we don't want to risk corner-case exposure and change in behavior of systemd ordering that some customers may rely on.

<details>
<summary> Test with runcmd user-data on noble with no `cloud.run("snap-seeded", util.wait_for_snap_seeded, [], freq=PER_ONCE)`:  time to ssh delta < 0.7 seconds diff   cloud-config.service delta <  1.2 seconds
 </summary>
```
------------------- Boot speed comparison ---------------------------
Boot image serial: 20231211
Cloud-init from: cloud-init-drop-snapd-seeded-from-runcmd.deb
Source image: /srv/pycloudlib/noble/20231211/noble-server-cloudimg-amd64.img
Number of samples: 4
---------------------------------------------------------------------


--------------------- Performance Deltas Encountered ---------------------
| Delta type and service name        | Original avg/samples | New avg/samples
--------------------------------------------------------------------------
| ***         client_time_to_ssh       | 034.12: ['035.189', '032.459', '033.809', '035.009'] | 034.88: ['035.478', '034.135', '035.168', '034.744']
| ***         time_systemd_userspace   | 019.78: ['019.372', '019.216', '019.918', '020.617'] | 019.22: ['019.935', '018.898', '019.235', '018.828']
| ***DEGRADED cloud-config.service     | 001.13: ['001.173', '001.039', '001.168'] | 002.45: ['002.420', '002.460', '002.445', '002.486']
| ***DEGRADED init-network/config-ssh  | 000.56: ['000.623', '000.405', '000.520', '000.678'] | 000.79: ['000.732', '000.563', '000.731', '001.154']
------------------- Control image ---------------------------
| Avg    |  Max   |  Min   | Metric Name
------------------------------------------------------------------
| 034.12 | 035.19 | 032.46 | client_time_to_ssh
| 040.07 | 040.85 | 039.49 | client_time_to_cloudinit_done
| 003.91 | 003.93 | 003.89 | time_systemd_kernel
| 019.78 | 020.62 | 019.22 | time_systemd_userspace
| 005.92 | 006.44 | 005.48 | snapd.seeded.service
| 002.71 | 002.80 | 002.67 | snapd.apparmor.service
| 002.53 | 002.67 | 002.42 | cloud-init.service
| 002.12 | 002.22 | 002.07 | cloud-init-local.service
| 001.64 | 001.71 | 001.60 | dev-sda1.device
| 001.80 | 002.01 | 001.50 | systemd-networkd-wait-online.service
| 001.22 | 001.33 | 001.13 | pollinate.service
| 001.13 | 001.17 | 001.04 | cloud-config.service
| 001.20 | 001.24 | 001.16 | snapd.service
| 001.12 | 001.17 | 001.06 | apport.service
| 000.85 | 000.87 | 000.82 | init-network/config-growpart
| 000.54 | 000.63 | 000.43 | modules-config/config-grub_dpkg
| 000.56 | 000.68 | 000.41 | init-network/config-ssh
| 000.53 | 000.57 | 000.51 | init-local/search-NoCloud
| 000.27 | 000.28 | 000.26 | init-network/config-users_groups
| 000.26 | 000.29 | 000.22 | init-network/config-resizefs
------------------- Updated cloud-init image ---------------------------
| Avg    |  Max   |  Min   | Metric Name
------------------------------------------------------------------
| 034.88 | 035.48 | 034.13 | client_time_to_ssh
| 039.15 | 039.94 | 038.65 | client_time_to_cloudinit_done
| 003.87 | 003.88 | 003.86 | time_systemd_kernel
| 019.22 | 019.93 | 018.83 | time_systemd_userspace
| 006.27 | 006.83 | 005.72 | snapd.seeded.service
| 002.68 | 002.69 | 002.66 | snapd.apparmor.service
| 002.78 | 003.14 | 002.55 | cloud-init.service
| 002.45 | 002.49 | 002.42 | cloud-config.service
| 002.10 | 002.10 | 002.10 | cloud-init-local.service
| 001.48 | 001.87 | 001.05 | systemd-networkd-wait-online.service
| 001.61 | 001.67 | 001.56 | dev-sda1.device
| 001.38 | 001.41 | 001.35 | snapd.service
| 001.30 | 001.38 | 001.24 | pollinate.service
| 001.19 | 001.23 | 001.14 | apport.service
| 001.07 | 001.07 | 001.07 | user@1000.service
| 001.03 | 001.03 | 001.03 | snap.lxd.activate.service
| 000.85 | 000.90 | 000.83 | init-network/config-growpart
| 000.79 | 001.15 | 000.56 | init-network/config-ssh
| 000.53 | 000.53 | 000.52 | init-local/search-NoCloud
| 000.47 | 000.48 | 000.45 | modules-config/config-grub_dpkg
| 000.29 | 000.30 | 000.27 | init-network/config-resizefs
| 000.27 | 000.31 | 000.25 | init-network/config-users_groups
```
</details>


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
./tools/run-container --package ubuntu-daily/noble
# Run simple ubuntu boot speed analysis script
python3 ../server-test-scripts/cloud-init/qemu_performance.py -c cloud-init*deb -n 3
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
