### PR TITLE
tests: upgrade tests should only validate current boot log

### DIFF
--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -203,6 +203,8 @@ def test_subsequent_boot_of_upgraded_package(session_cloud: IntegrationCloud):
 
     with session_cloud.launch(launch_kwargs=launch_kwargs) as instance:
         instance.install_new_cloud_init(source, clean=False)
+        # Ensure we aren't looking at any prior warnings/errors from prior boot
+        instance.execute("rm /var/log/cloud-init.log")
         instance.restart()
         log = instance.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)


### PR DESCRIPTION
## Proposed Commit Message
```
tests: upgrade tests should only validate current boot log

In upgrade tests, we should only validate clean log on the latest
boot to avoid false positives for warnings/errors which were removed
by upgrade.
```

## Additional Context
Failed jenkins job showing warning from boot prior to pkg upgrade
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-lxd_container/395/testReport/tests.integration_tests/test_upgrade/test_subsequent_boot_of_upgraded_package/
```
tests.integration_tests.test_upgrade.test_subsequent_boot_of_upgraded_package (from pytest)
...
    def test_subsequent_boot_of_upgraded_package(session_cloud: IntegrationCloud):
        source = get_validated_source(session_cloud)
        if not source.installs_new_version():
            if os.environ.get("GITHUB_ACTIONS"):
                # If this isn't running on CI, we should know
                pytest.fail(UNSUPPORTED_INSTALL_METHOD_MSG.format(source))
            else:
                pytest.skip(UNSUPPORTED_INSTALL_METHOD_MSG.format(source))
            return  # type checking doesn't understand that skip raises
    
        launch_kwargs = {"image_id": session_cloud.initial_image_id}
    
        with session_cloud.launch(launch_kwargs=launch_kwargs) as instance:
            instance.install_new_cloud_init(source, clean=False)
            instance.restart()
            log = instance.read_from_file("/var/log/cloud-init.log")
>           verify_clean_log(log)
...
AssertionError: Unexpected warning count != 0. Found: ['WARNING]: Unable to get zpool status of tank: Unexpected error while running command.']

```

## Test Steps
On a system with zfs-backed lxd configuration:
```
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily PYCLOUDLIB_CONFIG=pycloudlib.toml CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_OS_IMAGE=jammy  tox -e integration-tests-jenkins -- tests/integration_tests/test_upgrade.py::test_subsequent_boot_of_upgraded_package
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
