### PR TITLE
test(ec2): refactor multinic tests and add ipv6 coverage

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -1,7 +1,7 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib>=5.10.0,<1!7
+pycloudlib>=6.7.0,<1!7
 
 # Avoid breaking change in `testpaths` treatment forced
 # test/unittests/conftest.py to be loaded by our integration-tests tox env

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -218,17 +218,9 @@ class Ec2Cloud(IntegrationCloud):
                     name="ec2-cloud-init-integration"
                 )
 
-            # Enable IPv6 metadata at http://[fd00:ec2::254]
-            if "Ipv6AddressCount" not in launch_kwargs:
-                launch_kwargs["Ipv6AddressCount"] = 1
-            if "MetadataOptions" not in launch_kwargs:
-                launch_kwargs["MetadataOptions"] = {}
-            if "HttpProtocolIpv6" not in launch_kwargs["MetadataOptions"]:
-                launch_kwargs["MetadataOptions"] = {
-                    "HttpProtocolIpv6": "enabled"
-                }
-
-        pycloudlib_instance = self.cloud_instance.launch(**launch_kwargs)
+        pycloudlib_instance = self.cloud_instance.launch(
+            enable_ipv6=enable_ipv6, **launch_kwargs
+        )
         self._maybe_wait(pycloudlib_instance, wait)
         return pycloudlib_instance
 

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -61,7 +61,14 @@ def _get_ip_addr(client):
         attributes = line.split()
         interface, state = attributes[0], attributes[1]
         ip4_cidr = attributes[2] if len(attributes) > 2 else None
-        ip6_cidr = attributes[3] if len(attributes) > 3 else None
+        # The output of `ip --brief addr` can contain metric info:
+        # ens5 UP <ipv4_cidr> metric 100 <ipv6_cidr> ...
+        ip6_cidr = None
+        if len(attributes) > 3:
+            if attributes[3] != "metric":
+                ip6_cidr = attributes[3]
+            elif len(attributes) > 5:
+                ip6_cidr = attributes[5]
         ip4 = ip4_cidr.split("/")[0] if ip4_cidr else None
         ip6 = ip6_cidr.split("/")[0] if ip6_cidr else None
         ip = ip_addr(interface, state, ip4, ip6)
@@ -276,7 +283,6 @@ def test_multi_nic_hotplug(setup_image, session_cloud: IntegrationCloud):
             new_nic_cfg = config["network"]["ethernets"][
                 new_addition.interface
             ]
-            assert "routing-policy" in new_nic_cfg
             assert [{"from": secondary_priv_ip, "table": 101}] == new_nic_cfg[
                 "routing-policy"
             ]
@@ -327,42 +333,52 @@ def test_multi_nic_hotplug_vpc(setup_image, session_cloud: IntegrationCloud):
         user_data=USER_DATA
     ) as client, session_cloud.launch() as bastion:
         ips_before = _get_ip_addr(client)
-        primary_priv_ip = ips_before[1].ip4
-
-        secondary_priv_ip = client.instance.add_network_interface()
+        primary_priv_ip4 = ips_before[1].ip4
+        primary_priv_ip6 = ips_before[1].ip6
+        client.instance.add_network_interface(ipv6_address_count=1)
 
         _wait_till_hotplug_complete(client)
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
 
-        ips_after_add = _get_ip_addr(client)
-
         netplan_cfg = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
         config = yaml.safe_load(netplan_cfg)
+
+        ips_after_add = _get_ip_addr(client)
+        secondary_priv_ip4 = ips_after_add[2].ip4
+        secondary_priv_ip6 = ips_after_add[2].ip6
+        assert primary_priv_ip4 != secondary_priv_ip4
+
         new_addition = [
-            ip for ip in ips_after_add if ip.ip4 == secondary_priv_ip
+            ip for ip in ips_after_add if ip.ip4 == secondary_priv_ip4
         ][0]
         assert new_addition.interface in config["network"]["ethernets"]
         new_nic_cfg = config["network"]["ethernets"][new_addition.interface]
         assert "routing-policy" in new_nic_cfg
-        assert [{"from": secondary_priv_ip, "table": 101}] == new_nic_cfg[
-            "routing-policy"
-        ]
+        assert [
+            {"from": secondary_priv_ip4, "table": 101},
+            {"from": secondary_priv_ip6, "table": 101},
+        ] == new_nic_cfg["routing-policy"]
 
         assert len(ips_after_add) == len(ips_before) + 1
 
         # pings to primary and secondary NICs work
-        r = bastion.execute(f"ping -c1 {primary_priv_ip}")
+        r = bastion.execute(f"ping -c1 {primary_priv_ip4}")
         assert r.ok, r.stdout
-        r = bastion.execute(f"ping -c1 {secondary_priv_ip}")
+        r = bastion.execute(f"ping -c1 {secondary_priv_ip4}")
+        assert r.ok, r.stdout
+        r = bastion.execute(f"ping -c1 {primary_priv_ip6}")
+        assert r.ok, r.stdout
+        r = bastion.execute(f"ping -c1 {secondary_priv_ip6}")
         assert r.ok, r.stdout
 
         # Remove new NIC
-        client.instance.remove_network_interface(secondary_priv_ip)
+        client.instance.remove_network_interface(secondary_priv_ip4)
         _wait_till_hotplug_complete(client, expected_runs=2)
 
         # ping to primary NIC works
