### PR TITLE
networkd: Always respect accept-ra if set

### DIFF
--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -192,9 +192,7 @@ class Renderer(renderer.Renderer):
 
         cfg.update_section(sec, "DHCP", dhcp)
 
-        if dhcp in ["ipv6", "yes"] and isinstance(
-            iface.get("accept-ra", ""), bool
-        ):
+        if isinstance(iface.get("accept-ra", ""), bool):
             cfg.update_section(sec, "IPv6AcceptRA", iface["accept-ra"])
 
         return dhcp

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -127,6 +127,7 @@ onitake
 orndorffgrant
 Oursin
 outscale-mdr
+philsphicas
 phsm
 phunyguy
 qubidt


### PR DESCRIPTION
Support the explicit rejection of router advertisements in cases where
the network may be configured to send them, but they are not desireable,
for example, in a case where static IPv4 addressing is used.

Before this change, IPv6AcceptRA is only included in the rendered
networkd files if DHCP is used.

Now, if a boolean value for accept-ra is present, it will be included in
the rendered output, regardless of the configured addressing.

Fixes: #4927
