### PR TITLE
fix: Fix breaking changes in package install

### DIFF
--- a/cloudinit/config/cc_package_update_upgrade_install.py
+++ b/cloudinit/config/cc_package_update_upgrade_install.py
@@ -120,7 +120,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         try:
             cloud.distro.install_packages(pkglist)
         except Exception as e:
-            util.logexc(LOG, "Failed to install packages: %s", pkglist)
+            util.logexc(
+                LOG, "Failure when attempting to install packages: %s", pkglist
+            )
             errors.append(e)
 
     # TODO(smoser): handle this less violently

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -256,10 +256,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 continue
             failed = manager.install_packages(to_try)
             total_failed.update(failed)
-            unexpected_failed = {
-                pkg for pkg in failed if pkg not in generic_packages
-            }
-            if unexpected_failed:
+            if failed:
                 LOG.info(error_message, failed)
             # Ensure we don't attempt to install packages specific to
             # one particular package manager using another package manager

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -239,7 +239,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
         # First install packages using package manager(s)
         # supported by the distro
-        total_failed = set()
+        total_failed: Set[str] = set()
         for manager in self.package_managers:
 
             manager_packages = packages_by_manager.get(

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -247,6 +247,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             )
 
             to_try = manager_packages | generic_packages
+            # Remove any failed we will try for this package manager
             total_failed.difference_update(to_try)
             if not manager.available():
                 LOG.debug("Package manager '%s' not available", manager.name)

--- a/cloudinit/distros/package_management/apt.py
+++ b/cloudinit/distros/package_management/apt.py
@@ -135,7 +135,8 @@ class Apt(PackageManager):
         return [
             pkg
             for pkg in pkglist
-            if re.split("/|=|-", pkg)[0] not in self.get_all_packages()
+            if re.split("/|=", pkg)[0].rstrip("-")
+            not in self.get_all_packages()
         ]
 
     def install_packages(self, pkglist: Iterable) -> UninstalledPackages:

--- a/cloudinit/distros/package_management/apt.py
+++ b/cloudinit/distros/package_management/apt.py
@@ -3,6 +3,7 @@ import fcntl
 import functools
 import logging
 import os
+import re
 import time
 from typing import Any, Iterable, List, Mapping, Optional, Sequence, cast
 
@@ -83,11 +84,11 @@ class Apt(PackageManager):
     ):
         super().__init__(runner)
         if apt_get_command is None:
-            apt_get_command = APT_GET_COMMAND
+            self.apt_get_command = APT_GET_COMMAND
         if apt_get_upgrade_subcommand is None:
             apt_get_upgrade_subcommand = "dist-upgrade"
         self.apt_command = tuple(apt_get_wrapper_command) + tuple(
-            apt_get_command
+            self.apt_get_command
         )
 
         self.apt_get_upgrade_subcommand = apt_get_upgrade_subcommand
@@ -103,6 +104,9 @@ class Apt(PackageManager):
             apt_get_command=cfg.get("apt_get_command"),
             apt_get_upgrade_subcommand=cfg.get("apt_get_upgrade_subcommand"),
         )
+
+    def available(self) -> bool:
+        return bool(subp.which(self.apt_get_command[0]))
 
     def update_package_sources(self):
         self.runner.run(
@@ -123,7 +127,16 @@ class Apt(PackageManager):
         return set(resp.splitlines())
 
     def get_unavailable_packages(self, pkglist: Iterable[str]):
-        return [pkg for pkg in pkglist if pkg not in self.get_all_packages()]
+        # Packages ending with `-` signify to apt to not install a transitive
+        # dependency.
+        # Anything after "/" refers to a target release
+        # "=" allows specifying a specific version
+        # Strip all off when checking for availability
+        return [
+            pkg
+            for pkg in pkglist
+            if re.split("/|=|-", pkg)[0] not in self.get_all_packages()
+        ]
 
     def install_packages(self, pkglist: Iterable) -> UninstalledPackages:
         self.update_package_sources()
@@ -131,11 +144,12 @@ class Apt(PackageManager):
         unavailable = self.get_unavailable_packages(
             [x.split("=")[0] for x in pkglist]
         )
-        LOG.debug(
-            "The following packages were not found by APT so APT will "
-            "not attempt to install them: %s",
-            unavailable,
-        )
+        if unavailable:
+            LOG.debug(
+                "The following packages were not found by APT so APT will "
+                "not attempt to install them: %s",
+                unavailable,
+            )
         to_install = [p for p in pkglist if p not in unavailable]
         if to_install:
             self.run_package_command("install", pkgs=to_install)

--- a/cloudinit/distros/package_management/package_manager.py
+++ b/cloudinit/distros/package_management/package_manager.py
@@ -18,6 +18,10 @@ class PackageManager(ABC):
         return cls(runner)
 
     @abstractmethod
+    def available(self) -> bool:
+        """Return if package manager is installed on system."""
+
+    @abstractmethod
     def update_package_sources(self):
         ...
 

--- a/cloudinit/distros/package_management/snap.py
+++ b/cloudinit/distros/package_management/snap.py
@@ -14,6 +14,9 @@ LOG = logging.getLogger(__name__)
 class Snap(PackageManager):
     name = "snap"
 
+    def available(self) -> bool:
+        return bool(subp.which("snap"))
+
     def update_package_sources(self):
         pass
 

--- a/tests/unittests/config/test_cc_package_update_upgrade_install.py
+++ b/tests/unittests/config/test_cc_package_update_upgrade_install.py
@@ -37,6 +37,14 @@ def common_mocks(mocker):
         "cloudinit.distros.package_management.apt.Apt._apt_lock_available",
         return_value=True,
     )
