### PR TITLE
fix: Always use single datasource if specified

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -680,7 +680,7 @@ class TestDsIdentify(DsIdentifyBase):
         mydata = copy.deepcopy(VALID_CFG["Ec2-hvm"])
         cfgpath = "etc/cloud/cloud.cfg.d/myds.cfg"
         mydata["files"][cfgpath] = 'datasource_list: ["NoCloud"]\n'
-        self._check_via_dict(mydata, rc=RC_FOUND, dslist=["NoCloud", DS_NONE])
+        self._check_via_dict(mydata, rc=RC_FOUND, dslist=["NoCloud"])
 
     def test_configured_list_with_none(self):
         """When datasource_list already contains None, None is not added.

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -2018,7 +2018,11 @@ _main() {
     # if there is only a single entry in $DI_DSLIST
     if [ $# -eq 1 ] || [ $# -eq 2 -a "$2" = "None" ] ; then
         debug 1 "single entry in datasource_list ($DI_DSLIST) use that."
-        found "$@"
+        if [ $# -eq 1 ]; then
+            write_result "datasource_list: [ $1 ]"
+        else
+            found "$@"
+        fi
         return
     fi
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Always use single datasource if specified

ds-identify would automatically append "None" to the datasource_list
if a single entry was provided in /etc/cloud/cloud.cfg[.d].
This wasn't a problem in the past as the python code would detect
a single datasource along with None as an indication to automatically
use that datasource. Since the python code no longer does that,
we should ensure that one specified datasource results in one specified
datasource after ds-identify has run.

Fixes GH-5091
```

## Additional Context
Prior to this commit, in `/etc/cloud/cloud.cfg[.d]`, an entry of `datasource_list: [OpenStack]` results in `/run/cloud-init/cloud.cfg` containing `datasource_list: [ OpenStack, None ]` (OpenStack is just an example here...it's true for any datasource).

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
