### PR TITLE
Fix rename dhcpcd

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -839,11 +839,15 @@ def _rename_interfaces(
 
     if len(ops) + len(ups) == 0:
         if len(errors):
-            LOG.debug("unable to do any work for renaming of %s", renames)
+            LOG.warning(
+                "Unable to rename interfaces: %s due to errors: %s",
+                renames,
+                errors,
+            )
         else:
             LOG.debug("no work necessary for renaming of %s", renames)
     else:
-        LOG.debug("achieving renaming of %s with ops %s", renames, ops + ups)
+        LOG.debug("Renamed %s with ops %s", renames, ops + ups)
 
         for op, mac, new_name, params in ops + ups:
             try:

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -75,6 +75,7 @@ class EphemeralIPv4Network:
         # List of commands to run to cleanup state.
         self.cleanup_cmds: List[Callable] = []
         self.distro = distro
+        self.cidr = f"{self.ip}/{self.prefix}"
 
     def __enter__(self):
         """Perform ephemeral network setup if interface is not connected."""
@@ -122,15 +123,16 @@ class EphemeralIPv4Network:
 
     def _bringup_device(self):
         """Perform the ip commands to fully setup the device."""
-        cidr = "{0}/{1}".format(self.ip, self.prefix)
         LOG.debug(
             "Attempting setup of ephemeral network on %s with %s brd %s",
             self.interface,
-            cidr,
+            self.cidr,
             self.broadcast,
         )
         try:
-            self.distro.net_ops.add_addr(self.interface, cidr, self.broadcast)
+            self.distro.net_ops.add_addr(
+                self.interface, self.cidr, self.broadcast
+            )
         except ProcessExecutionError as e:
             if "File exists" not in str(e.stderr):
                 raise
@@ -150,7 +152,9 @@ class EphemeralIPv4Network:
                 )
             )
             self.cleanup_cmds.append(
-                partial(self.distro.net_ops.del_addr, self.interface, cidr)
+                partial(
+                    self.distro.net_ops.del_addr, self.interface, self.cidr
+                )
             )
 
     def _bringup_static_routes(self):
@@ -356,10 +360,22 @@ class EphemeralDHCPv4:
 class DhcpcdEphemeralIPv4Network(EphemeralIPv4Network):
     """dhcpcd sets up its own ephemeral network and routes"""
 
-    def __enter__(self):
-        return
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-    def __exit__(self, excp_type, excp_value, excp_traceback):
+        # clean up after dhcpcd
+        self.cleanup_cmds.append(
+            partial(
+                self.distro.net_ops.link_down,
+                self.interface,
+                family="inet",
+            )
+        )
+        self.cleanup_cmds.append(
+            partial(self.distro.net_ops.del_addr, self.interface, self.cidr)
+        )
+
+    def __enter__(self):
         return
 
 


### PR DESCRIPTION
## Proposed Commit Message

```
fix(dhcpcd): Interface rename
```

## Additional Context

I think that the issue that causes #5113 is that the rename code assumes that an interface will be down prior to attempting to rename. This was default behavior with isc-dhcp-client, but dhcpcd does IP assignment and link manipulation. This change works by bringing down the link and address, which will put the link into the same state that cloud-init's rename code expects.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
