### PR TITLE
ci: Add timezone for alpine unit tests

### DIFF
--- a/.github/workflows/alpine-unittests.yml
+++ b/.github/workflows/alpine-unittests.yml
@@ -55,5 +55,10 @@ jobs:
         # without this, tox fails during package install
         run: lxc exec alpine -- git clone cloud-init-ro/ cloud-init-rw
 
+      - name: Set a timezone
+        # test for regression of GH-5158
+        # https://github.com/canonical/cloud-init/issues/5158
+        run: lxc exec alpine -- ln -s /usr/share/zoneinfo/Europe/Brussels /etc/localtime
+
       - name: Run unittests
         run: lxc exec alpine --cwd /root/cloud-init-rw -- sh -c "tox -e py3"


### PR DESCRIPTION
## Proposed Commit Message
```
ci: Add timezone for alpine unit tests
```

## Additional Context
now that https://github.com/canonical/cloud-init/issues/5158 is fixed, we can add a timezone to the alpine instance to check for regressions

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
