### PR TITLE
feat: WSL datasource implementation

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -61,6 +61,7 @@ KNOWN_CLOUD_NAMES = [
     "Vultr",
     "ZStack",
     "Outscale",
+    "WSL",
     "Other",
 ]
 

--- a/cloudinit/cmd/clean.py
+++ b/cloudinit/cmd/clean.py
@@ -25,7 +25,7 @@ from cloudinit.util import (
     write_file,
 )
 
-ETC_MACHINE_ID = settings.MACHINE_ID_FILE
+ETC_MACHINE_ID = "/etc/machine-id"
 GEN_NET_CONFIG_FILES = [
     CLOUDINIT_NETPLAN_FILE,
     "/etc/NetworkManager/conf.d/99-cloud-init.conf",

--- a/cloudinit/cmd/clean.py
+++ b/cloudinit/cmd/clean.py
@@ -25,7 +25,7 @@ from cloudinit.util import (
     write_file,
 )
 
-ETC_MACHINE_ID = "/etc/machine-id"
+ETC_MACHINE_ID = settings.MACHINE_ID_FILE
 GEN_NET_CONFIG_FILES = [
     CLOUDINIT_NETPLAN_FILE,
     "/etc/NetworkManager/conf.d/99-cloud-init.conf",

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -49,6 +49,7 @@ CFG_BUILTIN = {
         "VMware",
         "NWCS",
         "Akamai",
+        "WSL",
         # At the end to act as a 'catch' when none of the above work...
         "None",
     ],

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -75,6 +75,3 @@ PER_ONCE = "once"
 
 # Used to sanity check incoming handlers/modules frequencies
 FREQUENCIES = [PER_INSTANCE, PER_ALWAYS, PER_ONCE]
-
-# Machine's unique ID usually assigned by the init system during first boot.
-MACHINE_ID_FILE = "/etc/machine-id"

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -74,3 +74,6 @@ PER_ONCE = "once"
 
 # Used to sanity check incoming handlers/modules frequencies
 FREQUENCIES = [PER_INSTANCE, PER_ALWAYS, PER_ONCE]
+
+# Machine's unique ID usually assigned by the init system during first boot.
+MACHINE_ID_FILE = "/etc/machine-id"

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -139,9 +139,7 @@ def candidate_user_data_file_names(instance_name) -> List[str]:
     Return a list of candidate file names that may contain user-data
     in some supported format, ordered by precedence.
     """
-    lsb_rel = util.lsb_release()
-    distribution_id = lsb_rel["id"]
-    release_codename = lsb_rel["codename"]
+    distribution_id, _, release_codename = util.get_linux_distro()
 
     return [
         # WSL instance specific:

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -118,7 +118,7 @@ def win_user_profile_dir() -> PurePath:
             "No output from cmd.exe to show the user profile dir."
         )
 
-    return win_path_2_wsl(home.rstrip())
+    return win_path_2_wsl(home)
 
 
 def machine_id():

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -6,13 +6,15 @@
 """ Datasource to support the Windows Subsystem for Linux platform. """
 
 import logging
+import os
 from pathlib import PurePath
+from typing import List, Optional, cast
 
-from cloudinit import subp
+from cloudinit import sources, subp, util
 
 LOG = logging.getLogger(__name__)
 
-WSLPATH_CMD = "wslpath"
+WSLPATH_CMD = "/usr/bin/wslpath"
 
 
 def wsl_path_2_win(path: str) -> PurePath:
@@ -36,3 +38,86 @@ def instance_name() -> str:
     """
     root_net_path = wsl_path_2_win("/")
     return root_net_path.name
+
+
+def mounted_win_drives() -> List[str]:
+    """
+    Return a list of mount points of the Windows drives inside the current
+    WSL instance, if drives are mounted, or an empty list otherwise
+    """
+    FS_TYPE = "9p"
+    OPTIONS_CONTAIN = "aname=drvfs"
+
+    mounts = util.mounts()
+    mounted = []
+    for mnt in mounts.values():
+        if mnt["fstype"] == FS_TYPE and OPTIONS_CONTAIN in mnt["opts"]:
+            mounted.append(mnt["mountpoint"])
+
+    return mounted
+
+
+def win_path_2_wsl(path: str) -> Optional[PurePath]:
+    """
+    Returns a translation of a Windows path to a Linux path that can be
+    accessed inside the current instance filesystem, or None if failed.
+
+    It requires the Windows drive mounting feature to be enabled and the
+    disk drive must exist for this to succeed.
+
+    Example:
+    # Assuming Windows drives are mounted under /mnt/ and "S:" doesn't exist:
+    p = winpath2wsl("C:\\ProgramData") # p == "/mnt/c/ProgramData/"
+    n = winpath2wsl("S:\\CoolFolder") # n is None (S doesn't exist)
+
+    :param path: string representing a Windows path. The root drive must exist,
+    although the path is not required to.
+    """
+    out, err = subp.subp([WSLPATH_CMD, "-au", path], rcs=[0, 1])
+    if err:
+        LOG.debug(err)
+        return None
+
+    return PurePath(out.rstrip())
+
+
+def cmd_executable() -> Optional[PurePath]:
+    """
+    Returns the Linux path to the Windows host's cmd.exe.
+    """
+
+    mounts = mounted_win_drives()
+    if not mounts:
+        LOG.error("Windows drives are not mounted.")
+        return None
+
+    # cmd.exe path is being stable for decades.
+    candidate = "%s/Windows/System32/cmd.exe"
+    for mnt in mounts:
+        cmd = candidate % mnt
+        if not os.access(cmd, os.X_OK):
+            continue
+
+        LOG.debug("Found cmd.exe at <%s>", cmd)
+        return PurePath(cmd)
+
+    LOG.error("Couldn't find cmd.exe in any mount point.")
+    return None
+
+
+def win_user_profile_dir() -> Optional[PurePath]:
+    """
+    Returns the Windows user profile directory translated as a Linux path
+    accessible inside the current WSL instance.
+    """
+    cmd = cmd_executable()
+    if cmd is None:
+        return None
+
+    home, _ = subp.subp([cmd.as_posix(), "/C", "echo %USERPROFILE%"])
+    home = home.rstrip()
+    if not home:
+        LOG.error("No output from cmd to show the user profile dir.")
+        return None
+
+    return win_path_2_wsl(home.rstrip())

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -132,8 +132,7 @@ def machine_id():
     """
     Returns the local machine ID value from /etc/machine-id.
     """
-    MACHINE_ID_FILE = "/etc/machine-id"
-
+    from cloudinit.settings import MACHINE_ID_FILE
     if util.wait_for_files([MACHINE_ID_FILE], 2.0):
         LOG.debug("%s file not found", MACHINE_ID_FILE)
         return None
@@ -196,8 +195,7 @@ class DataSourceWSL(sources.DataSource):
         # (ref https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity),
         # thus  better prevent it by always relying on case insensitive match.
         existing_files = {
-            ef.name.casefold(): ef.path
-            for ef in os.scandir(seed_dir)
+            ef.name.casefold(): ef.path for ef in os.scandir(seed_dir)
         }
         if not existing_files:
             LOG.warning("%s directory is empty", seed_dir)

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -131,7 +131,7 @@ def machine_id():
         LOG.debug("%s file not found", MACHINE_ID_FILE)
         return None
 
-    return util.load_file(MACHINE_ID_FILE, decode=True)
+    return util.load_binary_file(MACHINE_ID_FILE)
 
 
 def candidate_user_data_file_names(instance_name) -> List[str]:
@@ -209,7 +209,11 @@ class DataSourceWSL(sources.DataSource):
 
         try:
             file = self.find_user_data_file()
-            self.userdata_raw = cast(str, util.load_file(file, decode=True))
+            if file is None:
+                return False
+            self.userdata_raw = cast(
+                str, util.load_binary_file(file.as_posix())
+            )
             return True
         except IOError as err:
             LOG.error("Could not find any user data file: %s", str(err))

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -235,24 +235,20 @@ class DataSourceWSL(sources.DataSource):
 
     def _get_data(self) -> bool:
         self.vendordata_raw = None
+        self.metadata = dict()
+        seed_dir = cloud_init_data_dir()
         self.instance_name = instance_name()
 
-        self.metadata = dict()
-        m_id = machine_id()
-        if m_id is None:
-            LOG.debug("Instance ID will be the WSL instance name only")
-            self.metadata["instance-id"] = self.instance_name
-        else:
-            self.metadata["instance-id"] = "{}-{}".format(
-                self.instance_name, m_id
-            )
-
         try:
-            file = self.find_user_data_file()
+            self.metadata["instance-id"] = load_metadata_iid(
+                seed_dir, self.instance_name
+            )
+            file = self.find_user_data_file(seed_dir)
             self.userdata_raw = cast(
                 str, util.load_binary_file(file.as_posix())
             )
             return True
+
         except IOError as err:
             LOG.error("Could not find any user data file: %s", str(err))
             self.userdata_raw = ""

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -48,9 +48,8 @@ def mounted_win_drives() -> List[str]:
     FS_TYPE = "9p"
     OPTIONS_CONTAIN = "aname=drvfs"
 
-    mounts = util.mounts()
     mounted = []
-    for mnt in mounts.values():
+    for mnt in util.mounts().values():
         if mnt["fstype"] == FS_TYPE and OPTIONS_CONTAIN in mnt["opts"]:
             mounted.append(mnt["mountpoint"])
 

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -127,19 +127,6 @@ def cloud_init_data_dir() -> PurePath:
     return PurePath(seed_dir)
 
 
-def machine_id():
-    """
-    Returns the local machine ID value from /etc/machine-id.
-    """
-    from cloudinit.settings import MACHINE_ID_FILE
-
-    try:
-        return util.load_binary_file(MACHINE_ID_FILE)
-    except OSError as err:
-        LOG.error(err)
-        return None
-
-
 def candidate_user_data_file_names(instance_name) -> List[str]:
     """
     Return a list of candidate file names that may contain user-data

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -5,6 +5,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """ Datasource to support the Windows Subsystem for Linux platform. """
 
+import json
 import logging
 import os
 from pathlib import PurePath
@@ -156,6 +157,35 @@ def candidate_user_data_file_names(instance_name) -> List[str]:
         # generic, valid for all WSL distros and instances.
         "default.user-data",
     ]
+
+
+DEFAULT_INSTANCE_ID = "datasource-wsl"
+
+
+def load_metadata_iid(cloudinitdir: PurePath, instance_name: str) -> str:
+    """
+    Returns the relevant metadata loaded from cloudinit dir based on the
+    instance name
+    """
+    raw = dict()
+    try:
+        raw = json.loads(
+            util.load_binary_file(
+                os.path.join(
+                    cloudinitdir.as_posix(), "%s.meta-data" % instance_name
+                )
+            )
+        )
+
+    except IOError as err:
+        LOG.debug(
+            "Failed to load metadata file from %s for instance %s: %s",
+            cloudinitdir.as_posix(),
+            instance_name,
+            err
+        )
+
+    return raw.get("instance-id", DEFAULT_INSTANCE_ID)
 
 
 class DataSourceWSL(sources.DataSource):

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -5,7 +5,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """ Datasource to support the Windows Subsystem for Linux platform. """
 
-import json
 import logging
 import os
 from pathlib import PurePath
@@ -159,27 +158,17 @@ def load_instance_metadata(cloudinitdir: PurePath, instance_name: str) -> dict:
         cloudinitdir.as_posix(), "%s.meta-data" % instance_name
     )
     try:
-        metadata = json.loads(util.load_binary_file(metadata_path))
-
+        metadata = util.load_yaml(util.load_binary_file(metadata_path))
     except FileNotFoundError:
         LOG.debug(
             "No instance metadata found at %s. Using default instance-id.",
             metadata_path,
         )
-    except json.JSONDecodeError as err:
-        LOG.error(
-            "Unable to setup WSL datasource."
-            " Invalid JSON format found at %s: %s.",
-            metadata_path,
-            err,
-        )
-        raise err
-
-    if "instance-id" not in metadata:
+    if not metadata or "instance-id" not in metadata:
         # Parsed metadata file invalid
         msg = (
             f" Metadata at {metadata_path} does not contain instance-id key."
-            f"Instead received: {metadata}"
+            f" Instead received: {metadata}"
         )
         LOG.error(msg)
         raise ValueError(msg)

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -127,11 +127,11 @@ def machine_id():
     """
     from cloudinit.settings import MACHINE_ID_FILE
 
-    if util.wait_for_files([MACHINE_ID_FILE], 2.0):
-        LOG.debug("%s file not found", MACHINE_ID_FILE)
+    try:
+        return util.load_binary_file(MACHINE_ID_FILE)
+    except OSError as err:
+        LOG.error(err)
         return None
-
-    return util.load_binary_file(MACHINE_ID_FILE)
 
 
 def candidate_user_data_file_names(instance_name) -> List[str]:

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -188,6 +188,9 @@ class DataSourceWSL(sources.DataSource):
             LOG.warning("%s directory doesn't exist.", seed_dir)
             return None
 
+        # Notice that file name casing is irrelevant here. Windows filenames
+        # are case insensitive. Even though accessed through Linux, path
+        # translation just works with whichever casing we try.
         for filename in candidate_user_data_file_names(self.instance_name):
             file = os.path.join(seed_dir, filename)
             if os.path.isfile(file):

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -100,7 +100,9 @@ def cmd_executable() -> Optional[PurePath]:
         LOG.debug("Found cmd.exe at <%s>", cmd)
         return PurePath(cmd)
 
-    LOG.error("Couldn't find cmd.exe in any mount point.")
+    LOG.error(
+        "Couldn't find cmd.exe in any mount point: %s", ", ".join(mounts)
+    )
     return None
 
 

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -229,7 +229,7 @@ class DataSourceWSL(sources.DataSource):
 
         try:
             metadata = load_instance_metadata(
-                 cloud_init_data_dir(), self.instance_name
+                cloud_init_data_dir(), self.instance_name
             )
             return current == metadata.get("instance-id")
 

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -156,13 +156,6 @@ def candidate_user_data_file_names(instance_name) -> List[str]:
 class DataSourceWSL(sources.DataSource):
     dsname = "WSL"
 
-    def __init__(self, sys_cfg, distro, paths):
-        sources.DataSource.__init__(self, sys_cfg, distro, paths)
-        self._network_config = sources.UNSET
-        self.dsmode = sources.DSMODE_LOCAL
-        self.distro = distro
-        self.instance_name = instance_name()
-
     def find_user_data_file(self) -> Optional[PurePath]:
         """
         Finds the most precendent of the candidate files that may contain
@@ -202,6 +195,7 @@ class DataSourceWSL(sources.DataSource):
 
     def _get_data(self) -> bool:
         self.vendordata_raw = None
+        self.instance_name = instance_name()
 
         self.metadata = dict()
         m_id = machine_id()

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -242,12 +242,11 @@ class DataSourceWSL(sources.DataSource):
 
     def _get_data(self) -> bool:
         self.vendordata_raw = None
-        self.metadata = dict()
         seed_dir = cloud_init_data_dir()
         self.instance_name = instance_name()
 
         try:
-            self.metadata["instance-id"] = load_metadata_iid(
+            self.metadata = load_instance_metadata(
                 seed_dir, self.instance_name
             )
             file = self.find_user_data_file(seed_dir)
@@ -256,9 +255,8 @@ class DataSourceWSL(sources.DataSource):
             )
             return True
 
-        except IOError as err:
-            LOG.error("Could not find any user data file: %s", str(err))
-            self.userdata_raw = ""
+        except (ValueError, IOError) as err:
+            LOG.error("Unable to setup WSL datasource: %s", str(err))
             return False
 
 

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2024 Canonical Ltd.
+#
+# Author: Carlos Nihelton <carlos.santanadeoliveira@canonical.com>
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+""" Datasource to support the Windows Subsystem for Linux platform. """
+
+import logging
+from pathlib import PurePath
+
+from cloudinit import subp
+
+LOG = logging.getLogger(__name__)
+
+WSLPATH_CMD = "wslpath"
+
+
+def wsl_path_2_win(path: str) -> PurePath:
+    """
+    Translates a path inside the current WSL instance's filesystem to a
+    Windows accessible path.
+
+    Example:
+    # Running under an instance named "CoolInstance"
+    root = wslpath2win("/") # root == "//wsl.localhost/CoolInstance/"
+
+    :param path: string representing a Linux path, whether existing or not.
+    """
+    out, _ = subp.subp([WSLPATH_CMD, "-am", path])
+    return PurePath(out.rstrip())
+
+
+def instance_name() -> str:
+    """
+    Returns the name of the current WSL instance as seen from outside.
+    """
+    root_net_path = wsl_path_2_win("/")
+    return root_net_path.name

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -221,6 +221,18 @@ class DataSourceWSL(sources.DataSource):
             "%s doesn't contain any of the expected user-data files" % seed_dir
         )
 
+    def check_instance_id(self, sys_cfg):
+        current = self.get_instance_id()
+        if not current:
+            return None
+
+        try:
+            return current == load_metadata_iid(cloud_init_data_dir(),
+                                                self.instance_name)
+        except IOError as err:
+            LOG.error("Could not load updated instance ID: %s", err)
+            return None
+
     def _get_data(self) -> bool:
         self.vendordata_raw = None
         self.instance_name = instance_name()

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -169,7 +169,7 @@ def load_metadata_iid(cloudinitdir: PurePath, instance_name: str) -> str:
             "Failed to load metadata file from %s for instance %s: %s",
             cloudinitdir.as_posix(),
             instance_name,
-            err
+            err,
         )
 
     return raw.get("instance-id", DEFAULT_INSTANCE_ID)
@@ -214,8 +214,9 @@ class DataSourceWSL(sources.DataSource):
             return None
 
         try:
-            return current == load_metadata_iid(cloud_init_data_dir(),
-                                                self.instance_name)
+            return current == load_metadata_iid(
+                cloud_init_data_dir(), self.instance_name
+            )
         except IOError as err:
             LOG.error("Could not load updated instance ID: %s", err)
             return None

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -139,13 +139,13 @@ def candidate_user_data_file_names(instance_name) -> List[str]:
     Return a list of candidate file names that may contain user-data
     in some supported format, ordered by precedence.
     """
-    distribution_id, _, release_codename = util.get_linux_distro()
+    distribution_id, version_id, _ = util.get_linux_distro()
 
     return [
         # WSL instance specific:
         "%s.user-data" % instance_name,
         # release codename specific
-        "%s-%s.user-data" % (distribution_id, release_codename),
+        "%s-%s.user-data" % (distribution_id, version_id),
         # distribution specific (Alpine, Arch, Fedora, openSUSE, Ubuntu...)
         "%s-all.user-data" % distribution_id,
         # generic, valid for all WSL distros and instances.

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -114,7 +114,11 @@ def win_user_profile_dir() -> Optional[PurePath]:
     if cmd is None:
         return None
 
-    home, _ = subp.subp([cmd.as_posix(), "/C", "echo %USERPROFILE%"])
+    # cloud-init runs too early to rely on binfmt to execute Windows binaries.
+    # But we know that `/init` is the interpreter, so we can run it directly.
+    # See /proc/sys/fs/binfmt_misc/WSLInterop[-late]
+    # inside any WSL instance for more details.
+    home, _ = subp.subp(["/init", cmd.as_posix(), "/C", "echo %USERPROFILE%"])
     home = home.rstrip()
     if not home:
         LOG.error("No output from cmd to show the user profile dir.")

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -161,12 +161,11 @@ def candidate_user_data_file_names(instance_name) -> List[str]:
 class DataSourceWSL(sources.DataSource):
     dsname = "WSL"
 
-    def find_user_data_file(self) -> PurePath:
+    def find_user_data_file(self, seed_dir: PurePath) -> PurePath:
         """
         Finds the most precendent of the candidate files that may contain
         user-data, if any, or None otherwise.
         """
-        seed_dir = cloud_init_data_dir()
 
         # Notice that by default file name casing is irrelevant here. Windows
         # filenames are case insensitive. Even though accessed through Linux,

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -149,7 +149,7 @@ def candidate_user_data_file_names(instance_name) -> List[str]:
         # distribution specific (Alpine, Arch, Fedora, openSUSE, Ubuntu...)
         "%s-all.user-data" % distribution_id,
         # generic, valid for all WSL distros and instances.
-        "config.user-data",
+        "default.user-data",
     ]
 
 

--- a/doc/rtd/reference/datasources.rst
+++ b/doc/rtd/reference/datasources.rst
@@ -65,5 +65,6 @@ The following is a list of documentation for each supported datasource:
    datasources/upcloud.rst
    datasources/vmware.rst
    datasources/vultr.rst
+   datasources/wsl.rst
    datasources/zstack.rst
 

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -1,0 +1,173 @@
+.. _datasource_wsl:
+
+WSL
+***
+
+The Windows Subsystem for Linux (WSL) somewhat resembles a container
+hypervisor, a Windows user may have as many Linux distro instances as they
+wish, either created by the distro-launcher workflow (for the distros delivered
+through MS Store) or by importing a tarball containing a root filesystem. This
+page assumes the reader is familiar with WSL. To learn more about that, please
+visit the `Microsoft documentation <https://learn.microsoft.com/windows/wsl/about>`_.
+
+While in principle the :ref:`NoCloud datasource<datasource_nocloud>` could be
+used to deliver custom user data to initialize a WSL instance, having a
+datasource specific for WSL, aware of the unique features and constraints
+offered by that platform enables flexible ways to pass user data to cloud-init,
+such as using the same configuration data for all instances or per instance, as
+well as means of avoid possible race conditions specific to the WSL platform
+that the NoCloud datasource is not designed to handle.
+
+Requirements
+==============
+
+1. **WSL interoperability must be enabled**. The datasource needs to execute
+   some Windows binaries to compute the possible locations of the user data
+   files.
+
+2. **WSL automount must be enabled**. The datasource needs to access files in
+   the Windows host filesystem.
+
+3. **The init system must be aware of cloud-init**. WSL has opt-in support for
+   systemd, thus for distros that rely on it, such as Ubuntu, cloud-init will
+   run automatically if systemd is enabled via the ``/etc/wsl.conf``. The
+   Ubuntu applications distributed via Microsoft Store enable systemd in the
+   first boot, so no action is required if the user sets up a new instance by
+   using them. Users of other distros may find surprising that cloud-init
+   doesn't run automatically by default. At the time of this writing only
+   systemd distros are supported by the WSL datasource, although there is
+   nothing hard coded in the implementation code that requires it, so it's
+   possible that non-systemd distros find ways to run cloud-init and make it
+   just work.
+
+Notice that requirements 1 and 2 are met by default, i.e. WSL grants those
+features enabled, being the user allowed to opt out, if so desired.
+For more information about how to configure WSL,
+`check the official documentation <https://learn.microsoft.com/windows/wsl/wsl-config#configuration-settings-for-wslconf>`_.
+
+User data Configuration
+========================
+
+The WSL datasource relies exclusively on the Windows filesystem as the provider
+for user data. Access to those files is provided by WSL itself, unless disabled
+by the user, thus the datasource doesn't require any special component running
+on the Windows host to provide such data.
+
+User data can be supplied in any
+:ref:`format supported by cloud-init<user_data_formats>`, such as YAML
+cloud-config files or shell scripts. At runtime the WSL datasource looks for
+user data in the following locations inside the Windows host filesystem, in the
+order specified below:
+
+1. ``%USERPROFILE%\.cloud-init\<InstanceName>.user-data`` holds user data for a
+   specific instance configuration. The datasource resolves the name attributed
+   by WSL to the instance being initialized and looks for this file before any
+   of the subsequent alternatives. Example: ``sid-mlkit.user-data`` matches an
+   instance named ``Sid-MLKit``.
+
+2. ``%USERPROFILE%\.cloud-init\<ID>-<VERSION_CODENAME>.user-data`` for the
+   distro specific configuration, matched by the distro ID and VERSION_CODENAME
+   entries as specified in ``/etc/os-release``. Example:
+   ``ubuntu-jammy.userdata`` will affect any instance created from an Ubuntu
+   22.04 Jammy Jellyfish image, if a more specific configuration file does not
+   match.
+
+3. ``%USERPROFILE%\.cloud-init\<ID>-all.user-data`` for the distro specific
+   configuration, matched by the distro ID entry in ``/etc/os-release``,
+   regardless of the release version. Example: ``debian-all.user-data`` will
+   affect any instance created from any Debian GNU/Linux image, regardless of
+   which release, if a more specific configuration file does not match.
+
+4. ``%USERPROFILE%\.cloud-init\config.user-data`` for the configuration
+   affecting all instances, regardless of which distro and release version, if
+   a more specific configuration file does not match. That could be used, for
+   example, to automatically create a user with the same name across all WSL
+   instances a user may have.
+
+Only the first match is loaded, no config merging is done, even in the presence
+of errors. That avoids unexpected behavior due surprising merge scenarios.
+Also, notice that the file name casing is irrelevant since both the Windows
+file names as well as the WSL distro naming is case insensitive.
+
+Since WSL instances are scoped by Windows user, having the user data files
+inside the ``%USERPROFILE%`` directory (typically ``C:\Users\<USERNAME>``)
+ensures that WSL instances initialization won't be subject to naming conflicts
+if the Windows host is shared by multiple users.
+
+
+Vendor and metadata
+===================
+
+The current implementation doesn't allow supplying vendor data and metadata.
+The reasoning is that vendor data adds layering, thus complexity, for no real
+benefit to the user. Supplying vendor data could be relevant to WSL itself, if
+the subsystem was aware of cloud-init and intended to leverage it, which is not
+the case to the best of our knowledge at the time of this writing.
+
+Similarly, metadata such as hostname is not directly applicable to WSL
+instances, the subsystem sets it automatically.
+Internally, the WSL datasource sets the ``metadata.instance-id``, to
+fulfill cloud-init's internal contracts. While that could be used to make
+cloud-init "reset" a WSL instance, users find equally easy to just unregister
+and register a new instance from the Windows shell.
+
+Unsupported or restricted modules and features
+===============================================
+
+Certain features of cloud-init and its modules either require further
+customisation in the code to better fit the WSL platform or cannot be supported
+at all due constraints of that platform. When writing user-data config files,
+please check the following restrictions:
+
+* Network configuration is not suported.
+  WSL has full control of the instances' networking features and configuration.
+  A limited set of options for networking is exposed to the user via
+  ``/etc/wsl.conf``. Those options don't fit well with the networking model
+  cloud-init expects or understands.
+
+* Set Hostname.
+  WSL automatically assigns the instances hostname and any attempt to change it
+  will take effect only until the next boot, when WSL takes over again.
+  The user can set the desired hostname via ``/etc/wsl.conf``, if really
+  necessary.
+
+* Default user.
+  While creating users through cloud-init work as in any other platform, WSL
+  has the concept of the *default user*, which is the user logged in by
+  default. So, to create the default user with cloud-init, one must supply user
+  data to the :ref:`Users and Groups module <mod-users_groups>` and write the
+  entry in ``/etc/wsl.conf`` to make that user the default. See the example:
+
+.. code-block:: yaml
+
+    #cloud-config
+    users:
+    - name: j
+      gecos: Agent J
+      groups: users,sudo,netdev,audio
+      sudo: ALL=(ALL) NOPASSWD:ALL
+      shell: /bin/bash
+      lock_passwd: true
+
+    write_files:
+    - path: /etc/wsl.conf
+      append: true
+      contents: |
+        [user]
+        default=j
+
+* Disk setup, Growpart, Mounts and Resizefs.
+  The root filesystem must have the layout expected by WSL. Other mount points
+  may work, depending on how the hardware devices are exposed by the Windows
+  host, and fstab processing during boot is subject to configuration via
+  ``/etc/wsl.conf``, so users should expect limited functionality.
+
+* Grub Dpkg.
+  WSL controls the boot process, meaning that attempts to install and configure
+  Grub as any other bootloader won't be effective.
+
+* Resolv Conf and Update Etc Hosts.
+  WSL automatically generates those files by default, unless configured to
+  behave otherwise in ``/etc/wsl.conf``. Overwriting may work, but only
+  until the next reboot.
+

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -87,7 +87,14 @@ order specified below:
 Only the first match is loaded, no config merging is done, even in the presence
 of errors. That avoids unexpected behavior due surprising merge scenarios.
 Also, notice that the file name casing is irrelevant since both the Windows
-file names as well as the WSL distro naming is case insensitive.
+file names as well as the WSL distro names are case insensitive by default.
+
+.. note::
+   Some users may have configured case sensitivity for file names on Windows.
+   Note that user data files will still be matched case insensitively. If there
+   are both `InstanceName.user-data` and `instancename.user-data`, which one
+   will be chosen is arbitrary and should not be relied on. Thus it's
+   recommended to avoid that scenario to prevent confusion.
 
 Since WSL instances are scoped by Windows user, having the user data files
 inside the ``%USERPROFILE%`` directory (typically ``C:\Users\<USERNAME>``)

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -88,6 +88,7 @@ Only the first match is loaded, no config merging is done, even in the presence
 of errors. That avoids unexpected behavior due surprising merge scenarios.
 Also, notice that the file name casing is irrelevant since both the Windows
 file names as well as the WSL distro names are case insensitive by default.
+If none are found, cloud-init remains disabled.
 
 .. note::
    Some users may have configured case sensitivity for file names on Windows.

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -32,7 +32,8 @@ Requirements
    non-systemd distros may find ways to run cloud-init and make it just work.
 
 Notice that requirements 1 and 2 are met by default, i.e. WSL grants those
-features enabled, being the user allowed to opt-out if so desired.
+features enabled. Users can disable those features, though. That would prevent
+the datasource from working.
 For more information about how to configure WSL,
 `check the official documentation <https://learn.microsoft.com/windows/wsl/wsl-config#configuration-settings-for-wslconf>`_.
 

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -97,7 +97,7 @@ if the Windows host is shared by multiple users.
 Vendor and metadata
 ===================
 
-The current implementation doesn't allow supplying vendor data and metadata.
+The current implementation doesn't allow supplying vendor data.
 The reasoning is that vendor data adds layering, thus complexity, for no real
 benefit to the user. Supplying vendor data could be relevant to WSL itself, if
 the subsystem was aware of cloud-init and intended to leverage it, which is not

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -122,23 +122,49 @@ Unsupported or restricted modules and features
 ===============================================
 
 Certain features of cloud-init and its modules either require further
-customisation in the code to better fit the WSL platform or cannot be supported
+customization in the code to better fit the WSL platform or cannot be supported
 at all due constraints of that platform. When writing user-data config files,
 please check the following restrictions:
 
-* Network configuration is not suported.
+* File paths in an include file must be Linux absolute paths.
+
+  Users may get surprised with that requirement since the user data files are
+  inside the Windows file system. But remember that cloud-init is still running
+  inside a Linux instance, and the files referenced in the include user data
+  file will be read by cloud-init, thus they must be represented with paths
+  understandable inside the Linux instance. Most users will find their Windows
+  system drive mounted as `/mnt/c`, so let's consider that assumption in the
+  following example:
+
+``C:\Users\Me\.cloud-init\noble-cpp.user-data``
+
+.. code-block::
+
+   #include
+   /mnt/c/Users/me/.cloud-init/config.user-data
+   /mnt/c/Users/me/Downloads/cpp.yaml
+
+When initializing an instance named ``Noble-Cpp`` cloud-init will find that
+include file, referring to files inside the Windows file system, and will load
+them effectively. A failure would happen if Windows paths were otherwise in the
+include file.
+
+* Network configuration is not supported.
+
   WSL has full control of the instances' networking features and configuration.
   A limited set of options for networking is exposed to the user via
   ``/etc/wsl.conf``. Those options don't fit well with the networking model
   cloud-init expects or understands.
 
 * Set Hostname.
+
   WSL automatically assigns the instances hostname and any attempt to change it
   will take effect only until the next boot, when WSL takes over again.
   The user can set the desired hostname via ``/etc/wsl.conf``, if really
   necessary.
 
 * Default user.
+
   While creating users through cloud-init work as in any other platform, WSL
   has the concept of the *default user*, which is the user logged in by
   default. So, to create the default user with cloud-init, one must supply user
@@ -164,16 +190,19 @@ please check the following restrictions:
         default=j
 
 * Disk setup, Growpart, Mounts and Resizefs.
+
   The root filesystem must have the layout expected by WSL. Other mount points
   may work, depending on how the hardware devices are exposed by the Windows
   host, and fstab processing during boot is subject to configuration via
   ``/etc/wsl.conf``, so users should expect limited functionality.
 
 * Grub Dpkg.
+
   WSL controls the boot process, meaning that attempts to install and configure
   Grub as any other bootloader won't be effective.
 
 * Resolv Conf and Update Etc Hosts.
+
   WSL automatically generates those files by default, unless configured to
   behave otherwise in ``/etc/wsl.conf``. Overwriting may work, but only
   until the next reboot.

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -4,7 +4,7 @@ WSL
 ***
 
 The Windows Subsystem for Linux (WSL) somewhat resembles a container
-hypervisor, a Windows user may have as many Linux distro instances as they
+hypervisor. A Windows user may have as many Linux distro instances as they
 wish, either created by the distro-launcher workflow (for the distros delivered
 through MS Store) or by importing a tarball containing a root filesystem. This
 page assumes the reader is familiar with WSL. To learn more about that, please
@@ -28,7 +28,7 @@ Requirements
    using them. Users of other distros may find it surprising that cloud-init
    doesn't run automatically by default. At the time of this writing, only
    systemd distros are supported by the WSL datasource, although there is
-   nothing hard coded in the implementation code that requires it, so
+   nothing hard-coded in the implementation code that requires it, so
    non-systemd distros may find ways to run cloud-init and make it just work.
 
 Notice that requirements 1 and 2 are met by default, i.e. WSL grants those
@@ -36,7 +36,7 @@ features enabled, being the user allowed to opt-out if so desired.
 For more information about how to configure WSL,
 `check the official documentation <https://learn.microsoft.com/windows/wsl/wsl-config#configuration-settings-for-wslconf>`_.
 
-User data Configuration
+User data configuration
 ========================
 
 The WSL datasource relies exclusively on the Windows filesystem as the provider
@@ -88,9 +88,9 @@ default. If none are found, cloud-init remains disabled.
    will be chosen is arbitrary and should not be relied on. Thus it's
    recommended to avoid that scenario to prevent confusion.
 
-Since WSL instances are scoped by Windows user, having the user data files
+Since WSL instances are scoped by the Windows user, having the user data files
 inside the ``%USERPROFILE%`` directory (typically ``C:\Users\<USERNAME>``)
-ensures that WSL instances initialization won't be subject to naming conflicts
+ensures that WSL instance initialization won't be subject to naming conflicts
 if the Windows host is shared by multiple users.
 
 
@@ -153,7 +153,7 @@ include file.
   ``/etc/wsl.conf``. Those options don't fit well with the networking model
   cloud-init expects or understands.
 
-* Set Hostname.
+* Set hostname.
 
   WSL automatically assigns the instance hostname and any attempt to change it
   will take effect only until the next boot when WSL takes over again.
@@ -192,12 +192,12 @@ include file.
   host, and fstab processing during boot is subject to configuration via
   ``/etc/wsl.conf``, so users should expect limited functionality.
 
-* Grub Dpkg.
+* GRUB dpkg.
 
   WSL controls the boot process, meaning that attempts to install and configure
-  Grub as any other bootloader won't be effective.
+  GRUB as any other bootloader won't be effective.
 
-* Resolv Conf and Update Etc Hosts.
+* Resolv conf and update etc/ hosts.
 
   WSL automatically generates those files by default, unless configured to
   behave otherwise in ``/etc/wsl.conf``. Overwriting may work, but only

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -33,15 +33,14 @@ Requirements
    run automatically if systemd is enabled via the ``/etc/wsl.conf``. The
    Ubuntu applications distributed via Microsoft Store enable systemd in the
    first boot, so no action is required if the user sets up a new instance by
-   using them. Users of other distros may find surprising that cloud-init
-   doesn't run automatically by default. At the time of this writing only
+   using them. Users of other distros may find it surprising that cloud-init
+   doesn't run automatically by default. At the time of this writing, only
    systemd distros are supported by the WSL datasource, although there is
-   nothing hard coded in the implementation code that requires it, so it's
-   possible that non-systemd distros find ways to run cloud-init and make it
-   just work.
+   nothing hard coded in the implementation code that requires it, so
+   non-systemd distros may find ways to run cloud-init and make it just work.
 
 Notice that requirements 1 and 2 are met by default, i.e. WSL grants those
-features enabled, being the user allowed to opt out, if so desired.
+features enabled, being the user allowed to opt-out if so desired.
 For more information about how to configure WSL,
 `check the official documentation <https://learn.microsoft.com/windows/wsl/wsl-config#configuration-settings-for-wslconf>`_.
 
@@ -49,13 +48,13 @@ User data Configuration
 ========================
 
 The WSL datasource relies exclusively on the Windows filesystem as the provider
-for user data. Access to those files is provided by WSL itself, unless disabled
+of user data. Access to those files is provided by WSL itself unless disabled
 by the user, thus the datasource doesn't require any special component running
 on the Windows host to provide such data.
 
 User data can be supplied in any
 :ref:`format supported by cloud-init<user_data_formats>`, such as YAML
-cloud-config files or shell scripts. At runtime the WSL datasource looks for
+cloud-config files or shell scripts. At runtime, the WSL datasource looks for
 user data in the following locations inside the Windows host filesystem, in the
 order specified below:
 
@@ -66,13 +65,13 @@ order specified below:
    instance named ``Sid-MLKit``.
 
 2. ``%USERPROFILE%\.cloud-init\<ID>-<VERSION_ID>.user-data`` for the
-   distro specific configuration, matched by the distro ID and VERSION_CODENAME
+   distro-specific configuration, matched by the distro ID and VERSION_CODENAME
    entries as specified in ``/etc/os-release``. Example:
    ``ubuntu-22.04.user-data`` will affect any instance created from an Ubuntu
-   22.04 Jammy Jellyfish image, if a more specific configuration file does not
+   22.04 Jammy Jellyfish image if a more specific configuration file does not
    match.
 
-3. ``%USERPROFILE%\.cloud-init\<ID>-all.user-data`` for the distro specific
+3. ``%USERPROFILE%\.cloud-init\<ID>-all.user-data`` for the distro-specific
    configuration, matched by the distro ID entry in ``/etc/os-release``,
    regardless of the release version. Example: ``debian-all.user-data`` will
    affect any instance created from any Debian GNU/Linux image, regardless of
@@ -84,15 +83,15 @@ order specified below:
    example, to automatically create a user with the same name across all WSL
    instances a user may have.
 
-Only the first match is loaded, no config merging is done, even in the presence
-of errors. That avoids unexpected behavior due surprising merge scenarios.
-Also, notice that the file name casing is irrelevant since both the Windows
-file names as well as the WSL distro names are case insensitive by default.
-If none are found, cloud-init remains disabled.
+Only the first match is loaded, and no config merging is done, even in the
+presence of errors. That avoids unexpected behaviour due to surprising merge
+scenarios. Also, notice that the file name casing is irrelevant since both the
+Windows file names, as well as the WSL distro names, are case-insensitive by
+default. If none are found, cloud-init remains disabled.
 
 .. note::
    Some users may have configured case sensitivity for file names on Windows.
-   Note that user data files will still be matched case insensitively. If there
+   Note that user data files will still be matched case-insensitively. If there
    are both `InstanceName.user-data` and `instancename.user-data`, which one
    will be chosen is arbitrary and should not be relied on. Thus it's
    recommended to avoid that scenario to prevent confusion.
@@ -129,12 +128,12 @@ Unsupported or restricted modules and features
 
 Certain features of cloud-init and its modules either require further
 customization in the code to better fit the WSL platform or cannot be supported
-at all due constraints of that platform. When writing user-data config files,
-please check the following restrictions:
+at all due to the constraints of that platform. When writing user-data config
+files, please check the following restrictions:
 
 * File paths in an include file must be Linux absolute paths.
 
-  Users may get surprised with that requirement since the user data files are
+  Users may be surprised with that requirement since the user data files are
   inside the Windows file system. But remember that cloud-init is still running
   inside a Linux instance, and the files referenced in the include user data
   file will be read by cloud-init, thus they must be represented with paths
@@ -164,14 +163,13 @@ include file.
 
 * Set Hostname.
 
-  WSL automatically assigns the instances hostname and any attempt to change it
-  will take effect only until the next boot, when WSL takes over again.
-  The user can set the desired hostname via ``/etc/wsl.conf``, if really
-  necessary.
+  WSL automatically assigns the instance hostname and any attempt to change it
+  will take effect only until the next boot when WSL takes over again.
+  The user can set the desired hostname via ``/etc/wsl.conf``, if necessary.
 
 * Default user.
 
-  While creating users through cloud-init work as in any other platform, WSL
+  While creating users through cloud-init works as in any other platform, WSL
   has the concept of the *default user*, which is the user logged in by
   default. So, to create the default user with cloud-init, one must supply user
   data to the :ref:`Users and Groups module <mod-users_groups>` and write the

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -65,10 +65,10 @@ order specified below:
    of the subsequent alternatives. Example: ``sid-mlkit.user-data`` matches an
    instance named ``Sid-MLKit``.
 
-2. ``%USERPROFILE%\.cloud-init\<ID>-<VERSION_CODENAME>.user-data`` for the
+2. ``%USERPROFILE%\.cloud-init\<ID>-<VERSION_ID>.user-data`` for the
    distro specific configuration, matched by the distro ID and VERSION_CODENAME
    entries as specified in ``/etc/os-release``. Example:
-   ``ubuntu-jammy.userdata`` will affect any instance created from an Ubuntu
+   ``ubuntu-22.04.user-data`` will affect any instance created from an Ubuntu
    22.04 Jammy Jellyfish image, if a more specific configuration file does not
    match.
 

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -78,7 +78,7 @@ order specified below:
    affect any instance created from any Debian GNU/Linux image, regardless of
    which release, if a more specific configuration file does not match.
 
-4. ``%USERPROFILE%\.cloud-init\config.user-data`` for the configuration
+4. ``%USERPROFILE%\.cloud-init\default.user-data`` for the configuration
    affecting all instances, regardless of which distro and release version, if
    a more specific configuration file does not match. That could be used, for
    example, to automatically create a user with the same name across all WSL

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -10,14 +10,6 @@ through MS Store) or by importing a tarball containing a root filesystem. This
 page assumes the reader is familiar with WSL. To learn more about that, please
 visit the `Microsoft documentation <https://learn.microsoft.com/windows/wsl/about>`_.
 
-While in principle the :ref:`NoCloud datasource<datasource_nocloud>` could be
-used to deliver custom user data to initialize a WSL instance, having a
-datasource specific for WSL, aware of the unique features and constraints
-offered by that platform enables flexible ways to pass user data to cloud-init,
-such as using the same configuration data for all instances or per instance, as
-well as means of avoid possible race conditions specific to the WSL platform
-that the NoCloud datasource is not designed to handle.
-
 Requirements
 ==============
 

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -112,12 +112,17 @@ benefit to the user. Supplying vendor data could be relevant to WSL itself, if
 the subsystem was aware of cloud-init and intended to leverage it, which is not
 the case to the best of our knowledge at the time of this writing.
 
-Similarly, metadata such as hostname is not directly applicable to WSL
-instances, the subsystem sets it automatically.
-Internally, the WSL datasource sets the ``metadata.instance-id``, to
-fulfill cloud-init's internal contracts. While that could be used to make
-cloud-init "reset" a WSL instance, users find equally easy to just unregister
-and register a new instance from the Windows shell.
+Most of what ``metadata`` is intended for is not applicable under WSL, such as
+setting a hostname. Yet, the knowledge of ``metadata.instance-id`` is vital for
+cloud-init. So, this datasource provides a default value but also supports
+optionally sourcing metadata from a per-instance specific configuration file:
+``%USERPROFILE%\.cloud-init\<InstanceName>.meta-data``. If that file exists, it
+could contain a JSON dictionary optionally providing a value for instance ID
+such as: ``'{"instance-id": "x-y-z"}'``. Advanced users looking to share
+snapshots or relaunch a snapshot where cloud-init is re-triggered, must run
+``sudo cloud-init clean --logs`` on the instance before snapshot/export, or
+create the appropriate ``.meta-data`` file containing ``'{"instance-id":
+"some-new-instance-id"}'``.
 
 Unsupported or restricted modules and features
 ===============================================

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -108,12 +108,12 @@ setting a hostname. Yet, the knowledge of ``metadata.instance-id`` is vital for
 cloud-init. So, this datasource provides a default value but also supports
 optionally sourcing metadata from a per-instance specific configuration file:
 ``%USERPROFILE%\.cloud-init\<InstanceName>.meta-data``. If that file exists, it
