### PR TITLE
Ubuntu/jammy 23.4.x

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+23.4.1
+ - fix: Handle systemctl commands when dbus not ready (#4681)
+
 23.4
  - tests: datasourcenone use client.restart to block until done (#4635)
  - tests: increase number of retries across reboot to 90 (#4651)

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "23.4"
+__VERSION__ = "23.4.1"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (23.4.1-0ubuntu0~22.04.1) UNRELEASED; urgency=medium
+cloud-init (23.4.1-0ubuntu1~22.04.1) jammy; urgency=medium
 
   * d/p/retain-apt-pre-deb822.patch:
     - Disable apt source list generation with DEB822 style
@@ -9,7 +9,7 @@ cloud-init (23.4.1-0ubuntu0~22.04.1) UNRELEASED; urgency=medium
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/23.4.1/ChangeLog
 
- -- Alberto Contreras <alberto.contreras@canonical.com>  Fri, 15 Dec 2023 12:58:20 +0100
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Fri, 15 Dec 2023 12:58:40 +0100
 
 cloud-init (23.4-0ubuntu1~22.04.1) jammy; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,15 @@
-cloud-init (23.4-0ubuntu1~22.04.2) UNRELEASED; urgency=medium
+cloud-init (23.4.1-0ubuntu0~22.04.1) UNRELEASED; urgency=medium
 
   * d/p/retain-apt-pre-deb822.patch:
     - Disable apt source list generation with DEB822 style
+  * refresh patches:
+    - d/p/status-do-not-remove-duplicated-data.patch
+  * d/changelog: amend 23.4-0 refresh patches entry
+  * Upstream snapshot based on 23.4.1. (LP: #2045582).
+    List of changes from upstream can be found at
+    https://raw.githubusercontent.com/canonical/cloud-init/23.4.1/ChangeLog
 
- -- Alberto Contreras <alberto.contreras@canonical.com>  Thu, 14 Dec 2023 13:24:53 +0100
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Fri, 15 Dec 2023 12:58:20 +0100
 
 cloud-init (23.4-0ubuntu1~22.04.1) jammy; urgency=medium
 
@@ -12,6 +18,8 @@ cloud-init (23.4-0ubuntu1~22.04.1) jammy; urgency=medium
     - Revert behavior downstream, leave duplicate data
   * d/p/series: bring back retain-old-groups.patch.
     This patch was inadvertently dropped in 5d4a3cf.
+  * refresh patches:
+    - d/p/do-not-block-user-login.patch
   * Upstream snapshot based on 23.4. (LP: #2045582).
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/23.4/ChangeLog

--- a/debian/patches/retain-apt-pre-deb822.patch
+++ b/debian/patches/retain-apt-pre-deb822.patch
@@ -8,7 +8,7 @@ Last-Update: 2023-12-14
 This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 --- a/cloudinit/features.py
 +++ b/cloudinit/features.py
-@@ -80,7 +80,7 @@
+@@ -80,7 +80,7 @@ separators.
  (This flag can be removed when Jammy is no longer supported.)
  """
  

--- a/debian/patches/status-do-not-remove-duplicated-data.patch
+++ b/debian/patches/status-do-not-remove-duplicated-data.patch
@@ -18,7 +18,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
          prefix = "\n" if args.wait else ""
 --- a/tests/unittests/cmd/test_status.py
 +++ b/tests/unittests/cmd/test_status.py
-@@ -479,6 +479,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
+@@ -487,6 +487,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
                  dedent(
                      """\
                     ---
@@ -26,7 +26,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
                     boot_status_code: enabled-by-kernel-cmdline
                     datasource: ''
                     detail: 'Running in stage: init'
-@@ -492,6 +493,23 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
+@@ -500,6 +501,23 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
                         start: 123.45
                     last_update: Thu, 01 Jan 1970 00:02:04 +0000
                     recoverable_errors: {}
@@ -50,7 +50,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
                     stage: init
                     status: running
                     ...
-@@ -524,6 +542,25 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
+@@ -532,6 +550,25 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
                      "init-local": {"finished": 123.46, "start": 123.45},
                      "last_update": "Thu, 01 Jan 1970 00:02:04 +0000",
                      "recoverable_errors": {},
@@ -76,7 +76,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
                      "stage": "init",
                  },
                  id="running_json_format",
-@@ -555,6 +592,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
+@@ -563,6 +600,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
                  MyArgs(long=False, wait=False, format="json"),
                  1,
                  {
@@ -84,7 +84,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
                      "boot_status_code": "enabled-by-kernel-cmdline",
                      "datasource": "nocloud",
                      "detail": (
-@@ -576,6 +614,32 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
+@@ -584,6 +622,32 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
                      },
                      "last_update": "Thu, 01 Jan 1970 00:02:05 +0000",
                      "recoverable_errors": {},
@@ -117,7 +117,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
                      "stage": None,
                  },
                  id="running_json_format_with_errors",
-@@ -638,6 +702,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
+@@ -646,6 +710,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
                  MyArgs(long=False, wait=False, format="json"),
                  2,
                  {
@@ -125,7 +125,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
                      "boot_status_code": "enabled-by-kernel-cmdline",
                      "datasource": "nocloud",
                      "detail": (
-@@ -697,6 +762,89 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
+@@ -705,6 +770,89 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr
                              "don't try to open the hatch or we'll all be soup"
                          ],
                      },


### PR DESCRIPTION
## Do not squash

## Steps to reproduce

```bash
new_upstream_snapshot.py -c 23.4.1 -b 2045582
dch -r -D lunar ''
git commit -m 'releasing cloud-init version 23.4.1-0ubuntu1~22.04.1' debian/changelog
git tag ubuntu/23.4.1-0ubuntu1_22.04.1
```

- [x] build-package -- -S -d
- [x] sbuild --dist=jammy --arch=amd64 --arch-all ../out/cloud-init_23.4.1-0ubuntu1~22.04.1.dsc
- [x] No lintian errors / warnings.