### PR TITLE
feat(hotplug): add cmd to enable hotplug

### DIFF
--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -270,7 +270,7 @@ def enable_hotplug(hotplug_init: Init, subsystem) -> bool:
         settings.HOTPLUG_ENABLED_FILE,
         json.dumps(hotplug_enabled_file),
         omode="w",
-        mode="640",
+        mode=0o640,
     )
     install_hotplug(
         datasource, network_hotplug_enabled=True, cfg=hotplug_init.cfg

--- a/cloudinit/config/cc_install_hotplug.py
+++ b/cloudinit/config/cc_install_hotplug.py
@@ -106,8 +106,8 @@ def install_hotplug(
         return
 
     extra_rules = (
-        cloud.datasource.extra_hotplug_udev_rules
-        if cloud.datasource.extra_hotplug_udev_rules is not None
+        datasource.extra_hotplug_udev_rules
+        if datasource.extra_hotplug_udev_rules is not None
         else ""
     )
     if extra_rules:

--- a/cloudinit/config/cc_install_hotplug.py
+++ b/cloudinit/config/cc_install_hotplug.py
@@ -116,6 +116,7 @@ def install_hotplug(
     libexecdir = "/usr/libexec/cloud-init"
     if not os.path.exists(libexecdir):
         libexecdir = "/usr/lib/cloud-init"
+    LOG.info("Installing hotplug.")
     util.write_file(
         filename=HOTPLUG_UDEV_PATH,
         content=HOTPLUG_UDEV_RULES_TEMPLATE.format(

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -15,6 +15,7 @@ CFG_ENV_NAME = "CLOUD_CFG"
 CLOUD_CONFIG = "/etc/cloud/cloud.cfg"
 
 CLEAN_RUNPARTS_DIR = "/etc/cloud/clean.d"
+HOTPLUG_ENABLED_FILE = "/etc/cloud/hotplug.enabled"
 
 RUN_CLOUD_CONFIG = "/run/cloud-init/cloud.cfg"
 

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -15,7 +15,6 @@ CFG_ENV_NAME = "CLOUD_CFG"
 CLOUD_CONFIG = "/etc/cloud/cloud.cfg"
 
 CLEAN_RUNPARTS_DIR = "/etc/cloud/clean.d"
-HOTPLUG_ENABLED_FILE = "/etc/cloud/hotplug.enabled"
 
 RUN_CLOUD_CONFIG = "/run/cloud-init/cloud.cfg"
 
@@ -75,3 +74,5 @@ PER_ONCE = "once"
 
 # Used to sanity check incoming handlers/modules frequencies
 FREQUENCIES = [PER_INSTANCE, PER_ALWAYS, PER_ONCE]
+
+HOTPLUG_ENABLED_FILE = "/var/lib/cloud/hotplug.enabled"

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -40,6 +40,7 @@ from cloudinit.net import cmdline
 from cloudinit.reporting import events
 from cloudinit.settings import (
     CLOUD_CONFIG,
+    HOTPLUG_ENABLED_FILE,
     PER_ALWAYS,
     PER_INSTANCE,
     PER_ONCE,
@@ -58,8 +59,6 @@ COMBINED_CLOUD_CONFIG_DOC = (
     " vendordata and userdata. The combined_cloud_config represents"
     " the aggregated desired configuration acted upon by cloud-init."
 )
-
-HOTPLUG_ENABLED_FILE = "/etc/cloud/hotplug.enabled"
 
 
 def update_event_enabled(
@@ -93,11 +92,24 @@ def update_event_enabled(
             copy.deepcopy(default_events),
         ]
     )
-    if os.path.exists(HOTPLUG_ENABLED_FILE):
-        LOG.debug("%s detected.", HOTPLUG_ENABLED_FILE)
-        if not allowed.get(EventScope.NETWORK):
-            allowed[EventScope.NETWORK] = set()
-        allowed[EventScope.NETWORK].add(EventType.HOTPLUG)
+
+    # Add supplemental hotplug event if supported and present in
+    # settings.HOTPLUG_ENABLED_FILE
+    if EventType.HOTPLUG in datasource.supported_update_events.get(
+        scope, set()
+    ):
+        hotplug_enabled_file = util.read_hotplug_enabled_file()
+        if scope.value in hotplug_enabled_file["scopes"]:
+            LOG.debug(
+                "Adding event: scope=%s EventType=%s found in %s",
+                scope,
+                EventType.HOTPLUG,
+                HOTPLUG_ENABLED_FILE,
+            )
+            if not allowed.get(scope):
+                allowed[scope] = set()
+            allowed[scope].add(EventType.HOTPLUG)
+
     LOG.debug("Allowed events: %s", allowed)
 
     scopes: Iterable[EventScope] = [scope]
@@ -342,7 +354,6 @@ class Init:
             description="attempting to read from cache [%s]" % existing,
             parent=self.reporter,
         ) as myrep:
-
             ds, desc = self._restore_from_checked_cache(existing)
             myrep.description = desc
             self.ds_restored = bool(ds)
@@ -634,7 +645,7 @@ class Init:
             if not path or not os.path.isdir(path):
                 return
             potential_handlers = util.get_modules_from_dir(path)
-            for (fname, mod_name) in potential_handlers.items():
+            for fname, mod_name in potential_handlers.items():
                 try:
                     mod_locs, looked_locs = importer.find_module(
                         mod_name, [""], ["list_types", "handle_part"]
@@ -682,7 +693,7 @@ class Init:
 
         def init_handlers():
             # Init the handlers first
-            for (_ctype, mod) in c_handlers.items():
+            for _ctype, mod in c_handlers.items():
                 if mod in c_handlers.initialized:
                     # Avoid initiating the same module twice (if said module
                     # is registered to more than one content-type).
@@ -709,7 +720,7 @@ class Init:
 
         def finalize_handlers():
             # Give callbacks opportunity to finalize
-            for (_ctype, mod) in c_handlers.items():
+            for _ctype, mod in c_handlers.items():
                 if mod not in c_handlers.initialized:
                     # Said module was never inited in the first place, so lets
                     # not attempt to finalize those that never got called.

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -59,6 +59,8 @@ COMBINED_CLOUD_CONFIG_DOC = (
     " the aggregated desired configuration acted upon by cloud-init."
 )
 
+HOTPLUG_ENABLED_FILE = "/etc/cloud/hotplug.enabled"
+
 
 def update_event_enabled(
     datasource: sources.DataSource,
@@ -91,6 +93,11 @@ def update_event_enabled(
             copy.deepcopy(default_events),
         ]
     )
+    if os.path.exists(HOTPLUG_ENABLED_FILE):
+        LOG.debug("%s detected.", HOTPLUG_ENABLED_FILE)
+        if not allowed.get(EventScope.NETWORK):
+            allowed[EventScope.NETWORK] = set()
+        allowed[EventScope.NETWORK].add(EventType.HOTPLUG)
     LOG.debug("Allowed events: %s", allowed)
 
     scopes: Iterable[EventScope] = [scope]

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -99,7 +99,7 @@ def update_event_enabled(
         scope, set()
     ):
         hotplug_enabled_file = util.read_hotplug_enabled_file()
-        if scope.value in hotplug_enabled_file.get("scopes", []):
+        if scope.value in hotplug_enabled_file["scopes"]:
             LOG.debug(
                 "Adding event: scope=%s EventType=%s found in %s",
                 scope,

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -99,7 +99,7 @@ def update_event_enabled(
         scope, set()
     ):
         hotplug_enabled_file = util.read_hotplug_enabled_file()
-        if scope.value in hotplug_enabled_file["scopes"]:
+        if scope.value in hotplug_enabled_file.get("scopes", []):
             LOG.debug(
                 "Adding event: scope=%s EventType=%s found in %s",
                 scope,

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3294,8 +3294,10 @@ def read_hotplug_enabled_file() -> dict:
     content: dict = {"scopes": []}
     try:
         content = json.loads(
-            load_text_file(settings.HOTPLUG_ENABLED_FILE, quiet=True)
+            load_text_file(settings.HOTPLUG_ENABLED_FILE, quiet=False)
         )
+    except FileNotFoundError:
+        pass
     except json.JSONDecodeError as e:
         LOG.warning(
             "Ignoring contents of %s because it is not decodable. Error: %s",

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -59,6 +59,7 @@ from cloudinit import (
     mergers,
     net,
     safeyaml,
+    settings,
     subp,
     temp_utils,
     type_utils,
@@ -3287,3 +3288,22 @@ def deprecate_call(
         return decorator
 
     return wrapper
+
+
+def read_hotplug_enabled_file() -> dict:
+    content: dict = {"scopes": []}
+    try:
+        with open(settings.HOTPLUG_ENABLED_FILE, "r") as f:
+            content = json.load(f)
+    except FileNotFoundError:
+        pass
+    except json.JSONDecodeError as e:
+        LOG.warning(
+            "Ignoring contents of %s because it is not decodable. Error: %s",
+            settings.HOTPLUG_ENABLED_FILE,
+            e,
+        )
+    else:
+        if "scopes" not in content:
+            content["scopes"] = []
+    return content

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3297,7 +3297,7 @@ def read_hotplug_enabled_file() -> dict:
             load_text_file(settings.HOTPLUG_ENABLED_FILE, quiet=False)
         )
     except FileNotFoundError:
-        pass
+        LOG.debug("File not found: %s", settings.HOTPLUG_ENABLED_FILE)
     except json.JSONDecodeError as e:
         LOG.warning(
             "Ignoring contents of %s because it is not decodable. Error: %s",

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3293,10 +3293,9 @@ def deprecate_call(
 def read_hotplug_enabled_file() -> dict:
     content: dict = {"scopes": []}
     try:
-        with open(settings.HOTPLUG_ENABLED_FILE, "r") as f:
-            content = json.load(f)
-    except FileNotFoundError:
-        pass
+        content = json.loads(
+            load_text_file(settings.HOTPLUG_ENABLED_FILE, quiet=True)
+        )
     except json.JSONDecodeError as e:
         LOG.warning(
             "Ignoring contents of %s because it is not decodable. Error: %s",

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -160,10 +160,29 @@ content with any :file:`instance-data.json` variables present.
 :command:`hotplug-hook`
 -----------------------
 
-Respond to newly added system devices by retrieving updated system metadata
-and bringing up/down the corresponding device. This command is intended to be
+Hotplug related subcommands. This command is intended to be
 called via a ``systemd`` service and is not considered user-accessible except
 for debugging purposes.
+
+
+:command:`query`
+^^^^^^^^^^^^^^^^
+
+Query if hotplug is enabled for a given subsystem.
+
+:command:`handle`
+^^^^^^^^^^^^^^^^^
+
+Respond to newly added system devices by retrieving updated system metadata
+and bringing up/down the corresponding device.
+
+:command:`enable`
+^^^^^^^^^^^^^^^^^
+
+Enable hotplug for a given subsystem. This is a last resort command for
+administrators to enable hotplug in running instances. The recommended
+method is configuring :ref:`events`, if not enabled by default in the active
+datasource.
 
 .. _cli_features:
 

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -23,6 +23,13 @@ updates:
     when: ['hotplug']
 """
 
+USER_DATA_HOTPLUG_DISABLED = """\
+#cloud-config
+updates:
+  network:
+    when: ['boot-new-instance']
+"""
+
 ip_addr = namedtuple("ip_addr", "interface state ip4 ip6")
 
 
@@ -138,10 +145,11 @@ def _test_hotplug_enabled_by_cmd(client: IntegrationInstance):
         "{hotplug_action: query" in log
     )
     assert client.execute(
-        "test -f /etc/udev/rules.d/10-cloud-init-hook-hotplug.rules"
+        "test -f /etc/udev/rules.d/90-cloud-init-hook-hotplug.rules"
     ).ok
 
 
+@pytest.mark.user_data(USER_DATA_HOTPLUG_DISABLED)
 def test_hotplug_enable_cmd(client: IntegrationInstance):
     _test_hotplug_enabled_by_cmd(client)
 
@@ -153,6 +161,7 @@ def test_hotplug_enable_cmd(client: IntegrationInstance):
         "other platforms."
     ),
 )
+@pytest.mark.user_data(USER_DATA_HOTPLUG_DISABLED)
 def test_hotplug_enable_cmd_ec2(client: IntegrationInstance):
     _test_hotplug_enabled_by_cmd(client)
     ips_before = _get_ip_addr(client)

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -114,6 +114,63 @@ def test_hotplug_add_remove(client: IntegrationInstance):
 
 
 @pytest.mark.skipif(
+    PLATFORM != "ec2",
+    reason=(
+        f"Test was written for {PLATFORM} but can likely run on "
+        "other platforms."
+    ),
+)
+def test_hotplug_enable_cmd(client: IntegrationInstance):
+    ret = client.execute("cloud-init devel hotplug-hook -s net enable")
+    assert ret.ok, ret.stderr
+    log = client.read_from_file("/var/log/cloud-init.log")
+    assert (
+        "hotplug-hook called with the following arguments: "
+        "{hotplug_action: enable" in log
+    )
+
+    assert "enabled" == client.execute(
+        "cloud-init devel hotplug-hook -s net query"
+    )
+    log = client.read_from_file("/var/log/cloud-init.log")
+    assert (
+        "hotplug-hook called with the following arguments: "
+        "{hotplug_action: query" in log
+    )
+
+    ips_before = _get_ip_addr(client)
+    assert client.execute(
+        "test -f /etc/udev/rules.d/10-cloud-init-hook-hotplug.rules"
+    ).ok
+
+    # Add new NIC
+    added_ip = client.instance.add_network_interface()
+    _wait_till_hotplug_complete(client, expected_runs=3)
+    ips_after_add = _get_ip_addr(client)
+    new_addition = [ip for ip in ips_after_add if ip.ip4 == added_ip][0]
+
+    assert len(ips_after_add) == len(ips_before) + 1
+    assert added_ip not in [ip.ip4 for ip in ips_before]
+    assert added_ip in [ip.ip4 for ip in ips_after_add]
+    assert new_addition.state == "UP"
+
+    netplan_cfg = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
+    config = yaml.safe_load(netplan_cfg)
+    assert new_addition.interface in config["network"]["ethernets"]
+
+    # Remove new NIC
+    client.instance.remove_network_interface(added_ip)
+    _wait_till_hotplug_complete(client, expected_runs=4)
+    ips_after_remove = _get_ip_addr(client)
+    assert len(ips_after_remove) == len(ips_before)
+    assert added_ip not in [ip.ip4 for ip in ips_after_remove]
+
+    netplan_cfg = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
+    config = yaml.safe_load(netplan_cfg)
+    assert new_addition.interface not in config["network"]["ethernets"]
+
+
+@pytest.mark.skipif(
     PLATFORM != "openstack",
     reason=(
         f"Test was written for {PLATFORM} but can likely run on "

--- a/tests/unittests/cmd/devel/test_hotplug_hook.py
+++ b/tests/unittests/cmd/devel/test_hotplug_hook.py
@@ -279,7 +279,7 @@ class TestEnableHotplug:
                 settings.HOTPLUG_ENABLED_FILE,
                 '{"scopes": ["network"]}',
                 omode="w",
-                mode="640",
+                mode=0o640,
             )
         ] == m_write_file.call_args_list
         assert [

--- a/tests/unittests/cmd/devel/test_hotplug_hook.py
+++ b/tests/unittests/cmd/devel/test_hotplug_hook.py
@@ -4,13 +4,16 @@ from unittest.mock import call
 
 import pytest
 
-from cloudinit.cmd.devel.hotplug_hook import handle_hotplug
+from cloudinit import settings
+from cloudinit.cmd.devel.hotplug_hook import enable_hotplug, handle_hotplug
 from cloudinit.distros import Distro
-from cloudinit.event import EventType
+from cloudinit.event import EventScope, EventType
 from cloudinit.net.activators import NetworkActivator
 from cloudinit.net.network_state import NetworkState
 from cloudinit.sources import DataSource
 from cloudinit.stages import Init
+
+M_PATH = "cloudinit.cmd.devel.hotplug_hook."
 
 hotplug_args = namedtuple("hotplug_args", "udevaction, subsystem, devpath")
 FAKE_MAC = "11:22:33:44:55:66"
@@ -244,3 +247,99 @@ class TestHotplug:
             call(10),
             call(30),
         ]
+
+
+@pytest.mark.usefixtures("fake_filesystem")
+class TestEnableHotplug:
+    @mock.patch(M_PATH + "util.write_file")
+    @mock.patch(
+        M_PATH + "util.read_hotplug_enabled_file",
+        return_value={"scopes": []},
+    )
+    @mock.patch(M_PATH + "install_hotplug")
+    def test_enabling(
+        self,
+        m_install_hotplug,
+        m_read_hotplug_enabled_file,
+        m_write_file,
+        mocks,
+    ):
+        mocks.m_init.datasource.get_supported_events.return_value = {
+            EventScope.NETWORK: {EventType.HOTPLUG}
+        }
+
+        enable_hotplug(mocks.m_init, "net")
+
+        assert [
+            call([EventType.HOTPLUG])
+        ] == mocks.m_init.datasource.get_supported_events.call_args_list
+        assert [call()] == m_read_hotplug_enabled_file.call_args_list
+        assert [
+            call(
+                settings.HOTPLUG_ENABLED_FILE,
+                '{"scopes": ["network"]}',
+                omode="w",
+                mode="640",
+            )
+        ] == m_write_file.call_args_list
+        assert [
+            call(
+                mocks.m_init.datasource,
+                network_hotplug_enabled=True,
+                cfg=mocks.m_init.cfg,
+            )
+        ] == m_install_hotplug.call_args_list
+
+    @pytest.mark.parametrize(
+        ["supported_events"], [({},), ({EventScope.NETWORK: {}},)]
+    )
+    @mock.patch(M_PATH + "util.write_file")
+    @mock.patch(
+        M_PATH + "util.read_hotplug_enabled_file",
+        return_value={"scopes": []},
+    )
+    @mock.patch(M_PATH + "install_hotplug")
+    def test_hotplug_not_supported_in_ds(
+        self,
+        m_install_hotplug,
+        m_read_hotplug_enabled_file,
+        m_write_file,
+        supported_events,
+        mocks,
+    ):
+        mocks.m_init.datasource.get_supported_events.return_value = (
+            supported_events
+        )
+        enable_hotplug(mocks.m_init, "net")
+
+        assert [
+            call([EventType.HOTPLUG])
+        ] == mocks.m_init.datasource.get_supported_events.call_args_list
+        assert [] == m_read_hotplug_enabled_file.call_args_list
+        assert [] == m_write_file.call_args_list
+        assert [] == m_install_hotplug.call_args_list
+
+    @mock.patch(M_PATH + "util.write_file")
+    @mock.patch(
+        M_PATH + "util.read_hotplug_enabled_file",
+        return_value={"scopes": [EventScope.NETWORK.value]},
+    )
+    @mock.patch(M_PATH + "install_hotplug")
+    def test_hotplug_already_enabled_in_file(
+        self,
+        m_install_hotplug,
+        m_read_hotplug_enabled_file,
+        m_write_file,
+        mocks,
+    ):
+        mocks.m_init.datasource.get_supported_events.return_value = {
+            EventScope.NETWORK: {EventType.HOTPLUG}
+        }
+        enable_hotplug(mocks.m_init, "net")
+
+        assert [
+            call([EventType.HOTPLUG])
+        ] == mocks.m_init.datasource.get_supported_events.call_args_list
+        assert [call()] == m_read_hotplug_enabled_file.call_args_list
+        assert [] == m_write_file.call_args_list
+        assert [] == m_install_hotplug.call_args_list

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -9,12 +9,46 @@ import pytest
 
 from cloudinit import sources, stages
 from cloudinit.event import EventScope, EventType
-from cloudinit.sources import NetworkConfigSource
+from cloudinit.sources import DataSource, NetworkConfigSource
 from cloudinit.util import sym_link, write_file
 from tests.unittests.helpers import mock
 from tests.unittests.util import TEST_INSTANCE_ID, FakeDataSource
 
 M_PATH = "cloudinit.stages."
+
+
+class TestUpdateEventEnabled:
+    @pytest.mark.parametrize(
+        "cfg",
+        [
+            {},
+            {"updates": {}},
+            {"updates": {"when": ["boot"]}},
+            {"updates": {"when": ["hotplug"]}},
+            {"updates": {"when": ["boot", "hotplug"]}},
+        ],
+    )
+    @pytest.mark.parametrize(
+        ["enabled_file_content", "enabled"],
+        [
+            ({"scopes": ["network"]}, True),
+            ({"scopes": []}, False),
+        ],
+    )
+    @mock.patch(M_PATH + "util.read_hotplug_enabled_file")
+    def test_hotplug_added_by_file(
+        self, m_read_hotplug_enabled_file, cfg, enabled_file_content, enabled
+    ):
+        m_datasource = mock.MagicMock(spec=DataSource)
+        m_datasource.default_update_events = {}
+        m_datasource.supported_update_events = {
+            EventScope.NETWORK: [EventType.HOTPLUG]
+        }
+        m_read_hotplug_enabled_file.return_value = enabled_file_content
+        cfg = {}
+        assert enabled is stages.update_event_enabled(
+            m_datasource, cfg, EventType.HOTPLUG, EventScope.NETWORK
+        )
 
 
 class TestInit:

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -3224,3 +3224,31 @@ class TestMaybeB64Decode:
     )
     def test_happy_path(self, in_data, expected):
         assert expected == util.maybe_b64decode(in_data)
+
+
+@pytest.mark.usefixtures("fake_filesystem")
+class TestReadHotplugEnabledFile:
+    def test_file_not_found(self):
+        assert {"scopes": []} == util.read_hotplug_enabled_file()
+
+    def test_json_decode_error(self, caplog, tmpdir):
+        target_file = (
+            tmpdir.mkdir("var")
+            .mkdir("lib")
+            .mkdir("cloud")
+            .join("hotplug.enabled")
+        )
+        target_file.write("asdfasdfa")
+        assert {"scopes": []} == util.read_hotplug_enabled_file()
+        assert "not decodable" in caplog.text
+
+    @pytest.mark.parametrize("content", ['{"scopes": ["network"]}'])
+    def test_file_present(self, content, caplog, tmpdir):
+        target_file = (
+            tmpdir.mkdir("var")
+            .mkdir("lib")
+            .mkdir("cloud")
+            .join("hotplug.enabled")
+        )
+        target_file.write(content)
+        assert {"scopes": ["network"]} == util.read_hotplug_enabled_file()

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -3228,8 +3228,9 @@ class TestMaybeB64Decode:
 
 @pytest.mark.usefixtures("fake_filesystem")
 class TestReadHotplugEnabledFile:
-    def test_file_not_found(self):
+    def test_file_not_found(self, caplog):
         assert {"scopes": []} == util.read_hotplug_enabled_file()
+        assert "enabled because it is not decodable" not in caplog.text
 
     def test_json_decode_error(self, caplog, tmpdir):
         target_file = (


### PR DESCRIPTION
<!-- Include a proposed commit message because PRs are squash merged
by default.
## Proposed Commit Message
See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(hotplug): add cmd to enable hotplug
    
Add command to enable network config updates on hotplug events on
already booted instances:
    
cloud-init devel hotplug-hook -s net enable
    
The command creates a sentinel file in
/var/lib/cloud/hotplug.enabled containing the subsystems for 
which is enabled, which will override the allowed events, and
install the appropriate udev rules.
```

## Additional Context
<!-- If relevant -->
https://warthogs.atlassian.net/browse/SC-1664
This PR is going to have conflicts with https://github.com/canonical/cloud-init/pull/4799

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
CLOUD_INIT_PLATFORM=lxd_vm tox -e integration-tests -- tests/integration_tests/modules/test_hotplug.py::test_hotplug_enable_cmd
CLOUD_INIT_PLATFORM=ec2 tox -e integration-tests -- tests/integration_tests/modules/test_hotplug.py::test_hotplug_enable_cmd_ec2
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)