### PR TITLE
ci: Skip package build on tox runs

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,7 @@
 # Needed generally in tests
 
+-r requirements.txt
+
 # Avoid breaking change in `testpaths` treatment forced
 # test/unittests/conftest.py to be loaded by our integration-tests tox env
 # resulting in an unmet dependency issue:

--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -203,7 +203,7 @@ def parse_pip_requirements(requirements_path):
     with open(requirements_path, "r") as fp:
         for line in fp:
             line = line.strip()
-            if not line or line.startswith("#"):
+            if not line or line.startswith(("#", "-r ")):
                 continue
 
             # remove pip-style markers
@@ -212,9 +212,7 @@ def parse_pip_requirements(requirements_path):
             # remove version requirements
             version_comparison = re.compile(r"[~!>=.<]+")
             if version_comparison.search(dep):
-                dep_names.append(
-                    version_comparison.split(dep)[0].strip()
-                )
+                dep_names.append(version_comparison.split(dep)[0].strip())
             else:
                 dep_names.append(dep)
     return dep_names

--- a/tox.ini
+++ b/tox.ini
@@ -6,12 +6,12 @@ envlist =
     isort,
     mypy,
     pylint
-recreate = True
 
 [doc8]
 ignore-path-errors=doc/rtd/topics/faq.rst;D001
 
 [testenv]
+package = skip
 basepython = python3
 setenv =
     LC_ALL = en_US.utf-8


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
ci: Skip package build on tox runs

Building a wheel/sdist generally adds 5+ seconds to every tox run.
This is unnecessary because a built package isn't needed to run any
of the CI tasks.

Also remove the `recreate` line as it wasn't doing anything. To work
correctly, it should be defined under `[testenv]`,
not `[tox]`.
```

## Additional Context
`tox -e ruff` is near instant on Python 3.8+

`recreate` lives under https://tox.wiki/en/latest/config.html#tox-environment

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
