### PR TITLE
fix: Handle systemctl when dbus not ready

### DIFF
--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -93,6 +93,36 @@ boot_status_code: {boot_code}
 {description}"""
 
 
+def query_systemctl(
+    systemctl_args: List[str],
+    *,
+    wait: bool,
+    existing_status: Optional[UXAppStatus] = None,
+) -> str:
+    """Query systemd with retries and return output."""
+    while True:
+        try:
+            return subp.subp(["systemctl", *systemctl_args]).stdout.strip()
+        except subp.ProcessExecutionError as e:
+            if existing_status and existing_status in (
+                UXAppStatus.DEGRADED_RUNNING,
+                UXAppStatus.RUNNING,
+            ):
+                return ""
+            last_exception = e
+            if wait:
+                sleep(0.25)
+            else:
+                break
+    print(
+        "Failed to get status from systemd. "
+        "Cloud-init status may be inaccurate. ",
+        f"Error from systemctl: {last_exception.stderr}",
+        file=sys.stderr,
+    )
+    return ""
+
+
 def get_parser(parser=None):
     """Build or extend an arg parser for status utility.
 
@@ -229,7 +259,9 @@ def handle_status_args(name, args) -> int:
     return 0
 
 
-def get_bootstatus(disable_file, paths) -> Tuple[UXAppBootStatusCode, str]:
+def get_bootstatus(
+    disable_file, paths, wait
+) -> Tuple[UXAppBootStatusCode, str]:
     """Report whether cloud-init current boot status
 
     @param disable_file: The path to the cloud-init disable file.
@@ -253,7 +285,7 @@ def get_bootstatus(disable_file, paths) -> Tuple[UXAppBootStatusCode, str]:
     elif "cloud-init=disabled" in os.environ.get("KERNEL_CMDLINE", "") or (
         uses_systemd()
         and "cloud-init=disabled"
-        in subp.subp(["systemctl", "show-environment"]).stdout
+        in query_systemctl(["show-environment"], wait=wait)
     ):
         bootstatus_code = UXAppBootStatusCode.DISABLED_BY_ENV_VARIABLE
         reason = (
@@ -272,7 +304,9 @@ def get_bootstatus(disable_file, paths) -> Tuple[UXAppBootStatusCode, str]:
     return (bootstatus_code, reason)
 
 
-def _get_error_or_running_from_systemd() -> Optional[UXAppStatus]:
+def _get_error_or_running_from_systemd(
+    existing_status: UXAppStatus, wait: bool
+) -> Optional[UXAppStatus]:
     """Get if systemd is in error or running state.
 
     Using systemd, we can get more fine-grained status of the
@@ -288,14 +322,18 @@ def _get_error_or_running_from_systemd() -> Optional[UXAppStatus]:
         "cloud-init.service",
         "cloud-init-local.service",
     ]:
-        stdout = subp.subp(
+        stdout = query_systemctl(
             [
-                "systemctl",
                 "show",
                 "--property=ActiveState,UnitFileState,SubState,MainPID",
                 service,
             ],
-        ).stdout
+            wait=wait,
+            existing_status=existing_status,
+        )
+        if not stdout:
+            # Systemd isn't ready
+            return None
         states = dict(
             [[x.strip() for x in r.split("=")] for r in stdout.splitlines()]
         )
@@ -327,39 +365,6 @@ def _get_error_or_running_from_systemd() -> Optional[UXAppStatus]:
     return None
 
 
-def _get_error_or_running_from_systemd_with_retry(
-    existing_status: UXAppStatus, *, wait: bool
-) -> Optional[UXAppStatus]:
-    """Get systemd status and retry if dbus isn't ready.
-
-    If cloud-init has determined that we're still running, then we can
-    ignore the status from systemd. However, if cloud-init has detected error,
-    then we should retry on systemd status so we don't incorrectly report
-    error state while cloud-init is still running.
-    """
-    while True:
-        try:
-            return _get_error_or_running_from_systemd()
-        except subp.ProcessExecutionError as e:
-            last_exception = e
-            if existing_status in (
-                UXAppStatus.DEGRADED_RUNNING,
-                UXAppStatus.RUNNING,
-            ):
-                return None
-            if wait:
-                sleep(0.25)
-            else:
-                break
-    print(
-        "Failed to get status from systemd. "
-        "Cloud-init status may be inaccurate. ",
-        f"Error from systemctl: {last_exception.stderr}",
-        file=sys.stderr,
-    )
-    return None
-
-
 def get_status_details(
     paths: Optional[Paths] = None, wait: bool = False
 ) -> StatusDetails:
@@ -380,7 +385,7 @@ def get_status_details(
     result_file = os.path.join(paths.run_dir, "result.json")
 
     boot_status_code, description = get_bootstatus(
-        CLOUDINIT_DISABLED_FILE, paths
+        CLOUDINIT_DISABLED_FILE, paths, wait
     )
     if boot_status_code in DISABLED_BOOT_CODES:
         status = UXAppStatus.DISABLED
@@ -433,9 +438,7 @@ def get_status_details(
         UXAppStatus.NOT_RUN,
         UXAppStatus.DISABLED,
     ):
-        systemd_status = _get_error_or_running_from_systemd_with_retry(
-            status, wait=wait
-        )
+        systemd_status = _get_error_or_running_from_systemd(status, wait=wait)
         if systemd_status:
             status = systemd_status
 

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -1049,11 +1049,9 @@ class TestQuerySystemctl:
         m_sleep = mocker.patch(f"{M_PATH}sleep")
         m_subp = mocker.patch(
             f"{M_PATH}subp.subp",
-            side_effect=[
-                subp.ProcessExecutionError("Message recipient disconnected"),
-                subp.ProcessExecutionError("Message recipient disconnected"),
-                subp.ProcessExecutionError("Message recipient disconnected"),
-            ],
+            side_effect=subp.ProcessExecutionError(
+                "Message recipient disconnected"
+            ),
         )
 
         assert (


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Handle systemctl when dbus not ready

See commit d29b744, but this commit generalizes the solution for all
calls in status.py
```

## Additional Context
#4681 #4676 LP: #2046483

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
