### PR TITLE
Don't warn if cloud-init is disabled

### DIFF
--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -14,6 +14,7 @@ from cloudinit.cmd.devel.logs import (
     INSTALLER_APPORT_FILES,
     INSTALLER_APPORT_SENSITIVE_FILES,
 )
+from cloudinit.cmd.status import is_cloud_init_enabled
 
 try:
     from apport.hookutils import (
@@ -297,6 +298,8 @@ def general_add_info(report, _) -> None:
     /run/cloud/instance-data.json that will be helpful for debugging.
     """
     try:
+        if not is_cloud_init_enabled():
+            return
         with open("/run/cloud-init/instance-data.json", "r") as fopen:
             instance_data = json.load(fopen)
     except FileNotFoundError:

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -7,6 +7,7 @@
 import json
 import logging
 import os
+from typing import Dict
 
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.cmd.devel.logs import (
@@ -229,8 +230,7 @@ def add_info(report, ui):
     return True
 
 
-
-def _get_azure_data(ds_data) -> dict[str, str]:
+def _get_azure_data(ds_data) -> Dict[str, str]:
     compute = ds_data.get("meta_data", {}).get("imds", {}).get("compute")
     if not compute:
         return {}
@@ -247,7 +247,7 @@ def _get_azure_data(ds_data) -> dict[str, str]:
     return azure_data
 
 
-def _get_ec2_data(ds_data) -> dict[str, str]:
+def _get_ec2_data(ds_data) -> Dict[str, str]:
     document = (
         ds_data.get("dynamic", {}).get("instance-identity", {}).get("document")
     )

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -5,6 +5,7 @@
 """Cloud-init apport interface"""
 
 import json
+import logging
 import os
 
 from cloudinit.cmd.devel import read_cfg_paths
@@ -226,3 +227,101 @@ def add_info(report, ui):
     attach_ubuntu_pro_info(report, ui)
     add_bug_tags(report)
     return True
+
+
+
+def _get_azure_data(ds_data) -> dict[str, str]:
+    compute = ds_data.get("meta_data", {}).get("imds", {}).get("compute")
+    if not compute:
+        return {}
+    name_to_report_map = {
+        "publisher": "ImagePublisher",
+        "offer": "ImageOffer",
+        "sku": "ImageSKU",
+        "version": "ImageVersion",
+        "vmSize": "VMSize",
+    }
+    azure_data = {}
+    for src_key, report_key_name in name_to_report_map.items():
+        azure_data[report_key_name] = compute[src_key]
+    return azure_data
+
+
+def _get_ec2_data(ds_data) -> dict[str, str]:
+    document = (
+        ds_data.get("dynamic", {}).get("instance-identity", {}).get("document")
+    )
+    if not document:
+        return {}
+    wanted_keys = {
+        "architecture",
+        "billingProducts",
+        "imageId",
+        "instanceType",
+        "region",
+    }
+    return {
+        key: value for key, value in document.items() if key in wanted_keys
+    }
+
+
+PLATFORM_SPECIFIC_INFO = {"azure": _get_azure_data, "ec2": _get_ec2_data}
+
+
+def add_datasource_specific_info(report, platform: str, ds_data) -> None:
+    """Add datasoure specific information from the ds dictionary.
+
+    ds_data contains the "ds" entry from data from
+    /run/cloud/instance-data.json.
+    """
+    platform_info = PLATFORM_SPECIFIC_INFO.get(platform)
+    if not platform_info:
+        return
+    retrieved_data = platform_info(ds_data)
+    for key, value in retrieved_data.items():
+        if not value:
+            continue
+        report[platform.capitalize() + key.capitalize()] = value
+
+
+def general_add_info(report, ui) -> None:
+    """Entry point for Apport.
+
+    This hook runs for every apport report
+
+    Add a subset of non-sensitive cloud-init data from
+    /run/cloud/instance-data.json that will be helpful for debugging.
+    """
+    try:
+        with open("/run/cloud-init/instance-data.json", "r") as fopen:
+            instance_data = json.load(fopen)
+    except FileNotFoundError:
+        logging.getLogger().warning(
+            "cloud-init run data not found on system. "
+            "Unable to add cloud-specific data."
+        )
+        return
+
+    v1 = instance_data.get("v1")
+    if not v1:
+        logging.getLogger().warning(
+            "instance-data.json lacks 'v1' metadata. Present keys: %s",
+            sorted(instance_data.keys()),
+        )
+        return
+
+    for key, report_key in {
+        "cloud_id": "CloudID",
+        "cloud_name": "CloudName",
+        "machine": "CloudArchitecture",
+        "platform": "CloudPlatform",
+        "region": "CloudRegion",
+        "subplatform": "CloudSubPlatform",
+    }.items():
+        value = v1.get(key)
+        if value:
+            report[report_key] = value
+
+    add_datasource_specific_info(
+        report, v1["platform"], instance_data.get("ds")
+    )

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -78,7 +78,7 @@ def _get_user_data_file() -> str:
 
 def attach_cloud_init_logs(report, ui=None):
     """Attach cloud-init logs and tarfile from 'cloud-init collect-logs'."""
-    attach_root_command_outputs(
+    attach_root_command_outputs(  # pyright: ignore
         report,
         {
             "cloud-init-log-warnings": (
@@ -87,10 +87,12 @@ def attach_cloud_init_logs(report, ui=None):
             "cloud-init-output.log.txt": "cat /var/log/cloud-init-output.log",
         },
     )
-    root_command_output(
+    root_command_output(  # pyright: ignore
         ["cloud-init", "collect-logs", "-t", "/tmp/cloud-init-logs.tgz"]
     )
-    attach_file(report, "/tmp/cloud-init-logs.tgz", "logs.tgz")
+    attach_file(  # pyright: ignore
+        report, "/tmp/cloud-init-logs.tgz", "logs.tgz"
+    )
 
 
 def attach_hwinfo(report, ui=None):
@@ -160,7 +162,7 @@ def attach_installer_files(report, ui=None):
 def attach_ubuntu_pro_info(report, ui=None):
     """Attach ubuntu pro logs and tag if keys present in user-data."""
     realpath = os.path.realpath("/var/log/ubuntu-advantage.log")
-    attach_file_if_exists(report, realpath)
+    attach_file_if_exists(report, realpath)  # pyright: ignore
     if os.path.exists(realpath):
         report.setdefault("Tags", "")
         if report["Tags"]:
@@ -183,10 +185,12 @@ def attach_user_data(report, ui=None):
             raise StopIteration  # User cancelled
         if response:
             realpath = os.path.realpath(user_data_file)
-            attach_file(report, realpath, "user_data.txt")
+            attach_file(report, realpath, "user_data.txt")  # pyright: ignore
             for apport_file in INSTALLER_APPORT_SENSITIVE_FILES:
                 realpath = os.path.realpath(apport_file.path)
-                attach_file_if_exists(report, realpath, apport_file.label)
+                attach_file_if_exists(  # pyright: ignore
+                    report, realpath, apport_file.label
+                )
 
 
 def add_bug_tags(report):
@@ -210,7 +214,7 @@ def add_bug_tags(report):
 
 
 def add_info(report, ui):
-    """This is an entry point to run cloud-init's apport functionality.
+    """This is an entry point to run cloud-init's package-specific hook
 
     Distros which want apport support will have a cloud-init package-hook at
     /usr/share/apport/package-hooks/cloud-init.py which defines an add_info
@@ -284,7 +288,7 @@ def add_datasource_specific_info(report, platform: str, ds_data) -> None:
         report[platform.capitalize() + key.capitalize()] = value
 
 
-def general_add_info(report, ui) -> None:
+def general_add_info(report, _) -> None:
     """Entry point for Apport.
 
     This hook runs for every apport report

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -304,6 +304,13 @@ def get_bootstatus(
     return (bootstatus_code, reason)
 
 
+def is_cloud_init_enabled() -> bool:
+    return (
+        get_status_details(read_cfg_paths()).boot_status_code
+        not in DISABLED_BOOT_CODES
+    )
+
+
 def _get_error_or_running_from_systemd(
     existing_status: UXAppStatus, wait: bool
 ) -> Optional[UXAppStatus]:


### PR DESCRIPTION
## Proposed Commit Message
Use individual commit messages

## Additional Context
Also relocate apport functionality to main branch for better testing and less code duplication.

Fixes https://github.com/canonical/cloud-init/issues/4875, which is [this bug](https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2025376) which was never fixed in `ubuntu/focal` so it came back again in 23.3.


If we had included the apport code in the main branch rather than in packaging branches, our unit tests would have caught the invalid typing.

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
