### PR TITLE
tests: warning status zero on stable release

### DIFF
--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -71,8 +71,12 @@ def test_invalid_userdata(client: IntegrationInstance):
         " #cloud-boothook, #cloud-config" in result.stderr
     )
     result = client.execute("cloud-init status --long")
+    if CURRENT_RELEASE.series in ("focal", "jammy", "lunar", "mantic"):
+        return_code = 0  # Stable releases don't change exit code behavior
+    else:
+        return_code = 2  # 23.4 and later will exit 2 on warnings
     assert (
-        2 == result.return_code
+        return_code == result.return_code
     ), f"Unexpected exit code {result.return_code}"
 
 
@@ -83,8 +87,12 @@ def test_invalid_userdata_schema(client: IntegrationInstance):
     PR #1175
     """
     result = client.execute("cloud-init status --long")
+    if CURRENT_RELEASE.series in ("focal", "jammy", "lunar", "mantic"):
+        return_code = 0  # Stable releases don't change exit code behavior
+    else:
+        return_code = 2  # 23.4 and later will exit 2 on warnings
     assert (
-        2 == result.return_code
+        return_code == result.return_code
     ), f"Unexpected exit code {result.return_code}"
     log = client.read_from_file("/var/log/cloud-init.log")
     warning = (


### PR DESCRIPTION
## Proposed Commit Message
```
tests: stable ubuntu releases will not exit 2 on warnings
```

## Additional Context
<!-- If relevant -->

Branches such as https://github.com/canonical/cloud-init/pull/4755 just landed in stable release branches ubuntu/focal, jammy, lunar and mantic to retain exit 0 behavior when encountering warnings. As such, integation tests which source ppa:cloud-init-dev/daily should assert that exit 0 is seen on invalid_userdata warnings.


## Test Steps

```
CLOUD_INIT_OS_IMAGE=lunar CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily .tox/integration-tests/bin/pytest  tests/integration_tests/modules/test_cli.py
```
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
