### PR TITLE
fix(snapd): ubuntu do not snap refresh when snap absent

### DIFF
--- a/cloudinit/distros/ubuntu.py
+++ b/cloudinit/distros/ubuntu.py
@@ -40,7 +40,8 @@ class Distro(debian.Distro):
 
     def package_command(self, command, args=None, pkgs=None):
         super().package_command(command, args, pkgs)
-        self.snap.upgrade_packages()
+        if self.snap.available():
+            self.snap.upgrade_packages()
 
     @property
     def preferred_ntp_clients(self):

--- a/tests/unittests/distros/test_ubuntu.py
+++ b/tests/unittests/distros/test_ubuntu.py
@@ -1,0 +1,32 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+import pytest
+
+from cloudinit.distros import fetch
+
+
+class TestPackageCommand:
+    @pytest.mark.parametrize("snap_available", (True, False))
+    def test_package_command_only_refresh_snap_when_available(
+        self, snap_available, mocker
+    ):
+        """Avoid calls to snap refresh when snap command not available."""
+        m_snap_available = mocker.patch(
+            "cloudinit.distros.ubuntu.Snap.available",
+            return_value=snap_available,
+        )
+        m_snap_upgrade_packges = mocker.patch(
+            "cloudinit.distros.ubuntu.Snap.upgrade_packages",
+            return_value=snap_available,
+        )
+        m_apt_run_package_command = mocker.patch(
+            "cloudinit.distros.package_management.apt.Apt.run_package_command",
+        )
+        cls = fetch("ubuntu")
+        distro = cls("ubuntu", {}, None)
+        distro.package_command("upgrade")
+        m_apt_run_package_command.assert_called_once_with("upgrade")
+        m_snap_available.assert_called_once()
+        if snap_available:
+            m_snap_upgrade_packges.assert_called_once()
+        else:
+            m_snap_upgrade_packges.assert_not_called()


### PR DESCRIPTION
## Proposed Commit Message
```
fix(snapd): ubuntu do not snap refresh when snap absent

No longer call snap refresh when cloud-config user-data specifies upgade_packages:true and custom Ubuntu images do not have snapd package installed

LP: #2064300
```

## Additional Context
My commit a6f7577d582aa51d51ca129fcff65313e210d47b attempted to fix this issue, but the validation of the fix only looked at
`update_packages: true` config not `upgrade_packages: true`

During SRU validation we discovered that this former patch was not successful in closing the upgrade patches case.
https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2064132

## Test Steps
```
#!/bin/bash
set -ex
SERIES=$1

cat > pkg-upgrade.yaml <<EOF
#cloud-config
package_upgrade: true
EOF

#for SERIES in "focal" "jammy" "mantic"; do
for SERIES in "focal"; do
echo "---------- SRU verification: $SERIES"
name=test-no-snap-$SERIES
if [ "$SERIES" = "focal" ]; then
  LXC_CFG_KEY="user.user-data"
else
  LXC_CFG_KEY="cloud-init.user-data"
fi
lxc launch ubuntu-daily:$SERIES $name -c $LXC_CFG_KEY="$(cat pkg-upgrade.yaml)"
sleep 6
lxc exec $name -- cloud-init status --wait && echo "SUCCESS: upgrade success on system  with snapd" || echo "FAILED: package_upgrade error on system with snapd"

# assert snap refresh is called on system with snapd
lxc exec $name -- egrep 'snap.*refresh' /var/log/cloud-init.log && echo "SUCCESS: found snap refresh on system with snapd" || echo "FAILED: did not file snap refresh on system with snapd"

lxc exec $name -- apt-get remove snapd -y
lxc exec $name -- cloud-init clean --logs --reboot
sleep 6

lxc exec $name -- cloud-init status --wait || true # expect failure here because we aren't using the fixed version
lxc exec $name -- egrep 'snap.*refresh' /var/log/cloud-init.log && echo "SUCCESS: found snap refresh on failed system without snapd" || echo "FAILED: did not find snap refresh on failed system with snapd"

echo --- upgrade to proposed fix
lxc file push cloudinit/distros/ubuntu.py $name/usr/lib/python3/dist-packages/cloudinit/distros/
lxc exec $name -- cloud-init clean --logs --reboot
sleep 6

# expect no warnings/errors
lxc exec $name -- cloud-init status --wait --format=yaml || echo "FAILED: errors or warning found"

# ensure no calls to snap refresh
lxc exec $name -- egrep 'snap.*refresh' /var/log/cloud-init.log && echo "FAILED: found snap refresh system without snapd" || echo "SUCCESS: did not find snap refresh on system without snapd"

done
```


## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
