### PR TITLE
test: fix tmpdir in test_cc_apk_configure

### DIFF
--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -10,7 +10,7 @@ import textwrap
 
 import pytest
 
-from cloudinit import cloud, helpers, util
+from cloudinit import cloud, helpers, temp_utils, util
 from cloudinit.config import cc_apk_configure
 from cloudinit.config.schema import (
     SchemaValidationError,
@@ -60,6 +60,7 @@ class TestConfig(FilesystemMockingTestCase):
         self.name = "apk_configure"
         self.cloud = cloud.Cloud(None, self.paths, None, None, None)
         self.args = []
+        temp_utils._TMPDIR = self.new_root
 
     @mock.patch(CC_APK + "._write_repositories_file")
     def test_no_repo_settings(self, m_write_repos):

--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -62,6 +62,10 @@ class TestConfig(FilesystemMockingTestCase):
         self.args = []
         temp_utils._TMPDIR = self.new_root
 
+    def tearDown(self):
+        super().tearDown()
+        temp_utils._TMPDIR = None
+
     @mock.patch(CC_APK + "._write_repositories_file")
     def test_no_repo_settings(self, m_write_repos):
         """


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: fix tmpdir in test_cc_apk_configure

cc_apk_configure uses temp_utils.py, which has special logic to return
if the user is root that can't be retargeted using our current fixtures.
Fix it by setting that tmpdir in the test setup.
```

## Additional Context
Running tests in `tests/unittests/config/test_cc_apk_configure.py` as root will demonstrate the failure

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
