### PR TITLE
fix serial datasource definition for nocloud

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -1195,10 +1195,13 @@ def parse_cmdline() -> str:
     """Check if command line argument for this datasource was passed
     Passing by command line overrides runtime datasource detection
     """
-    cmdline = util.get_cmdline()
-    ds_parse_0 = re.search(r"(?:^|\s)ds=([^\s;]+)", cmdline)
-    ds_parse_1 = re.search(r"(?:^|\s)ci\.ds=([^\s;]+)", cmdline)
-    ds_parse_2 = re.search(r"(?:^|\s)ci\.datasource=([^\s;]+)", cmdline)
+    return parse_cmdline_or_dmi(util.get_cmdline())
+
+
+def parse_cmdline_or_dmi(input: str) -> str:
+    ds_parse_0 = re.search(r"(?:^|\s)ds=([^\s;]+)", input)
+    ds_parse_1 = re.search(r"(?:^|\s)ci\.ds=([^\s;]+)", input)
+    ds_parse_2 = re.search(r"(?:^|\s)ci\.datasource=([^\s;]+)", input)
     ds = ds_parse_0 or ds_parse_1 or ds_parse_2
     deprecated = ds_parse_1 or ds_parse_2
     if deprecated:

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -1,4 +1,6 @@
 """NoCloud datasource integration tests."""
+from textwrap import dedent
+
 import pytest
 from pycloudlib.lxd.instance import LXDInstance
 
@@ -88,3 +90,102 @@ def test_nocloud_seedfrom_vendordata(client: IntegrationInstance):
     client.restart()
     assert client.execute("cloud-init status").ok
     assert "seeded_vendordata_test_file" in client.execute("ls /var/tmp")
+
+
+SMBIOS_USERDATA = """\
+#cloud-config
+runcmd:
+  - touch /var/tmp/smbios_test_file
+"""
+SMBIOS_SEED_DIR = "/smbios_seed"
+
+
+def setup_nocloud_local_serial(instance: LXDInstance):
+    subp(
+        [
+            "lxc",
+            "config",
+            "set",
+            instance.name,
+            "raw.qemu=-smbios "
+            f"type=1,serial=ds=nocloud;s=file://{SMBIOS_SEED_DIR};h=myhost",
+        ]
+    )
+
+
+def setup_nocloud_network_serial(instance: LXDInstance):
+    subp(
+        [
+            "lxc",
+            "config",
+            "set",
+            instance.name,
+            "raw.qemu=-smbios "
+            "type=1,serial=ds=nocloud-net;s=http://0.0.0.0/;h=myhost",
+        ]
+    )
+
+
+@pytest.mark.lxd_use_exec
+@pytest.mark.skipif(
+    PLATFORM != "lxd_vm",
+    reason="Requires NoCloud with raw QEMU serial setup",
+)
+class TestSmbios:
+    @pytest.mark.lxd_setup.with_args(setup_nocloud_local_serial)
+    def test_smbios_seed_local(self, client: IntegrationInstance):
+        """Check that smbios seeds that use local disk work"""
+        assert client.execute(f"mkdir -p {SMBIOS_SEED_DIR}").ok
+        client.write_to_file(f"{SMBIOS_SEED_DIR}/user-data", SMBIOS_USERDATA)
+        client.write_to_file(f"{SMBIOS_SEED_DIR}/meta-data", "")
+        client.write_to_file(f"{SMBIOS_SEED_DIR}/vendor-data", "")
+        assert client.execute("cloud-init clean --logs").ok
+        client.restart()
+        assert client.execute("test -f /var/tmp/smbios_test_file").ok
+
+    @pytest.mark.lxd_setup.with_args(setup_nocloud_network_serial)
+    def test_smbios_seed_network(self, client: IntegrationInstance):
+        """Check that smbios seeds that use network (http/https) work"""
+        service_file = "/lib/systemd/system/local-server.service"
+        client.write_to_file(
+            service_file,
+            dedent(
+                """\
+                [Unit]
+                Description=Serve a local webserver
+                Before=cloud-init.service
+                Wants=cloud-init-local.service
+                DefaultDependencies=no
+                After=systemd-networkd-wait-online.service
+                After=networking.service
+
+
+                [Install]
+                WantedBy=cloud-init.target
+
+                [Service]
+                """
+                f"WorkingDirectory={SMBIOS_SEED_DIR}"
+                """
+                ExecStart=/usr/bin/env python3 -m http.server --bind 0.0.0.0 80
+                """
+            ),
+        )
+        assert client.execute(
+            "chmod 644 /lib/systemd/system/local-server.service"
+        ).ok
+        assert client.execute("systemctl enable local-server.service").ok
+        client.write_to_file(
+            "/etc/cloud/cloud.cfg.d/91_do_not_use_lxd.cfg",
+            "datasource_list: [ NoCloud, None ]\n",
+        )
+        assert client.execute(f"mkdir -p {SMBIOS_SEED_DIR}").ok
+        client.write_to_file(f"{SMBIOS_SEED_DIR}/user-data", SMBIOS_USERDATA)
+        client.write_to_file(f"{SMBIOS_SEED_DIR}/meta-data", "")
+        client.write_to_file(f"{SMBIOS_SEED_DIR}/vendor-data", "")
+        assert client.execute("cloud-init clean --logs").ok
+        client.restart()
+        assert client.execute("test -f /var/tmp/smbios_test_file").ok
+        assert "'nocloud-net' datasource name is deprecated" in client.execute(
+            "cloud-init status --format json"
+        )


### PR DESCRIPTION
## Proposed Commit Message
```
fix(nocloud): NoCloud serial datasource definition is broken

Fix it.
Deprecate the "nocloud-net" name.
```

## Additional Context
https://github.com/canonical/cloud-init/issues/4945
https://github.com/canonical/cloud-init/issues/4948

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
