### PR TITLE
fix(tests): make cmd/devel/tests work on non-GNU

### DIFF
--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -231,15 +231,14 @@ class TestCollectLogs:
                 "cloud-init? more like cloud-innit!\n",
             ),
             (
-                ["ls", "/nonexistent-directory"],
+                ["sh", "-c", "echo test 1>&2; exit 42"],
                 (
                     "Unexpected error while running command.\n"
-                    "Command: ['ls', '/nonexistent-directory']\n"
-                    "Exit code: 2\n"
+                    "Command: ['sh', '-c', 'echo test 1>&2; exit 42']\n"
+                    "Exit code: 42\n"
                     "Reason: -\n"
                     "Stdout: \n"
-                    "Stderr: ls: cannot access '/nonexistent-directory': "
-                    "No such file or directory"
+                    "Stderr: test"
                 ),
                 None,
             ),
@@ -270,13 +269,7 @@ class TestCollectLogs:
         "cmd, expected_file_contents",
         [
             (["echo", "cloud-init, shmoud-init"], "cloud-init, shmoud-init\n"),
-            (
-                ["ls", "/nonexistent-directory"],
-                (
-                    "ls: cannot access '/nonexistent-directory': "
-                    "No such file or directory\n"
-                ),
-            ),
+            (["sh", "-c", "echo test 1>&2; exit 42"], "test\n"),
         ],
     )
     def test_stream_command_output_to_file(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(tests): make cmd/devel/tests work on non-GNU

The tests were tied to the exact output of GNU ls.
Tests were failing on *BSD.
Fix them by using a different platform independent command.
POSIX sh should work everywhere.

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