-could contain a JSON dictionary optionally providing a value for instance ID
-such as: ``'{"instance-id": "x-y-z"}'``. Advanced users looking to share
+is a YAML-formatted file minimally providing a value for instance ID
+such as: ``instance-id: x-y-z``. Advanced users looking to share
 snapshots or relaunch a snapshot where cloud-init is re-triggered, must run
 ``sudo cloud-init clean --logs`` on the instance before snapshot/export, or
-create the appropriate ``.meta-data`` file containing ``'{"instance-id":
-"some-new-instance-id"}'``.
+create the appropriate ``.meta-data`` file containing ``instance-id:
+some-new-instance-id``.
 
 Unsupported or restricted modules and features
 ===============================================

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -33,6 +33,7 @@ from cloudinit.sources import DataSourceSmartOS as SmartOS
 from cloudinit.sources import DataSourceUpCloud as UpCloud
 from cloudinit.sources import DataSourceVMware as VMware
 from cloudinit.sources import DataSourceVultr as Vultr
+from cloudinit.sources import DataSourceWSL as WSL
 from tests.unittests import helpers as test_helpers
 
 DEFAULT_LOCAL = [
@@ -60,6 +61,7 @@ DEFAULT_LOCAL = [
     VMware.DataSourceVMware,
     NWCS.DataSourceNWCS,
     Akamai.DataSourceAkamaiLocal,
+    WSL.DataSourceWSL,
 ]
 
 DEFAULT_NETWORK = [

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -169,7 +169,7 @@ class TestWSLDataSource(CiTestCase):
         )
 
     @mock.patch("cloudinit.util.wait_for_files")
-    @mock.patch("cloudinit.util.load_file")
+    @mock.patch("cloudinit.util.load_binary_file")
     @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
     @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
     def test_metadata_id(self, m_prof_dir, m_iname, m_load_file, m_wait_file):

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -46,12 +46,7 @@ GOOD_MOUNTS = {
         "opts": "rw,relatime...",
     },
 }
