### PR TITLE
feat(net): provide network config to netplan.State for render

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -19,7 +19,7 @@ from cloudinit.util import is_true
 from tests.integration_tests.decorators import retry
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
+from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, MANTIC
 from tests.integration_tests.util import (
     get_feature_flag_value,
     get_inactive_modules,
@@ -89,6 +89,14 @@ class TestCombined:
         """
         Test that netplan config file is generated with proper permissions
         """
+        log = class_client.read_from_file("/var/log/cloud-init.log")
+        if CURRENT_RELEASE < MANTIC:
+            assert (
+                "No netplan python module. Fallback to write"
+                " /etc/netplan/50-cloud-init.yaml" in log
+            )
+        else:
+            assert "Rendered netplan config using netplan python API" in log
         file_perms = class_client.execute(
             "stat -c %a /etc/netplan/50-cloud-init.yaml"
         )

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -66,6 +66,13 @@ class TestNetplanGenerateBehaviorOnReboot:
         client.execute(
             "mv /var/log/cloud-init.log /var/log/cloud-init.log.bak"
         )
+        if CURRENT_RELEASE < MANTIC:
+            assert (
+                "No netplan python module. Fallback to write"
+                " /etc/netplan/50-cloud-init.yaml" in log
+            )
+        else:
+            assert "Rendered netplan config using netplan python API" in log
         netplan = yaml.safe_load(
             client.execute("cat /etc/netplan/50-cloud-init.yaml")
         )

--- a/tests/unittests/net/test_netplan.py
+++ b/tests/unittests/net/test_netplan.py
@@ -39,3 +39,14 @@ class TestNetplanRenderer:
         assert renderer_mocks["_netplan_generate"].call_args_list == [
             mock.call(run=True, same_content=write_config)
         ]
+
+
+class TestNetplanAPIWriteYAMLFile:
+    def test_no_netplan_python_api(self, caplog):
+        """Skip when no netplan available."""
+        with mock.patch("builtins.__import__", side_effect=ImportError):
+            netplan.netplan_api_write_yaml_file("network: {version: 2}")
+        assert (
+            "No netplan python module. Fallback to write"
+            f" {netplan.CLOUDINIT_NETPLAN_FILE}" in caplog.text
+        )

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -3394,7 +3394,7 @@ class TestNetplanPostcommands:
         mock_subp.side_effect = iter([subp.ProcessExecutionError])
         renderer.render_network_state(ns, target=render_dir)
 
-        mock_netplan_generate.assert_called_with(run=True, same_content=False)
+        mock_netplan_generate.assert_called_with(run=True, config_changed=True)
         mock_net_setup_link.assert_called_with(run=True)
 
     @mock.patch("cloudinit.util.SeLinuxGuard")


### PR DESCRIPTION
## Proposed Commit Message

```
feat(net): provide network config to netplan.State for render (#4981)

Rely on netplan API where present to write network config to
50-cloud-init.yaml. (SC-1402)

Allow cloud-init to be decoupled from security policies of netplan
libraries when rendering potentially senstive network configuratiion.

Newer netplan versions may filter sensitive network configuration parts
into separate files or subdirectories. Allow cloud-init to rely on
netplan's treatment of sensitive keys by using netplan.state.State to
write_yaml_file with cloud-init's requested base filename:
50-cloud-init.yaml.

If netplan security policy changes in the future, those changes will
be adopted under the hood of netplan.State.
```

## Additional Context
Some concerns with this approach: 
1.   Given that netplan API doesn't yet surface a public method, we are using _write_yaml_file under expectation that this interface does't change (needs netplan team sign-off for awareness) CC: @slyon 
2. The current `State._write_yaml_file` doesn't accept a header, strips any inline comments when processing network config yaml. This means that 50-cloud-init.yaml, as rendered by netplan's State._write_yaml will no long contain the helpful comment/header:
```
# This file is generated from information provided by the datasource.  Changes
# to it will not persist across an instance reboot.  To disable cloud-init's
# network configuration capabilities, write a file
# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
# network: {config: disabled}
````

If we want to take this approach to use netplan API to avoid policy changes in netplan, we probably should look to a feature request for `netplan.State._write_yaml_file` to allow a header or footer parameter to allow extending the config content that is written by netplan.



## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
