### PR TITLE
fix(schema): no network validation on netplan systems without API

### DIFF
--- a/tests/integration_tests/cmd/test_schema.py
+++ b/tests/integration_tests/cmd/test_schema.py
@@ -99,14 +99,14 @@ class TestSchemaDeprecations:
             # No netplan API available skips validation
             content_responses[NET_CFG_V2] = {
                 "out": (
-                    "Skipping network-config schema validation."
-                    " No network schema for version: 2"
+                    "Skipping network-config schema validation for version: 2."
+                    " No netplan API available."
                 )
             }
             content_responses[NET_CFG_V2_INVALID] = {
                 "out": (
-                    "Skipping network-config schema validation."
-                    " No network schema for version: 2"
+                    "Skipping network-config schema validation for version: 2."
+                    " No netplan API available."
                 )
             }
 

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -295,11 +295,11 @@ def test_invalid_network_v2_netplan(
         # Netplan python API only available on MANTIC and later
         if CURRENT_RELEASE < MANTIC:
             assert (
-                "Skipping netplan schema validation. No netplan available"
+                "Skipping netplan schema validation. No netplan API available"
             ) in client.read_from_file("/var/log/cloud-init.log")
             assert (
-                "Skipping network-config schema validation. No network schema"
-                " for version: 2"
+                "Skipping network-config schema validation for version: 2."
+                " No netplan API available."
             ) in client.execute("cloud-init schema --system")
         else:
             assert (

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -355,11 +355,11 @@ class TestNetplanValidateNetworkSchema:
             ({"version": 1}, ""),
             (
                 {"version": 2},
-                "Skipping netplan schema validation. No netplan available",
+                "Skipping netplan schema validation. No netplan API available",
             ),
             (
                 {"network": {"version": 2}},
-                "Skipping netplan schema validation. No netplan available",
+                "Skipping netplan schema validation. No netplan API available",
             ),
         ),
     )
@@ -1902,8 +1902,10 @@ class TestMain:
             ),
         ),
     )
+    @mock.patch("cloudinit.net.netplan.available", return_value=False)
     def test_main_validates_config_file(
         self,
+        _netplan_available,
         _read_cfg_paths,
         schema_type,
         content,
@@ -2046,7 +2048,7 @@ class TestMain:
                 "   dhcp4: true\n",
                 "  Valid schema network-config",
                 does_not_raise(),
-                id="netv2_schema_validated",
+                id="netv2_schema_validated_non_netplan",
             ),
             pytest.param(
                 "network: {}\n",
@@ -2073,10 +2075,12 @@ class TestMain:
     )
     @mock.patch(M_PATH + "read_cfg_paths")
     @mock.patch(M_PATH + "os.getuid", return_value=0)
+    @mock.patch("cloudinit.net.netplan.available", return_value=False)
     def test_main_validates_system_userdata_vendordata_and_network_config(
         self,
-        _read_cfg_paths,
+        _netplan_available,
         _getuid,
+        _read_cfg_paths,
         read_cfg_paths,
         net_config,
         net_output,
@@ -2467,8 +2471,15 @@ class TestNetworkSchema:
             ),
         ),
     )
+    @mock.patch("cloudinit.net.netplan.available", return_value=False)
     def test_network_schema(
-        self, src_config, schema_type_version, expectation, log, caplog
+        self,
+        _netplan_available,
+        src_config,
+        schema_type_version,
+        expectation,
+        log,
+        caplog,
     ):
         net_schema = get_schema(schema_type=schema_type_version)
         with expectation:


### PR DESCRIPTION
## Proposed Commit Message
```
fix(schema): no network validation on netplan systems without API

Do not validation network config against cloud-init's network v2 schema on netplan systems because netplan schema supports keys not present in cloud-init's v2 schema which can result in schema warnings from cloud-init which are perfectly acceptable netplan config keys.

Given that cloud-init performs a clean passthrough of network version 2 directly to netplan without trying to process the network configuration, there is little value in providing such schema warnings unless cloud-init's network v2 schema is aligned with the specific netplan schema supported for each release.

On mantic and later, cloud-init will call netplan's python API to validate schema with netplan itself, but prior to Ubuntu Mantic no python API exists, so we cannot validate network v2 against netplan.

Update skip messaging and integration tests.
```

## Additional Context
Jenkins jammy integration test failures which should "skip" network schema validation https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-lxd_container/440/testReport/

## Test Steps
```
for series in focal jammy mantic; do

 CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_OS_IMAGE=$series tox -e integration-tests -- tests/integration_tests/test_networking.py::test_invalid_network_v2_netplan tests/integration_tests/cmd/test_schema.py::TestSchemaDeprecations::test_network_config_schema_validation

done
```
## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
