### PR TITLE
Revert "ec2: Do not enable dhcp6 on EC2 (#5104)"

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -1066,6 +1066,8 @@ def convert_ec2_metadata_network_config(
             "set-name": nic_name,
         }
         nic_metadata = macs_metadata.get(mac)
+        if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
+            dev_config["dhcp6"] = True
         netcfg["ethernets"][nic_name] = dev_config
         return netcfg
     # Apply network config for all nics and any secondary IPv4/v6 addresses
@@ -1112,6 +1114,8 @@ def convert_ec2_metadata_network_config(
                 table=table,
             )
         if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
+            dev_config["dhcp6"] = True
+            dev_config["dhcp6-overrides"] = dhcp_override
             if (
                 is_netplan
                 and nic_metadata.get("device-number")

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -460,7 +460,7 @@ class TestEc2(test_helpers.ResponsesTestCase):
                     "match": {"macaddress": "06:17:04:d7:26:09"},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": False,
+                    "dhcp6": True,
                 }
             },
         }
@@ -545,7 +545,7 @@ class TestEc2(test_helpers.ResponsesTestCase):
                         "2600:1f16:292:100:f153:12a3:c37c:11f9/128",
                     ],
                     "dhcp4": True,
-                    "dhcp6": False,
+                    "dhcp6": True,
                 }
             },
         }
@@ -625,7 +625,7 @@ class TestEc2(test_helpers.ResponsesTestCase):
                     "match": {"macaddress": mac1},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": False,
+                    "dhcp6": True,
                 }
             },
         }
@@ -1154,7 +1154,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                     "match": {"macaddress": self.mac1},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": False,
+                    "dhcp6": True,
                 }
             },
         }
@@ -1234,7 +1234,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                     "match": {"macaddress": self.mac1},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": False,
+                    "dhcp6": True,
                 }
             },
         }
@@ -1267,7 +1267,8 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                     "set-name": "eth9",
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": False,
+                    "dhcp6": True,
+                    "dhcp6-overrides": {"route-metric": 100},
                 },
                 "eth10": {
                     "match": {"macaddress": mac2},
@@ -1326,9 +1327,10 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                 "eth9": {
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": False,
+                    "dhcp6": True,
                     "match": {"macaddress": "06:17:04:d7:26:09"},
                     "set-name": "eth9",
+                    "dhcp6-overrides": {"route-metric": 100},
                 },
                 "eth10": {
                     "dhcp4": True,
@@ -1336,7 +1338,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                         "route-metric": 200,
                         "use-routes": True,
                     },
-                    "dhcp6": False,
+                    "dhcp6": True,
                     "match": {"macaddress": "06:17:04:d7:26:08"},
                     "set-name": "eth10",
                     "routes": [
@@ -1359,6 +1361,10 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                             "table": 101,
                         },
                     ],
+                    "dhcp6-overrides": {
+                        "route-metric": 200,
+                        "use-routes": True,
+                    },
                     "addresses": ["2600:1f16:292:100:f153:12a3:c37c:11f9/128"],
                 },
             },
@@ -1388,7 +1394,7 @@ class TestConvertEc2MetadataNetworkConfig(test_helpers.CiTestCase):
                     "match": {"macaddress": self.mac1},
                     "set-name": "eth9",
                     "dhcp4": True,
-                    "dhcp6": False,
+                    "dhcp6": True,
                 }
             },
         }


### PR DESCRIPTION
## Proposed Commit Message
```
Revert "ec2: Do not enable dhcp6 on EC2 (#5104)"

This reverts commit f0fb841883b80c71618582e43e1b3cd87a0dcb58.

It appears that this bug was fixed already via another patch sometime
between the time I found the issue and submitted the PR #5104. This
patch isn't needed any longer and I want to avoid causing additional
problems. 😉
```

## Additional Context

See #5104 for more details, but it looks like this problem was fixed in between the time I found the bug and I submitted my PR. My PR likely makes things more complicated.

## Test Steps

N/A

## Checklist
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
