### PR TITLE
test: Update netplan-based integration tests

### DIFF
--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -198,7 +198,8 @@ def test_netplan_rendering(
     }
     with session_cloud.launch(launch_kwargs=launch_kwargs) as client:
         result = client.execute("cat /etc/netplan/50-cloud-init.yaml")
-        assert result.stdout.startswith(EXPECTED_NETPLAN_HEADER)
+        if CURRENT_RELEASE < JAMMY:
+            assert result.stdout.startswith(EXPECTED_NETPLAN_HEADER)
         assert expected == yaml.safe_load(result.stdout)
 
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Update netplan-based integration tests

c465de827 introduced rendering netplan config via calling the netplan
API. This results in some indentation changes and removal of the
header, so update integration tests accordingly.
```

## Additional Context
(Canonical only) see failures at https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-mantic-lxd_vm/180/

## Test Steps
I ran the above integration tests locally after these changes and they pass.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
