### PR TITLE
fix(tests): Fix TestFTP integration test SC-1779

### DIFF
--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -1,4 +1,5 @@
 """NoCloud datasource integration tests."""
+
 from textwrap import dedent
 
 import pytest
@@ -310,8 +311,11 @@ class TestFTP:
                 assert client.execute(
                     "git clone https://github.com/FiloSottile/mkcert && "
                     "cd mkcert && "
-                    "go build -ldflags "
-                    '"-X main.Version=$(git describe --tags)"'
+                    "export latest_ver=$(git describe --tags --abbrev=0) && "
+                    'wget "https://github.com/FiloSottile/mkcert/releases/'
+                    "download/${latest_ver}/mkcert-"
+                    '${latest_ver}-linux-amd64"'
+                    " -O mkcert"
                 ).ok
 
                 # giddyup


### PR DESCRIPTION
There seems to be a jenkins proxy issue with the test software.sslmate.com had an issue with the jenkins proxy

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->


## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_KEEP_INSTANCE=True tox -e integration-tests -- tests/integration_tests/datasources/test_nocloud.py::TestFTP::test_nocloud_ftps_encrypted_server_succeeds
```
```
CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests -- tests/integration_tests/datasources/test_nocloud.py::TestFTP::test_nocloud_ftp_encrypted_server_fails
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
