### PR TITLE
apt: deb822 comments aligned with livecd-rootfs

### DIFF
--- a/templates/sources.list.ubuntu.deb822.tmpl
+++ b/templates/sources.list.ubuntu.deb822.tmpl
@@ -31,10 +31,9 @@
 ##                      or updates from the Ubuntu security team.
 ## Components: Aside from main, the following components can be added to the list
 ##   restricted  - Software that may not be under a free license, or protected by patents.
-##   universe    - Community maintained packages.
-##                 Software from this repository is only maintained and supported by Canonical
-##                 for machines with Ubuntu Pro subscriptions. Without Ubuntu Pro, the Ubuntu
-##                 community provides best-effort security maintenance.
+##   universe    - Community maintained packages. Software in this repository receives maintenance
+##                 from volunteers in the Ubuntu community, or a 10 year security maintenance
+##                 commitment from Canonical when an Ubuntu Pro subscription is attached.
 ##   multiverse  - Community maintained of restricted. Software from this repository is
 ##                 ENTIRELY UNSUPPORTED by the Ubuntu team, and may not be under a free
 ##                 licence. Please satisfy yourself as to your rights to use the software.


### PR DESCRIPTION
Adjust commented deb822 text to align with livecd-rootfs

## Additional Context
livecd-rootfs-pr updating content: https://code.launchpad.net/~juliank/livecd-rootfs/+git/livecd-rootfs/+merge/464742
Fixes #5197 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
