### PR TITLE
Ignoring duplicate macs for calico network

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -984,6 +984,15 @@ def get_interfaces_by_mac_on_linux() -> dict:
                 )
                 continue
 
+            if name.startswith("cali") and mac == "ee:ee:ee:ee:ee:ee":
+                LOG.debug(
+                    "Ignoring duplicate macs from '%s' and '%s' due to "
+                    "calico network.",
+                    name,
+                    ret[mac],
+                )
+                continue
+
             msg = "duplicate mac found! both '%s' and '%s' have mac '%s'." % (
                 name,
                 ret[mac],


### PR DESCRIPTION
test_net failed in  the calico network env. error msg is:
```
                 msg = "duplicate mac found! both '%s' and '%s' have mac '%s'." % (
                     name,
                     ret[mac],
                     mac,
                 )
 >               raise RuntimeError(msg)
 E               RuntimeError: duplicate mac found! both 'caliaadab05bca1' and 'cali7a099f8b737' have mac 'ee:ee:ee:ee:ee:ee'.

 cloudinit/net/__init__.py:987: RuntimeError
```

 Checking the execution environment network interfaces information, it was found that multiple network interfaces's MAC addresses are ee:ee:ee:ee:ee:ee. eg:
```
 4789: calie4685cb71c1@if10: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1440 qdisc noqueue state UP group default
     link/ether ee:ee:ee:ee:ee:ee brd ff:ff:ff:ff:ff:ff link-netnsid 5
     inet6 fe80::ecee:eeff:feee:eeee/64 scope link
        valid_lft forever preferred_lft forever
 4799: calib73b89e79e5@if10: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1440 qdisc noqueue state UP group default
     link/ether ee:ee:ee:ee:ee:ee brd ff:ff:ff:ff:ff:ff link-netnsid 8
     inet6 fe80::ecee:eeff:feee:eeee/64 scope link
         valid_lft forever preferred_lft forever
```

 Q:Why do all cali* interfaces have the MAC address ee:ee:ee:ee:ee:ee?
 In some setups the kernel is unable to generate a persistent MAC address and so Calico assigns a MAC address itself. Since Calico uses point-to-point routed interfaces, traffic does not reach the data link layer so the MAC Address is never used and can therefore be the same for all the cali* interfaces. Reference:https://docs.tigera.io/calico/latest/reference/faq#why-do-all-cali-interfaces-have-the-mac-address-eeeeeeeeeeee

Fixes GH-4973



