### PR TITLE
fix: Make DataSourceOracle more resilient to early network issues

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -15,9 +15,11 @@ Notes:
 
 import base64
 import ipaddress
+import json
 import logging
+import time
 from collections import namedtuple
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from cloudinit import atomic_helper, dmi, net, sources, util
 from cloudinit.distros.networking import NetworkConfig
@@ -27,7 +29,7 @@ from cloudinit.net import (
     get_interfaces_by_mac,
     is_netfail_master,
 )
-from cloudinit.url_helper import UrlError, readurl
+from cloudinit.url_helper import wait_for_url
 
 LOG = logging.getLogger(__name__)
 
@@ -123,6 +125,11 @@ class DataSourceOracle(sources.DataSource):
     )
 
     _network_config: dict = {"config": [], "version": 1}
+    perform_dhcp_setup = True
+
+    # Careful...these can be overridden in __init__
+    url_max_wait = 30
+    url_timeout = 5
 
     def __init__(self, sys_cfg, *args, **kwargs):
         super(DataSourceOracle, self).__init__(sys_cfg, *args, **kwargs)
@@ -136,6 +143,10 @@ class DataSourceOracle(sources.DataSource):
         )
         self._network_config_source = KlibcOracleNetworkConfigSource()
 
+        url_params = self.get_url_params()
+        self.url_max_wait = url_params.max_wait_seconds
+        self.url_timeout = url_params.timeout_seconds
+
     def _has_network_config(self) -> bool:
         return bool(self._network_config.get("config", []))
 
@@ -148,23 +159,31 @@ class DataSourceOracle(sources.DataSource):
 
         self.system_uuid = _read_system_uuid()
 
-        network_context = ephemeral.EphemeralDHCPv4(
-            self.distro,
-            iface=net.find_fallback_nic(),
-            connectivity_url_data={
-                "url": METADATA_PATTERN.format(version=2, path="instance"),
-                "headers": V2_HEADERS,
-            },
-        )
+        if self.perform_dhcp_setup:
+            network_context = ephemeral.EphemeralDHCPv4(
+                self.distro,
+                iface=net.find_fallback_nic(),
+                connectivity_url_data={
+                    "url": METADATA_PATTERN.format(version=2, path="instance"),
+                    "headers": V2_HEADERS,
+                },
+            )
+        else:
+            network_context = util.nullcontext()
         fetch_primary_nic = not self._is_iscsi_root()
         fetch_secondary_nics = self.ds_cfg.get(
             "configure_secondary_nics",
             BUILTIN_DS_CONFIG["configure_secondary_nics"],
         )
+
         with network_context:
             fetched_metadata = read_opc_metadata(
-                fetch_vnics_data=fetch_primary_nic or fetch_secondary_nics
+                fetch_vnics_data=fetch_primary_nic or fetch_secondary_nics,
+                max_wait=self.url_max_wait,
+                timeout=self.url_timeout,
             )
