### PR TITLE
examples: set the home directory using homedir, not home

### DIFF
--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -142,7 +142,7 @@ users:
 #   default_user:
 #     name: Ubuntu
 #     plain_text_passwd: 'ubuntu'
-#     home: /home/ubuntu
+#     homedir: /home/ubuntu
 #     shell: /bin/bash
 #     lock_passwd: True
 #     gecos: Ubuntu

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -124,6 +124,7 @@ nicolasbock
 nishigori
 nkukard
 nmeyerhans
+ogayot
 olivierlemasle
 omBratteng
 onitake


### PR DESCRIPTION
## Proposed Commit Message

```
examples: set the home directory using homedir, not home

According to the JSON schema, the "homedir" directive should be used to
set a user's home directory. However, we use "home" in a documented
example. Supplying the example cloud-config to cloud-init schema fails
with:

  Additional properties are not allowed ('home' was unexpected),

Fixed by replacing "home" with "homedir" in the example.


LP: #2047796
```

## Test Steps
Place the following content in a filed called e.g., test.yaml
```yaml
#cloud-config
users:
  - name: ubuntu
    plain_text_passwd: ubuntu,
    home: /home/ubuntu
    shell: /bin/bash
    lock_passwd: false
    gecos: Ubuntu all-oem-init
    groups:
    - adm
    - cdrom
    - dip
    - lxd
    - sudo
```
```bash
cloud-init schema --config-file test.yaml
```


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
