### PR TITLE
feat: prefer udev's cdrom_id -e to eject

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1316,10 +1316,19 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
     @staticmethod
     def eject_media(device: str) -> None:
-        cmd = ["/lib/udev/cdrom_id", "--eject-media", device]
-        if not uses_systemd():
+        cmd = None
+        if subp.which("eject"):
             cmd = ["eject", device]
+        elif subp.which("/lib/udev/cdrom_id"):
+            cmd = ["/lib/udev/cdrom_id", "--eject-media", device]
+        else:
+            raise subp.ProcessExecutionError(
+                cmd="eject_media_cmd",
+                description="eject command not found",
+                reason="neither eject nor /lib/udev/cdrom_id are found",
+            )
         subp.subp(cmd)
+
 
 def _apply_hostname_transformations_to_url(url: str, transformations: list):
     """

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1314,6 +1314,12 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             )
         return None
 
+    @staticmethod
+    def eject_media(device: str) -> None:
+        cmd = ["/lib/udev/cdrom_id", "--eject-media", device]
+        if not uses_systemd():
+            cmd = ["eject", device]
+        subp.subp(cmd)
 
 def _apply_hostname_transformations_to_url(url: str, transformations: list):
     """

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1366,6 +1366,7 @@ class DataSourceAzure(sources.DataSource):
         try:
             data = get_metadata_from_fabric(
                 endpoint=self._wireserver_endpoint,
+                distro=self.distro,
                 iso_dev=self._iso_dev,
                 pubkey_info=pubkey_info,
             )

--- a/tests/integration_tests/datasources/test_azure.py
+++ b/tests/integration_tests/datasources/test_azure.py
@@ -1,0 +1,51 @@
+import pytest
+from pycloudlib.cloud import ImageType
+
+from tests.integration_tests.clouds import IntegrationCloud
+from tests.integration_tests.conftest import get_validated_source
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.integration_settings import PLATFORM
+from tests.integration_tests.releases import CURRENT_RELEASE
+from tests.integration_tests.util import verify_clean_log
+
+
+def _check_for_eject_errors(
+    instance: IntegrationInstance,
+):
+    assert "sr0" not in instance.execute("mount")
+    log = instance.read_from_file("/var/log/cloud-init.log")
+    assert "Failed ejecting the provisioning iso" not in log
+    verify_clean_log(log)
+
+
+@pytest.mark.skipif(PLATFORM != "azure", reason="Test is Azure specific")
+def test_azure_eject(session_cloud: IntegrationCloud):
+    """Integration test for GitHub #4732.
+
+    Azure uses `eject` but that is not always available on minimal images.
+    Ensure udev's eject can be used on systemd-enabled systems.
+    """
+    with session_cloud.launch(
+        launch_kwargs={
+            "image_id": session_cloud.cloud_instance.daily_image(
+                CURRENT_RELEASE.series, image_type=ImageType.MINIMAL
+            )
+        }
+    ) as instance:
+        source = get_validated_source(session_cloud)
+        if source.installs_new_version():
+            instance.install_new_cloud_init(
+                source, take_snapshot=False, clean=True
+            )
+            snapshot_id = instance.snapshot()
+            try:
+                with session_cloud.launch(
+                    launch_kwargs={
+                        "image_id": snapshot_id,
+                    }
+                ) as snapshot_instance:
+                    _check_for_eject_errors(snapshot_instance)
+            finally:
+                session_cloud.cloud_instance.delete_image(snapshot_id)
+        else:
+            _check_for_eject_errors(instance)

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3754,6 +3754,7 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             )
@@ -3919,11 +3920,13 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             ),
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev=None,
                 pubkey_info=None,
             ),
@@ -4039,11 +4042,13 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             ),
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev=None,
                 pubkey_info=None,
             ),
@@ -4195,11 +4200,13 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             ),
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev=None,
                 pubkey_info=None,
             ),
@@ -4283,6 +4290,7 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             ),
@@ -4392,6 +4400,7 @@ class TestProvisioning:
         assert self.mock_azure_get_metadata_from_fabric.mock_calls == [
             mock.call(
                 endpoint="10.11.12.13",
+                distro=self.azure_ds.distro,
                 iso_dev="/dev/sr0",
                 pubkey_info=None,
             )


### PR DESCRIPTION
Azure currently relies on eject for some use cases.  In noble minimal images eject is not installed by default.  This change prefers a udev command that performs the same action before trying eject.

A integration test has been created but is not functional.  Code changes have not been tested.

[1] https://github.com/canonical/cloud-init/issues/4732

## Proposed Commit Message
```
feat: fall back to cdrom_id eject if eject is not available

Azure currently relies on eject for some use cases.  In ubuntu noble
minimal images eject is not installed by default.  This change adds a
fallback of systemd udev's cdrom -e if eject is not found on the distro.

Fixes GH-4732
```


## Test Steps
Completely untested at this time.  @TheRealFalcon offered to work on an integration test for this.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
