### PR TITLE
Support sudoers in the "usr merge" location

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1041,7 +1041,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                         "#includedir %s" % (path),
                         "",
                     ]
-                    sudoers_contents = "\n".join(lines)
+                    sudoers_contents += "\n".join(lines)
                     util.write_file(sudo_base, sudoers_contents, 0o440)
                 else:
                     lines = [

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1041,6 +1041,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                         "#includedir %s" % (path),
                         "",
                     ]
+                    if sudoers_contents:
+                        LOG.info("Using content from '%s'", system_sudo_base)
                     sudoers_contents += "\n".join(lines)
                     util.write_file(sudo_base, sudoers_contents, 0o440)
                 else:

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1006,20 +1006,17 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                     )
                     raise e
 
-    def ensure_sudo_dir(
-            self, path, sudo_base=("/etc/sudoers","/usr/etc/sudoers")):
+    def ensure_sudo_dir(self, path, sudo_base="/etc/sudoers"):
         # Ensure the dir is included and that
         # it actually exists as a directory
         sudoers_contents = ""
         base_exists = False
-        admin_sudo_base = "/etc/sudoers"
-        if not isinstance(sudo_base, (list, tuple)):
-            sudo_base = [sudo_base]
-        for sudoers_base in sudo_base:
-            if os.path.exists(sudoers_base):
-                sudoers_contents = util.load_text_file(sudoers_base)
-                base_exists = True
-                break
+        system_sudo_base = "/usr/etc/sudoers"
+        if os.path.exists(sudo_base):
+            sudoers_contents = util.load_text_file(sudo_base)
+            base_exists = True
+        elif os.path.exists(system_sudo_base):
+            sudoers_contents = util.load_text_file(system_sudo_base)
         found_include = False
         for line in sudoers_contents.splitlines():
             line = line.strip()
@@ -1045,11 +1042,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                         "",
                     ]
                     sudoers_contents = "\n".join(lines)
-                    util.write_file(admin_sudo_base, sudoers_contents, 0o440)
+                    util.write_file(sudo_base, sudoers_contents, 0o440)
                 else:
-                    if sudoers_base != admin_sudo_base:
-                        util.write_file(
-                            admin_sudo_base, sudoers_contents, 0o440)
                     lines = [
                         "",
                         util.make_header(base="added"),
@@ -1057,10 +1051,10 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                         "",
                     ]
                     sudoers_contents = "\n".join(lines)
-                    util.append_file(admin_sudo_base, sudoers_contents)
-                LOG.debug("Added '#includedir %s' to %s", path, admin_sudo_base)
+                    util.append_file(sudo_base, sudoers_contents)
+                LOG.debug("Added '#includedir %s' to %s", path, sudo_base)
             except IOError as e:
-                util.logexc(LOG, "Failed to write %s", admin_sudo_base)
+                util.logexc(LOG, "Failed to write %s", sudo_base)
                 raise e
         util.ensure_dir(path, 0o750)
 

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -253,6 +253,8 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         util.write_file("/usr/etc/sudoers", "josh, josh\n")
         d.ensure_sudo_dir("/b")
         contents = util.load_text_file("/etc/sudoers")
+        self.assertIn("josh", contents)
+        self.assertEqual(2, contents.count("josh"))
         self.assertIn("includedir /b", contents)
         self.assertTrue(os.path.isdir("/b"))
 

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -245,7 +245,7 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.assertIn("josh", contents)
         self.assertEqual(2, contents.count("josh"))
 
-    def test_usr_sudoers_ensure_append(self):
+    def test_usr_sudoers_ensure_new(self):
         cls = distros.fetch("ubuntu")
         d = cls("ubuntu", {}, None)
         self.patchOS(self.tmp)
@@ -255,8 +255,6 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         contents = util.load_text_file("/etc/sudoers")
         self.assertIn("includedir /b", contents)
         self.assertTrue(os.path.isdir("/b"))
-        self.assertIn("josh", contents)
-        self.assertEqual(2, contents.count("josh"))
 
     def test_sudoers_ensure_only_one_includedir(self):
         cls = distros.fetch("ubuntu")

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -256,6 +256,15 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.assertIn("includedir /b", contents)
         self.assertTrue(os.path.isdir("/b"))
 
