### PR TITLE
feat(WSL): Add support for Ubuntu Pro configs

### DIFF
--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -7,7 +7,7 @@
 
 import logging
 import os
-import platform
+import typing
 from pathlib import PurePath
 from typing import Any, List, Optional, Tuple, Union, cast
 
@@ -296,7 +296,7 @@ class DataSourceWSL(sources.DataSource):
             return False
 
         # # Load Ubuntu Pro configs only on Ubuntu distros
-        if platform.freedesktop_os_release().get("NAME") == "Ubuntu":
+        if self.distro.name == "ubuntu":
             agent_data, user_data = load_ubuntu_pro_data(user_home)
 
         # Load regular user configs
@@ -327,7 +327,7 @@ class DataSourceWSL(sources.DataSource):
         # provides them instead.
         # That's the reason for not using util.mergemanydict().
         merged: dict = {}
-        overridden_keys: list[str] = []
+        overridden_keys: typing.List[str] = []
         if user_data:
             merged = user_data
         if agent_data:

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -25,27 +25,17 @@ LANDSCAPE_DATA_FILE = "%s.user-data"
 AGENT_DATA_FILE = "agent.yaml"
 
 
-def wsl_path_2_win(path: str) -> PurePath:
-    """
-    Translates a path inside the current WSL instance's filesystem to a
-    Windows accessible path.
-
-    Example:
-    # Running under an instance named "CoolInstance"
-    root = wslpath2win("/") # root == "//wsl.localhost/CoolInstance/"
-
-    :param path: string representing a Linux path, whether existing or not.
-    """
-    out, _ = subp.subp([WSLPATH_CMD, "-am", path])
-    return PurePath(out.rstrip())
-
-
 def instance_name() -> str:
     """
     Returns the name of the current WSL instance as seen from outside.
     """
-    root_net_path = wsl_path_2_win("/")
-    return root_net_path.name
+    # Translates a path inside the current WSL instance's filesystem to a
+    # Windows accessible path.
+    # Example:
+    # Running under an instance named "CoolInstance"
+    # WSLPATH_CMD -am "/" == "//wsl.localhost/CoolInstance/"
+    root_net_path, _ = subp.subp([WSLPATH_CMD, "-am", "/"])
+    return PurePath(root_net_path.rstrip()).name
 
 
 def mounted_win_drives() -> List[str]:

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -324,15 +324,25 @@ class DataSourceWSL(sources.DataSource):
         # iterate over the top level keys and write over them if the agent
         # provides them instead.
         # That's the reason for not using util.mergemanydict().
-        merged = {}
+        merged: dict = {}
+        overridden_keys: list[str] = []
         if user_data:
-            for key in user_data:
-                merged[key] = user_data[key]
+            merged = user_data
         if agent_data:
+            if user_data:
+                LOG.debug("Merging both user_data and agent.yaml configs.")
             for key in agent_data:
+                if key in merged:
+                    overridden_keys.append(key)
                 merged[key] = agent_data[key]
+            if overridden_keys:
+                LOG.debug(
+                    (
+                        " agent.yaml overrides config keys: "
+                        ", ".join(overridden_keys)
+                    )
+                )
 
-        LOG.debug("Merged data: %s", merged)
         self.userdata_raw = "#cloud-config\n%s" % yaml.dump(merged)
         return True
 

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -141,18 +141,6 @@ def cloud_init_data_dir(user_home: PurePath) -> Optional[PurePath]:
     return PurePath(seed_dir)
 
 
-def ubuntu_pro_data_dir(user_home: PurePath) -> Optional[PurePath]:
-    """
-    Get the path to the Ubuntu Pro cloud-init directory, or None if not found.
-    """
-    pro_dir = os.path.join(user_home, ".ubuntupro/.cloud-init")
-    if not os.path.isdir(pro_dir):
-        LOG.debug("Pro cloud-init dir %s was not found", pro_dir)
-        return None
-
-    return PurePath(pro_dir)
-
-
 def candidate_user_data_file_names(instance_name) -> List[str]:
     """
     Return a list of candidate file names that may contain user-data

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -7,6 +7,7 @@
 
 import logging
 import os
+import platform
 from pathlib import PurePath
 from typing import Any, List, Optional, Tuple, Union, cast
 
@@ -294,8 +295,9 @@ class DataSourceWSL(sources.DataSource):
             LOG.error("Unable to load metadata: %s", str(err))
             return False
 
-        # Load Ubuntu Pro configs
-        agent_data, user_data = load_ubuntu_pro_data(user_home)
+        # # Load Ubuntu Pro configs only on Ubuntu distros
+        if platform.freedesktop_os_release().get("NAME") == "Ubuntu":
+            agent_data, user_data = load_ubuntu_pro_data(user_home)
 
         # Load regular user configs
         try:

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -8,7 +8,8 @@
 import logging
 import os
 from pathlib import PurePath
-from typing import List, cast
+from typing import List
+
 import yaml
 
 from cloudinit import sources, subp, util
@@ -213,10 +214,12 @@ def load_instance_metadata(cloudinitdir: PurePath, instance_name: str) -> dict:
     return metadata
 
 
-def load_landscape_data(instance_name: str, user_home: str) -> dict | bytes | None:
+def load_landscape_data(
+    instance_name: str, user_home: str
+) -> dict | bytes | None:
     """
     Load Landscape config data into a dict, returning an empty dict if nothing
