### PR TITLE
Apply global DNS settings to individual interfaces in network-manager renderer

### DIFF
--- a/tests/unittests/net/test_net_rendering.py
+++ b/tests/unittests/net/test_net_rendering.py
@@ -88,6 +88,9 @@ def _check_network_manager(network_state: NetworkState, tmp_path: Path):
     "test_name, renderers",
     [("no_matching_mac_v2", Renderer.Netplan | Renderer.NetworkManager)],
 )
+@pytest.mark.xfail(
+    reason="v2 interface-specific DNS errantly gets applied globally"
+)
 def test_convert(test_name, renderers, tmp_path):
     network_config = safeyaml.load(
         Path(ARTIFACT_DIR, f"{test_name}.yaml").read_text()

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1209,8 +1209,8 @@ NETWORK_CONFIGS = {
                 may-fail=false
                 address1=192.168.21.3/24
                 route1=0.0.0.0/0,65.61.151.37
-                dns=1.2.3.4;5.6.7.8;8.8.4.4;8.8.8.8;
-                dns-search=barley.maas;sach.maas;wark.maas;
+                dns=8.8.8.8;8.8.4.4;
+                dns-search=barley.maas;sach.maas;
 
                 """
             ),
@@ -1385,7 +1385,7 @@ NETWORK_CONFIGS = {
                 may-fail=false
                 route1=0.0.0.0/0,65.61.151.37
                 address1=192.168.21.3/24
-                dns=8.8.4.4;8.8.8.8;
+                dns=8.8.8.8;8.8.4.4;
                 dns-search=barley.maas;sach.maas;
 
                 """
@@ -2798,8 +2798,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 [ipv4]
                 method=auto
                 may-fail=false
-                dns=4.4.4.4;8.8.4.4;8.8.8.8;
-                dns-search=barley.maas;foobar.maas;wark.maas;
+                dns=8.8.8.8;4.4.4.4;8.8.4.4;
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 """
             ),
@@ -2825,8 +2825,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 method=manual
                 may-fail=false
                 address1=192.168.200.7/24
-                dns=4.4.4.4;8.8.4.4;8.8.8.8;
-                dns-search=barley.maas;foobar.maas;wark.maas;
+                dns=8.8.8.8;4.4.4.4;8.8.4.4;
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 """
             ),
@@ -2851,8 +2851,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 [ipv4]
                 method=auto
                 may-fail=false
-                dns=4.4.4.4;8.8.4.4;8.8.8.8;
-                dns-search=barley.maas;foobar.maas;wark.maas;
+                dns=8.8.8.8;4.4.4.4;8.8.4.4;
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 """
             ),
@@ -2937,15 +2937,15 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 method=manual
                 may-fail=false
                 address1=192.168.14.2/24
-                dns=4.4.4.4;8.8.4.4;8.8.8.8;
-                dns-search=barley.maas;foobar.maas;wark.maas;
+                dns=8.8.8.8;4.4.4.4;8.8.4.4;
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 [ipv6]
                 method=manual
                 may-fail=false
                 address1=2001:1::1/64
                 route1=::/0,2001:4800:78ff:1b::1
-                dns-search=barley.maas;foobar.maas;wark.maas;
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 """
             ),
@@ -2973,8 +2973,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 address1=192.168.0.2/24
                 gateway=192.168.0.1
                 address2=192.168.2.10/24
-                dns=10.23.23.134;192.168.0.10;4.4.4.4;8.8.4.4;8.8.8.8;
-                dns-search=barley.maas;brettanomyces.maas;foobar.maas;sacchromyces.maas;wark.maas;
+                dns=192.168.0.10;10.23.23.134;
+                dns-search=barley.maas;sacchromyces.maas;brettanomyces.maas;
 
                 """
             ),
@@ -3000,7 +3000,7 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 [ipv6]
                 method=auto
                 may-fail=false
-                dns-search=barley.maas;foobar.maas;wark.maas;
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 """
             ),
@@ -4190,7 +4190,7 @@ iface bond0 inet6 static
                 route2=169.254.42.43/32,62.210.0.2
                 address1=192.168.1.20/16
                 dns=8.8.8.8;
-                dns-search=home;lab;
+                dns-search=lab;home;
 
                 [ipv6]
                 route1=::/0,fe80::dc00:ff:fe20:186
@@ -4199,7 +4199,7 @@ iface bond0 inet6 static
                 may-fail=true
                 address1=2001:bc8:1210:232:dc00:ff:fe20:185/64
                 dns=FEDC::1;
