### PR TITLE
test: allow downgrades when install debs

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -221,7 +221,7 @@ class IntegrationInstance:
         self.execute("apt update")
         # Use apt install instead of dpkg -i to pull in any changed pkg deps
         assert self.execute(
-            "apt install {path} --yes".format(path=remote_path)
+            f"apt install {remote_path} --yes --allow-downgrades"
         ).ok
 
     @retry(tries=30, delay=1)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: allow downgrades when install debs
```

## Additional Context
noble cloud-init has a pre-release of 24.1. Running bddeb has a 23.4+ release number until we release. Without the flag we can't apt install a deb on noble.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
