### PR TITLE
fix: linkcheck for ci to ignore scaleway anchor URL

### DIFF
--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -131,6 +131,7 @@ autosectionlabel_maxdepth = 2
 linkcheck_ignore = [
     r"http://\[fd00:ec2::254.*",
     r"http://instance-data.*",
+    r"https://www.scaleway.com/en/developers/api/instance.*",
     r"https://powersj.io.*",
     r"http://169.254.169.254.*",
     r"http://10.10.0.1.*",


### PR DESCRIPTION
## rebase merge

## Proposed Commit Message
```
Commit ce07818f9 introduced new doc links for Scaleway datasource.
Ignore anchors which sphinx link check cannot parse.

Fixes CI linkcheck failures.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
