### PR TITLE
Release bug-fix only cherry-picks from 24.1.4 upstream release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,26 @@
+cloud-init (24.1.3-0ubuntu2) UNRELEASED; urgency=medium
+
+  * Upstream bug fix release based on 24.1.4.
+    + functional fixes in debian/patches:
+      - cpick-f74b61ea-ephemeral-dhcpcd-Set-dhcpcd-interface-down
+        When dhcpcd client sets up a device to discover IMDS, ensure
+        link is set back down to avoid interface rename failures (GH-5019)
+      - cpick-372e80f8-net-dhcp-bump-dhcpcd-timeout-to-300s-5127
+        Extend default timeout of dhcpcd command to 300 seconds
+      - cpick-77771023-net-dhcp-raise-InvalidDHCPLeaseFileError-on-error
+        Raise any dhcpcd lease parse failures as InvalidDHCPLeaseFileError
+        (GH-5128)
+      - cpick-f6ac6ee8-fix-dhcpcd-Make-lease-parsing-more-robust-5129
+        Avoid tracebacks on empty invalid lease content from dhcpcd
+        and raise InvalidDHCPLeaseFileError with full lease parsed when errors
+        occur. (GH-5128)
+    + test fixes in debian/patches:
+      - d/p/cpick-accdfe6a-refactor-Import-log-module-rather-than-functions-5074
+        Avoid mock failures in unit tests by module-level import of log
+      - cpick-144782a8-test-Remove-side-effects-from-tests-5074
+
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 03 Apr 2024 12:09:38 -0600
+
 cloud-init (24.1.3-0ubuntu1) noble; urgency=medium
 
   * Upstream snapshot based on 24.1.3.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (24.1.3-0ubuntu2) UNRELEASED; urgency=medium
+cloud-init (24.1.3-0ubuntu2) noble; urgency=medium
 
   * Upstream bug fix release based on 24.1.4.
     + functional fixes in debian/patches:
@@ -19,7 +19,7 @@ cloud-init (24.1.3-0ubuntu2) UNRELEASED; urgency=medium
         Avoid mock failures in unit tests by module-level import of log
       - cpick-144782a8-test-Remove-side-effects-from-tests-5074
 
- -- Chad Smith <chad.smith@canonical.com>  Wed, 03 Apr 2024 12:09:38 -0600
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 03 Apr 2024 12:26:52 -0600
 
 cloud-init (24.1.3-0ubuntu1) noble; urgency=medium
 

