### PR TITLE
Split `load_file` based on return type

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -488,7 +488,7 @@ def main_init(name, args):
     cloud_cfg_path = init.paths.get_ipath_cur("cloud_config")
     if os.path.exists(cloud_cfg_path) and os.stat(cloud_cfg_path).st_size != 0:
         validate_cloudconfig_schema(
-            config=load(util.load_file(cloud_cfg_path)),
+            config=load(util.load_text_file(cloud_cfg_path)),
             strict=False,
             log_details=False,
             log_deprecations=True,
@@ -746,7 +746,7 @@ def status_wrapper(name, args, data_d=None, link_d=None):
             util.del_file(f)
     else:
         try:
-            status = json.loads(util.load_file(status_path))
+            status = json.loads(util.load_text_file(status_path))
         except Exception:
             pass
 

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -131,7 +131,7 @@ def load_userdata(ud_file_path):
 
     @returns: String of uncompressed userdata if possible, otherwise bytes.
     """
-    bdata = util.load_file(ud_file_path, decode=False)
+    bdata = util.load_binary_file(ud_file_path)
     try:
         return bdata.decode("utf-8")
     except UnicodeDecodeError:

--- a/cloudinit/cmd/query.py
+++ b/cloudinit/cmd/query.py
@@ -180,7 +180,7 @@ def _read_instance_data(instance_data, user_data, vendor_data) -> dict:
     combined_cloud_config_fn = paths.get_runpath("combined_cloud_config")
 
     try:
-        instance_json = util.load_file(instance_data_fn)
+        instance_json = util.load_text_file(instance_data_fn)
     except (IOError, OSError) as e:
         if e.errno == EACCES:
             LOG.error("No read permission on '%s'. Try sudo", instance_data_fn)
@@ -191,7 +191,7 @@ def _read_instance_data(instance_data, user_data, vendor_data) -> dict:
     instance_data = util.load_json(instance_json)
     try:
         combined_cloud_config = util.load_json(
-            util.load_file(combined_cloud_config_fn)
+            util.load_text_file(combined_cloud_config_fn)
         )
     except (IOError, OSError):
         # File will not yet be present in init-local stage.

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -19,7 +19,7 @@ from cloudinit import safeyaml, subp
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.distros import uses_systemd
 from cloudinit.helpers import Paths
-from cloudinit.util import get_cmdline, load_file, load_json
+from cloudinit.util import get_cmdline, load_json, load_text_file
 
 CLOUDINIT_DISABLED_FILE = "/etc/cloud/cloud-init.disabled"
 
@@ -387,7 +387,7 @@ def get_status_details(
     if os.path.exists(status_file):
         if not os.path.exists(result_file):
             status = UXAppStatus.RUNNING
-        status_v1 = load_json(load_file(status_file)).get("v1", {})
+        status_v1 = load_json(load_text_file(status_file)).get("v1", {})
     latest_event = 0
     recoverable_errors = {}
     for key, value in sorted(status_v1.items()):

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -659,7 +659,7 @@ def generate_sources_list(cfg, release, mirrors, cloud):
         if not template_fn:
             LOG.warning("No template found, not rendering %s", aptsrc_file)
             return
-        tmpl = util.load_file(template_fn)
+        tmpl = util.load_text_file(template_fn)
 
     rendered = templater.render_string(tmpl, params)
     if tmpl:

--- a/cloudinit/config/cc_ca_certs.py
+++ b/cloudinit/config/cc_ca_certs.py
@@ -205,7 +205,7 @@ def disable_system_ca_certs(distro_cfg):
     added_header = False
 
     if os.stat(ca_cert_cfg_fn).st_size:
-        orig = util.load_file(ca_cert_cfg_fn)
+        orig = util.load_text_file(ca_cert_cfg_fn)
         out_lines = []
         for line in orig.splitlines():
             if line == header_comment:

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -320,14 +320,14 @@ def device_part_info(devpath):
     if not os.path.exists(ptpath):
         raise TypeError("%s not a partition" % devpath)
 
-    ptnum = util.load_file(ptpath).rstrip()
+    ptnum = util.load_text_file(ptpath).rstrip()
 
     # for a partition, real syspath is something like:
     # /sys/devices/pci0000:00/0000:00:04.0/virtio1/block/vda/vda1
     rsyspath = os.path.realpath(syspath)
     disksyspath = os.path.dirname(rsyspath)
 
-    diskmajmin = util.load_file(os.path.join(disksyspath, "dev")).rstrip()
+    diskmajmin = util.load_text_file(os.path.join(disksyspath, "dev")).rstrip()
     diskdevpath = os.path.realpath("/dev/block/%s" % diskmajmin)
 
     # diskdevpath has something like 253:0

--- a/cloudinit/config/cc_mcollective.py
+++ b/cloudinit/config/cc_mcollective.py
@@ -98,7 +98,7 @@ def configure(
     # Read server.cfg (if it exists) values from the
     # original file in order to be able to mix the rest up.
     try:
-        old_contents = util.load_file(server_cfg, quiet=False, decode=False)
+        old_contents = util.load_binary_file(server_cfg, quiet=False)
         mcollective_config = ConfigObj(io.BytesIO(old_contents))
     except IOError as e:
         if e.errno != errno.ENOENT:

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -397,7 +397,7 @@ def handle_swapcfg(swapcfg):
             )
             return fname
         try:
-            for line in util.load_file("/proc/swaps").splitlines():
+            for line in util.load_text_file("/proc/swaps").splitlines():
                 if line.startswith(fname + " "):
                     LOG.debug("swap file %s already in use", fname)
                     return fname
@@ -450,7 +450,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     fstab_removed = []
 
     if os.path.exists(FSTAB_PATH):
-        for line in util.load_file(FSTAB_PATH).splitlines():
+        for line in util.load_text_file(FSTAB_PATH).splitlines():
             if MNT_COMMENT in line:
                 fstab_removed.append(line)
                 continue

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -573,14 +573,14 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     needswap = False
     need_mount_all = False
     dirs = []
-    for line in actlist:
+    for entry in actlist:
         # write 'comment' in the fs_mntops, entry,  claiming this
-        line[3] = "%s,%s" % (line[3], MNT_COMMENT)
-        if line[2] == "swap":
+        entry[3] = "%s,%s" % (entry[3], MNT_COMMENT)
+        if entry[2] == "swap":
             needswap = True
-        if line[1].startswith("/"):
-            dirs.append(line[1])
-        cc_lines.append("\t".join(line))
+        if entry[1].startswith("/"):
+            dirs.append(entry[1])
+        cc_lines.append("\t".join(entry))
 
     mount_points = [
         v["mountpoint"] for k, v in util.mounts().items() if "mountpoint" in v

--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -156,7 +156,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     for (n, path) in pubkeys.items():
         try:
-            all_keys[n] = util.load_file(path)
+            all_keys[n] = util.load_text_file(path)
         except Exception:
             util.logexc(
                 LOG, "%s: failed to open, can not phone home that data!", path

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -95,7 +95,7 @@ def givecmdline(pid):
             m = re.search(r"\d+ (\w|\.|-)+\s+(/\w.+)", line)
             return m.group(2)
         else:
-            return util.load_file("/proc/%s/cmdline" % pid)
+            return util.load_text_file("/proc/%s/cmdline" % pid)
     except IOError:
         return None
 

--- a/cloudinit/config/cc_puppet.py
+++ b/cloudinit/config/cc_puppet.py
@@ -287,7 +287,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # ... and then update the puppet configuration
     if "conf" in puppet_cfg:
         # Add all sections from the conf object to puppet.conf
-        contents = util.load_file(p_constants.conf_path)
+        contents = util.load_text_file(p_constants.conf_path)
         # Create object for reading puppet.conf values
         puppet_config = helpers.DefaultingConfigParser()
         # Read puppet.conf values from original file in order to be able to

--- a/cloudinit/config/cc_reset_rmc.py
+++ b/cloudinit/config/cc_reset_rmc.py
@@ -98,7 +98,7 @@ def reconfigure_rsct_subsystems():
 
 def get_node_id():
     try:
-        fp = util.load_file(NODE_ID_FILE)
+        fp = util.load_text_file(NODE_ID_FILE)
         node_id = fp.split("\n")[0]
         return node_id
     except Exception:

--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -114,7 +114,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     prev_fn = os.path.join(cloud.get_cpath("data"), "set-hostname")
     prev_hostname = {}
     if os.path.exists(prev_fn) and os.stat(prev_fn).st_size > 0:
-        prev_hostname = util.load_json(util.load_file(prev_fn))
+        prev_hostname = util.load_json(util.load_text_file(prev_fn))
     hostname_changed = hostname != prev_hostname.get(
         "hostname"
     ) or fqdn != prev_hostname.get("fqdn")

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -393,7 +393,7 @@ def get_public_host_keys(blacklist: Optional[Sequence[str]] = None):
     # Read host key files, retrieve first two fields as a tuple and
     # append that tuple to key_list.
     for file_name in file_list:
-        file_contents = util.load_file(file_name)
+        file_contents = util.load_text_file(file_name)
         key_data = file_contents.split()
         if key_data and len(key_data) > 1:
             key_list.append(tuple(key_data[:2]))

--- a/cloudinit/config/cc_zypper_add_repo.py
+++ b/cloudinit/config/cc_zypper_add_repo.py
@@ -172,7 +172,7 @@ def _write_zypp_config(zypper_config):
     if not zypper_config:
         return
     zypp_config = "/etc/zypp/zypp.conf"
-    zypp_conf_content = util.load_file(zypp_config)
+    zypp_conf_content = util.load_text_file(zypp_config)
     new_settings = ["# Added via cloud.cfg"]
     for setting, value in zypper_config.items():
         if setting == "configdir":

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -36,7 +36,12 @@ from cloudinit.handlers import INCLUSION_TYPES_MAP, type_from_starts_with
 from cloudinit.helpers import Paths
 from cloudinit.sources import DataSourceNotFoundException
 from cloudinit.temp_utils import mkdtemp
-from cloudinit.util import error, get_modules_from_dir, load_file, write_file
+from cloudinit.util import (
+    error,
+    get_modules_from_dir,
+    load_text_file,
+    write_file,
+)
 
 try:
     from jsonschema import ValidationError as _ValidationError
@@ -1051,7 +1056,7 @@ def validate_cloudconfig_file(
     :raises SchemaValidationError containing any of schema_errors encountered.
     :raises RuntimeError when config_path does not exist.
     """
-    decoded_content = load_file(config_path, decode=True)
+    decoded_content = load_text_file(config_path)
     if not decoded_content:
         print(
             "Empty '%s' found at %s. Nothing to validate."
@@ -1560,7 +1565,7 @@ def get_schema(schema_type: SchemaType = SchemaType.CLOUD_CONFIG) -> dict:
     )
     full_schema = None
     try:
-        full_schema = json.loads(load_file(schema_file))
+        full_schema = json.loads(load_text_file(schema_file))
     except (IOError, OSError):
         LOG.warning(
             "Skipping %s schema valiation. No JSON schema file found %s.",

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -582,7 +582,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def update_etc_hosts(self, hostname, fqdn):
         header = ""
         if os.path.exists(self.hosts_fn):
-            eh = hosts.HostsConf(util.load_file(self.hosts_fn))
+            eh = hosts.HostsConf(util.load_text_file(self.hosts_fn))
         else:
             eh = hosts.HostsConf("")
             header = util.make_header(base="added")
@@ -988,7 +988,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 util.logexc(LOG, "Failed to write doas file %s", doas_file)
                 raise e
         else:
-            if content not in util.load_file(doas_file):
+            if content not in util.load_text_file(doas_file):
                 try:
                     util.append_file(doas_file, content)
                 except IOError as e:
@@ -1003,7 +1003,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         sudoers_contents = ""
         base_exists = False
         if os.path.exists(sudo_base):
-            sudoers_contents = util.load_file(sudo_base)
+            sudoers_contents = util.load_text_file(sudo_base)
             base_exists = True
         found_include = False
         for line in sudoers_contents.splitlines():
@@ -1078,7 +1078,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 util.logexc(LOG, "Failed to write sudoers file %s", sudo_file)
                 raise e
         else:
-            if content not in util.load_file(sudo_file):
+            if content not in util.load_text_file(sudo_file):
                 try:
                     util.append_file(sudo_file, content)
                 except IOError as e:
@@ -1290,7 +1290,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         param field: field number within /proc/$pid/stat to return
         """
         try:
-            content: str = util.load_file(
+            content: str = util.load_text_file(
                 "/proc/%s/stat" % pid, quiet=True
             ).strip()  # pyright: ignore
             match = re.search(

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -104,7 +104,7 @@ class Distro(distros.Distro):
         return (self.hostname_conf_fn, sys_hostname)
 
     def _read_hostname_conf(self, filename):
-        conf = HostnameConf(util.load_file(filename))
+        conf = HostnameConf(util.load_text_file(filename))
         conf.parse()
         return conf
 

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -85,7 +85,7 @@ class Distro(distros.Distro):
         return (self.hostname_conf_fn, sys_hostname)
 
     def _read_hostname_conf(self, filename):
-        conf = HostnameConf(util.load_file(filename))
+        conf = HostnameConf(util.load_text_file(filename))
         conf.parse()
         return conf
 

--- a/cloudinit/distros/bsd_utils.py
+++ b/cloudinit/distros/bsd_utils.py
@@ -20,7 +20,7 @@ def _unquote(value):
 
 def get_rc_config_value(key, fn="/etc/rc.conf"):
     key_prefix = "{}=".format(key)
-    for line in util.load_file(fn).splitlines():
+    for line in util.load_text_file(fn).splitlines():
         if line.startswith(key_prefix):
             value = line.replace(key_prefix, "")
             return _unquote(value)
@@ -30,7 +30,7 @@ def set_rc_config_value(key, value, fn="/etc/rc.conf"):
     lines = []
     done = False
     value = shlex.quote(value)
-    original_content = util.load_file(fn)
+    original_content = util.load_text_file(fn)
     for line in original_content.splitlines():
         if "=" in line:
             k, v = line.split("=", 1)

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -155,7 +155,7 @@ class Distro(distros.Distro):
         return (self.hostname_conf_fn, sys_hostname)
 
     def _read_hostname_conf(self, filename):
-        conf = HostnameConf(util.load_file(filename))
+        conf = HostnameConf(util.load_text_file(filename))
         conf.parse()
         return conf
 
@@ -238,7 +238,7 @@ def _maybe_remove_legacy_eth0(path="/etc/network/interfaces.d/eth0.cfg"):
 
     bmsg = "Dynamic networking config may not apply."
     try:
-        contents = util.load_file(path)
+        contents = util.load_text_file(path)
         known_contents = ["auto eth0", "iface eth0 inet dhcp"]
         lines = [
             f.strip() for f in contents.splitlines() if not f.startswith("#")
@@ -261,7 +261,7 @@ def read_system_locale(sys_path=LOCALE_CONF_FN, keyname="LANG"):
         raise ValueError("Invalid path: %s" % sys_path)
 
     if os.path.exists(sys_path):
-        locale_content = util.load_file(sys_path)
+        locale_content = util.load_text_file(sys_path)
         sys_defaults = util.load_shell_content(locale_content)
         sys_val = sys_defaults.get(keyname, "")
 

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -177,7 +177,7 @@ class Distro(cloudinit.distros.bsd.BSD):
     def apply_locale(self, locale, out_fn=None):
         # Adjust the locales value to the new value
         newconf = StringIO()
-        for line in util.load_file(self.login_conf_fn).splitlines():
+        for line in util.load_text_file(self.login_conf_fn).splitlines():
             newconf.write(
                 re.sub(r"^default:", r"default:lang=%s:" % locale, line)
             )

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -89,7 +89,7 @@ class Distro(distros.Distro):
 
     @staticmethod
     def _read_hostname_conf(filename):
-        conf = HostnameConf(util.load_file(filename))
+        conf = HostnameConf(util.load_text_file(filename))
         conf.parse()
         return conf
 

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -15,7 +15,7 @@ class Distro(cloudinit.distros.netbsd.NetBSD):
     init_cmd = ["rcctl"]
 
     def _read_hostname(self, filename, default=None):
-        return util.load_file(self.hostname_conf_fn)
+        return util.load_text_file(self.hostname_conf_fn)
 
     def _write_hostname(self, hostname, filename):
         content = hostname + "\n"

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -160,7 +160,7 @@ class Distro(distros.Distro):
 
     def _read_hostname(self, filename, default=None):
         if self.uses_systemd() and filename.endswith("/previous-hostname"):
-            return util.load_file(filename).strip()
+            return util.load_text_file(filename).strip()
         elif self.uses_systemd():
             (out, _err) = subp.subp(["hostname"])
             if len(out):
@@ -181,7 +181,7 @@ class Distro(distros.Distro):
         return "127.0.1.1"
 
     def _read_hostname_conf(self, filename):
-        conf = HostnameConf(util.load_file(filename))
+        conf = HostnameConf(util.load_text_file(filename))
         conf.parse()
         return conf
 
@@ -200,7 +200,7 @@ class Distro(distros.Distro):
             if result:
                 (devpth, fs_type, mount_point) = result
                 # Check if the file system is read only
-                mounts = util.load_file("/proc/mounts").split("\n")
+                mounts = util.load_text_file("/proc/mounts").split("\n")
                 for mount in mounts:
                     if mount.startswith(devpth):
                         mount_info = mount.split()

--- a/cloudinit/distros/photon.py
+++ b/cloudinit/distros/photon.py
@@ -126,7 +126,7 @@ class Distro(distros.Distro):
 
     def _read_hostname(self, filename, default=None):
         if filename and filename.endswith("/previous-hostname"):
-            return util.load_file(filename).strip()
+            return util.load_text_file(filename).strip()
 
         _ret, out, _err = self.exec_cmd(["hostname", "-f"])
         return out.strip() if out else default

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -145,7 +145,7 @@ class Distro(distros.Distro):
 
     def _read_hostname(self, filename, default=None):
         if self.uses_systemd() and filename.endswith("/previous-hostname"):
-            return util.load_file(filename).strip()
+            return util.load_text_file(filename).strip()
         elif self.uses_systemd():
             (out, _err) = subp.subp(["hostname"])
             out = out.strip()

--- a/cloudinit/distros/rhel_util.py
+++ b/cloudinit/distros/rhel_util.py
@@ -43,7 +43,7 @@ def update_sysconfig_file(fn, adjustments, allow_empty=False):
 def read_sysconfig_file(fn):
     exists = False
     try:
-        contents = util.load_file(fn).splitlines()
+        contents = util.load_text_file(fn).splitlines()
         exists = True
     except IOError:
         contents = []

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -17,7 +17,7 @@ from cloudinit.templater import (
     detect_template,
     render_string,
 )
-from cloudinit.util import load_file, load_json
+from cloudinit.util import load_json, load_text_file
 
 JUndefinedError: Type[Exception]
 try:
@@ -116,7 +116,7 @@ def render_jinja_payload_from_file(
             " present at %s" % instance_data_file
         )
     try:
-        instance_data = load_json(load_file(instance_data_file))
+        instance_data = load_json(load_text_file(instance_data_file))
     except Exception as e:
         msg = "Loading Jinja instance data failed"
         if isinstance(e, (IOError, OSError)):

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -73,7 +73,7 @@ def read_sys_net(
 ):
     dev_path = sys_dev_path(devname, path)
     try:
-        contents = util.load_file(dev_path)
+        contents = util.load_text_file(dev_path)
     except (OSError, IOError) as e:
         e_errno = getattr(e, "errno", None)
         if e_errno in (errno.ENOENT, errno.ENOTDIR):

--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -166,7 +166,7 @@ class BSDRenderer(renderer.Renderer):
         # fails.
         try:
             resolvconf = ResolvConf(
-                util.load_file(
+                util.load_text_file(
                     subp.target_path(self.target, self.resolv_conf_fn)
                 )
             )

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -196,7 +196,7 @@ def config_from_klibc_net_cfg(files=None, mac_addrs=None):
     names = {}
     for cfg_file in files:
         name, entry = _klibc_to_config_entry(
-            util.load_file(cfg_file), mac_addrs=mac_addrs
+            util.load_text_file(cfg_file), mac_addrs=mac_addrs
         )
         if name in names:
             prev = names[name]["entry"]

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -125,7 +125,7 @@ def networkd_load_leases(leases_d=None):
         return ret
     for lfile in os.listdir(leases_d):
         ret[lfile] = networkd_parse_lease(
-            util.load_file(os.path.join(leases_d, lfile))
+            util.load_text_file(os.path.join(leases_d, lfile))
         )
     return ret
 
@@ -257,8 +257,7 @@ class IscDhclient(DhcpClient):
             content.
         """
         with suppress(FileNotFoundError):
-            content: str
-            content = util.load_file(self.lease_file)  # pyright: ignore
+            content = util.load_text_file(self.lease_file)
             if content:
                 dhcp_leases = self.parse_leases(content)
                 if dhcp_leases:
@@ -362,7 +361,7 @@ class IscDhclient(DhcpClient):
         debug_msg = ""
         for _ in range(sleep_cycles):
             try:
-                pid_content = util.load_file(pid_file).strip()
+                pid_content = util.load_text_file(pid_file).strip()
                 pid = int(pid_content)
             except FileNotFoundError:
                 debug_msg = (
@@ -562,8 +561,7 @@ class IscDhclient(DhcpClient):
         """
         lease_file = self.get_newest_lease_file_from_distro(distro)
         if lease_file:
-            content: str
-            content = util.load_file(lease_file)  # pyright: ignore
+            content = util.load_text_file(lease_file)
             if content:
                 for lease in reversed(self.parse_leases(content)):
                     server = lease.get(key)
@@ -638,7 +636,7 @@ class Dhcpcd(DhcpClient):
                 debug_msg = ""
                 for _ in range(sleep_cycles):
                     try:
-                        pid_content = util.load_file(pid_file).strip()
+                        pid_content = util.load_text_file(pid_file).strip()
                         pid = int(pid_content)
                         gid = distro.get_proc_pgid(pid)
                         if gid:
@@ -882,7 +880,7 @@ class Udhcpc(DhcpClient):
         @raises: InvalidDHCPLeaseFileError on empty or unparseable leasefile
             content.
         """
-        return util.load_json(util.load_file(self.lease_file))
+        return util.load_json(util.load_text_file(self.lease_file))
 
     @staticmethod
     def parse_static_routes(routes: str) -> List[Tuple[str, str]]:

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -212,7 +212,7 @@ def _clean_default(target=None):
     tpath = subp.target_path(target, "etc/netplan/00-snapd-config.yaml")
     if not os.path.isfile(tpath):
         return
-    content = util.load_file(tpath, decode=False)
+    content = util.load_binary_file(tpath)
     if content != KNOWN_SNAPD_CONFIG:
         return
 

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -835,7 +835,9 @@ class Renderer(renderer.Renderer):
             return None
         content = resolv_conf.ResolvConf("")
         if existing_dns_path and os.path.isfile(existing_dns_path):
-            content = resolv_conf.ResolvConf(util.load_file(existing_dns_path))
+            content = resolv_conf.ResolvConf(
+                util.load_text_file(existing_dns_path)
+            )
         for nameserver in network_state.dns_nameservers:
             content.add_nameserver(nameserver)
         for searchdomain in network_state.dns_searchdomains:

--- a/cloudinit/sources/DataSourceAltCloud.py
+++ b/cloudinit/sources/DataSourceAltCloud.py
@@ -58,10 +58,10 @@ def read_user_data_callback(mount_dir):
 
     # First try deltacloud_user_data_file. On failure try user_data_file.
     try:
-        user_data = util.load_file(deltacloud_user_data_file).strip()
+        user_data = util.load_text_file(deltacloud_user_data_file).strip()
     except IOError:
         try:
-            user_data = util.load_file(user_data_file).strip()
+            user_data = util.load_text_file(user_data_file).strip()
         except IOError:
             util.logexc(LOG, "Failed accessing user data file.")
             return None
@@ -100,7 +100,9 @@ class DataSourceAltCloud(sources.DataSource):
         """
         if os.path.exists(CLOUD_INFO_FILE):
             try:
-                cloud_type = util.load_file(CLOUD_INFO_FILE).strip().upper()
+                cloud_type = (
+                    util.load_text_file(CLOUD_INFO_FILE).strip().upper()
+                )
             except IOError:
                 util.logexc(
                     LOG,

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -986,7 +986,7 @@ class DataSourceAzure(sources.DataSource):
         )
         system_uuid = identity.query_system_uuid()
         if os.path.exists(prev_iid_path):
-            previous = util.load_file(prev_iid_path).strip()
+            previous = util.load_text_file(prev_iid_path).strip()
             swapped_id = identity.byte_swap_system_uuid(system_uuid)
 
             # Older kernels than 4.15 will have UPPERCASE product_uuid.

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1899,12 +1899,12 @@ def _get_random_seed(source=PLATFORM_ENTROPY_SOURCE):
     # now update ds_cfg to reflect contents pass in config
     if source is None:
         return None
-    seed = util.load_file(source, quiet=True, decode=False)
+    seed = util.load_binary_file(source, quiet=True)
 
-    # The seed generally contains non-Unicode characters. load_file puts
+    # The seed generally contains non-Unicode characters. load_binary_file puts
     # them into bytes (in python 3).
-    # bytes is a non-serializable type, and the handler load_file
-    # uses applies b64 encoding *again* to handle it. The simplest solution
+    # bytes is a non-serializable type, and the handler
+    # used applies b64 encoding *again* to handle it. The simplest solution
     # is to just b64encode the data and then decode it to a serializable
     # string. Same number of bits of entropy, just with 25% more zeroes.
     # There's no need to undo this base64-encoding when the random seed is

--- a/cloudinit/sources/DataSourceBigstep.py
+++ b/cloudinit/sources/DataSourceBigstep.py
@@ -41,7 +41,7 @@ class DataSourceBigstep(sources.DataSource):
             self.paths.cloud_dir, "data", "seed", "bigstep", "url"
         )
         try:
-            content = util.load_file(url_file)
+            content = util.load_text_file(url_file)
         except IOError as e:
             # If the file doesn't exist, then the server probably isn't a
             # Bigstep instance; otherwise, another problem exists which needs

--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -269,7 +269,7 @@ def get_data_server():
 
 def get_default_gateway():
     # Returns the default gateway ip address in the dotted format.
-    lines = util.load_file("/proc/net/route").splitlines()
+    lines = util.load_text_file("/proc/net/route").splitlines()
     for line in lines:
         items = line.split("\t")
         if items[1] == "00000000":

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -217,7 +217,7 @@ def get_previous_iid(paths):
     # hasn't declared itself found.
     fname = os.path.join(paths.get_cpath("data"), "instance-id")
     try:
-        return util.load_file(fname).rstrip("\n")
+        return util.load_text_file(fname).rstrip("\n")
     except IOError:
         return None
 

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -840,7 +840,7 @@ def _collect_platform_data():
     """
     data = {}
     try:
-        uuid = util.load_file("/sys/hypervisor/uuid").strip()
+        uuid = util.load_text_file("/sys/hypervisor/uuid").strip()
         data["uuid_source"] = "hypervisor"
     except Exception:
         uuid = dmi.read_dmi_data("system-uuid")

--- a/cloudinit/sources/DataSourceIBMCloud.py
+++ b/cloudinit/sources/DataSourceIBMCloud.py
@@ -192,7 +192,7 @@ def _read_system_uuid():
     uuid_path = "/sys/hypervisor/uuid"
     if not os.path.isfile(uuid_path):
         return None
-    return util.load_file(uuid_path).strip().lower()
+    return util.load_text_file(uuid_path).strip().lower()
 
 
 def _is_xen():

--- a/cloudinit/sources/DataSourceIBMCloud.py
+++ b/cloudinit/sources/DataSourceIBMCloud.py
@@ -361,7 +361,7 @@ def metadata_from_dir(source_dir):
         fpath = os.path.join(source_dir, path)
         raw = None
         try:
-            raw = util.load_file(fpath, decode=False)
+            raw = util.load_binary_file(fpath)
         except IOError as e:
             LOG.debug("Failed reading path '%s': %s", fpath, e)
 

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -175,7 +175,7 @@ def get_ovf_env(dirname):
         full_fn = os.path.join(dirname, fname)
         if os.path.isfile(full_fn):
             try:
-                contents = util.load_file(full_fn)
+                contents = util.load_text_file(full_fn)
                 return (fname, contents)
             except Exception:
                 util.logexc(LOG, "Failed loading ovf file %s", full_fn)

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -435,7 +435,7 @@ def read_context_disk_dir(source_dir, distro, asuser=None):
                 ) from e
         try:
             path = os.path.join(source_dir, "context.sh")
-            content = util.load_file(path)
+            content = util.load_text_file(path)
             context = parse_shell_config(content, asuser=asuser)
         except subp.ProcessExecutionError as e:
             raise BrokenContextDiskDir(

--- a/cloudinit/sources/DataSourceRbxCloud.py
+++ b/cloudinit/sources/DataSourceRbxCloud.py
@@ -153,9 +153,7 @@ def read_user_data_callback(mount_dir):
     @returns: A dict containing userdata, metadata and cfg based on metadata.
     """
     meta_data = util.load_json(
-        text=util.load_file(
-            fname=os.path.join(mount_dir, "cloud.json"), decode=False
-        )
+        text=util.load_binary_file(fname=os.path.join(mount_dir, "cloud.json"))
     )
     user_data = util.load_text_file(
         fname=os.path.join(mount_dir, "user.data"), quiet=True

--- a/cloudinit/sources/DataSourceRbxCloud.py
+++ b/cloudinit/sources/DataSourceRbxCloud.py
@@ -24,7 +24,7 @@ ETC_HOSTS = "/etc/hosts"
 
 
 def get_manage_etc_hosts():
-    hosts = util.load_file(ETC_HOSTS, quiet=True)
+    hosts = util.load_text_file(ETC_HOSTS, quiet=True)
     if hosts:
         LOG.debug("/etc/hosts exists - setting manage_etc_hosts to False")
         return False
@@ -157,7 +157,7 @@ def read_user_data_callback(mount_dir):
             fname=os.path.join(mount_dir, "cloud.json"), decode=False
         )
     )
-    user_data = util.load_file(
+    user_data = util.load_text_file(
         fname=os.path.join(mount_dir, "user.data"), quiet=True
     )
     if "vm" not in meta_data or "netadp" not in meta_data:

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -1169,7 +1169,7 @@ def pkl_load(fname: str) -> Optional[DataSource]:
     """Use pickle to deserialize a instance Datasource from a cache file."""
     pickle_contents = None
     try:
-        pickle_contents = util.load_file(fname, decode=False)
+        pickle_contents = util.load_binary_file(fname)
     except Exception as e:
         if os.path.isfile(fname):
             LOG.warning("failed loading pickle in %s: %s", fname, e)

--- a/cloudinit/sources/azure/imds.py
+++ b/cloudinit/sources/azure/imds.py
@@ -160,7 +160,7 @@ def _fetch_metadata(
     metadata = _fetch_url(url, retry_handler=retry_handler)
 
     try:
-        return util.load_json(metadata)
+        return util.load_json(metadata.decode("utf-8"))
     except ValueError as error:
         report_diagnostic_event(
             "Failed to parse metadata from IMDS: %s" % error,

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -364,7 +364,11 @@ class ConfigDriveReader(BaseReader):
         return os.path.join(*components)
 
     def _path_read(self, path, decode=False):
-        return util.load_file(path, decode=decode)
+        return (
+            util.load_text_file(path)
+            if decode
+            else util.load_binary_file(path)
+        )
 
     def _fetch_available_versions(self):
         if self._versions is None:

--- a/cloudinit/sources/helpers/vmware/imc/config_custom_script.py
+++ b/cloudinit/sources/helpers/vmware/imc/config_custom_script.py
@@ -50,9 +50,9 @@ class RunCustomScript:
         util.copy(self.scriptpath, CustomScriptConstant.CUSTOM_SCRIPT)
 
         # Strip any CR characters from the decoded script
-        content = util.load_file(CustomScriptConstant.CUSTOM_SCRIPT).replace(
-            "\r", ""
-        )
+        content = util.load_text_file(
+            CustomScriptConstant.CUSTOM_SCRIPT
+        ).replace("\r", "")
         util.write_file(
             CustomScriptConstant.CUSTOM_SCRIPT, content, mode=0o544
         )

--- a/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
@@ -251,7 +251,7 @@ def get_data_from_imc_raw_data_cust_cfg(cust_cfg):
             )
             return (None, None, None)
         try:
-            md = util.load_file(md_path)
+            md = util.load_text_file(md_path)
         except Exception as e:
             set_cust_error_status(
                 "Error loading cloud-init meta data file",
@@ -284,7 +284,7 @@ def get_data_from_imc_raw_data_cust_cfg(cust_cfg):
                 )
                 return (None, None, None)
             try:
-                ud = util.load_file(ud_path).replace("\r", "")
+                ud = util.load_text_file(ud_path).replace("\r", "")
             except Exception as e:
                 set_cust_error_status(
                     "Error loading cloud-init userdata file",

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -190,7 +190,7 @@ def parse_authorized_keys(fnames):
     for fname in fnames:
         try:
             if os.path.isfile(fname):
-                lines = util.load_file(fname).splitlines()
+                lines = util.load_text_file(fname).splitlines()
                 for line in lines:
                     contents.append(parser.parse(line))
         except (IOError, OSError):
@@ -501,7 +501,7 @@ class SshdConfigLine:
 def parse_ssh_config(fname) -> List[SshdConfigLine]:
     if not os.path.isfile(fname):
         return []
-    return parse_ssh_config_lines(util.load_file(fname).splitlines())
+    return parse_ssh_config_lines(util.load_text_file(fname).splitlines())
 
 
 def parse_ssh_config_lines(lines) -> List[SshdConfigLine]:

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -310,7 +310,7 @@ class Init:
 
         run_iid_fn = self.paths.get_runpath("instance_id")
         if os.path.exists(run_iid_fn):
-            run_iid = util.load_file(run_iid_fn).strip()
+            run_iid = util.load_text_file(run_iid_fn).strip()
         else:
             run_iid = None
 
@@ -392,7 +392,9 @@ class Init:
         network_link = self.paths.get_runpath("network_config")
         if os.path.exists(ncfg_instance_path):
             # Compare and only write on delta of current network-config
-            if netcfg != util.load_json(util.load_file(ncfg_instance_path)):
+            if netcfg != util.load_json(
+                util.load_text_file(ncfg_instance_path)
+            ):
                 atomic_helper.write_json(
                     ncfg_instance_path, netcfg, mode=0o600
                 )
@@ -423,7 +425,7 @@ class Init:
         previous_ds = None
         ds_fn = os.path.join(idir, "datasource")
         try:
-            previous_ds = util.load_file(ds_fn).strip()
+            previous_ds = util.load_text_file(ds_fn).strip()
         except Exception:
             pass
         if not previous_ds:
@@ -458,7 +460,7 @@ class Init:
         dp = self.paths.get_cpath("data")
         iid_fn = os.path.join(dp, "instance-id")
         try:
-            self._previous_iid = util.load_file(iid_fn).strip()
+            self._previous_iid = util.load_text_file(iid_fn).strip()
         except Exception:
             self._previous_iid = NO_PREVIOUS_INSTANCE_ID
 
@@ -770,7 +772,9 @@ class Init:
         )
         json_sensitive_file = self.paths.get_runpath("instance_data_sensitive")
         try:
-            instance_json = util.load_json(util.load_file(json_sensitive_file))
+            instance_json = util.load_json(
+                util.load_text_file(json_sensitive_file)
+            )
         except (OSError, IOError) as e:
             LOG.warning(
                 "Skipping write of system_info/features to %s."

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -193,7 +193,7 @@ def detect_template(text):
 def render_from_file(fn, params):
     if not params:
         params = {}
-    template_type, renderer, content = detect_template(util.load_file(fn))
+    template_type, renderer, content = detect_template(util.load_text_file(fn))
     LOG.debug("Rendering content of '%s' using renderer %s", fn, template_type)
     return renderer(content, params)
 

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -231,7 +231,7 @@ class UserDataProcessor:
             if include_once_on:
                 include_once_fn = self._get_include_once_filename(include_url)
             if include_once_on and os.path.isfile(include_once_fn):
-                content = util.load_file(include_once_fn)
+                content = util.load_text_file(include_once_fn)
             else:
                 try:
                     resp = read_file_or_url(

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -49,6 +49,8 @@ from typing import (
     Optional,
     Sequence,
     TypeVar,
+    Union,
+    cast,
 )
 from urllib import parse
 
@@ -124,18 +126,14 @@ def lsb_release():
     return data
 
 
-def decode_binary(blob, encoding="utf-8") -> str:
+def decode_binary(blob: Union[str, bytes], encoding="utf-8") -> str:
     # Converts a binary type into a text type using given encoding.
-    if isinstance(blob, str):
-        return blob
-    return blob.decode(encoding)
+    return blob if isinstance(blob, str) else blob.decode(encoding=encoding)
 
 
-def encode_text(text, encoding="utf-8") -> bytes:
+def encode_text(text: Union[str, bytes], encoding="utf-8") -> bytes:
     # Converts a text string into a binary type using given encoding.
-    if isinstance(text, bytes):
-        return text
-    return text.encode(encoding)
+    return text if isinstance(text, bytes) else text.encode(encoding=encoding)
 
 
 def maybe_b64decode(data: bytes) -> bytes:
@@ -309,7 +307,7 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
     )
 
     try:
-        config_file = load_file(fname)
+        config_file = load_text_file(fname)
     except FileNotFoundError:
         return {}
 
@@ -546,7 +544,7 @@ def _parse_redhat_release(release_file=None):
         release_file = "/etc/redhat-release"
     if not os.path.exists(release_file):
         return {}
-    redhat_release = load_file(release_file)
+    redhat_release = load_text_file(release_file)
     redhat_regex = (
         r"(?P<name>.+) release (?P<version>[\d\.]+) "
         r"\((?P<codename>[^)]+)\)"
@@ -583,7 +581,7 @@ def get_linux_distro():
     os_release = {}
     os_release_rhel = False
     if os.path.exists("/etc/os-release"):
-        os_release = load_shell_content(load_file("/etc/os-release"))
+        os_release = load_shell_content(load_text_file("/etc/os-release"))
     if not os_release:
         os_release_rhel = True
         os_release = _parse_redhat_release()
@@ -1269,7 +1267,7 @@ def get_fqdn_from_hosts(hostname, filename="/etc/hosts"):
     """
     fqdn = None
     try:
-        for line in load_file(filename).splitlines():
+        for line in load_text_file(filename).splitlines():
             hashpos = line.find("#")
             if hashpos >= 0:
                 line = line[0:hashpos]
@@ -1601,11 +1599,17 @@ def load_file(fname, read_cb=None, quiet=False, decode=True):
         return contents
 
 
+def load_text_file(fname, read_cb=None, quiet=False) -> str:
+    return cast(
+        str, load_file(fname, read_cb=read_cb, quiet=quiet, decode=True)
+    )
+
+
 @lru_cache()
 def _get_cmdline():
     if is_container():
         try:
-            contents = load_file("/proc/1/cmdline")
+            contents = load_text_file("/proc/1/cmdline")
             # replace nulls with space and drop trailing null
             cmdline = contents.replace("\x00", " ")[:-1]
         except Exception as e:
@@ -1613,7 +1617,7 @@ def _get_cmdline():
             cmdline = ""
     else:
         try:
-            cmdline = load_file("/proc/cmdline").strip()
+            cmdline = load_text_file("/proc/cmdline").strip()
         except Exception:
             cmdline = ""
 
@@ -1630,7 +1634,7 @@ def get_cmdline():
 def fips_enabled() -> bool:
     fips_proc = "/proc/sys/crypto/fips_enabled"
     try:
-        contents = load_file(fips_proc).strip()
+        contents = load_text_file(fips_proc).strip()
         return contents == "1"
     except (IOError, OSError):
         # for BSD systems and Linux systems where the proc entry is not
@@ -1912,7 +1916,7 @@ def mounts():
     try:
         # Go through mounts to see what is already mounted
         if os.path.exists("/proc/mounts"):
-            mount_locs = load_file("/proc/mounts").splitlines()
+            mount_locs = load_text_file("/proc/mounts").splitlines()
             method = "proc"
         else:
             out = subp.subp("mount")
@@ -2133,7 +2137,7 @@ def uptime():
     try:
         if os.path.exists("/proc/uptime"):
             method = "/proc/uptime"
-            contents = load_file("/proc/uptime")
+            contents = load_text_file("/proc/uptime")
             if contents:
                 uptime_str = contents.split()[0]
         else:
@@ -2427,7 +2431,7 @@ def is_container():
 
     try:
         # Detect Vserver containers
-        lines = load_file("/proc/self/status").splitlines()
+        lines = load_text_file("/proc/self/status").splitlines()
         for line in lines:
             if line.startswith("VxID:"):
                 (_key, val) = line.strip().split(":", 1)
@@ -2600,7 +2604,7 @@ def parse_mount_info(path, mountinfo_lines, log=LOG, get_mnt_opts=False):
 
 def parse_mtab(path):
     """On older kernels there's no /proc/$$/mountinfo, so use mtab."""
-    for line in load_file("/etc/mtab").splitlines():
+    for line in load_text_file("/etc/mtab").splitlines():
         devpth, mount_point, fs_type = line.split()[:3]
         if mount_point == path:
             return devpth, fs_type, mount_point
@@ -2788,7 +2792,7 @@ def get_mount_info(path, log=LOG, get_mnt_opts=False):
     # input path.
     mountinfo_path = "/proc/%s/mountinfo" % os.getpid()
     if os.path.exists(mountinfo_path):
-        lines = load_file(mountinfo_path).splitlines()
+        lines = load_text_file(mountinfo_path).splitlines()
         return parse_mount_info(path, lines, log, get_mnt_opts)
     elif os.path.exists("/etc/mtab"):
         return parse_mtab(path)
@@ -2892,7 +2896,7 @@ def read_meminfo(meminfo="/proc/meminfo", raw=False):
         "MemAvailable:": "available",
     }
     ret = {}
-    for line in load_file(meminfo).splitlines():
+    for line in load_text_file(meminfo).splitlines():
         try:
             key, value, unit = line.split()
         except ValueError:
@@ -2986,7 +2990,7 @@ def system_is_snappy():
     # this is certainly not a perfect test, but good enough for now.
     orpath = "/etc/os-release"
     try:
-        orinfo = load_shell_content(load_file(orpath, quiet=True))
+        orinfo = load_shell_content(load_text_file(orpath, quiet=True))
         if orinfo.get("ID", "").lower() == "ubuntu-core":
             return True
     except ValueError as e:
@@ -2996,7 +3000,7 @@ def system_is_snappy():
     if "snap_core=" in cmdline:
         return True
 
-    content = load_file("/etc/system-image/channel.ini", quiet=True)
+    content = load_text_file("/etc/system-image/channel.ini", quiet=True)
     if "ubuntu-core" in content.lower():
         return True
     if os.path.isdir("/etc/system-image/config.d/"):

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -11,7 +11,7 @@ import pytest
 from cloudinit.cmd.devel import logs
 from cloudinit.cmd.devel.logs import ApportFile
 from cloudinit.subp import SubpResult, subp
-from cloudinit.util import ensure_dir, load_file, write_file
+from cloudinit.util import ensure_dir, load_text_file, write_file
 from tests.unittests.helpers import mock
 
 M_PATH = "cloudinit.cmd.devel.logs."
@@ -125,29 +125,31 @@ class TestCollectLogs:
         ), (
             "Unexpected file found: %s" % INSTANCE_JSON_SENSITIVE_FILE
         )
-        assert "0.7fake\n" == load_file(
+        assert "0.7fake\n" == load_text_file(
             os.path.join(out_logdir, "dpkg-version")
         )
-        assert version_out == load_file(os.path.join(out_logdir, "version"))
-        assert "cloud-init-log" == load_file(
+        assert version_out == load_text_file(
+            os.path.join(out_logdir, "version")
+        )
+        assert "cloud-init-log" == load_text_file(
             os.path.join(out_logdir, "cloud-init.log")
         )
-        assert "cloud-init-log-rotated" == load_file(
+        assert "cloud-init-log-rotated" == load_text_file(
             os.path.join(out_logdir, "cloud-init.log.1.gz")
         )
-        assert "cloud-init-output-log" == load_file(
+        assert "cloud-init-output-log" == load_text_file(
             os.path.join(out_logdir, "cloud-init-output.log")
         )
-        assert "cloud-init-output-log-rotated" == load_file(
+        assert "cloud-init-output-log-rotated" == load_text_file(
             os.path.join(out_logdir, "cloud-init-output.log.1.gz")
         )
-        assert "dmesg-out\n" == load_file(
+        assert "dmesg-out\n" == load_text_file(
             os.path.join(out_logdir, "dmesg.txt")
         )
-        assert "journal-out\n" == load_file(
+        assert "journal-out\n" == load_text_file(
             os.path.join(out_logdir, "journal.txt")
         )
-        assert "results" == load_file(
+        assert "results" == load_text_file(
             os.path.join(out_logdir, "run", "cloud-init", "results.json")
         )
         fake_stderr.write.assert_any_call("Wrote %s\n" % output_tarfile)
@@ -229,10 +231,10 @@ class TestCollectLogs:
         # unpack the tarfile and check file contents
         subp(["tar", "zxvf", output_tarfile, "-C", str(tmpdir)])
         out_logdir = tmpdir.join(date_logdir)
-        assert "user-data" == load_file(
+        assert "user-data" == load_text_file(
             os.path.join(out_logdir, "user-data.txt")
         )
-        assert "sensitive" == load_file(
+        assert "sensitive" == load_text_file(
             os.path.join(
                 out_logdir,
                 "run",
@@ -283,7 +285,7 @@ class TestCollectLogs:
         )
 
         assert expected_return_value == return_output
-        assert expected_file_contents == load_file(output_file)
+        assert expected_file_contents == load_text_file(output_file)
 
     @pytest.mark.parametrize(
         "cmd, expected_file_contents",
@@ -305,7 +307,7 @@ class TestCollectLogs:
             verbosity=1,
         )
 
-        assert expected_file_contents == load_file(output_file)
+        assert expected_file_contents == load_text_file(output_file)
 
 
 class TestCollectInstallerLogs:

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -10,7 +10,7 @@ import pytest
 
 from cloudinit import safeyaml
 from cloudinit.cmd import main
-from cloudinit.util import ensure_dir, load_file, write_file
+from cloudinit.util import ensure_dir, load_text_file, write_file
 from tests.unittests.helpers import FilesystemMockingTestCase, wrap_and_call
 
 MyArgs = namedtuple("MyArgs", "debug files force local reporter subcommand")
@@ -82,12 +82,12 @@ class TestMain(FilesystemMockingTestCase):
         self.assertEqual(
             "iid-datasource-none\n",
             os.path.join(
-                load_file(os.path.join(self.new_root, instance_id_path))
+                load_text_file(os.path.join(self.new_root, instance_id_path))
             ),
         )
         # modules are run (including write_files)
         self.assertEqual(
-            "blah", load_file(os.path.join(self.new_root, "etc/blah.ini"))
+            "blah", load_text_file(os.path.join(self.new_root, "etc/blah.ini"))
         )
         expected_logs = [
             "network config is disabled by fallback",  # apply_network_config
@@ -152,12 +152,12 @@ class TestMain(FilesystemMockingTestCase):
         self.assertEqual(
             "iid-datasource-none\n",
             os.path.join(
-                load_file(os.path.join(self.new_root, instance_id_path))
+                load_text_file(os.path.join(self.new_root, instance_id_path))
             ),
         )
         # modules are run (including write_files)
         self.assertEqual(
-            "blah", load_file(os.path.join(self.new_root, "etc/blah.ini"))
+            "blah", load_text_file(os.path.join(self.new_root, "etc/blah.ini"))
         )
         expected_logs = [
             "network config is disabled by fallback",  # apply_network_config

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -166,7 +166,7 @@ class TestQuery:
             vendor_data="vd",
             varname=None,
         )
-        with mock.patch(M_PATH + "util.load_file") as m_load:
+        with mock.patch(M_PATH + "util.load_binary_file") as m_load:
             m_load.side_effect = OSError(errno.EACCES, "Not allowed")
             assert 1 == query.handle_args("anyname", args)
         msg = "No read permission on '%s'. Try sudo" % noread_fn

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -46,7 +46,7 @@ class TestStatus:
     maxDiff = None
 
     @mock.patch(
-        M_PATH + "load_file",
+        M_PATH + "load_text_file",
         return_value=(
             '{"v1": {"datasource": null, "init": {"errors": [], "finished": '
             'null, "start": null}, "init-local": {"errors": [], "finished": '

--- a/tests/unittests/config/test_apt_conf_v1.py
+++ b/tests/unittests/config/test_apt_conf_v1.py
@@ -33,7 +33,7 @@ class TestAptProxyConfig(TestCase):
         self.assertTrue(os.path.isfile(self.pfile))
         self.assertFalse(os.path.isfile(self.cfile))
 
-        contents = util.load_file(self.pfile)
+        contents = util.load_text_file(self.pfile)
         self.assertTrue(self._search_apt_config(contents, "http", "myproxy"))
 
     def test_apt_http_proxy_written(self):
@@ -43,7 +43,7 @@ class TestAptProxyConfig(TestCase):
         self.assertTrue(os.path.isfile(self.pfile))
         self.assertFalse(os.path.isfile(self.cfile))
 
-        contents = util.load_file(self.pfile)
+        contents = util.load_text_file(self.pfile)
         self.assertTrue(self._search_apt_config(contents, "http", "myproxy"))
 
     def test_apt_all_proxy_written(self):
@@ -64,7 +64,7 @@ class TestAptProxyConfig(TestCase):
         self.assertTrue(os.path.isfile(self.pfile))
         self.assertFalse(os.path.isfile(self.cfile))
 
-        contents = util.load_file(self.pfile)
+        contents = util.load_text_file(self.pfile)
 
         for ptype, pval in values.items():
             self.assertTrue(self._search_apt_config(contents, ptype, pval))
@@ -81,7 +81,7 @@ class TestAptProxyConfig(TestCase):
             {"proxy": "foo"}, self.pfile, self.cfile
         )
         self.assertTrue(os.path.isfile(self.pfile))
-        contents = util.load_file(self.pfile)
+        contents = util.load_text_file(self.pfile)
         self.assertTrue(self._search_apt_config(contents, "http", "foo"))
 
     def test_config_written(self):
@@ -93,7 +93,7 @@ class TestAptProxyConfig(TestCase):
         self.assertTrue(os.path.isfile(self.cfile))
         self.assertFalse(os.path.isfile(self.pfile))
 
-        self.assertEqual(util.load_file(self.cfile), payload)
+        self.assertEqual(util.load_text_file(self.cfile), payload)
 
     def test_config_replaced(self):
         util.write_file(self.pfile, "content doesnt matter")
@@ -101,7 +101,7 @@ class TestAptProxyConfig(TestCase):
             {"conf": "foo"}, self.pfile, self.cfile
         )
         self.assertTrue(os.path.isfile(self.cfile))
-        self.assertEqual(util.load_file(self.cfile), "foo")
+        self.assertEqual(util.load_text_file(self.cfile), "foo")
 
     def test_config_deleted(self):
         # if no 'conf' is provided, delete any previously written file

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -119,7 +119,7 @@ class TestAptSourceConfig:
 
         assert os.path.isfile(filename)
 
-        contents = util.load_file(filename)
+        contents = util.load_text_file(filename)
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -166,7 +166,7 @@ class TestAptSourceConfig:
         self.apt_src_basic(apt_lists[0], cfg)
 
         # extra verify on two extra files of this test
-        contents = util.load_file(apt_lists[1])
+        contents = util.load_text_file(apt_lists[1])
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -178,7 +178,7 @@ class TestAptSourceConfig:
             contents,
             flags=re.IGNORECASE,
         )
-        contents = util.load_file(apt_lists[2])
+        contents = util.load_text_file(apt_lists[2])
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -270,7 +270,7 @@ class TestAptSourceConfig:
 
         assert os.path.isfile(filename)
 
-        contents = util.load_file(filename)
+        contents = util.load_text_file(filename)
         assert re.search(
             r"%s %s %s %s\n"
             % ("deb", params["MIRROR"], params["RELEASE"], "multiverse"),
@@ -295,7 +295,7 @@ class TestAptSourceConfig:
 
         # extra verify on two extra files of this test
         params = self._get_default_params()
-        contents = util.load_file(apt_lists[1])
+        contents = util.load_text_file(apt_lists[1])
         assert re.search(
             r"%s %s %s %s\n"
             % ("deb", params["MIRROR"], params["RELEASE"], "main"),
@@ -303,7 +303,7 @@ class TestAptSourceConfig:
             flags=re.IGNORECASE,
         )
 
-        contents = util.load_file(apt_lists[2])
+        contents = util.load_text_file(apt_lists[2])
         assert re.search(
             r"%s %s %s %s\n"
             % ("deb", params["MIRROR"], params["RELEASE"], "universe"),
@@ -368,7 +368,7 @@ class TestAptSourceConfig:
 
         assert os.path.isfile(filename)
 
-        contents = util.load_file(filename)
+        contents = util.load_text_file(filename)
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -429,7 +429,7 @@ class TestAptSourceConfig:
         }
 
         self.apt_src_keyid(apt_lists[0], [cfg1, cfg2, cfg3], 3)
-        contents = util.load_file(apt_lists[1])
+        contents = util.load_text_file(apt_lists[1])
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -441,7 +441,7 @@ class TestAptSourceConfig:
             contents,
             flags=re.IGNORECASE,
         )
-        contents = util.load_file(apt_lists[2])
+        contents = util.load_text_file(apt_lists[2])
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -491,7 +491,7 @@ class TestAptSourceConfig:
 
         assert os.path.isfile(filename)
 
-        contents = util.load_file(filename)
+        contents = util.load_text_file(filename)
         assert re.search(
             r"%s %s %s %s\n"
             % (

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -97,7 +97,7 @@ class TestAptSourceConfig:
             os.path.isfile(filename) is True
         ), f"Missing expected file {filename}"
 
-        contents = util.load_file(filename)
+        contents = util.load_text_file(filename)
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -151,7 +151,7 @@ class TestAptSourceConfig:
         self._apt_src_basic(self.aptlistfile, cfg, tmpdir)
 
         # extra verify on two extra files of this test
-        contents = util.load_file(self.aptlistfile2)
+        contents = util.load_text_file(self.aptlistfile2)
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -163,7 +163,7 @@ class TestAptSourceConfig:
             contents,
             flags=re.IGNORECASE,
         ), f"Unexpected APT format of {self.aptlistfile2}: contents"
-        contents = util.load_file(self.aptlistfile3)
+        contents = util.load_text_file(self.aptlistfile3)
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -190,7 +190,7 @@ class TestAptSourceConfig:
 
         assert os.path.isfile(filename) is True, f"Unexpected file {filename}"
 
-        contents = util.load_file(filename)
+        contents = util.load_text_file(filename)
         assert re.search(
             r"%s %s %s %s\n"
             % ("deb", params["MIRROR"], params["RELEASE"], "multiverse"),
@@ -223,14 +223,14 @@ class TestAptSourceConfig:
 
         # extra verify on two extra files of this test
         params = self._get_default_params()
-        contents = util.load_file(self.aptlistfile2)
+        contents = util.load_text_file(self.aptlistfile2)
         assert re.search(
             r"%s %s %s %s\n"
             % ("deb", params["MIRROR"], params["RELEASE"], "main"),
             contents,
             flags=re.IGNORECASE,
         ), f"Unexpected APT format {self.aptlistfile2}: {contents}"
-        contents = util.load_file(self.aptlistfile3)
+        contents = util.load_text_file(self.aptlistfile3)
         assert re.search(
             r"%s %s %s %s\n"
             % ("deb", params["MIRROR"], params["RELEASE"], "universe"),
@@ -276,7 +276,7 @@ class TestAptSourceConfig:
 
         assert os.path.isfile(filename) is True
 
-        contents = util.load_file(filename)
+        contents = util.load_text_file(filename)
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -340,7 +340,7 @@ class TestAptSourceConfig:
         }
 
         self._apt_src_keyid(self.aptlistfile, cfg, 3, tmpdir)
-        contents = util.load_file(self.aptlistfile2)
+        contents = util.load_text_file(self.aptlistfile2)
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -352,7 +352,7 @@ class TestAptSourceConfig:
             contents,
             flags=re.IGNORECASE,
         )
-        contents = util.load_file(self.aptlistfile3)
+        contents = util.load_text_file(self.aptlistfile3)
         assert re.search(
             r"%s %s %s %s\n"
             % (
@@ -397,7 +397,7 @@ class TestAptSourceConfig:
             ),
         )
         mockobj.assert_has_calls(calls, any_order=True)
-        contents = util.load_file(self.aptlistfile)
+        contents = util.load_text_file(self.aptlistfile)
         assert re.search(
             r"%s %s %s %s\n"
             % (

--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -107,7 +107,7 @@ class TestConfig(FilesystemMockingTestCase):
             )
         )
 
-        self.assertEqual(expected_content, util.load_file(REPO_FILE))
+        self.assertEqual(expected_content, util.load_text_file(REPO_FILE))
 
     def test_main_and_community_repos(self):
         """
@@ -142,7 +142,7 @@ class TestConfig(FilesystemMockingTestCase):
             )
         )
 
-        self.assertEqual(expected_content, util.load_file(REPO_FILE))
+        self.assertEqual(expected_content, util.load_text_file(REPO_FILE))
 
     def test_main_community_testing_repos(self):
         """
@@ -182,7 +182,7 @@ class TestConfig(FilesystemMockingTestCase):
             )
         )
 
-        self.assertEqual(expected_content, util.load_file(REPO_FILE))
+        self.assertEqual(expected_content, util.load_text_file(REPO_FILE))
 
     def test_edge_main_community_testing_repos(self):
         """
@@ -219,7 +219,7 @@ class TestConfig(FilesystemMockingTestCase):
             )
         )
 
-        self.assertEqual(expected_content, util.load_file(REPO_FILE))
+        self.assertEqual(expected_content, util.load_text_file(REPO_FILE))
 
     def test_main_community_testing_local_repos(self):
         """
@@ -266,7 +266,7 @@ class TestConfig(FilesystemMockingTestCase):
             )
         )
 
-        self.assertEqual(expected_content, util.load_file(REPO_FILE))
+        self.assertEqual(expected_content, util.load_text_file(REPO_FILE))
 
     def test_edge_main_community_testing_local_repos(self):
         """
@@ -310,7 +310,7 @@ class TestConfig(FilesystemMockingTestCase):
             )
         )
 
-        self.assertEqual(expected_content, util.load_file(REPO_FILE))
+        self.assertEqual(expected_content, util.load_text_file(REPO_FILE))
 
 
 class TestApkConfigureSchema:

--- a/tests/unittests/config/test_cc_bootcmd.py
+++ b/tests/unittests/config/test_cc_bootcmd.py
@@ -92,7 +92,7 @@ class TestBootcmd(CiTestCase):
             with self.allow_subp(["/bin/sh"]):
                 handle("cc_bootcmd", valid_config, cc, [])
         self.assertEqual(
-            my_id + " iid-datasource-none\n", util.load_file(out_file)
+            my_id + " iid-datasource-none\n", util.load_text_file(out_file)
         )
 
     def test_handler_runs_bootcmd_script_with_error(self):

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -325,7 +325,7 @@ class TestRemoveDefaultCaCerts(TestCase):
                 )
                 mock_load = mocks.enter_context(
                     mock.patch.object(
-                        util, "load_file", return_value=ca_certs_content
+                        util, "load_text_file", return_value=ca_certs_content
                     )
                 )
                 mock_subp = mocks.enter_context(

--- a/tests/unittests/config/test_cc_chef.py
+++ b/tests/unittests/config/test_cc_chef.py
@@ -155,7 +155,7 @@ class TestChef(FilesystemMockingTestCase):
         Chef::Log::Formatter.show_time = true
         encrypted_data_bag_secret  "/etc/chef/encrypted_data_bag_secret"
         """
-        tpl_file = util.load_file(CLIENT_TEMPL)
+        tpl_file = util.load_text_file(CLIENT_TEMPL)
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
 
@@ -175,7 +175,7 @@ class TestChef(FilesystemMockingTestCase):
         cc_chef.handle("chef", cfg, get_cloud(), [])
         for d in cc_chef.CHEF_DIRS:
             self.assertTrue(os.path.isdir(d))
-        c = util.load_file(cc_chef.CHEF_RB_PATH)
+        c = util.load_text_file(cc_chef.CHEF_RB_PATH)
 
         # the content of these keys is not expected to be rendered to tmpl
         unrendered_keys = ("validation_cert",)
@@ -190,7 +190,7 @@ class TestChef(FilesystemMockingTestCase):
             val = cfg["chef"].get(k, v)
             if isinstance(val, str):
                 self.assertIn(val, c)
-        c = util.load_file(cc_chef.CHEF_FB_PATH)
+        c = util.load_text_file(cc_chef.CHEF_FB_PATH)
         self.assertEqual({}, json.loads(c))
 
     def test_firstboot_json(self):
@@ -208,7 +208,7 @@ class TestChef(FilesystemMockingTestCase):
             },
         }
         cc_chef.handle("chef", cfg, get_cloud(), [])
-        c = util.load_file(cc_chef.CHEF_FB_PATH)
+        c = util.load_text_file(cc_chef.CHEF_FB_PATH)
         self.assertEqual(
             {
                 "run_list": ["a", "b", "c"],
@@ -221,7 +221,7 @@ class TestChef(FilesystemMockingTestCase):
         not os.path.isfile(CLIENT_TEMPL), CLIENT_TEMPL + " is not available"
     )
     def test_template_deletes(self):
-        tpl_file = util.load_file(CLIENT_TEMPL)
+        tpl_file = util.load_text_file(CLIENT_TEMPL)
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
 
@@ -235,7 +235,7 @@ class TestChef(FilesystemMockingTestCase):
             },
         }
         cc_chef.handle("chef", cfg, get_cloud(), [])
-        c = util.load_file(cc_chef.CHEF_RB_PATH)
+        c = util.load_text_file(cc_chef.CHEF_RB_PATH)
         self.assertNotIn("json_attribs", c)
         self.assertNotIn("Formatter.show_time", c)
 
@@ -244,7 +244,7 @@ class TestChef(FilesystemMockingTestCase):
     )
     def test_validation_cert_and_validation_key(self):
         # test validation_cert content is written to validation_key path
-        tpl_file = util.load_file(CLIENT_TEMPL)
+        tpl_file = util.load_text_file(CLIENT_TEMPL)
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
 
@@ -260,14 +260,14 @@ class TestChef(FilesystemMockingTestCase):
             },
         }
         cc_chef.handle("chef", cfg, get_cloud(), [])
-        content = util.load_file(cc_chef.CHEF_RB_PATH)
+        content = util.load_text_file(cc_chef.CHEF_RB_PATH)
         self.assertIn(v_path, content)
-        util.load_file(v_path)
-        self.assertEqual(v_cert, util.load_file(v_path))
+        util.load_text_file(v_path)
+        self.assertEqual(v_cert, util.load_text_file(v_path))
 
     def test_validation_cert_with_system(self):
         # test validation_cert content is not written over system file
-        tpl_file = util.load_file(CLIENT_TEMPL)
+        tpl_file = util.load_text_file(CLIENT_TEMPL)
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
 
@@ -285,10 +285,10 @@ class TestChef(FilesystemMockingTestCase):
         util.write_file("/etc/cloud/templates/chef_client.rb.tmpl", tpl_file)
         util.write_file(v_path, expected_cert)
         cc_chef.handle("chef", cfg, get_cloud(), [])
-        content = util.load_file(cc_chef.CHEF_RB_PATH)
+        content = util.load_text_file(cc_chef.CHEF_RB_PATH)
         self.assertIn(v_path, content)
-        util.load_file(v_path)
-        self.assertEqual(expected_cert, util.load_file(v_path))
+        util.load_text_file(v_path)
+        self.assertEqual(expected_cert, util.load_text_file(v_path))
 
 
 @skipUnlessJsonSchema()

--- a/tests/unittests/config/test_cc_locale.py
+++ b/tests/unittests/config/test_cc_locale.py
@@ -55,7 +55,7 @@ class TestLocale(FilesystemMockingTestCase):
                     locale_configfile,
                 )
 
-                contents = util.load_file(cc.distro.locale_gen_fn)
+                contents = util.load_text_file(cc.distro.locale_gen_fn)
                 self.assertIn("%s UTF-8" % locale, contents)
                 m_subp.assert_called_with(
                     ["localectl", "set-locale", locale], capture=False

--- a/tests/unittests/config/test_cc_locale.py
+++ b/tests/unittests/config/test_cc_locale.py
@@ -72,7 +72,7 @@ class TestLocale(FilesystemMockingTestCase):
             locale_conf = cc.distro.systemd_locale_conf_fn
         else:
             locale_conf = cc.distro.locale_conf_fn
-        contents = util.load_file(locale_conf, decode=False)
+        contents = util.load_binary_file(locale_conf)
         n_cfg = ConfigObj(BytesIO(contents))
         if cc.distro.uses_systemd():
             self.assertEqual({"LANG": cfg["locale"]}, dict(n_cfg))
@@ -91,7 +91,7 @@ class TestLocale(FilesystemMockingTestCase):
             locale_conf = cc.distro.locale_conf_fn
             keyname = "RC_LANG"
 
-        contents = util.load_file(locale_conf, decode=False)
+        contents = util.load_binary_file(locale_conf)
         n_cfg = ConfigObj(BytesIO(contents))
         self.assertEqual({keyname: "en_US.UTF-8"}, dict(n_cfg))
 

--- a/tests/unittests/config/test_cc_mcollective.py
+++ b/tests/unittests/config/test_cc_mcollective.py
@@ -97,7 +97,7 @@ class TestConfig(t_help.FilesystemMockingTestCase):
         self.assertTrue(os.path.exists(self.server_cfg))
         self.assertTrue(os.path.exists(self.server_cfg + ".old"))
         self.assertEqual(
-            util.load_file(self.server_cfg + ".old"), STOCK_CONFIG
+            util.load_text_file(self.server_cfg + ".old"), STOCK_CONFIG
         )
 
     def test_existing_updated(self):
@@ -136,9 +136,11 @@ class TestConfig(t_help.FilesystemMockingTestCase):
         self.assertEqual(found["securityprovider"], "ssl")
 
         self.assertEqual(
-            util.load_file(self.pricert_file), cfg["private-cert"]
+            util.load_text_file(self.pricert_file), cfg["private-cert"]
         )
-        self.assertEqual(util.load_file(self.pubcert_file), cfg["public-cert"])
+        self.assertEqual(
+            util.load_text_file(self.pubcert_file), cfg["public-cert"]
+        )
 
 
 class TestHandler(t_help.TestCase):

--- a/tests/unittests/config/test_cc_mcollective.py
+++ b/tests/unittests/config/test_cc_mcollective.py
@@ -86,7 +86,7 @@ class TestConfig(t_help.FilesystemMockingTestCase):
 
         self.patchUtils(self.tmp)
         cc_mcollective.configure(cfg["mcollective"]["conf"])
-        contents = util.load_file(cc_mcollective.SERVER_CFG, decode=False)
+        contents = util.load_binary_file(cc_mcollective.SERVER_CFG)
         contents = configobj.ConfigObj(BytesIO(contents))
         self.assertEqual(expected, dict(contents))
 
@@ -149,7 +149,7 @@ class TestHandler(t_help.TestCase):
     def test_mcollective_install(self, mock_util, mock_subp):
         cc = get_cloud()
         cc.distro = t_help.mock.MagicMock()
-        mock_util.load_file.return_value = b""
+        mock_util.load_binary_file.return_value = b""
         mycfg = {"mcollective": {"conf": {"loglevel": "debug"}}}
         cc_mcollective.handle("cc_mcollective", mycfg, cc, [])
         self.assertTrue(cc.distro.install_packages.called)

--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -150,7 +150,7 @@ class TestNtp(FilesystemMockingTestCase):
             )
         self.assertEqual(
             "servers []\npools ['10.0.0.1', '10.0.0.2']\n",
-            util.load_file(confpath),
+            util.load_text_file(confpath),
         )
 
     def test_write_ntp_config_template_defaults_pools_w_empty_lists(self):
@@ -174,7 +174,8 @@ class TestNtp(FilesystemMockingTestCase):
                 template=None,
             )
         self.assertEqual(
-            "servers []\npools {0}\n".format(pools), util.load_file(confpath)
+            "servers []\npools {0}\n".format(pools),
+            util.load_text_file(confpath),
         )
 
     def test_defaults_pools_empty_lists_sles(self):
