### PR TITLE
chore: Update systemd description

### DIFF
--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -1,6 +1,7 @@
 ## template:jinja
 [Unit]
-Description=Apply the settings specified in cloud-config
+# https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
+Description=Cloud-init: Config Stage
 After=network-online.target cloud-config.target
 Before=systemd-user-sessions.service
 Wants=network-online.target cloud-config.target

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -1,6 +1,7 @@
 ## template:jinja
 [Unit]
-Description=Execute cloud user/final scripts
+# https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
+Description=Cloud-init: Final Stage
 After=network-online.target time-sync.target cloud-config.service rc-local.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 After=multi-user.target

--- a/systemd/cloud-init-hotplugd.service
+++ b/systemd/cloud-init-hotplugd.service
@@ -10,7 +10,7 @@
 # cloud-init-hotplud.service will read args from file descriptor 3
 
 [Unit]
-Description=cloud-init hotplug hook daemon
+Description=Cloud-init: Hotplug Hook
 After=cloud-init-hotplugd.socket
 Requires=cloud-init-hotplugd.socket
 ConditionPathExists=!/etc/cloud/cloud-init.disabled

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -1,6 +1,7 @@
 ## template:jinja
 [Unit]
-Description=Initial cloud-init job (pre-networking)
+# https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
+Description=Cloud-init: Local Stage
 {% if variant in ["ubuntu", "unknown", "debian", "rhel" ] %}
 DefaultDependencies=no
 {% endif %}

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -1,7 +1,7 @@
 ## template:jinja
 [Unit]
 # https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
-Description=Cloud-init: Local Stage
+Description=Cloud-init: Local Stage (pre-network)
 {% if variant in ["ubuntu", "unknown", "debian", "rhel" ] %}
 DefaultDependencies=no
 {% endif %}

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -1,6 +1,7 @@
 ## template:jinja
 [Unit]
-Description=Initial cloud-init job (metadata service crawler)
+# https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
+Description=Cloud-init: Network Stage
 {% if variant not in ["photon", "rhel"] %}
 DefaultDependencies=no
 {% endif %}


### PR DESCRIPTION
## Proposed Commit Message
```
chore: Update systemd description

The current descriptions do not follow systemd guidance and are misleading since some services have multiple roles.

systemd.unit(5) on Description:

    A short human readable title of the unit. This may be used by systemd
    (and other UIs) as a user-visible label for the unit, so this string
    should identify the unit rather than describe it, despite the name.

Yet these service files attempt to describe the unit rather than identify it.

Before:
May 01 09:49:49.238629 tiny systemd[1]: Starting cloud-config.service - Apply the settings specified in cloud-config...


After:
May 01 09:49:49.238629 tiny systemd[1]: Starting cloud-config.service - Cloud-init: Config Stage...
```

## Additional Context
There's also the fact that the service files allude to the hotplug command being a daemon when it actually isn't, but that's for a different PR. 

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
