### PR TITLE
docs: add create_hostname_file to all hostname user-data examples

### DIFF
--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -68,7 +68,7 @@ meta: MetaSchema = {
         dedent(
             """\
             # On a machine without an ``/etc/hostname`` file, don't create it
-            # In most clouds, this will results in a DHCP configured hostname
+            # In most clouds, this will result in a DHCP-configured hostname
             # provided by the cloud
             create_hostname_file: false
             """

--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -60,7 +60,7 @@ meta: MetaSchema = {
         dedent(
             """\
             hostname: myhost
-            ceate_hostname_file: true
+            create_hostname_file: true
             fqdn: myhost.example.com
             prefer_fqdn_over_hostname: true
             """

--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -60,8 +60,17 @@ meta: MetaSchema = {
         dedent(
             """\
             hostname: myhost
+            ceate_hostname_file: true
             fqdn: myhost.example.com
             prefer_fqdn_over_hostname: true
+            """
+        ),
+        dedent(
+            """\
+            # On a machine without an ``/etc/hostname`` file, don't create it
+            # In most clouds, this will results in a DHCP configured hostname
+            # provided by the cloud
+            create_hostname_file: false
             """
         ),
     ],

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -78,7 +78,7 @@ meta: MetaSchema = {
         dedent(
             """\
         # On a machine without an ``/etc/hostname`` file, don't create it
-        # In most clouds, this will results in a DHCP configured hostname
+        # In most clouds, this will result in a DHCP-configured hostname
         # provided by the cloud
         create_hostname_file: false
         """

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -65,6 +65,7 @@ meta: MetaSchema = {
         fqdn: external.fqdn.me
         hostname: myhost
         prefer_fqdn_over_hostname: true
+        create_hostname_file: true
         """
         ),
         dedent(
@@ -72,6 +73,14 @@ meta: MetaSchema = {
         # Set hostname to "external" instead of "external.fqdn.me" when
         # cloud metadata provides the ``local-hostname``: "external.fqdn.me".
         prefer_fqdn_over_hostname: false
+        """
+        ),
+        dedent(
+            """\
+        # On a machine without an ``/etc/hostname`` file, don't create it
+        # In most clouds, this will results in a DHCP configured hostname
+        # provided by the cloud
+        create_hostname_file: false
         """
         ),
     ],

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -216,7 +216,6 @@ Example ``meta-data``
       broadcast 192.168.1.255
       gateway 192.168.1.254
     hostname: myhost
-    create_hostname_file: true
 
 
 Network configuration can also be provided to ``cloud-init`` in either

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -141,7 +141,7 @@ sufficient disk by following the following example.
 .. code-block:: sh
 
    $ echo -e "instance-id: iid-local01\nlocal-hostname: cloudimg" > meta-data
-   $ echo -e "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n" > user-data
+   $ echo -e "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\ncreate_hostname_file: true\n" > user-data
 
 2. At this stage you have three options:
 
@@ -216,6 +216,7 @@ Example ``meta-data``
       broadcast 192.168.1.255
       gateway 192.168.1.254
     hostname: myhost
+    create_hostname_file: true
 
 
 Network configuration can also be provided to ``cloud-init`` in either

--- a/doc/rtd/reference/datasources/vmware.rst
+++ b/doc/rtd/reference/datasources/vmware.rst
@@ -338,6 +338,7 @@ this datasource using the GuestInfo keys transport:
 
        instance-id: cloud-vm
        local-hostname: cloud-vm
+       create_hostname_file: true
        network:
          version: 2
          ethernets:

--- a/doc/rtd/reference/datasources/vmware.rst
+++ b/doc/rtd/reference/datasources/vmware.rst
@@ -338,7 +338,6 @@ this datasource using the GuestInfo keys transport:
 
        instance-id: cloud-vm
        local-hostname: cloud-vm
-       create_hostname_file: true
        network:
          version: 2
          ethernets:

--- a/doc/rtd/tutorial/qemu-script.sh
+++ b/doc/rtd/tutorial/qemu-script.sh
@@ -21,8 +21,6 @@ EOF
 
 cat << EOF > meta-data
 instance-id: someid/somehostname
-local-hostname: jammy
-create_hostname_file: true
 EOF
 
 touch vendor-data

--- a/doc/rtd/tutorial/qemu-script.sh
+++ b/doc/rtd/tutorial/qemu-script.sh
@@ -22,6 +22,7 @@ EOF
 cat << EOF > meta-data
 instance-id: someid/somehostname
 local-hostname: jammy
+create_hostname_file: true
 EOF
 
 touch vendor-data

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -143,8 +143,6 @@ Now let's run the following command, which creates a file named
 
     $ cat << EOF > meta-data
     instance-id: someid/somehostname
-    local-hostname: jammy
-    create_hostname_file: true
 
     EOF
 

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -144,6 +144,7 @@ Now let's run the following command, which creates a file named
     $ cat << EOF > meta-data
     instance-id: someid/somehostname
     local-hostname: jammy
+    create_hostname_file: true
 
     EOF
 


### PR DESCRIPTION
If a cloud or user sets create_hostname_file to false (as GCP does) the examples in our docs for setting the hostname will not work. This change updates those examples to also set create_hostname_file to true.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
docs: add create_hostname_file to all hostname user-data examples
    
If a cloud or user sets create_hostname_file to false (as GCP does)
the examples in our docs for setting the hostname will not work.
This change updates those examples to also set create_hostname_file
to true.
```

## Additional Context
See https://github.com/canonical/cloud-init/pull/4330 for details on `create_hostname_file` key.

## Test Steps
This is left as a WIP because I want to go through and follow each of the changed examples to ensure they still work with the new key included.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly (N/A)
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
