### PR TITLE
test: Cleanup unwanted logger setup calls

### DIFF
--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -8,9 +8,7 @@ from unittest import mock
 
 import pytest
 
-from cloudinit import distros, helpers
-from cloudinit import log as logger
-from cloudinit import subp, util
+from cloudinit import distros, helpers, subp, util
 from cloudinit.config import cc_ca_certs
 from cloudinit.config.schema import (
     SchemaValidationError,
@@ -435,7 +433,6 @@ class TestCACertsSchema:
     @mock.patch.object(cc_ca_certs, "update_ca_certs")
     def test_deprecate_key_warnings(self, update_ca_certs, caplog):
         """Assert warnings are logged for deprecated keys."""
-        logger.setup_logging()
         cloud = get_cloud("ubuntu")
         cc_ca_certs.handle(
             "IGNORE", {"ca-certs": {"remove-defaults": False}}, cloud, []

--- a/tests/unittests/config/test_cc_disk_setup.py
+++ b/tests/unittests/config/test_cc_disk_setup.py
@@ -33,7 +33,7 @@ class TestIsDiskUsed(TestCase):
         )
 
     def tearDown(self):
-        super(TestIsDiskUsed, self).tearDown()
+        super().tearDown()
         self.patches.close()
 
     def test_multiple_child_nodes_returns_true(self):
@@ -65,7 +65,7 @@ class TestGetMbrHddSize(TestCase):
         )
 
     def tearDown(self):
-        super(TestGetMbrHddSize, self).tearDown()
+        super().tearDown()
         self.patches.close()
 
     def _configure_subp_mock(self, hdd_size_in_bytes, sector_size_in_bytes):

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -152,6 +152,7 @@ class CiTestCase(TestCase):
             handler.setFormatter(formatter)
             self.old_handlers = self.logger.handlers
             self.logger.handlers = [handler]
+            self.old_level = logging.root.level
         if self.allowed_subp is True:
             subp.subp = _real_subp
         else:
@@ -193,7 +194,7 @@ class CiTestCase(TestCase):
         if self.with_logs:
             # Remove the handler we setup
             logging.getLogger().handlers = self.old_handlers
-            logging.getLogger().setLevel(logging.NOTSET)
+            logging.getLogger().setLevel(self.old_level)
         subp.subp = _real_subp
         super(CiTestCase, self).tearDown()
 

--- a/tests/unittests/net/test_network_state.py
+++ b/tests/unittests/net/test_network_state.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from cloudinit import log, safeyaml, util
+from cloudinit import safeyaml, util
 from cloudinit.net import network_state
 from cloudinit.net.netplan import Renderer as NetplanRenderer
 from cloudinit.net.renderers import NAME_TO_RENDERER
@@ -214,8 +214,6 @@ class TestNetworkStateParseConfigV2:
         In netplan targets we perform a passthrough and the warning is not
         needed.
         """
-        log.setup_logging()
-
         util.deprecate._log = set()  # type: ignore
         ncfg = safeyaml.load(
             cfg.format(

--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -67,7 +67,7 @@ class TestOpenNebulaDataSource(CiTestCase):
 
     def tearDown(self):
         ds.switch_user_cmd = self.switch_user_cmd_real
-        super(TestOpenNebulaDataSource, self).tearDown()
+        super().tearDown()
 
     def test_get_data_non_contextdisk(self):
         orig_find_devs_with = util.find_devs_with

--- a/tests/unittests/sources/test_smartos.py
+++ b/tests/unittests/sources/test_smartos.py
@@ -1374,7 +1374,7 @@ class TestSerialConcurrency(CiTestCase):
         # os.kill() rather than mdata_proc.terminate() to avoid console spam.
         os.kill(self.mdata_proc.pid, signal.SIGKILL)
         self.mdata_proc.join()
-        super(TestSerialConcurrency, self).tearDown()
+        super().tearDown()
 
     def start_mdata_loop(self):
         """

--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -238,7 +238,7 @@ class TestDataSourceVMwareEnvVars(FilesystemMockingTestCase):
 
     def tearDown(self):
         del os.environ[DataSourceVMware.VMX_GUESTINFO]
-        return super(TestDataSourceVMwareEnvVars, self).tearDown()
+        return super().tearDown()
 
     def create_system_files(self):
         rootd = self.tmp_dir()

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 
 import pytest
 
-from cloudinit import helpers, log
+from cloudinit import helpers
 from cloudinit.cmd import main as cli
 from tests.unittests import helpers as test_helpers
 
@@ -30,7 +30,6 @@ class TestCLI:
         if not sysv_args:
             sysv_args = ["cloud-init"]
         try:
-            log.setup_logging()
             return cli.main(sysv_args=sysv_args)
         except SystemExit as e:
             return e.code

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -62,7 +62,6 @@ class TestCloudInitLogger(CiTestCase):
 class TestDeprecatedLogs:
     def test_deprecated_log_level(self, caplog):
         logger = logging.getLogger()
-        log.setup_logging()
         logger.deprecated("deprecated message")
         assert "DEPRECATED" == caplog.records[0].levelname
         assert "deprecated message" in caplog.text

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -13,7 +13,7 @@ from typing import Optional
 import pytest
 from yaml.serializer import Serializer
 
-from cloudinit import distros, log, net
+from cloudinit import distros, net
 from cloudinit import safeyaml as yaml
 from cloudinit import subp, temp_utils, util
 from cloudinit.net import (
@@ -5675,7 +5675,6 @@ USERCTL=no
                 """  # noqa: E501
             ),
         }
-        log.setup_logging()
 
         found = self._render_and_read(network_config=v2_data)
         self._compare_files_to_expected(expected, found)


### PR DESCRIPTION
## Proposed Commit Message
```
test: Cleanup unwanted logger setup calls

This was causing duplicate logs in test output.   
Also use modern class self() calls (less error-prone, easier to audit).
```

## Additional Context
While digging through test failures I noted that extra logging handlers were getting added in test code causing duplicate logs. Since the logging cleanup recently, a single root logger is used in unittests. Avoid polluting the logger with unwanted handlers - manual logger setup shouldn't be required in tests anymore. Also the CiTestCase class was overwriting the log level incorrectly.   

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
