### PR TITLE
fix(mount): When cloud-init is disabled, don't run cloud-init.service

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -38,7 +38,7 @@ unconfigured in `/etc/fstab`::
 
     mounts:
         - ["ephemeral0", "/mnt", "auto",\
-"defaults,nofail,x-systemd.requires=cloud-init.service", "0", "2"]
+"defaults,nofail,x-systemd.after=cloud-init.service", "0", "2"]
         - ["swap", "none", "swap", "sw", "0", "0"]
 
 In order to remove a previously listed mount, an entry can be added to
@@ -51,7 +51,7 @@ for the fields in a ``mounts`` entry that are not specified, aside from the
 containing 6 values. It defaults to::
 
     mount_default_fields: [none, none, "auto",\
-"defaults,nofail,x-systemd.requires=cloud-init.service", "0", "2"]
+"defaults,nofail,x-systemd.after=cloud-init.service", "0", "2"]
 
 Non-systemd init systems will vary in ``mount_default_fields``.
 
@@ -427,7 +427,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     uses_systemd = cloud.distro.uses_systemd()
     if uses_systemd:
         def_mnt_opts = (
-            "defaults,nofail,x-systemd.requires=cloud-init.service,_netdev"
+            "defaults,nofail,x-systemd.after=cloud-init.service,_netdev"
         )
 
     defvals = [None, None, "auto", def_mnt_opts, "0", "2"]

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1953,12 +1953,12 @@
         },
         "mount_default_fields": {
           "type": "array",
-          "description": "Default mount configuration for any mount entry with less than 6 options provided. When specified, 6 items are required and represent ``/etc/fstab`` entries. Default: ``defaults,nofail,x-systemd.requires=cloud-init.service,_netdev``",
+          "description": "Default mount configuration for any mount entry with less than 6 options provided. When specified, 6 items are required and represent ``/etc/fstab`` entries. Default: ``defaults,nofail,x-systemd.after=cloud-init.service,_netdev``",
           "default": [
             null,
             null,
             "auto",
-            "defaults,nofail,x-systemd.requires=cloud-init.service",
+            "defaults,nofail,x-systemd.after=cloud-init.service",
             "0",
             "2"
           ],

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -62,7 +62,7 @@ disable_root: true
                    "openmandriva", "photon", "TencentOS"] or is_rhel %}
 
 {% if is_rhel %}
-mount_default_fields: [~, ~, 'auto', 'defaults,nofail,x-systemd.requires=cloud-init.service,_netdev', '0', '2']
+mount_default_fields: [~, ~, 'auto', 'defaults,nofail,x-systemd.after=cloud-init.service,_netdev', '0', '2']
 {% else %}
 mount_default_fields: [~, ~, 'auto', 'defaults,nofail', '0', '2']
 {% endif %}


### PR DESCRIPTION
```
fix(mount): When cloud-init is disabled, don't run cloud-init.service

cc_mounts configures a `Requires=cloud-init.service` in the configured mount unit via `x-systemd.requires=cloud-init.service`. This creates a requirement dependency on cloud-init.service, even if cloud-init is disabled.

Fix this by changing the mount unit dependency to
`x-systemd.after=cloud-init.service`.

Fixes GH-2815
```

## Context
Fixes #2815

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
