### PR TITLE
Refactor status.py

### DIFF
--- a/cloudinit/cmd/cloud_id.py
+++ b/cloudinit/cmd/cloud_id.py
@@ -9,7 +9,7 @@ import json
 import sys
 
 from cloudinit.cmd.devel import read_cfg_paths
-from cloudinit.cmd.status import UXAppStatus, get_status_details
+from cloudinit.cmd.status import RunningStatus, get_status_details
 from cloudinit.sources import METADATA_UNKNOWN, canonical_cloud_id
 from cloudinit.util import error
 
@@ -66,11 +66,11 @@ def handle_args(name, args):
     @return: 0 on success, 1 on error, 2 on disabled, 3 on cloud-init not run.
     """
     status_details = get_status_details()
-    if status_details.status == UXAppStatus.DISABLED:
-        sys.stdout.write("{0}\n".format(status_details.status.value))
+    if status_details.running_status == RunningStatus.DISABLED:
+        sys.stdout.write("{0}\n".format(status_details.running_status.value))
         return 2
-    elif status_details.status == UXAppStatus.NOT_RUN:
-        sys.stdout.write("{0}\n".format(status_details.status.value))
+    elif status_details.running_status == RunningStatus.NOT_STARTED:
+        sys.stdout.write("{0}\n".format(status_details.running_status.value))
         return 3
 
     try:

--- a/doc/rtd/howto/status.rst
+++ b/doc/rtd/howto/status.rst
@@ -36,24 +36,59 @@ subcommand under the ``extended_status`` key.
 
     $ cloud-init status --format json
     {
-      "boot_status_code": "enabled-by-generator",
-      "datasource": "",
-      "detail": "Cloud-init enabled by systemd cloud-init-generator",
-      "errors": [],
-      "extended_status": "degraded done",
-      "last_update": "",
-      "recoverable_errors": {},
-      "status": "done"
+        "boot_status_code": "enabled-by-generator",
+        "datasource": "lxd",
+        "detail": "DataSourceLXD",
+        "errors": [],
+        "extended_status": "degraded done",
+        "init": {
+            "errors": [],
+            "finished": 1708550839.1837437,
+            "recoverable_errors": {},
+            "start": 1708550838.6881146
+        },
+        "init-local": {
+            "errors": [],
+            "finished": 1708550838.0196638,
+            "recoverable_errors": {},
+            "start": 1708550837.7719762
+        },
+        "last_update": "Wed, 21 Feb 2024 21:27:24 +0000",
+        "modules-config": {
+            "errors": [],
+            "finished": 1708550843.8297973,
+            "recoverable_errors": {
+            "WARNING": [
+                "Removing /etc/apt/sources.list to favor deb822 source format"
+            ]
+            },
+            "start": 1708550843.7163966
+        },
+        "modules-final": {
+            "errors": [],
+            "finished": 1708550844.0884337,
+            "recoverable_errors": {},
+            "start": 1708550844.029698
+        },
+        "recoverable_errors": {
+            "WARNING": [
+            "Removing /etc/apt/sources.list to favor deb822 source format"
+            ]
+        },
+        "stage": null,
+        "status": "done"
     }
+
 
 See the list of all possible reported statuses:
 
 .. code-block:: shell-session
 
-    "not running"
+    "not started"
     "running"
     "done"
-    "error"
+    "error - done"
+    "error - running"
     "degraded done"
     "degraded running"
     "disabled"

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -184,7 +184,7 @@ def wait_for_cloud_init(client: "IntegrationInstance", num_retries: int = 30):
             if (
                 result
                 and result.ok
-                and ("running" not in result or "not run" not in result)
+                and ("running" not in result or "not started" not in result)
             ):
                 return result
         except Exception as e:

--- a/tests/unittests/cmd/test_cloud_id.py
+++ b/tests/unittests/cmd/test_cloud_id.py
@@ -33,7 +33,7 @@ STATUS_DETAILS_DISABLED = status.StatusDetails(
     "",
     {},
 )
-STATUS_DETAILS_NOT_RUN = status.StatusDetails(
+STATUS_DETAILS_NOT_STARTED = status.StatusDetails(
     status.RunningStatus.NOT_STARTED,
     status.ConditionStatus.PEACHY,
     status.EnabledStatus.UNKNOWN,
@@ -226,7 +226,7 @@ class TestCloudId:
         "details, exit_code",
         (
             (STATUS_DETAILS_DISABLED, 2),
-            (STATUS_DETAILS_NOT_RUN, 3),
+            (STATUS_DETAILS_NOT_STARTED, 3),
             (STATUS_DETAILS_RUNNING, 0),
             (STATUS_DETAILS_RUNNING_DS_NONE, 0),
         ),

--- a/tests/unittests/cmd/test_cloud_id.py
+++ b/tests/unittests/cmd/test_cloud_id.py
@@ -12,8 +12,9 @@ from tests.unittests.helpers import mock
 M_PATH = "cloudinit.cmd.cloud_id."
 
 STATUS_DETAILS_DONE = status.StatusDetails(
-    status.UXAppStatus.DONE,
-    status.UXAppBootStatusCode.UNKNOWN,
+    status.RunningStatus.DONE,
+    status.ConditionStatus.PEACHY,
+    status.EnabledStatus.UNKNOWN,
     "DataSourceNoCloud somedetail",
     [],
     {},
@@ -22,8 +23,9 @@ STATUS_DETAILS_DONE = status.StatusDetails(
     {},
 )
 STATUS_DETAILS_DISABLED = status.StatusDetails(
-    status.UXAppStatus.DISABLED,
-    status.UXAppBootStatusCode.DISABLED_BY_GENERATOR,
+    status.RunningStatus.DISABLED,
+    status.ConditionStatus.PEACHY,
+    status.EnabledStatus.DISABLED_BY_GENERATOR,
     "DataSourceNoCloud somedetail",
     [],
     {},
@@ -32,8 +34,9 @@ STATUS_DETAILS_DISABLED = status.StatusDetails(
     {},
 )
 STATUS_DETAILS_NOT_RUN = status.StatusDetails(
-    status.UXAppStatus.NOT_RUN,
-    status.UXAppBootStatusCode.UNKNOWN,
+    status.RunningStatus.NOT_STARTED,
+    status.ConditionStatus.PEACHY,
+    status.EnabledStatus.UNKNOWN,
     "",
     [],
     {},
@@ -42,8 +45,9 @@ STATUS_DETAILS_NOT_RUN = status.StatusDetails(
     {},
 )
 STATUS_DETAILS_RUNNING = status.StatusDetails(
-    status.UXAppStatus.RUNNING,
-    status.UXAppBootStatusCode.UNKNOWN,
+    status.RunningStatus.RUNNING,
+    status.ConditionStatus.PEACHY,
+    status.EnabledStatus.UNKNOWN,
     "",
     [],
     {},
@@ -54,8 +58,9 @@ STATUS_DETAILS_RUNNING = status.StatusDetails(
 
 
 STATUS_DETAILS_RUNNING_DS_NONE = status.StatusDetails(
-    status.UXAppStatus.RUNNING,
-    status.UXAppBootStatusCode.UNKNOWN,
+    status.RunningStatus.RUNNING,
+    status.ConditionStatus.PEACHY,
+    status.EnabledStatus.UNKNOWN,
     "",
     [],
     {},
@@ -228,12 +233,17 @@ class TestCloudId:
     )
     @mock.patch(M_PATH + "get_status_details")
     def test_cloud_id_unique_exit_codes_for_status(
-        self, get_status_details, details, exit_code, tmpdir, capsys
+        self,
+        get_status_details,
+        details: status.StatusDetails,
+        exit_code,
+        tmpdir,
+        capsys,
     ):
         """cloud-id returns unique exit codes for status."""
         get_status_details.return_value = details
         instance_data = tmpdir.join("instance-data.json")
-        if details.status == cloud_id.UXAppStatus.RUNNING:
+        if details.running_status == cloud_id.RunningStatus.RUNNING:
             instance_data.write("{}")
         cmd = ["cloud-id", "--instance-data", instance_data.strpath, "--json"]
         with mock.patch("sys.argv", cmd):

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -12,10 +12,6 @@ import pytest
 from cloudinit import subp
 from cloudinit.atomic_helper import write_json
 from cloudinit.cmd import status
-from cloudinit.cmd.status import (
-    UXAppStatus,
-    _get_error_or_running_from_systemd,
-)
 from cloudinit.subp import SubpResult
 from cloudinit.util import ensure_file
 from tests.unittests.helpers import wrap_and_call
@@ -41,31 +37,41 @@ def config(tmpdir):
     )
 
 
+EXAMPLE_STATUS_RUNNING: Dict[str, Dict] = {
+    "v1": {
+        "datasource": None,
+        "init-local": {
+            "start": 1669231096.9621563,
+            "finished": None,
+            "errors": [],
+        },
+        "init": {"start": None, "finished": None, "errors": []},
+        "modules-config": {"start": None, "finished": None, "errors": []},
+        "modules-final": {"start": None, "finished": None, "errors": []},
+        "stage": "init-local",
+    }
+}
+
+
 class TestStatus:
     maxDiff = None
 
     @mock.patch(
         M_PATH + "load_text_file",
-        return_value=(
-            '{"v1": {"datasource": null, "init": {"errors": [], "finished": '
-            'null, "start": null}, "init-local": {"errors": [], "finished": '
-            'null, "start": 1669231096.9621563}, "modules-config": '
-            '{"errors": [], "finished": null, "start": null},'
-            '"modules-final": {"errors": [], "finished": null, '
-            '"start": null}, "stage": "init-local"} }'
-        ),
+        return_value=json.dumps(EXAMPLE_STATUS_RUNNING),
     )
     @mock.patch(M_PATH + "os.path.exists", return_value=True)
+    @mock.patch(M_PATH + "is_running", return_value=True)
     @mock.patch(
         M_PATH + "get_bootstatus",
         return_value=(
-            status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
+            status.EnabledStatus.ENABLED_BY_GENERATOR,
             "Cloud-init enabled by systemd cloud-init-generator",
         ),
     )
     @mock.patch(
-        f"{M_PATH}_get_error_or_running_from_systemd",
-        return_value=None,
+        f"{M_PATH}systemd_failed",
+        return_value=False,
     )
     def test_get_status_details_ds_none(
         self,
@@ -78,20 +84,21 @@ class TestStatus:
         paths = mock.Mock()
         paths.run_dir = str(tmpdir)
         assert status.StatusDetails(
-            status.UXAppStatus.RUNNING,
-            status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
+            status.RunningStatus.RUNNING,
+            status.ConditionStatus.PEACHY,
+            status.EnabledStatus.ENABLED_BY_GENERATOR,
             "Running in stage: init-local",
             [],
             {},
             "Wed, 23 Nov 2022 19:18:16 +0000",
             None,  # datasource
             {
-                "init": {"errors": [], "finished": None, "start": None},
                 "init-local": {
                     "errors": [],
                     "finished": None,
                     "start": 1669231096.9621563,
                 },
+                "init": {"errors": [], "finished": None, "start": None},
                 "modules-config": {
                     "errors": [],
                     "finished": None,
@@ -105,6 +112,43 @@ class TestStatus:
                 "stage": "init-local",
             },
         ) == status.get_status_details(paths)
+
+    @mock.patch(
+        M_PATH + "load_text_file",
+        return_value=json.dumps(EXAMPLE_STATUS_RUNNING),
+    )
+    @mock.patch(M_PATH + "os.path.exists", return_value=True)
+    @mock.patch(M_PATH + "is_running", return_value=True)
+    @mock.patch(
+        M_PATH + "get_bootstatus",
+        return_value=(
+            status.EnabledStatus.ENABLED_BY_GENERATOR,
+            "Cloud-init enabled by systemd cloud-init-generator",
+        ),
+    )
+    @mock.patch(
+        f"{M_PATH}systemd_failed",
+        return_value=True,
+    )
+    def test_get_status_systemd_failure(
+        self,
+        m_systemd_status,
+        m_boot_status,
+        m_p_exists,
+        m_load_json,
+        tmpdir,
+    ):
+        paths = mock.Mock()
+        paths.run_dir = str(tmpdir)
+        details = status.get_status_details(paths)
+        assert details.running_status == status.RunningStatus.DONE
+        assert details.condition_status == status.ConditionStatus.ERROR
+        assert details.description == "Failed due to systemd unit failure"
+        assert details.errors == [
+            "Failed due to sysetmd unit failure. Ensure all cloud-init "
+            "services are enabled, and check 'systemctl' or 'journalctl' "
+            "for more information."
+        ]
 
     @pytest.mark.parametrize(
         [
@@ -121,7 +165,7 @@ class TestStatus:
                 lambda config: config.disable_file,
                 False,
                 "root=/dev/my-root not-important",
-                status.UXAppBootStatusCode.ENABLED_BY_SYSVINIT,
+                status.EnabledStatus.ENABLED_BY_SYSVINIT,
                 "expected enabled cloud-init on sysvinit",
                 "Cloud-init enabled on sysvinit",
                 id="false_on_sysvinit",
@@ -131,7 +175,7 @@ class TestStatus:
                 lambda config: config.disable_file,
                 True,
                 "root=/dev/my-root not-important",
-                status.UXAppBootStatusCode.DISABLED_BY_MARKER_FILE,
+                status.EnabledStatus.DISABLED_BY_MARKER_FILE,
                 "expected disabled cloud-init",
                 lambda config: f"Cloud-init disabled by {config.disable_file}",
                 id="true_on_disable_file",
@@ -141,7 +185,7 @@ class TestStatus:
                 lambda config: config.disable_file,
                 True,
                 "something cloud-init=enabled else",
-                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                status.EnabledStatus.ENABLED_BY_KERNEL_CMDLINE,
                 "expected enabled cloud-init",
                 "Cloud-init enabled by kernel command line cloud-init=enabled",
                 id="false_on_kernel_cmdline_enable",
@@ -151,7 +195,7 @@ class TestStatus:
                 None,
                 True,
                 "something cloud-init=disabled else",
-                status.UXAppBootStatusCode.DISABLED_BY_KERNEL_CMDLINE,
+                status.EnabledStatus.DISABLED_BY_KERNEL_CMDLINE,
                 "expected disabled cloud-init",
                 "Cloud-init disabled by kernel parameter cloud-init=disabled",
                 id="true_on_kernel_cmdline",
@@ -161,7 +205,7 @@ class TestStatus:
                 lambda config: os.path.join(config.paths.run_dir, "disabled"),
                 True,
                 "something",
-                status.UXAppBootStatusCode.DISABLED_BY_GENERATOR,
+                status.EnabledStatus.DISABLED_BY_GENERATOR,
                 "expected disabled cloud-init",
                 "Cloud-init disabled by cloud-init-generator",
                 id="true_when_generator_disables",
@@ -171,7 +215,7 @@ class TestStatus:
                 lambda config: os.path.join(config.paths.run_dir, "enabled"),
                 True,
                 "something ignored",
-                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
+                status.EnabledStatus.ENABLED_BY_GENERATOR,
                 "expected enabled cloud-init",
                 "Cloud-init enabled by systemd cloud-init-generator",
                 id="false_when_enabled_in_systemd",
@@ -216,7 +260,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
     def test_status_returns_not_run(
         self, m_read_cfg_paths, config: Config, capsys
     ):
-        """When status.json does not exist yet, return 'not run'."""
+        """When status.json does not exist yet, return 'not started'."""
         m_read_cfg_paths.return_value = config.paths
         assert not os.path.exists(
             config.status_file
@@ -224,14 +268,14 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
         cmdargs = MyArgs(long=False, wait=False, format="tabular")
         retcode = wrap_and_call(
             M_NAME,
-            {"get_bootstatus": (status.UXAppBootStatusCode.UNKNOWN, "")},
+            {"get_bootstatus": (status.EnabledStatus.UNKNOWN, "")},
             status.handle_status_args,
             "ignored",
             cmdargs,
         )
         assert retcode == 0
         out, _err = capsys.readouterr()
-        assert out == "status: not run\n"
+        assert out == "status: not started\n"
 
     @mock.patch(M_PATH + "read_cfg_paths")
     def test_status_returns_disabled_long_on_presence_of_disable_file(
@@ -239,20 +283,14 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
     ):
         """When cloudinit is disabled, return disabled reason."""
         m_read_cfg_paths.return_value = config.paths
-        checked_files = []
-
-        def fakeexists(filepath):
-            checked_files.append(filepath)
-            status_file = os.path.join(config.paths.run_dir, "status.json")
-            return bool(not filepath == status_file)
 
         cmdargs = MyArgs(long=True, wait=False, format="tabular")
         retcode = wrap_and_call(
             M_NAME,
             {
-                "os.path.exists": {"side_effect": fakeexists},
+                "os.path.exists": {"return_value": False},
                 "get_bootstatus": (
-                    status.UXAppBootStatusCode.DISABLED_BY_KERNEL_CMDLINE,
+                    status.EnabledStatus.DISABLED_BY_KERNEL_CMDLINE,
                     "disabled for some reason",
                 ),
             },
@@ -261,16 +299,12 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             cmdargs,
         )
         assert retcode == 0
-        assert checked_files == [
-            os.path.join(config.paths.run_dir, "status.json")
-        ]
         expected = dedent(
             """\
             status: disabled
             extended_status: disabled
             boot_status_code: disabled-by-kernel-cmdline
