### PR TITLE
feat(apt): remove /etc/apt/sources.list when deb22 preferred

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -679,20 +679,12 @@ def generate_sources_list(cfg, release, mirrors, cloud):
             )
             aptsrc_file = apt_sources_list
     disabled = disable_suites(cfg.get("disable_suites"), rendered, release)
-    disable_apt_sources_list = False
-    if aptsrc_file == apt_sources_deb822 and os.path.exists(apt_sources_list):
-        disable_apt_sources_list = True
     util.write_file(aptsrc_file, disabled, mode=0o644)
-    if disable_apt_sources_list:
+    if aptsrc_file == apt_sources_deb822 and os.path.exists(apt_sources_list):
         LOG.warning(
-            "Disabling %s to favor deb822 source format", apt_sources_list
+            "Removing %s to favor deb822 source format", apt_sources_list
         )
-        content = pathlib.Path(apt_sources_list).read_bytes()
-        content = b"# disabled by cloud-init\n" + content
-        util.rename(apt_sources_list, f"{apt_sources_list}.disabled")
-        util.write_file(
-            f"{apt_sources_list}.disabled", content, preserve_mode=True
-        )
+        util.del_file(apt_sources_list)
 
 
 def add_apt_key_raw(key, file_name, hardened=False):

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -68,7 +68,7 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         "thinpool by default on Ubuntu due to LP #1982780",
         "WARNING]: Could not match supplied host pattern, ignoring:",
         # Old Ubuntu cloud-images contain /etc/apt/sources.list
-        "WARNING]: Disabling /etc/apt/sources.list to favor deb822 source"
+        "WARNING]: Removing /etc/apt/sources.list to favor deb822 source"
         " format",
     ]
     traceback_texts = []


### PR DESCRIPTION
## Proposed Commit Message

```
feat(apt): remove /etc/apt/sources.list when deb22 preferred (#....)

Some images may contain /etc/apt/sources.list which cloud-init historically would silently overwrite on first boot. Remove this file rather than preserve a vestigial disabled file as /etc/apt/sources.list.disabled because the disabled file may just confuse users as to the why the file exists and whether they should consider re-enabling it.

If a customer reenables a previously disabled
/etc/apt/sources.list.disabled file and the same APT sources are defined in both /etc/apt/sources.list and deb822 formatted /etc/apt/sources.list.d/ubuntu.sources, apt update and cache commands will emit warnings about duplicate sources being detected which could break tooling which attempts to parse apt command output.

Let's avoid leaving unnecessary artifacts on the sytem given all previous versions of cloud-init would silently overwrite this /etc/apt/sources.list file in on first boot anyway.
```

## Additional Context
Recommendation is that we don't want to leave vestigial apt configuration artifacts around that otherwise cloud-init would have overwritten. Having extra .disabled apt sources file could lead to customers trying to re-enable /etc/apt/sources.list which would collide with the now duplicate deb822 sources entries in /etc/apt/sources.list.d/ubuntu.sources that cloud-init sets up on first boot. The duplicate APT source configs emit warnings for update update apt upgrade and apt-cache commands. 
Better to leave the cloud-init warning in cloud-init.log to report this condition, but still remove the /etc/apt/sources.list file.

## Test Steps
```
CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_OS_IMAGE=noble tox -e  integration-tests tests/integration_tests/modules/test_apt_functionality.py
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
