### PR TITLE
fix(hotplug): remove literal quotes in args

### DIFF
--- a/tools/hook-hotplug
+++ b/tools/hook-hotplug
@@ -12,10 +12,10 @@ if is_finished; then
     # open cloud-init's hotplug-hook fifo rw
     exec 3<>/run/cloud-init/hook-hotplug-cmd
     env_params=" \
-        --subsystem=\"${SUBSYSTEM}\" \
+        --subsystem=${SUBSYSTEM} \
         handle \
-        --devpath=\"${DEVPATH}\" \
-        --udevaction=\"${ACTION}\" \
+        --devpath=${DEVPATH} \
+        --udevaction=${ACTION} \
     "
     # write params to cloud-init's hotplug-hook fifo
     echo "${env_params}" >&3


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(hotplug): remove literal quotes in args

Remove literal double quotes which cause
/usr/bin/cloud-init devel hotplug-hook: error: argument -s/--subsystem: invalid choice: '"net"' (choose from 'net') in cloud-init-hotplugd.service when a NIC is added/removed.

Literal quoutes provoke errors, an eval or something in those lines would bypass the error, but that would be equivalent to no quotes at all.

This quouting was introuced in e70cd47846120b83035daa87e089fa045355f03a.

Fixes: GH-4886
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