-SAMPLE_LSB = {
-    "id": "Ubuntu",
-    "description": "Ubuntu 24.04",
-    "release": "24.04",
-    "codename": "noble",
-}
+SAMPLE_LINUX_DISTRO = ("ubuntu", "24.04", "noble")
 
 
 class TestWSLHelperFunctions(CiTestCase):
@@ -129,18 +124,18 @@ class TestWSLHelperFunctions(CiTestCase):
         m_mounts.return_value.pop("D:\\")
         self.assertRaises(IOError, wsl.cmd_executable)
 
-    @mock.patch("cloudinit.util.lsb_release")
-    def test_candidate_files(self, m_lsb):
+    @mock.patch("cloudinit.util.get_linux_distro")
+    def test_candidate_files(self, m_gld):
         """
         Validate the file names candidate for holding user-data and their
         order of precedence.
         """
-        m_lsb.return_value = SAMPLE_LSB
+        m_gld.return_value = SAMPLE_LINUX_DISTRO
         self.assertListEqual(
             [
                 "%s.user-data" % INSTANCE_NAME,
-                "Ubuntu-noble.user-data",
-                "Ubuntu-all.user-data",
+                "ubuntu-noble.user-data",
+                "ubuntu-all.user-data",
                 "config.user-data",
             ],
             wsl.candidate_user_data_file_names(INSTANCE_NAME),
@@ -203,8 +198,8 @@ class TestWSLDataSource(CiTestCase):
     @mock.patch("cloudinit.util.lsb_release")
     @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
     @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
-    def test_get_data_cc(self, m_prof_dir, m_iname, m_lsb):
-        m_lsb.return_value = SAMPLE_LSB
+    def test_get_data_cc(self, m_prof_dir, m_iname, m_gld):
+        m_gld.return_value = SAMPLE_LINUX_DISTRO
         m_iname.return_value = INSTANCE_NAME
         m_prof_dir.return_value = self.tmp
         userdata_file = os.path.join(
@@ -233,8 +228,8 @@ class TestWSLDataSource(CiTestCase):
     @mock.patch("cloudinit.util.lsb_release")
     @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
     @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
-    def test_get_data_sh(self, m_prof_dir, m_iname, m_lsb):
-        m_lsb.return_value = SAMPLE_LSB
+    def test_get_data_sh(self, m_prof_dir, m_iname, m_gld):
+        m_gld.return_value = SAMPLE_LINUX_DISTRO
         m_iname.return_value = INSTANCE_NAME
         m_prof_dir.return_value = self.tmp
         userdata_file = os.path.join(
@@ -261,11 +256,11 @@ class TestWSLDataSource(CiTestCase):
         )
         self.assertIn(COMMAND, userdata)
 
-    @mock.patch("cloudinit.util.lsb_release")
+    @mock.patch("cloudinit.util.get_linux_distro")
     @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
     @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
-    def test_data_precedence(self, m_prof_dir, m_iname, m_lsb):
-        m_lsb.return_value = SAMPLE_LSB
+    def test_data_precedence(self, m_prof_dir, m_iname, m_gld):
+        m_gld.return_value = SAMPLE_LINUX_DISTRO
         m_iname.return_value = INSTANCE_NAME
         m_prof_dir.return_value = self.tmp
         # This is the most specific: should win over the other user-data files.

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -4,9 +4,12 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import os
 from copy import deepcopy
+from email.mime.multipart import MIMEMultipart
+from typing import cast
 
-from cloudinit import util
+from cloudinit import helpers, util
 from cloudinit.sources import DataSourceWSL as wsl
 from tests.unittests.helpers import CiTestCase, mock
 
@@ -42,6 +45,12 @@ GOOD_MOUNTS = {
         "mountpoint": "/dev/hugepages",
         "opts": "rw,relatime...",
     },
+}
+SAMPLE_LSB = {
+    "id": "Ubuntu",
+    "description": "Ubuntu 24.04",
+    "release": "24.04",
+    "codename": "noble",
 }
 
 
@@ -139,7 +148,188 @@ class TestWSLHelperFunctions(CiTestCase):
         m_mounts.return_value = deepcopy(GOOD_MOUNTS)
         m_mounts.return_value.pop("C:\\")
         m_mounts.return_value.pop("D:\\")
-        with self.assertRaises(RuntimeError) as ctx:
-            _ = wsl.cmd_executable()
+        self.assertIsNone(wsl.cmd_executable())
 
-        self.assertIn("drives", str(ctx.exception))
+    @mock.patch("cloudinit.util.lsb_release")
+    def test_candidate_files(self, m_lsb):
+        """
+        Validate the file names candidate for holding user-data and their
+        order of precedence.
+        """
+        m_lsb.return_value = SAMPLE_LSB
+        self.assertListEqual(
+            [
+                "%s.user-data" % INSTANCE_NAME,
+                "Ubuntu-noble.user-data",
+                "Ubuntu-all.user-data",
+                "config.user-data",
+            ],
+            wsl.candidate_user_data_file_names(INSTANCE_NAME),
+        )
+
+
+SAMPLE_CFG = {"datasource_list": ["NoCloud", "WSL"]}
+
+
+def join_payloads_from_content_type(
+    part: MIMEMultipart, content_type: str
+) -> str:
+    """
+    Helper function to decode and join all parts of a multipart MIME
+    message matched by the content type.
+    """
+    content = ""
+    for p in part.walk():
+        if p.get_content_type() == content_type:
+            content = content + str(p.get_payload(decode=True))
+
+    return content
+
+
+class TestWSLDataSource(CiTestCase):
+    def setUp(self):
+        super(TestWSLDataSource, self).setUp()
+        self.tmp = self.tmp_dir()
+        self.paths = helpers.Paths(
+            {"cloud_dir": self.tmp, "run_dir": self.tmp}
+        )
+
+    @mock.patch("cloudinit.util.wait_for_files")
+    @mock.patch("cloudinit.util.load_file")
+    @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
+    @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
+    def test_metadata_id(self, m_prof_dir, m_iname, m_load_file, m_wait_file):
+        """
+        Validates that instance-id is properly set, indepedent of the existence
+        of user-data.
+        """
+        m_wait_file.return_value = set()
+        NICE_MACHINE_ID = "A-Nice-Machine-ID_by_systemd"
+        m_load_file.return_value = NICE_MACHINE_ID
+        m_iname.return_value = INSTANCE_NAME
+        m_prof_dir.return_value = None
+
+        ds = wsl.DataSourceWSL(
+            sys_cfg=SAMPLE_CFG,
+            distro=None,
+            paths=self.paths,
+        )
+        ds.get_data()
+
+        self.assertEqual(
+            ds.get_instance_id(),
+            "%s-%s" % (INSTANCE_NAME, NICE_MACHINE_ID),
+        )
+
+    @mock.patch("cloudinit.util.lsb_release")
+    @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
+    @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
+    def test_get_data_cc(self, m_prof_dir, m_iname, m_lsb):
+        m_lsb.return_value = SAMPLE_LSB
+        m_iname.return_value = INSTANCE_NAME
+        m_prof_dir.return_value = self.tmp
+        userdata_file = os.path.join(
+            self.tmp, ".cloud-init", "%s.user-data" % INSTANCE_NAME
+        )
+        util.write_file(
+            userdata_file, "#cloud-config\nwrite_files:\n- path: /etc/wsl.conf"
+        )
+
+        ds = wsl.DataSourceWSL(
+            sys_cfg=SAMPLE_CFG,
+            distro=None,
+            paths=self.paths,
+        )
+
+        self.assertTrue(ds.get_data())
+        ud = ds.get_userdata()
+
+        self.assertIsNotNone(ud)
+        userdata = join_payloads_from_content_type(
+            cast(MIMEMultipart, ud), "text/cloud-config"
+        )
+        self.assertIsNotNone(userdata)
+        self.assertIn("wsl.conf", cast(str, userdata))
+
+    @mock.patch("cloudinit.util.lsb_release")
+    @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
+    @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
+    def test_get_data_sh(self, m_prof_dir, m_iname, m_lsb):
+        m_lsb.return_value = SAMPLE_LSB
+        m_iname.return_value = INSTANCE_NAME
+        m_prof_dir.return_value = self.tmp
+        userdata_file = os.path.join(
+            self.tmp, ".cloud-init", "%s.user-data" % INSTANCE_NAME
+        )
+        COMMAND = "echo Hello cloud-init on WSL!"
+        util.write_file(userdata_file, "#!/bin/sh\n%s\n" % COMMAND)
+
+        ds = wsl.DataSourceWSL(
+            sys_cfg=SAMPLE_CFG,
+            distro=None,
+            paths=self.paths,
+        )
+
+        self.assertTrue(ds.get_data())
+        ud = ds.get_userdata()
+
+        self.assertIsNotNone(ud)
+        userdata = cast(
+            str,
+            join_payloads_from_content_type(
+                cast(MIMEMultipart, ud), "text/x-shellscript"
+            ),
+        )
+        self.assertIn(COMMAND, userdata)
+
+    @mock.patch("cloudinit.util.lsb_release")
+    @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
+    @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
+    def test_data_precendence(self, m_prof_dir, m_iname, m_lsb):
+        m_lsb.return_value = SAMPLE_LSB
+        m_iname.return_value = INSTANCE_NAME
+        m_prof_dir.return_value = self.tmp
+        # This is the most specific: should win over the other user-data files.
+        userdata_file = os.path.join(
+            self.tmp, ".cloud-init", "Ubuntu-noble.user-data"
+        )
+        util.write_file(
+            userdata_file, "#cloud-config\nwrite_files:\n- path: /etc/wsl.conf"
+        )
+
+        distro_file = os.path.join(
+            self.tmp, ".cloud-init", "Ubuntu-all.user-data"
+        )
+        util.write_file(distro_file, "#!/bin/sh\n\necho Hello World\n")
+
+        generic_file = os.path.join(
+            self.tmp, ".cloud-init", "config.user-data"
+        )
+        util.write_file(generic_file, "#cloud-config\npackages:\n- g++-13\n")
+
+        ds = wsl.DataSourceWSL(
+            sys_cfg=SAMPLE_CFG,
+            distro=None,
+            paths=self.paths,
+        )
+
+        self.assertTrue(ds.get_data())
+        ud = ds.get_userdata()
+
+        self.assertIsNotNone(ud)
+        userdata = cast(
+            str,
+            join_payloads_from_content_type(
+                cast(MIMEMultipart, ud), "text/cloud-config"
+            ),
+        )
+        self.assertIn("wsl.conf", userdata)
+        self.assertNotIn("packages", userdata)
+        shell_script = cast(
+            str,
+            join_payloads_from_content_type(
+                cast(MIMEMultipart, ud), "text/x-shellscript"
+            ),
+        )
+
+        self.assertEqual("", shell_script)

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -4,13 +4,45 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from pathlib import PurePath
+from copy import deepcopy
 
 from cloudinit import util
 from cloudinit.sources import DataSourceWSL as wsl
 from tests.unittests.helpers import CiTestCase, mock
 
 INSTANCE_NAME = "Noble-MLKit"
+GOOD_MOUNTS = {
+    "none": {
+        "fstype": "tmpfs",
+        "mountpoint": "/mnt/wsl",
+        "opts": "rw,relatime",
+    },
+    "/dev/sdd": {
+        "fstype": "ext4",
+        "mountpoint": "/",
+        "opts": "rw,relatime,...",
+    },
+    "sysfs": {
+        "fstype": "sysfs",
+        "mountpoint": "/sys",
+        "opts": "rw,nosuid...",
+    },
+    "C:\\": {
+        "fstype": "9p",
+        "mountpoint": "/mnt/c",
+        "opts": "rw,noatime,dirsync,aname=drvfs;path=C:\\;...",
+    },
+    "D:\\": {
+        "fstype": "9p",
+        "mountpoint": "/mnt/d",
+        "opts": "rw,noatime,dirsync,aname=drvfs;path=D:\\;...",
+    },
+    "hugetblfs": {
+        "fstype": "hugetblfs",
+        "mountpoint": "/dev/hugepages",
+        "opts": "rw,relatime...",
+    },
+}
 
 
 class TestWSLHelperFunctions(CiTestCase):
@@ -24,3 +56,90 @@ class TestWSLHelperFunctions(CiTestCase):
 
         self.assertEqual(INSTANCE_NAME, inst)
 
+    @mock.patch("cloudinit.util.mounts")
+    def test_mounted_drives(self, m_mounts):
+        # A good output
+        m_mounts.return_value = deepcopy(GOOD_MOUNTS)
+        mounts = wsl.mounted_win_drives()
+        self.assertListEqual(["/mnt/c", "/mnt/d"], mounts)
+
+        # no more drvfs in C:\ options
+        m_mounts.return_value["C:\\"]["opts"] = "rw,relatime..."
+        mounts = wsl.mounted_win_drives()
+        self.assertListEqual(["/mnt/d"], mounts)
+
+        # fstype mismatch for D:\
+        m_mounts.return_value["D:\\"]["fstype"] = "zfs"
+        mounts = wsl.mounted_win_drives()
+        self.assertListEqual([], mounts)
+
+    @mock.patch("cloudinit.util.subp.subp")
+    def test_path_2_wsl_logic(self, m_subp):
+        """
+        Validates that we interpret stderr correctly when translating paths
+        from Windows into Linux.
+        """
+        m_subp.return_value = util.subp.SubpResult("/mnt/c/ProgramData/", "")
+
+        translated = wsl.win_path_2_wsl("C:\\ProgramData")
+        self.assertIsNotNone(translated)
+
+        # When an invalid drive is passed, wslpath prints the following pattern
+        # to stderr:
+        # wslpath: <ARGV_1 (aka the path)>
+        m_subp.return_value = util.subp.SubpResult(
+            "", "wslpath: X:\\ProgramData\\"
+        )
+
+        translated = wsl.win_path_2_wsl("X:\\ProgramData")
+        self.assertIsNone(translated)
+
+    @mock.patch("os.access")
+    @mock.patch("cloudinit.util.mounts")
+    def test_cmd_exe_ok(self, m_mounts, m_os_access):
+        """
+        Validates the happy path, when we find the Windows system drive and
+        cmd.exe is executable.
+        """
+        m_mounts.return_value = deepcopy(GOOD_MOUNTS)
+        m_os_access.return_value = True
+        cmd = wsl.cmd_executable()
+        # To please pyright not to complain about optional member access.
+        assert cmd is not None
+        self.assertIsNotNone(
+            cmd.relative_to(GOOD_MOUNTS["C:\\"]["mountpoint"])
+        )
+
+    @mock.patch("os.access")
+    @mock.patch("cloudinit.util.mounts")
+    def test_cmd_not_executable(self, m_mounts, m_os_access):
+        """
+        When the cmd.exe found is not executable, then RuntimeError is raised.
+        """
+        m_mounts.return_value = deepcopy(GOOD_MOUNTS)
+        m_os_access.return_value = True
+        cmd = wsl.cmd_executable()
+        # To please pyright not to complain about optional member access.
+        assert cmd is not None
+        self.assertIsNotNone(
+            cmd.relative_to(GOOD_MOUNTS["C:\\"]["mountpoint"])
+        )
+
+        m_os_access.return_value = False
+        self.assertIsNone(wsl.cmd_executable())
+
+    @mock.patch("os.access")
+    @mock.patch("cloudinit.util.mounts")
+    def test_cmd_exe_no_win_mounts(self, m_mounts, m_os_access):
+        """
+        When no Windows drives are found, then RuntimeError is raised.
+        """
+        m_os_access.return_value = True
+
+        m_mounts.return_value = deepcopy(GOOD_MOUNTS)
+        m_mounts.return_value.pop("C:\\")
+        m_mounts.return_value.pop("D:\\")
+        with self.assertRaises(RuntimeError) as ctx:
+            _ = wsl.cmd_executable()
+
+        self.assertIn("drives", str(ctx.exception))

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -219,9 +219,7 @@ class TestWSLDataSource(CiTestCase):
         m_gld.return_value = SAMPLE_LINUX_DISTRO
         m_iname.return_value = INSTANCE_NAME
         m_seed_dir.return_value = PurePath(self.tmp)
-        userdata_file = os.path.join(
-            self.tmp, "%s.user-data" % INSTANCE_NAME
-        )
+        userdata_file = os.path.join(self.tmp, "%s.user-data" % INSTANCE_NAME)
         util.write_file(
             userdata_file, "#cloud-config\nwrite_files:\n- path: /etc/wsl.conf"
         )
@@ -249,9 +247,7 @@ class TestWSLDataSource(CiTestCase):
         m_gld.return_value = SAMPLE_LINUX_DISTRO
         m_iname.return_value = INSTANCE_NAME
         m_seed_dir.return_value = PurePath(self.tmp)
-        userdata_file = os.path.join(
-            self.tmp, "%s.user-data" % INSTANCE_NAME
-        )
+        userdata_file = os.path.join(self.tmp, "%s.user-data" % INSTANCE_NAME)
         COMMAND = "echo Hello cloud-init on WSL!"
         util.write_file(userdata_file, "#!/bin/sh\n%s\n" % COMMAND)
 
@@ -282,9 +278,7 @@ class TestWSLDataSource(CiTestCase):
         m_seed_dir.return_value = PurePath(self.tmp)
         # This is the most specific: should win over the other user-data files.
         # Also, notice the file name casing: should be irrelevant.
-        userdata_file = os.path.join(
-            self.tmp, "ubuntu-24.04.user-data"
-        )
+        userdata_file = os.path.join(self.tmp, "ubuntu-24.04.user-data")
         util.write_file(
             userdata_file, "#cloud-config\nwrite_files:\n- path: /etc/wsl.conf"
         )

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2024 Canonical Ltd.
+#
+# Author: Carlos Nihelton <carlos.santanadeoliveira@canonical.com>
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from pathlib import PurePath
+
+from cloudinit import util
+from cloudinit.sources import DataSourceWSL as wsl
+from tests.unittests.helpers import CiTestCase, mock
+
+INSTANCE_NAME = "Noble-MLKit"
+
+
+class TestWSLHelperFunctions(CiTestCase):
+    @mock.patch("cloudinit.util.subp.subp")
+    def test_instance_name(self, m_subp):
+        m_subp.return_value = util.subp.SubpResult(
+            "//wsl.localhost/%s/" % (INSTANCE_NAME), ""
+        )
+
+        inst = wsl.instance_name()
+
+        self.assertEqual(INSTANCE_NAME, inst)
+

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -214,13 +214,13 @@ class TestWSLDataSource(CiTestCase):
 
     @mock.patch("cloudinit.util.lsb_release")
     @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
-    @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
-    def test_get_data_cc(self, m_prof_dir, m_iname, m_gld):
+    @mock.patch("cloudinit.sources.DataSourceWSL.cloud_init_data_dir")
+    def test_get_data_cc(self, m_seed_dir, m_iname, m_gld):
         m_gld.return_value = SAMPLE_LINUX_DISTRO
         m_iname.return_value = INSTANCE_NAME
-        m_prof_dir.return_value = self.tmp
+        m_seed_dir.return_value = PurePath(self.tmp)
         userdata_file = os.path.join(
-            self.tmp, ".cloud-init", "%s.user-data" % INSTANCE_NAME
+            self.tmp, "%s.user-data" % INSTANCE_NAME
         )
         util.write_file(
             userdata_file, "#cloud-config\nwrite_files:\n- path: /etc/wsl.conf"
@@ -244,13 +244,13 @@ class TestWSLDataSource(CiTestCase):
 
     @mock.patch("cloudinit.util.lsb_release")
     @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
-    @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
-    def test_get_data_sh(self, m_prof_dir, m_iname, m_gld):
+    @mock.patch("cloudinit.sources.DataSourceWSL.cloud_init_data_dir")
+    def test_get_data_sh(self, m_seed_dir, m_iname, m_gld):
         m_gld.return_value = SAMPLE_LINUX_DISTRO
         m_iname.return_value = INSTANCE_NAME
-        m_prof_dir.return_value = self.tmp
+        m_seed_dir.return_value = PurePath(self.tmp)
         userdata_file = os.path.join(
-            self.tmp, ".cloud-init", "%s.user-data" % INSTANCE_NAME
+            self.tmp, "%s.user-data" % INSTANCE_NAME
         )
         COMMAND = "echo Hello cloud-init on WSL!"
         util.write_file(userdata_file, "#!/bin/sh\n%s\n" % COMMAND)
@@ -275,15 +275,15 @@ class TestWSLDataSource(CiTestCase):
 
     @mock.patch("cloudinit.util.get_linux_distro")
     @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
-    @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
-    def test_data_precedence(self, m_prof_dir, m_iname, m_gld):
+    @mock.patch("cloudinit.sources.DataSourceWSL.cloud_init_data_dir")
+    def test_data_precedence(self, m_seed_dir, m_iname, m_gld):
         m_gld.return_value = SAMPLE_LINUX_DISTRO
         m_iname.return_value = INSTANCE_NAME
-        m_prof_dir.return_value = self.tmp
+        m_seed_dir.return_value = PurePath(self.tmp)
         # This is the most specific: should win over the other user-data files.
         # Also, notice the file name casing: should be irrelevant.
         userdata_file = os.path.join(
-            self.tmp, ".cloud-init", "ubuntu-24.04.user-data"
+            self.tmp, "ubuntu-24.04.user-data"
         )
         util.write_file(
             userdata_file, "#cloud-config\nwrite_files:\n- path: /etc/wsl.conf"

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -285,13 +285,14 @@ class TestWSLDataSource(CiTestCase):
     @mock.patch("cloudinit.util.lsb_release")
     @mock.patch("cloudinit.sources.DataSourceWSL.instance_name")
     @mock.patch("cloudinit.sources.DataSourceWSL.win_user_profile_dir")
-    def test_data_precendence(self, m_prof_dir, m_iname, m_lsb):
+    def test_data_precedence(self, m_prof_dir, m_iname, m_lsb):
         m_lsb.return_value = SAMPLE_LSB
         m_iname.return_value = INSTANCE_NAME
         m_prof_dir.return_value = self.tmp
         # This is the most specific: should win over the other user-data files.
+        # Also, notice the file name casing: should be irrelevant.
         userdata_file = os.path.join(
-            self.tmp, ".cloud-init", "Ubuntu-noble.user-data"
+            self.tmp, ".cloud-init", "ubuntu-Noble.user-data"
         )
         util.write_file(
             userdata_file, "#cloud-config\nwrite_files:\n- path: /etc/wsl.conf"

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -136,7 +136,7 @@ class TestWSLHelperFunctions(CiTestCase):
                 "%s.user-data" % INSTANCE_NAME,
                 "ubuntu-24.04.user-data",
                 "ubuntu-all.user-data",
-                "config.user-data",
+                "default.user-data",
             ],
             wsl.candidate_user_data_file_names(INSTANCE_NAME),
         )
@@ -278,7 +278,7 @@ class TestWSLDataSource(CiTestCase):
         util.write_file(distro_file, "#!/bin/sh\n\necho Hello World\n")
 
         generic_file = os.path.join(
-            self.tmp, ".cloud-init", "config.user-data"
+            self.tmp, ".cloud-init", "default.user-data"
         )
         util.write_file(generic_file, "#cloud-config\npackages:\n- g++-13\n")
 

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -178,7 +178,7 @@ class TestWSLHelperFunctions:
     def test_load_instance_metadata(
         self, md_content, raises, errors, warnings, md_expected, tmpdir, caplog
     ):
-        """meta-data file is optional. Errors are raised on ivalid content."""
+        """meta-data file is optional. Errors are raised on invalid content."""
         if md_content is not None:
             tmpdir.join("myinstance.meta-data").write(md_content)
         with caplog.at_level(logging.WARNING):

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -134,7 +134,7 @@ class TestWSLHelperFunctions(CiTestCase):
         self.assertListEqual(
             [
                 "%s.user-data" % INSTANCE_NAME,
-                "ubuntu-noble.user-data",
+                "ubuntu-24.04.user-data",
                 "ubuntu-all.user-data",
                 "config.user-data",
             ],
@@ -266,7 +266,7 @@ class TestWSLDataSource(CiTestCase):
         # This is the most specific: should win over the other user-data files.
         # Also, notice the file name casing: should be irrelevant.
         userdata_file = os.path.join(
-            self.tmp, ".cloud-init", "ubuntu-Noble.user-data"
+            self.tmp, ".cloud-init", "ubuntu-24.04.user-data"
         )
         util.write_file(
             userdata_file, "#cloud-config\nwrite_files:\n- path: /etc/wsl.conf"

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1084,9 +1084,17 @@ class TestWSL(DsIdentifyBase):
         """Simple negative test for WSL due other virt."""
         self._test_ds_not_found("Not-WSL")
 
-    def test_almost_found(self):
-        """Simple negative test by lack of host filesystem mount points."""
+    def test_no_fs_mounts(self):
+        """Negative test by lack of host filesystem mount points."""
         self._test_ds_not_found("WSL-no-host-mounts")
+
+    def test_no_cloudinitdir(self):
+        """Negative test by lack of host filesystem mount points."""
+        self._test_ds_not_found("WSL-no-cloudinit-dir")
+
+    def test_no_userdata(self):
+        """Negative test by lack of host filesystem mount points."""
+        self._test_ds_not_found("WSL-no-userdata")
 
 
 def blkid_out(disks=None):
@@ -2128,11 +2136,16 @@ VALID_CFG = {
             ),
         },
     },
-    "WSL-supported": {
+    "WSL-no-cloudinit-dir": {
         "ds": "WSL",
         "mocks": [
             MOCK_VIRT_IS_WSL,
             MOCK_UNAME_IS_WSL,
+            {
+                "name": "WSL_cloudinit_dir_in",
+                "ret": 1,
+                "out": "",
+            }
         ],
         "files": {
             "proc/mounts": (
@@ -2142,6 +2155,72 @@ VALID_CFG = {
                 "gid=0;symlinkroot=/mnt/...\n"
                 "snapfuse /snap/core22/1033 fuse.snapfuse ro,nodev,user_id=0,"
                 "group_id=0,allow_other 0 0"
+            ),
+        },
+    },
+    "WSL-no-userdata": {
+        "ds": "WSL",
+        "mocks": [
+            MOCK_VIRT_IS_WSL,
+            MOCK_UNAME_IS_WSL,
+            {
+                "name": "WSL_cloudinit_dir_in",
+                "ret": 0,
+                "out": "",
+            }
+        ],
+        "files": {
+            "proc/mounts": (
+                "/dev/sdd / ext4 rw,errors=remount-ro,data=ordered 0 0\n"
+                "cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec0 0\n"
+                "C:\\134 /mnt/c 9p rw,dirsync,aname=drvfs;path=C:\\;uid=0;"
+                "gid=0;symlinkroot=/mnt/...\n"
+                "snapfuse /snap/core22/1033 fuse.snapfuse ro,nodev,user_id=0,"
+                "group_id=0,allow_other 0 0"
+            ),
+            "etc/os-release": (
+                'PRETTY_NAME="Ubuntu Noble Numbat (development branch)"\n'
+                'NAME="Ubuntu"\n'
+                'VERSION_ID="24.04"\n'
+                'VERSION="24.04 (Noble Numbat)"\n'
+                'VERSION_CODENAME=noble\n'
+                'ID=ubuntu\n'
+                'ID_LIKE=debian\n'
+                'UBUNTU_CODENAME=noble\n'
+                'LOGO=ubuntu-logo\n'
+            ),
+        },
+    },
+    "WSL-supported": {
+        "ds": "WSL",
+        "mocks": [
+            MOCK_VIRT_IS_WSL,
+            MOCK_UNAME_IS_WSL,
+            {
+                "name": "WSL_cloudinit_dir_in",
+                "ret": 0,
+                "out": "",
+            }
+        ],
+        "files": {
+            "proc/mounts": (
+                "/dev/sdd / ext4 rw,errors=remount-ro,data=ordered 0 0\n"
+                "cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec0 0\n"
+                "C:\\134 /mnt/c 9p rw,dirsync,aname=drvfs;path=C:\\;uid=0;"
+                "gid=0;symlinkroot=/mnt/...\n"
+                "snapfuse /snap/core22/1033 fuse.snapfuse ro,nodev,user_id=0,"
+                "group_id=0,allow_other 0 0"
+            ),
+            "etc/os-release": (
+                'PRETTY_NAME="Ubuntu Noble Numbat (development branch)"\n'
+                'NAME="Ubuntu"\n'
+                'VERSION_ID="24.04"\n'
+                'VERSION="24.04 (Noble Numbat)"\n'
+                'VERSION_CODENAME=noble\n'
+                'ID=ubuntu\n'
+                'ID_LIKE=debian\n'
+                'UBUNTU_CODENAME=noble\n'
+                'LOGO=ubuntu-logo\n'
             ),
         },
     },

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1108,7 +1108,7 @@ class TestWSL(DsIdentifyBase):
             {
                 "name": "WSL_cloudinit_dir_in",
                 "ret": 1,
-                "out": "",
+                "RET": "",
             },
         )
         return self._check_via_dict(data, RC_NOT_FOUND)
@@ -1121,7 +1121,7 @@ class TestWSL(DsIdentifyBase):
             {
                 "name": "WSL_cloudinit_dir_in",
                 "ret": 0,
-                "out": cloudinitdir,
+                "RET": cloudinitdir,
             },
         )
         return self._check_via_dict(data, RC_NOT_FOUND)
@@ -1135,7 +1135,7 @@ class TestWSL(DsIdentifyBase):
             {
                 "name": "WSL_cloudinit_dir_in",
                 "ret": 0,
-                "out": cloudinitdir,
+                "RET": cloudinitdir,
             },
         )
         userdata_files = [
@@ -1151,7 +1151,8 @@ class TestWSL(DsIdentifyBase):
                 ),
             ),
             os.path.join(
-                cloudinitdir, MOCK_WSL_INSTANCE_DATA["name"] + "-all.user-data"
+                cloudinitdir,
+                MOCK_WSL_INSTANCE_DATA["distro"] + "-all.user-data",
             ),
             os.path.join(cloudinitdir, "default.user-data"),
         ]
