### PR TITLE
test(alpine): skip timezone-tests for non-glibc

### DIFF
--- a/tests/unittests/analyze/test_dump.py
+++ b/tests/unittests/analyze/test_dump.py
@@ -11,7 +11,7 @@ from cloudinit.analyze.dump import (
     parse_ci_logline,
     parse_timestamp,
 )
-from cloudinit.util import write_file
+from cloudinit.util import get_linux_distro, write_file
 from tests.unittests.helpers import mock
 
 
@@ -43,6 +43,10 @@ class TestParseTimestamp:
         dt = datetime.strptime(journal_stamp + " " + str(year), journal_fmt)
         assert float(dt.strftime("%s.%f")) == parse_timestamp(journal_stamp)
 
+    @pytest.mark.skipif(
+        get_linux_distro()[0] == "alpine",
+        reason="glibc timezone behaviour expected",
+    )
     @pytest.mark.allow_subp_for("date", "gdate")
     def test_parse_unexpected_timestamp_format_with_date_command(self):
         """Dump sends unexpected timestamp formats to date for processing."""
@@ -137,6 +141,10 @@ class TestParseCILogLine:
             [mock.call("2016-08-30 21:53:25.972325+00:00")]
         )
 
+    @pytest.mark.skipif(
+        get_linux_distro()[0] == "alpine",
+        reason="glibc timezone behaviour expected",
+    )
     def test_parse_logline_returns_event_for_amazon_linux_2_line(self):
         line = (
             "Apr 30 19:39:11 cloud-init[2673]: handlers.py[DEBUG]: start:"


### PR DESCRIPTION
Python 3.12 datetime.now() behaves differently on glibc and non- glibc regarding whether it incorporates a timezone or not.  These tests fail on non-glibc systems as a result.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test(alpine): skip timezone-tests for non-glibc

Python 3.12 datetime.now() behaves differently on glibc and non-
glibc regarding whether it incorporates a timezone or not.  These
tests fail on non-glibc systems as a result

Fixes GH-5158
```

## Test Steps

See comments

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
<!-- - [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly -->

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
