### PR TITLE
chore(safeyaml): Remove legacy Python 2 unicode helper

### DIFF
--- a/cloudinit/cmd/devel/net_convert.py
+++ b/cloudinit/cmd/devel/net_convert.py
@@ -115,7 +115,7 @@ def handle_args(name, args):
     if args.kind == "eni":
         pre_ns = eni.convert_eni_data(net_data)
     elif args.kind == "yaml":
-        pre_ns = safeyaml.load(net_data)
+        pre_ns = yaml.safe_load(net_data)
         if "network" in pre_ns:
             pre_ns = pre_ns.get("network")
         if args.debug:

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -19,6 +19,7 @@ import sys
 import time
 import traceback
 import logging
+import yaml
 from typing import Tuple
 
 from cloudinit import netinfo
@@ -37,7 +38,6 @@ from cloudinit.config.modules import Modules
 from cloudinit.config.schema import validate_cloudconfig_schema
 from cloudinit import log
 from cloudinit.reporting import events
-from cloudinit.safeyaml import load
 from cloudinit.settings import PER_INSTANCE, PER_ALWAYS, PER_ONCE, CLOUD_CONFIG
 
 # Welcome message template
@@ -481,7 +481,7 @@ def main_init(name, args):
     cloud_cfg_path = init.paths.get_ipath_cur("cloud_config")
     if os.path.exists(cloud_cfg_path) and os.stat(cloud_cfg_path).st_size != 0:
         validate_cloudconfig_schema(
-            config=load(util.load_text_file(cloud_cfg_path)),
+            config=yaml.safe_load(util.load_text_file(cloud_cfg_path)),
             strict=False,
             log_details=False,
             log_deprecations=True,

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -11,7 +11,9 @@ import os
 from textwrap import dedent
 from typing import List, Tuple
 
-from cloudinit import safeyaml, subp, util
+import yaml
+
+from cloudinit import subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema, get_meta_doc
@@ -512,8 +514,8 @@ def get_required_packages(init_cfg: dict, preseed_str: str) -> List[str]:
     if preseed_str and "storage_pools" in preseed_str:
         # Assume correct YAML preseed format
         try:
-            preseed_cfg = safeyaml.load(preseed_str)
-        except (safeyaml.YAMLError, TypeError, ValueError):
+            preseed_cfg = yaml.safe_load(preseed_str)
+        except (yaml.YAMLError, TypeError, ValueError):
             LOG.warning(
                 "lxd.preseed string value is not YAML. "
                 " Unable to determine required storage driver packages to"

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1083,7 +1083,7 @@ def validate_cloudconfig_file(
         if annotate:
             cloudconfig, marks = safeyaml.load_with_marks(content)
         else:
-            cloudconfig = safeyaml.load(content)
+            cloudconfig = yaml.safe_load(content)
             marks = {}
     except yaml.YAMLError as e:
         line = column = 1

--- a/cloudinit/safeyaml.py
+++ b/cloudinit/safeyaml.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, List, Tuple
 
 import yaml
 
-YAMLError = yaml.YAMLError
 
 # SchemaPathMarks track the path to an element within a loaded YAML file.
 # The start_mark and end_mark contain the row and column indicators
@@ -47,11 +46,6 @@ class SchemaPathMarks:
             and self.end_mark.line == other.end_mark.line
             and self.end_mark.column == other.end_mark.column
         )
-
-
-class _CustomSafeLoader(yaml.SafeLoader):
-    def construct_python_unicode(self, node):
-        return super().construct_scalar(node)
 
 
 def _find_closest_parent(child_mark, marks):
@@ -236,12 +230,6 @@ class _CustomSafeLoaderWithMarks(yaml.SafeLoader):
         return data
 
 
-_CustomSafeLoader.add_constructor(
-    "tag:yaml.org,2002:python/unicode",
-    _CustomSafeLoader.construct_python_unicode,
-)
-
-
 class NoAliasSafeDumper(yaml.dumper.SafeDumper):
     """A class which avoids constructing anchors/aliases on yaml dump"""
 
@@ -268,10 +256,6 @@ def load_with_marks(blob) -> Tuple[Any, Dict[str, int]]:
     else:
         schemamarks = result.pop("schemamarks")
     return result, schemamarks
-
-
-def load(blob):
-    return yaml.load(blob, Loader=_CustomSafeLoader)
 
 
 def dumps(obj, explicit_start=True, explicit_end=True, noalias=False):

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -19,7 +19,9 @@ import os
 import re
 from xml.dom import minidom  # nosec B408
 
-from cloudinit import safeyaml, sources, subp, util
+import yaml
+
+from cloudinit import sources, subp, util
 
 LOG = logging.getLogger(__name__)
 
@@ -408,4 +410,4 @@ def safeload_yaml_or_dict(data):
     """
     if not data:
         return {}
-    return safeyaml.load(data)
+    return yaml.safe_load(data)

--- a/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
@@ -11,7 +11,9 @@ import os
 import re
 import time
 
-from cloudinit import safeyaml, subp, util
+import yaml
+
+from cloudinit import subp, util
 
 from .config import Config
 from .config_custom_script import PostCustomScript, PreCustomScript
@@ -263,8 +265,8 @@ def get_data_from_imc_raw_data_cust_cfg(cust_cfg):
 
         try:
             logger.debug("Validating if meta data is valid or not")
-            md = safeyaml.load(md)
-        except safeyaml.YAMLError as e:
+            md = yaml.safe_load(md)
+        except yaml.YAMLError as e:
             set_cust_error_status(
                 "Error parsing the cloud-init meta data",
                 str(e),

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -56,12 +56,13 @@ from typing import (
 )
 from urllib import parse
 
+import yaml
+
 from cloudinit import (
     features,
     importer,
     mergers,
     net,
-    safeyaml,
     settings,
     subp,
     temp_utils,
@@ -1009,7 +1010,7 @@ def load_yaml(blob, default=None, allowed=(dict,)):
             len(blob),
             allowed,
         )
-        converted = safeyaml.load(blob)
+        converted = yaml.safe_load(blob)
         if converted is None:
             LOG.debug("loaded blob returned None, returning default.")
             converted = default
@@ -1020,7 +1021,7 @@ def load_yaml(blob, default=None, allowed=(dict,)):
                 % (allowed, type_utils.obj_name(converted))
             )
         loaded = converted
-    except (safeyaml.YAMLError, TypeError, ValueError) as e:
+    except (yaml.YAMLError, TypeError, ValueError) as e:
         msg = "Failed loading yaml blob"
         mark = None
         if hasattr(e, "context_mark") and getattr(e, "context_mark"):

--- a/tests/integration_tests/datasources/test_lxd_hotplug.py
+++ b/tests/integration_tests/datasources/test_lxd_hotplug.py
@@ -1,8 +1,8 @@
 import json
 
 import pytest
+import yaml
 
-from cloudinit import safeyaml
 from cloudinit.subp import subp
 from cloudinit.util import is_true
 from tests.integration_tests.decorators import retry
@@ -142,10 +142,10 @@ class TestLxdHotplug:
             f"nictype=bridged parent=ci-test-br-eth2".split()
         )
         ensure_hotplug_exited(client)
-        post_netplan = safeyaml.load(
+        post_netplan = yaml.safe_load(
             client.read_from_file("/etc/netplan/50-cloud-init.yaml")
         )
-        expected_netplan = safeyaml.load(UPDATED_NETWORK_CONFIG)
+        expected_netplan = yaml.safe_load(UPDATED_NETWORK_CONFIG)
         expected_netplan = {"network": expected_netplan}
         assert post_netplan == expected_netplan, client.read_from_file(
             "/var/log/cloud-init.log"

--- a/tests/unittests/cmd/devel/test_net_convert.py
+++ b/tests/unittests/cmd/devel/test_net_convert.py
@@ -3,8 +3,8 @@
 import itertools
 
 import pytest
+import yaml
 
-from cloudinit import safeyaml as yaml
 from cloudinit.cmd.devel import net_convert
 from cloudinit.distros.debian import NETWORK_FILE_HEADER
 from tests.unittests.helpers import mock
@@ -243,4 +243,4 @@ class TestNetConvert:
         with mock.patch("cloudinit.util.chownbyname"):
             net_convert.handle_args("somename", args)
         outfile = tmpdir.join("etc/netplan/50-cloud-init.yaml")
-        assert yaml.load(content) == yaml.load(outfile.read())
+        assert yaml.safe_load(content) == yaml.safe_load(outfile.read())

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -18,6 +18,7 @@ from types import ModuleType
 from typing import List, Optional, Sequence, Set
 
 import pytest
+import yaml
 
 from cloudinit.config.schema import (
     VERSIONED_USERDATA_SCHEMA_FILE,
@@ -39,7 +40,7 @@ from cloudinit.config.schema import (
     validate_cloudconfig_schema,
 )
 from cloudinit.distros import OSFAMILIES
-from cloudinit.safeyaml import load, load_with_marks
+from cloudinit.safeyaml import load_with_marks
 from cloudinit.settings import FREQUENCIES
 from cloudinit.sources import DataSourceNotFoundException
 from cloudinit.templater import JinjaSyntaxParsingException
@@ -777,7 +778,7 @@ class TestCloudConfigExamples:
         according to the unified schema of all config modules
         """
         schema = get_schema()
-        config_load = load(example)
+        config_load = yaml.safe_load(example)
         # cloud-init-schema-v1 is permissive of additionalProperties at the
         # top-level.
         # To validate specific schemas against known documented examples
@@ -2176,7 +2177,7 @@ class TestSchemaDocExamples:
     @skipUnlessJsonSchema()
     def test_network_config_schema_v1_doc_examples(self, example_path):
         validate_cloudconfig_schema(
-            config=load(open(example_path)),
+            config=yaml.safe_load(open(example_path)),
             schema=self.net_schema,
             strict=True,
         )

--- a/tests/unittests/distros/test_netconfig.py
+++ b/tests/unittests/distros/test_netconfig.py
@@ -7,15 +7,9 @@ from io import StringIO
 from textwrap import dedent
 from unittest import mock
 
-from cloudinit import (
-    distros,
-    features,
-    helpers,
-    safeyaml,
-    settings,
-    subp,
-    util,
-)
+import yaml
+
+from cloudinit import distros, features, helpers, settings, subp, util
 from cloudinit.distros.parsers.sys_conf import SysConf
 from cloudinit.net.activators import IfUpDownActivator
 from tests.unittests.helpers import (
@@ -1148,7 +1142,7 @@ class TestNetCfgDistroPhoton(TestNetCfgDistroBase):
         [Address]
         Address=192.168.0.102/24"""
 
-        net_cfg = safeyaml.load(V1_NET_CFG_WITH_DUPS)
+        net_cfg = yaml.safe_load(V1_NET_CFG_WITH_DUPS)
 
         expected = self.create_conf_dict(expected.splitlines())
         expected_cfgs = {
@@ -1273,7 +1267,7 @@ class TestNetCfgDistroMariner(TestNetCfgDistroBase):
         [Address]
         Address=192.168.0.102/24"""
 
-        net_cfg = safeyaml.load(V1_NET_CFG_WITH_DUPS)
+        net_cfg = yaml.safe_load(V1_NET_CFG_WITH_DUPS)
 
         expected = self.create_conf_dict(expected.splitlines())
         expected_cfgs = {
@@ -1398,7 +1392,7 @@ class TestNetCfgDistroAzureLinux(TestNetCfgDistroBase):
         [Address]
         Address=192.168.0.102/24"""
 
-        net_cfg = safeyaml.load(V1_NET_CFG_WITH_DUPS)
+        net_cfg = yaml.safe_load(V1_NET_CFG_WITH_DUPS)
 
         expected = self.create_conf_dict(expected.splitlines())
         expected_cfgs = {

--- a/tests/unittests/distros/test_networking.py
+++ b/tests/unittests/distros/test_networking.py
@@ -5,9 +5,9 @@ import textwrap
 from unittest import mock
 
 import pytest
+import yaml
 
 from cloudinit import net
-from cloudinit import safeyaml as yaml
 from cloudinit.distros.networking import (
     BSDNetworking,
     LinuxNetworking,
@@ -356,7 +356,7 @@ class TestLinuxNetworkingApplyNetworkCfgNames:
         networking = LinuxNetworking()
         m_device_driver.return_value = "virtio_net"
         m_device_devid.return_value = "0x15d8"
-        netcfg = yaml.load(getattr(self, config_attr))
+        netcfg = yaml.safe_load(getattr(self, config_attr))
 
         with mock.patch.object(
             networking, "_rename_interfaces"
@@ -381,7 +381,7 @@ class TestLinuxNetworkingApplyNetworkCfgNames:
         self, config_attr: str
     ):
         networking = LinuxNetworking()
-        netcfg = yaml.load(getattr(self, config_attr))
+        netcfg = yaml.safe_load(getattr(self, config_attr))
         with mock.patch.object(
             networking, "_rename_interfaces"
         ) as m_rename_interfaces:
@@ -391,4 +391,4 @@ class TestLinuxNetworkingApplyNetworkCfgNames:
     def test_apply_v2_renames_raises_runtime_error_on_unknown_version(self):
         networking = LinuxNetworking()
         with pytest.raises(RuntimeError):
-            networking.apply_network_config_names(yaml.load("version: 3"))
+            networking.apply_network_config_names(yaml.safe_load("version: 3"))

--- a/tests/unittests/net/test_dns.py
+++ b/tests/unittests/net/test_dns.py
@@ -2,7 +2,8 @@
 
 from unittest import mock
 
-from cloudinit import safeyaml
+import yaml
+
 from cloudinit.net import network_state
 
 
@@ -15,7 +16,7 @@ class TestNetDns:
         by_mac_state.return_value = {"00:11:22:33:44:55": "foobar"}
         by_mac_init.return_value = {"00:11:22:33:44:55": "foobar"}
         state = network_state.parse_net_config_data(
-            safeyaml.load(
+            yaml.safe_load(
                 """\
 version: 2
 ethernets:

--- a/tests/unittests/net/test_net_rendering.py
+++ b/tests/unittests/net/test_net_rendering.py
@@ -29,8 +29,8 @@ from enum import Flag, auto
 from pathlib import Path
 
 import pytest
+import yaml
 
-from cloudinit import safeyaml
 from cloudinit.net.netplan import Renderer as NetplanRenderer
 from cloudinit.net.network_manager import Renderer as NetworkManagerRenderer
 from cloudinit.net.network_state import NetworkState, parse_net_config_data
@@ -55,7 +55,7 @@ def _check_netplan(
     if network_state.version == 2:
         renderer = NetplanRenderer(config={"netplan_path": netplan_path})
         renderer.render_network_state(network_state)
-        assert safeyaml.load(netplan_path.read_text()) == expected_config, (
+        assert yaml.safe_load(netplan_path.read_text()) == expected_config, (
             f"Netplan config generated at {netplan_path} does not match v2 "
             "config defined for this test."
         )
@@ -89,7 +89,7 @@ def _check_network_manager(network_state: NetworkState, tmp_path: Path):
     [("no_matching_mac_v2", Renderer.Netplan | Renderer.NetworkManager)],
 )
 def test_convert(test_name, renderers, tmp_path):
-    network_config = safeyaml.load(
+    network_config = yaml.safe_load(
         Path(ARTIFACT_DIR, f"{test_name}.yaml").read_text()
     )
     network_state = parse_net_config_data(network_config["network"])

--- a/tests/unittests/net/test_network_state.py
+++ b/tests/unittests/net/test_network_state.py
@@ -3,8 +3,9 @@ import ipaddress
 from unittest import mock
 
 import pytest
+import yaml
 
-from cloudinit import safeyaml, util
+from cloudinit import util
 from cloudinit.net import network_state
 from cloudinit.net.netplan import Renderer as NetplanRenderer
 from cloudinit.net.renderers import NAME_TO_RENDERER
@@ -215,7 +216,7 @@ class TestNetworkStateParseConfigV2:
         needed.
         """
         util.deprecate._log = set()  # type: ignore
-        ncfg = safeyaml.load(
+        ncfg = yaml.safe_load(
             cfg.format(
                 gateway4="gateway4: 10.54.0.1",
                 gateway6="gateway6: 2a00:1730:fff9:100::1",
@@ -241,8 +242,8 @@ class TestNetworkStateParseConfigV2:
 class TestNetworkStateParseNameservers:
     def _parse_network_state_from_config(self, config):
         with mock.patch("cloudinit.net.network_state.get_interfaces_by_mac"):
-            yaml = safeyaml.load(config)
-            return network_state.parse_net_config_data(yaml["network"])
+            config = yaml.safe_load(config)
+            return network_state.parse_net_config_data(config["network"])
 
     def test_v1_nameservers_valid(self):
         config = self._parse_network_state_from_config(

--- a/tests/unittests/net/test_networkd.py
+++ b/tests/unittests/net/test_networkd.py
@@ -5,6 +5,7 @@ from string import Template
 from unittest import mock
 
 import pytest
+import yaml
 
 from cloudinit import safeyaml
 from cloudinit.net import network_state, networkd
@@ -448,8 +449,8 @@ network:
 class TestNetworkdRenderState:
     def _parse_network_state_from_config(self, config):
         with mock.patch("cloudinit.net.network_state.get_interfaces_by_mac"):
-            yaml = safeyaml.load(config)
-            return network_state.parse_net_config_data(yaml["network"])
+            config = yaml.safe_load(config)
+            return network_state.parse_net_config_data(config["network"])
 
     def test_networkd_render_with_set_name(self):
         with mock.patch("cloudinit.net.get_interfaces_by_mac"):
@@ -625,7 +626,7 @@ class TestNetworkdRenderState:
         with mock.patch("cloudinit.net.get_interfaces_by_mac"):
             # network-config v1 inputs
             if version == "v1":
-                config = safeyaml.load(V1_CONFIG_ACCEPT_RA_YAML)
+                config = yaml.safe_load(V1_CONFIG_ACCEPT_RA_YAML)
                 if address == "4" or address == "6":
                     config["network"]["config"][0]["subnets"] = [
                         {"type": f"dhcp{address}"}
@@ -638,7 +639,7 @@ class TestNetworkdRenderState:
                     config["network"]["config"][0]["accept-ra"] = accept_ra
             # network-config v2 inputs
             elif version == "v2":
-                config = safeyaml.load(V2_CONFIG_ACCEPT_RA_YAML)
+                config = yaml.safe_load(V2_CONFIG_ACCEPT_RA_YAML)
                 if address == "4" or address == "6":
                     config["network"]["ethernets"]["eth0"][
                         f"dhcp{address}"

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -10,8 +10,9 @@ from textwrap import dedent
 from uuid import uuid4
 
 import pytest
+import yaml
 
-from cloudinit import atomic_helper, safeyaml, subp, util
+from cloudinit import atomic_helper, subp, util
 from cloudinit.sources import DataSourceIBMCloud as ds_ibm
 from cloudinit.sources import DataSourceOracle as ds_oracle
 from cloudinit.sources import DataSourceSmartOS as ds_smartos
@@ -295,7 +296,7 @@ class DsIdentifyBase(CiTestCase):
         if os.path.exists(cfg_out):
             contents = util.load_text_file(cfg_out)
             try:
-                cfg = safeyaml.load(contents)
+                cfg = yaml.safe_load(contents)
             except Exception as e:
                 cfg = {"_INVALID_YAML": contents, "_EXCEPTION": str(e)}
 

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -12,11 +12,10 @@ import textwrap
 from typing import Optional
 
 import pytest
+import yaml
 from yaml.serializer import Serializer
 
-from cloudinit import distros, net
-from cloudinit import safeyaml as yaml
-from cloudinit import subp, temp_utils, util
+from cloudinit import distros, net, subp, temp_utils, util
 from cloudinit.net import (
     cmdline,
     eni,
@@ -1889,14 +1888,16 @@ USERCTL=no
     def test_config(self, expected_name, yaml_version):
         entry = NETWORK_CONFIGS[expected_name]
         found = self._render_and_read(
-            network_config=yaml.load(entry[yaml_version])
+            network_config=yaml.safe_load(entry[yaml_version])
         )
         self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)
 
     def test_all_config(self, caplog):
         entry = NETWORK_CONFIGS["all"]
-        found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        found = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
         self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)
         assert (
@@ -1906,7 +1907,9 @@ USERCTL=no
 
     def test_v4_and_v6_static_config(self, caplog):
         entry = NETWORK_CONFIGS["v4_and_v6_static"]
-        found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        found = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
         self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)
         expected_msg = (
@@ -1975,7 +1978,7 @@ USERCTL=no
 
     def test_netplan_dhcp_false_disable_dhcp_in_state(self):
         """netplan config with dhcp[46]: False should not add dhcp in state"""
-        net_config = yaml.load(NETPLAN_DHCP_FALSE)
+        net_config = yaml.safe_load(NETPLAN_DHCP_FALSE)
         ns = network_state.parse_net_config_data(net_config, skip_broken=False)
 
         dhcp_found = [
@@ -2018,7 +2021,9 @@ USERCTL=no
             },
         }
 
-        found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        found = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
         self._compare_files_to_expected(entry["expected_sysconfig"], found)
         self._assert_headers(found)
 
@@ -2293,7 +2298,9 @@ USERCTL=no
             dev_attrs=devices,
         )
         entry = NETWORK_CONFIGS["v2-dev-name-via-mac-lookup"]
-        found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        found = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
         self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)
 
@@ -2498,14 +2505,16 @@ STARTMODE=auto
         entry = NETWORK_CONFIGS[expected_name]
         yaml_name = "yaml" if "yaml" in entry else "yaml_v2"
         found = self._render_and_read(
-            network_config=yaml.load(entry[yaml_name])
+            network_config=yaml.safe_load(entry[yaml_name])
         )
         self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)
 
     def test_all_config(self, caplog):
         entry = NETWORK_CONFIGS["all"]
-        found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        found = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
         self._compare_files_to_expected(entry[self.expected_name], found)
         self._assert_headers(found)
         assert (
@@ -2733,7 +2742,9 @@ class TestNetworkManagerRendering:
 
     def test_all_config(self, caplog):
         entry = NETWORK_CONFIGS["all"]
-        found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        found = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
         self._compare_files_to_expected(
             entry[self.expected_name], self.expected_conf_d, found
         )
@@ -2744,7 +2755,9 @@ class TestNetworkManagerRendering:
 
     def test_v4_and_v6_static_config(self, caplog):
         entry = NETWORK_CONFIGS["v4_and_v6_static"]
-        found = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        found = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
         self._compare_files_to_expected(
             entry[self.expected_name], self.expected_conf_d, found
         )
@@ -2782,7 +2795,7 @@ class TestNetworkManagerRendering:
         entry = NETWORK_CONFIGS[expected_name]
         yaml_name = "yaml" if "yaml" in entry else "yaml_v2"
         found = self._render_and_read(
-            network_config=yaml.load(entry[yaml_name])
+            network_config=yaml.safe_load(entry[yaml_name])
         )
         self._compare_files_to_expected(
             entry[self.expected_name], self.expected_conf_d, found
@@ -3248,7 +3261,7 @@ class TestNetplanNetRendering:
         if network_cfg is None:
             network_cfg = net.generate_fallback_config()
         else:
-            network_cfg = yaml.load(network_cfg)
+            network_cfg = yaml.safe_load(network_cfg)
         assert isinstance(network_cfg, dict)
 
         ns = network_state.parse_net_config_data(
@@ -3269,7 +3282,7 @@ class TestNetplanNetRendering:
             contents = fh.read()
             print(contents)
 
-        assert yaml.load(expected) == yaml.load(contents)
+        assert yaml.safe_load(expected) == yaml.safe_load(contents)
         assert 1, mock_clean_default.call_count
 
 
@@ -3851,7 +3864,7 @@ class TestNetplanRoundTrip:
     def test_config(self, expected_name, yaml_version):
         entry = NETWORK_CONFIGS[expected_name]
         files = self._render_and_read(
-            network_config=yaml.load(entry[yaml_version])
+            network_config=yaml.safe_load(entry[yaml_version])
         )
         assert (
             entry["expected_netplan"].splitlines()
@@ -3861,7 +3874,7 @@ class TestNetplanRoundTrip:
     def testsimple_render_bond_v2_input_netplan(self):
         entry = NETWORK_CONFIGS["bond"]
         files = self._render_and_read(
-            network_config=yaml.load(entry["yaml-v2"])
+            network_config=yaml.safe_load(entry["yaml-v2"])
         )
         assert (
             entry["expected_netplan-v2"].splitlines()
@@ -3873,7 +3886,7 @@ class TestNetplanRoundTrip:
             "yaml": V1_NAMESERVER_ALIAS,
             "expected_netplan": NETPLAN_NO_ALIAS,
         }
-        network_config = yaml.load(entry["yaml"])
+        network_config = yaml.safe_load(entry["yaml"])
         ns = network_state.parse_net_config_data(network_config)
         files = self._render_and_read(state=ns)
         # check for alias
@@ -3881,7 +3894,7 @@ class TestNetplanRoundTrip:
 
         # test load the yaml to ensure we don't render something not loadable
         # this allows single aliases, but not duplicate ones
-        parsed = yaml.load(files["/etc/netplan/50-cloud-init.yaml"])
+        parsed = yaml.safe_load(files["/etc/netplan/50-cloud-init.yaml"])
         assert parsed is not None
 
         # now look for any alias, avoid rendering them entirely
@@ -3905,7 +3918,7 @@ class TestNetplanRoundTrip:
                 "gratuitious", "gratuitous"
             ),
         }
-        network_config = yaml.load(entry["yaml"]).get("network")
+        network_config = yaml.safe_load(entry["yaml"]).get("network")
         files = self._render_and_read(network_config=network_config)
         assert (
             entry["expected_netplan"].splitlines()
@@ -3991,7 +4004,7 @@ class TestEniRoundTrip:
     def test_config(self, expected_name, yaml_version):
         entry = NETWORK_CONFIGS[expected_name]
         files = self._render_and_read(
-            network_config=yaml.load(entry[yaml_version])
+            network_config=yaml.safe_load(entry[yaml_version])
         )
         assert (
             entry["expected_eni"].splitlines()
@@ -4282,7 +4295,7 @@ class TestNetworkdRoundTrip:
         nwk_fn = "/etc/systemd/network/10-cloud-init-iface0.network"
         entry = NETWORK_CONFIGS[expected_name]
         files = self._render_and_read(
-            network_config=yaml.load(entry[yaml_version])
+            network_config=yaml.safe_load(entry[yaml_version])
         )
 
         actual = files[nwk_fn].splitlines()
@@ -4298,7 +4311,9 @@ class TestNetworkdRoundTrip:
         nwk_fn1 = "/etc/systemd/network/10-cloud-init-eth99.network"
         nwk_fn2 = "/etc/systemd/network/10-cloud-init-eth1.network"
         entry = NETWORK_CONFIGS["small_v1"]
-        files = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        files = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
 
         actual = files[nwk_fn1].splitlines()
         actual = self.create_conf_dict(actual)
@@ -4321,7 +4336,9 @@ class TestNetworkdRoundTrip:
         nwk_fn1 = "/etc/systemd/network/10-cloud-init-eth99.network"
         nwk_fn2 = "/etc/systemd/network/10-cloud-init-eth1.network"
         entry = NETWORK_CONFIGS["small_v2"]
-        files = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        files = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
 
         actual = files[nwk_fn1].splitlines()
         actual = self.create_conf_dict(actual)
@@ -4346,7 +4363,9 @@ class TestNetworkdRoundTrip:
     def test_v1_dns(self, m_chown):
         nwk_fn = "/etc/systemd/network/10-cloud-init-eth0.network"
         entry = NETWORK_CONFIGS["v1-dns"]
-        files = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        files = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
 
         actual = self.create_conf_dict(files[nwk_fn].splitlines())
         expected = self.create_conf_dict(
@@ -4359,7 +4378,9 @@ class TestNetworkdRoundTrip:
     def test_v2_dns(self, m_chown):
         nwk_fn = "/etc/systemd/network/10-cloud-init-eth0.network"
         entry = NETWORK_CONFIGS["v2-dns"]
-        files = self._render_and_read(network_config=yaml.load(entry["yaml"]))
+        files = self._render_and_read(
+            network_config=yaml.safe_load(entry["yaml"])
+        )
 
         actual = self.create_conf_dict(files[nwk_fn].splitlines())
         expected = self.create_conf_dict(

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -3,6 +3,7 @@ from contextlib import ExitStack
 from unittest.mock import patch
 
 import pytest
+import yaml
 
 from cloudinit.net.activators import (
     DEFAULT_PRIORITY,
@@ -16,7 +17,6 @@ from cloudinit.net.activators import (
     select_activator,
 )
 from cloudinit.net.network_state import parse_net_config_data
-from cloudinit.safeyaml import load
 
 V1_CONFIG = """\
 version: 1
@@ -274,7 +274,7 @@ class TestActivatorsBringUp:
     def test_bring_up_all_interfaces_v1(
         self, m_subp, activator, expected_call_list, available_mocks
     ):
-        network_state = parse_net_config_data(load(V1_CONFIG))
+        network_state = parse_net_config_data(yaml.safe_load(V1_CONFIG))
         activator.bring_up_all_interfaces(network_state)
         for call in m_subp.call_args_list:
             assert call in expected_call_list
@@ -283,7 +283,7 @@ class TestActivatorsBringUp:
     def test_bring_up_all_interfaces_v2(
         self, m_subp, activator, expected_call_list, available_mocks
     ):
-        network_state = parse_net_config_data(load(V2_CONFIG))
+        network_state = parse_net_config_data(yaml.safe_load(V2_CONFIG))
         activator.bring_up_all_interfaces(network_state)
         for call in m_subp.call_args_list:
             assert call in expected_call_list

--- a/tests/unittests/test_net_freebsd.py
+++ b/tests/unittests/test_net_freebsd.py
@@ -1,8 +1,9 @@
 import os
 
+import yaml
+
 import cloudinit.net
 import cloudinit.net.network_state
-from cloudinit import safeyaml
 from tests.unittests.helpers import CiTestCase, dir2dict, mock, readResource
 
 SAMPLE_FREEBSD_IFCONFIG_OUT = readResource("netinfo/freebsd-ifconfig-output")
@@ -76,7 +77,7 @@ class TestFreeBSDRoundTrip(CiTestCase):
         entry = {
             "yaml": V1,
         }
-        network_config = safeyaml.load(entry["yaml"])
+        network_config = yaml.safe_load(entry["yaml"])
         ns = cloudinit.net.network_state.parse_net_config_data(network_config)
         files = self._render_and_read(state=ns)
         assert files == {


### PR DESCRIPTION
## Proposed Commit Message
```
chore(safeyaml): Remove legacy Python 2 unicode helper

PyYAML has built-in unicode support in Python3+.

The original code[1] was added as a helper to add
support for unicode to `yaml.safe_load()`. We
don't need this anymore, and can jettison it and
prefer `yaml.safe_load()`.

[1] a7a9de1a079
```

Note that the unittests that were added with this helper back in the python2 days still pass.

Rational: custom code that offers nothing over library code is an unnecessary complexity, remove it. 