### PR TITLE
Make logger name more useful

### DIFF
--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -166,6 +166,18 @@ def setup_backup_logging():
     logging.Handler.handleError = handleError
 
 
+class CloudInitLogRecord(logging.LogRecord):
+    """reporting the filename as __init__.py isn't very useful in logs
+
+    if the filename is __init__.py, use the parent directory as the filename
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if "__init__.py" == self.filename:
+            self.filename = os.path.basename(os.path.dirname(self.pathname))
+
+
 def configure_root_logger():
     """Customize the root logger for cloud-init"""
 
@@ -179,3 +191,6 @@ def configure_root_logger():
     handler = LogExporter()
     handler.setLevel(logging.WARN)
     logging.getLogger().addHandler(handler)
+
+    # LogRecord allows us to report more useful information than __init__.py
+    logging.setLogRecordFactory(CloudInitLogRecord)


### PR DESCRIPTION
## Additional Context
Using a logger name of `__name__` is useful to identify the source of a log.... Except when that source is named `__init__.py` because we have a few of those that contain lots of code. Use the module's directory name in that case.


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
