### PR TITLE
Ubuntu/focal 24 1.x:fix(cli): retain support for --files argument before subcommand

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (24.1.3-0ubuntu1~20.04.3) UNRELEASED; urgency=medium
+
+  * d/p/cli-retain-file-argument-as-main-cmd-arg.patch: retain ability to
+    provide -f or --file on the command line before cloud-init subcommands
+    init, modules or single (LP: #2064300)
+
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 30 Apr 2024 15:49:35 -0600
+
 cloud-init (24.1.3-0ubuntu1~20.04.2) focal; urgency=medium
 
   * cherry-pick a6f7577d: bug(package_update): avoid snap refresh in

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (24.1.3-0ubuntu1~20.04.3) UNRELEASED; urgency=medium
+cloud-init (24.1.3-0ubuntu1~20.04.3) focal; urgency=medium
 
   * d/p/cli-retain-file-argument-as-main-cmd-arg.patch: retain ability to
     provide -f or --file on the command line before cloud-init subcommands

--- a/debian/patches/cli-retain-file-argument-as-main-cmd-arg.patch
+++ b/debian/patches/cli-retain-file-argument-as-main-cmd-arg.patch
@@ -1,0 +1,70 @@
+Description: Retain support for cloud-init -f FILE argument on the commandline
+ Upstream has disallowed the use of -f/--file argument as a generic argument on
+ the command line before the positional cloud-init subcommand is provided.
+ Retain the ability to provide -f/--file on the commandline before the
+ subcommand init, modules or single.
+Author: Chad Smith <chad.smith@canonical.com>
+Origin: backport
+Bug: https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2064300
+Last-Update: 2024-04-30 <YYYY-MM-DD, last update of the meta-information, optional>
+--- a/cloudinit/cmd/main.py
++++ b/cloudinit/cmd/main.py
+@@ -107,6 +107,11 @@ def extract_fns(args):
+     # since it would of broke if it couldn't have
+     # read that file already...
+     fn_cfgs = []
++    if args.main_files:
++        # Append common --file argument to beginning of list when present.
++        # Avoid namespace collision with same --file arg defined in subcommands
++        for fh in args.main_files:
++            fn_cfgs.append(os.path.realpath(fh.name))
+     if args.files:
+         for fh in args.files:
+             # The realpath is more useful in logging
+@@ -877,6 +882,17 @@ def main(sysv_args=None):
+         default=False,
+     )
+     parser.add_argument(
++        "--file",
++        "-f",
++        action="append",
++        dest="main_files",
++        help=(
++            "Use additional yaml configuration files for subcommands: init,"
++            " modules or single"
++        ),
++        type=argparse.FileType("rb"),
++    )
++    parser.add_argument(
+         "--force",
+         action="store_true",
+         help=(
+--- a/tests/unittests/cmd/test_main.py
++++ b/tests/unittests/cmd/test_main.py
+@@ -13,7 +13,9 @@ from cloudinit.cmd import main
+ from cloudinit.util import ensure_dir, load_text_file, write_file
+ from tests.unittests.helpers import FilesystemMockingTestCase, wrap_and_call
+ 
+-MyArgs = namedtuple("MyArgs", "debug files force local reporter subcommand")
++MyArgs = namedtuple(
++    "MyArgs", "debug main_files files force local reporter subcommand"
++)
+ 
+ 
+ class TestMain(FilesystemMockingTestCase):
+@@ -59,6 +61,7 @@ class TestMain(FilesystemMockingTestCase
+         """Modules like write_files are run in 'net' mode."""
+         cmdargs = MyArgs(
+             debug=False,
++            main_files=None,
+             files=None,
+             force=False,
+             local=False,
+@@ -105,6 +108,7 @@ class TestMain(FilesystemMockingTestCase
+         write_file(self.cloud_cfg_file, cloud_cfg)
+         cmdargs = MyArgs(
+             debug=False,
++            main_files=None,
+             files=None,
+             force=False,
+             local=False,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -11,3 +11,4 @@ retain-apt-pre-deb822.patch
 status-retain-recoverable-error-exit-code.patch
 retain-ec2-default-net-update-events.patch
 cpick-a6f7577d-bug-package_update-avoid-snap-refresh-in-images-without
+cli-retain-file-argument-as-main-cmd-arg.patch


### PR DESCRIPTION
## Proposed Commit Message (rebase commit, not squash merge)
```
    fix(cli): retain support for --files argument before subcommand
    
    Upstream dropped support for a generic positional --file argument ordered
    on the command line before the cloud-init subcommand because the
    --files argument is only applicable to the specific subcommands init,
    modules and single.
    
    Add functionality to retain support for --file or -f argument both
    before and after the subcommand to avoid regressions in stable releases due
    to a change in behavior.
    
    LP: #2064300
```
## Additional Context
When approved, this same quilt patch will be applied to `upstream/ubuntu/(jammy|mantic)-24.1.x` branches and uploaded to unapproved queue for focal, jammy and mantic. This quilt patch and related debian/changelog entries will also by sync'd to the unreleased `upstream/ubuntu/(focal|jammy|mantic)` branches to ensure next new-upstream-snapshot SRU of 24.2 also includes this backport.

## Test Steps
```
quilt push -a; tox -e py3; quilt pop -a
build-package
sbuild .... ../out/*dsc
lxc launch ubuntu-daily:focal test-f
lxc exec test-f bash
$ cat >1.yaml <<EOF
#cloud-config
hostname: worked
EOF
$ cloud-init clean  --logs
# confirm failure of published deb
$ apt update; apt install cloud-init; cloud-init --version
/usr/bin/cloud-init 24.1.3-0ubuntu1~20.04.1
$ cloud-init -f 1.yaml init
usage: /usr/bin/cloud-init [-h] [--version] [--debug] [--force]
                           {init,modules,single,query,features,analyze,devel,collect-logs,clean,status,schema}
                           ...
/usr/bin/cloud-init: error: argument subcommand: invalid choice: '1.yaml' (choose from 'init', 'modules', 'single', 'query', 'features', 'analyze', 'devel', 'collect-logs', 'clean', 'status', 'schema')
$ exit
# Test new deb
lxc file push *deb test-f/
lxc exec test-f -- apt install /*deb
$ cloud-init -f 1.yaml init
$ hostname   # expect hostname to change to worked
worked
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
