### PR TITLE
Add ftp support to NoCloud

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -369,7 +369,7 @@ class DataSourceNoCloudNet(DataSourceNoCloud):
             "http://",
             "https://",
             "ftp://",
-            "stfp://",
+            "ftps://",
         )
 
     def ds_detect(self):

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -288,7 +288,9 @@ def load_cmdline_data(fill, cmdline=None):
 
         seedfrom = fill.get("seedfrom")
         if seedfrom:
-            if seedfrom.startswith(("http://", "https://")):
+            if seedfrom.startswith(
+                ("http://", "https://", "ftp://", "ftps://")
+            ):
                 fill["dsmode"] = sources.DSMODE_NETWORK
             elif seedfrom.startswith(("file://", "/")):
                 fill["dsmode"] = sources.DSMODE_LOCAL

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -365,7 +365,12 @@ def _merge_new_seed(cur, seeded):
 class DataSourceNoCloudNet(DataSourceNoCloud):
     def __init__(self, sys_cfg, distro, paths):
         DataSourceNoCloud.__init__(self, sys_cfg, distro, paths)
-        self.supported_seed_starts = ("http://", "https://")
+        self.supported_seed_starts = (
+            "http://",
+            "https://",
+            "ftp://",
+            "stfp://",
+        )
 
     def ds_detect(self):
         """Check dmi and kernel commandline for dsname

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -421,3 +421,14 @@ datasources = [
 # Return a list of data sources that match this set of dependencies
 def get_datasource_list(depends):
     return sources.list_from_depends(depends, datasources)
+
+
+if __name__ == "__main__":
+    from sys import argv
+
+    logging.basicConfig(level=logging.DEBUG)
+    seedfrom = argv[1]
+    md_seed, ud, vd = util.read_seeded(seedfrom)
+    print(f"seeded: {md_seed}")
+    print(f"ud: {ud}")
+    print(f"vd: {vd}")

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -123,21 +123,6 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     port=port,
                     timeout=timeout or 5.0,  # uses float internally
                 )
-                LOG.debug("Attempting to login with user [%s]", user)
-                ftp_tls.login(
-                    user=user,
-                    passwd=url_parts.password or "",
-                )
-                LOG.debug("Creating a secure connection")
-                ftp_tls.prot_p()
-                LOG.debug("Reading file: %s", url_parts.path)
-                ftp_tls.retrbinary(
-                    f"RETR {url_parts.path}", callback=buffer.write
-                )
-                response = FtpResponse(url_parts.path, contents=buffer)
-                LOG.debug("Closing connection")
-                ftp_tls.close()
-                return response
             except ftplib.all_errors as e:
                 code = ftp_get_return_code_from_exception(e)
                 raise UrlError(
@@ -149,6 +134,21 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     headers=None,
                     url=url,
                 ) from e
+            LOG.debug("Attempting to login with user [%s]", user)
+            ftp_tls.login(
+                user=user,
+                passwd=url_parts.password or "",
+            )
+            LOG.debug("Creating a secure connection")
+            ftp_tls.prot_p()
+            LOG.debug("Reading file: %s", url_parts.path)
+            ftp_tls.retrbinary(
+                f"RETR {url_parts.path}", callback=buffer.write
+            )
+            response = FtpResponse(url_parts.path, contents=buffer)
+            LOG.debug("Closing connection")
+            ftp_tls.close()
+            return response
         else:
             try:
                 ftp = ftplib.FTP()
@@ -159,17 +159,6 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     port=port,
                     timeout=timeout or 5.0,  # uses float internally
                 )
-                LOG.debug("Attempting to login with user [%s]", user)
-                ftp.login(
-                    user=user,
-                    passwd=url_parts.password or "",
-                )
-                LOG.debug("Reading file: %s", url_parts.path)
-                ftp.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
-                response = FtpResponse(url_parts.path, contents=buffer)
-                LOG.debug("Closing connection")
-                ftp.close()
-                return response
             except ftplib.all_errors as e:
                 code=ftp_get_return_code_from_exception(e),
                 raise UrlError(
@@ -181,6 +170,17 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     headers=None,
                     url=url,
                 ) from e
+            LOG.debug("Attempting to login with user [%s]", user)
+            ftp.login(
+                user=user,
+                passwd=url_parts.password or "",
+            )
+            LOG.debug("Reading file: %s", url_parts.path)
+            ftp.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
+            response = FtpResponse(url_parts.path, contents=buffer)
+            LOG.debug("Closing connection")
+            ftp.close()
+            return response
 
 
 def _read_file(path: str, **kwargs) -> "FileResponse":

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -227,7 +227,10 @@ def read_file_or_url(
     parameters. See: call-signature of readurl in this module for param docs.
     """
     url = url.lstrip()
