### PR TITLE
fix(apt_configure): disable source.list if rendering deb822

### DIFF
--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -336,6 +336,21 @@ class TestDefaults:
             assert 3 == sources_list.count(sec_deb_line)
             assert 3 == sources_list.count(sec_src_deb_line)
 
+    def test_no_duplicate_apt_sources(self, class_client: IntegrationInstance):
+        r = class_client.execute("apt-get update", use_sudo=True)
+        assert not re.match(
+            r"^W: Target Packages .+ is configured multiple times in", r.stderr
+        )
+
+    def test_disabled_apt_sources(self, class_client: IntegrationInstance):
+        feature_deb822 = is_true(
+            get_feature_flag_value(class_client, "APT_DEB822_SOURCE_LIST_FILE")
+        )
+        if feature_deb822:
+            assert class_client.execute(
+                f"test -f {ORIG_SOURCES_FILE}"
+            ).failed, f"Found unexpected {ORIG_SOURCES_FILE}"
+
 
 DEFAULT_DATA_WITH_URI = _DEFAULT_DATA.format(
     uri='uri: "http://something.random.invalid/ubuntu"'

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -67,6 +67,9 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         # Ubuntu lxd storage
         "thinpool by default on Ubuntu due to LP #1982780",
         "WARNING]: Could not match supplied host pattern, ignoring:",
+        # Old Ubuntu cloud-images contain /etc/apt/sources.list
+        "WARNING]: Disabling /etc/apt/sources.list to favor deb822 source"
+        " format",
     ]
     traceback_texts = []
     if "install canonical-livepatch" in log:

--- a/tests/unittests/config/test_cc_apt_configure.py
+++ b/tests/unittests/config/test_cc_apt_configure.py
@@ -3,9 +3,12 @@
 """ Tests for cc_apt_configure module """
 
 import re
+from pathlib import Path
+from unittest import mock
 
 import pytest
 
+from cloudinit import features
 from cloudinit.config import cc_apt_configure
 from cloudinit.config.schema import (
     SchemaValidationError,
@@ -14,6 +17,8 @@ from cloudinit.config.schema import (
 )
 from tests.unittests.helpers import skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
+
+M_PATH = "cloudinit.config.cc_apt_configure."
 
 
 class TestAPTConfigureSchema:
@@ -266,3 +271,33 @@ class TestEnsureDependencies:
             install_packages.assert_called_once_with(expected_install)
         else:
             install_packages.assert_not_called()
+
+
+class TestAptConfigure:
+    @mock.patch(M_PATH + "get_apt_cfg")
+    def test_disable_source(self, m_get_apt_cfg, tmpdir):
+        m_get_apt_cfg.return_value = {
+            "sourcelist": f"{tmpdir}/etc/apt/sources.list",
+            "sourceparts": f"{tmpdir}/etc/apt/sources.list.d/",
+        }
+        cloud = get_cloud("ubuntu")
+        features.APT_DEB822_SOURCE_LIST_FILE = True
+        sources_file = tmpdir.join("/etc/apt/sources.list")
+        Path(sources_file).parent.mkdir(parents=True, exist_ok=True)
+        with open(sources_file, "w") as f:
+            f.write("content")
+
+        cfg = {
+            "sources_list": """\
+Types: deb
+URIs: {{mirror}}
+Suites: {{codename}} {{codename}}-updates {{codename}}-backports
+Components: main restricted universe multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg"""
+        }
+        cc_apt_configure.generate_sources_list(cfg, "noble", {}, cloud)
+        assert not Path(f"{tmpdir}/etc/apt/sources.list").exists()
+        assert (
+            Path(f"{tmpdir}/etc/apt/sources.list.disabled").read_text()
+            == "# disabled by cloud-init\ncontent"
+        )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(apt_configure): disable sources.list if rendering deb822
    
If deb822 sources format is used and a preexistent
/etc/apt/sources.list exists, then disable the old sources file.
This prevents user-facing warnings while operating with apt or
apt-get and other possible conflicts.
    
This is safe to do as cloud-init owns the base APT configuration which
tipically/historically involved overwriting /etc/apt/sources.list

Fixes GH-4691
LP: #2045086
```

## Additional Context
<!-- If relevant -->
I think it is safe to disable `/etc/apt/source.list`, because previously cloud-init override it, before https://github.com/canonical/cloud-init/pull/4437, or now if features.APT_DEB822_SOURCE_LIST_FILE is false or if the provided sources config has the classic style.
https://github.com/canonical/cloud-init/issues/4691

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