@@ -1167,7 +1168,7 @@ class TestWSL(DsIdentifyBase):
             # Delete one by one
             Path(filename).unlink()
 
-        # Until ther is none, making the datasource no longer viable.
+        # Until there is none, making the datasource no longer viable.
         return self._check_via_dict(data, RC_NOT_FOUND)
 
 
@@ -2218,7 +2219,7 @@ VALID_CFG = {
             {
                 "name": "WSL_instance_name",
                 "ret": 0,
-                "out": MOCK_WSL_INSTANCE_DATA["name"],
+                "RET": MOCK_WSL_INSTANCE_DATA["name"],
             },
         ],
         "files": {

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -3,6 +3,7 @@
 import copy
 import os
 from collections import namedtuple
+from pathlib import Path
 from textwrap import dedent
 from uuid import uuid4
 
@@ -113,6 +114,22 @@ MOCK_UNAME_IS_PPC64 = {"name": "uname", "out": UNAME_PPC64EL, "ret": 0}
 MOCK_UNAME_IS_FREEBSD = {"name": "uname", "out": UNAME_FREEBSD, "ret": 0}
 MOCK_UNAME_IS_OPENBSD = {"name": "uname", "out": UNAME_OPENBSD, "ret": 0}
 MOCK_UNAME_IS_WSL = {"name": "uname", "out": UNAME_WSL, "ret": 0}
+MOCK_WSL_INSTANCE_DATA = {
+    "name": "Noble-MLKit",
+    "distro": "ubuntu",
+    "version": "24.04",
+    "os_release": (
+        'PRETTY_NAME="Ubuntu Noble Numbat (development branch)"\n'
+        'NAME="Ubuntu"\n'
+        'VERSION_ID="24.04"\n'
+        'VERSION="24.04 (Noble Numbat)"\n'
+        "VERSION_CODENAME=noble\n"
+        "ID=ubuntu\n"
+        "ID_LIKE=debian\n"
+        "UBUNTU_CODENAME=noble\n"
+        "LOGO=ubuntu-logo\n"
+    ),
+}
 
 shell_true = 0
 shell_false = 1
@@ -1076,11 +1093,7 @@ class TestOracle(DsIdentifyBase):
 
 
 class TestWSL(DsIdentifyBase):
-    def test_found(self):
-        """Simple positive test of WSL."""
-        self._test_ds_found("WSL-supported")
-
-    def test_not_found(self):
+    def test_not_found_virt(self):
         """Simple negative test for WSL due other virt."""
         self._test_ds_not_found("Not-WSL")
 
@@ -1089,12 +1102,73 @@ class TestWSL(DsIdentifyBase):
         self._test_ds_not_found("WSL-no-host-mounts")
 
     def test_no_cloudinitdir(self):
-        """Negative test by lack of host filesystem mount points."""
-        self._test_ds_not_found("WSL-no-cloudinit-dir")
+        """Negative test by not finding %USERPROFILE%/.cloud-init."""
+        data = copy.deepcopy(VALID_CFG["WSL-supported"])
+        data["mocks"].append(
+            {
+                "name": "WSL_cloudinit_dir_in",
+                "ret": 1,
+                "out": "",
+            },
+        )
+        return self._check_via_dict(data, RC_NOT_FOUND)
 
-    def test_no_userdata(self):
+    def test_empty_cloudinitdir(self):
         """Negative test by lack of host filesystem mount points."""
-        self._test_ds_not_found("WSL-no-userdata")
+        data = copy.deepcopy(VALID_CFG["WSL-supported"])
+        cloudinitdir = self.tmp_dir()
+        data["mocks"].append(
+            {
+                "name": "WSL_cloudinit_dir_in",
+                "ret": 0,
+                "out": cloudinitdir,
+            },
+        )
+        return self._check_via_dict(data, RC_NOT_FOUND)
+
+    def test_found_via_userdata(self):
+        """Asserts that WSL datasource is found if there is applicable
+        userdata files inside cloudinitdir."""
+        data = copy.deepcopy(VALID_CFG["WSL-supported"])
+        cloudinitdir = self.tmp_dir()
+        data["mocks"].append(
+            {
+                "name": "WSL_cloudinit_dir_in",
+                "ret": 0,
+                "out": cloudinitdir,
+            },
+        )
+        userdata_files = [
+            os.path.join(
+                cloudinitdir, MOCK_WSL_INSTANCE_DATA["name"] + ".user-data"
+            ),
+            os.path.join(
+                cloudinitdir,
+                "%s-%s.user-data"
+                % (
+                    MOCK_WSL_INSTANCE_DATA["distro"],
+                    MOCK_WSL_INSTANCE_DATA["version"],
+                ),
+            ),
+            os.path.join(
+                cloudinitdir, MOCK_WSL_INSTANCE_DATA["name"] + "-all.user-data"
+            ),
+            os.path.join(cloudinitdir, "default.user-data"),
+        ]
+
+        # Ensures all applicable user data files exist.
+        for filename in userdata_files:
+            Path(filename).touch()
+
+        for filename in userdata_files:
+            self._check_via_dict(
+                data, RC_FOUND, dslist=[data.get("ds"), DS_NONE]
+            )
+            # Delete one by one
+            Path(filename).unlink()
+
+        # Until ther is none, making the datasource no longer viable.
+        return self._check_via_dict(data, RC_NOT_FOUND)
 
 
 def blkid_out(disks=None):
@@ -2136,71 +2210,16 @@ VALID_CFG = {
             ),
         },
     },
