### PR TITLE
fix: Allow caret at the end of apt package

### DIFF
--- a/cloudinit/distros/package_management/apt.py
+++ b/cloudinit/distros/package_management/apt.py
@@ -135,7 +135,7 @@ class Apt(PackageManager):
         return [
             pkg
             for pkg in pkglist
-            if re.split("/|=", pkg)[0].rstrip("-")
+            if re.split("/|=", pkg)[0].rstrip("-^")
             not in self.get_all_packages()
         ]
 

--- a/cloudinit/distros/package_management/apt.py
+++ b/cloudinit/distros/package_management/apt.py
@@ -129,6 +129,7 @@ class Apt(PackageManager):
     def get_unavailable_packages(self, pkglist: Iterable[str]):
         # Packages ending with `-` signify to apt to not install a transitive
         # dependency.
+        # Packages ending with '^' signify to apt to install a Task.
         # Anything after "/" refers to a target release
         # "=" allows specifying a specific version
         # Strip all off when checking for availability

--- a/tests/unittests/distros/package_management/test_apt.py
+++ b/tests/unittests/distros/package_management/test_apt.py
@@ -90,19 +90,25 @@ class TestPackageCommand:
             apt._wait_for_apt_command("stub", {"args": "stub2"}, timeout=5)
 
     def test_search_stem(self, m_subp, m_which, mocker):
-        """Test that containing `-`, `/`, or `=` is handled correctly."""
+        """Test that containing `-`, `^`, `/`, or `=` is handled correctly."""
         mocker.patch(f"{M_PATH}update_package_sources")
         mocker.patch(
             f"{M_PATH}get_all_packages",
-            return_value=["cloud-init", "pkg2", "pkg3", "pkg4"],
+            return_value=["cloud-init", "pkg2", "pkg3", "pkg4", "pkg5"],
         )
         m_install = mocker.patch(f"{M_PATH}run_package_command")
 
         apt = Apt(runner=mock.Mock())
         apt.install_packages(
-            ["cloud-init", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2"]
+            ["cloud-init", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2", "pkg5^"]
         )
         m_install.assert_called_with(
             "install",
-            pkgs=["cloud-init", "pkg2-", "pkg3/jammy-updates", "pkg4=1.2"],
+            pkgs=[
+                "cloud-init",
+                "pkg2-",
+                "pkg3/jammy-updates",
+                "pkg4=1.2",
+                "pkg5^",
+            ],
         )


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Allow caret at the end of apt package
```

## Additional Context
https://github.com/canonical/cloud-init/pull/5069#issuecomment-2013974883

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
