### PR TITLE
test: fix pytest 8.0.0

### DIFF
--- a/cloudinit/sources/DataSourceAliYun.py
+++ b/cloudinit/sources/DataSourceAliYun.py
@@ -1,5 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import copy
 import logging
 from typing import List
 
@@ -29,6 +30,7 @@ class DataSourceAliYun(EC2.DataSourceEc2):
 
     def __init__(self, sys_cfg, distro, paths):
         super(DataSourceAliYun, self).__init__(sys_cfg, distro, paths)
+        self.default_update_events = copy.deepcopy(self.default_update_events)
         self.default_update_events[EventScope.NETWORK].add(EventType.BOOT)
 
     def get_hostname(self, fqdn=False, resolve_ip=False, metadata_only=False):

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -223,10 +223,28 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
     # The datasource also defines a set of default EventTypes that the
     # datasource can react to. These are the event types that will be used
     # if not overridden by the user.
+    #
     # A datasource requiring to write network config on each system boot
-    # would call default_update_events['network'].add(EventType.BOOT).
+    # would either:
+    #
+    # 1) Overwrite the class attribute `default_update_events` like:
+    #
+    # >>> default_update_events = {
+    # ...     EventScope.NETWORK: {
+    # ...         EventType.BOOT_NEW_INSTANCE,
+    # ...         EventType.BOOT,
+    # ...     }
+    # ... }
+    #
+    # 2) Or, if writing network config on every boot has to be determined at
+    # runtime, then deepcopy to not overwrite the class attribute on other
+    # elements of this class hierarchy, like:
+    #
+    # >>> self.default_update_events = copy.deepcopy(
+    # ...    self.default_update_events
+    # ... )
+    # >>> self.default_update_events[EventScope.NETWORK].add(EventType.BOOT)
 
-    # Default: generate network config on new instance id (first boot).
     supported_update_events = {
         EventScope.NETWORK: {
             EventType.BOOT_NEW_INSTANCE,
@@ -235,6 +253,8 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
             EventType.HOTPLUG,
         }
     }
+
+    # Default: generate network config on new instance id (first boot).
     default_update_events = {
         EventScope.NETWORK: {
             EventType.BOOT_NEW_INSTANCE,

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -7,7 +7,7 @@ pycloudlib>=5.10.0,<1!6
 # test/unittests/conftest.py to be loaded by our integration-tests tox env
 # resulting in an unmet dependency issue:
 # https://github.com/pytest-dev/pytest/issues/11104
-pytest!=7.3.2,<8.0.0
+pytest!=7.3.2
 
 packaging
 passlib

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@
 # test/unittests/conftest.py to be loaded by our integration-tests tox env
 # resulting in an unmet dependency issue:
 # https://github.com/pytest-dev/pytest/issues/11104
-pytest!=7.3.2,<8.0.0
+pytest!=7.3.2
 
 pytest-cov
 pytest-mock

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -136,6 +136,7 @@ class TestConfig(TestCase):
     def tearDown(self):
         self.tmpfile.close()
         os.remove(self.tmppath)
+        super().tearDown()
 
     @mock.patch.object(os.path, "isfile", return_value=False)
     def test_no_resizers_auto_is_fine(self, m_isfile):

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -42,6 +42,7 @@ class TestRandomSeed(TestCase):
     def tearDown(self):
         apply_patches([i for i in reversed(self.unapply)])
         util.del_file(self._seed_file)
+        super().tearDown()
 
     def apply_patches(self, patches):
         ret = apply_patches(patches)

--- a/tests/unittests/sources/test_altcloud.py
+++ b/tests/unittests/sources/test_altcloud.py
@@ -92,6 +92,7 @@ class TestGetCloudType(CiTestCase):
         # Reset
         dmi.read_dmi_data = self.dmi_data
         force_arch()
+        super().tearDown()
 
     def test_cloud_info_file_ioerror(self):
         """Return UNKNOWN when /etc/sysconfig/cloud-info exists but errors."""
@@ -230,6 +231,7 @@ class TestGetDataNoCloudInfoFile(CiTestCase):
         dmi.read_dmi_data = self.dmi_data
         # Return back to original arch
         force_arch()
+        super().tearDown()
 
     def test_rhev_no_cloud_file(self):
         """Test No cloud info file module get_data() forcing RHEV."""
@@ -346,6 +348,7 @@ class TestUserDataVsphere(CiTestCase):
             pass
 
         dsac.CLOUD_INFO_FILE = "/etc/sysconfig/cloud-info"
+        super().tearDown()
 
     @mock.patch("cloudinit.sources.DataSourceAltCloud.util.find_devs_with")
     @mock.patch("cloudinit.sources.DataSourceAltCloud.util.mount_cb")
@@ -409,6 +412,7 @@ class TestReadUserDataCallback(CiTestCase):
             shutil.rmtree(self.mount_dir)
         except OSError:
             pass
+        super().tearDown()
 
     def test_callback_both(self):
         """Test read_user_data_callback() with both files."""

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1055,7 +1055,6 @@ class TestAzureDataSource(CiTestCase):
                 mock.MagicMock(),
             )
         )
-        super(TestAzureDataSource, self).setUp()
 
     def apply_patches(self, patches):
         for module, name, new in patches:

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -441,6 +441,10 @@ class TestInit:
                 assert not self.tmpdir.join(path).exists()
 
     @mock.patch("cloudinit.distros.ubuntu.Distro")
+    @mock.patch.dict(
+        sources.DataSource.default_update_events,
+        {EventScope.NETWORK: {EventType.BOOT_NEW_INSTANCE}},
+    )
     def test_apply_network_on_same_instance_id(self, m_ubuntu, caplog):
         """Only call distro.networking.apply_network_config_names on same
         instance id."""


### PR DESCRIPTION
Fix tests after pytest 8.0.0 release. Changes in tests collection ordering are surfacing mocking issues.

<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->

## Additional Context
<!-- If relevant -->
https://docs.pytest.org/en/stable/changelog.html#collection-changes

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
`pytest test/unittest` on pytest==8.0.0

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
