### PR TITLE
fix: Ensure network config in DataSourceOracle can be unpickled

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -123,7 +123,6 @@ class DataSourceOracle(sources.DataSource):
         sources.NetworkConfigSource.INITRAMFS,
     )
 
-    _network_config: dict = {"config": [], "version": 1}
     perform_dhcp_setup = True
 
     # Careful...these can be overridden in __init__
@@ -141,6 +140,7 @@ class DataSourceOracle(sources.DataSource):
             ]
         )
         self._network_config_source = KlibcOracleNetworkConfigSource()
+        self._network_config: dict = {"config": [], "version": 1}
 
         url_params = self.get_url_params()
         self.url_max_wait = url_params.max_wait_seconds
@@ -156,6 +156,8 @@ class DataSourceOracle(sources.DataSource):
                 "_network_config_source",
                 KlibcOracleNetworkConfigSource(),
             )
+        if not hasattr(self, "_network_config"):
+            self._network_config = {"config": [], "version": 1}
 
     def _has_network_config(self) -> bool:
         return bool(self._network_config.get("config", []))


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Ensure network config in DataSourceOracle can be unpickled

`_network_config` is only explicitly set on the instance if
`_is_iscsi_root()` is True. This means that when `_is_iscsi_root()` is
False, we're modifying the class variable directly. When the instance
gets pickled, the class variable is not included so such changes do
not get persisted. This commit fixes this.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
