### PR TITLE
feat(alpine): add support for Busybox adduser/addgroup

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -914,8 +914,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
         if hashed:
             # Need to use the short option name '-e' instead of '--encrypted'
-            # (which would be more descriptive) since SLES 11 doesn't know
-            # about long names.
+            # (which would be more descriptive) since Busybox and SLES 11
+            # chpasswd don't know about long names.
             cmd.append("-e")
 
         try:

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -8,8 +8,10 @@
 
 import logging
 import os
+import re
 import stat
-from typing import Optional
+from datetime import datetime
+from typing import Any, Dict, Optional
 
 from cloudinit import distros, helpers, subp, util
 from cloudinit.distros.parsers.hostname import HostnameConf
@@ -32,6 +34,7 @@ class Distro(distros.Distro):
     keymap_path = "/usr/share/bkeymaps/"
     locale_conf_fn = "/etc/profile.d/50-cloud-init-locale.sh"
     network_conf_fn = "/etc/network/interfaces"
+    shadow_fn = "/etc/shadow"
     renderer_configs = {
         "eni": {"eni_path": network_conf_fn, "eni_header": NETWORK_FILE_HEADER}
     }
@@ -201,6 +204,339 @@ class Distro(distros.Distro):
             self._preferred_ntp_clients = ["chrony", "ntp"]
 
         return self._preferred_ntp_clients