+    mocker.patch(
+        "cloudinit.distros.package_management.apt.Apt.available",
+        return_value=True,
+    )
+    mocker.patch(
+        "cloudinit.distros.package_management.snap.Snap.available",
+        return_value=True,
+    )
 
 
 class TestRebootIfRequired:
@@ -275,7 +283,7 @@ class TestMultiplePackageManagers:
         assert caplog.records[-3].levelname == "WARNING"
         assert (
             caplog.records[-3].message
-            == "Failed to install packages: ['pkg1']"
+            == "Failure when attempting to install packages: ['pkg1']"
         )
 
 

--- a/tests/unittests/distros/package_management/test_apt.py
+++ b/tests/unittests/distros/package_management/test_apt.py
@@ -94,14 +94,15 @@ class TestPackageCommand:
         mocker.patch(f"{M_PATH}update_package_sources")
         mocker.patch(
             f"{M_PATH}get_all_packages",
-            return_value=["pkg1", "pkg2", "pkg3", "pkg4"],
+            return_value=["cloud-init", "pkg2", "pkg3", "pkg4"],
         )
         m_install = mocker.patch(f"{M_PATH}run_package_command")
 
         apt = Apt(runner=mock.Mock())
         apt.install_packages(
-            ["pkg1", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2"]
+            ["cloud-init", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2"]
         )
         m_install.assert_called_with(
-            "install", pkgs=["pkg1", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2"]
+            "install",
+            pkgs=["cloud-init", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2"],
         )

--- a/tests/unittests/distros/test_init.py
+++ b/tests/unittests/distros/test_init.py
@@ -256,6 +256,17 @@ class TestGetPackageMirrorInfo:
 class TestInstall:
     """Tests for cloudinit.distros.Distro.install_packages."""
 
+    @pytest.fixture(autouse=True)
+    def ensure_available(self, mocker):
+        mocker.patch(
+            "cloudinit.distros.package_management.apt.Apt.available",
+            return_value=True,
+        )
+        mocker.patch(
+            "cloudinit.distros.package_management.snap.Snap.available",
+            return_value=True,
+        )
+
     @pytest.fixture
     def m_apt_install(self, mocker):
         return mocker.patch(
@@ -318,7 +329,7 @@ class TestInstall:
         )
         with pytest.raises(
             PackageInstallerError,
-            match="Failed to install the following packages: \\['pkg3'\\]",
+            match="Failed to install the following packages: {'pkg3'}",
         ):
             _get_distro("debian").install_packages(
                 [{"apt": ["pkg1"]}, "pkg2", {"snap": ["pkg3"]}]
@@ -339,3 +350,120 @@ class TestInstall:
         assert "pkg3" not in apt_install_args
 
         m_snap_install.assert_not_called()
+
+    def test_specific_package_manager_fail_doesnt_retry(
+        self, mocker, m_snap_install
+    ):
+        """Test fail from package manager doesn't retry as generic."""
+        m_apt_install = mocker.patch(
+            "cloudinit.distros.package_management.apt.Apt.install_packages",
+            return_value=["pkg1"],
+        )
+        with pytest.raises(PackageInstallerError):
+            _get_distro("ubuntu").install_packages([{"apt": ["pkg1"]}])
+        apt_install_args = m_apt_install.call_args_list[0][0][0]
+        assert "pkg1" in apt_install_args
+        m_snap_install.assert_not_called()
+
+    def test_no_attempt_if_no_package_manager(
+        self, mocker, m_apt_install, m_snap_install, caplog
+    ):
+        """Test that no attempt is made if there are no package manager."""
+        mocker.patch(
+            "cloudinit.distros.package_management.apt.Apt.available",
+            return_value=False,
+        )
+        mocker.patch(
+            "cloudinit.distros.package_management.snap.Snap.available",
+            return_value=False,
+        )
+        with pytest.raises(PackageInstallerError):
+            _get_distro("ubuntu").install_packages(
+                ["pkg1", "pkg2", {"other": "pkg3"}]
+            )
+        m_apt_install.assert_not_called()
+        m_snap_install.assert_not_called()
+
+        assert "Package manager 'apt' not available" in caplog.text
+        assert "Package manager 'snap' not available" in caplog.text
+
+    @pytest.mark.parametrize(
+        "distro,pkg_list,apt_available,apt_failed,snap_failed,uninstalled",
+        [
+            pytest.param(
+                "debian",
+                ["pkg1", {"apt": ["pkg2"], "snap": ["pkg3"]}],
+                False,
+                [],
+                ["pkg1", "pkg3"],
+                ["pkg1", "pkg2", "pkg3"],
+                id="debian_no_apt",
+            ),
+            pytest.param(
+                "debian",
+                ["pkg1", {"apt": ["pkg2"], "snap": ["pkg3"]}],
+                True,
+                ["pkg2"],
+                ["pkg3"],
+                ["pkg2", "pkg3"],
+                id="debian_with_apt",
+            ),
+            pytest.param(
+                "ubuntu",
+                ["pkg1", {"apt": ["pkg2"], "snap": ["pkg3"]}],
+                False,
+                [],
+                [],
+                ["pkg2"],
+                id="ubuntu_no_apt",
+            ),
+            pytest.param(
+                "ubuntu",
+                ["pkg1", {"apt": ["pkg2"], "snap": ["pkg3"]}],
+                True,
+                ["pkg1"],
+                ["pkg3"],
+                ["pkg3"],
+                id="ubuntu_with_apt",
+            ),
+        ],
+    )
+    def test_uninstalled(
+        self,
+        distro,
+        pkg_list,
+        apt_available,
+        apt_failed,
+        snap_failed,
+        uninstalled,
+        mocker,
+        m_apt_install,
+        m_snap_install,
+    ):
+        """Test that uninstalled packages are properly tracked.
+
+        We need to ensure that the uninstalled packages are properly tracked:
+            1. When package install fails
+            2. When package manager is not available
+            3. When package manager is not explicitly supported by the distro
+
+        So test various combinations of these scenarios.
+        """
+        mocker.patch(
+            "cloudinit.distros.package_management.apt.Apt.available",
+            return_value=apt_available,
+        )
+        mocker.patch(
+            "cloudinit.distros.package_management.apt.Apt.install_packages",
+            return_value=apt_failed,
+        )
+        mocker.patch(
+            "cloudinit.distros.package_management.snap.Snap.install_packages",
+            return_value=snap_failed,
+        )
+        with pytest.raises(PackageInstallerError) as exc:
+            _get_distro(distro).install_packages(pkg_list)
+        message = exc.value.args[0]
+        assert "Failed to install the following packages" in message
+        for pkg in uninstalled:
+            assert pkg in message

--- a/tests/unittests/distros/test_init.py
+++ b/tests/unittests/distros/test_init.py
@@ -388,7 +388,7 @@ class TestInstall:
         assert "Package manager 'snap' not available" in caplog.text
 
     @pytest.mark.parametrize(
-        "distro,pkg_list,apt_available,apt_failed,snap_failed,uninstalled",
+        "distro,pkg_list,apt_available,apt_failed,snap_failed,total_failed",
         [
             pytest.param(
                 "debian",
@@ -428,22 +428,22 @@ class TestInstall:
             ),
         ],
     )
-    def test_uninstalled(
+    def test_failed(
         self,
         distro,
         pkg_list,
         apt_available,
         apt_failed,
         snap_failed,
-        uninstalled,
+        total_failed,
         mocker,
         m_apt_install,
         m_snap_install,
     ):
-        """Test that uninstalled packages are properly tracked.
+        """Test that failed packages are properly tracked.
 
-        We need to ensure that the uninstalled packages are properly tracked:
-            1. When package install fails
+        We need to ensure that the failed packages are properly tracked:
+            1. When package install fails normally
             2. When package manager is not available
             3. When package manager is not explicitly supported by the distro
 
@@ -465,5 +465,5 @@ class TestInstall:
             _get_distro(distro).install_packages(pkg_list)
         message = exc.value.args[0]
         assert "Failed to install the following packages" in message
-        for pkg in uninstalled:
+        for pkg in total_failed:
             assert pkg in message


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Fix breaking changes in package install

Ensure:
* Apt can still install packages that contain `-`, `/`, or `=`
* If a specified package manager fails we don't retry as a generic
  package
* We do not attempt to invoke a package manager that doesn't exist
* Packages that are unable to be installed are tracked and
  reported appropriately

Fixes GH-5066
```

## Additional Context
https://github.com/canonical/cloud-init/issues/5066

## Test Steps
Added additional unit tests

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
