### PR TITLE
Add alpine unittests to ci

### DIFF
--- a/.github/workflows/alpine-unittests.yml
+++ b/.github/workflows/alpine-unittests.yml
@@ -28,41 +28,42 @@ jobs:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
 
-      - name: Install incus
-        run: curl https://pkgs.zabbly.com/get/incus-stable | sudo sh -x
-
       - name: Reset the firewall
         run: |
           sudo iptables -I DOCKER-USER -j ACCEPT
 
-      - name: Init incus
+      - name: Make sure the latest version is installed
         run: |
-          sudo incus admin init --auto
+          sudo snap refresh lxd --channel latest/stable
+
+      - name: Init lxd
+        run: |
+          sudo lxd admin init --auto
 
           # we shouldn't have to do this, but the link is down and we need it up
-          sudo ip link set incusbr0 up
+          sudo ip link set lxdbr0 up
 
       - name: Create alpine container
-        # the current shell doesn't have incus-admin as one of the groups
-        # so switch groups to run incus commands
-        run: sudo sg incus-admin -c 'incus launch images:alpine/edge alpine'
+        # the current shell doesn't have lxd as one of the groups
+        # so switch groups to run lxd commands
+        run: sudo sg lxd -c 'lxc launch images:alpine/edge alpine'
 
       - name: Check networking (for debugging)
         run: |
-          sudo sg incus-admin -c 'incus exec alpine -- ping -c 1 google.com || true'
-          sudo sg incus-admin -c 'incus exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true'
-          sudo sg incus-admin -c 'incus exec alpine -- nslookup www.google.com || true'
-          sudo sg incus-admin -c 'incus exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true'
+          sudo sg lxd -c 'lxc exec alpine -- ping -c 1 google.com || true'
+          sudo sg lxd -c 'lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true'
+          sudo sg lxd -c 'lxc exec alpine -- nslookup www.google.com || true'
+          sudo sg lxd -c 'lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true'
 
       - name: Install dependencies
-        run: sudo sg incus-admin -c 'incus exec alpine -- apk add py3-tox git'
+        run: sudo sg lxd -c 'lxc exec alpine -- apk add py3-tox git'
 
       - name: Mount source into container directory
-        run: sudo sg incus-admin -c 'incus config device add alpine gitdir disk source=$(pwd) path=/root/cloud-init-ro'
+        run: sudo sg lxd -c 'lxc config device add alpine gitdir disk source=$(pwd) path=/root/cloud-init-ro'
 
       - name: Create a r/w directory to run tests in
         # without this, tox fails during package install
-        run: sudo sg incus-admin -c 'incus exec alpine -- git clone cloud-init-ro/ cloud-init-rw'
+        run: sudo sg lxd -c 'lxc exec alpine -- git clone cloud-init-ro/ cloud-init-rw'
 
       - name: Run unittests
-        run: sudo sg incus-admin -c 'incus exec alpine --cwd /root/cloud-init-rw -- sh -c "tox -e py3"'
+        run: sudo sg lxd -c 'lxc exec alpine --cwd /root/cloud-init-rw -- sh -c "tox -e py3"'

--- a/.github/workflows/alpine-unittests.yml
+++ b/.github/workflows/alpine-unittests.yml
@@ -28,42 +28,32 @@ jobs:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
 
-      - name: Reset the firewall
-        run: |
-          sudo iptables -I DOCKER-USER -j ACCEPT
-
-      - name: Make sure the latest version is installed
-        run: |
-          sudo snap refresh lxd --channel latest/stable
-
-      - name: Init lxd
-        run: |
-          sudo lxd admin init --auto
-
-          # we shouldn't have to do this, but the link is down and we need it up
-          sudo ip link set lxdbr0 up
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/candidate
 
       - name: Create alpine container
         # the current shell doesn't have lxd as one of the groups
         # so switch groups to run lxd commands
-        run: sudo sg lxd -c 'lxc launch images:alpine/edge alpine'
+        run: lxc launch images:alpine/edge alpine
 
       - name: Check networking (for debugging)
         run: |
