### PR TITLE
Release 24.1.2 to noble

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+24.1.2
+ - test: Don't assume ordering of ThreadPoolExecutor submissions (#5052)
+ - refactor(ec2): simplify convert_ec2_metadata_network_config
+ - tests: drop CiTestCase and convert to pytest
+ - bug(tests): mock reads of host's /sys/class/net via get_sys_class_path
+ - fix: Fix breaking changes in package install (#5069)
+ - fix: Undeprecate 'network' in schema route definition (#5072)
+ - fix(ec2): fix ipv6 policy routing
+ - fix: document and add 'accept-ra' to network schema (#5060)
+ - bug(maas): register the correct DatasourceMAASLocal in init-local
+   (#5068) (LP: #2057763)
+
 24.1.1
  - fix: Include DataSourceCloudStack attribute in unpickle test (#5039)
  - bug(vmware): initialize new DataSourceVMware attributes at unpickle (#5021)

--- a/cloudinit/config/cc_package_update_upgrade_install.py
+++ b/cloudinit/config/cc_package_update_upgrade_install.py
@@ -120,7 +120,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         try:
             cloud.distro.install_packages(pkglist)
         except Exception as e:
-            util.logexc(LOG, "Failed to install packages: %s", pkglist)
+            util.logexc(
+                LOG, "Failure when attempting to install packages: %s", pkglist
+            )
             errors.append(e)
 
     # TODO(smoser): handle this less violently

--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -36,6 +36,10 @@
           "items": {
             "$ref": "#/$defs/config_type_subnet"
           }
+        },
+        "accept-ra": {
+          "type": "boolean",
+          "description": "Whether to accept IPv6 Router Advertisements (RA) on this interface. If unset, it will not be rendered"
         }
       }
     },
@@ -446,10 +450,7 @@
         },
         "network": {
           "type": "string",
-          "description": "IPv4 network address with CIDR netmask notation or IPv6 with prefix length. Alias for ``destination`` and only read when ``destination`` key is absent.",
-          "deprecated": true,
-          "deprecated_version": "23.3",
-          "deprecated_description": "Use ``destination`` instead."
+          "description": "IPv4 network address with CIDR netmask notation or IPv6 with prefix length. Alias for ``destination`` and only read when ``destination`` key is absent. This exists for OpenStack support. OpenStack route definitions are passed through to v1 config and OpenStack's ``network_data.json`` uses ``network`` instead of ``destination``."
         },
         "destination": {
           "type": "string",

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -238,21 +238,29 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
         # First install packages using package manager(s)
         # supported by the distro
-        uninstalled = []
+        total_failed: Set[str] = set()
         for manager in self.package_managers:
-            to_try = (
-                packages_by_manager.get(manager.__class__, set())
-                | generic_packages
+
+            manager_packages = packages_by_manager.get(
+                manager.__class__, set()
             )
+
+            to_try = manager_packages | generic_packages
+            # Remove any failed we will try for this package manager
+            total_failed.difference_update(to_try)
+            if not manager.available():
+                LOG.debug("Package manager '%s' not available", manager.name)
+                total_failed.update(to_try)
+                continue
             if not to_try:
                 continue
-            uninstalled = manager.install_packages(to_try)
-            failed = {
-                pkg for pkg in uninstalled if pkg not in generic_packages
-            }
+            failed = manager.install_packages(to_try)
+            total_failed.update(failed)
             if failed:
                 LOG.info(error_message, failed)
-            generic_packages = set(uninstalled)
+            # Ensure we don't attempt to install packages specific to
+            # one particular package manager using another package manager
+            generic_packages = set(failed) - manager_packages
 
         # Now attempt any specified package managers not explicitly supported
         # by distro
@@ -260,14 +268,14 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             if manager_type.name in [p.name for p in self.package_managers]:
                 # We already installed/attempted these; don't try again
                 continue
-            uninstalled.extend(
+            total_failed.update(
                 manager_type.from_config(
                     self._runner, self._cfg
                 ).install_packages(pkglist=packages)
             )
 
-        if uninstalled:
-            raise PackageInstallerError(error_message % uninstalled)
+        if total_failed:
+            raise PackageInstallerError(error_message % total_failed)
 
     @property
     def dhcp_client(self) -> dhcp.DhcpClient:

--- a/cloudinit/distros/package_management/apt.py
+++ b/cloudinit/distros/package_management/apt.py
@@ -3,6 +3,7 @@ import fcntl
 import functools
 import logging
 import os
+import re
 import time
 from typing import Any, Iterable, List, Mapping, Optional, Sequence, cast
 
@@ -83,11 +84,11 @@ class Apt(PackageManager):
     ):
         super().__init__(runner)
         if apt_get_command is None:
-            apt_get_command = APT_GET_COMMAND
+            self.apt_get_command = APT_GET_COMMAND
         if apt_get_upgrade_subcommand is None:
             apt_get_upgrade_subcommand = "dist-upgrade"
         self.apt_command = tuple(apt_get_wrapper_command) + tuple(
-            apt_get_command
+            self.apt_get_command
         )
 
         self.apt_get_upgrade_subcommand = apt_get_upgrade_subcommand
@@ -103,6 +104,9 @@ class Apt(PackageManager):
             apt_get_command=cfg.get("apt_get_command"),
             apt_get_upgrade_subcommand=cfg.get("apt_get_upgrade_subcommand"),
         )
+
+    def available(self) -> bool:
+        return bool(subp.which(self.apt_get_command[0]))
 
     def update_package_sources(self):
         self.runner.run(
@@ -123,7 +127,17 @@ class Apt(PackageManager):
         return set(resp.splitlines())
 
     def get_unavailable_packages(self, pkglist: Iterable[str]):
-        return [pkg for pkg in pkglist if pkg not in self.get_all_packages()]
+        # Packages ending with `-` signify to apt to not install a transitive
+        # dependency.
+        # Anything after "/" refers to a target release
+        # "=" allows specifying a specific version
+        # Strip all off when checking for availability
+        return [
+            pkg
+            for pkg in pkglist
+            if re.split("/|=", pkg)[0].rstrip("-")
+            not in self.get_all_packages()
+        ]
 
     def install_packages(self, pkglist: Iterable) -> UninstalledPackages:
         self.update_package_sources()
@@ -131,11 +145,12 @@ class Apt(PackageManager):
         unavailable = self.get_unavailable_packages(
             [x.split("=")[0] for x in pkglist]
         )
-        LOG.debug(
-            "The following packages were not found by APT so APT will "
-            "not attempt to install them: %s",
-            unavailable,
-        )
+        if unavailable:
+            LOG.debug(
+                "The following packages were not found by APT so APT will "
+                "not attempt to install them: %s",
+                unavailable,
+            )
         to_install = [p for p in pkglist if p not in unavailable]
         if to_install:
             self.run_package_command("install", pkgs=to_install)

--- a/cloudinit/distros/package_management/package_manager.py
+++ b/cloudinit/distros/package_management/package_manager.py
@@ -18,6 +18,10 @@ class PackageManager(ABC):
         return cls(runner)
 
     @abstractmethod
+    def available(self) -> bool:
+        """Return if package manager is installed on system."""
+
+    @abstractmethod
     def update_package_sources(self):
         ...
 

--- a/cloudinit/distros/package_management/snap.py
+++ b/cloudinit/distros/package_management/snap.py
@@ -14,6 +14,9 @@ LOG = logging.getLogger(__name__)
 class Snap(PackageManager):
     name = "snap"
 
+    def available(self) -> bool:
+        return bool(subp.which("snap"))
+
     def update_package_sources(self):
         pass
 

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -17,6 +17,7 @@ from typing import Dict, List
 from cloudinit import dmi, net, sources
 from cloudinit import url_helper as uhelp
 from cloudinit import util, warnings
+from cloudinit.distros import Distro
 from cloudinit.event import EventScope, EventType
 from cloudinit.net import activators
 from cloudinit.net.dhcp import NoDHCPLeaseError
@@ -949,6 +950,82 @@ def _build_nic_order(
     }
 
 
+def _configure_policy_routing(
+    dev_config: dict,
+    *,
+    nic_name: str,
+    nic_metadata: dict,
+    distro: Distro,
+    is_ipv4: bool,
+    table: int,
+) -> None:
+    """
+    Configure policy-based routing on secondary NICs / secondary IPs to
+    ensure outgoing packets are routed via the correct interface.
+
+    @param: dev_config: network cfg v2 to be updated inplace.
+    @param: nic_name: nic name. Only used if ipv4.
+    @param: nic_metadata: nic metadata from IMDS.
+    @param: distro: Instance of Distro. Only used if ipv4.
+    @param: is_ipv4: Boolean indicating if we are acting over ipv4 or not.
+    @param: table: Routing table id.
+    """
+    if not dev_config.get("routes"):
+        dev_config["routes"] = []
+    if is_ipv4:
+        subnet_prefix_routes = nic_metadata["subnet-ipv4-cidr-block"]
+        ips = nic_metadata["local-ipv4s"]
+        try:
+            lease = distro.dhcp_client.dhcp_discovery(nic_name, distro=distro)
+            gateway = lease["routers"]
+        except NoDHCPLeaseError as e:
+            LOG.warning(
+                "Could not perform dhcp discovery on %s to find its "
+                "gateway. Not adding default route via the gateway. "
+                "Error: %s",
+                nic_name,
+                e,
+            )
+        else:
+            # Add default route via the NIC's gateway
+            dev_config["routes"].append(
+                {
+                    "to": "0.0.0.0/0",
+                    "via": gateway,
+                    "table": table,
+                },
+            )
+    else:
+        subnet_prefix_routes = nic_metadata["subnet-ipv6-cidr-blocks"]
+        ips = nic_metadata["ipv6s"]
+
+    subnet_prefix_routes = (
+        [subnet_prefix_routes]
+        if isinstance(subnet_prefix_routes, str)
+        else subnet_prefix_routes
+    )
+    for prefix_route in subnet_prefix_routes:
+        dev_config["routes"].append(
+            {
+                "to": prefix_route,
+                "table": table,
+            },
+        )
+
+    if not dev_config.get("routing-policy"):
+        dev_config["routing-policy"] = []
+    # Packets coming from any IP associated with the current NIC
+    # will be routed using `table` routing table
+    ips = [ips] if isinstance(ips, str) else ips
+    for ip in ips:
+        dev_config["routing-policy"].append(
+            {
+                "from": ip,
+                "table": table,
+            },
+        )
+
+
 def convert_ec2_metadata_network_config(
     network_md,
     distro,
@@ -1015,72 +1092,29 @@ def convert_ec2_metadata_network_config(
             "match": {"macaddress": mac.lower()},
             "set-name": nic_name,
         }
-        # Configure policy-based routing on secondary NICs / secondary IPs to
-        # ensure outgoing packets are routed via the correct interface.
-        #
         # This config only works on systems using Netplan because Networking
         # config V2 does not support `routing-policy`, but this config is
         # passed through on systems using Netplan.
+        # See: https://github.com/canonical/cloud-init/issues/4862
         #
         # If device-number is not present (AliYun or other ec2-like platforms),
         # do not configure source-routing as we cannot determine which is the
         # primary NIC.
+        table = 100 + nic_idx
         if (
             is_netplan
             and nic_metadata.get("device-number")
             and not is_primary_nic
         ):
             dhcp_override["use-routes"] = True
-            table = 100 + nic_idx
-            dev_config["routes"] = []
-            try:
-                lease = distro.dhcp_client.dhcp_discovery(
-                    nic_name, distro=distro
-                )
-                gateway = lease["routers"]
-            except NoDHCPLeaseError as e:
-                LOG.warning(
-                    "Could not perform dhcp discovery on %s to find its "
-                    "gateway. Not adding default route via the gateway. "
-                    "Error: %s",
-                    nic_name,
-                    e,
-                )
-            else:
-                # Add default route via the NIC's gateway
-                dev_config["routes"].append(
-                    {
-                        "to": "0.0.0.0/0",
-                        "via": gateway,
-                        "table": table,
-                    },
-                )
-            subnet_prefix_routes = nic_metadata["subnet-ipv4-cidr-block"]
-            subnet_prefix_routes = (
-                [subnet_prefix_routes]
-                if isinstance(subnet_prefix_routes, str)
-                else subnet_prefix_routes
+            _configure_policy_routing(
+                dev_config,
+                distro=distro,
+                nic_name=nic_name,
+                nic_metadata=nic_metadata,
+                is_ipv4=True,
+                table=table,
             )
-            for prefix_route in subnet_prefix_routes:
-                dev_config["routes"].append(
-                    {
-                        "to": prefix_route,
-                        "table": table,
-                    },
-                )
-
-            dev_config["routing-policy"] = []
-            # Packets coming from any IPv4 associated with the current NIC
-            # will be routed using `table` routing table
-            ipv4s = nic_metadata["local-ipv4s"]
-            ipv4s = [ipv4s] if isinstance(ipv4s, str) else ipv4s
-            for ipv4 in ipv4s:
-                dev_config["routing-policy"].append(
-                    {
-                        "from": ipv4,
-                        "table": table,
-                    },
-                )
         if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
             dev_config["dhcp6"] = True
             dev_config["dhcp6-overrides"] = dhcp_override
@@ -1089,31 +1123,14 @@ def convert_ec2_metadata_network_config(
                 and nic_metadata.get("device-number")
                 and not is_primary_nic
             ):
-                table = 100 + nic_idx
-                subnet_prefix_routes = nic_metadata["subnet-ipv6-cidr-block"]
-                subnet_prefix_routes = (
-                    [subnet_prefix_routes]
-                    if isinstance(subnet_prefix_routes, str)
-                    else subnet_prefix_routes
+                _configure_policy_routing(
+                    dev_config,
+                    distro=distro,
+                    nic_name=nic_name,
+                    nic_metadata=nic_metadata,
+                    is_ipv4=False,
+                    table=table,
                 )
-                for prefix_route in subnet_prefix_routes:
-                    dev_config["routes"].append(
-                        {
-                            "to": prefix_route,
-                            "table": table,
-                        },
-                    )
-
-                dev_config["routing-policy"] = []
-                ipv6s = nic_metadata["ipv6s"]
-                ipv6s = [ipv6s] if isinstance(ipv6s, str) else ipv6s
-                for ipv6 in ipv6s:
-                    dev_config["routing-policy"].append(
-                        {
-                            "from": ipv6,
-                            "table": table,
-                        },
-                    )
         dev_config["addresses"] = get_secondary_addresses(nic_metadata, mac)
         if not dev_config["addresses"]:
             dev_config.pop("addresses")  # Since we found none configured

--- a/cloudinit/sources/DataSourceMAAS.py
+++ b/cloudinit/sources/DataSourceMAAS.py
@@ -320,7 +320,7 @@ class MAASSeedDirMalformed(Exception):
 
 # Used to match classes to dependencies
 datasources = [
-    (DataSourceMAAS, (sources.DEP_FILESYSTEM,)),
+    (DataSourceMAASLocal, (sources.DEP_FILESYSTEM,)),
     (DataSourceMAAS, (sources.DEP_FILESYSTEM, sources.DEP_NETWORK)),
 ]
 

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "24.1.1"
+__VERSION__ = "24.1.2"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cloud-init (24.1.2-0ubuntu1) UNRELEASED; urgency=medium
+
+  * Upstream snapshot based on 24.1.2.
+    List of changes from upstream can be found at
+    https://raw.githubusercontent.com/canonical/cloud-init/24.1.2/ChangeLog
+    - Bugs fixed in this snapshot: (LP: #2057763)
+
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 21 Mar 2024 07:52:46 -0600
+
 cloud-init (24.1.1-0ubuntu1) noble; urgency=medium
 
   * Upstream snapshot based on 24.1.1.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,11 @@
-cloud-init (24.1.2-0ubuntu1) UNRELEASED; urgency=medium
+cloud-init (24.1.2-0ubuntu1) noble; urgency=medium
 
   * Upstream snapshot based on 24.1.2.
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/24.1.2/ChangeLog
     - Bugs fixed in this snapshot: (LP: #2057763)
 
- -- Chad Smith <chad.smith@canonical.com>  Thu, 21 Mar 2024 07:52:46 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Thu, 21 Mar 2024 07:53:15 -0600
 
 cloud-init (24.1.1-0ubuntu1) noble; urgency=medium
 

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -82,6 +82,13 @@ be sent in a packet- or frame-based network. Specifying ``mtu`` is optional.
    configuration time. It's possible to specify a value too large or to
    small for a device, and may be ignored by the device.
 
+``accept-ra: <boolean>``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``accept-ra`` key is a boolean value that specifies whether or not to
+accept Router Advertisements (RA) for this interface. Specifying ``accept-ra``
+is optional.
+
 Physical example
 ^^^^^^^^^^^^^^^^
 

--- a/tests/unittests/config/test_cc_package_update_upgrade_install.py
+++ b/tests/unittests/config/test_cc_package_update_upgrade_install.py
@@ -37,6 +37,14 @@ def common_mocks(mocker):
         "cloudinit.distros.package_management.apt.Apt._apt_lock_available",
         return_value=True,
     )
+    mocker.patch(
+        "cloudinit.distros.package_management.apt.Apt.available",
+        return_value=True,
+    )
+    mocker.patch(
+        "cloudinit.distros.package_management.snap.Snap.available",
+        return_value=True,
+    )
 
 
 class TestRebootIfRequired:
@@ -275,7 +283,7 @@ class TestMultiplePackageManagers:
         assert caplog.records[-3].levelname == "WARNING"
         assert (
             caplog.records[-3].message
-            == "Failed to install packages: ['pkg1']"
+            == "Failure when attempting to install packages: ['pkg1']"
         )
 
 

--- a/tests/unittests/distros/package_management/test_apt.py
+++ b/tests/unittests/distros/package_management/test_apt.py
@@ -7,6 +7,8 @@ import pytest
 from cloudinit import subp
 from cloudinit.distros.package_management.apt import APT_GET_COMMAND, Apt
 
+M_PATH = "cloudinit.distros.package_management.apt.Apt."
+
 
 @mock.patch.dict("os.environ", {}, clear=True)
 @mock.patch("cloudinit.distros.debian.subp.which", return_value=True)
@@ -86,3 +88,21 @@ class TestPackageCommand:
         )
         with pytest.raises(TimeoutError):
             apt._wait_for_apt_command("stub", {"args": "stub2"}, timeout=5)
+
+    def test_search_stem(self, m_subp, m_which, mocker):
+        """Test that containing `-`, `/`, or `=` is handled correctly."""
+        mocker.patch(f"{M_PATH}update_package_sources")
+        mocker.patch(
+            f"{M_PATH}get_all_packages",
+            return_value=["cloud-init", "pkg2", "pkg3", "pkg4"],
+        )
+        m_install = mocker.patch(f"{M_PATH}run_package_command")
+
+        apt = Apt(runner=mock.Mock())
+        apt.install_packages(
+            ["cloud-init", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2"]
+        )
+        m_install.assert_called_with(
+            "install",
+            pkgs=["cloud-init", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2"],
+        )

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -375,15 +375,13 @@ class TestDHCPParseStaticRoutes(CiTestCase):
         )
 
 
-class TestDHCPDiscoveryClean(CiTestCase):
-    with_logs = True
-
+class TestDHCPDiscoveryClean:
     @mock.patch("cloudinit.distros.net.find_fallback_nic", return_value="eth9")
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
     @mock.patch("cloudinit.net.dhcp.subp.which")
     def test_dhcpcd_exits_with_error(
-        self, m_which, m_subp, m_remove, m_fallback
+        self, m_which, m_subp, m_remove, m_fallback, caplog
     ):
         """Log and do nothing when nic is absent and no fallback is found."""
         m_subp.side_effect = [
@@ -394,16 +392,15 @@ class TestDHCPDiscoveryClean(CiTestCase):
         with pytest.raises(NoDHCPLeaseError):
             maybe_perform_dhcp_discovery(Distro("fake but not", {}, None))
 
-        self.assertIn(
-            "DHCP client selected: dhcpcd",
-            self.logs.getvalue(),
-        )
+        assert "DHCP client selected: dhcpcd" in caplog.text
 
     @mock.patch("cloudinit.distros.net.find_fallback_nic", return_value="eth9")
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
     @mock.patch("cloudinit.net.dhcp.subp.which")
-    def test_dhcp_client_failover(self, m_which, m_subp, m_remove, m_fallback):
+    def test_dhcp_client_failover(
+        self, m_which, m_subp, m_remove, m_fallback, caplog
+    ):
         """Log and do nothing when nic is absent and no fallback client is
         found."""
         m_subp.side_effect = [
@@ -415,40 +412,22 @@ class TestDHCPDiscoveryClean(CiTestCase):
         with pytest.raises(NoDHCPLeaseError):
             maybe_perform_dhcp_discovery(Distro("somename", {}, None))
 
-        self.assertIn(
-            "DHCP client not found: dhclient",
-            self.logs.getvalue(),
-        )
-        self.assertIn(
-            "DHCP client not found: dhcpcd",
-            self.logs.getvalue(),
-        )
-        self.assertIn(
-            "DHCP client not found: udhcpc",
-            self.logs.getvalue(),
-        )
+        assert "DHCP client not found: dhclient" in caplog.text
+        assert "DHCP client not found: dhcpcd" in caplog.text
+        assert "DHCP client not found: udhcpc" in caplog.text
 
     @mock.patch("cloudinit.net.dhcp.subp.which")
     @mock.patch("cloudinit.distros.net.find_fallback_nic")
-    def test_absent_dhclient_command(self, m_fallback, m_which):
+    def test_absent_dhclient_command(self, m_fallback, m_which, caplog):
         """When dhclient doesn't exist in the OS, log the issue and no-op."""
         m_fallback.return_value = "eth9"
         m_which.return_value = None  # dhclient isn't found
         with pytest.raises(NoDHCPLeaseMissingDhclientError):
             maybe_perform_dhcp_discovery(Distro("whoa", {}, None))
 
-        self.assertIn(
-            "DHCP client not found: dhclient",
-            self.logs.getvalue(),
-        )
-        self.assertIn(
-            "DHCP client not found: dhcpcd",
-            self.logs.getvalue(),
-        )
-        self.assertIn(
-            "DHCP client not found: udhcpc",
-            self.logs.getvalue(),
-        )
+        assert "DHCP client not found: dhclient" in caplog.text
+        assert "DHCP client not found: dhcpcd" in caplog.text
+        assert "DHCP client not found: udhcpc" in caplog.text
 
     @mock.patch("cloudinit.net.dhcp.os.remove")
     @mock.patch("time.sleep", mock.MagicMock())
@@ -457,7 +436,7 @@ class TestDHCPDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/sbin/dhclient")
     @mock.patch("cloudinit.net.dhcp.util.wait_for_files", return_value=False)
     def test_dhcp_discovery_warns_invalid_pid(
-        self, m_wait, m_which, m_subp, m_kill, m_remove
+        self, m_wait, m_which, m_subp, m_kill, m_remove, caplog
     ):
         """dhcp_discovery logs a warning when pidfile contains invalid content.
 
@@ -479,22 +458,18 @@ class TestDHCPDiscoveryClean(CiTestCase):
         with mock.patch(
             "cloudinit.util.load_text_file", return_value=lease_content
         ):
-            self.assertCountEqual(
-                {
-                    "interface": "eth9",
-                    "fixed-address": "192.168.2.74",
-                    "subnet-mask": "255.255.255.0",
-                    "routers": "192.168.2.1",
-                },
-                IscDhclient().get_newest_lease("eth0"),
-            )
-        with self.assertRaises(InvalidDHCPLeaseFileError):
+            assert {
+                "interface": "eth9",
+                "fixed-address": "192.168.2.74",
+                "subnet-mask": "255.255.255.0",
+                "routers": "192.168.2.1",
+            } == IscDhclient().get_newest_lease("eth0")
+        with pytest.raises(InvalidDHCPLeaseFileError):
             with mock.patch("cloudinit.util.load_text_file", return_value=""):
                 IscDhclient().dhcp_discovery("eth9", distro=MockDistro())
-        self.assertIn(
-            "dhclient(pid=, parentpid=unknown) failed "
-            "to daemonize after 10.0 seconds",
-            self.logs.getvalue(),
+        assert (
+            "dhclient(pid=, parentpid=unknown) failed to daemonize after"
+            " 10.0 seconds" in caplog.text
         )
         m_kill.assert_not_called()
 
@@ -504,23 +479,20 @@ class TestDHCPDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/sbin/dhclient")
     @mock.patch("cloudinit.net.dhcp.subp.subp")
     def test_dhcp_discovery_waits_on_lease_and_pid(
-        self, m_subp, m_which, m_wait, m_kill, m_remove
+        self, m_subp, m_which, m_wait, m_kill, m_remove, caplog
     ):
         """dhcp_discovery waits for the presence of pidfile and dhcp.leases."""
         m_subp.return_value = ("", "")
 
         # Don't create pid or leases file
         m_wait.return_value = [PID_F]  # Return the missing pidfile wait for
-        self.assertEqual(
-            {}, IscDhclient().dhcp_discovery("eth9", distro=MockDistro())
+        assert {} == IscDhclient().dhcp_discovery("eth9", distro=MockDistro())
+        m_wait.assert_called_once_with(
+            [PID_F, LEASE_F], maxwait=5, naplen=0.01
         )
-        self.assertEqual(
-            mock.call([PID_F, LEASE_F], maxwait=5, naplen=0.01),
-            m_wait.call_args_list[0],
-        )
-        self.assertIn(
-            "WARNING: dhclient did not produce expected files: dhclient.pid",
-            self.logs.getvalue(),
+        assert (
+            "dhclient did not produce expected files: dhclient.pid"
+            in caplog.text
         )
         m_kill.assert_not_called()
 
@@ -558,15 +530,12 @@ class TestDHCPDiscoveryClean(CiTestCase):
         with mock.patch(
             "cloudinit.util.load_text_file", side_effect=["1", lease_content]
         ):
-            self.assertCountEqual(
-                {
-                    "interface": "eth9",
-                    "fixed-address": "192.168.2.74",
-                    "subnet-mask": "255.255.255.0",
-                    "routers": "192.168.2.1",
-                },
-                IscDhclient().dhcp_discovery("eth9", distro=MockDistro()),
-            )
+            assert {
+                "interface": "eth9",
+                "fixed-address": "192.168.2.74",
+                "subnet-mask": "255.255.255.0",
+                "routers": "192.168.2.1",
+            } == IscDhclient().dhcp_discovery("eth9", distro=MockDistro())
         # Interface was brought up before dhclient called
         m_subp.assert_has_calls(
             [
@@ -634,15 +603,12 @@ class TestDHCPDiscoveryClean(CiTestCase):
         with mock.patch(
             "cloudinit.util.load_text_file", side_effect=["1", lease_content]
         ):
-            self.assertCountEqual(
-                {
-                    "interface": "ib0",
-                    "fixed-address": "192.168.2.74",
-                    "subnet-mask": "255.255.255.0",
-                    "routers": "192.168.2.1",
-                },
-                IscDhclient().dhcp_discovery("ib0", distro=MockDistro()),
-            )
+            assert {
+                "interface": "ib0",
+                "fixed-address": "192.168.2.74",
+                "subnet-mask": "255.255.255.0",
+                "routers": "192.168.2.1",
+            } == IscDhclient().dhcp_discovery("ib0", distro=MockDistro())
         # Interface was brought up before dhclient called
         m_subp.assert_has_calls(
             [
@@ -683,14 +649,13 @@ class TestDHCPDiscoveryClean(CiTestCase):
     @mock.patch("cloudinit.net.dhcp.subp.which", return_value="/sbin/dhclient")
     @mock.patch("cloudinit.util.wait_for_files")
     def test_dhcp_output_error_stream(
-        self, m_wait, m_which, m_subp, m_kill, m_remove
+        self, m_wait, m_which, m_subp, m_kill, m_remove, tmpdir
     ):
         """ "dhcp_log_func is called with the output and error streams of
         dhclient when the callable is passed."""
         dhclient_err = "FAKE DHCLIENT ERROR"
         dhclient_out = "FAKE DHCLIENT OUT"
         m_subp.return_value = (dhclient_out, dhclient_err)
-        tmpdir = self.tmp_dir()
         lease_content = dedent(
             """
                 lease {
@@ -708,8 +673,8 @@ class TestDHCPDiscoveryClean(CiTestCase):
         write_file(pid_file, "%d\n" % my_pid)
 
         def dhcp_log_func(out, err):
-            self.assertEqual(out, dhclient_out)
-            self.assertEqual(err, dhclient_err)
+            assert out == dhclient_out
+            assert err == dhclient_err
 
         IscDhclient().dhcp_discovery(
             "eth9", dhcp_log_func=dhcp_log_func, distro=MockDistro()

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -17,49 +17,55 @@ from cloudinit import subp
 from cloudinit.net.ephemeral import EphemeralIPv4Network, EphemeralIPv6Network
 from cloudinit.subp import ProcessExecutionError
 from cloudinit.util import ensure_file, write_file
-from tests.unittests.helpers import CiTestCase, ResponsesTestCase
+from tests.unittests.helpers import (
+    CiTestCase,
+    ResponsesTestCase,
+    random_string,
+)
 from tests.unittests.util import MockDistro
 
 
-class TestSysDevPath(CiTestCase):
+class TestSysDevPath:
     def test_sys_dev_path(self):
         """sys_dev_path returns a path under SYS_CLASS_NET for a device."""
         dev = "something"
         path = "attribute"
-        expected = net.SYS_CLASS_NET + dev + "/" + path
-        self.assertEqual(expected, net.sys_dev_path(dev, path))
+        expected = net.get_sys_class_path() + dev + "/" + path
+        assert expected == net.sys_dev_path(dev, path)
 
     def test_sys_dev_path_without_path(self):
         """When path param isn't provided it defaults to empty string."""
         dev = "something"
-        expected = net.SYS_CLASS_NET + dev + "/"
-        self.assertEqual(expected, net.sys_dev_path(dev))
+        expected = net.get_sys_class_path() + dev + "/"
+        assert expected == net.sys_dev_path(dev)
 
 
-class TestReadSysNet(CiTestCase):
-    with_logs = True
-
-    def setUp(self):
-        super(TestReadSysNet, self).setUp()
-        sys_mock = mock.patch("cloudinit.net.get_sys_class_path")
-        self.m_sys_path = sys_mock.start()
-        self.sysdir = self.tmp_dir() + "/"
-        self.m_sys_path.return_value = self.sysdir
-        self.addCleanup(sys_mock.stop)
+class TestReadSysNet:
+    @pytest.fixture(autouse=True)
+    @pytest.mark.parametrize(
+        "disable_sysfs_net", [False], indirect=["disable_sysfs_net"]
+    )
+    def setup(self, disable_sysfs_net, tmpdir_factory):
+        # We mock invididual numbered tmpdirs here because these tests write
+        # to the sysfs directory and stale test artifacts break later tests.
+        mock_sysfs = f"{tmpdir_factory.mktemp('sysfs', numbered=True)}/"
+        with mock.patch(
+            "cloudinit.net.get_sys_class_path", return_value=mock_sysfs
+        ):
+            self.sysdir = mock_sysfs
+            yield
 
     def test_read_sys_net_strips_contents_of_sys_path(self):
         """read_sys_net strips whitespace from the contents of a sys file."""
         content = "some stuff with trailing whitespace\t\r\n"
         write_file(os.path.join(self.sysdir, "dev", "attr"), content)
-        self.assertEqual(content.strip(), net.read_sys_net("dev", "attr"))
+        assert content.strip() == net.read_sys_net("dev", "attr")
 
     def test_read_sys_net_reraises_oserror(self):
         """read_sys_net raises OSError/IOError when file doesn't exist."""
         # Non-specific Exception because versions of python OSError vs IOError.
-        with self.assertRaises(Exception) as context_manager:  # noqa: H202
+        with pytest.raises(Exception, match="No such file or directory"):
             net.read_sys_net("dev", "attr")
-        error = context_manager.exception
-        self.assertIn("No such file or directory", str(error))
 
     def test_read_sys_net_handles_error_with_on_enoent(self):
         """read_sys_net handles OSError/IOError with on_enoent if provided."""
@@ -70,30 +76,27 @@ class TestReadSysNet(CiTestCase):
 
         net.read_sys_net("dev", "attr", on_enoent=on_enoent)
         error = handled_errors[0]
-        self.assertIsInstance(error, Exception)
-        self.assertIn("No such file or directory", str(error))
+        assert isinstance(error, Exception)
+        assert "No such file or directory" in str(error)
 
     def test_read_sys_net_translates_content(self):
         """read_sys_net translates content when translate dict is provided."""
         content = "you're welcome\n"
         write_file(os.path.join(self.sysdir, "dev", "attr"), content)
         translate = {"you're welcome": "de nada"}
-        self.assertEqual(
-            "de nada", net.read_sys_net("dev", "attr", translate=translate)
+        assert "de nada" == net.read_sys_net(
+            "dev", "attr", translate=translate
         )
 
-    def test_read_sys_net_errors_on_translation_failures(self):
+    def test_read_sys_net_errors_on_translation_failures(self, caplog):
         """read_sys_net raises a KeyError and logs details on failure."""
         content = "you're welcome\n"
         write_file(os.path.join(self.sysdir, "dev", "attr"), content)
-        with self.assertRaises(KeyError) as context_manager:
+        with pytest.raises(KeyError, match='"you\'re welcome"'):
             net.read_sys_net("dev", "attr", translate={})
-        error = context_manager.exception
-        self.assertEqual('"you\'re welcome"', str(error))
-        self.assertIn(
+        assert (
             "Found unexpected (not translatable) value 'you're welcome' in "
-            "'{0}dev/attr".format(self.sysdir),
-            self.logs.getvalue(),
+            "'{0}dev/attr".format(self.sysdir) in caplog.text
         )
 
     def test_read_sys_net_handles_handles_with_onkeyerror(self):
@@ -107,63 +110,63 @@ class TestReadSysNet(CiTestCase):
 
         net.read_sys_net("dev", "attr", translate={}, on_keyerror=on_keyerror)
         error = handled_errors[0]
-        self.assertIsInstance(error, KeyError)
-        self.assertEqual('"you\'re welcome"', str(error))
+        assert isinstance(error, KeyError)
+        assert '"you\'re welcome"' == str(error)
 
     def test_read_sys_net_safe_false_on_translate_failure(self):
         """read_sys_net_safe returns False on translation failures."""
         content = "you're welcome\n"
         write_file(os.path.join(self.sysdir, "dev", "attr"), content)
-        self.assertFalse(net.read_sys_net_safe("dev", "attr", translate={}))
+        assert not net.read_sys_net_safe("dev", "attr", translate={})
 
     def test_read_sys_net_safe_returns_false_on_noent_failure(self):
         """read_sys_net_safe returns False on file not found failures."""
-        self.assertFalse(net.read_sys_net_safe("dev", "attr"))
+        assert not net.read_sys_net_safe("dev", "attr")
 
     def test_read_sys_net_int_returns_none_on_error(self):
         """read_sys_net_safe returns None on failures."""
-        self.assertFalse(net.read_sys_net_int("dev", "attr"))
+        assert not net.read_sys_net_int("dev", "attr")
 
     def test_read_sys_net_int_returns_none_on_valueerror(self):
         """read_sys_net_safe returns None when content is not an int."""
         write_file(os.path.join(self.sysdir, "dev", "attr"), "NOTINT\n")
-        self.assertFalse(net.read_sys_net_int("dev", "attr"))
+        assert not net.read_sys_net_int("dev", "attr")
 
     def test_read_sys_net_int_returns_integer_from_content(self):
         """read_sys_net_safe returns None on failures."""
         write_file(os.path.join(self.sysdir, "dev", "attr"), "1\n")
-        self.assertEqual(1, net.read_sys_net_int("dev", "attr"))
+        assert 1 == net.read_sys_net_int("dev", "attr")
 
     def test_is_up_true(self):
         """is_up is True if sys/net/devname/operstate is 'up' or 'unknown'."""
         for state in ["up", "unknown"]:
             write_file(os.path.join(self.sysdir, "eth0", "operstate"), state)
-            self.assertTrue(net.is_up("eth0"))
+            assert net.is_up("eth0")
 
     def test_is_up_false(self):
         """is_up is False if sys/net/devname/operstate is 'down' or invalid."""
         for state in ["down", "incomprehensible"]:
             write_file(os.path.join(self.sysdir, "eth0", "operstate"), state)
-            self.assertFalse(net.is_up("eth0"))
+            assert not net.is_up("eth0")
 
     def test_is_bridge(self):
         """is_bridge is True when /sys/net/devname/bridge exists."""
-        self.assertFalse(net.is_bridge("eth0"))
+        assert not net.is_bridge("eth0")
         ensure_file(os.path.join(self.sysdir, "eth0", "bridge"))
-        self.assertTrue(net.is_bridge("eth0"))
+        assert net.is_bridge("eth0")
 
     def test_is_bond(self):
         """is_bond is True when /sys/net/devname/bonding exists."""
-        self.assertFalse(net.is_bond("eth0"))
+        assert not net.is_bond("eth0")
         ensure_file(os.path.join(self.sysdir, "eth0", "bonding"))
-        self.assertTrue(net.is_bond("eth0"))
+        assert net.is_bond("eth0")
 
     def test_get_master(self):
         """get_master returns the path when /sys/net/devname/master exists."""
-        self.assertIsNone(net.get_master("enP1s1"))
+        assert net.get_master("enP1s1") is None
         master_path = os.path.join(self.sysdir, "enP1s1", "master")
         ensure_file(master_path)
-        self.assertEqual(master_path, net.get_master("enP1s1"))
+        assert master_path == net.get_master("enP1s1")
 
     def test_master_is_bridge_or_bond(self):
         bridge_mac = "aa:bb:cc:aa:bb:cc"
@@ -173,8 +176,8 @@ class TestReadSysNet(CiTestCase):
         write_file(os.path.join(self.sysdir, "eth1", "address"), bridge_mac)
         write_file(os.path.join(self.sysdir, "eth2", "address"), bond_mac)
 
-        self.assertFalse(net.master_is_bridge_or_bond("eth1"))
-        self.assertFalse(net.master_is_bridge_or_bond("eth2"))
+        assert not net.master_is_bridge_or_bond("eth1")
+        assert not net.master_is_bridge_or_bond("eth2")
 
         # masters without bridge/bonding => False
         write_file(os.path.join(self.sysdir, "br0", "address"), bridge_mac)
@@ -183,15 +186,15 @@ class TestReadSysNet(CiTestCase):
         os.symlink("../br0", os.path.join(self.sysdir, "eth1", "master"))
         os.symlink("../bond0", os.path.join(self.sysdir, "eth2", "master"))
 
-        self.assertFalse(net.master_is_bridge_or_bond("eth1"))
-        self.assertFalse(net.master_is_bridge_or_bond("eth2"))
+        assert not net.master_is_bridge_or_bond("eth1")
+        assert not net.master_is_bridge_or_bond("eth2")
 
         # masters with bridge/bonding => True
         write_file(os.path.join(self.sysdir, "br0", "bridge"), "")
         write_file(os.path.join(self.sysdir, "bond0", "bonding"), "")
 
-        self.assertTrue(net.master_is_bridge_or_bond("eth1"))
-        self.assertTrue(net.master_is_bridge_or_bond("eth2"))
+        assert net.master_is_bridge_or_bond("eth1")
+        assert net.master_is_bridge_or_bond("eth2")
 
     def test_master_is_openvswitch(self):
         ovs_mac = "bb:cc:aa:bb:cc:aa"
@@ -199,7 +202,7 @@ class TestReadSysNet(CiTestCase):
         # No master => False
         write_file(os.path.join(self.sysdir, "eth1", "address"), ovs_mac)
 
-        self.assertFalse(net.master_is_bridge_or_bond("eth1"))
+        assert not net.master_is_bridge_or_bond("eth1")
 
         # masters without ovs-system => False
         write_file(os.path.join(self.sysdir, "ovs-system", "address"), ovs_mac)
@@ -208,7 +211,7 @@ class TestReadSysNet(CiTestCase):
             "../ovs-system", os.path.join(self.sysdir, "eth1", "master")
         )
 
-        self.assertFalse(net.master_is_openvswitch("eth1"))
+        assert not net.master_is_openvswitch("eth1")
 
         # masters with ovs-system => True
         os.symlink(
@@ -216,15 +219,15 @@ class TestReadSysNet(CiTestCase):
             os.path.join(self.sysdir, "eth1", "upper_ovs-system"),
         )
 
-        self.assertTrue(net.master_is_openvswitch("eth1"))
+        assert net.master_is_openvswitch("eth1")
 
     def test_is_vlan(self):
         """is_vlan is True when /sys/net/devname/uevent has DEVTYPE=vlan."""
         ensure_file(os.path.join(self.sysdir, "eth0", "uevent"))
-        self.assertFalse(net.is_vlan("eth0"))
+        assert not net.is_vlan("eth0")
         content = "junk\nDEVTYPE=vlan\njunk\n"
         write_file(os.path.join(self.sysdir, "eth0", "uevent"), content)
-        self.assertTrue(net.is_vlan("eth0"))
+        assert net.is_vlan("eth0")
 
 
 class TestGenerateFallbackConfig(CiTestCase):
@@ -1457,134 +1460,121 @@ class TestExtractPhysdevs(CiTestCase):
             net.extract_physdevs({"version": 3, "awesome_config": []})
 
 
-class TestNetFailOver(CiTestCase):
-    def setUp(self):
-        super(TestNetFailOver, self).setUp()
-        self.add_patch("cloudinit.net.util", "m_util")
-        self.add_patch("cloudinit.net.read_sys_net", "m_read_sys_net")
-        self.add_patch("cloudinit.net.device_driver", "m_device_driver")
+class TestNetFailOver:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker):
+        mocker.patch("cloudinit.net.util")
+        self.device_driver = mocker.patch("cloudinit.net.device_driver")
+        self.read_sys_net = mocker.patch("cloudinit.net.read_sys_net")
 
     def test_get_dev_features(self):
-        devname = self.random_string()
-        features = self.random_string()
-        self.m_read_sys_net.return_value = features
+        devname = random_string()
+        features = random_string()
+        self.read_sys_net.return_value = features
 
-        self.assertEqual(features, net.get_dev_features(devname))
-        self.assertEqual(1, self.m_read_sys_net.call_count)
-        self.assertEqual(
-            mock.call(devname, "device/features"),
-            self.m_read_sys_net.call_args_list[0],
-        )
+        assert features == net.get_dev_features(devname)
+        assert 1 == self.read_sys_net.call_count
+        self.read_sys_net.assert_called_once_with(devname, "device/features")
 
     def test_get_dev_features_none_returns_empty_string(self):
-        devname = self.random_string()
-        self.m_read_sys_net.side_effect = Exception("error")
-        self.assertEqual("", net.get_dev_features(devname))
-        self.assertEqual(1, self.m_read_sys_net.call_count)
-        self.assertEqual(
-            mock.call(devname, "device/features"),
-            self.m_read_sys_net.call_args_list[0],
-        )
+        devname = random_string()
+        self.read_sys_net.side_effect = Exception("error")
+        assert "" == net.get_dev_features(devname)
+        assert 1 == self.read_sys_net.call_count
+        self.read_sys_net.assert_called_once_with(devname, "device/features")
 
     @mock.patch("cloudinit.net.get_dev_features")
     def test_has_netfail_standby_feature(self, m_dev_features):
-        devname = self.random_string()
+        devname = random_string()
         standby_features = ("0" * 62) + "1" + "0"
         m_dev_features.return_value = standby_features
-        self.assertTrue(net.has_netfail_standby_feature(devname))
+        assert net.has_netfail_standby_feature(devname)
 
     @mock.patch("cloudinit.net.get_dev_features")
     def test_has_netfail_standby_feature_short_is_false(self, m_dev_features):
-        devname = self.random_string()
-        standby_features = self.random_string()
+        devname = random_string()
+        standby_features = random_string()
         m_dev_features.return_value = standby_features
-        self.assertFalse(net.has_netfail_standby_feature(devname))
+        assert not net.has_netfail_standby_feature(devname)
 
     @mock.patch("cloudinit.net.get_dev_features")
     def test_has_netfail_standby_feature_not_present_is_false(
         self, m_dev_features
     ):
-        devname = self.random_string()
+        devname = random_string()
         standby_features = "0" * 64
         m_dev_features.return_value = standby_features
-        self.assertFalse(net.has_netfail_standby_feature(devname))
+        assert not net.has_netfail_standby_feature(devname)
 
     @mock.patch("cloudinit.net.get_dev_features")
     def test_has_netfail_standby_feature_no_features_is_false(
         self, m_dev_features
     ):
-        devname = self.random_string()
+        devname = random_string()
         standby_features = None
         m_dev_features.return_value = standby_features
-        self.assertFalse(net.has_netfail_standby_feature(devname))
+        assert not net.has_netfail_standby_feature(devname)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     def test_is_netfail_master(self, m_exists, m_standby):
-        devname = self.random_string()
+        devname = random_string()
         driver = "virtio_net"
         m_exists.return_value = False  # no master sysfs attr
         m_standby.return_value = True  # has standby feature flag
-        self.assertTrue(net.is_netfail_master(devname, driver))
+        assert net.is_netfail_master(devname, driver)
 
     @mock.patch("cloudinit.net.sys_dev_path")
     def test_is_netfail_master_checks_master_attr(self, m_sysdev):
-        devname = self.random_string()
+        devname = random_string()
         driver = "virtio_net"
-        m_sysdev.return_value = self.random_string()
-        self.assertFalse(net.is_netfail_master(devname, driver))
-        self.assertEqual(1, m_sysdev.call_count)
-        self.assertEqual(
-            mock.call(devname, path="master"), m_sysdev.call_args_list[0]
-        )
+        m_sysdev.return_value = random_string()
+        assert not net.is_netfail_master(devname, driver)
+        assert 1 == m_sysdev.call_count
+        m_sysdev.assert_called_once_with(devname, path="master")
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     def test_is_netfail_master_wrong_driver(self, m_exists, m_standby):
-        devname = self.random_string()
-        driver = self.random_string()
-        self.assertFalse(net.is_netfail_master(devname, driver))
+        devname = random_string()
+        driver = random_string()
+        assert not net.is_netfail_master(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     def test_is_netfail_master_has_master_attr(self, m_exists, m_standby):
-        devname = self.random_string()
+        devname = random_string()
         driver = "virtio_net"
         m_exists.return_value = True  # has master sysfs attr
-        self.assertFalse(net.is_netfail_master(devname, driver))
+        assert not net.is_netfail_master(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     def test_is_netfail_master_no_standby_feat(self, m_exists, m_standby):
-        devname = self.random_string()
+        devname = random_string()
         driver = "virtio_net"
         m_exists.return_value = False  # no master sysfs attr
         m_standby.return_value = False  # no standby feature flag
-        self.assertFalse(net.is_netfail_master(devname, driver))
+        assert not net.is_netfail_master(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     @mock.patch("cloudinit.net.sys_dev_path")
     def test_is_netfail_primary(self, m_sysdev, m_exists, m_standby):
-        devname = self.random_string()
-        driver = self.random_string()  # device not virtio_net
-        master_devname = self.random_string()
+        devname = random_string()
+        driver = random_string()  # device not virtio_net
+        master_devname = random_string()
         m_sysdev.return_value = "%s/%s" % (
-            self.random_string(),
+            random_string(),
             master_devname,
         )
         m_exists.return_value = True  # has master sysfs attr
-        self.m_device_driver.return_value = "virtio_net"  # master virtio_net
+        self.device_driver.return_value = "virtio_net"  # master virtio_net
         m_standby.return_value = True  # has standby feature flag
-        self.assertTrue(net.is_netfail_primary(devname, driver))
-        self.assertEqual(1, self.m_device_driver.call_count)
-        self.assertEqual(
-            mock.call(master_devname), self.m_device_driver.call_args_list[0]
-        )
-        self.assertEqual(1, m_standby.call_count)
-        self.assertEqual(
-            mock.call(master_devname), m_standby.call_args_list[0]
-        )
+        assert net.is_netfail_primary(devname, driver)
+        self.device_driver.assert_called_once_with(master_devname)
+        assert 1 == m_standby.call_count
+        m_standby.assert_called_once_with(master_devname)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
@@ -1592,18 +1582,18 @@ class TestNetFailOver(CiTestCase):
     def test_is_netfail_primary_wrong_driver(
         self, m_sysdev, m_exists, m_standby
     ):
-        devname = self.random_string()
+        devname = random_string()
         driver = "virtio_net"
-        self.assertFalse(net.is_netfail_primary(devname, driver))
+        assert not net.is_netfail_primary(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     @mock.patch("cloudinit.net.sys_dev_path")
     def test_is_netfail_primary_no_master(self, m_sysdev, m_exists, m_standby):
-        devname = self.random_string()
-        driver = self.random_string()  # device not virtio_net
+        devname = random_string()
+        driver = random_string()  # device not virtio_net
         m_exists.return_value = False  # no master sysfs attr
-        self.assertFalse(net.is_netfail_primary(devname, driver))
+        assert not net.is_netfail_primary(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
@@ -1611,16 +1601,16 @@ class TestNetFailOver(CiTestCase):
     def test_is_netfail_primary_bad_master(
         self, m_sysdev, m_exists, m_standby
     ):
-        devname = self.random_string()
-        driver = self.random_string()  # device not virtio_net
-        master_devname = self.random_string()
+        devname = random_string()
+        driver = random_string()  # device not virtio_net
+        master_devname = random_string()
         m_sysdev.return_value = "%s/%s" % (
-            self.random_string(),
+            random_string(),
             master_devname,
         )
         m_exists.return_value = True  # has master sysfs attr
-        self.m_device_driver.return_value = "XXXX"  # master not virtio_net
-        self.assertFalse(net.is_netfail_primary(devname, driver))
+        self.device_driver.return_value = "XXXX"  # master not virtio_net
+        assert not net.is_netfail_primary(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
@@ -1628,77 +1618,77 @@ class TestNetFailOver(CiTestCase):
     def test_is_netfail_primary_no_standby(
         self, m_sysdev, m_exists, m_standby
     ):
-        devname = self.random_string()
-        driver = self.random_string()  # device not virtio_net
-        master_devname = self.random_string()
+        devname = random_string()
+        driver = random_string()  # device not virtio_net
+        master_devname = random_string()
         m_sysdev.return_value = "%s/%s" % (
-            self.random_string(),
+            random_string(),
             master_devname,
         )
         m_exists.return_value = True  # has master sysfs attr
-        self.m_device_driver.return_value = "virtio_net"  # master virtio_net
+        self.device_driver.return_value = "virtio_net"  # master virtio_net
         m_standby.return_value = False  # master has no standby feature flag
-        self.assertFalse(net.is_netfail_primary(devname, driver))
+        assert not net.is_netfail_primary(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     def test_is_netfail_standby(self, m_exists, m_standby):
-        devname = self.random_string()
+        devname = random_string()
         driver = "virtio_net"
         m_exists.return_value = True  # has master sysfs attr
         m_standby.return_value = True  # has standby feature flag
-        self.assertTrue(net.is_netfail_standby(devname, driver))
+        assert net.is_netfail_standby(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     def test_is_netfail_standby_wrong_driver(self, m_exists, m_standby):
-        devname = self.random_string()
-        driver = self.random_string()
-        self.assertFalse(net.is_netfail_standby(devname, driver))
+        devname = random_string()
+        driver = random_string()
+        assert not net.is_netfail_standby(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     def test_is_netfail_standby_no_master(self, m_exists, m_standby):
-        devname = self.random_string()
+        devname = random_string()
         driver = "virtio_net"
         m_exists.return_value = False  # has master sysfs attr
-        self.assertFalse(net.is_netfail_standby(devname, driver))
+        assert not net.is_netfail_standby(devname, driver)
 
     @mock.patch("cloudinit.net.has_netfail_standby_feature")
     @mock.patch("cloudinit.net.os.path.exists")
     def test_is_netfail_standby_no_standby_feature(self, m_exists, m_standby):
-        devname = self.random_string()
+        devname = random_string()
         driver = "virtio_net"
         m_exists.return_value = True  # has master sysfs attr
         m_standby.return_value = False  # has standby feature flag
-        self.assertFalse(net.is_netfail_standby(devname, driver))
+        assert not net.is_netfail_standby(devname, driver)
 
     @mock.patch("cloudinit.net.is_netfail_standby")
     @mock.patch("cloudinit.net.is_netfail_primary")
     def test_is_netfailover_primary(self, m_primary, m_standby):
-        devname = self.random_string()
-        driver = self.random_string()
+        devname = random_string()
+        driver = random_string()
         m_primary.return_value = True
         m_standby.return_value = False
-        self.assertTrue(net.is_netfailover(devname, driver))
+        assert net.is_netfailover(devname, driver)
 
     @mock.patch("cloudinit.net.is_netfail_standby")
     @mock.patch("cloudinit.net.is_netfail_primary")
     def test_is_netfailover_standby(self, m_primary, m_standby):
-        devname = self.random_string()
-        driver = self.random_string()
+        devname = random_string()
+        driver = random_string()
         m_primary.return_value = False
         m_standby.return_value = True
-        self.assertTrue(net.is_netfailover(devname, driver))
+        assert net.is_netfailover(devname, driver)
 
     @mock.patch("cloudinit.net.is_netfail_standby")
     @mock.patch("cloudinit.net.is_netfail_primary")
     def test_is_netfailover_returns_false(self, m_primary, m_standby):
-        devname = self.random_string()
-        driver = self.random_string()
+        devname = random_string()
+        driver = random_string()
         m_primary.return_value = False
         m_standby.return_value = False
-        self.assertFalse(net.is_netfailover(devname, driver))
+        assert not net.is_netfailover(devname, driver)
 
 
 class TestOpenvswitchIsInstalled:

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -3,14 +3,13 @@
 from unittest import mock
 
 from cloudinit.sources.helpers import openstack
-from tests.unittests import helpers as test_helpers
 
 
 @mock.patch(
     "cloudinit.net.is_openvswitch_internal_interface",
     mock.Mock(return_value=False),
 )
-class TestConvertNetJson(test_helpers.CiTestCase):
+class TestConvertNetJson:
     def test_phy_types(self):
         """Verify the different known physical types are handled."""
         # network_data.json example from
@@ -54,11 +53,8 @@ class TestConvertNetJson(test_helpers.CiTestCase):
 
         for t in openstack.KNOWN_PHYSICAL_TYPES:
             net_json["links"][0]["type"] = t
-            self.assertEqual(
-                expected,
-                openstack.convert_net_json(
-                    network_json=net_json, known_macs=macs
-                ),
+            assert expected == openstack.convert_net_json(
+                network_json=net_json, known_macs=macs
             )
 
     def test_subnet_dns(self):
@@ -113,9 +109,6 @@ class TestConvertNetJson(test_helpers.CiTestCase):
 
         for t in openstack.KNOWN_PHYSICAL_TYPES:
             net_json["links"][0]["type"] = t
-            self.assertEqual(
-                expected,
-                openstack.convert_net_json(
-                    network_json=net_json, known_macs=macs
-                ),
+            assert expected == openstack.convert_net_json(
+                network_json=net_json, known_macs=macs
             )

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -46,7 +46,7 @@ DEFAULT_LOCAL = [
     Hetzner.DataSourceHetzner,
     IBMCloud.DataSourceIBMCloud,
     LXD.DataSourceLXD,
-    MAAS.DataSourceMAAS,
+    MAAS.DataSourceMAASLocal,
     NoCloud.DataSourceNoCloud,
     OpenNebula.DataSourceOpenNebula,
     Oracle.DataSourceOracle,

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -172,6 +172,28 @@ NIC2_MD = {
     "vpc-ipv4-cidr-blocks": "172.31.0.0/16",
 }
 
+NIC2_MD_IPV4_IPV6_MULTI_IP = {
+    "device-number": "1",
+    "interface-id": "eni-043cdce36ded5e79f",
+    "ipv6s": [
+        "2600:1f16:292:100:c187:593c:4349:136",
+        "2600:1f16:292:100:f153:12a3:c37c:11f9",
+    ],
+    "local-hostname": "ip-172-31-47-221.us-east-2.compute.internal",
+    "local-ipv4s": "172.31.47.221",
+    "mac": "0a:75:69:92:e2:16",
+    "owner-id": "329910648901",
+    "security-group-ids": "sg-0d68fef37d8cc9b77",
+    "security-groups": "launch-wizard-17",
+    "subnet-id": "subnet-9d7ba0d1",
+    "subnet-ipv4-cidr-block": "172.31.32.0/20",
+    "subnet-ipv6-cidr-blocks": "2600:1f16:292:100::/64",
+    "vpc-id": "vpc-a07f62c8",
+    "vpc-ipv4-cidr-block": "172.31.0.0/16",
+    "vpc-ipv4-cidr-blocks": "172.31.0.0/16",
+    "vpc-ipv6-cidr-blocks": "2600:1f16:292:100::/56",
+}
+
 SECONDARY_IP_METADATA_2018_09_24 = {
     "ami-id": "ami-0986c2ac728528ac2",
     "ami-launch-index": "0",
@@ -1239,7 +1261,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
             ),
         )
 
-    def test_convert_ec2_metadata_network_config_handles_multiple_nics(self):
+    def test_convert_ec2_metadata_network_config_multi_nics_ipv4(self):
         """DHCP route-metric increases on secondary NICs for IPv4 and IPv6.
         Source-routing configured for secondary NICs (routing-policy and extra
         routing table)."""
@@ -1282,6 +1304,83 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                         # NIC2_MD["local-ipv4s"]
                         {"from": "172.31.47.221", "table": 101}
                     ],
+                },
+            },
+        }
+        distro = mock.Mock()
+        distro.network_activator = activators.NetplanActivator
+        distro.dhcp_client.dhcp_discovery.return_value = {
+            "routers": "172.31.1.0"
+        }
+        self.assertEqual(
+            expected,
+            ec2.convert_ec2_metadata_network_config(
+                network_metadata_both, distro, macs_to_nics
+            ),
+        )
+
+    def test_convert_ec2_metadata_network_config_multi_nics_ipv4_ipv6_multi_ip(
+        self,
+    ):
+        """DHCP route-metric increases on secondary NICs for IPv4 and IPv6.
+        Source-routing configured for secondary NICs (routing-policy and extra
+        routing table)."""
+        mac2 = "06:17:04:d7:26:08"
+        macs_to_nics = {self.mac1: "eth9", mac2: "eth10"}
+        network_metadata_both = copy.deepcopy(self.network_metadata)
+        # Add 2nd nic info
+        network_metadata_both["interfaces"]["macs"][
+            mac2
+        ] = NIC2_MD_IPV4_IPV6_MULTI_IP
+        nic1_metadata = network_metadata_both["interfaces"]["macs"][self.mac1]
+        nic1_metadata["ipv6s"] = "2620:0:1009:fd00:e442:c88d:c04d:dc85/64"
+        nic1_metadata.pop("public-ipv4s")  # No public-ipv4 IPs in cfg
+        nic1_metadata["local-ipv4s"] = "10.0.0.42"  # Local ipv4 only on vpc
+        expected = {
+            "version": 2,
+            "ethernets": {
+                "eth9": {
+                    "dhcp4": True,
+                    "dhcp4-overrides": {"route-metric": 100},
+                    "dhcp6": True,
+                    "match": {"macaddress": "06:17:04:d7:26:09"},
+                    "set-name": "eth9",
+                    "dhcp6-overrides": {"route-metric": 100},
+                },
+                "eth10": {
+                    "dhcp4": True,
+                    "dhcp4-overrides": {
+                        "route-metric": 200,
+                        "use-routes": True,
+                    },
+                    "dhcp6": True,
+                    "match": {"macaddress": "06:17:04:d7:26:08"},
+                    "set-name": "eth10",
+                    "routes": [
+                        # via DHCP gateway
+                        {"to": "0.0.0.0/0", "via": "172.31.1.0", "table": 101},
+                        # to NIC2_MD["subnet-ipv4-cidr-block"]
+                        {"to": "172.31.32.0/20", "table": 101},
+                        # to NIC2_MD["subnet-ipv6-cidr-blocks"]
+                        {"to": "2600:1f16:292:100::/64", "table": 101},
+                    ],
+                    "routing-policy": [
+                        # NIC2_MD["local-ipv4s"]
+                        {"from": "172.31.47.221", "table": 101},
+                        {
+                            "from": "2600:1f16:292:100:c187:593c:4349:136",
+                            "table": 101,
+                        },
+                        {
+                            "from": "2600:1f16:292:100:f153:12a3:c37c:11f9",
+                            "table": 101,
+                        },
+                    ],
+                    "dhcp6-overrides": {
+                        "route-metric": 200,
+                        "use-routes": True,
+                    },
+                    "addresses": ["2600:1f16:292:100:f153:12a3:c37c:11f9/128"],
                 },
             },
         }

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -6,6 +6,7 @@ import re
 from functools import partial
 from threading import Event
 from time import process_time
+from unittest.mock import ANY, call
 
 import pytest
 import requests
@@ -446,20 +447,72 @@ class TestDualStack:
         """Assert expected call intervals occur"""
         stagger = 0.1
         with mock.patch(M_PATH + "_run_func_with_delay") as delay_func:
+
+            def identity_of_first_arg(x, _):
+                return x
+
             dual_stack(
-                lambda x, _y: x,
+                identity_of_first_arg,
                 ["you", "and", "me", "and", "dog"],
                 stagger_delay=stagger,
                 timeout=1,
             )
 
-            # ensure that stagger delay for each subsequent call is:
+            # ensure that stagger delay for each call is made with args:
             # [ 0 * N, 1 * N, 2 * N, 3 * N, 4 * N, 5 * N] where N = stagger
             # it appears that without an explicit wait/join we can't assert
             # number of calls
-            for delay, call_item in enumerate(delay_func.call_args_list):
-                _, kwargs = call_item
-                assert stagger * delay == kwargs.get("delay")
+            calls = [
+                call(
+                    func=identity_of_first_arg,
+                    addr="you",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 0,
+                ),
+                call(
+                    func=identity_of_first_arg,
+                    addr="and",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 1,
+                ),
+                call(
+                    func=identity_of_first_arg,
+                    addr="me",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 2,
+                ),
+                call(
+                    func=identity_of_first_arg,
+                    addr="and",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 3,
+                ),
+                call(
+                    func=identity_of_first_arg,
+                    addr="dog",
+                    timeout=1,
+                    event=ANY,
+                    delay=stagger * 4,
+                ),
+            ]
+            num_calls = 0
+            for call_instance in calls:
+                if call_instance in delay_func.call_args_list:
+                    num_calls += 1
+
+            # we can't know the order of the submitted functions' execution
+            # we can't know how many of the submitted functions get called
+            # in advance
+            #
+            # we _do_ know what the possible arg combinations are
+            # we _do_ know from the mocked function how many got called
+            # assert that all calls that occurred had known valid arguments
+            # by checking for the correct number of matches
+            assert num_calls == len(delay_func.call_args_list)
 
 
 ADDR1 = "https://addr1/"

--- a/tox.ini
+++ b/tox.ini
@@ -329,7 +329,7 @@ markers =
     serial: tests that do not work in parallel, skipped with py3-fast
     unstable: skip this test because it is flakey
     user_data: the user data to be passed to the test instance
-	allow_dns_lookup: disable autochecking for host network configuration
+    allow_dns_lookup: disable autochecking for host network configuration
 
 [coverage:paths]
 source =


### PR DESCRIPTION
We are specifically avoiding merging this to ubuntu/devel as Ubuntu is in feature freeze at the moment and we only want to upload bugfix releases to ubuntu/noble-24.1.x.

## Branch creation process 
- Updated hotfix process card https://github.com/orgs/canonical/projects/29/views/1?pane=issue&itemId=23587201

```
git fetch upstream --tags
git checkout upstream/ubuntu/noble-24.1.x -B ubuntu/noble-24.1.x
new_upstream_snapshot -c 24.1.2  # expect merge failures on Changelog && cloudinit/version.py
vi Changelog cloudinit/version.py # Accept new 24.1.2 content
git add ChangeLog cloudinit/version.py
git merge --continue
# continue with new_upstream_snapshot post-merge
new_upstream_release.py -c 24.1.2 -p merge # proceed with refreshing debian/changelog entry creation post merge

# manually correct debian/changelog
# 1. package version 24.1.2-0ubuntu1 instead of 0ubuntu0
# 2. change "Upstream snapshot based on" -> "Upstream bugfix release based on" for clarity during feature freeze
# 3. drop duplicated bugs 2056439, 2056460, 2055077 2056194 referenced in latest change 24.1.2 change log entry
vi debian/changelog
git commit -am 'update changelog'
# squash commits to changelog 'fixup' the latest into the previous commit
git rebase -u HEAD~2
dch -r -D noble
git commit -m 'releasing cloudinit version 24.1.2-0ubuntu1' debian/changelog
```
## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