-    is found. If the file is not a YAML, returns the binary file.
+    is found. If the file is not a YAML, returns the raw binary file contents.
     """
     data_dir = ubuntu_pro_data_dir(user_home)
     if data_dir is None:
@@ -241,7 +244,8 @@ def load_landscape_data(instance_name: str, user_home: str) -> dict | bytes | No
 
 def load_agent_data(user_home: str) -> dict | bytes:
     """
-    Load agent.yaml data into a dict, returning an empty dict if nothing is found. If the file is not a YAML, returns the binary file.
+    Load agent.yaml data into a dict, returning an empty dict if nothing is
+    found. If the file is not a YAML, returns the raw binary file contents.
     """
     data_dir = ubuntu_pro_data_dir(user_home)
     if data_dir is None:
@@ -342,12 +346,16 @@ class DataSourceWSL(sources.DataSource):
                 if os.path.exists(file.as_posix()):
                     bin_user_data = util.load_binary_file(file.as_posix())
                     user_data = util.load_yaml(bin_user_data)
-                    user_data = bin_user_data if user_data is None else user_data
+                    user_data = (
+                        bin_user_data if user_data is None else user_data
+                    )
 
         except (ValueError, IOError) as err:
             LOG.error("Unable to load user data: %s", str(err))
 
-        should_list = isinstance(agent_data, bytes) or isinstance(user_data, bytes)
+        should_list = isinstance(agent_data, bytes) or isinstance(
+            user_data, bytes
+        )
         if should_list:
             self.userdata_raw = [user_data, agent_data]
             return True

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -204,7 +204,9 @@ def load_yaml_or_bin(data_path: str) -> dict | bytes | None:
 DEFAULT_INSTANCE_ID = "iid-datasource-wsl"
 
 
-def load_instance_metadata(cloudinitdir: PurePath | None, instance_name: str) -> dict:
+def load_instance_metadata(
+    cloudinitdir: PurePath | None, instance_name: str
+) -> dict:
     """
     Returns the relevant metadata loaded from cloudinit dir based on the
     instance name
@@ -386,7 +388,7 @@ class DataSourceWSL(sources.DataSource):
                 merged[key] = agent_data[key]
 
         LOG.debug("Merged data: %s", merged)
-        self.userdata_raw = yaml.dump(merged)
+        self.userdata_raw = "#cloud-config\n%s" % yaml.dump(merged)
         return True
 
 

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -284,7 +284,6 @@ class DataSourceWSL(sources.DataSource):
 
         seed_dir = cloud_init_data_dir(user_home)
         user_data: Optional[Union[dict, bytes]] = None
-        requires_multipart = False
 
         # Load any metadata
         try:
@@ -312,16 +311,12 @@ class DataSourceWSL(sources.DataSource):
 
         # No configs were found
         if not any([user_data, agent_data]):
-            self.userdata_raw = None
             return False
 
         # If we cannot reliably model data files as dicts, then we cannot merge
         # ourselves, so we can pass the data in ascending order as a list for
         # cloud-init to handle internally
-        requires_multipart = isinstance(agent_data, bytes) or isinstance(
-            user_data, bytes
-        )
-        if requires_multipart:
+        if isinstance(agent_data, bytes) or isinstance(user_data, bytes):
             self.userdata_raw = cast(Any, [user_data, agent_data])
             return True
 

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -216,7 +216,7 @@ class DataSourceWSL(sources.DataSource):
 
     def __init__(self, sys_cfg, distro: Distro, paths: Paths, ud_proc=None):
         super().__init__(sys_cfg, distro, paths, ud_proc)
-        self.instance_name = instance_name()
+        self.instance_name = ""
 
     def find_user_data_file(self, seed_dir: PurePath) -> PurePath:
         """
@@ -257,7 +257,7 @@ class DataSourceWSL(sources.DataSource):
 
         try:
             data_dir = cloud_init_data_dir(find_home())
-            metadata = load_instance_metadata(data_dir, self.instance_name)
+            metadata = load_instance_metadata(data_dir, instance_name())
             return current == metadata.get("instance-id")
 
         except (IOError, ValueError) as err:
@@ -268,8 +268,7 @@ class DataSourceWSL(sources.DataSource):
             return False
 
     def _get_data(self) -> bool:
-        self.vendordata_raw = None
-        user_home = find_home()
+        self.instance_name = instance_name()
         seed_dir = cloud_init_data_dir(user_home)
         user_data: Optional[Union[dict, bytes]] = None
         requires_multipart = False

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -104,7 +104,7 @@ def cmd_executable() -> PurePath:
     )
 
 
-def find_home() -> str:
+def find_home() -> PurePath:
     """
     Finds the user's home directory path.
     """
@@ -120,10 +120,10 @@ def find_home() -> str:
         raise subp.ProcessExecutionError(
             "No output from cmd.exe to show the user profile dir."
         )
-    return home
+    return PurePath(home)
 
 
-def cloud_init_data_dir(user_home: str) -> PurePath:
+def cloud_init_data_dir(user_home: PurePath) -> PurePath:
     """
     Returns the Windows user profile directory translated as a Linux path
     accessible inside the current WSL instance.
