### PR TITLE
test: limit test_no_hotplug_triggered_by_docker to stable releases

### DIFF
--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -9,7 +9,11 @@ from cloudinit.subp import subp
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
+from tests.integration_tests.releases import (
+    CURRENT_RELEASE,
+    FOCAL,
+    UBUNTU_STABLE,
+)
 from tests.integration_tests.util import verify_clean_log
 
 USER_DATA = """\
@@ -222,6 +226,10 @@ def test_multi_nic_hotplug(setup_image, session_cloud: IntegrationCloud):
 
 
 @pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")
+@pytest.mark.skipif(
+    CURRENT_RELEASE not in UBUNTU_STABLE,
+    reason="Docker repo does not contain pkgs for non stable releases.",
+)
 @pytest.mark.user_data(USER_DATA)
 def test_no_hotplug_triggered_by_docker(client: IntegrationInstance):
     # Install docker

--- a/tests/integration_tests/releases.py
+++ b/tests/integration_tests/releases.py
@@ -98,5 +98,7 @@ LUNAR = Release("ubuntu", "lunar", "23.04")
 MANTIC = Release("ubuntu", "mantic", "23.10")
 NOBLE = Release("ubuntu", "noble", "24.04")
 
+UBUNTU_STABLE = (FOCAL, JAMMY, MANTIC)
+
 CURRENT_RELEASE = Release.from_os_image()
 IS_UBUNTU = CURRENT_RELEASE.os == "ubuntu"


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: limit test_no_hotplug_triggered_by_docker to stable releases

docker repo does not contain pkgs for devel ubuntu series.
```

## Additional Context
<!-- If relevant -->
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-ec2/53/testReport/junit/tests.integration_tests.modules/test_hotplug/test_no_hotplug_triggered_by_docker/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=ec2 CLOUD_INIT_OS_IMAGE=noble tox -e integration-tests -- tests/integration_tests/modules/test_hotplug.py::test_no_hotplug_triggered_by_docker

```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
