### PR TITLE
test: Run Alpine tests without network

### DIFF
--- a/.github/workflows/alpine-unittests.yml
+++ b/.github/workflows/alpine-unittests.yml
@@ -60,9 +60,13 @@ jobs:
         # https://github.com/canonical/cloud-init/issues/5158
         run: lxc exec alpine -- ln -s /usr/share/zoneinfo/Europe/Brussels /etc/localtime
 
+      - name: Set up tox environment
+        # Setup the environment and then tell pytest to do essentially nothing
+        run: lxc exec alpine --cwd /root/cloud-init-rw -- tox -e py3 -- --cache-show=
+
       - name: Stop network
         # Take down network interfaces to ensure tests don't use network
         run: lxc exec alpine -- ifdown -a
 
       - name: Run unittests
-        run: lxc exec alpine --cwd /root/cloud-init-rw -- sh -c "tox -e py3"
+        run: lxc exec alpine --cwd /root/cloud-init-rw -- tox -e py3

--- a/.github/workflows/alpine-unittests.yml
+++ b/.github/workflows/alpine-unittests.yml
@@ -38,15 +38,8 @@ jobs:
         # so switch groups to run lxd commands
         run: lxc launch images:alpine/edge alpine
 
-      - name: Check networking (for debugging)
-        run: |
-          lxc exec alpine -- ping -c 1 google.com || true
-          lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true
-          lxc exec alpine -- nslookup www.google.com || true
-          lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true
-
       - name: Install dependencies
-        run: lxc exec alpine -- apk add py3-tox git
+        run: lxc exec alpine -- apk add py3-tox git tzdata
 
       - name: Mount source into container directory
         run: lxc config device add alpine gitdir disk source=$(pwd) path=/root/cloud-init-ro
@@ -59,6 +52,10 @@ jobs:
         # test for regression of GH-5158
         # https://github.com/canonical/cloud-init/issues/5158
         run: lxc exec alpine -- ln -s /usr/share/zoneinfo/Europe/Brussels /etc/localtime
+
+      - name: Stop network
+        # Take down network interfaces to ensure tests don't use network
+        run: lxc exec alpine -- ifdown -a
 
       - name: Run unittests
         run: lxc exec alpine --cwd /root/cloud-init-rw -- sh -c "tox -e py3"

--- a/.github/workflows/alpine-unittests.yml
+++ b/.github/workflows/alpine-unittests.yml
@@ -38,6 +38,13 @@ jobs:
         # so switch groups to run lxd commands
         run: lxc launch images:alpine/edge alpine
 
+      - name: Check networking (for debugging)
+        run: |
+          lxc exec alpine -- ping -c 1 google.com || true
+          lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true
+          lxc exec alpine -- nslookup www.google.com || true
+          lxc exec alpine -- ping -c 1 dl-cdn.alpinelinux.org || true
+
       - name: Install dependencies
         run: lxc exec alpine -- apk add py3-tox git tzdata
 


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Run Alpine tests without network

None of the unit tests should be reaching out to the network.
Since Alpine tests run under LXD, we can still easily run tests there
without network.

Also, include the tzdata package that was missed in 725f5fb and
remove unneeded network debug lines.
```

## Additional Context
See https://github.com/canonical/cloud-init/pull/5212#pullrequestreview-2023557564

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