@@ -136,7 +136,7 @@ def cloud_init_data_dir(user_home: str) -> PurePath:
     return PurePath(seed_dir)
 
 
-def ubuntu_pro_data_dir(user_home: str) -> PurePath | None:
+def ubuntu_pro_data_dir(user_home: PurePath) -> PurePath | None:
     """
     Get the path to the Ubuntu Pro cloud-init directory, or None if not found.
     """
@@ -314,7 +314,7 @@ class DataSourceWSL(sources.DataSource):
 
         try:
             metadata = load_instance_metadata(
-                cloud_init_data_dir(), self.instance_name
+                cloud_init_data_dir(find_home()), self.instance_name
             )
             return current == metadata.get("instance-id")
 

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -49,7 +49,25 @@ User data can be supplied in any
 :ref:`format supported by cloud-init<user_data_formats>`, such as YAML
 cloud-config files or shell scripts. At runtime, the WSL datasource looks for
 user data in the following locations inside the Windows host filesystem, in the
-order specified below:
+order specified below.
+
+First, configurations from Ubuntu Pro/Landscape are checked for in the
+following paths:
+
+1. ``%USERPROFILE%\.ubuntupro\.cloud-init\<InstanceName>.user-data`` holds data
+   provided by Landscape to configure a specific WSL instance. If this file
+   is present, normal user-provided configurations are not looked for. This
+   file is merged with (2) on a per-module basis. If this file is not present,
+   then the first user-provided configuration will be used in its place.
+
+2. ``%USERPROFILE%\.ubuntupro\.cloud-init\agent.yaml`` holds data provided by
+   the Ubuntu Pro for WSL agent. If this file is present, it's modules will be
+   merged with (1), overriding any conflicting modules. If (1) is not provided,
+   then this file will be merged with any valid user-provided configuration
+   instead.
+
+Then, if a file from (1) is not found, a user-provided configuration will be
+looked for instead in the following order:
 
 1. ``%USERPROFILE%\.cloud-init\<InstanceName>.user-data`` holds user data for a
    specific instance configuration. The datasource resolves the name attributed
@@ -82,7 +100,8 @@ Only the first match is loaded, and no config merging is done, even in the
 presence of errors. That avoids unexpected behaviour due to surprising merge
 scenarios. Also, notice that the file name casing is irrelevant since both the
 Windows file names, as well as the WSL distro names, are case-insensitive by
-default. If none are found, cloud-init remains disabled.
+default. If none are found, cloud-init remains disabled if no other
+configurations from previous steps were found.
 
 .. note::
    Some users may have configured case sensitivity for file names on Windows.
@@ -205,4 +224,3 @@ include file.
   WSL automatically generates those files by default, unless configured to
   behave otherwise in ``/etc/wsl.conf``. Overwriting may work, but only
   until the next reboot.
-

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -61,7 +61,7 @@ following paths:
    then the first user-provided configuration will be used in its place.
 
 2. ``%USERPROFILE%\.ubuntupro\.cloud-init\agent.yaml`` holds data provided by
