### PR TITLE
Fix logrotate config and integration test

### DIFF
--- a/packages/debian/cloud-init.logrotate
+++ b/packages/debian/cloud-init.logrotate
@@ -1,10 +1,11 @@
-/var/log/cloud-init.log
-/var/log/cloud-init-output.log
+/var/log/cloud-init*.log
 {
+    su root root
     missingok
     nocreate
     notifempty
-    rotate 5
+    rotate 6
     compress
+    delayacompress
     size 1M   
 }

--- a/tests/integration_tests/cmd/test_clean.py
+++ b/tests/integration_tests/cmd/test_clean.py
@@ -39,9 +39,7 @@ class TestCleanCommand:
     def test_clean_rotated_logs(self, class_client: IntegrationInstance):
         """Clean with log params alters expected files without error"""
         assert class_client.execute("cloud-init status --wait").ok
-        assert class_client.execute(
-            "logrotate /etc/logrotate.d/cloud-init.logrotate"
-        ).ok
+        assert class_client.execute("logrotate /etc/logrotate.d/cloud-init").ok
         log_paths = (
             "/var/log/cloud-init.log",
             "/var/log/cloud-init.log.1.gz",


### PR DESCRIPTION
## Rebase merge

Update  logrotate config for ubuntu to adhere to best practices across other products.
Fix config to specify `su root root` to avoid errors from logrotate about insecure permissions
```
error: skipping "/var/log/cloud-init-output.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.
```

Update the integration test to actually invoke the packaged logrotate.d file which lives at
/etc/logrotate.d/cloud-init once packaged.

## Additional Context

## Test Steps
```
# failures of existing daily PPA which doesn't deliver an /etc/logrotate.d/cloud-init yet
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_OS_IMAGE=lunar CLOUD_INIT_PLATFORM=lxd_container tox -e integration-tests -- tests/integration_tests/cmd/test_clean.py::TestCleanCommand::test_clean_rotated_logs
```
Then build a deb from #4789 (which delivers said logrotate.d/cloud-init config and re-run
```
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init*bddeb.deb CLOUD_INIT_OS_IMAGE=lunar CLOUD_INIT_PLATFORM=lxd_container tox -e integration-tests -- tests/integration_tests/cmd/test_clean.py::TestCleanCommand::test_clean_rotated_logs
```
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
