### PR TITLE
azure: replace BrokenAzureDataSource with reportable errors

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -33,7 +33,6 @@ from cloudinit.sources.azure import errors, identity, imds, kvp
 from cloudinit.sources.helpers import netlink
 from cloudinit.sources.helpers.azure import (
     DEFAULT_WIRESERVER_ENDPOINT,
-    BrokenAzureDataSource,
     NonAzureDataSource,
     OvfEnvXml,
     azure_ds_reporter,
@@ -615,10 +614,6 @@ class DataSourceAzure(sources.DataSource):
                     "%s was not mountable" % src, logger_func=LOG.debug
                 )
                 continue
-            except BrokenAzureDataSource as exc:
-                msg = "BrokenAzureDataSource: %s" % exc
-                report_diagnostic_event(msg, logger_func=LOG.error)
-                raise sources.InvalidMetaDataException(msg)
         else:
             msg = (
                 "Unable to find provisioning media, falling back to IMDS "
@@ -1184,7 +1179,7 @@ class DataSourceAzure(sources.DataSource):
             logger_func=LOG.info,
         )
         sleep(31536000)
-        raise BrokenAzureDataSource("Shutdown failure for PPS disk.")
+        raise errors.ReportableErrorOsDiskPpsFailure()
 
     @azure_ds_telemetry_reporter
     def _wait_for_pps_running_reuse(self) -> None:
@@ -1837,7 +1832,7 @@ def read_azure_ovf(contents):
     :return: Tuple of metadata, configuration, userdata dicts.
 
     :raises NonAzureDataSource: if XML is not in Azure's format.
-    :raises BrokenAzureDataSource: if XML is unparseable or invalid.
+    :raises errors.ReportableError: if XML is unparseable or invalid.
     """
     ovf_env = OvfEnvXml.parse_text(contents)
     md: Dict[str, Any] = {}

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -9,6 +9,7 @@ import traceback
 from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, List, Optional, Tuple
+from xml.etree import ElementTree
 
 import requests
 
@@ -150,11 +151,35 @@ class ReportableErrorImdsUrlError(ReportableError):
         self.supporting_data["url"] = exception.url
 
 
+class ReportableErrorImdsInvalidMetadata(ReportableError):
+    def __init__(self, *, key: str, value: Any) -> None:
+        super().__init__(f"invalid IMDS metadata for key={key}")
+
+        self.supporting_data["key"] = key
+        self.supporting_data["value"] = repr(value)
+
+
 class ReportableErrorImdsMetadataParsingException(ReportableError):
     def __init__(self, *, exception: ValueError) -> None:
         super().__init__("error parsing IMDS metadata")
 
         self.supporting_data["exception"] = repr(exception)
+
+
+class ReportableErrorOsDiskPpsFailure(ReportableError):
+    def __init__(self) -> None:
+        super().__init__("error waiting for host shutdown")
+
+
+class ReportableErrorOvfInvalidMetadata(ReportableError):
+    def __init__(self, message: str) -> None:
+        super().__init__(f"unexpected metadata parsing ovf-env.xml: {message}")
+
+
+class ReportableErrorOvfParsingException(ReportableError):
+    def __init__(self, *, exception: ElementTree.ParseError) -> None:
+        message = exception.msg
+        super().__init__(f"error parsing ovf-env.xml: {message}")
 
 
 class ReportableErrorUnhandledException(ReportableError):
@@ -170,11 +195,3 @@ class ReportableErrorUnhandledException(ReportableError):
 
         self.supporting_data["exception"] = repr(exception)
         self.supporting_data["traceback_base64"] = trace_base64
-
-
-class ReportableErrorImdsInvalidMetadata(ReportableError):
-    def __init__(self, *, key: str, value: Any) -> None:
-        super().__init__(f"invalid IMDS metadata for key={key}")
-
-        self.supporting_data["key"] = key
-        self.supporting_data["value"] = repr(value)

--- a/tests/unittests/sources/azure/test_kvp.py
+++ b/tests/unittests/sources/azure/test_kvp.py
@@ -17,12 +17,13 @@ def fake_utcnow():
         yield timestamp
 
 
-@pytest.fixture()
-def fake_vm_id():
-    vm_id = "fake-vm-id"
-    with mock.patch.object(kvp.identity, "query_vm_id", autospec=True) as m:
-        m.return_value = vm_id
-        yield vm_id
+@pytest.fixture
+def fake_vm_id(mocker):
+    vm_id = "foo"
+    mocker.patch(
+        "cloudinit.sources.azure.identity.query_vm_id", return_value=vm_id
+    )
+    yield vm_id
 
 
 @pytest.fixture


### PR DESCRIPTION
These errors would be reported as unhandled exceptions.  Replace them with reportable errors to clean things up:

- ReportableErrorOvfInvalidMetadata(ReportableError)
- ReportableErrorOvfParsingException(ReportableError)
- ReportableErrorOsDiskPpsFailure(ReportableError)