### PR TITLE
fix(apt): Don't warn on 822 source format

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -708,7 +708,7 @@ def generate_sources_list(cfg, release, mirrors, cloud):
         )
         if expected_content:
             if expected_content != util.load_text_file(apt_sources_list):
-                LOG.warning(
+                LOG.info(
                     "Replacing %s to favor deb822 source format",
                     apt_sources_list,
                 )
@@ -716,7 +716,7 @@ def generate_sources_list(cfg, release, mirrors, cloud):
                     apt_sources_list, UBUNTU_DEFAULT_APT_SOURCES_LIST
                 )
         else:
-            LOG.warning(
+            LOG.info(
                 "Removing %s to favor deb822 source format", apt_sources_list
             )
             util.del_file(apt_sources_list)

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -70,9 +70,6 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         # Ubuntu lxd storage
         "thinpool by default on Ubuntu due to LP #1982780",
         "WARNING]: Could not match supplied host pattern, ignoring:",
-        # Old Ubuntu cloud-images contain /etc/apt/sources.list
-        "WARNING]: Replacing /etc/apt/sources.list to favor deb822 source"
-        " format",
         # https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2041727
         "Cannot call Open vSwitch: ovsdb-server.service is not running.",
     ]


### PR DESCRIPTION
## Proposed Commit Message
```
fix(apt): Don't warn on 822 source format
```

spurious warnings, probably shouldn't do that to users
