### PR TITLE
bug(wait_for_url): when exceptions occur url is unset, use url_exc

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -575,7 +575,7 @@ def wait_for_url(
         time_taken = int(time.time() - start_time)
         max_wait_str = "%ss" % max_wait if max_wait else "unlimited"
         status_msg = "Calling '%s' failed [%s/%s]: %s" % (
-            url,
+            url or getattr(url_exc, "url", "url ? None"),
             time_taken,
             max_wait_str,
             reason,

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -695,29 +695,13 @@ class TestEc2(test_helpers.ResponsesTestCase):
             m_readurl.side_effect = (
                 conn_error,
                 conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
-                conn_error,
                 mock_success,
             )
             with mock.patch("cloudinit.url_helper.time.sleep"):
                 self.assertTrue(ds.wait_for_metadata_service())
 
         # Just one /latest/api/token request
-        self.assertEqual(19, len(m_readurl.call_args_list))
+        self.assertEqual(3, len(m_readurl.call_args_list))
         for readurl_call in m_readurl.call_args_list:
             self.assertIn("latest/api/token", readurl_call[0][0])
 

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -136,7 +136,7 @@ def _register_uris(version, ec2_files, ec2_meta, os_files, *, responses_mock):
 
     responses_mock.add_callback(
         responses.GET,
-        re.compile(r"http://169.254.169.254/.*"),
+        re.compile(r"http://(169.254.169.254|\[fe80::a9fe:a9fe\])/.*"),
         callback=get_request_callback,
     )
 
@@ -388,10 +388,10 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             found = ds_os.get_data()
         self.assertFalse(found)
         self.assertIsNone(ds_os.version)
-        self.assertIn(
-            "InvalidMetaDataException: Broken metadata address"
-            " http://169.254.169.25",
+        self.assertRegex(
             self.logs.getvalue(),
+            r"InvalidMetaDataException: Broken metadata address"
+            r" http://(169.254.169.254|\[fe80::a9fe:a9fe\])",
         )
 
     def test_no_datasource(self):


### PR DESCRIPTION
When processing multiple urls in wait_for_url and a timeout error occurs, the local variable url is None yet url_exc.url is set.

Fallback to url_exc.url with url is unet to provide sensible warning messages:
 Calling '<full_failed_url>' failed [3/120s]: request error

instead of:
 Calling 'None' failed [3/120s]

LP: #2055077

* two more commits to fix other unit tests (reduce test time for test_ec2, fix openstack test to also mock requests against IPv6 route

## Additional Context
Confusing logs generated from Ec2 datasource detection on any system where cloud-init is disabled where 
Failure to wait_for_urls finds no resolvable URLs.

```
 2024-02-26 19:29:49,617 WARNING cloudinit.sources.DataSourceEc2:583 Calling 'None' failed [119/120s]: request error [HTTPConnectionPool(host='169.254.169.254', port=80): Max retries exceeded with url: /2009-04-04/meta-data/instance-id (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x74a6d282ad70>, 'Connection to 169.254.169.254 timed out. (connect timeout=18.0)'))]
```
Fallback to url_exc.url which is set with the appropriate failed url to improve logged warnings.


## Test Steps
```
lxc launch ubuntu-daily:noble nn
cat > 91-ds-only-ec2.cfg <<EOF
datasource_list: [ Ec2, None ]
EOF
lxc file push 91-ds-only-ec2.cfg  nn/etc/cloud/cloud.cfg.d/
lxc exec nn -- cloud-init clean --logs
lxc exec nn -- rm -rf /run/cloud-init
lxc exec nn -- cloud-init init
```
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
