### PR TITLE
fix: document and add 'accept-ra' to network schema

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -36,6 +36,10 @@
           "items": {
             "$ref": "#/$defs/config_type_subnet"
           }
+        },
+        "accept-ra": {
+          "type": "boolean",
+          "description": "Whether to accept IPv6 Router Advertisements (RA) on this interface. If unset, it will not be rendered"
         }
       }
     },

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -82,6 +82,13 @@ be sent in a packet- or frame-based network. Specifying ``mtu`` is optional.
    configuration time. It's possible to specify a value too large or to
    small for a device, and may be ignored by the device.
 
+``accept-ra: <boolean>``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``accept-ra`` key is a boolean value that specifies whether or not to
+accept Router Advertisements (RA) for this interface. Specifying ``accept-ra``
+is optional.
+
 Physical example
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: document and add 'accept-ra' to network schema

It has been available in v1 config since 62bbc26
```

## Additional Context
https://github.com/canonical/cloud-init/pull/51
https://github.com/canonical/cloud-init/blob/main/tests/unittests/net/network_configs.py#L802

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