-    "WSL-no-cloudinit-dir": {
-        "ds": "WSL",
-        "mocks": [
-            MOCK_VIRT_IS_WSL,
-            MOCK_UNAME_IS_WSL,
-            {
-                "name": "WSL_cloudinit_dir_in",
-                "ret": 1,
-                "out": "",
-            }
-        ],
-        "files": {
-            "proc/mounts": (
-                "/dev/sdd / ext4 rw,errors=remount-ro,data=ordered 0 0\n"
-                "cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec0 0\n"
-                "C:\\134 /mnt/c 9p rw,dirsync,aname=drvfs;path=C:\\;uid=0;"
-                "gid=0;symlinkroot=/mnt/...\n"
-                "snapfuse /snap/core22/1033 fuse.snapfuse ro,nodev,user_id=0,"
-                "group_id=0,allow_other 0 0"
-            ),
-        },
-    },
-    "WSL-no-userdata": {
-        "ds": "WSL",
-        "mocks": [
-            MOCK_VIRT_IS_WSL,
-            MOCK_UNAME_IS_WSL,
-            {
-                "name": "WSL_cloudinit_dir_in",
-                "ret": 0,
-                "out": "",
-            }
-        ],
-        "files": {
-            "proc/mounts": (
-                "/dev/sdd / ext4 rw,errors=remount-ro,data=ordered 0 0\n"
-                "cgroup2 /sys/fs/cgroup cgroup2 rw,nosuid,nodev,noexec0 0\n"
-                "C:\\134 /mnt/c 9p rw,dirsync,aname=drvfs;path=C:\\;uid=0;"
-                "gid=0;symlinkroot=/mnt/...\n"
-                "snapfuse /snap/core22/1033 fuse.snapfuse ro,nodev,user_id=0,"
-                "group_id=0,allow_other 0 0"
-            ),
-            "etc/os-release": (
-                'PRETTY_NAME="Ubuntu Noble Numbat (development branch)"\n'
-                'NAME="Ubuntu"\n'
-                'VERSION_ID="24.04"\n'
-                'VERSION="24.04 (Noble Numbat)"\n'
-                'VERSION_CODENAME=noble\n'
-                'ID=ubuntu\n'
-                'ID_LIKE=debian\n'
-                'UBUNTU_CODENAME=noble\n'
-                'LOGO=ubuntu-logo\n'
-            ),
-        },
-    },
     "WSL-supported": {
         "ds": "WSL",
         "mocks": [
             MOCK_VIRT_IS_WSL,
             MOCK_UNAME_IS_WSL,
             {
-                "name": "WSL_cloudinit_dir_in",
+                "name": "WSL_instance_name",
                 "ret": 0,
-                "out": "",
-            }
+                "out": MOCK_WSL_INSTANCE_DATA["name"],
+            },
         ],
         "files": {
             "proc/mounts": (
@@ -2211,17 +2230,7 @@ VALID_CFG = {
                 "snapfuse /snap/core22/1033 fuse.snapfuse ro,nodev,user_id=0,"
                 "group_id=0,allow_other 0 0"
             ),
-            "etc/os-release": (
-                'PRETTY_NAME="Ubuntu Noble Numbat (development branch)"\n'
-                'NAME="Ubuntu"\n'
-                'VERSION_ID="24.04"\n'
-                'VERSION="24.04 (Noble Numbat)"\n'
-                'VERSION_CODENAME=noble\n'
-                'ID=ubuntu\n'
-                'ID_LIKE=debian\n'
-                'UBUNTU_CODENAME=noble\n'
-                'LOGO=ubuntu-logo\n'
-            ),
+            "etc/os-release": MOCK_WSL_INSTANCE_DATA["os_release"],
         },
     },
 }

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -118,16 +118,18 @@ MOCK_WSL_INSTANCE_DATA = {
     "name": "Noble-MLKit",
     "distro": "ubuntu",
     "version": "24.04",
-    "os_release": (
-        'PRETTY_NAME="Ubuntu Noble Numbat (development branch)"\n'
-        'NAME="Ubuntu"\n'
-        'VERSION_ID="24.04"\n'
-        'VERSION="24.04 (Noble Numbat)"\n'
-        "VERSION_CODENAME=noble\n"
-        "ID=ubuntu\n"
-        "ID_LIKE=debian\n"
-        "UBUNTU_CODENAME=noble\n"
-        "LOGO=ubuntu-logo\n"
+    "os_release": dedent(
+        """\
+        PRETTY_NAME="Ubuntu Noble Numbat (development branch)"
+        NAME="Ubuntu"
+        VERSION_ID="24.04"
+        VERSION="24.04 (Noble Numbat)"
+        VERSION_CODENAME=noble
+        ID=ubuntu
+        ID_LIKE=debian
+        UBUNTU_CODENAME=noble
+        LOGO=ubuntu-logo
+        """
     ),
 }
 

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1592,6 +1592,9 @@ WSL_cloudinit_dir_in() {
     for m in "$@"; do
         cmdexe="$m/Windows/System23/cmd.exe"
         if command -v "$cmdexe" > /dev/null 2>&1; then
+            # Here WSL's proprietary `/init` is used to start the Windows cmd.exe
+            # to output the Windows user profile directory path, which is
+            # held by the environment variable %USERPROFILE%.
             cloudinitdir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
             if [ -n "$cloudinitdir" ]; then
                 val=$(wslpath -au "$cloudinitdir") && _RET="$val"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1589,7 +1589,7 @@ dscheck_VMware() {
 WSL_cloudinit_dir_in() {
     for m in "$@"; do
         cmdexe="$m/Windows/System23/cmd.exe"
-        if [ -x "$cmdexe" ]; then
+        if command -v "$cmdexe" > /dev/null 2>&1; then
             cloudinitdir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
             if [ -n "$cloudinitdir" ]; then
                 wslpath -au "$cloudinitdir"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1586,12 +1586,34 @@ dscheck_VMware() {
     return "${DS_NOT_FOUND}"
 }
 
+WSL_cloudinit_dir_in() {
+    for m in "$@"; do
+        cmdexe="$m/Windows/System23/cmd.exe"
+        if [ -x "$cmdexe" ]; then
+            cloudinitdir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
+            if [ -n "$cloudinitdir" ]; then
+                wslpath -au "$cloudinitdir"
+                return $?
+            fi
+        fi
+    done
+
+    return 1
+}
+
+WSL_instance_name() {
+    instance_name=$(wslpath -am /)
+    basename "$instance_name"
+}
+
 dscheck_WSL() {
     if [ "${DI_UNAME_KERNEL_NAME}" != "Linux" ]; then
+        debug 1 "Kernel is not Linux"
         return "${DS_NOT_FOUND}"
     fi
 
     if [ "${DI_VIRT}" != "wsl" ]; then
+        debug 1 "Virtualization is not WSL, but rather ${DI_VIRT}"
         return "${DS_NOT_FOUND}"
     fi
 
@@ -1601,12 +1623,39 @@ dscheck_WSL() {
     # See https://youtu.be/lwhMThePdIo?t=2431&si=JKTHx39TyRgPbzkZ and
     # https://learn.microsoft.com/en-us/windows/wsl/wsl-config#what-is-drvfs
     # for more information.
-    if [ "$(grep -c '^[^[:space:]]* [^[:space:]]* 9p [^[:space:]]*aname=drvfs;.*' "${PATH_ROOT}/proc/mounts")" = 0 ]; then
+    mountpoints=$(grep '^[^[:space:]]* [^[:space:]]* 9p [^[:space:]]*aname=drvfs;.*' "/proc/mounts" | cut -f2 -d' ')
+
+    if [ -z "$mountpoints" ]; then
         debug 1 "WSL datasource requires access to Windows drives mount points"
         return "${DS_NOT_FOUND}"
     fi
 
-    return "${DS_FOUND}"
+    # We know we are under WSL and have acess to the host filesystem,
+    # so let's find the .cloud-init directory
+    cloudinitdir="$(WSL_cloudinit_dir_in "$mountpoints")"
+    if [ -z "$cloudinitdir" ]; then
+        debug 1 "%USERPROFILE/.cloud-init/ directory not found"
+        return "${DS_NOT_FOUND}"
+    fi
+
+    # and the applicable userdata file. Notice the ordering in the for-loop
+    # must match our expected precedence, so the file we find is what the
+    # datasource must process.
+    instance_name="$(WSL_instance_name)"
+    distro_id=$(grep "^ID=" "${PATH_ROOT}/etc/os-release" | cut -d'=' -f2 )
+    version_id=$(grep "^VERSION_ID=" "${PATH_ROOT}/etc/os-release" | cut -d'=' -f2 )
+
+    for userdatafile in "$instance_name.user-data" "$distro_id-$version_id" "$distro_id-all.user-data" "default.user-data"; do
+        candidate="$cloudinitdir/$userdatafile"
+        if [ -f "$candidate" ]; then
+            debug 1 "Found applicable user data file for this instance at: $candidate"
+            return ${DS_FOUND}
+        fi
+    done
+
+    debug 1 "Didn't find any applicable user data file for instance named $instance_name in $cloudinitdir"
+
+    return "${DS_NOT_FOUND}"
 }
 
 collect_info() {

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1597,6 +1597,9 @@ WSL_cloudinit_dir_in() {
             # held by the environment variable %USERPROFILE%.
             cloudinitdir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
             if [ -n "$cloudinitdir" ]; then
+                # wslpath is a program supplied by WSL itself that translates Windows and Linux paths,
+                # respecting the mountpoints where the Windows drives are mounted.
+                # (in fact it's a symlink to /init).
                 val=$(wslpath -au "$cloudinitdir") && _RET="$val"
                 return $?
             fi

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1644,10 +1644,9 @@ dscheck_WSL() {
     # datasource must process.
     WSL_instance_name
     instance_name="${_RET}"
-    distro_id=$(grep "^ID=" "${PATH_ROOT}/etc/os-release" | cut -d'=' -f2 )
-    version_id=$(grep "^VERSION_ID=" "${PATH_ROOT}/etc/os-release" | cut -d'=' -f2 )
-
-    for userdatafile in "$instance_name.user-data" "$distro_id-$version_id" "$distro_id-all.user-data" "default.user-data"; do
+    # shellcheck source=/dev/null
+    . /etc/os-release
+    for userdatafile in "${instance_name}.user-data" "${ID}-${VERSION_ID}" "${ID}-all.user-data" "default.user-data"; do
         candidate="$cloudinitdir/$userdatafile"
         if [ -f "$candidate" ]; then
             debug 1 "Found applicable user data file for this instance at: $candidate"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1609,7 +1609,7 @@ WSL_cloudinit_dir_in() {
 WSL_instance_name() {
     local val="" instance_name=""
     instance_name=$(wslpath -am /)
-    val=$(basename "$instance_name")
+    val="${instance_name##*/}"
     _RET="${val}"
 }
 

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1587,12 +1587,13 @@ dscheck_VMware() {
 }
 
 WSL_cloudinit_dir_in() {
+    _RET=""
     for m in "$@"; do
         cmdexe="$m/Windows/System23/cmd.exe"
         if command -v "$cmdexe" > /dev/null 2>&1; then
             cloudinitdir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
             if [ -n "$cloudinitdir" ]; then
-                wslpath -au "$cloudinitdir"
+                val=$(wslpath -au "$cloudinitdir") && _RET="$val"
                 return $?
             fi
         fi
@@ -1603,7 +1604,8 @@ WSL_cloudinit_dir_in() {
 
 WSL_instance_name() {
     instance_name=$(wslpath -am /)
-    basename "$instance_name"
+    val=$(basename "$instance_name")
+    _RET="${val}"
 }
 
 dscheck_WSL() {
@@ -1630,7 +1632,8 @@ dscheck_WSL() {
 
     # We know we are under WSL and have acess to the host filesystem,
     # so let's find the .cloud-init directory
-    cloudinitdir="$(WSL_cloudinit_dir_in "$mountpoints")"
+    WSL_cloudinit_dir_in "$mountpoints"
+    cloudinitdir="${_RET}"
     if [ -z "$cloudinitdir" ]; then
         debug 1 "%USERPROFILE/.cloud-init/ directory not found"
         return "${DS_NOT_FOUND}"
@@ -1639,7 +1642,8 @@ dscheck_WSL() {
     # and the applicable userdata file. Notice the ordering in the for-loop
     # must match our expected precedence, so the file we find is what the
     # datasource must process.
-    instance_name="$(WSL_instance_name)"
+    WSL_instance_name
+    instance_name="${_RET}"
     distro_id=$(grep "^ID=" "${PATH_ROOT}/etc/os-release" | cut -d'=' -f2 )
     version_id=$(grep "^VERSION_ID=" "${PATH_ROOT}/etc/os-release" | cut -d'=' -f2 )
 

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1623,7 +1623,7 @@ dscheck_WSL() {
     # See https://youtu.be/lwhMThePdIo?t=2431&si=JKTHx39TyRgPbzkZ and
     # https://learn.microsoft.com/en-us/windows/wsl/wsl-config#what-is-drvfs
     # for more information.
-    mountpoints=$(grep '^[^[:space:]]* [^[:space:]]* 9p [^[:space:]]*aname=drvfs;.*' "/proc/mounts" | cut -f2 -d' ')
+    mountpoints=$(grep '^[^[:space:]]* [^[:space:]]* 9p [^[:space:]]*aname=drvfs;.*' "${PATH_ROOT}/proc/mounts" | cut -f2 -d' ')
 
     if [ -z "$mountpoints" ]; then
         debug 1 "WSL datasource requires access to Windows drives mount points"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1588,6 +1588,7 @@ dscheck_VMware() {
 
 WSL_cloudinit_dir_in() {
     _RET=""
+    local cmdexe="" cloudinitdir="" val=""
     for m in "$@"; do
         cmdexe="$m/Windows/System23/cmd.exe"
         if command -v "$cmdexe" > /dev/null 2>&1; then
@@ -1603,12 +1604,14 @@ WSL_cloudinit_dir_in() {
 }
 
 WSL_instance_name() {
+    local val="" instance_name=""
     instance_name=$(wslpath -am /)
     val=$(basename "$instance_name")
     _RET="${val}"
 }
 
 dscheck_WSL() {
+    local mountpoints="" cloudinitdir="" candidate="" instance_name=""
     if [ "${DI_UNAME_KERNEL_NAME}" != "Linux" ]; then
         return "${DS_NOT_FOUND}"
     fi

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1608,12 +1608,10 @@ WSL_instance_name() {
 
 dscheck_WSL() {
     if [ "${DI_UNAME_KERNEL_NAME}" != "Linux" ]; then
-        debug 1 "Kernel is not Linux"
         return "${DS_NOT_FOUND}"
     fi
 
     if [ "${DI_VIRT}" != "wsl" ]; then
-        debug 1 "Virtualization is not WSL, but rather ${DI_VIRT}"
         return "${DS_NOT_FOUND}"
     fi
 


### PR DESCRIPTION
## Proposed Commit Message

```
feat: Implements the WSL datasource

A new datasource is implemented for the WSL platform.
It relies on being able to access the Windows filesystem and execute cmd.exe
to determine where the user data configuration files are.
Reference documentation for that datasource is also added, explaining where
the user should place the config files, the requirements for the datasource to work
and some details that are expected to work differently or not at all.
I'm not sure that list is exhaustive, so we should expect revisions to it in the short future.
For now at least the implementation is focused on locating and ingesting user-data,
without being too smart.

Closes UDENG-1989
```

## Additional Context
Following #4730 , this brings in the Python module with its unit tests implementing the WSL datasource.

Enabling the datasource and integration tests are subject to subsequent PR's, as well as adding a tutorial on how to setup a fresh WSL instance with cloud-init.

This PR brings no inteligence on how to deal with the data supplied, i.e., we ingest whatever user data supplied, whether it may work as intended or not under the WSL platform. While the documentation covers some limitations imposed by the platform, we may soon consider reducing the gaps, such as the discussion we had around setting the hostname. I'd rather have those as separate PR's so we can exhaust the implementation details that would certainly affect not only the datasource.

With those changes plus adding the word "WSL" into a few lists to make cloud-init consider it a viable candidate and exporting an image with the changes already baked in, I could successfully initialize WSL instances with user data stored in my Windows filesystem. The screenshots below depict some scenarios I played with.

![image](https://github.com/canonical/cloud-init/assets/11138291/ad73ffa4-3331-44b0-96f3-20307710bf69)

![image](https://github.com/canonical/cloud-init/assets/11138291/04b23958-9df8-4ee5-9486-e6718f40815e)

Closes UDENG-1989

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
