### PR TITLE
Make exception handling explicit

### DIFF
--- a/cloudinit/cloud.py
+++ b/cloudinit/cloud.py
@@ -56,7 +56,7 @@ class Cloud:
         # Ensure that cfg is not indirectly modified
         return copy.deepcopy(self._cfg)
 
-    def run(self, name, functor, args, freq=None, clear_on_fail=False):
+    def run(self, name, functor, args, freq=None):
         """Run a function gated by a named semaphore for a desired frequency.
 
         The typical case for this method would be to limit running of the
@@ -68,7 +68,7 @@ class Cloud:
         even if they happen to be run in different boot stages or across
         reboots.
         """
-        return self._runners.run(name, functor, args, freq, clear_on_fail)
+        return self._runners.run(name, functor, args, freq)
 
     def get_template_filename(self, name):
         fn = self.paths.template_tpl % (name)

--- a/cloudinit/cmd/clean.py
+++ b/cloudinit/cmd/clean.py
@@ -8,7 +8,6 @@
 
 import argparse
 import glob
-import logging
 import os
 import sys
 
@@ -38,7 +37,6 @@ GEN_NET_CONFIG_FILES = [
 GEN_SSH_CONFIG_FILES = [
     "/etc/ssh/sshd_config.d/50-cloud-init.conf",
 ]
-LOG = logging.getLogger(__name__)
 
 
 def get_parser(parser=None):

--- a/cloudinit/cmd/clean.py
+++ b/cloudinit/cmd/clean.py
@@ -8,6 +8,7 @@
 
 import argparse
 import glob
+import logging
 import os
 import sys
 
@@ -37,6 +38,7 @@ GEN_NET_CONFIG_FILES = [
 GEN_SSH_CONFIG_FILES = [
     "/etc/ssh/sshd_config.d/50-cloud-init.conf",
 ]
+LOG = logging.getLogger(__name__)
 
 
 def get_parser(parser=None):

--- a/cloudinit/cmd/cloud_id.py
+++ b/cloudinit/cmd/cloud_id.py
@@ -76,7 +76,7 @@ def handle_args(name, args):
     try:
         with open(args.instance_data) as file:
             instance_data = json.load(file)
-    except IOError:
+    except OSError:
         return log_util.error(
             "File not found '%s'. Provide a path to instance data json file"
             " using --instance-data" % args.instance_data

--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -237,6 +237,12 @@ def handle_hotplug(hotplug_init: Init, devpath, subsystem, udevaction):
             event_handler.success()
             break
         except Exception as e:
+            # The number of possible exceptions handled here is large and
+            # difficult to audit. If retries fail this exception is always
+            # re-raised. Therefore, this callsite is allowed to be an exception
+            # to the rule that handle Exception must log a warning or reraise
+            # or call util.logexc() - since it does technically do this on
+            # timeout.
             LOG.debug("Exception while processing hotplug event. %s", e)
             time.sleep(wait)
             last_exception = e

--- a/cloudinit/cmd/devel/render.py
+++ b/cloudinit/cmd/devel/render.py
@@ -86,7 +86,7 @@ def render_template(user_data_path, instance_data_path=None, debug=False):
     try:
         with open(user_data_path) as stream:
             user_data = stream.read()
-    except IOError:
+    except OSError:
         LOG.error("Missing user-data file: %s", user_data_path)
         return 1
     try:

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -801,8 +801,12 @@ def status_wrapper(name, args):
     else:
         try:
             status = json.loads(util.load_text_file(status_path))
-        except Exception:
-            pass
+        except OSError:
+            LOG.warning("File %s cannot be accessed %s.", status_path, mode)
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            LOG.warning("File %s not valid json %s: %s", status_path, mode, e)
+        except Exception as e:
+            LOG.warning("File %s not valid json %s: %s", status_path, mode, e)
 
     if mode not in status["v1"]:
         # this should never happen, but leave it just to be safe

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -802,11 +802,13 @@ def status_wrapper(name, args):
         try:
             status = json.loads(util.load_text_file(status_path))
         except OSError:
-            LOG.warning("File %s cannot be accessed %s.", status_path, mode)
+            LOG.warning("File %s cannot be accessed: %s", status_path, mode)
         except (UnicodeDecodeError, json.JSONDecodeError) as e:
-            LOG.warning("File %s not valid json %s: %s", status_path, mode, e)
+            LOG.warning("File %s not valid json: %s", status_path, e)
         except Exception as e:
-            LOG.warning("File %s not valid json %s: %s", status_path, mode, e)
+            LOG.warning(
+                "Unhandled exception loading file %s: %s", status_path, e
+            )
 
     if mode not in status["v1"]:
         # this should never happen, but leave it just to be safe

--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -153,7 +153,7 @@ def apply_apt(cfg, cloud, gpg):
 
     try:
         apply_apt_config(cfg, APT_PROXY_FN, APT_CONFIG_FN)
-    except (IOError, OSError):
+    except OSError:
         LOG.exception("Failed to apply proxy or apt config info:")
 
     # Process 'apt_source -> sources {dict}'
@@ -733,7 +733,7 @@ def add_apt_sources(
                 omode = "w"
 
             util.write_file(sourcefn, contents, omode=omode)
-        except IOError as detail:
+        except OSError as detail:
             LOG.exception("failed write to file %s: %s", sourcefn, detail)
             raise
 

--- a/cloudinit/config/cc_bootcmd.py
+++ b/cloudinit/config/cc_bootcmd.py
@@ -47,10 +47,6 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             util.logexc(LOG, "Failed to shellify bootcmd: %s", str(e))
             raise
 
-        try:
-            iid = cloud.get_instance_id()
-            env = {"INSTANCE_ID": str(iid)} if iid else {}
-            subp.subp(["/bin/sh", tmpf.name], update_env=env, capture=False)
-        except Exception:
-            util.logexc(LOG, "Failed to run bootcmd module %s", name)
-            raise
+        iid = cloud.get_instance_id()
+        env = {"INSTANCE_ID": str(iid)} if iid else {}
+        subp.subp(["/bin/sh", tmpf.name], update_env=env, capture=False)

--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -125,7 +125,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     try:
         subp.subp(["debconf-set-selections"], data=dconf_sel)
-    except subp.ProcessExecutionError as e:
+    except Exception as e:
         util.logexc(
             LOG, "Failed to run debconf-set-selections for grub_dpkg: %s", e
         )

--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -125,7 +125,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     try:
         subp.subp(["debconf-set-selections"], data=dconf_sel)
-    except Exception as e:
+    except subp.ProcessExecutionError as e:
         util.logexc(
             LOG, "Failed to run debconf-set-selections for grub_dpkg: %s", e
         )

--- a/cloudinit/config/cc_keys_to_console.py
+++ b/cloudinit/config/cc_keys_to_console.py
@@ -62,12 +62,6 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         cfg, "ssh_key_console_blacklist", []
     )
 
-    try:
-        cmd = [helper_path, ",".join(fp_blacklist), ",".join(key_blacklist)]
-        (stdout, _stderr) = subp.subp(cmd)
-        log_util.multi_log(
-            "%s\n" % (stdout.strip()), stderr=False, console=True
-        )
-    except Exception:
-        LOG.warning("Writing keys to the system console failed!")
-        raise
+    cmd = [helper_path, ",".join(fp_blacklist), ",".join(key_blacklist)]
+    stdout, _stderr = subp.subp(cmd)
+    log_util.multi_log("%s\n" % (stdout.strip()), stderr=False, console=True)

--- a/cloudinit/config/cc_mcollective.py
+++ b/cloudinit/config/cc_mcollective.py
@@ -48,7 +48,7 @@ def configure(
     try:
         old_contents = util.load_binary_file(server_cfg, quiet=False)
         mcollective_config = ConfigObj(io.BytesIO(old_contents))
-    except IOError as e:
+    except OSError as e:
         if e.errno != errno.ENOENT:
             raise
         else:
@@ -85,7 +85,7 @@ def configure(
         # We got all our config as wanted we'll copy
         # the previous server.cfg and overwrite the old with our new one
         util.copy(server_cfg, "%s.old" % (server_cfg))
-    except IOError as e:
+    except OSError as e:
         if e.errno == errno.ENOENT:
             # Doesn't exist to copy...
             pass

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -331,12 +331,10 @@ def handle_swapcfg(swapcfg):
                     LOG.debug("swap file %s already in use", fname)
                     return fname
             LOG.debug("swap file %s exists, but not in /proc/swaps", fname)
-        except OSError:
-            LOG.warning(
-                "swap file %s exists. Error reading /proc/swaps", fname
-            )
+        except OSError as e:
+            LOG.warning("Error reading /proc/swaps: %s", e)
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
+            LOG.warning("Unhandled exception while reading /proc/swaps: %s", e)
         return fname
 
     try:

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -282,7 +282,7 @@ def setup_swapfile(fname, size=None, maxsize=None):
     if str(size).lower() == "auto":
         try:
             memsize = util.read_meminfo()["total"]
-        except IOError:
+        except OSError:
             LOG.debug("Not creating swap: failed to read meminfo")
             return
 

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -331,11 +331,13 @@ def handle_swapcfg(swapcfg):
                     LOG.debug("swap file %s already in use", fname)
                     return fname
             LOG.debug("swap file %s exists, but not in /proc/swaps", fname)
-        except Exception:
+        except OSError:
             LOG.warning(
                 "swap file %s exists. Error reading /proc/swaps", fname
             )
-            return fname
+        except Exception as e:
+            LOG.warning("Unhandled exception: %s", e)
+        return fname
 
     try:
         if isinstance(size, str) and size != "auto":
@@ -344,7 +346,10 @@ def handle_swapcfg(swapcfg):
             maxsize = util.human2bytes(maxsize)
         return setup_swapfile(fname=fname, size=size, maxsize=maxsize)
 
+    except OSError as e:
+        LOG.warning("failed to setup swap: %s", e)
     except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
         LOG.warning("failed to setup swap: %s", e)
 
     return None

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -48,7 +48,7 @@ def givecmdline(pid):
             return m.group(2)
         else:
             return util.load_text_file("/proc/%s/cmdline" % pid)
-    except IOError:
+    except OSError:
         return None
 
 
@@ -194,11 +194,11 @@ def run_after_pid_gone(pid, pidcmdline, timeout, condition, func, args):
                 msg = "cmdline changed for %s [now: %s]" % (pid, cmdline)
                 break
 
-        except IOError as ioerr:
+        except OSError as ioerr:
             if ioerr.errno in known_errnos:
                 msg = "pidfile gone [%d]" % ioerr.errno
             else:
-                fatal("IOError during wait: %s" % ioerr)
+                fatal("OSError during wait: %s" % ioerr)
             break
 
         except Exception as e:

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -71,11 +71,7 @@ def check_condition(cond):
         else:
             LOG.warning("%sunexpected exit %s. do not apply change.", pre, ret)
             return False
-    except OSError as e:
-        LOG.warning("%sUnexpected error: %s", pre, e)
-        return False
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
         LOG.warning("%sUnexpected error: %s", pre, e)
         return False
 

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -71,7 +71,11 @@ def check_condition(cond):
         else:
             LOG.warning("%sunexpected exit %s. do not apply change.", pre, ret)
             return False
+    except OSError as e:
+        LOG.warning("%sUnexpected error: %s", pre, e)
+        return False
     except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
         LOG.warning("%sUnexpected error: %s", pre, e)
         return False
 

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -8,7 +8,6 @@
 
 """Resizefs: cloud-config module which resizes the filesystem"""
 
-import errno
 import logging
 import os
 import re
@@ -215,19 +214,17 @@ def maybe_get_writable_device_path(devpath, info):
 
     try:
         statret = os.stat(devpath)
-    except OSError as exc:
-        if container and exc.errno == errno.ENOENT:
+    except FileNotFoundError:
+        if container:
             LOG.debug(
                 "Device '%s' did not exist in container. cannot resize: %s",
                 devpath,
                 info,
             )
-        elif exc.errno == errno.ENOENT:
+        else:
             LOG.warning(
                 "Device '%s' did not exist. cannot resize: %s", devpath, info
             )
-        else:
-            raise exc
         return None
 
     if not stat.S_ISBLK(statret.st_mode) and not stat.S_ISCHR(statret.st_mode):

--- a/cloudinit/config/cc_runcmd.py
+++ b/cloudinit/config/cc_runcmd.py
@@ -47,4 +47,5 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         content = util.shellify(cmd)
         util.write_file(out_fn, content, 0o700)
     except Exception as e:
-        raise type(e)("Failed to shellify {} into file {}".format(cmd, out_fn))
+        util.logexc(LOG, "Failed to shellify runcmd: %s", e)
+        raise

--- a/cloudinit/config/cc_scripts_per_boot.py
+++ b/cloudinit/config/cc_scripts_per_boot.py
@@ -37,7 +37,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     runparts_path = os.path.join(cloud.get_cpath(), "scripts", SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
-    except Exception:
+    except RuntimeError:
         LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,

--- a/cloudinit/config/cc_scripts_per_boot.py
+++ b/cloudinit/config/cc_scripts_per_boot.py
@@ -37,7 +37,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     runparts_path = os.path.join(cloud.get_cpath(), "scripts", SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
-    except RuntimeError:
+    except Exception:
         LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,

--- a/cloudinit/config/cc_scripts_per_instance.py
+++ b/cloudinit/config/cc_scripts_per_instance.py
@@ -35,7 +35,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     runparts_path = os.path.join(cloud.get_cpath(), "scripts", SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
-    except Exception:
+    except RuntimeError:
         LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,

--- a/cloudinit/config/cc_scripts_per_once.py
+++ b/cloudinit/config/cc_scripts_per_once.py
@@ -35,7 +35,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     runparts_path = os.path.join(cloud.get_cpath(), "scripts", SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
-    except Exception:
+    except RuntimeError:
         LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,

--- a/cloudinit/config/cc_scripts_per_once.py
+++ b/cloudinit/config/cc_scripts_per_once.py
@@ -35,7 +35,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     runparts_path = os.path.join(cloud.get_cpath(), "scripts", SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
-    except RuntimeError:
+    except Exception:
         LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,

--- a/cloudinit/config/cc_scripts_user.py
+++ b/cloudinit/config/cc_scripts_user.py
@@ -36,7 +36,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     runparts_path = os.path.join(cloud.get_ipath_cur(), SCRIPT_SUBDIR)
     try:
         subp.runparts(runparts_path)
-    except Exception:
+    except RuntimeError:
         LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,

--- a/cloudinit/config/cc_scripts_vendor.py
+++ b/cloudinit/config/cc_scripts_vendor.py
@@ -38,7 +38,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     try:
         subp.runparts(runparts_path, exe_prefix=prefix)
-    except Exception:
+    except RuntimeError:
         LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,

--- a/cloudinit/config/cc_scripts_vendor.py
+++ b/cloudinit/config/cc_scripts_vendor.py
@@ -38,7 +38,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     try:
         subp.runparts(runparts_path, exe_prefix=prefix)
-    except RuntimeError:
+    except Exception:
         LOG.warning(
             "Failed to run module %s (%s in %s)",
             name,

--- a/cloudinit/config/cc_seed_random.py
+++ b/cloudinit/config/cc_seed_random.py
@@ -39,7 +39,7 @@ def _decode(data, encoding=None):
     elif encoding.lower() in ["gzip", "gz"]:
         return util.decomp_gzip(data, quiet=False, decode=None)
     else:
-        raise IOError("Unknown random_seed encoding: %s" % (encoding))
+        raise OSError("Unknown random_seed encoding: %s" % (encoding))
 
 
 def handle_random_seed_command(command, required, update_env):

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -225,7 +225,8 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if publish_hostkeys:
         hostkeys = get_public_host_keys(blacklist=host_key_blacklist)
         try:
-            cloud.datasource.publish_host_keys(hostkeys)
+            if not cloud.datasource.publish_host_keys(hostkeys):
+                LOG.warning("Publishing host keys failed!")
         except Exception:
             util.logexc(LOG, "Publishing host keys failed!")
 

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -150,11 +150,7 @@ def import_ssh_ids(ids, user):
         return
     LOG.debug("Importing SSH ids for user %s.", user)
 
-    try:
-        subp.subp(cmd, capture=False)
-    except subp.ProcessExecutionError as exc:
-        util.logexc(LOG, "Failed to run command to import %s SSH ids", user)
-        raise exc
+    subp.subp(cmd, capture=False)
 
 
 def is_key_in_nested_dict(config: dict, search_key: str) -> bool:

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -11,7 +11,7 @@ import logging
 import pwd
 from typing import List
 
-from cloudinit import subp, util
+from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -83,8 +83,12 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         try:
             import_ssh_ids(import_ids, user)
         except Exception as exc:
-            util.logexc(
-                LOG, "ssh-import-id failed for: %s %s", user, import_ids
+            lifecycle.log_with_downgradable_level(
+                logger=LOG,
+                version="24.4",
+                requested_level=logging.WARN,
+                msg=f"ssh-import-id failed for {user} {import_ids} with: %s",
+                args=exc,
             )
             elist.append(exc)
 

--- a/cloudinit/config/cc_wireguard.py
+++ b/cloudinit/config/cc_wireguard.py
@@ -6,7 +6,7 @@
 import logging
 import re
 
-from cloudinit import subp, util
+from cloudinit import lifecycle, subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -73,6 +73,18 @@ def write_config(wg_int: dict):
     except (OSError, KeyError) as e:
         raise RuntimeError(
             "Failure writing Wireguard configuration file"
+            f' {wg_int["config_path"]}:{NL}{str(e)}'
+        ) from e
+    except Exception as e:
+        lifecycle.log_with_downgradable_level(
+            logger=LOG,
+            version="24.4",
+            requested_level=logging.WARN,
+            msg="Unhandled exception: %s",
+            args=e,
+        )
+        raise RuntimeError(
+            "Unhandled failure writing Wireguard configuration file"
             f' {wg_int["config_path"]}:{NL}{str(e)}'
         ) from e
 

--- a/cloudinit/config/cc_wireguard.py
+++ b/cloudinit/config/cc_wireguard.py
@@ -70,7 +70,7 @@ def write_config(wg_int: dict):
         util.write_file(
             wg_int["config_path"], wg_int["content"], mode=WG_CONFIG_FILE_MODE
         )
-    except Exception as e:
+    except (OSError, KeyError) as e:
         raise RuntimeError(
             "Failure writing Wireguard configuration file"
             f' {wg_int["config_path"]}:{NL}{str(e)}'

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -14,7 +14,6 @@ from collections.abc import Iterable
 from contextlib import suppress
 from copy import deepcopy
 from enum import Enum
-from errno import EACCES
 from functools import partial
 from itertools import chain
 from typing import (
@@ -1771,14 +1770,12 @@ def get_config_paths_from_args(
 
     try:
         paths = read_cfg_paths(fetch_existing_datasource="trust")
-    except OSError as e:
-        if e.errno == EACCES:
-            LOG.debug(
-                "Using default instance-data/user-data paths for non-root user"
-            )
-            paths = read_cfg_paths()
-        else:
-            raise
+    except PermissionError:
+        LOG.debug(
+            "Using default instance-data/user-data "
+            "paths with insufficient permissions"
+        )
+        paths = read_cfg_paths()
     except DataSourceNotFoundException:
         paths = read_cfg_paths()
         LOG.warning(

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1631,7 +1631,7 @@ def get_schema(schema_type: SchemaType = SchemaType.CLOUD_CONFIG) -> dict:
     full_schema = None
     try:
         full_schema = json.loads(load_text_file(schema_file))
-    except (IOError, OSError):
+    except OSError:
         LOG.warning(
             "Skipping %s schema validation. No JSON schema file found %s.",
             schema_type.value,
@@ -1771,7 +1771,7 @@ def get_config_paths_from_args(
 
     try:
         paths = read_cfg_paths(fetch_existing_datasource="trust")
-    except (IOError, OSError) as e:
+    except OSError as e:
         if e.errno == EACCES:
             LOG.debug(
                 "Using default instance-data/user-data paths for non-root user"

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -416,10 +416,6 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 continue
             try:
                 manager.update_package_sources(force=force)
-            except subp.ProcessExecutionError as e:
-                LOG.error(
-                    "Failed to update package using %s: %s", manager.name, e
-                )
             except Exception as e:
                 LOG.error(
                     "Failed to update package using %s: %s", manager.name, e
@@ -1780,5 +1776,11 @@ def uses_systemd():
     except OSError:
         return False
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
+        lifecycle.log_with_downgradable_level(
+            logger=LOG,
+            version="24.4",
+            requested_level=logging.WARN,
+            msg="Unhandled exception: %s",
+            args=e,
+        )
         return False

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -378,7 +378,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def _find_tz_file(self, tz):
         tz_file = os.path.join(self.tz_zone_dir, str(tz))
         if not os.path.isfile(tz_file):
-            raise IOError(
+            raise OSError(
                 "Invalid timezone %s, no file found at %s" % (tz, tz_file)
             )
         return tz_file
@@ -595,7 +595,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         for fn in update_files:
             try:
                 self._write_hostname(hostname, fn)
-            except IOError:
+            except OSError:
                 util.logexc(
                     LOG, "Failed to write hostname %s to %s", hostname, fn
                 )
@@ -1169,14 +1169,14 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             contents = [util.make_header(), content]
             try:
                 util.write_file(doas_file, "\n".join(contents), mode=0o440)
-            except IOError as e:
+            except OSError as e:
                 util.logexc(LOG, "Failed to write doas file %s", doas_file)
                 raise e
         else:
             if content not in util.load_text_file(doas_file):
                 try:
                     util.append_file(doas_file, content)
-                except IOError as e:
+                except OSError as e:
                     util.logexc(
                         LOG, "Failed to append to doas file %s", doas_file
                     )
@@ -1231,7 +1231,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                     sudoers_contents = "\n".join(lines)
                     util.append_file(sudo_base, sudoers_contents)
                 LOG.debug("Added '#includedir %s' to %s", path, sudo_base)
-            except IOError as e:
+            except OSError as e:
                 util.logexc(LOG, "Failed to write %s", sudo_base)
                 raise e
         util.ensure_dir(path, 0o750)
@@ -1264,14 +1264,14 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             ]
             try:
                 util.write_file(sudo_file, "\n".join(contents), 0o440)
-            except IOError as e:
+            except OSError as e:
                 util.logexc(LOG, "Failed to write sudoers file %s", sudo_file)
                 raise e
         else:
             if content not in util.load_text_file(sudo_file):
                 try:
                     util.append_file(sudo_file, content)
-                except IOError as e:
+                except OSError as e:
                     util.logexc(
                         LOG, "Failed to append to sudoers file %s", sudo_file
                     )
@@ -1493,7 +1493,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 )
                 return None
             return int(match.group(field))
-        except IOError as e:
+        except OSError as e:
             LOG.warning("Failed to load /proc/%s/stat. %s", pid, e)
         except IndexError:
             LOG.warning(

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -416,6 +416,10 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 continue
             try:
                 manager.update_package_sources(force=force)
+            except subp.ProcessExecutionError as e:
+                LOG.error(
+                    "Failed to update package using %s: %s", manager.name, e
+                )
             except Exception as e:
                 LOG.error(
                     "Failed to update package using %s: %s", manager.name, e
@@ -1773,5 +1777,8 @@ def uses_systemd():
     try:
         res = os.lstat("/run/systemd/system")
         return stat.S_ISDIR(res.st_mode)
-    except Exception:
+    except OSError:
+        return False
+    except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
         return False

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -88,7 +88,7 @@ class Distro(distros.Distro):
             # Try to update the previous one
             # so lets see if we can read it first.
             conf = self._read_hostname_conf(filename)
-        except IOError:
+        except OSError:
             create_hostname_file = util.get_cfg_option_bool(
                 self._cfg, "create_hostname_file", True
             )
@@ -118,7 +118,7 @@ class Distro(distros.Distro):
         try:
             conf = self._read_hostname_conf(filename)
             hostname = conf.hostname
-        except IOError:
+        except OSError:
             pass
         if not hostname:
             return default
@@ -412,7 +412,7 @@ class Distro(distros.Distro):
                 util.write_file(
                     shadow_file, shadow_contents, omode="w", preserve_mode=True
                 )
-            except IOError as e:
+            except OSError as e:
                 util.logexc(LOG, "Failed to update %s file", shadow_file)
                 raise e
         else:
@@ -530,7 +530,7 @@ class Distro(distros.Distro):
                         omode="w",
                         preserve_mode=True,
                     )
-                except IOError as e:
+                except OSError as e:
                     util.logexc(LOG, "Failed to update %s file", shadow_file)
                     raise e
             else:

--- a/cloudinit/distros/aosc.py
+++ b/cloudinit/distros/aosc.py
@@ -121,7 +121,7 @@ def read_locale_conf(sys_path):
     try:
         contents = util.load_text_file(sys_path).splitlines()
         exists = True
-    except IOError:
+    except OSError:
         contents = []
     return (exists, SysConf(contents))
 

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -64,7 +64,7 @@ class Distro(distros.Distro):
             # Try to update the previous one
             # so lets see if we can read it first.
             conf = self._read_hostname_conf(filename)
-        except IOError:
+        except OSError:
             create_hostname_file = util.get_cfg_option_bool(
                 self._cfg, "create_hostname_file", True
             )
@@ -94,7 +94,7 @@ class Distro(distros.Distro):
         try:
             conf = self._read_hostname_conf(filename)
             hostname = conf.hostname
-        except IOError:
+        except OSError:
             pass
         if not hostname:
             return default

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -129,7 +129,7 @@ class Distro(distros.Distro):
             # Try to update the previous one
             # so lets see if we can read it first.
             conf = self._read_hostname_conf(filename)
-        except IOError:
+        except OSError:
             create_hostname_file = util.get_cfg_option_bool(
                 self._cfg, "create_hostname_file", True
             )
@@ -159,7 +159,7 @@ class Distro(distros.Distro):
         try:
             conf = self._read_hostname_conf(filename)
             hostname = conf.hostname
-        except IOError:
+        except OSError:
             pass
         if not hostname:
             return default

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -219,7 +219,7 @@ class Distro(cloudinit.distros.bsd.BSD):
             util.logexc(LOG, "Failed to apply locale %s", locale)
             try:
                 util.copy(self.login_conf_fn_bak, self.login_conf_fn)
-            except IOError:
+            except OSError:
                 util.logexc(
                     LOG, "Failed to restore %s backup", self.login_conf_fn
                 )

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -63,7 +63,7 @@ class Distro(distros.Distro):
             # Try to update the previous one
             # so lets see if we can read it first.
             conf = self._read_hostname_conf(filename)
-        except IOError:
+        except OSError:
             create_hostname_file = util.get_cfg_option_bool(
                 self._cfg, "create_hostname_file", True
             )
@@ -98,7 +98,7 @@ class Distro(distros.Distro):
         try:
             conf = self._read_hostname_conf(filename)
             hostname = conf.hostname
-        except IOError:
+        except OSError:
             pass
         if not hostname:
             return default

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -169,7 +169,7 @@ class Distro(distros.Distro):
             try:
                 conf = self._read_hostname_conf(filename)
                 hostname = conf.hostname
-            except IOError:
+            except OSError:
                 pass
             if not hostname:
                 return default
@@ -242,7 +242,7 @@ class Distro(distros.Distro):
                 # Try to update the previous one
                 # so lets see if we can read it first.
                 conf = self._read_hostname_conf(filename)
-            except IOError:
+            except OSError:
                 if create_hostname_file:
                     pass
                 else:

--- a/cloudinit/distros/parsers/hostname.py
+++ b/cloudinit/distros/parsers/hostname.py
@@ -71,5 +71,5 @@ class HostnameConf:
             entries.append(("hostname", [head, tail]))
             hostnames_found.add(head)
         if len(hostnames_found) > 1:
-            raise IOError("Multiple hostnames (%s) found!" % (hostnames_found))
+            raise OSError("Multiple hostnames (%s) found!" % (hostnames_found))
         return entries

--- a/cloudinit/distros/parsers/resolv_conf.py
+++ b/cloudinit/distros/parsers/resolv_conf.py
@@ -148,7 +148,7 @@ class ResolvConf:
             try:
                 (cfg_opt, cfg_values) = head.split(None, 1)
             except (IndexError, ValueError) as e:
-                raise IOError(
+                raise OSError(
                     "Incorrectly formatted resolv.conf line %s" % (i + 1)
                 ) from e
             if cfg_opt not in [
@@ -158,6 +158,6 @@ class ResolvConf:
                 "sortlist",
                 "options",
             ]:
-                raise IOError("Unexpected resolv.conf option %s" % (cfg_opt))
+                raise OSError("Unexpected resolv.conf option %s" % (cfg_opt))
             entries.append(("option", [cfg_opt, cfg_values, tail]))
         return entries

--- a/cloudinit/distros/rhel_util.py
+++ b/cloudinit/distros/rhel_util.py
@@ -45,6 +45,6 @@ def read_sysconfig_file(fn):
     try:
         contents = util.load_text_file(fn).splitlines()
         exists = True
-    except IOError:
+    except OSError:
         contents = []
     return (exists, SysConf(contents))

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -7,7 +7,7 @@ import re
 from errno import EACCES
 from typing import Optional, Type
 
-from cloudinit import handlers
+from cloudinit import handlers, lifecycle
 from cloudinit.atomic_helper import b64d, json_dumps
 from cloudinit.helpers import Paths
 from cloudinit.settings import PER_ALWAYS
@@ -126,7 +126,14 @@ def render_jinja_payload_from_file(
     except (OSError, ValueError, TypeError) as e:
         raise JinjaLoadError("Loading Jinja instance data failed") from e
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
+        lifecycle.log_with_downgradable_level(
+            logger=LOG,
+            version="24.4",
+            requested_level=logging.WARN,
+            msg="Unhandled exception: %s",
+            args=e,
+        )
+
         raise JinjaLoadError("Loading Jinja instance data failed") from e
 
     rendered_payload = render_jinja_payload(

--- a/cloudinit/handlers/jinja_template.py
+++ b/cloudinit/handlers/jinja_template.py
@@ -4,7 +4,6 @@ import copy
 import logging
 import os
 import re
-from errno import EACCES
 from typing import Optional, Type
 
 from cloudinit import handlers, lifecycle

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -70,7 +70,7 @@ class FileSemaphores:
         sem_file = self._get_path(name, freq)
         try:
             util.del_file(sem_file)
-        except (IOError, OSError):
+        except OSError:
             util.logexc(LOG, "Failed deleting semaphore %s", sem_file)
             return False
         return True
@@ -86,7 +86,7 @@ class FileSemaphores:
         contents = "%s: %s\n" % (os.getpid(), time())
         try:
             util.write_file(sem_file, contents)
-        except (IOError, OSError):
+        except OSError:
             util.logexc(LOG, "Failed writing semaphore file %s", sem_file)
             return None
         return FileLock(sem_file)

--- a/cloudinit/log/loggers.py
+++ b/cloudinit/log/loggers.py
@@ -57,7 +57,7 @@ def flush_loggers(root):
         return
     for h in root.handlers:
         if isinstance(h, (logging.StreamHandler)):
-            with suppress(IOError):
+            with suppress(OSError):
                 h.flush()
     flush_loggers(root.parent)
 
@@ -185,7 +185,7 @@ def setup_backup_logging():
 
     def handleError(self, record):
         """A closure that emits logs on stderr when other methods fail"""
-        with suppress(IOError):
+        with suppress(OSError):
             fallback_handler.handle(record)
             fallback_handler.flush()
 

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -209,6 +209,8 @@ def get_dev_features(devname):
         features = read_sys_net(devname, "device/features")
     except (OSError, UnicodeError):
         pass
+    except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
     return features
 
 
@@ -815,9 +817,15 @@ def _rename_interfaces(
         for op, mac, new_name, params in ops + ups:
             try:
                 opmap[op](*params)
-            except Exception as e:
+            except subp.ProcessExecutionError as e:
                 errors.append(
                     "[unknown] Error performing %s%s for %s, %s: %s"
+                    % (op, params, mac, new_name, e)
+                )
+            except Exception as e:
+                errors.append(
+                    "[unknown] Unexpected exception "
+                    "performing %s%s for %s, %s: %s"
                     % (op, params, mac, new_name, e)
                 )
 

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -78,8 +78,10 @@ def read_sys_net_safe(iface, field):
             iface,
             field,
         )
+    except (FileNotFoundError, NotADirectoryError):
+        return False
     except OSError as e:
-        if e.errno in (errno.ENOENT, errno.ENOTDIR, errno.EINVAL):
+        if e.errno == errno.EINVAL:
             return False
         raise
 

--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -172,7 +172,7 @@ class BSDRenderer(renderer.Renderer):
                 )
             )
             resolvconf.parse()
-        except IOError:
+        except OSError:
             util.logexc(
                 LOG,
                 "Failed to parse %s, use new empty file",

--- a/cloudinit/net/cmdline.py
+++ b/cloudinit/net/cmdline.py
@@ -247,7 +247,7 @@ def _decomp_gzip(blob):
         try:
             gzfp = gzip.GzipFile(mode="rb", fileobj=iobuf)
             return gzfp.read()
-        except IOError:
+        except OSError:
             return blob
         finally:
             if gzfp:

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -273,10 +273,9 @@ def netplan_api_write_yaml_file(net_config_content: str) -> bool:
         )
         return False
     except Exception as e:
-        LOG.warning("Unhandled exception: %s")
         LOG.warning(
-            "Unable to render network config using netplan python module."
-            " Fallback to write %s. %s",
+            "Unhandled exception while rendering network config using "
+            "netplan python module. Fallback to write %s. %s",
             CLOUDINIT_NETPLAN_FILE,
             e,
         )

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -238,6 +238,7 @@ def netplan_api_write_yaml_file(net_config_content: str) -> bool:
     separate file or directory paths than world-readable configuration parts.
     """
     try:
+        from netplan import NetplanException  # type: ignore
         from netplan.parser import Parser  # type: ignore
         from netplan.state import State  # type: ignore
     except ImportError:
@@ -263,7 +264,16 @@ def netplan_api_write_yaml_file(net_config_content: str) -> bool:
             state_output_file._write_yaml_file(
                 os.path.basename(CLOUDINIT_NETPLAN_FILE)
             )
+    except (NetplanException, OSError) as e:
+        LOG.warning(
+            "Unable to render network config using netplan python module."
+            " Fallback to write %s. %s",
+            CLOUDINIT_NETPLAN_FILE,
+            e,
+        )
+        return False
     except Exception as e:
+        LOG.warning("Unhandled exception: %s")
         LOG.warning(
             "Unable to render network config using netplan python module."
             " Fallback to write %s. %s",

--- a/cloudinit/netinfo.py
+++ b/cloudinit/netinfo.py
@@ -573,7 +573,16 @@ def netdev_pformat():
     empty = "."
     try:
         netdev = netdev_info(empty=empty)
+    except (OSError, subp.ProcessExecutionError) as e:
+        lines.append(
+            util.center(
+                "Net device info failed ({error})".format(error=str(e)),
+                "!",
+                80,
+            )
+        )
     except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
         lines.append(
             util.center(
                 "Net device info failed ({error})".format(error=str(e)),
@@ -624,7 +633,15 @@ def route_pformat():
     lines = []
     try:
         routes = route_info()
+    except subp.ProcessExecutionError as e:
+        lines.append(
+            util.center(
+                "Route info failed ({error})".format(error=str(e)), "!", 80
+            )
+        )
+        util.logexc(LOG, "Route info failed: %s" % e)
     except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
         lines.append(
             util.center(
                 "Route info failed ({error})".format(error=str(e)), "!", 80

--- a/cloudinit/netinfo.py
+++ b/cloudinit/netinfo.py
@@ -582,7 +582,13 @@ def netdev_pformat():
             )
         )
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
+        lifecycle.log_with_downgradable_level(
+            logger=LOG,
+            version="24.4",
+            requested_level=logging.WARN,
+            msg="Unhandled exception: %s",
+            args=e,
+        )
         lines.append(
             util.center(
                 "Net device info failed ({error})".format(error=str(e)),
@@ -641,7 +647,13 @@ def route_pformat():
         )
         util.logexc(LOG, "Route info failed: %s" % e)
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
+        lifecycle.log_with_downgradable_level(
+            logger=LOG,
+            version="24.4",
+            requested_level=logging.WARN,
+            msg="Unhandled exception: %s",
+            args=e,
+        )
         lines.append(
             util.center(
                 "Route info failed ({error})".format(error=str(e)), "!", 80

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -50,7 +50,7 @@ class LogHandler(ReportingHandler):
             input_level = level
             try:
                 level = getattr(logging, level.upper())
-            except Exception:
+            except AttributeError:
                 LOG.warning("invalid level '%s', using WARN", input_level)
                 level = logging.WARN
         self.level = level
@@ -131,7 +131,15 @@ class WebHookHandler(ReportingHandler):
                     log_req_resp=False,
                 )
                 consecutive_failed = 0
+            except url_helper.UrlError as e:
+                LOG.warning(
+                    "Failed posting event: %s. This was caused by: %s",
+                    args[1],
+                    e,
+                )
+                consecutive_failed += 1
             except Exception as e:
+                LOG.warning("Unhandled exception: %s", e)
                 LOG.warning(
                     "Failed posting event: %s. This was caused by: %s",
                     args[1],

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -50,7 +50,7 @@ class LogHandler(ReportingHandler):
             input_level = level
             try:
                 level = getattr(logging, level.upper())
-            except AttributeError:
+            except Exception:
                 LOG.warning("invalid level '%s', using WARN", input_level)
                 level = logging.WARN
         self.level = level
@@ -131,15 +131,7 @@ class WebHookHandler(ReportingHandler):
                     log_req_resp=False,
                 )
                 consecutive_failed = 0
-            except url_helper.UrlError as e:
-                LOG.warning(
-                    "Failed posting event: %s. This was caused by: %s",
-                    args[1],
-                    e,
-                )
-                consecutive_failed += 1
             except Exception as e:
-                LOG.warning("Unhandled exception: %s", e)
                 LOG.warning(
                     "Failed posting event: %s. This was caused by: %s",
                     args[1],

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -234,7 +234,7 @@ class HyperVKvpReportingHandler(ReportingHandler):
             if os.path.getmtime(kvp_file) < boot_time:
                 with open(kvp_file, "w"):
                     pass
-        except (OSError, IOError) as e:
+        except OSError as e:
             LOG.warning("failed to truncate kvp pool file, %s", e)
         finally:
             cls._already_truncated_pool_file = True
@@ -361,7 +361,7 @@ class HyperVKvpReportingHandler(ReportingHandler):
 
         try:
             self._append_kvp_item(data)
-        except (OSError, IOError):
+        except OSError:
             LOG.warning("failed posting kvp=%s value=%s", key, value)
 
     def _encode_event(self, event):
@@ -408,7 +408,7 @@ class HyperVKvpReportingHandler(ReportingHandler):
                         event = None
                 try:
                     self._append_kvp_item(encoded_data)
-                except (OSError, IOError) as e:
+                except OSError as e:
                     LOG.warning("failed posting events to kvp, %s", e)
                 finally:
                     for _ in range(items_from_queue):

--- a/cloudinit/sources/DataSourceAltCloud.py
+++ b/cloudinit/sources/DataSourceAltCloud.py
@@ -59,10 +59,10 @@ def read_user_data_callback(mount_dir):
     # First try deltacloud_user_data_file. On failure try user_data_file.
     try:
         user_data = util.load_text_file(deltacloud_user_data_file).strip()
-    except IOError:
+    except OSError:
         try:
             user_data = util.load_text_file(user_data_file).strip()
-        except IOError:
+        except OSError:
             util.logexc(LOG, "Failed accessing user data file.")
             return None
 
@@ -109,7 +109,7 @@ class DataSourceAltCloud(sources.DataSource):
                 cloud_type = (
                     util.load_text_file(CLOUD_INFO_FILE).strip().upper()
                 )
-            except IOError:
+            except OSError:
                 util.logexc(
                     LOG,
                     "Unable to access cloud info file at %s.",

--- a/cloudinit/sources/DataSourceAltCloud.py
+++ b/cloudinit/sources/DataSourceAltCloud.py
@@ -12,7 +12,6 @@ This file contains code used to gather the user data passed to an
 instance on RHEVm and vSphere.
 """
 
-import errno
 import logging
 import os
 import os.path
@@ -213,9 +212,8 @@ class DataSourceAltCloud(sources.DataSource):
 
         try:
             return_str = util.mount_cb(floppy_dev, read_user_data_callback)
-        except OSError as err:
-            if err.errno != errno.ENOENT:
-                raise
+        except FileNotFoundError:
+            pass
         except util.MountFailedError:
             util.logexc(
                 LOG,
@@ -253,9 +251,8 @@ class DataSourceAltCloud(sources.DataSource):
                 if return_str:
                     self.source = cdrom_dev
                     break
-            except OSError as err:
-                if err.errno != errno.ENOENT:
-                    raise
+            except FileNotFoundError:
+                pass
             except util.MountFailedError:
                 util.logexc(
                     LOG,

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1974,7 +1974,7 @@ def _check_freebsd_cdrom(cdrom_dev):
         with open(cdrom_dev) as fp:
             fp.read(1024)
             return True
-    except IOError:
+    except OSError:
         LOG.debug("cdrom (%s) is not configured", cdrom_dev)
     return False
 

--- a/cloudinit/sources/DataSourceBigstep.py
+++ b/cloudinit/sources/DataSourceBigstep.py
@@ -42,7 +42,7 @@ class DataSourceBigstep(sources.DataSource):
         )
         try:
             content = util.load_text_file(url_file)
-        except IOError as e:
+        except OSError as e:
             # If the file doesn't exist, then the server probably isn't a
             # Bigstep instance; otherwise, another problem exists which needs
             # investigation

--- a/cloudinit/sources/DataSourceBigstep.py
+++ b/cloudinit/sources/DataSourceBigstep.py
@@ -4,7 +4,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import errno
 import json
 import os
 
@@ -41,16 +40,12 @@ class DataSourceBigstep(sources.DataSource):
             self.paths.cloud_dir, "data", "seed", "bigstep", "url"
         )
         try:
-            content = util.load_text_file(url_file)
-        except OSError as e:
+            return util.load_text_file(url_file)
+        except FileNotFoundError:
             # If the file doesn't exist, then the server probably isn't a
             # Bigstep instance; otherwise, another problem exists which needs
             # investigation
-            if e.errno == errno.ENOENT:
-                return None
-            else:
-                raise
-        return content
+            return None
 
 
 # Used to match classes to dependencies

--- a/cloudinit/sources/DataSourceBigstep.py
+++ b/cloudinit/sources/DataSourceBigstep.py
@@ -26,7 +26,7 @@ class DataSourceBigstep(sources.DataSource):
         if url is None:
             return False
         response = url_helper.readurl(url)
-        decoded = json.loads(response.contents.decode())
+        decoded = json.loads(response.contents)
         self.metadata = decoded["metadata"]
         self.vendordata_raw = decoded["vendordata_raw"]
         self.userdata_raw = decoded["userdata_raw"]

--- a/cloudinit/sources/DataSourceCloudSigma.py
+++ b/cloudinit/sources/DataSourceCloudSigma.py
@@ -10,7 +10,7 @@ from base64 import b64decode
 
 from serial import SerialException, SerialTimeoutException
 
-from cloudinit import dmi, sources
+from cloudinit import dmi, lifecycle, sources
 from cloudinit.sources import DataSourceHostname
 from cloudinit.sources.helpers.cloudsigma import SERIAL_PORT, Cepko
 
@@ -61,10 +61,16 @@ class DataSourceCloudSigma(sources.DataSource):
             LOG.debug("CloudSigma: Unable to read from serial port")
             return False
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
             # TODO: check for explicit "config on", and then warn
-            # but since no explicit config is available now, just debug.
-            LOG.debug("CloudSigma: Unable to read from serial port")
+            # but since no explicit config is available now, just log.
+            lifecycle.log_with_downgradable_level(
+                logger=LOG,
+                version="24.4",
+                requested_level=logging.WARN,
+                msg="Unhandled exception, could not read from serial port: %s",
+                args=e,
+            )
+
             return False
 
         self.dsmode = self._determine_dsmode(

--- a/cloudinit/sources/DataSourceCloudSigma.py
+++ b/cloudinit/sources/DataSourceCloudSigma.py
@@ -8,6 +8,8 @@ import logging
 import re
 from base64 import b64decode
 
+from serial import SerialException, SerialTimeoutException
+
 from cloudinit import dmi, sources
 from cloudinit.sources import DataSourceHostname
 from cloudinit.sources.helpers.cloudsigma import SERIAL_PORT, Cepko
@@ -55,7 +57,11 @@ class DataSourceCloudSigma(sources.DataSource):
         try:
             server_context = self.cepko.all().result
             server_meta = server_context["meta"]
-        except Exception:
+        except (ValueError, SerialException, SerialTimeoutException, OSError):
+            LOG.debug("CloudSigma: Unable to read from serial port")
+            return False
+        except Exception as e:
+            LOG.warning("Unhandled exception: %s", e)
             # TODO: check for explicit "config on", and then warn
             # but since no explicit config is available now, just debug.
             LOG.debug("CloudSigma: Unable to read from serial port")

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -223,7 +223,7 @@ def get_previous_iid(paths):
     fname = os.path.join(paths.get_cpath("data"), "instance-id")
     try:
         return util.load_text_file(fname).rstrip("\n")
-    except IOError:
+    except OSError:
         return None
 
 
@@ -249,7 +249,7 @@ def write_injected_files(files):
                 filename = os.sep + filename
             try:
                 util.write_file(filename, content, mode=0o660)
-            except IOError:
+            except OSError:
                 util.logexc(LOG, "Failed writing file: %s", filename)
 
 

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -826,7 +826,6 @@ def identify_platform():
             if result:
                 return result
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
             LOG.warning(
                 "calling %s with %s raised exception: %s", checker, data, e
             )

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -826,6 +826,7 @@ def identify_platform():
             if result:
                 return result
         except Exception as e:
+            LOG.warning("Unhandled exception: %s", e)
             LOG.warning(
                 "calling %s with %s raised exception: %s", checker, data, e
             )

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -7,7 +7,7 @@ import json
 import logging
 from base64 import b64decode
 
-from cloudinit import dmi, net, sources, url_helper, util
+from cloudinit import dmi, lifecycle, net, sources, url_helper, util
 from cloudinit.distros import ug_util
 from cloudinit.event import EventScope, EventType
 from cloudinit.net.dhcp import NoDHCPLeaseError
@@ -109,13 +109,18 @@ class DataSourceGCE(sources.DataSource):
                                 url_params=url_params,
                             )
                         except Exception as e:
-                            LOG.warning("Unhandled exception: %s", e)
-                            LOG.debug(
-                                "Error fetching IMD with candidate NIC %s: %s",
-                                candidate_nic,
-                                e,
+                            lifecycle.log_with_downgradable_level(
+                                logger=LOG,
+                                version="24.4",
+                                requested_level=logging.WARN,
+                                msg=(
+                                    "Error fetching IMD with candidate NIC "
+                                    f"{candidate_nic}: %s"
+                                ),
+                                args=e,
                             )
                             continue
+
                 except NoDHCPLeaseError:
                     continue
                 if ret["success"]:

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -109,6 +109,7 @@ class DataSourceGCE(sources.DataSource):
                                 url_params=url_params,
                             )
                         except Exception as e:
+                            LOG.warning("Unhandled exception: %s", e)
                             LOG.debug(
                                 "Error fetching IMD with candidate NIC %s: %s",
                                 candidate_nic,
@@ -191,9 +192,7 @@ def _write_host_key_to_guest_attributes(key_type, key_value) -> bool:
         LOG.debug("Wrote %s host key to guest attributes.", key_type)
         return True
     else:
-        LOG.info(
-            "Unable to write %s host key to guest attributes.", key_type
-        )
+        LOG.info("Unable to write %s host key to guest attributes.", key_type)
         return False
 
 

--- a/cloudinit/sources/DataSourceIBMCloud.py
+++ b/cloudinit/sources/DataSourceIBMCloud.py
@@ -370,11 +370,17 @@ def metadata_from_dir(source_dir: str) -> Dict[str, Any]:
         try:
             raw = util.load_binary_file(path)
             return translator(raw)
-        except IOError as e:
-            LOG.debug("Failed reading path '%s': %s", path, e)
+        except OSError as e:
+            LOG.warning("Failed reading path '%s': %s", path, e)
             return None
+        except UnicodeError as e:
+            LOG.warning("Failed decoding %s", path)
+            raise sources.BrokenMetadata(f"Failed to decode {path}: {e}")
         except Exception as e:
-            raise sources.BrokenMetadata(f"Failed decoding {path}: {e}")
+            LOG.warning("Unhandled exception %s", e)
+            raise sources.BrokenMetadata(
+                f"Unhandled exception reading {path}: {e}"
+            )
 
     files = [
         # tuples of (results_name, path, translator)

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -369,7 +369,8 @@ def parse_cmdline_data(ds_id, fill, cmdline=None):
             continue
         try:
             (k, v) = item.split("=", 1)
-        except Exception:
+        except Exception as e:
+            LOG.warning("Unhandled exception: %s", e)
             k = item
             v = None
         if k in s2l:

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -8,7 +8,6 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import errno
 import logging
 import os
 from functools import partial
@@ -157,9 +156,8 @@ class DataSourceNoCloud(sources.DataSource):
                     LOG.debug("Using data from %s", dev)
                     found.append(dev)
                     break
-                except OSError as e:
-                    if e.errno != errno.ENOENT:
-                        raise
+                except FileNotFoundError:
+                    pass
                 except util.MountFailedError:
                     util.logexc(
                         LOG, "Failed to mount %s when looking for data", dev

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -370,7 +370,13 @@ def parse_cmdline_data(ds_id, fill, cmdline=None):
         try:
             (k, v) = item.split("=", 1)
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
+            lifecycle.log_with_downgradable_level(
+                logger=LOG,
+                version="24.4",
+                requested_level=logging.WARN,
+                msg="Unhandled exception: %s",
+                args=e,
+            )
             k = item
             v = None
         if k in s2l:

--- a/cloudinit/sources/DataSourceOpenNebula.py
+++ b/cloudinit/sources/DataSourceOpenNebula.py
@@ -430,7 +430,7 @@ def read_context_disk_dir(source_dir, distro, asuser=None):
             raise BrokenContextDiskDir(
                 "Error processing context.sh: %s" % (e)
             ) from e
-        except IOError as e:
+        except OSError as e:
             raise NonContextDiskDir(
                 "Error reading context.sh: %s" % (e)
             ) from e

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -212,9 +212,9 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
                 raise sources.InvalidMetaDataException(
                     "No active metadata service found"
                 )
-        except IOError as e:
+        except OSError as e:
             raise sources.InvalidMetaDataException(
-                "IOError contacting metadata service: {error}".format(
+                "OSError contacting metadata service: {error}".format(
                     error=str(e)
                 )
             )
@@ -230,7 +230,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             )
         except openstack.NonReadable as e:
             raise sources.InvalidMetaDataException(str(e))
-        except (openstack.BrokenMetadata, IOError) as e:
+        except (openstack.BrokenMetadata, OSError) as e:
             msg = "Broken metadata address {addr}".format(
                 addr=self.metadata_address
             )

--- a/cloudinit/sources/DataSourceRbxCloud.py
+++ b/cloudinit/sources/DataSourceRbxCloud.py
@@ -153,7 +153,7 @@ def read_user_data_callback(mount_dir):
     @returns: A dict containing userdata, metadata and cfg based on metadata.
     """
     meta_data = util.load_json(
-        text=util.load_binary_file(fname=os.path.join(mount_dir, "cloud.json"))
+        util.load_binary_file(fname=os.path.join(mount_dir, "cloud.json"))
     )
     user_data = util.load_text_file(
         fname=os.path.join(mount_dir, "user.data"), quiet=True

--- a/cloudinit/sources/DataSourceRbxCloud.py
+++ b/cloudinit/sources/DataSourceRbxCloud.py
@@ -9,7 +9,6 @@
 This file contains code used to gather the user data passed to an
 instance on rootbox / hyperone cloud platforms
 """
-import errno
 import logging
 import os
 import os.path
@@ -96,9 +95,8 @@ def get_md():
             )
             if rbx_data:
                 return rbx_data
-        except OSError as err:
-            if err.errno != errno.ENOENT:
-                raise
+        except FileNotFoundError:
+            pass
         except util.MountFailedError:
             util.logexc(
                 LOG, "Failed to mount %s when looking for user data", device

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -225,7 +225,7 @@ class DataSourceScaleway(sources.DataSource):
         resp = url_helper.readurl(
             self.metadata_url, timeout=self.timeout, retries=self.retries
         )
-        self.metadata = json.loads(util.decode_binary(resp.contents))
+        self.metadata = json.loads(resp.contents)
 
         self.userdata_raw = query_data_api(
             "user-data", self.userdata_url, self.retries, self.timeout

--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -810,7 +810,7 @@ def write_boot_content(
             if content and os.path.exists(content_f):
                 util.ensure_dir(os.path.dirname(link))
                 os.symlink(content_f, link)
-        except IOError as e:
+        except OSError as e:
             util.logexc(LOG, "failed establishing content link: %s", e)
 
 

--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -22,7 +22,6 @@
 
 import base64
 import binascii
-import errno
 import fcntl
 import json
 import logging
@@ -443,12 +442,8 @@ class JoyentMetadataClient:
                 if byte == b"\n":
                     return as_ascii()
                 response.append(byte)
-            except OSError as exc:
-                if exc.errno == errno.EAGAIN:
-                    raise JoyentMetadataTimeoutException(
-                        msg % as_ascii()
-                    ) from exc
-                raise
+            except BlockingIOError as e:
+                raise JoyentMetadataTimeoutException(msg % as_ascii()) from e
 
     def _write(self, msg):
         self.fp.write(msg.encode("ascii"))

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -27,7 +27,15 @@ import os
 import socket
 import time
 
-from cloudinit import atomic_helper, dmi, net, netinfo, sources, util
+from cloudinit import (
+    atomic_helper,
+    dmi,
+    lifecycle,
+    net,
+    netinfo,
+    sources,
+    util,
+)
 from cloudinit.log import loggers
 from cloudinit.sources.helpers.vmware.imc import guestcust_util
 from cloudinit.subp import ProcessExecutionError, subp, which
@@ -1065,7 +1073,14 @@ def main():
     try:
         loggers.setup_basic_logging()
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
+        lifecycle.log_with_downgradable_level(
+            logger=LOG,
+            version="24.4",
+            requested_level=logging.WARN,
+            msg="Unhandled exception while setting up logging: %s",
+            args=e,
+        )
+
     metadata = {
         WAIT_ON_NETWORK: {
             WAIT_ON_NETWORK_IPV4: True,

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -1064,8 +1064,8 @@ def main():
     """
     try:
         loggers.setup_basic_logging()
-    except Exception:
-        pass
+    except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
     metadata = {
         WAIT_ON_NETWORK: {
             WAIT_ON_NETWORK_IPV4: True,

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -63,7 +63,7 @@ def cmd_executable() -> PurePath:
 
     mounts = mounted_win_drives()
     if not mounts:
-        raise IOError("Windows drives are not mounted.")
+        raise OSError("Windows drives are not mounted.")
 
     # cmd.exe path is being stable for decades.
     candidate = "%s/Windows/System32/cmd.exe"
@@ -75,7 +75,7 @@ def cmd_executable() -> PurePath:
         LOG.debug("Found cmd.exe at <%s>", cmd)
         return PurePath(cmd)
 
-    raise IOError(
+    raise OSError(
         "Couldn't find cmd.exe in any mount point: %s" % ", ".join(mounts)
     )
 
@@ -84,7 +84,7 @@ def find_home() -> PurePath:
     """
     Finds the user's home directory path as a WSL path.
 
-    raises: IOError when no mountpoint with cmd.exe is found
+    raises: OSError when no mountpoint with cmd.exe is found
                ProcessExecutionError when either cmd.exe is unable to retrieve
                the user's home directory
     """
@@ -334,7 +334,7 @@ class DataSourceWSL(sources.DataSource):
             ef.name.casefold(): ef.path for ef in os.scandir(seed_dir)
         }
         if not existing_files:
-            raise IOError("%s directory is empty" % seed_dir)
+            raise OSError("%s directory is empty" % seed_dir)
 
         folded_names = [
             f.casefold()
@@ -344,7 +344,7 @@ class DataSourceWSL(sources.DataSource):
             if filename in existing_files.keys():
                 return PurePath(existing_files[filename])
 
-        raise IOError(
+        raise OSError(
             "%s doesn't contain any of the expected user-data files" % seed_dir
         )
 
@@ -360,7 +360,7 @@ class DataSourceWSL(sources.DataSource):
             metadata = load_instance_metadata(data_dir, instance_name())
             return current == metadata.get("instance-id")
 
-        except (IOError, ValueError) as err:
+        except (OSError, ValueError) as err:
             LOG.warning(
                 "Unable to check_instance_id from metadata file: %s",
                 str(err),
@@ -378,7 +378,7 @@ class DataSourceWSL(sources.DataSource):
 
         try:
             user_home = find_home()
-        except IOError as e:
+        except OSError as e:
             LOG.debug("Unable to detect WSL datasource: %s", e)
             return False
 
@@ -391,7 +391,7 @@ class DataSourceWSL(sources.DataSource):
             self.metadata = load_instance_metadata(
                 seed_dir, self.instance_name
             )
-        except (ValueError, IOError) as err:
+        except (ValueError, OSError) as err:
             LOG.error("Unable to load metadata: %s", str(err))
             return False
 
@@ -404,7 +404,7 @@ class DataSourceWSL(sources.DataSource):
             if user_data is None and seed_dir is not None:
                 user_data = ConfigData(self.find_user_data_file(seed_dir))
 
-        except (ValueError, IOError) as err:
+        except (ValueError, OSError) as err:
             log = LOG.info if agent_data else LOG.error
             log(
                 "Unable to load any user-data file in %s: %s",

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -1210,7 +1210,11 @@ def pkl_load(fname: str) -> Optional[DataSource]:
     pickle_contents = None
     try:
         pickle_contents = util.load_binary_file(fname)
+    except OSError as e:
+        if os.path.isfile(fname):
+            LOG.warning("failed loading pickle in %s: %s", fname, e)
     except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
         if os.path.isfile(fname):
             LOG.warning("failed loading pickle in %s: %s", fname, e)
 

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -1167,7 +1167,7 @@ def convert_vendordata(data, recurse=True):
     raise ValueError("Unknown data type for vendordata: %s" % type(data))
 
 
-class BrokenMetadata(IOError):
+class BrokenMetadata(OSError):
     pass
 
 

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -1214,9 +1214,13 @@ def pkl_load(fname: str) -> Optional[DataSource]:
         if os.path.isfile(fname):
             LOG.warning("failed loading pickle in %s: %s", fname, e)
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
-        if os.path.isfile(fname):
-            LOG.warning("failed loading pickle in %s: %s", fname, e)
+        lifecycle.log_with_downgradable_level(
+            logger=LOG,
+            version="24.4",
+            requested_level=logging.WARN,
+            msg="Unhandled exception while reading pickle file: %s",
+            args=e,
+        )
 
     # This is allowed so just return nothing successfully loaded...
     if not pickle_contents:

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -757,14 +757,16 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def get_public_ssh_keys(self):
         return normalize_pubkey_data(self.metadata.get("public-keys"))
 
-    def publish_host_keys(self, hostkeys):
+    def publish_host_keys(self, hostkeys) -> bool:
         """Publish the public SSH host keys (found in /etc/ssh/*.pub).
 
         @param hostkeys: List of host key tuples (key_type, key_value),
             where key_type is the first field in the public key file
             (e.g. 'ssh-rsa') and key_value is the key itself
             (e.g. 'AAAAB3NzaC1y...').
+        @return: True if publishing host keys succeeded, otherwise False
         """
+        return True
 
     def _remap_device(self, short_name):
         # LP: #611137

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -13,7 +13,7 @@ from xml.etree import ElementTree as ET  # nosec B405
 
 import requests
 
-from cloudinit import subp, version
+from cloudinit import lifecycle, subp, version
 from cloudinit.sources.azure import identity
 from cloudinit.url_helper import UrlError
 
@@ -56,10 +56,17 @@ class ReportableError(Exception):
 
         try:
             self.vm_id = identity.query_vm_id()
+
         except (RuntimeError, OSError, ValueError) as e:
             self.vm_id = f"failed to read vm id: {e!r}"
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
+            lifecycle.log_with_downgradable_level(
+                logger=LOG,
+                version="24.4",
+                requested_level=logging.WARN,
+                msg="Unhandled exception while querying VM ID: %s",
+                args=e,
+            )
             self.vm_id = f"failed to read vm id: {e!r}"
 
     def as_encoded_report(

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -56,8 +56,11 @@ class ReportableError(Exception):
 
         try:
             self.vm_id = identity.query_vm_id()
-        except Exception as id_error:
-            self.vm_id = f"failed to read vm id: {id_error!r}"
+        except (RuntimeError, OSError, ValueError) as e:
+            self.vm_id = f"failed to read vm id: {e!r}"
+        except Exception as e:
+            LOG.warning("Unhandled exception: %s", e)
+            self.vm_id = f"failed to read vm id: {e!r}"
 
     def as_encoded_report(
         self,

--- a/cloudinit/sources/azure/kvp.py
+++ b/cloudinit/sources/azure/kvp.py
@@ -42,8 +42,11 @@ def report_failure_to_host(error: errors.ReportableError) -> bool:
 def report_success_to_host() -> bool:
     try:
         vm_id = identity.query_vm_id()
-    except Exception as id_error:
-        vm_id = f"failed to read vm id: {id_error!r}"
+    except (RuntimeError, OSError, ValueError) as e:
+        vm_id = f"failed to read vm id: {e!r}"
+    except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
+        vm_id = f"failed to read vm id: {e!r}"
 
     report = errors.encode_report(
         [

--- a/cloudinit/sources/azure/kvp.py
+++ b/cloudinit/sources/azure/kvp.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from cloudinit import version
+from cloudinit import lifecycle, version
 from cloudinit.reporting import handlers, instantiated_handler_registry
 from cloudinit.sources.azure import errors, identity
 
@@ -45,7 +45,13 @@ def report_success_to_host() -> bool:
     except (RuntimeError, OSError, ValueError) as e:
         vm_id = f"failed to read vm id: {e!r}"
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
+        lifecycle.log_with_downgradable_level(
+            logger=LOG,
+            version="24.4",
+            requested_level=logging.WARN,
+            msg="Unhandled exception while querying VM ID: %s",
+            args=e,
+        )
         vm_id = f"failed to read vm id: {e!r}"
 
     report = errors.encode_report(

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -207,13 +207,7 @@ def report_dmesg_to_kvp():
     try:
         out, _ = subp.subp(["dmesg"], decode=False, capture=True)
         report_compressed_event("dmesg", out)
-    except (zlib.error, subp.ProcessExecutionError) as e:
-        report_diagnostic_event(
-            "Exception when dumping dmesg log: %s" % repr(e),
-            logger_func=LOG.warning,
-        )
     except Exception as e:
-        LOG.warning("Unhandled exception: %s", e)
         report_diagnostic_event(
             "Exception when dumping dmesg log: %s" % repr(e),
             logger_func=LOG.warning,
@@ -718,13 +712,7 @@ class WALinuxAgentShim:
         LOG.debug("Ejecting the provisioning iso")
         try:
             distro.eject_media(iso_dev)
-        except subp.ProcessExecutionError as e:
-            report_diagnostic_event(
-                "Failed ejecting the provisioning iso: %s" % e,
-                logger_func=LOG.error,
-            )
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
             report_diagnostic_event(
                 "Failed ejecting the provisioning iso: %s" % e,
                 logger_func=LOG.error,

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -207,9 +207,15 @@ def report_dmesg_to_kvp():
     try:
         out, _ = subp.subp(["dmesg"], decode=False, capture=True)
         report_compressed_event("dmesg", out)
-    except Exception as ex:
+    except (zlib.error, subp.ProcessExecutionError) as e:
         report_diagnostic_event(
-            "Exception when dumping dmesg log: %s" % repr(ex),
+            "Exception when dumping dmesg log: %s" % repr(e),
+            logger_func=LOG.warning,
+        )
+    except Exception as e:
+        LOG.warning("Unhandled exception: %s", e)
+        report_diagnostic_event(
+            "Exception when dumping dmesg log: %s" % repr(e),
             logger_func=LOG.warning,
         )
 
@@ -712,7 +718,13 @@ class WALinuxAgentShim:
         LOG.debug("Ejecting the provisioning iso")
         try:
             distro.eject_media(iso_dev)
+        except subp.ProcessExecutionError as e:
+            report_diagnostic_event(
+                "Failed ejecting the provisioning iso: %s" % e,
+                logger_func=LOG.error,
+            )
         except Exception as e:
+            LOG.warning("Unhandled exception: %s", e)
             report_diagnostic_event(
                 "Failed ejecting the provisioning iso: %s" % e,
                 logger_func=LOG.error,

--- a/cloudinit/sources/helpers/digitalocean.py
+++ b/cloudinit/sources/helpers/digitalocean.py
@@ -201,7 +201,7 @@ def read_metadata(url, timeout=2, sec_between=2, retries=30):
     )
     if not response.ok():
         raise RuntimeError("unable to read metadata at %s" % url)
-    return json.loads(response.contents.decode())
+    return json.loads(response.contents)
 
 
 def read_sysinfo():

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -14,7 +14,7 @@ import json
 import logging
 import os
 
-from cloudinit import net, sources, subp, url_helper, util
+from cloudinit import lifecycle, net, sources, subp, url_helper, util
 from cloudinit.sources import BrokenMetadata
 from cloudinit.sources.helpers import ec2
 
@@ -190,11 +190,15 @@ class BaseReader(metaclass=abc.ABCMeta):
                 e,
             )
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
-            LOG.debug(
-                "Unable to read openstack versions from %s due to: %s",
-                self.base_path,
-                e,
+            lifecycle.log_with_downgradable_level(
+                logger=LOG,
+                version="24.4",
+                requested_level=logging.WARN,
+                msg=(
+                    "Unhandled exception while reading openstack version "
+                    f"from {self.base_path} due to: {e}"
+                ),
+                args=e,
             )
 
         # openstack.OS_VERSIONS is stored in chronological order, so
@@ -301,7 +305,13 @@ class BaseReader(metaclass=abc.ABCMeta):
                         "Failed to process path %s: %s" % (path, e)
                     ) from e
                 except Exception as e:
-                    LOG.warning("Unhandled exception: %s", e)
+                    lifecycle.log_with_downgradable_level(
+                        logger=LOG,
+                        version="24.4",
+                        requested_level=logging.WARN,
+                        msg=("Unhandled exception while decoding data: %s"),
+                        args=e,
+                    )
                     raise BrokenMetadata(
                         "Failed to process path %s: %s" % (path, e)
                     ) from e
@@ -318,7 +328,13 @@ class BaseReader(metaclass=abc.ABCMeta):
                     "Badly formatted metadata random_seed entry: %s" % e
                 ) from e
             except Exception as e:
-                LOG.warning("Unhandled exception: %s", e)
+                lifecycle.log_with_downgradable_level(
+                    logger=LOG,
+                    version="24.4",
+                    requested_level=logging.WARN,
+                    msg=("Unhandled exception while getting random seed: %s"),
+                    args=e,
+                )
                 raise BrokenMetadata(
                     "Badly formatted metadata random_seed entry: %s" % e
                 ) from e
@@ -413,7 +429,15 @@ class ConfigDriveReader(BaseReader):
                     "Failed to process path %s: %s" % (path, e)
                 ) from e
             except Exception as e:
-                LOG.warning("Unhandled exception: %s", e)
+                lifecycle.log_with_downgradable_level(
+                    logger=LOG,
+                    version="24.4",
+                    requested_level=logging.WARN,
+                    msg=(
+                        "Unhandled exception while reading meta-data.json: %s"
+                    ),
+                    args=e,
+                )
                 raise BrokenMetadata(
                     "Failed to process path %s: %s" % (path, e)
                 ) from e

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -79,7 +79,7 @@ KNOWN_PHYSICAL_TYPES = (
 )
 
 
-class NonReadable(IOError):
+class NonReadable(OSError):
     pass
 
 
@@ -362,7 +362,7 @@ class BaseReader(metaclass=abc.ABCMeta):
             try:
                 content = self._read_content_path(net_item, decode=True)
                 results["network_config"] = content
-            except IOError as e:
+            except OSError as e:
                 raise BrokenMetadata(
                     "Failed to read network configuration: %s" % (e)
                 ) from e
@@ -464,7 +464,7 @@ class ConfigDriveReader(BaseReader):
                 path = found[name]
                 try:
                     contents = self._path_read(path)
-                except IOError as e:
+                except OSError as e:
                     raise BrokenMetadata("Failed to read: %s" % path) from e
                 try:
                     # Disable not-callable pylint check; pylint isn't able to

--- a/cloudinit/sources/helpers/upcloud.py
+++ b/cloudinit/sources/helpers/upcloud.py
@@ -199,7 +199,7 @@ def read_metadata(url, timeout=2, sec_between=2, retries=30):
     )
     if not response.ok():
         raise RuntimeError("unable to read metadata at %s" % url)
-    return json.loads(response.contents.decode())
+    return json.loads(response.contents)
 
 
 def read_sysinfo():

--- a/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
@@ -52,9 +52,8 @@ def send_rpc(rpc):
         # Remove the trailing newline in the output.
         if out:
             out = out.rstrip()
-    except subp.ProcessExecutionError as e:
-        logger.debug("Failed to send RPC command")
-        logger.exception(e)
+    except Exception:
+        logger.exception("Failed to send RPC command")
 
     return (out, err)
 

--- a/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
+++ b/cloudinit/sources/helpers/vmware/imc/guestcust_util.py
@@ -52,7 +52,7 @@ def send_rpc(rpc):
         # Remove the trailing newline in the output.
         if out:
             out = out.rstrip()
-    except Exception as e:
+    except subp.ProcessExecutionError as e:
         logger.debug("Failed to send RPC command")
         logger.exception(e)
 

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -32,7 +32,7 @@ def get_metadata(
                 connectivity_url_data={"url": url},
             ):
                 # Fetch the metadata
-                v1 = read_metadata(url, timeout, retries, sec_between, agent)
+                v1 = _read_metadata(url, timeout, retries, sec_between, agent)
 
                 metadata = json.loads(v1)
                 refactor_metadata(metadata)
@@ -101,7 +101,7 @@ def is_vultr():
 
 
 # Read Metadata endpoint
-def read_metadata(url, timeout, retries, sec_between, agent):
+def _read_metadata(url, timeout, retries, sec_between, agent) -> bytes:
     url = "%s/v1.json" % url
 
     # Announce os details so we can handle non Vultr origin
@@ -121,7 +121,7 @@ def read_metadata(url, timeout, retries, sec_between, agent):
             "Failed to connect to %s: Code: %s" % url, response.code
         )
 
-    return response.contents.decode()
+    return response.contents
 
 
 # Wrapped for caching

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -193,7 +193,7 @@ def parse_authorized_keys(fnames):
                 lines = util.load_text_file(fname).splitlines()
                 for line in lines:
                     contents.append(parser.parse(line))
-        except (IOError, OSError):
+        except OSError:
             util.logexc(LOG, "Error reading lines from %s", fname)
 
     return contents
@@ -396,7 +396,7 @@ def check_create_path(username, filename, strictmodes):
         )
         if not permissions:
             return False
-    except (IOError, OSError) as e:
+    except OSError as e:
         util.logexc(LOG, str(e))
         return False
 
@@ -419,7 +419,7 @@ def extract_authorized_keys(username, sshd_cfg_file=DEF_SSHD_CFG):
                 key_paths, pw_ent.pw_dir, username
             )
 
-        except (IOError, OSError):
+        except OSError:
             # Give up and use a default key filename
             auth_key_fns[0] = default_authorizedkeys_file
             util.logexc(

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -487,10 +487,15 @@ class Init:
             previous_ds = util.load_text_file(ds_fn, quiet=True).strip()
         except OSError:
             pass
-        except UnicodeDecodeError:
-            LOG.warning("Invalid previous datasource in file: %s", previous_ds)
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
+            lifecycle.log_with_downgradable_level(
+                logger=LOG,
+                version="24.4",
+                requested_level=logging.WARN,
+                msg=f"Unhandled error loading datasource file {ds_fn}: %s",
+                args=e,
+            )
+
         if not previous_ds:
             previous_ds = ds
         util.write_file(ds_fn, "%s\n" % ds)
@@ -533,10 +538,17 @@ class Init:
             self._previous_iid = util.load_text_file(iid_fn).strip()
         except OSError:
             pass
-        except UnicodeDecodeError:
-            LOG.warning("Invalid instance id in file: %s", iid_fn)
         except Exception as e:
-            LOG.warning("Unhandled exception: %s", e)
+            lifecycle.log_with_downgradable_level(
+                logger=LOG,
+                version="24.4",
+                requested_level=logging.WARN,
+                msg=(
+                    "Unhandled error loading previous instance id "
+                    f"{iid_fn}: %s"
+                ),
+                args=e,
+            )
 
         LOG.debug("previous iid found to be %s", self._previous_iid)
         return self._previous_iid
@@ -1042,7 +1054,7 @@ class Init:
             LOG.debug("applying net config names for %s", netcfg)
             self.distro.networking.apply_network_config_names(netcfg)
         except Exception as e:
-            util.logexc(LOG, "Failed to rename devices: %s", e)
+            LOG.warning(LOG, "Failed to rename devices: %s", e)
 
     def _get_per_boot_network_semaphore(self):
         return namedtuple("Semaphore", "semaphore args")(

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -870,7 +870,7 @@ class Init:
             instance_json = util.load_json(
                 util.load_text_file(json_sensitive_file)
             )
-        except (OSError, IOError) as e:
+        except OSError as e:
             LOG.warning(
                 "Skipping write of system_info/features to %s."
                 " Unable to read file: %s",

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -67,7 +67,7 @@ def prepend_base_command(base_command, commands):
     return fixed_commands
 
 
-class ProcessExecutionError(IOError):
+class ProcessExecutionError(OSError):
     MESSAGE_TMPL = (
         "%(description)s\n"
         "Command: %(cmd)s\n"
@@ -123,7 +123,7 @@ class ProcessExecutionError(IOError):
             "stderr": self._ensure_string(self.stderr),
             "reason": self._ensure_string(self.reason),
         }
-        IOError.__init__(self, message)
+        OSError.__init__(self, message)
 
     def _ensure_string(self, text):
         """

--- a/cloudinit/temp_utils.py
+++ b/cloudinit/temp_utils.py
@@ -1,11 +1,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import contextlib
-import errno
 import logging
 import os
 import shutil
 import tempfile
+from contextlib import suppress
 
 from cloudinit import util
 
@@ -61,11 +61,8 @@ def ExtendedTemporaryFile(**kwargs):
     # file to unlink has been unlinked elsewhere..
 
     def _unlink_if_exists(path):
-        try:
+        with suppress(FileNotFoundError):
             os.unlink(path)
-        except OSError as e:
-            if e.errno != errno.ENOENT:
-                raise e
 
     fh.unlink = _unlink_if_exists
 

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -163,8 +163,6 @@ def detect_template(text):
             raise JinjaSyntaxParsingException(
                 error=template_syntax_error,
             ) from template_syntax_error
-        except Exception as unknown_error:
-            raise unknown_error from unknown_error
 
     if text.find("\n") != -1:
         ident, rest = text.split("\n", 1)  # remove the first line

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -226,7 +226,7 @@ def _read_file(path: str, **kwargs) -> "FileResponse":
         return FileResponse(contents, path)
     except FileNotFoundError as e:
         raise UrlError(cause=e, code=NOT_FOUND, headers=None, url=path) from e
-    except IOError as e:
+    except OSError as e:
         raise UrlError(cause=e, code=e.errno, headers=None, url=path) from e
 
 
@@ -333,9 +333,9 @@ class UrlResponse:
         yield from self._response.iter_content(chunk_size, decode_unicode)
 
 
-class UrlError(IOError):
+class UrlError(OSError):
     def __init__(self, cause, code=None, headers=None, url=None):
-        IOError.__init__(self, str(cause))
+        OSError.__init__(self, str(cause))
         self.cause = cause
         self.code = code
         self.headers = headers

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -745,6 +745,7 @@ def wait_for_url(
             reason = "request error [%s]" % e
             url_exc = e
         except Exception as e:
+            LOG.warning("Unhandled exception: %s", e)
             reason = "unexpected error [%s]" % e
             url_exc = e
         time_taken = int(time.monotonic() - start_time)
@@ -925,7 +926,11 @@ class OauthUrlHelper:
         date = exception.headers["date"]
         try:
             remote_time = time.mktime(parsedate(date))
+        except (ValueError, OverflowError) as e:
+            LOG.warning("Failed to convert datetime '%s': %s", date, e)
+            return
         except Exception as e:
+            LOG.warning("Unhandled exception: %s", e)
             LOG.warning("Failed to convert datetime '%s': %s", date, e)
             return
 

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -15,6 +15,8 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.nonmultipart import MIMENonMultipart
 from email.mime.text import MIMEText
 
+import yaml
+
 from cloudinit import features, handlers, util
 from cloudinit.url_helper import UrlError, read_file_or_url
 
@@ -177,8 +179,10 @@ class UserDataProcessor:
                 payload = util.load_yaml(msg.get_payload(decode=True))
                 if payload:
                     payload_idx = payload.get("launch-index")
-            except Exception:
+            except yaml.YAMLError:
                 pass
+            except Exception as e:
+                LOG.warning("Unhandled exception: %s", e)
         # Header overrides contents, for now (?) or the other way around?
         if header_idx is not None:
             payload_idx = header_idx

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -272,7 +272,7 @@ class UserDataProcessor:
                     if include_url not in message:
                         message += " for url: {0}".format(include_url)
                     _handle_error(message, urle)
-                except IOError as ioe:
+                except OSError as ioe:
                     error_message = "Fetching from {} resulted in {}".format(
                         include_url, ioe
                     )

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -17,7 +17,7 @@ from email.mime.text import MIMEText
 
 import yaml
 
-from cloudinit import features, handlers, util
+from cloudinit import features, handlers, lifecycle, util
 from cloudinit.url_helper import UrlError, read_file_or_url
 
 LOG = logging.getLogger(__name__)
@@ -182,7 +182,14 @@ class UserDataProcessor:
             except yaml.YAMLError:
                 pass
             except Exception as e:
-                LOG.warning("Unhandled exception: %s", e)
+                lifecycle.log_with_downgradable_level(
+                    logger=LOG,
+                    version="24.4",
+                    requested_level=logging.WARN,
+                    msg="Unhandled exception getting launch-index: %s",
+                    args=e,
+                )
+
         # Header overrides contents, for now (?) or the other way around?
         if header_idx is not None:
             payload_idx = header_idx

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1296,7 +1296,7 @@ def get_fqdn_from_hosts(hostname, filename="/etc/hosts"):
             if hostname in toks[2:]:
                 fqdn = toks[1]
                 break
-    except IOError:
+    except OSError:
         pass
     return fqdn
 
@@ -1646,7 +1646,7 @@ def fips_enabled() -> bool:
     try:
         contents = load_text_file(fips_proc).strip()
         return contents == "1"
-    except (IOError, OSError):
+    except OSError:
         # for BSD systems and Linux systems where the proc entry is not
         # available, we assume FIPS is disabled to retain the old behavior
         # for now.
@@ -1995,7 +1995,7 @@ def mounts():
                 "opts": opts,
             }
         LOG.debug("Fetched %s mounts from %s", mounted, method)
-    except (IOError, OSError):
+    except OSError:
         logexc(LOG, "Failed fetching mount points")
     return mounted
 
@@ -2065,7 +2065,7 @@ def mount_cb(
                     umount = tmpd  # This forces it to be unmounted (when set)
                     mountpoint = tmpd
                     break
-                except (IOError, OSError) as exc:
+                except OSError as exc:
                     if log_error:
                         LOG.debug(
                             "Failed to mount device: '%s' with type: '%s' "
@@ -2479,7 +2479,7 @@ def is_container():
             return True
         if "LIBVIRT_LXC_UUID" in pid1env:
             return True
-    except (IOError, OSError):
+    except OSError:
         pass
 
     # Detect OpenVZ containers
@@ -2494,7 +2494,7 @@ def is_container():
                 (_key, val) = line.strip().split(":", 1)
                 if val != "0":
                     return True
-    except (IOError, OSError):
+    except OSError:
         pass
 
     return False
@@ -2520,7 +2520,7 @@ def get_proc_env(
     contents: Union[str, bytes]
     try:
         contents = load_binary_file(fn)
-    except (IOError, OSError):
+    except OSError:
         return {}
 
     env = {}

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -115,7 +115,7 @@ class IntegrationInstance:
         if result.failed:
             # TODO: Raise here whatever pycloudlib raises when it has
             # a consistent error response
-            raise IOError(
+            raise OSError(
                 "Failed reading remote file via cat: {}\n"
                 "Return code: {}\n"
                 "Stderr: {}\n"

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -177,7 +177,7 @@ class TestQuery:
         [
             (OSError(errno.EACCES, "Not allowed"),),
             (OSError(errno.ENOENT, "Not allowed"),),
-            (IOError,),
+            (OSError,),
         ],
     )
     def test_handle_args_error_when_no_read_permission_init_cfg(

--- a/tests/unittests/cmd/test_query.py
+++ b/tests/unittests/cmd/test_query.py
@@ -1,6 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import errno
 import gzip
 import json
 import os
@@ -167,7 +166,7 @@ class TestQuery:
             varname=None,
         )
         with mock.patch(M_PATH + "util.load_binary_file") as m_load:
-            m_load.side_effect = OSError(errno.EACCES, "Not allowed")
+            m_load.side_effect = PermissionError("Not allowed")
             assert 1 == query.handle_args("anyname", args)
         msg = "No read permission on '%s'. Try sudo" % noread_fn
         assert msg in caplog.text
@@ -175,8 +174,8 @@ class TestQuery:
     @pytest.mark.parametrize(
         "exception",
         [
-            (OSError(errno.EACCES, "Not allowed"),),
-            (OSError(errno.ENOENT, "Not allowed"),),
+            (PermissionError("Not allowed"),),
+            (FileNotFoundError("Not allowed"),),
             (OSError,),
         ],
     )

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -1,7 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 # pylint: disable=attribute-defined-outside-init
 
-import errno
 import logging
 import os
 import re
@@ -361,9 +360,7 @@ class TestResize(unittest.TestCase):
             if path in devs:
                 return devstat_ret
             if path in enoent:
-                e = OSError("%s: does not exist" % path)
-                e.errno = errno.ENOENT
-                raise e
+                raise FileNotFoundError("%s: does not exist" % path)
             return real_stat(path)
 
         opinfo = self.distro.device_part_info

--- a/tests/unittests/config/test_cc_runcmd.py
+++ b/tests/unittests/config/test_cc_runcmd.py
@@ -50,21 +50,23 @@ class TestRuncmd(FilesystemMockingTestCase):
         cls.side_effect = TypeError("patched shellify")
         valid_config = {"runcmd": ["echo 42"]}
         cc = get_cloud(paths=self.paths)
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             with self.allow_subp(["/bin/sh"]):
                 handle("cc_runcmd", valid_config, cc, None)
-        self.assertIn("Failed to shellify", str(cm.exception))
+        self.assertIn(
+            "Failed to shellify",
+            self.logs.getvalue(),
+        )
 
     def test_handler_invalid_command_set(self):
         """Commands which can't be converted to shell will raise errors."""
         invalid_config = {"runcmd": 1}
         cc = get_cloud(paths=self.paths)
-        with self.assertRaises(TypeError) as cm:
+        with self.assertRaises(TypeError):
             handle("cc_runcmd", invalid_config, cc, [])
         self.assertIn(
-            "Failed to shellify 1 into file"
-            " /var/lib/cloud/instances/iid-datasource-none/scripts/runcmd",
-            str(cm.exception),
+            "Failed to shellify",
+            self.logs.getvalue(),
         )
 
     def test_handler_write_valid_runcmd_schema_to_file(self):

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -85,7 +85,7 @@ class TestRandomSeed:
             }
         }
         pytest.raises(
-            IOError,
+            OSError,
             cc_seed_random.handle,
             "test",
             cfg,

--- a/tests/unittests/config/test_cc_yum_add_repo.py
+++ b/tests/unittests/config/test_cc_yum_add_repo.py
@@ -45,7 +45,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_yum_add_repo.handle("yum_add_repo", cfg, None, [])
         self.assertRaises(
-            IOError, util.load_text_file, "/etc/yum.repos.d/epel_testing.repo"
+            OSError, util.load_text_file, "/etc/yum.repos.d/epel_testing.repo"
         )
 
     def test_metalink_config(self):

--- a/tests/unittests/config/test_cc_zypper_add_repo.py
+++ b/tests/unittests/config/test_cc_zypper_add_repo.py
@@ -28,7 +28,7 @@ class TestConfig(helpers.FilesystemMockingTestCase):
         self.patchUtils(self.tmp)
         cc_zypper_add_repo._write_repos(cfg["repos"], "/etc/zypp/repos.d")
         self.assertRaises(
-            IOError, util.load_text_file, "/etc/zypp/repos.d/foo.repo"
+            OSError, util.load_text_file, "/etc/zypp/repos.d/foo.repo"
         )
 
     def test_write_repos(self):

--- a/tests/unittests/config/test_modules.py
+++ b/tests/unittests/config/test_modules.py
@@ -134,7 +134,7 @@ class TestModules:
         assert mods.run_section("not_matter")
         if active:
             assert [
-                mock.call([list(module_details)])
+                mock.call([module_details])
             ] == m_run_modules.call_args_list
             assert not caplog.text
         else:
@@ -171,9 +171,7 @@ class TestModules:
         mocker.patch.object(module, "handle")
         m_run_modules = mocker.patch.object(mods, "_run_modules")
         assert mods.run_section("not_matter")
-        assert [
-            mock.call([list(module_details)])
-        ] == m_run_modules.call_args_list
+        assert [mock.call([module_details])] == m_run_modules.call_args_list
         assert "Skipping" not in caplog.text
 
     @mock.patch(M_PATH + "signature")

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -11,7 +11,6 @@ import sys
 import unittest
 from collections import namedtuple
 from copy import deepcopy
-from errno import EACCES
 from pathlib import Path
 from textwrap import dedent
 from types import ModuleType
@@ -2691,8 +2690,11 @@ class TestHandleSchemaArgs:
         "failure, expected_logs",
         (
             (
-                OSError("No permissions on /var/lib/cloud/instance"),
-                ["Using default instance-data/user-data paths for non-root"],
+                PermissionError("No permissions on /var/lib/cloud/instance"),
+                [
+                    "Using default instance-data/user-data paths with "
+                    "insufficient permissions"
+                ],
             ),
             (
                 DataSourceNotFoundException("No cached datasource found yet"),
@@ -2711,8 +2713,6 @@ class TestHandleSchemaArgs:
         caplog,
         tmpdir,
     ):
-        if isinstance(failure, OSError):
-            failure.errno = EACCES
         read_cfg_paths.side_effect = [failure, paths]
         user_data_fn = tmpdir.join("user-data")
         with open(user_data_fn, "w") as f:

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -2691,7 +2691,7 @@ class TestHandleSchemaArgs:
         "failure, expected_logs",
         (
             (
-                IOError("No permissions on /var/lib/cloud/instance"),
+                OSError("No permissions on /var/lib/cloud/instance"),
                 ["Using default instance-data/user-data paths for non-root"],
             ),
             (
@@ -2711,7 +2711,7 @@ class TestHandleSchemaArgs:
         caplog,
         tmpdir,
     ):
-        if isinstance(failure, IOError):
+        if isinstance(failure, OSError):
             failure.errno = EACCES
         read_cfg_paths.side_effect = [failure, paths]
         user_data_fn = tmpdir.join("user-data")

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -61,13 +61,12 @@ class TestReadSysNet:
         assert content.strip() == net.read_sys_net("dev", "attr")
 
     def test_read_sys_net_reraises_oserror(self):
-        """read_sys_net raises OSError/IOError when file doesn't exist."""
-        # Non-specific Exception because versions of python OSError vs IOError.
+        """read_sys_net raises OSError when file doesn't exist."""
         with pytest.raises(Exception, match="No such file or directory"):
             net.read_sys_net("dev", "attr")
 
     def test_read_sys_net_safe_handles_error(self):
-        """read_sys_net_safe handles OSError/IOError"""
+        """read_sys_net_safe handles OSError"""
         assert not net.read_sys_net_safe("dev", "attr")
 
     def test_read_sys_net_safe_returns_false_on_noent_failure(self):

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -2,7 +2,6 @@
 # pylint: disable=attribute-defined-outside-init
 
 import copy
-import errno
 import ipaddress
 import os
 from pathlib import Path
@@ -532,10 +531,9 @@ class TestGetDeviceList(CiTestCase):
 
     def test_get_devicelist_raise_oserror(self):
         """get_devicelist raise any non-ENOENT OSerror."""
-        error = OSError("Can not do it")
-        error.errno = errno.EPERM  # Set non-ENOENT
+        error = PermissionError("Can not do it")
         self.m_sys_path.side_effect = error
-        with self.assertRaises(OSError) as context_manager:
+        with self.assertRaises(PermissionError) as context_manager:
             net.get_devicelist()
         exception = context_manager.exception
         self.assertEqual("Can not do it", str(exception))

--- a/tests/unittests/sources/test_altcloud.py
+++ b/tests/unittests/sources/test_altcloud.py
@@ -98,7 +98,7 @@ class TestGetCloudType(CiTestCase):
         """Return UNKNOWN when /etc/sysconfig/cloud-info exists but errors."""
         self.assertEqual("/etc/sysconfig/cloud-info", dsac.CLOUD_INFO_FILE)
         dsrc = dsac.DataSourceAltCloud({}, None, self.paths)
-        # Attempting to read the directory generates IOError
+        # Attempting to read the directory generates OSError
         with mock.patch.object(dsac, "CLOUD_INFO_FILE", self.tmp):
             self.assertEqual("UNKNOWN", dsrc.get_cloud_type())
         self.assertIn(
@@ -110,7 +110,7 @@ class TestGetCloudType(CiTestCase):
         dsrc = dsac.DataSourceAltCloud({}, None, self.paths)
         cloud_info = self.tmp_path("cloud-info", dir=self.tmp)
         util.write_file(cloud_info, " OverRiDdeN CloudType ")
-        # Attempting to read the directory generates IOError
+        # Attempting to read the directory generates OSError
         with mock.patch.object(dsac, "CLOUD_INFO_FILE", cloud_info):
             self.assertEqual("OVERRIDDEN CLOUDTYPE", dsrc.get_cloud_type())
 

--- a/tests/unittests/sources/test_vmware.py
+++ b/tests/unittests/sources/test_vmware.py
@@ -905,6 +905,7 @@ class TestDataSourceVMwareIMC(CiTestCase):
                     "util.del_dir": True,
                     "guestcust_util.search_file": self.tdir,
                     "guestcust_util.wait_for_cust_cfg_file": conf_file,
+                    "guestcust_util.send_rpc": ("", ""),
                 },
                 ds.get_imc_data_fn,
             )

--- a/tests/unittests/sources/test_vultr.py
+++ b/tests/unittests/sources/test_vultr.py
@@ -371,7 +371,7 @@ class TestDataSourceVultr(CiTestCase):
         "cloudinit.net.ephemeral.EphemeralDHCPv4.__exit__", override_exit
     )
     @mock.patch("cloudinit.sources.helpers.vultr.is_vultr")
-    @mock.patch("cloudinit.sources.helpers.vultr.read_metadata")
+    @mock.patch("cloudinit.sources.helpers.vultr._read_metadata")
     @mock.patch("cloudinit.sources.helpers.vultr.get_interface_list")
     def test_interface_seek(
         self,

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -132,7 +132,7 @@ class TestWSLHelperFunctions:
         assert None is not cmd.relative_to(GOOD_MOUNTS["C:\\"]["mountpoint"])
 
         m_os_access.return_value = False
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             wsl.cmd_executable()
 
     @mock.patch("os.access")
@@ -146,7 +146,7 @@ class TestWSLHelperFunctions:
         m_mounts.return_value = deepcopy(GOOD_MOUNTS)
         m_mounts.return_value.pop("C:\\")
         m_mounts.return_value.pop("D:\\")
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             wsl.cmd_executable()
 
     @pytest.mark.parametrize(

--- a/tests/unittests/test_builtin_handlers.py
+++ b/tests/unittests/test_builtin_handlers.py
@@ -3,7 +3,6 @@
 """Tests of the built-in user data handlers."""
 
 import copy
-import errno
 import os
 import re
 
@@ -189,7 +188,7 @@ class TestJinjaTemplatePartHandler:
         h = JinjaTemplatePartHandler(paths, sub_handlers=[script_handler])
         with mock.patch(MPATH + "load_text_file") as m_load:
             with pytest.raises(JinjaLoadError) as context_manager:
-                m_load.side_effect = OSError(errno.EACCES, "Not allowed")
+                m_load.side_effect = PermissionError("Not allowed")
                 h.handle_part(
                     data="data",
                     ctype="!" + handlers.CONTENT_START,

--- a/tests/unittests/test_merging.py
+++ b/tests/unittests/test_merging.py
@@ -110,14 +110,14 @@ class TestSimpleRun(helpers.ResourceUsingTestCase):
             base_fn = os.path.basename(fn)
             file_id = re.match(r"source(\d+)\-(\d+)[.]yaml", base_fn)
             if not file_id:
-                raise IOError(
+                raise OSError(
                     "File %s does not have a numeric identifier" % (fn)
                 )
             file_id = int(file_id.group(1))
             source_ids[file_id].append(fn)
             expected_fn = os.path.join(merge_root, EXPECTED_PAT % (file_id))
             if not os.path.isfile(expected_fn):
-                raise IOError("No expected file found at %s" % (expected_fn))
+                raise OSError("No expected file found at %s" % (expected_fn))
             expected_files[file_id] = expected_fn
         for i in sorted(source_ids.keys()):
             source_file_contents = []

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -1299,10 +1299,6 @@ def _setup_test(
     def fake_read(
         devname,
         path,
-        translate=None,
-        on_enoent=None,
-        on_keyerror=None,
-        on_einval=None,
     ):
         return dev_attrs[devname][path]
 

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -378,7 +378,7 @@ class TestParseSSHConfig:
         "is_file, file_content",
         [
             pytest.param(True, ("",), id="empty-file"),
-            pytest.param(False, IOError, id="not-a-file"),
+            pytest.param(False, OSError, id="not-a-file"),
         ],
     )
     def test_dummy_file(self, m_is_file, m_load_file, is_file, file_content):

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2063,7 +2063,7 @@ class TestFipsEnabled:
         def fake_load_file(path):
             assert path == "/proc/sys/crypto/fips_enabled"
             if fips_enabled_content is None:
-                raise IOError("No file exists Bob")
+                raise OSError("No file exists Bob")
             return fips_enabled_content
 
         load_file.side_effect = fake_load_file
@@ -2697,7 +2697,7 @@ class TestProcessExecutionError(helpers.TestCase):
         )
 
     def test_pexec_error_type(self):
-        self.assertIsInstance(subp.ProcessExecutionError(), IOError)
+        self.assertIsInstance(subp.ProcessExecutionError(), OSError)
 
     def test_pexec_error_empty_msgs(self):
         error = subp.ProcessExecutionError()

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1317,7 +1317,7 @@ class TestGetLinuxDistro(CiTestCase):
     ):
         """Verify we get an empty tuple when no information exists and
         Exceptions are not propagated"""
-        m_platform_dist.side_effect = Exception()
+        m_platform_dist.side_effect = AttributeError()
         m_platform_system.return_value = "Linux"
         m_path_exists.return_value = 0
         dist = util.get_linux_distro()

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -3,7 +3,6 @@
 """Tests for cloudinit.util"""
 
 import base64
-import errno
 import io
 import json
 import logging
@@ -551,7 +550,7 @@ class TestUtil:
 
     @mock.patch(
         M_PATH + "read_conf",
-        side_effect=(OSError(errno.EACCES, "Not allowed"), {"0": "0"}),
+        side_effect=(PermissionError("Not allowed"), {"0": "0"}),
     )
     def test_read_conf_d_no_permissions(
         self, m_read_conf, caplog, capsys, tmpdir
@@ -586,7 +585,7 @@ class TestUtil:
     @mock.patch(M_PATH + "mergemanydict")
     @mock.patch(M_PATH + "read_conf_d", return_value={"my_config": "foo"})
     @mock.patch(
-        M_PATH + "read_conf", side_effect=OSError(errno.EACCES, "Not allowed")
+        M_PATH + "read_conf", side_effect=PermissionError("Not allowed")
     )
     def test_read_conf_with_confd_no_permissions(
         self,


### PR DESCRIPTION
#### Impetus

Following the transition to the new exit code (2) for easier user introspection of cloud-init, there was a request to audit current callsites for error conditions that are logged at too high or low of a logging level. This PR starts that effort, but only scratches the surface. Much more work needs to be done auditing log levels.

#### Objective 

This PR is the result of an audit of exceptions of type `Exception`. This audit had a simple goal: prevent cloud-init from swallowing exceptions. We don't want exceptions such as `AttributeError`, `IndexError`, `KeyError`, `TypeError`, `ZeroDivisionError` to be ignored when the exception that we expect to handle is a failed filesystem operation - this would mask important errors at runtime.

#### Rules

To complete the objective, a set of rules was defined and implemented. They are described in one of the commit messages:

> Require a minimum of one of the following in each Exception handler:
>
> - Log a warning at level WARN or higher containing the exception type and message
> - Re-raise the exception without redefining its type.

By following these rules, we can expect that every `Exception` handler will either issue its own warning or raise to another exception which will raise a warning. By doing this, silently ignoring important classes of exceptions will not happen.

Any log of `WARN` would suffice for ensuring that these exceptions are logged, however standardizing this message across the codebase simplifies code auditing and makes it clear to developers when they see this message what has happened.

#### Methodology

Inspect the code for sources of **expected** exceptions and add them above the `Exception` handler, and adding a proper `WARN` log to the existing `Exception` exception. This allows us to flesh out any unexpected changes easily in integration testing without risking unintentional logic changes. 

#### Reviewer notes

I recommend reading the individual commit messages while reviewing. This PR carries some risk of changing cloud-init logic, but it attempts to mitigate the risk by retaining `Exception` (in most cases) while making all Exception handling into a recoverable error. I believe that the risk that this poses will (after thoroughly reviewed) be outweighed by the current risk we have of unintentionally silencing unexpected exceptions.

A few things to keep in mind while reviewing:
 
1) `subp.subp()` throws `OSError`
2) `OSError` is thrown by many filesystem and operating system operations. It is used liberally in this PR.
3) I don't like the repetitive `LOG.warning("Unhandled...")`. Ideas are welcome for better messaging and maybe a helper function would make sense - maybe something in `log.py`?
4) Perhaps the rules above should probably go in a dev doc?

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
