### PR TITLE
Update cacerts to support VMware Photon

### DIFF
--- a/cloudinit/config/cc_ca_certs.py
+++ b/cloudinit/config/cc_ca_certs.py
@@ -45,6 +45,13 @@ DISTRO_OVERRIDES = {
         "ca_cert_config": None,
         "ca_cert_update_cmd": ["update-ca-certificates"],
     },
+    "photon":{
+        "ca_cert_path": "/etc/ssl/certs/",
+        "ca_cert_local_path": "/etc/ssl/certs/",
+        "ca_cert_filename": "cloud-init-ca-cert-{cert_index}.crt",
+        "ca_cert_config": None,
+        "ca_cert_update_cmd": ["rehash_ca_certificates.sh"],
+    },
 }
 
 for distro in (
@@ -84,6 +91,7 @@ distros = [
     "sle-micro",
     "sles",
     "ubuntu",
+    "photon",
 ]
 
 meta: MetaSchema = {

--- a/cloudinit/config/cc_ca_certs.py
+++ b/cloudinit/config/cc_ca_certs.py
@@ -47,7 +47,7 @@ DISTRO_OVERRIDES = {
     },
     "photon":{
         "ca_cert_path": "/etc/ssl/certs/",
-        "ca_cert_local_path": "/etc/ssl/certs/",
+        "ca_cert_local_path": "/etc/pki/tls/certs/",
         "ca_cert_filename": "cloud-init-ca-cert-{cert_index}.crt",
         "ca_cert_config": None,
         "ca_cert_update_cmd": ["rehash_ca_certificates.sh"],
@@ -173,7 +173,7 @@ def disable_default_ca_certs(distro_name, distro_cfg):
     @param distro_name: String providing the distro class name.
     @param distro_cfg: A hash providing _distro_ca_certs_configs function.
     """
-    if distro_name == "rhel":
+    if distro_name in ["rhel", "photon"]:
         remove_default_ca_certs(distro_cfg)
     elif distro_name in ["alpine", "debian", "ubuntu"]:
         disable_system_ca_certs(distro_cfg)

--- a/cloudinit/config/cc_ca_certs.py
+++ b/cloudinit/config/cc_ca_certs.py
@@ -45,7 +45,7 @@ DISTRO_OVERRIDES = {
         "ca_cert_config": None,
         "ca_cert_update_cmd": ["update-ca-certificates"],
     },
-    "photon":{
+    "photon": {
         "ca_cert_path": "/etc/ssl/certs/",
         "ca_cert_local_path": "/etc/pki/tls/certs/",
         "ca_cert_filename": "cloud-init-ca-cert-{cert_index}.crt",

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -339,7 +339,7 @@ class TestRemoveDefaultCaCerts(TestCase):
 
                 cc_ca_certs.disable_default_ca_certs(distro_name, conf)
 
-                if distro_name == "rhel":
+                if distro_name in ["rhel", "photon"]:
                     mock_delete.assert_has_calls(
                         [
                             mock.call(conf["ca_cert_path"]),

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -41,6 +41,7 @@ Conan-Kudo
 cvstealth
 dankenigsberg
 dankm
+dark2phoenix
 david-caro
 dbungert
 ddymko


### PR DESCRIPTION
## Proposed Commit Message
feat(cacerts) : Enable support for VMware Photon
```
<type>(optional scope): <summary>  # no more than 72 characters

This feature enables cacerts functionality for VMware Photon.  It 
allows for adding 3rd party certificates as well as for cloud-init
to use them in modules like phone_home.

## Test Steps
1. Add a certificate in the cloud-init configuration cacerts
2. Execute cloud-init
3. Verify that the certificate has been added to /etc/ssl/certs/ directory
4. Verify that the phone_home module can access a website built from the applied root certifcate

## Checklist
- [X ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
