### PR TITLE
chore: Handle all level 1 TiCS security violations

### DIFF
--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -167,7 +167,7 @@ def _stream_command_output_to_file(cmd, filename, msg, verbosity):
     ensure_dir(os.path.dirname(filename))
     try:
         with open(filename, "w") as f:
-            subprocess.call(cmd, stdout=f, stderr=f)
+            subprocess.call(cmd, stdout=f, stderr=f)  # nosec
     except OSError as e:
         write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)

--- a/cloudinit/cmd/devel/logs.py
+++ b/cloudinit/cmd/devel/logs.py
@@ -167,7 +167,7 @@ def _stream_command_output_to_file(cmd, filename, msg, verbosity):
     ensure_dir(os.path.dirname(filename))
     try:
         with open(filename, "w") as f:
-            subprocess.call(cmd, stdout=f, stderr=f)  # nosec
+            subprocess.call(cmd, stdout=f, stderr=f)  # nosec B603
     except OSError as e:
         write_file(filename, str(e))
         _debug("collecting %s failed.\n" % msg, 1, verbosity)

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -205,7 +205,7 @@ def doexit(sysexit):
 def execmd(exe_args, output=None, data_in=None):
     ret = 1
     try:
-        proc = subprocess.Popen(
+        proc = subprocess.Popen(  # nosec
             exe_args,
             stdin=subprocess.PIPE,
             stdout=output,

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -205,7 +205,7 @@ def doexit(sysexit):
 def execmd(exe_args, output=None, data_in=None):
     ret = 1
     try:
-        proc = subprocess.Popen(  # nosec
+        proc = subprocess.Popen(  # nosec B603
             exe_args,
             stdin=subprocess.PIPE,
             stdout=output,

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -11,7 +11,7 @@ import os
 import os.path
 import re
 import socket
-import xml.etree.ElementTree as ET
+import xml.etree.ElementTree as ET  # nosec
 from enum import Enum
 from pathlib import Path
 from time import sleep, time
@@ -1799,7 +1799,7 @@ def write_files(datadir, files, dirmode=None):
     def _redact_password(cnt, fname):
         """Azure provides the UserPassword in plain text. So we redact it"""
         try:
-            root = ET.fromstring(cnt)
+            root = ET.fromstring(cnt)  # nosec
             for elem in root.iter():
                 if (
                     "UserPassword" in elem.tag

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -11,7 +11,7 @@ import os
 import os.path
 import re
 import socket
-import xml.etree.ElementTree as ET  # nosec
+import xml.etree.ElementTree as ET  # nosec B405
 from enum import Enum
 from pathlib import Path
 from time import sleep, time
@@ -1799,7 +1799,7 @@ def write_files(datadir, files, dirmode=None):
     def _redact_password(cnt, fname):
         """Azure provides the UserPassword in plain text. So we redact it"""
         try:
-            root = ET.fromstring(cnt)  # nosec
+            root = ET.fromstring(cnt)  # nosec B314
             for elem in root.iter():
                 if (
                     "UserPassword" in elem.tag

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -17,7 +17,7 @@ import base64
 import logging
 import os
 import re
-from xml.dom import minidom  # nosec
+from xml.dom import minidom  # nosec B408
 
 from cloudinit import safeyaml, sources, subp, util
 
@@ -353,7 +353,7 @@ def find_child(node, filter_func):
 
 
 def get_properties(contents):
-    dom = minidom.parseString(contents)  # nosec
+    dom = minidom.parseString(contents)  # nosec B318
     if dom.documentElement.localName != "Environment":
         raise XmlError("No Environment Node")
 

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -17,7 +17,7 @@ import base64
 import logging
 import os
 import re
-from xml.dom import minidom
+from xml.dom import minidom  # nosec
 
 from cloudinit import safeyaml, sources, subp, util
 
@@ -353,7 +353,7 @@ def find_child(node, filter_func):
 
 
 def get_properties(contents):
-    dom = minidom.parseString(contents)
+    dom = minidom.parseString(contents)  # nosec
     if dom.documentElement.localName != "Environment":
         raise XmlError("No Environment Node")
 

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -9,7 +9,7 @@ import traceback
 from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, List, Optional, Tuple
-from xml.etree import ElementTree  # nosec
+from xml.etree import ElementTree  # B405
 
 import requests
 

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -9,7 +9,7 @@ import traceback
 from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, List, Optional, Tuple
-from xml.etree import ElementTree
+from xml.etree import ElementTree  # nosec
 
 import requests
 

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -9,7 +9,7 @@ import traceback
 from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, List, Optional, Tuple
-from xml.etree import ElementTree  # B405
+from xml.etree import ElementTree  # nosec B405
 
 import requests
 

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -10,8 +10,8 @@ from contextlib import contextmanager
 from datetime import datetime
 from time import sleep, time
 from typing import Callable, List, Optional, TypeVar, Union
-from xml.etree import ElementTree
-from xml.sax.saxutils import escape  # nosec
+from xml.etree import ElementTree  # nosec B405
+from xml.sax.saxutils import escape  # nosec B406
 
 from cloudinit import distros, subp, temp_utils, url_helper, util, version
 from cloudinit.reporting import events
@@ -360,7 +360,7 @@ class GoalState:
         self.azure_endpoint_client = azure_endpoint_client
 
         try:
-            self.root = ElementTree.fromstring(unparsed_xml)  # nosec
+            self.root = ElementTree.fromstring(unparsed_xml)  # nosec B314
         except ElementTree.ParseError as e:
             report_diagnostic_event(
                 "Failed to parse GoalState XML: %s" % e,
@@ -493,7 +493,9 @@ class OpenSSLManager:
         """Decrypt the certificates XML document using the our private key;
         return the list of certs and private keys contained in the doc.
         """
-        tag = ElementTree.fromstring(certificates_xml).find(".//Data")  # nosec
+        tag = ElementTree.fromstring(certificates_xml).find(  # nosec B314
+            ".//Data"
+        )
         certificates_content = tag.text
         lines = [
             b"MIME-Version: 1.0",
@@ -1001,7 +1003,7 @@ class OvfEnvXml:
                 unparsable or invalid.
         """
         try:
-            root = ElementTree.fromstring(ovf_env_xml)  # nosec
+            root = ElementTree.fromstring(ovf_env_xml)  # nosec B314
         except ElementTree.ParseError as e:
             raise errors.ReportableErrorOvfParsingException(exception=e) from e
 

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from time import sleep, time
 from typing import Callable, List, Optional, TypeVar, Union
 from xml.etree import ElementTree
-from xml.sax.saxutils import escape
+from xml.sax.saxutils import escape  # nosec
 
 from cloudinit import distros, subp, temp_utils, url_helper, util, version
 from cloudinit.reporting import events
@@ -360,7 +360,7 @@ class GoalState:
         self.azure_endpoint_client = azure_endpoint_client
 
         try:
-            self.root = ElementTree.fromstring(unparsed_xml)
+            self.root = ElementTree.fromstring(unparsed_xml)  # nosec
         except ElementTree.ParseError as e:
             report_diagnostic_event(
                 "Failed to parse GoalState XML: %s" % e,
@@ -493,7 +493,7 @@ class OpenSSLManager:
         """Decrypt the certificates XML document using the our private key;
         return the list of certs and private keys contained in the doc.
         """
-        tag = ElementTree.fromstring(certificates_xml).find(".//Data")
+        tag = ElementTree.fromstring(certificates_xml).find(".//Data")  # nosec
         certificates_content = tag.text
         lines = [
             b"MIME-Version: 1.0",
@@ -1001,7 +1001,7 @@ class OvfEnvXml:
                 unparsable or invalid.
         """
         try:
-            root = ElementTree.fromstring(ovf_env_xml)
+            root = ElementTree.fromstring(ovf_env_xml)  # nosec
         except ElementTree.ParseError as e:
             raise errors.ReportableErrorOvfParsingException(exception=e) from e
 

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ def render_tmpl(template, mode=None, is_yaml=False):
         cmd_variant = ["--variant", VARIANT]
     if PREFIX:
         cmd_prefix = ["--prefix", PREFIX]
-    subprocess.run(
+    subprocess.run(  # nosec
         [
             sys.executable,
             "./tools/render-template",

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ def render_tmpl(template, mode=None, is_yaml=False):
         cmd_variant = ["--variant", VARIANT]
     if PREFIX:
         cmd_prefix = ["--prefix", PREFIX]
-    subprocess.run(  # nosec
+    subprocess.run(  # nosec B603
         [
             sys.executable,
             "./tools/render-template",

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -25,7 +25,7 @@ def pkg_config_read(library: str, var: str) -> str:
     }
     cmd = ["pkg-config", f"--variable={var}", library]
     try:
-        path = subprocess.check_output(cmd).decode("utf-8")  # nosec
+        path = subprocess.check_output(cmd).decode("utf-8")  # nosec B603
         path = path.strip()
     except Exception:
         path = fallbacks[library][var]
@@ -53,12 +53,12 @@ def version_to_pep440(version: str) -> str:
 
 def get_version() -> str:
     cmd = [sys.executable, "tools/read-version"]
-    ver = subprocess.check_output(cmd)  # nosec
+    ver = subprocess.check_output(cmd)  # B603
     version = ver.decode("utf-8").strip()
     return version_to_pep440(version)
 
 
 def read_requires() -> List[str]:
     cmd = [sys.executable, "tools/read-dependencies"]
-    deps = subprocess.check_output(cmd)  # nosec
+    deps = subprocess.check_output(cmd)  # nosec B603
     return deps.decode("utf-8").splitlines()

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -25,7 +25,7 @@ def pkg_config_read(library: str, var: str) -> str:
     }
     cmd = ["pkg-config", f"--variable={var}", library]
     try:
-        path = subprocess.check_output(cmd).decode("utf-8")
+        path = subprocess.check_output(cmd).decode("utf-8")  # nosec
         path = path.strip()
     except Exception:
         path = fallbacks[library][var]
@@ -53,12 +53,12 @@ def version_to_pep440(version: str) -> str:
 
 def get_version() -> str:
     cmd = [sys.executable, "tools/read-version"]
-    ver = subprocess.check_output(cmd)
+    ver = subprocess.check_output(cmd)  # nosec
     version = ver.decode("utf-8").strip()
     return version_to_pep440(version)
 
 
 def read_requires() -> List[str]:
     cmd = [sys.executable, "tools/read-dependencies"]
-    deps = subprocess.check_output(cmd)
+    deps = subprocess.check_output(cmd)  # nosec
     return deps.decode("utf-8").splitlines()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
chore: Handle all level 1 TiCS security violations

Ignore these bandit violations as we're not dealing with untrusted
input. Violations ignored in this commit are:
 B314: xml_bad_ElementTree
 B318: xml_bad_mindom
 B405: import_xml_etree
 B406: import_xml_sax
 B408: import_xml_minidom
 B603: subprocess_without_shell_equals_true
```

## Additional Context
This PR addresses all of the level 1 warnings at: https://canonical.tiobe.com/tiobeweb/TICS/ViolationsDashboard.html#axes=Project(cloud-init)&sort=T(4,worst)&x=Ap(type),Ap(rule),Ap(level),Ap(impactAtProject),Ap(impactAtScope),Ap(message)

(Link is Canonical only)

I attempted to add a bandit config to ignore certain warnings, but TiCS won't pick it up. We have to go line by line. 

As of right now, we're only concerned with Level 1 warnings. Running locally, I got this result:
```
SUMMARY
=======


Violations per rule
===================

 RULE ID                    | LEVEL |     # | DELTA | SYNOPSIS
----------------------------+-------+-------+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 BANDIT_PY_B103             |     2 |     1 |       | Setting bad file permissions.
 BANDIT_PY_B104             |     3 |    22 |    +1 | Binding to all network interfaces can potentially open up a service to traffic on unintended interfaces, that may not be properly documented or secured.
 BANDIT_PY_B105             |     2 |     4 |       | Possible hardcoded password in assigned variable or used in a comparison with a variable that looks like a password.
 BANDIT_PY_B107             |     2 |     1 |       | Possible hardcoded password.
 BANDIT_PY_B108             |     3 |     5 |       | Insecure usage of tmp file/directory.
 BANDIT_PY_B110             |     2 |    11 |       | Pass in the except block: Suppressing errors can be a potential security issue.
 BANDIT_PY_B112             |     2 |     1 |       | A continue in the except block: Suppressing errors can be a potential security issue.
 BANDIT_PY_B301             |     2 |     1 |       | Pickle and modules that wrap it can be unsafe when used to deserialize untrusted data.
 BANDIT_PY_B303             |     2 |     1 |       | Use of insecure MD2, MD4, MD5, or SHA1 hash function.
 BANDIT_PY_B311             |     5 |     3 |       | Standard pseudo-random generators are not suitable for security/cryptographic purposes.
 BANDIT_PY_B314             |     1 |     0 |    -4 | Using various XML methods (xml.etree.ElementTree.parse, xml.etree.ElementTree.iterparse, xml.etree.ElementTree.fromstring, xml.etree.ElementTree.XMLParser) to parse untrusted XML data is known to be vulnerable to XML attacks. Methods should be replaced with their defusedxml equivalents.
 BANDIT_PY_B318             |     1 |     0 |    -1 | Using various XML methods (xml.dom.minidom.parse, xml.dom.minidom.parseString) to parse untrusted XML data is known to be vulnerable to XML attacks. Methods should be replaced with their defusedxml equivalents.
 BANDIT_PY_B403             |     2 |     1 |       | Possible security implications associated with pickle modules (pickle, cPickle,dill, shelve).
 BANDIT_PY_B404             |     2 |     5 |    +1 | Consider possible security implications associated with subprocess modules.
 BANDIT_PY_B405             |     1 |     1 |    -1 | Using xml.sax to parse untrusted XML data is known to be vulnerable to XML attacks. Replace vulnerable imports with the equivalent defusedxml package, or make sure defusedxml.defuse_stdlib() is called.
 BANDIT_PY_B406             |     1 |     0 |    -1 | Using xml.sax to parse untrusted XML data is known to be vulnerable to XML attacks. Replace vulnerable imports with the equivalent defusedxml package, or make sure defusedxml.defuse_stdlib() is called.
 BANDIT_PY_B408             |     1 |     0 |    -1 | Using xml.dom.minidom to parse untrusted XML data is known to be vulnerable to XML attacks. Replace vulnerable imports with the equivalent defusedxml package, or make sure defusedxml.defuse_stdlib() is called.
 BANDIT_PY_B506             |     2 |     2 |       | Unsafe usage of the yaml.load function from the PyYAML package.
 BANDIT_PY_B602             |     5 |     4 |       | Subprocess call with shell=True seems safe, but may be changed in the future, consider rewriting without shell.
 BANDIT_PY_B603             |     1 |     0 |    -2 | Subprocess call - check for execution of untrusted input.
 BANDIT_PY_B604             |     2 |     6 |       | Method calls for the presence of a keyword parameter shell equalling true.
 COV_PY_RISKY_CRYPTO_PYTHON |     4 |     1 |       | A violation of user-specified RISKY_CRYPTO policy was detected.
----------------------------+-------+-------+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 TOTAL                      |       |    70 |    -8 |

```

Since this is all purely ignores, I see no reason to add the ruff-equivalent checks to CI yet. When we get to addressing real issues, those checks can be added then.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
