### PR TITLE
Update ubuntu/mantic to 24.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,255 @@
+24.1
+ - fix: Don't warn on vendor directory (#4986)
+ - apt: kill spawned keyboxd after gpg cmd interaction
+ - tests: upgrade tests should only validate current boot log
+ - net/dhcp: fix maybe_perform_dhcp_discovery check for interface=None
+   [Chris Patterson]
+ - doc(network-v2): fix section nesting levels
+ - fix(tests): don't check for clean log on minimal image (#4965) [Cat Red]
+ - fix(cc_resize): Don't warn if zpool command not found (#4969)
+   (LP: #2055219)
+ - feat(subp): Make invalid command warning more user-friendly (#4972)
+ - docs: Remove statement about device path matching (#4966)
+ - test: Fix xfail to check the dhcp client name (#4971)
+ - tests: avoid console prompts when removing gpg on Noble
+ - test: fix test_get_status_systemd_failure
+ - fix: Remove hardcoded /var/lib/cloud hotplug path (#4940)
+ - refactor: Refactor status.py (#4864)
+ - test: Use correct lxd network-config keys (#4950)
+ - test: limit temp dhcp6 changes to < NOBLE (#4942)
+ - test: allow downgrades when install debs (#4941)
+ - tests: on noble, expect default /etc/apt/sources.list
+ - tests: lxd_vm early boot status test ordered After=systemd-remount-fs
+   (#4936)
+ - tests: pro integration tests supply ubuntu_advantage until pro v32
+   (#4935)
+ - feat(hotplug): add cmd to enable hotplug (#4821)
+ - test: fix test_combined_cloud_config_json (#4925)
+ - test: xfail udhcpc on azure (#4924)
+ - feat: Implement the WSL datasource (#4786) [Carlos Nihelton]
+ - refactor(openrc):  Improve the OpenRC files (#4916) [dermotbradley]
+ - tests: use apt install instead of dpkg -i to install pkg deps
+ - tests: inactive module rename ubuntu_advantage to ubuntu_pro
+ - test: fix tmpdir in test_cc_apk_configure (#4914)
+ - test: fix jsonschema version checking in pro test (#4915)
+ - feat(dhcp): Make dhcpcd the default dhcp client (#4912)
+ - feat(Alpine) cc_growpart.py: fix handling of /dev/mapper devices (#4876)
+   [dermotbradley]
+ - test: Retry longer in test_status.py integration test (#4910)
+ - test: fix kernel override test (#4913)
+ - chore: Rename sysvinit/gentoo directory to sysvinit/openrc (#4906)
+   [dermotbradley]
+ - doc: update ubuntu_advantage references to pro
+ - chore: rename cc_ubuntu_advantage to cc_ubuntu_pro (SC-1555)
+ - feat(ubuntu pro): deprecate ubuntu_pro key in favor of ubuntu_advantage
+ - feat(schema): support ubuntu_pro key and deprecate ubuntu_advantage
+ - test: fix verify_clean_log (#4903)
+ - test: limit test_no_hotplug_triggered_by_docker to stable releases
+ - tests: generalize warning Open vSwitch warning from netplan apply (#4894)
+ - fix(hotplug): remove literal quotes in args
+ - feat(apt): skip known /etc/apt/sources.list content
+ - feat(apt): use APT deb822 source format by default
+ - test(ubuntu-pro): change livepatch to esm-infra
+ - doc(ec2): fix metadata urls (#4880)
+ - fix: unpin jsonschema and update tests (#4882)
+ - distro: add eject FreeBSD code path (#4838) [Mina Galić]
+ - feat(ec2): add hotplug as a default network update event (#4799)
+ - feat(ec2): support instances with repeated device-number (#4799)
+ - feat(cc_install_hotplug): trigger hook on known ec2 drivers (#4799)
+ - feat(ec2): support multi NIC/IP setups (#4799)
+ - feat(hotplug): hook-hotplug is now POSIX shell add OpenRC init script
+   [dermotbradley]
+ - test: harden test_dhcp.py::test_noble_and_newer_force_client
+ - test: fix test_combined_cloud_config_json (#4868)
+ - feat(apport): Disable hook when disabled (#4874)
+ - chore: Add pyright ignore comments (#4874)
+ - bug(apport): Fix invalid typing (#4874)
+ - refactor: Move general apport hook to main branch (#4874)
+ - feat(bootspeed)!: cloud-config.service drop After=snapd.seeded
+ - chore: update CI package build to oldest supported Ubuntu release focal
+   (#4871)
+ - test: fix test_cli.test_valid_userdata
+ - feat: handle error when log file is empty (#4859) [Hasan]
+ - test: fix test_ec2_ipv6
+ - fix: Address TIOBE abstract interpretation issues (#4866)
+ - feat(dhcp): Make udhcpc use same client id (#4830)
+ - feat(dhcp): Support InfiniBand with dhcpcd (#4830)
+ - feat(azure): Add ProvisionGuestProxyAgent OVF setting (#4860)
+   [Ksenija Stanojevic]
+ - test: Bring back dhcp6 integration test changes (#4855)
+ - tests: add status --wait blocking test from early boot
+ - tests: fix retry decorator to return the func value
+ - docs: add create_hostname_file to all hostname user-data examples
+   (#4727) [Cat Red]
+ - fix: Fix typos (#4850) [Viktor Szépe]
+ - feat(dhcpcd): Read dhcp option 245 for azure wireserver (#4835)
+ - tests(dhcp): Add udhcpc client to test matrix (#4839)
+ - fix: Add types to network v1 schema (#4841)
+ - docs(vmware): fixed indentation on example userdata yaml (#4854)
+   [Alec Warren]
+ - tests: Remove invalid keyword from method call
+ - fix: Handle systemctl when dbus not ready (#4842) (LP: #2046483)
+ - fix(schema cli): avoid netplan validation on net-config version 1
+ - tests: reduce expected reports due to dropped rightscale module
+ - tests(net-config): add awareness of netplan on stable Ubuntu
+   [Gilbert Gilb's]
+ - feat: fall back to cdrom_id eject if eject is not available (#4769)
+   [Cat Red]
+ - fix(packages/bddeb): restrict debhelper-compat to 12 in focal (#4831)
+ - tests: Add kernel commandline test (#4833)
+ - fix: Ensure NetworkManager renderer works without gateway (#4829)
+ - test: Correct log parsing in schema test (#4832)
+ - refactor: Remove cc_rightscale_userdata (#4813)
+ - refactor: Replace load_file with load_binary_file to simplify typing
+   (#4823)
+ - refactor: Add load_text_file function to simplify typing (#4823)
+ - refactor: Change variable name for consistent typing (#4823)
+ - feat(dhcp): Add support for dhcpcd (#4746)
+ - refactor: Remove unused networking code (#4810)
+ - test: Add more DNS net tests
+ - BREAKING CHANGE: Stop adding network v2 DNS to global DNS
+ - doc: update DataSource.default_update_events doc (#4815)
+ - chore: do not modify instance attribute (#4815)
+ - test: fix mocking leaks (#4815)
+ - Revert "ci: Pin pytest<8.0.0. (#4816)" (#4815)
+ - test: Update tests for passlib (#4818)
+ - fix(net-schema): no warn when skipping schema check on non-netplan
+ - feat(SUSE): reboot marker file is written as /run/reboot-needed (#4788)
+   [Robert Schweikert]
+ - test: Cleanup unwanted logger setup calls (#4817)
+ - refactor(cloudinit.util): Modernize error handling, add better warnings
+   (#4812)
+ - ci: Pin pytest<8.0.0. (#4816)
+ - fix(tests): fixing KeyError on integrations tests (#4811) [Cat Red]
+ - tests: integration for network schema on netplan systems (#4767)
+ - feat(schema): use netplan API to validate network-config (#4767)
+ - chore: define CLOUDINIT_NETPLAN_FILE static var (#4767)
+ - fix: cli schema config-file option report network-config type (#4767)
+ - refactor(azure): replace BrokenAzureDataSource with reportable errors
+   (#4807) [Chris Patterson]
+ - Fix Alpine and Mariner /etc/hosts templates (#4780) [dermotbradley]
+ - tests: revert #4792 as noble images no longer return 2 (#4809) [Cat Red]
+ - tests: use client fixture instead of class_client in cleantest (#4806)
+ - tests: enable ds-idenitfy xfail test LXD-kvm-not-MAAS-1 (#4808)
+ - fix(tests): failing integration tests due to missing ua token (#4802)
+   [Cat Red]
+ - Revert "Use grep for faster parsing of cloud config in ds-identify
+   (#4327)"
+ - tests: Demonstrate ds-identify yaml parsing broken
+ - tests: add exit 2 on noble from cloud-init status (#4792)
+ - fix: linkcheck for ci to ignore scaleway anchor URL (#4793)
+ - feat: Update cacerts to support VMware Photon (#4763)
+   [Christopher McCann]
+ - fix: netplan rendering integrations tests (#4795) [Cat Red]
+ - azure: remove cloud-init.log reporting via KVP (#4715) [Chris Patterson]
+ - feat(Alpine): Modify ds-identify for Alpine support and add OpenRC
+   init.d script (#4785) [dermotbradley]
+ - doc: Add DatasourceScaleway documentation (#4773) [Louis Bouchard]
+ - fix: packaged logrotate file lacks suffix on ubuntu (#4790)
+ - feat(logrotate): config flexibility more backups (#4790)
+ - fix(clean): stop warning when running clean command (#4761) [d1r3ct0r]
+ - feat: network schema v1 strict on nic name length 15 (#4774)
+ - logrotate config (#4721) [Fabian Lichtenegger-Lukas]
+ - test: Enable coverage in integration tests (#4682)
+ - test: Move unit test helpers to global test helpers (#4682)
+ - test: Remove snapshot option from install_new_cloud_init (#4682)
+ - docs: fix cloud-init single param docs (#4682)
+ - Alpine: fix location of dhclient leases file (#4782) [dermotbradley]
+ - test(jsonschema): Pin jsonschema version (#4781)
+ - refactor(IscDhclient): discover DHCP leases at distro-provided location
+   (#4683) [Phsm Qwerty]
+ - feat: datasource check for WSL (#4730) [Carlos Nihelton]
+ - test: Update hostname integration tests (#4744)
+ - test: Add mantic and noble releases to integration tests (#4744)
+ - refactor: Ensure internal DNS state same for v1 and v2 (#4756)
+ - feat: Add v2 route mtu rendering to NetworkManager (#4748)
+ - tests: stable ubuntu releases will not exit 2 on warnings (#4757)
+ - doc(ds-identify): Describe ds-identify irrespective of distro (#4742)
+ - fix: relax NetworkManager renderer rules (#4745)
+ - fix: fix growpart race (#4618)
+ - feat: apply global DNS to interfaces in network-manager  (#4723)
+   [Florian Apolloner]
+ - feat(apt): remove /etc/apt/sources.list when deb22 preferred (#4740)
+ - chore: refactor schema data as enums and namedtuples (#4585)
+ - feat(schema): improve CLI message on unprocessed data files (#4585)
+ - fix(config): relocate /run to /var/run on BSD (canonical#4677)
+   [Mina Galić]
+ - fix(ds-identify): relocate /run on *BSD (#4677) [Mina Galić]
+ - fix(sysvinit): make code a bit more consistent (#4677) [Mina Galić]
+ - doc: Document how cloud-init is, not how it was (#4737)
+ - tests: add expected exit 2 on noble from cloud-init status (#4738)
+ - test(linkcheck): ignore github md and rst link headers (#4734)
+ - test: Update webhook test due to removed cc_migrator module (#4726)
+ - fix(ds-identify): Return code 2 is a valid result, use cached value
+ - fix(cloudstack): Use parsed lease file for virtual router in cloudstack
+ - fix(dhcp): Guard against FileNotFoundError and NameError exceptions
+ - fix(apt_configure): disable sources.list if rendering deb822 (#4699)
+   (LP: #2045086)
+ - docs: Add link to contributing to docs (#4725) [Cat Red]
+ - chore: remove commented code (#4722)
+ - chore: Add log message when create_hostname_file key is false (#4724)
+   [Cat Red]
+ - fix: Correct v2 NetworkManager route rendering (#4637)
+ - azure/imds: log http failures as warnings instead of info (#4714)
+   [Chris Patterson]
+ - fix(setup): Relocate libexec on OpenBSD (#4708) [Mina Galić]
+ - feat(jinja): better jinja feedback and error catching (#4629)
+   [Alec Warren]
+ - test: Fix silent swallowing of unexpected subp error (#4702)
+ - fix: Move cloud-final.service after time-sync.target (#4610)
+   [Dave Jones] (LP: #1951639)
+ - feat(log): Make logger name more useful for __init__.py
+ - chore: Remove cc_migrator module (#4690)
+ - fix(tests): make cmd/devel/tests work on non-GNU [Mina Galić]
+ - chore: Remove cmdline from spelling list (#4670)
+ - doc: Document boot status meaning (#4670)
+ - doc: Set expectations for new datasources (#4670)
+ - ci: Show linkcheck broken links in job output (#4670)
+ - dmi: Add support for OpenBSD (#4654) [Mina Galić]
+ - ds-identify: fake dmidecode support on OpenBSD (#4654) [Mina Galić]
+ - ds-identify: add OpenBSD support in uname (#4654) [Mina Galić]
+ - refactor: Ensure '_cfg' in Init class is dict (#4674)
+ - refactor: Make event scope required in stages.py (#4674)
+ - refactor: Remove unused argument (#4674)
+ - chore: Move from lintian to a sphinx spelling plugin (#3639)
+ - fix(doc): Fix spelling errors found by sphinxcontrib-spelling (#3639)
+ - ci: Add Python 3.13 (#4567)
+ - Add AlexSv04047 to CLA signers file (#4671) [AlexSv04047]
+ - fix(openbsd): services & build tool (#4660) [CodeBleu]
+ - tests/unittests: add a new unit test for network manager net activator
+   (#4672) [Ani Sinha]
+ - Implement DataSourceCloudStack.get_hostname() (#4433) [Phsm Qwerty]
+ - net/nm: check for presence of ifcfg files when nm connection files
+   are absent (#4645) [Ani Sinha]
+ - doc: Overhaul debugging documentation (#4578)
+ - doc: Move dangerous commands to dev docs (#4578)
+ - doc: Relocate file location docs (#4578)
+ - doc: Remove the debugging page (#4578)
+ - fix(util): Fix boottime to work on OpenBSD (#4667) [Mina Galić]
+ - net: allow dhcp6 configuration from generate_fallback_configuration()
+   [Ani Sinha]
+ - net/network_manager: do not set "may-fail" to False for both ipv4 and
+   ipv6 dhcp [Ani Sinha]
+ - feat(subp): Measure subprocess command time (#4606)
+ - fix(python3.13): Fix import error for passlib on Python 3.13 (#4669)
+ - style(brpm/bddeb): add black and ruff for packages build scripts (#4666)
+ - copr: remove TODO.rst from spec file
+ - fix(packages/brpm): correct syntax error and typo
+ - style(ruff): fix tip target
+ - config: Module documentation updates (#4599)
+ - refactor(subp): Remove redundant parameter 'env' (#4555)
+ - refactor(subp): Remove unused parameter 'target' (#4555)
+ - refactor: Remove 'target' boilerplate from cc_apt_configure (#4555)
+ - refactor(subp): Re-add return type to subp() (#4555)
+ - refactor(subp): Add type information to args (#4555)
+ - refactor(subp): Use subprocess.DEVNULL (#4555)
+ - refactor(subp): Remove parameter 'combine_capture' (#4555)
+ - refactor(subp): Remove unused parameter 'status_cb' (#4555)
+ - fix(cli): fix parsing of argparse subcommands (#4559)
+   [Calvin Mwadime] (LP: #2040325)
+ - chore!: drop support for dsa ssh hostkeys in docs and schema (#4456)
+ - chore!: do not generate ssh dsa host keys (#4456) [shixuantong]
+
 23.4.4
  - fix(nocloud): smbios datasource definition
  - tests: Check that smbios seed works

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -286,7 +286,17 @@ def apply_apt(cfg, cloud):
     # GH: 4344 - stop gpg-agent/dirmgr daemons spawned by gpg key imports.
     # Daemons spawned by cloud-config.service on systemd v253 report (running)
     gpg_process_out, _err = subp.subp(
-        ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+        [
+            "ps",
+            "-o",
+            "ppid,pid",
+            "-C",
+            "keyboxd",
+            "-C",
+            "dirmngr",
+            "-C",
+            "gpg-agent",
+        ],
         capture=True,
         rcs=[0, 1],
     )

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -11,8 +11,10 @@
 import errno
 import logging
 import os
+import re
 import stat
 from textwrap import dedent
+from typing import Optional
 
 from cloudinit import subp, util
 from cloudinit.cloud import Cloud
@@ -146,6 +148,36 @@ RESIZE_FS_PREFIXES_CMDS = [
 RESIZE_FS_PRECHECK_CMDS = {"ufs": _can_skip_resize_ufs}
 
 
+def get_device_info_from_zpool(zpool) -> Optional[str]:
+    # zpool has 10 second timeout waiting for /dev/zfs LP: #1760173
+    log_warn = LOG.debug if util.is_container() else LOG.warning
+    if not os.path.exists("/dev/zfs"):
+        LOG.debug("Cannot get zpool info, no /dev/zfs")
+        return None
+    try:
+        zpoolstatus, err = subp.subp(["zpool", "status", zpool])
+        if err:
+            LOG.info(
+                "zpool status returned error: [%s] for zpool [%s]",
+                err,
+                zpool,
+            )
+            return None
+    except subp.ProcessExecutionError as err:
+        log_warn("Unable to get zpool status of %s: %s", zpool, err)
+        return None
+    r = r".*(ONLINE).*"
+    for line in zpoolstatus.split("\n"):
+        if re.search(r, line) and zpool not in line and "state" not in line:
+            disk = line.split()[0]
+            LOG.debug('found zpool "%s" on disk %s', zpool, disk)
+            return disk
+    log_warn(
+        "No zpool found: [%s]: out: [%s] err: %s", zpool, zpoolstatus, err
+    )
+    return None
+
+
 def can_skip_resize(fs_type, resize_what, devpth):
     fstype_lc = fs_type.lower()
     for i, func in RESIZE_FS_PRECHECK_CMDS.items():
@@ -259,7 +291,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # so the _resize_zfs function gets the right attribute.
     if fs_type == "zfs":
         zpool = devpth.split("/")[0]
-        devpth = util.get_device_info_from_zpool(zpool)
+        devpth = get_device_info_from_zpool(zpool)
         if not devpth:
             return  # could not find device from zpool
         resize_what = zpool

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -95,6 +95,10 @@ def maybe_perform_dhcp_discovery(distro, nic=None, dhcp_log_func=None):
         returned.
     """
     interface = nic or distro.fallback_interface
+    if interface is None:
+        LOG.debug("Skip dhcp_discovery: Unable to find fallback nic.")
+        raise NoDHCPLeaseInterfaceError()
+
     return distro.dhcp_client.dhcp_discovery(interface, dhcp_log_func, distro)
 
 

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -379,13 +379,15 @@ def runparts(dirp, skip_no_exist=True, exe_prefix=None):
             except ProcessExecutionError as e:
                 LOG.debug(e)
                 failed.append(exe_name)
-        else:
+        elif os.path.isfile(exe_path):
             LOG.warning(
                 "skipping %s as its not executable "
                 "or the underlying file system is mounted without "
                 "executable permissions.",
                 exe_path,
             )
+        else:
+            LOG.debug("Not executing special file [%s]", exe_path)
 
     if failed and attempted:
         raise RuntimeError(

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -144,6 +144,23 @@ class ProcessExecutionError(IOError):
         return text.rstrip(b"\n").replace(b"\n", b"\n" + b" " * indent_level)
 
 
+def raise_on_invalid_command(args: Union[List[str], List[bytes]]):
+    """check argument types to ensure that subp() can run the argument
+
+    Throw a user-friendly exception which explains the issue.
+
+    args: list of arguments passed to subp()
+    raises: ProcessExecutionError with information explaining the issue
+    """
+    for component in args:
+        # if already bytes, or implements encode(), then it should be safe
+        if not (isinstance(component, bytes) or hasattr(component, "encode")):
+            LOG.warning("Running invalid command: %s", args)
+            raise ProcessExecutionError(
+                cmd=args, reason=f"Running invalid command: {args}"
+            )
+
+
 def subp(
     args: Union[str, bytes, List[str], List[bytes]],
     *,
@@ -241,6 +258,7 @@ def subp(
     elif isinstance(args, str):
         bytes_args = args.encode("utf-8")
     else:
+        raise_on_invalid_command(args)
         bytes_args = [
             x if isinstance(x, bytes) else x.encode("utf-8") for x in args
         ]

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2665,26 +2665,6 @@ def get_freebsd_devpth(path):
     return "/dev/" + label_part
 
 
-def get_device_info_from_zpool(zpool):
-    # zpool has 10 second timeout waiting for /dev/zfs LP: #1760173
-    if not os.path.exists("/dev/zfs"):
-        LOG.debug("Cannot get zpool info, no /dev/zfs")
-        return None
-    try:
-        (zpoolstatus, err) = subp.subp(["zpool", "status", zpool])
-    except subp.ProcessExecutionError as err:
-        LOG.warning("Unable to get zpool status of %s: %s", zpool, err)
-        return None
-    if len(err):
-        return None
-    r = r".*(ONLINE).*"
-    for line in zpoolstatus.split("\n"):
-        if re.search(r, line) and zpool not in line and "state" not in line:
-            disk = line.split()[0]
-            LOG.debug('found zpool "%s" on disk %s', zpool, disk)
-            return disk
-
-
 def parse_mount(path, get_mnt_opts=False):
     """Return the mount information for PATH given the lines ``mount(1)``
     This function is compatible with ``util.parse_mount_info()``"""

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "23.4.4"
+__VERSION__ = "24.1"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (24.1-0ubuntu1~23.10.1) UNRELEASED; urgency=medium
+cloud-init (24.1-0ubuntu1~23.10.1) mantic; urgency=medium
 
   * d/apport-general-hook.py: Move apport hook to main branch
   * d/cloud-init.maintscript: remove /etc/cloud/clean.d/README
@@ -22,7 +22,7 @@ cloud-init (24.1-0ubuntu1~23.10.1) UNRELEASED; urgency=medium
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/24.1/ChangeLog
 
- -- Brett Holman <brett.holman@canonical.com>  Tue, 05 Mar 2024 22:38:51 -0700
+ -- Brett Holman <brett.holman@canonical.com>  Tue, 05 Mar 2024 22:41:18 -0700
 
 cloud-init (23.4.4-0ubuntu0~23.10.1) mantic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -23,6 +23,31 @@ cloud-init (23.4.1-0ubuntu1~23.10.3) UNRELEASED; urgency=medium
 
  -- James Falcon <james.falcon@canonical.com>  Tue, 27 Feb 2024 09:26:13 -0600
 
+cloud-init (23.4.4-0ubuntu0~23.10.1) mantic; urgency=medium
+
+  * Upstream snapshot based on 23.4.4. (LP: #2055081).
+    List of changes from upstream can be found at
+    https://raw.githubusercontent.com/canonical/cloud-init/23.4.4/ChangeLog
+
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 27 Feb 2024 08:17:49 -0700
+
+cloud-init (23.4.3-0ubuntu0~23.10.1) mantic; urgency=medium
+
+  * Upstream snapshot based on 23.4.3. (LP: #2046483).
+    List of changes from upstream can be found at
+    https://raw.githubusercontent.com/canonical/cloud-init/23.4.3/ChangeLog
+
+ -- James Falcon <james.falcon@canonical.com>  Fri, 02 Feb 2024 16:00:04 -0600
+
+cloud-init (23.4.2-0ubuntu0~23.10.1) mantic; urgency=medium
+
+  * Upstream snapshot based on 23.4.2. (LP: #2045582).
+    List of changes from upstream can be found at
+    https://raw.githubusercontent.com/canonical/cloud-init/23.4.2/ChangeLog
+    - Bugs fixed in this snapshot: (LP: #2051147)
+
+ -- Alberto Contreras <alberto.contreras@canonical.com>  Wed, 24 Jan 2024 18:57:50 +0100
+
 cloud-init (23.4.1-0ubuntu1~23.10.2) mantic; urgency=medium
 
   * d/p/status-retain-recoverable-error-exit-code.patch:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (23.4.1-0ubuntu1~23.10.3) UNRELEASED; urgency=medium
+cloud-init (24.1-0ubuntu1~23.10.1) UNRELEASED; urgency=medium
 
   * d/apport-general-hook.py: Move apport hook to main branch
   * d/cloud-init.maintscript: remove /etc/cloud/clean.d/README
@@ -18,10 +18,11 @@ cloud-init (23.4.1-0ubuntu1~23.10.3) UNRELEASED; urgency=medium
   * refresh patches:
     - d/p/status-do-not-remove-duplicated-data.patch
     - d/p/status-retain-recoverable-error-exit-code.patch
-    - d/p/revert-551f560d-cloud-config-after-snap-seeding.patch
-  * Upstream snapshot based on upstream/main at d8b6ac2b.
+  * Upstream snapshot based on 24.1. (LP: #2056100).
+    List of changes from upstream can be found at
+    https://raw.githubusercontent.com/canonical/cloud-init/24.1/ChangeLog
 
- -- James Falcon <james.falcon@canonical.com>  Tue, 27 Feb 2024 09:26:13 -0600
+ -- Brett Holman <brett.holman@canonical.com>  Tue, 05 Mar 2024 22:38:51 -0700
 
 cloud-init (23.4.4-0ubuntu0~23.10.1) mantic; urgency=medium
 

--- a/debian/patches/revert-551f560d-cloud-config-after-snap-seeding.patch
+++ b/debian/patches/revert-551f560d-cloud-config-after-snap-seeding.patch
@@ -75,7 +75,7 @@ Last-Update: 2024-02-14
  
  if TYPE_CHECKING:
      # Avoid circular import
-@@ -3101,18 +3101,6 @@ def wait_for_files(flist, maxwait, naple
+@@ -3081,18 +3081,6 @@ def wait_for_files(flist, maxwait, naple
      return need
  
  

--- a/doc/rtd/reference/network-config-format-v2.rst
+++ b/doc/rtd/reference/network-config-format-v2.rst
@@ -71,7 +71,7 @@ Physical devices (e.g., ethernet, wifi)
 These can dynamically come and go between reboots and even during runtime
 (hotplugging). In the generic case, they can be selected by ``match:``
 rules on desired properties, such as name/name pattern, MAC address,
-driver, or device paths. In general these will match any number of
+or driver. In general these will match any number of
 devices (unless they refer to properties which are unique such as the full
 path or MAC address), so without further knowledge about the hardware,
 these will always be considered as a group.

--- a/doc/rtd/reference/network-config-format-v2.rst
+++ b/doc/rtd/reference/network-config-format-v2.rst
@@ -149,7 +149,7 @@ Example: ::
     name: en*s0
 
 ``set-name: <(scalar)>``
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 When matching on unique properties such as path or MAC, or with additional
 assumptions such as "there will only ever be one wifi device", match rules
@@ -160,7 +160,7 @@ will then fail to get renamed and keep the original kernel name (and dmesg
 will show an error).
 
 ``wakeonlan: <(bool)>``
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 
 Enable wake on LAN. Off by default.
 
@@ -180,17 +180,17 @@ particular device definition. Default is ``networkd``.
    config to the instance.
 
 ``dhcp4: <(bool)>``
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 Enable DHCP for IPv4. Off by default.
 
 ``dhcp6: <(bool)>``
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 Enable DHCP for IPv6. Off by default.
 
 ``dhcp4-overrides and dhcp6-overrides: <(mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------------------------
 
 DHCP behaviour overrides. Overrides will only have an effect if
 the corresponding DHCP type is enabled. Refer to `Netplan#dhcp-overrides`_
@@ -231,7 +231,7 @@ Example: ::
     use-routes: false
 
 ``addresses: <(sequence of scalars)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------
 
 Add static addresses to the interface in addition to the ones received
 through DHCP or RA. Each sequence entry is in CIDR notation, i.e., of the
@@ -241,7 +241,7 @@ by ``inet_pton(3)`` and ``prefixlen`` the number of bits of the subnet.
 Example: ``addresses: [192.168.14.2/24, 2001:1::1/64]``
 
 ``gateway4: or gateway6: <(scalar)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------
 
 Deprecated, see `Netplan#default-routes`_.
 Set default gateway for IPv4/6, for manual address configuration. This
@@ -252,14 +252,14 @@ Example for IPv4: ``gateway4: 172.16.0.1``
 Example for IPv6: ``gateway6: 2001:4::1``
 
 ``mtu: <MTU SizeBytes>``
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 The MTU key represents a device's Maximum Transmission Unit, the largest size
 packet or frame, specified in octets (eight-bit bytes), that can be sent in a
 packet- or frame-based network. Specifying ``mtu`` is optional.
 
 ``nameservers: <(mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------
 
 Set DNS servers and search domains, for manual address configuration. There
 are two supported fields: ``addresses:`` is a list of IPv4 or IPv6 addresses
@@ -272,7 +272,7 @@ Example: ::
     addresses: [8.8.8.8, FEDC::1]
 
 ``routes: <(sequence of mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------
 
 Add device specific routes. Each mapping includes a ``to``, ``via`` key
 with an IPv4 or IPv6 address as value. ``metric`` is an optional value.
@@ -285,16 +285,16 @@ Example: ::
      metric: 3
 
 Ethernets
----------
+=========
 
 Ethernet device definitions do not support any specific properties beyond the
 common ones described above.
 
 Bonds
------
+=====
 
 ``interfaces: <(sequence of scalars)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 All devices matching this ID list will be added to the bond.
 
@@ -309,7 +309,7 @@ Example: ::
       interfaces: [switchports]
 
 ``parameters: <(mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 Customisation parameters for special bonding options. Time values are
 specified in seconds unless otherwise specified.
@@ -450,10 +450,10 @@ value is ``1``. This option only affects ``balance-tlb`` and
 
 
 Bridges
--------
+=======
 
 ``interfaces: <(sequence of scalars)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------------------
 
 All devices matching this ID list will be added to the bridge.
 
@@ -468,7 +468,7 @@ Example: ::
       interfaces: [switchports]
 
 ``parameters: <(mapping)>``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+---------------------------
 
 Customisation parameters for special bridging options. Time values are
 specified in seconds unless otherwise stated.
@@ -523,15 +523,15 @@ default value is "true", which means that Spanning Tree should be
 used.
 
 VLANs
------
+=====
 
 ``id: <(scalar)>``
-^^^^^^^^^^^^^^^^^^
+------------------
 
 VLAN ID, a number between 0 and 4094.
 
 ``link: <(scalar)>``
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 ID of the underlying device definition on which this VLAN gets created.
 

--- a/tests/integration_tests/datasources/test_azure.py
+++ b/tests/integration_tests/datasources/test_azure.py
@@ -6,7 +6,6 @@ from tests.integration_tests.conftest import get_validated_source
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE
-from tests.integration_tests.util import verify_clean_log
 
 
 def _check_for_eject_errors(
@@ -15,7 +14,6 @@ def _check_for_eject_errors(
     assert "sr0" not in instance.execute("mount")
     log = instance.read_from_file("/var/log/cloud-init.log")
     assert "Failed ejecting the provisioning iso" not in log
-    verify_clean_log(log)
 
 
 @pytest.mark.skipif(PLATFORM != "azure", reason="Test is Azure specific")

--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -8,6 +8,7 @@ import pytest
 from cloudinit import gpg
 from cloudinit.config import cc_apt_configure
 from cloudinit.util import is_true
+from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
@@ -435,8 +436,6 @@ def test_apt_proxy(client: IntegrationInstance):
 
 INSTALL_ANY_MISSING_RECOMMENDED_DEPENDENCIES = """\
 #cloud-config
-bootcmd:
-    - apt-get remove gpg -y
 apt:
   sources:
     test_keyserver:
@@ -455,10 +454,24 @@ RE_GPG_SW_PROPERTIES_INSTALLED = (
     r" (gnupg software-properties-common|software-properties-common gnupg)"
 )
 
+REMOVE_GPG_USERDATA = """
+#cloud-config
+runcmd:
+  - DEBIAN_FRONTEND=noninteractive apt-get remove gpg -y
+"""
+
 
 @pytest.mark.skipif(not IS_UBUNTU, reason="Apt usage")
-@pytest.mark.user_data(INSTALL_ANY_MISSING_RECOMMENDED_DEPENDENCIES)
-def test_install_missing_deps(client: IntegrationInstance):
-    log = client.read_from_file("/var/log/cloud-init.log")
-    verify_clean_log(log)
-    assert re.search(RE_GPG_SW_PROPERTIES_INSTALLED, log)
+def test_install_missing_deps(setup_image, session_cloud: IntegrationCloud):
+    # Two stage install: First stage:  remove gpg noninteractively from image
+    instance1 = session_cloud.launch(user_data=REMOVE_GPG_USERDATA)
+    snapshot_id = instance1.snapshot()
+    instance1.destroy()
+    # Second stage: provide active apt user-data which will install missing gpg
+    with session_cloud.launch(
+        user_data=INSTALL_ANY_MISSING_RECOMMENDED_DEPENDENCIES,
+        launch_kwargs={"image_id": snapshot_id},
+    ) as minimal_client:
+        log = minimal_client.read_from_file("/var/log/cloud-init.log")
+        verify_clean_log(log)
+        assert re.search(RE_GPG_SW_PROPERTIES_INSTALLED, log)

--- a/tests/integration_tests/net/test_dhcp.py
+++ b/tests/integration_tests/net/test_dhcp.py
@@ -80,7 +80,7 @@ class TestDHCP:
         if not "ec2" == PLATFORM:
             assert "Received dhcp lease on " in log, "EphemeralDHCPv4 failed"
         if "azure" == PLATFORM:
-            if "udhcpc" == client:
+            if "udhcpc" == dhcp_client:
                 pytest.xfail(
                     "udhcpc implementation doesn't support azure, see GH-4765"
                 )

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -203,6 +203,8 @@ def test_subsequent_boot_of_upgraded_package(session_cloud: IntegrationCloud):
 
     with session_cloud.launch(launch_kwargs=launch_kwargs) as instance:
         instance.install_new_cloud_init(source, clean=False)
+        # Ensure we aren't looking at any prior warnings/errors from prior boot
+        instance.execute("rm /var/log/cloud-init.log")
         instance.restart()
         log = instance.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)

--- a/tests/unittests/config/test_apt_configure_sources_list_v1.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v1.py
@@ -161,7 +161,17 @@ class TestAptSourceConfigSourceList:
         assert 0o644 == stat.S_IMODE(sources_file.stat().mode)
 
         self.subp.assert_called_once_with(
-            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            [
+                "ps",
+                "-o",
+                "ppid,pid",
+                "-C",
+                "keyboxd",
+                "-C",
+                "dirmngr",
+                "-C",
+                "gpg-agent",
+            ],
             capture=True,
             rcs=[0, 1],
         )
@@ -220,7 +230,17 @@ class TestAptSourceConfigSourceList:
         mockresolve.assert_any_call("http://does.not.exist")
         mockresolve.assert_any_call(mirrorcheck)
         self.subp.assert_called_once_with(
-            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            [
+                "ps",
+                "-o",
+                "ppid,pid",
+                "-C",
+                "keyboxd",
+                "-C",
+                "dirmngr",
+                "-C",
+                "gpg-agent",
+            ],
             capture=True,
             rcs=[0, 1],
         )
@@ -282,7 +302,17 @@ class TestAptSourceConfigSourceList:
         assert expected == sources_file.read()
         assert 0o644 == stat.S_IMODE(sources_file.stat().mode)
         self.subp.assert_called_once_with(
-            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            [
+                "ps",
+                "-o",
+                "ppid,pid",
+                "-C",
+                "keyboxd",
+                "-C",
+                "dirmngr",
+                "-C",
+                "gpg-agent",
+            ],
             capture=True,
             rcs=[0, 1],
         )

--- a/tests/unittests/config/test_apt_configure_sources_list_v3.py
+++ b/tests/unittests/config/test_apt_configure_sources_list_v3.py
@@ -331,7 +331,17 @@ class TestAptSourceConfigSourceList:
         assert expected == sources_file.read()
         assert 0o644 == stat.S_IMODE(sources_file.stat().mode)
         self.subp.assert_called_once_with(
-            ["ps", "-o", "ppid,pid", "-C", "dirmngr", "-C", "gpg-agent"],
+            [
+                "ps",
+                "-o",
+                "ppid,pid",
+                "-C",
+                "keyboxd",
+                "-C",
+                "dirmngr",
+                "-C",
+                "gpg-agent",
+            ],
             capture=True,
             rcs=[0, 1],
         )

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -672,6 +672,8 @@ class TestAptSourceConfig:
                     "-o",
                     "ppid,pid",
                     "-C",
+                    "keyboxd",
+                    "-C",
                     "dirmngr",
                     "-C",
                     "gpg-agent",

--- a/tests/unittests/config/test_cc_resizefs.py
+++ b/tests/unittests/config/test_cc_resizefs.py
@@ -13,6 +13,7 @@ from cloudinit.config.cc_resizefs import (
     _resize_xfs,
     _resize_zfs,
     can_skip_resize,
+    get_device_info_from_zpool,
     handle,
     maybe_get_writable_device_path,
 )
@@ -25,12 +26,14 @@ from cloudinit.subp import ProcessExecutionError
 from tests.unittests.helpers import (
     CiTestCase,
     mock,
+    readResource,
     skipUnlessJsonSchema,
     util,
     wrap_and_call,
 )
 
 LOG = logging.getLogger(__name__)
+M_PATH = "cloudinit.config.cc_resizefs."
 
 
 class TestResizefs(CiTestCase):
@@ -180,7 +183,7 @@ class TestResizefs(CiTestCase):
 
     @mock.patch("cloudinit.util.is_container", return_value=False)
     @mock.patch("cloudinit.util.parse_mount")
-    @mock.patch("cloudinit.util.get_device_info_from_zpool")
+    @mock.patch("cloudinit.config.cc_resizefs.get_device_info_from_zpool")
     @mock.patch("cloudinit.util.get_mount_info")
     def test_handle_zfs_root(
         self, mount_info, zpool_info, parse_mount, is_container
@@ -204,7 +207,7 @@ class TestResizefs(CiTestCase):
 
     @mock.patch("cloudinit.util.is_container", return_value=False)
     @mock.patch("cloudinit.util.get_mount_info")
-    @mock.patch("cloudinit.util.get_device_info_from_zpool")
+    @mock.patch("cloudinit.config.cc_resizefs.get_device_info_from_zpool")
     @mock.patch("cloudinit.util.parse_mount")
     def test_handle_modern_zfsroot(
         self, mount_info, zpool_info, parse_mount, is_container
@@ -517,3 +520,48 @@ class TestResizefsSchema:
         else:
             with pytest.raises(SchemaValidationError, match=error_msg):
                 validate_cloudconfig_schema(config, get_schema(), strict=True)
+
+
+class TestZpool:
+    @mock.patch(M_PATH + "os")
+    @mock.patch("cloudinit.subp.subp")
+    def test_get_device_info_from_zpool(self, zpool_output, m_os):
+        # mock /dev/zfs exists
+        m_os.path.exists.return_value = True
+        # mock subp command from util.get_mount_info_fs_on_zpool
+        zpool_output.return_value = (
+            readResource("zpool_status_simple.txt"),
+            "",
+        )
+        ret = get_device_info_from_zpool("vmzroot")
+        assert "gpt/system" == ret
+        m_os.path.exists.assert_called_with("/dev/zfs")
+
+    @mock.patch(M_PATH + "os")
+    @mock.patch("cloudinit.subp.subp", return_value=("", ""))
+    def test_get_device_info_from_zpool_no_dev_zfs(self, m_os, m_subp):
+        # mock /dev/zfs missing
+        m_os.path.exists.return_value = False
+        assert not get_device_info_from_zpool("vmzroot")
+
+    @mock.patch(M_PATH + "os")
+    @mock.patch("cloudinit.subp.subp")
+    def test_get_device_info_from_zpool_handles_no_zpool(self, m_sub, m_os):
+        """Handle case where there is no zpool command"""
+        # mock /dev/zfs exists
+        m_os.path.exists.return_value = True
+        m_sub.side_effect = ProcessExecutionError("No zpool cmd")
+        assert not get_device_info_from_zpool("vmzroot")
+
+    @mock.patch(M_PATH + "os")
+    @mock.patch("cloudinit.subp.subp")
+    def test_get_device_info_from_zpool_on_error(self, zpool_output, m_os):
+        # mock /dev/zfs exists
+        m_os.path.exists.return_value = True
+
+        # mock subp command from get_mount_info_fs_on_zpool
+        zpool_output.return_value = (
+            readResource("zpool_status_simple.txt"),
+            "error",
+        )
+        assert not get_device_info_from_zpool("vmzroot")

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -1318,3 +1318,10 @@ class TestDhcpcd:
                 ),
             ]
         )
+
+
+class TestMaybePerformDhcpDiscovery:
+    def test_none_and_missing_fallback(self):
+        with pytest.raises(NoDHCPLeaseInterfaceError):
+            distro = mock.Mock(fallback_interface=None)
+            maybe_perform_dhcp_discovery(distro, None)

--- a/tests/unittests/test_subp.py
+++ b/tests/unittests/test_subp.py
@@ -239,6 +239,14 @@ class TestSubp(CiTestCase):
         self.assertTrue(isinstance(cm.exception.stdout, str))
         self.assertTrue(isinstance(cm.exception.stderr, str))
 
+    def test_exception_invalid_command(self):
+        args = [None, "first", "arg", "missing"]
+        with self.assertRaises(
+            subp.ProcessExecutionError, msg="Running invalid command"
+        ):
+            with self.allow_subp(args):
+                subp.subp(args)
+
     def test_bunch_of_slashes_in_path(self):
         self.assertEqual(
             "/target/my/path/", subp.target_path("/target/", "//my/path/")

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2177,54 +2177,6 @@ class TestMountinfoParsing(helpers.ResourceUsingTestCase):
         expected = ("none", "tmpfs", "/run/lock")
         self.assertEqual(expected, util.parse_mount_info("/run/lock", lines))
 
-    @mock.patch(M_PATH + "os")
-    @mock.patch("cloudinit.subp.subp")
-    def test_get_device_info_from_zpool(self, zpool_output, m_os):
-        # mock /dev/zfs exists
-        m_os.path.exists.return_value = True
-        # mock subp command from util.get_mount_info_fs_on_zpool
-        zpool_output.return_value = (
-            helpers.readResource("zpool_status_simple.txt"),
-            "",
-        )
-        # save function return values and do asserts
-        ret = util.get_device_info_from_zpool("vmzroot")
-        self.assertEqual("gpt/system", ret)
-        self.assertIsNotNone(ret)
-        m_os.path.exists.assert_called_with("/dev/zfs")
-
-    @mock.patch(M_PATH + "os")
-    def test_get_device_info_from_zpool_no_dev_zfs(self, m_os):
-        # mock /dev/zfs missing
-        m_os.path.exists.return_value = False
-        # save function return values and do asserts
-        ret = util.get_device_info_from_zpool("vmzroot")
-        self.assertIsNone(ret)
-
-    @mock.patch(M_PATH + "os")
-    @mock.patch("cloudinit.subp.subp")
-    def test_get_device_info_from_zpool_handles_no_zpool(self, m_sub, m_os):
-        """Handle case where there is no zpool command"""
-        # mock /dev/zfs exists
-        m_os.path.exists.return_value = True
-        m_sub.side_effect = subp.ProcessExecutionError("No zpool cmd")
-        ret = util.get_device_info_from_zpool("vmzroot")
-        self.assertIsNone(ret)
-
-    @mock.patch(M_PATH + "os")
-    @mock.patch("cloudinit.subp.subp")
-    def test_get_device_info_from_zpool_on_error(self, zpool_output, m_os):
-        # mock /dev/zfs exists
-        m_os.path.exists.return_value = True
-        # mock subp command from util.get_mount_info_fs_on_zpool
-        zpool_output.return_value = (
-            helpers.readResource("zpool_status_simple.txt"),
-            "error",
-        )
-        # save function return values and do asserts
-        ret = util.get_device_info_from_zpool("vmzroot")
-        self.assertIsNone(ret)
-
     @mock.patch("cloudinit.subp.subp")
     def test_parse_mount_with_ext(self, mount_out):
         mount_out.return_value = (


### PR DESCRIPTION
## Additional Context
This syncs ubuntu/mantic to 24.1 for the [SRU](https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2056100), will create a release branch for mantic after this lands. Will follow with Jammy and Focal once this is approved.

- manual patch refreshes
- synced changelogs from 23.4.x

In the github UI I see merge conflicts, yet testing locally I do not. I'm not sure if this is a temporary GitHub web issue or if I'm just missing something.

## Test Steps
```
quilt push -a
tox -e py3
quilt pop -a
```


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
