### PR TITLE
atomic_helper.py: ensure presence of parent directories

### DIFF
--- a/cloudinit/atomic_helper.py
+++ b/cloudinit/atomic_helper.py
@@ -7,6 +7,8 @@ import stat
 import tempfile
 from base64 import b64decode, b64encode
 
+from cloudinit import util
+
 _DEF_PERMS = 0o644
 LOG = logging.getLogger(__name__)
 
@@ -43,9 +45,9 @@ def write_file(
 
     tf = None
     try:
-        tf = tempfile.NamedTemporaryFile(
-            dir=os.path.dirname(filename), delete=False, mode=omode
-        )
+        dirname = os.path.dirname(filename)
+        util.ensure_dir(dirname)
+        tf = tempfile.NamedTemporaryFile(dir=dirname, delete=False, mode=omode)
         LOG.debug(
             "Atomically writing to file %s (via temporary file %s) - %s: [%o]"
             " %d bytes/chars",

--- a/tests/unittests/test_atomic_helper.py
+++ b/tests/unittests/test_atomic_helper.py
@@ -63,3 +63,9 @@ class TestAtomicHelper(CiTestCase):
     def check_perms(self, path, perms):
         file_stat = os.stat(path)
         self.assertEqual(perms, stat.S_IMODE(file_stat.st_mode))
+
+    def test_write_file_ensure_dirs(self):
+        path = self.tmp_path("ensure_dirs") + "/ensure/dir"
+        contents = b"Hey there\n"
+        atomic_helper.write_file(path, contents)
+        self.check_file(path, contents)


### PR DESCRIPTION
## Proposed Commit Message
```
fix(atomic_helper.py): ensure presence of parent directories
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
Steps to reproduce:

$ cloud-init clean -ls
$ cloud-init -d modules -m init
2024-02-22 18:59:46,522 - handlers.py[DEBUG]: start: modules-init: running modules for init
2024-02-22 18:59:46,522 - util.py[DEBUG]: Reading from /proc/uptime (quiet=False)
....
[('set_hostname', FileNotFoundError(2, 'No such file or directory'))]
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
