### PR TITLE
docs: Add link to contributing to docs

### DIFF
--- a/doc/rtd/development/contribute_docs.rst
+++ b/doc/rtd/development/contribute_docs.rst
@@ -10,8 +10,9 @@ Contribute to our docs
     Style guide <style_docs.rst>
     Directory layout <docs_layout.rst>
 
-The documentation for cloud-init is hosted in GitHub and rendered on
-`Read the Docs`_. It is mostly written in reStructuredText.
+The documentation for cloud-init is hosted in the
+`cloud-init GitHub repository`_ and rendered on `Read the Docs`_. It is mostly
+written in reStructuredText.
 
 The process for contributing to the docs is largely the same as for code,
 except that for cosmetic changes to the documentation (spelling, grammar, etc)
@@ -65,6 +66,7 @@ reviewer.
 
 .. LINKS
 .. include:: ../links.txt
+.. _cloud-init GitHub repository: https://github.com/canonical/cloud-init/tree/main/doc/rtd
 .. _Read the Docs: https://readthedocs.com/
 .. _tools/.github-cla-signers: https://github.com/canonical/cloud-init/blob/main/tools/.github-cla-signers
 .. _tagging s-makin: https://github.com/s-makin


### PR DESCRIPTION
On the page for contributing to the docs, there is no direct link to the docs source code.  This change adds a link to the top of that page.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
docs: Add link to contributing to docs
    
On the page for contributing to the docs, there is no direct link
to the docs source code.  This change adds a link to the top of
that page.

```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
