### PR TITLE
feat(apt): deb822 sources update ubuntu.sources template and replace invalid /etc/apt/sources.list with Ubuntu default

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -184,6 +184,18 @@ PORTS_MIRRORS = {
 PRIMARY_ARCHES = ["amd64", "i386"]
 PORTS_ARCHES = ["s390x", "arm64", "armhf", "powerpc", "ppc64el", "riscv64"]
 
+UBUNTU_DEFAULT_APT_SOURCES_LIST = """\
+# Ubuntu sources have moved to the /etc/apt/sources.list.d/ubuntu.sources
+# file, which uses the deb822 format. Use deb822-formatted .sources files
+# to manage package sources in the /etc/apt/sources.list.d/ directory.
+# See the sources.list(5) manual page for details.
+"""
+
+# List of allowed content in /etc/apt/sources.list when features
+# APT_DEB822_SOURCE_LIST_FILE is set. Otherwise issue warning about
+# invalid non-deb822 configuration.
+DEB822_ALLOWED_APT_SOURCES_LIST = {"ubuntu": UBUNTU_DEFAULT_APT_SOURCES_LIST}
+
 
 def get_default_mirrors(
     arch=None,
@@ -681,10 +693,23 @@ def generate_sources_list(cfg, release, mirrors, cloud):
     disabled = disable_suites(cfg.get("disable_suites"), rendered, release)
     util.write_file(aptsrc_file, disabled, mode=0o644)
     if aptsrc_file == apt_sources_deb822 and os.path.exists(apt_sources_list):
-        LOG.warning(
-            "Removing %s to favor deb822 source format", apt_sources_list
+        expected_content = DEB822_ALLOWED_APT_SOURCES_LIST.get(
+            cloud.distro.name
         )
-        util.del_file(apt_sources_list)
+        if expected_content:
+            if expected_content != util.load_text_file(apt_sources_list):
+                LOG.warning(
+                    "Replacing %s to favor deb822 source format",
+                    apt_sources_list,
+                )
+                util.write_file(
+                    apt_sources_list, UBUNTU_DEFAULT_APT_SOURCES_LIST
+                )
+        else:
+            LOG.warning(
+                "Removing %s to favor deb822 source format", apt_sources_list
+            )
+            util.del_file(apt_sources_list)
 
 
 def add_apt_key_raw(key, file_name, hardened=False):

--- a/templates/sources.list.ubuntu.deb822.tmpl
+++ b/templates/sources.list.ubuntu.deb822.tmpl
@@ -1,61 +1,57 @@
 ## template:jinja
 ## Note, this file is written by cloud-init on first boot of an instance
 ## modifications made here will not survive a re-bundle.
-## if you wish to make changes you can:
+##
+## If you wish to make changes you can:
 ## a.) add 'apt_preserve_sources_list: true' to /etc/cloud/cloud.cfg
 ##     or do the same in user-data
 ## b.) add supplemental sources in /etc/apt/sources.list.d
 ## c.) make changes to template file
 ##      /etc/cloud/templates/sources.list.ubuntu.deb822.tmpl
 ##
-## See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
-## newer versions of the distribution.
+
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+
+## Ubuntu distribution repository
 ##
-## The following settings can be tweaked to configure which packages to use
-## from Ubuntu.
-## Mirror your choices (except for URIs and Suites) in the security section
-## below to ensure timely security updates.
+## The following settings can be adjusted to configure which packages to use from Ubuntu.
+## Mirror your choices (except for URIs and Suites) in the security section below to
+## ensure timely security updates.
 ##
 ## Types: Append deb-src to enable the fetching of source package.
 ## URIs: A URL to the repository (you may add multiple URLs)
 ## Suites: The following additional suites can be configured
-##   <name>-updates   - Major bug fix updates produced after the final release
-##                      of the distribution.
-##   <name>-backports - software from this repository may not have been tested
-##                      as extensively as that contained in the main release,
-##                      although it includes newer versions of some
-##                      applications which may provide useful features.
-##                      Also, please note that software in backports WILL NOT
-##                      receive any review or updates from the Ubuntu security
-##                      team.
-## Components: Aside from main, the following components can be added to the
-## list:
-##   restricted  - Software that may not be under a free license, or protected
-##                 by patents.
-##   universe    - Community maintained packages. Software from this repository
-##                 is ENTIRELY UNSUPPORTED by the Ubuntu team. Also, please
-##                 note that software in universe WILL NOT receive any
+##   <name>-updates   - Major bug fix updates produced after the final release of the
+##                      distribution.
+##   <name>-backports - software from this repository may not have been tested as
+##                      extensively as that contained in the main release, although it includes
+##                      newer versions of some applications which may provide useful features.
+##                      Also, please note that software in backports WILL NOT receive any review
+##                      or updates from the Ubuntu security team.
+## Components: Aside from main, the following components can be added to the list
+##   restricted  - Software that may not be under a free license, or protected by patents.
+##   universe    - Community maintained packages.
+##                 Software from this repository is only maintained and supported by Canonical
+##                 for machines with Ubuntu Pro subscriptions. Without Ubuntu Pro, the Ubuntu
+##                 community provides best-effort security maintenance.
+##   multiverse  - Community maintained of restricted. Software from this repository is
+##                 ENTIRELY UNSUPPORTED by the Ubuntu team, and may not be under a free
+##                 licence. Please satisfy yourself as to your rights to use the software.
+##                 Also, please note that software in multiverse WILL NOT receive any
 ##                 review or updates from the Ubuntu security team.
-##   multiverse  - Community maintained of restricted. Software from this
-##                 repository is ENTIRELY UNSUPPORTED by the Ubuntu team, and
-##                 may not be under a free licence. Please satisfy yourself as
-##                 to your rights to use the software.
-##                 Also, please note that software in multiverse WILL NOT
-##                 receive any review or updates from the Ubuntu security team.
 ##
 ## See the sources.list(5) manual page for further settings.
-# Types: deb deb-src
 Types: deb
 URIs: {{mirror}}
 Suites: {{codename}} {{codename}}-updates {{codename}}-backports
-Components: main restricted universe multiverse
+Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 ## Ubuntu security updates. Aside from URIs and Suites,
 ## this should mirror your choices in the previous section.
-# Types: deb deb-src
 Types: deb
 URIs: {{security}}
 Suites: {{codename}}-security
-Components: main restricted universe multiverse
+Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -71,7 +71,7 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         "thinpool by default on Ubuntu due to LP #1982780",
         "WARNING]: Could not match supplied host pattern, ignoring:",
         # Old Ubuntu cloud-images contain /etc/apt/sources.list
-        "WARNING]: Removing /etc/apt/sources.list to favor deb822 source"
+        "WARNING]: Replacing /etc/apt/sources.list to favor deb822 source"
         " format",
     ]
     traceback_texts = []


### PR DESCRIPTION
## Rebase merge mutiple separate commits
 Updated per changes that just merged into Ubuntu Noble per https://code.launchpad.net/~juliank/livecd-rootfs/+git/livecd-rootfs/+merge/458366. The changset indicates that livecd-rootfs will leave around an "empty" breadcrumb `/etc/apt/sources.list` which will contain comments about the intent of Ubuntu to use deb822 format but no active APT configuration. cloud-init will now leave this breadcrumb in place and not warn in this case by checking md5sum of the file. If it is unaltered, leave it in place.

## Proposed Commit Message(s)
```
--- feat(apt): skip known md5sums /etc/apt/sources.list
    
    Some image creation software will place known stub files in
    /etc/apt/sources.list to inform users in comments of desired
    deb822 format.
    
    When deb822 is preferred and /etc/apt/sources.list exists, do
    not remove that file if it is has a known safe md5sum value.
    
    Add md5um for Ubuntu's default /etc/apt/sources.list which
    has the following content:
     # Ubuntu sources have moved to the /etc/apt/sources.list.d/ubuntu.sources
     # file, which uses the deb822 format. Use deb822-formatted .sources files
     # to manage package sources in the /etc/apt/sources.list.d/ directory.
     # See the sources.list(5) manual page for details.

--- feat(apt): use APT deb822 source format by default
    
    Prefer default APT configuration expressed as deb822 format.
    
    Update default ubuntu.deb822.tmpl documentation and suites/components
    for APT configuration on Ubuntu Noble only which cloud-init renders
    on first boot.
    
    Default deb sources content for Ubuntu is sourced from
    livecd-rootfs:live-build/functions.
```

## Additional Context
A [livecd-rootfs merge request](https://code.launchpad.net/~juliank/livecd-rootfs/+git/livecd-rootfs/+merge/458366) is in flight to update this doc data for other Ubuntu image builds as well and cloud-init should align with common text, suites and components in livecd-rootfs as well. CC: @julian-klode  for review/acceptance on this PR for cloud-init once final livecd-roots PR default text,suites and components is settled.
PR Merged as of Feb 12th

## Test Steps
```
make deb
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init*bddeb.deb  tox -e integration-tests -- tests/integration-tests/modules/test_apt_functionality.py::TestDefaults
```

<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
