### PR TITLE
test: Fix udhcpc xfail

### DIFF
--- a/tests/integration_tests/net/test_dhcp.py
+++ b/tests/integration_tests/net/test_dhcp.py
@@ -80,7 +80,7 @@ class TestDHCP:
         if not "ec2" == PLATFORM:
             assert "Received dhcp lease on " in log, "EphemeralDHCPv4 failed"
         if "azure" == PLATFORM:
-            if "udhcpc" == client:
+            if "udhcpc" == dhcp_client:
                 pytest.xfail(
                     "udhcpc implementation doesn't support azure, see GH-4765"
                 )


### PR DESCRIPTION
## Proposed Commit Message
```
test: Fix xfail to check the dhcp client name

Rather than the instance client object
```

## Additional Context
[Failing test](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-azure/lastCompletedBuild/testReport/tests.integration_tests.net.test_dhcp/TestDHCP/test_noble_and_newer_force_client_udhcpc_udhcpc_/)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
