### PR TITLE
feat(ec2): Fetch metadata every boot

### DIFF
--- a/cloudinit/sources/DataSourceAliYun.py
+++ b/cloudinit/sources/DataSourceAliYun.py
@@ -23,6 +23,13 @@ class DataSourceAliYun(EC2.DataSourceEc2):
     min_metadata_version = "2016-01-01"
     extended_metadata_versions: List[str] = []
 
+    default_update_events = {
+        EventScope.NETWORK: {
+            EventType.BOOT_NEW_INSTANCE,
+            EventType.HOTPLUG,
+        }
+    }
+
     # Aliyun metadata server security enhanced mode overwrite
     @property
     def imdsv2_token_put_header(self):

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -108,6 +108,7 @@ class DataSourceEc2(sources.DataSource):
     default_update_events = {
         EventScope.NETWORK: {
             EventType.BOOT_NEW_INSTANCE,
+            EventType.BOOT,
             EventType.HOTPLUG,
         }
     }


### PR DESCRIPTION
WIP as I am manually running integration tests.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(ec2): Fetch metadata every boot

Following 7f87fa33, we'll setup networking first boot and also respond
to hotplug events, but if network is modified while an instance is
powered off, updates won't be visible to the instance upon next boot.

This commit ensures that on ec2, networking information is fetched
every boot.

Salesforce #00378972
```

## Additional Context
Ubuntu: This will be added to 24.04 but patched out of existing releases. The behavior can be manually enabled using update events.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
