### PR TITLE
ubuntu/jammy: refresh patches against upstream/main

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,7 +17,7 @@ defaults:
     shell: sh -ex {0}
 
 env:
-  RELEASE: bionic
+  RELEASE: focal
 
 jobs:
   package-build:

--- a/.pylintrc
+++ b/.pylintrc
@@ -6,7 +6,7 @@ jobs=4
 
 [MESSAGES CONTROL]
 
-# Errors and warings with some filtered:
+# Errors and warnings with some filtered:
 # W0201(attribute-defined-outside-init)
 # W0212(protected-access)
 # W0221(arguments-differ)

--- a/cloudinit/analyze/show.py
+++ b/cloudinit/analyze/show.py
@@ -7,6 +7,7 @@
 import datetime
 import json
 import os
+import sys
 import time
 
 from cloudinit import subp, util
@@ -370,6 +371,9 @@ def load_events_infile(infile):
     :return: json version of logfile, raw file
     """
     data = infile.read()
+    if not data.strip():
+        sys.stderr.write("Empty file %s\n" % infile.name)
+        sys.exit(1)
     try:
         return json.loads(data), data
     except ValueError:

--- a/cloudinit/apport.py
+++ b/cloudinit/apport.py
@@ -5,13 +5,16 @@
 """Cloud-init apport interface"""
 
 import json
+import logging
 import os
+from typing import Dict
 
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.cmd.devel.logs import (
     INSTALLER_APPORT_FILES,
     INSTALLER_APPORT_SENSITIVE_FILES,
 )
+from cloudinit.cmd.status import is_cloud_init_enabled
 
 try:
     from apport.hookutils import (
@@ -76,7 +79,7 @@ def _get_user_data_file() -> str:
 
 def attach_cloud_init_logs(report, ui=None):
     """Attach cloud-init logs and tarfile from 'cloud-init collect-logs'."""
-    attach_root_command_outputs(
+    attach_root_command_outputs(  # pyright: ignore
         report,
         {
             "cloud-init-log-warnings": (
@@ -85,10 +88,12 @@ def attach_cloud_init_logs(report, ui=None):
             "cloud-init-output.log.txt": "cat /var/log/cloud-init-output.log",
         },
     )
-    root_command_output(
+    root_command_output(  # pyright: ignore
         ["cloud-init", "collect-logs", "-t", "/tmp/cloud-init-logs.tgz"]
     )
-    attach_file(report, "/tmp/cloud-init-logs.tgz", "logs.tgz")
+    attach_file(  # pyright: ignore
+        report, "/tmp/cloud-init-logs.tgz", "logs.tgz"
+    )
 
 
 def attach_hwinfo(report, ui=None):
@@ -158,7 +163,7 @@ def attach_installer_files(report, ui=None):
 def attach_ubuntu_pro_info(report, ui=None):
     """Attach ubuntu pro logs and tag if keys present in user-data."""
     realpath = os.path.realpath("/var/log/ubuntu-advantage.log")
-    attach_file_if_exists(report, realpath)
+    attach_file_if_exists(report, realpath)  # pyright: ignore
     if os.path.exists(realpath):
         report.setdefault("Tags", "")
         if report["Tags"]:
@@ -181,10 +186,12 @@ def attach_user_data(report, ui=None):
             raise StopIteration  # User cancelled
         if response:
             realpath = os.path.realpath(user_data_file)
-            attach_file(report, realpath, "user_data.txt")
+            attach_file(report, realpath, "user_data.txt")  # pyright: ignore
             for apport_file in INSTALLER_APPORT_SENSITIVE_FILES:
                 realpath = os.path.realpath(apport_file.path)
-                attach_file_if_exists(report, realpath, apport_file.label)
+                attach_file_if_exists(  # pyright: ignore
+                    report, realpath, apport_file.label
+                )
 
 
 def add_bug_tags(report):
@@ -208,7 +215,7 @@ def add_bug_tags(report):
 
 
 def add_info(report, ui):
-    """This is an entry point to run cloud-init's apport functionality.
+    """This is an entry point to run cloud-init's package-specific hook
 
     Distros which want apport support will have a cloud-init package-hook at
     /usr/share/apport/package-hooks/cloud-init.py which defines an add_info
@@ -226,3 +233,102 @@ def add_info(report, ui):
     attach_ubuntu_pro_info(report, ui)
     add_bug_tags(report)
     return True
+
+
+def _get_azure_data(ds_data) -> Dict[str, str]:
+    compute = ds_data.get("meta_data", {}).get("imds", {}).get("compute")
+    if not compute:
+        return {}
+    name_to_report_map = {
+        "publisher": "ImagePublisher",
+        "offer": "ImageOffer",
+        "sku": "ImageSKU",
+        "version": "ImageVersion",
+        "vmSize": "VMSize",
+    }
+    azure_data = {}
+    for src_key, report_key_name in name_to_report_map.items():
+        azure_data[report_key_name] = compute[src_key]
+    return azure_data
+
+
+def _get_ec2_data(ds_data) -> Dict[str, str]:
+    document = (
+        ds_data.get("dynamic", {}).get("instance-identity", {}).get("document")
+    )
+    if not document:
+        return {}
+    wanted_keys = {
+        "architecture",
+        "billingProducts",
+        "imageId",
+        "instanceType",
+        "region",
+    }
+    return {
+        key: value for key, value in document.items() if key in wanted_keys
+    }
+
+
+PLATFORM_SPECIFIC_INFO = {"azure": _get_azure_data, "ec2": _get_ec2_data}
+
+
+def add_datasource_specific_info(report, platform: str, ds_data) -> None:
+    """Add datasoure specific information from the ds dictionary.
+
+    ds_data contains the "ds" entry from data from
+    /run/cloud/instance-data.json.
+    """
+    platform_info = PLATFORM_SPECIFIC_INFO.get(platform)
+    if not platform_info:
+        return
+    retrieved_data = platform_info(ds_data)
+    for key, value in retrieved_data.items():
+        if not value:
+            continue
+        report[platform.capitalize() + key.capitalize()] = value
+
+
+def general_add_info(report, _) -> None:
+    """Entry point for Apport.
+
+    This hook runs for every apport report
+
+    Add a subset of non-sensitive cloud-init data from
+    /run/cloud/instance-data.json that will be helpful for debugging.
+    """
+    try:
+        if not is_cloud_init_enabled():
+            return
+        with open("/run/cloud-init/instance-data.json", "r") as fopen:
+            instance_data = json.load(fopen)
+    except FileNotFoundError:
+        logging.getLogger().warning(
+            "cloud-init run data not found on system. "
+            "Unable to add cloud-specific data."
+        )
+        return
+
+    v1 = instance_data.get("v1")
+    if not v1:
+        logging.getLogger().warning(
+            "instance-data.json lacks 'v1' metadata. Present keys: %s",
+            sorted(instance_data.keys()),
+        )
+        return
+
+    for key, report_key in {
+        "cloud_id": "CloudID",
+        "cloud_name": "CloudName",
+        "machine": "CloudArchitecture",
+        "platform": "CloudPlatform",
+        "region": "CloudRegion",
+        "subplatform": "CloudSubPlatform",
+    }.items():
+        value = v1.get(key)
+        if value:
+            report[report_key] = value
+
+    add_datasource_specific_info(
+        report, v1["platform"], instance_data.get("ds")
+    )

--- a/cloudinit/cloud.py
+++ b/cloudinit/cloud.py
@@ -57,6 +57,17 @@ class Cloud:
         return copy.deepcopy(self._cfg)
 
     def run(self, name, functor, args, freq=None, clear_on_fail=False):
+        """Run a function gated by a named semaphore for a desired frequency.
+
+        The typical case for this method would be to limit running of the
+        provided func to a single well-defined frequency:
+            PER_INSTANCE, PER_BOOT or PER_ONCE
+
+        The semaphore provides a gate that persists across cloud-init
+        boot stage boundaries so multiple modules can share this state
+        even if they happen to be run in different boot stages or across
+        reboots.
+        """
         return self._runners.run(name, functor, args, freq, clear_on_fail)
 
     def get_template_filename(self, name):

--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -160,14 +160,14 @@ class NetHandler(UeventHandler):
         return len(found) > 0
 
 
-SUBSYSTEM_PROPERTES_MAP = {
+SUBSYSTEM_PROPERTIES_MAP = {
     "net": (NetHandler, EventScope.NETWORK),
 }
 
 
 def is_enabled(hotplug_init, subsystem):
     try:
-        scope = SUBSYSTEM_PROPERTES_MAP[subsystem][1]
+        scope = SUBSYSTEM_PROPERTIES_MAP[subsystem][1]
     except KeyError as e:
         raise RuntimeError(
             "hotplug-hook: cannot handle events for subsystem: {}".format(
@@ -201,7 +201,7 @@ def handle_hotplug(hotplug_init: Init, devpath, subsystem, udevaction):
     datasource = initialize_datasource(hotplug_init, subsystem)
     if not datasource:
         return
-    handler_cls = SUBSYSTEM_PROPERTES_MAP[subsystem][0]
+    handler_cls = SUBSYSTEM_PROPERTIES_MAP[subsystem][0]
     LOG.debug("Creating %s event handler", subsystem)
     event_handler: UeventHandler = handler_cls(
         datasource=datasource,

--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -196,7 +196,7 @@ def handle_status_args(name, args) -> int:
     if args.format == "tabular":
         prefix = "\n" if args.wait else ""
 
-        # For backwards compatability, don't report degraded status here,
+        # For backwards compatibility, don't report degraded status here,
         # extended_status key reports the complete status (includes degraded)
         state = UXAppStatusDegradedMapCompat.get(
             details.status, details.status
@@ -304,6 +304,13 @@ def get_bootstatus(
     return (bootstatus_code, reason)
 
 
+def is_cloud_init_enabled() -> bool:
+    return (
+        get_status_details(read_cfg_paths()).boot_status_code
+        not in DISABLED_BOOT_CODES
+    )
+
+
 def _get_error_or_running_from_systemd(
     existing_status: UXAppStatus, wait: bool
 ) -> Optional[UXAppStatus]:
@@ -349,7 +356,7 @@ def _get_error_or_running_from_systemd(
                 continue
             elif states["SubState"] == "running" and states["MainPID"] == "0":
                 # Service is active, substate still reports running due to
-                # daemon or backgroud process spawned by CGroup/slice still
+                # daemon or background process spawned by CGroup/slice still
                 # running. MainPID being set back to 0 means control of the
                 # service/unit has exited in this case and
                 # "the process is no longer around".

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -584,7 +584,7 @@ def get_apt_cfg() -> Dict[str, str]:
 
     Prefer python apt_pkg if present.
     Fallback to apt-config dump command if present out output parsed
-    Fallback to DEFAULT_APT_CFG if apt-config commmand absent or
+    Fallback to DEFAULT_APT_CFG if apt-config command absent or
     output unparsable.
     """
     try:

--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -670,7 +670,7 @@ def purge_disk_ptable(device):
 
 def purge_disk(device):
     """
-    Remove parition table entries
+    Remove partition table entries
     """
 
     # wipe any file systems first
@@ -791,7 +791,7 @@ def mkpart(device, definition):
 
             The following are supported values in the dict:
                 overwrite: Should the partition table be created regardless
-                            of any pre-exisiting data?
+                            of any pre-existing data?
                 layout: the layout of the partition table
                 table_type: Which partition table to use, defaults to MBR
                 device: the device to work on.
@@ -940,12 +940,12 @@ def mkfs(fs_cfg):
                 LOG.warning("Destroying filesystem on %s", device)
 
         else:
-            LOG.debug("Device %s is cleared for formating", device)
+            LOG.debug("Device %s is cleared for formatting", device)
 
     elif partition and str(partition).lower() in ("auto", "any"):
         # For auto devices, we match if the filesystem does exist
         odevice = device
-        LOG.debug("Identifying device to create %s filesytem on", label)
+        LOG.debug("Identifying device to create %s filesystem on", label)
 
         # 'any' means pick the first match on the device with matching fs_type
         label_match = True
@@ -962,7 +962,7 @@ def mkfs(fs_cfg):
         LOG.debug("Automatic device for %s identified as %s", odevice, device)
 
         if reuse:
-            LOG.debug("Found filesystem match, skipping formating.")
+            LOG.debug("Found filesystem match, skipping formatting.")
             return
 
         if not reuse and fs_replace and device:

