### PR TITLE
docs: update 404 page for new doc site and bug link

### DIFF
--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -146,14 +146,22 @@ linkcheck_anchors_ignore_for_url = (
     r"https://github.com/canonical/ubuntu-pro-client.*",
 )
 
+new_doc_issue_link = (
+    "https://github.com/canonical/cloud-init/issues/new?"
+    "labels=documentation%2C+new&projects=&template=documentation.md&"
+    "title=%5Bdocs%5D%3A+missing+redirect"
+)
+docs_url = "https://docs.cloud-init.io"
+
 # Sphinx-copybutton config options:
 notfound_body = (
     "<h1>Page not found</h1><p>Sorry we missed you! Our docs have had a"
-    " remodel and some deprecated links have changed.</p><p>"
-    "<a href='https://canonical-cloud-init.readthedocs-hosted.com'>Back to our"
-    " homepage now hosted at"
-    " https://canonical-cloud-init.readthedocs-hosted.com</a></p>"
+    " remodel and some deprecated links have changed. Please"
+    f" <a href='{new_doc_issue_link}'>file a documentation bug</a> and"
+    " we'll fix this redirect.</p><p>"
+    f"<a href='{docs_url}'>Back to our homepage hosted at {docs_url}</a></p>"
 )
+
 notfound_context = {
     "title": "Page not found",
     "body": notfound_body,


### PR DESCRIPTION
When someone receives a 404, the splash page should no longer point to https://canonical-cloud-init.readthedocs-hosted.com as Canonical now has a CNAME docs.cloud-init.io available.

Add a documentation bug link for broken references which allow users to quickly report a bug with a failed link if necessary.

## Additional Context
The new https://docs.cloud-init.io primary site is up and functional. All redirects should be in place, we will ask the community before we switch 

## Test Steps
```
tox -e doc
# Open up the 404 template locally and scroll to the bottom to check links for bug filing link and the reference to the new docs.cloud-init.io
# page rendering will be off as it's generated with custom stylesheets once it publishes to RTD.
xdg-open doc/rtd_html/404.html
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
