### PR TITLE
docs: Add deprecated system_info to schema

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -577,6 +577,12 @@
         },
         "merge_type": {
           "$ref": "#/$defs/merge_definition"
+        },
+        "system_info": {
+          "type": "object",
+          "description": "System and/or distro specific settings. This is not intended to be overridden by user data or vendor data.",
+          "deprecated": true,
+          "deprecated_version": "24.2"
         }
       }
     },
@@ -3876,6 +3882,7 @@
     "ssh_pwauth": {},
     "ssh_quiet_keygen": {},
     "swap": {},
+    "system_info": {},
     "timezone": {},
     "ubuntu_advantage": {},
     "ubuntu_pro": {},

--- a/doc/examples/cloud-config-apt.txt
+++ b/doc/examples/cloud-config-apt.txt
@@ -8,29 +8,6 @@
 #   Number: Set pipelining to some number (not recommended)
 apt_pipelining: False
 
-## apt config via system_info:
-# under the 'system_info', you can customize cloud-init's interaction
-# with apt.
-#  system_info:
-#    apt_get_command: [command, argument, argument]
-#    apt_get_upgrade_subcommand: dist-upgrade
-#
-# apt_get_command:
-#  To specify a different 'apt-get' command, set 'apt_get_command'.
-#  This must be a list, and the subcommand (update, upgrade) is appended to it.
-#  default is:
-#    ['apt-get', '--option=Dpkg::Options::=--force-confold',
-#     '--option=Dpkg::options::=--force-unsafe-io', '--assume-yes', '--quiet']
-#
-# apt_get_upgrade_subcommand: "dist-upgrade"
-#  Specify a different subcommand for 'upgrade. The default is 'dist-upgrade'.
-#  This is the subcommand that is invoked for package_upgrade.
-#
-# apt_get_wrapper:
-#   command: eatmydata
-#   enabled: [True, False, "auto"]
-#
-
 # Install additional packages on first boot
 #
 # Default: none

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -137,13 +137,5 @@ users:
 #
 # users[0] (the first user in users) overrides the user directive.
 #
-# The 'default' user above references the distro's config:
-# system_info:
-#   default_user:
-#     name: Ubuntu
-#     plain_text_passwd: 'ubuntu'
-#     homedir: /home/ubuntu
-#     shell: /bin/bash
-#     lock_passwd: True
-#     gecos: Ubuntu
-#     groups: [adm, cdrom, dip, lxd, sudo]
+# The 'default' user above references the distro's config set in
+# /etc/cloud/cloud.cfg.

--- a/tests/data/user_data.1.txt
+++ b/tests/data/user_data.1.txt
@@ -3,13 +3,3 @@ write_files:
 -   content: blah
     path: /etc/blah.ini
     permissions: 493
-
-system_info:
- package_mirrors:
-   - arches: [i386, amd64, blah]
-     failsafe:
-      primary: http://my.archive.mydomain.com/ubuntu
-      security: http://my.security.mydomain.com/ubuntu
-     search:
-      primary: []
-      security: []

--- a/tests/unittests/runs/test_merge_run.py
+++ b/tests/unittests/runs/test_merge_run.py
@@ -22,7 +22,21 @@ class TestMergeRun(helpers.FilesystemMockingTestCase):
         cfg = {
             "datasource_list": ["None"],
             "cloud_init_modules": ["write_files"],
-            "system_info": {"paths": {"run_dir": new_root}},
+            "system_info": {
+                "paths": {"run_dir": new_root},
+                "package_mirrors": [
+                    {
+                        "arches": ["i386", "amd64", "blah"],
+                        "failsafe": {
+                            "primary": "http://my.archive.mydomain.com/ubuntu",
+                            "security": (
+                                "http://my.security.mydomain.com/ubuntu"
+                            ),
+                        },
+                        "search": {"primary": [], "security": []},
+                    },
+                ],
+            },
         }
         ud = helpers.readResource("user_data.1.txt")
         cloud_cfg = safeyaml.dumps(cfg)

--- a/tests/unittests/sources/test_vultr.py
+++ b/tests/unittests/sources/test_vultr.py
@@ -22,9 +22,6 @@ chpasswd:
   expire: false
   list:
   - root:$6$SxXx...k2mJNIzZB5vMCDBlYT1
-system_info:
-  default_user:
-    name: root
 """
 
 # Vultr metadata test data


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
docs: Add deprecated system_info to schema

In some cases, `system_info` can be passed via user data or vendor data
to override the system_info in /etc/cloud/cloud.cfg . While this
technically can work, this is a use case we no longer support and should
indicate that it is deprecated.

Also remove/update examples.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