--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -59,7 +59,7 @@ meta: MetaSchema = {
 LOG = logging.getLogger(__name__)
 __doc__ = get_meta_doc(meta)
 
-# Jinja formated default message
+# Jinja formatted default message
 FINAL_MESSAGE_DEF = (
     "## template: jinja\n"
     "Cloud-init v. {{version}} finished at {{timestamp}}."

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -306,7 +306,7 @@ def device_part_info(devpath):
         # FreeBSD doesn't know of sysfs so just get everything we need from
         # the device, like /dev/vtbd0p2.
         fpart = "/dev/" + util.find_freebsd_part(devpath)
-        # Handle both GPT partions and MBR slices with partitions
+        # Handle both GPT partitions and MBR slices with partitions
         m = re.search(
             r"^(?P<dev>/dev/.+)[sp](?P<part_slice>\d+[a-z]*)$", fpart
         )

--- a/cloudinit/config/cc_install_hotplug.py
+++ b/cloudinit/config/cc_install_hotplug.py
@@ -21,11 +21,11 @@ meta: MetaSchema = {
         This module will install the udev rules to enable hotplug if
         supported by the datasource and enabled in the userdata. The udev
         rules will be installed as
-        ``/etc/udev/rules.d/10-cloud-init-hook-hotplug.rules``.
+        ``/etc/udev/rules.d/90-cloud-init-hook-hotplug.rules``.
 
         When hotplug is enabled, newly added network devices will be added
         to the system by cloud-init. After udev detects the event,
-        cloud-init will referesh the instance metadata from the datasource,
+        cloud-init will refresh the instance metadata from the datasource,
         detect the device in the updated metadata, then apply the updated
         network configuration.
 
@@ -59,10 +59,12 @@ __doc__ = get_meta_doc(meta)
 LOG = logging.getLogger(__name__)
 
 
-HOTPLUG_UDEV_PATH = "/etc/udev/rules.d/10-cloud-init-hook-hotplug.rules"
+# 90 to be sorted after 80-net-setup-link.rules which sets ID_NET_DRIVER and
+# some datasources match on drivers
+HOTPLUG_UDEV_PATH = "/etc/udev/rules.d/90-cloud-init-hook-hotplug.rules"
 HOTPLUG_UDEV_RULES_TEMPLATE = """\
 # Installed by cloud-init due to network hotplug userdata
-ACTION!="add|remove", GOTO="cloudinit_end"
+ACTION!="add|remove", GOTO="cloudinit_end"{extra_rules}
 LABEL="cloudinit_hook"
 SUBSYSTEM=="net", RUN+="{libexecdir}/hook-hotplug"
 LABEL="cloudinit_end"
@@ -104,12 +106,21 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         LOG.debug("Skipping hotplug install, udevadm not found")
         return
 
+    extra_rules = (
+        cloud.datasource.extra_hotplug_udev_rules
+        if cloud.datasource.extra_hotplug_udev_rules is not None
+        else ""
+    )
+    if extra_rules:
+        extra_rules = "\n" + extra_rules
     # This may need to turn into a distro property at some point
     libexecdir = "/usr/libexec/cloud-init"
     if not os.path.exists(libexecdir):
         libexecdir = "/usr/lib/cloud-init"
     util.write_file(
         filename=HOTPLUG_UDEV_PATH,
-        content=HOTPLUG_UDEV_RULES_TEMPLATE.format(libexecdir=libexecdir),
+        content=HOTPLUG_UDEV_RULES_TEMPLATE.format(
+            extra_rules=extra_rules, libexecdir=libexecdir
+        ),
     )
     subp.subp(["udevadm", "control", "--reload-rules"])

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -210,6 +210,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             f" '{type(lxd_cfg).__name__}'"
         )
 
+    util.wait_for_snap_seeded(cloud)
     # Grab the configuration
     init_cfg = lxd_cfg.get("init", {})
     preseed_str = lxd_cfg.get("preseed", "")
@@ -432,7 +433,7 @@ def bridge_to_cmd(bridge_cfg):
             % (bridge_cfg.get("ipv6_address"), bridge_cfg.get("ipv6_netmask"))
         )
 
-        if bridge_cfg.get("ipv6_nat", "false") == "true":
+        if bridge_cfg.get("ipv6_nat") == "true":
             cmd_create.append("ipv6.nat=true")
 
     else:

--- a/cloudinit/config/cc_puppet.py
+++ b/cloudinit/config/cc_puppet.py
@@ -240,7 +240,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
         if install_type == "packages":
             to_install: List[Union[str, List[str]]]
-            if package_name is None:  # conf has no package_nam
+            if package_name is None:  # conf has no package_name
                 for puppet_name in PUPPET_PACKAGE_NAMES:
                     with suppress(PackageInstallerError):
                         to_install = (

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -29,7 +29,7 @@ meta: MetaSchema = {
     "title": "Resize filesystem",
     "description": dedent(
         """\
-        Resize a filesystem to use all avaliable space on partition. This
+        Resize a filesystem to use all available space on partition. This
         module is useful along with ``cc_growpart`` and will ensure that if the
         root partition has been resized the root filesystem will be resized
         along with it. By default, ``cc_resizefs`` will resize the root

--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -505,7 +505,7 @@ class SubscriptionManager:
 
 def _sub_man_cli(cmd, logstring_val=False):
     """
-    Uses the prefered cloud-init subprocess def of subp.subp
+    Uses the preferred cloud-init subprocess def of subp.subp
     and runs subscription-manager.  Breaking this to a
     separate function for later use in mocking and unittests
     """

--- a/cloudinit/config/cc_set_hostname.py
+++ b/cloudinit/config/cc_set_hostname.py
@@ -60,8 +60,17 @@ meta: MetaSchema = {
         dedent(
             """\
             hostname: myhost
+            create_hostname_file: true
             fqdn: myhost.example.com
             prefer_fqdn_over_hostname: true
+            """
+        ),
+        dedent(
+            """\
+            # On a machine without an ``/etc/hostname`` file, don't create it
+            # In most clouds, this will result in a DHCP-configured hostname
+            # provided by the cloud
+            create_hostname_file: false
             """
         ),
     ],

--- a/cloudinit/config/cc_snap.py
+++ b/cloudinit/config/cc_snap.py
@@ -191,7 +191,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             "Skipping module named %s, no 'snap' key in configuration", name
         )
         return
-
+    util.wait_for_snap_seeded(cloud)
     add_assertions(
         cfgin.get("assertions", []),
         os.path.join(cloud.paths.get_ipath_cur(), "snapd.assertions"),

--- a/cloudinit/config/cc_ubuntu_autoinstall.py
+++ b/cloudinit/config/cc_ubuntu_autoinstall.py
@@ -6,6 +6,7 @@ import logging
 import re
 from textwrap import dedent
 
+from cloudinit import util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import (
@@ -32,7 +33,7 @@ meta: MetaSchema = {
         next generation desktop installer, via `ubuntu-desktop-install` snap.
         When "autoinstall" directives are provided in either
         ``#cloud-config`` user-data or ``/etc/cloud/cloud.cfg.d`` validate
-        minimal autoinstall schema adherance and emit a warning if the
+        minimal autoinstall schema adherence and emit a warning if the
         live-installer is not present.
 
         The live-installer will use autoinstall directives to seed answers to
@@ -83,6 +84,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         )
         return
 
+    util.wait_for_snap_seeded(cloud)
     snap_list, _ = subp(["snap", "list"])
     installer_present = None
     for snap_name in LIVE_INSTALLER_SNAPS:

--- a/cloudinit/config/cc_update_hostname.py
+++ b/cloudinit/config/cc_update_hostname.py
@@ -65,6 +65,7 @@ meta: MetaSchema = {
         fqdn: external.fqdn.me
         hostname: myhost
         prefer_fqdn_over_hostname: true
+        create_hostname_file: true
         """
         ),
         dedent(
@@ -72,6 +73,14 @@ meta: MetaSchema = {
         # Set hostname to "external" instead of "external.fqdn.me" when
         # cloud metadata provides the ``local-hostname``: "external.fqdn.me".
         prefer_fqdn_over_hostname: false
+        """
+        ),
+        dedent(
+            """\
+        # On a machine without an ``/etc/hostname`` file, don't create it
+        # In most clouds, this will result in a DHCP-configured hostname
+        # provided by the cloud
+        create_hostname_file: false
         """
         ),
     ],

--- a/cloudinit/config/cc_wireguard.py
+++ b/cloudinit/config/cc_wireguard.py
@@ -226,7 +226,7 @@ def maybe_install_wireguard_packages(cloud: Cloud):
     if subp.which("wg"):
         return
 
-    # Install DKMS when Kernel Verison lower 5.6
+    # Install DKMS when Kernel Version lower 5.6
     if util.kernel_version() < MIN_KERNEL_VERSION:
         packages.append("wireguard")
 

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -74,7 +74,7 @@ meta: MetaSchema = {
         ),
         dedent(
             """\
-        # Provide gziped binary content
+        # Provide gzipped binary content
         write_files:
         - encoding: gzip
           content: !!binary |
@@ -146,7 +146,7 @@ def canonicalize_extraction(encoding_type):
     # Yaml already encodes binary data as base64 if it is given to the
     # yaml file as binary, so those will be automatically decoded for you.
     # But the above b64 is just for people that are more 'comfortable'
-    # specifing it manually (which might be a possibility)
+    # specifying it manually (which might be a possibility)
     if encoding_type in ["b64", "base64"]:
         return ["application/base64"]
     if encoding_type == TEXT_PLAIN_ENC:

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -151,7 +151,7 @@ SchemaProblems = List[SchemaProblem]
 
 
 class SchemaType(Enum):
-    """Supported schema types are etiher cloud-config or network-config.
+    """Supported schema types are either cloud-config or network-config.
 
     Vendordata and Vendordata2 format adheres to cloud-config schema type.
     Cloud Metadata is unique schema to each cloud platform and likely will not
@@ -638,7 +638,7 @@ def netplan_validate_network_schema(
     parser = Parser()
     errors = []
     try:
-        # Parse all netplan *.yaml files.load_yaml_heirarchy looks for nested
+        # Parse all netplan *.yaml files.load_yaml_hierarchy looks for nested
         # etc/netplan subdir under "/".
         parser.load_yaml_hierarchy(parse_dir)
     except NetplanParserException as e:
@@ -922,7 +922,7 @@ def annotated_cloudconfig_file(
     """Return contents of the cloud-config file annotated with schema errors.
 
     @param cloudconfig: YAML-loaded dict from the original_content or empty
-        dict if unparseable.
+        dict if unparsable.
     @param original_content: The contents of a cloud-config file
     @param schemamarks: Dict with schema marks.
     @param schema_errors: Instance of `SchemaProblems`.
@@ -942,7 +942,7 @@ def process_merged_cloud_config_part_problems(
 
     When merging multiple cloud-config parts cloud-init logs an error and
     ignores any user-data parts which are declared as #cloud-config but
-    cannot be processed. the hanlder.cloud_config module also leaves comments
+    cannot be processed. the handler.cloud_config module also leaves comments
     in the final merged config for every invalid part file which begin with
     MERGED_CONFIG_SCHEMA_ERROR_PREFIX to aid in triage.
     """
@@ -1570,7 +1570,7 @@ def get_schema(schema_type: SchemaType = SchemaType.CLOUD_CONFIG) -> dict:
         full_schema = json.loads(load_text_file(schema_file))
     except (IOError, OSError):
         LOG.warning(
-            "Skipping %s schema valiation. No JSON schema file found %s.",
+            "Skipping %s schema validation. No JSON schema file found %s.",
             schema_type.value,
             schema_file,
         )
@@ -1669,7 +1669,7 @@ def _assert_exclusive_args(args):
 def get_config_paths_from_args(
     args,
 ) -> Tuple[str, List[InstanceDataPart]]:
-    """Return appropiate instance-data.json and instance data parts
+    """Return appropriate instance-data.json and instance data parts
 
     Based on commandline args, and user permissions, determine the
     appropriate instance-data.json to source for jinja templates and
@@ -1696,7 +1696,7 @@ def get_config_paths_from_args(
           user-data.
           In the case of invalid raw user-data header, prefer
           raw_fallback_path_key so actionable sensible warnings can be
-          reported ot the user about the raw unparseable user-data.
+          reported to the user about the raw unparsable user-data.
         """
         primary_datapath = paths.get_ipath(primary_path_key) or ""
         with suppress(FileNotFoundError):

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -418,7 +418,7 @@
         ]
       }
     },
-    "merge_defintion": {
+    "merge_definition": {
       "oneOf": [
         {
           "type": "string"
@@ -481,10 +481,10 @@
           "description": "The launch index for the specified cloud-config."
         },
         "merge_how": {
-          "$ref": "#/$defs/merge_defintion"
+          "$ref": "#/$defs/merge_definition"
         },
         "merge_type": {
-          "$ref": "#/$defs/merge_defintion"
+          "$ref": "#/$defs/merge_definition"
         }
       }
     },
@@ -1739,7 +1739,7 @@
                 },
                 "ipv4_dhcp_leases": {
                   "type": "integer",
-                  "description": "Number of DHCP leases to allocate within the range. Automatically calculated based on `ipv4_dhcp_first` and `ipv4_dchp_last` when unset."
+                  "description": "Number of DHCP leases to allocate within the range. Automatically calculated based on `ipv4_dhcp_first` and `ipv4_dhcp_last` when unset."
                 },
                 "ipv4_nat": {
                   "type": "boolean",

--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -73,7 +73,7 @@
           "description": "The MTU size in bytes. This ``mtu`` key represents a device's Maximum Transmission Unit, which is the largest size packet or frame, specified in octets (eight-bit bytes), that can be sent in a packet- or frame-based network. Specifying ``mtu`` is optional. Values too small or too large for a device may be ignored by that device."
         },
         "params": {
-          "desciption": "The ``params`` key in a bond holds a dictionary of bonding parameters. This dictionary may be empty. For more details on what the various bonding parameters mean please read the [Linux Kernel Bonding.txt](https://www.kernel.org/doc/Documentation/networking/bonding.txt).",
+          "description": "The ``params`` key in a bond holds a dictionary of bonding parameters. This dictionary may be empty. For more details on what the various bonding parameters mean please read the [Linux Kernel Bonding.txt](https://www.kernel.org/doc/Documentation/networking/bonding.txt).",
           "additionalProperties": false,
           "properties": {
             "bond-active_slave": {

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -53,7 +53,7 @@ from cloudinit.net import activators, dhcp, renderers
 from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.net.renderer import Renderer
 
-# Used when a cloud-config module can be run on all cloud-init distibutions.
+# Used when a cloud-config module can be run on all cloud-init distributions.
 # The value 'all' is surfaced in module documentation for distro support.
 ALL_DISTROS = "all"
 
@@ -274,7 +274,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         """access the distro's preferred dhcp client
 
         if no client has been selected yet select one - uses
-        self.dhcp_client_priority, which may be overriden in each distro's
+        self.dhcp_client_priority, which may be overridden in each distro's
         object to eliminate checking for clients which will not be provided
         by the distro
         """
@@ -637,7 +637,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         """
         Add a user to the system using standard GNU tools
 
-        This should be overriden on distros where useradd is not desirable or
+        This should be overridden on distros where useradd is not desirable or
         not available.
         """
         # XXX need to make add_user idempotent somehow as we
@@ -701,7 +701,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             # that came in as a string like: groups: group1, group2
             groups = [g.strip() for g in groups]
 
-            # kwargs.items loop below wants a comma delimeted string
+            # kwargs.items loop below wants a comma delimited string
             # that can go right through to the command.
             kwargs["groups"] = ",".join(groups)
 
@@ -1347,7 +1347,7 @@ def _apply_hostname_transformations_to_url(url: str, transformations: list):
 
     :return:
         A string whose value is ``url`` with the hostname ``transformations``
-        applied, or ``None`` if ``url`` is unparseable.
+        applied, or ``None`` if ``url`` is unparsable.
     """
     try:
         parts = urllib.parse.urlsplit(url)

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -41,7 +41,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.default_locale = "C.UTF-8"

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -29,7 +29,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "arch"

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -32,7 +32,7 @@ class BSD(distros.Distro):
     def __init__(self, name, cfg, paths):
         super().__init__(name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         cfg["ssh_svcname"] = "sshd"

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -56,7 +56,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         super().__init__(name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self.osfamily = "debian"
         self.default_locale = "C.UTF-8"

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -226,3 +226,7 @@ class Distro(cloudinit.distros.bsd.BSD):
         return [path, "-l", lease_file, "-p", pid_file] + (
             ["-c", config_file, interface] if config_file else [interface]
         )
+
+    @staticmethod
+    def eject_media(device: str) -> None:
+        subp.subp(["camcontrol", "eject", device])

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -28,7 +28,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "gentoo"

--- a/cloudinit/distros/mariner.py
+++ b/cloudinit/distros/mariner.py
@@ -44,7 +44,7 @@ class Distro(photon.Distro):
     def __init__(self, name, cfg, paths):
         photon.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "mariner"

--- a/cloudinit/distros/parsers/ifconfig.py
+++ b/cloudinit/distros/parsers/ifconfig.py
@@ -102,6 +102,7 @@ class Ifconfig:
         """
         ifindex = 0
         ifs_by_mac = defaultdict(list)
+        dev = None
         for line in text.splitlines():
             if len(line) == 0:
                 continue
@@ -118,6 +119,11 @@ class Ifconfig:
                 dev = Ifstate(curif)
                 dev.index = ifindex
                 self._ifs_by_name[curif] = dev
+
+            if not dev:
+                # This shouldn't happen with normal ifconfig output, but
+                # if it does, ensure we don't Traceback
+                continue
 
             toks = line.lower().strip().split()
 

--- a/cloudinit/distros/photon.py
+++ b/cloudinit/distros/photon.py
@@ -31,7 +31,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "photon"
@@ -66,7 +66,7 @@ class Distro(distros.Distro):
         return None
 
     def apply_locale(self, locale, out_fn=None):
-        # This has a dependancy on glibc-i18n, user need to manually install it
+        # This has a dependency on glibc-i18n, user need to manually install it
         # and enable the option in cloud.cfg
         if not out_fn:
             out_fn = self.systemd_locale_conf_fn

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -53,7 +53,7 @@ class Distro(distros.Distro):
     def __init__(self, name, cfg, paths):
         distros.Distro.__init__(self, name, cfg, paths)
         # This will be used to restrict certain
-        # calls from repeatly happening (when they
+        # calls from repeatedly happening (when they
         # should only happen say once per instance...)
         self._runner = helpers.Runners(paths)
         self.osfamily = "redhat"

--- a/cloudinit/distros/ug_util.py
+++ b/cloudinit/distros/ug_util.py
@@ -17,7 +17,7 @@ LOG = logging.getLogger(__name__)
 
 
 # Normalizes an input group configuration which can be:
-# Comma seperated string or a list or a dictionary
+# Comma separated string or a list or a dictionary
 #
 # Returns dictionary of group names => members of that group which is the
 # standard form used in the rest of cloud-init

--- a/cloudinit/gpg.py
+++ b/cloudinit/gpg.py
@@ -68,7 +68,7 @@ def recv_key(key, keyserver, retries=(1, 1)):
 
     Retries are done by default because keyservers can be unreliable.
     Additionally, there is no way to determine the difference between
-    a non-existant key and a failure.  In both cases gpg (at least 2.2.4)
+    a non-existent key and a failure.  In both cases gpg (at least 2.2.4)
     exits with status 2 and stderr: "keyserver receive failed: No data"
     It is assumed that a key provided to cloud-init exists on the keyserver
     so re-trying makes better sense than failing.

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -50,7 +50,7 @@ INCLUSION_TYPES_MAP = {
     "## template: jinja": "text/jinja2",
     # Note: for the next 3 entries, the prefix doesn't matter because these
     # are for types that can only be used as part of a MIME message. However,
-    # including these entries supresses warnings during `cloudinit devel
+    # including these entries suppresses warnings during `cloudinit devel
     # make-mime`, which otherwise would require `--force`.
     "text/x-shellscript-per-boot": "text/x-shellscript-per-boot",
     "text/x-shellscript-per-instance": "text/x-shellscript-per-instance",
@@ -93,7 +93,7 @@ def run_part(mod, data, filename, payload, frequency, headers):
         or (frequency == PER_INSTANCE and mod_freq == PER_INSTANCE)
     ):
         return
-    # Sanity checks on version (should be an int convertable)
+    # Sanity checks on version (should be an int convertible)
     try:
         mod_ver = mod.handler_version
         mod_ver = int(mod_ver)

--- a/cloudinit/log.py
+++ b/cloudinit/log.py
@@ -146,7 +146,7 @@ def reset_logging():
 
 def setup_backup_logging():
     """In the event that internal logging exception occurs and logging is not
-    possible for some reason, make a desparate final attempt to log to stderr
+    possible for some reason, make a desperate final attempt to log to stderr
     which may ease debugging.
     """
     fallback_handler = logging.StreamHandler(sys.stderr)

--- a/cloudinit/mergers/__init__.py
+++ b/cloudinit/mergers/__init__.py
@@ -110,7 +110,7 @@ def string_extract_mergers(merge_how):
             continue
         match = NAME_MTCH.match(m_name)
         if not match:
-            msg = "Matcher identifer '%s' is not in the right format" % (
+            msg = "Matcher identifier '%s' is not in the right format" % (
                 m_name
             )
             raise ValueError(msg)

--- a/cloudinit/net/eni.py
+++ b/cloudinit/net/eni.py
@@ -179,7 +179,7 @@ def _parse_deb_config_data(ifaces, contents, src_dir, src_path):
     """Parses the file contents, placing result into ifaces.
 
     '_source_path' is added to every dictionary entry to define which file
-    the configration information came from.
+    the configuration information came from.
 
     :param ifaces: interface dictionary
     :param contents: contents of interfaces file

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -116,7 +116,7 @@ class EphemeralIPv4Network:
             cmd()
 
     def _bringup_device(self):
-        """Perform the ip comands to fully setup the device."""
+        """Perform the ip commands to fully setup the device."""
         cidr = "{0}/{1}".format(self.ip, self.prefix)
         LOG.debug(
             "Attempting setup of ephemeral network on %s with %s brd %s",

--- a/cloudinit/persistence.py
+++ b/cloudinit/persistence.py
@@ -13,7 +13,7 @@ class CloudInitPickleMixin:
     use it.  Versioning is done at the class level.
 
     The current version of a class's pickle should be set in the class variable
-    ``_ci_pkl_version``, as an int.  If not overriden, it will default to 0.
+    ``_ci_pkl_version``, as an int.  If not overridden, it will default to 0.
 
     On unpickle, the object's state will be restored and then
     ``self._unpickle`` is called with the version of the stored pickle as the

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1830,7 +1830,7 @@ def read_azure_ovf(contents):
     :return: Tuple of metadata, configuration, userdata dicts.
 
     :raises NonAzureDataSource: if XML is not in Azure's format.
-    :raises errors.ReportableError: if XML is unparseable or invalid.
+    :raises errors.ReportableError: if XML is unparsable or invalid.
     """
     ovf_env = OvfEnvXml.parse_text(contents)
     md: Dict[str, Any] = {}
@@ -1868,6 +1868,12 @@ def read_azure_ovf(contents):
     cfg["PreprovisionedVMType"] = ovf_env.preprovisioned_vm_type
     report_diagnostic_event(
         "PreprovisionedVMType: %s" % ovf_env.preprovisioned_vm_type,
+        logger_func=LOG.info,
+    )
+
+    cfg["ProvisionGuestProxyAgent"] = ovf_env.provision_guest_proxy_agent
+    report_diagnostic_event(
+        "ProvisionGuestProxyAgent: %s" % ovf_env.provision_guest_proxy_agent,
         logger_func=LOG.info,
     )
     return (md, ud, cfg)
@@ -1947,7 +1953,7 @@ def generate_network_config_from_instance_network_metadata(
 ) -> dict:
     """Convert imds network metadata dictionary to network v2 configuration.
 
-    :param: network_metadata: Dict of "network" key from instance metdata.
+    :param: network_metadata: Dict of "network" key from instance metadata.
 
     :return: Dictionary containing network version 2 standard configuration.
     """

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -157,7 +157,7 @@ class DataSourceConfigDrive(openstack.SourceMixin, sources.DataSource):
             LOG.warning("Invalid content in vendor-data2: %s", e)
             self.vendordata2_raw = None
 
-        # network_config is an /etc/network/interfaces formated file and is
+        # network_config is an /etc/network/interfaces formatted file and is
         # obsolete compared to networkdata (from network_data.json) but both
         # might be present.
         self.network_eni = results.get("network_config")

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -12,12 +12,13 @@ import copy
 import logging
 import os
 import time
-from typing import List
+from typing import Dict, List
 
 from cloudinit import dmi, net, sources
 from cloudinit import url_helper as uhelp
 from cloudinit import util, warnings
 from cloudinit.event import EventScope, EventType
+from cloudinit.net import activators
 from cloudinit.net.dhcp import NoDHCPLeaseError
 from cloudinit.net.ephemeral import EphemeralIPNetwork
 from cloudinit.sources.helpers import ec2
@@ -53,9 +54,15 @@ def skip_404_tag_errors(exception):
 # Cloud platforms that support IMDSv2 style metadata server
 IDMSV2_SUPPORTED_CLOUD_PLATFORMS = [CloudNames.AWS, CloudNames.ALIYUN]
 
+# Only trigger hook-hotplug on NICs with Ec2 drivers. Avoid triggering
+# it on docker virtual NICs and the like. LP: #1946003
+_EXTRA_HOTPLUG_UDEV_RULES = """
+ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", GOTO="cloudinit_hook"
+GOTO="cloudinit_end"
+"""
+
 
 class DataSourceEc2(sources.DataSource):
-
     dsname = "Ec2"
     # Default metadata urls that will be used if none are provided
     # They will be checked for 'resolveability' and some of the
@@ -97,9 +104,22 @@ class DataSourceEc2(sources.DataSource):
         }
     }
 
+    default_update_events = {
+        EventScope.NETWORK: {
+            EventType.BOOT_NEW_INSTANCE,
+            EventType.HOTPLUG,
+        }
+    }
+
+    extra_hotplug_udev_rules = _EXTRA_HOTPLUG_UDEV_RULES
+
     def __init__(self, sys_cfg, distro, paths):
         super(DataSourceEc2, self).__init__(sys_cfg, distro, paths)
         self.metadata_address = None
+
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+        self.extra_hotplug_udev_rules = _EXTRA_HOTPLUG_UDEV_RULES
 
     def _get_cloud_name(self):
         """Return the cloud name as identified during _get_data."""
@@ -299,7 +319,7 @@ class DataSourceEc2(sources.DataSource):
                 connect_synchronously=False,
             )
         except uhelp.UrlError:
-            # We use the raised exception to interupt the retry loop.
+            # We use the raised exception to interrupt the retry loop.
             # Nothing else to do here.
             pass
 
@@ -402,7 +422,7 @@ class DataSourceEc2(sources.DataSource):
             LOG.debug("block-device-mapping not a dictionary: '%s'", bdm)
             return None
 
-        for (entname, device) in bdm.items():
+        for entname, device in bdm.items():
             if entname == name:
                 found = device
                 break
@@ -508,6 +528,7 @@ class DataSourceEc2(sources.DataSource):
             # behavior on those releases.
             result = convert_ec2_metadata_network_config(
                 net_md,
+                self.distro,
                 fallback_nic=iface,
                 full_network_config=util.get_cfg_option_bool(
                     self.ds_cfg, "apply_full_imds_network_config", True
@@ -871,8 +892,69 @@ def _collect_platform_data():
     return data
 
 
+def _build_nic_order(
+    macs_metadata: Dict[str, Dict], macs: List[str]
+) -> Dict[str, int]:
+    """
+    Builds a dictionary containing macs as keys nad nic orders as values,
+    taking into account `network-card` and `device-number` if present.
+
+    Note that the first NIC will be the primary NIC as it will be the one with
+    [network-card] == 0 and device-number == 0 if present.
+
+    @param macs_metadata: dictionary with mac address as key and contents like:
+    {"device-number": "0", "interface-id": "...", "local-ipv4s": ...}
+    @macs: list of macs to consider
+
+    @return: Dictionary with macs as keys and nic orders as values.
+    """
+    nic_order: Dict[str, int] = {}
+    if len(macs) == 0 or len(macs_metadata) == 0:
+        return nic_order
+
+    valid_macs_metadata = filter(
+        # filter out nics without metadata (not a physical nic)
+        lambda mmd: mmd[1] is not None,
+        # filter by macs
+        map(lambda mac: (mac, macs_metadata.get(mac)), macs),
+    )
+
+    def _get_key_as_int_or(dikt, key, alt_value):
+        value = dikt.get(key, None)
+        if value is not None:
+            return int(value)
+        return alt_value
+
+    # Sort by (network_card, device_index) as some instances could have
+    # multiple network cards with repeated device indexes.
+    #
+    # On platforms where network-card and device-number are not present,
+    # as AliYun, the order will be by mac, as before the introduction of this
+    # function.
+    return {
+        mac: i
+        for i, (mac, _mac_metadata) in enumerate(
+            sorted(
+                valid_macs_metadata,
+                key=lambda mmd: (
+                    _get_key_as_int_or(
+                        mmd[1], "network-card", float("infinity")
+                    ),
+                    _get_key_as_int_or(
+                        mmd[1], "device-number", float("infinity")
+                    ),
+                ),
+            )
+        )
+    }
+
+
 def convert_ec2_metadata_network_config(
-    network_md, macs_to_nics=None, fallback_nic=None, full_network_config=True
+    network_md,
+    distro,
+    macs_to_nics=None,
+    fallback_nic=None,
+    full_network_config=True,
 ):
     """Convert ec2 metadata to network config version 2 data dict.
 
@@ -880,6 +962,7 @@ def convert_ec2_metadata_network_config(
        generally formed as {"interfaces": {"macs": {}} where
        'macs' is a dictionary with mac address as key and contents like:
        {"device-number": "0", "interface-id": "...", "local-ipv4s": ...}
+    @param: distro: instance of Distro.
     @param: macs_to_nics: Optional dict of mac addresses and nic names. If
        not provided, get_interfaces_by_mac is called to get it from the OS.
     @param: fallback_nic: Optionally provide the primary nic interface name.
@@ -913,15 +996,18 @@ def convert_ec2_metadata_network_config(
         netcfg["ethernets"][nic_name] = dev_config
         return netcfg
     # Apply network config for all nics and any secondary IPv4/v6 addresses
-    nic_idx = 0
-    for mac, nic_name in sorted(macs_to_nics.items()):
+    is_netplan = distro.network_activator == activators.NetplanActivator
+    macs = sorted(macs_to_nics.keys())
+    nic_order = _build_nic_order(macs_metadata, macs)
+    for mac in macs:
+        nic_name = macs_to_nics[mac]
         nic_metadata = macs_metadata.get(mac)
         if not nic_metadata:
             continue  # Not a physical nic represented in metadata
-        # device-number is zero-indexed, we want it 1-indexed for the
-        # multiplication on the following line
-        nic_idx = int(nic_metadata.get("device-number", nic_idx)) + 1
-        dhcp_override = {"route-metric": nic_idx * 100}
+        nic_idx = nic_order[mac]
+        is_primary_nic = nic_idx == 0
+        # nic_idx + 1 to start route_metric at 100 (nic_idx is 0-indexed)
+        dhcp_override = {"route-metric": (nic_idx + 1) * 100}
         dev_config = {
             "dhcp4": True,
             "dhcp4-overrides": dhcp_override,
@@ -929,18 +1015,118 @@ def convert_ec2_metadata_network_config(
             "match": {"macaddress": mac.lower()},
             "set-name": nic_name,
         }
+        # Configure policy-based routing on secondary NICs / secondary IPs to
+        # ensure outgoing packets are routed via the correct interface.
+        #
+        # This config only works on systems using Netplan because Networking
+        # config V2 does not support `routing-policy`, but this config is
+        # passed through on systems using Netplan.
+        #
+        # If device-number is not present (AliYun or other ec2-like platforms),
+        # do not configure source-routing as we cannot determine which is the
+        # primary NIC.
+        if (
+            is_netplan
+            and nic_metadata.get("device-number")
+            and not is_primary_nic
+        ):
+            dhcp_override["use-routes"] = True
+            table = 100 + nic_idx
+            dev_config["routes"] = []
+            try:
+                lease = distro.dhcp_client.dhcp_discovery(
+                    nic_name, distro=distro
+                )
+                gateway = lease["routers"]
+            except NoDHCPLeaseError as e:
+                LOG.warning(
+                    "Could not perform dhcp discovery on %s to find its "
+                    "gateway. Not adding default route via the gateway. "
+                    "Error: %s",
+                    nic_name,
+                    e,
+                )
+            else:
+                # Add default route via the NIC's gateway
+                dev_config["routes"].append(
+                    {
+                        "to": "0.0.0.0/0",
+                        "via": gateway,
+                        "table": table,
+                    },
+                )
+            subnet_prefix_routes = nic_metadata["subnet-ipv4-cidr-block"]
+            subnet_prefix_routes = (
+                [subnet_prefix_routes]
+                if isinstance(subnet_prefix_routes, str)
+                else subnet_prefix_routes
+            )
+            for prefix_route in subnet_prefix_routes:
+                dev_config["routes"].append(
+                    {
+                        "to": prefix_route,
+                        "table": table,
+                    },
+                )
+
+            dev_config["routing-policy"] = []
+            # Packets coming from any IPv4 associated with the current NIC
+            # will be routed using `table` routing table
+            ipv4s = nic_metadata["local-ipv4s"]
+            ipv4s = [ipv4s] if isinstance(ipv4s, str) else ipv4s
+            for ipv4 in ipv4s:
+                dev_config["routing-policy"].append(
+                    {
+                        "from": ipv4,
+                        "table": table,
+                    },
+                )
         if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
             dev_config["dhcp6"] = True
             dev_config["dhcp6-overrides"] = dhcp_override
+            if (
+                is_netplan
+                and nic_metadata.get("device-number")
+                and not is_primary_nic
+            ):
+                table = 100 + nic_idx
+                subnet_prefix_routes = nic_metadata["subnet-ipv6-cidr-block"]
+                subnet_prefix_routes = (
+                    [subnet_prefix_routes]
+                    if isinstance(subnet_prefix_routes, str)
+                    else subnet_prefix_routes
+                )
+                for prefix_route in subnet_prefix_routes:
+                    dev_config["routes"].append(
+                        {
+                            "to": prefix_route,
+                            "table": table,
+                        },
+                    )
+
+                dev_config["routing-policy"] = []
+                ipv6s = nic_metadata["ipv6s"]
+                ipv6s = [ipv6s] if isinstance(ipv6s, str) else ipv6s
+                for ipv6 in ipv6s:
+                    dev_config["routing-policy"].append(
+                        {
+                            "from": ipv6,
+                            "table": table,
+                        },
+                    )
         dev_config["addresses"] = get_secondary_addresses(nic_metadata, mac)
         if not dev_config["addresses"]:
             dev_config.pop("addresses")  # Since we found none configured
+
         netcfg["ethernets"][nic_name] = dev_config
-    # Remove route-metric dhcp overrides if only one nic configured
+    # Remove route-metric dhcp overrides and routes / routing-policy if only
+    # one nic configured
     if len(netcfg["ethernets"]) == 1:
         for nic_name in netcfg["ethernets"].keys():
             netcfg["ethernets"][nic_name].pop("dhcp4-overrides")
             netcfg["ethernets"][nic_name].pop("dhcp6-overrides", None)
+            netcfg["ethernets"][nic_name].pop("routes", None)
+            netcfg["ethernets"][nic_name].pop("routing-policy", None)
     return netcfg
 
 

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -154,7 +154,7 @@ class DataSourceGCE(sources.DataSource):
 
     @property
     def launch_index(self):
-        # GCE does not provide lauch_index property.
+        # GCE does not provide launch_index property.
         return None
 
     def get_instance_id(self):
@@ -222,7 +222,7 @@ def _has_expired(public_key):
     except ValueError:
         return False
 
-    # Do not expire keys if there is no expriation timestamp.
+    # Do not expire keys if there is no expiration timestamp.
     if "expireOn" not in json_obj:
         return False
 

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -78,7 +78,7 @@ def query_data_api_once(api_address, timeout, requests_session):
             api_address,
             data=None,
             timeout=timeout,
-            # It's the caller's responsability to recall this function in case
+            # It's the caller's responsibility to recall this function in case
             # of exception. Don't let url_helper.readurl() retry by itself.
             retries=0,
             session=requests_session,

--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -775,7 +775,7 @@ def write_boot_content(
     @param shebang: if no file magic, set shebang
     @param mode: file mode
 
-    Becuase of the way that Cloud-init executes scripts (no shell),
+    Because of the way that Cloud-init executes scripts (no shell),
     a script will fail to execute if does not have a magic bit (shebang) set
     for the file. If shebang=True, then the script will be checked for a magic
     bit and to the SmartOS default of assuming that bash.

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -129,7 +129,7 @@ class DataSourceVMware(sources.DataSource):
             For CloudinitPrep customization, Network config Version 2 data
             is parsed from the customization specification.
 
-        envvar and guestinfo tranports:
+        envvar and guestinfo transports:
             Network Config Version 2 data is supported as long as the Linux
             distro's cloud-init package is new enough to parse the data.
             The metadata key "network.encoding" may be used to indicate the

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -296,6 +296,9 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
     # in the updated metadata
     skip_hotplug_detect = False
 
+    # Extra udev rules for cc_install_hotplug
+    extra_hotplug_udev_rules: Optional[str] = None
+
     _ci_pkl_version = 1
 
     def __init__(self, sys_cfg, distro: Distro, paths: Paths, ud_proc=None):
@@ -344,6 +347,8 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
                     e,
                 )
                 raise DatasourceUnpickleUserDataError() from e
+        if not hasattr(self, "extra_hotplug_udev_rules"):
+            self.extra_hotplug_udev_rules = None
 
     def __str__(self):
         return type_utils.obj_name(self)
@@ -524,7 +529,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         cloud_id = instance_data["v1"].get("cloud_id", "none")
         cloud_id_file = os.path.join(self.paths.run_dir, "cloud-id")
         util.write_file(f"{cloud_id_file}-{cloud_id}", f"{cloud_id}\n")
-        # cloud-id not found, then no previous cloud-id fle
+        # cloud-id not found, then no previous cloud-id file
         prev_cloud_id_file = None
         new_cloud_id_file = f"{cloud_id_file}-{cloud_id}"
         # cloud-id found, then the prev cloud-id file is source of symlink
@@ -720,7 +725,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def get_vendordata2_raw(self):
         return self.vendordata2_raw
 
-    # the data sources' config_obj is a cloud-config formated
+    # the data sources' config_obj is a cloud-config formatted
     # object that came to it from ways other than cloud-config
     # because cloud-config content would be handled elsewhere
     def get_config_obj(self):

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -977,6 +977,7 @@ class OvfEnvXml:
         public_keys: Optional[List[dict]] = None,
         preprovisioned_vm: bool = False,
         preprovisioned_vm_type: Optional[str] = None,
+        provision_guest_proxy_agent: bool = False,
     ) -> None:
         self.username = username
         self.password = password
@@ -986,6 +987,7 @@ class OvfEnvXml:
         self.public_keys: List[dict] = public_keys or []
         self.preprovisioned_vm = preprovisioned_vm
         self.preprovisioned_vm_type = preprovisioned_vm_type
+        self.provision_guest_proxy_agent = provision_guest_proxy_agent
 
     def __eq__(self, other) -> bool:
         return self.__dict__ == other.__dict__
@@ -996,7 +998,7 @@ class OvfEnvXml:
 
         :raises NonAzureDataSource: if XML is not in Azure's format.
         :raises errors.ReportableErrorOvfParsingException: if XML is
-                unparseable or invalid.
+                unparsable or invalid.
         """
         try:
             root = ElementTree.fromstring(ovf_env_xml)
@@ -1127,6 +1129,12 @@ class OvfEnvXml:
         self.preprovisioned_vm_type = self._parse_property(
             platform_settings,
             "PreprovisionedVMType",
+            required=False,
+        )
+        self.provision_guest_proxy_agent = self._parse_property(
+            platform_settings,
+            "ProvisionGuestProxyAgent",
+            default=False,
             required=False,
         )
 

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -552,7 +552,7 @@ def convert_net_json(network_json=None, known_macs=None):
     There are additional fields that are populated in the network_data.json
     from OpenStack that are not relevant to network_config yaml, so we
     enumerate a dictionary of valid keys for network_yaml and apply filtering
-    to drop these superflous keys from the network_config yaml.
+    to drop these superfluous keys from the network_config yaml.
     """
     if network_json is None:
         return None

--- a/cloudinit/sources/helpers/vmware/imc/config.py
+++ b/cloudinit/sources/helpers/vmware/imc/config.py
@@ -88,7 +88,7 @@ class Config:
 
     @property
     def reset_password(self):
-        """Retreives if the root password needs to be reset."""
+        """Retrieves if the root password needs to be reset."""
         resetPass = self._configFile.get(Config.RESETPASS, "no")
         resetPass = resetPass.lower()
         if resetPass not in ("yes", "no"):

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 def get_metadata(
     distro, url, timeout, retries, sec_between, agent, tmp_dir=None
 ):
-    # Bring up interface (and try untill one works)
+    # Bring up interface (and try until one works)
     exception = RuntimeError("Failed to DHCP")
 
     # Seek iface with DHCP

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -661,7 +661,7 @@ def get_opensshd_version():
 
 
 def get_opensshd_upstream_version():
-    """Get the upstream version of the OpenSSH sshd dameon on the system.
+    """Get the upstream version of the OpenSSH sshd daemon on the system.
 
     This will NOT include the portable number, so if the Ubuntu version looks
     like `1.2p1 Ubuntu-1ubuntu0.1`, then this function would return

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -687,7 +687,7 @@ class Init:
             # Walk the user data
             part_data = {
                 "handlers": c_handlers,
-                # Any new handlers that are encountered get writen here
+                # Any new handlers that are encountered get written here
                 "handlerdir": idir,
                 "data": data,
                 # The default frequency if handlers don't have one

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -58,7 +58,7 @@ class JinjaSyntaxParsingException(TemplateSyntaxError):
         self.source = error.source
 
     def __str__(self):
-        """Avoid jinja2.TemplateSyntaxErrror multi-line __str__ format."""
+        """Avoid jinja2.TemplateSyntaxError multi-line __str__ format."""
         return self.format_error_message(
             syntax_error=self.message,
             line_number=self.lineno,
@@ -71,7 +71,7 @@ class JinjaSyntaxParsingException(TemplateSyntaxError):
         line_number: str,
         line_content: str = "",
     ) -> str:
-        """Avoid jinja2.TemplateSyntaxErrror multi-line __str__ format."""
+        """Avoid jinja2.TemplateSyntaxError multi-line __str__ format."""
         line_content = f": {line_content}" if line_content else ""
         return JinjaSyntaxParsingException.message_template.format(
             syntax_error=syntax_error,

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -51,8 +51,8 @@ DECOMP_TYPES = [
 # Msg header used to track attachments
 ATTACHMENT_FIELD = "Number-Attachments"
 
-# Only the following content types can have there launch index examined
-# in there payload, evey other content type can still provide a header
+# Only the following content types can have their launch index examined
+# in their payload, every other content type can still provide a header
 EXAMINE_FOR_LAUNCH_INDEX = ["text/cloud-config"]
 
 

--- a/config/cloud.cfg.d/05_logging.cfg
+++ b/config/cloud.cfg.d/05_logging.cfg
@@ -1,7 +1,7 @@
-## This yaml formated config file handles setting
+## This yaml formatted config file handles setting
 ## logger information.  The values that are necessary to be set
 ## are seen at the bottom.  The top '_log' are only used to remove
-## redundency in a syslog and fallback-to-file case.
+## redundancy in a syslog and fallback-to-file case.
 ##
 ## The 'log_cfgs' entry defines a list of logger configs
 ## Each entry in the list is tried, and the first one that

--- a/debian/changelog
+++ b/debian/changelog
@@ -11,8 +11,9 @@ cloud-init (23.4.1-0ubuntu1~22.04.3) UNRELEASED; urgency=medium
   * refresh patches:
     - d/p/status-do-not-remove-duplicated-data.patch
     - d/p/status-retain-recoverable-error-exit-code.patch
+  * Upstream snapshot based on upstream/main at c948e418.
 
- -- Brett Holman <brett.holman@canonical.com>  Tue, 13 Feb 2024 13:19:53 -0500
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 14 Feb 2024 18:00:25 -0700
 
 cloud-init (23.4.1-0ubuntu1~22.04.2) jammy; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -6,10 +6,11 @@ cloud-init (23.4.1-0ubuntu1~22.04.3) UNRELEASED; urgency=medium
   * Drop d/p/retain-netplan-world-readable.patch:
     - Limit perms to 600 of /etc/netplan/50-cloud-init.yaml instead of 644
       (LP: #2053157)
+  * d/p/revert-551f560d-cloud-config-after-snap-seeding.patch
+    - Retain systemd ordering cloud-config.service After=snapd.seeded.service
   * refresh patches:
     - d/p/status-do-not-remove-duplicated-data.patch
     - d/p/status-retain-recoverable-error-exit-code.patch
-  * Upstream snapshot based on upstream/main at 33148a07.
 
  -- Brett Holman <brett.holman@canonical.com>  Tue, 13 Feb 2024 13:19:53 -0500
 

--- a/debian/patches/expire-on-hashed-users.patch
+++ b/debian/patches/expire-on-hashed-users.patch
@@ -18,7 +18,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  in cc_set_passwords, hashed passwords will be expired. Previous to 22.3,
 --- a/tests/unittests/config/test_cc_set_passwords.py
 +++ b/tests/unittests/config/test_cc_set_passwords.py
-@@ -190,61 +190,6 @@ class TestSetPasswordsHandle:
+@@ -194,61 +194,6 @@ class TestSetPasswordsHandle:
      @pytest.mark.parametrize(
          "user_cfg",
          [
@@ -80,7 +80,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
              {"expire": "false", "list": ["root:R", "ubuntu:RANDOM"]},
              {
                  "expire": "false",
-@@ -504,6 +449,7 @@ expire_cases = [
+@@ -508,6 +453,7 @@ expire_cases = [
  class TestExpire:
      @pytest.mark.parametrize("cfg", expire_cases)
      def test_expire(self, cfg, mocker, caplog):

--- a/debian/patches/revert-551f560d-cloud-config-after-snap-seeding.patch
+++ b/debian/patches/revert-551f560d-cloud-config-after-snap-seeding.patch
@@ -1,0 +1,338 @@
+Description: Retain systemd ordering cloud-config.service After=snapd.seeded
+ Revert of upstream commit 551f560d which drops After=snapd.seeded.service
+ from cloud-config.service configuration. Stable releases want to retain
+ this behavior.
+Author: chad.smith@canonical.com
+Origin: backport
+Last-Update: 2024-02-14
+--- a/cloudinit/cloud.py
++++ b/cloudinit/cloud.py
+@@ -57,17 +57,6 @@ class Cloud:
+         return copy.deepcopy(self._cfg)
+ 
+     def run(self, name, functor, args, freq=None, clear_on_fail=False):
+-        """Run a function gated by a named semaphore for a desired frequency.
+-
+-        The typical case for this method would be to limit running of the
+-        provided func to a single well-defined frequency:
+-            PER_INSTANCE, PER_BOOT or PER_ONCE
+-
+-        The semaphore provides a gate that persists across cloud-init
+-        boot stage boundaries so multiple modules can share this state
+-        even if they happen to be run in different boot stages or across
+-        reboots.
+-        """
+         return self._runners.run(name, functor, args, freq, clear_on_fail)
+ 
+     def get_template_filename(self, name):
+--- a/cloudinit/config/cc_lxd.py
++++ b/cloudinit/config/cc_lxd.py
+@@ -210,7 +210,6 @@ def handle(name: str, cfg: Config, cloud
+             f" '{type(lxd_cfg).__name__}'"
+         )
+ 
+-    util.wait_for_snap_seeded(cloud)
+     # Grab the configuration
+     init_cfg = lxd_cfg.get("init", {})
+     preseed_str = lxd_cfg.get("preseed", "")
+--- a/cloudinit/config/cc_snap.py
++++ b/cloudinit/config/cc_snap.py
+@@ -191,7 +191,7 @@ def handle(name: str, cfg: Config, cloud
+             "Skipping module named %s, no 'snap' key in configuration", name
+         )
+         return
+-    util.wait_for_snap_seeded(cloud)
++
+     add_assertions(
+         cfgin.get("assertions", []),
+         os.path.join(cloud.paths.get_ipath_cur(), "snapd.assertions"),
+--- a/cloudinit/config/cc_ubuntu_autoinstall.py
++++ b/cloudinit/config/cc_ubuntu_autoinstall.py
+@@ -6,7 +6,6 @@ import logging
+ import re
+ from textwrap import dedent
+ 
+-from cloudinit import util
+ from cloudinit.cloud import Cloud
+ from cloudinit.config import Config
+ from cloudinit.config.schema import (
+@@ -84,7 +83,6 @@ def handle(name: str, cfg: Config, cloud
+         )
+         return
+ 
+-    util.wait_for_snap_seeded(cloud)
+     snap_list, _ = subp(["snap", "list"])
+     installer_present = None
+     for snap_name in LIVE_INSTALLER_SNAPS:
+--- a/cloudinit/util.py
++++ b/cloudinit/util.py
+@@ -65,7 +65,7 @@ from cloudinit import (
+     url_helper,
+     version,
+ )
+-from cloudinit.settings import CFG_BUILTIN, PER_ONCE
++from cloudinit.settings import CFG_BUILTIN
+ 
+ _DNS_REDIRECT_IP = None
+ LOG = logging.getLogger(__name__)
+@@ -3095,18 +3095,6 @@ def wait_for_files(flist, maxwait, naple
+     return need
+ 
+ 
+-def wait_for_snap_seeded(cloud):
+-    """Helper to wait on completion of snap seeding."""
+-
+-    def callback():
+-        if not subp.which("snap"):
+-            LOG.debug("Skipping snap wait, no snap command present")
+-            return
+-        subp.subp(["snap", "wait", "system", "seed.loaded"])
+-
+-    cloud.run("snap-seeded", callback, [], freq=PER_ONCE)
+-
+-
+ def mount_is_read_write(mount_point):
+     """Check whether the given mount point is mounted rw"""
+     result = get_mount_info(mount_point, get_mnt_opts=True)
+--- a/systemd/cloud-config.service.tmpl
++++ b/systemd/cloud-config.service.tmpl
+@@ -2,6 +2,7 @@
+ [Unit]
+ Description=Apply the settings specified in cloud-config
+ After=network-online.target cloud-config.target
++After=snapd.seeded.service
+ Before=systemd-user-sessions.service
+ Wants=network-online.target cloud-config.target
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+--- a/tests/integration_tests/modules/test_frequency_override.py
++++ b/tests/integration_tests/modules/test_frequency_override.py
+@@ -1,7 +1,6 @@
+ import pytest
+ 
+ from tests.integration_tests.instances import IntegrationInstance
+-from tests.integration_tests.releases import CURRENT_RELEASE
+ 
+ USER_DATA = """\
+ #cloud-config
+@@ -18,17 +17,6 @@ def test_frequency_override(client: Inte
+         in client.read_from_file("/var/log/cloud-init.log")
+     )
+     assert client.read_from_file("/var/tmp/hi").strip().count("hi") == 1
+-    if CURRENT_RELEASE.os == "ubuntu":
+-        if CURRENT_RELEASE.series in ("focal", "jammy", "lunar", "mantic"):
+-            # Stable series will block on snapd.seeded.service and create a
+-            # semaphore file
+-            assert client.execute("test -f /var/lib/cloud/snap-seeded.once").ok
+-        else:
+-            # Newer series will not block on snapd.seeded.service nor create a
+-            # semaphore file
+-            assert not client.execute(
+-                "test -f /var/lib/cloud/snap-seeded.once"
+-            ).ok
+ 
+     # Change frequency of scripts_user to always
+     config = client.read_from_file("/etc/cloud/cloud.cfg")
+--- a/tests/unittests/config/test_cc_lxd.py
++++ b/tests/unittests/config/test_cc_lxd.py
+@@ -11,8 +11,6 @@ from cloudinit.config.schema import (
+     get_schema,
+     validate_cloudconfig_schema,
+ )
+-from cloudinit.helpers import Paths
+-from cloudinit.util import del_file
+ from tests.unittests import helpers as t_help
+ from tests.unittests.util import get_cloud
+ 
+@@ -46,9 +44,7 @@ class TestLxd(t_help.CiTestCase):
+     )
+     def test_lxd_init(self, maybe_clean, which, subp, exists, system_info):
+         system_info.return_value = {"uname": [0, 1, "mykernel"]}
+-        tmpdir = self.tmp_dir()
+-        sem_file = f"{tmpdir}/sem/snap_seeded.once"
+-        cc = get_cloud(mocked_distro=True, paths=Paths({"cloud_dir": tmpdir}))
++        cc = get_cloud(mocked_distro=True)
+         install = cc.distro.install_packages
+ 
+         for backend, cmd, package in BACKEND_DEF:
+@@ -88,23 +84,21 @@ class TestLxd(t_help.CiTestCase):
+             if backend == "lvm":
+                 self.assertEqual(
+                     [
+-                        mock.call(sem_file),
+                         mock.call(
+                             "/lib/modules/mykernel/"
+                             "kernel/drivers/md/dm-thin-pool.ko"
+-                        ),
++                        )
+                     ],
+                     exists.call_args_list,
+                 )
+             else:
+-                self.assertEqual([mock.call(sem_file)], exists.call_args_list)
+-            del_file(sem_file)
++                self.assertEqual([], exists.call_args_list)
+ 
+     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
+     @mock.patch("cloudinit.config.cc_lxd.subp")
+     @mock.patch("cloudinit.config.cc_lxd.subp.which", return_value=False)
+     def test_lxd_install(self, m_which, mock_subp, m_maybe_clean):
+-        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
++        cc = get_cloud()
+         cc.distro = mock.MagicMock()
+         mock_subp.which.return_value = None
+         cc_lxd.handle("cc_lxd", LXD_INIT_CFG, cc, [])
+@@ -118,7 +112,7 @@ class TestLxd(t_help.CiTestCase):
+     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
+     @mock.patch("cloudinit.config.cc_lxd.subp")
+     def test_no_init_does_nothing(self, mock_subp, m_maybe_clean):
+-        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
++        cc = get_cloud()
+         cc.distro = mock.MagicMock()
+         cc_lxd.handle("cc_lxd", {"lxd": {}}, cc, [])
+         self.assertFalse(cc.distro.install_packages.called)
+@@ -128,17 +122,16 @@ class TestLxd(t_help.CiTestCase):
+     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
+     @mock.patch("cloudinit.config.cc_lxd.subp")
+     def test_no_lxd_does_nothing(self, mock_subp, m_maybe_clean):
+-        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
++        cc = get_cloud()
+         cc.distro = mock.MagicMock()
+         cc_lxd.handle("cc_lxd", {"package_update": True}, cc, [])
+         self.assertFalse(cc.distro.install_packages.called)
+         self.assertFalse(mock_subp.subp.called)
+         self.assertFalse(m_maybe_clean.called)
+ 
+-    @mock.patch("cloudinit.config.cc_lxd.util.wait_for_snap_seeded")
+     @mock.patch("cloudinit.config.cc_lxd.subp")
+-    def test_lxd_preseed(self, mock_subp, wait_for_snap_seeded):
+-        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
++    def test_lxd_preseed(self, mock_subp):
++        cc = get_cloud()
+         cc.distro = mock.MagicMock()
+         cc_lxd.handle(
+             "cc_lxd",
+@@ -153,7 +146,6 @@ class TestLxd(t_help.CiTestCase):
+             ],
+             mock_subp.subp.call_args_list,
+         )
+-        wait_for_snap_seeded.assert_called_once_with(cc)
+ 
+     def test_lxd_debconf_new_full(self):
+         data = {
+--- a/tests/unittests/config/test_cc_snap.py
++++ b/tests/unittests/config/test_cc_snap.py
+@@ -301,11 +301,8 @@ class TestSnapSchema:
+ 
+ 
+ class TestHandle:
+-    @mock.patch("cloudinit.util.wait_for_snap_seeded")
+     @mock.patch("cloudinit.config.cc_snap.subp.subp")
+-    def test_handle_adds_assertions(
+-        self, m_subp, wait_for_snap_seeded, fake_cloud, tmpdir
+-    ):
++    def test_handle_adds_assertions(self, m_subp, fake_cloud, tmpdir):
+         """Any configured snap assertions are provided to add_assertions."""
+         assert_file = os.path.join(
+             fake_cloud.paths.get_ipath_cur(), "snapd.assertions"
+@@ -320,4 +317,3 @@ class TestHandle:
+         assert util.load_text_file(compare_file) == util.load_text_file(
+             assert_file
+         )
+-        wait_for_snap_seeded.assert_called_once_with(fake_cloud)
+--- a/tests/unittests/config/test_cc_ubuntu_autoinstall.py
++++ b/tests/unittests/config/test_cc_ubuntu_autoinstall.py
+@@ -11,7 +11,6 @@ from cloudinit.config.schema import (
+     get_schema,
+     validate_cloudconfig_schema,
+ )
+-from cloudinit.helpers import Paths
+ from tests.unittests.helpers import skipUnlessJsonSchema
+ from tests.unittests.util import get_cloud
+ 
+@@ -65,20 +64,18 @@ class TestvalidateConfigSchema:
+             cc_ubuntu_autoinstall.validate_config_schema(src_cfg)
+ 
+ 
+-@mock.patch(MODPATH + "util.wait_for_snap_seeded")
+ @mock.patch(MODPATH + "subp")
+ class TestHandleAutoinstall:
+     """Test cc_ubuntu_autoinstall handling of config."""
+ 
+     @pytest.mark.parametrize(
+-        "cfg,snap_list,subp_calls,logs,snap_wait_called",
++        "cfg,snap_list,subp_calls,logs",
+         [
+             pytest.param(
+                 {},
+                 SAMPLE_SNAP_LIST_OUTPUT,
+                 [],
+                 ["Skipping module named name, no 'autoinstall' key"],
+-                False,
+                 id="skip_no_cfg",
+             ),
+             pytest.param(
+@@ -90,7 +87,6 @@ class TestHandleAutoinstall:
+                     " installer snap packages to be present: subiquity,"
+                     " ubuntu-desktop-installer"
+                 ],
+-                True,
+                 id="valid_autoinstall_schema_checks_snaps",
+             ),
+             pytest.param(
+@@ -101,7 +97,6 @@ class TestHandleAutoinstall:
+                     "Valid autoinstall schema. Config will be processed by"
+                     " subiquity"
+                 ],
+-                True,
+                 id="valid_autoinstall_schema_sees_subiquity",
+             ),
+             pytest.param(
+@@ -112,33 +107,19 @@ class TestHandleAutoinstall:
+                     "Valid autoinstall schema. Config will be processed by"
+                     " ubuntu-desktop-installer"
+                 ],
+-                True,
+                 id="valid_autoinstall_schema_sees_desktop_installer",
+             ),
+         ],
+     )
+     def test_handle_autoinstall_cfg(
+-        self,
+-        subp,
+-        wait_for_snap_seeded,
+-        cfg,
+-        snap_list,
+-        subp_calls,
+-        logs,
+-        snap_wait_called,
+-        caplog,
+-        tmpdir,
++        self, subp, cfg, snap_list, subp_calls, logs, caplog
+     ):
+         subp.return_value = snap_list, ""
+-        cloud = get_cloud(distro="ubuntu", paths=Paths({"cloud_dir": tmpdir}))
++        cloud = get_cloud(distro="ubuntu")
+         cc_ubuntu_autoinstall.handle("name", cfg, cloud, None)
+         assert subp_calls == subp.call_args_list
+         for log in logs:
+             assert log in caplog.text
+-        if snap_wait_called:
+-            wait_for_snap_seeded.assert_called_once_with(cloud)
+-        else:
+-            wait_for_snap_seeded.assert_not_called()
+ 
+ 
+ class TestAutoInstallSchema:
+--- a/tests/unittests/util.py
++++ b/tests/unittests/util.py
+@@ -33,9 +33,7 @@ def get_cloud(
+         myds.metadata.update(metadata)
+     if paths:
+         paths.datasource = myds
+-    return cloud.Cloud(
+-        myds, paths, sys_cfg, mydist, runners=helpers.Runners(paths)
+-    )
++    return cloud.Cloud(myds, paths, sys_cfg, mydist, None)
+ 
+ 
+ def abstract_to_concrete(abclass):

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,5 +1,6 @@
 expire-on-hashed-users.patch
 retain-old-groups.patch
+revert-551f560d-cloud-config-after-snap-seeding.patch
 do-not-block-user-login.patch
 status-do-not-remove-duplicated-data.patch
 retain-apt-pre-deb822.patch

--- a/doc/examples/cloud-config-lxd.txt
+++ b/doc/examples/cloud-config-lxd.txt
@@ -49,7 +49,7 @@ lxd:
     domain: lxd
 
 
-# The simplist working configuration is
+# The simplest working configuration is
 # lxd:
 #  init:
 #   storage_backend: dir

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -264,7 +264,7 @@ resize_rootfs: True
 #
 #  * fqdn:
 #      this option will be used wherever 'fqdn' is needed.
-#      simply substitue it in the description above.
+#      simply substitute it in the description above.
 #      default: fqdn as returned by the metadata service.  on EC2 'hostname'
 #               is used, so this is like: ip-10-244-170-199.ec2.internal
 #

--- a/doc/rtd/development/summit/2023_summit.rst
+++ b/doc/rtd/development/summit/2023_summit.rst
@@ -58,8 +58,8 @@ Thanks to all our presenters; Mina Galic (FreeBSD) and Dermot Bradley
 Catherine Redfield, Alberto Contreras, Sally Makin, John Chittum, Daniel
 Bungert and Chad Smith. You really helped to make this event a success.
 
-Presentation take-aways
------------------------
+Presentation takeaways
+----------------------
 
 * **Integration-testing tour/demo**: James showed how Canonical uses our
   integration tests and pycloudlib during SRU verification, and demonstrated

--- a/doc/rtd/explanation/events.rst
+++ b/doc/rtd/explanation/events.rst
@@ -72,9 +72,10 @@ metadata, ``cloud-init`` will also bring up/down the newly added interface.
 
 .. warning::
    Due to its use of ``systemd`` sockets, ``hotplug`` functionality is
-   currently incompatible with SELinux. This issue is being `tracked
-   in GitHub #3890`_. Additionally, ``hotplug`` support is considered
-   experimental for non-Debian-based systems.
+   currently incompatible with SELinux on Linux distributions using systemd.
+   This issue is being `tracked in GitHub #3890`_. Additionally, ``hotplug``
+   support is considered experimental for non-Alpine and non-Debian-based
+   systems.
 
 Example
 =======
@@ -92,4 +93,4 @@ On every boot, apply network configuration found in the datasource.
        when: ['boot']
 
 .. _Cloud-init: https://launchpad.net/cloud-init
-.. _tracked in Github #3890: https://github.com/canonical/cloud-init/issues/3890
+.. _tracked in GitHub #3890: https://github.com/canonical/cloud-init/issues/3890

--- a/doc/rtd/explanation/instancedata.rst
+++ b/doc/rtd/explanation/instancedata.rst
@@ -232,7 +232,7 @@ represents the data collected by ``cloudinit.util.system_info``.
 
 This is a cloud-init configuration key present in :file:`/etc/cloud/cloud.cfg`
 which describes cloud-init's configured `default_user`, `distro`, `network`
-renderes, and `paths` that cloud-init will use. Not to be confused with the
+renderers, and `paths` that cloud-init will use. Not to be confused with the
 underlying host ``sys_info`` key above.
 
 ``v1``

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -85,7 +85,7 @@ re-run all stages as it did on first boot.
 
    Cloud-init provides the directory :file:`/etc/cloud/clean.d/` for third party
    applications which need additional configuration artifact cleanup from
-   the fileystem when the `clean` command is invoked.
+   the filesystem when the `clean` command is invoked.
 
    The :command:`clean` operation is typically performed by image creators
    when preparing a golden image for clone and redeployment. The clean command

--- a/doc/rtd/reference/datasources/ec2.rst
+++ b/doc/rtd/reference/datasources/ec2.rst
@@ -150,4 +150,11 @@ Notes
    For example: the primary NIC will have a DHCP route-metric of 100,
    the next NIC will have 200.
 
+ * For EC2 instances with multiple NICs, policy-based routing will be
+   configured on secondary NICs / secondary IPs to ensure outgoing packets
+   are routed via the correct interface.
+   This network configuration is only applied on distros using Netplan and
+   at first boot only but it can be configured to be applied on every boot
+   and when NICs are hotplugged, see :ref:`events`.
+
 .. _EC2 tags user guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS

--- a/doc/rtd/reference/datasources/nocloud.rst
+++ b/doc/rtd/reference/datasources/nocloud.rst
@@ -141,7 +141,7 @@ sufficient disk by following the following example.
 .. code-block:: sh
 
    $ echo -e "instance-id: iid-local01\nlocal-hostname: cloudimg" > meta-data
-   $ echo -e "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\n" > user-data
+   $ echo -e "#cloud-config\npassword: passw0rd\nchpasswd: { expire: False }\nssh_pwauth: True\ncreate_hostname_file: true\n" > user-data
 
 2. At this stage you have three options:
 

--- a/doc/rtd/reference/datasources/smartos.rst
+++ b/doc/rtd/reference/datasources/smartos.rst
@@ -164,7 +164,7 @@ The SmartOS datasource has built-in cloud-config which instructs the
 
 You can control the ``disk_setup`` in 2 ways:
 
-1. Through the datasource config, you can change the 'alias' of ``ephermeral0``
+1. Through the datasource config, you can change the 'alias' of ``ephemeral0``
    to reference another device. The default is:
 
    .. code-block::

--- a/doc/rtd/tutorial/qemu-script.sh
+++ b/doc/rtd/tutorial/qemu-script.sh
@@ -21,7 +21,6 @@ EOF
 
 cat << EOF > meta-data
 instance-id: someid/somehostname
-local-hostname: jammy
 EOF
 
 touch vendor-data

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -143,7 +143,6 @@ Now let's run the following command, which creates a file named
 
     $ cat << EOF > meta-data
     instance-id: someid/somehostname
-    local-hostname: jammy
 
     EOF
 

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -109,7 +109,8 @@ def write_debian_folder(root, templ_data, cloud_util_deps):
     # We consolidate all deps as Build-Depends as our package build runs all
     # tests so we need all runtime dependencies anyway.
     # NOTE: python package was moved to the front after debuild -S would fail
-    # with 'Please add apropriate interpreter' errors (as in debian bug 861132)
+    # with 'Please add appropriate interpreter' errors
+    # (as in debian bug 861132)
     requires.extend(["python3"] + reqs + test_reqs)
     if templ_data["debian_release"] in (
         "buster",

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ requests
 jsonpatch
 
 # For validating cloud-config sections per schema definitions
-jsonschema<=4.20.0
+jsonschema
 
 # Used by DataSourceVMware to inspect the host's network configuration during
 # the "setup()" function.

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,7 @@ INITSYS_FILES = {
     "sysvinit_openrc": lambda: [
         f for f in glob("sysvinit/gentoo/*") if is_f(f)
     ],
+    "sysvinit_openrc.dep": lambda: ["tools/cloud-init-hotplugd"],
     "systemd": lambda: [
         render_tmpl(f)
         for f in (
@@ -164,6 +165,7 @@ INITSYS_ROOTS = {
     "sysvinit_openbsd": "etc/rc.d",
     "sysvinit_deb": "etc/init.d",
     "sysvinit_openrc": "etc/init.d",
+    "sysvinit_openrc.dep": "usr/lib/cloud-init",
     "systemd": pkg_config_read("systemd", "systemdsystemunitdir"),
     "systemd.generators": pkg_config_read(
         "systemd", "systemdsystemgeneratordir"

--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -2,7 +2,6 @@
 [Unit]
 Description=Apply the settings specified in cloud-config
 After=network-online.target cloud-config.target
-After=snapd.seeded.service
 Before=systemd-user-sessions.service
 Wants=network-online.target cloud-config.target
 ConditionPathExists=!/etc/cloud/cloud-init.disabled

--- a/systemd/cloud-init-hotplugd.service
+++ b/systemd/cloud-init-hotplugd.service
@@ -1,6 +1,6 @@
 # Paired with cloud-init-hotplugd.socket to read from the FIFO
 # /run/cloud-init/hook-hotplug-cmd which is created during a udev network
-# add or remove event as processed by 10-cloud-init-hook-hotplug.rules.
+# add or remove event as processed by 90-cloud-init-hook-hotplug.rules.
 
 # On start, read args from the FIFO, process and provide structured arguments
 # to `cloud-init devel hotplug-hook` which will setup or teardown network

--- a/systemd/cloud-init-hotplugd.socket
+++ b/systemd/cloud-init-hotplugd.socket
@@ -1,6 +1,6 @@
 # cloud-init-hotplugd.socket listens on the FIFO file
 # /run/cloud-init/hook-hotplug-cmd which is created during a udev network
-# add or remove event as processed by 10-cloud-init-hook-hotplug.rules.
+# add or remove event as processed by 90-cloud-init-hook-hotplug.rules.
 
 # Known bug with an enforcing SELinux policy: LP: #1936229
 [Unit]

--- a/sysvinit/gentoo/cloud-init-hotplug
+++ b/sysvinit/gentoo/cloud-init-hotplug
@@ -1,0 +1,23 @@
+#!/sbin/openrc-run
+
+description="cloud-init hotplug daemon"
+
+command="/usr/lib/cloud-init/cloud-init-hotplugd"
+pidfile="/run/$RC_SVCNAME.pid"
+
+depend() {
+  after cloud-final
+}
+
+start() {
+  if grep -q 'cloud-init=disabled' /proc/cmdline; then
+    ewarn "$RC_SVCNAME is disabled via /proc/cmdline."
+  elif test -e /etc/cloud/cloud-init.disabled; then
+    ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
+  else
+    ebegin "$description"
+    start-stop-daemon --start --background --exec $command \
+      --make-pidfile --pidfile $pidfile
+    eend $?
+  fi
+}

--- a/templates/chrony.conf.cos.tmpl
+++ b/templates/chrony.conf.cos.tmpl
@@ -1,6 +1,6 @@
 ## template:jinja
 # Welcome to the chrony configuration file. See chrony.conf(5) for more
-# information about usuable directives.
+# information about usable directives.
 
 {% if pools %}# pools
 {% endif %}

--- a/templates/chrony.conf.debian.tmpl
+++ b/templates/chrony.conf.debian.tmpl
@@ -1,6 +1,6 @@
 ## template:jinja
 # Welcome to the chrony configuration file. See chrony.conf(5) for more
-# information about usuable directives.
+# information about usable directives.
 {% if pools %}# pools
 {% endif %}
 {% for pool in pools -%}

--- a/templates/chrony.conf.ubuntu.tmpl
+++ b/templates/chrony.conf.ubuntu.tmpl
@@ -1,6 +1,6 @@
 ## template:jinja
 # Welcome to the chrony configuration file. See chrony.conf(5) for more
-# information about usuable directives.
+# information about usable directives.
 
 # Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
 # on 2011-02-08 (LP: #104525). See http://www.pool.ntp.org/join.html for

--- a/templates/ntp.conf.ubuntu.tmpl
+++ b/templates/ntp.conf.ubuntu.tmpl
@@ -67,7 +67,7 @@ restrict source notrap nomodify noquery
 #disable auth
 #broadcastclient
 
-#Changes recquired to use pps synchonisation as explained in documentation:
+#Changes required to use pps synchronisation as explained in documentation:
 #http://www.ntp.org/ntpfaq/NTP-s-config-adv.htm#AEN3918
 
 #server 127.127.8.1 mode 135 prefer    # Meinberg GPS167 with PPS

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,6 +9,6 @@ pytest!=7.3.2
 pytest-cov
 pytest-mock
 setuptools
-jsonschema<=4.20.0
+jsonschema
 responses
 passlib

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -209,20 +209,24 @@ class Ec2Cloud(IntegrationCloud):
         )
 
     def _perform_launch(
-        self, *, launch_kwargs, wait=True, **kwargs
+        self, *, launch_kwargs, wait=True, enable_ipv6=True, **kwargs
     ) -> EC2Instance:
         """Use a dual-stack VPC for cloud-init integration testing."""
-        if "vpc" not in launch_kwargs:
-            launch_kwargs["vpc"] = self.cloud_instance.get_or_create_vpc(
-                name="ec2-cloud-init-integration"
-            )
-        # Enable IPv6 metadata at http://[fd00:ec2::254]
-        if "Ipv6AddressCount" not in launch_kwargs:
-            launch_kwargs["Ipv6AddressCount"] = 1
-        if "MetadataOptions" not in launch_kwargs:
-            launch_kwargs["MetadataOptions"] = {}
-        if "HttpProtocolIpv6" not in launch_kwargs["MetadataOptions"]:
-            launch_kwargs["MetadataOptions"] = {"HttpProtocolIpv6": "enabled"}
+        if enable_ipv6:
+            if "vpc" not in launch_kwargs:
+                launch_kwargs["vpc"] = self.cloud_instance.get_or_create_vpc(
+                    name="ec2-cloud-init-integration"
+                )
+
+            # Enable IPv6 metadata at http://[fd00:ec2::254]
+            if "Ipv6AddressCount" not in launch_kwargs:
+                launch_kwargs["Ipv6AddressCount"] = 1
+            if "MetadataOptions" not in launch_kwargs:
+                launch_kwargs["MetadataOptions"] = {}
+            if "HttpProtocolIpv6" not in launch_kwargs["MetadataOptions"]:
+                launch_kwargs["MetadataOptions"] = {
+                    "HttpProtocolIpv6": "enabled"
+                }
 
         pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
         self._maybe_wait(pycloudlib_instance, wait)

--- a/tests/integration_tests/decorators.py
+++ b/tests/integration_tests/decorators.py
@@ -20,7 +20,7 @@ def retry(*, tries: int = 30, delay: int = 1):
             last_error = None
             for _ in range(tries):
                 try:
-                    func(*args, **kwargs)
+                    retval = func(*args, **kwargs)
                     break
                 except Exception as e:
                     last_error = e
@@ -28,6 +28,7 @@ def retry(*, tries: int = 30, delay: int = 1):
             else:
                 if last_error:
                     raise last_error
+            return retval
 
         return wrapper
 

--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -45,10 +45,7 @@ def test_valid_userdata(client: IntegrationInstance):
     assert result.ok
     assert "Valid schema user-data" in result.stdout.strip()
     result = client.execute("cloud-init status --long")
-    # Ubuntu Noble will exit 2 for status due to cloud-init's warning about
-    # disabling /etc/apt/sources.list in favor of deb822 sources
-    return_code = 2 if CURRENT_RELEASE.series == "noble" else 0
-    assert return_code == result.return_code, (
+    assert 0 == result.return_code, (
         f"Unexpected exit {result.return_code} from cloud-init status:"
         f" {result}"
     )

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -1,12 +1,16 @@
+import contextlib
 import time
 from collections import namedtuple
 
 import pytest
 import yaml
 
+from cloudinit.subp import subp
+from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
+from tests.integration_tests.util import verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -59,7 +63,7 @@ def test_hotplug_add_remove(client: IntegrationInstance):
     log = client.read_from_file("/var/log/cloud-init.log")
     assert "Exiting hotplug handler" not in log
     assert client.execute(
-        "test -f /etc/udev/rules.d/10-cloud-init-hook-hotplug.rules"
+        "test -f /etc/udev/rules.d/90-cloud-init-hook-hotplug.rules"
     ).ok
 
     # Add new NIC
@@ -105,7 +109,7 @@ def test_no_hotplug_in_userdata(client: IntegrationInstance):
     log = client.read_from_file("/var/log/cloud-init.log")
     assert "Exiting hotplug handler" not in log
     assert client.execute(
-        "test -f /etc/udev/rules.d/10-cloud-init-hook-hotplug.rules"
+        "test -f /etc/udev/rules.d/90-cloud-init-hook-hotplug.rules"
     ).failed
 
     # Add new NIC
@@ -122,5 +126,120 @@ def test_no_hotplug_in_userdata(client: IntegrationInstance):
         assert len(ips_after_add) == len(ips_before)
 
     assert "disabled" == client.execute(
+        "cloud-init devel hotplug-hook -s net query"
+    )
+
+
+@pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")
+def test_multi_nic_hotplug(setup_image, session_cloud: IntegrationCloud):
+    """Tests that additional secondary NICs are routable from non-local
+    networks after the hotplug hook is executed when network updates
+    are configured on the HOTPLUG event."""
+    ec2 = session_cloud.cloud_instance.client
+    with session_cloud.launch(launch_kwargs={}, user_data=USER_DATA) as client:
+        ips_before = _get_ip_addr(client)
+        instance_pub_ip = client.instance.ip
+        secondary_priv_ip = client.instance.add_network_interface()
+        response = ec2.describe_network_interfaces(
+            Filters=[
+                {
+                    "Name": "private-ip-address",
+                    "Values": [secondary_priv_ip],
+                },
+            ],
+        )
+        nic_id = response["NetworkInterfaces"][0]["NetworkInterfaceId"]
+
+        # Create Elastic IP
+        # Refactor after https://github.com/canonical/pycloudlib/issues/337 is
+        # completed
+        allocation = ec2.allocate_address(Domain="vpc")
+        try:
+            secondary_pub_ip = allocation["PublicIp"]
+            association = ec2.associate_address(
+                AllocationId=allocation["AllocationId"],
+                NetworkInterfaceId=nic_id,
+            )
+            assert association["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+            _wait_till_hotplug_complete(client)
+
+            log_content = client.read_from_file("/var/log/cloud-init.log")
+            verify_clean_log(log_content)
+
+            ips_after_add = _get_ip_addr(client)
+
+            netplan_cfg = client.read_from_file(
+                "/etc/netplan/50-cloud-init.yaml"
+            )
+            config = yaml.safe_load(netplan_cfg)
+            new_addition = [
+                ip for ip in ips_after_add if ip.ip4 == secondary_priv_ip
+            ][0]
+            assert new_addition.interface in config["network"]["ethernets"]
+            new_nic_cfg = config["network"]["ethernets"][
+                new_addition.interface
+            ]
+            assert "routing-policy" in new_nic_cfg
+            assert [{"from": secondary_priv_ip, "table": 101}] == new_nic_cfg[
+                "routing-policy"
+            ]
+
+            assert len(ips_after_add) == len(ips_before) + 1
+
+            # SSH over primary NIC works
+            subp("nc -w 5 -zv " + instance_pub_ip + " 22", shell=True)
+
+            # THE TEST: SSH over secondary NIC works
+            subp("nc -w 5 -zv " + secondary_pub_ip + " 22", shell=True)
+
+            # Remove new NIC
+            client.instance.remove_network_interface(secondary_priv_ip)
+            _wait_till_hotplug_complete(client, expected_runs=2)
+
+            # SSH over primary NIC works
+            subp("nc -w 1 -zv " + instance_pub_ip + " 22", shell=True)
+
+            ips_after_remove = _get_ip_addr(client)
+            assert len(ips_after_remove) == len(ips_before)
+            assert secondary_priv_ip not in [ip.ip4 for ip in ips_after_remove]
+
+            netplan_cfg = client.read_from_file(
+                "/etc/netplan/50-cloud-init.yaml"
+            )
+            config = yaml.safe_load(netplan_cfg)
+            assert new_addition.interface not in config["network"]["ethernets"]
+
+            log_content = client.read_from_file("/var/log/cloud-init.log")
+            verify_clean_log(log_content)
+        finally:
+            with contextlib.suppress(Exception):
+                ec2.disassociate_address(
+                    AssociationId=association["AssociationId"]
+                )
+            with contextlib.suppress(Exception):
+                ec2.release_address(AllocationId=allocation["AllocationId"])
+
+
+@pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")
+@pytest.mark.user_data(USER_DATA)
+def test_no_hotplug_triggered_by_docker(client: IntegrationInstance):
+    # Install docker
+    r = client.execute("curl -fsSL https://get.docker.com | sh")
+    assert r.ok, r.stderr
+
+    # Start and stop a container
+    r = client.execute("docker run -dit --name ff ubuntu:focal")
+    assert r.ok, r.stderr
+    r = client.execute("docker stop ff")
+    assert r.ok, r.stderr
+
+    # Verify hotplug-hook was not called
+    log = client.read_from_file("/var/log/cloud-init.log")
+    assert "Exiting hotplug handler" not in log
+    assert "hotplug-hook" not in log
+
+    # Verify hotplug was enabled
+    assert "enabled" == client.execute(
         "cloud-init devel hotplug-hook -s net query"
     )

--- a/tests/integration_tests/net/test_dhcp.py
+++ b/tests/integration_tests/net/test_dhcp.py
@@ -55,13 +55,13 @@ class TestDHCP:
     )
     def test_noble_and_newer_force_client(self, client, dhcp_client, package):
         """force noble to use dhcpcd and test that it worked"""
-        client.execute(f"apt install -yq {package}")
-        client.execute(
+        assert client.execute(f"apt update && apt install -yq {package}").ok
+        assert client.execute(
             "sed -i 's|"
             "dhcp_client_priority.*$"
             f"|dhcp_client_priority: [{dhcp_client}]"
             "|' /etc/cloud/cloud.cfg"
-        )
+        ).ok
         client.execute("cloud-init clean --logs")
         client.restart()
         log = client.read_from_file("/var/log/cloud-init.log")

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -1,7 +1,11 @@
 """Networking-related tests."""
+import contextlib
+import json
+
 import pytest
 import yaml
 
+from cloudinit.subp import subp
 from tests.integration_tests import random_mac_address
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
@@ -13,6 +17,7 @@ from tests.integration_tests.releases import (
     MANTIC,
     NOBLE,
 )
+from tests.integration_tests.util import verify_clean_log
 
 
 def _add_dummy_bridge_to_netplan(client: IntegrationInstance):
@@ -282,3 +287,220 @@ def test_invalid_network_v2_netplan(
                 "# E1: Invalid netplan schema. Error in network definition:"
                 " invalid boolean value 'badval"
             ) in client.execute("cloud-init schema --system --annotate")
+
+
+@pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")
+def test_ec2_multi_nic_reboot(setup_image, session_cloud: IntegrationCloud):
+    """Tests that additional secondary NICs and secondary IPs on them are
+    routable from non-local networks after a reboot event when network updates
+    are configured on every boot."""
+    ec2 = session_cloud.cloud_instance.client
+    with session_cloud.launch(launch_kwargs={}, user_data=USER_DATA) as client:
+        # Add secondary NIC
+        secondary_priv_ip_0 = client.instance.add_network_interface()
+        response = ec2.describe_network_interfaces(
+            Filters=[
+                {
+                    "Name": "private-ip-address",
+                    "Values": [secondary_priv_ip_0],
+                },
+            ],
+        )
+        nic_id = response["NetworkInterfaces"][0]["NetworkInterfaceId"]
+        # Add secondary IP to secondary NIC
+        association_0 = ec2.assign_private_ip_addresses(
+            NetworkInterfaceId=nic_id, SecondaryPrivateIpAddressCount=1
+        )
+        assert association_0["ResponseMetadata"]["HTTPStatusCode"] == 200
+        secondary_priv_ip_1 = association_0["AssignedPrivateIpAddresses"][0][
+            "PrivateIpAddress"
+        ]
+
+        # Assing elastic IPs
+        # Refactor after https://github.com/canonical/pycloudlib/issues/337 is
+        # completed
+        allocation_0 = ec2.allocate_address(Domain="vpc")
+        allocation_1 = ec2.allocate_address(Domain="vpc")
+        try:
+            secondary_pub_ip_0 = allocation_0["PublicIp"]
+            secondary_pub_ip_1 = allocation_1["PublicIp"]
+
+            association_0 = ec2.associate_address(
+                AllocationId=allocation_0["AllocationId"],
+                NetworkInterfaceId=nic_id,
+                PrivateIpAddress=secondary_priv_ip_0,
+            )
+            assert association_0["ResponseMetadata"]["HTTPStatusCode"] == 200
+            association_1 = ec2.associate_address(
+                AllocationId=allocation_1["AllocationId"],
+                NetworkInterfaceId=nic_id,
+                PrivateIpAddress=secondary_priv_ip_1,
+            )
+            assert association_1["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+            # Reboot to update network config
+            client.execute("cloud-init clean --logs")
+            client.restart()
+
+            log_content = client.read_from_file("/var/log/cloud-init.log")
+            verify_clean_log(log_content)
+
+            # SSH over primary NIC works
+            instance_pub_ip = client.instance.ip
+            subp("nc -w 5 -zv " + instance_pub_ip + " 22", shell=True)
+
+            # SSH over secondary NIC works
+            subp("nc -w 5 -zv " + secondary_pub_ip_0 + " 22", shell=True)
+            subp("nc -w 5 -zv " + secondary_pub_ip_1 + " 22", shell=True)
+        finally:
+            with contextlib.suppress(Exception):
+                ec2.disassociate_address(
+                    AssociationId=association_0["AssociationId"]
+                )
+            with contextlib.suppress(Exception):
+                ec2.release_address(AllocationId=allocation_0["AllocationId"])
+            with contextlib.suppress(Exception):
+                ec2.disassociate_address(
+                    AssociationId=association_1["AssociationId"]
+                )
+            with contextlib.suppress(Exception):
+                ec2.release_address(AllocationId=allocation_1["AllocationId"])
+
+
+@pytest.mark.adhoc  # costly instance not available in all regions / azs
+@pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")
+def test_ec2_multi_network_cards(setup_image, session_cloud: IntegrationCloud):
+    """
+    Tests that with an interface type with multiple network cards (non unique
+    device indexes).
+
+    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html
+    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/p5-efa.html
+    """
+    ec2 = session_cloud.cloud_instance.client
+
+    vpc = session_cloud.cloud_instance.get_or_create_vpc(
+        name="ec2-cloud-init-integration"
+    )
+    [subnet_id] = [s.id for s in vpc.vpc.subnets.all()]
+    security_group_ids = [sg.id for sg in vpc.vpc.security_groups.all()]
+
+    launch_kwargs = {
+        "InstanceType": "p5.48xlarge",
+        "NetworkInterfaces": [
+            {
+                "NetworkCardIndex": 0,
+                "DeviceIndex": 0,
+                "InterfaceType": "efa",
+                "DeleteOnTermination": True,
+                "Groups": security_group_ids,
+                "SubnetId": subnet_id,
+            },
+            {
+                "NetworkCardIndex": 1,
+                "DeviceIndex": 1,
+                "InterfaceType": "efa",
+                "DeleteOnTermination": True,
+                "Groups": security_group_ids,
+                "SubnetId": subnet_id,
+            },
+            {
+                "NetworkCardIndex": 2,
+                "DeviceIndex": 1,
+                "InterfaceType": "efa",
+                "DeleteOnTermination": True,
+                "Groups": security_group_ids,
+                "SubnetId": subnet_id,
+            },
+        ],
+    }
+    # Instances with this network setups do not get a public ip.
+    # Do not wait until we associate one to the primary interface so that we
+    # can interact with it.
+    with session_cloud.launch(
+        launch_kwargs=launch_kwargs,
+        user_data=USER_DATA,
+        enable_ipv6=False,
+        wait=False,
+    ) as client:
+        client.instance._instance.wait_until_running(
+            Filters=[
+                {
+                    "Name": "instance-id",
+                    "Values": [client.instance.id],
+                }
+            ]
+        )
+
+        network_interfaces = iter(
+            ec2.describe_network_interfaces(
+                Filters=[
+                    {
+                        "Name": "attachment.instance-id",
+                        "Values": [client.instance.id],
+                    }
+                ]
+            )["NetworkInterfaces"]
+        )
+        nic_id_0 = next(network_interfaces)["NetworkInterfaceId"]
+
+        try:
+            allocation_0 = ec2.allocate_address(Domain="vpc")
+            association_0 = ec2.associate_address(
+                AllocationId=allocation_0["AllocationId"],
+                NetworkInterfaceId=nic_id_0,
+            )
+            assert association_0["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+            result = client.execute(
+                "cloud-init query ds.meta-data.network.interfaces.macs"
+            )
+            assert result.ok, result.stderr
+            for _macs, net_metadata in json.load(result.stdout):
+                assert "network-card" in net_metadata
+
+            nic_id_1 = next(network_interfaces)["NetworkInterfaceId"]
+            allocation_1 = ec2.allocate_address(Domain="vpc")
+            association_1 = ec2.associate_address(
+                AllocationId=allocation_1["AllocationId"],
+                NetworkInterfaceId=nic_id_1,
+            )
+            assert association_1["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+            nic_id_2 = next(network_interfaces)["NetworkInterfaceId"]
+            allocation_2 = ec2.allocate_address(Domain="vpc")
+            association_2 = ec2.associate_address(
+                AllocationId=allocation_2["AllocationId"],
+                NetworkInterfaceId=nic_id_2,
+            )
+            assert association_2["ResponseMetadata"]["HTTPStatusCode"] == 200
+
+            # Reboot to update network config
+            client.execute("cloud-init clean --logs")
+            client.restart()
+
+            log_content = client.read_from_file("/var/log/cloud-init.log")
+            verify_clean_log(log_content)
+
+            # SSH over secondary NICs works
+            subp("nc -w 5 -zv " + allocation_1["PublicIp"] + " 22", shell=True)
+            subp("nc -w 5 -zv " + allocation_2["PublicIp"] + " 22", shell=True)
+        finally:
+            with contextlib.suppress(Exception):
+                ec2.disassociate_address(
+                    AssociationId=association_0["AssociationId"]
+                )
+            with contextlib.suppress(Exception):
+                ec2.release_address(AllocationId=allocation_0["AllocationId"])
+            with contextlib.suppress(Exception):
+                ec2.disassociate_address(
+                    AssociationId=association_1["AssociationId"]
+                )
+            with contextlib.suppress(Exception):
+                ec2.release_address(AllocationId=allocation_1["AllocationId"])
+            with contextlib.suppress(Exception):
+                ec2.disassociate_address(
+                    AssociationId=association_2["AssociationId"]
+                )
+            with contextlib.suppress(Exception):
+                ec2.release_address(AllocationId=allocation_2["AllocationId"])

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -73,6 +73,10 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         # Old Ubuntu cloud-images contain /etc/apt/sources.list
         "WARNING]: Removing /etc/apt/sources.list to favor deb822 source"
         " format",
+        # https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2041727
+        "WARNING]: Running ['netplan', 'apply'] resulted in stderr output: "
+        "WARNING:root:Cannot call Open vSwitch: ovsdb-server.service is not "
+        "running.",
     ]
     traceback_texts = []
     if "install canonical-livepatch" in log:

--- a/tests/unittests/analyze/test_show.py
+++ b/tests/unittests/analyze/test_show.py
@@ -1,0 +1,24 @@
+from collections import namedtuple
+
+import pytest
+
+from cloudinit.analyze import analyze_show
+
+
+@pytest.fixture
+def mock_io(tmp_path):
+    """Mock args for configure_io function"""
+    infile = tmp_path / "infile"
+    outfile = tmp_path / "outfile"
+    return namedtuple("MockIO", ["infile", "outfile"])(infile, outfile)
+
+
+class TestAnalyzeShow:
+    """Test analyze_show (and/or helpers) in cloudinit/analyze/__init__.py"""
+
+    def test_empty_logfile(self, mock_io, capsys):
+        """Test analyze_show with an empty logfile"""
+        mock_io.infile.write_text("")
+        with pytest.raises(SystemExit):
+            analyze_show("dontcare", mock_io)
+        assert capsys.readouterr().err == f"Empty file {mock_io.infile}\n"

--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -18,6 +18,7 @@ from cloudinit.config.schema import (
     validate_cloudconfig_schema,
 )
 from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
     FilesystemMockingTestCase,
     mock,
     skipUnlessJsonSchema,
@@ -355,7 +356,7 @@ class TestApkConfigureSchema:
             (
                 {"apk_repos": {"alpine_repo": {}}},
                 "apk_repos.alpine_repo: 'version' is a required property,"
-                " apk_repos.alpine_repo: {} does not have enough properties",
+                f" apk_repos.alpine_repo: {{}} {SCHEMA_EMPTY_ERROR}",
             ),
             (
                 {"apk_repos": {"alpine_repo": True}},
@@ -368,7 +369,7 @@ class TestApkConfigureSchema:
             ),
             (
                 {"apk_repos": {}},
-                "apk_repos: {} does not have enough properties",
+                f"apk_repos: {{}} {SCHEMA_EMPTY_ERROR}",
             ),
             (
                 {"apk_repos": {"local_repo_base_url": None}},

--- a/tests/unittests/config/test_cc_apt_configure.py
+++ b/tests/unittests/config/test_cc_apt_configure.py
@@ -15,7 +15,7 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
-from tests.unittests.helpers import skipUnlessJsonSchema
+from tests.unittests.helpers import SCHEMA_EMPTY_ERROR, skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
 
 M_PATH = "cloudinit.config.cc_apt_configure."
@@ -39,7 +39,7 @@ class TestAPTConfigureSchema:
                     " ('boguskey' was unexpected)"
                 ),
             ),
-            ({"apt": {}}, "apt: {} does not have enough properties"),
+            ({"apt": {}}, f"apt: {{}} {SCHEMA_EMPTY_ERROR}"),
             (
                 {"apt": {"preserve_sources_list": 1}},
                 "apt.preserve_sources_list: 1 is not of type 'boolean'",
@@ -50,7 +50,7 @@ class TestAPTConfigureSchema:
             ),
             (
                 {"apt": {"disable_suites": []}},
-                re.escape("apt.disable_suites: [] is too short"),
+                re.escape("apt.disable_suites: [] ") + SCHEMA_EMPTY_ERROR,
             ),
             (
                 {"apt": {"disable_suites": [1]}},
@@ -70,7 +70,7 @@ class TestAPTConfigureSchema:
             ),
             (
                 {"apt": {"primary": []}},
-                re.escape("apt.primary: [] is too short"),
+                re.escape("apt.primary: [] ") + SCHEMA_EMPTY_ERROR,
             ),
             (
                 {"apt": {"primary": ["nonobj"]}},
@@ -107,7 +107,7 @@ class TestAPTConfigureSchema:
             ),
             (
                 {"apt": {"primary": [{"arches": ["amd64"], "search": []}]}},
-                re.escape("apt.primary.0.search: [] is too short"),
+                re.escape("apt.primary.0.search: [] ") + SCHEMA_EMPTY_ERROR,
             ),
             (
                 {
@@ -139,7 +139,7 @@ class TestAPTConfigureSchema:
             ),
             (
                 {"apt": {"debconf_selections": {}}},
-                "apt.debconf_selections: {} does not have enough properties",
+                f"apt.debconf_selections: {{}} {SCHEMA_EMPTY_ERROR}",
             ),
             (
                 {"apt": {"sources_list": True}},
@@ -175,7 +175,7 @@ class TestAPTConfigureSchema:
             ),
             (
                 {"apt": {"sources": {"opaquekey": {}}}},
-                "apt.sources.opaquekey: {} does not have enough properties",
+                f"apt.sources.opaquekey: {{}} {SCHEMA_EMPTY_ERROR}",
             ),
             (
                 {"apt": {"sources": {"opaquekey": {"boguskey": True}}}},

--- a/tests/unittests/config/test_cc_bootcmd.py
+++ b/tests/unittests/config/test_cc_bootcmd.py
@@ -11,7 +11,12 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
-from tests.unittests.helpers import CiTestCase, mock, skipUnlessJsonSchema
+from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
+    CiTestCase,
+    mock,
+    skipUnlessJsonSchema,
+)
 from tests.unittests.util import get_cloud
 
 
@@ -128,12 +133,14 @@ class TestBootCMDSchema:
                 "Cloud config schema errors: bootcmd: 1 is not of type"
                 " 'array'",
             ),
-            ({"bootcmd": []}, re.escape("bootcmd: [] is too short")),
             (
                 {"bootcmd": []},
-                re.escape(
-                    "Cloud config schema errors: bootcmd: [] is too short"
-                ),
+                re.escape("bootcmd: [] ") + SCHEMA_EMPTY_ERROR,
+            ),
+            (
+                {"bootcmd": []},
+                re.escape("Cloud config schema errors: bootcmd: [] ")
+                + SCHEMA_EMPTY_ERROR,
             ),
             (
                 {

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -15,7 +15,11 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
-from tests.unittests.helpers import TestCase, skipUnlessJsonSchema
+from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
+    TestCase,
+    skipUnlessJsonSchema,
+)
 from tests.unittests.util import get_cloud
 
 
@@ -396,7 +400,7 @@ class TestCACertsSchema:
             ),
             (
                 {"ca_certs": {}},
-                re.escape("ca_certs: {} does not have enough properties"),
+                re.escape("ca_certs: {} ") + SCHEMA_EMPTY_ERROR,
             ),
             (
                 {"ca_certs": {"boguskey": 1}},
@@ -415,7 +419,7 @@ class TestCACertsSchema:
             ),
             (
                 {"ca_certs": {"trusted": []}},
-                re.escape("ca_certs.trusted: [] is too short"),
+                re.escape("ca_certs.trusted: [] ") + SCHEMA_EMPTY_ERROR,
             ),
         ),
     )

--- a/tests/unittests/config/test_cc_chef.py
+++ b/tests/unittests/config/test_cc_chef.py
@@ -16,6 +16,7 @@ from cloudinit.config.schema import (
 )
 from tests.helpers import cloud_init_project_dir
 from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
     FilesystemMockingTestCase,
     ResponsesTestCase,
     mock,
@@ -306,7 +307,7 @@ class TestBootCMDSchema:
             ),
             (
                 {"chef": {}},
-                re.escape(" chef: {} does not have enough properties"),
+                re.escape(" chef: {} ") + SCHEMA_EMPTY_ERROR,
             ),
             (
                 {"chef": {"boguskey": True}},
@@ -321,7 +322,7 @@ class TestBootCMDSchema:
             ),
             (
                 {"chef": {"directories": []}},
-                re.escape("chef.directories: [] is too short"),
+                re.escape("chef.directories: [] ") + SCHEMA_EMPTY_ERROR,
             ),
             (
                 {"chef": {"directories": [1]}},

--- a/tests/unittests/config/test_cc_lxd.py
+++ b/tests/unittests/config/test_cc_lxd.py
@@ -11,6 +11,8 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
+from cloudinit.helpers import Paths
+from cloudinit.util import del_file
 from tests.unittests import helpers as t_help
 from tests.unittests.util import get_cloud
 
@@ -44,7 +46,9 @@ class TestLxd(t_help.CiTestCase):
     )
     def test_lxd_init(self, maybe_clean, which, subp, exists, system_info):
         system_info.return_value = {"uname": [0, 1, "mykernel"]}
-        cc = get_cloud(mocked_distro=True)
+        tmpdir = self.tmp_dir()
+        sem_file = f"{tmpdir}/sem/snap_seeded.once"
+        cc = get_cloud(mocked_distro=True, paths=Paths({"cloud_dir": tmpdir}))
         install = cc.distro.install_packages
 
         for backend, cmd, package in BACKEND_DEF:
@@ -84,21 +88,23 @@ class TestLxd(t_help.CiTestCase):
             if backend == "lvm":
                 self.assertEqual(
                     [
+                        mock.call(sem_file),
                         mock.call(
                             "/lib/modules/mykernel/"
                             "kernel/drivers/md/dm-thin-pool.ko"
-                        )
+                        ),
                     ],
                     exists.call_args_list,
                 )
             else:
-                self.assertEqual([], exists.call_args_list)
+                self.assertEqual([mock.call(sem_file)], exists.call_args_list)
+            del_file(sem_file)
 
     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
     @mock.patch("cloudinit.config.cc_lxd.subp")
     @mock.patch("cloudinit.config.cc_lxd.subp.which", return_value=False)
     def test_lxd_install(self, m_which, mock_subp, m_maybe_clean):
-        cc = get_cloud()
+        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
         cc.distro = mock.MagicMock()
         mock_subp.which.return_value = None
         cc_lxd.handle("cc_lxd", LXD_INIT_CFG, cc, [])
@@ -112,7 +118,7 @@ class TestLxd(t_help.CiTestCase):
     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
     @mock.patch("cloudinit.config.cc_lxd.subp")
     def test_no_init_does_nothing(self, mock_subp, m_maybe_clean):
-        cc = get_cloud()
+        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
         cc.distro = mock.MagicMock()
         cc_lxd.handle("cc_lxd", {"lxd": {}}, cc, [])
         self.assertFalse(cc.distro.install_packages.called)
@@ -122,16 +128,17 @@ class TestLxd(t_help.CiTestCase):
     @mock.patch("cloudinit.config.cc_lxd.maybe_cleanup_default")
     @mock.patch("cloudinit.config.cc_lxd.subp")
     def test_no_lxd_does_nothing(self, mock_subp, m_maybe_clean):
-        cc = get_cloud()
+        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
         cc.distro = mock.MagicMock()
         cc_lxd.handle("cc_lxd", {"package_update": True}, cc, [])
         self.assertFalse(cc.distro.install_packages.called)
         self.assertFalse(mock_subp.subp.called)
         self.assertFalse(m_maybe_clean.called)
 
+    @mock.patch("cloudinit.config.cc_lxd.util.wait_for_snap_seeded")
     @mock.patch("cloudinit.config.cc_lxd.subp")
-    def test_lxd_preseed(self, mock_subp):
-        cc = get_cloud()
+    def test_lxd_preseed(self, mock_subp, wait_for_snap_seeded):
+        cc = get_cloud(paths=Paths({"cloud_dir": self.tmp_dir()}))
         cc.distro = mock.MagicMock()
         cc_lxd.handle(
             "cc_lxd",
@@ -146,6 +153,7 @@ class TestLxd(t_help.CiTestCase):
             ],
             mock_subp.subp.call_args_list,
         )
+        wait_for_snap_seeded.assert_called_once_with(cc)
 
     def test_lxd_debconf_new_full(self):
         data = {
@@ -385,7 +393,7 @@ class TestLXDSchema:
             # Require bridge.mode
             ({"lxd": {"bridge": {}}}, "bridge: 'mode' is a required property"),
             # Require init or bridge keys
-            ({"lxd": {}}, "lxd: {} does not have enough properties"),
+            ({"lxd": {}}, f"lxd: {{}} {t_help.SCHEMA_EMPTY_ERROR}"),
             # Require some non-empty preseed config of type string
             ({"lxd": {"preseed": {}}}, "not of type 'string'"),
             ({"lxd": {"preseed": ""}}, None),

--- a/tests/unittests/config/test_cc_mounts.py
+++ b/tests/unittests/config/test_cc_mounts.py
@@ -583,9 +583,15 @@ class TestMountsSchema:
         "config, error_msg",
         [
             # We expect to see one mount if provided in user-data.
-            ({"mounts": []}, re.escape("mounts: [] is too short")),
+            (
+                {"mounts": []},
+                re.escape("mounts: [] ") + test_helpers.SCHEMA_EMPTY_ERROR,
+            ),
             # Disallow less than 1 item per mount entry
-            ({"mounts": [[]]}, re.escape("mounts.0: [] is too short")),
+            (
+                {"mounts": [[]]},
+                re.escape("mounts.0: [] ") + test_helpers.SCHEMA_EMPTY_ERROR,
+            ),
             # Disallow more than 6 items per mount entry
             ({"mounts": [["1"] * 7]}, "mounts.0:.* is too long"),
             # Disallow mount_default_fields will anything other than 6 items

--- a/tests/unittests/config/test_cc_package_update_upgrade_install.py
+++ b/tests/unittests/config/test_cc_package_update_upgrade_install.py
@@ -16,7 +16,11 @@ from cloudinit.config.schema import (
 )
 from cloudinit.distros import PackageInstallerError
 from cloudinit.subp import SubpResult
-from tests.unittests.helpers import does_not_raise, skipUnlessJsonSchema
+from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
+    does_not_raise,
+    skipUnlessJsonSchema,
+)
 from tests.unittests.util import get_cloud
 
 M_PATH = "cloudinit.config.cc_package_update_upgrade_install."
@@ -284,7 +288,7 @@ class TestPackageUpdateUpgradeSchema:
             # packages list with three entries (2 required)
             ({"packages": ["p1", ["p2", "p3", "p4"]]}, ""),
             # empty packages list
-            ({"packages": []}, "is too short"),
+            ({"packages": []}, SCHEMA_EMPTY_ERROR),
             (
                 {"apt_update": False},
                 (

--- a/tests/unittests/config/test_cc_runcmd.py
+++ b/tests/unittests/config/test_cc_runcmd.py
@@ -14,6 +14,7 @@ from cloudinit.config.schema import (
     validate_cloudconfig_schema,
 )
 from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
     FilesystemMockingTestCase,
     skipUnlessJsonSchema,
 )
@@ -92,7 +93,7 @@ class TestRunCmdSchema:
             ({"runcmd": ["echo bye", "echo bye"]}, None),
             # Invalid schemas
             ({"runcmd": 1}, "1 is not of type 'array'"),
-            ({"runcmd": []}, r"runcmd: \[\] is too short"),
+            ({"runcmd": []}, rf"runcmd: \[\] {SCHEMA_EMPTY_ERROR}"),
             (
                 {
                     "runcmd": [

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -12,7 +12,11 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
-from tests.unittests.helpers import does_not_raise, skipUnlessJsonSchema
+from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
+    does_not_raise,
+    skipUnlessJsonSchema,
+)
 from tests.unittests.util import get_cloud
 
 MODPATH = "cloudinit.config.cc_set_passwords."
@@ -718,7 +722,8 @@ class TestSetPasswordsSchema:
             (
                 {"chpasswd": {"list": []}},
                 pytest.raises(
-                    SchemaValidationError, match=r"\[\] is too short"
+                    SchemaValidationError,
+                    match=rf"\[\] {SCHEMA_EMPTY_ERROR}",
                 ),
             ),
         ],

--- a/tests/unittests/config/test_cc_snap.py
+++ b/tests/unittests/config/test_cc_snap.py
@@ -12,7 +12,12 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
-from tests.unittests.helpers import CiTestCase, mock, skipUnlessJsonSchema
+from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
+    CiTestCase,
+    mock,
+    skipUnlessJsonSchema,
+)
 from tests.unittests.util import get_cloud
 
 M_PATH = "cloudinit.config.cc_snap."
@@ -253,15 +258,18 @@ class TestSnapSchema:
                 {"snap": {"commands": ["ls"], "invalid-key": ""}},
                 "Additional properties are not allowed",
             ),
-            ({"snap": {}}, "{} does not have enough properties"),
+            ({"snap": {}}, f"{{}} {SCHEMA_EMPTY_ERROR}"),
             (
                 {"snap": {"commands": "broken"}},
                 "'broken' is not of type 'object', 'array'",
             ),
-            ({"snap": {"commands": []}}, r"snap.commands: \[\] is too short"),
+            (
+                {"snap": {"commands": []}},
+                rf"snap.commands: \[\] {SCHEMA_EMPTY_ERROR}",
+            ),
             (
                 {"snap": {"commands": {}}},
-                r"snap.commands: {} does not have enough properties",
+                rf"snap.commands: {{}} {SCHEMA_EMPTY_ERROR}",
             ),
             ({"snap": {"commands": [123]}}, ""),
             ({"snap": {"commands": {"01": 123}}}, ""),
@@ -276,10 +284,10 @@ class TestSnapSchema:
                 {"snap": {"assertions": "broken"}},
                 "'broken' is not of type 'object', 'array'",
             ),
-            ({"snap": {"assertions": []}}, r"\[\] is too short"),
+            ({"snap": {"assertions": []}}, rf"\[\] {SCHEMA_EMPTY_ERROR}"),
             (
                 {"snap": {"assertions": {}}},
-                r"\{} does not have enough properties",
+                rf"\{{}} {SCHEMA_EMPTY_ERROR}",
             ),
         ],
     )
@@ -293,8 +301,11 @@ class TestSnapSchema:
 
 
 class TestHandle:
+    @mock.patch("cloudinit.util.wait_for_snap_seeded")
     @mock.patch("cloudinit.config.cc_snap.subp.subp")
-    def test_handle_adds_assertions(self, m_subp, fake_cloud, tmpdir):
+    def test_handle_adds_assertions(
+        self, m_subp, wait_for_snap_seeded, fake_cloud, tmpdir
+    ):
         """Any configured snap assertions are provided to add_assertions."""
         assert_file = os.path.join(
             fake_cloud.paths.get_ipath_cur(), "snapd.assertions"
@@ -309,3 +320,4 @@ class TestHandle:
         assert util.load_text_file(compare_file) == util.load_text_file(
             assert_file
         )
+        wait_for_snap_seeded.assert_called_once_with(fake_cloud)

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -18,6 +18,7 @@ from cloudinit.config.schema import (
     validate_cloudconfig_schema,
 )
 from tests.unittests.helpers import (
+    SCHEMA_EMPTY_ERROR,
     CiTestCase,
     FilesystemMockingTestCase,
     skipUnlessJsonSchema,
@@ -222,7 +223,10 @@ class TestWriteFilesSchema:
         [
             # Top-level write_files type validation
             ({"write_files": 1}, "write_files: 1 is not of type 'array'"),
-            ({"write_files": []}, re.escape("write_files: [] is too short")),
+            (
+                {"write_files": []},
+                re.escape("write_files: [] ") + SCHEMA_EMPTY_ERROR,
+            ),
             (
                 {"write_files": [{}]},
                 "write_files.0: 'path' is a required property",

--- a/tests/unittests/config/test_cc_yum_add_repo.py
+++ b/tests/unittests/config/test_cc_yum_add_repo.py
@@ -141,7 +141,7 @@ class TestAddYumRepoSchema:
             ),
             (
                 {"yum_repos": {}},
-                re.escape("yum_repos: {} does not have enough properties"),
+                re.escape("yum_repos: {} ") + helpers.SCHEMA_EMPTY_ERROR,
             ),
             # baseurl required
             (

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -46,6 +46,14 @@ except ImportError:
     HAS_APT_PKG = False
 
 
+# Used by tests to verify the error message when a jsonschema structure
+# is empty but should not be.
+# Version 4.20.0 of jsonschema changed the error messages for empty structures.
+SCHEMA_EMPTY_ERROR = (
+    "(is too short|should be non-empty|does not have enough properties)"
+)
+
+
 # Makes the old path start
 # with new base instead of whatever
 # it previously had

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -23,6 +23,7 @@ from cloudinit.net.dhcp import (
     networkd_load_leases,
 )
 from cloudinit.net.ephemeral import EphemeralDHCPv4
+from cloudinit.subp import SubpResult
 from cloudinit.util import ensure_file, load_binary_file, subp, write_file
 from tests.unittests.helpers import (
     CiTestCase,
@@ -35,6 +36,7 @@ from tests.unittests.util import MockDistro
 PID_F = "/run/dhclient.pid"
 LEASE_F = "/run/dhclient.lease"
 DHCLIENT = "/sbin/dhclient"
+ib_address_prefix = "00:00:00:00:00:00:00:00:00:00:00:00"
 
 
 @pytest.mark.parametrize(
@@ -374,7 +376,6 @@ class TestDHCPParseStaticRoutes(CiTestCase):
 
 class TestDHCPDiscoveryClean(CiTestCase):
     with_logs = True
-    ib_address_prefix = "00:00:00:00:00:00:00:00:00:00:00:00"
 
     @mock.patch("cloudinit.distros.net.find_fallback_nic", return_value="eth9")
     @mock.patch("cloudinit.net.dhcp.os.remove")
@@ -994,7 +995,10 @@ class TestUDHCPCDiscoveryClean(CiTestCase):
         )
 
     @mock.patch("cloudinit.net.dhcp.is_ib_interface", return_value=True)
-    @mock.patch("cloudinit.net.dhcp.get_ib_interface_hwaddr")
+    @mock.patch(
+        "cloudinit.net.dhcp.get_interface_mac",
+        return_value="%s:AA:AA:AA:00:00:AA:AA:AA" % ib_address_prefix,
+    )
     @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/sbin/udhcpc")
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
@@ -1021,7 +1025,6 @@ class TestUDHCPCDiscoveryClean(CiTestCase):
             "routers": "192.168.2.1",
             "static_routes": "10.240.0.1/32 0.0.0.0 0.0.0.0/0 10.240.0.1",
         }
-        m_get_ib_interface_hwaddr.return_value = "00:21:28:00:01:cf:4b:01"
         self.assertEqual(
             {
                 "fixed-address": "192.168.2.74",
@@ -1052,7 +1055,7 @@ class TestUDHCPCDiscoveryClean(CiTestCase):
                         "-f",
                         "-v",
                         "-x",
-                        "0x3d:0021280001cf4b01",
+                        "0x3d:20AAAAAA0000AAAAAA",
                     ],
                     update_env={
                         "LEASE_FILE": "/var/tmp/cloud-init/ib0.lease.json"
@@ -1273,3 +1276,45 @@ class TestDhcpcd:
             ("168.63.129.16/32", "10.0.0.1"),
             ("169.254.169.254/32", "10.0.0.1"),
         ] == Dhcpcd.parse_static_routes(parsed_lease["static_routes"])
+
+    @mock.patch("cloudinit.net.dhcp.is_ib_interface", return_value=True)
+    @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/sbin/dhcpcd")
+    @mock.patch("cloudinit.net.dhcp.os.killpg")
+    @mock.patch("cloudinit.net.dhcp.subp.subp")
+    @mock.patch("cloudinit.util.load_json")
+    @mock.patch("cloudinit.util.load_binary_file")
+    @mock.patch("cloudinit.util.write_file")
+    def test_dhcpcd_discovery_ib(
+        self,
+        m_write_file,
+        m_load_file,
+        m_loadjson,
+        m_subp,
+        m_remove,
+        m_which,
+        m_is_ib_interface,
+    ):
+        """dhcp_discovery runs udcpc and parse the dhcp leases."""
+        m_subp.return_value = SubpResult("a=b", "")
+        Dhcpcd().dhcp_discovery("ib0", distro=MockDistro())
+        # Interface was brought up before dhclient called
+        m_subp.assert_has_calls(
+            [
+                mock.call(
+                    ["ip", "link", "set", "dev", "ib0", "up"],
+                ),
+                mock.call(
+                    [
+                        "/sbin/dhcpcd",
+                        "--ipv4only",
+                        "--waitip",
+                        "--persistent",
+                        "--noarp",
+                        "--script=/bin/true",
+                        "--clientid",
+                        "ib0",
+                    ],
+                    timeout=Dhcpcd.timeout,
+                ),
+            ]
+        )

--- a/tests/unittests/sources/test_aliyun.py
+++ b/tests/unittests/sources/test_aliyun.py
@@ -291,6 +291,7 @@ class TestAliYunDatasource(test_helpers.ResponsesTestCase):
                     }
                 }
             },
+            mock.Mock(),
             macs_to_nics={
                 "06:17:04:d7:26:09": "eth0",
                 "06:17:04:d7:26:08": "eth1",
@@ -302,6 +303,14 @@ class TestAliYunDatasource(test_helpers.ResponsesTestCase):
 
         # route-metric numbers should be 100 apart
         assert 100 == abs(met0 - met1)
+
+        # No policy routing
+        assert not {"routing-policy", "routes"}.intersection(
+            netcfg["ethernets"]["eth0"].keys()
+        )
+        assert not {"routing-policy", "routes"}.intersection(
+            netcfg["ethernets"]["eth1"].keys()
+        )
 
 
 class TestIsAliYun(test_helpers.CiTestCase):

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -387,6 +387,7 @@ def construct_ovf_env(
     disable_ssh_password_auth=None,
     preprovisioned_vm=None,
     preprovisioned_vm_type=None,
+    provision_guest_proxy_agent=None,
 ):
     content = [
         '<?xml version="1.0" encoding="utf-8"?>',
@@ -456,6 +457,11 @@ def construct_ovf_env(
         content.append(
             "<ns1:PreprovisionedVMType>%s</ns1:PreprovisionedVMType>"
             % preprovisioned_vm_type
+        )
+    if provision_guest_proxy_agent is not None:
+        content.append(
+            "<ns1:ProvisionGuestProxyAgent>%s</ns1:ProvisionGuestProxyAgent>"
+            % provision_guest_proxy_agent
         )
     content += [
         "</ns1:PlatformSettings>",
@@ -1442,6 +1448,7 @@ scbus-1 on xpt0 bus 0
         expected_cfg = {
             "PreprovisionedVMType": None,
             "PreprovisionedVm": False,
+            "ProvisionGuestProxyAgent": False,
             "system_info": {"default_user": {"name": "myuser"}},
         }
         expected_metadata = {
@@ -2818,6 +2825,14 @@ class TestPreprovisioningReadAzureOvfFlag(CiTestCase):
         cfg = ret[2]
         self.assertTrue(cfg["PreprovisionedVm"])
         self.assertEqual("Savable", cfg["PreprovisionedVMType"])
+
+    def test_read_azure_ovf_with_proxy_guest_agent(self):
+        """The read_azure_ovf method should set ProvisionGuestProxyAgent
+        cfg flag to True."""
+        content = construct_ovf_env(provision_guest_proxy_agent=True)
+        ret = dsaz.read_azure_ovf(content)
+        cfg = ret[2]
+        self.assertTrue(cfg["ProvisionGuestProxyAgent"])
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/test_merging.py
+++ b/tests/unittests/test_merging.py
@@ -270,7 +270,7 @@ class TestMergingSchema:
         [
             ({"merge_how": "list()+dict()+str()"}, None),
             ({"merge_type": "list()+dict()+str()"}, None),
-            ({"merge_how": []}, "\\[\\] is too short"),
+            ({"merge_how": []}, f"\\[\\] {helpers.SCHEMA_EMPTY_ERROR}"),
             (
                 {"merge_how": {"name": "list", "settings": ["append"]}},
                 "is not of type",

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -33,7 +33,9 @@ def get_cloud(
         myds.metadata.update(metadata)
     if paths:
         paths.datasource = myds
-    return cloud.Cloud(myds, paths, sys_cfg, mydist, None)
+    return cloud.Cloud(
+        myds, paths, sys_cfg, mydist, runners=helpers.Runners(paths)
+    )
 
 
 def abstract_to_concrete(abclass):
@@ -90,6 +92,10 @@ class MockDistro(distros.Distro):
     @staticmethod
     def get_proc_ppid(_):
         return 1
+
+    @staticmethod
+    def get_proc_pgid(_):
+        return 99999
 
     def get_primary_arch(self):
         return "i386"

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -7,6 +7,7 @@ ajmyyra
 akutz
 AlexBaranowski
 AlexSv04047
+AliyevH
 Aman306
 andgein
 andrew-lee-metaswitch

--- a/tools/Z99-cloud-locale-test.sh
+++ b/tools/Z99-cloud-locale-test.sh
@@ -18,7 +18,7 @@ locale_warn() {
     $_local w1 w2 w3 w4 remain
 
     # if shell is zsh, act like sh only for this function (-L).
-    # The behavior change will not permenently affect user's shell.
+    # The behavior change will not permanently affect user's shell.
     [ "${ZSH_NAME+zsh}" = "zsh" ] && emulate -L sh
 
     # locale is expected to output either:

--- a/tools/ccfg-merge-debug
+++ b/tools/ccfg-merge-debug
@@ -60,7 +60,7 @@ def main():
     # Walk the user data
     part_data = {
         'handlers': c_handlers,
-        # Any new handlers that are encountered get writen here
+        # Any new handlers that are encountered get written here
         'handlerdir': handler_dir,
         'data': data,
         # The default frequency if handlers don't have one

--- a/tools/cloud-init-hotplugd
+++ b/tools/cloud-init-hotplugd
@@ -1,0 +1,23 @@
+#!/bin/sh
+# This file is part of cloud-init. See LICENSE file for license information.
+
+# This script is used on non-systemd systems. It is called by the
+# cloud-init-hotplug init.d script.
+#
+# Creates a named pipe and then continually listens to this pipe. The pipe
+# is written to by the hook-hotplug script (which is called by a udev rule
+# upon a network device event). Anything received via the pipe is then
+# passed on via the "cloud-init devel hotplug-hook handle" command.
+
+PIPE="/run/cloud-init/hook-hotplug-cmd"
+
+mkfifo -m700 $PIPE
+
+while true; do
+  # shellcheck disable=SC2162
+  read args < $PIPE
+  # shellcheck disable=SC2086
+  exec /usr/bin/cloud-init devel hotplug-hook $args
+done
+
+exit

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -712,7 +712,7 @@ has_fs_with_label() {
 
 nocase_equal() {
     # nocase_equal(a, b)
-    # return 0 if case insenstive comparision a.lower() == b.lower()
+    # return 0 if case insensitive comparison a.lower() == b.lower()
     # different lengths
     [ "${#1}" = "${#2}" ] || return 1
     # case sensitive equal
@@ -1167,7 +1167,7 @@ dscheck_Azure() {
 }
 
 dscheck_Bigstep() {
-    # bigstep is activated by presense of seed file 'url'
+    # bigstep is activated by presence of seed file 'url'
     [ -f "${PATH_VAR_LIB_CLOUD}/data/seed/bigstep/url" ] &&
         return ${DS_FOUND}
     return ${DS_NOT_FOUND}
@@ -1254,7 +1254,7 @@ ec2_identify_platform() {
     local uuid="${DI_DMI_PRODUCT_UUID}"
     case "$uuid:$serial" in
         [Ee][Cc]2*:[Ee][Cc]2*)
-            # both start with ec2, now check for case insenstive equal
+            # both start with ec2, now check for case insensitive equal
             nocase_equal "$uuid" "$serial" &&
                 { _RET="AWS"; return 0; };;
     esac

--- a/tools/hook-hotplug
+++ b/tools/hook-hotplug
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # This file is part of cloud-init. See LICENSE file for license information.
 
 # This script checks if cloud-init has hotplug hooked and if
@@ -11,12 +11,12 @@ is_finished() {
 if is_finished; then
     # open cloud-init's hotplug-hook fifo rw
     exec 3<>/run/cloud-init/hook-hotplug-cmd
-    env_params=(
-        --subsystem="${SUBSYSTEM}"
-        handle
-        --devpath="${DEVPATH}"
-        --udevaction="${ACTION}"
-    )
+    env_params=" \
+        --subsystem=\"${SUBSYSTEM}\" \
+        handle \
+        --devpath=\"${DEVPATH}\" \
+        --udevaction=\"${ACTION}\" \
+    "
     # write params to cloud-init's hotplug-hook fifo
-    echo "${env_params[@]}" >&3
+    echo "${env_params}" >&3
 fi

--- a/tools/make-tarball
+++ b/tools/make-tarball
@@ -60,7 +60,7 @@ if [ -z "$output" ]; then
 fi
 
 # when building an archiving from HEAD, ensure that there aren't any
-# uncomitted changes in the working directory (because these would not
+# uncommitted changes in the working directory (because these would not
 # end up in the archive).
 if [ "$rev" = HEAD ] && ! git diff-index --quiet HEAD --; then
     if [ -z "$SKIP_UNCOMITTED_CHANGES_CHECK" ]; then

--- a/tools/migrate-lp-user-to-github
+++ b/tools/migrate-lp-user-to-github
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Link your Launchpad user to github, proposing branches to LP and Github"""
+"""Link your Launchpad user to GitHub, proposing branches to LP and GitHub"""
 
 from argparse import ArgumentParser
 from subprocess import Popen, PIPE
@@ -175,7 +175,7 @@ def add_lp_and_github_remotes(lp_user, gh_user):
 def create_migration_branch(
     branch_name, upstream, lp_user, gh_user, commit_msg
 ):
-    """Create an LP to Github migration branch and add lp_user->gh_user."""
+    """Create an LP to GitHub migration branch and add lp_user->gh_user."""
     log(
         "Creating a migration branch: {} adding your users".format(
             MIGRATE_BRANCH_NAME

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -224,8 +224,8 @@ def translate_pip_to_system_pkg(pip_requires, renames):
     """Translate pip package names to distro-specific package names.
 
     @param pip_requires: List of versionless pip package names to translate.
-    @param renames: Dict containg special case renames from pip name to system
-        package name for the distro.
+    @param renames: Dict containing special case renames from pip name to
+        system package name for the distro.
     """
     prefix = "python3-"
     standard_pkg_name = "{0}{1}"

--- a/tools/uncloud-init
+++ b/tools/uncloud-init
@@ -105,7 +105,7 @@ done
 if [ "${ubuntu_pass}" = "R" -o "${ubuntu_pass}" = "random" ]; then
 	ubuntu_pass=$(python -c 'import string, random;
 random.seed(); print "".join(random.sample(string.letters+string.digits, 8))')
-	log "settting ubuntu pass = ${ubuntu_pass}" 
+	log "setting ubuntu pass = ${ubuntu_pass}" 
 	printf "\n===\nubuntu_pass = %s\n===\n" "${ubuntu_pass}" >/dev/ttyS0
 fi
 

--- a/tools/xkvm
+++ b/tools/xkvm
@@ -126,7 +126,7 @@ isdevopt() {
 qemu_supports_file_locking() {
     # hackily check if qemu has file.locking in -drive params (LP: #1716028)
     if [ -z "$_QEMU_SUPPORTS_FILE_LOCKING" ]; then
-        # The only way we could find to check presense of file.locking is
+        # The only way we could find to check presence of file.locking is
         # qmp (query-qmp-schema).  Simply checking if the virtio-blk driver
         # supports 'share-rw' is expected to be equivalent and simpler.
         isdevopt virtio-blk share-rw &&


### PR DESCRIPTION
Blocked on review of https://github.com/canonical/cloud-init/pull/4884. But follows exactly the same process for that PR to revert upstream commit 551f560d  as a quilt patch.


Take an unreleased new_upstream_snapshot, and create a quilt patch reverting upstream commit 551f560d1a2decdb58f3a8352c2e5cbe6f56c5d7 to retain original systemd ordering of cloud-config.service After=snapd.seeded.service

This also fixes daily build recipes which failed due to inability to apply the `d/patches/do-not-block-user-login.patch`.

## procedure to create this branch
```
git fetch upstream
git checkout -B upstream/ubuntu/jammy -B ubuntu/jammy
new_upstream_snapshot.py -c c948e418 # watch quilt patches fail
# add new quilt patch which is a full revert of upstream commit 551f560d1a2decdb58f3a8352c2e5cbe6f56c5d7
quilt new revert-551f560d-cloud-config-after-snap-seeding.patch
# Add all affected files in revert to quilt patch
 git show 551f560d --pretty="" --name-only | xargs -n 1 quilt add
# Actually revert the commit and ingest it into the quilt patch
git revert 551f560d
git reset HEAD~1
quilt refresh

# setup quilt header
quilt header -e --dep3
quilt pop -a

# test push/pop and tests
quilt push -a 
tox -e py3 
quilt pop -a

# commit the new quilt patch
git add debian/patches/revert-551f560d-cloud-config-after-snap-seeding.patch
git commit -am 'Add patch revert-551f560d-cloud-config-after-snap-seeding.patch'

 # add message about new d/p/revert-..... patch 
# delete the prior duplicated line Upstreamsnapshot from upstream/main at 33148a07
vi debian/changelog
git commit -am 'update changelog'

new_upstream_snapshot.py -p quilt
```
## rebase merge

## to test daily recipe build manually
```
git fetch upstream
git checkout upstream/main -B main
git merge <this_branch>
quilt push -a # no errors
tox -e py3 # no test errors
quilt pop -a # no errors
```
