### PR TITLE
fix(tests): fixing KeyError on integrations tests

### DIFF
--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -199,6 +199,7 @@ def test_schema_warnings(
         },
     }
     expected = yaml.safe_load(EXPECTED_NET_CONFIG)
+    expected["network"]["ethernets"]["eth0"]["match"] = {}
     expected["network"]["ethernets"]["eth0"]["match"]["macaddress"] = mac_addr
     with session_cloud.launch(launch_kwargs=launch_kwargs) as client:
         result = client.execute("cloud-init status --format=json")


### PR DESCRIPTION
From jenkins integrations tests failures 2024-01-26.

Related to: #4795

## Proposed Commit Message
```
fix(tests): fixing KeyError on integrations tests

From jenkins integrations tests failures 2024-01-26.

Related to: #4795
```

## Test Steps
Tested integrations test locally: `$ CLOUD_INIT_OS_IMAGE=focal CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=gce  tox -e integration-tests  -- tests/integration_tests/modules/test_ubuntu_advantage.py::TestUbuntuAdvantagePro`


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
