### PR TITLE
tests: lxd_vm early boot status test ordered After=systemd-remount-fs

### DIFF
--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -112,6 +112,7 @@ write_files:
     [Unit]
     Description=BEFORE cloud-init local
     DefaultDependencies=no
+    After=systemd-remount-fs.service
     Before=cloud-init-local.service
     Before=shutdown.target
     Before=sysinit.target


### PR DESCRIPTION
## Proposed Commit Message
```
tests: lxd_vm early boot status test ordered After=systemd-remount-fs

Fix errors seen on lxd_vm where test service
before-cloud-init-local.service gets run before the filesytem is mounted read-write.

Test failures exhibit the following failure:
 systemctl status before-cloud-init-local.service:

/waitoncloudinit.sh: 7: cannot create /before-local: Read-only file system
```
## Additional Context
Failing Jenkins tests show no test artifact files emitted by the example before-cloud-init-local.service which is setup by the test.
The issue is that the service is executing on the system while the filesystem is still read-only and before systemd-remount-fs.service has run. This leaves the early boot test service with the following types of script permission errors as seen from systemctl status

```
# systemctl status before-cloud-init-local.service
Warning: The unit file, source configuration file or drop-ins of before-cloud-init-local.service changed on disk. Run 'systemctl daemon-reload' to reload units.
● before-cloud-init-local.service - BEFORE cloud-init local
     Loaded: loaded (/lib/systemd/system/before-cloud-init-local.service; enabled; vendor preset: enabled)
     Active: failed (Result: exit-code) since Thu 2024-02-22 01:27:42 UTC; 16min ago
   Main PID: 100 (code=exited, status=2)

Feb 22 01:27:42 cloudinit-0222-01263934jph42x waitoncloudinit.sh[100]: /waitoncloudinit.sh: 7: cannot create /before-local: Read-only file system
Feb 22 01:27:42 cloudinit-0222-01263934jph42x waitoncloudinit.sh[100]: /waitoncloudinit.sh: 8: cannot create //before-local.start-nostatusjson: Read-only file system
Warning: journal has been rotated since unit was started, output may be incomplete.
```

## Test Steps
```
$ CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_OS_IMAGE=focal tox -e integration-tests -- tests/integration_tests/cmd/test_status.py::test_status_block_through_all_boot_status

# Confirm that the sample before-cloud-init-local.service was healthy and didn't exit non-zero
$ lxc exec cloudinit..... -- systemctl status before-cloud-init-local.service
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)