### PR TITLE
bug(maas): register the correct DatasourceMAASLocal in init-local

### DIFF
--- a/cloudinit/sources/DataSourceMAAS.py
+++ b/cloudinit/sources/DataSourceMAAS.py
@@ -319,7 +319,7 @@ class MAASSeedDirMalformed(Exception):
 
 # Used to match classes to dependencies
 datasources = [
-    (DataSourceMAAS, (sources.DEP_FILESYSTEM,)),
+    (DataSourceMAASLocal, (sources.DEP_FILESYSTEM,)),
     (DataSourceMAAS, (sources.DEP_FILESYSTEM, sources.DEP_NETWORK)),
 ]
 

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -46,7 +46,7 @@ DEFAULT_LOCAL = [
     Hetzner.DataSourceHetzner,
     IBMCloud.DataSourceIBMCloud,
     LXD.DataSourceLXD,
-    MAAS.DataSourceMAAS,
+    MAAS.DataSourceMAASLocal,
     NoCloud.DataSourceNoCloud,
     OpenNebula.DataSourceOpenNebula,
     Oracle.DataSourceOracle,


### PR DESCRIPTION
## Proposed Commit Message
```
    bug(maas): register the correct DatasourceMAASLocal in init-local
    
    Incorrectly registering DataSourceMAAS for init-local DEP_FILESYSTEM
    inadvertently short-circuits the _get_data checks performed by
    DataSourceMAASLocal for presence of network config from initramfs.
    This results in a 2 minute timeout on physical system
    reboots because the network stage DataSourceMAAS expects all system
    networking is already configured and the IMDS to be accessible.
    
    Correct this registration to do the proper initramfs checks and avoid
    trying to perform GETs against the IMDS in init-local timeframe when
    we know network is not yet available.
    
    Fixes GH-5064
    LP: #2057763
```

## Additional Context


## Test Steps


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
