### PR TITLE
fix(cc_resize): Don't warn if zpool command not found

### DIFF
--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -158,7 +158,7 @@ def get_device_info_from_zpool(zpool) -> Optional[str]:
         zpoolstatus, err = subp.subp(["zpool", "status", zpool])
         if err:
             LOG.info(
-                "zpool status returned: [%s] for zpool",
+                "zpool status returned error: [%s] for zpool [%s]",
                 err,
                 zpool,
             )

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -11,8 +11,10 @@
 import errno
 import logging
 import os
+import re
 import stat
 from textwrap import dedent
+from typing import Optional
 
 from cloudinit import subp, util
 from cloudinit.cloud import Cloud
@@ -146,6 +148,31 @@ RESIZE_FS_PREFIXES_CMDS = [
 RESIZE_FS_PRECHECK_CMDS = {"ufs": _can_skip_resize_ufs}
 
 
+def get_device_info_from_zpool(zpool) -> Optional[str]:
+    # zpool has 10 second timeout waiting for /dev/zfs LP: #1760173
+    if not os.path.exists("/dev/zfs"):
+        LOG.debug("Cannot get zpool info, no /dev/zfs")
+        return None
+    try:
+        zpoolstatus, err = subp.subp(["zpool", "status", zpool])
+    except subp.ProcessExecutionError as err:
+        if util.is_container():
+            LOG.info(
+                "Unable to get zpool status of %s: %s in container", zpool, err
+            )
+            return None
+        LOG.warning("Unable to get zpool status of %s: %s", zpool, err)
+        return None
+    if err:
+        return None
+    r = r".*(ONLINE).*"
+    for line in zpoolstatus.split("\n"):
+        if re.search(r, line) and zpool not in line and "state" not in line:
+            disk = line.split()[0]
+            LOG.debug('found zpool "%s" on disk %s', zpool, disk)
+            return disk
+
+
 def can_skip_resize(fs_type, resize_what, devpth):
     fstype_lc = fs_type.lower()
     for i, func in RESIZE_FS_PRECHECK_CMDS.items():
@@ -259,7 +286,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # so the _resize_zfs function gets the right attribute.
     if fs_type == "zfs":
         zpool = devpth.split("/")[0]
-        devpth = util.get_device_info_from_zpool(zpool)
+        devpth = get_device_info_from_zpool(zpool)
         if not devpth:
             return  # could not find device from zpool
         resize_what = zpool

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -150,7 +150,7 @@ RESIZE_FS_PRECHECK_CMDS = {"ufs": _can_skip_resize_ufs}
 
 def get_device_info_from_zpool(zpool) -> Optional[str]:
     # zpool has 10 second timeout waiting for /dev/zfs LP: #1760173
-    log_warn = LOG.debug if util.is_container() else LOG.warn
+    log_warn = LOG.debug if util.is_container() else LOG.warning
     if not os.path.exists("/dev/zfs"):
         LOG.debug("Cannot get zpool info, no /dev/zfs")
         return None

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2665,26 +2665,6 @@ def get_freebsd_devpth(path):
     return "/dev/" + label_part
 
 
-def get_device_info_from_zpool(zpool):
-    # zpool has 10 second timeout waiting for /dev/zfs LP: #1760173
-    if not os.path.exists("/dev/zfs"):
-        LOG.debug("Cannot get zpool info, no /dev/zfs")
-        return None
-    try:
-        (zpoolstatus, err) = subp.subp(["zpool", "status", zpool])
-    except subp.ProcessExecutionError as err:
-        LOG.warning("Unable to get zpool status of %s: %s", zpool, err)
-        return None
-    if len(err):
-        return None
-    r = r".*(ONLINE).*"
-    for line in zpoolstatus.split("\n"):
-        if re.search(r, line) and zpool not in line and "state" not in line:
-            disk = line.split()[0]
-            LOG.debug('found zpool "%s" on disk %s', zpool, disk)
-            return disk
-
-
 def parse_mount(path, get_mnt_opts=False):
     """Return the mount information for PATH given the lines ``mount(1)``
     This function is compatible with ``util.parse_mount_info()``"""

--- a/tests/unittests/config/test_cc_resizefs.py
+++ b/tests/unittests/config/test_cc_resizefs.py
@@ -538,7 +538,8 @@ class TestZpool:
         m_os.path.exists.assert_called_with("/dev/zfs")
 
     @mock.patch(M_PATH + "os")
-    def test_get_device_info_from_zpool_no_dev_zfs(self, m_os):
+    @mock.patch("cloudinit.subp.subp", return_value=("", ""))
+    def test_get_device_info_from_zpool_no_dev_zfs(self, m_os, m_subp):
         # mock /dev/zfs missing
         m_os.path.exists.return_value = False
         assert not get_device_info_from_zpool("vmzroot")

--- a/tests/unittests/config/test_cc_resizefs.py
+++ b/tests/unittests/config/test_cc_resizefs.py
@@ -22,7 +22,7 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
-from cloudinit.subp import ProcessExecutionError, subp
+from cloudinit.subp import ProcessExecutionError
 from tests.unittests.helpers import (
     CiTestCase,
     mock,

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2177,54 +2177,6 @@ class TestMountinfoParsing(helpers.ResourceUsingTestCase):
         expected = ("none", "tmpfs", "/run/lock")
         self.assertEqual(expected, util.parse_mount_info("/run/lock", lines))
 
-    @mock.patch(M_PATH + "os")
-    @mock.patch("cloudinit.subp.subp")
-    def test_get_device_info_from_zpool(self, zpool_output, m_os):
-        # mock /dev/zfs exists
-        m_os.path.exists.return_value = True
-        # mock subp command from util.get_mount_info_fs_on_zpool
-        zpool_output.return_value = (
-            helpers.readResource("zpool_status_simple.txt"),
-            "",
-        )
-        # save function return values and do asserts
-        ret = util.get_device_info_from_zpool("vmzroot")
-        self.assertEqual("gpt/system", ret)
-        self.assertIsNotNone(ret)
-        m_os.path.exists.assert_called_with("/dev/zfs")
-
-    @mock.patch(M_PATH + "os")
-    def test_get_device_info_from_zpool_no_dev_zfs(self, m_os):
-        # mock /dev/zfs missing
-        m_os.path.exists.return_value = False
-        # save function return values and do asserts
-        ret = util.get_device_info_from_zpool("vmzroot")
-        self.assertIsNone(ret)
-
-    @mock.patch(M_PATH + "os")
-    @mock.patch("cloudinit.subp.subp")
-    def test_get_device_info_from_zpool_handles_no_zpool(self, m_sub, m_os):
-        """Handle case where there is no zpool command"""
-        # mock /dev/zfs exists
-        m_os.path.exists.return_value = True
-        m_sub.side_effect = subp.ProcessExecutionError("No zpool cmd")
-        ret = util.get_device_info_from_zpool("vmzroot")
-        self.assertIsNone(ret)
-
-    @mock.patch(M_PATH + "os")
-    @mock.patch("cloudinit.subp.subp")
-    def test_get_device_info_from_zpool_on_error(self, zpool_output, m_os):
-        # mock /dev/zfs exists
-        m_os.path.exists.return_value = True
-        # mock subp command from util.get_mount_info_fs_on_zpool
-        zpool_output.return_value = (
-            helpers.readResource("zpool_status_simple.txt"),
-            "error",
-        )
-        # save function return values and do asserts
-        ret = util.get_device_info_from_zpool("vmzroot")
-        self.assertIsNone(ret)
-
     @mock.patch("cloudinit.subp.subp")
     def test_parse_mount_with_ext(self, mount_out):
         mount_out.return_value = (


### PR DESCRIPTION
## Proposed Commit Message
```
fix(cc_resize): Don't warn if zpool command not found

Not resizing the rootfs should not cause warnings in containers.
This is expected, and how cloud-init currently behaves. Similarly,
if the image doesn't include the tools to resize the rootfs in a
container, cloud-init should similarly not raise warnings.

Other changes:
- relocate single-use helper function from cc_resize to util.py
- add warning on non-containers when no device is found.

LP: #2055219
```

## Additional Context
many container test failures, [including this one](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_container/lastCompletedBuild/testReport/)

## Test Steps
To hit this codepath, I believe you need zfs-backed lxd storage, which I do not have. Should be reproducible via:
```
tox -e integration-tests --  tests/integration_tests/modules/test_cli.py::test_valid_userdata
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
