### PR TITLE
fix: Warn when signal is handled

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -745,12 +745,7 @@ def status_wrapper(name, args):
     else:
         raise ValueError("unknown name: %s" % name)
 
-    if mode not in (
-        "init",
-        "init-local",
-        "modules-config",
-        "modules-final",
-    ):
+    if mode not in STAGE_NAME:
         raise ValueError(
             "Invalid cloud init mode specified '{0}'".format(mode)
         )

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -815,6 +815,12 @@ def status_wrapper(name, args):
         v1[mode]["errors"].append(str(e))
         raise
     except SystemExit as e:
+        # All calls to sys.exit() will resume running here. Before exiting,
+        # cloud-init will:
+        # 1) Write status.json (and result.json if in Final stage).
+        # 2) Write the final log message containing module run time.
+        # 3) Flush any queued reporting event handlers.
+        #
         # silence a pylint false positive
         # https://github.com/pylint-dev/pylint/issues/9556
         if e.code:  # pylint: disable=using-constant-test
@@ -823,7 +829,6 @@ def status_wrapper(name, args):
             LOG.exception("failed stage %s", mode)
             print_exc("failed run of stage %s" % mode)
             v1[mode]["errors"].append(f"sys.exit({str(e.code)}) called")
-        raise
     finally:
         # It is desireable to write to status.json before exiting, even when
         # sys.exit() is called.

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -788,7 +788,7 @@ def status_wrapper(name, args):
     if v1[mode]["start"] and not v1[mode]["finished"]:
         # This stage was restarted, which isn't expected.
         LOG.warning(
-            "Unexpected start time found for %s. " "Was this stage restarted?",
+            "Unexpected start time found for %s. Was this stage restarted?",
             STAGE_NAME[mode],
         )
 

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -808,19 +808,12 @@ def status_wrapper(name, args):
             errors = ret
 
         v1[mode]["errors"].extend([str(e) for e in errors])
-
     except Exception as e:
         LOG.exception("failed stage %s", mode)
         print_exc("failed run of stage %s" % mode)
         v1[mode]["errors"].append(str(e))
-        raise
     except SystemExit as e:
-        # All calls to sys.exit() will resume running here. Before exiting,
-        # cloud-init will:
-        # 1) Write status.json (and result.json if in Final stage).
-        # 2) Write the final log message containing module run time.
-        # 3) Flush any queued reporting event handlers.
-        #
+        # All calls to sys.exit() resume running here.
         # silence a pylint false positive
         # https://github.com/pylint-dev/pylint/issues/9556
         if e.code:  # pylint: disable=using-constant-test
@@ -830,8 +823,10 @@ def status_wrapper(name, args):
             print_exc("failed run of stage %s" % mode)
             v1[mode]["errors"].append(f"sys.exit({str(e.code)}) called")
     finally:
-        # It is desireable to write to status.json before exiting, even when
-        # sys.exit() is called.
+        # Before it exits, cloud-init will:
+        # 1) Write status.json (and result.json if in Final stage).
+        # 2) Write the final log message containing module run time.
+        # 3) Flush any queued reporting event handlers.
         v1[mode]["finished"] = float(util.uptime())
         v1["stage"] = None
 

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -56,6 +56,14 @@ FREQ_SHORT_NAMES = {
     "once": PER_ONCE,
 }
 
+# https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
+STAGE_NAME = {
+    "init-local": "Local Stage",
+    "init": "Network Stage",
+    "modules-config": "Config Stage",
+    "modules-final": "Final Stage",
+}
+
 LOG = logging.getLogger(__name__)
 
 
@@ -749,7 +757,7 @@ def status_wrapper(name, args):
 
     nullstatus = {
         "errors": [],
-        "recoverable_errors": [],
+        "recoverable_errors": {},
         "start": None,
         "finished": None,
     }
@@ -780,8 +788,8 @@ def status_wrapper(name, args):
     if v1[mode]["start"] and not v1[mode]["finished"]:
         # This stage was restarted, which isn't expected.
         LOG.warning(
-            "Unexpected start time for stage %s. " "Was this stage restarted?",
-            mode,
+            "Unexpected start time found for %s. " "Was this stage restarted?",
+            STAGE_NAME[mode],
         )
 
     v1[mode]["start"] = float(util.uptime())

--- a/cloudinit/signal_handler.py
+++ b/cloudinit/signal_handler.py
@@ -44,7 +44,7 @@ def _handle_exit(signum, frame):
     contents = StringIO()
     contents.write("%s\n" % (msg))
     _pprint_frame(frame, 1, BACK_FRAME_TRACE_DEPTH, contents)
