### PR TITLE
fix: Add "broadcast" to network v1 schema

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -503,6 +503,10 @@
           "type": "string",
           "description": "IPv4 subnet mask in dotted format or CIDR notation"
         },
+        "broadcast": {
+          "type": "string",
+          "description": "IPv4 broadcast address in dotted format."
+        },
         "gateway": {
           "type": "string",
           "description": "IPv4 address of the default gateway for this subnet."

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -296,6 +296,8 @@ Valid keys for ``subnets`` include the following:
   interface will be handled during boot.
 - ``address``: IPv4 or IPv6 address. It may include CIDR netmask notation.
 - ``netmask``: IPv4 subnet mask in dotted format or CIDR notation.
+- ``broadcast`` : IPv4 broadcast address in dotted format. This is
+  only rendered if :file:`/etc/network/interfaces` is used.
 - ``gateway``: IPv4 address of the default gateway for this subnet.
 - ``dns_nameservers``: Specify a list of IPv4 dns server IPs to end up in
   :file:`resolv.conf`.


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Add "broadcast" to network v1 schema

Both the klibc initramfs code and the eni code will write a network v1
configuration including the broadcast address if it is provided. It
gets rendered if using the eni renderer.

LP: #2056460
```

## Additional Context
https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2056460

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
