### PR TITLE
test: Update tests for passlib requirements

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -216,7 +216,6 @@ class IntegrationInstance:
             local_path=integration_settings.CLOUD_INIT_SOURCE,
             remote_path=remote_path,
         )
-        assert self.execute("apt-get install -qy python3-passlib").ok
         assert self.execute("dpkg -i {path}".format(path=remote_path)).ok
 
     @retry(tries=30, delay=1)

--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -8,7 +8,6 @@ other tests chpasswd's list being a string.  Both expect the same results, so
 they use a mixin to share their test definitions, because we can (of course)
 only specify one user-data per instance.
 """
-import sys
 
 import pytest
 import yaml

--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -8,6 +8,8 @@ other tests chpasswd's list being a string.  Both expect the same results, so
 they use a mixin to share their test definitions, because we can (of course)
 only specify one user-data per instance.
 """
+import sys
+
 import pytest
 import yaml
 
@@ -160,11 +162,20 @@ class Mixin:
         assert "dick:" in console_log
         assert "harry:" in console_log
 
+    @pytest.mark.xfail(sys.version_info[:2] > (3, 12))
     def test_explicit_password_set_correctly(self, class_client):
         """Test that an explicitly-specified password is set correctly."""
+        minor_version = int(
+            class_client.execute(
+                "python3 -c 'import sys;print(sys.version_info[1])'"
+            ).strip()
+        )
+        if minor_version > 12:
+            pytest.xfail("Instance under test doesn't have 'crypt' in stdlib")
         shadow_users, _ = self._fetch_and_parse_etc_shadow(class_client)
 
         fmt_and_salt = shadow_users["tom"].rsplit("$", 1)[0]
+
         GEN_CRYPT_CONTENT = (
             "import crypt\n"
             f"print(crypt.crypt('mypassword123!', '{fmt_and_salt}'))\n"

--- a/tests/integration_tests/modules/test_set_password.py
+++ b/tests/integration_tests/modules/test_set_password.py
@@ -162,7 +162,6 @@ class Mixin:
         assert "dick:" in console_log
         assert "harry:" in console_log
 
-    @pytest.mark.xfail(sys.version_info[:2] > (3, 12))
     def test_explicit_password_set_correctly(self, class_client):
         """Test that an explicitly-specified password is set correctly."""
         minor_version = int(


### PR DESCRIPTION
## Proposed Commit Message
```
test: Update tests for passlib requirements

- Add one xfail for a test that assumes that 'crypt' will exist on the host.
- Don't manually install python3-passlib. This is unecessary unless the Python version is > 3.12, and it could mask future problems in cloud-init packaging requirements.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
