### PR TITLE
Fix snapd growpart and final message warnings

### DIFF
--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -110,5 +110,6 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     except Exception:
         util.logexc(LOG, "Failed to write boot finished file %s", boot_fin_fn)
 
-    if cloud.datasource.is_disconnected:
-        LOG.warning("Used fallback datasource")
+    if cloud.datasource.dsname == "None":
+        if cloud.datasource.sys_cfg.get("datasource_list") != ["None"]:
+            LOG.warning("Used fallback datasource")

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -600,7 +600,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if util.is_false(mode):
         if mode != "off":
             util.deprecate(
-                deprecated="Growpart's 'mode' key with value '{mode}'",
+                deprecated=f"Growpart's 'mode' key with value '{mode}'",
                 deprecated_version="22.2",
                 extra_message="Use 'off' instead.",
             )

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1494,7 +1494,7 @@
           "properties": {
             "mode": {
               "default": "auto",
-              "description": "The utility to use for resizing. Default: ``auto``\n\nPossible options:\n\n* ``auto`` - Use any available utility\n\n* ``growpart`` - Use growpart utility\n\n* ``gpart`` - Use BSD gpart utility\n\n* ``off`` - Take no action",
+              "description": "The utility to use for resizing. Default: ``auto``\n\nPossible options:\n\n* ``auto`` - Use any available utility\n\n* ``growpart`` - Use growpart utility\n\n* ``gpart`` - Use BSD gpart utility\n\n* ``'off'`` - Take no action",
               "oneOf": [
                 {
                   "enum": [
@@ -1510,7 +1510,7 @@
                   ],
                   "changed": true,
                   "changed_version": "22.3",
-                  "changed_description": "Specifying a boolean ``false`` value for ``mode`` is deprecated. Use ``off`` instead."
+                  "changed_description": "Specifying a boolean ``false`` value for ``mode`` is deprecated. Use the string ``'off'`` instead."
                 }
               ]
             },

--- a/cloudinit/sources/DataSourceNone.py
+++ b/cloudinit/sources/DataSourceNone.py
@@ -32,10 +32,6 @@ class DataSourceNone(sources.DataSource):
     def get_instance_id(self):
         return "iid-datasource-none"
 
-    @property
-    def is_disconnected(self):
-        return True
-
 
 # Used to match classes to dependencies
 datasources = [

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -726,10 +726,6 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
             new_ud = f.apply(new_ud)
         return new_ud
 
-    @property
-    def is_disconnected(self):
-        return False
-
     def get_userdata_raw(self):
         return self.userdata_raw
 

--- a/doc/rtd/explanation/configuration.rst
+++ b/doc/rtd/explanation/configuration.rst
@@ -11,12 +11,16 @@ higher priority source overwrites the lower priority source.
 Base configuration
 ==================
 
+The base configuration format uses `YAML version 1.1`_, but may be
+declared as jinja templates which cloud-init will render at runtime with
+:ref:`instance data <instancedata-Using>` variables.
+
 From lowest priority to highest, configuration sources are:
 
-- **Hardcoded config**: Config_ that lives within the source of ``cloud-init``
+- **Hardcoded config** Config_ that lives within the source of ``cloud-init``
   and cannot be changed.
 - **Configuration directory**: Anything defined in :file:`/etc/cloud/cloud.cfg`
-  and :file:`/etc/cloud/cloud.cfg.d`.
+  and :file:`/etc/cloud/cloud.cfg.d/*.cfg`.
 - **Runtime config**: Anything defined in :file:`/run/cloud-init/cloud.cfg`.
 - **Kernel command line**: On the kernel command line, anything found between
   ``cc:`` and ``end_cc`` will be interpreted as cloud-config user data.
@@ -25,6 +29,11 @@ These four sources make up the base configuration. The contents of this
 configuration are defined in the
 :ref:`base configuration reference page<base_config_reference>`.
 
+.. note::
+   Base configuration may contain
+   :ref:`cloud-config<explanation/format:Cloud config data>` which may be
+   overridden by vendor data and user data.
+
 Vendor and user data
 ====================
 
@@ -32,11 +41,6 @@ Added to the base configuration are :ref:`vendor data<vendordata>` and
 :ref:`user data<user_data_formats>` which are both provided by the datasource.
 
 These get fetched from the datasource and are defined at instance launch.
-
-.. note::
-   While much of what is defined in the base configuration can be overridden by
-   vendor data and user data, base configuration sources do not conform to
-   :ref:`#cloud-config<user_data_formats>`.
 
 Network configuration
 =====================
@@ -81,3 +85,4 @@ images.
 
 .. _Config: https://github.com/canonical/cloud-init/blob/b861ea8a5e1fd0eb33096f60f54eeff42d80d3bd/cloudinit/settings.py#L22
 .. _cloud.cfg template: https://github.com/canonical/cloud-init/blob/main/config/cloud.cfg.tmpl
+.. _YAML version 1.1: https://yaml.org/spec/1.1/current.html

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -3,28 +3,26 @@
 User data formats
 *****************
 
-User data that will be acted upon by ``cloud-init`` must be in one of the
-following types.
+User data is opaque configuration data provided by a platform to an instance at
+launch configure the instance. User data can be one of the following types.
 
 .. _user_data_formats-cloud_config:
 
 Cloud config data
 =================
 
-Cloud-config is the simplest way to accomplish some things via user data.
-Using cloud-config syntax, the user can specify certain things in a
-human-friendly format.
+Cloud-config is the preferred user data format. The cloud config format is a
+declarative syntax which uses `YAML version 1.1`_ with keys which describe
+desired instance state. Cloud-config can be used to define how an instance
+should be configured in a human-friendly format.
 
-These things include:
+These things may include:
 
-- ``apt upgrade`` should be run on first boot
-- a different ``apt`` mirror should be used
-- additional ``apt`` sources should be added
-- certain SSH keys should be imported
+- performing package upgrades on first boot
+- configuration of different package mirrors or sources
+- initial user or group setup
+- importing certain SSH keys or host keys
 - *and many more...*
-
-.. note::
-   This file must be valid YAML syntax.
 
 See the :ref:`yaml_examples` section for a commented set of examples of
 supported cloud config formats.
@@ -34,7 +32,7 @@ using a MIME archive.
 
 .. note::
    Cloud config data can also render cloud instance metadata variables using
-   jinja templating. See :ref:`instance_metadata` for more information.
+   :ref:`jinja templates <instancedata-Using>`.
 
 .. _user_data_script:
 
@@ -47,7 +45,7 @@ Begins with: ``#!`` or ``Content-Type: text/x-shellscript`` when using a MIME
 archive.
 
 User data scripts can optionally render cloud instance metadata variables using
-jinja templating. See :ref:`instance_metadata` for more information.
+:ref:`jinja templates <instancedata-Using>`.
 
 Example script
 --------------
@@ -222,5 +220,6 @@ appliances. Setting ``allow_userdata: false`` in the configuration will disable
 ``cloud-init`` from processing user data.
 
 .. _make-mime: https://github.com/canonical/cloud-init/blob/main/cloudinit/cmd/devel/make_mime.py
+.. _YAML version 1.1: https://yaml.org/spec/1.1/current.html
 .. [#] See your cloud provider for applicable user-data size limitations...
 .. _this blog post: http://foss-boss.blogspot.com/2011/01/advanced-cloud-init-custom-handlers.html

--- a/tests/unittests/config/test_cc_final_message.py
+++ b/tests/unittests/config/test_cc_final_message.py
@@ -1,9 +1,11 @@
 # This file is part of cloud-init. See LICENSE file for license information.
-from unittest import mock
+from logging import DEBUG, WARNING
+from pathlib import Path
 
 import pytest
 
 from cloudinit.config.cc_final_message import handle
+from tests.unittests.util import get_cloud
 
 
 class TestHandle:
@@ -24,17 +26,15 @@ class TestHandle:
         file_is_written,
         expected_log_substring,
         caplog,
+        paths,
         tmpdir,
     ):
-        instance_dir = tmpdir.join("var/lib/cloud/instance")
+        instance_dir = Path(paths.get_ipath_cur())
         if instance_dir_exists:
-            instance_dir.ensure_dir()
-        boot_finished = instance_dir.join("boot-finished")
+            instance_dir.mkdir()
+        boot_finished = instance_dir / "boot-finished"
 
-        m_cloud = mock.Mock(
-            paths=mock.Mock(boot_finished=boot_finished.strpath)
-        )
-
+        m_cloud = get_cloud(paths=paths)
         handle(None, {}, m_cloud, [])
 
         # We should not change the status of the instance directory
@@ -43,3 +43,36 @@ class TestHandle:
 
         if expected_log_substring:
             assert expected_log_substring in caplog.text
+
+    @pytest.mark.parametrize(
+        "dsname,datasource_list,expected_log,log_level",
+        [
+            ("None", ["None"], "Used fallback datasource", DEBUG),
+            ("None", ["LXD", "None"], "Used fallback datasource", WARNING),
+            ("LXD", ["LXD", "None"], None, DEBUG),
+        ],
+    )
+    def test_only_warn_when_datasourcenone_is_fallback_in_datasource_list(
+        self,
+        dsname,
+        datasource_list,
+        expected_log,
+        log_level,
+        caplog,
+        paths,
+    ):
+        """Only warn when None is a fallback in multi-item datasource_list.
+
+        It is not a warning when datasource_list: [ None ] is configured.
+        """
+        m_cloud = get_cloud(paths=paths)
+        m_cloud.datasource.dsname = dsname
+        Path(paths.get_ipath_cur()).mkdir()
+        with caplog.at_level(log_level):
+            handle(None, {}, m_cloud, [])
+
+        # We should not change the status of the instance directory
+        if expected_log:
+            assert expected_log in caplog.text
+        else:
+            assert "Used fallback datasource" not in caplog.text

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -772,7 +772,8 @@ class TestGrowpartSchema:
                         "Cloud config schema deprecations: "
                         "growpart.mode:  Changed in version 22.3. "
                         "Specifying a boolean ``false`` value for "
-                        "``mode`` is deprecated. Use ``off`` instead."
+                        "``mode`` is deprecated. Use the string ``'off'`` "
+                        "instead."
                     ),
                 ),
             ),


### PR DESCRIPTION
## rebase merge use individual commits

## Proposed Commit Message(s)
*   fix(final_message): do not warn on datasourcenone when single ds
    
    Avoid warning level log "Used fallback datasource" when base
    configuration defines `datasource_list: [ None ]`.
    
    Using DataSourceNone in this case is desired behavior.
    
    Also drop unused is_disconnected property from DataSource
    which was only used by DataSourceNone in cc_final_message.
    
    Instead compare based on dsname property.
    
    Fixes: GH-5192

* fix(growpart): correct growpart log message to include value of mode

## Additional Context
Affects snapd UC24 which sets `datasource_list: [ None ]' in some configs

## Test Steps

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
