### PR TITLE
tests: Add kernel commandline test

### DIFF
--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -67,17 +67,19 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance):
 @pytest.mark.skipif(PLATFORM != "lxd_vm", reason="Modifies grub config")
 @pytest.mark.lxd_use_exec
 @pytest.mark.parametrize(
-    "ds_str, configured",
+    "ds_str, configured, cmdline_configured",
     (
         (
             "ds=nocloud;s=http://my-url/;h=hostname",
             "DataSourceNoCloud [seed=None][dsmode=net]",
+            True,
         ),
-        ("ci.ds=openstack", "DataSourceOpenStack"),
+        ("ci.ds=openstack", "DataSourceOpenStack", True),
+        ("bonding.max_bonds=0", "DataSourceLXD", False),
     ),
 )
 def test_lxd_datasource_kernel_override(
-    ds_str, configured, client: IntegrationInstance
+    ds_str, configured, cmdline_configured, client: IntegrationInstance
 ):
     """This test is twofold: it tests kernel commandline override, which also
     validates OpenStack Ironic requirements. OpenStack Ironic does not
@@ -90,10 +92,19 @@ def test_lxd_datasource_kernel_override(
     """
 
     override_kernel_cmdline(ds_str, client)
-    assert (
-        "Machine is configured by the kernel commandline to run on single "
-        f"datasource {configured}"
-    ) in client.execute("cat /var/log/cloud-init.log")
+    if cmdline_configured:
+        assert (
+            "Machine is configured by the kernel commandline to run on single "
+            f"datasource {configured}"
+        ) in client.execute("cat /var/log/cloud-init.log")
+    else:
+        # verify that no plat
+        log = client.execute("cat /var/log/cloud-init.log")
+        assert (f"Detected platform: {configured}") in log
+        assert (
+            "Machine is configured by the kernel "
+            "commandline to run on single "
+        ) not in log
 
 
 GH_REPO_PATH = "https://raw.githubusercontent.com/canonical/cloud-init/main/"


### PR DESCRIPTION
## Proposed Commit Message

```
test: Add kernel commandline test

Verify that ds-identify doesn't identify bonding.max_bonds=0
as a datasource definition "ds=0".
```

## Additional Context
https://github.com/canonical/cloud-init/pull/4825

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
