### PR TITLE
test: harden test_dhcp.py::test_noble_and_newer_force_client

### DIFF
--- a/tests/integration_tests/net/test_dhcp.py
+++ b/tests/integration_tests/net/test_dhcp.py
@@ -55,13 +55,13 @@ class TestDHCP:
     )
     def test_noble_and_newer_force_client(self, client, dhcp_client, package):
         """force noble to use dhcpcd and test that it worked"""
-        client.execute(f"apt install -yq {package}")
-        client.execute(
+        assert client.execute(f"apt update && apt install -yq {package}").ok
+        assert client.execute(
             "sed -i 's|"
             "dhcp_client_priority.*$"
             f"|dhcp_client_priority: [{dhcp_client}]"
             "|' /etc/cloud/cloud.cfg"
-        )
+        ).ok
         client.execute("cloud-init clean --logs")
         client.restart()
         log = client.read_from_file("/var/log/cloud-init.log")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: harden test_dhcp.py::test_noble_and_newer_force_client

Update apt sources and ensure target dhcp client is correctly installed.
```

## Additional Context
<!-- If relevant -->
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-ec2/51/testReport/junit/tests.integration_tests.net.test_dhcp/TestDHCP/test_noble_and_newer_force_client_udhcpc_udhcpc_/
From there, we can see that udhcpc wasn't properly installed:

`'2024-02-12 21:22:06,618 - distros[DEBUG]: DHCP client not found: udhcpc\n'`

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Execute modified test on lxd_vm and noble.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
