### PR TITLE
fix(crypt): Add salt to passlib calls

### DIFF
--- a/cloudinit/crypt.py
+++ b/cloudinit/crypt.py
@@ -1,0 +1,36 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+from contextlib import suppress
+
+
+def _not_available(secret: str, salt: str):
+    """Raise when called so that importing this module doesn't throw
+    ImportError when ds_detect() returns false. In this case, crypt
+    and passlib are not needed.
+    """
+    raise ImportError("crypt/passlib not found, missing dependency")
+
+
+encrypt_pass = _not_available
+_passlib_crypt = _not_available
+_deprecated_crypt = _not_available
+
+
+# lowest priority: external python dependency with an uncertain future
+with suppress(ImportError, AttributeError):
+    import passlib.hash
+
+    def _passlib_crypt(secret: str, salt: str):
+        """crypt.crypt() interface based on passlib"""
+        return passlib.hash.sha512_crypt.hash(secret, salt=salt, rounds=5000)
+
+    encrypt_pass = _passlib_crypt
+
+# higher priority: savor while it lasts
+with suppress(ImportError, AttributeError):
+    import crypt
+
+    def _deprecated_crypt(secret: str, salt: str):
+        """crypt.crypt() from the deprecated library crypt"""
+        return crypt.crypt(secret, salt=f"$6${salt}")
+
+    encrypt_pass = _deprecated_crypt

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -4825,4 +4825,4 @@ class TestDependencyFallback:
         """Ensure that crypt/passlib import failover gets exercised on all
         Python versions
         """
-        assert dsaz.encrypt_pass("`")
+        assert dsaz.crypt.encrypt_pass("`", "")

--- a/tests/unittests/test_crypt.py
+++ b/tests/unittests/test_crypt.py
@@ -1,0 +1,47 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+import logging
+
+import pytest
+
+from cloudinit import crypt, util
+
+LOG = logging.getLogger(__name__)
+
+RAND = util.rand_str(strlen=16)
+
+
+class TestSubp:
+    @pytest.mark.parametrize(
+        "password, salt, expected",
+        [
+            (
+                "thankee",
+                "danke",
+                "$6$danke$YV5PUooeXRfA/Lo2pYfXUTWIG6yonctF"
+                "txKIpaA1JXX6vfEA5ANdiRrdrFP7fp7lztIC.fFj/jvBsHgXTnoru/",
+            ),
+            # the following test requires that the unittest environment
+            # provide at least one of the required dependencies: crypt or
+            # passlib
+            (
+                "allshouldmatchthis",
+                RAND,
+                crypt.encrypt_pass("allshouldmatchthis", RAND),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "name, function",
+        [
+            ("crypt:passlib", crypt._passlib_crypt),
+            ("crypt:deprecated_crypt", crypt._deprecated_crypt),
+        ],
+    )
+    def test_passwords(self, password, salt, expected, name, function):
+        """verify that the crypt.crypt() replacement implementation behaviors
+        match and provide expected behavior
+        """
+        try:
+            assert expected == function(password, salt)
+        except ImportError:
+            LOG.info("%s implementation not available, not testing it", name)


### PR DESCRIPTION
## Proposed Commit Message
```
fix(crypt): Add salt to passlib calls

- Refactor multiple crypt callsites to a single Python module.
- Add tests to verify standardized behavior between passlib and crypt.

[1] https://github.com/canonical/cloud-init/issues/4791
```

## Additional Context
It would be trivial to add openssl support as well, but this isn't a dependency in minimal images currently so probably not worth it.

In the standard library `hashlib.sha512()` also exists, but this isn't in the right format and I couldn't find documentation to make this compatible with `crypt`. 

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