-   the Ubuntu Pro for WSL agent. If this file is present, it's modules will be
+   the Ubuntu Pro for WSL agent. If this file is present, its modules will be
    merged with (1), overriding any conflicting modules. If (1) is not provided,
    then this file will be merged with any valid user-provided configuration
    instead.

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -483,6 +483,6 @@ package_update: true"""
             " nor ignored"
         )
         assert "landscape" in userdata
-        assert "landscapetest" not in userdata and "agenttest" in userdata, (
-            "Landscape account name should have been overriden by agent data"
-        )
+        assert (
+            "landscapetest" not in userdata and "agenttest" in userdata
+        ), "Landscape account name should have been overriden by agent data"

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -4,9 +4,9 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 import logging
+import os
 from copy import deepcopy
 from email.mime.multipart import MIMEMultipart
-import os
 from pathlib import PurePath
 from typing import cast
 
@@ -369,9 +369,6 @@ class TestWSLDataSource:
 
         generic_file = tmpdir.join(".cloud-init", "default.user-data")
         generic_file.write("#cloud-config\npackages:\n- g++-13\n")
-
-        another_file = tmpdir.join(".cloud-iniawdawdawdawdawdt", "default.user-data")
-        another_file.write("#cloud-config\npackages:\n- g++-13\n")
 
         ubuntu_pro_tmp = tmpdir.join(".ubuntupro", ".cloud-init")
         os.makedirs(ubuntu_pro_tmp, exist_ok=True)

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1183,14 +1183,27 @@ class TestWSL(DsIdentifyBase):
         """Negative test by lack of host filesystem mount points."""
         self._test_ds_not_found("WSL-no-host-mounts")
 
-    def test_no_cloudinitdir(self):
-        """Negative test by not finding %USERPROFILE%/.cloud-init."""
+    def test_no_userprofile(self):
+        """Negative test by failing to read the %USERPROFILE% environment variable."""
         data = copy.deepcopy(VALID_CFG["WSL-supported"])
         data["mocks"].append(
             {
-                "name": "WSL_cloudinit_dir_in",
-                "ret": 1,
-                "RET": "",
+                "name": "WSL_run_cmd",
+                "ret": 0,
+                "RET": "\r\n",
+            },
+        )
+        return self._check_via_dict(data, RC_NOT_FOUND)
+
+    def test_no_cloudinitdir_in_userprofile(self):
+        """Negative test by not finding %USERPROFILE%/.cloud-init."""
+        data = copy.deepcopy(VALID_CFG["WSL-supported"])
+        userprofile = self.tmp_dir()
+        data["mocks"].append(
+            {
+                "name": "WSL_profile_dir",
+                "ret": 0,
+                "RET": userprofile,
             },
         )
         return self._check_via_dict(data, RC_NOT_FOUND)
@@ -1198,27 +1211,56 @@ class TestWSL(DsIdentifyBase):
     def test_empty_cloudinitdir(self):
         """Negative test by lack of host filesystem mount points."""
         data = copy.deepcopy(VALID_CFG["WSL-supported"])
-        cloudinitdir = self.tmp_dir()
+        userprofile = self.tmp_dir()
         data["mocks"].append(
             {
-                "name": "WSL_cloudinit_dir_in",
+                "name": "WSL_profile_dir",
                 "ret": 0,
-                "RET": cloudinitdir,
+                "RET": userprofile,
             },
         )
+        cloudinitdir = os.path.join(userprofile, ".cloud-init")
+        os.mkdir(cloudinitdir)
         return self._check_via_dict(data, RC_NOT_FOUND)
+
+    def test_found_fail_due_instance_name_parsing(self):
+        """WLS datasource detection fail due parsing error even though the file exists."""
+        data = copy.deepcopy(VALID_CFG["WSL-supported-debian"])
+        userprofile = self.tmp_dir()
+        data["mocks"].append(
+            {
+                "name": "WSL_profile_dir",
+                "ret": 0,
+                "RET": userprofile,
+            },
+        )
+
+        # Forcing WSL_linux2win_path to return a path we'll fail to parse
+        # (missing one / in the begining of the path).
+        for i, m in enumerate(data["mocks"]):
+            if m["name"] == "WSL_linux2win_path":
+                data["mocks"][i]["RET"] = "/wsl.localhost/cant-findme"
+
+        cloudinitdir = os.path.join(userprofile, ".cloud-init")
+        os.mkdir(cloudinitdir)
+        filename = os.path.join(cloudinitdir, "cant-findme.user-data")
+        Path(filename).touch()
+        self._check_via_dict(data, RC_NOT_FOUND)
+        Path(filename).unlink()
 
     def test_found_via_userdata_version_codename(self):
         """WLS datasource detected by VERSION_CODENAME when no VERSION_ID"""
         data = copy.deepcopy(VALID_CFG["WSL-supported-debian"])
-        cloudinitdir = self.tmp_dir()
+        userprofile = self.tmp_dir()
         data["mocks"].append(
             {
-                "name": "WSL_cloudinit_dir_in",
+                "name": "WSL_profile_dir",
                 "ret": 0,
-                "RET": cloudinitdir,
+                "RET": userprofile,
             },
         )
+        cloudinitdir = os.path.join(userprofile, ".cloud-init")
+        os.mkdir(cloudinitdir)
         filename = os.path.join(cloudinitdir, "debian-trixie.user-data")
         Path(filename).touch()
         self._check_via_dict(data, RC_FOUND, dslist=[data.get("ds"), DS_NONE])
@@ -1229,15 +1271,25 @@ class TestWSL(DsIdentifyBase):
         WSL datasource is found on applicable userdata files in cloudinitdir.
         """
         data = copy.deepcopy(VALID_CFG["WSL-supported"])
-        cloudinitdir = self.tmp_dir()
+        userprofile = self.tmp_dir()
         data["mocks"].append(
             {
-                "name": "WSL_cloudinit_dir_in",
+                "name": "WSL_profile_dir",
                 "ret": 0,
-                "RET": cloudinitdir,
+                "RET": userprofile,
             },
         )
