### PR TITLE
test: Retry longer in test_status.py integration test

### DIFF
--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -20,7 +20,7 @@ def _remove_nocloud_dir_and_reboot(client: IntegrationInstance):
     client.instance._wait_for_execute(old_boot_id=old_boot_id)
 
 
-@retry(tries=5, delay=1)
+@retry(tries=30, delay=1)
 def retry_read_from_file(client: IntegrationInstance, path: str):
     """Retry read_from_file expecting it shortly"""
     return client.read_from_file(path)


### PR DESCRIPTION
Saw "cat: /before-local.start-nostatusjson: No such file or directory" failures. After this change, I no longer see these failures.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Retry longer in test_status.py integration test

Saw "cat: /before-local.start-nostatusjson: No such file or directory"
failures. After this change, I no longer see these failures.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_container/410/testReport/junit/tests.integration_tests.cmd/test_status/test_status_block_through_all_boot_status/

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
