### PR TITLE
DS VMware: Fix ipv6 addr converter from netinfo to netifaces

### DIFF
--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -94,8 +94,16 @@ VMW_IPV6_NETDEV_ADDR = {
     "scope6": "global",
 }
 VMW_IPV6_NETIFACES_ADDR = {
-    "addr": "fd42:baa2:3dd:17a:216:3eff:fe16:db54",
     "netmask": "ffff:ffff:ffff:ffff::/64",
+    "addr": "fd42:baa2:3dd:17a:216:3eff:fe16:db54",
+}
+VMW_IPV6_NETDEV_PEER_ADDR = {
+    "ip": "fd42:baa2:3dd:17a:216:3eff:fe16:db54",
+    "scope6": "global",
+}
+VMW_IPV6_NETIFACES_PEER_ADDR = {
+    "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/128",
+    "addr": "fd42:baa2:3dd:17a:216:3eff:fe16:db54",
 }
 
 
@@ -167,6 +175,10 @@ class TestDataSourceVMware(CiTestCase):
             VMW_IPV6_NETDEV_ADDR
         )
         self.assertEqual(netifaces_format, VMW_IPV6_NETIFACES_ADDR)
+        netifaces_format = DataSourceVMware.convert_to_netifaces_ipv6_format(
+            VMW_IPV6_NETDEV_PEER_ADDR
+        )
+        self.assertEqual(netifaces_format, VMW_IPV6_NETIFACES_PEER_ADDR)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")
     def test_get_host_info_ipv4(self, m_fn_ipaddr):

--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -77,6 +77,11 @@ VMW_IPV4_NETDEV_ADDR = {
     "mask": "255.255.255.0",
     "scope": "global",
 }
+VMW_IPV4_NETIFACES_ADDR = {
+    "broadcast": "10.85.130.255",
+    "netmask": "255.255.255.0",
+    "addr": "10.85.130.116",
+}
 VMW_IPV6_ROUTEINFO = {
     "destination": "::/0",
     "flags": "UG",
@@ -87,6 +92,10 @@ VMW_IPV6_ROUTEINFO = {
 VMW_IPV6_NETDEV_ADDR = {
     "ip": "fd42:baa2:3dd:17a:216:3eff:fe16:db54/64",
     "scope6": "global",
+}
+VMW_IPV6_NETIFACES_ADDR = {
+    "addr": "fd42:baa2:3dd:17a:216:3eff:fe16:db54",
+    "netmask": "ffff:ffff:ffff:ffff::/64",
 }
 
 
@@ -146,6 +155,18 @@ class TestDataSourceVMware(CiTestCase):
         ):
             ret = ds.get_data()
         self.assertFalse(ret)
+
+    def test_convert_to_netifaces_ipv4_format(self):
+        netifaces_format = DataSourceVMware.convert_to_netifaces_ipv4_format(
+            VMW_IPV4_NETDEV_ADDR
+        )
+        self.assertEqual(netifaces_format, VMW_IPV4_NETIFACES_ADDR)
+
+    def test_convert_to_netifaces_ipv6_format(self):
+        netifaces_format = DataSourceVMware.convert_to_netifaces_ipv6_format(
+            VMW_IPV6_NETDEV_ADDR
+        )
+        self.assertEqual(netifaces_format, VMW_IPV6_NETIFACES_ADDR)
 
     @mock.patch("cloudinit.sources.DataSourceVMware.get_default_ip_addrs")
     def test_get_host_info_ipv4(self, m_fn_ipaddr):


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
DS VMware: Fix ipv6 addr converter from netinfo to netifaces

Found an issue when verifying PR 4634 on vSphere platform, 
which is failing to convert ipv6 addr from netinfo format to
netifaces format due to 'bcast' is not existing in ipv6.

This PR is fixing this by updating ipv4 converter function and
adding a new ipv6 converter function,  also adding unit tests.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
