### PR TITLE
Ubuntu/mantic 23.4.x: Retain exit code in cloud-init status for recoverable errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,10 @@
-cloud-init (23.4.1-0ubuntu1~23.10.2) UNRELEASED; urgency=medium
+cloud-init (23.4.1-0ubuntu1~23.10.2) mantic; urgency=medium
 
   * d/p/status-retain-recoverable-error-exit-code.patch:
     Retain exit code in cloud-init status for recoverable errors.
     (LP: #2048522).
 
- -- Alberto Contreras <alberto.contreras@canonical.com>  Mon, 08 Jan 2024 12:21:08 +0100
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Mon, 08 Jan 2024 17:00:52 +0100
 
 cloud-init (23.4.1-0ubuntu1~23.10.1) mantic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (23.4.1-0ubuntu1~23.10.2) UNRELEASED; urgency=medium
+
+  * d/p/status-retain-recoverable-error-exit-code.patch:
+    Retain exit code in cloud-init status for recoverable errors.
+    (LP: #2048522).
+
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Mon, 08 Jan 2024 12:21:08 +0100
+
 cloud-init (23.4.1-0ubuntu1~23.10.1) mantic; urgency=medium
 
   * d/p/retain-apt-pre-deb822.patch:

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 do-not-block-user-login.patch
 status-do-not-remove-duplicated-data.patch
 retain-apt-pre-deb822.patch
+status-retain-recoverable-error-exit-code.patch

--- a/debian/patches/status-retain-recoverable-error-exit-code.patch
+++ b/debian/patches/status-retain-recoverable-error-exit-code.patch
@@ -1,0 +1,28 @@
+Description: Retain exit code in cloud-init status for recoverable errors
+ (LP: #2048522).
+Author: Alberto Contreras <alberto.contreras@canonical.com>
+Last-Update: 2024-01-08
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/cloudinit/cmd/status.py
++++ b/cloudinit/cmd/status.py
+@@ -227,7 +227,7 @@
+         return 1
+     # Recoverable error
+     elif details.status in UXAppStatusDegradedMap.values():
+-        return 2
++        return 0
+     return 0
+
+
+--- a/tests/unittests/cmd/test_status.py
++++ b/tests/unittests/cmd/test_status.py
+@@ -708,7 +708,7 @@
+                 },
+                 None,
+                 MyArgs(long=False, wait=False, format="json"),
+-                2,
++                0,
+                 {
+                     "_schema_version": "1",
+                     "boot_status_code": "enabled-by-kernel-cmdline",


### PR DESCRIPTION
## do not squash

- [x] `quilt push -a && tox -e py3 && quilt pop -a`