### PR TITLE
test(linkcheck): ignore github md and rst link headers

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check for broken links below threshold
         run: |
           broken_count=$(grep -c "broken" output.txt)
-          if [[ $broken_count -ge 6 ]]; then
+          if [[ $broken_count -ge 5 ]]; then
             echo "Too many broken links detected: $broken_count"
             broken_matches=$(grep "broken" output.txt)
             echo "Broken links \n$broken_matches"

--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -137,6 +137,10 @@ linkcheck_ignore = [
 ]
 
 linkcheck_anchors_ignore_for_url = (
+    # Ignore github anchors in rst or md files
+    r"https://github.com/.*\.rst",
+    r"https://github.com/.*\.md",
+    # Ignore github line number anchors in cloud-init and ubuntu-pro-client
     r"https://github.com/canonical/cloud-init.*",
     r"https://github.com/canonical/ubuntu-pro-client.*",
 )


### PR DESCRIPTION
## Proposed Commit Message
```
sphinx linkcheck cannot process link anchors in generated github
markdown or rst formatted pages. Ignore those expect failing links.

Also reduce expected github action linkcheck expected broken link count.
```

## Additional Context
Should resolve linkcheck GH action failures seen in #4726

## Test Steps
```
# note on main vs on this branch github md and rst link files from virt-manager and ubuntu-maintainers-handbook will no longer error as they are no longer checked.
tox -e linkcheck | grep broken   
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
