### PR TITLE
tests: validate netplan API YAML instead of strict content

### DIFF
--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -198,7 +198,10 @@ def test_netplan_rendering(
     }
     with session_cloud.launch(launch_kwargs=launch_kwargs) as client:
         result = client.execute("cat /etc/netplan/50-cloud-init.yaml")
-        assert result.stdout.startswith(EXPECTED_NETPLAN_HEADER)
+        if CURRENT_RELEASE < MANTIC:
+            assert result.stdout.startswith(EXPECTED_NETPLAN_HEADER)
+        else:
+            assert EXPECTED_NETPLAN_HEADER not in result.stdout
         assert expected == yaml.safe_load(result.stdout)
 
 

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -12,6 +12,7 @@ from tests.integration_tests.releases import (
     CURRENT_RELEASE,
     FOCAL,
     IS_UBUNTU,
+    MANTIC,
     NOBLE,
 )
 from tests.integration_tests.util import verify_clean_log
@@ -154,7 +155,12 @@ def test_clean_boot_of_upgraded_package(session_cloud: IntegrationCloud):
                 values.pop("dhcp6")
             assert yaml.dump(pre_network) == yaml.dump(post_network)
         else:
-            assert pre_network == post_network
+            if CURRENT_RELEASE < MANTIC:
+                assert pre_network == post_network
+            else:
+                # Mantic and later Netplan API is used which doesn't allow
+                # for cloud-init to write a header in network config
+                assert yaml.load(pre_network) == yaml.load(post_network)
 
         # Calculate and log all the boot numbers
         pre_analyze_totals = [

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -156,11 +156,16 @@ def test_clean_boot_of_upgraded_package(session_cloud: IntegrationCloud):
             assert yaml.dump(pre_network) == yaml.dump(post_network)
         else:
             if CURRENT_RELEASE < MANTIC:
+                # Assert the full content is preserved including header comment
+                # since cloud-init writes the file directly and does not use
+                # netplan API to write 50-cloud-init.yaml.
                 assert pre_network == post_network
             else:
-                # Mantic and later Netplan API is used which doesn't allow
-                # for cloud-init to write a header in network config
-                assert yaml.load(pre_network) == yaml.load(post_network)
+                # Mantic and later Netplan API is used and doesn't allow
+                # cloud-init to write header comments in network config
+                assert yaml.safe_load(pre_network) == yaml.safe_load(
+                    post_network
+                )
 
         # Calculate and log all the boot numbers
         pre_analyze_totals = [


### PR DESCRIPTION
## Proposed Commit Message
```
tests: validate netplan API YAML instead of strict content

Netplan API is used on Mantic and later which prevents cloud-init
from writing a header comment in /etc/netplan/50-cloud-init.yaml.

So, the former header comments cloud-init wrote when it
created /etc/netplan/50-cloud-init.yaml instead of netplan API will
disappear when using netplan's API to write 50-cloud-init.yaml.

Only compare the loaded YAML dict of networking config instead of
the full content of the file before and after upgrade to assert
the equality of network config.
```


## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-azure/110/testReport/junit/tests.integration_tests/test_upgrade/test_clean_boot_of_upgraded_package/


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
