### PR TITLE
Describe ds-identify irrespective of distro

### DIFF
--- a/doc/rtd/explanation/boot.rst
+++ b/doc/rtd/explanation/boot.rst
@@ -19,7 +19,8 @@ Detect
 A platform identification tool called ``ds-identify`` runs in the first stage.
 This tool detects which platform the instance is running on. This tool is
 integrated into the init system to disable cloud-init when no platform is
-found, and enable cloud-init when a valid platform is detected.
+found, and enable cloud-init when a valid platform is detected. This stage
+might not be present for every installation of cloud-init.
 
 .. _boot-Local:
 

--- a/doc/rtd/explanation/boot.rst
+++ b/doc/rtd/explanation/boot.rst
@@ -3,23 +3,23 @@
 Boot stages
 ***********
 
-To be able to provide the functionality that it does, ``cloud-init`` must be
-integrated into the boot in a fairly controlled way. There are five
-stages to boot:
+There are five stages to boot:
 
-1. Generator
+1. Detect
 2. Local
 3. Network
 4. Config
 5. Final
 
-.. _boot-Generator:
+.. _boot-Detect:
 
-Generator
-=========
-When booting under ``systemd``, a generator will run that determines if
-cloud-init.target should be included in the boot goals. ``ds-identify``
-runs at this stage.
+Detect
+======
+
+A platform identification tool called ``ds-identify`` runs in the first stage.
+This tool detects which platorm the instance is running on. This tool is
+integrated into the init system to disable cloud-init when no platform is
+found, and enable cloud-init when a valid platform is detected.
 
 .. _boot-Local:
 

--- a/doc/rtd/explanation/boot.rst
+++ b/doc/rtd/explanation/boot.rst
@@ -17,7 +17,7 @@ Detect
 ======
 
 A platform identification tool called ``ds-identify`` runs in the first stage.
-This tool detects which platorm the instance is running on. This tool is
+This tool detects which platform the instance is running on. This tool is
 integrated into the init system to disable cloud-init when no platform is
 found, and enable cloud-init when a valid platform is detected.
 

--- a/doc/rtd/howto/debugging.rst
+++ b/doc/rtd/howto/debugging.rst
@@ -48,8 +48,8 @@ Cloud-init did not run
 
 2. Check the contents of :file:`/run/cloud-init/ds-identify.log`
 
-   This log file is used by the systemd generator and sets cloud-init
-   to be enabled or disabled.
+   This log file is used when the platform that cloud-init is running on
+   :ref:`is detected<boot-Detect>`. This stage enables or disables cloud-init.
 
 3. Check the status of the services
 

--- a/doc/rtd/reference/base_config_reference.rst
+++ b/doc/rtd/reference/base_config_reference.rst
@@ -232,19 +232,24 @@ Automatically includes ``cloudinit.sources``.
 ``datasource_list``
 ^^^^^^^^^^^^^^^^^^^
 
-Prioritised list of datasources that ``cloud-init`` will attempt to find on
-boot. By default, this will be defined in :file:`/etc/cloud/cloud.cfg.d`. There
-are two primary use cases for modifying the ``datasource_list``:
+This key contains a prioritised list of datasources that ``cloud-init``
+attempts to discover on boot. By default, this is defined in
+:file:`/etc/cloud/cloud.cfg.d`.
 
-1. Remove known invalid datasources. This may avoid long timeouts when
-   attempting to detect datasources on any system without a systemd-generator
-   hook that invokes ``ds-identify``.
-2. Override default datasource ordering to discover a different datasource
-   type than would typically be prioritised.
+There are a few reasons to modify the ``datasource_list``:
 
-If ``datasource_list`` has only a single entry (or a single entry + ``None``),
-`cloud-init` will automatically assume and use this datasource without
-attempting detection.
+1. Override default datasource discovery priority order
+2. Force cloud-init to use a specific datasource: A single entry in
+   the list (or a single entry and ``None``) will override datasource
+   discovery, which will force the specified datasource to run.
+3. Remove known invalid datasources: On distros that do not use ``ds-identify``
+   to detect and select the datasource, this might improve boot speed.
+
+.. warning::
+
+   This key is unique in that it uses a subset of YAML syntax. It **requires**
+   that the key and its contents, a list, must share a single line - no
+   newlines.
 
 ``vendor_data``/``vendor_data2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/rtd/reference/base_config_reference.rst
+++ b/doc/rtd/reference/base_config_reference.rst
@@ -242,8 +242,8 @@ There are a few reasons to modify the ``datasource_list``:
 2. Force cloud-init to use a specific datasource: A single entry in
    the list (or a single entry and ``None``) will override datasource
    discovery, which will force the specified datasource to run.
-3. Remove known invalid datasources: On distros that do not use ``ds-identify``
-   to detect and select the datasource, this might improve boot speed.
+3. Remove known invalid datasources: this might improve boot speed on distros
+   that do not use ``ds-identify`` to detect and select the datasource, 
 
 .. warning::
 

--- a/doc/rtd/reference/base_config_reference.rst
+++ b/doc/rtd/reference/base_config_reference.rst
@@ -243,7 +243,7 @@ There are a few reasons to modify the ``datasource_list``:
    the list (or a single entry and ``None``) will override datasource
    discovery, which will force the specified datasource to run.
 3. Remove known invalid datasources: this might improve boot speed on distros
-   that do not use ``ds-identify`` to detect and select the datasource, 
+   that do not use ``ds-identify`` to detect and select the datasource,
 
 .. warning::
 

--- a/doc/rtd/reference/datasources/lxd.rst
+++ b/doc/rtd/reference/datasources/lxd.rst
@@ -25,7 +25,7 @@ warnings from ``cloud-init``, and ``cloud-init`` will keep the
 originally-detected LXD datasource.
 
 The LXD datasource is detected as viable by ``ds-identify`` during the
-:ref:`detect stage<boot-Detect>` when either ``/dev/lxd/sock`` exists, or
+:ref:`detect stage<boot-Detect>` when either ``/dev/lxd/sock`` exists or
 ``/sys/class/dmi/id/board_name`` matches "LXD".
 
 The LXD datasource provides ``cloud-init`` with the ability to react to

--- a/doc/rtd/reference/datasources/lxd.rst
+++ b/doc/rtd/reference/datasources/lxd.rst
@@ -24,8 +24,8 @@ Disabling ``security.devlxd`` over the life of the container will result in
 warnings from ``cloud-init``, and ``cloud-init`` will keep the
 originally-detected LXD datasource.
 
-The LXD datasource is detected as viable by ``ds-identify`` during ``systemd``
-generator time when either ``/dev/lxd/sock`` exists, or
+The LXD datasource is detected as viable by ``ds-identify`` during the
+:ref:`detect stage<boot-Detect>` when either ``/dev/lxd/sock`` exists, or
 ``/sys/class/dmi/id/board_name`` matches "LXD".
 
 The LXD datasource provides ``cloud-init`` with the ability to react to


### PR DESCRIPTION
## Commit message 
```
doc(ds-identify): Describe ds-identify irrespective of distro
    
- add links to the detect stage where appropriate
- add note about datasource_list requiring a subset of YAML
- rename "Generator" stage to "Detect"
```
## Additional Context

This stage may have originally been specific to systemd-generator, but today it is used by various other init systems for the same purpose. Update the docs to use generic vocabulary, include some links to this section where appropriate, and update language to be direct. Also include the importance of the `datasource_list` key being a subset of YAML.  

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
