### PR TITLE
feat: Ensure internal DNS state same for v1 and v2

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -336,7 +336,7 @@ class NetworkStateInterpreter:
             if iface:
                 nameservers, search = dns
                 iface["dns"] = {
-                    "addresses": nameservers,
+                    "nameservers": nameservers,
                     "search": search,
                 }
 

--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -221,12 +221,6 @@ class Renderer(renderer.Renderer):
     def parse_dns(self, iface, cfg: CfgParser, ns: NetworkState):
         sec = "Network"
 
-        dns_cfg_map = {
-            "search": "Domains",
-            "nameservers": "DNS",
-            "addresses": "DNS",
-        }
-
         dns = iface.get("dns")
         if not dns and ns.version == 1:
             dns = {
@@ -236,9 +230,10 @@ class Renderer(renderer.Renderer):
         elif not dns and ns.version == 2:
             return
 
-        for k, v in dns_cfg_map.items():
-            if k in dns and dns[k]:
-                cfg.update_section(sec, v, " ".join(dns[k]))
+        if dns.get("search"):
+            cfg.update_section(sec, "Domains", " ".join(dns["search"]))
+        if dns.get("nameservers"):
+            cfg.update_section(sec, "DNS", " ".join(dns["nameservers"]))
 
     def parse_dhcp_overrides(self, cfg: CfgParser, device, dhcp, version):
         dhcp_config_maps = {

--- a/tests/unittests/net/test_network_state.py
+++ b/tests/unittests/net/test_network_state.py
@@ -258,7 +258,10 @@ class TestNetworkStateParseNameservers:
         # If an interface was specified, DNS should be part of the interface
         for iface in config.iter_interfaces():
             if iface["name"] == "eth1":
-                assert iface["dns"]["addresses"] == ["192.168.1.1", "8.8.8.8"]
+                assert iface["dns"]["nameservers"] == [
+                    "192.168.1.1",
+                    "8.8.8.8",
+                ]
                 assert iface["dns"]["search"] == ["spam.local"]
             else:
                 assert "dns" not in iface


### PR DESCRIPTION
When defining interface-level DNS on the network state, v1 uses the "nameservers" key whereas v2 was using an "addresses" key. This commit updates the v2 parsing to set the key as "nameservers".

Also update networkd renderer as this was only renderer using the v2 "addresses" key.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat: Ensure internal DNS state same for v1 and v2

When defining interface-level DNS on the network state, v1 uses the
"nameservers" key whereas v2 was using an "addresses" key.
This commit updates the v2 parsing to set the key as "nameservers".

Also update networkd renderer as this was only renderer using the v2
"addresses" key.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
