### PR TITLE
Enable interactively running cloud-init local --local

### DIFF
--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -182,8 +182,8 @@ class EphemeralIPv4Network:
             self.distro.net_ops.link_up(self.interface, family="inet")
         if had_link:
             LOG.debug(
-                "Not queueing link down: link was up prior before receiving a "
-                "dhcp lease",
+                "Not queueing link down: link [%s] was up prior before "
+                "receiving a dhcp lease",
                 self.interface,
             )
         else:
@@ -196,9 +196,9 @@ class EphemeralIPv4Network:
             )
         if had_ip:
             LOG.debug(
-                "Not queueing address removal: address was assigned before "
+                "Not queueing address removal: address %s was assigned before "
                 "receiving a dhcp lease",
-                self.interface,
+                self.ip,
             )
         else:
             self.cleanup_cmds.append(

--- a/cloudinit/netinfo.py
+++ b/cloudinit/netinfo.py
@@ -13,6 +13,7 @@ import logging
 import re
 from copy import copy, deepcopy
 from ipaddress import IPv4Network
+from typing import Dict, List, Union
 
 from cloudinit import subp, util
 from cloudinit.net.network_state import net_prefix_to_ipv4_mask
@@ -282,7 +283,45 @@ def _netdev_info_ifconfig(ifconfig_data):
     return devs
 
 
-def netdev_info(empty=""):
+def netdev_info(
+    empty="",
+) -> Dict[str, Dict[str, Union[str, List[Dict[str, str]]]]]:
+    """return the instance's interfaces and interface data
+
+    includes, interface name, link state, hardware address, and lists of ipv4
+    and ipv6 addresses
+
+    example output:
+    {
+    'lo': {
+        'up': True,
+        'hwaddr': '',
+        'ipv4': [
+        {
+            'bcast': '',
+            'ip': '127.0.0.1',
+            'mask': '255.0.0.0',
+            'scope': 'host',
+        }],
+        'ipv6': [{'ip': '::1/128', 'scope6': 'host'}],
+    },
+    'lxdbr0': {
+        'up': True
+        'hwaddr': '00:16:3e:fa:84:30',
+        'ipv4': [{
+            'bcast': '',
+            'ip': '10.161.80.1',
+            'mask': '255.255.255.0',
+            'scope': 'global',
+        }],
+        'ipv6': [
+            {'ip': 'fd42:80e2:4695:1e96::1/64', 'scope6': 'global'},
+            {'ip': 'fe80::216:3eff:fefa:8430/64', 'scope6': 'link'},
+        ]
+    },
+    }
+
+    """
     devs = {}
     if util.is_NetBSD():
         (ifcfg_out, _err) = subp.subp(["ifconfig", "-a"], rcs=[0, 1])

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from cloudinit import atomic_helper, log, util
 from cloudinit.gpg import GPG
 from tests.hypothesis import HAS_HYPOTHESIS
-from tests.unittests.helpers import retarget_many_wrapper
+from tests.unittests.helpers import example_netdev, retarget_many_wrapper
 
 
 @pytest.fixture
@@ -99,6 +99,15 @@ def disable_sysfs_net(tmpdir_factory):
         "cloudinit.net.get_sys_class_path", return_value=mock_sysfs
     ):
         yield mock_sysfs
+
+
+@pytest.fixture(scope="class")
+def disable_netdev_info(request):
+    """Avoid tests which read the underlying host's /syc/class/net."""
+    with mock.patch(
+        "cloudinit.netinfo.netdev_info", return_value=example_netdev
+    ) as mock_netdev:
+        yield mock_netdev
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -54,6 +54,41 @@ SCHEMA_EMPTY_ERROR = (
     "(is too short|should be non-empty|does not have enough properties)"
 )
 
+example_netdev = {
+    "eth0": {
+        "hwaddr": "00:16:3e:16:db:54",
+        "ipv4": [
+            {
+                "bcast": "10.85.130.255",
+                "ip": "10.85.130.116",
+                "mask": "255.255.255.0",
+                "scope": "global",
+            }
+        ],
+        "ipv6": [
+            {
+                "ip": "fd42:baa2:3dd:17a:216:3eff:fe16:db54/64",
+                "scope6": "global",
+            },
+            {"ip": "fe80::216:3eff:fe16:db54/64", "scope6": "link"},
+        ],
+        "up": True,
+    },
+    "lo": {
+        "hwaddr": "",
+        "ipv4": [
+            {
+                "bcast": "",
+                "ip": "127.0.0.1",
+                "mask": "255.0.0.0",
+                "scope": "host",
+            }
+        ],
+        "ipv6": [{"ip": "::1/128", "scope6": "host"}],
+        "up": True,
+    },
+}
+
 
 # Makes the old path start
 # with new base instead of whatever

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -29,6 +29,7 @@ from cloudinit.util import ensure_file, load_binary_file, subp, write_file
 from tests.unittests.helpers import (
     CiTestCase,
     ResponsesTestCase,
+    example_netdev,
     mock,
     populate_dir,
 )