-          sudo sg lxd -c 'lxc exec alpine -- ping -c 1 google.com || true'
-          sudo sg lxd -c 'lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true'
-          sudo sg lxd -c 'lxc exec alpine -- nslookup www.google.com || true'
-          sudo sg lxd -c 'lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true'
+          lxc exec alpine -- ping -c 1 google.com || true
+          lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true
+          lxc exec alpine -- nslookup www.google.com || true
+          lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true
 
       - name: Install dependencies
-        run: sudo sg lxd -c 'lxc exec alpine -- apk add py3-tox git'
+        run: lxc exec alpine -- apk add py3-tox git
 
       - name: Mount source into container directory
-        run: sudo sg lxd -c 'lxc config device add alpine gitdir disk source=$(pwd) path=/root/cloud-init-ro'
+        run: lxc config device add alpine gitdir disk source=$(pwd) path=/root/cloud-init-ro
 
       - name: Create a r/w directory to run tests in
         # without this, tox fails during package install
-        run: sudo sg lxd -c 'lxc exec alpine -- git clone cloud-init-ro/ cloud-init-rw'
+        run: lxc exec alpine -- git clone cloud-init-ro/ cloud-init-rw
 
       - name: Run unittests
-        run: sudo sg lxd -c 'lxc exec alpine --cwd /root/cloud-init-rw -- sh -c "tox -e py3"'
+        run: lxc exec alpine --cwd /root/cloud-init-rw -- sh -c "tox -e py3"

--- a/.github/workflows/alpine-unittests.yml
+++ b/.github/workflows/alpine-unittests.yml
@@ -1,0 +1,68 @@
+
+name: Alpine Unittests
+
+on:
+  pull_request:
+    branches-ignore:
+      - 'ubuntu/**'
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: 'ci-${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: sh -ex {0}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          # Fetch all tags for tools/read-version
+          fetch-depth: 0
+
+      - name: Install incus
+        run: curl https://pkgs.zabbly.com/get/incus-stable | sudo sh -x
+
+      - name: Reset the firewall
+        run: |
+          sudo iptables -I DOCKER-USER -j ACCEPT
+
+      - name: Init incus
+        run: |
+          sudo incus admin init --auto
+
+          # we shouldn't have to do this, but the link is down and we need it up
+          sudo ip link set incusbr0 up
+
+      - name: Create alpine container
+        # the current shell doesn't have incus-admin as one of the groups
+        # so switch groups to run incus commands
+        run: sudo sg incus-admin -c 'incus launch images:alpine/edge alpine'
+
+      - name: Check networking (for debugging)
+        run: |
+          sudo sg incus-admin -c 'incus exec alpine -- ping -c 1 google.com || true'
+          sudo sg incus-admin -c 'incus exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true'
+          sudo sg incus-admin -c 'incus exec alpine -- nslookup www.google.com || true'
+          sudo sg incus-admin -c 'incus exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true'
+
+      - name: Install dependencies
+        run: sudo sg incus-admin -c 'incus exec alpine -- apk add py3-tox git'
+
+      - name: Mount source into container directory
+        run: sudo sg incus-admin -c 'incus config device add alpine gitdir disk source=$(pwd) path=/root/cloud-init-ro'
+
+      - name: Create a r/w directory to run tests in
+        # without this, tox fails during package install
+        run: sudo sg incus-admin -c 'incus exec alpine -- git clone cloud-init-ro/ cloud-init-rw'
+
+      - name: Run unittests
+        run: sudo sg incus-admin -c 'incus exec alpine --cwd /root/cloud-init-rw -- sh -c "tox -e py3"'


### PR DESCRIPTION
## Proposed Commit Message
```
test: Add alpine to ci

Cloud-init has Alpine Linux support, yet does not regularly test it.

Alpine is an attractive addition to the test matrix since it is easily
available to run in lxc, and it has several alternative components to test
against:

- busybox: non-GNU posix-compliant tools
- musl: libc alternative to glibc
- openrc: init system alternative to systemd
```

## Additional Context
~~Blocked by https://github.com/canonical/cloud-init/pull/5119 and https://github.com/canonical/cloud-init/pull/5120. Once those land, unittests will pass on Alpine.~~

Both have landed, ready for review.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
