### PR TITLE
tests: add status --wait blocking test from early boot

### DIFF
--- a/tests/integration_tests/decorators.py
+++ b/tests/integration_tests/decorators.py
@@ -20,7 +20,7 @@ def retry(*, tries: int = 30, delay: int = 1):
             last_error = None
             for _ in range(tries):
                 try:
-                    func(*args, **kwargs)
+                    retval = func(*args, **kwargs)
                     break
                 except Exception as e:
                     last_error = e
@@ -28,6 +28,7 @@ def retry(*, tries: int = 30, delay: int = 1):
             else:
                 if last_error:
                     raise last_error
+            return retval
 
         return wrapper
 


### PR DESCRIPTION
## rebase merge commit

```
tests: add status --wait blocking test from early boot

In bugs such as LP: #2046483, cloud-init status --wait produces a traceback early when dbus or other resources are not yet available resulting in an early unblock from status --wait.

Add an integration test inserting a systemd unit before cloud-init-local.service that will block until cloud-init is done.

Assert that the timestamp of marker file created when this test unit unblocks, occurs after cloud-init.target was reached.
```

## Additional Context
<!-- If relevant -->
Supplemental test coverage to make sure future changes to cloud-init boot stages don't break cloud-init --wait expected behavior.

## Test Steps
```
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/cmd/test_status.py::test_status_block_through_all_boot_status
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
