### PR TITLE
fix(schema cli): avoid netplan validation on net-config version 1

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1119,11 +1119,13 @@ def validate_cloudconfig_file(
         if not cloudconfig.get("network", cloudconfig):
             print("Skipping network-config schema validation on empty config.")
             return False
-        if netplan_validate_network_schema(
-            network_config=cloudconfig, strict=True, annotate=annotate
-        ):
-            return True  # schema validation performed by netplan
-        if network_schema_version(cloudconfig) != 1:
+        network_version = network_schema_version(cloudconfig)
+        if network_version == 2:
+            if netplan_validate_network_schema(
+                network_config=cloudconfig, strict=True, annotate=annotate
+            ):
+                return True  # schema validation performed by netplan
+        if network_version != 1:
             # Validation requires JSON schema definition in
             # cloudinit/config/schemas/schema-network-config-v1.json
             print(

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -1892,6 +1892,14 @@ class TestMain:
                 "Skipping network-config schema validation. No network schema"
                 " for version: 2",
             ),
+            (
+                "network-config",
+                (
+                    b"network:\n version: 1\n config:\n  - type: physical\n"
+                    b"    name: eth0\n    subnets:\n      - type: dhcp\n"
+                ),
+                "Valid schema",
+            ),
         ),
     )
     def test_main_validates_config_file(


### PR DESCRIPTION
## Proposed Commit Message take from rebase
```
fix(schema cli): avoid netplan validation on net-config version 1

Commit e168b4a1 moved network-config version 2 checking out of netplan_validate_network_schema and up into the callsite in netplan_validate_network_schema.

An oversight didn't apply the same version 2 check to the second callsite in validate_cloudconfig_file.

Add unittest coverage to supplement the integration test which already caught this failure in tests.integration_tests.cmd.test_schema.
```

## Additional Context
<!-- If relevant -->
Failed jenkins job https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-ec2/lastSuccessfulBuild/testReport/junit/tests.integration_tests.cmd.test_schema/TestSchemaDeprecations/test_network_config_schema_validation/
## Test Steps
```
# test main to see errors vs this branch for the fix
CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_PLATFORM=lxd_container  tox -e integration-tests  -- tests/integration_tests/cmd/test_schema.py::TestSchemaDeprecations::test_network_config_schema_validation
```
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