-    parsed = urlparse(url)
+    try:
+        parsed = urlparse(url)
+    except ValueError as e:
+        raise UrlError(cause=e, url=url) from e
     scheme = parsed.scheme
     if scheme == "file" or (url and "/" == url[0]):
         return _read_file(parsed.path, **kwargs)

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -159,7 +159,7 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     timeout=timeout or 5.0,  # uses float internally
                 )
             except ftplib.all_errors as e:
-                code = (ftp_get_return_code_from_exception(e),)
+                code = ftp_get_return_code_from_exception(e)
                 raise UrlError(
                     cause=(
                         "Reading file from ftp server"

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -143,7 +143,7 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
             except ftplib.error_perm as e:
                 LOG.warning(
                     "Attempted to connect to an insecure ftp server but used "
-                    "a scheme of ftps://, which is not allowed. Use ftp://"
+                    "a scheme of ftps://, which is not allowed. Use ftp:// "
                     "to allow connecting to insecure ftp servers."
                 )
                 raise UrlError(
@@ -293,7 +293,7 @@ class UrlResponse:
             return False
 
     @property
-    def headers(self) -> str:
+    def headers(self):
         return self._response.headers
 
     @property

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -144,7 +144,7 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
             LOG.debug("Reading file: %s", url_parts.path)
             ftp_tls.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
 
-            response = FtpResponse(buffer.getvalue())
+            response = FtpResponse(buffer.getvalue(), url)
             LOG.debug("Closing connection")
             ftp_tls.close()
             return response
@@ -177,7 +177,7 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
             )
             LOG.debug("Reading file: %s", url_parts.path)
             ftp.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
-            response = FtpResponse(contents=buffer.getvalue())
+            response = FtpResponse(buffer.getvalue(), url)
             LOG.debug("Closing connection")
             ftp.close()
             return response

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -119,7 +119,7 @@ def read_ftps(url: str, timeout: Optional[float] = None) -> "FtpResponse":
                     code=get_return_code_from_exception(e),
                     headers=None,
                     url=url,
-                )
+                ) from e
         try:
             LOG.debug(
                 "Couldn't connect to %s over tls. Strict mode not "
@@ -145,7 +145,7 @@ def read_ftps(url: str, timeout: Optional[float] = None) -> "FtpResponse":
                 code=get_return_code_from_exception(e),
                 headers=None,
                 url=url,
-            )
+            ) from e
 
 
 def read_file(path: str, **kwargs) -> "FileResponse":

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -142,9 +142,7 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
             LOG.debug("Creating a secure connection")
             ftp_tls.prot_p()
             LOG.debug("Reading file: %s", url_parts.path)
-            ftp_tls.retrbinary(
-                f"RETR {url_parts.path}", callback=buffer.write
-            )
+            ftp_tls.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
             response = FtpResponse(url_parts.path, contents=buffer)
             LOG.debug("Closing connection")
             ftp_tls.close()
