### PR TITLE
fix(dhcpcd): Make lease parsing more robust

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -796,8 +796,15 @@ class Dhcpcd(DhcpClient):
                     if "=" in a
                 ]
             )
+            if not lease:
+                msg = (
+                    "No valid DHCP lease configuration "
+                    "found in dhcpcd lease: %r"
+                )
+                LOG.error(msg, lease_dump)
+                raise InvalidDHCPLeaseFileError(msg % lease_dump)
         except ValueError as error:
-            LOG.error("Error parsing dhcpcd lease: %r", error)
+            LOG.error("Error parsing dhcpcd lease: %r", lease_dump)
             raise InvalidDHCPLeaseFileError from error
 
         # this is expected by cloud-init's code

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -791,8 +791,9 @@ class Dhcpcd(DhcpClient):
         try:
             lease = dict(
                 [
-                    a.split("=")
+                    a.split("=", maxsplit=1)
                     for a in lease_dump.strip().replace("'", "").split("\n")
+                    if "=" in a
                 ]
             )
         except ValueError as error:

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -1204,13 +1204,6 @@ class TestDhcpcd:
         (
             pytest.param(
                 """
-                fail
-                """,
-                {},
-                id="lease_has_no_keys",
-            ),
-            pytest.param(
-                """
 
                 domain_name='us-east-2.compute.internal'
 
@@ -1250,6 +1243,7 @@ class TestDhcpcd:
         with mock.patch("cloudinit.net.dhcp.util.load_binary_file"):
             Dhcpcd.parse_dhcpcd_lease(dedent(lease), "eth0")
 
+
     def test_parse_lease_dump_fails(self):
         def _raise():
             raise ValueError()
@@ -1259,6 +1253,15 @@ class TestDhcpcd:
 
         with pytest.raises(InvalidDHCPLeaseFileError):
             with mock.patch("cloudinit.net.dhcp.util.load_binary_file"):
+                Dhcpcd.parse_dhcpcd_lease(lease, "eth0")
+
+        with pytest.raises(InvalidDHCPLeaseFileError):
+            with mock.patch("cloudinit.net.dhcp.util.load_binary_file"):
+                lease = dedent(
+                    """
+                    fail
+                    """
+                )
                 Dhcpcd.parse_dhcpcd_lease(lease, "eth0")
 
     @pytest.mark.parametrize(

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -1243,7 +1243,6 @@ class TestDhcpcd:
         with mock.patch("cloudinit.net.dhcp.util.load_binary_file"):
             Dhcpcd.parse_dhcpcd_lease(dedent(lease), "eth0")
 
-
     def test_parse_lease_dump_fails(self):
         def _raise():
             raise ValueError()


### PR DESCRIPTION
## Proposed Commit Message
```
fix(dhcpcd): Make lease parsing more robust
```

## Additional Context
Followup to https://github.com/canonical/cloud-init/pull/5128 (rebase before merge)

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
