### PR TITLE
fix: Add subnet ipv4/ipv6  to network schema

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -532,6 +532,14 @@
           "items": {
             "$ref": "#/$defs/anyOf_type_route"
           }
+        },
+        "ipv4": {
+          "type": "boolean",
+          "description": "Indicate if the subnet is IPv4. If not specified, it will be inferred from the subnet type or address. This exists for compatibility with OpenStack's ``network_data.json`` when rendered through sysconfig."
+        },
+        "ipv6": {
+          "type": "boolean",
+          "description": "Indicate if the subnet is IPv6. If not specified, it will be inferred from the subnet type or address. This is exists for compatibility with OpenStack's ``network_data.json`` when rendered through sysconfig."
         }
       }
     },


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Add subnet ipv4/ipv6  to network schema

These are used by our openstack network_data.json parsing code and
get used by the sysconfig renderer.

Fixes GH-4911
```

## Additional Context
https://github.com/canonical/cloud-init/issues/4911
and

https://github.com/canonical/cloud-init/blob/70581bb0833f0ce77a2ca0ae1ee203ecc2a7bf62/cloudinit/net/sysconfig.py#L623-L636

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
