### PR TITLE
tests: reduce expected reports due to dropped rightscale module

### DIFF
--- a/tests/integration_tests/reporting/test_webhook_reporting.py
+++ b/tests/integration_tests/reporting/test_webhook_reporting.py
@@ -54,7 +54,7 @@ def test_webhook_reporting(client: IntegrationInstance):
     events = [json.loads(line) for line in server_output]
 
     # Only time this should be less is if we remove modules
-    assert len(events) > 54, events
+    assert len(events) > 52, events
 
     # Assert our first and last expected messages exist
     ds_events = [


### PR DESCRIPTION
## Proposed Commit Message
```
tests: reduce expected reports due to dropped rightscale module

Commit 1a248b592 dropped cc_rightscale_user_data module.
When a module is dropped or added we need to account for the
two related start and finish events related to that module.
```

## Additional Context
<!-- If relevant -->
Failed jenkins job
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-lxd_container/382/testReport/junit/tests.integration_tests.reporting/test_webhook_reporting/test_webhook_reporting/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_OS_IMAGE=noble  CLOUD_INIT_PLATFORM=lxd_container  tox -e integration-tests  -- tests/integration_tests/reporting/test_webhook_reporting.py::test_webhook_reporting
```


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
