### PR TITLE
Alpine: fix location of dhclient leases file

### DIFF
--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -33,6 +33,10 @@ class Distro(distros.Distro):
     renderer_configs = {
         "eni": {"eni_path": network_conf_fn, "eni_header": NETWORK_FILE_HEADER}
     }
+    # Alpine stores dhclient leases at following location:
+    # /var/lib/dhcp/dhclient.leases
+    dhclient_lease_directory = "/var/lib/dhcp"
+    dhclient_lease_file_regex = r"dhclient\.leases"
 
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 import pytest
 import responses
 
-from cloudinit.distros import amazon, centos, debian, freebsd, rhel
+from cloudinit.distros import alpine, amazon, centos, debian, freebsd, rhel
 from cloudinit.net.dhcp import (
     DHCLIENT_FALLBACK_LEASE_DIR,
     InvalidDHCPLeaseFileError,
@@ -1203,6 +1203,28 @@ class TestISCDHClient(CiTestCase):
             IscDhclient.get_latest_lease(
                 freebsd.Distro.dhclient_lease_directory,
                 freebsd.Distro.dhclient_lease_file_regex,
+            ),
+        )
+
+    @mock.patch(
+        "os.listdir",
+        return_value=(
+            "some_file",
+            # alpine style lease file
+            "dhclient.leases",
+            "some_other_file",
+        ),
+    )
+    @mock.patch("os.path.getmtime", return_value=123.45)
+    def test_get_latest_lease_alpine(self, *_):
+        """
+        Test that an alpine style lease has been found
+        """
+        self.assertEqual(
+            "/var/lib/dhcp/dhclient.leases",
+            IscDhclient.get_latest_lease(
+                alpine.Distro.dhclient_lease_directory,
+                alpine.Distro.dhclient_lease_file_regex,
             ),
         )
 


### PR DESCRIPTION
## Proposed Commit Message

```
Alpine: fix location of dhclient leases file

PR #4683 changes missed Alpine. This PR addresses this.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
