### PR TITLE
Do not hardcode reboot command

### DIFF
--- a/cloudinit/cmd/clean.py
+++ b/cloudinit/cmd/clean.py
@@ -106,9 +106,10 @@ def get_parser(parser=None):
     return parser
 
 
-def remove_artifacts(remove_logs, remove_seed=False, remove_config=None):
+def remove_artifacts(init, remove_logs, remove_seed=False, remove_config=None):
     """Helper which removes artifacts dir and optionally log files.
 
+    @param: init: Init object to use
     @param: remove_logs: Boolean. Set True to delete the cloud_dir path. False
         preserves them.
     @param: remove_seed: Boolean. Set True to also delete seed subdir in
@@ -117,7 +118,6 @@ def remove_artifacts(remove_logs, remove_seed=False, remove_config=None):
         Can be any of: all, network, ssh_config.
     @returns: 0 on success, 1 otherwise.
     """
-    init = Init(ds_deps=[])
     init.read_cfg()
     if remove_logs:
         for log_file in get_config_logfiles(init.cfg):
@@ -158,8 +158,9 @@ def remove_artifacts(remove_logs, remove_seed=False, remove_config=None):
 
 def handle_clean_args(name, args):
     """Handle calls to 'cloud-init clean' as a subcommand."""
+    init = Init(ds_deps=[])
     exit_code = remove_artifacts(
-        args.remove_logs, args.remove_seed, args.remove_config
+        init, args.remove_logs, args.remove_seed, args.remove_config
     )
     if args.machine_id:
         if uses_systemd():
@@ -169,7 +170,9 @@ def handle_clean_args(name, args):
             # Non-systemd like FreeBSD regen machine-id when file is absent
             del_file(ETC_MACHINE_ID)
     if exit_code == 0 and args.reboot:
-        cmd = ["shutdown", "-r", "now"]
+        cmd = init.distro.shutdown_command(
+            mode="reboot", delay="now", message=None
+        )
         try:
             subp(cmd, capture=False)
         except ProcessExecutionError as e:

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1128,9 +1128,10 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 subp.subp(["usermod", "-a", "-G", name, member])
                 LOG.info("Added user '%s' to group '%s'", member, name)
 
-    def shutdown_command(self, *, mode, delay, message):
+    @classmethod
+    def shutdown_command(cls, *, mode, delay, message):
         # called from cc_power_state_change.load_power_state
-        command = ["shutdown", self.shutdown_options_map[mode]]
+        command = ["shutdown", cls.shutdown_options_map[mode]]
         try:
             if delay != "now":
                 delay = "+%d" % int(delay)

--- a/tests/unittests/test_traceback.py
+++ b/tests/unittests/test_traceback.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+class TestLogExc:
+    def test_logexc(self, caplog):
+        with pytest.raises(Exception):
+            _ = 1 / 0
+
+        assert caplog.record_tuples == []

--- a/tests/unittests/test_traceback.py
+++ b/tests/unittests/test_traceback.py
@@ -1,9 +1,0 @@
-import pytest
-
-
-class TestLogExc:
-    def test_logexc(self, caplog):
-        with pytest.raises(Exception):
-            _ = 1 / 0
-
-        assert caplog.record_tuples == []


### PR DESCRIPTION
## Proposed Commit Message
```
fix(cmd): Do not hardcode reboot command

Attempting a `cloud-init clean --reboot` fails on alpine because this
command is hard-coded. This code already has an Init object available,
which has a Distro attribute. Stamp out the duplicate hard-coded
implementation and re-use distro reboot code to acquire cross-distro
compatiblity.

Error:
Could not reboot this system using "['shutdown', '-r', 'now']": Unexpected error while running comma  nd.
Command: ['shutdown', '-r', 'now']
Exit code: -
Reason: [Errno 2] No such file or directory: b'shutdown'
Stdout: -
Stderr: -
```

# Context
This change is mostly test updates - the code change is trivial: just reuse the existing reboot code which already has multi-distro support.