### PR TITLE
tests: revert #4792 as noble images no longer return 2

### DIFF
--- a/tests/integration_tests/cmd/test_clean.py
+++ b/tests/integration_tests/cmd/test_clean.py
@@ -4,7 +4,7 @@ import re
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
+from tests.integration_tests.releases import IS_UBUNTU
 
 USER_DATA = """\
 #cloud-config
@@ -38,14 +38,7 @@ class TestCleanCommand:
     )
     def test_clean_rotated_logs(self, client: IntegrationInstance):
         """Clean with log params alters expected files without error"""
-        # Expect warning exit code 2 on Ubuntu Noble due to cloud-init
-        # disabling /etc/apt/sources.list build artifact in favor of deb822
-        result = client.execute("cloud-init status --wait --long")
-        return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
-        assert return_code == result.return_code, (
-            f"Unexpected cloud-init status exit code {result.return_code}\n"
-            f"Output:\n{result}"
-        )
+        assert client.execute("cloud-init status --wait --long").ok
         assert client.execute("logrotate /etc/logrotate.d/cloud-init").ok
         log_paths = (
             "/var/log/cloud-init.log",
@@ -62,15 +55,7 @@ class TestCleanCommand:
 
     def test_clean_by_param(self, client: IntegrationInstance):
         """Clean with various params alters expected files without error"""
-        result = client.execute("cloud-init status --wait --long")
-
-        # Expect warning exit code 2 on Ubuntu Noble due to cloud-init
-        # disabling /etc/apt/sources.list build artifact in favor of deb822
-        return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
-        assert return_code == result.return_code, (
-            f"Unexpected cloud-init status exit code {result.return_code}\n"
-            f"Output:\n{result}"
-        )
+        assert client.execute("cloud-init status --wait --long").ok
         result = client.execute("cloud-init clean")
         assert (
             result.ok


### PR DESCRIPTION
New noble download images are building again so they should not return 2 on cloud-init status --wait.  This change reverts the temporary fix to allow our tests to pass during the out of sync period.

## Proposed Commit Message

```
tests: revert #4792 as noble images no longer return 2

New noble download images are building again so they should not
return 2 on cloud-init status --wait.  This change reverts the
temporary fix to allow our tests to pass during the out of sync
period.
```

## Additional Context

Not a clean `git revert` because there have been intervening commits that touched the same files.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
