### PR TITLE
tests: add expected exit 2 on noble from cloud-init status

### DIFF
--- a/tests/integration_tests/cmd/test_clean.py
+++ b/tests/integration_tests/cmd/test_clean.py
@@ -4,6 +4,7 @@ import re
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.releases import CURRENT_RELEASE
 
 USER_DATA = """\
 #cloud-config
@@ -32,7 +33,15 @@ write_files:
 class TestCleanCommand:
     def test_clean_by_param(self, class_client: IntegrationInstance):
         """Clean with various params alters expected files without error"""
-        assert class_client.execute("cloud-init status --wait").ok
+        result = class_client.execute("cloud-init status --wait --long")
+
+        # Expect warning exit code 2 on Ubuntu Noble due to cloud-init
+        # disabling /etc/apt/sources.list build artifact in favor of deb822
+        return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
+        assert return_code == result.return_code, (
+            f"Unexpected cloud-init status exit code {result.return_code}\n"
+            f"Output:\n{result}"
+        )
         result = class_client.execute("cloud-init clean")
         assert (
             result.ok


### PR DESCRIPTION
## Proposed Commit Message
```
Commit d662ffc5 introduced a warning from cloud-init when disabling an image build artifact /etc/apt/sources.lists in favor of writing deb822 format sources file at /etc/apt/sources.list.d/ubuntu.sources.

As such, integration tests cannot check execute(cloud-init status).ok, they have to instead expect to see non-zero exit 2 due to the warning.

We want to make this strict expectation of exit 2 on noble so we can track in jenkins when Ubuntu Noble image builds correctly remove this undesired build artifact /etc/apt/sources.list.
```

## Additional Context
Failing jenkins noble jobs https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-ec2/20/

## Test Steps
```
# test from main and from this branch
CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily .tox/integration-tests/bin/pytest tests/integration_tests/modules/test_cli.py::test_valid_userdata tests/integration_tests/cmd/test_clean.py::TestCleanCommand::test_clean_by_param
```
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
