### PR TITLE
tests: Fix wsl test file mocks, set defaults for optional os-release fields

### DIFF
--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -131,13 +131,14 @@ def candidate_user_data_file_names(instance_name) -> List[str]:
     Return a list of candidate file names that may contain user-data
     in some supported format, ordered by precedence.
     """
-    distribution_id, version_id, _ = util.get_linux_distro()
+    distribution_id, version_id, version_codename = util.get_linux_distro()
+    version = version_id if version_id else version_codename
 
     return [
         # WSL instance specific:
         "%s.user-data" % instance_name,
         # release codename specific
-        "%s-%s.user-data" % (distribution_id, version_id),
+        "%s-%s.user-data" % (distribution_id, version),
         # distribution specific (Alpine, Arch, Fedora, openSUSE, Ubuntu...)
         "%s-all.user-data" % distribution_id,
         # generic, valid for all WSL distros and instances.

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -58,8 +58,10 @@ order specified below:
    instance named ``Sid-MLKit``.
 
 2. ``%USERPROFILE%\.cloud-init\<ID>-<VERSION_ID>.user-data`` for the
-   distro-specific configuration, matched by the distro ID and VERSION_CODENAME
-   entries as specified in ``/etc/os-release``. Example:
+   distro-specific configuration, matched by the distro ID and VERSION_ID
+   entries as specified in ``/etc/os-release``.  If VERSION_ID is not present,
+   then VERSION_CODENAME will be used instead.
+   Example:
    ``ubuntu-22.04.user-data`` will affect any instance created from an Ubuntu
    22.04 Jammy Jellyfish image if a more specific configuration file does not
    match.

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -49,6 +49,7 @@ GOOD_MOUNTS = {
     },
 }
 SAMPLE_LINUX_DISTRO = ("ubuntu", "24.04", "noble")
+SAMPLE_LINUX_DISTRO_NO_VERSION_ID = ("debian", "", "trixie")
 
 
 class TestWSLHelperFunctions:
@@ -122,19 +123,37 @@ class TestWSLHelperFunctions:
         with pytest.raises(IOError):
             wsl.cmd_executable()
 
+    @pytest.mark.parametrize(
+        "linux_distro_value,files",
+        (
+            (
+                SAMPLE_LINUX_DISTRO,
+                [
+                    f"{INSTANCE_NAME}.user-data",
+                    "ubuntu-24.04.user-data",
+                    "ubuntu-all.user-data",
+                    "default.user-data",
+                ],
+            ),
+            (
+                SAMPLE_LINUX_DISTRO_NO_VERSION_ID,
+                [
+                    f"{INSTANCE_NAME}.user-data",
+                    "debian-trixie.user-data",
+                    "debian-all.user-data",
+                    "default.user-data",
+                ],
+            ),
+        ),
+    )
     @mock.patch("cloudinit.util.get_linux_distro")
-    def test_candidate_files(self, m_gld):
+    def test_candidate_files(self, m_gld, linux_distro_value, files):
         """
         Validate the file names candidate for holding user-data and their
         order of precedence.
         """
-        m_gld.return_value = SAMPLE_LINUX_DISTRO
-        assert [
-            f"{INSTANCE_NAME}.user-data",
-            "ubuntu-24.04.user-data",
-            "ubuntu-all.user-data",
-            "default.user-data",
-        ] == wsl.candidate_user_data_file_names(INSTANCE_NAME)
+        m_gld.return_value = linux_distro_value
+        assert files == wsl.candidate_user_data_file_names(INSTANCE_NAME)
 
     @pytest.mark.parametrize(
         "md_content,raises,errors,warnings,md_expected",

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1654,8 +1654,8 @@ dscheck_WSL() {
     WSL_instance_name
     instance_name="${_RET}"
     # shellcheck source=/dev/null
-    . /etc/os-release
-    for userdatafile in "${instance_name}.user-data" "${ID}-${VERSION_ID}" "${ID}-all.user-data" "default.user-data"; do
+    . "${PATH_ROOT}/etc/os-release"
+    for userdatafile in "${instance_name}.user-data" "${ID:-linux}-${VERSION_ID:-}" "${ID:-linux}-all.user-data" "default.user-data"; do
         candidate="$cloudinitdir/$userdatafile"
         if [ -f "$candidate" ]; then
             debug 1 "Found applicable user data file for this instance at: $candidate"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1655,7 +1655,7 @@ dscheck_WSL() {
     instance_name="${_RET}"
     # shellcheck source=/dev/null
     . "${PATH_ROOT}/etc/os-release"
-    for userdatafile in "${instance_name}.user-data" "${ID:-linux}-${VERSION_ID:-}" "${ID:-linux}-all.user-data" "default.user-data"; do
+    for userdatafile in "${instance_name}.user-data" "${ID:-linux}-${VERSION_ID:-${VERSION_CODENAME}}".user-data "${ID:-linux}-all.user-data" "default.user-data"; do
         candidate="$cloudinitdir/$userdatafile"
         if [ -f "$candidate" ]; then
             debug 1 "Found applicable user data file for this instance at: $candidate"


### PR DESCRIPTION
## Proposed Commit Message
```
tests: Fix wsl test

Force ds-identify to use the correct file mocks
Set defaults for optional os-release fields [1]

VERSION_ID and ID might not be set; set defaults.

[1] man 5 os-release

Fixes GH-5002
```

## Additional Context
Fixes GH-5002

## Test Steps
Comment out `VERSION_ID` in the host system's os-release file, run 

```bash
tox -e py3 -- tests/unittests/test_ds_identify.py::TestWSL
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
