### PR TITLE
timeout parameter for cloud-init --wait  #4059

### DIFF
--- a/doc/rtd/howto/status.rst
+++ b/doc/rtd/howto/status.rst
@@ -84,3 +84,12 @@ contain any of the following states:
 
 See :ref:`our explanation of failure states<failure_states>` for more
 information.
+
+Cloud-init status --wait
+-----------------
+To wait for the status to be fetched use ``cloud-init status --wait``: script will wait forever
+for the status response.
+To wait for the status to be fetched add the ``--timeout`` flag to set desired time for script to
+terminate in seconds e.g. ``--timeout 5``. **Using '--timeout' flag will exit without finishing the configuration if
+there are no status changes**
+


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feature: timeout for cloud-init status --wait command

Added `--timeout` flag for `cloud-init status --wait` command to terminate after 
declared amount of seconds.

Fixes GH-#4059
LP: #1999876
```

## Additional Context
<!-- If relevant -->
Example usage `cloud-init status --wait --timeout 5`
Time to terminate provided in timeout flag might not be 1:1 with real time in seconds because of the time library behavior (I suppose), the implemented solution meant to be clear and readable and also fulfills requirements assumed based on the context from https://irclogs.ubuntu.com/2022/12/15/%23cloud-init.html
[#4059](https://github.com/canonical/cloud-init/issues/4059)
## Test Steps
```
cd cloud-init/cmd
python main.py status --wait --timeout 10
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
