### PR TITLE
test: install software-properties-common if absent during PPA setup

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -211,10 +211,15 @@ class IntegrationInstance:
 
     def install_ppa(self):
         log.info("Installing PPA")
+        if self.execute("which add-apt-repository").failed:
+            log.info("Installing missing software-properties-common package")
+            self._apt_update()
+            assert self.execute(
+                "apt install -qy software-properties-common"
+            ).ok
         assert self.execute(
             "add-apt-repository {} -y".format(self.settings.CLOUD_INIT_SOURCE)
         ).ok
-        self._apt_update()
         assert self.execute("apt-get install -qy cloud-init").ok
 
     @retry(tries=30, delay=1)


### PR DESCRIPTION
## Proposed Commit Message
```
test: install software-properties-common if absent during PPA setup

In minimal images, add-apt-repository command will be absent because
software-properties-common is not installed.

This breaks integration tests which use ImageType.MINIMAL and attempt
to install cloud-init from a PPA.

Before calling add-apt-repository, check presence of the command.
When absent, apt install software-properties-common.
```


## Additional Context
<!-- If relevant -->
https://github.com/canonical/pycloudlib/pull/361 updates the correct image stream source for Azure minimal noble daily images.




## Test Steps
The following integration test will fall over due to inability to call add-apt-repository in minimal azure images because software-properties-common deb isn't installed by default :
```
CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/dailyCLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_PLATFORM=azure test -e integration-tests-jenkins -- tests/integration_tests/datasources/test_azure.py::test_azure_eject
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