-    util.multi_log(contents.getvalue(), console=True, stderr=False, log=LOG)
+    util.multi_log(contents.getvalue(), log=LOG, log_level=logging.ERROR)
     sys.exit(rc)
 
 

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -184,6 +184,10 @@ def verify_clean_log(log: str, ignore_deprecations: bool = True):
         raise AssertionError(
             "Found unexpected errors: %s" % "\n".join(error_logs)
         )
+    if re.findall("Cloud-init.*received SIG", log):
+        raise AssertionError(
+            "Found unexpected signal termination: %s" % "\n".join(error_logs)
+        )
 
     warning_count = log.count("[WARNING]")
     expected_warnings = 0

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -498,25 +498,25 @@ class TestSignalHandling:
                                 ),
                                 "init": {
                                     "errors": [],
-                                    "recoverable_errors": [],
+                                    "recoverable_errors": {},
                                     "start": 124.567,
                                     "finished": None,
                                 },
                                 "init-local": {
                                     "errors": [],
-                                    "recoverable_errors": [],
+                                    "recoverable_errors": {},
                                     "start": 100.0,
                                     "finished": 100.00001,
                                 },
                                 "modules-config": {
                                     "errors": [],
-                                    "recoverable_errors": [],
+                                    "recoverable_errors": {},
                                     "start": None,
                                     "finished": None,
                                 },
                                 "modules-final": {
                                     "errors": [],
-                                    "recoverable_errors": [],
+                                    "recoverable_errors": {},
                                     "start": None,
                                     "finished": None,
                                 },
@@ -540,8 +540,7 @@ class TestSignalHandling:
 
         # assert that the status shows recoverable errors
         assert (
-            "[init] Unexpected value found in status.json. "
-            "Was this stage restarted?"
+            'Unexpected start time found for Network Stage. Was this stage restarted?'
             in m_json.call_args[0][1]["v1"]["init"]["recoverable_errors"][
                 "WARNING"
             ]

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -540,7 +540,8 @@ class TestSignalHandling:
 
         # assert that the status shows recoverable errors
         assert (
-            'Unexpected start time found for Network Stage. Was this stage restarted?'
+            "Unexpected start time found for Network Stage. "
+            "Was this stage restarted?"
             in m_json.call_args[0][1]["v1"]["init"]["recoverable_errors"][
                 "WARNING"
             ]

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -470,6 +470,7 @@ class TestSignalHandling:
                 ),
             )
             assert 1 == e.code
