### PR TITLE
sync ChangeLog and version.py from 24.1.x

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,18 @@
+24.1.5
+ - fix(package_update): avoid snap refresh in images without snap command
+   (LP: #2064132)
+
+24.1.4
+ - fix(dhcpcd): Make lease parsing more robust (#5129)
+ - net/dhcp: raise InvalidDHCPLeaseFileError on error parsing dhcpcd lease
+   (#5128) [Chris Patterson]
+ - fix: Fix runtime file locations for cloud-init (#4820)
+ - net/dhcp: bump dhcpcd timeout to 300s (#5127) [Chris Patterson]
+ - net: Warn when interface rename fails
+ - ephemeral(dhcpcd): Set dhcpcd interface down
+ - test: Remove side effects from tests (#5074)
+ - refactor: Import log module rather than functions (#5074)
+
 24.1.3
  - fix: Always use single datasource if specified (#5098)
  - fix: Allow caret at the end of apt package (#5099)

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "24.1.3"
+__VERSION__ = "24.1.5"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [


### PR DESCRIPTION
## Sync ChangeLog and cloudinit/version.py from 24.1.x branch.
