### PR TITLE
fix: Undeprecate 'network' in schema route definition

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -450,10 +450,7 @@
         },
         "network": {
           "type": "string",
-          "description": "IPv4 network address with CIDR netmask notation or IPv6 with prefix length. Alias for ``destination`` and only read when ``destination`` key is absent.",
-          "deprecated": true,
-          "deprecated_version": "23.3",
-          "deprecated_description": "Use ``destination`` instead."
+          "description": "IPv4 network address with CIDR netmask notation or IPv6 with prefix length. Alias for ``destination`` and only read when ``destination`` key is absent. This exists for OpenStack support. OpenStack route definitions are passed through to v1 config and OpenStack's ``network_data.json`` uses ``network`` instead of ``destination``."
         },
         "destination": {
           "type": "string",


### PR DESCRIPTION
It is passed through to our v1 schema from OpenStack network_data.json

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Undeprecate 'network' in schema route definition

It is passed through to our v1 schema from OpenStack network_data.json

Fixes GH-5051
```

## Additional Context
https://github.com/canonical/cloud-init/issues/5051

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
