### PR TITLE
test: fix verify_clean_log

### DIFF
--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -115,7 +115,7 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
     for traceback_text in traceback_texts:
         expected_tracebacks += log.count(traceback_text)
 
-    assert warning_count == expected_warnings, (
+    assert warning_count <= expected_warnings, (
         f"Unexpected warning count != {expected_warnings}. Found: "
         f"{re.findall('WARNING.*', log)}"
     )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: fix verify_clean_log

verify_clean_log assumed shadowed warning messages to be contained
in a single line entry with a `[WARNING]`, but warnings can be
multiline as:

'''
2024-02-16 15:01:49,354 - activators.py[WARNING]: Running ['netplan', 'apply'] resulted in stderr output: Cannot call Open vSwitch: ovsdb-server.service is not running.
Failed to connect system bus: No such file or directory
Falling back to a hard restart of systemd-networkd.service
'''

wrongly asserting the number of expected_warnings.

Make this check more reliable by asserting that the number of
lines containing `WARNINGS` is less or equal than the number of
appearances of the shadowed warning messages.
```

## Additional Context
<!-- If relevant -->
Fixes: https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/46/testReport/junit/tests.integration_tests.datasources/test_none/test_datasource_none_discovery/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
export CLOUD_INIT_PLATFORM=lxd_vm
export CLOUD_INIT_OS_IMAGE=noble

tox -e integration-tests -- --pdb tests/integration_tests/datasources/test_none.py::test_datasource_none_discovery
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
