### PR TITLE
Ubuntu/focal 24.1.x

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (24.1.3-0ubuntu1~20.04.4) UNRELEASED; urgency=medium
+cloud-init (24.1.3-0ubuntu1~20.04.4) focal; urgency=medium
 
   * cherry-pick 51c6569f: fix(snapd): ubuntu do not snap refresh when
     snap absent (LP: #2064132)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (24.1.3-0ubuntu1~20.04.4) UNRELEASED; urgency=medium
+
+  * cherry-pick 51c6569f: fix(snapd): ubuntu do not snap refresh when
+    snap absent (LP: #2064132)
+    - fix in 24.1.3-0ubuntu1~20.04.2 did not handle package_upgrade case
+
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 03 May 2024 15:38:58 -0600
+
 cloud-init (24.1.3-0ubuntu1~20.04.3) focal; urgency=medium
 
   * d/p/cli-retain-file-argument-as-main-cmd-arg.patch: retain ability to

--- a/debian/patches/cpick-51c6569f-fix-snapd-ubuntu-do-not-snap-refresh-when-snap-absent
+++ b/debian/patches/cpick-51c6569f-fix-snapd-ubuntu-do-not-snap-refresh-when-snap-absent
@@ -1,0 +1,63 @@
+From 51c6569f96bee4f91aad5db58765c7abab7ffcdf Mon Sep 17 00:00:00 2001
+From: Chad Smith <chad.smith@canonical.com>
+Date: Fri, 3 May 2024 14:58:01 -0600
+Subject: [PATCH] fix(snapd): ubuntu do not snap refresh when snap absent
+
+No longer call snap refresh when cloud-config user-data
+specifies upgade_packages:true and custom Ubuntu images
+do not have snapd package installed
+
+LP: #2064132
+---
+ cloudinit/distros/ubuntu.py            |  3 ++-
+ tests/unittests/distros/test_ubuntu.py | 32 ++++++++++++++++++++++++++
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+ create mode 100644 tests/unittests/distros/test_ubuntu.py
+
+--- a/cloudinit/distros/ubuntu.py
++++ b/cloudinit/distros/ubuntu.py
+@@ -40,7 +40,8 @@ class Distro(debian.Distro):
+ 
+     def package_command(self, command, args=None, pkgs=None):
+         super().package_command(command, args, pkgs)
+-        self.snap.upgrade_packages()
++        if self.snap.available():
++            self.snap.upgrade_packages()
+ 
+     @property
+     def preferred_ntp_clients(self):
+--- /dev/null
++++ b/tests/unittests/distros/test_ubuntu.py
+@@ -0,0 +1,32 @@
++# This file is part of cloud-init. See LICENSE file for license information.
++import pytest
++
++from cloudinit.distros import fetch
++
++
++class TestPackageCommand:
++    @pytest.mark.parametrize("snap_available", (True, False))
++    def test_package_command_only_refresh_snap_when_available(
++        self, snap_available, mocker
++    ):
++        """Avoid calls to snap refresh when snap command not available."""
++        m_snap_available = mocker.patch(
++            "cloudinit.distros.ubuntu.Snap.available",
++            return_value=snap_available,
++        )
++        m_snap_upgrade_packges = mocker.patch(
++            "cloudinit.distros.ubuntu.Snap.upgrade_packages",
++            return_value=snap_available,
++        )
++        m_apt_run_package_command = mocker.patch(
++            "cloudinit.distros.package_management.apt.Apt.run_package_command",
++        )
++        cls = fetch("ubuntu")
++        distro = cls("ubuntu", {}, None)
++        distro.package_command("upgrade")
++        m_apt_run_package_command.assert_called_once_with("upgrade")
++        m_snap_available.assert_called_once()
++        if snap_available:
++            m_snap_upgrade_packges.assert_called_once()
++        else:
++            m_snap_upgrade_packges.assert_not_called()

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -12,3 +12,4 @@ status-retain-recoverable-error-exit-code.patch
 retain-ec2-default-net-update-events.patch
 cpick-a6f7577d-bug-package_update-avoid-snap-refresh-in-images-without
 cli-retain-file-argument-as-main-cmd-arg.patch
+cpick-51c6569f-fix-snapd-ubuntu-do-not-snap-refresh-when-snap-absent


### PR DESCRIPTION
Bug fix release to pull in fix for `package_upgrade: true` discovered during SRU verification testing of https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2064132. The real fix is 51c6569f96bee4f91aad5db58765c7abab7ffcdf which prevents the upgrade path (not update)
Note as well the bug reference in the upstream commit shouldn't have been LP: #2064300 but LP: #2064132. Manually correct that in the d/changelog.

Will reflect the same quilt patch to jammy and mantic once approved.

## procedure to create branch
```
git fetch upstream
git checkout upstream/ubuntu/focal-24.1.x -B ubuntu/focal-24.1.x
cherry-pick 51c6569f96bee4f91aad5db58765c7abab7ffcdf
vi debian/changelog # correct package version suffix to  `~20.04.4` and correct LP bug number
git commit -am 'changelog' 
# squash merge top 2 commits
 sed -i '1s/UNRELEASED/focal/' debian/changelog 
git commt -am 'releasing cloud-init version 24.1.3-0ubuntu1~20.04.4'
```
