### PR TITLE
test: fix test_get_status_systemd_failure

### DIFF
--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -130,10 +130,16 @@ class TestStatus:
         f"{M_PATH}systemd_failed",
         return_value=True,
     )
+    @mock.patch(
+        f"{M_PATH}uses_systemd",
+        return_value=True,
+    )
     def test_get_status_systemd_failure(
         self,
+        m_uses_systemd,
         m_systemd_status,
         m_boot_status,
+        m_is_running,
         m_p_exists,
         m_load_json,
         tmpdir,


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: fix test_get_status_systemd_failure

"uses_systemd" wasn't mocked. Also, `m_is_running` needed
to be specified in the mock list.
```

## Additional Context
https://launchpadlibrarian.net/716284641/buildlog_ubuntu-mantic-amd64.cloud-init_99.daily-202402270455-1447bfe4~ubuntu23.10.1_BUILDING.txt.gz

In a container, moved the `/run/systemd/system` dir and test fails on main like it does currently, but passes on this branch.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
