### PR TITLE
feat: Warn user of unexpected run mode

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -79,23 +79,30 @@ def print_exc(msg=""):
     sys.stderr.write("\n")
 
 
+DEPRECATE_BOOT_STAGE_MESSAGE = (
+    "Triggering cloud-init boot stages outside of intial system boot is not a"
+    " fully supported operation which can lead to incomplete or incorrect"
+    " configuration. As such, cloud-init is deprecating this feature in the"
+    " future. If you currently use cloud-init in this way,"
+    " please file an issue describing in detail your use case so that"
+    " cloud-init can better support your needs:"
+    " https://github.com/canonical/cloud-init/issues/new"
+)
+
+
 def log_ppid(distro, bootstage_name):
     if distro.is_linux:
         ppid = os.getppid()
-        log = LOG.info
-        extra_message = ""
         if 1 != ppid and distro.uses_systemd():
-            log = LOG.warning
-            extra_message = (
-                " Unsupported configuration: boot stage called "
-                "outside of systemd"
+            util.deprecate(
+                deprecated=(
+                    "Unsupported configuration: boot stage called "
+                    f"by PID [{ppid}] outside of systemd"
+                ),
+                deprecated_version="24.3",
+                extra_message=DEPRECATE_BOOT_STAGE_MESSAGE,
             )
-        log(
-            "PID [%s] started cloud-init '%s'.%s",
-            ppid,
-            bootstage_name,
-            extra_message,
-        )
+    LOG.info("PID [%s] started cloud-init '%s'.", ppid, bootstage_name)
 
 
 def welcome(action, msg=None):

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -171,6 +171,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         self.package_managers: List[PackageManager] = []
         self._dhcp_client = None
         self._fallback_interface = None
+        self.is_linux = True
 
     def _unpickle(self, ci_pkl_version: int) -> None:
         """Perform deserialization fixes for Distro."""
@@ -187,6 +188,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             self._dhcp_client = None
         if not hasattr(self, "_fallback_interface"):
             self._fallback_interface = None
+        if not hasattr(self, "is_linux"):
+            self.is_linux = True
 
     def _validate_entry(self, entry):
         if isinstance(entry, str):

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -40,6 +40,13 @@ class BSD(distros.Distro):
         cfg["rsyslog_svcname"] = "rsyslogd"
         self.osfamily = platform.system().lower()
         self.net_ops = bsd_netops.BsdNetOps
+        self.is_linux = False
+
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+
+        # this needs to be after the super class _unpickle to override it
+        self.is_linux = False
 
     def _read_system_hostname(self):
         sys_hostname = self._read_hostname(self.hostname_conf_fn)

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -495,6 +495,12 @@ def multi_log(
 
 @lru_cache()
 def is_Linux():
+    """deprecated: prefer Distro object's `is_linux` property
+
+    Multiple sources of truth is bad, and already know whether we are
+    working with Linux from the Distro class. Using Distro offers greater code
+    reusablity, cleaner code, and easier maintenance.
+    """
     return "Linux" in platform.system()
 
 

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -212,9 +212,10 @@ Example output:
 
 Generally run by OS init systems to execute ``cloud-init``'s stages:
 *init* and *init-local*. See :ref:`boot_stages` for more info.
-Can be run on the command line, but is generally gated to run only once
-due to semaphores in :file:`/var/lib/cloud/instance/sem/` and
-:file:`/var/lib/cloud/sem`.
+Can be run on the command line, but is deprecated, because incomplete
+configuration can be applied when run later in boot. The boot stages are
+generally gated to run only once due to semaphores in
+:file:`/var/lib/cloud/instance/sem/` and :file:`/var/lib/cloud/sem`.
 
 * :command:`--local`: Run *init-local* stage instead of *init*.
 * :command:`--file` : Use additional yaml configuration files.
@@ -226,16 +227,19 @@ due to semaphores in :file:`/var/lib/cloud/instance/sem/` and
 
 Generally run by OS init systems to execute ``modules:config`` and
 ``modules:final`` boot stages. This executes cloud config :ref:`modules`
-configured to run in the Init, Config and Final stages. The modules are
-declared to run in various boot stages in the file
+configured to run in the Init, Config and Final stages. Can be run on the
+command line, but this is not recommended and will generate a warning because
+incomplete configuration can be applied when run later in boot.
+The modules are declared to run in various boot stages in the file
 :file:`/etc/cloud/cloud.cfg` under keys:
 
 * ``cloud_init_modules``
 * ``cloud_config_modules``
 * ``cloud_final_modules``
 
-Can be run on the command line, but each module is gated to run only once due
-to semaphores in :file:`/var/lib/cloud/`.
+Can be run on the command line, but is deprecated, because incomplete
+configuration can be applied when run later in boot. Each module is gated to
+run only once due to semaphores in :file:`/var/lib/cloud/`.
 
 * :command:`--mode [init|config|final]`: Run ``modules:init``,
   ``modules:config`` or ``modules:final`` ``cloud-init`` stages.

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -427,6 +427,10 @@ class TestFTP:
                 " a scheme of ftps://, which is not allowed. Use ftp:// "
                 "to allow connecting to insecure ftp servers.",
             ],
+            ignore_tracebacks=[
+                'ftplib.error_perm: 500 Command "AUTH" not understood.',
+                "UrlError: Attempted to connect to an insecure ftp server",
+            ],
         )
 
     def test_nocloud_ftps_encrypted_server_succeeds(

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -14,7 +14,7 @@ from tests.integration_tests.releases import (
     IS_UBUNTU,
     MANTIC,
 )
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 LOG = logging.getLogger("integration_testing.test_upgrade")
 
@@ -81,11 +81,8 @@ def test_clean_boot_of_upgraded_package(session_cloud: IntegrationCloud):
         pre_cloud_blame = instance.execute("cloud-init analyze blame")
 
         # Ensure no issues pre-upgrade
-        log = instance.read_from_file("/var/log/cloud-init.log")
-        assert not json.loads(pre_result)["v1"]["errors"]
-
         try:
-            verify_clean_log(log)
+            verify_clean_boot(instance)
         except AssertionError:
             LOG.warning(
                 "There were errors/warnings/tracebacks pre-upgrade. "
@@ -122,10 +119,7 @@ def test_clean_boot_of_upgraded_package(session_cloud: IntegrationCloud):
         post_cloud_blame = instance.execute("cloud-init analyze blame")
 
         # Ensure no issues post-upgrade
-        assert not json.loads(pre_result)["v1"]["errors"]
-
-        log = instance.read_from_file("/var/log/cloud-init.log")
-        verify_clean_log(log)
+        verify_clean_boot(instance)
 
         # Ensure important things stayed the same
         assert pre_hostname == post_hostname

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, List, Optional, Set, Union
 import pytest
 
 from cloudinit.subp import subp
+from tests.integration_tests.integration_settings import PLATFORM
 
 LOG = logging.getLogger("integration_testing.util")
 
@@ -70,7 +71,8 @@ def verify_clean_boot(
 ):
     """raise assertions if the client experienced unexpected warnings or errors
 
-    fail when an required error isn't found
+    Fail when a required error isn't found.
+    Expected warnings and errors are defined in this function.
 
     This function is similar to verify_clean_log, hence the similar name.
 
@@ -89,6 +91,77 @@ def verify_clean_boot(
     require_errors: Optional[list] = None,
     fail_when_expected_not_found: optional list of expected errors
     """
+
+    def append_or_create_list(
+        maybe_list: Optional[Union[List[str], bool]], value: str
+    ) -> List[str]:
+        """handle multiple types"""
+        if isinstance(maybe_list, list):
+            maybe_list.append(value)
+        elif maybe_list is None or isinstance(maybe_list, bool):
+            maybe_list = [value]
+        return maybe_list
+
+    # Define exceptions by matrix of platform and Ubuntu release
+    if "azure" == PLATFORM:
+        # Consistently on all Azure launches:
+        ignore_warnings = append_or_create_list(
+            ignore_warnings, "No lease found; using default endpoint"
+        )
+    elif "lxd_vm" == PLATFORM:
+        # Ubuntu lxd storage
+        ignore_warnings = append_or_create_list(
+            ignore_warnings, "thinpool by default on Ubuntu due to LP #1982780"
+        )
+        ignore_warnings = append_or_create_list(
+            ignore_warnings,
+            "Could not match supplied host pattern, ignoring:",
+        )
+    elif "oracle" == PLATFORM:
+        # LP: #1842752
+        ignore_errors = append_or_create_list(
+            ignore_warnings, "Stderr: RTNETLINK answers: File exists"
+        )
+        # LP: #1833446
+        ignore_warnings = append_or_create_list(
+            ignore_warnings,
+            "UrlError: 404 Client Error: Not Found for url: "
+            "http://169.254.169.254/latest/meta-data/",
+        )
+        # Oracle has a file in /etc/cloud/cloud.cfg.d that contains
+        # users:
+        # - default
+        # - name: opc
+        #   ssh_redirect_user: true
+        # This can trigger a warning about opc having no public key
+        ignore_warnings = append_or_create_list(
+            ignore_warnings,
+            "Unable to disable SSH logins for opc given ssh_redirect_user",
+        )
+
+    _verify_clean_boot(
+        instance,
+        ignore_warnings=ignore_warnings,
+        ignore_errors=ignore_errors,
+        require_warnings=require_warnings,
+        require_errors=require_errors,
+    )
+    # assert no Tracebacks
+    assert (
+        "0"
+        == instance.execute(
+            "grep --count Traceback /var/log/cloud-init.log"
+        ).stdout.strip()
+    ), "Unexpected traceback found in /var/log/cloud-init.log"
+
+
+def _verify_clean_boot(
+    instance: "IntegrationInstance",
+    ignore_warnings: Optional[Union[List[str], bool]] = None,
+    ignore_errors: Optional[Union[List[str], bool]] = None,
+    require_warnings: Optional[list] = None,
+    require_errors: Optional[list] = None,
+):
     ignore_errors = ignore_errors or []
     ignore_warnings = ignore_warnings or []
     require_errors = require_errors or []


### PR DESCRIPTION
## Proposed Commit Message
```
feat: Warn user of unexpected run mode
  
On systemd, services are started by PID 1. When this doesn't happen, cloud-init
is in an unknown run state and should warn the user.

- Reorder pid log to be able to reuse Distro information.
- Add docstring deprecating util.is_Linux().
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
