### PR TITLE
fix(url_helper): fix TCP connection leak on readurl() retries

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -242,6 +242,7 @@ def readurl(
     :param stream: if False, the response content will be immediately
     downloaded.
     """
+    create_sessions = session is None
     url = _cleanurl(url)
     req_args = {
         "url": url,
@@ -281,11 +282,9 @@ def readurl(
     if sec_between is None:
         sec_between = -1
 
-    excps = []
     # Handle retrying ourselves since the built-in support
     # doesn't handle sleeping between tries...
-    # Infinitely retry if infinite is True
-    for i in count() if infinite else range(manual_tries):
+    for i in count():
         req_args["headers"] = headers_cb(url)
         filtered_req_args = {}
         for (k, v) in req_args.items():
@@ -300,7 +299,6 @@ def readurl(
             else:
                 filtered_req_args[k] = v
         try:
-
             if log_req_resp:
                 LOG.debug(
                     "[%s/%s] open '%s' with %s configuration",
@@ -310,7 +308,7 @@ def readurl(
                     filtered_req_args,
                 )
 
-            if session is None:
+            if create_sessions:
                 session = requests.Session()
 
             with session as sess:
@@ -329,6 +327,10 @@ def readurl(
             # subclass for responses, so add our own backward-compat
             # attrs
             return UrlResponse(r)
+        except exceptions.SSLError as e:
+            # ssl exceptions are not going to get fixed by waiting a
+            # few seconds
+            raise UrlError(e, url=url) from e
         except exceptions.RequestException as e:
             if (
                 isinstance(e, (exceptions.HTTPError))
@@ -337,29 +339,26 @@ def readurl(
                     e.response, "status_code"
                 )
             ):
-                excps.append(
-                    UrlError(
-                        e,
-                        code=e.response.status_code,
-                        headers=e.response.headers,
-                        url=url,
-                    )
+                url_error = UrlError(
+                    e,
+                    code=e.response.status_code,
+                    headers=e.response.headers,
+                    url=url,
                 )
             else:
-                excps.append(UrlError(e, url=url))
-                if isinstance(e, exceptions.SSLError):
-                    # ssl exceptions are not going to get fixed by waiting a
-                    # few seconds
-                    break
-            if exception_cb and not exception_cb(req_args.copy(), excps[-1]):
+                url_error = UrlError(e, url=url)
+
+            if exception_cb and not exception_cb(req_args.copy(), url_error):
                 # if an exception callback was given, it should return True
                 # to continue retrying and False to break and re-raise the
                 # exception
-                break
-            if (infinite and sec_between > 0) or (
-                i + 1 < manual_tries and sec_between > 0
-            ):
+                raise url_error from e
 
+            will_retry = infinite or (i + 1 < manual_tries)
+            if not will_retry:
+                raise url_error from e
+
+            if sec_between > 0:
                 if log_req_resp:
                     LOG.debug(
                         "Please wait %s seconds while we wait to try again",
@@ -367,7 +366,7 @@ def readurl(
                     )
                 time.sleep(sec_between)
 
-    raise excps[-1]
+    raise RuntimeError("This path should be unreachable...")
 
 
 def _run_func_with_delay(


### PR DESCRIPTION
In scenarios where a lot of retries are expected, Ubuntu 24.04 fails regularly with "Too many open files".  The `ulimit -n` shows the same number of allowed open files in Ubuntu 20.04 (1024), but the connections must be holding out longer on 24.04 for some reason. As the retry count gets close to 1024 in readurl(), the open file limit is hit and exceptions sprout up in a number of places.

The leak appears to occur because the same session is reused and all prior failures are recorded in excps[] which in turn appears to keep the connection open.

- create a new Session() for each connection attempt if session was not passed in explicitly

- raise exceptions immediately when required rather than saving them to do outside of the exception handler