### PR TITLE
fix(ec2): Do not enable dhcp6 on EC2

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -1066,8 +1066,6 @@ def convert_ec2_metadata_network_config(
             "set-name": nic_name,
         }
         nic_metadata = macs_metadata.get(mac)
-        if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
-            dev_config["dhcp6"] = True
         netcfg["ethernets"][nic_name] = dev_config
         return netcfg
     # Apply network config for all nics and any secondary IPv4/v6 addresses
@@ -1114,8 +1112,6 @@ def convert_ec2_metadata_network_config(
                 table=table,
             )
         if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
-            dev_config["dhcp6"] = True
-            dev_config["dhcp6-overrides"] = dhcp_override
             if (
                 is_netplan
                 and nic_metadata.get("device-number")

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -460,7 +460,7 @@ class TestEc2(test_helpers.ResponsesTestCase):
                     "match": {"macaddress": "06:17:04:d7:26:09"},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": True,
+                    "dhcp6": False,
                 }
             },
         }
@@ -545,7 +545,7 @@ class TestEc2(test_helpers.ResponsesTestCase):
                         "2600:1f16:292:100:f153:12a3:c37c:11f9/128",
                     ],
                     "dhcp4": True,
-                    "dhcp6": True,
+                    "dhcp6": False,
                 }
             },
         }
@@ -625,7 +625,7 @@ class TestEc2(test_helpers.ResponsesTestCase):
                     "match": {"macaddress": mac1},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": True,
+                    "dhcp6": False,
                 }
             },
         }
@@ -1154,7 +1154,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                     "match": {"macaddress": self.mac1},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": True,
+                    "dhcp6": False,
                 }
             },
         }
@@ -1234,7 +1234,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                     "match": {"macaddress": self.mac1},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": True,
+                    "dhcp6": False,
                 }
             },
         }
@@ -1267,8 +1267,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                     "set-name": "eth9",
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": True,
-                    "dhcp6-overrides": {"route-metric": 100},
+                    "dhcp6": False,
                 },
                 "eth10": {
                     "match": {"macaddress": mac2},
@@ -1327,10 +1326,9 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                 "eth9": {
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": True,
+                    "dhcp6": False,
                     "match": {"macaddress": "06:17:04:d7:26:09"},
                     "set-name": "eth9",
-                    "dhcp6-overrides": {"route-metric": 100},
                 },
                 "eth10": {
                     "dhcp4": True,
@@ -1338,7 +1336,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                         "route-metric": 200,
                         "use-routes": True,
                     },
-                    "dhcp6": True,
+                    "dhcp6": False,
                     "match": {"macaddress": "06:17:04:d7:26:08"},
                     "set-name": "eth10",
                     "routes": [
@@ -1361,10 +1359,6 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                             "table": 101,
                         },
                     ],
-                    "dhcp6-overrides": {
-                        "route-metric": 200,
-                        "use-routes": True,
-                    },
                     "addresses": ["2600:1f16:292:100:f153:12a3:c37c:11f9/128"],
                 },
             },
@@ -1394,7 +1388,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                     "match": {"macaddress": self.mac1},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": True,
+                    "dhcp6": False,
                 }
             },
         }


### PR DESCRIPTION
## Proposed Commit Message
```
fix(ec2): Do not enable dhcp6 on EC2

When cloud-init finds any ipv6 information in the instance metadata, it
automatically enables dhcp6 for the network interface. However, this
brings up the instance with a broken IPv6 configuration because SLAAC
should be used for almost all situations on EC2.

Red Hat BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2092459
Fedora Pagure: https://pagure.io/cloud-sig/issue/382
Upstream: https://bugs.launchpad.net/cloud-init/+bug/1976526

Fixes: canonical/cloud-init#3980

Signed-off-by: Major Hayden <major@redhat.com>
```

## Additional Context

* Red Hat BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2092459
* Fedora Pagure: https://pagure.io/cloud-sig/issue/382

## Test Steps

1. Deploy an instance on AWS with a VPC attached that has IPv6 subnets
2. The instance should come online with an IPv6 address configured

## Checklist
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