-            detail:
-            disabled for some reason
+            detail: disabled for some reason
             errors: []
             recoverable_errors: {}
         """
@@ -292,7 +326,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             # Report running when status.json exists but result.json does not.
             pytest.param(
                 None,
-                status.UXAppBootStatusCode.UNKNOWN,
+                status.EnabledStatus.UNKNOWN,
                 {},
                 lambda config: config.result_file,
                 MyArgs(long=False, wait=False, format="tabular"),
@@ -300,21 +334,10 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 "status: running\n",
                 id="running_on_no_results_json",
             ),
-            # Report running when status exists with an unfinished stage.
-            pytest.param(
-                lambda config: config.result_file,
-                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
-                {"v1": {"init": {"start": 1, "finished": None}}},
-                None,
-                MyArgs(long=False, wait=False, format="tabular"),
-                0,
-                "status: running\n",
-                id="running",
-            ),
             # Report done results.json exists no stages are unfinished.
             pytest.param(
                 lambda config: config.result_file,
-                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
+                status.EnabledStatus.ENABLED_BY_GENERATOR,
                 {
                     "v1": {
                         "stage": None,  # No current stage running
@@ -341,7 +364,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             # Long format of done status includes datasource info.
             pytest.param(
                 lambda config: config.result_file,
-                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
+                status.EnabledStatus.ENABLED_BY_GENERATOR,
                 {
                     "v1": {
                         "stage": None,
@@ -363,19 +386,17 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     extended_status: done
                     boot_status_code: enabled-by-generator
                     last_update: Thu, 01 Jan 1970 00:02:05 +0000
-                    detail:
-                    DataSourceNoCloud [seed=/var/.../seed/nocloud-net]\
-[dsmode=net]
+                    detail: DataSourceNoCloud [seed=/var/.../seed/nocloud-net][dsmode=net]
                     errors: []
                     recoverable_errors: {}
-                    """
+                    """  # noqa: E501
                 ),
                 id="returns_done_long",
             ),
             # Reports error when any stage has errors.
             pytest.param(
-                None,
-                status.UXAppBootStatusCode.ENABLED_BY_GENERATOR,
+                lambda config: config.result_file,
+                status.EnabledStatus.ENABLED_BY_GENERATOR,
                 {
                     "v1": {
                         "stage": None,
@@ -397,7 +418,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             # Long format of error status includes all error messages.
             pytest.param(
                 None,
-                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                status.EnabledStatus.ENABLED_BY_KERNEL_CMDLINE,
                 {
                     "v1": {
                         "stage": None,
@@ -424,24 +445,23 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 dedent(
                     """\
                 status: error
