### PR TITLE
fix: netplan rendering integrations tests

### DIFF
--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -150,6 +150,7 @@ def test_netplan_rendering(
         },
     }
     expected = yaml.safe_load(EXPECTED_NET_CONFIG)
+    expected["network"]["ethernets"]["eth0"]["match"] = {}
     expected["network"]["ethernets"]["eth0"]["match"]["macaddress"] = mac_addr
     with session_cloud.launch(launch_kwargs=launch_kwargs) as client:
         result = client.execute("cat /etc/netplan/50-cloud-init.yaml")


### PR DESCRIPTION
Netplan tests are failing on KeyError: 'match' for expected; this change initializes the key.

## Proposed Commit Message
```
(fix: netplan rendering integrations tests)

Netplan tests are failing on KeyError: 'match' for expected; this change initializes the key.
```

## Additional Context
Jenkins integrations tests are failing due to test added in PR#4774; I think this should fix it.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
