### PR TITLE
fix: Ensure DataSourceCloudStack can be unpickled

### DIFF
--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -96,6 +96,11 @@ class DataSourceCloudStack(sources.DataSource):
         self.metadata_address = f"http://{self.vr_addr}/"
         self.cfg = {}
 
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+        if not getattr(self, "metadata_address"):
+            self.metadata_address = f"http://{self.vr_addr}/"
+
     def _get_domainname(self):
         """
         Try obtaining a "domain-name" DHCP lease parameter:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Ensure DataSourceCloudStack can be unpickled

`self.metadata_address` was recently added. Ensure it can be unpickled
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