@@ -199,7 +200,7 @@ class TestNtp(FilesystemMockingTestCase):
             self.assertIn("opensuse", pool)
         self.assertEqual(
             "servers []\npools {0}\n".format(default_pools),
-            util.load_file(confpath),
+            util.load_text_file(confpath),
         )
         self.assertIn(
             "Adding distro default ntp pool servers: {0}".format(
@@ -225,7 +226,7 @@ class TestNtp(FilesystemMockingTestCase):
         )
         self.assertEqual(
             "[Time]\nNTP=%s %s \n" % (" ".join(servers), " ".join(pools)),
-            util.load_file(confpath),
+            util.load_text_file(confpath),
         )
 
     def test_distro_ntp_client_configs(self):
@@ -313,7 +314,7 @@ class TestNtp(FilesystemMockingTestCase):
                     path=confpath,
                     template_fn=template_fn,
                 )
-                content = util.load_file(confpath)
+                content = util.load_text_file(confpath)
                 if client in ["ntp", "chrony"]:
                     content_lines = content.splitlines()
                     expected_servers = self._get_expected_servers(
@@ -388,13 +389,13 @@ class TestNtp(FilesystemMockingTestCase):
                     servers = cc_ntp.generate_server_names(mycloud.distro.name)
                     self.assertEqual(
                         "servers {0}\npools []\n".format(servers),
-                        util.load_file(confpath),
+                        util.load_text_file(confpath),
                     )
                 else:
                     pools = cc_ntp.generate_server_names(mycloud.distro.name)
                     self.assertEqual(
                         "servers []\npools {0}\n".format(pools),
-                        util.load_file(confpath),
+                        util.load_text_file(confpath),
                     )
             self.assertNotIn(
                 "Invalid cloud-config provided:", self.logs.getvalue()
@@ -417,7 +418,7 @@ class TestNtp(FilesystemMockingTestCase):
             cc_ntp.handle("cc_ntp", cfg, mycloud, [])
             self.assertEqual(
                 "[Time]\nNTP=192.168.2.1 192.168.2.2 0.mypool.org \n",
-                util.load_file(confpath),
+                util.load_text_file(confpath),
             )
 
     @mock.patch("cloudinit.config.cc_ntp.select_ntp_client")
@@ -506,7 +507,7 @@ class TestNtp(FilesystemMockingTestCase):
                     expected_service_call, capture=True, rcs=None
                 )
 
-            self.assertEqual(expected_content, util.load_file(confpath))
+            self.assertEqual(expected_content, util.load_text_file(confpath))
 
     @mock.patch("cloudinit.util.system_info")
     def test_opensuse_picks_chrony(self, m_sysinfo):
@@ -674,7 +675,7 @@ class TestNtp(FilesystemMockingTestCase):
                 cc_ntp.handle("notimportant", cfg, mycloud, None)
             self.assertEqual(
                 "servers []\npools ['mypool.org']\n%s" % custom,
-                util.load_file(confpath),
+                util.load_text_file(confpath),
             )
 
     @mock.patch("cloudinit.config.cc_ntp.supplemental_schema_validation")
@@ -714,7 +715,7 @@ class TestNtp(FilesystemMockingTestCase):
                 cc_ntp.handle("notimportant", {"ntp": cfg}, mycloud, None)
             self.assertEqual(
                 "servers []\npools ['mypool.org']\n%s" % custom,
-                util.load_file(confpath),
+                util.load_text_file(confpath),
             )
         m_schema.assert_called_with(expected_merged_cfg)
 

--- a/tests/unittests/config/test_cc_phone_home.py
+++ b/tests/unittests/config/test_cc_phone_home.py
@@ -18,7 +18,7 @@ phone_home = partial(handle, name="test", cloud=get_cloud(), args=[])
 
 @pytest.fixture(autouse=True)
 def common_mocks(mocker):
-    mocker.patch("cloudinit.util.load_file", side_effect=count())
+    mocker.patch("cloudinit.util.load_text_file", side_effect=count())
 
 
 @mock.patch("cloudinit.url_helper.readurl")

--- a/tests/unittests/config/test_cc_puppet.py
+++ b/tests/unittests/config/test_cc_puppet.py
@@ -261,7 +261,7 @@ class TestPuppetHandle(CiTestCase):
         util.write_file(self.conf, "[agent]\nserver = origpuppet\nother = 3")
         self.cloud.distro = mock.MagicMock()
         cc_puppet.handle("notimportant", cfg, self.cloud, None)
-        content = util.load_file(self.conf)
+        content = util.load_text_file(self.conf)
         expected = "[agent]\nserver = puppetserver.example.org\nother = 3\n\n"
         self.assertEqual(expected, content)
 
@@ -298,7 +298,7 @@ class TestPuppetHandle(CiTestCase):
             }
         }
         cc_puppet.handle("notimportant", cfg, self.cloud, None)
