### PR TITLE
fix: Add types to network v1 schema

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -25,7 +25,10 @@
           "description": "The lowercase MAC address of the physical device."
         },
         "mtu": {
-          "type": "integer",
+          "type": [
+            "integer",
+            "null"
+          ],
           "description": "The MTU size in bytes. The ``mtu`` key represents a device's Maximum Transmission Unit, which is the largest size packet or frame, specified in octets (eight-bit bytes), that can be sent in a packet- or frame-based network. Specifying ``mtu`` is optional. Values too small or too large for a device may be ignored by that device."
         },
         "subnets": {
@@ -385,8 +388,7 @@
       "additionalProperties": false,
       "required": [
         "type",
-        "address",
-        "search"
+        "address"
       ],
       "properties": {
         "type": {
@@ -397,7 +399,10 @@
         },
         "address": {
           "description": "List of IPv4 or IPv6 address of nameservers.",
-          "type": "array",
+          "type": [
+            "array",
+            "string"
+          ],
           "items": {
             "type": "string"
           }

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -251,9 +251,10 @@ Nameserver
 Users can specify a ``nameserver`` type. Nameserver dictionaries include
 the following keys:
 
-- ``address``: List of IPv4 or IPv6 address of nameservers.
-- ``search``: List of hostnames to include in the :file:`resolv.conf` search
-  path.
+- ``address``: List of IPv4 or IPv6 address of nameservers or string with
+  single nameserver.
+- ``search``: Optional. List of hostnames to include in the :file:`resolv.conf`
+  search path.
 - ``interface``: Optional. Ties the nameserver definition to the specified
   interface. The value specified here must match the ``name`` of an interface
   defined in this config. If unspecified, this nameserver will be considered

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -251,8 +251,7 @@ Nameserver
 Users can specify a ``nameserver`` type. Nameserver dictionaries include
 the following keys:
 
-- ``address``: List of IPv4 or IPv6 address of nameservers or string with
-  single nameserver.
+- ``address``: List of IPv4 or IPv6 address of nameservers.
 - ``search``: Optional. List of hostnames to include in the :file:`resolv.conf`
   search path.
 - ``interface``: Optional. Ties the nameserver definition to the specified

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -2328,6 +2328,20 @@ class TestNetworkSchema:
                 "",
                 id="bond_with_all_known_properties",
             ),
+            pytest.param(
+                {
+                    "network": {
+                        "version": 1,
+                        "config": [
+                            {"type": "physical", "name": "eth0", "mtu": None},
+                            {"type": "nameserver", "address": "8.8.8.8"},
+                        ],
+                    }
+                },
+                does_not_raise(),
+                "",
+                id="GH-4710_mtu_none_and_str_address",
+            ),
         ),
     )
     def test_network_schema(self, src_config, expectation, log, caplog):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Add types to network v1 schema

Even though it has conflicted with our documentation, we have allowed
nameserver address to a be a string, mtu to be empty, and nameserver
search to be missing. Since we have allowed these, expand our schema
and documentation accordingly.

Fixes GH-4710
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
