### PR TITLE
fix: Include DataSourceCloudStack attribute in unpickle test

### DIFF
--- a/tests/unittests/test_upgrade.py
+++ b/tests/unittests/test_upgrade.py
@@ -48,7 +48,13 @@ class TestUpgrade:
             "seed_dir",
         },
         "CloudSigma": {"cepko", "ssh_public_key"},
-        "CloudStack": {"api_ver", "cfg", "seed_dir", "vr_addr"},
+        "CloudStack": {
+            "api_ver",
+            "cfg",
+            "metadata_address",
+            "seed_dir",
+            "vr_addr",
+        },
         "ConfigDrive": {
             "_network_config",
             "ec2_metadata",


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Include DataSourceCloudStack attribute in unpickle test

Ensure  is ignored in the _unpickle test for
DataSourceCloudStack. It has existed for many years.
```

## Additional Context
Tested that it also works on the 24.1.x branch

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
