### PR TITLE
feat(hotlug): trigger hotplug after cloud-init.service

### DIFF
--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -2,6 +2,7 @@ import contextlib
 import time
 from collections import namedtuple
 
+import paramiko
 import pytest
 import yaml
 
@@ -14,7 +15,7 @@ from tests.integration_tests.releases import (
     FOCAL,
     UBUNTU_STABLE,
 )
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_log, wait_for_cloud_init
 
 USER_DATA = """\
 #cloud-config
@@ -394,3 +395,145 @@ def test_no_hotplug_triggered_by_docker(client: IntegrationInstance):
     assert "enabled" == client.execute(
         "cloud-init devel hotplug-hook -s net query"
     )
+
+
+def wait_for_cmd(
+    client: IntegrationInstance, cmd: str, return_code: int
+) -> None:
+    for _ in range(60):
+        try:
+            res = client.execute(cmd)
+        except paramiko.ssh_exception.SSHException:
+            pass
+        else:
+            if res.return_code == return_code:
+                return
+        time.sleep(1)
+    assert False, f"`{cmd}` never exited with {return_code}"
+
+
+def assert_systemctl_status_code(
+    client: IntegrationInstance, service: str, return_code: int
+):
+    result = client.execute(f"systemctl status {service}")
+    assert result.return_code == return_code, (
+        f"status of {service} expected to be {return_code} but was"
+        f" {result.return_code}\nstdout: {result.stdout}\n"
+        f"stderr {result.stderr}"
+    )
+
+
+BLOCK_CLOUD_CONFIG = """\
+[Unit]
+Description=Block cloud-config.service
+After=cloud-config.target
+Before=cloud-config.service
+
+DefaultDependencies=no
+Before=shutdown.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/sleep 360
+TimeoutSec=0
+
+# Output needs to appear in instance console output
+StandardOutput=journal+console
+
+[Install]
+WantedBy=cloud-config.service
+"""  # noqa: E501
+
+
+BLOCK_CLOUD_FINAL = """\
+[Unit]
+Description=Block cloud-final.service
+After=cloud-config.target
+Before=cloud-final.service
+
+DefaultDependencies=no
+Before=shutdown.target
+Conflicts=shutdown.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/sleep 360
+TimeoutSec=0
+
+# Output needs to appear in instance console output
+StandardOutput=journal+console
+
+[Install]
+WantedBy=cloud-final.service
+"""  # noqa: E501
+
+
+def _customize_environment(client: IntegrationInstance):
+    def enable_block_service(service_name: str, content: str):
+        service_filename = f"/lib/systemd/system/{service_name}.service"
+        client.write_to_file(service_filename, content)
+        client.execute(f"chmod 0644 {service_filename}", use_sudo=True)
+        client.execute(
+            f"systemctl enable {service_name}.service", use_sudo=True
+        )
+
+    enable_block_service("block-cloud-config", BLOCK_CLOUD_CONFIG)
+    enable_block_service("block-cloud-final", BLOCK_CLOUD_FINAL)
+
+    # Allows ssh access for 1000 user before boot has finished
+    contents = client.read_from_file("/etc/pam.d/sshd")
+    contents = (
+        "account [success=1 default=ignore] pam_succeed_if.so quiet uid eq"
+        " 1000\n\n" + contents
+    )
+    client.write_to_file("/etc/pam.d/sshd", contents)
+
+    client.instance.shutdown(wait=True)
+    client.instance.start(wait=False)
+
+
+@pytest.mark.skipif(
+    PLATFORM != "ec2",
+    reason="test is ec2 specific but should work on other platforms with the"
+    " ability to add_network_interface",
+)
+@pytest.mark.user_data(USER_DATA)
+def test_nics_before_config_trigger_hotplug(client: IntegrationInstance):
+    """
+    Test that NICs added/removed after the Network boot stage but before
+    the rest boot stages do trigger cloud-init-hotplugd.
+
+    Note: Do not test first boot, as cc_install_hotplug runs at
+    config-final.service time.
+    """
+    _customize_environment(client)
+
+    # wait until we are between cloud-config.target done and
+    # cloud-config.service
+    wait_for_cmd(client, "systemctl status cloud-config.target", 0)
+    wait_for_cmd(client, "systemctl status block-cloud-config.service", 3)
+
+    assert_systemctl_status_code(client, "cloud-config.service", 3)
+    assert_systemctl_status_code(client, "cloud-final.service", 3)
+
+    added_ip_0 = client.instance.add_network_interface()
+    _wait_till_hotplug_complete(client, expected_runs=1)
+
+    # unblock cloud-config.service
+    assert client.execute("systemctl stop block-cloud-config.service").ok
+    wait_for_cmd(client, "systemctl status cloud-config.service", 0)
+    wait_for_cmd(client, "systemctl status block-cloud-final.service", 3)
+    assert_systemctl_status_code(client, "cloud-final.service", 3)
+
+    client.instance.remove_network_interface(added_ip_0)
+    _wait_till_hotplug_complete(client, expected_runs=2)
+
+    # unblock cloud-final.service
+    assert client.execute("systemctl stop block-cloud-final.service").ok
+
+    wait_for_cloud_init(client)
+
+    _wait_till_hotplug_complete(client, expected_runs=2)
+    client.instance.add_network_interface()
+    _wait_till_hotplug_complete(client, expected_runs=3)

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -178,10 +178,8 @@ def wait_for_cloud_init(client: "IntegrationInstance", num_retries: int = 30):
     for _ in range(num_retries):
         try:
             result = client.execute("cloud-init status")
-            if (
-                result
-                and result.ok
-                and ("running" not in result or "not started" not in result)
+            if result.return_code in (0, 2) and (
+                "running" not in result or "not started" not in result
             ):
                 return result
         except Exception as e:

--- a/tools/hook-hotplug
+++ b/tools/hook-hotplug
@@ -2,13 +2,32 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 # This script checks if cloud-init has hotplug hooked and if
-# cloud-init has finished; if so invoke cloud-init hotplug-hook
+# init-local and init boot stages have finished; if so invoke cloud-init hotplug-hook
 
-is_finished() {
-    [ -e /run/cloud-init/result.json ]
+has_init_finished() {
+    python3 << EOF
+"""
+Determines if init-local and init boot stages have finished.
+Errors are intentionally not handled, as in that case,
+the exit code will be non 0.
+"""
+
+import json
+import sys
+
+from pathlib import Path
+
+with Path("/run/cloud-init/status.json").open("r") as f:
+    status = json.load(f)
+
+if status["v1"]["init-local"]["finished"] is None or status["v1"]["init"]["finished"] is None:
+    sys.exit(1)
+
+sys.exit(0)
+EOF
 }
 
-if is_finished; then
+if has_init_finished; then
     # open cloud-init's hotplug-hook fifo rw
     exec 3<>/run/cloud-init/hook-hotplug-cmd
     env_params=" \


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore

```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```
-->
See individual commits.

## Additional Context
<!-- If relevant -->
https://warthogs.atlassian.net/browse/SC-1716

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