@@ -153,14 +151,15 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
             try:
                 ftp = ftplib.FTP()
                 LOG.debug(
-                    "Attempting to connect to %s via port %s.", url, port)
+                    "Attempting to connect to %s via port %s.", url, port
+                )
                 ftp.connect(
                     host=url_parts.hostname,
                     port=port,
                     timeout=timeout or 5.0,  # uses float internally
                 )
             except ftplib.all_errors as e:
-                code=ftp_get_return_code_from_exception(e),
+                code = (ftp_get_return_code_from_exception(e),)
                 raise UrlError(
                     cause=(
                         "Reading file from ftp server"

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -950,13 +950,14 @@ def del_dir(path):
     shutil.rmtree(path)
 
 
-# read_optional_seed
-# returns boolean indicating success or failure (presence of files)
-# if files are present, populates 'fill' dictionary with 'user-data' and
-# 'meta-data' entries
 def read_optional_seed(fill, base="", ext="", timeout=5):
+    """
+    returns boolean indicating success or failure (presense of files)
+    if files are present, populates 'fill' dictionary with 'user-data' and
+    'meta-data' entries
+    """
     try:
-        (md, ud, vd) = read_seeded(base, ext, timeout)
+        md, ud, vd = read_seeded(base=base, ext=ext, timeout=timeout)
         fill["user-data"] = ud
         fill["vendor-data"] = vd
         fill["meta-data"] = md

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -12,4 +12,3 @@ pytest!=7.3.2
 packaging
 passlib
 coverage==7.2.7  # Last version supported in Python 3.7
-pyftpdlib

--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -12,3 +12,4 @@ pytest!=7.3.2
 packaging
 passlib
 coverage==7.2.7  # Last version supported in Python 3.7
+pyftpdlib

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -196,6 +196,7 @@ class TestSmbios:
             "cloud-init status --format json"
         )
 
+
 @pytest.mark.skipif(PLATFORM != "lxd_vm", reason="Modifies grub config")
 @pytest.mark.lxd_use_exec
 class TestFTP:
@@ -409,7 +410,7 @@ class TestFTP:
                 "Used fallback datasource",
                 "Attempted to connect to an insecure ftp server but used"
                 " a scheme of ftps://, which is not allowed. Use ftp:// "
-                "to allow connecting to insecure ftp servers."
+                "to allow connecting to insecure ftp servers.",
             ],
         )
 

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -328,7 +328,7 @@ class TestFTP:
             dedent(
                 """\
                 [Unit]
-                Description=run a local ftp server against
+                Description=TESTING USE ONLY ftp server
                 Wants=cloud-init-local.service
                 DefaultDependencies=no
 

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -387,7 +387,7 @@ class TestFTP:
         cmdline = "ds=nocloud;seedfrom=ftp://0.0.0.0:2121"
         self._boot_with_cmdline(cmdline, client)
         verify_clean_boot(client, ignore_warnings=self.expected_warnings)
-        assert "ftp-instance" == client.execute("hostname").rstrip()
+        assert "ftp-bootstrapper" == client.execute("hostname").rstrip()
 
     def test_nocloud_ftps_unencrypted_server_fails(
         self, client: IntegrationInstance
@@ -420,7 +420,7 @@ class TestFTP:
         cmdline = "ds=nocloud;seedfrom=ftps://localhost:2121"
         self._boot_with_cmdline(cmdline, client, encrypted=True)
         verify_clean_boot(client, ignore_warnings=self.expected_warnings)
-        assert "ftp-instance" == client.execute("hostname").rstrip()
+        assert "ftp-bootstrapper" == client.execute("hostname").rstrip()
 
     def test_nocloud_ftp_encrypted_server_fails(
         self, client: IntegrationInstance

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -405,7 +405,9 @@ class TestFTP:
                 "Getting data from <class 'cloudinit.sources.DataSourc"
                 "eNoCloud.DataSourceNoCloudNet'> failed",
                 "Used fallback datasource",
-                "Reading file from server over tls failed for url",
+                "Attempted to connect to an insecure ftp server but used"
+                " a scheme of ftps://, which is not allowed. Use ftp:// "
+                "to allow connecting to insecure ftp servers."
             ],
         )
 

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -371,7 +371,7 @@ class TestFTP:
                 """
             ),
         )
