### PR TITLE
Fix focal dailies

### DIFF
--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -382,7 +382,7 @@ class TestNetplanValidateNetworkSchema:
                     column=12,
                     message="incorrect YAML value: yes for dhcp value",
                 ),
-                "Invalid network-config provided:\nformat-l1.c12: Invalid"
+                r"Invalid network-config provided:.*format-l1.c12: Invalid"
                 " netplan schema. incorrect YAML value: yes for dhcp value",
             ),
         ),
@@ -412,9 +412,10 @@ class TestNetplanValidateNetworkSchema:
                 "cloudinit.config.schema.mkdtemp",
                 return_value=fake_tmpdir.strpath,
             ):
-                assert netplan_validate_network_schema({"version": 2})
+                with caplog.at_level(logging.WARNING):
+                    assert netplan_validate_network_schema({"version": 2})
             if error_log:
-                assert error_log in caplog.text
+                assert re.match(error_log, caplog.records[0].msg, re.DOTALL)
 
 
 class TestValidateCloudConfigSchema:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Simplify log parsing in schema test

On focal, when using caplog, additional whitespace is getting added
on a newline. Simplify the schema test that is failing of focal so this
is no longer encountered.
```

## Additional Context
On focal, this is what caplog is capturing:
```
2024-01-31 14:28:16 DEBUG     cloudinit.util:util.py:2282 Writing to /tmp/pytest-of-root/pytest-6/test_network_config_schema_val1/mkdtmp/etc/netplan/network-config.yaml - wb: [600] 32 bytes
2024-01-31 14:28:16 WARNING   cloudinit.config.schema:schema.py:676 Invalid network-config provided:
                                                                    format-l1.c12: Invalid netplan schema. incorrect YAML value: yes for dhcp value
```
the additional whitespace after the newline was causing failure.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
