### PR TITLE
fix(cmd-modules): exit code when --mode init

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -1148,6 +1148,12 @@ def main(sysv_args=None):
             args=(name, args),
         )
     reporting.flush_events()
+
+    # handle return code for main_modules, as it is not wrapped by
+    # status_wrapped when mode == init
+    if "modules" == name and "init" == args.mode:
+        retval = len(retval)
+
     return retval
 
 

--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -20,6 +20,14 @@ runcmd:
   - echo 'hi' > /var/tmp/test
 """
 
+FAILING_USER_DATA = """\
+#cloud-config
+bootcmd:
+  - exit 1
+runcmd:
+  - exit 1
+"""
+
 # The '-' in 'hashed-password' fails schema validation
 INVALID_USER_DATA_SCHEMA = """\
 #cloud-config
@@ -36,19 +44,26 @@ users:
 
 
 @pytest.mark.user_data(VALID_USER_DATA)
-def test_valid_userdata(client: IntegrationInstance):
-    """Test `cloud-init schema` with valid userdata.
+class TestValidUserData:
+    def test_schema_status(self, class_client: IntegrationInstance):
+        """Test `cloud-init schema` with valid userdata.
 
-    PR #575
-    """
-    result = client.execute("cloud-init schema --system")
-    assert result.ok
-    assert "Valid schema user-data" in result.stdout.strip()
-    result = client.execute("cloud-init status --long")
-    assert 0 == result.return_code, (
-        f"Unexpected exit {result.return_code} from cloud-init status:"
-        f" {result}"
-    )
+        PR #575
+        """
+        result = class_client.execute("cloud-init schema --system")
+        assert result.ok
+        assert "Valid schema user-data" in result.stdout.strip()
+        result = class_client.execute("cloud-init status --long")
+        assert 0 == result.return_code, (
+            f"Unexpected exit {result.return_code} from cloud-init status:"
+            f" {result}"
+        )
+
+    def test_modules_init(self, class_client: IntegrationInstance):
+        for mode in ("init", "config", "final"):
+            result = class_client.execute(f"cloud-init modules --mode {mode}")
+            assert result.ok
+            assert f"'modules:{mode}'" in result.stdout.strip()
 
 
 @pytest.mark.skipif(
@@ -98,3 +113,12 @@ def test_invalid_userdata_schema(client: IntegrationInstance):
     )
     assert warning in log
     assert "asdfasdf" not in log
+
+
+@pytest.mark.user_data(FAILING_USER_DATA)
+def test_failing_userdata_modules_exit_codes(client: IntegrationInstance):
+    """Test failing in modules representd in exit status"""
+    for mode in ("init", "config", "final"):
+        result = client.execute(f"cloud-init modules --mode {mode}")
+        assert result.failed if mode == "init" else result.ok
+        assert f"'modules:{mode}'" in result.stdout.strip()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(cmd-modules): exit code when --mode init

Co-authored-by: Chad Smith <chad.smith@canonical.com>
```

## Additional Context
<!-- If relevant -->
Supersedes https://github.com/canonical/cloud-init/pull/4939
Execute `cloud-init modules --mode init` on any instance.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
