### PR TITLE
fix(net/networkd): add GatewayOnLink flag when necessary

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1283,6 +1283,48 @@ def is_ipv6_network(address: str) -> bool:
     )
 
 
+def is_ip_in_subnet(address: str, subnet: str) -> bool:
+    """Returns a bool indicating if ``s`` is in subnet.
+
+    :param address:
+        The string of IP address.
+
+    :param subnet:
+        The string of subnet.
+
+    :return:
+        A bool indicating if the string is in subnet.
+    """
+    ip_address = ipaddress.ip_address(address)
+    subnet_network = ipaddress.ip_network(subnet, strict=False)
+    return ip_address in subnet_network
+
+
+def should_add_gateway_onlink_flag(gateway: str, subnet: str) -> bool:
+    """Returns a bool indicating if should add gateway onlink flag.
+
+    :param gateway:
+        The string of gateway address.
+
+    :param subnet:
+        The string of subnet.
+
+    :return:
+        A bool indicating if the string is in subnet.
+    """
+    try:
+        return not is_ip_in_subnet(gateway, subnet)
+    except ValueError as e:
+        LOG.warning(
+            "Failed to check whether gateway %s"
+            " is contained within subnet %s: %s",
+            gateway,
+            subnet,
+            e,
+        )
+        return False
+
+
 def subnet_is_ipv6(subnet) -> bool:
     """Common helper for checking network_state subnets for ipv6."""
     # 'static6', 'dhcp6', 'ipv6_dhcpv6-stateful', 'ipv6_dhcpv6-stateless' or

--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -9,7 +9,7 @@ from collections import OrderedDict
 from typing import Optional
 
 from cloudinit import subp, util
-from cloudinit.net import renderer
+from cloudinit.net import renderer, should_add_gateway_onlink_flag
 from cloudinit.net.network_state import NetworkState
 
 LOG = logging.getLogger(__name__)
@@ -68,7 +68,7 @@ class CfgParser:
                     contents += "[" + k + "]\n"
                     for e in sorted(v[n]):
                         contents += e + "\n"
-                        contents += "\n"
+                    contents += "\n"
             else:
                 contents += "[" + k + "]\n"
                 for e in sorted(v):
@@ -169,6 +169,9 @@ class Renderer(renderer.Renderer):
                     self.parse_routes(f"r{rid}", i, cfg)
                     rid = rid + 1
             if "address" in e:
+                addr = e["address"]
+                if "prefix" in e:
+                    addr += "/" + str(e["prefix"])
                 subnet_cfg_map = {
                     "address": "Address",
                     "gateway": "Gateway",
@@ -177,15 +180,23 @@ class Renderer(renderer.Renderer):
                 }
                 for k, v in e.items():
                     if k == "address":
-                        if "prefix" in e:
-                            v += "/" + str(e["prefix"])
-                        cfg.update_section("Address", subnet_cfg_map[k], v)
+                        cfg.update_section("Address", subnet_cfg_map[k], addr)
                     elif k == "gateway":
                         # Use "a" as a dict key prefix for this route to
                         # isolate it from other sources of routes
                         cfg.update_route_section(
                             "Route", f"a{rid}", subnet_cfg_map[k], v
                         )
+                        if should_add_gateway_onlink_flag(v, addr):
+                            LOG.debug(
+                                "Gateway %s is not contained within subnet %s,"
+                                " adding GatewayOnLink flag",
+                                v,
+                                addr,
+                            )
+                            cfg.update_route_section(
+                                "Route", f"a{rid}", "GatewayOnLink", "yes"
+                            )
                         rid = rid + 1
                     elif k == "dns_nameservers" or k == "dns_search":
                         cfg.update_section(sec, subnet_cfg_map[k], " ".join(v))

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -1892,3 +1892,29 @@ class TestIsIpNetwork:
     )
     def test_is_ip_network(self, func, arg, expected_return):
         assert func(arg) == expected_return
+
+
+class TestIsIpInSubnet:
+    """Tests for net.is_ip_in_subnet()."""
+
+    @pytest.mark.parametrize(
+        "func,ip,subnet,expected_return",
+        (
+            (net.is_ip_in_subnet, "192.168.1.1", "2001:67c::1/64", False),
+            (net.is_ip_in_subnet, "2001:67c::1", "192.168.1.1/24", False),
+            (net.is_ip_in_subnet, "192.168.1.1", "192.168.1.1/24", True),
+            (net.is_ip_in_subnet, "192.168.1.1", "192.168.1.1/32", True),
+            (net.is_ip_in_subnet, "192.168.1.2", "192.168.1.1/24", True),
+            (net.is_ip_in_subnet, "192.168.1.2", "192.168.1.1/32", False),
+            (net.is_ip_in_subnet, "192.168.2.2", "192.168.1.1/24", False),
+            (net.is_ip_in_subnet, "192.168.2.2", "192.168.1.1/32", False),
+            (net.is_ip_in_subnet, "2001:67c1::1", "2001:67c1::1/64", True),
+            (net.is_ip_in_subnet, "2001:67c1::1", "2001:67c1::1/128", True),
+            (net.is_ip_in_subnet, "2001:67c1::2", "2001:67c1::1/64", True),
+            (net.is_ip_in_subnet, "2001:67c1::2", "2001:67c1::1/128", False),
+            (net.is_ip_in_subnet, "2002:67c1::1", "2001:67c1::1/8", True),
+            (net.is_ip_in_subnet, "2002:67c1::1", "2001:67c1::1/16", False),
+        ),
+    )
+    def test_is_ip_in_subnet(self, func, ip, subnet, expected_return):
+        assert func(ip, subnet) == expected_return


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(net/networkd): add GatewayOnLink flag when necessary

When the gateway isn't part of the subnet's network, the "GatewayOnLink" flag is required for the route to work.

Fixes GH-4995
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