-                dns-search=home;lab;
+                dns-search=lab;home;
 
             """
             )
@@ -4251,13 +4251,13 @@ iface bond0 inet6 static
                 method=auto
                 may-fail=true
                 dns=8.8.8.8;
-                dns-search=home;lab;
+                dns-search=lab;home;
 
                 [ipv6]
                 method=auto
                 may-fail=true
                 dns=FEDC::1;
-                dns-search=home;lab;
+                dns-search=lab;home;
 
             """
             )

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1209,8 +1209,8 @@ NETWORK_CONFIGS = {
                 may-fail=false
                 address1=192.168.21.3/24
                 route1=0.0.0.0/0,65.61.151.37
-                dns=8.8.8.8;8.8.4.4;
-                dns-search=barley.maas;sach.maas;
+                dns=1.2.3.4;5.6.7.8;8.8.4.4;8.8.8.8;
+                dns-search=barley.maas;sach.maas;wark.maas;
 
                 """
             ),
@@ -1385,7 +1385,7 @@ NETWORK_CONFIGS = {
                 may-fail=false
                 route1=0.0.0.0/0,65.61.151.37
                 address1=192.168.21.3/24
-                dns=8.8.8.8;8.8.4.4;
+                dns=8.8.4.4;8.8.8.8;
                 dns-search=barley.maas;sach.maas;
 
                 """
@@ -2798,6 +2798,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 [ipv4]
                 method=auto
                 may-fail=false
+                dns=4.4.4.4;8.8.4.4;8.8.8.8;
+                dns-search=barley.maas;foobar.maas;wark.maas;
 
                 """
             ),
@@ -2823,8 +2825,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 method=manual
                 may-fail=false
                 address1=192.168.200.7/24
-                dns=8.8.8.8;4.4.4.4;8.8.4.4;
-                dns-search=barley.maas;wark.maas;foobar.maas;
+                dns=4.4.4.4;8.8.4.4;8.8.8.8;
+                dns-search=barley.maas;foobar.maas;wark.maas;
 
                 """
             ),
@@ -2849,6 +2851,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 [ipv4]
                 method=auto
                 may-fail=false
+                dns=4.4.4.4;8.8.4.4;8.8.8.8;
+                dns-search=barley.maas;foobar.maas;wark.maas;
 
                 """
             ),
@@ -2933,15 +2937,15 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 method=manual
                 may-fail=false
                 address1=192.168.14.2/24
-                dns=8.8.8.8;4.4.4.4;8.8.4.4;
-                dns-search=barley.maas;wark.maas;foobar.maas;
+                dns=4.4.4.4;8.8.4.4;8.8.8.8;
+                dns-search=barley.maas;foobar.maas;wark.maas;
 
                 [ipv6]
                 method=manual
                 may-fail=false
                 address1=2001:1::1/64
                 route1=::/0,2001:4800:78ff:1b::1
-                dns-search=barley.maas;wark.maas;foobar.maas;
+                dns-search=barley.maas;foobar.maas;wark.maas;
 
                 """
             ),
@@ -2969,8 +2973,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 address1=192.168.0.2/24
                 gateway=192.168.0.1
                 address2=192.168.2.10/24
-                dns=192.168.0.10;10.23.23.134;
-                dns-search=barley.maas;sacchromyces.maas;brettanomyces.maas;
+                dns=10.23.23.134;192.168.0.10;4.4.4.4;8.8.4.4;8.8.8.8;
+                dns-search=barley.maas;brettanomyces.maas;foobar.maas;sacchromyces.maas;wark.maas;
 
                 """
             ),
@@ -2996,6 +3000,7 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 [ipv6]
                 method=auto
                 may-fail=false
+                dns-search=barley.maas;foobar.maas;wark.maas;
 
                 """
             ),
@@ -4185,7 +4190,7 @@ iface bond0 inet6 static
                 route2=169.254.42.43/32,62.210.0.2
                 address1=192.168.1.20/16
                 dns=8.8.8.8;
-                dns-search=lab;home;
+                dns-search=home;lab;
 
                 [ipv6]
                 route1=::/0,fe80::dc00:ff:fe20:186
@@ -4194,7 +4199,7 @@ iface bond0 inet6 static
                 may-fail=true
                 address1=2001:bc8:1210:232:dc00:ff:fe20:185/64
                 dns=FEDC::1;
-                dns-search=lab;home;
+                dns-search=home;lab;
 
             """
             )
@@ -4246,13 +4251,13 @@ iface bond0 inet6 static
                 method=auto
                 may-fail=true
                 dns=8.8.8.8;
-                dns-search=lab;home;
+                dns-search=home;lab;
 
                 [ipv6]
                 method=auto
                 may-fail=true
                 dns=FEDC::1;
-                dns-search=lab;home;
+                dns-search=home;lab;
 
             """
             )

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -646,6 +646,7 @@ method=manual
 may-fail=false
 address1=172.19.1.34/22
 route1=0.0.0.0/0,172.19.3.254
+dns=172.19.0.12;
 
 """.lstrip(),
             ),
@@ -2822,6 +2823,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 method=manual
                 may-fail=false
                 address1=192.168.200.7/24
+                dns=8.8.8.8;4.4.4.4;8.8.4.4;
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 """
             ),
@@ -2930,12 +2933,15 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 method=manual
                 may-fail=false
                 address1=192.168.14.2/24
+                dns=8.8.8.8;4.4.4.4;8.8.4.4;
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 [ipv6]
                 method=manual
                 may-fail=false
                 address1=2001:1::1/64
                 route1=::/0,2001:4800:78ff:1b::1
+                dns-search=barley.maas;wark.maas;foobar.maas;
 
                 """
             ),

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -14,6 +14,7 @@ andrewbogott
 andrewlukoshko
 ani-sinha
 antonyc
+apollo13
 aswinrajamannar
 bdrung
 beantaxi


### PR DESCRIPTION
This basically applies the logic of d29eeccd to network-manager as well.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
net/nm: Apply global DNS settings to interfaces

Sometimes DNS settings in cloud configs are specified globally and
not per interface / subnet. This results in a configuration without
proper nameservers. This was fixed for netplan in d29eeccd and is
now also applied to the network-manager renderer.
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
