### PR TITLE
fix(util): Check if the zpool command is available before using it

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2670,6 +2670,11 @@ def get_device_info_from_zpool(zpool):
     if not os.path.exists("/dev/zfs"):
         LOG.debug("Cannot get zpool info, no /dev/zfs")
         return None
+    if not subp.which("zpool"):
+        # lxd containers may have /dev/zfs but not necessarily the zpool
+        # command available (LP: #2055219)
+        LOG.debug("Cannot get zpool info, no zpool command available")
+        return None
     try:
         (zpoolstatus, err) = subp.subp(["zpool", "status", zpool])
     except subp.ProcessExecutionError as err:


### PR DESCRIPTION
## Proposed Commit Message
```
fix(util): Check if the zpool command is available before using it

LXD exposes `/dev/zfs` inside containers backed by a ZFS storage
pool (see https://github.com/canonical/lxd/pull/12056). This device
being visible caused cloud-init to try and get some zpool information
by calling `zpool status <pool>`.

However, the zpool command might not be available in the container
where cloud-init executes. When not available, it would cause the
following warning/error to be displayed:

WARNING:
- Unable to get zpool status of default: Unexpected error while running
  command. Command: ['zpool', 'status', 'default'] Exit code: - 
  Reason: [Errno 2] No such file or directory: b'zpool' Stdout: - Stderr: -

Fixes LP: #2055219
```