### PR TITLE
tests: generalize warning Open vSwitch warning from netplan apply

### DIFF
--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -74,9 +74,7 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         "WARNING]: Removing /etc/apt/sources.list to favor deb822 source"
         " format",
         # https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2041727
-        "WARNING]: Running ['netplan', 'apply'] resulted in stderr output: "
-        "WARNING:root:Cannot call Open vSwitch: ovsdb-server.service is not "
-        "running.",
+        "Cannot call Open vSwitch: ovsdb-server.service is not running.",
     ]
     traceback_texts = []
     if "install canonical-livepatch" in log:


### PR DESCRIPTION
On newer netplan, logging format now includes logging scope in warning messages. Generalize the expected warning log to match old and new warning messages.

## Proposed Commit Message
```
tests: generalize warning Open vSwitch warning from netplan apply

On newer netplan, logging format now includes logging scope in
warning messages. Generalize the expected warning log to match old
and new warning messages.
```

## Additional Context
Failure seen from integraiton test run against daily PPA:
```
E       AssertionError: Unexpected warning count != 0. Found: ["WARNING]: Running ['netplan', 'apply'] resulted in stderr output: Cannot call Open vSwitch: ovsdb-server.service is not running."]

```

## Test Steps
```
# Failure can be seen with
CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily  CLOUD_INIT_PLATFORM=ec2 tox -e integration-tests -- tests/integration_tests/modules/test_hotplug.py::test_multi_nic_hotplug
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
