### PR TITLE
fix(apt): Allow opt-in for calling apt update multiple times

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -769,10 +769,6 @@ def add_apt_key(ent, cloud, gpg, hardened=False, file_name=None):
         )
 
 
-def update_packages(cloud):
-    cloud.distro.update_package_sources()
-
-
 def add_apt_sources(
     srcdict, cloud, gpg, template_params=None, aa_repo_match=None
 ):
@@ -856,7 +852,7 @@ def add_apt_sources(
             LOG.exception("failed write to file %s: %s", sourcefn, detail)
             raise
 
-    update_packages(cloud)
+    cloud.distro.update_package_sources(force=True)
 
     return
 

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -395,7 +395,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         # managers.
         raise NotImplementedError()
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         for manager in self.package_managers:
             if not manager.available():
                 LOG.debug(
@@ -404,7 +404,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 )
                 continue
             try:
-                manager.update_package_sources()
+                manager.update_package_sources(force=force)
             except Exception as e:
                 LOG.error(
                     "Failed to update package using %s: %s", manager.name, e

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from cloudinit import distros, helpers, subp, util
 from cloudinit.distros.parsers.hostname import HostnameConf
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_INSTANCE, PER_ALWAYS
 
 LOG = logging.getLogger(__name__)
 
@@ -186,12 +186,12 @@ class Distro(distros.Distro):
         # Allow the output of this to flow outwards (ie not be captured)
         subp.subp(cmd, capture=False)
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         self._runner.run(
             "update-sources",
             self.package_command,
             ["update"],
-            freq=PER_INSTANCE,
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )
 
     @property

--- a/cloudinit/distros/alpine.py
+++ b/cloudinit/distros/alpine.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from cloudinit import distros, helpers, subp, util
 from cloudinit.distros.parsers.hostname import HostnameConf
-from cloudinit.settings import PER_INSTANCE, PER_ALWAYS
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 

--- a/cloudinit/distros/amazon.py
+++ b/cloudinit/distros/amazon.py
@@ -20,5 +20,5 @@ class Distro(rhel.Distro):
     dhclient_lease_directory = "/var/lib/dhcp"
     dhclient_lease_file_regex = r"dhclient-[\w-]+\.lease"
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         return None

--- a/cloudinit/distros/arch.py
+++ b/cloudinit/distros/arch.py
@@ -10,7 +10,7 @@ from cloudinit import distros, helpers, subp, util
 from cloudinit.distros import PackageList
 from cloudinit.distros.parsers.hostname import HostnameConf
 from cloudinit.net.netplan import CLOUDINIT_NETPLAN_FILE
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
@@ -141,7 +141,10 @@ class Distro(distros.Distro):
         # Allow the output of this to flow outwards (ie not be captured)
         subp.subp(cmd, capture=False)
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         self._runner.run(
-            "update-sources", self.package_command, ["-y"], freq=PER_INSTANCE
+            "update-sources",
+            self.package_command,
+            ["-y"],
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -12,7 +12,7 @@ from io import StringIO
 import cloudinit.distros.bsd
 from cloudinit import subp, util
 from cloudinit.distros.networking import FreeBSDNetworking
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
@@ -203,12 +203,12 @@ class Distro(cloudinit.distros.bsd.BSD):
         operations"""
         return {"ASSUME_ALWAYS_YES": "YES"}
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         self._runner.run(
             "update-sources",
             self.package_command,
             ["update"],
-            freq=PER_INSTANCE,
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )
 
     @staticmethod

--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -11,7 +11,7 @@ import logging
 from cloudinit import distros, helpers, subp, util
 from cloudinit.distros import PackageList
 from cloudinit.distros.parsers.hostname import HostnameConf
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
@@ -132,10 +132,10 @@ class Distro(distros.Distro):
         # Allow the output of this to flow outwards (ie not be captured)
         subp.subp(cmd, capture=False)
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         self._runner.run(
             "update-sources",
             self.package_command,
             ["--sync"],
-            freq=PER_INSTANCE,
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )

--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -153,7 +153,7 @@ class NetBSD(cloudinit.distros.bsd.BSD):
             )
         }
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         pass
 
 

--- a/cloudinit/distros/opensuse.py
+++ b/cloudinit/distros/opensuse.py
@@ -15,7 +15,7 @@ from cloudinit import distros, helpers, subp, util
 from cloudinit.distros import PackageList
 from cloudinit.distros import rhel_util as rhutil
 from cloudinit.distros.parsers.hostname import HostnameConf
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
@@ -150,12 +150,12 @@ class Distro(distros.Distro):
             # This ensures that the correct tz will be used for the system
             util.copy(tz_file, self.tz_local_fn)
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         self._runner.run(
             "update-sources",
             self.package_command,
             ["refresh"],
-            freq=PER_INSTANCE,
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )
 
     def _read_hostname(self, filename, default=None):

--- a/cloudinit/distros/package_management/apt.py
+++ b/cloudinit/distros/package_management/apt.py
@@ -12,7 +12,7 @@ from cloudinit.distros.package_management.package_manager import (
     PackageManager,
     UninstalledPackages,
 )
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
@@ -108,12 +108,12 @@ class Apt(PackageManager):
     def available(self) -> bool:
         return bool(subp.which(self.apt_get_command[0]))
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         self.runner.run(
             "update-sources",
             self.run_package_command,
             ["update"],
-            freq=PER_INSTANCE,
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )
 
     @functools.lru_cache(maxsize=1)

--- a/cloudinit/distros/package_management/apt.py
+++ b/cloudinit/distros/package_management/apt.py
@@ -182,14 +182,12 @@ class Apt(PackageManager):
             },
         )
 
-    def _apt_lock_available(self, lock_files=None):
+    def _apt_lock_available(self):
         """Determines if another process holds any apt locks.
 
         If all locks are clear, return True else False.
         """
-        if lock_files is None:
-            lock_files = APT_LOCK_FILES
-        for lock in lock_files:
+        for lock in APT_LOCK_FILES:
             if not os.path.exists(lock):
                 # Only wait for lock files that already exist
                 continue

--- a/cloudinit/distros/package_management/package_manager.py
+++ b/cloudinit/distros/package_management/package_manager.py
@@ -22,7 +22,7 @@ class PackageManager(ABC):
         """Return if package manager is installed on system."""
 
     @abstractmethod
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         ...
 
     @abstractmethod

--- a/cloudinit/distros/package_management/snap.py
+++ b/cloudinit/distros/package_management/snap.py
@@ -17,7 +17,7 @@ class Snap(PackageManager):
     def available(self) -> bool:
         return bool(subp.which("snap"))
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         pass
 
     def install_packages(self, pkglist: Iterable) -> UninstalledPackages:

--- a/cloudinit/distros/photon.py
+++ b/cloudinit/distros/photon.py
@@ -7,7 +7,7 @@ import logging
 from cloudinit import distros, helpers, net, subp, util
 from cloudinit.distros import PackageList
 from cloudinit.distros import rhel_util as rhutil
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
@@ -156,10 +156,10 @@ class Distro(distros.Distro):
         if ret:
             LOG.error("Error while installing packages: %s", err)
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         self._runner.run(
             "update-sources",
             self.package_command,
             ["makecache"],
-            freq=PER_INSTANCE,
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -13,7 +13,7 @@ import os
 from cloudinit import distros, helpers, subp, util
 from cloudinit.distros import PackageList, rhel_util
 from cloudinit.distros.parsers.hostname import HostnameConf
-from cloudinit.settings import PER_INSTANCE
+from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
@@ -209,10 +209,10 @@ class Distro(distros.Distro):
         # Allow the output of this to flow outwards (ie not be captured)
         subp.subp(cmd, capture=False)
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         self._runner.run(
             "update-sources",
             self.package_command,
             ["makecache"],
-            freq=PER_INSTANCE,
+            freq=PER_ALWAYS if force else PER_INSTANCE,
         )

--- a/tests/unittests/config/test_apt_source_v1.py
+++ b/tests/unittests/config/test_apt_source_v1.py
@@ -42,7 +42,7 @@ ADD_APT_REPO_MATCH = r"^[\w-]+:\w"
 class FakeDistro:
     """Fake Distro helper object"""
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         """Fake update_package_sources helper method"""
         return
 

--- a/tests/unittests/config/test_apt_source_v3.py
+++ b/tests/unittests/config/test_apt_source_v3.py
@@ -65,8 +65,8 @@ class TestAptSourceConfig:
 
     @staticmethod
     def _add_apt_sources(cfg, cloud, gpg, **kwargs):
-        with mock.patch.object(cc_apt_configure, "update_packages"):
-            cc_apt_configure.add_apt_sources(cfg, cloud, gpg, **kwargs)
+        # with mock.patch.object(cloud.distro, "update_package_sources"):
+        cc_apt_configure.add_apt_sources(cfg, cloud, gpg, **kwargs)
 
     @staticmethod
     def _get_default_params():
@@ -89,7 +89,7 @@ class TestAptSourceConfig:
 
         self._add_apt_sources(
             cfg,
-            cloud=None,
+            cloud=mock.Mock(),
             gpg=gpg,
             template_params=params,
             aa_repo_match=self.matcher,
@@ -185,7 +185,7 @@ class TestAptSourceConfig:
         params = self._get_default_params()
         self._add_apt_sources(
             cfg,
-            cloud=None,
+            cloud=mock.Mock(),
             gpg=gpg,
             template_params=params,
             aa_repo_match=self.matcher,
@@ -261,10 +261,11 @@ class TestAptSourceConfig:
         """
         params = self._get_default_params()
 
+        cloud = get_cloud()
         with mock.patch.object(cc_apt_configure, "add_apt_key") as mockobj:
             self._add_apt_sources(
                 cfg,
-                cloud=None,
+                cloud=cloud,
                 gpg=gpg,
                 template_params=params,
                 aa_repo_match=self.matcher,
@@ -274,9 +275,9 @@ class TestAptSourceConfig:
         calls = []
         for key in cfg:
             if is_hardened is not None:
-                calls.append(call(cfg[key], None, gpg, hardened=is_hardened))
+                calls.append(call(cfg[key], cloud, gpg, hardened=is_hardened))
             else:
-                calls.append(call(cfg[key], None, gpg))
+                calls.append(call(cfg[key], cloud, gpg))
 
         mockobj.assert_has_calls(calls, any_order=True)
 
@@ -389,7 +390,7 @@ class TestAptSourceConfig:
         mockobj = mocker.patch.object(cc_apt_configure, "apt_key")
         self._add_apt_sources(
             cfg,
-            cloud=None,
+            cloud=mock.Mock(),
             gpg=m_gpg,
             template_params=params,
             aa_repo_match=self.matcher,
@@ -427,7 +428,7 @@ class TestAptSourceConfig:
         mockobj = mocker.patch.object(cc_apt_configure, "apt_key")
         self._add_apt_sources(
             cfg,
-            cloud=None,
+            cloud=mock.Mock(),
             gpg=m_gpg,
             template_params=params,
             aa_repo_match=self.matcher,
@@ -458,7 +459,7 @@ class TestAptSourceConfig:
             with mock.patch.object(cc_apt_configure, "apt_key") as mockobj:
                 self._add_apt_sources(
                     cfg,
-                    cloud=None,
+                    cloud=mock.Mock(),
                     gpg=m_gpg,
                     template_params=params,
                     aa_repo_match=self.matcher,
@@ -494,7 +495,7 @@ class TestAptSourceConfig:
             ) as mockgetkey:
                 self._add_apt_sources(
                     cfg,
-                    cloud=None,
+                    cloud=mock.Mock(),
                     gpg=gpg,
                     template_params=params,
                     aa_repo_match=self.matcher,
@@ -559,7 +560,7 @@ class TestAptSourceConfig:
         with mock.patch.object(cc_apt_configure, "add_apt_key_raw") as mockadd:
             self._add_apt_sources(
                 cfg,
-                cloud=None,
+                cloud=mock.Mock(),
                 gpg=m_gpg,
                 template_params=params,
                 aa_repo_match=self.matcher,
@@ -584,7 +585,7 @@ class TestAptSourceConfig:
         with mock.patch("cloudinit.subp.subp") as mockobj:
             self._add_apt_sources(
                 cfg,
-                cloud=None,
+                cloud=mock.Mock(),
                 gpg=m_gpg,
                 template_params=params,
                 aa_repo_match=self.matcher,
@@ -614,7 +615,7 @@ class TestAptSourceConfig:
         with mock.patch("cloudinit.subp.subp") as mockobj:
             self._add_apt_sources(
                 cfg,
-                cloud=None,
+                cloud=mock.Mock(),
                 gpg=m_gpg,
                 template_params=params,
                 aa_repo_match=self.matcher,

--- a/tests/unittests/distros/package_management/test_apt.py
+++ b/tests/unittests/distros/package_management/test_apt.py
@@ -1,13 +1,18 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+import tempfile
 from itertools import count, cycle
 from unittest import mock
 
 import pytest
 
-from cloudinit import subp
+from cloudinit import helpers, subp
+from cloudinit.distros.package_management import apt
 from cloudinit.distros.package_management.apt import APT_GET_COMMAND, Apt
+from tests.unittests.helpers import MockPaths
+from tests.unittests.util import FakeDataSource
 
 M_PATH = "cloudinit.distros.package_management.apt.Apt."
+TMP_DIR = tempfile.TemporaryDirectory()
 
 
 @mock.patch.dict("os.environ", {}, clear=True)
@@ -112,3 +117,40 @@ class TestPackageCommand:
                 "pkg5^",
             ],
         )
+
+
+@mock.patch.object(
+    apt,
+    "APT_LOCK_FILES",
+    [f"{TMP_DIR}/{FILE}" for FILE in apt.APT_LOCK_FILES],
+)
+class TestUpdatePackageSources:
+    @mock.patch.object(apt.subp, "which", return_value=True)
+    @mock.patch.object(apt.subp, "subp")
+    def test_force_update_calls_twice(self, m_subp, m_which):
+        """Ensure that force=true calls apt update again"""
+        instance = apt.Apt(helpers.Runners(MockPaths({}, FakeDataSource())))
+        instance.update_package_sources()
+        instance.update_package_sources(force=True)
+        assert 2 == len(m_subp.call_args_list)
+        TMP_DIR.cleanup()
+
+    @mock.patch.object(apt.subp, "which", return_value=True)
+    @mock.patch.object(apt.subp, "subp")
+    def test_force_update_twice_calls_twice(self, m_subp, m_which):
+        """Ensure that force=true calls apt update again when called twice"""
+        instance = apt.Apt(helpers.Runners(MockPaths({}, FakeDataSource())))
+        instance.update_package_sources(force=True)
+        instance.update_package_sources(force=True)
+        assert 2 == len(m_subp.call_args_list)
+        TMP_DIR.cleanup()
+
+    @mock.patch.object(apt.subp, "which", return_value=True)
+    @mock.patch.object(apt.subp, "subp")
+    def test_no_force_update_calls_once(self, m_subp, m_which):
+        """Ensure that apt-get update calls are deduped unless expected"""
+        instance = apt.Apt(helpers.Runners(MockPaths({}, FakeDataSource())))
+        instance.update_package_sources()
+        instance.update_package_sources()
+        assert 1 == len(m_subp.call_args_list)
+        TMP_DIR.cleanup()

--- a/tests/unittests/helpers.py
+++ b/tests/unittests/helpers.py
@@ -273,11 +273,7 @@ class CiTestCase(TestCase):
         self.new_root = self.tmp_dir()
         if not sys_cfg:
             sys_cfg = {}
-        tmp_paths = {}
-        for var in ["templates_dir", "run_dir", "cloud_dir"]:
-            tmp_paths[var] = self.tmp_path(var, dir=self.new_root)
-            util.ensure_dir(tmp_paths[var])
-        self.paths = ch.Paths(tmp_paths)
+        self.paths = MockPaths({})
         cls = distros.fetch(distro)
         mydist = cls(distro, sys_cfg, self.paths)
         myds = DataSourceNone.DataSourceNone(sys_cfg, mydist, self.paths)
@@ -462,6 +458,20 @@ class CiRequestsMock(responses.RequestsMock):
                 f"Expected URL '{url}' to be called {count} times. "
                 f"Called {call_count} times."
             )
+
+
+class MockPaths(ch.Paths):
+    def __init__(self, path_cfgs: dict, ds=None):
+        super().__init__(path_cfgs=path_cfgs, ds=ds)
+        self.temp = tempfile.TemporaryDirectory()
+
+        self.cloud_dir: str = path_cfgs.get(
+            "cloud_dir", f"{self.temp}/var/lib/cloud"
+        )
+        self.run_dir: str = path_cfgs.get("run_dir", f"{self.temp}/run/cloud/")
+        self.template_dir: str = path_cfgs.get(
+            "templates_dir", f"{self.temp}/etc/cloud/templates/"
+        )
 
 
 class ResponsesTestCase(CiTestCase):

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -163,7 +163,7 @@ class MockDistro(distros.Distro):
     def package_command(self, command, args=None, pkgs=None):
         pass
 
-    def update_package_sources(self):
+    def update_package_sources(self, *, force=False):
         return (True, "yay")
 
     def do_as(self, command, args=None, **kwargs):


### PR DESCRIPTION
```
fix(apt): Enable calling apt update multiple times

This is required to configure apt when dependency is not installed.

Fixes GH-5223
```

## Additional Context

**note for reviewers**: does this kwarg name make it obvious what it is supposed to do? 

Calling this multiple times isn't ideal, but we support installing gpg as needed for apt-configure, and without calling apt-update after the gpg install we won't be able to actually install packages whose repositories are configured in apt_configure, so our hands are tied if we want to continue to support this for minimal images.



Fixes https://github.com/canonical/cloud-init/issues/5223

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
