### PR TITLE
tests: separate integration tests which invoke cloud-init clean

### DIFF
--- a/tests/integration_tests/cmd/test_clean.py
+++ b/tests/integration_tests/cmd/test_clean.py
@@ -32,92 +32,96 @@ packages:
 
 
 @pytest.mark.user_data(USER_DATA)
-class TestCleanCommand:
-    @pytest.mark.skipif(
-        not IS_UBUNTU, reason="Hasn't been tested on other distros"
+@pytest.mark.skipif(
+    not IS_UBUNTU, reason="Hasn't been tested on other distros"
+)
+def test_clean_rotated_logs(client: IntegrationInstance):
+    """Clean with log params alters expected files without error"""
+    # Expect warning exit code 2 on Ubuntu Noble due to cloud-init
+    # disabling /etc/apt/sources.list build artifact in favor of deb822
+    result = client.execute("cloud-init status --wait --long")
+    return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
+    assert return_code == result.return_code, (
+        f"Unexpected cloud-init status exit code {result.return_code}\n"
+        f"Output:\n{result}"
     )
-    def test_clean_rotated_logs(self, class_client: IntegrationInstance):
-        """Clean with log params alters expected files without error"""
-        # Expect warning exit code 2 on Ubuntu Noble due to cloud-init
-        # disabling /etc/apt/sources.list build artifact in favor of deb822
-        result = class_client.execute("cloud-init status --wait --long")
-        return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
-        assert return_code == result.return_code, (
-            f"Unexpected cloud-init status exit code {result.return_code}\n"
-            f"Output:\n{result}"
-        )
-        assert class_client.execute("logrotate /etc/logrotate.d/cloud-init").ok
-        log_paths = (
-            "/var/log/cloud-init.log",
-            "/var/log/cloud-init.log.1.gz",
-            "/var/log/cloud-init-output.log",
-            "/var/log/cloud-init-output.log.1.gz",
-        )
+    assert client.execute("logrotate /etc/logrotate.d/cloud-init").ok
+    log_paths = (
+        "/var/log/cloud-init.log",
+        "/var/log/cloud-init.log.1.gz",
+        "/var/log/cloud-init-output.log",
+        "/var/log/cloud-init-output.log.1.gz",
+    )
 
-        assert class_client.execute("cloud-init clean --logs").ok
-        for path in log_paths:
-            assert class_client.execute(
-                f"test -f {path}"
-            ).failed, f"Unexpected file found {path}"
+    assert client.execute("cloud-init clean --logs").ok
+    for path in log_paths:
+        assert client.execute(
+            f"test -f {path}"
+        ).failed, f"Unexpected file found {path}"
 
-    def test_clean_by_param(self, class_client: IntegrationInstance):
-        """Clean with various params alters expected files without error"""
-        result = class_client.execute("cloud-init status --wait --long")
 
-        # Expect warning exit code 2 on Ubuntu Noble due to cloud-init
-        # disabling /etc/apt/sources.list build artifact in favor of deb822
-        return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
-        assert return_code == result.return_code, (
-            f"Unexpected cloud-init status exit code {result.return_code}\n"
-            f"Output:\n{result}"
-        )
-        result = class_client.execute("cloud-init clean")
-        assert (
-            result.ok
-        ), "non-zero exit on cloud-init clean runparts of /etc/cloud/clean.d"
-        # Log files are not removed without --logs
-        log_paths = (
-            "/var/log/cloud-init.log",
-            "/var/log/cloud-init-output.log",
-        )
-        net_cfg_paths = (
-            "/etc/network/interfaces.d/50-cloud-init.cfg",
-            "/etc/netplan/50-cloud-init.yaml",
-            "/etc/systemd/network/10-cloud-init-eth0.network",
-        )
-        for path in log_paths + net_cfg_paths:
-            assert class_client.execute(
-                f"test -f {path}"
-            ).ok, f"Missing expected file {path}"
-        # /etc/cloud/clean.d runparts scripts are run if executable
-        assert result.stdout == "/etc/cloud/clean.d/runme.sh RAN"
+@pytest.mark.user_data(USER_DATA)
+@pytest.mark.skipif(
+    not IS_UBUNTU, reason="Hasn't been tested on other distros"
+)
+def test_clean_by_param(client: IntegrationInstance):
+    """Clean with various params alters expected files without error"""
+    result = client.execute("cloud-init status --wait --long")
 
-        # Log files removed with --logs
-        assert class_client.execute("cloud-init clean --logs").ok
-        for path in log_paths:
-            assert class_client.execute(
-                f"test -f {path}"
-            ).failed, f"Unexpected file found {path}"
-        for path in net_cfg_paths:
-            assert class_client.execute(
-                f"test -f {path}"
-            ).ok, f"Missing expected file {path}"
+    # Expect warning exit code 2 on Ubuntu Noble due to cloud-init
+    # disabling /etc/apt/sources.list build artifact in favor of deb822
+    return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
+    assert return_code == result.return_code, (
+        f"Unexpected cloud-init status exit code {result.return_code}\n"
+        f"Output:\n{result}"
+    )
+    result = client.execute("cloud-init clean")
+    assert (
+        result.ok
+    ), "non-zero exit on cloud-init clean runparts of /etc/cloud/clean.d"
+    # Log files are not removed without --logs
+    log_paths = (
+        "/var/log/cloud-init.log",
+        "/var/log/cloud-init-output.log",
+    )
+    net_cfg_paths = (
+        "/etc/network/interfaces.d/50-cloud-init.cfg",
+        "/etc/netplan/50-cloud-init.yaml",
+        "/etc/systemd/network/10-cloud-init-eth0.network",
+    )
+    for path in log_paths + net_cfg_paths:
+        assert client.execute(
+            f"test -f {path}"
+        ).ok, f"Missing expected file {path}"
+    # /etc/cloud/clean.d runparts scripts are run if executable
+    assert result.stdout == "/etc/cloud/clean.d/runme.sh RAN"
 
-        prev_machine_id = class_client.read_from_file("/etc/machine-id")
-        assert re.match(
-            r"^[a-f0-9]{32}$", prev_machine_id
-        ), f"Unexpected machine-id format {prev_machine_id}"
+    # Log files removed with --logs
+    assert client.execute("cloud-init clean --logs").ok
+    for path in log_paths:
+        assert client.execute(
+            f"test -f {path}"
+        ).failed, f"Unexpected file found {path}"
+    for path in net_cfg_paths:
+        assert client.execute(
+            f"test -f {path}"
+        ).ok, f"Missing expected file {path}"
 
-        # --machine-id sets /etc/machine-id
-        assert class_client.execute("cloud-init clean --machine-id").ok
-        machine_id = class_client.read_from_file("/etc/machine-id")
-        assert machine_id != prev_machine_id
-        assert "uninitialized" == machine_id
+    prev_machine_id = client.read_from_file("/etc/machine-id")
+    assert re.match(
+        r"^[a-f0-9]{32}$", prev_machine_id
+    ), f"Unexpected machine-id format {prev_machine_id}"
 
-        # --configs remove network scope
-        assert class_client.execute("cloud-init clean --configs network").ok
+    # --machine-id sets /etc/machine-id
+    assert client.execute("cloud-init clean --machine-id").ok
+    machine_id = client.read_from_file("/etc/machine-id")
+    assert machine_id != prev_machine_id
+    assert "uninitialized" == machine_id
 
-        for path in log_paths + net_cfg_paths:
-            assert class_client.execute(
-                f"test -f {path}"
-            ).failed, f"Unexpected file found {path}"
+    # --configs remove network scope
+    assert client.execute("cloud-init clean --configs network").ok
+
+    for path in log_paths + net_cfg_paths:
+        assert client.execute(
+            f"test -f {path}"
+        ).failed, f"Unexpected file found {path}"


### PR DESCRIPTION
## Proposed Commit Message

```
tests: use client fixture instead of class_client avoiding timeout

Tests invoking cloud-init clean end up removing all logs on the test
instance. Therefore, we cannot use the class_client fixture because
subsequent tests which call cloud-init status --wait will block
forever because the instance state has been removed by the prior
logrotate test.

Integration tests defined using the class_client fixture will
run using the same launched instance which should be reserved for
testcases where there is no cross-test interaction or artifact that
may invalidate the subsequent tests.

A cleaned system with no cloud-init.log will sit at
cloud-init status --wait indefinitely. This results in integration
test timeouts which cause our Jenkins runners to eventually fail.
```

## Additional Context
<!-- If relevant -->
Failed jenkins integration runs will timeout about 13% through integration tests blocking on a `cloud-init status --wait` that will never return because the prior test on the same instance ran a `cloud-init clean --logs`.
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-lunar-lxd_vm/lastSuccessfulBuild/console

## Test Steps

* See failure(integration tests never completing) in tip of main with lxd_container
```
CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=lxd_container  tox -e integration-tests  -- tests/integration_tests/cmd/test_clean.py
```
* see fix (integration tests completing) with this PR
```
CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=lxd_container  tox -e integration-tests  -- tests/integration_tests/cmd/test_clean.py
```
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