+
+    def add_user(self, name, **kwargs):
+        """
+        Add a user to the system using standard tools
+
+        On Alpine this may use either 'useradd' or 'adduser' depending
+        on whether the 'shadow' package is installed.
+        """
+        if util.is_user(name):
+            LOG.info("User %s already exists, skipping.", name)
+            return
+
+        if "selinux_user" in kwargs:
+            LOG.warning("Ignoring selinux_user parameter for Alpine Linux")
+            del kwargs["selinux_user"]
+
+        # If 'useradd' is available then use the generic
+        # add_user function from __init__.py instead.
+        if subp.which("useradd"):
+            return super().add_user(name, **kwargs)
+
+        create_groups = kwargs.pop("create_groups", True)
+
+        adduser_cmd = ["adduser", "-D"]
+
+        # Since we are creating users, we want to carefully validate
+        # the inputs. If something goes wrong, we can end up with a
+        # system that nobody can login to.
+        adduser_opts = {
+            "gecos": "-g",
+            "homedir": "-h",
+            "primary_group": "-G",
+            "shell": "-s",
+            "uid": "-u",
+        }
+
+        adduser_flags = {"system": "-S"}
+
+        # support kwargs having groups=[list] or groups="g1,g2"
+        groups = kwargs.get("groups")
+        if groups:
+            if isinstance(groups, str):
+                groups = groups.split(",")
+            elif isinstance(groups, dict):
+                util.deprecate(
+                    deprecated=f"The user {name} has a 'groups' config value "
+                    "of type dict",
+                    deprecated_version="22.3",
+                    extra_message="Use a comma-delimited string or "
+                    "array instead: group1,group2.",
+                )
+
+            # remove any white spaces in group names, most likely
+            # that came in as a string like: groups: group1, group2
+            groups = [g.strip() for g in groups]
+
+            # kwargs.items loop below wants a comma delimited string
+            # that can go right through to the command.
+            kwargs["groups"] = ",".join(groups)
+
+            if kwargs.get("primary_group"):
+                groups.append(kwargs["primary_group"])
+
+        if create_groups and groups:
+            for group in groups:
+                if not util.is_group(group):
+                    self.create_group(group)
+                    LOG.debug("created group '%s' for user '%s'", group, name)
+        if "uid" in kwargs:
+            kwargs["uid"] = str(kwargs["uid"])
+
+        unsupported_busybox_values: Dict[str, Any] = {
+            "groups": [],
+            "expiredate": None,
+            "inactive": None,
+            "passwd": None,
+        }
+
+        # Check the values and create the command
+        for key, val in sorted(kwargs.items()):
+            if key in adduser_opts and val and isinstance(val, str):
+                adduser_cmd.extend([adduser_opts[key], val])
+            elif (
+                key in unsupported_busybox_values
+                and val
+                and isinstance(val, str)
+            ):
+                # Busybox's 'adduser' does not support specifying these
+                # options so store them for use via alternative means.
+                if key == "groups":
+                    unsupported_busybox_values[key] = val.split(",")
+                else:
+                    unsupported_busybox_values[key] = val
+            elif key in adduser_flags and val:
+                adduser_cmd.append(adduser_flags[key])
+
+        # Don't create the home directory if directed so
+        # or if the user is a system user
+        if kwargs.get("no_create_home") or kwargs.get("system"):
+            adduser_cmd.append("-H")
+
+        # Busybox's 'adduser' puts username at end of command
+        adduser_cmd.append(name)
+
+        # Run the command
+        LOG.debug("Adding user %s", name)
+        try:
+            subp.subp(adduser_cmd)
+        except subp.ProcessExecutionError as e:
+            LOG.warning("Failed to create user %s", name)
+            raise e
+
+        # Process remaining options that Busybox's 'adduser' does not support
+
+        # Separately add user to each additional group as Busybox's
+        # 'adduser' does not support specifying additional groups.
+        for addn_group in unsupported_busybox_values[
+            "groups"
+        ]:  # pylint: disable=E1133
+            LOG.debug("Adding user to group %s", addn_group)
+            try:
+                subp.subp(["addgroup", name, addn_group])
+            except subp.ProcessExecutionError as e:
+                util.logexc(
+                    LOG, "Failed to add user %s to group %s", name, addn_group
+                )
+                raise e
+
+        if unsupported_busybox_values["passwd"]:
+            # Separately set password as Busybox's 'adduser' does
+            # not support passing password as CLI option.
+            super().set_passwd(
+                name, unsupported_busybox_values["passwd"], hashed=True
+            )
+
+        # Busybox's 'adduser' is hardcoded to always set the following field
+        # values (numbered from "0") in /etc/shadow unlike 'useradd':
+        #
+        # Field                          Value set
+        #
+        #   3    minimum password age    0 (no min age)
+        #   4    maximum password age    99999 (days)
+        #   5    warning period          7 (warn days before max age)
+        #
+        # so modify these fields to be empty.
+        #
+        # Also set expiredate (field '7') and/or inactive (field '6')
+        # values directly in /etc/shadow file as Busybox's 'adduser'
+        # does not support passing these as CLI options.
+
+        expiredate = unsupported_busybox_values["expiredate"]
+        inactive = unsupported_busybox_values["inactive"]
+
+        shadow_contents = None
+        shadow_file = self.shadow_fn
+        try:
+            shadow_contents = util.load_text_file(shadow_file)
+        except FileNotFoundError as e:
+            LOG.warning("Failed to read %s file, file not found", shadow_file)
+            raise e
+
+        # Find the line in /etc/shadow for the user
+        original_line = None
+        for line in shadow_contents.splitlines():
+            new_line_parts = line.split(":")
+            if new_line_parts[0] == name:
+                original_line = line
+                break
+
+        if original_line:
+            # Modify field(s) in copy of user's shadow file entry
+            update_type = ""
+
+            # Minimum password age
+            new_line_parts[3] = ""
+            # Maximum password age
+            new_line_parts[4] = ""
+            # Password warning period
+            new_line_parts[5] = ""
+            update_type = "password aging"
+
+            if expiredate is not None:
+                # Convert date into number of days since 1st Jan 1970
+                days = (
+                    datetime.fromisoformat(expiredate)
+                    - datetime.fromisoformat("1970-01-01")
+                ).days
+                new_line_parts[7] = str(days)
+                if update_type != "":
+                    update_type = update_type + " & "
+                update_type = update_type + "acct expiration date"
+            if inactive is not None:
+                new_line_parts[6] = inactive
+                if update_type != "":
+                    update_type = update_type + " & "
+                update_type = update_type + "inactivity period"
+
+            # Replace existing line for user with modified line
+            shadow_contents = shadow_contents.replace(
+                original_line, ":".join(new_line_parts)
+            )
+            LOG.debug("Updating %s for user %s", update_type, name)
+            try:
+                util.write_file(
+                    shadow_file, shadow_contents, omode="w", preserve_mode=True
+                )
+            except IOError as e:
+                util.logexc(LOG, "Failed to update %s file", shadow_file)
+                raise e
+        else:
+            util.logexc(
+                LOG, "Failed to update %s for user %s", shadow_file, name
+            )
+
+    def lock_passwd(self, name):
+        """
+        Lock the password of a user, i.e., disable password logins
+        """
+
+        # Check whether Shadow's or Busybox's version of 'passwd'.
+        # If Shadow's 'passwd' is available then use the generic
+        # lock_passwd function from __init__.py instead.
+        if not os.path.islink(
+            "/usr/bin/passwd"
+        ) or "bbsuid" not in os.readlink("/usr/bin/passwd"):
+            return super().lock_passwd(name)
+
+        cmd = ["passwd", "-l", name]
+        # Busybox's 'passwd', unlike Shadow's 'passwd', errors
+        # if password is already locked:
+        #
+        #   "passwd: password for user2 is already locked"
+        #
+        # with exit code 1
+        try:
+            (_out, err) = subp.subp(cmd, rcs=[0, 1])
+            if re.search(r"is already locked", err):
+                return True
+        except subp.ProcessExecutionError as e:
+            util.logexc(LOG, "Failed to disable password for user %s", name)
+            raise e
+
+    def expire_passwd(self, user):
+        # Check whether Shadow's or Busybox's version of 'passwd'.
+        # If Shadow's 'passwd' is available then use the generic
+        # expire_passwd function from __init__.py instead.
+        if not os.path.islink(
+            "/usr/bin/passwd"
+        ) or "bbsuid" not in os.readlink("/usr/bin/passwd"):
+            return super().expire_passwd(user)
+
+        # Busybox's 'passwd' does not provide an expire option
+        # so have to manipulate the shadow file directly.
+        shadow_contents = None
+        shadow_file = self.shadow_fn
+        try:
+            shadow_contents = util.load_text_file(shadow_file)
+        except FileNotFoundError as e:
+            LOG.warning("Failed to read %s file, file not found", shadow_file)
+            raise e
+
+        # Find the line in /etc/shadow for the user
+        original_line = None
+        for line in shadow_contents.splitlines():
+            new_line_parts = line.split(":")
+            if new_line_parts[0] == user:
+                LOG.debug("Found /etc/shadow line matching user %s", user)
+                original_line = line
+                break
+
+        if original_line:
+            # Replace existing line for user with modified line
+            #
+            # Field '2' (numbered from '0') in /etc/shadow
+            # is the "date of last password change".
+            if new_line_parts[2] != "0":
+                # Busybox's 'adduser' always expires password so only
+                # need to expire it now if this is not a new user.
+                new_line_parts[2] = "0"
+                shadow_contents = shadow_contents.replace(
+                    original_line, ":".join(new_line_parts), 1
+                )
+
+                LOG.debug("Expiring password for user %s", user)
+                try:
+                    util.write_file(
+                        shadow_file,
+                        shadow_contents,
+                        omode="w",
+                        preserve_mode=True,
+                    )
+                except IOError as e:
+                    util.logexc(LOG, "Failed to update %s file", shadow_file)
+                    raise e
+            else:
+                LOG.debug("Password for user %s is already expired", user)
+        else:
+            util.logexc(LOG, "Failed to set 'expire' for %s", user)
+
+    def create_group(self, name, members=None):
+        # If 'groupadd' is available then use the generic
+        # create_group function from __init__.py instead.
+        if subp.which("groupadd"):
+            return super().create_group(name, members)
+
+        group_add_cmd = ["addgroup", name]
+        if not members:
+            members = []
+
+        # Check if group exists, and then add if it doesn't
+        if util.is_group(name):
+            LOG.warning("Skipping creation of existing group '%s'", name)
+        else:
+            try:
+                subp.subp(group_add_cmd)
+                LOG.info("Created new group %s", name)
+            except subp.ProcessExecutionError:
+                util.logexc(LOG, "Failed to create group %s", name)
+
+        # Add members to the group, if so defined
+        if len(members) > 0:
+            for member in members:
+                if not util.is_user(member):
+                    LOG.warning(
+                        "Unable to add group member '%s' to group '%s'"
+                        "; user does not exist.",
+                        member,
+                        name,
+                    )
+                    continue
+
+                subp.subp(["addgroup", member, name])
+                LOG.info("Added user '%s' to group '%s'", member, name)
 
     def shutdown_command(self, mode="poweroff", delay="now", message=None):
         # called from cc_power_state_change.load_power_state

