### PR TITLE
Ubuntu/focal: new_upstream_snapshot to fix daily build recipe (merge conflicts)

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -184,6 +184,18 @@ PORTS_MIRRORS = {
 PRIMARY_ARCHES = ["amd64", "i386"]
 PORTS_ARCHES = ["s390x", "arm64", "armhf", "powerpc", "ppc64el", "riscv64"]
 
+UBUNTU_DEFAULT_APT_SOURCES_LIST = """\
+# Ubuntu sources have moved to the /etc/apt/sources.list.d/ubuntu.sources
+# file, which uses the deb822 format. Use deb822-formatted .sources files
+# to manage package sources in the /etc/apt/sources.list.d/ directory.
+# See the sources.list(5) manual page for details.
+"""
+
+# List of allowed content in /etc/apt/sources.list when features
+# APT_DEB822_SOURCE_LIST_FILE is set. Otherwise issue warning about
+# invalid non-deb822 configuration.
+DEB822_ALLOWED_APT_SOURCES_LIST = {"ubuntu": UBUNTU_DEFAULT_APT_SOURCES_LIST}
+
 
 def get_default_mirrors(
     arch=None,
@@ -681,10 +693,23 @@ def generate_sources_list(cfg, release, mirrors, cloud):
     disabled = disable_suites(cfg.get("disable_suites"), rendered, release)
     util.write_file(aptsrc_file, disabled, mode=0o644)
     if aptsrc_file == apt_sources_deb822 and os.path.exists(apt_sources_list):
-        LOG.warning(
-            "Removing %s to favor deb822 source format", apt_sources_list
+        expected_content = DEB822_ALLOWED_APT_SOURCES_LIST.get(
+            cloud.distro.name
         )
-        util.del_file(apt_sources_list)
+        if expected_content:
+            if expected_content != util.load_text_file(apt_sources_list):
+                LOG.warning(
+                    "Replacing %s to favor deb822 source format",
+                    apt_sources_list,
+                )
+                util.write_file(
+                    apt_sources_list, UBUNTU_DEFAULT_APT_SOURCES_LIST
+                )
+        else:
+            LOG.warning(
+                "Removing %s to favor deb822 source format", apt_sources_list
+            )
+            util.del_file(apt_sources_list)
 
 
 def add_apt_key_raw(key, file_name, hardened=False):

--- a/debian/changelog
+++ b/debian/changelog
@@ -11,8 +11,9 @@ cloud-init (23.4.1-0ubuntu1~20.04.3) UNRELEASED; urgency=medium
     - d/p/status-do-not-remove-duplicated-data.patch
     - d/p/status-retain-recoverable-error-exit-code.patch
   * Upstream snapshot based on upstream/main at c948e418.
+  * Upstream snapshot based on upstream/main at a4140119.
 
- -- Chad Smith <chad.smith@canonical.com>  Thu, 15 Feb 2024 14:42:48 -0700
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 15 Feb 2024 20:12:30 -0700
 
 cloud-init (23.4.1-0ubuntu1~20.04.2) focal; urgency=medium
 

--- a/doc/rtd/reference/datasources/ec2.rst
+++ b/doc/rtd/reference/datasources/ec2.rst
@@ -86,8 +86,8 @@ This list of URLs will be searched for an EC2 metadata service. The first
 entry that successfully returns a 200 response for
 ``<url>/<version>/meta-data/instance-id`` will be selected.
 
-Default: ['http://169.254.169.254', 'http://[fd00:ec2::254]',
-'http://instance-data:8773'].
+Default: [``'http://169.254.169.254'``, ``'http://[fd00:ec2::254]'``,
+``'http://instance-data.:8773'``].
 
 ``max_wait``
 ------------

--- a/templates/sources.list.ubuntu.deb822.tmpl
+++ b/templates/sources.list.ubuntu.deb822.tmpl
@@ -1,61 +1,57 @@
 ## template:jinja
 ## Note, this file is written by cloud-init on first boot of an instance
 ## modifications made here will not survive a re-bundle.
-## if you wish to make changes you can:
+##
+## If you wish to make changes you can:
 ## a.) add 'apt_preserve_sources_list: true' to /etc/cloud/cloud.cfg
 ##     or do the same in user-data
 ## b.) add supplemental sources in /etc/apt/sources.list.d
 ## c.) make changes to template file
 ##      /etc/cloud/templates/sources.list.ubuntu.deb822.tmpl
 ##
-## See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
-## newer versions of the distribution.
+
+# See http://help.ubuntu.com/community/UpgradeNotes for how to upgrade to
+# newer versions of the distribution.
+
+## Ubuntu distribution repository
 ##
-## The following settings can be tweaked to configure which packages to use
-## from Ubuntu.
-## Mirror your choices (except for URIs and Suites) in the security section
-## below to ensure timely security updates.
+## The following settings can be adjusted to configure which packages to use from Ubuntu.
+## Mirror your choices (except for URIs and Suites) in the security section below to
+## ensure timely security updates.
 ##
 ## Types: Append deb-src to enable the fetching of source package.
 ## URIs: A URL to the repository (you may add multiple URLs)
 ## Suites: The following additional suites can be configured
-##   <name>-updates   - Major bug fix updates produced after the final release
-##                      of the distribution.
-##   <name>-backports - software from this repository may not have been tested
-##                      as extensively as that contained in the main release,
-##                      although it includes newer versions of some
-##                      applications which may provide useful features.
-##                      Also, please note that software in backports WILL NOT
-##                      receive any review or updates from the Ubuntu security
-##                      team.
-## Components: Aside from main, the following components can be added to the
-## list:
-##   restricted  - Software that may not be under a free license, or protected
-##                 by patents.
-##   universe    - Community maintained packages. Software from this repository
-##                 is ENTIRELY UNSUPPORTED by the Ubuntu team. Also, please
-##                 note that software in universe WILL NOT receive any
+##   <name>-updates   - Major bug fix updates produced after the final release of the
+##                      distribution.
+##   <name>-backports - software from this repository may not have been tested as
+##                      extensively as that contained in the main release, although it includes
+##                      newer versions of some applications which may provide useful features.
+##                      Also, please note that software in backports WILL NOT receive any review
+##                      or updates from the Ubuntu security team.
+## Components: Aside from main, the following components can be added to the list
+##   restricted  - Software that may not be under a free license, or protected by patents.
+##   universe    - Community maintained packages.
+##                 Software from this repository is only maintained and supported by Canonical
+##                 for machines with Ubuntu Pro subscriptions. Without Ubuntu Pro, the Ubuntu
+##                 community provides best-effort security maintenance.
+##   multiverse  - Community maintained of restricted. Software from this repository is
+##                 ENTIRELY UNSUPPORTED by the Ubuntu team, and may not be under a free
+##                 licence. Please satisfy yourself as to your rights to use the software.
+##                 Also, please note that software in multiverse WILL NOT receive any
 ##                 review or updates from the Ubuntu security team.
-##   multiverse  - Community maintained of restricted. Software from this
-##                 repository is ENTIRELY UNSUPPORTED by the Ubuntu team, and
-##                 may not be under a free licence. Please satisfy yourself as
-##                 to your rights to use the software.
-##                 Also, please note that software in multiverse WILL NOT
-##                 receive any review or updates from the Ubuntu security team.
 ##
 ## See the sources.list(5) manual page for further settings.
-# Types: deb deb-src
 Types: deb
 URIs: {{mirror}}
 Suites: {{codename}} {{codename}}-updates {{codename}}-backports
-Components: main restricted universe multiverse
+Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
 
 ## Ubuntu security updates. Aside from URIs and Suites,
 ## this should mirror your choices in the previous section.
-# Types: deb deb-src
 Types: deb
 URIs: {{security}}
 Suites: {{codename}}-security
-Components: main restricted universe multiverse
+Components: main universe restricted multiverse
 Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg

--- a/tests/integration_tests/modules/test_ubuntu_advantage.py
+++ b/tests/integration_tests/modules/test_ubuntu_advantage.py
@@ -62,7 +62,7 @@ AUTO_ATTACH_CUSTOM_SERVICES = """\
 #cloud-config
 ubuntu_advantage:
   enable:
-  - livepatch
+  - esm-infra
 """
 
 
@@ -112,7 +112,8 @@ def get_services_status(client: IntegrationInstance) -> dict:
     assert status_resp.ok
     status = json.loads(status_resp.stdout)
     return {
-        svc["name"]: svc["status"] == "enabled" for svc in status["services"]
+        svc["name"]: svc["status"] in ("enabled", "warning")
+        for svc in status["services"]
     }
 
 
@@ -234,8 +235,8 @@ class TestUbuntuAdvantagePro:
             assert is_attached(client)
             services_status = get_services_status(client)
             assert services_status.pop(
-                "livepatch"
-            ), "livepatch expected to be enabled"
+                "esm-infra"
+            ), "esm-infra expected to be enabled"
             enabled_services = {
                 svc for svc, status in services_status.items() if status
             }

--- a/tests/integration_tests/releases.py
+++ b/tests/integration_tests/releases.py
@@ -98,5 +98,7 @@ LUNAR = Release("ubuntu", "lunar", "23.04")
 MANTIC = Release("ubuntu", "mantic", "23.10")
 NOBLE = Release("ubuntu", "noble", "24.04")
 
+UBUNTU_STABLE = (FOCAL, JAMMY, MANTIC)
+
 CURRENT_RELEASE = Release.from_os_image()
 IS_UBUNTU = CURRENT_RELEASE.os == "ubuntu"

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -71,12 +71,10 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         "thinpool by default on Ubuntu due to LP #1982780",
         "WARNING]: Could not match supplied host pattern, ignoring:",
         # Old Ubuntu cloud-images contain /etc/apt/sources.list
-        "WARNING]: Removing /etc/apt/sources.list to favor deb822 source"
+        "WARNING]: Replacing /etc/apt/sources.list to favor deb822 source"
         " format",
         # https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2041727
-        "WARNING]: Running ['netplan', 'apply'] resulted in stderr output: "
-        "WARNING:root:Cannot call Open vSwitch: ovsdb-server.service is not "
-        "running.",
+        "Cannot call Open vSwitch: ovsdb-server.service is not running.",
     ]
     traceback_texts = []
     if "install canonical-livepatch" in log:

--- a/tools/hook-hotplug
+++ b/tools/hook-hotplug
@@ -12,10 +12,10 @@ if is_finished; then
     # open cloud-init's hotplug-hook fifo rw
     exec 3<>/run/cloud-init/hook-hotplug-cmd
     env_params=" \
-        --subsystem=\"${SUBSYSTEM}\" \
+        --subsystem=${SUBSYSTEM} \
         handle \
-        --devpath=\"${DEVPATH}\" \
-        --udevaction=\"${ACTION}\" \
+        --devpath=${DEVPATH} \
+        --udevaction=${ACTION} \
     "
     # write params to cloud-init's hotplug-hook fifo
     echo "${env_params}" >&3


### PR DESCRIPTION
Perform new_upstream_snapshot to fix merge conflicts against tip of main for focal

## unable to rebase merge due to merge conflicts

## Additional Context
integration test changes in tip of main introduced inability to merge cleanly in daily recipes:
https://launchpadlibrarian.net/714590161/buildlog.txt.gz
## branch creation procedure
```
git fetch upstream
git checkout upstream/ubuntu/focal -B ubuntu/focal
new_upstream_snapshot.py -c a4140119 # resolve merge conflicts
git add ...
git merge --continue
new_upstream_snapshot  -p merge
```

## Test Steps
```
# Ensure daily recipe will build
git checkout main
git merge ubuntu/mantic # this branch
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
