### PR TITLE
Remove dependency on bash

### DIFF
--- a/tests/unittests/sources/test_opennebula.py
+++ b/tests/unittests/sources/test_opennebula.py
@@ -43,7 +43,7 @@ DS_PATH = "cloudinit.sources.DataSourceOpenNebula"
 
 class TestOpenNebulaDataSource(CiTestCase):
     parsed_user = None
-    allowed_subp = ["bash"]
+    allowed_subp = ["bash", "sh"]
 
     def setUp(self):
         super(TestOpenNebulaDataSource, self).setUp()
@@ -1023,7 +1023,7 @@ class TestOpenNebulaNetwork(unittest.TestCase):
 
 
 class TestParseShellConfig:
-    @pytest.mark.allow_subp_for("bash")
+    @pytest.mark.allow_subp_for("bash", "sh")
     def test_no_seconds(self):
         cfg = "\n".join(["foo=bar", "SECONDS=2", "xx=foo"])
         # we could test 'sleep 2', but that would make the test run slower.

--- a/tests/unittests/test_conftest.py
+++ b/tests/unittests/test_conftest.py
@@ -38,19 +38,19 @@ class TestDisableSubpUsage:
         assert "allowed: whoami" in str(excinfo.value)
         subp.subp(["whoami"])
 
-    @pytest.mark.allow_subp_for("whoami", "bash")
+    @pytest.mark.allow_subp_for("whoami", "sh")
     def test_subp_usage_can_be_conditionally_reenabled_for_multiple_cmds(self):
         with pytest.raises(UnexpectedSubpError) as excinfo:
             subp.subp(["some", "args"])
-        assert "allowed: whoami,bash" in str(excinfo.value)
-        subp.subp(["bash", "-c", "true"])
+        assert "allowed: whoami,sh" in str(excinfo.value)
+        subp.subp(["sh", "-c", "true"])
         subp.subp(["whoami"])
 
     @pytest.mark.allow_all_subp
-    @pytest.mark.allow_subp_for("bash")
+    @pytest.mark.allow_subp_for("sh")
     def test_both_marks_raise_an_error(self):
         with pytest.raises(UnexpectedSubpError, match="marked both"):
-            subp.subp(["bash"])
+            subp.subp(["sh"])
 
 
 class TestDisableSubpUsageInTestSubclass(CiTestCase):
@@ -68,6 +68,6 @@ class TestDisableSubpUsageInTestSubclass(CiTestCase):
         _old_allowed_subp = self.allow_subp
         self.allowed_subp = True
         try:
-            subp.subp(["bash", "-c", "true"])
+            subp.subp(["sh", "-c", "true"])
         finally:
             self.allowed_subp = _old_allowed_subp


### PR DESCRIPTION
## Context
This change removes cloud-init's dependency on `bash` in both runtime code and in unittests. 

There are two runtime changes in this PR:

1) It standardizes the failure path and tests for systems that don't include GNU date. This fallback path to GNU date isn't used in 99.99% of cases. It is only exercised when a user has set a custom datetime format in their logs which Python code doesn't understand. GNU date offers a parsing capability which is used only in these cases.

2) The main change in this PR is adding support for posix shell in the OpenNebula datasource. It is of course possible for the OpenNebula cloud (or the end user) to pass non-posix shell data to cloud-init, but with this change at least cloud-init codepaths exist for posix shell. 

cc @dermotbradley @igalic 

## Test Steps
```
incus create images:alpine/edge alpine
incus start alpine
incus shell alpine
$ apk add py3-tox git
$ git clone --branch holmanb/no-bash-deps https://github.com/holmanb/cloud-init.git
$ cd cloud-init
$ tox -e py3
```
also see the ci report in [this pr](https://github.com/canonical/cloud-init/actions/runs/8511072014/job/23309980900?pr=5121) which adds alpine to ci

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
