### PR TITLE
test(ec2): fix mocking with responses==0.9.0 (focal)

### DIFF
--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -598,7 +598,12 @@ class TestEc2:
 
         def _remove_md(resp_list: List) -> None:
             for index, url in enumerate(resp_list):
-                if url["url"].startswith(
+                try:
+                    url = url.url
+                except AttributeError:
+                    # Can be removed when Bionic is EOL
+                    url = url["url"]
+                if url.startswith(
                     "http://169.254.169.254/2009-04-04/meta-data/"
                 ):
                     del resp_list[index]
@@ -615,6 +620,11 @@ class TestEc2:
         elif hasattr(responses, "_matches"):
             # Can be removed when Focal is EOL
             _remove_md(responses._matches)
+        elif hasattr(responses, "_default_mock") and hasattr(
+            responses._default_mock, "_matches"
+        ):
+            # Can be removed when Focal is EOL
+            _remove_md(responses._default_mock._matches)
 
         # Provide new revision of metadata that contains network data
         register_mock_metaserver(


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test(ec2): fix mocking with responses==0.9.0 (focal)
```

## Additional Context
<!-- If relevant -->
https://code.launchpad.net/~cloud-init-dev/+recipe/cloud-init-daily-focal
https://launchpadlibrarian.net/723825121/buildlog_ubuntu-focal-amd64.cloud-init_23.4.daily-202404082138-6d5978bb6~ubuntu20.04.1_BUILDING.txt.gz

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Apply the following patch to simulate focal deps:

```diff
diff --git a/tox.ini b/tox.ini
index 473e937cb..6a51772ca 100644
--- a/tox.ini
+++ b/tox.ini
@@ -186,22 +186,22 @@ commands = {envpython} -X tracemalloc=40 -Wall -m pytest \
 # To obtain these versions, check the versions of these libraries
 # in the oldest support Ubuntu distro. Theses versions are from bionic.
 deps =
-    jinja2==2.10
-    oauthlib==2.0.6
-    pyserial==3.4
-    configobj==5.0.6
-    pyyaml==3.12
-    requests==2.18.4
-    jsonpatch==1.16
-    jsonschema==2.6.0
+    jinja2
+    oauthlib
+    pyserial
+    configobj
+    pyyaml
+    requests==2.22.0
+    jsonpatch
+    jsonschema
     # test-requirements
-    pytest==3.3.2
-    pytest-cov==2.5.1
-    pytest-mock==1.7.1
-    setuptools==44.0.0
+    pytest==4.6.9
+    pytest-cov
+    pytest-mock
+    setuptools
     # Needed by pytest and default causes failures
-    attrs==17.4.0
-    responses==0.5.1
+    attrs
+    responses==0.9.0
     passlib
 commands = {[testenv:py3]commands}
```

With python3.8:

`tox -re lowest-supported -- tests/unittests/sources/test_ec2.py`

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
