### PR TITLE
fix: Fix typos

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@ jobs=4
 
 [MESSAGES CONTROL]
 
-# Errors and warings with some filtered:
+# Errors and warnings with some filtered:
 # W0201(attribute-defined-outside-init)
 # W0212(protected-access)
 # W0221(arguments-differ)

--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -160,14 +160,14 @@ class NetHandler(UeventHandler):
         return len(found) > 0
 
 
-SUBSYSTEM_PROPERTES_MAP = {
+SUBSYSTEM_PROPERTIES_MAP = {
     "net": (NetHandler, EventScope.NETWORK),
 }
 
 
 def is_enabled(hotplug_init, subsystem):
     try:
-        scope = SUBSYSTEM_PROPERTES_MAP[subsystem][1]
+        scope = SUBSYSTEM_PROPERTIES_MAP[subsystem][1]
     except KeyError as e:
         raise RuntimeError(
             "hotplug-hook: cannot handle events for subsystem: {}".format(
@@ -201,7 +201,7 @@ def handle_hotplug(hotplug_init: Init, devpath, subsystem, udevaction):
     datasource = initialize_datasource(hotplug_init, subsystem)
     if not datasource:
         return
-    handler_cls = SUBSYSTEM_PROPERTES_MAP[subsystem][0]
+    handler_cls = SUBSYSTEM_PROPERTIES_MAP[subsystem][0]
     LOG.debug("Creating %s event handler", subsystem)
     event_handler: UeventHandler = handler_cls(
         datasource=datasource,

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -196,7 +196,7 @@ def handle_status_args(name, args) -> int:
     if args.format == "tabular":
         prefix = "\n" if args.wait else ""
 
-        # For backwards compatability, don't report degraded status here,
+        # For backwards compatibility, don't report degraded status here,
         # extended_status key reports the complete status (includes degraded)
         state = UXAppStatusDegradedMapCompat.get(
             details.status, details.status
@@ -349,7 +349,7 @@ def _get_error_or_running_from_systemd(
                 continue
             elif states["SubState"] == "running" and states["MainPID"] == "0":
                 # Service is active, substate still reports running due to
-                # daemon or backgroud process spawned by CGroup/slice still
+                # daemon or background process spawned by CGroup/slice still
                 # running. MainPID being set back to 0 means control of the
                 # service/unit has exited in this case and
                 # "the process is no longer around".

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -584,7 +584,7 @@ def get_apt_cfg() -> Dict[str, str]:
 
     Prefer python apt_pkg if present.
     Fallback to apt-config dump command if present out output parsed
-    Fallback to DEFAULT_APT_CFG if apt-config commmand absent or
+    Fallback to DEFAULT_APT_CFG if apt-config command absent or
     output unparsable.
     """
     try:

--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -670,7 +670,7 @@ def purge_disk_ptable(device):
 
 def purge_disk(device):
     """
-    Remove parition table entries
+    Remove partition table entries
     """
 
     # wipe any file systems first
@@ -791,7 +791,7 @@ def mkpart(device, definition):
 
             The following are supported values in the dict:
                 overwrite: Should the partition table be created regardless
-                            of any pre-exisiting data?
+                            of any pre-existing data?
                 layout: the layout of the partition table
                 table_type: Which partition table to use, defaults to MBR
                 device: the device to work on.
@@ -940,12 +940,12 @@ def mkfs(fs_cfg):
                 LOG.warning("Destroying filesystem on %s", device)
 
         else:
-            LOG.debug("Device %s is cleared for formating", device)
+            LOG.debug("Device %s is cleared for formatting", device)
 
     elif partition and str(partition).lower() in ("auto", "any"):
         # For auto devices, we match if the filesystem does exist
         odevice = device
-        LOG.debug("Identifying device to create %s filesytem on", label)
+        LOG.debug("Identifying device to create %s filesystem on", label)
 
         # 'any' means pick the first match on the device with matching fs_type
         label_match = True
@@ -962,7 +962,7 @@ def mkfs(fs_cfg):
         LOG.debug("Automatic device for %s identified as %s", odevice, device)
 
         if reuse:
-            LOG.debug("Found filesystem match, skipping formating.")
+            LOG.debug("Found filesystem match, skipping formatting.")
             return
 
         if not reuse and fs_replace and device:

--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -59,7 +59,7 @@ meta: MetaSchema = {
 LOG = logging.getLogger(__name__)
 __doc__ = get_meta_doc(meta)
 
-# Jinja formated default message
+# Jinja formatted default message
 FINAL_MESSAGE_DEF = (
     "## template: jinja\n"
     "Cloud-init v. {{version}} finished at {{timestamp}}."

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -306,7 +306,7 @@ def device_part_info(devpath):
         # FreeBSD doesn't know of sysfs so just get everything we need from
         # the device, like /dev/vtbd0p2.
         fpart = "/dev/" + util.find_freebsd_part(devpath)
-        # Handle both GPT partions and MBR slices with partitions
+        # Handle both GPT partitions and MBR slices with partitions
         m = re.search(
             r"^(?P<dev>/dev/.+)[sp](?P<part_slice>\d+[a-z]*)$", fpart
         )

--- a/cloudinit/config/cc_install_hotplug.py
+++ b/cloudinit/config/cc_install_hotplug.py
@@ -25,7 +25,7 @@ meta: MetaSchema = {
 
         When hotplug is enabled, newly added network devices will be added
         to the system by cloud-init. After udev detects the event,
-        cloud-init will referesh the instance metadata from the datasource,
+        cloud-init will refresh the instance metadata from the datasource,
         detect the device in the updated metadata, then apply the updated
         network configuration.
 

--- a/cloudinit/config/cc_puppet.py
+++ b/cloudinit/config/cc_puppet.py
@@ -240,7 +240,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
         if install_type == "packages":
             to_install: List[Union[str, List[str]]]
-            if package_name is None:  # conf has no package_nam
+            if package_name is None:  # conf has no package_name
                 for puppet_name in PUPPET_PACKAGE_NAMES:
                     with suppress(PackageInstallerError):
                         to_install = (

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -29,7 +29,7 @@ meta: MetaSchema = {
     "title": "Resize filesystem",
     "description": dedent(
         """\
-        Resize a filesystem to use all avaliable space on partition. This
+        Resize a filesystem to use all available space on partition. This
         module is useful along with ``cc_growpart`` and will ensure that if the
         root partition has been resized the root filesystem will be resized
         along with it. By default, ``cc_resizefs`` will resize the root

--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -505,7 +505,7 @@ class SubscriptionManager:
 
 def _sub_man_cli(cmd, logstring_val=False):
     """
-    Uses the prefered cloud-init subprocess def of subp.subp
+    Uses the preferred cloud-init subprocess def of subp.subp
     and runs subscription-manager.  Breaking this to a
     separate function for later use in mocking and unittests
     """

--- a/cloudinit/config/cc_ubuntu_autoinstall.py
+++ b/cloudinit/config/cc_ubuntu_autoinstall.py
@@ -32,7 +32,7 @@ meta: MetaSchema = {
         next generation desktop installer, via `ubuntu-desktop-install` snap.
         When "autoinstall" directives are provided in either
         ``#cloud-config`` user-data or ``/etc/cloud/cloud.cfg.d`` validate
-        minimal autoinstall schema adherance and emit a warning if the
+        minimal autoinstall schema adherence and emit a warning if the
         live-installer is not present.
 
         The live-installer will use autoinstall directives to seed answers to

--- a/cloudinit/config/cc_wireguard.py
+++ b/cloudinit/config/cc_wireguard.py
@@ -226,7 +226,7 @@ def maybe_install_wireguard_packages(cloud: Cloud):
     if subp.which("wg"):
         return
 
-    # Install DKMS when Kernel Verison lower 5.6
+    # Install DKMS when Kernel Version lower 5.6
     if util.kernel_version() < MIN_KERNEL_VERSION:
         packages.append("wireguard")
 

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -74,7 +74,7 @@ meta: MetaSchema = {
         ),
         dedent(
             """\
-        # Provide gziped binary content
+        # Provide gzipped binary content
         write_files:
         - encoding: gzip
           content: !!binary |
@@ -146,7 +146,7 @@ def canonicalize_extraction(encoding_type):
     # Yaml already encodes binary data as base64 if it is given to the
     # yaml file as binary, so those will be automatically decoded for you.
     # But the above b64 is just for people that are more 'comfortable'
-    # specifing it manually (which might be a possibility)
+    # specifying it manually (which might be a possibility)
     if encoding_type in ["b64", "base64"]:
         return ["application/base64"]
     if encoding_type == TEXT_PLAIN_ENC:

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -151,7 +151,7 @@ SchemaProblems = List[SchemaProblem]
 
 
 class SchemaType(Enum):
-    """Supported schema types are etiher cloud-config or network-config.
+    """Supported schema types are either cloud-config or network-config.
 
     Vendordata and Vendordata2 format adheres to cloud-config schema type.
     Cloud Metadata is unique schema to each cloud platform and likely will not
@@ -638,7 +638,7 @@ def netplan_validate_network_schema(
     parser = Parser()
     errors = []
     try:
-        # Parse all netplan *.yaml files.load_yaml_heirarchy looks for nested
+        # Parse all netplan *.yaml files.load_yaml_hierarchy looks for nested
         # etc/netplan subdir under "/".
         parser.load_yaml_hierarchy(parse_dir)
     except NetplanParserException as e:
@@ -922,7 +922,7 @@ def annotated_cloudconfig_file(
     """Return contents of the cloud-config file annotated with schema errors.
 
     @param cloudconfig: YAML-loaded dict from the original_content or empty
-        dict if unparseable.
+        dict if unparsable.
     @param original_content: The contents of a cloud-config file
     @param schemamarks: Dict with schema marks.
     @param schema_errors: Instance of `SchemaProblems`.
@@ -942,7 +942,7 @@ def process_merged_cloud_config_part_problems(
 
     When merging multiple cloud-config parts cloud-init logs an error and
     ignores any user-data parts which are declared as #cloud-config but
-    cannot be processed. the hanlder.cloud_config module also leaves comments
+    cannot be processed. the handler.cloud_config module also leaves comments
     in the final merged config for every invalid part file which begin with
     MERGED_CONFIG_SCHEMA_ERROR_PREFIX to aid in triage.
     """
@@ -1570,7 +1570,7 @@ def get_schema(schema_type: SchemaType = SchemaType.CLOUD_CONFIG) -> dict:
         full_schema = json.loads(load_text_file(schema_file))
     except (IOError, OSError):
         LOG.warning(
-            "Skipping %s schema valiation. No JSON schema file found %s.",
+            "Skipping %s schema validation. No JSON schema file found %s.",
             schema_type.value,
             schema_file,
         )
@@ -1669,7 +1669,7 @@ def _assert_exclusive_args(args):
 def get_config_paths_from_args(
     args,
 ) -> Tuple[str, List[InstanceDataPart]]:
-    """Return appropiate instance-data.json and instance data parts
+    """Return appropriate instance-data.json and instance data parts
 
     Based on commandline args, and user permissions, determine the
     appropriate instance-data.json to source for jinja templates and
@@ -1696,7 +1696,7 @@ def get_config_paths_from_args(
           user-data.
           In the case of invalid raw user-data header, prefer
           raw_fallback_path_key so actionable sensible warnings can be
-          reported ot the user about the raw unparseable user-data.
+          reported to the user about the raw unparsable user-data.
         """
         primary_datapath = paths.get_ipath(primary_path_key) or ""
         with suppress(FileNotFoundError):

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -418,7 +418,7 @@
         ]
       }
     },
-    "merge_defintion": {
+    "merge_definition": {
       "oneOf": [
         {
           "type": "string"
@@ -1739,7 +1739,7 @@
                 },
                 "ipv4_dhcp_leases": {
                   "type": "integer",
-                  "description": "Number of DHCP leases to allocate within the range. Automatically calculated based on `ipv4_dhcp_first` and `ipv4_dchp_last` when unset."
+                  "description": "Number of DHCP leases to allocate within the range. Automatically calculated based on `ipv4_dhcp_first` and `ipv4_dhcp_last` when unset."
                 },
                 "ipv4_nat": {
                   "type": "boolean",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -481,10 +481,10 @@
           "description": "The launch index for the specified cloud-config."
         },
         "merge_how": {
-          "$ref": "#/$defs/merge_defintion"
+          "$ref": "#/$defs/merge_definition"
         },
         "merge_type": {
-          "$ref": "#/$defs/merge_defintion"
+          "$ref": "#/$defs/merge_definition"
         }
       }
     },

--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -70,7 +70,7 @@
           "description": "The MTU size in bytes. This ``mtu`` key represents a device's Maximum Transmission Unit, which is the largest size packet or frame, specified in octets (eight-bit bytes), that can be sent in a packet- or frame-based network. Specifying ``mtu`` is optional. Values too small or too large for a device may be ignored by that device."
         },
         "params": {
-          "desciption": "The ``params`` key in a bond holds a dictionary of bonding parameters. This dictionary may be empty. For more details on what the various bonding parameters mean please read the [Linux Kernel Bonding.txt](https://www.kernel.org/doc/Documentation/networking/bonding.txt).",
+          "description": "The ``params`` key in a bond holds a dictionary of bonding parameters. This dictionary may be empty. For more details on what the various bonding parameters mean please read the [Linux Kernel Bonding.txt](https://www.kernel.org/doc/Documentation/networking/bonding.txt).",
           "additionalProperties": false,
           "properties": {
             "bond-active_slave": {

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -53,7 +53,7 @@ from cloudinit.net import activators, dhcp, renderers
 from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.net.renderer import Renderer
 
-# Used when a cloud-config module can be run on all cloud-init distibutions.
+# Used when a cloud-config module can be run on all cloud-init distributions.
 # The value 'all' is surfaced in module documentation for distro support.
 ALL_DISTROS = "all"
 
@@ -274,7 +274,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         """access the distro's preferred dhcp client
 
         if no client has been selected yet select one - uses
-        self.dhcp_client_priority, which may be overriden in each distro's
+        self.dhcp_client_priority, which may be overridden in each distro's
         object to eliminate checking for clients which will not be provided
         by the distro
         """
@@ -637,7 +637,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         """
         Add a user to the system using standard GNU tools
 
-        This should be overriden on distros where useradd is not desirable or
+        This should be overridden on distros where useradd is not desirable or
         not available.
         """
         # XXX need to make add_user idempotent somehow as we
@@ -701,7 +701,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             # that came in as a string like: groups: group1, group2
             groups = [g.strip() for g in groups]
 
-            # kwargs.items loop below wants a comma delimeted string
+            # kwargs.items loop below wants a comma delimited string
             # that can go right through to the command.
             kwargs["groups"] = ",".join(groups)
 
@@ -1347,7 +1347,7 @@ def _apply_hostname_transformations_to_url(url: str, transformations: list):
 
     :return:
         A string whose value is ``url`` with the hostname ``transformations``
-        applied, or ``None`` if ``url`` is unparseable.
+        applied, or ``None`` if ``url`` is unparsable.
     """
     try:
         parts = urllib.parse.urlsplit(url)

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -41,7 +41,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.default_locale = "C.UTF-8"

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -29,7 +29,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "arch"

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -32,7 +32,7 @@ class BSD(distros.Distro):
     def __init__(self, name, cfg, paths):
         super().__init__(name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         cfg["ssh_svcname"] = "sshd"

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -56,7 +56,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         super().__init__(name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self.osfamily = "debian"
         self.default_locale = "C.UTF-8"

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -28,7 +28,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "gentoo"

--- a/cloudinit/distros/mariner.py
+++ b/cloudinit/distros/mariner.py
@@ -44,7 +44,7 @@ class Distro(photon.Distro):
     def __init__(self, name, cfg, paths):
         photon.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "mariner"

--- a/cloudinit/distros/photon.py
+++ b/cloudinit/distros/photon.py
@@ -31,7 +31,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "photon"
@@ -66,7 +66,7 @@ class Distro(distros.Distro):
         return None
 
     def apply_locale(self, locale, out_fn=None):
-        # This has a dependancy on glibc-i18n, user need to manually install it
+        # This has a dependency on glibc-i18n, user need to manually install it
         # and enable the option in cloud.cfg
         if not out_fn:
             out_fn = self.systemd_locale_conf_fn

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -53,7 +53,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "redhat"

--- a/cloudinit/distros/ug_util.py
+++ b/cloudinit/distros/ug_util.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 
 
 # Normalizes an input group configuration which can be:
-# Comma seperated string or a list or a dictionary
+# Comma separated string or a list or a dictionary
 #
 # Returns dictionary of group names => members of that group which is the
 # standard form used in the rest of cloud-init

--- a/cloudinit/gpg.py
+++ b/cloudinit/gpg.py
@@ -68,7 +68,7 @@ def recv_key(key, keyserver, retries=(1, 1)):
 
     Retries are done by default because keyservers can be unreliable.
     Additionally, there is no way to determine the difference between
-    a non-existant key and a failure.  In both cases gpg (at least 2.2.4)
+    a non-existent key and a failure.  In both cases gpg (at least 2.2.4)
     exits with status 2 and stderr: "keyserver receive failed: No data"
     It is assumed that a key provided to cloud-init exists on the keyserver
     so re-trying makes better sense than failing.

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -50,7 +50,7 @@ INCLUSION_TYPES_MAP = {
     "## template: jinja": "text/jinja2",
     # Note: for the next 3 entries, the prefix doesn't matter because these
     # are for types that can only be used as part of a MIME message. However,
-    # including these entries supresses warnings during `cloudinit devel
+    # including these entries suppresses warnings during `cloudinit devel
     # make-mime`, which otherwise would require `--force`.
     "text/x-shellscript-per-boot": "text/x-shellscript-per-boot",
     "text/x-shellscript-per-instance": "text/x-shellscript-per-instance",
@@ -93,7 +93,7 @@ def run_part(mod, data, filename, payload, frequency, headers):
         or (frequency == PER_INSTANCE and mod_freq == PER_INSTANCE)
     ):
         return
-    # Sanity checks on version (should be an int convertable)
+    # Sanity checks on version (should be an int convertible)
     try:
         mod_ver = mod.handler_version
         mod_ver = int(mod_ver)

--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -146,7 +146,7 @@ def reset_logging():
 
 def setup_backup_logging():
     """In the event that internal logging exception occurs and logging is not
-    possible for some reason, make a desparate final attempt to log to stderr
+    possible for some reason, make a desperate final attempt to log to stderr
     which may ease debugging.
     """
     fallback_handler = logging.StreamHandler(sys.stderr)

--- a/cloudinit/mergers/__init__.py
+++ b/cloudinit/mergers/__init__.py
@@ -110,7 +110,7 @@ def string_extract_mergers(merge_how):
             continue
         match = NAME_MTCH.match(m_name)
         if not match:
-            msg = "Matcher identifer '%s' is not in the right format" % (
+            msg = "Matcher identifier '%s' is not in the right format" % (
                 m_name
             )
             raise ValueError(msg)

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -253,7 +253,7 @@ class IscDhclient(DhcpClient):
         @param interface: an interface string - not used in this class, but
             required for function signature compatibility with other classes
             that require a distro object
-        @raises: InvalidDHCPLeaseFileError on empty or unparseable leasefile
+        @raises: InvalidDHCPLeaseFileError on empty or unparsable leasefile
             content.
         """
         with suppress(FileNotFoundError):
@@ -735,7 +735,7 @@ class Dhcpcd(DhcpClient):
         """Return a dict of dhcp options.
 
         @param interface: which interface to dump the lease from
-        @raises: InvalidDHCPLeaseFileError on empty or unparseable leasefile
+        @raises: InvalidDHCPLeaseFileError on empty or unparsable leasefile
             content.
         """
         try:
@@ -877,7 +877,7 @@ class Udhcpc(DhcpClient):
         @param interface: an interface name - not used in this class, but
             required for function signature compatibility with other classes
             that require a distro object
-        @raises: InvalidDHCPLeaseFileError on empty or unparseable leasefile
+        @raises: InvalidDHCPLeaseFileError on empty or unparsable leasefile
             content.
         """
         return util.load_json(util.load_text_file(self.lease_file))

--- a/cloudinit/net/eni.py
+++ b/cloudinit/net/eni.py
@@ -179,7 +179,7 @@ def _parse_deb_config_data(ifaces, contents, src_dir, src_path):
     """Parses the file contents, placing result into ifaces.
 
     '_source_path' is added to every dictionary entry to define which file
-    the configration information came from.
+    the configuration information came from.
 
     :param ifaces: interface dictionary
     :param contents: contents of interfaces file

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -116,7 +116,7 @@ class EphemeralIPv4Network:
             cmd()
 
     def _bringup_device(self):
-        """Perform the ip comands to fully setup the device."""
+        """Perform the ip commands to fully setup the device."""
         cidr = "{0}/{1}".format(self.ip, self.prefix)
         LOG.debug(
             "Attempting setup of ephemeral network on %s with %s brd %s",

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -840,7 +840,7 @@ class NetworkStateInterpreter:
             # We accept both spellings (as netplan does).  LP: #1756701
             # Normalize internally to the new spelling:
             params = item_params.get("parameters", {})
-            grat_value = params.pop("gratuitous-arp", None)
+            grat_value = params.pop("gratuitious-arp", None)
             if grat_value:
                 params["gratuitous-arp"] = grat_value
 

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -840,7 +840,7 @@ class NetworkStateInterpreter:
             # We accept both spellings (as netplan does).  LP: #1756701
             # Normalize internally to the new spelling:
             params = item_params.get("parameters", {})
-            grat_value = params.pop("gratuitious-arp", None)
+            grat_value = params.pop("gratuitous-arp", None)
             if grat_value:
                 params["gratuitous-arp"] = grat_value
 

--- a/cloudinit/persistence.py
+++ b/cloudinit/persistence.py
@@ -13,7 +13,7 @@ class CloudInitPickleMixin:
     use it.  Versioning is done at the class level.
 
     The current version of a class's pickle should be set in the class variable
-    ``_ci_pkl_version``, as an int.  If not overriden, it will default to 0.
+    ``_ci_pkl_version``, as an int.  If not overridden, it will default to 0.
 
     On unpickle, the object's state will be restored and then
     ``self._unpickle`` is called with the version of the stored pickle as the

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1833,7 +1833,7 @@ def read_azure_ovf(contents):
     :return: Tuple of metadata, configuration, userdata dicts.
 
     :raises NonAzureDataSource: if XML is not in Azure's format.
-    :raises errors.ReportableError: if XML is unparseable or invalid.
+    :raises errors.ReportableError: if XML is unparsable or invalid.
     """
     ovf_env = OvfEnvXml.parse_text(contents)
     md: Dict[str, Any] = {}
@@ -1950,7 +1950,7 @@ def generate_network_config_from_instance_network_metadata(
 ) -> dict:
     """Convert imds network metadata dictionary to network v2 configuration.
 
-    :param: network_metadata: Dict of "network" key from instance metdata.
+    :param: network_metadata: Dict of "network" key from instance metadata.
 
     :return: Dictionary containing network version 2 standard configuration.
     """

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -157,7 +157,7 @@ class DataSourceConfigDrive(openstack.SourceMixin, sources.DataSource):
             LOG.warning("Invalid content in vendor-data2: %s", e)
             self.vendordata2_raw = None
 
-        # network_config is an /etc/network/interfaces formated file and is
+        # network_config is an /etc/network/interfaces formatted file and is
         # obsolete compared to networkdata (from network_data.json) but both
         # might be present.
         self.network_eni = results.get("network_config")

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -299,7 +299,7 @@ class DataSourceEc2(sources.DataSource):
                 connect_synchronously=False,
             )
         except uhelp.UrlError:
-            # We use the raised exception to interupt the retry loop.
+            # We use the raised exception to interrupt the retry loop.
             # Nothing else to do here.
             pass
 

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -154,7 +154,7 @@ class DataSourceGCE(sources.DataSource):
 
     @property
     def launch_index(self):
-        # GCE does not provide lauch_index property.
+        # GCE does not provide launch_index property.
         return None
 
     def get_instance_id(self):
@@ -222,7 +222,7 @@ def _has_expired(public_key):
     except ValueError:
         return False
 
-    # Do not expire keys if there is no expriation timestamp.
+    # Do not expire keys if there is no expiration timestamp.
     if "expireOn" not in json_obj:
         return False
 

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -78,7 +78,7 @@ def query_data_api_once(api_address, timeout, requests_session):
             api_address,
             data=None,
             timeout=timeout,
-            # It's the caller's responsability to recall this function in case
+            # It's the caller's responsibility to recall this function in case
             # of exception. Don't let url_helper.readurl() retry by itself.
             retries=0,
             session=requests_session,

--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -775,7 +775,7 @@ def write_boot_content(
     @param shebang: if no file magic, set shebang
     @param mode: file mode
 
-    Becuase of the way that Cloud-init executes scripts (no shell),
+    Because of the way that Cloud-init executes scripts (no shell),
     a script will fail to execute if does not have a magic bit (shebang) set
     for the file. If shebang=True, then the script will be checked for a magic
     bit and to the SmartOS default of assuming that bash.

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -129,7 +129,7 @@ class DataSourceVMware(sources.DataSource):
             For CloudinitPrep customization, Network config Version 2 data
             is parsed from the customization specification.
 
-        envvar and guestinfo tranports:
+        envvar and guestinfo transports:
             Network Config Version 2 data is supported as long as the Linux
             distro's cloud-init package is new enough to parse the data.
             The metadata key "network.encoding" may be used to indicate the

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -524,7 +524,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         cloud_id = instance_data["v1"].get("cloud_id", "none")
         cloud_id_file = os.path.join(self.paths.run_dir, "cloud-id")
         util.write_file(f"{cloud_id_file}-{cloud_id}", f"{cloud_id}\n")
-        # cloud-id not found, then no previous cloud-id fle
+        # cloud-id not found, then no previous cloud-id file
         prev_cloud_id_file = None
         new_cloud_id_file = f"{cloud_id_file}-{cloud_id}"
         # cloud-id found, then the prev cloud-id file is source of symlink
@@ -720,7 +720,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def get_vendordata2_raw(self):
         return self.vendordata2_raw
 
-    # the data sources' config_obj is a cloud-config formated
+    # the data sources' config_obj is a cloud-config formatted
     # object that came to it from ways other than cloud-config
     # because cloud-config content would be handled elsewhere
     def get_config_obj(self):

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -1012,7 +1012,7 @@ class OvfEnvXml:
 
         :raises NonAzureDataSource: if XML is not in Azure's format.
         :raises errors.ReportableErrorOvfParsingException: if XML is
-                unparseable or invalid.
+                unparsable or invalid.
         """
         try:
             root = ElementTree.fromstring(ovf_env_xml)

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -552,7 +552,7 @@ def convert_net_json(network_json=None, known_macs=None):
     There are additional fields that are populated in the network_data.json
     from OpenStack that are not relevant to network_config yaml, so we
     enumerate a dictionary of valid keys for network_yaml and apply filtering
-    to drop these superflous keys from the network_config yaml.
+    to drop these superfluous keys from the network_config yaml.
     """
     if network_json is None:
         return None

--- a/cloudinit/sources/helpers/vmware/imc/config.py
+++ b/cloudinit/sources/helpers/vmware/imc/config.py
@@ -88,7 +88,7 @@ class Config:
 
     @property
     def reset_password(self):
-        """Retreives if the root password needs to be reset."""
+        """Retrieves if the root password needs to be reset."""
         resetPass = self._configFile.get(Config.RESETPASS, "no")
         resetPass = resetPass.lower()
         if resetPass not in ("yes", "no"):

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 def get_metadata(
     distro, url, timeout, retries, sec_between, agent, tmp_dir=None
 ):
-    # Bring up interface (and try untill one works)
+    # Bring up interface (and try until one works)
     exception = RuntimeError("Failed to DHCP")
 
     # Seek iface with DHCP

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -661,7 +661,7 @@ def get_opensshd_version():
 
 
 def get_opensshd_upstream_version():
-    """Get the upstream version of the OpenSSH sshd dameon on the system.
+    """Get the upstream version of the OpenSSH sshd daemon on the system.
 
     This will NOT include the portable number, so if the Ubuntu version looks
     like `1.2p1 Ubuntu-1ubuntu0.1`, then this function would return

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -687,7 +687,7 @@ class Init:
             # Walk the user data
             part_data = {
                 "handlers": c_handlers,
-                # Any new handlers that are encountered get writen here
+                # Any new handlers that are encountered get written here
                 "handlerdir": idir,
                 "data": data,
                 # The default frequency if handlers don't have one

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -58,7 +58,7 @@ class JinjaSyntaxParsingException(TemplateSyntaxError):
         self.source = error.source
 
     def __str__(self):
-        """Avoid jinja2.TemplateSyntaxErrror multi-line __str__ format."""
+        """Avoid jinja2.TemplateSyntaxError multi-line __str__ format."""
         return self.format_error_message(
             syntax_error=self.message,
             line_number=self.lineno,
@@ -71,7 +71,7 @@ class JinjaSyntaxParsingException(TemplateSyntaxError):
         line_number: str,
         line_content: str = "",
     ) -> str:
-        """Avoid jinja2.TemplateSyntaxErrror multi-line __str__ format."""
+        """Avoid jinja2.TemplateSyntaxError multi-line __str__ format."""
         line_content = f": {line_content}" if line_content else ""
         return JinjaSyntaxParsingException.message_template.format(
             syntax_error=syntax_error,

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -51,8 +51,8 @@ DECOMP_TYPES = [
 # Msg header used to track attachments
 ATTACHMENT_FIELD = "Number-Attachments"
 
-# Only the following content types can have there launch index examined
-# in there payload, every other content type can still provide a header
+# Only the following content types can have their launch index examined
+# in their payload, every other content type can still provide a header
 EXAMINE_FOR_LAUNCH_INDEX = ["text/cloud-config"]
 
 

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -52,7 +52,7 @@ DECOMP_TYPES = [
 ATTACHMENT_FIELD = "Number-Attachments"
 
 # Only the following content types can have there launch index examined
-# in there payload, evey other content type can still provide a header
+# in there payload, every other content type can still provide a header
 EXAMINE_FOR_LAUNCH_INDEX = ["text/cloud-config"]
 
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -941,7 +941,7 @@ def del_dir(path):
 
 
 # read_optional_seed
-# returns boolean indicating success or failure (presense of files)
+# returns boolean indicating success or failure (presence of files)
 # if files are present, populates 'fill' dictionary with 'user-data' and
 # 'meta-data' entries
 def read_optional_seed(fill, base="", ext="", timeout=5):
@@ -1683,7 +1683,7 @@ def chownbyname(fname, user=None, group=None):
     chownbyid(fname, uid, gid)
 
 
-# Always returns well formated values
+# Always returns well formatted values
 # cfg is expected to have an entry 'output' in it, which is a dictionary
 # that includes entries for 'init', 'config', 'final' or 'all'
 #   init: /var/log/cloud.out

--- a/config/cloud.cfg.d/05_logging.cfg
+++ b/config/cloud.cfg.d/05_logging.cfg
@@ -1,7 +1,7 @@
-## This yaml formated config file handles setting
+## This yaml formatted config file handles setting
 ## logger information.  The values that are necessary to be set
 ## are seen at the bottom.  The top '_log' are only used to remove
-## redundency in a syslog and fallback-to-file case.
+## redundancy in a syslog and fallback-to-file case.
 ##
 ## The 'log_cfgs' entry defines a list of logger configs
 ## Each entry in the list is tried, and the first one that

--- a/doc/examples/cloud-config-lxd.txt
+++ b/doc/examples/cloud-config-lxd.txt
@@ -49,7 +49,7 @@ lxd:
     domain: lxd
 
 
-# The simplist working configuration is
+# The simplest working configuration is
 # lxd:
 #  init:
 #   storage_backend: dir

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -264,7 +264,7 @@ resize_rootfs: True
 #
 #  * fqdn:
 #      this option will be used wherever 'fqdn' is needed.
-#      simply substitue it in the description above.
+#      simply substitute it in the description above.
 #      default: fqdn as returned by the metadata service.  on EC2 'hostname'
 #               is used, so this is like: ip-10-244-170-199.ec2.internal
 #

--- a/doc/rtd/development/summit/2023_summit.rst
+++ b/doc/rtd/development/summit/2023_summit.rst
@@ -58,8 +58,8 @@ Thanks to all our presenters; Mina Galic (FreeBSD) and Dermot Bradley
 Catherine Redfield, Alberto Contreras, Sally Makin, John Chittum, Daniel
 Bungert and Chad Smith. You really helped to make this event a success.
 
-Presentation take-aways
------------------------
+Presentation takeaways
+----------------------
 
 * **Integration-testing tour/demo**: James showed how Canonical uses our
   integration tests and pycloudlib during SRU verification, and demonstrated

--- a/doc/rtd/explanation/events.rst
+++ b/doc/rtd/explanation/events.rst
@@ -92,4 +92,4 @@ On every boot, apply network configuration found in the datasource.
        when: ['boot']
 
 .. _Cloud-init: https://launchpad.net/cloud-init
-.. _tracked in Github #3890: https://github.com/canonical/cloud-init/issues/3890
+.. _tracked in GitHub #3890: https://github.com/canonical/cloud-init/issues/3890

--- a/doc/rtd/explanation/instancedata.rst
+++ b/doc/rtd/explanation/instancedata.rst
@@ -232,7 +232,7 @@ represents the data collected by ``cloudinit.util.system_info``.
 
 This is a cloud-init configuration key present in :file:`/etc/cloud/cloud.cfg`
 which describes cloud-init's configured `default_user`, `distro`, `network`
-renderes, and `paths` that cloud-init will use. Not to be confused with the
+renders, and `paths` that cloud-init will use. Not to be confused with the
 underlying host ``sys_info`` key above.
 
 ``v1``

--- a/doc/rtd/explanation/instancedata.rst
+++ b/doc/rtd/explanation/instancedata.rst
@@ -232,7 +232,7 @@ represents the data collected by ``cloudinit.util.system_info``.
 
 This is a cloud-init configuration key present in :file:`/etc/cloud/cloud.cfg`
 which describes cloud-init's configured `default_user`, `distro`, `network`
-renders, and `paths` that cloud-init will use. Not to be confused with the
+renderers, and `paths` that cloud-init will use. Not to be confused with the
 underlying host ``sys_info`` key above.
 
 ``v1``

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -85,7 +85,7 @@ re-run all stages as it did on first boot.
 
    Cloud-init provides the directory :file:`/etc/cloud/clean.d/` for third party
    applications which need additional configuration artifact cleanup from
-   the fileystem when the `clean` command is invoked.
+   the filesystem when the `clean` command is invoked.
 
    The :command:`clean` operation is typically performed by image creators
    when preparing a golden image for clone and redeployment. The clean command

--- a/doc/rtd/reference/datasources/smartos.rst
+++ b/doc/rtd/reference/datasources/smartos.rst
@@ -164,7 +164,7 @@ The SmartOS datasource has built-in cloud-config which instructs the
 
 You can control the ``disk_setup`` in 2 ways:
 
-1. Through the datasource config, you can change the 'alias' of ``ephermeral0``
+1. Through the datasource config, you can change the 'alias' of ``ephemeral0``
    to reference another device. The default is:
 
    .. code-block::

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -109,7 +109,7 @@ def write_debian_folder(root, templ_data, cloud_util_deps):
     # We consolidate all deps as Build-Depends as our package build runs all
     # tests so we need all runtime dependencies anyway.
     # NOTE: python package was moved to the front after debuild -S would fail
-    # with 'Please add apropriate interpreter' errors (as in debian bug 861132)
+    # with 'Please add appropriate interpreter' errors (as in debian bug 861132)
     requires.extend(["python3"] + reqs + test_reqs)
     if templ_data["debian_release"] in (
         "buster",

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -109,7 +109,8 @@ def write_debian_folder(root, templ_data, cloud_util_deps):
     # We consolidate all deps as Build-Depends as our package build runs all
     # tests so we need all runtime dependencies anyway.
     # NOTE: python package was moved to the front after debuild -S would fail
-    # with 'Please add appropriate interpreter' errors (as in debian bug 861132)
+    # with 'Please add appropriate interpreter' errors
+    # (as in debian bug 861132)
     requires.extend(["python3"] + reqs + test_reqs)
     if templ_data["debian_release"] in (
         "buster",

--- a/templates/chrony.conf.cos.tmpl
+++ b/templates/chrony.conf.cos.tmpl
@@ -1,6 +1,6 @@
 ## template:jinja
 # Welcome to the chrony configuration file. See chrony.conf(5) for more
-# information about usuable directives.
+# information about usable directives.
 
 {% if pools %}# pools
 {% endif %}

--- a/templates/chrony.conf.debian.tmpl
+++ b/templates/chrony.conf.debian.tmpl
@@ -1,6 +1,6 @@
 ## template:jinja
 # Welcome to the chrony configuration file. See chrony.conf(5) for more
-# information about usuable directives.
+# information about usable directives.
 {% if pools %}# pools
 {% endif %}
 {% for pool in pools -%}

--- a/templates/chrony.conf.ubuntu.tmpl
+++ b/templates/chrony.conf.ubuntu.tmpl
@@ -1,6 +1,6 @@
 ## template:jinja
 # Welcome to the chrony configuration file. See chrony.conf(5) for more
-# information about usuable directives.
+# information about usable directives.
 
 # Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
 # on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html for

--- a/templates/ntp.conf.ubuntu.tmpl
+++ b/templates/ntp.conf.ubuntu.tmpl
@@ -67,7 +67,7 @@ restrict source notrap nomodify noquery
 #disable auth
 #broadcastclient
 
-#Changes recquired to use pps synchonisation as explained in documentation:
+#Changes required to use pps synchronisation as explained in documentation:
 #http://www.ntp.org/ntpfaq/NTP-s-config-adv.htm#AEN3918
 
 #server 127.127.8.1 mode 135 prefer    # Meinberg GPS167 with PPS

--- a/tools/Z99-cloud-locale-test.sh
+++ b/tools/Z99-cloud-locale-test.sh
@@ -18,7 +18,7 @@ locale_warn() {
     $_local w1 w2 w3 w4 remain
 
     # if shell is zsh, act like sh only for this function (-L).
-    # The behavior change will not permenently affect user's shell.
+    # The behavior change will not permanently affect user's shell.
     [ "${ZSH_NAME+zsh}" = "zsh" ] && emulate -L sh
 
     # locale is expected to output either:

--- a/tools/ccfg-merge-debug
+++ b/tools/ccfg-merge-debug
@@ -60,7 +60,7 @@ def main():
     # Walk the user data
     part_data = {
         'handlers': c_handlers,
-        # Any new handlers that are encountered get writen here
+        # Any new handlers that are encountered get written here
         'handlerdir': handler_dir,
         'data': data,
         # The default frequency if handlers don't have one

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -712,7 +712,7 @@ has_fs_with_label() {
 
 nocase_equal() {
     # nocase_equal(a, b)
-    # return 0 if case insenstive comparision a.lower() == b.lower()
+    # return 0 if case insensitive comparison a.lower() == b.lower()
     # different lengths
     [ "${#1}" = "${#2}" ] || return 1
     # case sensitive equal
@@ -1167,7 +1167,7 @@ dscheck_Azure() {
 }
 
 dscheck_Bigstep() {
-    # bigstep is activated by presense of seed file 'url'
+    # bigstep is activated by presence of seed file 'url'
     [ -f "${PATH_VAR_LIB_CLOUD}/data/seed/bigstep/url" ] &&
         return ${DS_FOUND}
     return ${DS_NOT_FOUND}
@@ -1254,7 +1254,7 @@ ec2_identify_platform() {
     local uuid="${DI_DMI_PRODUCT_UUID}"
     case "$uuid:$serial" in
         [Ee][Cc]2*:[Ee][Cc]2*)
-            # both start with ec2, now check for case insenstive equal
+            # both start with ec2, now check for case insensitive equal
             nocase_equal "$uuid" "$serial" &&
                 { _RET="AWS"; return 0; };;
     esac

--- a/tools/make-tarball
+++ b/tools/make-tarball
@@ -60,10 +60,10 @@ if [ -z "$output" ]; then
 fi
 
 # when building an archiving from HEAD, ensure that there aren't any
-# uncomitted changes in the working directory (because these would not
+# uncommitted changes in the working directory (because these would not
 # end up in the archive).
 if [ "$rev" = HEAD ] && ! git diff-index --quiet HEAD --; then
-    if [ -z "$SKIP_UNCOMITTED_CHANGES_CHECK" ]; then
+    if [ -z "$SKIP_UNCOMMITTED_CHANGES_CHECK" ]; then
         echo "ERROR: There are uncommitted changes in your working directory." >&2
         exit 1
     else

--- a/tools/make-tarball
+++ b/tools/make-tarball
@@ -63,7 +63,7 @@ fi
 # uncommitted changes in the working directory (because these would not
 # end up in the archive).
 if [ "$rev" = HEAD ] && ! git diff-index --quiet HEAD --; then
-    if [ -z "$SKIP_UNCOMMITTED_CHANGES_CHECK" ]; then
+    if [ -z "$SKIP_UNCOMITTED_CHANGES_CHECK" ]; then
         echo "ERROR: There are uncommitted changes in your working directory." >&2
         exit 1
     else

--- a/tools/migrate-lp-user-to-github
+++ b/tools/migrate-lp-user-to-github
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Link your Launchpad user to github, proposing branches to LP and Github"""
+"""Link your Launchpad user to GitHub, proposing branches to LP and GitHub"""
 
 from argparse import ArgumentParser
 from subprocess import Popen, PIPE
@@ -175,7 +175,7 @@ def add_lp_and_github_remotes(lp_user, gh_user):
 def create_migration_branch(
     branch_name, upstream, lp_user, gh_user, commit_msg
 ):
-    """Create an LP to Github migration branch and add lp_user->gh_user."""
+    """Create an LP to GitHub migration branch and add lp_user->gh_user."""
     log(
         "Creating a migration branch: {} adding your users".format(
             MIGRATE_BRANCH_NAME

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -224,7 +224,7 @@ def translate_pip_to_system_pkg(pip_requires, renames):
     """Translate pip package names to distro-specific package names.
 
     @param pip_requires: List of versionless pip package names to translate.
-    @param renames: Dict containg special case renames from pip name to system
+    @param renames: Dict containing special case renames from pip name to system
         package name for the distro.
     """
     prefix = "python3-"

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -224,8 +224,8 @@ def translate_pip_to_system_pkg(pip_requires, renames):
     """Translate pip package names to distro-specific package names.
 
     @param pip_requires: List of versionless pip package names to translate.
-    @param renames: Dict containing special case renames from pip name to system
-        package name for the distro.
+    @param renames: Dict containing special case renames from pip name to
+        system package name for the distro.
     """
     prefix = "python3-"
     standard_pkg_name = "{0}{1}"

--- a/tools/uncloud-init
+++ b/tools/uncloud-init
@@ -105,7 +105,7 @@ done
 if [ "${ubuntu_pass}" = "R" -o "${ubuntu_pass}" = "random" ]; then
 	ubuntu_pass=$(python -c 'import string, random;
 random.seed(); print "".join(random.sample(string.letters+string.digits, 8))')
-	log "settting ubuntu pass = ${ubuntu_pass}" 
+	log "setting ubuntu pass = ${ubuntu_pass}" 
 	printf "\n===\nubuntu_pass = %s\n===\n" "${ubuntu_pass}" >/dev/ttyS0
 fi
 

--- a/tools/xkvm
+++ b/tools/xkvm
@@ -126,7 +126,7 @@ isdevopt() {
 qemu_supports_file_locking() {
     # hackily check if qemu has file.locking in -drive params (LP: #1716028)
     if [ -z "$_QEMU_SUPPORTS_FILE_LOCKING" ]; then
-        # The only way we could find to check presense of file.locking is
+        # The only way we could find to check presence of file.locking is
         # qmp (query-qmp-schema).  Simply checking if the virtio-blk driver
         # supports 'share-rw' is expected to be equivalent and simpler.
         isdevopt virtio-blk share-rw &&


### PR DESCRIPTION
Found few misspellings.

Excluded: tests/ and ChangeLog

`typos` config:
```toml
[files]
extend-exclude = [
    ".git/",
    "doc/rtd/spelling_word_list.txt",
    "ChangeLog",
    "tests/",
]
ignore-hidden = false

[default]
extend-ignore-re = [
    "[+0-9/A-Za-z=]{64,76}",
    '"-ba",',
    "CVE Numbering Authority \\(CNA\\)",
    '"als"',
    "32:d5:ba:4a:",
    "ami-0fecc35d3c8ba8d60",
    "\\bchage\\b",
    "\\bsystemd-localed\\b",
]

[default.extend-words]
"doas" = "doas"
"grat" = "grat"

[default.extend-identifiers]
"clen" = "clen"
"hda" = "hda"
"mybe_key" = "mybe_key"
"nd6" = "nd6"
"nd6_opts" = "nd6_opts"
"nto" = "nto"
"ser" = "ser"
"splitted" = "splitted"
"DES_EDE3_CBC" = "DES_EDE3_CBC"
```
