### PR TITLE
fix(pdb): Enable running cloud-init under pdb

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -328,9 +328,12 @@ def main_init(name, args):
     outfmt = None
     errfmt = None
     try:
-        early_logs.append((logging.DEBUG, "Closing stdin."))
-        util.close_stdin()
-        (outfmt, errfmt) = util.fixup_output(init.cfg, name)
+        if not os.isatty(sys.stdin.fileno()):
+            early_logs.append((logging.DEBUG, "Closing stdin."))
+            util.close_stdin()
+        else:
+            LOG.warning("Not closing stdin, stdin is a tty.")
+        outfmt, errfmt = util.fixup_output(init.cfg, name)
     except Exception:
         msg = "Failed to setup output redirection!"
         util.logexc(LOG, msg)
@@ -598,8 +601,11 @@ def main_modules(action_name, args):
     mods = Modules(init, extract_fns(args), reporter=args.reporter)
     # Stage 4
     try:
-        LOG.debug("Closing stdin")
-        util.close_stdin()
+        if not os.isatty(sys.stdin.fileno()):
+            LOG.debug("Closing stdin")
+            util.close_stdin()
+        else:
+            LOG.warning("Not closing stdin, stdin is a tty.")
         util.fixup_output(mods.cfg, name)
     except Exception:
         util.logexc(LOG, "Failed to setup output redirection!")
@@ -667,8 +673,11 @@ def main_single(name, args):
         mod_freq = FREQ_SHORT_NAMES.get(mod_freq)
     # Stage 4
     try:
-        LOG.debug("Closing stdin")
-        util.close_stdin()
+        if not os.isatty(sys.stdin.fileno()):
+            LOG.debug("Closing stdin")
+            util.close_stdin()
+        else:
+            LOG.warning("Not closing stdin, stdin is a tty.")
         util.fixup_output(mods.cfg, None)
     except Exception:
         util.logexc(LOG, "Failed to setup output redirection!")

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1392,20 +1392,6 @@ def search_for_mirror(candidates):
     return None
 
 
-def close_stdin():
-    """
-    reopen stdin as /dev/null so even subprocesses or other os level things get
-    /dev/null as input.
-
-    if _CLOUD_INIT_SAVE_STDIN is set in environment to a non empty and true
-    value then input will not be closed (useful for debugging).
-    """
-    if is_true(os.environ.get("_CLOUD_INIT_SAVE_STDIN")):
-        return
-    with open(os.devnull) as fp:
-        os.dup2(fp.fileno(), sys.stdin.fileno())
-
-
 def find_devs_with_freebsd(
     criteria=None, oformat="device", tag=None, no_cache=False, path=None
 ):

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -80,7 +80,7 @@ class TestMain(FilesystemMockingTestCase):
         (_item1, item2) = wrap_and_call(
             "cloudinit.cmd.main",
             {
-                "util.close_stdin": True,
+                "close_stdin": True,
                 "netinfo.debug_info": "my net debug info",
                 "util.fixup_output": ("outfmt", "errfmt"),
             },
@@ -149,7 +149,7 @@ class TestMain(FilesystemMockingTestCase):
         (_item1, item2) = wrap_and_call(
             "cloudinit.cmd.main",
             {
-                "util.close_stdin": True,
+                "close_stdin": True,
                 "netinfo.debug_info": "my net debug info",
                 "cc_set_hostname.handle": {"side_effect": set_hostname},
                 "util.fixup_output": ("outfmt", "errfmt"),


### PR DESCRIPTION
## Proposed Commit Message

```
fix(pdb): Enable running cloud-init under pdb

Cloud-init closes stdin on startup, which breaks interactively running cloud-init under pdb.

Leave stdin open if it is connected to a tty, which fixes pdb use.


File "/usr/lib/python3.12/bdb.py", line 90, in trace_dispatch
  return self.dispatch_line(frame)
         ^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/lib/python3.12/bdb.py", line 115, in dispatch_line
    if self.quitting: raise BdbQuit
                      ^^^^^^^^^^^^^
bdb.BdbQuit
------------------------------------------------------------
The program exited via sys.exit(). Exit status: 1
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
