### PR TITLE
feat(url_helper): add default timeout to readurl() to prevent hanging

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -193,7 +193,7 @@ def _get_ssl_args(url, ssl_details):
 def readurl(
     url,
     data=None,
-    timeout=None,
+    timeout=30,
     retries=0,
     sec_between=1,
     headers=None,
@@ -215,7 +215,8 @@ def readurl(
     :param data: Optional form data to post the URL. Will set request_method
         to 'POST' if present.
     :param timeout: Timeout in seconds to wait for a response. May be a tuple
-        if specifying (connection timeout, read timeout).
+        if specifying (connection timeout, read timeout). Default is 30 so that
+        we don't hang forever.
     :param retries: Number of times to retry on exception if exception_cb is
         None or exception_cb returns True for the exception caught. Default is
         to fail with 0 retries on exception.

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -193,7 +193,7 @@ def _get_ssl_args(url, ssl_details):
 def readurl(
     url,
     data=None,
-    timeout=30,
+    timeout=60,
     retries=0,
     sec_between=1,
     headers=None,
@@ -215,7 +215,7 @@ def readurl(
     :param data: Optional form data to post the URL. Will set request_method
         to 'POST' if present.
     :param timeout: Timeout in seconds to wait for a response. May be a tuple
-        if specifying (connection timeout, read timeout). Default is 30 so that
+        if specifying (connection timeout, read timeout). Default is 60 so that
         we don't hang forever.
     :param retries: Number of times to retry on exception if exception_cb is
         None or exception_cb returns True for the exception caught. Default is


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(url_helper): add default timeout to readurl() to prevent hanging

If there is an issue with networking, we don't want any calls to hang 
forever. This is never a desireable outcome, because this prevents 
cloud-init from finishing and thus makes debugging much more difficult.
```

## Additional Context
This issue was discovered when attempting to contact the IMDS from an
oracle VM that had failed setting up its networking.  

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [X] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [X] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