--- a/tests/unittests/distros/test_alpine.py
+++ b/tests/unittests/distros/test_alpine.py
@@ -1,0 +1,78 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from unittest import mock
+
+import pytest
+
+from cloudinit import distros, util
+from tests.unittests.helpers import TestCase
+
+
+class TestAlpineBusyboxUserGroup:
+    @mock.patch("cloudinit.distros.alpine.subp.subp")
+    @mock.patch("cloudinit.distros.subp.which", return_value=False)
+    def test_busybox_add_group(self, m_which, m_subp):
+        distro = distros.fetch("alpine")("alpine", {}, None)
+
+        group = "mygroup"
+
+        distro.create_group(group)
+
+        m_subp.assert_called_with(["addgroup", group])
+
+    @pytest.mark.usefixtures("fake_filesystem")
+    @mock.patch("cloudinit.distros.alpine.subp.subp")
+    @mock.patch("cloudinit.distros.subp.which", return_value=False)
+    def test_busybox_add_user(self, m_which, m_subp, tmpdir):
+        distro = distros.fetch("alpine")("alpine", {}, None)
+
+        shadow_file = tmpdir.join("/etc/shadow")
+        shadow_file.dirpath().mkdir()
+
+        user = "me2"
+
+        # Need to place entry for user in /etc/shadow as
+        # "adduser" is stubbed and so will not create it.
+        root_entry = "root::19848:0:::::"
+        shadow_file.write(
+            root_entry + "\n" + user + ":!:19848:0:99999:7:::" + "\n"
+        )
+
+        distro.shadow_fn = shadow_file
+
+        distro.add_user(user, lock_passwd=True)
+
+        m_subp.assert_called_with(["adduser", "-D", user])
+
+        contents = util.load_text_file(shadow_file)
+        expected = root_entry + "\n" + user + ":!:19848::::::" + "\n"
+
+        assert contents == expected
+
+
+class TestAlpineShadowUserGroup(TestCase):
+    distro = distros.fetch("alpine")("alpine", {}, None)
+
+    @mock.patch("cloudinit.distros.alpine.subp.subp")
+    @mock.patch(
+        "cloudinit.distros.subp.which", return_value=("/usr/sbin/groupadd")
+    )
+    def test_shadow_add_group(self, m_which, m_subp):
+        group = "mygroup"
+
+        self.distro.create_group(group)
+
+        m_subp.assert_called_with(["groupadd", group])
+
+    @mock.patch("cloudinit.distros.alpine.subp.subp")
+    @mock.patch(
+        "cloudinit.distros.subp.which", return_value=("/usr/sbin/useradd")
+    )
+    def test_shadow_add_user(self, m_which, m_subp):
+        user = "me2"
+
+        self.distro.add_user(user)
+
+        m_subp.assert_called_with(
+            ["useradd", user, "-m"], logstring=["useradd", user, "-m"]
+        )


### PR DESCRIPTION
```
feat(alpine): add support for Busybox adduser/addgroup

By default Alpine Linux provides Busybox utilities such as adduser
and addgroup for managing users and groups. Optionally the Alpine
"shadow" package provides the traditional useradd/groupadd utilities.

Add fallback support for the Busybox user/group management utilities
for Alpine Linux.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
