### PR TITLE
chore: Remove obsolete nose workaround

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1797,17 +1797,10 @@ def get_config_logfiles(cfg):
     return list(set(logs + rotated_logs))
 
 
-def logexc(log, msg, *args, log_level: int = logging.WARNING) -> None:
+def logexc(
+    log, msg, *args, log_level: int = logging.WARNING, exc_info=True
+) -> None:
     log.log(log_level, msg, *args)
-
-    # Debug gets the full trace.  However, nose has a bug whereby its
-    # logcapture plugin doesn't properly handle the case where there is no
-    # actual exception.  To avoid tracebacks during the test suite then, we'll
-    # do the actual exc_info extraction here, and if there is no exception in
-    # flight, we'll just pass in None.
-    exc_info = sys.exc_info()
-    if exc_info == (None, None, None):
-        exc_info = None  # type: ignore
     log.debug(msg, exc_info=exc_info, *args)
 
 


### PR DESCRIPTION
## Proposed Commit Message
```
chore: Remove obsolete nose workaround
```

## Additional Context

The comments allude to a nose bug that resulted in tracebacks when `exc_info=True` and no traceback occurred. I checked the lowest supported unittests and spot-checked a couple of other python versions in unit tests - none had these tracebacks and we no longer use nose, so I think that this is obsolete.