+        if not fetched_metadata:
+            return False
 
         data = self._crawled_metadata = fetched_metadata.instance_data
         self.metadata_address = METADATA_ROOT.format(
@@ -332,6 +351,10 @@ class DataSourceOracle(sources.DataSource):
                 self._network_config["ethernets"][name] = interface_config
 
 
+class DataSourceOracleNet(DataSourceOracle):
+    perform_dhcp_setup = False
+
+
 def _read_system_uuid() -> Optional[str]:
     sys_uuid = dmi.read_dmi_data("system-uuid")
     return None if sys_uuid is None else sys_uuid.lower()
@@ -342,15 +365,20 @@ def _is_platform_viable() -> bool:
     return asset_tag == CHASSIS_ASSET_TAG
 
 
-def _fetch(metadata_version: int, path: str, retries: int = 2) -> dict:
-    return readurl(
-        url=METADATA_PATTERN.format(version=metadata_version, path=path),
-        headers=V2_HEADERS if metadata_version > 1 else None,
-        retries=retries,
-    )._response.json()
+def _url_version(url: str) -> int:
+    return 2 if url.startswith("http://169.254.169.254/opc/v2") else 1
 
 
-def read_opc_metadata(*, fetch_vnics_data: bool = False) -> OpcMetadata:
+def _headers_cb(url: str) -> Optional[Dict[str, str]]:
+    return V2_HEADERS if _url_version(url) == 2 else None
+
+
+def read_opc_metadata(
+    *,
+    fetch_vnics_data: bool = False,
+    max_wait=DataSourceOracle.url_max_wait,
+    timeout=DataSourceOracle.url_timeout,
+) -> Optional[OpcMetadata]:
     """Fetch metadata from the /opc/ routes.
 
     :return:
@@ -359,30 +387,60 @@ def read_opc_metadata(*, fetch_vnics_data: bool = False) -> OpcMetadata:
           The JSON-decoded value of the instance data endpoint on the IMDS
           The JSON-decoded value of the vnics data endpoint if
             `fetch_vnics_data` is True, else None
+        or None if fetching metadata failed
 
     """
     # Per Oracle, there are short windows (measured in milliseconds) throughout
     # an instance's lifetime where the IMDS is being updated and may 404 as a
-    # result.  To work around these windows, we retry a couple of times.
-    metadata_version = 2
-    try:
-        instance_data = _fetch(metadata_version, path="instance")
-    except UrlError:
-        metadata_version = 1
-        instance_data = _fetch(metadata_version, path="instance")
+    # result.
+    urls = [
+        METADATA_PATTERN.format(version=2, path="instance"),
+        METADATA_PATTERN.format(version=1, path="instance"),
+    ]
+    start_time = time.time()
+    instance_url, instance_response = wait_for_url(
+        urls,
+        max_wait=max_wait,
+        timeout=timeout,
+        headers_cb=_headers_cb,
+        sleep_time=0,
+    )
+    if not instance_url:
+        LOG.warning("Failed to fetch IMDS metadata!")
+        return None
+    instance_data = json.loads(instance_response.decode("utf-8"))
+
+    metadata_version = _url_version(instance_url)
 
     vnics_data = None
     if fetch_vnics_data:
-        try:
-            vnics_data = _fetch(metadata_version, path="vnics")
-        except UrlError:
-            util.logexc(LOG, "Failed to fetch IMDS network configuration!")
+        # This allows us to go over the max_wait time by the timeout length,
+        # but if we were able to retrieve instance metadata, that seems
+        # like a worthwhile tradeoff rather than having incomplete metadata.
+        vnics_url, vnics_response = wait_for_url(
+            [METADATA_PATTERN.format(version=metadata_version, path="vnics")],
+            max_wait=max_wait - (time.time() - start_time),
+            timeout=timeout,
+            headers_cb=_headers_cb,
+            sleep_time=0,
+        )
+        if vnics_url:
+            vnics_data = json.loads(vnics_response.decode("utf-8"))
+        else:
+            LOG.warning("Failed to fetch IMDS network configuration!")
     return OpcMetadata(metadata_version, instance_data, vnics_data)
 
 
 # Used to match classes to dependencies
 datasources = [
     (DataSourceOracle, (sources.DEP_FILESYSTEM,)),
+    (
+        DataSourceOracleNet,
+        (
+            sources.DEP_FILESYSTEM,
+            sources.DEP_NETWORK,
+        ),
+    ),
 ]
 
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -36,15 +36,17 @@ import sys
 import time
 from base64 import b64decode
 from collections import deque, namedtuple
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from errno import ENOENT
 from functools import lru_cache, total_ordering
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Deque,
     Dict,
+    Generator,
     List,
     Mapping,
     Optional,
@@ -3293,3 +3295,12 @@ def read_hotplug_enabled_file(paths: "Paths") -> dict:
         if "scopes" not in content:
             content["scopes"] = []
     return content
+
+
+@contextmanager
+def nullcontext() -> Generator[None, Any, None]:
+    """Context manager that does nothing.
+
+    Note: In python-3.7+, this can be substituted by contextlib.nullcontext
+    """
+    yield

--- a/doc/rtd/reference/datasources/oracle.rst
+++ b/doc/rtd/reference/datasources/oracle.rst
@@ -39,6 +39,18 @@ to configure the non-primary network interface controllers in the system. If
 set to True on an OCI Bare Metal Machine, it will have no effect (though this
 may change in the future).
 
+``max_wait``
+------------
+
+An integer, defaulting to 30. The maximum time in seconds to wait for the
+metadata service to become available. If the metadata service is not
+available within this time, the datasource will fail.
+
+``timeout``
+-----------
+An integer, defaulting to 5. The time in seconds to wait for a response from
+the metadata service before retrying.
+
 Example configuration
 ---------------------
 
@@ -49,5 +61,7 @@ An example configuration with the default values is provided below:
    datasource:
     Oracle:
      configure_secondary_nics: false
+     max_wait: 30
+     timeout: 5
 
 .. _Oracle Compute Infrastructure: https://cloud.oracle.com/

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -76,6 +76,7 @@ DEFAULT_NETWORK = [
     MAAS.DataSourceMAAS,
     NoCloud.DataSourceNoCloudNet,
     OpenStack.DataSourceOpenStack,
+    Oracle.DataSourceOracleNet,
     OVF.DataSourceOVFNet,
     UpCloud.DataSourceUpCloud,
     Akamai.DataSourceAkamai,

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -4,6 +4,7 @@ import base64
 import copy
 import json
 import logging
+from itertools import count
 from unittest import mock
 
 import pytest
@@ -14,7 +15,6 @@ from cloudinit.sources import NetworkConfigSource
 from cloudinit.sources.DataSourceOracle import OpcMetadata
 from cloudinit.url_helper import UrlError
 from tests.unittests import helpers as test_helpers
-from tests.unittests.helpers import does_not_raise
 
 DS_PATH = "cloudinit.sources.DataSourceOracle"
 
@@ -730,84 +730,70 @@ class TestReadOpcMetadata:
         assert instance_data == metadata.instance_data
         assert vnics_data == metadata.vnics_data
 
-    # No need to actually wait between retries in the tests
     @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
-    @pytest.mark.parametrize(
-        "v2_failure_count,v1_failure_count,expected_body,expectation",
-        [
-            (1, 0, json.loads(OPC_V2_METADATA), does_not_raise()),
-            (2, 0, json.loads(OPC_V2_METADATA), does_not_raise()),
-            (3, 0, json.loads(OPC_V1_METADATA), does_not_raise()),
-            (3, 1, json.loads(OPC_V1_METADATA), does_not_raise()),
-            (3, 2, json.loads(OPC_V1_METADATA), does_not_raise()),
-            (3, 3, None, pytest.raises(UrlError)),
-        ],
+    @mock.patch("cloudinit.url_helper.time.time", side_effect=count(0, 1))
+    @mock.patch("cloudinit.url_helper.readurl", side_effect=UrlError)
+    def test_retry(self, m_readurl, m_time):
+        # Since wait_for_url has its own retry tests, just verify that we
+        # attempted to contact both endpoints multiple times
+        oracle.read_opc_metadata()
+        assert len(m_readurl.call_args_list) > 3
+        assert (
+            m_readurl.call_args_list[0][0][0]
+            == "http://169.254.169.254/opc/v2/instance/"
+        )
+        assert (
+            m_readurl.call_args_list[1][0][0]
+            == "http://169.254.169.254/opc/v1/instance/"
+        )
+        assert (
+            m_readurl.call_args_list[2][0][0]
+            == "http://169.254.169.254/opc/v2/instance/"
+        )
+        assert (
+            m_readurl.call_args_list[3][0][0]
+            == "http://169.254.169.254/opc/v1/instance/"
+        )
+
+    @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
+    @mock.patch("cloudinit.url_helper.time.time", side_effect=[0, 11])
+    @mock.patch(
+        "cloudinit.sources.DataSourceOracle.wait_for_url",
+        return_value=("http://hi", b'{"some": "value"}'),
     )
-    def test_retries(
-        self,
-        v2_failure_count,
-        v1_failure_count,
-        expected_body,
-        expectation,
-        mocked_responses,
-    ):
-        # Workaround https://github.com/getsentry/responses/pull/171
-        # This mocking can be unrolled when Bionic is EOL
-        url_v2_call_count = 0
+    def test_fetch_vnics_max_wait(self, m_wait_for_url, m_time):
+        oracle.read_opc_metadata(fetch_vnics_data=True)
+        assert m_wait_for_url.call_count == 2
+        # 19 because start time was 0, next time was 11 and max wait is 30
+        assert m_wait_for_url.call_args_list[-1][1]["max_wait"] == 19
 
-        def url_v2_callback(request):
-            nonlocal url_v2_call_count
-            url_v2_call_count += 1
-            if url_v2_call_count <= v2_failure_count:
-                return (
-                    404,
-                    request.headers,
-                    f"403 Client Error: Forbidden for url: {url_v2}",
-                )
-            return 200, request.headers, OPC_V2_METADATA
-
-        url_v2 = "http://169.254.169.254/opc/v2/instance/"
-        mocked_responses.add_callback(
-            responses.GET, url_v2, callback=url_v2_callback
-        )
-
-        # Workaround https://github.com/getsentry/responses/pull/171
-        # This mocking can be unrolled when Bionic is EOL
-        url_v1_call_count = 0
-
-        def url_v1_callback(request):
-            nonlocal url_v1_call_count
-            url_v1_call_count += 1
-            if url_v1_call_count <= v1_failure_count:
-                return (
-                    404,
-                    request.headers,
-                    f"403 Client Error: Forbidden for url: {url_v1}",
-                )
-            return 200, request.headers, OPC_V1_METADATA
-
-        url_v1 = "http://169.254.169.254/opc/v1/instance/"
-        mocked_responses.add_callback(
-            responses.GET, url_v1, callback=url_v1_callback
-        )
-
-        with expectation:
-            assert expected_body == oracle.read_opc_metadata().instance_data
+    @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
+    @mock.patch("cloudinit.url_helper.time.time", side_effect=[0, 1000])
+    @mock.patch(
+        "cloudinit.sources.DataSourceOracle.wait_for_url",
+        return_value=("http://hi", b'{"some": "value"}'),
+    )
+    def test_attempt_vnics_after_max_wait_expire(self, m_wait_for_url, m_time):
+        oracle.read_opc_metadata(fetch_vnics_data=True)
+        assert m_wait_for_url.call_count == 2
+        assert m_wait_for_url.call_args_list[-1][1]["max_wait"] < 0
 
     # No need to actually wait between retries in the tests
     @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
     def test_fetch_vnics_error(self, caplog):
-        def mocked_fetch(*args, path="instance", **kwargs):
-            if path == "vnics":
-                raise UrlError("cause")
+        def m_wait(*args, **kwargs):
+            for url in args[0]:
+                if "vnics" in url:
+                    return False, None
+            return ("http://localhost", b"{}")
 
-        with mock.patch(DS_PATH + "._fetch", side_effect=mocked_fetch):
+        with mock.patch(DS_PATH + ".wait_for_url", side_effect=m_wait):
             opc_metadata = oracle.read_opc_metadata(fetch_vnics_data=True)
             assert None is opc_metadata.vnics_data
         assert (
             logging.WARNING,
             "Failed to fetch IMDS network configuration!",
-        ) == caplog.record_tuples[-2][1:]
+        ) == caplog.record_tuples[-1][1:], caplog.record_tuples
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Make DataSourceOracle more resilient to early network issues

If DataSourceOracle fails to retrieve IMDS info in init-local, try
again during network timeframe. Additionally, ensure max_wait,
timeout, and retries are respected.

LP: #2056194
```

## Additional Context
Launch on noble instance (with an added timeout hack): https://paste.ubuntu.com/p/NNrrC3G3FY/
Launch on noble instance with these changes: https://paste.ubuntu.com/p/NMthRQrJS2/

Note that the weirdness in retries/timeouts is fixed with https://github.com/canonical/cloud-init/pull/5024


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
