### PR TITLE
fix(azure): Avoid non-primary nics from having routes to DNS CPC-4224

### DIFF
--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -976,7 +976,17 @@ class TestNetworkConfig:
                     "dhcp6": False,
                     "match": {"macaddress": "00:0d:3a:04:75:98"},
                     "set-name": "eth0",
-                }
+                },
+                "primary": {
+                    "dhcp4": True,
+                    "match": {"driver": "hv_netvsc", "name": "eth0"},
+                },
+                "secondary": {
+                    "dhcp4": True,
+                    "dhcp4-overrides": {"use-dns": False},
+                    "optional": True,
+                    "match": {"driver": "hv_netvsc", "name": "!eth0"},
+                },
             },
             "version": 2,
         }
@@ -1557,7 +1567,17 @@ scbus-1 on xpt0 bus 0
                     "dhcp6": False,
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
-                }
+                },
+                "primary": {
+                    "dhcp4": True,
+                    "match": {"driver": "hv_netvsc", "name": "eth0"},
+                },
+                "secondary": {
+                    "dhcp4": True,
+                    "dhcp4-overrides": {"use-dns": False},
+                    "optional": True,
+                    "match": {"driver": "hv_netvsc", "name": "!eth0"},
+                },
             },
             "version": 2,
         }
@@ -1595,6 +1615,16 @@ scbus-1 on xpt0 bus 0
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 300},
                 },
+                "primary": {
+                    "dhcp4": True,
+                    "match": {"driver": "hv_netvsc", "name": "eth0"},
+                },
+                "secondary": {
+                    "dhcp4": True,
+                    "dhcp4-overrides": {"use-dns": False},
+                    "optional": True,
+                    "match": {"driver": "hv_netvsc", "name": "!eth0"},
+                },
             },
             "version": 2,
         }
@@ -1626,7 +1656,17 @@ scbus-1 on xpt0 bus 0
                     "dhcp6": False,
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
-                }
+                },
+                "primary": {
+                    "dhcp4": True,
+                    "match": {"driver": "hv_netvsc", "name": "eth0"},
+                },
+                "secondary": {
+                    "dhcp4": True,
+                    "dhcp4-overrides": {"use-dns": False},
+                    "optional": True,
+                    "match": {"driver": "hv_netvsc", "name": "!eth0"},
+                },
             },
             "version": 2,
         }


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(azure): Avoid non-primary nics from having routes to DNS

From jammy, we have routes to dhcp by all NICS,since  RoutesToDns=true 
is the default in networkd.
```

## Additional Context
<!-- If relevant -->
From jammy, RouteToDns=true is the default for systemd-networkd.
This causes slow resolution of urls and failures in journalctl.
We need to limit the route to DHCP to the primary NIC.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
CLOUD_INIT_PLATFORM=azure CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init-bddeb.deb tox -e integration-tests -- tests/integration_tests/datasources/test_azure.py::test_azure_multi_nic_setup
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
