### PR TITLE
feat(systemd): Improve AlmaLinux OS and CloudLinux OS support

### DIFF
--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -19,7 +19,7 @@ ExecStart=/usr/bin/cloud-init modules --mode=final
 RemainAfterExit=yes
 TimeoutSec=0
 KillMode=process
-{% if variant == "rhel" %}
+{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
 # Restart NetworkManager if it is present and running.
 ExecStartPost=/bin/sh -c 'u=NetworkManager.service; \
  out=$(systemctl show --property=SubState $u) || exit; \

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -2,23 +2,23 @@
 [Unit]
 # https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
 Description=Cloud-init: Local Stage (pre-network)
-{% if variant in ["ubuntu", "unknown", "debian", "rhel" ] %}
+{% if variant in ["almalinux", "cloudlinux", "ubuntu", "unknown", "debian", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
 Wants=network-pre.target
 After=hv_kvp_daemon.service
 After=systemd-remount-fs.service
-{% if variant == "rhel" %}
+{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
 Requires=dbus.socket
 After=dbus.socket
 {% endif %}
 Before=NetworkManager.service
-{% if variant == "rhel" %}
+{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
 Before=network.service
 {% endif %}
 Before=network-pre.target
 Before=shutdown.target
-{% if variant == "rhel" %}
+{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
 Before=firewalld.target
 Conflicts=shutdown.target
 {% endif %}
@@ -33,7 +33,7 @@ ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
 
 [Service]
 Type=oneshot
-{% if variant == "rhel" %}
+{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
 ExecStartPre=/bin/mkdir -p /run/cloud-init
 ExecStartPre=/sbin/restorecon /run/cloud-init
 ExecStartPre=/usr/bin/touch /run/cloud-init/enabled

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -2,7 +2,7 @@
 [Unit]
 # https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
 Description=Cloud-init: Network Stage
-{% if variant not in ["photon", "rhel"] %}
+{% if variant not in ["almalinux", "cloudlinux", "photon", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
 Wants=cloud-init-local.service


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(systemd): Improve AlmaLinux OS and CloudLinux OS support

AlmaLinux OS is binary compatible with RHEL
and CloudLinux OS based on AlmaLinux OS.

Use the same options with rhel on these systemd services:
- Cloud-init: Local Stage (pre-network): cloud-init-local.service
- Cloud-init: Network Stage: cloud-init.service
- Cloud-init: Final Stage: cloud-final.service
```

## Additional Context
<!-- If relevant -->
This improvement is part of a [patch](https://git.almalinux.org/rpms/cloud-init/src/branch/a9/SOURCES/0031-Improvements-for-AlmaLinux-OS-and-CloudLinux-OS.patch) which is used in cloud-init packages of AlmaLinux OS 8 and 9.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Check if template files correctly rendered to the systemd services:
```
systemctl cat cloud-init-local.service
systemctl cat cloud-init.service
systemctl cat cloud-final.service
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
