### PR TITLE
fix(setup): Relocate libexec on OpenBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,7 @@ USR = "usr"
 ETC = "etc"
 USR_LIB_EXEC = "usr/lib"
 LIB = "lib"
-if os.uname()[0] in ["FreeBSD", "DragonFly"]:
+if os.uname()[0] in ["FreeBSD", "DragonFly", "OpenBSD"]:
     USR = "usr/local"
     USR_LIB_EXEC = "usr/local/lib"
 elif os.path.isfile("/etc/redhat-release"):

--- a/tools/build-on-openbsd
+++ b/tools/build-on-openbsd
@@ -44,7 +44,7 @@ else
     RC_LOCAL="/etc/rc.local"
     RC_LOCAL_CONTENT="
 
-/usr/lib/cloud-init/ds-identify
+/usr/local/lib/cloud-init/ds-identify
 
 cloud-init init --local
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(setup): Relocate libexec on OpenBSD

our setup.py didn't relocate our USR_LIB_EXEC path on OpenBSD.
Thus, leaving tools installed in /usr/lib/cloud-init on that platform.
OpenBSD ports install things in /usr/local, so follow suit.

Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
