### PR TITLE
tests: add exit 2 on noble from cloud-init status

### DIFF
--- a/tests/integration_tests/cmd/test_clean.py
+++ b/tests/integration_tests/cmd/test_clean.py
@@ -38,7 +38,14 @@ class TestCleanCommand:
     )
     def test_clean_rotated_logs(self, class_client: IntegrationInstance):
         """Clean with log params alters expected files without error"""
-        assert class_client.execute("cloud-init status --wait").ok
+        # Expect warning exit code 2 on Ubuntu Noble due to cloud-init
+        # disabling /etc/apt/sources.list build artifact in favor of deb822
+        result = class_client.execute("cloud-init status --wait --long")
+        return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
+        assert return_code == result.return_code, (
+            f"Unexpected cloud-init status exit code {result.return_code}\n"
+            f"Output:\n{result}"
+        )
         assert class_client.execute("logrotate /etc/logrotate.d/cloud-init").ok
         log_paths = (
             "/var/log/cloud-init.log",


### PR DESCRIPTION
## rebase merge

## Proposed Commit Message
```
tests: add exit 2 on noble from cloud-init status

Supplemental integration test missed in commit 720665263.
This will all be reverted with Noble cloud-image builds with
/etc/cloud/build.info serial that is greater than 20240110.
```

## Additional Context
One other integration test missed expecting exit 2 on noble due to deb822 duplicated source warnings.
Both this PR and 72066526310cb58f6c6d657c49466d76f0be2910 will likely need to be revoked within a week when cloudimage builds are unblocked for noble.
- failure seen in [jenkins results](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_container/393/testReport/tests.integration_tests.cmd.test_clean/TestCleanCommand/test_clean_rotated_logs/)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```

#  Without this PR, the following test fails on `execute.(cloud-init status --wait).ok` on line 45
 CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_PLATFORM=lxd_container .tox/integration-tests/bin/pytest tests/integration_tests/cmd/test_clean.py::TestCleanCommand::test_clean_rotated_logs

```
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
