### PR TITLE
Run container from commitish

### DIFF
--- a/tools/run-container
+++ b/tools/run-container
@@ -41,6 +41,7 @@ Usage: ${0##*/} [ options ] [images:]image-ref
       -u | --unittest        run unit tests
            --vm              use a VM instead of a container
            --wait-max        max time to wait or a container or VM to be ready
+           --commitish       commit to package and run, default: HEAD
 
     Example:
       * ${0##*/} --package --source-package --unittest centos/6
@@ -112,8 +113,8 @@ inject_cloud_init(){
     esac
 
     # attempt to get branch name.
-    commitish=$(git rev-parse --abbrev-ref HEAD) || {
-        errorrc "Failed git rev-parse --abbrev-ref HEAD"
+    commitish=$(git rev-parse --abbrev-ref "$COMMITISH") || {
+        errorrc "Failed git rev-parse --abbrev-ref $COMMITISH"
         return
     }
     if [ "$commitish" = "HEAD" ]; then
@@ -402,7 +403,7 @@ run_self_inside_as_cd() {
 
 main() {
     local short_opts="a:hknpsuv"
-    local long_opts="artifacts:,dirty,help,keep,name:,package,source-package,unittest,verbose,vm,wait-max:"
+    local long_opts="artifacts:,dirty,help,keep,name:,package,source-package,unittest,verbose,vm,wait-max:,commitish:"
     local getopt_out=""
     getopt_out=$(getopt --name "${0##*/}" \
         --options "${short_opts}" --long "${long_opts}" -- "$@") &&
@@ -428,10 +429,12 @@ main() {
             -v|--verbose) VERBOSITY=$((VERBOSITY+1));;
                --vm) use_vm=true;;
                --wait-max) WAIT_MAX="$next"; shift;;
+               --commitish) COMMITISH="$next"; shift;;
             --) shift; break;;
         esac
         shift;
     done
+    COMMITISH=${COMMITISH:-HEAD}
 
     [ $# -eq 1 ] || { bad_Usage "Expected 1 arg, got $# ($*)"; return; }
     local img_ref_in="$1"


### PR DESCRIPTION
## Proposed Commit Message
```
feat(run-container): Run from arbitrary commitish
```

## Additional Context
Assuming HEAD is a reasonable default. If one wants to run using [an alternate lxc binary](https://github.com/canonical/cloud-init/commit/d15779535b16f0f379c0feee2af6dfef0e8a1d5c) from a commit-ish that did not yet support doing that, for example, this would be useful. 

## Test Steps
```
./tools/run-container --commitish 24.1 --source-package --unittest --artifacts=./srpm/ rockylinux/8
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
