### PR TITLE
test: Mock ds-identify systemd path

### DIFF
--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -438,7 +438,7 @@ cached() {
 
 detect_virt() {
     local virt="${UNAVAILABLE}" r="" out=""
-    if [ -d /run/systemd ]; then
+    if [ -d "${PATH_ROOT}/run/systemd" ]; then
         if [ -n "$DI_SYSTEMD_VIRTUALIZATION" ]; then
             virt=${DI_SYSTEMD_VIRTUALIZATION#*:}
             debug 2 "detected $virt via env variable SYSTEMD_VIRTUALIZATION"


### PR DESCRIPTION
## Proposed Commit Message
```
test: Mock ds-identify systemd path

Fixes GH-5095
```

## Additional Context
The previous fix missed the systemd path mock.

tested on alpine with
```
tox -e py3 -- tests/unittests/test_ds_identify.py::TestDsIdentify::test_lxd_kvm_jammy_env
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
