### PR TITLE
Deprecate the users ssh-authorized-keys property

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -361,6 +361,22 @@
           },
           "minItems": 1
         },
+        "ssh-authorized-keys": {
+          "allOf": [
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "minItems": 1
+            },
+            {
+              "deprecated": true,
+              "deprecated_version": "18.3",
+              "deprecated_description": "Use ``ssh_authorized_keys`` instead."
+            }
+          ]
+        },
         "ssh_import_id": {
           "description": "List of ssh ids to import for user. Can not be combined with ``ssh_redirect_user``. See the man page[1] for more details. [1] https://manpages.ubuntu.com/manpages/noble/en/man1/ssh-import-id.1.html",
           "type": "array",

--- a/tests/unittests/config/test_cc_users_groups.py
+++ b/tests/unittests/config/test_cc_users_groups.py
@@ -505,6 +505,36 @@ class TestUsersGroupsSchema:
                 ),
                 True,
             ),
+            (
+                {
+                    "users": [
+                        {
+                            "name": "lima",
+                            "uid": "1000",
+                            "homedir": "/home/lima.linux",
+                            "shell": "/bin/bash",
+                            "sudo": "ALL=(ALL) NOPASSWD:ALL",
+                            "lock_passwd": True,
+                            "ssh-authorized-keys": ["ssh-ed25519 ..."],
+                        }
+                    ]
+                },
+                pytest.raises(
+                    SchemaValidationError,
+                    match=(
+                        "Cloud config schema deprecations: "
+                        "users.0.ssh-authorized-keys: "
+                        " Deprecated in version 18.3."
+                        " Use ``ssh_authorized_keys`` instead."
+                        ", "
+                        "users.0.uid: "
+                        " Changed in version 22.3."
+                        " The use of ``string`` type is deprecated."
+                        " Use an ``integer`` instead."
+                    ),
+                ),
+                False,
+            ),
         ],
     )
     @skipUnlessJsonSchema()

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -3,6 +3,7 @@ aciba90
 acourdavAkamai
 ader1990
 adobley
+afbjorklund
 ajmyyra
 akutz
 AlexBaranowski


### PR DESCRIPTION
The previous cloud-config still works without any issues, but it doesn't pass validation - not even as deprecated.

Example from https://lima-vm.io default

Currently it does not validate, therefore.

commit b27f713ae5b4c5b38eda63758dbaeab92be13b9d

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: deprecate ssh-authorized-keys in schema

Deprecate the users ssh-authorized-keys property
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