+    def test_usr_sudoers_ensure_no_etc_creat(self):
+        cls = distros.fetch("ubuntu")
+        d = cls("ubuntu", {}, None)
+        self.patchOS(self.tmp)
+        self.patchUtils(self.tmp)
+        util.write_file("/usr/etc/sudoers", "#includedir /b")
+        d.ensure_sudo_dir("/b")
+        self.assertTrue(not os.path.exists("/etc/sudoers"))
+
     def test_sudoers_ensure_only_one_includedir(self):
         cls = distros.fetch("ubuntu")
         d = cls("ubuntu", {}, None)

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -232,6 +232,32 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.assertIn("josh", contents)
         self.assertEqual(2, contents.count("josh"))
 
+    def test_sudoers_ensure_append_sudoer_file(self):
+        cls = distros.fetch("ubuntu")
+        d = cls("ubuntu", {}, None)
+        self.patchOS(self.tmp)
+        self.patchUtils(self.tmp)
+        util.write_file("/etc/sudoers", "josh, josh\n")
+        d.ensure_sudo_dir("/b", "/etc/sudoers")
+        contents = util.load_text_file("/etc/sudoers")
+        self.assertIn("includedir /b", contents)
+        self.assertTrue(os.path.isdir("/b"))
+        self.assertIn("josh", contents)
+        self.assertEqual(2, contents.count("josh"))
+
+    def test_usr_sudoers_ensure_append(self):
+        cls = distros.fetch("ubuntu")
+        d = cls("ubuntu", {}, None)
+        self.patchOS(self.tmp)
+        self.patchUtils(self.tmp)
+        util.write_file("/usr/etc/sudoers", "josh, josh\n")
+        d.ensure_sudo_dir("/b")
+        contents = util.load_text_file("/etc/sudoers")
+        self.assertIn("includedir /b", contents)
+        self.assertTrue(os.path.isdir("/b"))
+        self.assertIn("josh", contents)
+        self.assertEqual(2, contents.count("josh"))
+
     def test_sudoers_ensure_only_one_includedir(self):
         cls = distros.fetch("ubuntu")
         d = cls("ubuntu", {}, None)

--- a/tests/unittests/distros/test__init__.py
+++ b/tests/unittests/distros/test__init__.py
@@ -55,6 +55,8 @@ gapmi = distros._get_arch_package_mirror_info
 
 
 class TestGenericDistro(helpers.FilesystemMockingTestCase):
+    with_logs = True
+
     def setUp(self):
         super(TestGenericDistro, self).setUp()
         # Make a temp directoy for tests to use.
@@ -231,6 +233,9 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.assertTrue(os.path.isdir("/b"))
         self.assertIn("josh", contents)
         self.assertEqual(2, contents.count("josh"))
+        self.assertIn(
+            "Added '#includedir /b' to /etc/sudoers", self.logs.getvalue()
+        )
 
     def test_sudoers_ensure_append_sudoer_file(self):
         cls = distros.fetch("ubuntu")
@@ -257,8 +262,11 @@ class TestGenericDistro(helpers.FilesystemMockingTestCase):
         self.assertEqual(2, contents.count("josh"))
         self.assertIn("includedir /b", contents)
         self.assertTrue(os.path.isdir("/b"))
+        self.assertIn(
+            "Using content from '/usr/etc/sudoers", self.logs.getvalue()
+        )
 
-    def test_usr_sudoers_ensure_no_etc_creat(self):
+    def test_usr_sudoers_ensure_no_etc_create_when_include_in_usr_etc(self):
         cls = distros.fetch("ubuntu")
         d = cls("ubuntu", {}, None)
         self.patchOS(self.tmp)


### PR DESCRIPTION
## Proposed Commit Message
When sudo is compiled with the `secure-path` option and the configuration file exists in `/usr/etc` and not in `/etc` take the configuration in `/usr/etc` into account. If the desired include directive exists in the system (`/usr/etc` ) configuration there is nothing to do if there is no file in `etc`.

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
