### PR TITLE
doc(network-v2): fix section nesting levels

### DIFF
--- a/doc/rtd/reference/network-config-format-v2.rst
+++ b/doc/rtd/reference/network-config-format-v2.rst
@@ -149,7 +149,7 @@ Example: ::
     name: en*s0
 
 ``set-name: <(scalar)>``
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 When matching on unique properties such as path or MAC, or with additional
 assumptions such as "there will only ever be one wifi device", match rules
@@ -160,7 +160,7 @@ will then fail to get renamed and keep the original kernel name (and dmesg
 will show an error).
 
 ``wakeonlan: <(bool)>``
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 Enable wake on LAN. Off by default.
 
@@ -180,17 +180,17 @@ particular device definition. Default is ``networkd``.
    config to the instance.
 
 ``dhcp4: <(bool)>``
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 Enable DHCP for IPv4. Off by default.
 
 ``dhcp6: <(bool)>``
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 Enable DHCP for IPv6. Off by default.
 
 ``dhcp4-overrides and dhcp6-overrides: <(mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------------------------
 
 DHCP behaviour overrides. Overrides will only have an effect if
 the corresponding DHCP type is enabled. Refer to `Netplan#dhcp-overrides`_
@@ -231,7 +231,7 @@ Example: ::
     use-routes: false
 
 ``addresses: <(sequence of scalars)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------
 
 Add static addresses to the interface in addition to the ones received
 through DHCP or RA. Each sequence entry is in CIDR notation, i.e., of the
@@ -241,7 +241,7 @@ by ``inet_pton(3)`` and ``prefixlen`` the number of bits of the subnet.
 Example: ``addresses: [192.168.14.2/24, 2001:1::1/64]``
 
 ``gateway4: or gateway6: <(scalar)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------
 
 Deprecated, see `Netplan#default-routes`_.
 Set default gateway for IPv4/6, for manual address configuration. This
@@ -252,14 +252,14 @@ Example for IPv4: ``gateway4: 172.16.0.1``
 Example for IPv6: ``gateway6: 2001:4::1``
 
 ``mtu: <MTU SizeBytes>``
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 The MTU key represents a device's Maximum Transmission Unit, the largest size
 packet or frame, specified in octets (eight-bit bytes), that can be sent in a
 packet- or frame-based network. Specifying ``mtu`` is optional.
 
 ``nameservers: <(mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 
 Set DNS servers and search domains, for manual address configuration. There
 are two supported fields: ``addresses:`` is a list of IPv4 or IPv6 addresses
@@ -272,7 +272,7 @@ Example: ::
     addresses: [8.8.8.8, FEDC::1]
 
 ``routes: <(sequence of mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------
 
 Add device specific routes. Each mapping includes a ``to``, ``via`` key
 with an IPv4 or IPv6 address as value. ``metric`` is an optional value.
@@ -285,16 +285,16 @@ Example: ::
      metric: 3
 
 Ethernets
----------
+=========
 
 Ethernet device definitions do not support any specific properties beyond the
 common ones described above.
 
 Bonds
------
+=====
 
 ``interfaces: <(sequence of scalars)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 All devices matching this ID list will be added to the bond.
 
@@ -309,7 +309,7 @@ Example: ::
       interfaces: [switchports]
 
 ``parameters: <(mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 Customisation parameters for special bonding options. Time values are
 specified in seconds unless otherwise specified.
@@ -450,10 +450,10 @@ value is ``1``. This option only affects ``balance-tlb`` and
 
 
 Bridges
--------
+=======
 
 ``interfaces: <(sequence of scalars)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 All devices matching this ID list will be added to the bridge.
 
@@ -468,7 +468,7 @@ Example: ::
       interfaces: [switchports]
 
 ``parameters: <(mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 Customisation parameters for special bridging options. Time values are
 specified in seconds unless otherwise stated.
@@ -523,15 +523,15 @@ default value is "true", which means that Spanning Tree should be
 used.
 
 VLANs
------
+=====
 
 ``id: <(scalar)>``
-^^^^^^^^^^^^^^^^^^
+------------------
 
 VLAN ID, a number between 0 and 4094.
 
 ``link: <(scalar)>``
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 ID of the underlying device definition on which this VLAN gets created.
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
doc(network-v2): fix section nesting levels

Place `set-name` and `wakeonlan` out of `match`, see [0]. Move the elements under the previous part one level up.

References:

[0] https://netplan.readthedocs.io/en/latest/netplan-yaml/#properties-for-physical-device-types
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