-        client.write_to_file("/vendor-data", "\n")
+        client.write_to_file("/vendor-data", "")
 
         # set the kernel commandline, reboot with it
         override_kernel_cmdline(cmdline, client)
@@ -387,6 +387,7 @@ class TestFTP:
         cmdline = "ds=nocloud;seedfrom=ftp://0.0.0.0:2121"
         self._boot_with_cmdline(cmdline, client)
         verify_clean_boot(client, ignore_warnings=self.expected_warnings)
+        assert "ftp-instance" == client.execute("hostname").rstrip()
 
     def test_nocloud_ftps_unencrypted_server_fails(
         self, client: IntegrationInstance
@@ -419,6 +420,7 @@ class TestFTP:
         cmdline = "ds=nocloud;seedfrom=ftps://localhost:2121"
         self._boot_with_cmdline(cmdline, client, encrypted=True)
         verify_clean_boot(client, ignore_warnings=self.expected_warnings)
+        assert "ftp-instance" == client.execute("hostname").rstrip()
 
     def test_nocloud_ftp_encrypted_server_fails(
         self, client: IntegrationInstance

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -11,6 +11,7 @@ from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
 from tests.integration_tests.util import (
     override_kernel_cmdline,
     verify_clean_boot,
+    verify_clean_log,
 )
 
 VENDOR_DATA = """\
@@ -388,6 +389,7 @@ class TestFTP:
         self._boot_with_cmdline(cmdline, client)
         verify_clean_boot(client, ignore_warnings=self.expected_warnings)
         assert "ftp-bootstrapper" == client.execute("hostname").rstrip()
+        verify_clean_log(client.execute("cat /var/log/cloud-init.log").stdout)
 
     def test_nocloud_ftps_unencrypted_server_fails(
         self, client: IntegrationInstance
@@ -422,6 +424,7 @@ class TestFTP:
         self._boot_with_cmdline(cmdline, client, encrypted=True)
         verify_clean_boot(client, ignore_warnings=self.expected_warnings)
         assert "ftp-bootstrapper" == client.execute("hostname").rstrip()
+        verify_clean_log(client.execute("cat /var/log/cloud-init.log").stdout)
 
     def test_nocloud_ftp_encrypted_server_fails(
         self, client: IntegrationInstance

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -398,8 +398,6 @@ class TestFTP:
         """
         cmdline = "ds=nocloud;seedfrom=ftps://localhost:2121"
         self._boot_with_cmdline(cmdline, client)
-        log = client.read_from_file("/var/log/cloud-init.log")
-        assert "Reading file from server over tls failed for url" in log
         verify_clean_boot(
             client,
             ignore_warnings=self.expected_warnings,
@@ -407,6 +405,7 @@ class TestFTP:
                 "Getting data from <class 'cloudinit.sources.DataSourc"
                 "eNoCloud.DataSourceNoCloudNet'> failed",
                 "Used fallback datasource",
+                "Reading file from server over tls failed for url",
             ],
         )
 

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -9,7 +9,6 @@ from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.util import (
     lxd_has_nocloud,
     override_kernel_cmdline,
-    restart_cloud_init,
     wait_for_cloud_init,
 )
 
@@ -130,7 +129,7 @@ def test_lxd_disable_cloud_init_file(client: IntegrationInstance):
 
     client.execute("touch /etc/cloud/cloud-init.disabled")
     client.execute("cloud-init --clean")
-    restart_cloud_init(client)
+    client.restart()
     assert "Active: inactive (dead)" in client.execute(
         "systemctl status cloud-init"
     )
@@ -144,7 +143,7 @@ def test_lxd_disable_cloud_init_env(client: IntegrationInstance):
     client.execute(f'echo "{env}" >> /etc/systemd/system.conf')
 
     client.execute("cloud-init --clean")
-    restart_cloud_init(client)
+    client.restart()
     assert "Active: inactive (dead)" in client.execute(
         "systemctl status cloud-init"
     )

--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -7,6 +7,7 @@ from tests.integration_tests.conftest import get_validated_source
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.util import (
+    lxd_has_nocloud,
     override_kernel_cmdline,
     restart_cloud_init,
     wait_for_cloud_init,

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import multiprocessing
 import os
@@ -8,11 +9,13 @@ from contextlib import contextmanager
 from functools import lru_cache
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Set
+from typing import TYPE_CHECKING, List, Optional, Set, Union
 
 import pytest
 
 from cloudinit.subp import subp
+
+LOG = logging.getLogger("integration_testing.util")
 
 if TYPE_CHECKING:
     # instances.py has imports util.py, so avoid circular import
@@ -40,6 +43,132 @@ def verify_ordered_items_in_text(to_verify: list, text: str):
             matched = re.search(re.escape(item), text[index:])
         assert matched, "Expected item not found: '{}'".format(item)
         index = matched.start()
+
+
+def format_found(header: str, items: list) -> str:
+    """Helper function to format assertion message """
+
+    # do nothing, allows this formatter to be "stackable"
+    if not items:
+        return ""
+
+    # if only one error put the header and the error message on a single line
+    if 1 == len(items):
+        return f"\n{header}: {items.pop(0)}"
+
+    # otherwise make a list after header
+    else:
+        return f"\n{header}:\n\t- " + "\n\t- ".join(items)
+
+
+def verify_clean_boot(
+    c: "IntegrationInstance",
+    ignore_warnings: Optional[Union[List[str], bool]] = None,
+    ignore_errors: Optional[Union[List[str], bool]] = None,
+    require_warnings: Optional[list] = None,
+    require_errors: Optional[list] = None,
+):
+    """raise assertions if the client experienced unexpected warnings or errors
+
+    fail when an required error isn't found
+
+    This function is similar to verify_clean_log, hence the similar name.
+
+    differences from verify_clean_log:
+
+    - more expressive syntax
+    - extensible (can be easily extended for other log levels)
+    - less resource intensive (no log copying required)
+    - nice error formatting
+
+    c: test instance
+    ignored_warnings: list of expected warnings to ignore,
+        or true to ignore all
+    ignored_errors: list of expected errors to ignore, or true to ignore all
+    require_warnings: Optional[list] = None,
+    require_errors: Optional[list] = None,
+    fail_when_expected_not_found: optional list of expected errors
+    """
+    unexpected_warnings = []
+    unexpected_errors = []
+    ignore_errors = ignore_errors or []
+    ignore_warnings = ignore_warnings or []
+    require_errors = require_errors or []
+    require_warnings = require_warnings or []
+    status = json.loads(c.execute("cloud-init status --format=json"))
+
+    unexpected_errors = set()
+    unexpected_warnings = set()
+
+    required_warnings_found = set()
+    required_errors_found = set()
+
+    for current_error in status["errors"]:
+
+        # check for required errors
+        for expected in require_errors:
+            if expected in current_error:
+                required_errors_found.add(expected)
+
+        # check for unexpected errors
+        if ignore_errors is True:
+            continue
+        for expected in [*ignore_errors, *require_errors]:
+            if expected in current_error:
+                break
+        else:
+            unexpected_errors.add(current_error)
+
+    # check for unexpected warnings
+    for current_warning in status["recoverable_errors"].get("WARNING", []):
+
+        # check for required warnings
+        for expected in require_warnings:
+            if expected in current_warning:
+                required_warnings_found.add(expected)
+
+        # check for unexpected warnings
+        if ignore_warnings is True:
+            continue
+        for expected in [*ignore_warnings, *require_warnings]:
+            if expected in current_warning:
+                break
+        else:
+            unexpected_warnings.add(current_warning)
+
+    required_errors_not_found = set(require_errors) - required_errors_found
+    required_warnings_not_found = (
+        set(require_warnings) - required_warnings_found
+    )
+
+    errors = [
+        *unexpected_errors,
+        *required_errors_not_found,
+        *unexpected_warnings,
+        *required_warnings_not_found,
+    ]
+    if errors:
+        message = ""
+        # if there is only one message, don't include the generic header
+        # so that the user can read the exact message in the pytest summary
+        if len(errors) > 1:
+            # more than one error, so include a generic message
+            message += "Unexpected warnings or errors found"
+
+        # errors are probably more important, order them first
+        message += format_found(
+            "Found unexpected errors", list(unexpected_errors)
+        )
+        message += format_found(
+            "Required errors not found", list(required_errors_not_found)
+        )
+        message += format_found(
+            "Found unexpected warnings", list(unexpected_warnings)
+        )
+        message += format_found(
+            "Required warnings not found", list(required_warnings_not_found)
+        )
+        assert not errors, message
 
 
 def verify_clean_log(log: str, ignore_deprecations: bool = True):
@@ -219,3 +348,63 @@ def get_feature_flag_value(client: "IntegrationInstance", key):
     if "NameError" in value:
         raise NameError(f"name '{key}' is not defined")
     return value
+
+
+def restart_cloud_init(c: "IntegrationInstance"):
+    """restart cloud-init on an instance, wait for cloud-init to boot
+
+    c: instance to restart
+    """
+    client = c
+    client.instance.shutdown(wait=False)
+    try:
+        client.instance.wait_for_state("STOPPED", num_retries=20)
+    except RuntimeError as e:
+        log.warning(
+            "Retrying shutdown due to timeout on initial shutdown request %s",
+            str(e),
+        )
+        client.instance.shutdown()
+
+    # required for lxc
+    client.instance.execute_via_ssh = False
+    client.instance.start()
+    client.execute("cloud-init status --wait")
+
+
+def override_kernel_cmdline(ds_str: str, c: "IntegrationInstance"):
+    """set the kernel commandline and reboot, return after boot done
+
+    This will not work with containers. This is only tested with lxd vms
+    but in theory should work on any virtual machine using grub.
+
+    ds_str: the string that will be inserted into /proc/cmdline
+    c: instance to set kernel commandline for
+    """
+    client = c
+
+    # The final output in /etc/default/grub should be:
+    #
+    # GRUB_CMDLINE_LINUX="'ds=nocloud;s=http://my-url/'"
+    #
+    # That ensures that the kernel commandline passed into
+    # /boot/efi/EFI/ubuntu/grub.cfg will be properly single-quoted
+    #
+    # Example:
+    #
+    # linux /boot/vmlinuz-5.15.0-1030-kvm ro 'ds=nocloud;s=http://my-url/'
+    #
+    # Not doing this will result in a semicolon-delimited ds argument
+    # terminating the kernel arguments prematurely.
+    assert client.execute(
+        'printf "GRUB_CMDLINE_LINUX=\\"" >> /etc/default/grub'
+    ).ok
+    assert client.execute('printf "\'" >> /etc/default/grub').ok
+    assert client.execute(f"printf '{ds_str}' >> /etc/default/grub").ok
+    assert client.execute('printf "\'\\"" >> /etc/default/grub').ok
+
+    # We should probably include non-systemd distros at some point. This should
+    # most likely be as simple as updating the output path for grub-mkconfig
+    assert client.execute("grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg").ok
+    assert client.execute("cloud-init clean --logs").ok
+    restart_cloud_init(client)

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -45,7 +45,7 @@ def verify_ordered_items_in_text(to_verify: list, text: str):
         index = matched.start()
 
 
-def format_found(header: str, items: list) -> str:
+def _format_found(header: str, items: list) -> str:
     """Helper function to format assertion message"""
 
     # do nothing, allows this formatter to be "stackable"
@@ -154,16 +154,16 @@ def verify_clean_boot(
             message += "Unexpected warnings or errors found"
 
         # errors are probably more important, order them first
-        message += format_found(
+        message += _format_found(
             "Found unexpected errors", list(unexpected_errors)
         )
-        message += format_found(
+        message += _format_found(
             "Required errors not found", list(required_errors_not_found)
         )
-        message += format_found(
+        message += _format_found(
             "Found unexpected warnings", list(unexpected_warnings)
         )
-        message += format_found(
+        message += _format_found(
             "Required warnings not found", list(required_warnings_not_found)
         )
         assert not errors, message

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -348,28 +348,6 @@ def get_feature_flag_value(client: "IntegrationInstance", key):
     return value
 
 
-def restart_cloud_init(c: "IntegrationInstance"):
-    """restart cloud-init on an instance, wait for cloud-init to boot
-
-    c: instance to restart
-    """
-    client = c
-    client.instance.shutdown(wait=False)
-    try:
-        client.instance.wait_for_state("STOPPED", num_retries=20)
-    except RuntimeError as e:
-        log.warning(
-            "Retrying shutdown due to timeout on initial shutdown request %s",
-            str(e),
-        )
-        client.instance.shutdown()
-
-    # required for lxc
-    client.instance.execute_via_ssh = False
-    client.instance.start()
-    client.execute("cloud-init status --wait")
-
-
 def override_kernel_cmdline(ds_str: str, c: "IntegrationInstance"):
     """set the kernel commandline and reboot, return after boot done
 
@@ -405,4 +383,4 @@ def override_kernel_cmdline(ds_str: str, c: "IntegrationInstance"):
     # most likely be as simple as updating the output path for grub-mkconfig
     assert client.execute("grub-mkconfig -o /boot/efi/EFI/ubuntu/grub.cfg").ok
     assert client.execute("cloud-init clean --logs").ok
-    restart_cloud_init(client)
+    client.restart()

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -89,8 +89,6 @@ def verify_clean_boot(
     require_errors: Optional[list] = None,
     fail_when_expected_not_found: optional list of expected errors
     """
-    unexpected_warnings = []
-    unexpected_errors = []
     ignore_errors = ignore_errors or []
     ignore_warnings = ignore_warnings or []
     require_errors = require_errors or []

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -46,7 +46,7 @@ def verify_ordered_items_in_text(to_verify: list, text: str):
 
 
 def format_found(header: str, items: list) -> str:
-    """Helper function to format assertion message """
+    """Helper function to format assertion message"""
 
     # do nothing, allows this formatter to be "stackable"
     if not items:

--- a/tests/unittests/sources/test_maas.py
+++ b/tests/unittests/sources/test_maas.py
@@ -116,7 +116,7 @@ class TestMAASDataSource:
             short = url[len(prefix) :]
             if short not in data:
                 raise url_helper.UrlError("not found", code=404, url=url)
-            return url_helper.StringResponse(data[short])
+            return url_helper.StringResponse(data[short], url)
 
         # Now do the actual call of the code under test.
         with mock.patch("cloudinit.url_helper.readurl") as mock_readurl:

--- a/tests/unittests/test__init__.py
+++ b/tests/unittests/test__init__.py
@@ -252,7 +252,7 @@ class TestCmdlineUrl:
         key = "cloud-config-url"
         url = "http://example.com/foo"
         cmdline = "ro %s=%s bar=1" % (key, url)
-        m_read.return_value = url_helper.StringResponse(b"unexpected blob")
+        m_read.return_value = url_helper.StringResponse(b"unexpected blob", "http://example.com/")
 
         fpath = tmpdir.join("ccfile")
         lvl, msg = main.attempt_cmdline_url(
@@ -288,7 +288,7 @@ class TestCmdlineUrl:
         payload = b"#cloud-config\nmydata: foo\nbar: wark\n"
         cmdline = "ro %s=%s bar=1" % ("cloud-config-url", url)
 
-        m_read.return_value = url_helper.StringResponse(payload)
+        m_read.return_value = url_helper.StringResponse(payload, "http://example.com")
         fpath = tmpdir.join("ccfile")
         lvl, msg = main.attempt_cmdline_url(
             fpath, network=True, cmdline=cmdline

--- a/tests/unittests/test__init__.py
+++ b/tests/unittests/test__init__.py
@@ -252,7 +252,9 @@ class TestCmdlineUrl:
         key = "cloud-config-url"
         url = "http://example.com/foo"
         cmdline = "ro %s=%s bar=1" % (key, url)
-        m_read.return_value = url_helper.StringResponse(b"unexpected blob", "http://example.com/")
+        m_read.return_value = url_helper.StringResponse(
+            b"unexpected blob", "http://example.com/"
+        )
 
         fpath = tmpdir.join("ccfile")
         lvl, msg = main.attempt_cmdline_url(
@@ -288,7 +290,9 @@ class TestCmdlineUrl:
         payload = b"#cloud-config\nmydata: foo\nbar: wark\n"
         cmdline = "ro %s=%s bar=1" % ("cloud-config-url", url)
 
-        m_read.return_value = url_helper.StringResponse(payload, "http://example.com")
+        m_read.return_value = url_helper.StringResponse(
+            payload, "http://example.com"
+        )
         fpath = tmpdir.join("ccfile")
         lvl, msg = main.attempt_cmdline_url(
             fpath, network=True, cmdline=cmdline

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2529,7 +2529,7 @@ class TestReadSeeded:
                 else:
                     _url, _, md_type = parsed_url.netloc.partition("8008")
                 path = f"/{md_type}"
-            return url_helper.StringResponse(f"{path}: 1")
+            return url_helper.StringResponse(f"{path}: 1", "http://url/")
 
         m_read.side_effect = fake_response
 


### PR DESCRIPTION
## Proposed Commit Message
```
feat: Add support for FTP and FTP over TLS

Use Python's ftplib to connect to and read instance configurations from a
remove server. Like the current http support, nocloud's configuration URI
is defined via kernel command line or dmi product serial.

Notes on FTP and FTP over TLS
=============================

FTP is insecure, use at your own risk.

The FTP over TLS implementation follows library best practices[1][2].
From the ssl documentation regarding create_default_context():

> It will load the system’s trusted CA certificates, enable certificate
> validation and hostname checking, and try to choose reasonably secure
> protocol and cipher settings.

Test Changes
============

tests/i/util.py
---------------

- new helper function verify_clean_boot() to verify cloud-init state
- acquire override_kernel_cmdline() for reuse in other tests
- acquire restart_cloud_init() for reuse in other tests

tests/i/datasources/test_nocloud.py
-----------------------------------

- new test class for FTP/FTPS uses pyftpdlib for server, mkcert for test certs
- 2 test additions for FTP
- 2 test additions for FTPS

Implements via ftplib
=====================

RFC 959 - File Transfer Protocol
RFC 2640 - FTP Internationalization (UTF-8)
RFC 4217 - FTP over TLS

[1] https://docs.python.org/3/library/ftplib.html#ftp-tls-objects
[2] https://docs.python.org/3/library/ssl.html#ssl-security
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
PLATFORM="lxd_vm" CLOUD_INIT_SOURCE="./cloud-init_all.deb" python -m
pytest -vv --log-cli-level=INFO --durations 10 tests/integration_tests/datasources/test_nocloud.py::TestFTP
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
