### PR TITLE
fix(packages/bddeb): restrict debhelper-compat to 12 in focal

### DIFF
--- a/packages/bddeb
+++ b/packages/bddeb
@@ -127,6 +127,9 @@ def write_debian_folder(root, templ_data, cloud_util_deps):
         if templ_data["debian_release"] == "bionic":
             # Bionic doesn't support debhelper-compat > 11
             build_deps += ",debhelper-compat (= 11)"
+        elif templ_data["debian_release"] == "focal":
+            # Focal doesn't support debhelper-compat > 12
+            build_deps += ",debhelper-compat (= 12)"
         else:
             build_deps += f",{debhelper_matches[-1]}"
     templater.render_to_file(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(packages/bddeb): restrict debhelper-compat to 12 in focal

debhelper-compat (= 13) is not available in focal.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
release=focal
./packages/bddeb -S -d --release $release
DEB_BUILD_OPTIONS=nocheck sbuild --nolog --no-run-lintian --no-run-autopkgtest --verbose --dist=$release cloud-init_*.dsc
```

Without this patch, sbuild fails with:

```
...
Install main build dependencies (apt-based resolver)                                                                                                                                          
----------------------------------------------------                                                                                                                                          
                                                                                                                                                                                              
Installing build dependencies                                                                                                                                                                 
Reading package lists...                                                                                                                                                                      
Building dependency tree...                                                                                                                                                                   
Reading state information...                                                                                                                                                                  
Some packages could not be installed. This may mean that you have                                                                                                                             
requested an impossible situation or if you are using the unstable                                                                                                                            
distribution that some required packages have not yet been created                                                                                                                            
or been moved out of Incoming.                                                                                                                                                                
The following information may help to resolve the situation:                                                                                                                                  
                                                                                                                                                                                              
The following packages have unmet dependencies:                                                                                                                                               
 sbuild-build-depends-main-dummy : Depends: debhelper-compat (= 13)                                                                                                                           
E: Unable to correct problems, you have held broken packages.                                                                                                                                 
apt-get failed.                                                                                                                                                                               
E: Package installation failed                                                                                                                                                                
Not removing build depends: cloned chroot in use          
...
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
