### PR TITLE
azure: parse ProvisionGuestProxyAgent as bool

### DIFF
--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -1136,6 +1136,7 @@ class OvfEnvXml:
         self.provision_guest_proxy_agent = self._parse_property(
             platform_settings,
             "ProvisionGuestProxyAgent",
+            parse_bool=True,
             default=False,
             required=False,
         )

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2827,14 +2827,21 @@ class TestPreprovisioningReadAzureOvfFlag(CiTestCase):
         self.assertTrue(cfg["PreprovisionedVm"])
         self.assertEqual("Savable", cfg["PreprovisionedVMType"])
 
-    @pytest.mark.parametrize("provision_guest_proxy_agent", [False, True])
-    def test_read_azure_ovf_with_proxy_guest_agent(self, provision_guest_proxy_agent):
+    def test_read_azure_ovf_with_proxy_guest_agent_true(self):
         """The read_azure_ovf method should set ProvisionGuestProxyAgent
         cfg flag to True."""
-        content = construct_ovf_env(provision_guest_proxy_agent=provision_guest_proxy_agent)
+        content = construct_ovf_env(provision_guest_proxy_agent=True)
         ret = dsaz.read_azure_ovf(content)
         cfg = ret[2]
-        assert (cfg["ProvisionGuestProxyAgent"] is provision_guest_proxy_agent)
+        assert cfg["ProvisionGuestProxyAgent"] is True
+
+    def test_read_azure_ovf_with_proxy_guest_agent_false(self):
+        """The read_azure_ovf method should set ProvisionGuestProxyAgent
+        cfg flag to False."""
+        content = construct_ovf_env(provision_guest_proxy_agent=False)
+        ret = dsaz.read_azure_ovf(content)
+        cfg = ret[2]
+        assert cfg["ProvisionGuestProxyAgent"] is False
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2835,6 +2835,14 @@ class TestPreprovisioningReadAzureOvfFlag(CiTestCase):
         cfg = ret[2]
         self.assertTrue(cfg["ProvisionGuestProxyAgent"])
 
+    def test_read_azure_ovf_with_proxy_guest_agent(self):
+        """The read_azure_ovf method should set ProvisionGuestProxyAgent
+        cfg flag to True."""
+        content = construct_ovf_env(provision_guest_proxy_agent=False)
+        ret = dsaz.read_azure_ovf(content)
+        cfg = ret[2]
+        self.assertTrue(cfg["ProvisionGuestProxyAgent"] == False)
+
 
 @pytest.mark.parametrize(
     "ovf_cfg,imds_md,pps_type",

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2827,21 +2827,14 @@ class TestPreprovisioningReadAzureOvfFlag(CiTestCase):
         self.assertTrue(cfg["PreprovisionedVm"])
         self.assertEqual("Savable", cfg["PreprovisionedVMType"])
 
-    def test_read_azure_ovf_with_proxy_guest_agent(self):
+    @pytest.mark.parametrize("provision_guest_proxy_agent", [False, True])
+    def test_read_azure_ovf_with_proxy_guest_agent(self, provision_guest_proxy_agent):
         """The read_azure_ovf method should set ProvisionGuestProxyAgent
         cfg flag to True."""
-        content = construct_ovf_env(provision_guest_proxy_agent=True)
+        content = construct_ovf_env(provision_guest_proxy_agent=provision_guest_proxy_agent)
         ret = dsaz.read_azure_ovf(content)
         cfg = ret[2]
-        assert cfg["ProvisionGuestProxyAgent"] is True
-
-    def test_read_azure_ovf_with_proxy_guest_agent(self):
-        """The read_azure_ovf method should set ProvisionGuestProxyAgent
-        cfg flag to True."""
-        content = construct_ovf_env(provision_guest_proxy_agent=False)
-        ret = dsaz.read_azure_ovf(content)
-        cfg = ret[2]
-        assert cfg["ProvisionGuestProxyAgent"] is False
+        assert (cfg["ProvisionGuestProxyAgent"] is provision_guest_proxy_agent)
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -2833,7 +2833,7 @@ class TestPreprovisioningReadAzureOvfFlag(CiTestCase):
         content = construct_ovf_env(provision_guest_proxy_agent=True)
         ret = dsaz.read_azure_ovf(content)
         cfg = ret[2]
-        self.assertTrue(cfg["ProvisionGuestProxyAgent"])
+        assert cfg["ProvisionGuestProxyAgent"] is True
 
     def test_read_azure_ovf_with_proxy_guest_agent(self):
         """The read_azure_ovf method should set ProvisionGuestProxyAgent
@@ -2841,7 +2841,7 @@ class TestPreprovisioningReadAzureOvfFlag(CiTestCase):
         content = construct_ovf_env(provision_guest_proxy_agent=False)
         ret = dsaz.read_azure_ovf(content)
         cfg = ret[2]
-        self.assertTrue(cfg["ProvisionGuestProxyAgent"] == False)
+        assert cfg["ProvisionGuestProxyAgent"] is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Parse ProvisionGuestProxyAgent  property as bool instead of string.