@@ -138,6 +139,7 @@ class TestParseDHCPLeasesFile(CiTestCase):
 
 
 @pytest.mark.usefixtures("dhclient_exists")
+@pytest.mark.usefixtures("disable_netdev_info")
 class TestDHCPRFC3442(CiTestCase):
     def test_parse_lease_finds_rfc3442_classless_static_routes(self):
         """IscDhclient().get_newest_lease() returns
@@ -222,6 +224,7 @@ class TestDHCPRFC3442(CiTestCase):
         eph.obtain_lease()
         expected_kwargs = {
             "interface": "wlp3s0",
+            "interface_addrs_before_dhcp": example_netdev,
             "ip": "192.168.2.74",
             "prefix_or_mask": "255.255.255.0",
             "broadcast": "192.168.2.255",
@@ -251,6 +254,7 @@ class TestDHCPRFC3442(CiTestCase):
         eph.obtain_lease()
         expected_kwargs = {
             "interface": "wlp3s0",
+            "interface_addrs_before_dhcp": example_netdev,
             "ip": "192.168.2.74",
             "prefix_or_mask": "255.255.255.0",
             "broadcast": "192.168.2.255",
@@ -810,6 +814,7 @@ class TestSystemdParseLeases(CiTestCase):
         )
 
 
+@pytest.mark.usefixtures("disable_netdev_info")
 class TestEphemeralDhcpNoNetworkSetup(ResponsesTestCase):
     @mock.patch("cloudinit.net.dhcp.maybe_perform_dhcp_discovery")
     def test_ephemeral_dhcp_no_network_if_url_connectivity(self, m_dhcp):
@@ -857,6 +862,7 @@ class TestEphemeralDhcpNoNetworkSetup(ResponsesTestCase):
         NoDHCPLeaseMissingDhclientError,
     ],
 )
+@pytest.mark.usefixtures("disable_netdev_info")
 class TestEphemeralDhcpLeaseErrors:
     @mock.patch("cloudinit.net.ephemeral.maybe_perform_dhcp_discovery")
     def test_obtain_lease_raises_error(self, m_dhcp, error_class):

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -923,29 +923,6 @@ class TestEphemeralIPV4Network(CiTestCase):
         for teardown in expected_teardown_calls:
             assert teardown in m_subp.call_args_list
 
-    @mock.patch("cloudinit.net.readurl")
-    def test_ephemeral_ipv4_no_network_if_url_connectivity(
-        self, m_readurl, m_subp
-    ):
-        """No network setup is performed if we can successfully connect to
-        connectivity_url."""
-        params = {
-            "interface": "eth0",
-            "ip": "192.168.2.2",
-            "prefix_or_mask": "255.255.255.0",
-            "broadcast": "192.168.2.255",
-            "interface_addrs_before_dhcp": example_netdev,
-            "connectivity_url_data": {"url": "http://example.org/index.html"},
-        }
-
-        with EphemeralIPv4Network(MockDistro(), **params):
-            self.assertEqual(
-                [mock.call(url="http://example.org/index.html", timeout=5)],
-                m_readurl.call_args_list,
-            )
-        # Ensure that no teardown happens:
-        m_subp.assert_has_calls([])
-
     def test_ephemeral_ipv4_network_noop_when_configured(self, m_subp):
         """EphemeralIPv4Network handles exception when address is setup.
 

--- a/tests/unittests/sources/test_aliyun.py
+++ b/tests/unittests/sources/test_aliyun.py
@@ -4,6 +4,7 @@ import functools
 import os
 from unittest import mock
 
+import pytest
 import responses
 
 from cloudinit import helpers
@@ -186,6 +187,7 @@ class TestAliYunDatasource(test_helpers.ResponsesTestCase):
     @mock.patch("cloudinit.net.find_fallback_nic")
     @mock.patch("cloudinit.net.ephemeral.maybe_perform_dhcp_discovery")
     @mock.patch("cloudinit.sources.DataSourceEc2.util.is_FreeBSD")
+    @pytest.mark.usefixtures("disable_netdev_info")
     def test_aliyun_local_with_mock_server(
         self,
         m_is_bsd,

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -29,6 +29,7 @@ from cloudinit.util import (
 from tests.unittests.helpers import (
     CiTestCase,
     ExitStack,
+    example_netdev,
     mock,
     populate_dir,
     resourceLocation,
@@ -96,6 +97,11 @@ def mock_device_driver():
         return_value="fake_driver",
     ) as m:
         yield m
+
+
+@pytest.fixture(autouse=True)
+def mock_netinfo(disable_netdev_info):
+    pass
 
 
 @pytest.fixture
@@ -3001,6 +3007,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
             ip="10.0.0.4",
             prefix_or_mask="32",
             broadcast="255.255.255.255",
+            interface_addrs_before_dhcp=example_netdev,
             router="10.0.0.1",
             static_routes=[
                 ("0.0.0.0/0", "10.0.0.1"),
@@ -3030,6 +3037,7 @@ class TestPreprovisioningHotAttachNics(CiTestCase):
             ip="10.0.0.4",
             prefix_or_mask="32",
             broadcast="255.255.255.255",
+            interface_addrs_before_dhcp=example_netdev,
             router="10.0.0.1",
             static_routes=None,
         )
@@ -3594,6 +3602,7 @@ class TestCheckIfPrimary:
             ip="10.0.0.4",
             prefix_or_mask="32",
             broadcast="255.255.255.255",
+            interface_addrs_before_dhcp=example_netdev,
             router="10.0.0.1",
             static_routes=static_routes,
         )
@@ -3607,6 +3616,7 @@ class TestCheckIfPrimary:
             ip="10.0.0.4",
             prefix_or_mask="32",
             broadcast="255.255.255.255",
+            interface_addrs_before_dhcp=example_netdev,
             router="10.0.0.1",
             static_routes=[("1.2.3.4/32", "10.0.0.1")],
         )
