### PR TITLE
Multiple fixes related to system time

### DIFF
--- a/cloudinit/analyze/show.py
+++ b/cloudinit/analyze/show.py
@@ -6,7 +6,6 @@
 
 import datetime
 import json
-import os
 import sys
 import time
 

--- a/cloudinit/analyze/show.py
+++ b/cloudinit/analyze/show.py
@@ -243,19 +243,6 @@ def gather_timestamps_using_systemd():
         # lxc based containers do not set their monotonic zero point to be when
         # the container starts, instead keep using host boot as zero point
         if util.is_container():
-            # clock.monotonic also uses host boot as zero point
-            base_time = float(time.time()) - float(time.monotonic())
-            # TODO: lxcfs automatically truncates /proc/uptime to seconds
-            # in containers when https://github.com/lxc/lxcfs/issues/292
-            # is fixed, util.uptime() should be used instead of stat on
-            try:
-                file_stat = os.stat("/proc/1/cmdline")
-                kernel_start = file_stat.st_atime
-            except OSError as err:
-                raise RuntimeError(
-                    "Could not determine container boot "
-                    "time from /proc/1/cmdline. ({})".format(err)
-                ) from err
             status = CONTAINER_CODE
         kernel_end = base_time + delta_k_end
         cloudinit_sysd = base_time + delta_ci_s

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -16,7 +16,6 @@ import argparse
 import json
 import os
 import sys
-import time
 import traceback
 import logging
 import yaml
@@ -764,7 +763,8 @@ def status_wrapper(name, args):
 
     v1 = status["v1"]
     v1["stage"] = mode
-    v1[mode]["start"] = time.time()
+    uptime = util.uptime()
+    v1[mode]["start"] = float(uptime)
     v1[mode]["recoverable_errors"] = next(
         filter(lambda h: isinstance(h, log.LogExporter), root_logger.handlers)
     ).export_logs()
@@ -791,7 +791,7 @@ def status_wrapper(name, args):
         print_exc("failed run of stage %s" % mode)
         v1[mode]["errors"] = [str(e)]
 
-    v1[mode]["finished"] = time.time()
+    v1[mode]["finished"] = float(util.uptime())
     v1["stage"] = None
 
     # Write status.json after running init / module code

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -223,7 +223,7 @@ def run_after_pid_gone(pid, pidcmdline, timeout, condition, func, args):
     # is no longer alive.  After it is gone, or timeout has passed
     # execute func(args)
     msg = None
-    end_time = time.time() + timeout
+    end_time = time.monotonic() + timeout
 
     def fatal(msg):
         LOG.warning(msg)
@@ -232,7 +232,7 @@ def run_after_pid_gone(pid, pidcmdline, timeout, condition, func, args):
     known_errnos = (errno.ENOENT, errno.ESRCH)
 
     while True:
-        if time.time() > end_time:
+        if time.monotonic() > end_time:
             msg = "timeout reached before %s ended" % pid
             break
 

--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -177,7 +177,7 @@ class DataSourceCloudStack(sources.DataSource):
                 self.metadata_address, "latest/meta-data/instance-id"
             )
         ]
-        start_time = time.time()
+        start_time = time.monotonic()
         url, _response = uhelp.wait_for_url(
             urls=urls,
             max_wait=url_params.max_wait_seconds,
@@ -192,7 +192,7 @@ class DataSourceCloudStack(sources.DataSource):
                 "Giving up on waiting for the metadata from %s"
                 " after %s seconds",
                 urls,
-                int(time.time() - start_time),
+                int(time.monotonic() - start_time),
             )
 
         return bool(url)
@@ -210,7 +210,7 @@ class DataSourceCloudStack(sources.DataSource):
         try:
             if not self.wait_for_metadata_service():
                 return False
-            start_time = time.time()
+            start_time = time.monotonic()
             self.userdata_raw = ec2.get_instance_userdata(
                 self.api_ver, self.metadata_address
             )
@@ -219,7 +219,7 @@ class DataSourceCloudStack(sources.DataSource):
             )
             LOG.debug(
                 "Crawl of metadata service took %s seconds",
-                int(time.time() - start_time),
+                int(time.monotonic() - start_time),
             )
             password_client = CloudStackPasswordServerClient(self.vr_addr)
             try:

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -378,7 +378,7 @@ class DataSourceEc2(sources.DataSource):
                 urls.append(cur)
                 url2base[cur] = url
 
