### PR TITLE
fix(ds-identify): Return code 2 is a valid result, use cached value

### DIFF
--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1967,7 +1967,7 @@ main() {
     if [ "${1:+$1}" != "--force" ] && [ -f "$PATH_RUN_CI_CFG" ] &&
         [ -f "$PATH_RUN_DI_RESULT" ]; then
         if read ret < "$PATH_RUN_DI_RESULT"; then
-            if [ "$ret" = "0" ] || [ "$ret" = "1" ]; then
+            if [ "$ret" = "0" ] || [ "$ret" = "1" ] || [ "$ret" = "2" ]; then
                 debug 2 "used cached result $ret. pass --force to re-run."
                 return "$ret";
             fi


### PR DESCRIPTION
```
fix(ds-identify): Return code 2 is a valid result, use cached value
      
Commit de5fc365f1 added a new return code (2) for indicating disabled status.
Without this change, ds-identify will re-run when it shouldn't, and users will
see a bogus log message:

    previous run returned unexpected '$ret'. Re-running.

Fix it.
```