### PR TITLE
net/dhcp: fix maybe_perform_dhcp_discovery check for interface=None

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -95,6 +95,10 @@ def maybe_perform_dhcp_discovery(distro, nic=None, dhcp_log_func=None):
         returned.
     """
     interface = nic or distro.fallback_interface
+    if interface is None:
+        LOG.debug("Skip dhcp_discovery: Unable to find fallback nic.")
+        raise NoDHCPLeaseInterfaceError()
+
     return distro.dhcp_client.dhcp_discovery(interface, dhcp_log_func, distro)
 
 

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -1318,3 +1318,10 @@ class TestDhcpcd:
                 ),
             ]
         )
+
+
+class TestMaybePerformDhcpDiscovery:
+    def test_none_and_missing_fallback(self):
+        with pytest.raises(NoDHCPLeaseInterfaceError):
+            distro = mock.Mock(fallback_interface=None)
+            maybe_perform_dhcp_discovery(distro, None)


### PR DESCRIPTION
If there are no NICs available when attempting to perform DHCP, dhcp_discovery() will pass along interface=None.  Here is an example failing backtrace:

```
  File "/usr/lib/python3/dist-packages/cloudinit/net/ephemeral.py", line 288, in obtain_lease
    self.lease = maybe_perform_dhcp_discovery(
  File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 98, in maybe_perform_dhcp_discovery
    return distro.dhcp_client.dhcp_discovery(interface, dhcp_log_func, distro)
  File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 324, in dhcp_discovery
    distro.net_ops.link_up(interface)
  File "/usr/lib/python3/dist-packages/cloudinit/net/netops/iproute2.py", line 10, in link_up
    subp.subp(
  File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 244, in subp
    bytes_args = [
  File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 245, in <listcomp>
    x if isinstance(x, bytes) else x.encode("utf-8") for x in args
AttributeError: 'NoneType' object has no attribute 'encode'
```

Restore the previous guard which raised NoDHCPLeaseInterfaceError and add a unit test for coverage.

Note that the original checks included `if nic not in get_devicelist()` which is not restored in this PR.