### PR TITLE
tests: pro integration tests supply ubuntu_advantage until pro v32

### DIFF
--- a/tests/integration_tests/modules/test_ubuntu_pro.py
+++ b/tests/integration_tests/modules/test_ubuntu_pro.py
@@ -43,6 +43,14 @@ ubuntu_pro:
 
 PRO_AUTO_ATTACH_DISABLED = """\
 #cloud-config
+# ubuntu_advantage config kept as duplication until the release of this
+# commit in proclient (ubuntu-advantage-tools v. 32):
+# https://github.com/canonical/ubuntu-pro-client/commit/7bb69e3ad
+# Without a top-level ubuntu_advantage key Pro will automatically attach
+# instead of defer to cloud-init for all attach operations.
+ubuntu_advantage:
+  features:
+    disable_auto_attach: true
 ubuntu_pro:
   features:
     disable_auto_attach: true
@@ -51,6 +59,10 @@ ubuntu_pro:
 PRO_DAEMON_DISABLED = """\
 #cloud-config
 # Disable Pro daemon (only needed in GCE)
+# Drop ubuntu_advantage key once ubuntu-advantage-tools v. 32 is SRU'd
+ubuntu_advantage:
+  features:
+    disable_auto_attach: true
 ubuntu_pro:
   features:
     disable_auto_attach: true
@@ -60,6 +72,10 @@ bootcmd:
 
 AUTO_ATTACH_CUSTOM_SERVICES = """\
 #cloud-config
+# Drop ubuntu_advantage key once ubuntu-advantage-tools v. 32 is SRU'd
+ubuntu_advantage:
+  enable:
+  - esm-infra
 ubuntu_pro:
   enable:
   - esm-infra


### PR DESCRIPTION
Until ubuntu-advantage-tools version 32 is SRU'd to stable series Pro images will continue to auto-attach by default unless an ubuntu_advantage key is provided in user-data.

Allow our integration test to provide ubuntu_advantage and ubuntu_pro keys knowing that any ubuntu_pro config overrides ubuntu_advantage in latest cloud-init.

This will emit a warning message about preference of ubuntu_pro over ubuntu_advantage and deprecation warnings, but the integration test doesn't validate deprecation warnings.

We can drop ubuntu_advantage from our user-data in May when Pro 32 releases.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