-        content = util.load_file(self.csr_attributes_path)
+        content = util.load_text_file(self.csr_attributes_path)
         expected = textwrap.dedent(
             """\
             custom_attributes:

--- a/tests/unittests/config/test_cc_rsyslog.py
+++ b/tests/unittests/config/test_cc_rsyslog.py
@@ -115,7 +115,7 @@ class TestApplyChanges(TestCase):
 
         fname = os.path.join(self.tmp, "foo.cfg")
         self.assertEqual([fname], changed)
-        self.assertEqual(util.load_file(fname), cfgline + "\n")
+        self.assertEqual(util.load_text_file(fname), cfgline + "\n")
 
     def test_multiple_files(self):
         configs = [
@@ -139,11 +139,11 @@ class TestApplyChanges(TestCase):
         self.assertEqual([f[0] for f in expected], changed)
         actual = []
         for fname, _content in expected:
-            util.load_file(fname)
+            util.load_text_file(fname)
             actual.append(
                 (
                     fname,
-                    util.load_file(fname),
+                    util.load_text_file(fname),
                 )
             )
         self.assertEqual(expected, actual)
@@ -159,7 +159,7 @@ class TestApplyChanges(TestCase):
         self.assertEqual([fname], changed)
 
         expected_content = "\n".join([c for c in configs]) + "\n"
-        found_content = util.load_file(fname)
+        found_content = util.load_text_file(fname)
         self.assertEqual(expected_content, found_content)
 
     def test_multiline_content(self):
@@ -171,7 +171,7 @@ class TestApplyChanges(TestCase):
 
         fname = os.path.join(self.tmp, "default.cfg")
         expected_content = "\n".join([c for c in configs])
-        found_content = util.load_file(fname)
+        found_content = util.load_text_file(fname)
         self.assertEqual(expected_content, found_content)
 
 

--- a/tests/unittests/config/test_cc_runcmd.py
+++ b/tests/unittests/config/test_cc_runcmd.py
@@ -75,7 +75,9 @@ class TestRuncmd(FilesystemMockingTestCase):
             self.new_root,
             "var/lib/cloud/instances/iid-datasource-none/scripts/runcmd",
         )
-        self.assertEqual("#!/bin/sh\n'ls' '/'\n", util.load_file(runcmd_file))
+        self.assertEqual(
+            "#!/bin/sh\n'ls' '/'\n", util.load_text_file(runcmd_file)
+        )
         file_stat = os.stat(runcmd_file)
         self.assertEqual(0o700, stat.S_IMODE(file_stat.st_mode))
 

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -73,7 +73,7 @@ class TestRandomSeed(TestCase):
             }
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
-        contents = util.load_file(self._seed_file)
+        contents = util.load_text_file(self._seed_file)
         self.assertEqual("tiny-tim-was-here", contents)
 
     def test_append_random_unknown_encoding(self):
@@ -104,7 +104,7 @@ class TestRandomSeed(TestCase):
             }
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
-        contents = util.load_file(self._seed_file)
+        contents = util.load_text_file(self._seed_file)
         self.assertEqual("tiny-toe", contents)
 
     def test_append_random_gz(self):
@@ -117,7 +117,7 @@ class TestRandomSeed(TestCase):
             }
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
-        contents = util.load_file(self._seed_file)
+        contents = util.load_text_file(self._seed_file)
         self.assertEqual("big-toe", contents)
 
     def test_append_random_base64(self):
@@ -130,7 +130,7 @@ class TestRandomSeed(TestCase):
             }
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
-        contents = util.load_file(self._seed_file)
+        contents = util.load_text_file(self._seed_file)
         self.assertEqual("bubbles", contents)
 
     def test_append_random_b64(self):
@@ -143,7 +143,7 @@ class TestRandomSeed(TestCase):
             }
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
-        contents = util.load_file(self._seed_file)
+        contents = util.load_text_file(self._seed_file)
         self.assertEqual("kit-kat", contents)
 
     def test_append_random_metadata(self):
@@ -155,7 +155,7 @@ class TestRandomSeed(TestCase):
         }
         c = get_cloud("ubuntu", metadata={"random_seed": "-so-was-josh"})
         cc_seed_random.handle("test", cfg, c, [])
-        contents = util.load_file(self._seed_file)
+        contents = util.load_text_file(self._seed_file)
         self.assertEqual("tiny-tim-was-here-so-was-josh", contents)
 
     def test_seed_command_provided_and_available(self):

--- a/tests/unittests/config/test_cc_set_hostname.py
+++ b/tests/unittests/config/test_cc_set_hostname.py
@@ -62,7 +62,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
-        contents = util.load_file("/etc/sysconfig/network", decode=False)
+        contents = util.load_binary_file("/etc/sysconfig/network")
         n_cfg = ConfigObj(BytesIO(contents))
         self.assertEqual({"HOSTNAME": "blah"}, dict(n_cfg))
 
@@ -75,7 +75,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
-        contents = util.load_file("/etc/sysconfig/network", decode=False)
+        contents = util.load_binary_file("/etc/sysconfig/network")
         n_cfg = ConfigObj(BytesIO(contents))
         self.assertEqual({"HOSTNAME": "blah.blah.blah.yahoo.com"}, dict(n_cfg))
 

--- a/tests/unittests/config/test_cc_set_hostname.py
+++ b/tests/unittests/config/test_cc_set_hostname.py
@@ -46,7 +46,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
-        contents = util.load_file("/etc/hostname")
+        contents = util.load_text_file("/etc/hostname")
         self.assertEqual("blah.yahoo.com", contents.strip())
 
     @mock.patch("cloudinit.distros.Distro.uses_systemd", return_value=False)
@@ -90,7 +90,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
-        contents = util.load_file("/etc/hostname")
+        contents = util.load_text_file("/etc/hostname")
         self.assertEqual("blah", contents.strip())
 
     @mock.patch("cloudinit.distros.Distro.uses_systemd", return_value=False)
@@ -104,7 +104,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
-        contents = util.load_file(distro.hostname_conf_fn)
+        contents = util.load_text_file(distro.hostname_conf_fn)
         self.assertEqual("blah", contents.strip())
 
     @mock.patch("cloudinit.distros.photon.subp.subp")
@@ -166,7 +166,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc_set_hostname.handle(
             "cc_set_hostname", {"hostname": "hostname1.me.com"}, cc, []
         )
-        contents = util.load_file("/etc/hostname")
+        contents = util.load_text_file("/etc/hostname")
         self.assertEqual("hostname1", contents.strip())
         cc_set_hostname.handle(
             "cc_set_hostname", {"hostname": "hostname1.me.com"}, cc, []
@@ -178,7 +178,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc_set_hostname.handle(
             "cc_set_hostname", {"hostname": "hostname2.me.com"}, cc, []
         )
-        contents = util.load_file("/etc/hostname")
+        contents = util.load_text_file("/etc/hostname")
         self.assertEqual("hostname2", contents.strip())
         self.assertIn(
             "Non-persistently setting the system hostname to hostname2",
@@ -199,7 +199,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
 
         util.write_file("/etc/hostname", "")
         cc_set_hostname.handle("cc_set_hostname", {}, cc, [])
-        contents = util.load_file("/etc/hostname")
+        contents = util.load_text_file("/etc/hostname")
         self.assertEqual("", contents.strip())
 
     @mock.patch("cloudinit.util.get_hostname", return_value="localhost")
@@ -218,7 +218,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         cc_set_hostname.handle(
             "cc_set_hostname", {"hostname": "localhost"}, cc, []
         )
-        contents = util.load_file("/etc/hostname")
+        contents = util.load_text_file("/etc/hostname")
         self.assertEqual("localhost", contents.strip())
 
     def test_error_on_distro_set_hostname_errors(self):
@@ -256,7 +256,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         prev_fn = Path(cc.get_cpath("data")) / "set-hostname"
         prev_fn.touch()
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
-        contents = util.load_file("/etc/hostname")
+        contents = util.load_text_file("/etc/hostname")
         self.assertEqual("blah", contents.strip())
 
     def test_create_hostname_file_false(self):
@@ -272,7 +272,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         with self.assertRaises(FileNotFoundError):
-            util.load_file("/etc/hostname")
+            util.load_text_file("/etc/hostname")
 
     def test_create_hostname_file_false_arch(self):
         cfg = {
@@ -287,7 +287,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         with self.assertRaises(FileNotFoundError):
-            util.load_file("/etc/hostname")
+            util.load_text_file("/etc/hostname")
 
     def test_create_hostname_file_false_alpine(self):
         cfg = {
@@ -302,7 +302,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         with self.assertRaises(FileNotFoundError):
-            util.load_file("/etc/hostname")
+            util.load_text_file("/etc/hostname")
 
     def test_create_hostname_file_false_gentoo(self):
         cfg = {
@@ -317,7 +317,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         with self.assertRaises(FileNotFoundError):
-            util.load_file("/etc/hostname")
+            util.load_text_file("/etc/hostname")
 
     def test_create_hostname_file_false_photon(self):
         cfg = {
@@ -332,7 +332,7 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         with self.assertRaises(FileNotFoundError):
-            util.load_file("/etc/hostname")
+            util.load_text_file("/etc/hostname")
 
     def test_create_hostname_file_false_rhel(self):
         cfg = {
@@ -347,4 +347,4 @@ class TestHostname(t_help.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_set_hostname.handle("cc_set_hostname", cfg, cc, [])
         with self.assertRaises(FileNotFoundError):
-            util.load_file("/etc/hostname")
+            util.load_text_file("/etc/hostname")

--- a/tests/unittests/config/test_cc_snap.py
+++ b/tests/unittests/config/test_cc_snap.py
@@ -131,7 +131,9 @@ class TestAddAssertions:
         ] == m_subp.call_args_list
         compare_file = tmpdir.join("comparison")
         util.write_file(compare_file, "\n".join(assertions).encode("utf-8"))
-        assert util.load_file(compare_file) == util.load_file(assert_file)
+        assert util.load_text_file(compare_file) == util.load_text_file(
+            assert_file
+        )
 
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
     def test_add_assertions_adds_assertions_as_dict(
@@ -159,7 +161,9 @@ class TestAddAssertions:
         compare_file = tmpdir.join("comparison")
         combined = "\n".join(assertions.values())
         util.write_file(compare_file, combined.encode("utf-8"))
-        assert util.load_file(compare_file) == util.load_file(assert_file)
+        assert util.load_text_file(compare_file) == util.load_text_file(
+            assert_file
+        )
 
 
 class TestRunCommands(CiTestCase):
@@ -200,7 +204,7 @@ class TestCommands:
         expected_messages = ["Running user-provided snap commands"]
         for message in expected_messages:
             assert message in caplog.text
-        assert "MOM\nHI\n" == util.load_file(outfile)
+        assert "MOM\nHI\n" == util.load_text_file(outfile)
 
     def test_run_command_as_lists(self, caplog, tmp_path):
         """When commands are specified as a list, run them in order."""
@@ -212,7 +216,7 @@ class TestCommands:
         run_commands(commands=commands)
 
         assert "Running user-provided snap commands" in caplog.text
-        assert "HI\nMOM\n" == util.load_file(f"{tmp_path}/{outfile}")
+        assert "HI\nMOM\n" == util.load_text_file(f"{tmp_path}/{outfile}")
         assert "Non-snap commands in snap config:" in caplog.text
 
 
@@ -302,4 +306,6 @@ class TestHandle:
         handle("snap", cfg=cfg, cloud=fake_cloud, args=None)
         content = "\n".join(cfg["snap"]["assertions"])
         util.write_file(compare_file, content.encode("utf-8"))
-        assert util.load_file(compare_file) == util.load_file(assert_file)
+        assert util.load_text_file(compare_file) == util.load_text_file(
+            assert_file
+        )

--- a/tests/unittests/config/test_cc_timezone.py
+++ b/tests/unittests/config/test_cc_timezone.py
@@ -46,5 +46,5 @@ class TestTimezone(t_help.FilesystemMockingTestCase):
         n_cfg = ConfigObj(BytesIO(contents))
         self.assertEqual({"TIMEZONE": cfg["timezone"]}, dict(n_cfg))
 
-        contents = util.load_file("/etc/localtime")
+        contents = util.load_text_file("/etc/localtime")
         self.assertEqual(dummy_contents, contents.strip())

--- a/tests/unittests/config/test_cc_timezone.py
+++ b/tests/unittests/config/test_cc_timezone.py
@@ -42,7 +42,7 @@ class TestTimezone(t_help.FilesystemMockingTestCase):
 
         cc_timezone.handle("cc_timezone", cfg, cc, [])
 
-        contents = util.load_file("/etc/sysconfig/clock", decode=False)
+        contents = util.load_binary_file("/etc/sysconfig/clock")
         n_cfg = ConfigObj(BytesIO(contents))
         self.assertEqual({"TIMEZONE": cfg["timezone"]}, dict(n_cfg))
 

--- a/tests/unittests/config/test_cc_update_etc_hosts.py
+++ b/tests/unittests/config/test_cc_update_etc_hosts.py
@@ -46,7 +46,7 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
         cc_update_etc_hosts.handle("test", cfg, cc, [])
-        contents = util.load_file("%s/etc/hosts" % self.tmp)
+        contents = util.load_text_file("%s/etc/hosts" % self.tmp)
         if "127.0.1.1\tcloud-init.test.us\tcloud-init" not in contents:
             self.assertIsNone("No entry for 127.0.1.1 in etc/hosts")
         if "192.168.1.1\tblah.blah.us\tblah" not in contents:
@@ -69,7 +69,7 @@ class TestHostsFile(t_help.FilesystemMockingTestCase):
         cc = cloud.Cloud(ds, paths, {}, distro, None)
         self.patchUtils(self.tmp)
         cc_update_etc_hosts.handle("test", cfg, cc, [])
-        contents = util.load_file("%s/etc/hosts" % self.tmp)
+        contents = util.load_text_file("%s/etc/hosts" % self.tmp)
         if "127.0.1.1 cloud-init.test.us cloud-init" not in contents:
             self.assertIsNone("No entry for 127.0.1.1 in etc/hosts")
         if "::1 cloud-init.test.us cloud-init" not in contents:

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -137,7 +137,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
         write_files("test_decoding", files, self.owner)
 
         for path, content in expected:
-            self.assertEqual(util.load_file(path, decode=False), content)
+            self.assertEqual(util.load_binary_file(path), content)
 
         # make sure we actually wrote *some* files.
         flen_expected = len(gz_aliases + gz_b64_aliases + b64_aliases) * len(

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -81,7 +81,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
             [{"content": expected, "path": filename}],
             self.owner,
         )
-        self.assertEqual(util.load_file(filename), expected)
+        self.assertEqual(util.load_text_file(filename), expected)
 
     def test_append(self):
         self.patchUtils(self.tmp)
@@ -95,14 +95,14 @@ class TestWriteFiles(FilesystemMockingTestCase):
             [{"content": added, "path": filename, "append": "true"}],
             self.owner,
         )
-        self.assertEqual(util.load_file(filename), expected)
+        self.assertEqual(util.load_text_file(filename), expected)
 
     def test_yaml_binary(self):
         self.patchUtils(self.tmp)
         data = util.load_yaml(YAML_TEXT)
         write_files("testname", data["write_files"], self.owner)
         for path, content in YAML_CONTENT_EXPECTED.items():
-            self.assertEqual(util.load_file(path), content)
+            self.assertEqual(util.load_text_file(path), content)
 
     def test_all_decodings(self):
         self.patchUtils(self.tmp)
@@ -161,7 +161,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
         }
         cc = self.tmp_cloud("ubuntu")
         handle("ignored", cfg, cc, [])
-        assert content == util.load_file(file_path)
+        assert content == util.load_text_file(file_path)
         self.assertNotIn(
             "Unknown encoding type text/plain", self.logs.getvalue()
         )
@@ -173,7 +173,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
         cc = self.tmp_cloud("ubuntu")
         handle("cc_write_file", config, cc, [])
         with self.assertRaises(FileNotFoundError):
-            util.load_file(file_path)
+            util.load_text_file(file_path)
 
 
 class TestDecodePerms(CiTestCase):

--- a/tests/unittests/config/test_cc_write_files_deferred.py
+++ b/tests/unittests/config/test_cc_write_files_deferred.py
@@ -45,9 +45,9 @@ class TestWriteFilesDeferred(FilesystemMockingTestCase):
         }
         cc = self.tmp_cloud("ubuntu")
         handle("cc_write_files_deferred", config, cc, [])
-        self.assertEqual(util.load_file("/tmp/deferred.file"), expected)
+        self.assertEqual(util.load_text_file("/tmp/deferred.file"), expected)
         with self.assertRaises(FileNotFoundError):
-            util.load_file("/tmp/not_deferred.file")
+            util.load_text_file("/tmp/not_deferred.file")
 
 
 class TestWriteFilesDeferredSchema:

--- a/tests/unittests/config/test_cc_yum_add_repo.py
+++ b/tests/unittests/config/test_cc_yum_add_repo.py
@@ -43,7 +43,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_yum_add_repo.handle("yum_add_repo", cfg, None, [])
         self.assertRaises(
-            IOError, util.load_file, "/etc/yum.repos.d/epel_testing.repo"
+            IOError, util.load_text_file, "/etc/yum.repos.d/epel_testing.repo"
         )
 
     def test_write_config(self):
@@ -62,7 +62,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         self.patchOS(self.tmp)
         cc_yum_add_repo.handle("yum_add_repo", cfg, None, [])
-        contents = util.load_file("/etc/yum.repos.d/epel-testing.repo")
+        contents = util.load_text_file("/etc/yum.repos.d/epel-testing.repo")
         parser = configparser.ConfigParser()
         parser.read_string(contents)
         expected = {
@@ -102,7 +102,9 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         }
         self.patchUtils(self.tmp)
         cc_yum_add_repo.handle("yum_add_repo", cfg, None, [])
-        contents = util.load_file("/etc/yum.repos.d/puppetlabs-products.repo")
+        contents = util.load_text_file(
+            "/etc/yum.repos.d/puppetlabs-products.repo"
+        )
         parser = configparser.ConfigParser()
         parser.read_string(contents)
         expected = {

--- a/tests/unittests/config/test_cc_zypper_add_repo.py
+++ b/tests/unittests/config/test_cc_zypper_add_repo.py
@@ -29,7 +29,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_zypper_add_repo._write_repos(cfg["repos"], "/etc/zypp/repos.d")
         self.assertRaises(
-            IOError, util.load_file, "/etc/zypp/repos.d/foo.repo"
+            IOError, util.load_text_file, "/etc/zypp/repos.d/foo.repo"
         )
 
     def test_write_repos(self):
@@ -60,7 +60,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         }
         root_d = self.tmp_dir()
         cc_zypper_add_repo._write_repos(cfg["repos"], root_d)
-        contents = util.load_file("%s/testing-foo.repo" % root_d)
+        contents = util.load_text_file("%s/testing-foo.repo" % root_d)
         parser = configparser.ConfigParser()
         parser.read_string(contents)
         expected = {
@@ -87,7 +87,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.reRoot(root_d)
         cc_zypper_add_repo._write_zypp_config(cfg["config"])
         cfg_out = os.path.join(root_d, self.zypp_conf)
-        contents = util.load_file(cfg_out)
+        contents = util.load_text_file(cfg_out)
         expected = [
             "# Zypp config",
             "# Added via cloud.cfg",
@@ -113,7 +113,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.reRoot(root_d)
         cc_zypper_add_repo._write_zypp_config(cfg["config"])
         cfg_out = os.path.join(root_d, self.zypp_conf)
-        contents = util.load_file(cfg_out)
+        contents = util.load_text_file(cfg_out)
         expected = [
             "# Zypp config",
             "# Added via cloud.cfg",
@@ -136,7 +136,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.reRoot(root_d)
         cc_zypper_add_repo._write_zypp_config(cfg.get("config", {}))
         cfg_out = os.path.join(root_d, self.zypp_conf)
-        contents = util.load_file(cfg_out)
+        contents = util.load_text_file(cfg_out)
         self.assertEqual(contents, "# No data")
 
     def test_empty_config_value_no_new_data(self):
@@ -149,7 +149,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.reRoot(root_d)
         cc_zypper_add_repo._write_zypp_config(cfg.get("config", {}))
         cfg_out = os.path.join(root_d, self.zypp_conf)
-        contents = util.load_file(cfg_out)
+        contents = util.load_text_file(cfg_out)
         self.assertEqual(contents, "# No data")
 
     def test_handler_full_setup(self):
@@ -164,7 +164,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.reRoot(root_d)
         cc_zypper_add_repo.handle("zypper_add_repo", cfg, None, [])
         cfg_out = os.path.join(root_d, self.zypp_conf)
-        contents = util.load_file(cfg_out)
+        contents = util.load_text_file(cfg_out)
         expected = [
             "# Zypp config",
             "# Added via cloud.cfg",
@@ -191,7 +191,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.reRoot(root_d)
         cc_zypper_add_repo._write_zypp_config(cfg.get("config", {}))
         cfg_out = os.path.join(root_d, self.zypp_conf)
-        contents = util.load_file(cfg_out)
+        contents = util.load_text_file(cfg_out)
         self.assertEqual(contents, "# No data")
 
     def test_no_repo_data(self):

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -43,7 +43,7 @@ from cloudinit.safeyaml import load, load_with_marks
 from cloudinit.settings import FREQUENCIES
 from cloudinit.sources import DataSourceNotFoundException
 from cloudinit.templater import JinjaSyntaxParsingException
-from cloudinit.util import load_file, write_file
+from cloudinit.util import load_text_file, write_file
 from tests.helpers import cloud_init_project_dir
 from tests.hypothesis import given
 from tests.hypothesis_jsonschema import from_schema
@@ -138,7 +138,7 @@ class TestVersionedSchemas:
                 r"https:\/\/raw.githubusercontent.com\/canonical\/"
                 r"cloud-init\/main\/cloudinit\/config\/schemas\/",
                 f"file://{schema_dir}/",
-                load_file(version_schemafile),
+                load_text_file(version_schemafile),
             )
         )
         if error_msg:
@@ -926,11 +926,11 @@ class TestValidateCloudConfigFile:
         invalid_jinja_template = "## template: jinja\na:b\nc:{{ d } }"
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
-            "cloudinit.util.load_file",
+            "cloudinit.util.load_text_file",
             return_value=invalid_jinja_template,
         )
         mocker.patch(
-            "cloudinit.handlers.jinja_template.load_file",
+            "cloudinit.handlers.jinja_template.load_text_file",
             return_value='{"c": "d"}',
         )
         config_file = tmpdir.join("my.yaml")

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -31,6 +31,7 @@ FS_FUNCS = {
         ("write_file", 1),
         ("append_file", 1),
         ("load_file", 1),
+        ("load_text_file", 1),
         ("ensure_dir", 1),
         ("chmod", 1),
         ("delete_dir_contents", 1),

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -30,7 +30,7 @@ FS_FUNCS = {
     util: [
         ("write_file", 1),
         ("append_file", 1),
-        ("load_file", 1),
+        ("load_binary_file", 1),
         ("load_text_file", 1),
         ("ensure_dir", 1),
         ("chmod", 1),

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -69,7 +69,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.patchOS(self.tmp)
         self.patchUtils(self.tmp)
         d.write_doas_rules(user, rules)
-        contents = util.load_file(d.doas_fn)
+        contents = util.load_text_file(d.doas_fn)
         return contents, cls, d
 
     def _write_load_sudoers(self, _user, rules):
@@ -80,7 +80,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.patchOS(self.tmp)
         self.patchUtils(self.tmp)
         d.write_sudo_rules("harlowja", rules)
-        contents = util.load_file(d.ci_sudoers_fn)
+        contents = util.load_text_file(d.ci_sudoers_fn)
         return contents, cls, d
 
     def _count_in(self, lines_look_for, text_content):
@@ -121,7 +121,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         d = self._write_load_doas("harlowja", rules)[2]
         # write to doas.conf again - should not create duplicate rules
         d.write_doas_rules("harlowja", rules)
-        contents = util.load_file(d.doas_fn)
+        contents = util.load_text_file(d.doas_fn)
         expected = [
             "permit nopass harlowja cmd ls",
             "permit nopass harlowja cmd pwd",
@@ -195,7 +195,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         d = self._write_load_sudoers("harlowja", rules)[2]
         # write to sudoers again - should not create duplicate rules
         d.write_sudo_rules("harlowja", rules)
-        contents = util.load_file(d.ci_sudoers_fn)
+        contents = util.load_text_file(d.ci_sudoers_fn)
         expected = [
             "harlowja ALL=(ALL:ALL) ALL",
             "harlowja B-ALL=(ALL:ALL) ALL",
@@ -215,7 +215,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.patchOS(self.tmp)
         self.patchUtils(self.tmp)
         d.ensure_sudo_dir("/b")
-        contents = util.load_file("/etc/sudoers")
+        contents = util.load_text_file("/etc/sudoers")
         self.assertIn("includedir /b", contents)
         self.assertTrue(os.path.isdir("/b"))
 
@@ -226,7 +226,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         util.write_file("/etc/sudoers", "josh, josh\n")
         d.ensure_sudo_dir("/b")
-        contents = util.load_file("/etc/sudoers")
+        contents = util.load_text_file("/etc/sudoers")
         self.assertIn("includedir /b", contents)
         self.assertTrue(os.path.isdir("/b"))
         self.assertIn("josh", contents)
@@ -240,7 +240,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         for char in ["#", "@"]:
             util.write_file("/etc/sudoers", "{}includedir /b".format(char))
             d.ensure_sudo_dir("/b")
-            contents = util.load_file("/etc/sudoers")
+            contents = util.load_text_file("/etc/sudoers")
             self.assertIn("includedir /b", contents)
             self.assertTrue(os.path.isdir("/b"))
             self.assertEqual(1, contents.count("includedir /b"))

--- a/tests/unittests/distros/test_arch.py
+++ b/tests/unittests/distros/test_arch.py
@@ -11,4 +11,4 @@ class TestArch(CiTestCase):
         hostname = "myhostname"
         hostfile = self.tmp_path("hostfile")
         distro._write_hostname(hostname, hostfile)
-        self.assertEqual(hostname + "\n", util.load_file(hostfile))
+        self.assertEqual(hostname + "\n", util.load_text_file(hostfile))

--- a/tests/unittests/distros/test_bsd_utils.py
+++ b/tests/unittests/distros/test_bsd_utils.py
@@ -18,7 +18,7 @@ class TestBsdUtils(CiTestCase):
         self.addCleanup(patches.close)
 
         self.load_file = patches.enter_context(
-            mock.patch.object(bsd_utils.util, "load_file")
+            mock.patch.object(bsd_utils.util, "load_text_file")
         )
 
         self.write_file = patches.enter_context(

--- a/tests/unittests/distros/test_gentoo.py
+++ b/tests/unittests/distros/test_gentoo.py
@@ -11,7 +11,9 @@ class TestGentoo(CiTestCase):
         hostname = "myhostname"
         hostfile = self.tmp_path("hostfile")
         distro._write_hostname(hostname, hostfile)
-        self.assertEqual('hostname="myhostname"\n', util.load_file(hostfile))
+        self.assertEqual(
+            'hostname="myhostname"\n', util.load_text_file(hostfile)
+        )
 
     def test_write_existing_hostname_with_comments(self):
         distro = _get_distro("gentoo")
@@ -22,5 +24,5 @@ class TestGentoo(CiTestCase):
         distro._write_hostname(hostname, hostfile)
         self.assertEqual(
             '#This is the hostname\nhostname="myhostname"\n',
-            util.load_file(hostfile),
+            util.load_text_file(hostfile),
         )

--- a/tests/unittests/distros/test_opensuse.py
+++ b/tests/unittests/distros/test_opensuse.py
@@ -14,7 +14,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "xfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / xfs rw,bar\n",
     )
     @mock.patch(
@@ -33,7 +33,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "xfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / xfs rw,bar\n",
     )
     @mock.patch(
@@ -58,7 +58,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "xfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / xfs rw,bar\n",
     )
     @mock.patch(
@@ -77,7 +77,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "xfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / xfs rw,bar\n",
     )
     @mock.patch(
@@ -102,7 +102,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "xfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / xfs rw,bar\n",
     )
     @mock.patch(
@@ -128,7 +128,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "btrfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
     )
     @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
@@ -150,7 +150,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "btrfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
     )
     @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
@@ -175,7 +175,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "btrfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / btrf rw,bar\n",
     )
     @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
@@ -197,7 +197,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "btrfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
     )
     @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
@@ -222,7 +222,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "btrfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
     )
     @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
@@ -248,7 +248,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "btrfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / btrfs ro,bar\n",
     )
     @mock.patch(
@@ -270,7 +270,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "btrfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / btrfs rw,bar\n",
     )
     @mock.patch(
@@ -293,7 +293,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "xfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / xfs ro,bar\n",
     )
     @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)
@@ -314,7 +314,7 @@ class TestPackageCommands:
         return_value=("/dev/sda1", "btrfs", "/"),
     )
     @mock.patch(
-        "cloudinit.distros.opensuse.util.load_file",
+        "cloudinit.distros.opensuse.util.load_text_file",
         return_value="foo\n/dev/sda1 / btrfs ro,bar\n",
     )
     @mock.patch("cloudinit.distros.opensuse.os.path.exists", return_value=True)

--- a/tests/unittests/distros/test_photon.py
+++ b/tests/unittests/distros/test_photon.py
@@ -29,7 +29,7 @@ class TestPhoton(CiTestCase):
         hostname = "myhostname"
         hostfile = self.tmp_path("previous-hostname")
         self.distro._write_hostname(hostname, hostfile)
-        self.assertEqual(hostname, util.load_file(hostfile))
+        self.assertEqual(hostname, util.load_text_file(hostfile))
 
         ret = self.distro._read_hostname(hostfile)
         self.assertEqual(ret, hostname)

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -286,6 +286,7 @@ class FilesystemMockingTestCase(ResourceUsingTestCase):
                 ("write_file", 1),
                 ("append_file", 1),
                 ("load_file", 1),
+                ("load_text_file", 1),
                 ("ensure_dir", 1),
                 ("chmod", 1),
                 ("delete_dir_contents", 1),
@@ -481,7 +482,7 @@ def dir2dict(startdir, prefix=None):
         for fname in files:
             fpath = os.path.join(root, fname)
             key = fpath[len(prefix) :]
-            flist[key] = util.load_file(fpath)
+            flist[key] = util.load_text_file(fpath)
     return flist
 
 

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -285,7 +285,7 @@ class FilesystemMockingTestCase(ResourceUsingTestCase):
             util: [
                 ("write_file", 1),
                 ("append_file", 1),
-                ("load_file", 1),
+                ("load_binary_file", 1),
                 ("load_text_file", 1),
                 ("ensure_dir", 1),
                 ("chmod", 1),

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -474,7 +474,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
         )
 
         with mock.patch(
-            "cloudinit.util.load_file", return_value=lease_content
+            "cloudinit.util.load_text_file", return_value=lease_content
         ):
             self.assertCountEqual(
                 {
@@ -486,7 +486,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
                 IscDhclient().get_newest_lease("eth0"),
             )
         with self.assertRaises(InvalidDHCPLeaseFileError):
-            with mock.patch("cloudinit.util.load_file", return_value=""):
+            with mock.patch("cloudinit.util.load_text_file", return_value=""):
                 IscDhclient().dhcp_discovery("eth9", distro=MockDistro())
         self.assertIn(
             "dhclient(pid=, parentpid=unknown) failed "
@@ -553,7 +553,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
         )
         my_pid = 1
         with mock.patch(
-            "cloudinit.util.load_file", side_effect=["1", lease_content]
+            "cloudinit.util.load_text_file", side_effect=["1", lease_content]
         ):
             self.assertCountEqual(
                 {
@@ -629,7 +629,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
         )
         my_pid = 1
         with mock.patch(
-            "cloudinit.util.load_file", side_effect=["1", lease_content]
+            "cloudinit.util.load_text_file", side_effect=["1", lease_content]
         ):
             self.assertCountEqual(
                 {
@@ -933,7 +933,7 @@ class TestUDHCPCDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
     @mock.patch("cloudinit.util.load_json")
-    @mock.patch("cloudinit.util.load_file")
+    @mock.patch("cloudinit.util.load_text_file")
     @mock.patch("cloudinit.util.write_file")
     def test_udhcpc_discovery(
         self,
@@ -998,7 +998,7 @@ class TestUDHCPCDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
     @mock.patch("cloudinit.util.load_json")
-    @mock.patch("cloudinit.util.load_file")
+    @mock.patch("cloudinit.util.load_text_file")
     @mock.patch("cloudinit.util.write_file")
     def test_udhcpc_discovery_ib(
         self,

--- a/tests/unittests/runs/test_merge_run.py
+++ b/tests/unittests/runs/test_merge_run.py
@@ -55,5 +55,5 @@ class TestMergeRun(helpers.FilesystemMockingTestCase):
         self.assertTrue(len(failures) == 0)
         self.assertTrue(os.path.exists("/etc/blah.ini"))
         self.assertIn("write_files", which_ran)
-        contents = util.load_file("/etc/blah.ini")
+        contents = util.load_text_file("/etc/blah.ini")
         self.assertEqual(contents, "blah")

--- a/tests/unittests/runs/test_simple_run.py
+++ b/tests/unittests/runs/test_simple_run.py
@@ -77,7 +77,7 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
         initer.apply_network_config(False)
         self.assertEqual(
             f"{atomic_helper.json_dumps(netcfg)}\n",
-            util.load_file("/var/lib/cloud/instance/network-config.json"),
+            util.load_text_file("/var/lib/cloud/instance/network-config.json"),
         )
 
     def test_none_ds_runs_modules_which_do_not_define_distros(self):
@@ -100,7 +100,7 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
         self.assertTrue(len(failures) == 0)
         self.assertTrue(os.path.exists("/etc/blah.ini"))
         self.assertIn("write_files", which_ran)
-        contents = util.load_file("/etc/blah.ini")
+        contents = util.load_text_file("/etc/blah.ini")
         self.assertEqual(contents, "blah")
         self.assertNotIn(
             "Skipping modules ['write_files'] because they are not verified on"

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -19,7 +19,12 @@ from cloudinit.sources import UNSET
 from cloudinit.sources import DataSourceAzure as dsaz
 from cloudinit.sources.azure import errors, identity, imds
 from cloudinit.sources.helpers import netlink
-from cloudinit.util import MountFailedError, load_file, load_json, write_file
+from cloudinit.util import (
+    MountFailedError,
+    load_json,
+    load_text_file,
+    write_file,
+)
 from tests.unittests.helpers import (
     CiTestCase,
     ExitStack,
@@ -1870,7 +1875,7 @@ scbus-1 on xpt0 bus 0
         ovf_env_path = os.path.join(self.waagent_d, "ovf-env.xml")
 
         # The XML should not be same since the user password is redacted
-        on_disk_ovf = load_file(ovf_env_path)
+        on_disk_ovf = load_text_file(ovf_env_path)
         self.xml_notequals(data["ovfcontent"], on_disk_ovf)
 
         # Make sure that the redacted password on disk is not used by CI
@@ -1893,7 +1898,7 @@ scbus-1 on xpt0 bus 0
         # we expect that the ovf-env.xml file is copied there.
         ovf_env_path = os.path.join(self.waagent_d, "ovf-env.xml")
         self.assertTrue(os.path.exists(ovf_env_path))
-        self.xml_equals(xml, load_file(ovf_env_path))
+        self.xml_equals(xml, load_text_file(ovf_env_path))
 
     def test_ovf_can_include_unicode(self):
         xml = construct_ovf_env()

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -311,7 +311,7 @@ def mock_util_find_devs_with():
 @pytest.fixture
 def mock_util_load_file():
     with mock.patch(
-        MOCKPATH + "util.load_file",
+        MOCKPATH + "util.load_binary_file",
         autospec=True,
         return_value=b"",
     ) as m:

--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -14,7 +14,7 @@ from cloudinit import url_helper
 from cloudinit.sources.azure import errors
 from cloudinit.sources.helpers import azure as azure_helper
 from cloudinit.sources.helpers.azure import WALinuxAgentShim as wa_shim
-from cloudinit.util import load_file
+from cloudinit.util import load_text_file
 from tests.unittests.helpers import CiTestCase, ExitStack, mock
 from tests.unittests.sources.test_azure import construct_ovf_env
 
@@ -531,8 +531,8 @@ class TestOpenSSLManagerActions(CiTestCase):
 
     @unittest.skip("todo move to cloud_test")
     def test_pubkey_extract(self):
-        cert = load_file(self._data_file("pubkey_extract_cert"))
-        good_key = load_file(self._data_file("pubkey_extract_ssh_key"))
+        cert = load_text_file(self._data_file("pubkey_extract_cert"))
+        good_key = load_text_file(self._data_file("pubkey_extract_ssh_key"))
         sslmgr = azure_helper.OpenSSLManager()
         key = sslmgr._get_ssh_key_from_cert(cert)
         self.assertEqual(good_key, key)
@@ -549,8 +549,10 @@ class TestOpenSSLManagerActions(CiTestCase):
         from certs are extracted and that fingerprints are converted to
         the form specified in the ovf-env.xml file.
         """
-        cert_contents = load_file(self._data_file("parse_certificates_pem"))
-        fingerprints = load_file(
+        cert_contents = load_text_file(
+            self._data_file("parse_certificates_pem")
+        )
+        fingerprints = load_text_file(
             self._data_file("parse_certificates_fingerprints")
         ).splitlines()
         mock_decrypt_certs.return_value = cert_contents

--- a/tests/unittests/sources/test_bigstep.py
+++ b/tests/unittests/sources/test_bigstep.py
@@ -22,7 +22,7 @@ METADATA_BODY = json.dumps(
 
 class TestBigstep:
     @pytest.mark.parametrize("custom_paths", [False, True])
-    @mock.patch(M_PATH + "util.load_file", return_value=IMDS_URL)
+    @mock.patch(M_PATH + "util.load_text_file", return_value=IMDS_URL)
     @responses.activate
     def test_get_data_honor_cloud_dir(self, m_load_file, custom_paths, tmpdir):
         responses.add(responses.GET, IMDS_URL, body=METADATA_BODY)

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -38,7 +38,7 @@ class TestCloudStackHostname(CiTestCase):
         )
         self.patches.enter_context(
             mock.patch(
-                DHCP_MOD_PATH + ".util.load_file",
+                DHCP_MOD_PATH + ".util.load_text_file",
                 return_value=dedent(
                     """
                     lease {
@@ -161,7 +161,7 @@ class TestCloudStackHostname(CiTestCase):
             {}, rhel.Distro, helpers.Paths({"run_dir": self.tmp})
         )
         with mock.patch(
-            MOD_PATH + ".util.load_file",
+            MOD_PATH + ".util.load_text_file",
             return_value=dedent(
                 """
                 lease {
@@ -284,7 +284,7 @@ class TestCloudStackHostname(CiTestCase):
 
         self.patches.enter_context(
             mock.patch(
-                DHCP_MOD_PATH + ".util.load_file",
+                DHCP_MOD_PATH + ".util.load_text_file",
                 return_value=dedent(
                     """
                     lease {
@@ -317,7 +317,7 @@ class TestCloudStackHostname(CiTestCase):
             {}, ubuntu.Distro("", {}, {}), helpers.Paths({"run_dir": self.tmp})
         )
         ds.distro.fallback_interface = "eth0"
-        with mock.patch(MOD_PATH + ".util.load_file"):
+        with mock.patch(MOD_PATH + ".util.load_text_file"):
             result = ds.get_hostname(fqdn=True)
             self.assertTupleEqual(expected, result)
 
@@ -414,7 +414,7 @@ class TestCloudStackPasswordFetching(CiTestCase):
     def test_bad_request_doesnt_stop_ds_from_working(self, m_wait):
         m_wait.return_value = True
         self._set_password_server_response("bad_request")
-        # with mock.patch(DHCP_MOD_PATH + ".util.load_file"):
+        # with mock.patch(DHCP_MOD_PATH + ".util.load_text_file"):
         ds = DataSourceCloudStack(
             {}, MockDistro(), helpers.Paths({"run_dir": self.tmp})
         )

--- a/tests/unittests/sources/test_init.py
+++ b/tests/unittests/sources/test_init.py
@@ -396,7 +396,7 @@ class TestDataSource(CiTestCase):
             ):
                 datasource.get_data()
         json_file = Paths({"run_dir": tmp}).get_runpath("instance_data")
-        content = util.load_file(json_file)
+        content = util.load_text_file(json_file)
         expected = {
             "base64_encoded_keys": [],
             "merged_cfg": REDACT_SENSITIVE_VALUE,
@@ -501,7 +501,7 @@ class TestDataSource(CiTestCase):
         with mock.patch("cloudinit.util.system_info", return_value=sys_info):
             datasource.get_data()
         json_file = Paths({"run_dir": tmp}).get_runpath("instance_data")
-        redacted = util.load_json(util.load_file(json_file))
+        redacted = util.load_json(util.load_text_file(json_file))
         expected = {
             "base64_encoded_keys": [],
             "merged_cfg": REDACT_SENSITIVE_VALUE,
@@ -619,7 +619,7 @@ class TestDataSource(CiTestCase):
         sensitive_json_file = Paths({"run_dir": tmp}).get_runpath(
             "instance_data_sensitive"
         )
-        content = util.load_file(sensitive_json_file)
+        content = util.load_text_file(sensitive_json_file)
         expected = {
             "base64_encoded_keys": [],
             "merged_cfg": {
@@ -700,7 +700,7 @@ class TestDataSource(CiTestCase):
         )
         datasource.get_data()
         json_file = paths.get_runpath("instance_data")
-        content = util.load_file(json_file)
+        content = util.load_text_file(json_file)
         expected_metadata = {
             "key1": "val1",
             "key2": {
@@ -727,11 +727,11 @@ class TestDataSource(CiTestCase):
         datasource.ec2_metadata = UNSET
         datasource.get_data()
         json_file = paths.get_runpath("instance_data")
-        instance_data = util.load_json(util.load_file(json_file))
+        instance_data = util.load_json(util.load_text_file(json_file))
         self.assertNotIn("ec2_metadata", instance_data["ds"])
         datasource.ec2_metadata = {"ec2stuff": "is good"}
         datasource.persist_instance_data()
-        instance_data = util.load_json(util.load_file(json_file))
+        instance_data = util.load_json(util.load_text_file(json_file))
         self.assertEqual(
             {"ec2stuff": "is good"}, instance_data["ds"]["ec2_metadata"]
         )
@@ -757,7 +757,7 @@ class TestDataSource(CiTestCase):
             "cloudinit.sources.canonical_cloud_id", return_value="my-cloud"
         ):
             datasource.get_data()
-            self.assertEqual("my-cloud\n", util.load_file(cloud_id_link))
+            self.assertEqual("my-cloud\n", util.load_text_file(cloud_id_link))
             # A symlink with the generic /run/cloud-init/cloud-id
             # link is present
             self.assertTrue(util.is_link(cloud_id_link))
@@ -769,12 +769,12 @@ class TestDataSource(CiTestCase):
             "cloudinit.sources.canonical_cloud_id", return_value="my-cloud2"
         ):
             datasource.persist_instance_data()
-        self.assertEqual("my-cloud2\n", util.load_file(cloud_id2_file))
+        self.assertEqual("my-cloud2\n", util.load_text_file(cloud_id2_file))
         # Previous cloud-id-<cloud-type> file removed
         self.assertFalse(os.path.exists(cloud_id_file))
         # Generic link persisted which contains canonical-cloud-id as content
         self.assertTrue(util.is_link(cloud_id_link))
-        self.assertEqual("my-cloud2\n", util.load_file(cloud_id_link))
+        self.assertEqual("my-cloud2\n", util.load_text_file(cloud_id_link))
 
     def test_persist_instance_data_writes_network_json_when_set(self):
         """When network_data.json class attribute is set, persist to json."""
@@ -789,11 +789,11 @@ class TestDataSource(CiTestCase):
         )
         datasource.get_data()
         json_file = paths.get_runpath("instance_data")
-        instance_data = util.load_json(util.load_file(json_file))
+        instance_data = util.load_json(util.load_text_file(json_file))
         self.assertNotIn("network_json", instance_data["ds"])
         datasource.network_json = {"network_json": "is good"}
         datasource.persist_instance_data()
-        instance_data = util.load_json(util.load_file(json_file))
+        instance_data = util.load_json(util.load_text_file(json_file))
         self.assertEqual(
             {"network_json": "is good"}, instance_data["ds"]["network_json"]
         )
@@ -838,7 +838,7 @@ class TestDataSource(CiTestCase):
         )
         self.assertTrue(datasource.get_data())
         json_file = paths.get_runpath("instance_data")
-        content = util.load_file(json_file)
+        content = util.load_text_file(json_file)
         instance_json = util.load_json(content)
         self.assertCountEqual(
             ["ds/meta_data/key2/key2.1"], instance_json["base64_encoded_keys"]

--- a/tests/unittests/test__init__.py
+++ b/tests/unittests/test__init__.py
@@ -293,7 +293,7 @@ class TestCmdlineUrl:
         lvl, msg = main.attempt_cmdline_url(
             fpath, network=True, cmdline=cmdline
         )
-        assert util.load_file(fpath, decode=False) == payload
+        assert util.load_binary_file(fpath) == payload
         assert logging.INFO == lvl
         assert url in msg
 
@@ -310,7 +310,7 @@ class TestCmdlineUrl:
         lvl, msg = main.attempt_cmdline_url(
             fpath, network=True, cmdline=cmdline
         )
-        assert util.load_file(fpath, decode=False) == payload
+        assert util.load_binary_file(fpath) == payload
         assert logging.INFO == lvl
         assert url in msg
 

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -189,7 +189,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
         instance_json = os.path.join(self.run_dir, INSTANCE_DATA_FILE)
         util.write_file(instance_json, atomic_helper.json_dumps({}))
         h = JinjaTemplatePartHandler(self.paths, sub_handlers=[script_handler])
-        with mock.patch(self.mpath + "load_file") as m_load:
+        with mock.patch(self.mpath + "load_text_file") as m_load:
             with self.assertRaises(JinjaLoadError) as context_manager:
                 m_load.side_effect = OSError(errno.EACCES, "Not allowed")
                 h.handle_part(
@@ -239,7 +239,7 @@ class TestJinjaTemplatePartHandler(CiTestCase):
             self.logs.getvalue(),
         )
         self.assertEqual(
-            "#!/bin/bash\necho himom", util.load_file(script_file)
+            "#!/bin/bash\necho himom", util.load_text_file(script_file)
         )
 
     @skipUnlessJinja()
@@ -450,6 +450,8 @@ class TestBootHookHandler:
             payload=payload,
             frequency=None,
         )
-        assert payload == util.load_file(f"{handler.boothook_dir}/part-001")
-        assert "id:i-testing\n" == util.load_file(f"{tmpdir}/boothook")
+        assert payload == util.load_text_file(
+            f"{handler.boothook_dir}/part-001"
+        )
+        assert "id:i-testing\n" == util.load_text_file(f"{tmpdir}/boothook")
         assert "id:i-testing\n" == capfd.readouterr().out

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -82,7 +82,9 @@ class TestConsumeUserData:
         init_tmp.fetch()
         with mock.patch.object(init_tmp, "_reset"):
             init_tmp.consume_data()
-        cc_contents = util.load_file(init_tmp.paths.get_ipath("cloud_config"))
+        cc_contents = util.load_text_file(
+            init_tmp.paths.get_ipath("cloud_config")
+        )
         cc = util.load_yaml(cc_contents)
         assert len(cc) == 2
         assert cc["baz"] == "qux"
@@ -215,7 +217,9 @@ c: d
         init_tmp.fetch()
         with mock.patch.object(init_tmp, "_reset"):
             init_tmp.consume_data()
-        cc_contents = util.load_file(init_tmp.paths.get_ipath("cloud_config"))
+        cc_contents = util.load_text_file(
+            init_tmp.paths.get_ipath("cloud_config")
+        )
         cc = util.load_yaml(cc_contents)
         assert len(cc) == 1
         assert cc["a"] == "c"
@@ -248,7 +252,9 @@ c: d
         init_tmp.fetch()
         with mock.patch.object(init_tmp, "_reset"):
             init_tmp.consume_data()
-        cc_contents = util.load_file(init_tmp.paths.get_ipath("cloud_config"))
+        cc_contents = util.load_text_file(
+            init_tmp.paths.get_ipath("cloud_config")
+        )
         cc = util.load_yaml(cc_contents)
         assert len(cc) == 1
         assert cc["a"] == "c"
@@ -392,7 +398,7 @@ p: 1
         cloud_cfg.handle_part(
             None, handlers.CONTENT_END, None, None, None, None
         )
-        contents = util.load_file(paths.get_ipath("cloud_config"))
+        contents = util.load_text_file(paths.get_ipath("cloud_config"))
         contents = util.load_yaml(contents)
         assert contents["run"], ["b", "c", "stuff", "morestuff"]
         assert contents["a"] == "be"
@@ -441,7 +447,9 @@ c: 4
         init_tmp.fetch()
         with mock.patch.object(init_tmp, "_reset"):
             init_tmp.consume_data()
-        contents = util.load_file(init_tmp.paths.get_ipath("cloud_config"))
+        contents = util.load_text_file(
+            init_tmp.paths.get_ipath("cloud_config")
+        )
         contents = util.load_yaml(contents)
         assert isinstance(contents, dict) is True
         assert len(contents) == 3
@@ -519,7 +527,7 @@ c: 4
         }
 
         loaded_json = util.load_json(
-            util.load_file(
+            util.load_text_file(
                 init_tmp.paths.get_runpath("instance_data_sensitive")
             )
         )
@@ -527,7 +535,9 @@ c: 4
 
         expected["_doc"] = stages.COMBINED_CLOUD_CONFIG_DOC
         assert expected == util.load_json(
-            util.load_file(init_tmp.paths.get_runpath("combined_cloud_config"))
+            util.load_text_file(
+                init_tmp.paths.get_runpath("combined_cloud_config")
+            )
         )
 
     def test_mime_text_x_shellscript(self, init_tmp, caplog):
@@ -685,7 +695,9 @@ class TestConsumeUserDataHttp:
         with mock.patch.object(init_tmp, "_reset") as _reset:
             init_tmp.consume_data()
             assert _reset.call_count == 1
-        cc_contents = util.load_file(init_tmp.paths.get_ipath("cloud_config"))
+        cc_contents = util.load_text_file(
+            init_tmp.paths.get_ipath("cloud_config")
+        )
         cc = util.load_yaml(cc_contents)
         assert cc.get("included") is True
 
@@ -711,7 +723,7 @@ class TestConsumeUserDataHttp:
                 assert _reset.call_count == 1
 
         with pytest.raises(FileNotFoundError):
-            util.load_file(init_tmp.paths.get_ipath("cloud_config"))
+            util.load_text_file(init_tmp.paths.get_ipath("cloud_config"))
 
     @responses.activate
     @mock.patch("cloudinit.url_helper.time.sleep")
@@ -750,7 +762,9 @@ class TestConsumeUserDataHttp:
             "403 Client Error: Forbidden for url: %s" % bad_url in caplog.text
         )
 
-        cc_contents = util.load_file(init_tmp.paths.get_ipath("cloud_config"))
+        cc_contents = util.load_text_file(
+            init_tmp.paths.get_ipath("cloud_config")
+        )
         cc = util.load_yaml(cc_contents)
         assert cc.get("bad") is None
         assert cc.get("included") is True

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -238,7 +238,7 @@ class DsIdentifyBase(CiTestCase):
         cfg = None
         cfg_out = os.path.join(rootd, runpath, "cloud-init/cloud.cfg")
         if os.path.exists(cfg_out):
-            contents = util.load_file(cfg_out)
+            contents = util.load_text_file(cfg_out)
             try:
                 cfg = safeyaml.load(contents)
             except Exception as e:

--- a/tests/unittests/test_merging.py
+++ b/tests/unittests/test_merging.py
@@ -122,8 +122,8 @@ class TestSimpleRun(helpers.ResourceUsingTestCase):
         for i in sorted(source_ids.keys()):
             source_file_contents = []
             for fn in sorted(source_ids[i]):
-                source_file_contents.append([fn, util.load_file(fn)])
-            expected = util.load_yaml(util.load_file(expected_files[i]))
+                source_file_contents.append([fn, util.load_text_file(fn)])
+            expected = util.load_yaml(util.load_text_file(expected_files[i]))
             entry = [source_file_contents, [expected, expected_files[i]]]
             tests.append(entry)
         return tests

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -371,7 +371,7 @@ class TestUpdateAuthorizedKeys:
         assert expected == found
 
 
-@mock.patch(M_PATH + "util.load_file")
+@mock.patch(M_PATH + "util.load_text_file")
 @mock.patch(M_PATH + "os.path.isfile")
 class TestParseSSHConfig:
     @pytest.mark.parametrize(
@@ -538,7 +538,7 @@ class TestUpdateSshConfig:
         util.write_file(mycfg, self.cfgdata)
         ret = ssh_util.update_ssh_config({"MyKey": "NEW_VAL"}, mycfg)
         assert True is ret
-        found = util.load_file(mycfg)
+        found = util.load_text_file(mycfg)
         assert self.cfgdata.replace("ORIG_VAL", "NEW_VAL") == found
         # assert there is a newline at end of file (LP: #1677205)
         assert "\n" == found[-1]
@@ -549,7 +549,7 @@ class TestUpdateSshConfig:
         with patch("cloudinit.ssh_util.util.write_file") as m_write_file:
             ret = ssh_util.update_ssh_config({"MyKey": "ORIG_VAL"}, mycfg)
         assert False is ret
-        assert self.cfgdata == util.load_file(mycfg)
+        assert self.cfgdata == util.load_text_file(mycfg)
         m_write_file.assert_not_called()
 
     def test_without_include(self, tmpdir):
@@ -557,7 +557,7 @@ class TestUpdateSshConfig:
         cfg = "X Y"
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
-        assert "X Y\nkey value\n" == util.load_file(mycfg)
+        assert "X Y\nkey value\n" == util.load_text_file(mycfg)
         expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
 
@@ -572,14 +572,14 @@ class TestUpdateSshConfig:
         expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert os.path.isfile(expected_conf_file)
         assert 0o600 == stat.S_IMODE(os.stat(expected_conf_file).st_mode)
-        assert "key value\n" == util.load_file(expected_conf_file)
+        assert "key value\n" == util.load_text_file(expected_conf_file)
 
     def test_with_commented_include(self, tmpdir):
         mycfg = tmpdir.join("sshd_config")
         cfg = f"# Include {mycfg}.d/*.conf"
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
-        assert f"{cfg}\nkey value\n" == util.load_file(mycfg)
+        assert f"{cfg}\nkey value\n" == util.load_text_file(mycfg)
         expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
 
@@ -588,7 +588,7 @@ class TestUpdateSshConfig:
         cfg = f"Include other_{mycfg}.d/*.conf"
         util.write_file(mycfg, cfg)
         assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
-        assert f"{cfg}\nkey value\n" == util.load_file(mycfg)
+        assert f"{cfg}\nkey value\n" == util.load_text_file(mycfg)
         expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
         assert not os.path.isfile(f"other_{mycfg}.d/50-cloud-init.conf")
@@ -605,7 +605,7 @@ class TestAppendSshConfig:
         ssh_util.append_ssh_config(
             [("MyKey", "NEW_VAL"), ("MyKey", "NEW_VAL_2")], mycfg
         )
-        found = util.load_file(mycfg)
+        found = util.load_text_file(mycfg)
         expected_cfg = dedent(
             """\
             #Option val

--- a/tests/unittests/test_subp.py
+++ b/tests/unittests/test_subp.py
@@ -119,7 +119,7 @@ class TestSubp(CiTestCase):
         (out, _err) = subp.subp(cmd.encode("utf-8"), shell=True)
         self.assertEqual("", out)
         self.assertEqual("", _err)
-        self.assertEqual("HI MOM\n", util.load_file(tmp_file))
+        self.assertEqual("HI MOM\n", util.load_text_file(tmp_file))
 
     def test_subp_handles_strings(self):
         """subp can run a string command if shell is True."""
@@ -128,7 +128,7 @@ class TestSubp(CiTestCase):
         (out, _err) = subp.subp(cmd, shell=True)
         self.assertEqual("", out)
         self.assertEqual("", _err)
-        self.assertEqual("HI MOM\n", util.load_file(tmp_file))
+        self.assertEqual("HI MOM\n", util.load_text_file(tmp_file))
 
     def test_subp_handles_utf8(self):
         # The given bytes contain utf-8 accented characters as seen in e.g.

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -10,7 +10,7 @@ import pytest
 
 from cloudinit import templater
 from cloudinit.templater import JinjaSyntaxParsingException
-from cloudinit.util import load_file, write_file
+from cloudinit.util import load_binary_file, write_file
 from tests.unittests import helpers as test_helpers
 
 
@@ -126,7 +126,7 @@ class TestTemplates(test_helpers.CiTestCase):
             content=self.add_header("jinja", self.jinja_utf8).encode("utf-8"),
         )
         templater.render_to_file(tmpl_fn, out_fn, {"name": "bob"})
-        result = load_file(out_fn, decode=False).decode("utf-8")
+        result = load_binary_file(out_fn).decode("utf-8")
         self.assertEqual(result, self.jinja_utf8_rbob)
 
     def test_jinja_nonascii_render_from_file(self):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -444,18 +444,20 @@ class TestUtil:
         assert is_rw is False
 
     def test_read_conf(self, mocker):
-        mocker.patch("cloudinit.util.load_file", return_value='{"a": "b"}')
+        mocker.patch(
+            "cloudinit.util.load_text_file", return_value='{"a": "b"}'
+        )
         assert util.read_conf("any") == {"a": "b"}
 
     @skipUnlessJinja()
     def test_read_conf_with_template(self, mocker, caplog):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
-            "cloudinit.util.load_file",
+            "cloudinit.util.load_text_file",
             return_value='## template: jinja\n{"a": "{{c}}"}',
         )
         mocker.patch(
-            "cloudinit.handlers.jinja_template.load_file",
+            "cloudinit.handlers.jinja_template.load_text_file",
             return_value='{"c": "d"}',
         )
 
@@ -470,11 +472,11 @@ class TestUtil:
     def test_read_conf_with_failed_config_json(self, mocker, caplog):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
-            "cloudinit.util.load_file",
+            "cloudinit.util.load_text_file",
             return_value='## template: jinja\n{"a": "{{c}}"',  # missing }
         )
         mocker.patch(
-            "cloudinit.handlers.jinja_template.load_file",
+            "cloudinit.handlers.jinja_template.load_text_file",
             return_value='{"c": "d"}',
         )
         conf = util.read_conf("cfg_path", instance_data_file="vars_path")
@@ -485,11 +487,11 @@ class TestUtil:
     def test_read_conf_with_failed_instance_data_json(self, mocker, caplog):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
-            "cloudinit.util.load_file",
+            "cloudinit.util.load_text_file",
             return_value='## template: jinja\n{"a": "{{c}}"}',
         )
         mocker.patch(
-            "cloudinit.handlers.jinja_template.load_file",
+            "cloudinit.handlers.jinja_template.load_text_file",
             return_value='{"c": "d"',  # missing }
         )
         conf = util.read_conf("cfg_path", instance_data_file="vars_path")
@@ -510,11 +512,11 @@ class TestUtil:
     ):
         mocker.patch("os.path.exists", return_value=True)
         mocker.patch(
-            "cloudinit.util.load_file",
+            "cloudinit.util.load_text_file",
             return_value="## template: jinja\n" + template,
         )
         mocker.patch(
-            "cloudinit.handlers.jinja_template.load_file",
+            "cloudinit.handlers.jinja_template.load_text_file",
             return_value='{"c": "d"}',
         )
         conf = util.read_conf("cfg_path", instance_data_file="vars_path")
@@ -638,7 +640,7 @@ class TestSymlink(CiTestCase):
 
         util.sym_link(target2, link, force=True)
         self.assertTrue(os.path.exists(link))
-        self.assertEqual("hello2", util.load_file(link))
+        self.assertEqual("hello2", util.load_text_file(link))
 
     def test_sym_link_dangling_link(self):
         tmpd = self.tmp_dir()
@@ -966,7 +968,7 @@ class TestGetLinuxDistro(CiTestCase):
         if path == "/etc/redhat-release":
             return 1
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_distro_quoted_name(self, m_os_release, m_path_exists):
         """Verify we get the correct name if the os-release file has
         the distro name in quotes"""
@@ -975,7 +977,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("sles", "12.3", platform.machine()), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_distro_bare_name(self, m_os_release, m_path_exists):
         """Verify we get the correct name if the os-release file does not
         have the distro name in quotes"""
@@ -1003,7 +1005,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("freebsd", "12.0-RELEASE-p10", ""), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_centos6(self, m_os_release, m_path_exists):
         """Verify we get the correct name and release name on CentOS 6."""
         m_os_release.return_value = REDHAT_RELEASE_CENTOS_6
@@ -1011,7 +1013,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("centos", "6.10", "Final"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_centos7_redhat_release(self, m_os_release, m_exists):
         """Verify the correct release info on CentOS 7 without os-release."""
         m_os_release.return_value = REDHAT_RELEASE_CENTOS_7
@@ -1019,7 +1021,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("centos", "7.5.1804", "Core"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_redhat7_osrelease(self, m_os_release, m_path_exists):
         """Verify redhat 7 read from os-release."""
         m_os_release.return_value = OS_RELEASE_REDHAT_7
@@ -1027,7 +1029,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("redhat", "7.5", "Maipo"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_redhat7_rhrelease(self, m_os_release, m_path_exists):
         """Verify redhat 7 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_REDHAT_7
@@ -1035,7 +1037,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("redhat", "7.5", "Maipo"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_redhat6_rhrelease(self, m_os_release, m_path_exists):
         """Verify redhat 6 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_REDHAT_6
@@ -1043,7 +1045,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("redhat", "6.10", "Santiago"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_copr_centos(self, m_os_release, m_path_exists):
         """Verify we get the correct name and release name on COPR CentOS."""
         m_os_release.return_value = OS_RELEASE_CENTOS
@@ -1051,7 +1053,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("centos", "7", "Core"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_almalinux8_rhrelease(self, m_os_release, m_path_exists):
         """Verify almalinux 8 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_ALMALINUX_8
@@ -1059,7 +1061,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("almalinux", "8.3", "Purple Manul"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_almalinux8_osrelease(self, m_os_release, m_path_exists):
         """Verify almalinux 8 read from os-release."""
         m_os_release.return_value = OS_RELEASE_ALMALINUX_8
@@ -1067,7 +1069,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("almalinux", "8.3", "Purple Manul"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_eurolinux7_rhrelease(self, m_os_release, m_path_exists):
         """Verify eurolinux 7 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_EUROLINUX_7
@@ -1075,7 +1077,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("eurolinux", "7.9", "Minsk"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_eurolinux7_osrelease(self, m_os_release, m_path_exists):
         """Verify eurolinux 7 read from os-release."""
         m_os_release.return_value = OS_RELEASE_EUROLINUX_7
@@ -1083,7 +1085,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("eurolinux", "7.9", "Minsk"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_eurolinux8_rhrelease(self, m_os_release, m_path_exists):
         """Verify eurolinux 8 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_EUROLINUX_8
@@ -1091,7 +1093,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("eurolinux", "8.4", "Vaduz"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_eurolinux8_osrelease(self, m_os_release, m_path_exists):
         """Verify eurolinux 8 read from os-release."""
         m_os_release.return_value = OS_RELEASE_EUROLINUX_8
@@ -1099,7 +1101,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("eurolinux", "8.4", "Vaduz"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_miraclelinux8_rhrelease(
         self, m_os_release, m_path_exists
     ):
@@ -1109,7 +1111,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("miracle", "8.4", "Peony"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_miraclelinux8_osrelease(
         self, m_os_release, m_path_exists
     ):
@@ -1119,7 +1121,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("miraclelinux", "8", "Peony"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_rocky8_rhrelease(self, m_os_release, m_path_exists):
         """Verify rocky linux 8 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_ROCKY_8
@@ -1127,7 +1129,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("rocky", "8.3", "Green Obsidian"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_rocky8_osrelease(self, m_os_release, m_path_exists):
         """Verify rocky linux 8 read from os-release."""
         m_os_release.return_value = OS_RELEASE_ROCKY_8
@@ -1135,7 +1137,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("rocky", "8.3", "Green Obsidian"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_virtuozzo8_rhrelease(self, m_os_release, m_path_exists):
         """Verify virtuozzo linux 8 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_VIRTUOZZO_8
@@ -1143,7 +1145,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("virtuozzo", "8", "Virtuozzo Linux"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_virtuozzo8_osrelease(self, m_os_release, m_path_exists):
         """Verify virtuozzo linux 8 read from os-release."""
         m_os_release.return_value = OS_RELEASE_VIRTUOZZO_8
@@ -1151,7 +1153,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("virtuozzo", "8", "Virtuozzo Linux"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_cloud8_rhrelease(self, m_os_release, m_path_exists):
         """Verify cloudlinux 8 read from redhat-release."""
         m_os_release.return_value = REDHAT_RELEASE_CLOUDLINUX_8
@@ -1159,7 +1161,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("cloudlinux", "8.4", "Valery Rozhdestvensky"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_cloud8_osrelease(self, m_os_release, m_path_exists):
         """Verify cloudlinux 8 read from os-release."""
         m_os_release.return_value = OS_RELEASE_CLOUDLINUX_8
@@ -1167,7 +1169,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("cloudlinux", "8.4", "Valery Rozhdestvensky"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_debian(self, m_os_release, m_path_exists):
         """Verify we get the correct name and release name on Debian."""
         m_os_release.return_value = OS_RELEASE_DEBIAN
@@ -1175,7 +1177,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("debian", "9", "stretch"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_openeuler(self, m_os_release, m_path_exists):
         """Verify get the correct name and release name on Openeuler."""
         m_os_release.return_value = OS_RELEASE_OPENEULER_20
@@ -1183,7 +1185,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("openEuler", "20.03", "LTS-SP2"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_opencloudos(self, m_os_release, m_path_exists):
         """Verify get the correct name and release name on OpenCloudOS."""
         m_os_release.return_value = OS_RELEASE_OPENCLOUDOS_8
@@ -1191,7 +1193,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("OpenCloudOS", "8.6", ""), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_tencentos(self, m_os_release, m_path_exists):
         """Verify get the correct name and release name on TencentOS."""
         m_os_release.return_value = OS_RELEASE_TENCENTOS_3
@@ -1199,7 +1201,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("TencentOS", "3.1", ""), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_opensuse(self, m_os_release, m_path_exists):
         """Verify we get the correct name and machine arch on openSUSE
         prior to openSUSE Leap 15.
@@ -1209,7 +1211,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("opensuse", "42.3", platform.machine()), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_opensuse_l15(self, m_os_release, m_path_exists):
         """Verify we get the correct name and machine arch on openSUSE
         for openSUSE Leap 15.0 and later.
@@ -1219,7 +1221,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("opensuse-leap", "15.0", platform.machine()), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_opensuse_tw(self, m_os_release, m_path_exists):
         """Verify we get the correct name and machine arch on openSUSE
         for openSUSE Tumbleweed
@@ -1231,7 +1233,7 @@ class TestGetLinuxDistro(CiTestCase):
             ("opensuse-tumbleweed", "20180920", platform.machine()), dist
         )
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_photon_os_release(self, m_os_release, m_path_exists):
         """Verify we get the correct name and machine arch on PhotonOS"""
         m_os_release.return_value = OS_RELEASE_PHOTON
@@ -1239,7 +1241,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("photon", "4.0", "VMware Photon OS/Linux"), dist)
 
-    @mock.patch("cloudinit.util.load_file")
+    @mock.patch("cloudinit.util.load_text_file")
     def test_get_linux_mariner_os_release(self, m_os_release, m_path_exists):
         """Verify we get the correct name and machine arch on MarinerOS"""
         m_os_release.return_value = OS_RELEASE_MARINER
@@ -1247,7 +1249,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("mariner", "2.0", ""), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_openmandriva(self, m_os_release, m_path_exists):
         """Verify we get the correct name and machine arch on OpenMandriva"""
         m_os_release.return_value = OS_RELEASE_OPENMANDRIVA
@@ -1255,7 +1257,7 @@ class TestGetLinuxDistro(CiTestCase):
         dist = util.get_linux_distro()
         self.assertEqual(("openmandriva", "4.90", "nickel"), dist)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_get_linux_cos(self, m_os_release, m_path_exists):
         """Verify we get the correct name and machine arch on COS"""
         m_os_release.return_value = OS_RELEASE_COS
@@ -2018,7 +2020,7 @@ class TestFipsEnabled:
             pytest.param("1", True, id="true_when_fips_enabled_no_newline"),
         ),
     )
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_text_file")
     def test_fips_enabled_based_on_proc_crypto(
         self, load_file, fips_enabled_content, expected, tmpdir
     ):
@@ -2921,7 +2923,7 @@ class TestGetProcPpid(helpers.TestCase):
             ),
         ):
             with mock.patch(
-                "cloudinit.util.load_file", return_value=proc_data
+                "cloudinit.util.load_text_file", return_value=proc_data
             ):
                 assert ppid == Distro.get_proc_ppid(-999)
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2804,7 +2804,7 @@ class TestGetProcEnv(helpers.TestCase):
         # return the value portion of key=val decoded.
         return blob.split(b"=", 1)[1].decode(encoding, errors)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_binary_file")
     def test_non_utf8_in_environment(self, m_load_file):
         """env may have non utf-8 decodable content."""
         content = self.null.join(
@@ -2823,7 +2823,7 @@ class TestGetProcEnv(helpers.TestCase):
         )
         self.assertEqual(1, m_load_file.call_count)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_binary_file")
     def test_encoding_none_returns_bytes(self, m_load_file):
         """encoding none returns bytes."""
         lines = (self.bootflag, self.simple1, self.simple2, self.mixed)
@@ -2836,7 +2836,7 @@ class TestGetProcEnv(helpers.TestCase):
         )
         self.assertEqual(1, m_load_file.call_count)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_binary_file")
     def test_all_utf8_encoded(self, m_load_file):
         """common path where only utf-8 decodable content."""
         content = self.null.join((self.simple1, self.simple2))
@@ -2846,7 +2846,7 @@ class TestGetProcEnv(helpers.TestCase):
         )
         self.assertEqual(1, m_load_file.call_count)
 
-    @mock.patch(M_PATH + "load_file")
+    @mock.patch(M_PATH + "load_binary_file")
     def test_non_existing_file_returns_empty_dict(self, m_load_file):
         """as implemented, a non-existing pid returns empty dict.
         This is how it was originally implemented."""


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
Use individual commits
```

## Additional Context
I did see a few places we could further refactor things, but I didn't want to complicate this PR any more than necessary. Other than the function definitions of `load_text_file` and `load_binary_file`, all other changes should be replacing the `load_file` as necessary. There is also one additional mypy related commit that surfaced from these changes.

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