+            assert not m_json.call_args[0][1]["v1"]["init"]["errors"]
 
     @mock.patch("cloudinit.cmd.main.atomic_helper.write_json")
     def test_status_wrapper_signal_warnings(

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -2,8 +2,10 @@
 
 import contextlib
 import io
+import json
 import logging
 import os
+import sys
 from collections import namedtuple
 
 import pytest
@@ -16,6 +18,7 @@ mock = test_helpers.mock
 
 M_PATH = "cloudinit.cmd.main."
 Tmpdir = namedtuple("Tmpdir", ["tmpdir", "link_d", "data_d"])
+FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
 
 
 @pytest.fixture()
@@ -76,7 +79,6 @@ class TestCLI:
     def test_status_wrapper_errors(
         self, action, name, match, caplog, mock_status_wrapper
     ):
-        FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
         my_action = mock.Mock()
 
         myargs = FakeArgs((action, my_action), False, "bogusmode")
@@ -101,8 +103,6 @@ class TestCLI:
             test_helpers.populate_dir(
                 str(_dir), {"status.json": "old", "result.json": "old"}
             )
-
-        FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
 
         def myaction(name, args):
             # Return an error to watch status capture them
@@ -139,8 +139,6 @@ class TestCLI:
         mocker.patch(M_PATH + "read_cfg_paths", return_value=paths)
         data_d = mock_status_wrapper.data_d
         link_d = mock_status_wrapper.link_d
-
-        FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
 
         def myaction(name, args):
             # Return an error to watch status capture them
@@ -414,3 +412,137 @@ class TestCLI:
         assert "features" == parseargs.action[0]
         assert False is parseargs.debug
         assert False is parseargs.force
+
+
+class TestSignalHandling:
+    @mock.patch("cloudinit.cmd.main.atomic_helper.write_json")
+    def test_status_wrapper_signal_sys_exit(
+        self,
+        m_json,
+        mocker,
+        mock_status_wrapper,
+    ):
+        """make sure that when sys.exit(N) is called, the correct code is
+        called
+        """
+        for code in [1, 2, 3, 4]:
+            with pytest.raises(SystemExit) as e:
+                cli.status_wrapper(
+                    "init",
+                    FakeArgs(
+                        (
+                            None,
+                            # silence pylint false positive
+                            # https://github.com/pylint-dev/pylint/issues/9557
+                            lambda *_: sys.exit(code),  # pylint: disable=W0640
+                        ),
+                        False,
+                        "bogusmode",
+                    ),
+                )
+                assert code == e.value.code
+
+            # assert that the status shows errors
+            assert (
+                f"sys.exit({code}) called"
+                in m_json.call_args[0][1]["v1"]["init"]["errors"]
+            )
+
+    @mock.patch("cloudinit.cmd.main.atomic_helper.write_json")
+    def test_status_wrapper_no_signal_sys_exit(
+        self,
+        m_json,
+        mock_status_wrapper,
+    ):
+        """if sys.exit() is called from a non-signal handler, make sure that
+        cloud-init doesn't interfere - just re-raise"""
+        # call status_wrapper() with the required args
+        with pytest.raises(SystemExit) as e:
+            cli.status_wrapper(
+                "init",
+                FakeArgs(
+                    (
+                        None,
+                        lambda *_: sys.exit(1),
+                    ),
+                    False,
+                    "bogusmode",
+                ),
+            )
+            assert 1 == e.code
+
+    @mock.patch("cloudinit.cmd.main.atomic_helper.write_json")
+    def test_status_wrapper_signal_warnings(
+        self,
+        m_json,
+        mock_status_wrapper,
+    ):
+        """If a stage is started and status.json already has a start time but
+        no end time for that stage, this is an unknown state - make sure that
+        a warning is logged.
+        """
+
+        # Write a status.json to the mocked temporary directory
+        for dir in mock_status_wrapper.data_d, mock_status_wrapper.link_d:
+            test_helpers.populate_dir(
+                str(dir),
+                {
+                    "status.json": json.dumps(
+                        {
+                            "v1": {
+                                "stage": "init",
+                                "datasource": (
+                                    "DataSourceNoCloud "
+                                    "[seed=/var/.../seed/nocloud-net]"
+                                    "[dsmode=net]"
+                                ),
+                                "init": {
+                                    "errors": [],
+                                    "recoverable_errors": [],
+                                    "start": 124.567,
+                                    "finished": None,
+                                },
+                                "init-local": {
+                                    "errors": [],
+                                    "recoverable_errors": [],
+                                    "start": 100.0,
+                                    "finished": 100.00001,
+                                },
+                                "modules-config": {
+                                    "errors": [],
+                                    "recoverable_errors": [],
+                                    "start": None,
+                                    "finished": None,
+                                },
+                                "modules-final": {
+                                    "errors": [],
+                                    "recoverable_errors": [],
+                                    "start": None,
+                                    "finished": None,
+                                },
+                            }
+                        }
+                    )
+                },
+            )
+        # call status_wrapper() with the required args
+        cli.status_wrapper(
+            "init",
+            FakeArgs(
+                (
+                    None,
+                    lambda *_: ("SomeDataSource", []),
+                ),
+                False,
+                "bogusmode",
+            ),
+        )
+
+        # assert that the status shows recoverable errors
+        assert (
+            "[init] Unexpected value found in status.json. "
+            "Was this stage restarted?"
+            in m_json.call_args[0][1]["v1"]["init"]["recoverable_errors"][
+                "WARNING"
+            ]
+        )


### PR DESCRIPTION
```
fix: Warn when a signal is handled

Cloud-init is expected to run to completion. It does not expect to be
stopped or restarted. Therefore, cloud-init should loudly warn when this
happens so that the user is aware that the unexpected has happened. 

Problems:

- When systemd stops cloud-init, no warning is logged.
- When systemd restarts cloud-init, status info and return code from the
  current stage is lost.

The net effect of these problems is that when cloud-init is restarted
no warning is logged, and cloud-init status indicates no problem.

Communicate unexpected state by:

- Increase signal handling log level to ERROR, add log to stderr.
- Write status.json before exiting when sys.exit() is called.
- Warn when status.json contains existing data when the stage
  starts[1].
- Append existing errors and recoverable status.json errors rather
  than overwriting[2].

This should make cloud-init properly warn in status output and logs that
something is amiss.

[1] This should never happen and indicates that something restarted the
    service. When cloud-init doesn't have the opportunity to handle a
    signal (SIGKILL), other mitigations will fail.
[2] Pre-existing warnings were previously silently lost from
    `cloud-init status`'s output.

Fixes GH-5190
```

Fixes https://github.com/canonical/cloud-init/issues/5190