### PR TITLE
packages/debian: remove dependency on isc-dhcp-client

### DIFF
--- a/packages/debian/control.in
+++ b/packages/debian/control.in
@@ -12,7 +12,6 @@ Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
          iproute2,
-         isc-dhcp-client,
          python3-debconf
 Recommends: eatmydata, sudo, software-properties-common, gdisk
 Suggests: ssh-import-id, openssh-server


### PR DESCRIPTION
With support for new clients, remove hard dependency on dhclient.