### PR TITLE
fix(cmd/main.py): use correct return value

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -126,12 +126,12 @@ def run_module_section(mods: Modules, action_name, section):
         )
         sys.stderr.write("%s\n" % (msg))
         LOG.debug(msg)
-        return []
+        return 1
     else:
         LOG.debug(
             "Ran %s modules with %s failures", len(which_ran), len(failures)
         )
-        return failures
+        return failures if failures else 0
 
 
 def apply_reporting_cfg(cfg):
@@ -786,7 +786,10 @@ def status_wrapper(name, args, data_d=None, link_d=None):
         else:
             errors = ret
 
-        v1[mode]["errors"] = [str(e) for e in errors]
+        if isinstance(errors, list):
+            v1[mode]["errors"] = [str(e) for e in errors]
+        else:
+            v1[mode]["errors"] = []
 
     except Exception as e:
         util.logexc(LOG, "failed stage %s", mode)

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -76,7 +76,7 @@ class TestMain(FilesystemMockingTestCase):
             "init",
             cmdargs,
         )
-        self.assertEqual([], item2)
+        self.assertEqual(0, item2)
         # Instancify is called
         instance_id_path = "var/lib/cloud/data/instance-id"
         self.assertEqual(
@@ -146,7 +146,7 @@ class TestMain(FilesystemMockingTestCase):
             "init",
             cmdargs,
         )
-        self.assertEqual([], item2)
+        self.assertEqual(0, item2)
         # Instancify is called
         instance_id_path = "var/lib/cloud/data/instance-id"
         self.assertEqual(


### PR DESCRIPTION
## Proposed Commit Message
```
fix(cmd/main.py): use correct return value
```

## Additional Context
```
$ cloud-init -d modules -m init
Above command returns non zero exit status
```

## Test Steps
```
root@ph4dev [ ~/cloud-init ]# cloud-init -d modules -m init
2024-02-22 19:10:07,659 - handlers.py[DEBUG]: start: modules-init: running modules for init
2024-02-22 19:10:07,659 - util.py[DEBUG]: Reading from /proc/uptime (quiet=False)
...
Cloud-init v. 23.4 running 'modules:init' at Thu, 22 Feb 2024 19:10:07 +0000. Up 26599.38 seconds.
[]

root@ph4dev [ ~/cloud-init ]# echo $?
1
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
