### PR TITLE
Net v1 name length

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -17,6 +17,7 @@
         },
         "name": {
           "type": "string",
+          "maxLength": 15,
           "description": "Desired device name should be less than 15 characters. Any characters exceeding 15 will be truncated. This is a limitation of the Linux kernel network-device structure."
         },
         "mac_address": {

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -2,6 +2,8 @@
 import pytest
 import yaml
 
+from tests.integration_tests import random_mac_address
+from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 
@@ -91,3 +93,107 @@ class TestNetplanGenerateBehaviorOnReboot:
             client.execute("cat /etc/netplan/50-cloud-init.yaml")
         )
         assert netplan != netplan_new, "changes expected in netplan config"
+
+
+NET_V1_CONFIG = """
+config:
+- name: eth0
+  type: physical
+  mac_address: '{mac_addr}'
+  subnets:
+  - control: auto
+    type: dhcp
+version: 1
+"""
+
+
+NET_V2_MATCH_CONFIG = """
+version: 2
+ethernets:
+  eth0:
+      dhcp4: true
+      match:
+        macaddress: {mac_addr}
+      set-name: eth0
+"""
+
+EXPECTED_NETPLAN_HEADER = """\
+# This file is generated from information provided by the datasource.  Changes
+# to it will not persist across an instance reboot.  To disable cloud-init's
+# network configuration capabilities, write a file
+# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
+# network: {config: disabled}"""
+
+EXPECTED_NET_CONFIG = """\
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: true
+      set-name: eth0
+"""
+
+
+@pytest.mark.skipif(
+    PLATFORM != "lxd_vm",
+    reason="Test requires custom networking provided by LXD",
+)
+@pytest.mark.parametrize("net_config", (NET_V1_CONFIG, NET_V2_MATCH_CONFIG))
+def test_netplan_rendering(
+    net_config, session_cloud: IntegrationCloud, setup_image
+):
+    mac_addr = random_mac_address()
+    launch_kwargs = {
+        "config_dict": {
+            "cloud-init.network-config": net_config.format(mac_addr=mac_addr),
+            "volatile.eth0.hwaddr": mac_addr,
+        },
+    }
+    expected = yaml.safe_load(EXPECTED_NET_CONFIG)
+    expected["network"]["ethernets"]["eth0"]["match"]["macaddress"] = mac_addr
+    with session_cloud.launch(launch_kwargs=launch_kwargs) as client:
+        result = client.execute("cat /etc/netplan/50-cloud-init.yaml")
+        assert result.stdout.startswith(EXPECTED_NETPLAN_HEADER)
+        assert expected == yaml.safe_load(result.stdout)
+
+
+NET_V1_NAME_TOO_LONG = """\
+config:
+- name: eth01234567890123
+  type: physical
+  mac_address: '{mac_addr}'
+  subnets:
+  - control: auto
+    type: dhcp
+version: 1
+"""
+
+
+@pytest.mark.skipif(
+    PLATFORM != "lxd_vm",
+    reason="Test requires custom networking provided by LXD",
+)
+@pytest.mark.parametrize("net_config", (NET_V1_NAME_TOO_LONG,))
+def test_schema_warnings(
+    net_config, session_cloud: IntegrationCloud, setup_image
+):
+    mac_addr = random_mac_address()
+    launch_kwargs = {
+        "execute_via_ssh": False,
+        "config_dict": {
+            "cloud-init.network-config": net_config.format(mac_addr=mac_addr),
+            "volatile.eth0.hwaddr": mac_addr,
+        },
+    }
+    expected = yaml.safe_load(EXPECTED_NET_CONFIG)
+    expected["network"]["ethernets"]["eth0"]["match"]["macaddress"] = mac_addr
+    with session_cloud.launch(launch_kwargs=launch_kwargs) as client:
+        result = client.execute("cloud-init status --format=json")
+        assert result.failed
+        assert result.return_code == 2  # Warning
+        assert (
+            'eth01234567890123\\" is wrong: \\"name\\" not a valid ifname'
+            in result.stdout
+        )
+        result = client.execute("cloud-init schema --system")
+        assert "Invalid network-config" in result.stdout

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -1931,6 +1931,14 @@ class TestMain:
                 pytest.raises(SystemExit),
                 id="netv1_schema_errors_handled",
             ),
+            pytest.param(
+                "network:\n version: 1\n config:\n  - type: physical\n"
+                "    name: eth01234567890123\n    subnets:\n"
+                "      - type: dhcp\n",
+                "  Invalid network-config {network_file}",
+                pytest.raises(SystemExit),
+                id="netv1_schema_error_on_nic_name_length",
+            ),
         ),
     )
     @mock.patch(M_PATH + "read_cfg_paths")


### PR DESCRIPTION
## Proposed Commit Message
```
feat: network schema v1 strict on nic name length 15

Add schema validation for physical nic name length of 15.
Add integration tests to assert this schema validation behavior.
    
Fixes: GH-4743
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_PLATFORM=lxd_vm .tox/integration-tests/bin/pytest tests/integration_tests/test_networking.py::test_netplan_rendering
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