-        bastion.execute(f"ping -c1 {primary_priv_ip}")
+        assert bastion.execute(f"ping -c1 {primary_priv_ip4}").ok
+        assert bastion.execute(f"ping -c1 {primary_priv_ip6}").ok
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -78,8 +78,7 @@ def _get_ip_addr(client):
 @pytest.mark.skipif(
     PLATFORM != "openstack",
     reason=(
-        f"Test was written for {PLATFORM} but can likely run on "
-        "other platforms."
+        "Test was written for openstack but can likely run on other platforms."
     ),
 )
 @pytest.mark.skipif(
@@ -202,8 +201,7 @@ def test_hotplug_enable_cmd_ec2(client: IntegrationInstance):
 @pytest.mark.skipif(
     PLATFORM != "openstack",
     reason=(
-        f"Test was written for {PLATFORM} but can likely run on "
-        "other platforms."
+        "Test was written for openstack but can likely run on other platforms."
     ),
 )
 def test_no_hotplug_in_userdata(client: IntegrationInstance):

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -1,4 +1,5 @@
 """Networking-related tests."""
+
 import contextlib
 import json
 
@@ -320,77 +321,28 @@ def test_ec2_multi_nic_reboot(setup_image, session_cloud: IntegrationCloud):
     """Tests that additional secondary NICs and secondary IPs on them are
     routable from non-local networks after a reboot event when network updates
     are configured on every boot."""
-    ec2 = session_cloud.cloud_instance.client
     with session_cloud.launch(launch_kwargs={}, user_data=USER_DATA) as client:
-        # Add secondary NIC
-        secondary_priv_ip_0 = client.instance.add_network_interface()
-        response = ec2.describe_network_interfaces(
-            Filters=[
-                {
-                    "Name": "private-ip-address",
-                    "Values": [secondary_priv_ip_0],
-                },
-            ],
+        # Add secondary NIC with two private and public ips
+        client.instance.add_network_interface(
+            ipv4_address_count=2, ipv4_public_ip_count=2
         )
-        nic_id = response["NetworkInterfaces"][0]["NetworkInterfaceId"]
-        # Add secondary IP to secondary NIC
-        association_0 = ec2.assign_private_ip_addresses(
-            NetworkInterfaceId=nic_id, SecondaryPrivateIpAddressCount=1
+
+        public_ips = client.instance.public_ips
+        assert len(public_ips) == 3, (
+            "Expected 3 public ips, one from the primary nic and 2 from the"
+            " secondary one"
         )
-        assert association_0["ResponseMetadata"]["HTTPStatusCode"] == 200
-        secondary_priv_ip_1 = association_0["AssignedPrivateIpAddresses"][0][
-            "PrivateIpAddress"
-        ]
 
-        # Assing elastic IPs
-        # Refactor after https://github.com/canonical/pycloudlib/issues/337 is
-        # completed
-        allocation_0 = ec2.allocate_address(Domain="vpc")
-        allocation_1 = ec2.allocate_address(Domain="vpc")
-        try:
-            secondary_pub_ip_0 = allocation_0["PublicIp"]
-            secondary_pub_ip_1 = allocation_1["PublicIp"]
+        # Reboot to update network config
+        client.execute("cloud-init clean --logs")
+        client.restart()
 
-            association_0 = ec2.associate_address(
-                AllocationId=allocation_0["AllocationId"],
-                NetworkInterfaceId=nic_id,
-                PrivateIpAddress=secondary_priv_ip_0,
-            )
-            assert association_0["ResponseMetadata"]["HTTPStatusCode"] == 200
-            association_1 = ec2.associate_address(
-                AllocationId=allocation_1["AllocationId"],
-                NetworkInterfaceId=nic_id,
-                PrivateIpAddress=secondary_priv_ip_1,
-            )
-            assert association_1["ResponseMetadata"]["HTTPStatusCode"] == 200
+        log_content = client.read_from_file("/var/log/cloud-init.log")
+        verify_clean_log(log_content)
 
-            # Reboot to update network config
-            client.execute("cloud-init clean --logs")
-            client.restart()
-
-            log_content = client.read_from_file("/var/log/cloud-init.log")
-            verify_clean_log(log_content)
-
-            # SSH over primary NIC works
-            instance_pub_ip = client.instance.ip
-            subp("nc -w 5 -zv " + instance_pub_ip + " 22", shell=True)
-
-            # SSH over secondary NIC works
-            subp("nc -w 5 -zv " + secondary_pub_ip_0 + " 22", shell=True)
-            subp("nc -w 5 -zv " + secondary_pub_ip_1 + " 22", shell=True)
-        finally:
-            with contextlib.suppress(Exception):
-                ec2.disassociate_address(
-                    AssociationId=association_0["AssociationId"]
-                )
-            with contextlib.suppress(Exception):
-                ec2.release_address(AllocationId=allocation_0["AllocationId"])
-            with contextlib.suppress(Exception):
-                ec2.disassociate_address(
-                    AssociationId=association_1["AssociationId"]
-                )
-            with contextlib.suppress(Exception):
-                ec2.release_address(AllocationId=allocation_1["AllocationId"])
+        # SSH over primary and secondary NIC works
+        for ip in public_ips:
+            subp("nc -w 5 -zv " + ip + " 22", shell=True)
 
 
 @pytest.mark.adhoc  # costly instance not available in all regions / azs


### PR DESCRIPTION
Adopt changes from https://github.com/canonical/pycloudlib/pull/355. See individual commits.

<!--
## Proposed Commit Message
 Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore

```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```
-->

## Additional Context
<!-- If relevant -->
https://warthogs.atlassian.net/browse/SC-1754

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
CLOUD_INIT_PLATFORM=ec2 tox -e integration-tests -- \
        tests/integration_tests/modules/test_hotplug.py::test_multi_nic_hotplug_vpc \
        tests/integration_tests/modules/test_hotplug.py::test_multi_nic_hotplug \
        tests/integration_tests/test_networking.py::test_ec2_multi_nic_reboot
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
