### PR TITLE
fix(net-schema): no warn when skipping schema check on non-netplan

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -609,9 +609,6 @@ def netplan_validate_network_schema(
     @raises: SchemaValidationError when netplan's parser raises
         NetplanParserExceptions.
     """
-    if network_schema_version(network_config) != 2:
-        return False  # Netplan only validates network version 2 config
-
     try:
         from netplan import NetplanParserException, Parser  # type: ignore
     except ImportError:
@@ -715,11 +712,16 @@ def validate_cloudconfig_schema(
         NETWORK_CONFIG
     """
     if schema_type == SchemaType.NETWORK_CONFIG:
-        if netplan_validate_network_schema(
-            network_config=config, strict=strict, log_details=log_details
-        ):
-            # Schema was validated by netplan
-            return True
+        if network_schema_version(config) == 2:
+            if netplan_validate_network_schema(
+                network_config=config, strict=strict, log_details=log_details
+            ):
+                # Schema was validated by netplan
+                return True
+            # network-config schema version 2 but no netplan.
+            # TODO(add JSON schema definition for network version 2)
+            return False
+
     if schema is None:
         schema = get_schema(schema_type)
     try:

--- a/tests/integration_tests/cmd/test_schema.py
+++ b/tests/integration_tests/cmd/test_schema.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.releases import CURRENT_RELEASE, NOBLE
+from tests.integration_tests.releases import CURRENT_RELEASE, MANTIC
 from tests.integration_tests.util import verify_clean_log
 
 USER_DATA = """\
@@ -81,7 +81,7 @@ class TestSchemaDeprecations:
                 "annotate": NET_V1_ANNOTATED,
             },
         }
-        if CURRENT_RELEASE >= NOBLE:
+        if CURRENT_RELEASE >= MANTIC:
             # Support for netplan API available
             content_responses[NET_CFG_V2] = {
                 "out": "Valid schema /root/net.yaml"

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -2229,15 +2229,13 @@ class TestNetworkSchema:
     net_schema = get_schema(schema_type=SchemaType.NETWORK_CONFIG)
 
     @pytest.mark.parametrize(
-        "src_config, expectation",
+        "src_config, expectation, log",
         (
             pytest.param(
                 {"network": {"config": [], "version": 2}},
-                pytest.raises(
-                    SchemaValidationError,
-                    match=re.escape("network.version: 2 is not one of [1]"),
-                ),
-                id="net_v2_invalid",
+                does_not_raise(),
+                "Skipping netplan schema validation. No netplan available",
+                id="net_v2_skipped",
             ),
             pytest.param(
                 {"network": {"version": 1}},
@@ -2245,11 +2243,13 @@ class TestNetworkSchema:
                     SchemaValidationError,
                     match=re.escape("'config' is a required property"),
                 ),
+                "",
                 id="config_key_required",
             ),
             pytest.param(
                 {"network": {"version": 1, "config": []}},
                 does_not_raise(),
+                "",
                 id="config_key_required",
             ),
             pytest.param(
@@ -2266,6 +2266,7 @@ class TestNetworkSchema:
                         " not valid under any of the given schemas"
                     ),
                 ),
+                "",
                 id="unknown_config_type_item",
             ),
             pytest.param(
@@ -2274,6 +2275,7 @@ class TestNetworkSchema:
                     SchemaValidationError,
                     match=r"network.config.0: 'name' is a required property.*",
                 ),
+                "",
                 id="physical_requires_name_property",
             ),
             pytest.param(
@@ -2284,6 +2286,7 @@ class TestNetworkSchema:
                     }
                 },
                 does_not_raise(),
+                "",
                 id="physical_with_name_succeeds",
             ),
             pytest.param(
@@ -2299,6 +2302,7 @@ class TestNetworkSchema:
                     SchemaValidationError,
                     match=r"Additional properties are not allowed.*",
                 ),
+                "",
                 id="physical_no_additional_properties",
             ),
             pytest.param(
@@ -2309,6 +2313,7 @@ class TestNetworkSchema:
                     }
                 },
                 does_not_raise(),
+                "",
                 id="physical_with_all_known_properties",
             ),
             pytest.param(
@@ -2319,18 +2324,21 @@ class TestNetworkSchema:
                     }
                 },
                 does_not_raise(),
+                "",
                 id="bond_with_all_known_properties",
             ),
         ),
     )
-    def test_network_schema(self, src_config, expectation):
+    def test_network_schema(self, src_config, expectation, log, caplog):
         with expectation:
             validate_cloudconfig_schema(
                 config=src_config,
                 schema=self.net_schema,
-                schema_type="netork-config",
+                schema_type=SchemaType.NETWORK_CONFIG,
                 strict=True,
             )
+        if log:
+            assert log in caplog.text
 
 
 class TestStrictMetaschema:


### PR DESCRIPTION
## Proposed Commit Message
```
    fix(net-schema): no warn when skipping schema check on non-netplan
    
    Avoid warning when network-config schema is version 2 and we
    are on non-netplan systems because cloud-init doesn't yet
    have static JSON network-config schema defined yet for
    version 2.
    
    Also fixes integration test to expect python3 netplan API
    on Ubuntu Mantic and newer.
    
    Fixes GH-4814
```

## Additional Context
<!-- If relevant -->
Also failed our Jenkins test runners
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-lxd_container/139/testReport/junit/tests.integration_tests.cmd.test_schema/TestSchemaDeprecations/test_network_config_schema_validation/

## Test Steps

Validation performed with this PR on a system with no netplan python imports available
Notice: 

1. happy cloud-init status without warnings
2. skipping netplan schema validation debug log
3. schema validation reporting same reason for skipped validation
```
root@nnn:~# grep netplan /var/log/cloud-init.log 
2024-01-29 22:09:53,263 - schema.py[DEBUG]: Skipping netplan schema validation. No netplan available
2024-01-29 22:09:53,265 - distros[DEBUG]: Selected renderer 'netplan' from priority list: ['netplan', 'eni', 'sysconfig']
2024-01-29 22:09:53,265 - network_state.py[DEBUG]: Passthrough netplan v2 config
2024-01-29 22:09:53,265 - netplan.py[DEBUG]: V2 to V2 passthrough
2024-01-29 22:09:53,265 - util.py[DEBUG]: Writing to /etc/netplan/50-cloud-init.yaml - wb: [600] 389 bytes
2024-01-29 22:09:53,265 - netplan.py[DEBUG]: skipping call to `netplan generate`. reason: identical netplan config
root@nnn:~# cloud-init schema --system
Found cloud-config data types: user-data, network-config

1. user-data at /var/lib/cloud/instances/77a8ebd1-cae8-4727-83ff-330bf7c9c5e4/cloud-config.txt:
  Valid schema user-data

2. network-config at /var/lib/cloud/instances/77a8ebd1-cae8-4727-83ff-330bf7c9c5e4/network-config.json:
Skipping network-config schema validation. No network schema for version: 2
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