-            start_time = time.time()
+            start_time = time.monotonic()
             url, _ = uhelp.wait_for_url(
                 urls=urls,
                 max_wait=url_params.max_wait_seconds,
@@ -401,7 +401,7 @@ class DataSourceEc2(sources.DataSource):
             LOG.critical(
                 "Giving up on md from %s after %s seconds",
                 urls,
-                int(time.time() - start_time),
+                int(time.monotonic() - start_time),
             )
 
         return bool(metadata_address)

--- a/cloudinit/sources/DataSourceMAAS.py
+++ b/cloudinit/sources/DataSourceMAAS.py
@@ -124,7 +124,7 @@ class DataSourceMAAS(sources.DataSource):
         if url_params.max_wait_seconds == 0:
             return False
 
-        starttime = time.time()
+        starttime = time.monotonic()
         url = url.rstrip("/")
         check_url = "%s/%s/meta-data/instance-id" % (url, MD_VERSION)
         urls = [check_url]
@@ -140,7 +140,7 @@ class DataSourceMAAS(sources.DataSource):
             LOG.critical(
                 "Giving up on md from %s after %i seconds",
                 urls,
-                int(time.time() - starttime),
+                int(time.monotonic() - starttime),
             )
 
         return bool(url)

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -94,7 +94,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             url2base[md_url] = url
 
         url_params = self.get_url_params()
-        start_time = time.time()
+        start_time = time.monotonic()
         avail_url, _response = url_helper.wait_for_url(
             urls=md_urls,
             max_wait=url_params.max_wait_seconds,
@@ -107,7 +107,7 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
             LOG.debug(
                 "Giving up on OpenStack md from %s after %s seconds",
                 md_urls,
-                int(time.time() - start_time),
+                int(time.monotonic() - start_time),
             )
 
         self.metadata_address = url2base.get(avail_url)

--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -409,7 +409,7 @@ def read_opc_metadata(
         METADATA_PATTERN.format(version=2, path="instance"),
         METADATA_PATTERN.format(version=1, path="instance"),
     ]
-    start_time = time.time()
+    start_time = time.monotonic()
     instance_url, instance_response = wait_for_url(
         urls,
         max_wait=max_wait,
@@ -431,7 +431,7 @@ def read_opc_metadata(
         # like a worthwhile tradeoff rather than having incomplete metadata.
         vnics_url, vnics_response = wait_for_url(
             [METADATA_PATTERN.format(version=metadata_version, path="vnics")],
-            max_wait=max_wait - (time.time() - start_time),
+            max_wait=max_wait - (time.monotonic() - start_time),
             timeout=timeout,
             headers_cb=_headers_cb,
             sleep_time=0,

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -200,7 +200,7 @@ class DataSourceScaleway(sources.DataSource):
         Define metadata_url based upon api-metadata URL availability.
         """
 
-        start_time = time.time()
+        start_time = time.monotonic()
         avail_url, _ = url_helper.wait_for_url(
             urls=urls,
             max_wait=self.max_wait,
@@ -217,7 +217,7 @@ class DataSourceScaleway(sources.DataSource):
             LOG.debug(
                 "Unable to reach api-metadata at %s after %s seconds",
                 urls,
-                int(time.time() - start_time),
+                int(time.monotonic() - start_time),
             )
             raise ConnectionError
 

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -256,7 +256,7 @@ def subp(
             x if isinstance(x, bytes) else x.encode("utf-8") for x in args
         ]
     try:
-        before = time.time()
+        before = time.monotonic()
         sp = subprocess.Popen(
             bytes_args,
             stdout=stdout,
@@ -267,7 +267,7 @@ def subp(
             cwd=cwd,
         )
         out, err = sp.communicate(data, timeout=timeout)
-        total = time.time() - before
+        total = time.monotonic() - before
         if total > 0.1:
             LOG.debug(
                 "%s took %.3ss to run",

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -693,7 +693,7 @@ def wait_for_url(
         if max_wait in (float("inf"), None):
             return False
         return (max_wait <= 0) or (
-            time.time() - start_time + sleep_time > max_wait
+            time.monotonic() - start_time + sleep_time > max_wait
         )
 
     def handle_url_response(response, url):
@@ -736,7 +736,7 @@ def wait_for_url(
         except Exception as e:
             reason = "unexpected error [%s]" % e
             url_exc = e
-        time_taken = int(time.time() - start_time)
+        time_taken = int(time.monotonic() - start_time)
         max_wait_str = "%ss" % max_wait if max_wait else "unlimited"
         status_msg = "Calling '%s' failed [%s/%s]: %s" % (
             url or getattr(url_exc, "url", "url ? None"),
@@ -770,7 +770,7 @@ def wait_for_url(
             return (url, read_url_cb(url, timeout))
 
         for url in urls:
-            now = time.time()
+            now = time.monotonic()
             if loop_n != 0:
                 if timeup(max_wait, start_time):
                     return
@@ -804,7 +804,7 @@ def wait_for_url(
         if out:
             return out
 
-    start_time = time.time()
+    start_time = time.monotonic()
     if sleep_time and sleep_time_cb:
         raise ValueError("sleep_time and sleep_time_cb are mutually exclusive")
 
@@ -840,7 +840,7 @@ def wait_for_url(
         time.sleep(current_sleep_time)
 
         # shorten timeout to not run way over max_time
-        current_time = time.time()
+        current_time = time.monotonic()
         if timeout and current_time + timeout > start_time + max_wait:
             timeout = max_wait - (current_time - start_time)
             if timeout <= 0:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -2806,7 +2806,7 @@ def log_time(
     if kwargs is None:
         kwargs = {}
 
-    start = time.time()
+    start = time.monotonic()
 
     ustart = None
     if get_uptime:
@@ -2818,7 +2818,7 @@ def log_time(
     try:
         ret = func(*args, **kwargs)
     finally:
-        delta = time.time() - start
+        delta = time.monotonic() - start
         udelta = None
         if ustart is not None:
             try:

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -123,6 +123,15 @@ def mock_time():
 
 
 @pytest.fixture
+def mock_monotonic():
+    with mock.patch(
+        MOCKPATH + "monotonic",
+        autospec=True,
+    ) as m:
+        yield m
+
+
+@pytest.fixture
 def mock_dmi_read_dmi_data():
     def fake_read(key: str) -> str:
         if key == "system-uuid":
@@ -3553,10 +3562,11 @@ class TestEphemeralNetworking:
         mock_kvp_report_failure_to_host,
         mock_sleep,
         mock_time,
+        mock_monotonic,
         error_class,
         error_reason,
     ):
-        mock_time.side_effect = [
+        mock_monotonic.side_effect = [
             0.0,  # start
             60.1,  # duration check for host error report
             60.11,  # loop check
@@ -4530,6 +4540,7 @@ class TestGetMetadataFromImds:
         mock_imds_fetch_metadata_with_api_fallback,
         mock_kvp_report_failure_to_host,
         mock_time,
+        mock_monotonic,
         monkeypatch,
         report_failure,
         reported_error_type,
@@ -4540,7 +4551,7 @@ class TestGetMetadataFromImds:
         )
         azure_ds._route_configured_for_imds = route_configured_for_imds
         mock_imds_fetch_metadata_with_api_fallback.side_effect = exception
-        mock_time.return_value = 0.0
+        mock_monotonic.return_value = 0.0
         max_connection_errors = None if route_configured_for_imds else 11
 
         assert (

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -731,7 +731,7 @@ class TestReadOpcMetadata:
         assert vnics_data == metadata.vnics_data
 
     @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
-    @mock.patch("cloudinit.url_helper.time.time", side_effect=count(0, 1))
+    @mock.patch("cloudinit.url_helper.time.monotonic", side_effect=count(0, 1))
     @mock.patch("cloudinit.url_helper.readurl", side_effect=UrlError)
     def test_retry(self, m_readurl, m_time):
         # Since wait_for_url has its own retry tests, just verify that we
@@ -756,7 +756,7 @@ class TestReadOpcMetadata:
         )
 
     @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
-    @mock.patch("cloudinit.url_helper.time.time", side_effect=[0, 11])
+    @mock.patch("cloudinit.url_helper.time.monotonic", side_effect=[0, 11])
     @mock.patch(
         "cloudinit.sources.DataSourceOracle.wait_for_url",
         return_value=("http://hi", b'{"some": "value"}'),
@@ -768,7 +768,7 @@ class TestReadOpcMetadata:
         assert m_wait_for_url.call_args_list[-1][1]["max_wait"] == 19
 
     @mock.patch("cloudinit.url_helper.time.sleep", lambda _: None)
-    @mock.patch("cloudinit.url_helper.time.time", side_effect=[0, 1000])
+    @mock.patch("cloudinit.url_helper.time.monotonic", side_effect=[0, 1000])
     @mock.patch(
         "cloudinit.sources.DataSourceOracle.wait_for_url",
         return_value=("http://hi", b'{"some": "value"}'),

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -541,7 +541,9 @@ class TestUrlHelper:
         m_sleep = mocker.patch(
             f"{M_PATH}time.sleep", side_effect=self.sleep_side_effect
         )
-        mocker.patch(f"{M_PATH}time.time", side_effect=self.time_side_effect)
+        mocker.patch(
+            f"{M_PATH}time.monotonic", side_effect=self.time_side_effect
+        )
 
         yield m_readurl, m_sleep
 
@@ -691,9 +693,9 @@ class TestUrlHelper:
         assert actual_sleep_times == expected_sleep_times
 
     # These side effect methods are a way of having a somewhat predictable
-    # output for time.time(). Otherwise, we have to track too many calls
-    # to time.time() and unrelated changes to code being called could cause
-    # these tests to fail.
+    # output for time.monotonic(). Otherwise, we have to track too many calls
+    # to time.monotonic() and unrelated changes to code being called could
+    # cause these tests to fail.
     # 0.0000001 is added to simulate additional execution time but keep it
     # small enough for pytest.approx() to work
     def sleep_side_effect(self, sleep_time):


### PR DESCRIPTION
## Additional Context
This PR contains two commits related to system time.

The first fixes container to be more accurate with `cloud-init analyze` commands.
The second hardens cloud-init against clock changes, which are possible (and likely)
during early boot.

Fixes #2423
Fixes #3149

## Test Steps
See commit messages for test steps.

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
