### PR TITLE
dhcp: support configuring static routes for dhclient's unknown-121 op…

### DIFF
--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -453,13 +453,26 @@ class IscDhclient(DhcpClient):
         ("0.0.0.0/0", "192.168.128.1")
         ]
 
+        # unknown-121 option format
+        sr3 = parse_static_routes(\
+        "0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1")
+        sr3 = [
+            ("0.0.0.0/0", "10.0.0.1"),
+            ("168.63.129.16/32", "10.0.0.1"),
+            ("169.254.169.254/32", "10.0.0.1"),
+        ]
+
         Python version of isc-dhclient's hooks:
            /etc/dhcp/dhclient-exit-hooks.d/rfc3442-classless-routes
         """
         # raw strings from dhcp lease may end in semi-colon
         rfc3442 = routes.rstrip(";")
-        tokens = [tok for tok in re.split(r"[, .]", rfc3442) if tok]
+        tokens = [tok for tok in re.split(r"[, . :]", rfc3442) if tok]
         static_routes: List[Tuple[str, str]] = []
+
+        # Handle unknown-121 format by converting hex to base 10.
+        if ":" in rfc3442:
+            tokens = [str(int(tok, 16)) for tok in tokens]
 
         def _trunc_error(cidr, required, remain):
             msg = (

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -314,6 +314,7 @@ class EphemeralDHCPv4:
                 "rfc3442-classless-static-routes",
                 "classless-static-routes",
                 "static_routes",
+                "unknown-121",
             ],
             "router": "routers",
         }

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -288,6 +288,17 @@ class TestDHCPParseStaticRoutes(CiTestCase):
             IscDhclient.parse_static_routes(rfc3442),
         )
 
+    def test_unknown_121(self):
+        for unknown121 in [
+            "0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1",
+            "0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1;",
+        ]:
+            assert IscDhclient.parse_static_routes(unknown121) == [
+                ("0.0.0.0/0", "10.0.0.1"),
+                ("168.63.129.16/32", "10.0.0.1"),
+                ("169.254.169.254/32", "10.0.0.1"),
+            ]
+
     def test_parse_static_routes_default_route(self):
         rfc3442 = "0,130,56,240,1"
         self.assertEqual(


### PR DESCRIPTION
Cloud-init does not configure rfc3442-classless-static-routes if dhclient isn't patched to support them or it is not configured with:

```
option rfc3442-classless-static-routes code 121 = array of unsigned integer 8;
```

Example lease with option configured (typical):

lease {
  interface "eth0";
  <...cut...>
  option rfc3442-classless-static-routes 0,10,0,0,1,32,168,63,129,16,10,0,0,1,32,169,254,169,254,10,0,0,1;
  <...cut...>
}

Example lease without option, where it is presented as "unknown-121":

lease {
  interface "eth0";
  <...cut...>
  option unknown-121 0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1;
  <...cut...>
}

The primary difference is that dhclient outputs the bytes in a hex-encoded format and with `:` delimiter. Extend existing parsing to support this format.

With a couple added INFO logs, here is a sample DHCP on Azure with static routes being parsed from unknown-121 option with this patch:

```
2024-04-04 16:12:01,677 - ephemeral.py[DEBUG]: Received dhcp lease on eth0 for 10.0.0.11/255.255.255.0
2024-04-04 16:12:01,677 - dhcp.py[INFO]: Parsing: '0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1'
2024-04-04 16:12:01,677 - dhcp.py[INFO]: Tokens: ['0', '10', '0', '0', '1', '32', '168', '63', '129', '16', '10', '0', '0', '1', '32', '169', '254', '169', '254', '10', '0', '0', '1']
2024-04-04 16:12:01,677 - ephemeral.py[DEBUG]: Attempting setup of ephemeral network on eth0 with 10.0.0.11/24 brd 10.0.0.255
2024-04-04 16:12:01,677 - subp.py[DEBUG]: Running command ['ip', '-family', 'inet', 'addr', 'add', '10.0.0.11/24', 'broadcast', '10.0.0.255', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
2024-04-04 16:12:01,679 - subp.py[DEBUG]: Running command ['ip', '-family', 'inet', 'link', 'set', 'dev', 'eth0', 'up'] with allowed return codes [0] (shell=False, capture=True)
2024-04-04 16:12:01,681 - subp.py[DEBUG]: Running command ['ip', '-4', 'route', 'append', '0.0.0.0/0', 'via', '10.0.0.1', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
2024-04-04 16:12:01,683 - subp.py[DEBUG]: Running command ['ip', '-4', 'route', 'append', '168.63.129.16/32', 'via', '10.0.0.1', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
2024-04-04 16:12:01,684 - subp.py[DEBUG]: Running command ['ip', '-4', 'route', 'append', '169.254.169.254/32', 'via', '10.0.0.1', 'dev', 'eth0'] with allowed return codes [0] (shell=False, capture=True)
2024-04-04 16:12:01,686 - handlers.py[DEBUG]: start: azure-ds/_check_if_primary: _check_if_primary
2024-04-04 16:12:01,686 - handlers.py[DEBUG]: finish: azure-ds/_check_if_primary: SUCCESS: _check_if_primary
2024-04-04 16:12:01,687 - azure.py[DEBUG]: Obtained DHCP lease on interface 'eth0' (primary=True driver='hv_netvsc' router='10.0.0.1' routes=[('0.0.0.0/0', '10.0.0.1'), ('168.63.129.16/32', '10.0.0.1'), ('169.254.169.254/32', '10.0.0.1')] lease={'inter
face': 'eth0', 'fixed-address': '10.0.0.11', 'server-name': 'BL24A1071918060SOC', 'subnet-mask': '255.255.255.0', 'dhcp-lease-time': '4294967295', 'routers': '10.0.0.1', 'dhcp-message-type': '5', 'domain-name-servers': '168.63.129.16', 'dhcp-server-ide
ntifier': '168.63.129.16', 'dhcp-renewal-time': '4294967295', 'unknown-121': '0:a:0:0:1:20:a8:3f:81:10:a:0:0:1:20:a9:fe:a9:fe:a:0:0:1', 'dhcp-rebinding-time': '4294967295', 'unknown-245': 'a8:3f:81:10', 'domain-name': 'fyoqc4gghleevjxtq4h4pjbded.bx.int
ernal.cloudapp.net', 'renew': '0 2160/05/11 22:40:16', 'rebind': '0 2160/05/11 22:40:16', 'expire': '0 2160/05/11 22:40:16'} imds_routed=True wireserver_routed=True)
```