### PR TITLE
fix: Don't warn on vendor directory

### DIFF
--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -379,13 +379,15 @@ def runparts(dirp, skip_no_exist=True, exe_prefix=None):
             except ProcessExecutionError as e:
                 LOG.debug(e)
                 failed.append(exe_name)
-        else:
+        elif os.path.isfile(exe_path):
             LOG.warning(
                 "skipping %s as its not executable "
                 "or the underlying file system is mounted without "
                 "executable permissions.",
                 exe_path,
             )
+        else:
+            LOG.debug("Not executing special file [%s]", exe_path)
 
     if failed and attempted:
         raise RuntimeError(


### PR DESCRIPTION
## Proposed Commit Message
```
fix: Don't warn on vendor directory

Fixes GH-4919
```

## Additional Context
fixes https://github.com/canonical/cloud-init/issues/4919

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
