### PR TITLE
Support reboot on SUSE distros on package install/update/upgrade

### DIFF
--- a/cloudinit/config/cc_package_update_upgrade_install.py
+++ b/cloudinit/config/cc_package_update_upgrade_install.py
@@ -19,7 +19,7 @@ from cloudinit.distros import ALL_DISTROS
 from cloudinit.log import flush_loggers
 from cloudinit.settings import PER_INSTANCE
 
-REBOOT_FILE = "/var/run/reboot-required"
+REBOOT_FILES = ("/var/run/reboot-required", "/run/reboot-needed")
 REBOOT_CMD = ["/sbin/reboot"]
 
 MODULE_DESCRIPTION = """\
@@ -127,11 +127,14 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # kernel and openssl (possibly some other packages)
     # write a file /var/run/reboot-required after upgrading.
     # if that file exists and configured, then just stop right now and reboot
-    reboot_fn_exists = os.path.isfile(REBOOT_FILE)
+    for reboot_marker in REBOOT_FILES:
+        reboot_fn_exists = os.path.isfile(reboot_marker)
+        if reboot_fn_exists:
+            break
     if (upgrade or pkglist) and reboot_if_required and reboot_fn_exists:
         try:
             LOG.warning(
-                "Rebooting after upgrade or install per %s", REBOOT_FILE
+                "Rebooting after upgrade or install per %s", reboot_marker
             )
             # Flush the above warning + anything else out...
             flush_loggers(LOG)


### PR DESCRIPTION
On SUSE distributions the reboot marker file is written as /run/reboot-needed. Recognize this as an additional indicator that a reboot is needed on package update/upgrade.

## Proposed Commit Message

feat(SUSE): On SUSE distributions the reboot marker file is written as /run/reboot-needed. Recognize this as an additional indicator that a reboot is needed on package update/upgrade.


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
