### PR TITLE
pro: honor but warn on custom ubuntu_advantage in /etc/cloud/cloud.cfg

### DIFF
--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -35,6 +35,10 @@ REMOVED_MODULES = [
     "cc_rightscale_userdata",  # Removed in 24.1
 ]
 
+RENAMED_MODULES = {
+    "cc_ubuntu_advantage": "cc_ubuntu_pro",  # Renamed 24.1
+}
+
 
 class ModuleDetails(NamedTuple):
     module: ModuleType
@@ -190,14 +194,26 @@ class Modules:
             if not mod_name:
                 continue
             if freq and freq not in FREQUENCIES:
-                LOG.warning(
-                    "Config specified module %s has an unknown frequency %s",
-                    raw_name,
-                    freq,
+                util.deprecate(
+                    deprecated=(
+                        f"Config specified module {raw_name} has an unknown"
+                        f" frequency {freq}"
+                    ),
+                    deprecated_version="22.1",
                 )
                 # Misconfigured in /etc/cloud/cloud.cfg. Reset so cc_* module
                 # default meta attribute "frequency" value is used.
                 freq = None
+            if mod_name in RENAMED_MODULES:
+                util.deprecate(
+                    deprecated=(
+                        f"Module has been renamed from {mod_name} to "
+                        f"{RENAMED_MODULES[mod_name][1]}. Update any"
+                        " references in /etc/cloud/cloud.cfg"
+                    ),
+                    deprecated_version="24.1",
+                )
+                mod_name = RENAMED_MODULES[mod_name]
             mod_locs, looked_locs = importer.find_module(
                 mod_name, ["", type_utils.obj_name(config)], ["handle"]
             )

--- a/tests/integration_tests/modules/test_ubuntu_pro.py
+++ b/tests/integration_tests/modules/test_ubuntu_pro.py
@@ -144,6 +144,19 @@ class TestUbuntuAdvantage:
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
         assert is_attached(client)
+        client.execute("pro detach")
+        # Replace ubuntu_pro with previously named ubuntu_advantage
+        client.execute(
+            "sed -i 's/ubuntu_pro$/ubuntu_advantage/' /etc/cloud/cloud.cfg"
+        )
+        client.restart()
+        status_resp = client.execute("cloud-init status --format json")
+        status = json.loads(status_resp.stdout)
+        assert (
+            "Module has been renamed from cc_ubuntu_advantage to cc_ubuntu_pro"
+            in "\n".join(status["recoverable_errors"]["DEPRECATED"])
+        )
+        assert is_attached(client)
 
     @pytest.mark.user_data(ATTACH.format(token=CLOUD_INIT_UA_TOKEN))
     def test_idempotency(self, client: IntegrationInstance):


### PR DESCRIPTION
Add RENAMED_MODULES to allow support for custom /etc/cloud/cloud.cfg.d/* which may still contain the old ubuntu_advantage module name instead of ubuntu_pro.

While the typical package upgrade path would replace ubuntu_avantage with ubuntu_pro in /etc/cloud/cloud.cfg. It's possible a customer has a customized /etc/cloud/cloud.cfg that they do not wish to update with the version delivered by the cloud-init upstream package.

In cases where ubuntu_advantage is listed in system config, allow cloud-init to WARN about the rename, but still load and run ubuntu_pro.

Fixes GH-5019

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
