### PR TITLE
test: fix test_cli.test_valid_userdata

### DIFF
--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -45,10 +45,7 @@ def test_valid_userdata(client: IntegrationInstance):
     assert result.ok
     assert "Valid schema user-data" in result.stdout.strip()
     result = client.execute("cloud-init status --long")
-    # Ubuntu Noble will exit 2 for status due to cloud-init's warning about
-    # disabling /etc/apt/sources.list in favor of deb822 sources
-    return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
-    assert return_code == result.return_code, (
+    assert 0 == result.return_code, (
         f"Unexpected exit {result.return_code} from cloud-init status:"
         f" {result}"
     )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: fix test_cli.test_valid_userdata

cloud-init status should not fail on valid userdata.
```

## Additional Context
<!-- If relevant -->
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/44/testReport/junit/tests.integration_tests.modules/test_cli/test_valid_userdata/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
export CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily
export CLOUD_INIT_PLATFORM=lxd_vm
export CLOUD_INIT_OS_IMAGE=noble

tox -e integration-tests -- --pdb tests/integration_tests/modules/test_cli.py::test_valid_userdata
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
