### PR TITLE
feat(subp): Make identifying invalid commands easier

### DIFF
--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -144,7 +144,7 @@ class ProcessExecutionError(IOError):
         return text.rstrip(b"\n").replace(b"\n", b"\n" + b" " * indent_level)
 
 
-def is_invalid_command(args: Union[List[str], List[bytes]]):
+def raise_on_invalid_command(args: Union[List[str], List[bytes]]):
     """check argument types to ensure that subp() can run the argument
 
     Throw a user-friendly exception which explains the issue.
@@ -155,9 +155,9 @@ def is_invalid_command(args: Union[List[str], List[bytes]]):
     for component in args:
         # if already bytes, or implements encode(), then it should be safe
         if not (isinstance(component, bytes) or hasattr(component, "encode")):
-            LOG.warning("Running invalid command %s", args)
+            LOG.warning("Running invalid command: %s", args)
             raise ProcessExecutionError(
-                cmd=args, reason=f"Running invalid command {args}"
+                cmd=args, reason=f"Running invalid command: {args}"
             )
 
 
@@ -258,7 +258,7 @@ def subp(
     elif isinstance(args, str):
         bytes_args = args.encode("utf-8")
     else:
-        is_invalid_command(args)
+        raise_on_invalid_command(args)
         bytes_args = [
             x if isinstance(x, bytes) else x.encode("utf-8") for x in args
         ]

--- a/tests/unittests/test_subp.py
+++ b/tests/unittests/test_subp.py
@@ -239,6 +239,14 @@ class TestSubp(CiTestCase):
         self.assertTrue(isinstance(cm.exception.stdout, str))
         self.assertTrue(isinstance(cm.exception.stderr, str))
 
+    def test_exception_invalid_command(self):
+        args = [None, "first", "arg", "missing"]
+        with self.assertRaises(
+            subp.ProcessExecutionError, msg="Running invalid command"
+        ):
+            with self.allow_subp(args):
+                subp.subp(args)
+
     def test_bunch_of_slashes_in_path(self):
         self.assertEqual(
             "/target/my/path/", subp.target_path("/target/", "//my/path/")


### PR DESCRIPTION
## Proposed Commit Message
```
feat(subp): Make invalid command warning more user-friendly
```

## Additional Context

from https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-azure/lastCompletedBuild/testReport/tests.integration_tests.datasources/test_azure/test_azure_eject/

current tracebacks look like this:
```
 'Traceback (most recent call last):\n'
 '  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_disk_setup.py", '
 'line 491, in check_partition_gpt_layout\n'
 '    out, _err = subp.subp(prt_cmd, update_env=LANG_C_ENV)\n'
 '                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n'
 '  File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 244, in '
 'subp\n'
 '    bytes_args = [\n'
 '                 ^\n'
 '  File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 245, in '
 '<listcomp>\n'
 '    x if isinstance(x, bytes) else x.encode("utf-8") for x in args\n'
 '                                   ^^^^^^^^\n'
 "AttributeError: 'NoneType' object has no attribute 'encode'\n"
 '\n'
 'The above exception was the direct cause of the following exception:\n'
 '\n'
 'Traceback (most recent call last):\n'
 '  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_disk_setup.py", '
 'line 136, in handle\n'
 '    util.log_time(\n'
 '  File "/usr/lib/python3/dist-packages/cloudinit/util.py", line 2845, in '
 'log_time\n'
 '    ret = func(*args, **kwargs)\n'
 '          ^^^^^^^^^^^^^^^^^^^^^\n'
 '  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_disk_setup.py", '
 'line 829, in mkpart\n'
 '    if check_partition_layout(table_type, device, layout):\n'
 '       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n'
 '  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_disk_setup.py", '
 'line 538, in check_partition_layout\n'
 '    found_layout = check_partition_gpt_layout(device, layout)\n'
 '                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n'
 '  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_disk_setup.py", '
 'line 493, in check_partition_gpt_layout\n'
 '    raise RuntimeError(\n'
 'RuntimeError: Error running partition command on /dev/sda\n'
 "'NoneType' object has no attribute 'encode'\n"
```

## Test Steps
```
tox -e py3
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
