### PR TITLE
distro(freebsd): add_user: respect homedir

### DIFF
--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -121,14 +121,10 @@ class Distro(cloudinit.distros.bsd.BSD):
             pw_useradd_cmd.append("-d/nonexistent")
             log_pw_useradd_cmd.append("-d/nonexistent")
         else:
-            pw_useradd_cmd.append(
-                "-d{home_dir}/{name}".format(home_dir=self.home_dir, name=name)
-            )
+            homedir = kwargs.get("homedir", f"{self.home_dir}/{name}")
+            pw_useradd_cmd.append("-d" + homedir)
             pw_useradd_cmd.append("-m")
-            log_pw_useradd_cmd.append(
-                "-d{home_dir}/{name}".format(home_dir=self.home_dir, name=name)
-            )
-
+            log_pw_useradd_cmd.append("-d" + homedir)
             log_pw_useradd_cmd.append("-m")
 
         # Run the command

--- a/tests/unittests/config/test_cc_users_groups.py
+++ b/tests/unittests/config/test_cc_users_groups.py
@@ -97,6 +97,7 @@ class TestHandleUsersGroups(CiTestCase):
                 "lock_passwd": True,
                 "groups": ["wheel"],
                 "shell": "/bin/tcsh",
+                "homedir": "/home/freebsd",
             }
         }
         metadata = {}
@@ -116,6 +117,7 @@ class TestHandleUsersGroups(CiTestCase):
                     groups="wheel",
                     lock_passwd=True,
                     shell="/bin/tcsh",
+                    homedir="/home/freebsd",
                 ),
                 mock.call("me2", uid=1234, default=False),
             ],


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
distro(freebsd): add_user: respect homedir

reportedly, passing `homedir` to a user struct doesn't actually change
the homedir to the desired value. This is because we hard-code the path.
Respect the value we are passed, and only make up a default when we
don't get a `homedir`.

Simplify style to remove cerimonious verbosity around strings, and amend
tests to verify what we did.


Sponsored by: The FreeBSD Foundation
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
