### PR TITLE
util: add log_level kwarg for logexc()

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1796,13 +1796,9 @@ def get_config_logfiles(cfg):
     return list(set(logs + rotated_logs))
 
 
-def logexc(log, msg, *args):
-    # Setting this here allows this to change
-    # levels easily (not always error level)
-    # or even desirable to have that much junk
-    # coming out to a non-debug stream
-    if msg:
-        log.warning(msg, *args)
+def logexc(log, msg, *args, log_level: int = logging.WARNING) -> None:
+    log.log(log_level, msg, *args)
+
     # Debug gets the full trace.  However, nose has a bug whereby its
     # logcapture plugin doesn't properly handle the case where there is no
     # actual exception.  To avoid tracebacks during the test suite then, we'll
@@ -1810,7 +1806,7 @@ def logexc(log, msg, *args):
     # flight, we'll just pass in None.
     exc_info = sys.exc_info()
     if exc_info == (None, None, None):
-        exc_info = None
+        exc_info = None  # type: ignore
     log.debug(msg, exc_info=exc_info, *args)
 
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -3245,3 +3245,39 @@ class TestReadHotplugEnabledFile:
         assert {"scopes": ["network"]} == util.read_hotplug_enabled_file(
             MockPath(target_file.strpath)
         )
+
+
+class TestLogExc:
+    def test_logexc(self, caplog):
+        try:
+            _ = 1 / 0
+        except Exception as _:
+            util.logexc(LOG, "an error occurred")
+
+        assert caplog.record_tuples == [
+            (
+                "tests.unittests.test_util",
+                logging.WARNING,
+                "an error occurred",
+            ),
+            ("tests.unittests.test_util", logging.DEBUG, "an error occurred"),
+        ]
+
+    @pytest.mark.parametrize(
+        "log_level",
+        [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR],
+    )
+    def test_logexc_with_log_level(self, caplog, log_level):
+        try:
+            _ = 1 / 0
+        except Exception as _:
+            util.logexc(LOG, "an error occurred", log_level=log_level)
+
+        assert caplog.record_tuples == [
+            (
+                "tests.unittests.test_util",
+                log_level,
+                "an error occurred",
+            ),
+            ("tests.unittests.test_util", logging.DEBUG, "an error occurred"),
+        ]


### PR DESCRIPTION
Many failures are being treated as warnings instead of errors due to usage of logexc() to emit the failure.

Add log_level parameter to allow increasing the log level without requiring an additional log.

Add tests but I'm unsure why its not logging the backtrace when the failure occurs within the test method.
