### PR TITLE
dhcpcd InfiniBand support

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -615,6 +615,7 @@ class Dhcpcd(DhcpClient):
         LOG.debug("Performing a dhcp discovery on %s", interface)
         sleep_time = 0.01
         sleep_cycles = int(self.timeout / sleep_time)
+        infiniband_argument = []
 
         # dhcpcd needs the interface up to send initial discovery packets
         # Generally dhclient relies on dhclient-script PREINIT action to bring
@@ -633,6 +634,8 @@ class Dhcpcd(DhcpClient):
             # Until fixed, we allow dhcpcd to spawn background processes so
             # that we can use --dumplease, but when any option above is fixed,
             # it would be safer to avoid spawning processes using --oneshot
+            if is_ib_interface(interface):
+                infiniband_argument = ["--clientid"]
             command = [
                 self.dhcp_client_path,  # pyright: ignore
                 "--ipv4only",  # only attempt configuring ipv4
@@ -640,6 +643,7 @@ class Dhcpcd(DhcpClient):
                 "--persistent",  # don't deconfigure when dhcpcd exits
                 "--noarp",  # don't be slow
                 "--script=/bin/true",  # disable hooks
+                *infiniband_argument,
                 interface,
             ]
             out, err = subp.subp(

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -20,11 +20,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 import configobj
 
 from cloudinit import subp, temp_utils, util
-from cloudinit.net import (
-    get_ib_interface_hwaddr,
-    get_interface_mac,
-    is_ib_interface,
-)
+from cloudinit.net import get_interface_mac, is_ib_interface
 
 LOG = logging.getLogger(__name__)
 
@@ -922,11 +918,13 @@ class Udhcpc(DhcpClient):
         # INFINIBAND or not. If yes, we are generating the the client-id to be
         # used with the udhcpc
         if is_ib_interface(interface):
-            dhcp_client_identifier = get_ib_interface_hwaddr(
-                interface, ethernet_format=True
-            )
             cmd.extend(
-                ["-x", "0x3d:%s" % dhcp_client_identifier.replace(":", "")]
+                [
+                    "-x",
+                    "0x3d:20{}".format(
+                        get_interface_mac(interface)[36:].replace(":", "")
+                    ),
+                ]
             )
         try:
             out, err = subp.subp(

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -23,6 +23,7 @@ from cloudinit.net.dhcp import (
     networkd_load_leases,
 )
 from cloudinit.net.ephemeral import EphemeralDHCPv4
+from cloudinit.subp import SubpResult
 from cloudinit.util import ensure_file, load_binary_file, subp, write_file
 from tests.unittests.helpers import (
     CiTestCase,
@@ -1273,3 +1274,45 @@ class TestDhcpcd:
             ("168.63.129.16/32", "10.0.0.1"),
             ("169.254.169.254/32", "10.0.0.1"),
         ] == Dhcpcd.parse_static_routes(parsed_lease["static_routes"])
+
+    @mock.patch("cloudinit.net.dhcp.is_ib_interface", return_value=True)
+    @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/sbin/dhcpcd")
+    @mock.patch("cloudinit.net.dhcp.os.killpg")
+    @mock.patch("cloudinit.net.dhcp.subp.subp")
+    @mock.patch("cloudinit.util.load_json")
+    @mock.patch("cloudinit.util.load_binary_file")
+    @mock.patch("cloudinit.util.write_file")
+    def test_dhcpcd_discovery_ib(
+        self,
+        m_write_file,
+        m_load_file,
+        m_loadjson,
+        m_subp,
+        m_remove,
+        m_which,
+        m_is_ib_interface,
+    ):
+        """dhcp_discovery runs udcpc and parse the dhcp leases."""
+        m_subp.return_value = SubpResult("a=b", "")
+        Dhcpcd().dhcp_discovery("ib0", distro=MockDistro())
+        # Interface was brought up before dhclient called
+        m_subp.assert_has_calls(
+            [
+                mock.call(
+                    ["ip", "link", "set", "dev", "ib0", "up"],
+                ),
+                mock.call(
+                    [
+                        "/sbin/dhcpcd",
+                        "--ipv4only",
+                        "--waitip",
+                        "--persistent",
+                        "--noarp",
+                        "--script=/bin/true",
+                        "--clientid",
+                        "ib0",
+                    ],
+                    timeout=Dhcpcd.timeout,
+                ),
+            ]
+        )

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -36,6 +36,7 @@ from tests.unittests.util import MockDistro
 PID_F = "/run/dhclient.pid"
 LEASE_F = "/run/dhclient.lease"
 DHCLIENT = "/sbin/dhclient"
+ib_address_prefix = "00:00:00:00:00:00:00:00:00:00:00:00"
 
 
 @pytest.mark.parametrize(
@@ -375,7 +376,6 @@ class TestDHCPParseStaticRoutes(CiTestCase):
 
 class TestDHCPDiscoveryClean(CiTestCase):
     with_logs = True
-    ib_address_prefix = "00:00:00:00:00:00:00:00:00:00:00:00"
 
     @mock.patch("cloudinit.distros.net.find_fallback_nic", return_value="eth9")
     @mock.patch("cloudinit.net.dhcp.os.remove")
@@ -995,7 +995,10 @@ class TestUDHCPCDiscoveryClean(CiTestCase):
         )
 
     @mock.patch("cloudinit.net.dhcp.is_ib_interface", return_value=True)
-    @mock.patch("cloudinit.net.dhcp.get_ib_interface_hwaddr")
+    @mock.patch(
+        "cloudinit.net.dhcp.get_interface_mac",
+        return_value="%s:AA:AA:AA:00:00:AA:AA:AA" % ib_address_prefix,
+    )
     @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/sbin/udhcpc")
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
@@ -1022,7 +1025,6 @@ class TestUDHCPCDiscoveryClean(CiTestCase):
             "routers": "192.168.2.1",
             "static_routes": "10.240.0.1/32 0.0.0.0 0.0.0.0/0 10.240.0.1",
         }
-        m_get_ib_interface_hwaddr.return_value = "00:21:28:00:01:cf:4b:01"
         self.assertEqual(
             {
                 "fixed-address": "192.168.2.74",
@@ -1053,7 +1055,7 @@ class TestUDHCPCDiscoveryClean(CiTestCase):
                         "-f",
                         "-v",
                         "-x",
-                        "0x3d:0021280001cf4b01",
+                        "0x3d:20AAAAAA0000AAAAAA",
                     ],
                     update_env={
                         "LEASE_FILE": "/var/tmp/cloud-init/ib0.lease.json"

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -91,6 +91,10 @@ class MockDistro(distros.Distro):
     def get_proc_ppid(_):
         return 1
 
+    @staticmethod
+    def get_proc_pgid(_):
+        return 99999
+
     def get_primary_arch(self):
         return "i386"
 


### PR DESCRIPTION
## Additional Context
Adds InifiniBand support to dhcpcd, updates udhcpc support to use the same client-id as dhcpcd and isc-dhclient.


#### Context on dhcp with InfiniBand:

InfinBand has its own software stack, but also uses a shim layer, IPoIB, to assign an IP address and provide compatibility with traditional transports (TCP / UDP) over its own transport. Its own transport uses RDMA to transfer data and typical users use a userspace library called libibverbs, on top of which various transports are built.

DHCP             -> https://www.rfc-editor.org/rfc/rfc2855
DHCP InfinBand   -> https://www.rfc-editor.org/rfc/rfc4390.html
DHCP hwaddr      -> https://www.iana.org/assignments/arp-parameters/arp-parameters.txt


Some relevant excerpts from RFC4390:

> A DHCP client, when working over an IPoIB interface, MUST follow the
>   following rules:
>
>    "htype" (hardware address type) MUST be 32 [[ARPPARAM](https://www.rfc-editor.org/rfc/rfc4390.html#ref-ARPPARAM)].
>
>    "hlen" (hardware address length) MUST be 0.
>
>    "chaddr" (client hardware address) field MUST be zeroed.
>
>    "client-identifier" option MUST be used in DHCP messages.
>
>   The "client identifier" used in DHCP messages MUST conform to
>   [[RFC4361](https://www.rfc-editor.org/rfc/rfc4361)].

The htype of 32 is the reason for setting "20" for udhcpc:
```python
>>> int("20", base=16)
32
```

> The "chaddr" field is 16 octets in length.  The IPoIB link-layer
>   address is 20 octets in length [[RFC4391](https://www.rfc-editor.org/rfc/rfc4391)].  Therefore, the IPoIB
>   link-layer address will not fit in the "chaddr" field
>

An InfiniBand address is longer than the required address.

> The DHCP protocol states that the "client identifier" option may be
>   used as the unique identifying value for the client [[RFC2132](https://www.rfc-editor.org/rfc/rfc2132)].  This
>   value must be unique within the client's subnet.

The purpose of the client id is to provide a unique identifier within the subnet.

>   The "client identifier" option includes a type and identifier pair.
>   The identifier included in the "client identifier" option may consist
>   of a hardware address or any other unique value such as the DNS name
>   of the client.

A client id is a type & unique identifier.

### Matching implementation

The importance of client id is to provide a unique identifier to the dhcp server. Therefore, diverging implementations in cloud-init dhcp clients could cause a collision that would be problematic if say, an Alpine instance using udhcpc and an Ubuntu instance using dhcpcd or isc-dhclient on the same subnet report the same client id. The udhcpc code uses `get_ib_interface_hwaddr()`, which is implemented as:
```
def get_ib_interface_hwaddr(ifname, ethernet_format):
    """Returns the string value of an Infiniband interface's hardware
    address. If ethernet_format is True, an Ethernet MAC-style 6 byte
    representation of the address will be returned.
    """
    # Type 32 is Infiniband.
    if read_sys_net_safe(ifname, "type") == "32":
        mac = get_interface_mac(ifname)
        if mac and ethernet_format:
            # Use bytes 13-15 and 18-20 of the hardware address.
            mac = mac[36:-14] + mac[51:]
        return mac
```
This diverges from the isc-dhclient implementation which uses `get_interface_mac(interface)[36:]`. The change in udhcpc is to ensure that a collision like this wouldn't occur.


## Test Steps
tox -e py3

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
