### PR TITLE
tests: use apt install instead of dpkg -i to install pkg deps

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -216,7 +216,13 @@ class IntegrationInstance:
             local_path=integration_settings.CLOUD_INIT_SOURCE,
             remote_path=remote_path,
         )
-        assert self.execute("dpkg -i {path}".format(path=remote_path)).ok
+        # Update APT cache so all package data is recent to avoid inability
+        # to install missing dependency errors due to stale cache.
+        self.execute("apt update")
+        # Use apt install instead of dpkg -i to pull in any changed pkg deps
+        assert self.execute(
+            "apt install {path} --yes".format(path=remote_path)
+        ).ok
 
     @retry(tries=30, delay=1)
     def upgrade_cloud_init(self):


### PR DESCRIPTION
## Proposed Commit Message
```
tests: use apt instead of dpkg -i to install pkg deps

On Ubuntu Noble dhcpcd-base is a hard package Depends and
also not included by default in ubuntu-minimal images until
cloud-init the new cloud-init images contain latest cloud-init.

When provided with a DEB_PATH source, use apt instead of dpkg -i
to any missing install package dependencies.

Fixes: GH-4908
```

## Additional Context
Failed jenkins job
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-azure/51/console

There is a separate bug with Ubuntu Minimal  images (missing sgdisk https://github.com/canonical/cloud-init/issues/4907) which leaves a WARNING in logs that will not be addressed by this particular PR.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)