--- a/debian/patches/cpick-144782a8-test-Remove-side-effects-from-tests-5074
+++ b/debian/patches/cpick-144782a8-test-Remove-side-effects-from-tests-5074
@@ -1,0 +1,606 @@
+From 144782a838123099334fe44c07566b07503fd67b Mon Sep 17 00:00:00 2001
+From: James Falcon <james.falcon@canonical.com>
+Date: Tue, 19 Mar 2024 14:52:52 -0500
+Subject: [PATCH] test: Remove side effects from tests (#5074)
+
+These are the failures I could find when running tests in random order.
+Changes that aren't self-explanatory should include a comment in the
+test itself.
+
+test_vultr.py includes a refactor to remove global state and remove
+a test that didn't work and wasn't needed after the changes.
+---
+ cloudinit/sources/helpers/openstack.py        |   2 +-
+ tests/unittests/cmd/devel/test_net_convert.py |  24 ++-
+ tests/unittests/cmd/test_main.py              |  12 ++
+ .../unittests/config/test_cc_apt_configure.py |   2 +-
+ tests/unittests/config/test_cc_ca_certs.py    |   1 +
+ .../unittests/config/test_cc_set_passwords.py |   6 +-
+ tests/unittests/config/test_cc_ssh.py         |  22 ++-
+ tests/unittests/conftest.py                   |  15 +-
+ tests/unittests/distros/test_netconfig.py     |   2 +-
+ tests/unittests/helpers.py                    |   1 +
+ tests/unittests/runs/test_simple_run.py       |  10 ++
+ tests/unittests/sources/test_lxd.py           |   6 +-
+ tests/unittests/sources/test_vultr.py         | 151 ++++--------------
+ tests/unittests/test_cli.py                   |  10 +-
+ 14 files changed, 127 insertions(+), 137 deletions(-)
+
+--- a/cloudinit/sources/helpers/openstack.py
++++ b/cloudinit/sources/helpers/openstack.py
+@@ -763,7 +763,7 @@ def convert_net_json(network_json=None,
+                 cfg["type"] = "infiniband"
+ 
+     for service in services:
+-        cfg = service
++        cfg = copy.deepcopy(service)
+         cfg.update({"type": "nameserver"})
+         config.append(cfg)
+ 
+--- a/tests/unittests/cmd/devel/test_net_convert.py
++++ b/tests/unittests/cmd/devel/test_net_convert.py
+@@ -90,6 +90,18 @@ may-fail=false
+ """
+ 
+ 
++@pytest.fixture
++def mock_setup_logging():
++    """Mock setup_basic_logging to avoid changing log level.
++
++    net_convert.handle_args() can call setup_basic_logging() with a
++    WARNING level, which would be a side-effect for future tests.
++    It's behavior isn't checked in these tests, so mock it out.
++    """
++    with mock.patch(f"{M_PATH}log.setup_basic_logging"):
++        yield
++
++
+ class TestNetConvert:
+ 
+     missing_required_args = itertools.combinations(
+@@ -155,7 +167,13 @@ class TestNetConvert:
+         ),
+     )
+     def test_convert_output_kind_artifacts(
+-        self, output_kind, outfile_content, debug, capsys, tmpdir
++        self,
++        output_kind,
++        outfile_content,
++        debug,
++        capsys,
++        tmpdir,
++        mock_setup_logging,
+     ):
+         """Assert proper output-kind artifacts are written."""
+         network_data = tmpdir.join("network_data")
+@@ -186,7 +204,9 @@ class TestNetConvert:
+                 ] == chown.call_args_list
+ 
+     @pytest.mark.parametrize("debug", (False, True))
+-    def test_convert_netplan_passthrough(self, debug, tmpdir):
++    def test_convert_netplan_passthrough(
++        self, debug, tmpdir, mock_setup_logging
++    ):
+         """Assert that if the network config's version is 2 and the renderer is
+         Netplan, then the config is passed through as-is.
+         """
+--- a/tests/unittests/cmd/test_main.py
++++ b/tests/unittests/cmd/test_main.py
+@@ -54,6 +54,18 @@ class TestMain(FilesystemMockingTestCase
+         self.patchUtils(self.new_root)
+         self.stderr = StringIO()
+         self.patchStdoutAndStderr(stderr=self.stderr)
++        # Every cc_ module calls get_meta_doc on import.
++        # This call will fail if filesystem redirection mocks are in place
++        # and the module hasn't already been imported which can depend
++        # on test ordering.
++        self.m_doc = mock.patch(
++            "cloudinit.config.schema.get_meta_doc", return_value={}
++        )
++        self.m_doc.start()
++
++    def tearDown(self):
++        self.m_doc.stop()
++        super().tearDown()
+ 
+     def test_main_init_run_net_runs_modules(self):
+         """Modules like write_files are run in 'net' mode."""
+--- a/tests/unittests/config/test_cc_apt_configure.py
++++ b/tests/unittests/config/test_cc_apt_configure.py
+@@ -298,6 +298,7 @@ class TestAptConfigure:
+         ),
+     )
+     @mock.patch(M_PATH + "get_apt_cfg")
++    @mock.patch.object(features, "APT_DEB822_SOURCE_LIST_FILE", True)
+     def test_remove_source(
+         self,
+         m_get_apt_cfg,
+@@ -312,7 +313,6 @@ class TestAptConfigure:
+             "sourceparts": f"{tmpdir}/etc/apt/sources.list.d/",
+         }
+         cloud = get_cloud(distro_name)
+-        features.APT_DEB822_SOURCE_LIST_FILE = True
+         sources_file = tmpdir.join("/etc/apt/sources.list")
+         deb822_sources_file = tmpdir.join(
+             f"/etc/apt/sources.list.d/{distro_name}.sources"
+--- a/tests/unittests/config/test_cc_ca_certs.py
++++ b/tests/unittests/config/test_cc_ca_certs.py
+@@ -379,6 +379,7 @@ class TestRemoveDefaultCaCerts(TestCase)
+                 cc_ca_certs.disable_default_ca_certs(distro_name, conf)
+ 
+ 
++@pytest.mark.usefixtures("clear_deprecation_log")
+ class TestCACertsSchema:
+     """Directly test schema rather than through handle."""
+ 
+--- a/tests/unittests/config/test_cc_set_passwords.py
++++ b/tests/unittests/config/test_cc_set_passwords.py
+@@ -1,5 +1,6 @@
+ # This file is part of cloud-init. See LICENSE file for license information.
+ 
++import copy
+ import logging
+ from unittest import mock
+ 
+@@ -508,6 +509,7 @@ expire_cases = [
+ class TestExpire:
+     @pytest.mark.parametrize("cfg", expire_cases)
+     def test_expire(self, cfg, mocker, caplog):
++        cfg = copy.deepcopy(cfg)
+         cloud = get_cloud()
+         mocker.patch(f"{MODPATH}subp.subp")
+         mocker.patch.object(cloud.distro, "chpasswd")
+@@ -533,7 +535,9 @@ class TestExpire:
+     def test_expire_old_behavior(self, cfg, mocker, caplog):
+         # Previously expire didn't apply to hashed passwords.
+         # Ensure we can preserve that case on older releases
+-        features.EXPIRE_APPLIES_TO_HASHED_USERS = False
++        mocker.patch.object(features, "EXPIRE_APPLIES_TO_HASHED_USERS", False)
++
++        cfg = copy.deepcopy(cfg)
+         cloud = get_cloud()
+         mocker.patch(f"{MODPATH}subp.subp")
+         mocker.patch.object(cloud.distro, "chpasswd")
+--- a/tests/unittests/config/test_cc_ssh.py
++++ b/tests/unittests/config/test_cc_ssh.py
+@@ -38,8 +38,10 @@ def publish_hostkey_test_setup(tmpdir):
+         with open(filepath, "w") as f:
+             f.write(" ".join(test_hostkeys[key_type]))
+ 
+-    cc_ssh.KEY_FILE_TPL = os.path.join(hostkey_tmpdir, "ssh_host_%s_key")
+-    yield test_hostkeys, test_hostkey_files
++    with mock.patch.object(
++        cc_ssh, "KEY_FILE_TPL", os.path.join(hostkey_tmpdir, "ssh_host_%s_key")
++    ):
++        yield test_hostkeys, test_hostkey_files
+ 
+ 
+ def _replace_options(user: Optional[str] = None) -> str:
+@@ -255,6 +257,7 @@ class TestHandleSsh:
+     @mock.patch(MODPATH + "ug_util.normalize_users_groups")
+     @mock.patch(MODPATH + "os.path.exists")
+     @mock.patch(MODPATH + "util.fips_enabled", return_value=False)
++    @mock.patch.object(cc_ssh, "PUBLISH_HOST_KEYS", True)
+     def test_handle_publish_hostkeys(
+         self,
+         m_fips,
+@@ -268,7 +271,6 @@ class TestHandleSsh:
+     ):
+         """Test handle with various configs for ssh_publish_hostkeys."""
+         test_hostkeys, test_hostkey_files = publish_hostkey_test_setup
+-        cc_ssh.PUBLISH_HOST_KEYS = True
+         keys = ["key1"]
+         user = "clouduser"
+         # Return no matching keys for first glob, test keys for second.
+@@ -282,7 +284,6 @@ class TestHandleSsh:
+         m_path_exists.return_value = True
+         m_nug.return_value = ({user: {"default": user}}, {})
+         cloud = get_cloud(distro="ubuntu", metadata={"public-keys": keys})
+-        cloud.datasource.publish_host_keys = mock.Mock()
+ 
+         expected_calls = []
+         if expected_key_types is not None:
+@@ -294,10 +295,15 @@ class TestHandleSsh:
+                     ]
+                 )
+             ]
+-        cc_ssh.handle("name", cfg, cloud, None)
+-        assert (
+-            expected_calls == cloud.datasource.publish_host_keys.call_args_list
+-        )
++
++        with mock.patch.object(
++            cloud.datasource, "publish_host_keys", mock.Mock()
++        ):
++            cc_ssh.handle("name", cfg, cloud, None)
++            assert (
++                expected_calls
++                == cloud.datasource.publish_host_keys.call_args_list
++            )
+ 
+     @pytest.mark.parametrize(
+         "ssh_keys_group_exists,sshd_version,expected_private_permissions",
+--- a/tests/unittests/conftest.py
++++ b/tests/unittests/conftest.py
+@@ -110,12 +110,21 @@ def dhclient_exists():
+ log.configure_root_logger()
+ 
+ 
+-@pytest.fixture(autouse=True)
+-def disable_root_logger_setup(request):
+-    with mock.patch("cloudinit.cmd.main.configure_root_logger", autospec=True):
++@pytest.fixture(autouse=True, scope="session")
++def disable_root_logger_setup():
++    with mock.patch("cloudinit.log.configure_root_logger", autospec=True):
+         yield
+ 
+ 
++@pytest.fixture
++def clear_deprecation_log():
++    """Clear any deprecation warnings before and after running tests."""
++    # Since deprecations are de-duped, the existance (or non-existance) of
++    # a deprecation warning in a previous test can cause the next test to
++    # fail.
++    util.deprecate._log = set()
++
++
+ PYTEST_VERSION_TUPLE = tuple(map(int, pytest.__version__.split(".")))
+ 
+ if PYTEST_VERSION_TUPLE < (3, 9, 0):
+--- a/tests/unittests/distros/test_netconfig.py
++++ b/tests/unittests/distros/test_netconfig.py
+@@ -303,7 +303,7 @@ class TestNetCfgDistroBase(FilesystemMoc
+ 
+     def _get_distro(self, dname, renderers=None, activators=None):
+         cls = distros.fetch(dname)
+-        cfg = settings.CFG_BUILTIN
++        cfg = copy.deepcopy(settings.CFG_BUILTIN)
+         cfg["system_info"]["distro"] = dname
+         system_info_network_cfg = {}
+         if renderers:
+--- a/tests/unittests/helpers.py
++++ b/tests/unittests/helpers.py
+@@ -161,6 +161,7 @@ class CiTestCase(TestCase):
+             self.old_handlers = self.logger.handlers
+             self.logger.handlers = [handler]
+             self.old_level = logging.root.level
++            self.logger.level = logging.DEBUG
+         if self.allowed_subp is True:
+             subp.subp = _real_subp
+         else:
+--- a/tests/unittests/runs/test_simple_run.py
++++ b/tests/unittests/runs/test_simple_run.py
+@@ -2,6 +2,7 @@
+ 
+ import copy
+ import os
++from unittest import mock
+ 
+ from cloudinit import atomic_helper, safeyaml, stages, util
+ from cloudinit.config.modules import Modules
+@@ -45,6 +46,15 @@ class TestSimpleRun(helpers.FilesystemMo
+         self.patchOS(self.new_root)
+         self.patchUtils(self.new_root)
+ 
++        self.m_doc = mock.patch(
++            "cloudinit.config.schema.get_meta_doc", return_value={}
++        )
++        self.m_doc.start()
++
++    def tearDown(self):
++        self.m_doc.stop()
++        super().tearDown()
++
+     def test_none_ds_populates_var_lib_cloud(self):
+         """Init and run_section default behavior creates appropriate dirs."""
+         # Now start verifying whats created
+--- a/tests/unittests/sources/test_lxd.py
++++ b/tests/unittests/sources/test_lxd.py
+@@ -333,13 +333,13 @@ class TestDataSourceLXD:
+         assert NETWORK_V1 == lxd_ds.network_config
+         assert LXD_V1_METADATA == lxd_ds._crawled_metadata
+ 
++    @mock.patch.object(lxd, "generate_network_config", return_value=NETWORK_V1)
+     def test_network_config_crawled_metadata_no_network_config(
+-        self, lxd_ds_no_network_config
++        self, m_generate, lxd_ds_no_network_config
+     ):
+         """network_config is correctly computed when _network_config is unset
+         and _crawled_metadata does not contain network_config.
+         """
+-        lxd.generate_network_config = mock.Mock(return_value=NETWORK_V1)
+         assert UNSET == lxd_ds_no_network_config._crawled_metadata
+         assert UNSET == lxd_ds_no_network_config._network_config
+         assert None is lxd_ds_no_network_config.userdata_raw
+@@ -349,7 +349,7 @@ class TestDataSourceLXD:
+             LXD_V1_METADATA_NO_NETWORK_CONFIG
+             == lxd_ds_no_network_config._crawled_metadata
+         )
+-        assert 1 == lxd.generate_network_config.call_count
++        assert 1 == m_generate.call_count
+ 
+ 
+ class TestIsPlatformViable:
+--- a/tests/unittests/sources/test_vultr.py
++++ b/tests/unittests/sources/test_vultr.py
+@@ -5,7 +5,7 @@
+ # Vultr Metadata API:
+ # https://www.vultr.com/metadata/
+ 
+-import json
++import copy
+ 
+ from cloudinit import helpers, settings
+ from cloudinit.net.dhcp import NoDHCPLeaseError
+@@ -13,6 +13,20 @@ from cloudinit.sources import DataSource
+ from cloudinit.sources.helpers import vultr
+ from tests.unittests.helpers import CiTestCase, mock
+ 
++VENDOR_DATA = """\
++#cloud-config
++package_upgrade: true
++disable_root: 0
++ssh_pwauth: 1
++chpasswd:
++  expire: false
++  list:
++  - root:$6$SxXx...k2mJNIzZB5vMCDBlYT1
++system_info:
++  default_user:
++    name: root
++"""
++
+ # Vultr metadata test data
+ VULTR_V1_1 = {
+     "bgp": {
+@@ -58,18 +72,7 @@ VULTR_V1_1 = {
+     "startup-script": "echo No configured startup script",
+     "raid1-script": "",
+     "user-data": [],
+-    "vendor-data": [
+-        {
+-            "package_upgrade": "true",
+-            "disable_root": 0,
+-            "ssh_pwauth": 1,
+-            "chpasswd": {
+-                "expire": False,
+-                "list": ["root:$6$S2Smuj.../VqxmIR9Urw0jPZ88i4yvB/"],
+-            },
+-            "system_info": {"default_user": {"name": "root"}},
+-        }
+-    ],
++    "vendor-data": VENDOR_DATA,
+ }
+ 
+ VULTR_V1_2 = {
+@@ -130,22 +133,9 @@ VULTR_V1_2 = {
+     "user-defined": [],
+     "startup-script": "echo No configured startup script",
+     "user-data": [],
+-    "vendor-data": [
+-        {
+-            "package_upgrade": "true",
+-            "disable_root": 0,
+-            "ssh_pwauth": 1,
+-            "chpasswd": {
+-                "expire": False,
+-                "list": ["root:$6$SxXx...k2mJNIzZB5vMCDBlYT1"],
+-            },
+-            "system_info": {"default_user": {"name": "root"}},
+-        }
+-    ],
++    "vendor-data": VENDOR_DATA,
+ }
+ 
+-VULTR_V1_3 = None
+-
+ SSH_KEYS_1 = ["ssh-rsa AAAAB3NzaC1y...IQQhv5PAOKaIl+mM3c= test3@key"]
+ 
+ CLOUD_INTERFACES = {
+@@ -190,20 +180,6 @@ ORDERED_INTERFACES = ["eth0", "eth1", "e
+ 
+ FILTERED_INTERFACES = ["eth1", "eth2", "eth0"]
+ 
+-# Expected generated objects
+-
+-# Expected config
+-EXPECTED_VULTR_CONFIG = {
+-    "package_upgrade": "true",
+-    "disable_root": 0,
+-    "ssh_pwauth": 1,
+-    "chpasswd": {
+-        "expire": False,
+-        "list": ["root:$6$SxXx...k2mJNIzZB5vMCDBlYT1"],
+-    },
+-    "system_info": {"default_user": {"name": "root"}},
+-}
+-
+ # Expected network config object from generator
+ EXPECTED_VULTR_NETWORK_1 = {
+     "version": 1,
+@@ -271,28 +247,9 @@ INTERFACE_MAP = {
+ }
+ 
+ 
+-FINAL_INTERFACE_USED = ""
+-
+-
+ class TestDataSourceVultr(CiTestCase):
+     def setUp(self):
+-        global VULTR_V1_3
+         super(TestDataSourceVultr, self).setUp()
+-
+-        # Create v3
+-        VULTR_V1_3 = VULTR_V1_2.copy()
+-        VULTR_V1_3["cloud_interfaces"] = CLOUD_INTERFACES.copy()
+-        VULTR_V1_3["interfaces"] = []
+-
+-        # Stored as a dict to make it easier to maintain
+-        raw1 = json.dumps(VULTR_V1_1["vendor-data"][0])
+-        raw2 = json.dumps(VULTR_V1_2["vendor-data"][0])
+-
+-        # Make expected format
+-        VULTR_V1_1["vendor-data"] = [raw1]
+-        VULTR_V1_2["vendor-data"] = [raw2]
+-        VULTR_V1_3["vendor-data"] = [raw2]
+-
+         self.tmp = self.tmp_dir()
+ 
+     # Test the datasource itself
+@@ -330,8 +287,8 @@ class TestDataSourceVultr(CiTestCase):
+ 
+         # Test vendor config
+         self.assertEqual(
+-            EXPECTED_VULTR_CONFIG,
+-            json.loads(vendordata[0].replace("#cloud-config", "")),
++            VENDOR_DATA,
++            vendordata,
+         )
+ 
+         self.maxDiff = orig_val
+@@ -339,6 +296,15 @@ class TestDataSourceVultr(CiTestCase):
+         # Test network config generation
+         self.assertEqual(EXPECTED_VULTR_NETWORK_2, source.network_config)
+ 
++    def _get_metadata(self):
++        # Create v1_3
++        vultr_v1_3 = VULTR_V1_2.copy()
++        vultr_v1_3["cloud_interfaces"] = CLOUD_INTERFACES.copy()
++        vultr_v1_3["interfaces"] = []
++        vultr_v1_3["vendor-data"] = copy.deepcopy(VULTR_V1_2["vendor-data"])
++
++        return vultr_v1_3
++
+     # Test the datasource with new network config type
+     @mock.patch("cloudinit.net.get_interfaces_by_mac")
+     @mock.patch("cloudinit.sources.helpers.vultr.is_vultr")
+@@ -346,7 +312,7 @@ class TestDataSourceVultr(CiTestCase):
+     def test_datasource_cloud_interfaces(
+         self, mock_getmeta, mock_isvultr, mock_netmap
+     ):
+-        mock_getmeta.return_value = VULTR_V1_3
++        mock_getmeta.return_value = self._get_metadata()
+         mock_isvultr.return_value = True
+         mock_netmap.return_value = INTERFACE_MAP
+ 
+@@ -375,7 +341,7 @@ class TestDataSourceVultr(CiTestCase):
+     @mock.patch("cloudinit.net.get_interfaces_by_mac")
+     def test_private_network_config(self, mock_netmap):
+         mock_netmap.return_value = INTERFACE_MAP
+-        interf = VULTR_V1_2["interfaces"].copy()
++        interf = copy.deepcopy(VULTR_V1_2["interfaces"])
+ 
+         # Test configuring
+         self.assertEqual(
+@@ -384,28 +350,11 @@ class TestDataSourceVultr(CiTestCase):
+ 
+         # Test unconfigured
+         interf[1]["unconfigured"] = True
+-        expected = EXPECTED_VULTR_NETWORK_2.copy()
++        expected = copy.deepcopy(EXPECTED_VULTR_NETWORK_2)
+         expected["config"].pop(2)
+         self.assertEqual(expected, vultr.generate_network_config(interf))
+ 
+     # Override ephemeral for proper unit testing
+-    def ephemeral_init(
+-        self, distro, iface="", connectivity_url_data=None, tmp_dir=None
+-    ):
+-        global FINAL_INTERFACE_USED
+-        FINAL_INTERFACE_USED = iface
+-        if iface == "eth0":
+-            return
+-        raise NoDHCPLeaseError("Generic for testing")
+-
+-    # Override ephemeral for proper unit testing
+-    def ephemeral_init_always(
+-        self, iface="", connectivity_url_data=None, tmp_dir=None
+-    ):
+-        global FINAL_INTERFACE_USED
+-        FINAL_INTERFACE_USED = iface
+-
+-    # Override ephemeral for proper unit testing
+     def override_enter(self):
+         return
+ 
+@@ -415,7 +364,8 @@ class TestDataSourceVultr(CiTestCase):
+ 
+     # Test interface seeking to ensure we are able to find the correct one
+     @mock.patch(
+-        "cloudinit.net.ephemeral.EphemeralDHCPv4.__init__", ephemeral_init
++        "cloudinit.net.ephemeral.EphemeralDHCPv4.__init__",
++        side_effect=(NoDHCPLeaseError("Generic for testing"), None),
+     )
+     @mock.patch(
+         "cloudinit.net.ephemeral.EphemeralDHCPv4.__enter__", override_enter
+@@ -431,6 +381,7 @@ class TestDataSourceVultr(CiTestCase):
+         mock_interface_list,
+         mock_read_metadata,
+         mock_isvultr,
++        mock_eph_init,
+     ):
+         mock_read_metadata.return_value = {}
+         mock_isvultr.return_value = True
+@@ -447,36 +398,4 @@ class TestDataSourceVultr(CiTestCase):
+         except Exception:
+             pass
+ 
+-        self.assertEqual(FINAL_INTERFACE_USED, INTERFACES[3])
+-
+-    # Test route checking sucessful DHCPs
+-    @mock.patch(
+-        "cloudinit.net.ephemeral.EphemeralDHCPv4.__init__",
+-        ephemeral_init_always,
+-    )
+-    @mock.patch(
+-        "cloudinit.net.ephemeral.EphemeralDHCPv4.__enter__", override_enter
+-    )
+-    @mock.patch(
+-        "cloudinit.net.ephemeral.EphemeralDHCPv4.__exit__", override_exit
+-    )
+-    @mock.patch("cloudinit.sources.helpers.vultr.get_interface_list")
+-    @mock.patch("cloudinit.sources.helpers.vultr.is_vultr")
+-    @mock.patch("cloudinit.sources.helpers.vultr.read_metadata")
+-    def test_interface_seek_route_check(
+-        self, mock_read_metadata, mock_isvultr, mock_interface_list
+-    ):
+-        mock_read_metadata.return_value = {}
+-        mock_interface_list.return_value = FILTERED_INTERFACES
+-        mock_isvultr.return_value = True
+-
+-        source = DataSourceVultr.DataSourceVultr(
+-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+-        )
+-
+-        try:
+-            source._get_data()
+-        except Exception:
+-            pass
+-
+-        self.assertEqual(FINAL_INTERFACE_USED, INTERFACES[3])
++        assert mock_eph_init.call_args[1]["iface"] == FILTERED_INTERFACES[1]
+--- a/tests/unittests/test_cli.py
++++ b/tests/unittests/test_cli.py
+@@ -25,6 +25,14 @@ def mock_get_user_data_file(mocker, tmpd
+     )
+ 
+ 
++@pytest.fixture(autouse=True, scope="module")
++def disable_setup_logging():
++    # setup_basic_logging can change the logging level to WARNING, so
++    # ensure it is always mocked
++    with mock.patch(f"{M_PATH}log.setup_basic_logging", autospec=True):
++        yield
++
++
+ class TestCLI:
+     def _call_main(self, sysv_args=None):
+         if not sysv_args:
+@@ -193,7 +201,7 @@ class TestCLI:
+             ),
+         ),
+     )
+-    @mock.patch("cloudinit.cmd.main.setup_basic_logging")
++    @mock.patch("cloudinit.cmd.main.log.setup_basic_logging")
+     def test_subcommands_log_to_stderr_via_setup_basic_logging(
+         self, setup_basic_logging, subcommand, log_to_stderr, mocks
+     ):

--- a/debian/patches/cpick-372e80f8-net-dhcp-bump-dhcpcd-timeout-to-300s-5127
+++ b/debian/patches/cpick-372e80f8-net-dhcp-bump-dhcpcd-timeout-to-300s-5127
@@ -1,0 +1,34 @@
+From 372e80f8e6e01441e69d277782e2367678994abb Mon Sep 17 00:00:00 2001
+From: Chris Patterson <cpatterson@microsoft.com>
+Date: Mon, 1 Apr 2024 17:41:25 -0400
+Subject: [PATCH] net/dhcp: bump dhcpcd timeout to 300s (#5127)
+
+On most distros, including Ubuntu, the default timeout for dhclient is 300s.
+There is no cloud-init controlled duration for the dhclient process as
+it doesn't fork until after it receives an IP address and there is no timeout
+value passed to subp().
+
+I have seen some distros configure dhclient with a timeout of 60s, but
+is far less common.
+
+Given that a cloud VM is not very useful with DHCP, err on the generous
+side and allow up to 300 seconds for dhcpcd to get an address.
+
+Note that there is still an issue with dhcpcd retries which will be
+addressed later in a separate PR.
+
+Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
+---
+ cloudinit/net/dhcp.py | 1 +
+ 1 file changed, 1 insertion(+)
+
+--- a/cloudinit/net/dhcp.py
++++ b/cloudinit/net/dhcp.py
+@@ -596,6 +596,7 @@ class IscDhclient(DhcpClient):
+ 
+ class Dhcpcd(DhcpClient):
+     client_name = "dhcpcd"
++    timeout = 300
+ 
+     def dhcp_discovery(
+         self,

--- a/debian/patches/cpick-77771023-net-dhcp-raise-InvalidDHCPLeaseFileError-on-error
+++ b/debian/patches/cpick-77771023-net-dhcp-raise-InvalidDHCPLeaseFileError-on-error
@@ -1,0 +1,115 @@
+From 77771023ab5bda43a25cdc3dd4eb69a79169b3cb Mon Sep 17 00:00:00 2001
+From: Chris Patterson <cpatterson@microsoft.com>
+Date: Tue, 2 Apr 2024 12:11:39 -0400
+Subject: [PATCH] net/dhcp: raise InvalidDHCPLeaseFileError on error parsing
+ dhcpcd lease (#5128)
+
+Seeing a fairly large number of lease parsing failures on Azure similar
+to:
+```
+Traceback (most recent call last):
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceAzure.py", line 851, in _get_data
+    crawled_data = util.log_time(
+                   ^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/util.py", line 2828, in log_time
+    ret = func(*args, **kwargs)
+          ^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/helpers/azure.py", line 45, in impl
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceAzure.py", line 660, in crawl_metadata
+    self._wait_for_pps_savable_reuse()
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/helpers/azure.py", line 45, in impl
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceAzure.py", line 1236, in _wait_for_pps_savable_reuse
+    self._wait_for_hot_attached_primary_nic(nl_sock)
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/helpers/azure.py", line 45, in impl
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceAzure.py", line 1142, in _wait_for_hot_attached_primary_nic
+    primary_nic_found = self._setup_ephemeral_networking(
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/helpers/azure.py", line 45, in impl
+    return func(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceAzure.py", line 440, in _setup_ephemeral_networking
+    lease = self._ephemeral_dhcp_ctx.obtain_lease()
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/net/ephemeral.py", line 293, in obtain_lease
+    self.lease = maybe_perform_dhcp_discovery(
+                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 103, in maybe_perform_dhcp_discovery
+    return distro.dhcp_client.dhcp_discovery(interface, dhcp_log_func, distro)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 656, in dhcp_discovery
+    lease = self.get_newest_lease(interface)
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 829, in get_newest_lease
+    return self.parse_dhcpcd_lease(
+           ^^^^^^^^^^^^^^^^^^^^^^^^
+  File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 787, in parse_dhcpcd_lease
+    lease = dict(
+            ^^^^^
+ValueError: dictionary update sequence element #0 has length 1; 2 is required
+```
+
+Catch this error in parse_dhcpcd_lease() and raise
+InvalidDHCPLeaseFileError after logging an error.
+
+Signed-off-by: Chris Patterson <cpatterson@microsoft.com>
+---
+ cloudinit/net/dhcp.py            | 19 +++++++++++++------
+ tests/unittests/net/test_dhcp.py | 11 +++++++++++
+ 2 files changed, 24 insertions(+), 6 deletions(-)
+
+--- a/cloudinit/net/dhcp.py
++++ b/cloudinit/net/dhcp.py
+@@ -783,14 +783,21 @@ class Dhcpcd(DhcpClient):
+         subnet_cidr='20'
+         subnet_mask='255.255.240.0'
+         """
++        LOG.debug(
++            "Parsing dhcpcd lease for interface %s: %r", interface, lease_dump
++        )
+ 
+         # create a dict from dhcpcd dump output - remove single quotes
+-        lease = dict(
+-            [
+-                a.split("=")
+-                for a in lease_dump.strip().replace("'", "").split("\n")
+-            ]
+-        )
++        try:
++            lease = dict(
++                [
++                    a.split("=")
++                    for a in lease_dump.strip().replace("'", "").split("\n")
++                ]
++            )
++        except ValueError as error:
++            LOG.error("Error parsing dhcpcd lease: %r", error)
++            raise InvalidDHCPLeaseFileError from error
+ 
+         # this is expected by cloud-init's code
+         lease["interface"] = interface
+--- a/tests/unittests/net/test_dhcp.py
++++ b/tests/unittests/net/test_dhcp.py
+@@ -1199,6 +1199,17 @@ class TestDhcpcd:
+         assert "255.255.240.0" == parsed_lease["subnet-mask"]
+         assert "192.168.0.1" == parsed_lease["routers"]
+ 
++    def test_parse_lease_dump_fails(self):
++        lease = dedent(
++            """
++            fail
++            """
++        )
++
++        with pytest.raises(InvalidDHCPLeaseFileError):
++            with mock.patch("cloudinit.net.dhcp.util.load_binary_file"):
++                Dhcpcd.parse_dhcpcd_lease(lease, "eth0")
++
+     @pytest.mark.parametrize(
+         "lease_file, option_245",
+         (

--- a/debian/patches/cpick-8f806e20-net-Warn-when-interface-rename-fails
+++ b/debian/patches/cpick-8f806e20-net-Warn-when-interface-rename-fails
@@ -1,0 +1,29 @@
+From 8f806e20bda1bdf0e00ff180183990470e241837 Mon Sep 17 00:00:00 2001
+From: Brett Holman <brett.holman@canonical.com>
+Date: Thu, 28 Mar 2024 14:50:25 -0600
+Subject: [PATCH] net: Warn when interface rename fails
+
+---
+ cloudinit/net/__init__.py | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+--- a/cloudinit/net/__init__.py
++++ b/cloudinit/net/__init__.py
+@@ -839,11 +839,15 @@ def _rename_interfaces(
+ 
+     if len(ops) + len(ups) == 0:
+         if len(errors):
+-            LOG.debug("unable to do any work for renaming of %s", renames)
++            LOG.warning(
++                "Unable to rename interfaces: %s due to errors: %s",
++                renames,
++                errors,
++            )
+         else:
+             LOG.debug("no work necessary for renaming of %s", renames)
+     else:
+-        LOG.debug("achieving renaming of %s with ops %s", renames, ops + ups)
++        LOG.debug("Renamed %s with ops %s", renames, ops + ups)
+ 
+         for op, mac, new_name, params in ops + ups:
+             try:

--- a/debian/patches/cpick-accdfe6a-refactor-Import-log-module-rather-than-functions-5074
+++ b/debian/patches/cpick-accdfe6a-refactor-Import-log-module-rather-than-functions-5074
@@ -1,0 +1,120 @@
+From accdfe6a8b2ffff82731c8bae2d672ff7c3f0974 Mon Sep 17 00:00:00 2001
+From: James Falcon <james.falcon@canonical.com>
+Date: Sun, 17 Mar 2024 19:31:31 -0500
+Subject: [PATCH] refactor: Import log module rather than functions (#5074)
+
+Mocking doesn't work when we import functions directly.
+---
+ cloudinit/cmd/main.py | 37 ++++++++++++++++---------------------
+ 1 file changed, 16 insertions(+), 21 deletions(-)
+
+--- a/cloudinit/cmd/main.py
++++ b/cloudinit/cmd/main.py
+@@ -35,14 +35,7 @@ from cloudinit.cmd.devel import read_cfg
+ from cloudinit.config import cc_set_hostname
+ from cloudinit.config.modules import Modules
+ from cloudinit.config.schema import validate_cloudconfig_schema
+-from cloudinit.log import (
+-    LogExporter,
+-    setup_basic_logging,
+-    setup_logging,
+-    reset_logging,
+-    configure_root_logger,
+-    DEPRECATED,
+-)
++from cloudinit import log
+ from cloudinit.reporting import events
+ from cloudinit.safeyaml import load
+ from cloudinit.settings import PER_INSTANCE, PER_ALWAYS, PER_ONCE, CLOUD_CONFIG
+@@ -223,7 +216,7 @@ def attempt_cmdline_url(path, network=Tr
+             if is_cloud_cfg:
+                 if cmdline_name == "url":
+                     return (
+-                        DEPRECATED,
++                        log.DEPRECATED,
+                         str(
+                             util.deprecate(
+                                 deprecated="The kernel command line key `url`",
+@@ -348,8 +341,8 @@ def main_init(name, args):
+         LOG.debug(
+             "Logging being reset, this logger may no longer be active shortly"
+         )
+-        reset_logging()
+-    setup_logging(init.cfg)
++        log.reset_logging()
++    log.setup_logging(init.cfg)
+     apply_reporting_cfg(init.cfg)
+ 
+     # Any log usage prior to setup_logging above did not have local user log
+@@ -510,7 +503,7 @@ def main_init(name, args):
+             (outfmt, errfmt) = util.fixup_output(mods.cfg, name)
+     except Exception:
+         util.logexc(LOG, "Failed to re-adjust output redirection!")
+-    setup_logging(mods.cfg)
++    log.setup_logging(mods.cfg)
+ 
+     # give the activated datasource a chance to adjust
+     init.activate_datasource()
+@@ -615,8 +608,8 @@ def main_modules(action_name, args):
+         LOG.debug(
+             "Logging being reset, this logger may no longer be active shortly"
+         )
+-        reset_logging()
+-    setup_logging(mods.cfg)
++        log.reset_logging()
++    log.setup_logging(mods.cfg)
+     apply_reporting_cfg(init.cfg)
+ 
+     # now that logging is setup and stdout redirected, send welcome
+@@ -677,8 +670,8 @@ def main_single(name, args):
+         LOG.debug(
+             "Logging being reset, this logger may no longer be active shortly"
+         )
+-        reset_logging()
+-    setup_logging(mods.cfg)
++        log.reset_logging()
++    log.setup_logging(mods.cfg)
+     apply_reporting_cfg(init.cfg)
+ 
+     # now that logging is setup and stdout redirected, send welcome
+@@ -768,7 +761,7 @@ def status_wrapper(name, args, data_d=No
+     v1["stage"] = mode
+     v1[mode]["start"] = time.time()
+     v1[mode]["recoverable_errors"] = next(
+-        filter(lambda h: isinstance(h, LogExporter), root_logger.handlers)
++        filter(lambda h: isinstance(h, log.LogExporter), root_logger.handlers)
+     ).export_logs()
+ 
+     # Write status.json prior to running init / module code
+@@ -798,7 +791,7 @@ def status_wrapper(name, args, data_d=No
+ 
+     # Write status.json after running init / module code
+     v1[mode]["recoverable_errors"] = next(
+-        filter(lambda h: isinstance(h, LogExporter), root_logger.handlers)
++        filter(lambda h: isinstance(h, log.LogExporter), root_logger.handlers)
+     ).export_logs()
+     atomic_helper.write_json(status_path, status)
+ 
+@@ -856,7 +849,7 @@ def main_features(name, args):
+ 
+ 
+ def main(sysv_args=None):
+-    configure_root_logger()
++    log.configure_root_logger()
+     if not sysv_args:
+         sysv_args = sys.argv
+     parser = argparse.ArgumentParser(prog=sysv_args.pop(0))
+@@ -1080,9 +1073,11 @@ def main(sysv_args=None):
+     #   - if --debug is passed, logging.DEBUG
+     #   - if --debug is not passed, logging.WARNING
+     if name not in ("init", "modules"):
+-        setup_basic_logging(logging.DEBUG if args.debug else logging.WARNING)
++        log.setup_basic_logging(
++            logging.DEBUG if args.debug else logging.WARNING
++        )
+     elif args.debug:
+-        setup_basic_logging()
++        log.setup_basic_logging()
+ 
+     # Setup signal handlers before running
+     signal_handler.attach_handlers()

--- a/debian/patches/cpick-f6ac6ee8-fix-dhcpcd-Make-lease-parsing-more-robust-5129
+++ b/debian/patches/cpick-f6ac6ee8-fix-dhcpcd-Make-lease-parsing-more-robust-5129
@@ -1,0 +1,111 @@
+From f6ac6ee8a4321ba959ae8f3ae9f1b9ac3b9fafd0 Mon Sep 17 00:00:00 2001
+From: Brett Holman <brett.holman@canonical.com>
+Date: Tue, 2 Apr 2024 14:40:06 -0600
+Subject: [PATCH] fix(dhcpcd): Make lease parsing more robust (#5129)
+
+---
+ cloudinit/net/dhcp.py            | 12 +++++-
+ tests/unittests/net/test_dhcp.py | 63 +++++++++++++++++++++++++++++---
+ 2 files changed, 68 insertions(+), 7 deletions(-)
+
+--- a/cloudinit/net/dhcp.py
++++ b/cloudinit/net/dhcp.py
+@@ -791,12 +791,20 @@ class Dhcpcd(DhcpClient):
+         try:
+             lease = dict(
+                 [
+-                    a.split("=")
++                    a.split("=", maxsplit=1)
+                     for a in lease_dump.strip().replace("'", "").split("\n")
++                    if "=" in a
+                 ]
+             )
++            if not lease:
++                msg = (
++                    "No valid DHCP lease configuration "
++                    "found in dhcpcd lease: %r"
++                )
++                LOG.error(msg, lease_dump)
++                raise InvalidDHCPLeaseFileError(msg % lease_dump)
+         except ValueError as error:
+-            LOG.error("Error parsing dhcpcd lease: %r", error)
++            LOG.error("Error parsing dhcpcd lease: %r", lease_dump)
+             raise InvalidDHCPLeaseFileError from error
+ 
+         # this is expected by cloud-init's code
+--- a/tests/unittests/net/test_dhcp.py
++++ b/tests/unittests/net/test_dhcp.py
+@@ -1199,15 +1199,68 @@ class TestDhcpcd:
+         assert "255.255.240.0" == parsed_lease["subnet-mask"]
+         assert "192.168.0.1" == parsed_lease["routers"]
+ 
++    @pytest.mark.parametrize(
++        "lease, parsed",
++        (
++            pytest.param(
++                """
++
++                domain_name='us-east-2.compute.internal'
++
++                domain_name_servers='192.168.0.2'
++
++                """,
++                {
++                    "domain_name": "us-east-2.compute.internal",
++                    "domain_name_servers": "192.168.0.2",
++                },
++                id="lease_has_empty_lines",
++            ),
++            pytest.param(
++                """
++                domain_name='us-east-2.compute.internal'
++                not-a-kv-pair
++                domain_name_servers='192.168.0.2'
++                """,
++                {
++                    "domain_name": "us-east-2.compute.internal",
++                    "domain_name_servers": "192.168.0.2",
++                },
++                id="lease_has_values_that_arent_key_value_pairs",
++            ),
++            pytest.param(
++                """
++                domain_name='us-east=2.compute.internal'
++                """,
++                {
++                    "domain_name": "us-east=2.compute.internal",
++                },
++                id="lease_has_kv_pair_including_equals_sign_in_value",
++            ),
++        ),
++    )
++    def test_parse_lease_dump_resilience(self, lease, parsed):
++        with mock.patch("cloudinit.net.dhcp.util.load_binary_file"):
++            Dhcpcd.parse_dhcpcd_lease(dedent(lease), "eth0")
++
+     def test_parse_lease_dump_fails(self):
+-        lease = dedent(
+-            """
+-            fail
+-            """
+-        )
++        def _raise():
++            raise ValueError()
++
++        lease = mock.Mock()
++        lease.strip = _raise
++
++        with pytest.raises(InvalidDHCPLeaseFileError):
++            with mock.patch("cloudinit.net.dhcp.util.load_binary_file"):
++                Dhcpcd.parse_dhcpcd_lease(lease, "eth0")
+ 
+         with pytest.raises(InvalidDHCPLeaseFileError):
+             with mock.patch("cloudinit.net.dhcp.util.load_binary_file"):
++                lease = dedent(
++                    """
++                    fail
++                    """
++                )
+                 Dhcpcd.parse_dhcpcd_lease(lease, "eth0")
+ 
+     @pytest.mark.parametrize(

--- a/debian/patches/cpick-f74b61ea-ephemeral-dhcpcd-Set-dhcpcd-interface-down
+++ b/debian/patches/cpick-f74b61ea-ephemeral-dhcpcd-Set-dhcpcd-interface-down
@@ -1,0 +1,81 @@
+From f74b61eae24706dd313efc06792198a718f06672 Mon Sep 17 00:00:00 2001
+From: Brett Holman <brett.holman@canonical.com>
+Date: Thu, 28 Mar 2024 14:43:15 -0600
+Subject: [PATCH] ephemeral(dhcpcd): Set dhcpcd interface down
+
+Address assignment and link management is manual for isc-dhcp-client
+whereas dhcpcd brings up its own interface and assigns the IP address.
+
+Interface rename code assumes that the link will be down for rename.
+Make sure to set dhcpcd's interface to the same state.
+---
+ cloudinit/net/ephemeral.py | 30 +++++++++++++++++++++++-------
+ 1 file changed, 23 insertions(+), 7 deletions(-)
+
+--- a/cloudinit/net/ephemeral.py
++++ b/cloudinit/net/ephemeral.py
+@@ -75,6 +75,7 @@ class EphemeralIPv4Network:
+         # List of commands to run to cleanup state.
+         self.cleanup_cmds: List[Callable] = []
+         self.distro = distro
++        self.cidr = f"{self.ip}/{self.prefix}"
+ 
+     def __enter__(self):
+         """Perform ephemeral network setup if interface is not connected."""
+@@ -117,15 +118,16 @@ class EphemeralIPv4Network:
+ 
+     def _bringup_device(self):
+         """Perform the ip commands to fully setup the device."""
+-        cidr = "{0}/{1}".format(self.ip, self.prefix)
+         LOG.debug(
+             "Attempting setup of ephemeral network on %s with %s brd %s",
+             self.interface,
+-            cidr,
++            self.cidr,
+             self.broadcast,
+         )
+         try:
+-            self.distro.net_ops.add_addr(self.interface, cidr, self.broadcast)
++            self.distro.net_ops.add_addr(
++                self.interface, self.cidr, self.broadcast
++            )
+         except ProcessExecutionError as e:
+             if "File exists" not in str(e.stderr):
+                 raise
+@@ -145,7 +147,9 @@ class EphemeralIPv4Network:
+                 )
+             )
+             self.cleanup_cmds.append(
+-                partial(self.distro.net_ops.del_addr, self.interface, cidr)
++                partial(
++                    self.distro.net_ops.del_addr, self.interface, self.cidr
++                )
+             )
+ 
+     def _bringup_static_routes(self):
+@@ -351,10 +355,22 @@ class EphemeralDHCPv4:
+ class DhcpcdEphemeralIPv4Network(EphemeralIPv4Network):
+     """dhcpcd sets up its own ephemeral network and routes"""
+ 
+-    def __enter__(self):
+-        return
++    def __init__(self, *args, **kwargs):
++        super().__init__(*args, **kwargs)
+ 
+-    def __exit__(self, excp_type, excp_value, excp_traceback):
++        # clean up after dhcpcd
++        self.cleanup_cmds.append(
++            partial(
++                self.distro.net_ops.link_down,
++                self.interface,
++                family="inet",
++            )
++        )
++        self.cleanup_cmds.append(
++            partial(self.distro.net_ops.del_addr, self.interface, self.cidr)
++        )
++
++    def __enter__(self):
+         return
+ 
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+cpick-accdfe6a-refactor-Import-log-module-rather-than-functions-5074

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@ cpick-accdfe6a-refactor-Import-log-module-rather-than-functions-5074
 cpick-144782a8-test-Remove-side-effects-from-tests-5074
 cpick-f74b61ea-ephemeral-dhcpcd-Set-dhcpcd-interface-down
 cpick-8f806e20-net-Warn-when-interface-rename-fails
+cpick-372e80f8-net-dhcp-bump-dhcpcd-timeout-to-300s-5127

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -4,3 +4,4 @@ cpick-f74b61ea-ephemeral-dhcpcd-Set-dhcpcd-interface-down
 cpick-8f806e20-net-Warn-when-interface-rename-fails
 cpick-372e80f8-net-dhcp-bump-dhcpcd-timeout-to-300s-5127
 cpick-77771023-net-dhcp-raise-InvalidDHCPLeaseFileError-on-error
+cpick-f6ac6ee8-fix-dhcpcd-Make-lease-parsing-more-robust-5129

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 cpick-accdfe6a-refactor-Import-log-module-rather-than-functions-5074
 cpick-144782a8-test-Remove-side-effects-from-tests-5074
+cpick-f74b61ea-ephemeral-dhcpcd-Set-dhcpcd-interface-down

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@ cpick-144782a8-test-Remove-side-effects-from-tests-5074
 cpick-f74b61ea-ephemeral-dhcpcd-Set-dhcpcd-interface-down
 cpick-8f806e20-net-Warn-when-interface-rename-fails
 cpick-372e80f8-net-dhcp-bump-dhcpcd-timeout-to-300s-5127
+cpick-77771023-net-dhcp-raise-InvalidDHCPLeaseFileError-on-error

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 cpick-accdfe6a-refactor-Import-log-module-rather-than-functions-5074
 cpick-144782a8-test-Remove-side-effects-from-tests-5074
 cpick-f74b61ea-ephemeral-dhcpcd-Set-dhcpcd-interface-down
+cpick-8f806e20-net-Warn-when-interface-rename-fails

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 cpick-accdfe6a-refactor-Import-log-module-rather-than-functions-5074
+cpick-144782a8-test-Remove-side-effects-from-tests-5074


### PR DESCRIPTION
Sync applicable bug fixes from 24.1.4 to ubuntu/noble-24.1.x for release.

We are in beta freeze for Ubuntu noble, and we want to limit changes published to noble to Ubuntu bug-fixes only.
So this PR is a cherry-picked set of changes from 24.1.4 with the exclusion of the commit a6e09d9bfd3ef0770bc4d9452d978ba93dbe1245 which is  run_dir support for BSD and not applicable to Ubuntu images.

## process to create this branch:
```
git fetch upstream
git checkout upstream/ubuntu/noble-24.1.x -B ubuntu/noble-24.1.x

#  Pull in 7 of the 8 commits in 24.1.4 into noble-24.1.x branch as cpick files
for hash in accdfe6a8b2ffff82731c8bae2d672ff7c3f0974 144782a838123099334fe44c07566b07503fd67b f74b61eae24706dd313efc06792198a718f06672 8f806e20bda1bdf0e00ff180183990470e241837 372e80f8e6e01441e69d277782e2367678994abb 77771023ab5bda43a25cdc3dd4eb69a79169b3cb f6ac6ee8a4321ba959ae8f3ae9f1b9ac3b9fafd0; do cherry-pick $hash; done

# Manually update d/changelog to the right package version `24.1.3-0ubuntu2` and refactor the d/changelog entry to represent 
# functional bug fixes vs test fixes
git commit -am 'update changelog'
git rebase -i HEAD~10 # collapse all  `update changelog` commits
dch -r -D noble ''
 git commit -am 'releasing cloud-init version 24.1.3-0ubuntu2'
```
## Proposed Commit Message [REBASE merge]
See individ commits.
## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
