### PR TITLE
tests: Don't wait for GCE instance teardown

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -8,6 +8,7 @@ from tempfile import NamedTemporaryFile
 from typing import Union
 
 from pycloudlib.instance import BaseInstance
+from pycloudlib.gce.instance import GceInstance
 from pycloudlib.result import Result
 
 from tests.helpers import cloud_init_project_dir
@@ -67,7 +68,10 @@ class IntegrationInstance:
         self._ip = ""
 
     def destroy(self):
-        self.instance.delete()
+        if isinstance(self.instance, GceInstance):
+            self.instance.delete(wait=False)
+        else:
+            self.instance.delete()
 
     def restart(self):
         """Restart this instance (via cloud mechanism) and wait for boot.

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Union
 
-from pycloudlib.instance import BaseInstance
 from pycloudlib.gce.instance import GceInstance
+from pycloudlib.instance import BaseInstance
 from pycloudlib.result import Result
 
 from tests.helpers import cloud_init_project_dir


### PR DESCRIPTION
## Proposed Commit Message
```
tests: Don't wait for GCE instance teardown

Fixes GH-4987
```


## Additional Context
It feels like an abstraction would be better here for cloud-specific instance behavior customizations, but I think that would be a bigger refactor.

Fixes https://github.com/canonical/cloud-init/issues/4987