### PR TITLE
test: Update webhook test due to removed cc_migrator module

### DIFF
--- a/tests/integration_tests/reporting/test_webhook_reporting.py
+++ b/tests/integration_tests/reporting/test_webhook_reporting.py
@@ -54,7 +54,7 @@ def test_webhook_reporting(client: IntegrationInstance):
     events = [json.loads(line) for line in server_output]
 
     # Only time this should be less is if we remove modules
-    assert len(events) > 56, events
+    assert len(events) > 54, events
 
     # Assert our first and last expected messages exist
     ds_events = [


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Update webhook test due to removed cc_migrator module

Removed cc_migrator module means 2 less events, one from start, one
from end.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_container/376/testReport/junit/tests.integration_tests.reporting/test_webhook_reporting/test_webhook_reporting/

I don't love the arbitrary number that changes when the number of modules changes, but I also haven't found a simple way of representing the total number of modules that will run and send events.
