### PR TITLE
test: Use correct lxd network-config keys

### DIFF
--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -19,6 +19,13 @@ from tests.integration_tests.releases import (
 )
 from tests.integration_tests.util import verify_clean_log
 
+# Older Ubuntu series didn't read cloud-init.* config keys
+LXD_NETWORK_CONFIG_KEY = (
+    "user.network-config"
+    if CURRENT_RELEASE < JAMMY
+    else "cloud-init.network-config"
+)
+
 
 def _add_dummy_bridge_to_netplan(client: IntegrationInstance):
     # Update netplan configuration to ensure it doesn't change on reboot
@@ -161,20 +168,27 @@ ethernets:
     PLATFORM != "lxd_vm",
     reason="Test requires custom networking provided by LXD",
 )
-@pytest.mark.parametrize("net_config", (NET_V1_CONFIG, NET_V2_MATCH_CONFIG))
+@pytest.mark.parametrize(
+    "net_config",
+    (
+        pytest.param(NET_V1_CONFIG, id="v1"),
+        pytest.param(NET_V2_MATCH_CONFIG, id="v2"),
+    ),
+)
 def test_netplan_rendering(
     net_config, session_cloud: IntegrationCloud, setup_image
 ):
     mac_addr = random_mac_address()
     launch_kwargs = {
         "config_dict": {
-            "cloud-init.network-config": net_config.format(mac_addr=mac_addr),
+            LXD_NETWORK_CONFIG_KEY: net_config.format(mac_addr=mac_addr),
             "volatile.eth0.hwaddr": mac_addr,
         },
     }
     expected = yaml.safe_load(EXPECTED_NET_CONFIG)
-    expected["network"]["ethernets"]["eth0"]["match"] = {}
-    expected["network"]["ethernets"]["eth0"]["match"]["macaddress"] = mac_addr
+    expected["network"]["ethernets"]["eth0"]["match"] = {
+        "macaddress": mac_addr
+    }
     with session_cloud.launch(launch_kwargs=launch_kwargs) as client:
         result = client.execute("cat /etc/netplan/50-cloud-init.yaml")
         assert result.stdout.startswith(EXPECTED_NETPLAN_HEADER)
@@ -201,11 +215,18 @@ version: 1
 def test_schema_warnings(
     net_config, session_cloud: IntegrationCloud, setup_image
 ):
+    # TODO: This test takes a lot more time than it needs to.
+    # The default launch wait will wait until cloud-init done, but the
+    # init network stage will wait 2 minutes for network timeout.
+    # We could set wait=False and do our own waiting, but there's also the
+    # issue of `execute_via_ssh=False` on pycloudlib means we `sudo -u ubuntu`
+    # the exec commands, but the ubuntu user won't exist until
+    # # after the init network stage runs.
     mac_addr = random_mac_address()
     launch_kwargs = {
         "execute_via_ssh": False,
         "config_dict": {
-            "cloud-init.network-config": net_config.format(mac_addr=mac_addr),
+            LXD_NETWORK_CONFIG_KEY: net_config.format(mac_addr=mac_addr),
             "volatile.eth0.hwaddr": mac_addr,
         },
     }
@@ -240,21 +261,16 @@ def test_invalid_network_v2_netplan(
 ):
     mac_addr = random_mac_address()
 
-    # Older Ubuntu series didn't read cloud-init.* config keys
-    if CURRENT_RELEASE < JAMMY:
-        lxd_network_config_key = "user.network-config"
-    else:
-        lxd_network_config_key = "cloud-init.network-config"
     if PLATFORM == "lxd_vm":
         config_dict = {
-            lxd_network_config_key: BAD_NETWORK_V2.format(
+            LXD_NETWORK_CONFIG_KEY: BAD_NETWORK_V2.format(
                 match_condition=f"macaddress: {mac_addr}"
             ),
             "volatile.eth0.hwaddr": mac_addr,
         }
     else:
         config_dict = {
-            lxd_network_config_key: BAD_NETWORK_V2.format(
+            LXD_NETWORK_CONFIG_KEY: BAD_NETWORK_V2.format(
                 match_condition="name: eth0"
             )
         }


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Use correct lxd network-config keys

Focal uses user.network-config while others use
cloud-init.network-config. Ensure we handle all cases approparitely in
test_networking.py

There are also some minor refactors
```

## Additional Context
Last 3 failures here: https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_vm/408/#showFailuresLink

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
