### PR TITLE
logging: Add log message when create_hostname_file key is false

### DIFF
--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -86,6 +86,9 @@ class Distro(distros.Distro):
             if create_hostname_file:
                 pass
             else:
+                LOG.info(
+                    "create_hostname_file is False; hostname file not created"
+                )
                 return
         if not conf:
             conf = HostnameConf("")

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -124,6 +124,9 @@ class Distro(distros.Distro):
             if create_hostname_file:
                 pass
             else:
+                LOG.info(
+                    "create_hostname_file is False; hostname file not created"
+                )
                 return
         if not conf:
             conf = HostnameConf("")

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -136,6 +136,9 @@ class Distro(distros.Distro):
             if create_hostname_file:
                 pass
             else:
+                LOG.info(
+                    "create_hostname_file is False; hostname file not created"
+                )
                 return
         if not conf:
             conf = HostnameConf("")

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -189,6 +189,9 @@ class Distro(distros.Distro):
             if create_hostname_file:
                 pass
             else:
+                LOG.info(
+                    "create_hostname_file is False; hostname file not created"
+                )
                 return
         if not conf:
             conf = HostnameConf("")

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -248,6 +248,10 @@ class Distro(distros.Distro):
                 if create_hostname_file:
                     pass
                 else:
+                    LOG.info(
+                        "create_hostname_file is False; hostname file not"
+                        "created"
+                    )
                     return
             if not conf:
                 conf = HostnameConf("")

--- a/cloudinit/distros/photon.py
+++ b/cloudinit/distros/photon.py
@@ -108,6 +108,9 @@ class Distro(distros.Distro):
                         str(hostname),
                     ]
                 )
+                LOG.info(
+                    "create_hostname_file is False; hostname set transiently"
+                )
             if ret:
                 LOG.warning(
                     (

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -121,6 +121,9 @@ class Distro(distros.Distro):
                         str(hostname),
                     ]
                 )
+                LOG.info(
+                    "create_hostname_file is False; hostname set transiently"
+                )
         else:
             host_cfg = {
                 "HOSTNAME": hostname,


### PR DESCRIPTION
Setting create_hostname_file to False while trying to set the hostname via userdata can result in the hostname not being correctly set (it is overwritten by the cloud provider's DHCP service).  This change adds a log line every time a hostname file is not created due to create_hostname_file being False for easier debugging of that situation.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
chore: Add log message when create_hostname_file key is false

Setting create_hostname_file to False while trying to set the
hostname via userdata can result in the hostname not being
correctly set (it is overwritten by the cloud provider's DHCP
service).  This change adds a log line every time a hostname file
is not created due to create_hostname_file being False for easier
debugging of that situation.
```

## Additional Context
Added logging related to this PR: https://github.com/canonical/cloud-init/pull/4330

## Test Steps
No test changes as this PR only adds logs

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly (N/A)
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly -- no docs changes needed for the added logs but there will be a separate docs PR for general create_hostname_file key documentation updates

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
