### PR TITLE
Updates for 24.1.1

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -708,7 +708,7 @@ def generate_sources_list(cfg, release, mirrors, cloud):
         )
         if expected_content:
             if expected_content != util.load_text_file(apt_sources_list):
-                LOG.warning(
+                LOG.info(
                     "Replacing %s to favor deb822 source format",
                     apt_sources_list,
                 )
@@ -716,7 +716,7 @@ def generate_sources_list(cfg, release, mirrors, cloud):
                     apt_sources_list, UBUNTU_DEFAULT_APT_SOURCES_LIST
                 )
         else:
-            LOG.warning(
+            LOG.info(
                 "Removing %s to favor deb822 source format", apt_sources_list
             )
             util.del_file(apt_sources_list)

--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -35,6 +35,10 @@ REMOVED_MODULES = [
     "cc_rightscale_userdata",  # Removed in 24.1
 ]
 
+RENAMED_MODULES = {
+    "cc_ubuntu_advantage": "cc_ubuntu_pro",  # Renamed 24.1
+}
+
 
 class ModuleDetails(NamedTuple):
     module: ModuleType
@@ -190,14 +194,26 @@ class Modules:
             if not mod_name:
                 continue
             if freq and freq not in FREQUENCIES:
-                LOG.warning(
-                    "Config specified module %s has an unknown frequency %s",
-                    raw_name,
-                    freq,
+                util.deprecate(
+                    deprecated=(
+                        f"Config specified module {raw_name} has an unknown"
+                        f" frequency {freq}"
+                    ),
+                    deprecated_version="22.1",
                 )
                 # Misconfigured in /etc/cloud/cloud.cfg. Reset so cc_* module
                 # default meta attribute "frequency" value is used.
                 freq = None
+            if mod_name in RENAMED_MODULES:
+                util.deprecate(
+                    deprecated=(
+                        f"Module has been renamed from {mod_name} to "
+                        f"{RENAMED_MODULES[mod_name][1]}. Update any"
+                        " references in /etc/cloud/cloud.cfg"
+                    ),
+                    deprecated_version="24.1",
+                )
+                mod_name = RENAMED_MODULES[mod_name]
             mod_locs, looked_locs = importer.find_module(
                 mod_name, ["", type_utils.obj_name(config)], ["handle"]
             )

--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -503,6 +503,10 @@
           "type": "string",
           "description": "IPv4 subnet mask in dotted format or CIDR notation"
         },
+        "broadcast": {
+          "type": "string",
+          "description": "IPv4 broadcast address in dotted format."
+        },
         "gateway": {
           "type": "string",
           "description": "IPv4 address of the default gateway for this subnet."

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -15,6 +15,7 @@ import struct
 import time
 from contextlib import suppress
 from io import StringIO
+from subprocess import TimeoutExpired
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import configobj
@@ -698,9 +699,17 @@ class Dhcpcd(DhcpClient):
                 return lease
             raise NoDHCPLeaseError("No lease found")
 
+        except TimeoutExpired as error:
+            LOG.debug(
+                "dhcpcd timed out after %s seconds: stderr: %r stdout: %r",
+                error.timeout,
+                error.stderr,
+                error.stdout,
+            )
+            raise NoDHCPLeaseError from error
         except subp.ProcessExecutionError as error:
             LOG.debug(
-                "dhclient exited with code: %s stderr: %r stdout: %r",
+                "dhcpcd exited with code: %s stderr: %r stdout: %r",
                 error.exit_code,
                 error.stderr,
                 error.stdout,

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -147,6 +147,17 @@ class DataSourceOracle(sources.DataSource):
         self.url_max_wait = url_params.max_wait_seconds
         self.url_timeout = url_params.timeout_seconds
 
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+        if not hasattr(self, "_vnics_data"):
+            setattr(self, "_vnics_data", None)
+        if not hasattr(self, "_network_config_source"):
+            setattr(
+                self,
+                "_network_config_source",
+                KlibcOracleNetworkConfigSource(),
+            )
+
     def _has_network_config(self) -> bool:
         return bool(self._network_config.get("config", []))
 

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -15,9 +15,11 @@ Notes:
 
 import base64
 import ipaddress
+import json
 import logging
+import time
 from collections import namedtuple
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 from cloudinit import atomic_helper, dmi, net, sources, util
 from cloudinit.distros.networking import NetworkConfig
@@ -27,7 +29,7 @@ from cloudinit.net import (
     get_interfaces_by_mac,
     is_netfail_master,
 )
-from cloudinit.url_helper import UrlError, readurl
+from cloudinit.url_helper import wait_for_url
 
 LOG = logging.getLogger(__name__)
 
@@ -123,6 +125,11 @@ class DataSourceOracle(sources.DataSource):
     )
 
     _network_config: dict = {"config": [], "version": 1}
+    perform_dhcp_setup = True
+
+    # Careful...these can be overridden in __init__
+    url_max_wait = 30
+    url_timeout = 5
 
     def __init__(self, sys_cfg, *args, **kwargs):
         super(DataSourceOracle, self).__init__(sys_cfg, *args, **kwargs)
@@ -136,6 +143,10 @@ class DataSourceOracle(sources.DataSource):
         )
         self._network_config_source = KlibcOracleNetworkConfigSource()
 
+        url_params = self.get_url_params()
+        self.url_max_wait = url_params.max_wait_seconds
+        self.url_timeout = url_params.timeout_seconds
+
     def _has_network_config(self) -> bool:
         return bool(self._network_config.get("config", []))
 
@@ -148,23 +159,31 @@ class DataSourceOracle(sources.DataSource):
 
         self.system_uuid = _read_system_uuid()
 
-        network_context = ephemeral.EphemeralDHCPv4(
-            self.distro,
-            iface=net.find_fallback_nic(),
-            connectivity_url_data={
-                "url": METADATA_PATTERN.format(version=2, path="instance"),
-                "headers": V2_HEADERS,
-            },
-        )
+        if self.perform_dhcp_setup:
+            network_context = ephemeral.EphemeralDHCPv4(
+                self.distro,
+                iface=net.find_fallback_nic(),
+                connectivity_url_data={
+                    "url": METADATA_PATTERN.format(version=2, path="instance"),
+                    "headers": V2_HEADERS,
+                },
+            )
+        else:
+            network_context = util.nullcontext()
         fetch_primary_nic = not self._is_iscsi_root()
         fetch_secondary_nics = self.ds_cfg.get(
             "configure_secondary_nics",
             BUILTIN_DS_CONFIG["configure_secondary_nics"],
         )
+
         with network_context:
             fetched_metadata = read_opc_metadata(
-                fetch_vnics_data=fetch_primary_nic or fetch_secondary_nics
+                fetch_vnics_data=fetch_primary_nic or fetch_secondary_nics,
+                max_wait=self.url_max_wait,
+                timeout=self.url_timeout,
             )
+        if not fetched_metadata:
+            return False
 
         data = self._crawled_metadata = fetched_metadata.instance_data
         self.metadata_address = METADATA_ROOT.format(
@@ -332,6 +351,10 @@ class DataSourceOracle(sources.DataSource):
                 self._network_config["ethernets"][name] = interface_config
 
 
+class DataSourceOracleNet(DataSourceOracle):
+    perform_dhcp_setup = False
+
+
 def _read_system_uuid() -> Optional[str]:
     sys_uuid = dmi.read_dmi_data("system-uuid")
     return None if sys_uuid is None else sys_uuid.lower()
@@ -342,15 +365,20 @@ def _is_platform_viable() -> bool:
     return asset_tag == CHASSIS_ASSET_TAG
 
 
-def _fetch(metadata_version: int, path: str, retries: int = 2) -> dict:
-    return readurl(
-        url=METADATA_PATTERN.format(version=metadata_version, path=path),
-        headers=V2_HEADERS if metadata_version > 1 else None,
-        retries=retries,
-    )._response.json()
+def _url_version(url: str) -> int:
+    return 2 if url.startswith("http://169.254.169.254/opc/v2") else 1
 
 
-def read_opc_metadata(*, fetch_vnics_data: bool = False) -> OpcMetadata:
+def _headers_cb(url: str) -> Optional[Dict[str, str]]:
+    return V2_HEADERS if _url_version(url) == 2 else None
+
+
+def read_opc_metadata(
+    *,
+    fetch_vnics_data: bool = False,
+    max_wait=DataSourceOracle.url_max_wait,
+    timeout=DataSourceOracle.url_timeout,
+) -> Optional[OpcMetadata]:
     """Fetch metadata from the /opc/ routes.
 
     :return:
@@ -359,30 +387,60 @@ def read_opc_metadata(*, fetch_vnics_data: bool = False) -> OpcMetadata:
           The JSON-decoded value of the instance data endpoint on the IMDS
           The JSON-decoded value of the vnics data endpoint if
             `fetch_vnics_data` is True, else None
+        or None if fetching metadata failed
 
     """
     # Per Oracle, there are short windows (measured in milliseconds) throughout
     # an instance's lifetime where the IMDS is being updated and may 404 as a
-    # result.  To work around these windows, we retry a couple of times.
-    metadata_version = 2
-    try:
-        instance_data = _fetch(metadata_version, path="instance")
-    except UrlError:
-        metadata_version = 1
-        instance_data = _fetch(metadata_version, path="instance")
+    # result.
+    urls = [
+        METADATA_PATTERN.format(version=2, path="instance"),
+        METADATA_PATTERN.format(version=1, path="instance"),
+    ]
+    start_time = time.time()
+    instance_url, instance_response = wait_for_url(
+        urls,
+        max_wait=max_wait,
+        timeout=timeout,
+        headers_cb=_headers_cb,
+        sleep_time=0,
+    )
+    if not instance_url:
+        LOG.warning("Failed to fetch IMDS metadata!")
+        return None
+    instance_data = json.loads(instance_response.decode("utf-8"))
+
+    metadata_version = _url_version(instance_url)
 
     vnics_data = None
     if fetch_vnics_data:
-        try:
-            vnics_data = _fetch(metadata_version, path="vnics")
-        except UrlError:
-            util.logexc(LOG, "Failed to fetch IMDS network configuration!")
+        # This allows us to go over the max_wait time by the timeout length,
+        # but if we were able to retrieve instance metadata, that seems
+        # like a worthwhile tradeoff rather than having incomplete metadata.
+        vnics_url, vnics_response = wait_for_url(
+            [METADATA_PATTERN.format(version=metadata_version, path="vnics")],
+            max_wait=max_wait - (time.time() - start_time),
+            timeout=timeout,
+            headers_cb=_headers_cb,
+            sleep_time=0,
+        )
+        if vnics_url:
+            vnics_data = json.loads(vnics_response.decode("utf-8"))
+        else:
+            LOG.warning("Failed to fetch IMDS network configuration!")
     return OpcMetadata(metadata_version, instance_data, vnics_data)
 
 
 # Used to match classes to dependencies
 datasources = [
     (DataSourceOracle, (sources.DEP_FILESYSTEM,)),
+    (
+        DataSourceOracleNet,
+        (
+            sources.DEP_FILESYSTEM,
+            sources.DEP_NETWORK,
+        ),
+    ),
 ]
 
 

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -180,6 +180,20 @@ class DataSourceScaleway(sources.DataSource):
         if "metadata_urls" in self.ds_cfg.keys():
             self.metadata_urls += self.ds_cfg["metadata_urls"]
 
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+        attr_defaults = {
+            "ephemeral_fixed_address": None,
+            "has_ipv4": True,
+            "max_wait": DEF_MD_MAX_WAIT,
+            "metadata_urls": DS_BASE_URLS,
+            "userdata_url": None,
+            "vendordata_url": None,
+        }
+        for attr in attr_defaults:
+            if not hasattr(self, attr):
+                setattr(self, attr, attr_defaults[attr])
+
     def _set_metadata_url(self, urls):
         """
         Define metadata_url based upon api-metadata URL availability.

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -160,6 +160,32 @@ class DataSourceVMware(sources.DataSource):
             (DATA_ACCESS_METHOD_IMC, self.get_imc_data_fn, True),
         ]
 
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+        for attr in ("rpctool", "rpctool_fn"):
+            if not hasattr(self, attr):
+                setattr(self, attr, None)
+        if not hasattr(self, "cfg"):
+            setattr(self, "cfg", {})
+        if not hasattr(self, "possible_data_access_method_list"):
+            setattr(
+                self,
+                "possible_data_access_method_list",
+                [
+                    (
+                        DATA_ACCESS_METHOD_ENVVAR,
+                        self.get_envvar_data_fn,
+                        False,
+                    ),
+                    (
+                        DATA_ACCESS_METHOD_GUESTINFO,
+                        self.get_guestinfo_data_fn,
+                        True,
+                    ),
+                    (DATA_ACCESS_METHOD_IMC, self.get_imc_data_fn, True),
+                ],
+            )
+
     def __str__(self):
         root = sources.DataSource.__str__(self)
         return "%s [seed=%s]" % (root, self.data_access_method)

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -131,13 +131,14 @@ def candidate_user_data_file_names(instance_name) -> List[str]:
     Return a list of candidate file names that may contain user-data
     in some supported format, ordered by precedence.
     """
-    distribution_id, version_id, _ = util.get_linux_distro()
+    distribution_id, version_id, version_codename = util.get_linux_distro()
+    version = version_id if version_id else version_codename
 
     return [
         # WSL instance specific:
         "%s.user-data" % instance_name,
         # release codename specific
-        "%s-%s.user-data" % (distribution_id, version_id),
+        "%s-%s.user-data" % (distribution_id, version),
         # distribution specific (Alpine, Arch, Fedora, openSUSE, Ubuntu...)
         "%s-all.user-data" % distribution_id,
         # generic, valid for all WSL distros and instances.

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -473,14 +473,14 @@ def dual_stack(
 
 def wait_for_url(
     urls,
-    max_wait=None,
-    timeout=None,
+    max_wait: float = float("inf"),
+    timeout: Optional[float] = None,
     status_cb: Callable = LOG.debug,  # some sources use different log levels
     headers_cb: Optional[Callable] = None,
     headers_redact=None,
-    sleep_time: int = 1,
+    sleep_time: Optional[float] = None,
     exception_cb: Optional[Callable] = None,
-    sleep_time_cb: Optional[Callable[[Any, int], int]] = None,
+    sleep_time_cb: Optional[Callable[[Any, float], float]] = None,
     request_method: str = "",
     connect_synchronously: bool = True,
     async_delay: float = 0.150,
@@ -496,10 +496,15 @@ def wait_for_url(
     headers_cb: call method with single argument of url to get headers
                 for request.
     headers_redact: a list of header names to redact from the log
+    sleep_time: Amount of time to sleep between retries. If this and
+                sleep_time_cb are None, the default sleep time
+                defaults to 1 second and increases by 1 seconds every 5
+                tries. Cannot be specified along with `sleep_time_cb`.
     exception_cb: call method with 2 arguments 'msg' (per status_cb) and
                   'exception', the exception that occurred.
     sleep_time_cb: call method with 2 arguments (response, loop_n) that
-                   generates the next sleep time.
+                   generates the next sleep time. Cannot be specified
+                   along with 'sleep_time`.
     request_method: indicate the type of HTTP request, GET, PUT, or POST
     connect_synchronously: if false, enables executing requests in parallel
     async_delay: delay before parallel metadata requests, see RFC 6555
@@ -520,17 +525,19 @@ def wait_for_url(
     data host (169.254.169.254) may be firewalled off Entirely for a system,
     meaning that the connection will block forever unless a timeout is set.
 
-    A value of None for max_wait will retry indefinitely.
+    The default value for max_wait will retry indefinitely.
     """
 
-    def default_sleep_time(_, loop_number: int) -> int:
-        return int(loop_number / 5) + 1
+    def default_sleep_time(_, loop_number: int) -> float:
+        return sleep_time if sleep_time is not None else loop_number // 5 + 1
 
-    def timeup(max_wait, start_time):
+    def timeup(max_wait: float, start_time: float, sleep_time: float = 0):
         """Check if time is up based on start time and max wait"""
-        if max_wait is None:
+        if max_wait in (float("inf"), None):
             return False
-        return (max_wait <= 0) or (time.time() - start_time > max_wait)
+        return (max_wait <= 0) or (
+            time.time() - start_time + sleep_time > max_wait
+        )
 
     def handle_url_response(response, url):
         """Map requests response code/contents to internal "UrlError" type"""
@@ -641,6 +648,8 @@ def wait_for_url(
             return out
 
     start_time = time.time()
+    if sleep_time and sleep_time_cb:
+        raise ValueError("sleep_time and sleep_time_cb are mutually exclusive")
 
     # Dual-stack support factored out serial and parallel execution paths to
     # allow the retry loop logic to exist separately from the http calls.
@@ -656,25 +665,30 @@ def wait_for_url(
     loop_n: int = 0
     response = None
     while True:
-        sleep_time = calculate_sleep_time(response, loop_n)
+        current_sleep_time = calculate_sleep_time(response, loop_n)
 
         url = do_read_url(start_time, timeout, exception_cb, status_cb)
         if url:
             address, response = url
             return (address, response.contents)
 
-        if timeup(max_wait, start_time):
+        if timeup(max_wait, start_time, current_sleep_time):
             break
 
         loop_n = loop_n + 1
         LOG.debug(
-            "Please wait %s seconds while we wait to try again", sleep_time
+            "Please wait %s seconds while we wait to try again",
+            current_sleep_time,
         )
-        time.sleep(sleep_time)
+        time.sleep(current_sleep_time)
 
         # shorten timeout to not run way over max_time
-        # timeout=0.0 causes exceptions in urllib, set to None if zero
-        timeout = int((start_time + max_wait) - time.time()) or None
+        current_time = time.time()
+        if timeout and current_time + timeout > start_time + max_wait:
+            timeout = max_wait - (current_time - start_time)
+            if timeout <= 0:
+                # We've already exceeded our max_wait. Time to bail.
+                break
 
     LOG.error("Timed out, no response from urls: %s", urls)
     return False, None

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -575,7 +575,7 @@ def wait_for_url(
         time_taken = int(time.time() - start_time)
         max_wait_str = "%ss" % max_wait if max_wait else "unlimited"
         status_msg = "Calling '%s' failed [%s/%s]: %s" % (
-            url,
+            url or getattr(url_exc, "url", "url ? None"),
             time_taken,
             max_wait_str,
             reason,

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -36,15 +36,17 @@ import sys
 import time
 from base64 import b64decode
 from collections import deque, namedtuple
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from errno import ENOENT
 from functools import lru_cache, total_ordering
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
+    Any,
     Callable,
     Deque,
     Dict,
+    Generator,
     List,
     Mapping,
     Optional,
@@ -3293,3 +3295,12 @@ def read_hotplug_enabled_file(paths: "Paths") -> dict:
         if "scopes" not in content:
             content["scopes"] = []
     return content
+
+
+@contextmanager
+def nullcontext() -> Generator[None, Any, None]:
+    """Context manager that does nothing.
+
+    Note: In python-3.7+, this can be substituted by contextlib.nullcontext
+    """
+    yield

--- a/doc/rtd/reference/datasources/oracle.rst
+++ b/doc/rtd/reference/datasources/oracle.rst
@@ -39,6 +39,18 @@ to configure the non-primary network interface controllers in the system. If
 set to True on an OCI Bare Metal Machine, it will have no effect (though this
 may change in the future).
 
+``max_wait``
+------------
+
+An integer, defaulting to 30. The maximum time in seconds to wait for the
+metadata service to become available. If the metadata service is not
+available within this time, the datasource will fail.
+
+``timeout``
+-----------
+An integer, defaulting to 5. The time in seconds to wait for a response from
+the metadata service before retrying.
+
 Example configuration
 ---------------------
 
@@ -49,5 +61,7 @@ An example configuration with the default values is provided below:
    datasource:
     Oracle:
      configure_secondary_nics: false
+     max_wait: 30
+     timeout: 5
 
 .. _Oracle Compute Infrastructure: https://cloud.oracle.com/

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -58,8 +58,10 @@ order specified below:
    instance named ``Sid-MLKit``.
 
 2. ``%USERPROFILE%\.cloud-init\<ID>-<VERSION_ID>.user-data`` for the
-   distro-specific configuration, matched by the distro ID and VERSION_CODENAME
-   entries as specified in ``/etc/os-release``. Example:
+   distro-specific configuration, matched by the distro ID and VERSION_ID
+   entries as specified in ``/etc/os-release``.  If VERSION_ID is not present,
+   then VERSION_CODENAME will be used instead.
+   Example:
    ``ubuntu-22.04.user-data`` will affect any instance created from an Ubuntu
    22.04 Jammy Jellyfish image if a more specific configuration file does not
    match.

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -296,6 +296,8 @@ Valid keys for ``subnets`` include the following:
   interface will be handled during boot.
 - ``address``: IPv4 or IPv6 address. It may include CIDR netmask notation.
 - ``netmask``: IPv4 subnet mask in dotted format or CIDR notation.
+- ``broadcast`` : IPv4 broadcast address in dotted format. This is
+  only rendered if :file:`/etc/network/interfaces` is used.
 - ``gateway``: IPv4 address of the default gateway for this subnet.
 - ``dns_nameservers``: Specify a list of IPv4 dns server IPs to end up in
   :file:`resolv.conf`.

--- a/tests/integration_tests/modules/test_ubuntu_pro.py
+++ b/tests/integration_tests/modules/test_ubuntu_pro.py
@@ -144,6 +144,19 @@ class TestUbuntuAdvantage:
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
         assert is_attached(client)
+        client.execute("pro detach")
+        # Replace ubuntu_pro with previously named ubuntu_advantage
+        client.execute(
+            "sed -i 's/ubuntu_pro$/ubuntu_advantage/' /etc/cloud/cloud.cfg"
+        )
+        client.restart()
+        status_resp = client.execute("cloud-init status --format json")
+        status = json.loads(status_resp.stdout)
+        assert (
+            "Module has been renamed from cc_ubuntu_advantage to cc_ubuntu_pro"
+            in "\n".join(status["recoverable_errors"]["DEPRECATED"])
+        )
+        assert is_attached(client)
 
     @pytest.mark.user_data(ATTACH.format(token=CLOUD_INIT_UA_TOKEN))
     def test_idempotency(self, client: IntegrationInstance):

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -70,9 +70,6 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         # Ubuntu lxd storage
         "thinpool by default on Ubuntu due to LP #1982780",
         "WARNING]: Could not match supplied host pattern, ignoring:",
-        # Old Ubuntu cloud-images contain /etc/apt/sources.list
-        "WARNING]: Replacing /etc/apt/sources.list to favor deb822 source"
-        " format",
         # https://bugs.launchpad.net/ubuntu/+source/netplan.io/+bug/2041727
         "Cannot call Open vSwitch: ovsdb-server.service is not running.",
     ]

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -3,6 +3,7 @@
 import os
 import signal
 import socket
+import subprocess
 from textwrap import dedent
 
 import pytest
@@ -1167,9 +1168,11 @@ class TestISCDHClient(CiTestCase):
     # otherwise mock a reply with leasefile
     @mock.patch(
         "os.listdir",
-        side_effect=lambda x: []
-        if x == "/var/lib/NetworkManager"
-        else ["some_file", "!@#$-eth0.lease", "some_other_file"],
+        side_effect=lambda x: (
+            []
+            if x == "/var/lib/NetworkManager"
+            else ["some_file", "!@#$-eth0.lease", "some_other_file"]
+        ),
     )
     @mock.patch("os.path.getmtime", return_value=123.45)
     def test_fallback_when_nothing_found(self, *_):
@@ -1313,6 +1316,51 @@ class TestDhcpcd:
                         "--script=/bin/true",
                         "--clientid",
                         "ib0",
+                    ],
+                    timeout=Dhcpcd.timeout,
+                ),
+            ]
+        )
+
+    @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/sbin/dhcpcd")
+    @mock.patch("cloudinit.net.dhcp.os.killpg")
+    @mock.patch("cloudinit.net.dhcp.subp.subp")
+    @mock.patch("cloudinit.util.load_json")
+    @mock.patch("cloudinit.util.load_binary_file")
+    @mock.patch("cloudinit.util.write_file")
+    def test_dhcpcd_discovery_timeout(
+        self,
+        m_write_file,
+        m_load_file,
+        m_loadjson,
+        m_subp,
+        m_remove,
+        m_which,
+    ):
+        """Verify dhcpcd timeout results in NoDHCPLeaseError exception."""
+        m_subp.side_effect = [
+            SubpResult("a=b", ""),
+            subprocess.TimeoutExpired(
+                "/sbin/dhcpcd", timeout=6, output="testout", stderr="testerr"
+            ),
+        ]
+        with pytest.raises(NoDHCPLeaseError):
+            Dhcpcd().dhcp_discovery("eth0", distro=MockDistro())
+
+        m_subp.assert_has_calls(
+            [
+                mock.call(
+                    ["ip", "link", "set", "dev", "eth0", "up"],
+                ),
+                mock.call(
+                    [
+                        "/sbin/dhcpcd",
+                        "--ipv4only",
+                        "--waitip",
+                        "--persistent",
+                        "--noarp",
+                        "--script=/bin/true",
+                        "eth0",
                     ],
                     timeout=Dhcpcd.timeout,
                 ),

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -76,6 +76,7 @@ DEFAULT_NETWORK = [
     MAAS.DataSourceMAAS,
     NoCloud.DataSourceNoCloudNet,
     OpenStack.DataSourceOpenStack,
+    Oracle.DataSourceOracleNet,
     OVF.DataSourceOVFNet,
     UpCloud.DataSourceUpCloud,
     Akamai.DataSourceAkamai,

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -4,6 +4,7 @@ import base64
 import copy
 import json
 import logging
+from itertools import count
 from unittest import mock
 
 import pytest
@@ -14,7 +15,6 @@ from cloudinit.sources import NetworkConfigSource
 from cloudinit.sources.DataSourceOracle import OpcMetadata
 from cloudinit.url_helper import UrlError
 from tests.unittests import helpers as test_helpers
-from tests.unittests.helpers import does_not_raise
 
 DS_PATH = "cloudinit.sources.DataSourceOracle"
 
@@ -730,84 +730,70 @@ class TestReadOpcMetadata:
         assert instance_data == metadata.instance_data
         assert vnics_data == metadata.vnics_data
 
-    # No need to actually wait between retries in the tests
     @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
-    @pytest.mark.parametrize(
-        "v2_failure_count,v1_failure_count,expected_body,expectation",
-        [
-            (1, 0, json.loads(OPC_V2_METADATA), does_not_raise()),
-            (2, 0, json.loads(OPC_V2_METADATA), does_not_raise()),
-            (3, 0, json.loads(OPC_V1_METADATA), does_not_raise()),
-            (3, 1, json.loads(OPC_V1_METADATA), does_not_raise()),
-            (3, 2, json.loads(OPC_V1_METADATA), does_not_raise()),
-            (3, 3, None, pytest.raises(UrlError)),
-        ],
+    @mock.patch("cloudinit.url_helper.time.time", side_effect=count(0, 1))
+    @mock.patch("cloudinit.url_helper.readurl", side_effect=UrlError)
+    def test_retry(self, m_readurl, m_time):
+        # Since wait_for_url has its own retry tests, just verify that we
+        # attempted to contact both endpoints multiple times
+        oracle.read_opc_metadata()
+        assert len(m_readurl.call_args_list) > 3
+        assert (
+            m_readurl.call_args_list[0][0][0]
+            == "http://169.254.169.254/opc/v2/instance/"
+        )
+        assert (
+            m_readurl.call_args_list[1][0][0]
+            == "http://169.254.169.254/opc/v1/instance/"
+        )
+        assert (
+            m_readurl.call_args_list[2][0][0]
+            == "http://169.254.169.254/opc/v2/instance/"
+        )
+        assert (
+            m_readurl.call_args_list[3][0][0]
+            == "http://169.254.169.254/opc/v1/instance/"
+        )
+
+    @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
+    @mock.patch("cloudinit.url_helper.time.time", side_effect=[0, 11])
+    @mock.patch(
+        "cloudinit.sources.DataSourceOracle.wait_for_url",
+        return_value=("http://hi", b'{"some": "value"}'),
     )
-    def test_retries(
-        self,
-        v2_failure_count,
-        v1_failure_count,
-        expected_body,
-        expectation,
-        mocked_responses,
-    ):
-        # Workaround https://github.com/getsentry/responses/pull/171
-        # This mocking can be unrolled when Bionic is EOL
-        url_v2_call_count = 0
+    def test_fetch_vnics_max_wait(self, m_wait_for_url, m_time):
+        oracle.read_opc_metadata(fetch_vnics_data=True)
+        assert m_wait_for_url.call_count == 2
+        # 19 because start time was 0, next time was 11 and max wait is 30
+        assert m_wait_for_url.call_args_list[-1][1]["max_wait"] == 19
 
-        def url_v2_callback(request):
-            nonlocal url_v2_call_count
-            url_v2_call_count += 1
-            if url_v2_call_count <= v2_failure_count:
-                return (
-                    404,
-                    request.headers,
-                    f"403 Client Error: Forbidden for url: {url_v2}",
-                )
-            return 200, request.headers, OPC_V2_METADATA
-
-        url_v2 = "http://169.254.169.254/opc/v2/instance/"
-        mocked_responses.add_callback(
-            responses.GET, url_v2, callback=url_v2_callback
-        )
-
-        # Workaround https://github.com/getsentry/responses/pull/171
-        # This mocking can be unrolled when Bionic is EOL
-        url_v1_call_count = 0
-
-        def url_v1_callback(request):
-            nonlocal url_v1_call_count
-            url_v1_call_count += 1
-            if url_v1_call_count <= v1_failure_count:
-                return (
-                    404,
-                    request.headers,
-                    f"403 Client Error: Forbidden for url: {url_v1}",
-                )
-            return 200, request.headers, OPC_V1_METADATA
-
-        url_v1 = "http://169.254.169.254/opc/v1/instance/"
-        mocked_responses.add_callback(
-            responses.GET, url_v1, callback=url_v1_callback
-        )
-
-        with expectation:
-            assert expected_body == oracle.read_opc_metadata().instance_data
+    @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
+    @mock.patch("cloudinit.url_helper.time.time", side_effect=[0, 1000])
+    @mock.patch(
+        "cloudinit.sources.DataSourceOracle.wait_for_url",
+        return_value=("http://hi", b'{"some": "value"}'),
+    )
+    def test_attempt_vnics_after_max_wait_expire(self, m_wait_for_url, m_time):
+        oracle.read_opc_metadata(fetch_vnics_data=True)
+        assert m_wait_for_url.call_count == 2
+        assert m_wait_for_url.call_args_list[-1][1]["max_wait"] < 0
 
     # No need to actually wait between retries in the tests
     @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
     def test_fetch_vnics_error(self, caplog):
-        def mocked_fetch(*args, path="instance", **kwargs):
-            if path == "vnics":
-                raise UrlError("cause")
+        def m_wait(*args, **kwargs):
+            for url in args[0]:
+                if "vnics" in url:
+                    return False, None
+            return ("http://localhost", b"{}")
 
-        with mock.patch(DS_PATH + "._fetch", side_effect=mocked_fetch):
+        with mock.patch(DS_PATH + ".wait_for_url", side_effect=m_wait):
             opc_metadata = oracle.read_opc_metadata(fetch_vnics_data=True)
             assert None is opc_metadata.vnics_data
         assert (
             logging.WARNING,
             "Failed to fetch IMDS network configuration!",
-        ) == caplog.record_tuples[-2][1:]
+        ) == caplog.record_tuples[-1][1:], caplog.record_tuples
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -476,6 +476,7 @@ class TestDataSourceScaleway(ResponsesTestCase):
         self.assertIsNone(self.datasource.get_userdata_raw())
         self.assertIsNone(self.datasource.get_vendordata_raw())
 
+    @mock.patch("cloudinit.url_helper.time.sleep", lambda x: None)
     @mock.patch("cloudinit.sources.DataSourceScaleway.EphemeralDHCPv4")
     def test_metadata_connection_errors_legacy_ipv4_url(self, dhcpv4):
         """
@@ -497,11 +498,6 @@ class TestDataSourceScaleway(ResponsesTestCase):
                 callback=ConnectionError,
             )
             self.datasource._set_metadata_url(self.datasource.metadata_urls)
-        if sys.version_info.minor >= 7:
-            self.responses.assert_call_count(
-                f"{self.datasource.metadata_urls[0]}/",
-                self.datasource.retries,
-            )
         self.assertEqual(self.datasource.metadata, {})
         self.assertIsNone(self.datasource.get_userdata_raw())
         self.assertIsNone(self.datasource.get_vendordata_raw())

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -49,6 +49,7 @@ GOOD_MOUNTS = {
     },
 }
 SAMPLE_LINUX_DISTRO = ("ubuntu", "24.04", "noble")
+SAMPLE_LINUX_DISTRO_NO_VERSION_ID = ("debian", "", "trixie")
 
 
 class TestWSLHelperFunctions:
@@ -122,19 +123,37 @@ class TestWSLHelperFunctions:
         with pytest.raises(IOError):
             wsl.cmd_executable()
 
+    @pytest.mark.parametrize(
+        "linux_distro_value,files",
+        (
+            (
+                SAMPLE_LINUX_DISTRO,
+                [
+                    f"{INSTANCE_NAME}.user-data",
+                    "ubuntu-24.04.user-data",
+                    "ubuntu-all.user-data",
+                    "default.user-data",
+                ],
+            ),
+            (
+                SAMPLE_LINUX_DISTRO_NO_VERSION_ID,
+                [
+                    f"{INSTANCE_NAME}.user-data",
+                    "debian-trixie.user-data",
+                    "debian-all.user-data",
+                    "default.user-data",
+                ],
+            ),
+        ),
+    )
     @mock.patch("cloudinit.util.get_linux_distro")
-    def test_candidate_files(self, m_gld):
+    def test_candidate_files(self, m_gld, linux_distro_value, files):
         """
         Validate the file names candidate for holding user-data and their
         order of precedence.
         """
-        m_gld.return_value = SAMPLE_LINUX_DISTRO
-        assert [
-            f"{INSTANCE_NAME}.user-data",
-            "ubuntu-24.04.user-data",
-            "ubuntu-all.user-data",
-            "default.user-data",
-        ] == wsl.candidate_user_data_file_names(INSTANCE_NAME)
+        m_gld.return_value = linux_distro_value
+        assert files == wsl.candidate_user_data_file_names(INSTANCE_NAME)
 
     @pytest.mark.parametrize(
         "md_content,raises,errors,warnings,md_expected",

--- a/tests/unittests/test_upgrade.py
+++ b/tests/unittests/test_upgrade.py
@@ -48,7 +48,13 @@ class TestUpgrade:
             "seed_dir",
         },
         "CloudSigma": {"cepko", "ssh_public_key"},
-        "CloudStack": {"api_ver", "cfg", "seed_dir", "vr_addr"},
+        "CloudStack": {
+            "api_ver",
+            "cfg",
+            "metadata_address",
+            "seed_dir",
+            "vr_addr",
+        },
         "ConfigDrive": {
             "_network_config",
             "ec2_metadata",

--- a/tests/unittests/test_upgrade.py
+++ b/tests/unittests/test_upgrade.py
@@ -13,13 +13,15 @@ tests in ``TestUpgrade``) and then checks that these hold true after unpickling
 
 import operator
 import pathlib
+from unittest import mock
 
 import pytest
 
-from cloudinit.sources import pkl_load
+from cloudinit import importer, settings, sources, type_utils
 from cloudinit.sources.DataSourceAzure import DataSourceAzure
 from cloudinit.sources.DataSourceNoCloud import DataSourceNoCloud
 from tests.unittests.helpers import resourceLocation
+from tests.unittests.util import MockDistro
 
 DSNAME_TO_CLASS = {
     "Azure": DataSourceAzure,
@@ -28,6 +30,131 @@ DSNAME_TO_CLASS = {
 
 
 class TestUpgrade:
+    # Expect the following "gaps" in unpickling per-datasource.
+    # The presence of these attributes existed in 20.1.
+    ds_expected_unpickle_attrs = {
+        "AltCloud": {"seed", "supported_seed_starts"},
+        "AliYun": {"identity", "metadata_address", "default_update_events"},
+        "Azure": {
+            "_ephemeral_dhcp_ctx",
+            "_iso_dev",
+            "_network_config",
+            "_reported_ready_marker_file",
+            "_route_configured_for_imds",
+            "_route_configured_for_wireserver",
+            "_wireserver_endpoint",
+            "cfg",
+            "seed",
+            "seed_dir",
+        },
+        "CloudSigma": {"cepko", "ssh_public_key"},
+        "CloudStack": {"api_ver", "cfg", "seed_dir", "vr_addr"},
+        "ConfigDrive": {
+            "_network_config",
+            "ec2_metadata",
+            "files",
+            "known_macs",
+            "network_eni",
+            "network_json",
+            "seed_dir",
+            "source",
+            "version",
+        },
+        "DigitalOcean": {
+            "_network_config",
+            "metadata_address",
+            "metadata_full",
+            "retries",
+            "timeout",
+            "use_ip4LL",
+            "wait_retry",
+        },
+        "Ec2": {"identity", "metadata_address"},
+        "Exoscale": {
+            "api_version",
+            "extra_config",
+            "metadata_url",
+            "password_server_port",
+            "url_retries",
+            "url_timeout",
+        },
+        "GCE": {"default_user", "metadata_address"},
+        "Hetzner": {
+            "_network_config",
+            "dsmode",
+            "metadata_address",
+            "metadata_full",
+            "retries",
+            "timeout",
+            "userdata_address",
+            "wait_retry",
+        },
+        "IBMCloud": {"source", "_network_config", "network_json", "platform"},
+        "RbxCloud": {"cfg", "gratuitous_arp", "seed"},
+        "Scaleway": {
+            "_network_config",
+            "metadata_url",
+            "retries",
+            "timeout",
+        },
+        "Joyent": {
+            "_network_config",
+            "network_data",
+            "routes_data",
+            "script_base_d",
+        },
+        "MAAS": {"base_url", "seed_dir"},
+        "NoCloud": {
+            "_network_eni",
+            "_network_config",
+            "supported_seed_starts",
+            "seed_dir",
+            "seed",
+            "seed_dirs",
+        },
+        "NWCS": {
+            "_network_config",
+            "dsmode",
+            "metadata_address",
+            "metadata_full",
+            "retries",
+            "timeout",
+            "wait_retry",
+        },
+        "OpenNebula": {"network", "seed", "seed_dir"},
+        "OpenStack": {
+            "ec2_metadata",
+            "files",
+            "metadata_address",
+            "network_json",
+            "ssl_details",
+            "version",
+        },
+        "OVF": {
+            "cfg",
+            "environment",
+            "_network_config",
+            "seed",
+            "seed_dir",
+            "supported_seed_starts",
+        },
+        "UpCloud": {
+            "_network_config",
+            "metadata_address",
+            "metadata_full",
+            "retries",
+            "timeout",
+            "wait_retry",
+        },
+        "Vultr": {"netcfg"},
+        "VMware": {
+            "data_access_method",
+            "rpctool",
+            "rpctool_fn",
+        },
+        "WSL": {"instance_name"},
+    }
+
     @pytest.fixture(
         params=pathlib.Path(resourceLocation("old_pickles")).glob("*.pkl"),
         scope="class",
@@ -39,7 +166,102 @@ class TestUpgrade:
         Test implementations _must not_ modify the ``previous_obj_pkl`` which
         they are passed, as that will affect tests that run after them.
         """
-        return pkl_load(str(request.param))
+        return sources.pkl_load(str(request.param))
+
+    @pytest.mark.parametrize(
+        "mode",
+        (
+            [sources.DEP_FILESYSTEM],
+            [sources.DEP_FILESYSTEM, sources.DEP_NETWORK],
+        ),
+    )
+    @mock.patch.object(
+        importer,
+        "match_case_insensitive_module_name",
+        lambda name: f"DataSource{name}",
+    )
+    def test_all_ds_init_vs_unpickle_attributes(
+        self, mode, mocker, paths, tmpdir
+    ):
+        """Unpickle resets any instance attributes created in __init__
+
+        This test asserts that deserialization of a datasource cache
+        does proper initialization of any 'new' instance attributes
+        created as a side-effect of the __init__ method.
+
+        Without proper _unpickle coverage for newly introduced attributes,
+        the new deserialized instance will hit AttributeErrors at runtime.
+        """
+        # Load all cloud-init init-local time-frame DataSource classes
+        for ds_class in sources.list_sources(
+            settings.CFG_BUILTIN["datasource_list"],
+            mode,
+            [type_utils.obj_name(sources)],
+        ):
+            # Expected common instance attrs from __init__ that are typically
+            # handled via existing _unpickling and setup in _get_data
+            common_instance_attrs = {
+                "paths",
+                "vendordata2",
+                "sys_cfg",
+                "ud_proc",
+                "vendordata",
+                "vendordata2_raw",
+                "ds_cfg",
+                "distro",
+                "userdata",
+                "userdata_raw",
+                "metadata",
+                "vendordata_raw",
+            }
+            # Grab initial specific-class attributes from magic method
+            class_attrs = set(ds_class.__dict__)
+
+            # Mock known subp calls from some datasource __init__ setup
+            mocker.patch("cloudinit.util.is_container", return_value=False)
+            mocker.patch("cloudinit.dmi.read_dmi_data", return_value="")
+            mocker.patch("cloudinit.subp.subp", return_value=("", ""))
+
+            # Initialize the class to grab the instance attributes from
+            # instance.__dict__ magic method.
+            ds = ds_class(sys_cfg={}, distro=MockDistro(), paths=paths)
+
+            if getattr(ds.__class__.__bases__[0], "dsname", None) == ds.dsname:
+                # We are a subclass in a different boot mode (Local/Net) and
+                # share a common parent with class atttributes
+                class_attrs.update(ds.__class__.__bases__[0].__dict__)
+
+            # Determine new instance attributes created by __init__
+            # by calling the __dict__ magic method on the instance.
+            # Then, subtract common_instance_attrs and
+            # ds_expected_unpickle_attrs from the list of current attributes.
+            # What's left is our 'new' instance attributes added as a
+            # side-effect of __init__.
+            init_attrs = (
+                set(ds.__dict__)
+                - class_attrs
+                - common_instance_attrs
+                - self.ds_expected_unpickle_attrs.get(ds_class.dsname, set())
+            )
+
+            # Remove all side-effect attributes added by __init__
+            for side_effect_attr in init_attrs:
+                delattr(ds, side_effect_attr)
+
+            # Pickle the version of the DataSource with all init_attrs removed
+            sources.pkl_store(ds, tmpdir.join(f"{ds.dsname}.obj.pkl"))
+
+            # Reload the pickled bare-bones datasource to ensure all instance
+            # attributes are reconstituted by _unpickle helpers.
+            ds2 = sources.pkl_load(tmpdir.join(f"{ds.dsname}.obj.pkl"))
+            unpickled_attrs = (
+                set(ds2.__dict__) - class_attrs - common_instance_attrs
+            )
+            missing_unpickled_attrs = init_attrs - unpickled_attrs
+            assert not missing_unpickled_attrs, (
+                f"New {ds_class.dsname} attributes need unpickle coverage:"
+                f" {missing_unpickled_attrs}"
+            )
 
     def test_pkl_load_defines_all_init_side_effect_attributes(
         self, previous_obj_pkl

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -1,4 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+# pylint: disable=attribute-defined-outside-init
 
 import logging
 import re
@@ -471,6 +472,21 @@ class TestUrlHelper:
     fail = "FAIL"
     event = Event()
 
+    @pytest.fixture
+    def retry_mocks(self, mocker):
+        self.mock_time_value = 0
+        m_readurl = mocker.patch(
+            f"{M_PATH}readurl", side_effect=self.readurl_side_effect
+        )
+        m_sleep = mocker.patch(
+            f"{M_PATH}time.sleep", side_effect=self.sleep_side_effect
+        )
+        mocker.patch(f"{M_PATH}time.time", side_effect=self.time_side_effect)
+
+        yield m_readurl, m_sleep
+
+        self.mock_time_value = 0
+
     @classmethod
     def response_wait(cls, _request):
         cls.event.wait(0.1)
@@ -562,3 +578,71 @@ class TestUrlHelper:
         assert re.search(
             r"open 'https:\/\/sleep1\/'.*Timed out", caplog.text, re.DOTALL
         )
+
+    def test_explicit_arguments(self, retry_mocks):
+        """Ensure that explicit arguments are respected"""
+        m_readurl, m_sleep = retry_mocks
+        wait_for_url(
+            urls=["http://localhost/"],
+            max_wait=23,
+            timeout=5,
+            sleep_time=3,
+        )
+
+        assert len(m_readurl.call_args_list) == 3
+        assert len(m_sleep.call_args_list) == 2
+
+        for readurl_call in m_readurl.call_args_list:
+            assert readurl_call[1]["timeout"] == 5
+        for sleep_call in m_sleep.call_args_list:
+            assert sleep_call[0][0] == 3
+
+        # Call 1 starts 0
+        # Call 2 starts at 8-ish after 5 second timeout and 3 second sleep
+        # Call 3 starts at 16-ish for same reasons
+        # The 5 second timeout puts us at 21-ish and now we break
+        # because 21-ish + the sleep time puts us over max wait of 23
+        assert pytest.approx(self.mock_time_value) == 21
+
+    def test_shortened_timeout(self, retry_mocks):
+        """Test that we shorten the last timeout to align with max_wait"""
+        m_readurl, _m_sleep = retry_mocks
+        wait_for_url(
+            urls=["http://localhost/"], max_wait=10, timeout=9, sleep_time=0
+        )
+
+        assert len(m_readurl.call_args_list) == 2
+        assert m_readurl.call_args_list[-1][1]["timeout"] == pytest.approx(1)
+
+    def test_default_sleep_time(self, retry_mocks):
+        """Test default sleep behavior when not specified"""
+        _m_readurl, m_sleep = retry_mocks
+        wait_for_url(
+            urls=["http://localhost/"],
+            max_wait=50,
+            timeout=1,
+        )
+
+        expected_sleep_times = [1] * 5 + [2] * 5 + [3] * 5
+        actual_sleep_times = [
+            m_sleep.call_args_list[i][0][0]
+            for i in range(len(m_sleep.call_args_list))
+        ]
+        assert actual_sleep_times == expected_sleep_times
+
+    # These side effect methods are a way of having a somewhat predictable
+    # output for time.time(). Otherwise, we have to track too many calls
+    # to time.time() and unrelated changes to code being called could cause
+    # these tests to fail.
+    # 0.0000001 is added to simulate additional execution time but keep it
+    # small enough for pytest.approx() to work
+    def sleep_side_effect(self, sleep_time):
+        self.mock_time_value += sleep_time + 0.0000001
+
+    def time_side_effect(self):
+        return self.mock_time_value
+
+    def readurl_side_effect(self, *args, **kwargs):
+        if "timeout" in kwargs:
+            self.mock_time_value += kwargs["timeout"] + 0.0000001
+        raise UrlError("test")

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1654,8 +1654,8 @@ dscheck_WSL() {
     WSL_instance_name
     instance_name="${_RET}"
     # shellcheck source=/dev/null
-    . /etc/os-release
-    for userdatafile in "${instance_name}.user-data" "${ID}-${VERSION_ID}" "${ID}-all.user-data" "default.user-data"; do
+    . "${PATH_ROOT}/etc/os-release"
+    for userdatafile in "${instance_name}.user-data" "${ID:-linux}-${VERSION_ID:-${VERSION_CODENAME}}".user-data "${ID:-linux}-all.user-data" "default.user-data"; do
         candidate="$cloudinitdir/$userdatafile"
         if [ -f "$candidate" ]; then
             debug 1 "Found applicable user data file for this instance at: $candidate"


### PR DESCRIPTION
## 24.1.1

Include the bugfixes planned for 24.1.1 (and dependent commits to avoid cherry-pick conflicts and failing tests), waiting on #5021 and #5028 to land and then will include them in this PR.


2516aed4408f140fad8de888e2decaddc39e2c8f (HEAD -> 24.1.x, origin/24.1.x) fix: Add "broadcast" to network v1 schema (#5034)
db8272a439a30c129e517cbaf51966debe899593 pro: honor but warn on custom ubuntu_advantage in /etc/cloud/cloud.cfg (#5030)
95d6a658824c84971def7be118cb5afc869633be net/dhcp: handle timeouts for dhcpcd (#5022)
1c4b7d57241076785717a0a804a3c00b93aa07a4 fix: Make wait_for_url respect explicit arguments
888507d4cab4124931a0675333cce7eb21425069 bug(wait_for_url): when exceptions occur url is unset, use url_exc
74481d2deea3ee3a640c568b6eca742ca41665de test: Fix scaleway retry assumptions
a5aba0c0425afb71772a2572ab6054b01d626a18 fix: Make DataSourceOracle more resilient to early network issues (#5025)
38b69c8d8500337a1906d81066b5c99729b98ff2 tests: Fix wsl test (#5008)


- [x] Rebase merge
