### PR TITLE
[DISCUSSION] d/needrestart-cloud-init.conf: skip automated restarts of cloud-final

### DIFF
--- a/debian/needrestart-cloud-init.conf
+++ b/debian/needrestart-cloud-init.conf
@@ -1,0 +1,5 @@
+# Add a needrestart skip for cloud-final.service across APT upgrade operations.
+# This avoids SIGTERMs disrupting cloud-init before it is able to install
+# packages and/or setup PPAs. LP: #2059337
+#
+$nrconf{override_rc}->{qr(^cloud-final\.service$)} = 0;

--- a/debian/rules
+++ b/debian/rules
@@ -23,6 +23,7 @@ override_dh_auto_install:
 	install -D -m 0644 ./tools/21-cloudinit.conf debian/cloud-init/etc/rsyslog.d/21-cloudinit.conf
 	install -D ./tools/Z99-cloud-locale-test.sh debian/cloud-init/etc/profile.d/Z99-cloud-locale-test.sh
 	install -D ./tools/Z99-cloudinit-warnings.sh debian/cloud-init/etc/profile.d/Z99-cloudinit-warnings.sh
+	install -m 0644 -D debian/needrestart-cloud-init.conf debian/cloud-init/etc/needrestart/conf.d/cloud-init.conf
 	install -m 0644 -D debian/apport-general-hook.py debian/cloud-init/usr/share/apport/general-hooks/cloud-init.py
 	install -m 0644 -D debian/apport-launcher.py debian/cloud-init/usr/share/apport/package-hooks/cloud-init.py
 	flist=$$(find $(CURDIR)/debian/ -type f -name version.py) && sed -i 's,@@PACKAGED_VERSION@@,$(DEB_VERSION),' $${flist:-did-not-find-version-py-for-replacement}


### PR DESCRIPTION
Potential alternative to fixing upstream needrestart of downstream Ubuntu needrestart would be for cloud-init to deliver a conf file to skip automated restarts of cloud-final.service.

## Proposed Commit Message

```
d/needrestart-cloud-init.conf: skip automated restarts of cloud-final

Install /etc/needrestart/conf.d/cloud-init.conf which will avoid automated needrestart of cloud-final.service when apt-get dist-upgrade also triggers a cloud-init package upgrade. The SIGTERM for cloud-final from needrestart prevents cloud-init from installing any deb packages or PPA source configuration after it invokes apt-get dist-upgrade leaving the system in a partially conigured state.

LP:# 2059337
```

## Additional Context
Only Ubuntu Noble behaves this way per downstream Ubuntu modifications which put the needrestart mode into "autorestart" during non-interactive apt-get dist-upgrade calls that cloud-init executes.

https://bugs.launchpad.net/ubuntu/+source/needrestart/+bug/2059337

## Test Steps
```



## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
