### PR TITLE
Add missing mock, to prevent bleed through to test system

### DIFF
--- a/tests/unittests/config/test_apt_key.py
+++ b/tests/unittests/config/test_apt_key.py
@@ -123,7 +123,7 @@ class TestAptKey:
 
     @mock.patch.object(cc_apt_configure.os, "listdir", return_value=())
     @mock.patch.object(cc_apt_configure.os.path, "isfile", return_value=False)
-    def test_apt_key_list_fail_no_keys(self, m_listdir, m_gpg):
+    def test_apt_key_list_fail_no_keys(self, m_isfile, m_listdir, m_gpg):
         """Ensure falsy output for no keys"""
         keys = cc_apt_configure.apt_key("list", m_gpg)
         assert not keys
@@ -140,7 +140,7 @@ class TestAptKey:
 
     @mock.patch.object(cc_apt_configure.os, "listdir", return_value=())
     @mock.patch.object(cc_apt_configure.os.path, "isfile", return_value=False)
-    def test_apt_key_list_fail_bad_key_file(self, m_listdir, m_gpg):
+    def test_apt_key_list_fail_bad_key_file(self, m_isfile, m_listdir, m_gpg):
         """Ensure bad gpg key doesn't throw exeption."""
         m_gpg.list_keys = mock.Mock(side_effect=subp.ProcessExecutionError)
         assert not cc_apt_configure.apt_key("list", m_gpg)

--- a/tests/unittests/config/test_apt_key.py
+++ b/tests/unittests/config/test_apt_key.py
@@ -138,7 +138,9 @@ class TestAptKey:
             "list", m_gpg
         )
 
-    def test_apt_key_list_fail_bad_key_file(self, m_gpg):
+    @mock.patch.object(cc_apt_configure.os, "listdir", return_value=())
+    @mock.patch.object(cc_apt_configure.os.path, "isfile", return_value=False)
+    def test_apt_key_list_fail_bad_key_file(self, m_listdir, m_gpg):
         """Ensure bad gpg key doesn't throw exeption."""
         m_gpg.list_keys = mock.Mock(side_effect=subp.ProcessExecutionError)
         assert not cc_apt_configure.apt_key("list", m_gpg)


### PR DESCRIPTION
## Proposed Commit Message
Fix test on non Debian based systems. Add mock to prevent bleed through to system tests are running on.

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
