### PR TITLE
feat(dhcp): Make dhcpcd the default dhcp client

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -967,4 +967,4 @@ class Udhcpc(DhcpClient):
         return []
 
 
-ALL_DHCP_CLIENTS = [IscDhclient, Dhcpcd, Udhcpc]
+ALL_DHCP_CLIENTS = [Dhcpcd, IscDhclient, Udhcpc]

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -301,7 +301,7 @@ system_info:
 {% elif variant in ["ubuntu", "unknown"] %}
 {# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
   network:
-    dhcp_client_priority: [dhclient, dhcpcd, udhcpc]
+    dhcp_client_priority: [dhcpcd, dhclient, udhcpc]
     renderers: ['netplan', 'eni', 'sysconfig']
     activators: ['netplan', 'eni', 'network-manager', 'networkd']
 {% elif is_rhel %}

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -543,10 +543,10 @@ class TestDistro:
             id="first_client_is_found_from_config_udhcpc",
         ),
         pytest.param(
-            IscDhclient,
+            Dhcpcd,
             {"network": {"dhcp_client_priority": []}},
             None,
-            id="first_client_is_found_no_config_dhclient",
+            id="first_client_is_found_no_config_dhcpcd",
         ),
         pytest.param(
             Dhcpcd,

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -381,7 +381,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
     @mock.patch("cloudinit.net.dhcp.subp.which")
-    def test_dhclient_exits_with_error(
+    def test_dhcpcd_exits_with_error(
         self, m_which, m_subp, m_remove, m_fallback
     ):
         """Log and do nothing when nic is absent and no fallback is found."""
@@ -394,7 +394,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
             maybe_perform_dhcp_discovery(Distro("fake but not", {}, None))
 
         self.assertIn(
-            "DHCP client selected: dhclient",
+            "DHCP client selected: dhcpcd",
             self.logs.getvalue(),
         )
 

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -268,17 +268,23 @@ class TestCloudStackHostname(CiTestCase):
             )
         )
 
+        lease = {
+            "interface": "eth0",
+            "fixed-address": "192.168.0.1",
+            "subnet-mask": "255.255.255.0",
+            "routers": "192.168.0.1",
+            "renew": "4 2017/07/27 18:02:30",
+            "expire": "5 2017/07/28 07:08:15",
+        }
         self.patches.enter_context(
             mock.patch(
                 DHCP_MOD_PATH + ".IscDhclient.get_newest_lease",
-                return_value={
-                    "interface": "eth0",
-                    "fixed-address": "192.168.0.1",
-                    "subnet-mask": "255.255.255.0",
-                    "routers": "192.168.0.1",
-                    "renew": "4 2017/07/27 18:02:30",
-                    "expire": "5 2017/07/28 07:08:15",
-                },
+                return_value=lease,
+            )
+        )
+        self.patches.enter_context(
+            mock.patch(
+                DHCP_MOD_PATH + ".Dhcpcd.get_newest_lease", return_value=lease
             )
         )
 


### PR DESCRIPTION
## Proposed Commit Message

```
feat(dhcp): Make dhcpcd the default dhcp client

isc-dhcp-client is no longer supported by upstream

BREAKING_CHANGE: Distros that want the old behavior may
set their own custom client list in cloud.cfg.
```

## Additional context

Will be followed up by patches into Ubuntu non-noble downstreams.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
