### PR TITLE
test: Skip test if console log is None

### DIFF
--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -325,6 +325,8 @@ def get_console_log(client: "IntegrationInstance"):
         console_log = client.instance.console_log()
     except NotImplementedError:
         pytest.skip("NotImplementedError when requesting console log")
+    if console_log is None:
+        pytest.skip("Console log has not been setup")
     if console_log.lower().startswith("no console output"):
         pytest.fail("no console output")
     return console_log


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Skip test if console log is None

In the recent pycloudlib bump, Azure's console_log call went from
raising NotImplementedError to returning None if the boot diagnostic
log hasn't been initialized.
```

## Additional Context
Ran the failures from https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-azure/188/ locally with these changes and they're skipped instead (as they were before).

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
