### PR TITLE
net/dhcp: bump dhcpcd timeout to 300s

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -596,6 +596,7 @@ class IscDhclient(DhcpClient):
 
 class Dhcpcd(DhcpClient):
     client_name = "dhcpcd"
+    timeout = 300
 
     def dhcp_discovery(
         self,


### PR DESCRIPTION
On most distros, including Ubuntu, the default timeout for dhclient is 300s. There is no cloud-init controlled duration for the dhclient process as it doesn't fork and there is no timeout value passed to subp().

I have seen some distros configure dhclient with a timeout of 60s, but is far less common.

Given that a cloud VM is not very useful with DHCP, err on the generous side and allow up to 300 seconds for dhcpcd to get an address.

Note that there is still an issue with dhcpcd retries which will be addressed later in a separate PR.