### PR TITLE
fix: Remove hardcoded /var/lib/cloud hotplug path

### DIFF
--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -10,7 +10,7 @@ import os
 import sys
 import time
 
-from cloudinit import log, reporting, settings, stages, util
+from cloudinit import log, reporting, stages, util
 from cloudinit.config.cc_install_hotplug import install_hotplug
 from cloudinit.event import EventScope, EventType
 from cloudinit.net import read_sys_net_safe
@@ -256,7 +256,7 @@ def enable_hotplug(hotplug_init: Init, subsystem) -> bool:
             f"hotplug not supported for event of {subsystem}", file=sys.stderr
         )
         return False
-    hotplug_enabled_file = util.read_hotplug_enabled_file()
+    hotplug_enabled_file = util.read_hotplug_enabled_file(hotplug_init.paths)
     if scope.value in hotplug_enabled_file["scopes"]:
         print(
             f"Not installing hotplug for event of type {subsystem}."
@@ -267,7 +267,7 @@ def enable_hotplug(hotplug_init: Init, subsystem) -> bool:
 
     hotplug_enabled_file["scopes"].append(scope.value)
     util.write_file(
-        settings.HOTPLUG_ENABLED_FILE,
+        hotplug_init.paths.get_cpath("hotplug.enabled"),
         json.dumps(hotplug_enabled_file),
         omode="w",
         mode=0o640,

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -347,6 +347,7 @@ class Paths(persistence.CloudInitPickleMixin):
             "vendor_cloud_config": "vendor-cloud-config.txt",
             "vendor_scripts": "scripts/vendor",
             "warnings": "warnings",
+            "hotplug.enabled": "hotplug.enabled",
         }
         # Set when a datasource becomes active
         self.datasource = ds

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -40,7 +40,6 @@ from cloudinit.net import cmdline
 from cloudinit.reporting import events
 from cloudinit.settings import (
     CLOUD_CONFIG,
-    HOTPLUG_ENABLED_FILE,
     PER_ALWAYS,
     PER_INSTANCE,
     PER_ONCE,
@@ -94,17 +93,17 @@ def update_event_enabled(
     )
 
     # Add supplemental hotplug event if supported and present in
-    # settings.HOTPLUG_ENABLED_FILE
+    # hotplug.enabled file
     if EventType.HOTPLUG in datasource.supported_update_events.get(
         scope, set()
     ):
-        hotplug_enabled_file = util.read_hotplug_enabled_file()
+        hotplug_enabled_file = util.read_hotplug_enabled_file(datasource.paths)
         if scope.value in hotplug_enabled_file["scopes"]:
             LOG.debug(
                 "Adding event: scope=%s EventType=%s found in %s",
                 scope,
                 EventType.HOTPLUG,
-                HOTPLUG_ENABLED_FILE,
+                datasource.paths.get_cpath("hotplug.enabled"),
             )
             if not allowed.get(scope):
                 allowed[scope] = set()

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -41,6 +41,7 @@ from errno import ENOENT
 from functools import lru_cache, total_ordering
 from pathlib import Path
 from typing import (
+    TYPE_CHECKING,
     Callable,
     Deque,
     Dict,
@@ -67,6 +68,10 @@ from cloudinit import (
     version,
 )
 from cloudinit.settings import CFG_BUILTIN, PER_ONCE
+
+if TYPE_CHECKING:
+    # Avoid circular import
+    from cloudinit.helpers import Paths
 
 _DNS_REDIRECT_IP = None
 LOG = logging.getLogger(__name__)
@@ -3290,14 +3295,14 @@ def deprecate_call(
     return wrapper
 
 
-def read_hotplug_enabled_file() -> dict:
+def read_hotplug_enabled_file(paths: "Paths") -> dict:
     content: dict = {"scopes": []}
     try:
         content = json.loads(
-            load_text_file(settings.HOTPLUG_ENABLED_FILE, quiet=False)
+            load_text_file(paths.get_cpath("hotplug.enabled"), quiet=False)
         )
     except FileNotFoundError:
-        LOG.debug("File not found: %s", settings.HOTPLUG_ENABLED_FILE)
+        LOG.debug("File not found: %s", paths.get_cpath("hotplug.enabled"))
     except json.JSONDecodeError as e:
         LOG.warning(
             "Ignoring contents of %s because it is not decodable. Error: %s",

--- a/tests/unittests/cmd/devel/test_hotplug_hook.py
+++ b/tests/unittests/cmd/devel/test_hotplug_hook.py
@@ -267,13 +267,16 @@ class TestEnableHotplug:
         mocks.m_init.datasource.get_supported_events.return_value = {
             EventScope.NETWORK: {EventType.HOTPLUG}
         }
+        mocks.m_init.paths.get_cpath.return_value = (
+            "/var/lib/cloud/hotplug.enabled"
+        )
 
         enable_hotplug(mocks.m_init, "net")
 
         assert [
             call([EventType.HOTPLUG])
         ] == mocks.m_init.datasource.get_supported_events.call_args_list
-        assert [call()] == m_read_hotplug_enabled_file.call_args_list
+        m_read_hotplug_enabled_file.assert_called_once()
         assert [
             call(
                 settings.HOTPLUG_ENABLED_FILE,
@@ -335,11 +338,14 @@ class TestEnableHotplug:
         mocks.m_init.datasource.get_supported_events.return_value = {
             EventScope.NETWORK: {EventType.HOTPLUG}
         }
+        mocks.m_init.paths.get_cpath.return_value = (
+            "/var/lib/cloud/hotplug.enabled"
+        )
         enable_hotplug(mocks.m_init, "net")
 
         assert [
             call([EventType.HOTPLUG])
         ] == mocks.m_init.datasource.get_supported_events.call_args_list
-        assert [call()] == m_read_hotplug_enabled_file.call_args_list
+        m_read_hotplug_enabled_file.assert_called_once()
         assert [] == m_write_file.call_args_list
         assert [] == m_install_hotplug.call_args_list

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -9,6 +9,7 @@ import pytest
 
 from cloudinit import sources, stages
 from cloudinit.event import EventScope, EventType
+from cloudinit.helpers import Paths
 from cloudinit.sources import DataSource, NetworkConfigSource
 from cloudinit.util import sym_link, write_file
 from tests.unittests.helpers import mock
@@ -40,6 +41,7 @@ class TestUpdateEventEnabled:
         self, m_read_hotplug_enabled_file, cfg, enabled_file_content, enabled
     ):
         m_datasource = mock.MagicMock(spec=DataSource)
+        m_datasource.paths = mock.MagicMock(spec=Paths)
         m_datasource.default_update_events = {}
         m_datasource.supported_update_events = {
             EventScope.NETWORK: [EventType.HOTPLUG]

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -3226,10 +3226,18 @@ class TestMaybeB64Decode:
         assert expected == util.maybe_b64decode(in_data)
 
 
+class MockPath:
+    def __init__(self, target_file="/does/not/exist"):
+        self.target_file = target_file
+
+    def get_cpath(self, *args):
+        return self.target_file
+
+
 @pytest.mark.usefixtures("fake_filesystem")
 class TestReadHotplugEnabledFile:
     def test_file_not_found(self, caplog):
-        assert {"scopes": []} == util.read_hotplug_enabled_file()
+        assert {"scopes": []} == util.read_hotplug_enabled_file(MockPath())
         assert "enabled because it is not decodable" not in caplog.text
 
     def test_json_decode_error(self, caplog, tmpdir):
@@ -3240,7 +3248,9 @@ class TestReadHotplugEnabledFile:
             .join("hotplug.enabled")
         )
         target_file.write("asdfasdfa")
-        assert {"scopes": []} == util.read_hotplug_enabled_file()
+        assert {"scopes": []} == util.read_hotplug_enabled_file(
+            MockPath(target_file.strpath)
+        )
         assert "not decodable" in caplog.text
 
     @pytest.mark.parametrize("content", ['{"scopes": ["network"]}'])
@@ -3252,4 +3262,6 @@ class TestReadHotplugEnabledFile:
             .join("hotplug.enabled")
         )
         target_file.write(content)
-        assert {"scopes": ["network"]} == util.read_hotplug_enabled_file()
+        assert {"scopes": ["network"]} == util.read_hotplug_enabled_file(
+            MockPath(target_file.strpath)
+        )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Remove hardcoded /var/lib/cloud hotplug path

The cloud dir is configurable, so we shouldn't be hardcoding the
hotplug.enabled file location
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_vm/407/testReport/junit/tests.integration_tests.test_paths/TestHonorCloudDir/test_honor_cloud_dir/

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