@@ -3629,6 +3639,7 @@ class TestCheckIfPrimary:
             ip="10.0.0.4",
             prefix_or_mask="32",
             broadcast="255.255.255.255",
+            interface_addrs_before_dhcp=example_netdev,
             router="10.0.0.1",
             static_routes=static_routes,
         )

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -15,6 +15,7 @@ from cloudinit import helpers
 from cloudinit.net import activators
 from cloudinit.sources import DataSourceEc2 as ec2
 from cloudinit.sources import NicOrder
+from tests.unittests.helpers import example_netdev
 from tests.unittests.util import MockDistro
 
 DYNAMIC_METADATA = {
@@ -930,6 +931,7 @@ class TestEc2:
         )
 
     @responses.activate
+    @pytest.mark.usefixtures("disable_netdev_info")
     @mock.patch("cloudinit.net.ephemeral.EphemeralIPv6Network")
     @mock.patch("cloudinit.net.ephemeral.EphemeralIPv4Network")
     @mock.patch("cloudinit.distros.net.find_fallback_nic")
@@ -945,6 +947,7 @@ class TestEc2:
         caplog,
         mocker,
         tmpdir,
+        disable_netdev_info,
     ):
         """Ec2Local returns True for valid platform data on non-BSD with dhcp.
 
@@ -978,6 +981,7 @@ class TestEc2:
         m_net4.assert_called_once_with(
             ds.distro,
             broadcast="192.168.2.255",
+            interface_addrs_before_dhcp=example_netdev,
             interface="eth9",
             ip="192.168.2.9",
             prefix_or_mask="255.255.255.0",

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -322,6 +322,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
     @test_helpers.mock.patch(
         "cloudinit.net.ephemeral.maybe_perform_dhcp_discovery"
     )
+    @pytest.mark.usefixtures("disable_netdev_info")
     def test_local_datasource(self, m_dhcp, m_net):
         """OpenStackLocal calls EphemeralDHCPNetwork and gets instance data."""
         _register_uris(

--- a/tests/unittests/sources/test_upcloud.py
+++ b/tests/unittests/sources/test_upcloud.py
@@ -4,12 +4,14 @@
 
 import json
 
+import pytest
+
 from cloudinit import helpers, importer, settings, sources
 from cloudinit.sources.DataSourceUpCloud import (
     DataSourceUpCloud,
     DataSourceUpCloudLocal,
 )
-from tests.unittests.helpers import CiTestCase, mock
+from tests.unittests.helpers import CiTestCase, example_netdev, mock
 
 UC_METADATA = json.loads(
     """
@@ -216,6 +218,7 @@ class TestUpCloudNetworkSetup(CiTestCase):
             ds._get_sysinfo = get_sysinfo
         return ds
 
+    @pytest.mark.usefixtures("disable_netdev_info")
     @mock.patch("cloudinit.sources.helpers.upcloud.read_metadata")
     @mock.patch("cloudinit.net.find_fallback_nic")
     @mock.patch("cloudinit.net.ephemeral.maybe_perform_dhcp_discovery")
@@ -245,6 +248,7 @@ class TestUpCloudNetworkSetup(CiTestCase):
         m_net.assert_called_once_with(
             ds.distro,
             broadcast="10.6.3.255",
+            interface_addrs_before_dhcp=example_netdev,
             interface="eth1",
             ip="10.6.3.27",
             prefix_or_mask="22",


### PR DESCRIPTION
## Proposed Commit Message
```
fix(dhcp): Enable interactively running cloud-init init --local (#5166)

Check network interface state before and after receiving dhcp lease. Return
link and address to pre-existing state prior to running dhcp client.

While this isn't a supported cloud-init use case, it does make some
testing easier.
      
- add function typing and a docstring to a netinfo function
- remove unnecessary connectivity url check from EphemeralIPv4Network
```

## Test Steps
Build a deb from this branch
On both noble and mantic, do the following:
- `cloud-init clean --logs`
- `cloud-init init --local`
- still connected? cool

My logs: [interactive-init-local-support.tar.gz](https://github.com/canonical/cloud-init/files/14952135/interactive-init-local-support.tar.gz)


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
