### PR TITLE
feat(freebsd): support freebsd find part by gptid and ufsid

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2631,7 +2631,7 @@ def find_freebsd_part(fs):
         return splitted[0]
     elif len(splitted) == 3:
         return splitted[2]
-    elif splitted[2] in ["label", "gpt", "ufs"]:
+    elif splitted[2] in ["label", "gpt", "gptid", "ufs", "ufsid"]:
         target_label = fs[5:]
         (part, _err) = subp.subp(["glabel", "status", "-s"])
         for labels in part.split("\n"):

--- a/tests/unittests/distros/test_freebsd.py
+++ b/tests/unittests/distros/test_freebsd.py
@@ -76,7 +76,7 @@ gptid/4cd084b4-7fb4-11ee-a7ba-002590ec5bf2  N/A  vtbd0p4
         mock_subp.return_value = (glabel_out, "")
         res = find_freebsd_part(
             "/dev/gptid/4cd084b4-7fb4-11ee-a7ba-002590ec5bf2"
-            )
+        )
         self.assertEqual("vtbd0p4", res)
 
     @mock.patch("cloudinit.subp.subp")

--- a/tests/unittests/distros/test_freebsd.py
+++ b/tests/unittests/distros/test_freebsd.py
@@ -65,6 +65,32 @@ gptid/3f4cbe26-75da-11e8-a8f2-002590ec6166  N/A  vtbd0p1
         res = find_freebsd_part("/dev/gpt/rootfs")
         self.assertEqual("vtbd0p3", res)
 
+    @mock.patch("cloudinit.subp.subp")
+    def test_find_freebsd_part_gptid(self, mock_subp):
+        glabel_out = """
+                                gpt/bootfs  N/A  vtbd0p1
+                                gpt/efiesp  N/A  vtbd0p2
+                                gpt/swapfs  N/A  vtbd0p3
+gptid/4cd084b4-7fb4-11ee-a7ba-002590ec5bf2  N/A  vtbd0p4
+"""
+        mock_subp.return_value = (glabel_out, "")
+        res = find_freebsd_part(
+            "/dev/gptid/4cd084b4-7fb4-11ee-a7ba-002590ec5bf2"
+            )
+        self.assertEqual("vtbd0p4", res)
+
+    @mock.patch("cloudinit.subp.subp")
+    def test_find_freebsd_part_ufsid(self, mock_subp):
+        glabel_out = """
+                                gpt/bootfs  N/A  vtbd0p1
+                                gpt/efiesp  N/A  vtbd0p2
+                                gpt/swapfs  N/A  vtbd0p3
+                    ufsid/654e0663786f5131  N/A  vtbd0p4
+"""
+        mock_subp.return_value = (glabel_out, "")
+        res = find_freebsd_part("/dev/ufsid/654e0663786f5131")
+        self.assertEqual("vtbd0p4", res)
+
     def test_get_path_dev_freebsd_label(self):
         mnt_list = """
 /dev/label/rootfs  /                ufs     rw              1 1

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -83,6 +83,7 @@ Jehops
 jf
 jfroche
 Jille
+jinkkkang
 JohnKepplers
 johnsonshi
 jordimassaguerpla


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(freebsd): support freebsd find part by gptid and ufsid

freebsd obtained device partition name by the function find_freebsd_part, the params of function is the device name mounted,  usually is first  field of /etc/fstab ,  like /dev/gpt/rootfs,  but freebsd fstab also support gptid or ufsid for a unique id to identify  
 partitions, like /dev/gptid/xxx, /dev/ufsid/xxx,  update function to  support
```

## Additional Context

Regarding the FreeBSD fstab configuration supporting  gptid  and ufsid , can refer to these two links
[ufsid](https://forums.freebsd.org/threads/how-to-use-drive-unique-id-in-fstab.19690/)
[gptid](https://forums.freebsd.org/threads/how-to-use-uuid-to-identify-partitions-on-freebsd.89163/)

