### PR TITLE
fix: Don't assume ordering of ThreadPoolExecutor submissions

### DIFF
--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -500,7 +500,10 @@ class TestDualStack:
                         event=ANY,
                         delay=stagger * 4,
                     ),
-                ]
+                ][: len(delay_func.call_args_list)]
+                # truncate the list to the number of call args
+                # this is non-deterministic because the first future to
+                # complete causes the rest to be canceled.
             )
 
 

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -463,48 +463,57 @@ class TestDualStack:
             # it appears that without an explicit wait/join we can't assert
             # number of calls
             # call order is not strict as of Python 3.13
-            delay_func.assert_has_calls(
-                [
-                    call(
-                        func=identity_of_first_arg,
-                        addr="you",
-                        timeout=1,
-                        event=ANY,
-                        delay=stagger * 0,
-                    ),
-                    call(
-                        func=identity_of_first_arg,
-                        addr="and",
-                        timeout=1,
-                        event=ANY,
-                        delay=stagger * 1,
-                    ),
-                    call(
-                        func=identity_of_first_arg,
-                        addr="me",
-                        timeout=1,
-                        event=ANY,
-                        delay=stagger * 2,
-                    ),
-                    call(
-                        func=identity_of_first_arg,
-                        addr="and",
-                        timeout=1,
-                        event=ANY,
-                        delay=stagger * 3,
-                    ),
-                    call(
-                        func=identity_of_first_arg,
-                        addr="dog",
-                        timeout=1,
-                        event=ANY,
-                        delay=stagger * 4,
-                    ),
-                ][: len(delay_func.call_args_list)]
-                # truncate the list to the number of call args
-                # this is non-deterministic because the first future to
-                # complete causes the rest to be canceled.
-            )
+            calls = [
+                call(
+                    func=identity_of_first_arg,
+                    addr="you",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 0,
+                ),
+                call(
+                    func=identity_of_first_arg,
+                    addr="and",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 1,
+                ),
+                call(
+                    func=identity_of_first_arg,
+                    addr="me",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 2,
+                ),
+                call(
+                    func=identity_of_first_arg,
+                    addr="and",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 3,
+                ),
+                call(
+                    func=identity_of_first_arg,
+                    addr="dog",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 4,
+                ),
+            ]
+            num_calls = 0
+            for call_instance in calls:
+                if call_instance in delay_func.call_args_list:
+                    num_calls += 1
+
+            # we can't know the order of the submitted functions' execution
+            # we can't know how many of the submitted functions get called
+            # in advance
+            #
+            # we _do_ know what the possible arg combinations are
+            # we _do_ know from the mocked function how many got called
+            # assert that all calls that occurred had known valid arguments
+            # by checking for the correct number of matches
+            assert num_calls == len(delay_func.call_args_list)
 
 
 ADDR1 = "https://addr1/"

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -462,7 +462,6 @@ class TestDualStack:
             # [ 0 * N, 1 * N, 2 * N, 3 * N, 4 * N, 5 * N] where N = stagger
             # it appears that without an explicit wait/join we can't assert
             # number of calls
-            # call order is not strict as of Python 3.13
             calls = [
                 call(
                     func=identity_of_first_arg,


### PR DESCRIPTION
## Proposed Commit Message
```
fix: Don't assume ordering of ThreadPoolExecutor submissions

This test breaks in Python 3.13 and was never guaranteed to
succeed in earlier versions of Python but apparently did due
to the way that cPython was implementated previously.
```

## Additional Context
We've had some flaky test failures for a bit now: [[example]()]

This test was never guaranteed to succeed, it just apparently did because of cPython ThreadpoolExecutor implementation. Python 3.13 brings lots of threading changes - it is unsurprising that this test now fails occasionally.
```
self = <tests.unittests.test_url_helper.TestDualStack object at 0x7f07de5e12e0>

    def test_dual_stack_staggered(self):
        """Assert expected call intervals occur"""
        stagger = 0.1
        with mock.patch(M_PATH + "_run_func_with_delay") as delay_func:
            dual_stack(
                lambda x, _y: x,
                ["you", "and", "me", "and", "dog"],
                stagger_delay=stagger,
                timeout=1,
            )
    
            # ensure that stagger delay for each subsequent call is:
            # [ 0 * N, 1 * N, 2 * N, 3 * N, 4 * N, 5 * N] where N = stagger
            # it appears that without an explicit wait/join we can't assert
            # number of calls
            for delay, call_item in enumerate(delay_func.call_args_list):
                _, kwargs = call_item
>               assert stagger * delay == kwargs.get("delay")
E               AssertionError: assert (0.1 * 1) == 0.2
E                +  where 0.2 = <built-in method get of dict object at 0x7f077cee4d40>('delay')
E                +    where <built-in method get of dict object at 0x7f077cee4d40> = {'addr': 'me', 'delay': 0.2, 'event': <threading.Event at 0x7f07ac855700: set>, 'func': <function TestDualStack.test_dual_stack_staggered.<locals>.<lambda> at 0x7f077cef02c0>, ...}.get

_          = ()
call_item  = call(func=<function TestDualStack.test_dual_stack_staggered.<locals>.<lambda> at 0x7f077cef02c0>, addr='me', timeout=1, event=<threading.Event at 0x7f07ac855700: set>, delay=0.2)
delay      = 1
delay_func = <MagicMock name='_run_func_with_delay' id='139670934497200'>
kwargs     = {'addr': 'me',
 'delay': 0.2,
 'event': <threading.Event at 0x7f07ac855700: set>,
 'func': <function TestDualStack.test_dual_stack_staggered.<locals>.<lambda> at 0x7f077cef02c0>,
 'timeout': 1}
self       = <tests.unittests.test_url_helper.TestDualStack object at 0x7f07de5e12e0>
stagger    = 0.1
```

## Test Steps

It passes for me locally and I don't have a Python 3.13 interpreter locally so... did ci pass?