+        cloudinitdir = os.path.join(userprofile, ".cloud-init")
+        os.mkdir(cloudinitdir)
+        up4wcloudinitdir = os.path.join(userprofile, ".ubuntupro/.cloud-init")
+        os.makedirs(up4wcloudinitdir, exist_ok=True)
         userdata_files = [
+            os.path.join(
+                up4wcloudinitdir, MOCK_WSL_INSTANCE_DATA["name"] + ".user-data"
+            ),
+             os.path.join(
+                up4wcloudinitdir, "agent.yaml"
+            ),
             os.path.join(
                 cloudinitdir, MOCK_WSL_INSTANCE_DATA["name"] + ".user-data"
             ),
@@ -2362,9 +2414,9 @@ VALID_CFG = {
             MOCK_VIRT_IS_WSL,
             MOCK_UNAME_IS_WSL,
             {
-                "name": "WSL_instance_name",
+                "name": "WSL_linux2win_path",
                 "ret": 0,
-                "RET": MOCK_WSL_INSTANCE_DATA["name"],
+                "RET": "//wsl.localhost/%s/" % MOCK_WSL_INSTANCE_DATA["name"],
             },
         ],
         "files": {
@@ -2385,9 +2437,9 @@ VALID_CFG = {
             MOCK_VIRT_IS_WSL,
             MOCK_UNAME_IS_WSL,
             {
-                "name": "WSL_instance_name",
+                "name": "WSL_linux2win_path",
                 "ret": 0,
-                "RET": MOCK_WSL_INSTANCE_DATA["name"],
+                "RET": "//wsl.localhost/%s/" % MOCK_WSL_INSTANCE_DATA["name"],
             },
         ],
         "files": {

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1184,7 +1184,9 @@ class TestWSL(DsIdentifyBase):
         self._test_ds_not_found("WSL-no-host-mounts")
 
     def test_no_userprofile(self):
-        """Negative test by failing to read the %USERPROFILE% environment variable."""
+        """Negative test by failing to read the %USERPROFILE% environment
+        variable.
+        """
         data = copy.deepcopy(VALID_CFG["WSL-supported"])
         data["mocks"].append(
             {
@@ -1224,7 +1226,9 @@ class TestWSL(DsIdentifyBase):
         return self._check_via_dict(data, RC_NOT_FOUND)
 
     def test_found_fail_due_instance_name_parsing(self):
-        """WSL datasource detection fail due parsing error even though the file exists."""
+        """WSL datasource detection fail due parsing error even though the file
+        exists.
+        """
         data = copy.deepcopy(VALID_CFG["WSL-supported-debian"])
         userprofile = self.tmp_dir()
         data["mocks"].append(
@@ -1287,9 +1291,7 @@ class TestWSL(DsIdentifyBase):
             os.path.join(
                 up4wcloudinitdir, MOCK_WSL_INSTANCE_DATA["name"] + ".user-data"
             ),
-             os.path.join(
-                up4wcloudinitdir, "agent.yaml"
-            ),
+            os.path.join(up4wcloudinitdir, "agent.yaml"),
             os.path.join(
                 cloudinitdir, MOCK_WSL_INSTANCE_DATA["name"] + ".user-data"
             ),

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -2416,7 +2416,7 @@ VALID_CFG = {
             MOCK_VIRT_IS_WSL,
             MOCK_UNAME_IS_WSL,
             {
-                "name": "WSL_linux2win_path",
+                "name": "WSL_path",
                 "ret": 0,
                 "RET": "//wsl.localhost/%s/" % MOCK_WSL_INSTANCE_DATA["name"],
             },
@@ -2439,7 +2439,7 @@ VALID_CFG = {
             MOCK_VIRT_IS_WSL,
             MOCK_UNAME_IS_WSL,
             {
-                "name": "WSL_linux2win_path",
+                "name": "WSL_path",
                 "ret": 0,
                 "RET": "//wsl.localhost/%s/" % MOCK_WSL_INSTANCE_DATA["name"],
             },

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -1224,7 +1224,7 @@ class TestWSL(DsIdentifyBase):
         return self._check_via_dict(data, RC_NOT_FOUND)
 
     def test_found_fail_due_instance_name_parsing(self):
-        """WLS datasource detection fail due parsing error even though the file exists."""
+        """WSL datasource detection fail due parsing error even though the file exists."""
         data = copy.deepcopy(VALID_CFG["WSL-supported-debian"])
         userprofile = self.tmp_dir()
         data["mocks"].append(
@@ -1249,7 +1249,7 @@ class TestWSL(DsIdentifyBase):
         Path(filename).unlink()
 
     def test_found_via_userdata_version_codename(self):
-        """WLS datasource detected by VERSION_CODENAME when no VERSION_ID"""
+        """WSL datasource detected by VERSION_CODENAME when no VERSION_ID"""
         data = copy.deepcopy(VALID_CFG["WSL-supported-debian"])
         userprofile = self.tmp_dir()
         data["mocks"].append(

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -16,6 +16,7 @@ andrewlukoshko
 ani-sinha
 antonyc
 apollo13
+ashuntu
 aswinrajamannar
 bdrung
 beantaxi

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1597,18 +1597,19 @@ dscheck_VMware() {
 WSL_cloudinit_dir_in() {
     _RET=""
     local cmdexe="" cloudinitdir="" val=""
-    for m in "$@"; do
-        cmdexe="$m/Windows/System23/cmd.exe"
+    for m in $@; do
+        cmdexe="$m/Windows/System32/cmd.exe"
         if command -v "$cmdexe" > /dev/null 2>&1; then
             # Here WSL's proprietary `/init` is used to start the Windows cmd.exe
             # to output the Windows user profile directory path, which is
             # held by the environment variable %USERPROFILE%.
             cloudinitdir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
+            cloudinitdir="${cloudinitdir%%[[:cntrl:]]}"
             if [ -n "$cloudinitdir" ]; then
                 # wslpath is a program supplied by WSL itself that translates Windows and Linux paths,
                 # respecting the mountpoints where the Windows drives are mounted.
                 # (in fact it's a symlink to /init).
-                val=$(wslpath -au "$cloudinitdir") && _RET="$val"
+                val=$(wslpath -au "$cloudinitdir/.cloud-init/") && _RET="$val"
                 return $?
             fi
         fi

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1623,8 +1623,7 @@ WSL_profile_dir() {
             # to output the Windows user profile directory path, which is
             # held by the environment variable %USERPROFILE%.
             WSL_run_cmd "echo %USERPROFILE%"
-            profiledir="{$_RET}"
-            profiledir="${profiledir%%[[:cntrl:]]}"
+            profiledir="${_RET%%[[:cntrl:]]}"
             if [ -n "$profiledir" ]; then
                 # wslpath is a program supplied by WSL itself that translates Windows and Linux paths,
                 # respecting the mountpoints where the Windows drives are mounted.

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1607,9 +1607,9 @@ WSL_linux2win_path() {
 }
 
 WSL_run_cmd() {
-    local val=""
-    val=$(/init "$cmdexe" /c "$@" 2>/dev/null)
-    _RET="$val"
+    local val="" exepath="$1"
+    shift
+    _RET=$(/init "$exepath" /c "$@" 2>/dev/null)
 }
 
 WSL_profile_dir() {
@@ -1623,7 +1623,7 @@ WSL_profile_dir() {
             # Here WSL's proprietary `/init` is used to start the Windows cmd.exe
             # to output the Windows user profile directory path, which is
             # held by the environment variable %USERPROFILE%.
-            WSL_run_cmd "echo %USERPROFILE%"
+            WSL_run_cmd "$cmdexe" "echo %USERPROFILE%"
             profiledir="${_RET%%[[:cntrl:]]}"
             if [ -n "$profiledir" ]; then
                 # wslpath is a program supplied by WSL itself that translates Windows and Linux paths,

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1642,7 +1642,9 @@ WSL_instance_name() {
     local val="" instance_name=""
     WSL_linux2win_path "/"
     instance_name="${_RET}"
+    # Extracts "Ubuntu/" from "//wsl.localhost/Ubuntu/"
     val="${instance_name#//*/}"
+    # Extracts "Ubuntu" from "Ubuntu/"
     _RET="${val%/}"
 }
 

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1594,15 +1594,9 @@ dscheck_VMware() {
     return "${DS_NOT_FOUND}"
 }
 
-WSL_win2linux_path() {
-    local val=""
-    val="$(wslpath -au "$1" )"
-    _RET="$val"
-}
-
-WSL_linux2win_path() {
-    local val=""
-    val="$(wslpath -am "$1" )"
+WSL_path() {
+    local params="$1" path="$2" val=""
+    val="$(wslpath "$params" "$1")"
     _RET="$val"
 }
 
@@ -1629,7 +1623,7 @@ WSL_profile_dir() {
                 # wslpath is a program supplied by WSL itself that translates Windows and Linux paths,
                 # respecting the mountpoints where the Windows drives are mounted.
                 # (in fact it's a symlink to /init).
-                WSL_win2linux_path "$profiledir"
+                WSL_path "-au" "$profiledir"
                 return $?
             fi
         fi
@@ -1640,7 +1634,7 @@ WSL_profile_dir() {
 
 WSL_instance_name() {
     local val="" instance_name=""
-    WSL_linux2win_path "/"
+    WSL_path "-am" "/"
     instance_name="${_RET}"
     # Extracts "Ubuntu/" from "//wsl.localhost/Ubuntu/"
     val="${instance_name#//*/}"

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1618,6 +1618,31 @@ WSL_cloudinit_dir_in() {
     return 1
 }
 
+WSL_profile_dir() {
+    # Determine where a suitable user profile home is located
+    _RET=""
+    local cmdexe="" profiledir="" val=""
+    for m in $@; do
+        cmdexe="$m/Windows/System32/cmd.exe"
+        if command -v "$cmdexe" > /dev/null 2>&1; then
+            # Here WSL's proprietary `/init` is used to start the Windows cmd.exe
+            # to output the Windows user profile directory path, which is
+            # held by the environment variable %USERPROFILE%.
+            profiledir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
+            profiledir="${profiledir%%[[:cntrl:]]}"
+            if [ -n "$profiledir" ]; then
+                # wslpath is a program supplied by WSL itself that translates Windows and Linux paths,
+                # respecting the mountpoints where the Windows drives are mounted.
+                # (in fact it's a symlink to /init).
+                val=$(wslpath -au "$profiledir") && _RET="$val"
+                return $?
+            fi
+        fi
+    done
+
+    return 1
+}
+
 WSL_instance_name() {
     local val="" instance_name=""
     instance_name=$(wslpath -am /)
@@ -1649,25 +1674,42 @@ dscheck_WSL() {
     fi
 
     # We know we are under WSL and have acess to the host filesystem,
-    # so let's find the .cloud-init directory
-    WSL_cloudinit_dir_in "$mountpoints"
-    cloudinitdir="${_RET}"
-    if [ -z "$cloudinitdir" ]; then
-        debug 1 "%USERPROFILE/.cloud-init/ directory not found"
+    # so let's find the user's home directory
+    WSL_profile_dir "$mountpoints"
+    profile_dir="${_RET}"
+    if [ -z "$profile_dir" ]; then
+        debug 1 "%USERPROFILE% directory not found"
         return "${DS_NOT_FOUND}"
     fi
 
-    # and the applicable userdata file. Notice the ordering in the for-loop
-    # must match our expected precedence, so the file we find is what the
-    # datasource must process.
+    # Then we can check for any .cloud-init folders for the user
+    if [ ! -d "$profile_dir/.cloud-init/" ] && [ ! -d "$profile_dir/.ubuntupro/.cloud-init/" ]; then
+        debug 1 "No .cloud-init directories found"
+        return "${DS_NOT_FOUND}"
+    fi
+
     WSL_instance_name
     instance_name="${_RET}"
     # shellcheck source=/dev/null
     . "${PATH_ROOT}/etc/os-release"
+
+    # and the applicable userdata file. Notice the ordering in the for-loop
+    # must match our expected precedence, so the file we find is what the
+    # datasource must process.
+    cloudinitdir="$profile_dir/.cloud-init"
     for userdatafile in "${instance_name}.user-data" "${ID:-linux}-${VERSION_ID:-${VERSION_CODENAME}}".user-data "${ID:-linux}-all.user-data" "default.user-data"; do
         candidate="$cloudinitdir/$userdatafile"
         if [ -f "$candidate" ]; then
             debug 1 "Found applicable user data file for this instance at: $candidate"
+            return ${DS_FOUND}
+        fi
+    done
+
+    cloudinitdir="$profile_dir/.ubuntupro/.cloud-init"
+    for userdatafile in "${instance_name}.user-data" "agent.yaml"; do
+        candidate="$cloudinitdir/$userdatafile"
+        if [ -f "$candidate" ]; then
+            debug 1 "Found applicable pro data file for this instance at: $candidate"
             return ${DS_FOUND}
         fi
     done

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1689,6 +1689,7 @@ dscheck_WSL() {
     # must match our expected precedence, so the file we find is what the
     # datasource must process.
     # We only care about ubuntupro configs if the distro is an Ubuntu distro.
+    # shellcheck disable=SC2153
     if [ "$NAME" = "Ubuntu" ]; then
         cloudinitdir="$profile_dir/.ubuntupro/.cloud-init"
         for userdatafile in "${instance_name}.user-data" "agent.yaml"; do

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1594,28 +1594,22 @@ dscheck_VMware() {
     return "${DS_NOT_FOUND}"
 }
 
-WSL_cloudinit_dir_in() {
-    _RET=""
-    local cmdexe="" cloudinitdir="" val=""
-    for m in $@; do
-        cmdexe="$m/Windows/System32/cmd.exe"
-        if command -v "$cmdexe" > /dev/null 2>&1; then
-            # Here WSL's proprietary `/init` is used to start the Windows cmd.exe
-            # to output the Windows user profile directory path, which is
-            # held by the environment variable %USERPROFILE%.
-            cloudinitdir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
-            cloudinitdir="${cloudinitdir%%[[:cntrl:]]}"
-            if [ -n "$cloudinitdir" ]; then
-                # wslpath is a program supplied by WSL itself that translates Windows and Linux paths,
-                # respecting the mountpoints where the Windows drives are mounted.
-                # (in fact it's a symlink to /init).
-                val=$(wslpath -au "$cloudinitdir/.cloud-init/") && _RET="$val"
-                return $?
-            fi
-        fi
-    done
+WSL_win2linux_path() {
+    local val=""
+    val="$(wslpath -au "$1" )"
+    _RET="$val"
+}
 
-    return 1
+WSL_linux2win_path() {
+    local val=""
+    val="$(wslpath -am "$1" )"
+    _RET="$val"
+}
+
+WSL_run_cmd() {
+    local val=""
+    val=$(/init "$cmdexe" /c "$@" 2>/dev/null)
+    _RET="$val"
 }
 
 WSL_profile_dir() {
@@ -1628,13 +1622,14 @@ WSL_profile_dir() {
             # Here WSL's proprietary `/init` is used to start the Windows cmd.exe
             # to output the Windows user profile directory path, which is
             # held by the environment variable %USERPROFILE%.
-            profiledir=$(/init "$cmdexe" /c echo %USERPROFILE% 2>/dev/null)
+            WSL_run_cmd "echo %USERPROFILE%"
+            profiledir="{$_RET}"
             profiledir="${profiledir%%[[:cntrl:]]}"
             if [ -n "$profiledir" ]; then
                 # wslpath is a program supplied by WSL itself that translates Windows and Linux paths,
                 # respecting the mountpoints where the Windows drives are mounted.
                 # (in fact it's a symlink to /init).
-                val=$(wslpath -au "$profiledir") && _RET="$val"
+                WSL_win2linux_path "$profiledir"
                 return $?
             fi
         fi
@@ -1645,9 +1640,10 @@ WSL_profile_dir() {
 
 WSL_instance_name() {
     local val="" instance_name=""
-    instance_name=$(wslpath -am /)
-    val="${instance_name##*/}"
-    _RET="${val}"
+    WSL_linux2win_path "/"
+    instance_name="${_RET}"
+    val="${instance_name#//*/}"
+    _RET="${val%/}"
 }
 
 dscheck_WSL() {
@@ -1696,20 +1692,20 @@ dscheck_WSL() {
     # and the applicable userdata file. Notice the ordering in the for-loop
     # must match our expected precedence, so the file we find is what the
     # datasource must process.
-    cloudinitdir="$profile_dir/.cloud-init"
-    for userdatafile in "${instance_name}.user-data" "${ID:-linux}-${VERSION_ID:-${VERSION_CODENAME}}".user-data "${ID:-linux}-all.user-data" "default.user-data"; do
-        candidate="$cloudinitdir/$userdatafile"
-        if [ -f "$candidate" ]; then
-            debug 1 "Found applicable user data file for this instance at: $candidate"
-            return ${DS_FOUND}
-        fi
-    done
-
     cloudinitdir="$profile_dir/.ubuntupro/.cloud-init"
     for userdatafile in "${instance_name}.user-data" "agent.yaml"; do
         candidate="$cloudinitdir/$userdatafile"
         if [ -f "$candidate" ]; then
             debug 1 "Found applicable pro data file for this instance at: $candidate"
+            return ${DS_FOUND}
+        fi
+    done
+
+    cloudinitdir="$profile_dir/.cloud-init"
+    for userdatafile in "${instance_name}.user-data" "${ID:-linux}-${VERSION_ID:-${VERSION_CODENAME}}.user-data" "${ID:-linux}-all.user-data" "default.user-data"; do
+        candidate="$cloudinitdir/$userdatafile"
+        if [ -f "$candidate" ]; then
+            debug 1 "Found applicable user data file for this instance at: $candidate"
             return ${DS_FOUND}
         fi
     done

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1616,6 +1616,7 @@ WSL_profile_dir() {
     # Determine where a suitable user profile home is located
     _RET=""
     local cmdexe="" profiledir="" val=""
+    # shellcheck disable=SC2068
     for m in $@; do
         cmdexe="$m/Windows/System32/cmd.exe"
         if command -v "$cmdexe" > /dev/null 2>&1; then

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1688,14 +1688,17 @@ dscheck_WSL() {
     # and the applicable userdata file. Notice the ordering in the for-loop
     # must match our expected precedence, so the file we find is what the
     # datasource must process.
-    cloudinitdir="$profile_dir/.ubuntupro/.cloud-init"
-    for userdatafile in "${instance_name}.user-data" "agent.yaml"; do
-        candidate="$cloudinitdir/$userdatafile"
-        if [ -f "$candidate" ]; then
-            debug 1 "Found applicable pro data file for this instance at: $candidate"
-            return ${DS_FOUND}
-        fi
-    done
+    # We only care about ubuntupro configs if the distro is an Ubuntu distro.
+    if [ "$NAME" = "Ubuntu" ]; then
+        cloudinitdir="$profile_dir/.ubuntupro/.cloud-init"
+        for userdatafile in "${instance_name}.user-data" "agent.yaml"; do
+            candidate="$cloudinitdir/$userdatafile"
+            if [ -f "$candidate" ]; then
+                debug 1 "Found applicable pro data file for this instance at: $candidate"
+                return ${DS_FOUND}
+            fi
+        done
+    fi
 
     cloudinitdir="$profile_dir/.cloud-init"
     for userdatafile in "${instance_name}.user-data" "${ID:-linux}-${VERSION_ID:-${VERSION_CODENAME}}.user-data" "${ID:-linux}-all.user-data" "default.user-data"; do


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(WSL): Add support for Ubuntu Pro configs

Currently, WSL only supports manual cloud-init configurations provided
in the host Windows filesystem. This adds support for Landscape/Ubuntu
Pro for WSL to provide cloud-init configurations and have them merged 
with or override manual user configurations. This adds support for 
organizations to better provision WSL instances using cloud-init.
```

## Additional Context
Currently, the WSL datasource can only work with user-provided configurations manually created in the host Windows filesystem. This change allows organizations to provide configurations via Landscape/Ubuntu Pro and have them loaded into WSL instances. These new configurations will be created under `%USERPROFILE%/.ubuntupro/.cloud-init`. This change will require [ubuntu-pro-for-wsl](https://github.com/canonical/ubuntu-pro-for-wsl) to implement these files after this is merged, as already created in https://github.com/canonical/ubuntu-pro-for-wsl/pull/506.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
As described in the updated docs and the spec sheet for this change, you can test this by manually creating the necessary files on your Windows host system. If an `agent.yaml` file is found, it should properly merge (overriding any conflicts) on a per-module basis with either a Landscape config (in `%USERPROFILE%/.ubuntupro/.cloud-init/<InstanceName>.user-data`) or a user-data found by the previous implementation as described in #4786.

ds-check should also verify the environment by using any one of the files described above.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)

Edit:
*Force pushed to add more context to some commits*

UDENG-2381