### PR TITLE
tests: inactive module rename ubuntu_advantage to ubuntu_pro

### DIFF
--- a/tests/integration_tests/modules/test_ca_certs.py
+++ b/tests/integration_tests/modules/test_ca_certs.py
@@ -125,7 +125,7 @@ class TestCaCerts:
             "snap",
             "timezone",
             "ubuntu_autoinstall",
-            "ubuntu_advantage",
+            "ubuntu_pro",
             "ubuntu_drivers",
             "update_etc_hosts",
             "wireguard",


### PR DESCRIPTION
## Proposed Commit Message
same as commit summary

## Additional Context
Failed jenkins test runner. Looks like a missed case of ubuntu_advantage in an unrelated integration test.
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-ec2/lastSuccessfulBuild/testReport/junit/tests.integration_tests.modules.test_ca_certs/TestCaCerts/test_clean_log/


```
>       assert (
            not diff
        ), f"Expected inactive modules do not match, diff: {diff}"
E       AssertionError: Expected inactive modules do not match, diff: {'ubuntu_pro', 'ubuntu_advantage'}
E       assert not {'ubuntu_advantage', 'ubuntu_pro'}
```

## Test Steps
```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests -- tests/integration_tests/modules/test_ca_certs.py::TestCaCerts
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
