### PR TITLE
test: fix kernel override test

### DIFF
--- a/tests/integration_tests/test_kernel_commandline_match.py
+++ b/tests/integration_tests/test_kernel_commandline_match.py
@@ -6,7 +6,7 @@ from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.conftest import get_validated_source
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import wait_for_cloud_init
+from tests.integration_tests.util import lxd_has_nocloud, wait_for_cloud_init
 
 log = logging.getLogger("integration_testing")
 
@@ -75,7 +75,7 @@ def override_kernel_cmdline(ds_str: str, c: IntegrationInstance):
             True,
         ),
         ("ci.ds=openstack", "DataSourceOpenStack", True),
-        ("bonding.max_bonds=0", "DataSourceLXD", False),
+        ("bonding.max_bonds=0", "lxd_or_nocloud", False),
     ),
 )
 def test_lxd_datasource_kernel_override(
@@ -91,6 +91,10 @@ def test_lxd_datasource_kernel_override(
     kernel commandline in Python code is required.
     """
 
+    if configured == "lxd_or_nocloud":
+        configured = (
+            "DataSourceNoCloud" if lxd_has_nocloud(client) else "DataSourceLXD"
+        )
     override_kernel_cmdline(ds_str, client)
     if cmdline_configured:
         assert (


### PR DESCRIPTION
On focal we detect NoCloud rather than LXD, so ensure the test reflects this.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: fix kernel override test

On focal we detect NoCloud rather than LXD, so ensure the test reflects
this.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_vm/398/testReport/junit/tests.integration_tests/test_kernel_commandline_match/test_lxd_datasource_kernel_override_bonding_max_bonds_0_DataSourceLXD_False_/

Slightly concerning that this has been failing for weeks and nobody caught it

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
