### PR TITLE
fix: Logging sensitive data

### DIFF
--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -218,21 +218,14 @@ def subp(
     if update_env:
         env.update(update_env)
 
-    if not logstring:
-        LOG.debug(
-            "Running command %s with allowed return codes %s"
-            " (shell=%s, capture=%s)",
-            args,
-            rcs,
-            shell,
-            capture,
-        )
-    else:
-        LOG.debug(
-            "Running hidden command to protect sensitive "
-            "input/output logstring: %s",
-            logstring,
-        )
+    LOG.debug(
+        "Running command %s with allowed return codes %s"
+        " (shell=%s, capture=%s)",
+        logstring if logstring else args,
+        rcs,
+        shell,
+        capture,
+    )
 
     stdin: Union[TextIOWrapper, int]
     stdout = None
@@ -276,7 +269,11 @@ def subp(
         out, err = sp.communicate(data, timeout=timeout)
         total = time.time() - before
         if total > 0.1:
-            LOG.debug("command %s took %.3ss to run", args, total)
+            LOG.debug(
+                "%s took %.3ss to run",
+                logstring if logstring else args,
+                total,
+            )
     except OSError as e:
         raise ProcessExecutionError(
             cmd=args,


### PR DESCRIPTION
```
fix: Don't log sensitive data

Since /var/log/cloud-init.log is a priviledged file, this
does not expose a secure system (no CVE). However, we don't
want to log this information so that users can file reports
without having to manually redact logs.

Standardize log messages so that redacted and non-redacted logs match.
```
