### PR TITLE
fix(tests): failing integration tests due to missing ua token

### DIFF
--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -207,6 +207,7 @@ def maybe_install_cloud_init(session_cloud: IntegrationCloud):
             ).ok
 
         client.install_new_cloud_init(source)
+        session_cloud.snapshot_id = client.snapshot()
         client.destroy()
 
     return {"image_id": session_cloud.snapshot_id}


### PR DESCRIPTION
Focal and Jammy integration tests on jenkins foor GCE, AWS, and Azure were failing on checking for clean log finding an error about missing a necessary token.  The issue was in the test which did not take a proper snapshot.

## Proposed Commit Message

```
fix(tests): failing integration tests due to missing ua token

Focal and Jammy integration tests on GCE, AWS, and Azure were
failing on checking for clean log finding an error about missing
a necessary token.  The issue was in the test which did not take
a proper snapshot.


If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Test Steps

Validated the change locally for GCE with:
```
$ CLOUD_INIT_OS_IMAGE=focal CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=gce  tox -e integration-tests  -- tests/integration_tests/modules/test_ubuntu_advantage.py::TestUbuntuAdvantagePro::test_custom_services
$ CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=gce  tox -e integration-tests  -- tests/integration_tests/modules/test_ubuntu_advantage.py::TestUbuntuAdvantagePro::test_custom_services
```

@blackboxsw validated for EC2.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
