### PR TITLE
fix: Remove invalid ipv4/ipv6 from openstack network rendering

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -658,10 +658,6 @@ def convert_net_json(network_json=None, known_macs=None):
             if network["type"] in ["ipv6_dhcpv6-stateful", "ipv6_dhcp"]:
                 cfg.update({"accept-ra": True})
 
-            if network["type"] == "ipv4":
-                subnet["ipv4"] = True
-            if network["type"] == "ipv6":
-                subnet["ipv6"] = True
             subnets.append(subnet)
         cfg.update({"subnets": subnets})
         if link["type"] in ["bond"]:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Remove invalid ipv4/ipv6 from openstack network rendering

Fixes GH-4911
```

## Additional Context
See https://github.com/canonical/cloud-init/issues/4911

If we call `convert_net_json()` with the following:
```json
{
  "links": [
    {
      "name": "eth0",
      "id": "tap945ebbab-18",
      "mtu": 1500,
      "type": "phy",
      "vif_id": "945ebbab-18b8-4a87-a1c0-068c263cf6e3"
    }
  ],
  "networks": [
    {
      "id": "network0",
      "link": "tap945ebbab-18",
      "network_id": "bcf59eb2-9d83-41cc-b4f5-0435ed594833",
      "type": "ipv4_dhcp"
    },
    {
      "id": "network1",
      "ip_address": "xxxx:xxxx:xxx:xxx::xxxx",
      "link": "tap945ebbab-18",
      "netmask": "ffff:ffff:ffff:ff00::",
      "network_id": "bcf59eb2-9d83-41cc-b4f5-0435ed594833",
      "routes": [
        {
          "gateway": "[2001:41d0:304:300::1](xxxx:xxxx:xxx:xxx::xxxx)",
          "netmask": "::",
          "network": "::"
        }
      ],
      "services": [],
      "type": "ipv6"
    }
  ],
  "services": [
    {
      "address": "1.1.1.1",
      "type": "dns"
    }
  ]
}
```

Without this change, we get a v1 config with an `ipv6` under subnets:
```json
{
    "version": 1,
    "config": [
        {
            "name": "eth0",
            "mtu": 1500,
            "type": "physical",
            "accept-ra": false,
            "subnets": [
                {
                    "type": "dhcp4"
                },
                {
                    "netmask": "ffff:ffff:ffff:ff00::",
                    "routes": [
                        {
                            "gateway": "[2001:41d0:304:300::1](xxxx:xxxx:xxx:xxx::xxxx)",
                            "netmask": "::",
                            "network": "::"
                        }
                    ],
                    "type": "static6",
                    "address": "xxxx:xxxx:xxx:xxx::xxxx",
                    "ipv6": true
                }
            ],
            "mac_address": null
        },
        {
            "address": "1.1.1.1",
            "type": "nameserver"
        }
    ]
}
```

With the change, that `ipv6` key no longer exists:
```json
{
    "version": 1,
    "config": [
        {
            "name": "eth0",
            "mtu": 1500,
            "type": "physical",
            "accept-ra": false,
            "subnets": [
                {
                    "type": "dhcp4"
                },
                {
                    "netmask": "ffff:ffff:ffff:ff00::",
                    "routes": [
                        {
                            "gateway": "[2001:41d0:304:300::1](xxxx:xxxx:xxx:xxx::xxxx)",
                            "netmask": "::",
                            "network": "::"
                        }
                    ],
                    "type": "static6",
                    "address": "xxxx:xxxx:xxx:xxx::xxxx"
                }
            ],
            "mac_address": null
        },
        {
            "address": "1.1.1.1",
            "type": "nameserver"
        }
    ]
}
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