-                extended_status: error
+                extended_status: error - running
                 boot_status_code: enabled-by-kernel-cmdline
                 last_update: Thu, 01 Jan 1970 00:02:05 +0000
-                detail:
-                DataSourceNoCloud [seed=/var/.../seed/nocloud-net][dsmode=net]
+                detail: DataSourceNoCloud [seed=/var/.../seed/nocloud-net][dsmode=net]
                 errors:
                 \t- error1
                 \t- error2
                 \t- error3
                 recoverable_errors: {}
-                """
+                """  # noqa: E501
                 ),
                 id="on_errors_long",
             ),
             # Long format reports the stage in which we are running.
             pytest.param(
                 None,
-                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                status.EnabledStatus.ENABLED_BY_KERNEL_CMDLINE,
                 {
                     "v1": {
                         "stage": "init",
@@ -458,8 +478,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     extended_status: running
                     boot_status_code: enabled-by-kernel-cmdline
                     last_update: Thu, 01 Jan 1970 00:02:04 +0000
-                    detail:
-                    Running in stage: init
+                    detail: Running in stage: init
                     errors: []
                     recoverable_errors: {}
                     """
@@ -468,7 +487,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             ),
             pytest.param(
                 None,
-                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                status.EnabledStatus.ENABLED_BY_KERNEL_CMDLINE,
                 {
                     "v1": {
                         "stage": "init",
@@ -505,7 +524,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             ),
             pytest.param(
                 None,
-                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                status.EnabledStatus.ENABLED_BY_KERNEL_CMDLINE,
                 {
                     "v1": {
                         "stage": "init",
@@ -533,7 +552,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             ),
             pytest.param(
                 None,
-                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                status.EnabledStatus.ENABLED_BY_KERNEL_CMDLINE,
                 {
                     "v1": {
                         "stage": None,
@@ -566,7 +585,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     ),
                     "errors": ["error1", "error2", "error3"],
                     "status": "error",
-                    "extended_status": "error",
+                    "extended_status": "error - running",
                     "init": {
                         "finished": 125.678,
                         "start": 124.567,
@@ -585,7 +604,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             ),
             pytest.param(
                 lambda config: config.result_file,
-                status.UXAppBootStatusCode.ENABLED_BY_KERNEL_CMDLINE,
+                status.EnabledStatus.ENABLED_BY_KERNEL_CMDLINE,
                 {
                     "v1": {
                         "stage": None,
@@ -708,7 +727,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
     )
     @mock.patch(M_PATH + "read_cfg_paths")
     @mock.patch(
-        f"{M_PATH}_get_error_or_running_from_systemd",
+        f"{M_PATH}systemd_failed",
         return_value=None,
     )
     def test_status_output(
@@ -716,7 +735,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
         m_get_systemd_status,
         m_read_cfg_paths,
         ensured_file: Optional[Callable],
-        bootstatus: status.UXAppBootStatusCode,
+        bootstatus: status.EnabledStatus,
         status_content: Dict,
         assert_file,
         cmdargs: MyArgs,
@@ -752,7 +771,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 
     @mock.patch(M_PATH + "read_cfg_paths")
     @mock.patch(
-        f"{M_PATH}_get_error_or_running_from_systemd",
+        f"{M_PATH}systemd_failed",
         return_value=None,
     )
     def test_status_wait_blocks_until_done(
@@ -793,7 +812,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             M_NAME,
             {
                 "sleep": {"side_effect": fake_sleep},
-                "get_bootstatus": (status.UXAppBootStatusCode.UNKNOWN, ""),
+                "get_bootstatus": (status.EnabledStatus.UNKNOWN, ""),
             },
             status.handle_status_args,
             "ignored",
@@ -806,7 +825,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 
     @mock.patch(M_PATH + "read_cfg_paths")
     @mock.patch(
-        f"{M_PATH}_get_error_or_running_from_systemd",
+        f"{M_PATH}systemd_failed",
         return_value=None,
     )
     def test_status_wait_blocks_until_error(
@@ -843,13 +862,14 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 write_json(config.status_file, running_json)
             elif sleep_calls == 3:
                 write_json(config.status_file, error_json)
+                write_json(config.result_file, "{}")
 
         cmdargs = MyArgs(long=False, wait=True, format="tabular")
         retcode = wrap_and_call(
             M_NAME,
             {
                 "sleep": {"side_effect": fake_sleep},
-                "get_bootstatus": (status.UXAppBootStatusCode.UNKNOWN, ""),
+                "get_bootstatus": (status.EnabledStatus.UNKNOWN, ""),
             },
             status.handle_status_args,
             "ignored",
@@ -862,7 +882,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 
     @mock.patch(M_PATH + "read_cfg_paths")
     @mock.patch(
-        f"{M_PATH}_get_error_or_running_from_systemd",
+        f"{M_PATH}systemd_failed",
         return_value=None,
     )
     def test_status_main(
@@ -879,7 +899,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 M_NAME,
                 {
                     "sys.argv": {"new": ["status"]},
-                    "get_bootstatus": (status.UXAppBootStatusCode.UNKNOWN, ""),
+                    "get_bootstatus": (status.EnabledStatus.UNKNOWN, ""),
                 },
                 status.main,
             )
@@ -888,14 +908,20 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
         assert out == "status: running\n"
 
 
-class TestGetErrorOrRunningFromSystemd:
+class TestSystemdFailed:
     @pytest.fixture(autouse=True)
     def common_mocks(self, mocker):
         mocker.patch("cloudinit.cmd.status.sleep")
         yield
 
     @pytest.mark.parametrize(
-        ["active_state", "unit_file_state", "sub_state", "main_pid", "status"],
+        [
+            "active_state",
+            "unit_file_state",
+            "sub_state",
+            "main_pid",
+            "expected_failed",
+        ],
         [
             # To cut down on the combination of states, I'm grouping
             # enabled, enabled-runtime, and static into an "enabled" state
@@ -904,34 +930,39 @@ class TestGetErrorOrRunningFromSystemd:
             # different depending on the ActiveState they are mapped to.
             # Because of this I'm only testing SubState combinations seen
             # in real-world testing (or using "any" string if we dont care).
-            ("activating", "enabled", "start", "123", UXAppStatus.RUNNING),
-            ("activating", "enabled", "start", "123", UXAppStatus.RUNNING),
-            ("active", "enabled-runtime", "exited", "0", None),
-            ("active", "enabled", "exited", "0", None),
-            ("active", "enabled", "running", "345", UXAppStatus.RUNNING),
-            ("active", "enabled", "running", "0", None),
-            # Dead doesn't mean exited here. It means not run yet.
-            ("inactive", "static", "dead", "123", UXAppStatus.RUNNING),
-            ("reloading", "enabled", "start", "123", UXAppStatus.RUNNING),
+            ("activating", "enabled", "start", "123", False),
+            ("activating", "enabled", "start", "123", False),
+            ("active", "enabled-runtime", "exited", "0", False),
+            ("active", "enabled", "exited", "0", False),
+            ("active", "enabled", "running", "345", False),
+            ("active", "enabled", "running", "0", False),
+            # Dead doesn't mean exited here. It means not started yet.
+            ("inactive", "static", "dead", "123", False),
+            ("reloading", "enabled", "start", "123", False),
             (
                 "deactivating",
                 "enabled-runtime",
                 "any",
                 "123",
-                UXAppStatus.RUNNING,
+                False,
             ),
-            ("failed", "static", "failed", "0", UXAppStatus.ERROR),
+            ("failed", "static", "failed", "0", True),
             # Try previous combinations again with "not enabled" states
-            ("activating", "linked", "start", "0", UXAppStatus.ERROR),
-            ("active", "linked-runtime", "exited", "0", UXAppStatus.ERROR),
-            ("inactive", "masked", "dead", "0", UXAppStatus.ERROR),
-            ("reloading", "masked-runtime", "start", "0", UXAppStatus.ERROR),
-            ("deactivating", "disabled", "any", "0", UXAppStatus.ERROR),
-            ("failed", "invalid", "failed", "0", UXAppStatus.ERROR),
+            ("activating", "linked", "start", "0", True),
+            ("active", "linked-runtime", "exited", "0", True),
+            ("inactive", "masked", "dead", "0", True),
+            ("reloading", "masked-runtime", "start", "0", True),
+            ("deactivating", "disabled", "any", "0", True),
+            ("failed", "invalid", "failed", "0", True),
         ],
     )
-    def test_get_error_or_running_from_systemd(
-        self, active_state, unit_file_state, sub_state, main_pid, status
+    def test_systemd_failed(
+        self,
+        active_state,
+        unit_file_state,
+        sub_state,
+        main_pid,
+        expected_failed,
     ):
         with mock.patch(
             f"{M_PATH}subp.subp",
@@ -943,25 +974,7 @@ class TestGetErrorOrRunningFromSystemd:
                 stderr=None,
             ),
         ):
-            assert (
-                _get_error_or_running_from_systemd(UXAppStatus.RUNNING, False)
-                == status
-            )
-
-    def test_exception_while_running(self, mocker, capsys):
-        m_subp = mocker.patch(
-            f"{M_PATH}subp.subp",
-            side_effect=subp.ProcessExecutionError(
-                "Message recipient disconnected from message bus without"
-                " replying"
-            ),
-        )
-        assert (
-            _get_error_or_running_from_systemd(UXAppStatus.RUNNING, wait=True)
-            is None
-        )
-        assert 1 == m_subp.call_count
-        assert "Failed to get status" not in capsys.readouterr().err
+            assert status.systemd_failed(wait=False) == expected_failed
 
     def test_retry(self, mocker, capsys):
         m_subp = mocker.patch(
@@ -982,10 +995,7 @@ class TestGetErrorOrRunningFromSystemd:
                 ),
             ],
         )
-        assert (
-            _get_error_or_running_from_systemd(UXAppStatus.ERROR, wait=True)
-            is UXAppStatus.RUNNING
-        )
+        assert status.systemd_failed(wait=True) is False
         assert 3 == m_subp.call_count
         assert "Failed to get status" not in capsys.readouterr().err
 
@@ -998,10 +1008,7 @@ class TestGetErrorOrRunningFromSystemd:
             ),
         )
         mocker.patch("time.time", side_effect=[1, 2, 50])
-        assert (
-            _get_error_or_running_from_systemd(UXAppStatus.ERROR, wait=False)
-            is None
-        )
+        assert status.systemd_failed(wait=False) is False
         assert 1 == m_subp.call_count
         assert (
             "Failed to get status from systemd. "
@@ -1044,23 +1051,3 @@ class TestQuerySystemctl:
         assert status.query_systemctl(["some", "args"], wait=True) == "hello"
         assert m_subp.call_count == 4
         assert m_sleep.call_count == 3
-
-    def test_query_systemctl_wait_with_exception_status(self, mocker):
-        m_sleep = mocker.patch(f"{M_PATH}sleep")
-        m_subp = mocker.patch(
-            f"{M_PATH}subp.subp",
-            side_effect=subp.ProcessExecutionError(
-                "Message recipient disconnected"
-            ),
-        )
-
-        assert (
-            status.query_systemctl(
-                ["some", "args"],
-                wait=True,
-                existing_status=UXAppStatus.RUNNING,
-            )
-            == ""
-        )
-        assert m_subp.call_count == 1
-        assert m_sleep.call_count == 0


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
refactor: Refactor status.py

The one major functional change in this commit is around how we detect
running vs error states. Status reporting has a fundamental problem in
that we can't accurately tell if cloud-init is done because cloud-init
is actually several processes. There isn't always a way to tell whether
a service isn't running because it simply hasn't started yet vs the
service being blocked/crashed and will never start/finish.

In the past, if any of the cloud-init services reported an error, we
would assume that cloud-init as a whole has crashed and report that
cloud-init is "done", but with error. This commit flips that logic to
assume that cloud-init is always running unless we see indication that
cloud-init has completely finished. This means that
`cloud-init status --wait` may run forever if cloud-init has crashed or
is blocked on another service. This is preferable to returning early
and potentially allowing provisioning scripts that wait for cloud-init
to continue provisioning. On systemd-enabled systems, there is extra
logic to inspect the state of the services, so this should rarely be a
problem in practice.

Additionally, this commit includes the following refactoring:
- Split UXAppStatus into RunningStatus and ConditionStatus so they can
  be tracked independently
- Simplify the tabular printing
- On error print extended_status as "error - done" or "error - running"
- Add several helper functions in `get_status_details` to simplify
  logic
- Rename `_get_error_or_running_from_systemd` to `systemd_failed`
  and only return if error is detected
- Change "is running" logic to be determined solely by the existence
  of the status.json and results.json files.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
