### PR TITLE
fix(source): fix argument boundaries when parsing cmdline

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -1185,9 +1185,9 @@ def parse_cmdline() -> str:
     Passing by command line overrides runtime datasource detection
     """
     cmdline = util.get_cmdline()
-    ds_parse_0 = re.search(r"ds=([^\s;]+)", cmdline)
-    ds_parse_1 = re.search(r"ci\.ds=([^\s;]+)", cmdline)
-    ds_parse_2 = re.search(r"ci\.datasource=([^\s;]+)", cmdline)
+    ds_parse_0 = re.search(r"(?:^|\s)ds=([^\s;]+)", cmdline)
+    ds_parse_1 = re.search(r"(?:^|\s)ci\.ds=([^\s;]+)", cmdline)
+    ds_parse_2 = re.search(r"(?:^|\s)ci\.datasource=([^\s;]+)", cmdline)
     ds = ds_parse_0 or ds_parse_1 or ds_parse_2
     deprecated = ds_parse_1 or ds_parse_2
     if deprecated:

--- a/tests/unittests/sources/test___init__.py
+++ b/tests/unittests/sources/test___init__.py
@@ -17,6 +17,7 @@ openstack_ds_name = ds.DataSourceOpenStack.dsname.lower()
         ("aosiejfoij ci.ds=OpenStack faljskebflk", openstack_ds_name),
         ("ci.ds=OpenStack;", openstack_ds_name),
         ("ci.ds=openstack;", openstack_ds_name),
+        ("notci.ds=somecloud ci.ds=openstack", openstack_ds_name),
         # test ci.datasource=
         ("aosiejfoij ci.datasource=OpenStack ", openstack_ds_name),
         ("ci.datasource=OpenStack", openstack_ds_name),
@@ -24,6 +25,7 @@ openstack_ds_name = ds.DataSourceOpenStack.dsname.lower()
         ("aosiejfoij ci.datasource=OpenStack faljskebflk", openstack_ds_name),
         ("ci.datasource=OpenStack;", openstack_ds_name),
         ("ci.datasource=openstack;", openstack_ds_name),
+        ("notci.datasource=0 ci.datasource=nocloud", "nocloud"),
         # weird whitespace
         ("ci.datasource=OpenStack\n", openstack_ds_name),
         ("ci.datasource=OpenStack\t", openstack_ds_name),
@@ -35,6 +37,11 @@ openstack_ds_name = ds.DataSourceOpenStack.dsname.lower()
         ("ci.ds=OpenStack\v", openstack_ds_name),
         ("ci.ds=nocloud-net\v", "nocloud-net"),
         ("ci.datasource=nocloud\v", "nocloud"),
+        # test ds=
+        ("ds=nocloud-net", "nocloud-net"),
+        ("foo ds=nocloud-net bar", "nocloud-net"),
+        ("bonding.max_bonds=0", ""),
+        ("foo bonding.max_bonds=0 ds=nocloud-net bar", "nocloud-net"),
     ),
 )
 def test_ds_detect_kernel_commandline(m_cmdline, expected_ds):

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -61,6 +61,7 @@ frantisekz
 GabrielNagy
 garzdin
 giggsoff
+gilbsgilbs
 glyg
 hamalq
 holmanb


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(source): fix argument boundaries when parsing cmdline

When the command-line includes an argument that contains `ds=`, the rest
of the argument is always interpreted as a datasource, regardless of
wether the argument is `ds` or just the suffix of another argument.
While this doesn't cause issues in a majority of cases, it starts
conflicting with other arguments that also include `ds=` but do not
refer to a cloud-init datasource. For instance, setting
`bonding.max_bonds=0` in the command-line (which is a real-world
use-case) conflicts with the current implementation.

To fix this issue, this commit ensures that `ds`, `ci.ds` and
`ci.datasource` arguments are either at the very beginning of the
command-line, or just before a whitespace, so that we don't match
another argument.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Add `bonding.max_bonds=0` to the command-line, and then `ds=nocloud-net;s=https://some`. Result: the parsed datasource is `0` instead of `nocloud-net;s=https://some`.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] (irrelevant as it is a bugfix) I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
