### PR TITLE
Ensure subp doesn't run during logs.py import

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -1091,7 +1091,7 @@ def main(sysv_args=None):
                 handle_collect_logs_args,
             )
 
-            logs_parser(parser_collect_logs)
+            logs_parser(parser=parser_collect_logs)
             parser_collect_logs.set_defaults(
                 action=("collect-logs", handle_collect_logs_args)
             )

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -35,7 +35,9 @@ class TestCollectLogs:
             " Try sudo cloud-init collect-logs\n" == m_stderr.getvalue()
         )
 
-    def test_collect_logs_creates_tarfile(self, m_getuid, mocker, tmpdir):
+    def test_collect_logs_creates_tarfile(
+        self, m_getuid, m_log_paths, mocker, tmpdir
+    ):
         """collect-logs creates a tarfile with all related cloud-init info."""
         m_getuid.return_value = 100
         log1 = tmpdir.join("cloud-init.log")
@@ -46,12 +48,10 @@ class TestCollectLogs:
         write_file(log2, "cloud-init-output-log")
         log2_rotated = tmpdir.join("cloud-init-output.log.1.gz")
         write_file(log2_rotated, "cloud-init-output-log-rotated")
-        run_dir = tmpdir.join("run")
-        write_file(run_dir.join("results.json"), "results")
+        run_dir = m_log_paths.run_dir
+        write_file(str(run_dir / "results.json"), "results")
         write_file(
-            run_dir.join(
-                INSTANCE_JSON_SENSITIVE_FILE,
-            ),
+            str(m_log_paths.instance_data_sensitive),
             "sensitive",
         )
         output_tarfile = str(tmpdir.join("logs.tgz"))
@@ -108,7 +108,6 @@ class TestCollectLogs:
             M_PATH + "subprocess.call", side_effect=fake_subprocess_call
         )
         mocker.patch(M_PATH + "sys.stderr", fake_stderr)
-        mocker.patch(M_PATH + "CLOUDINIT_RUN_DIR", run_dir)
         mocker.patch(M_PATH + "INSTALLER_APPORT_FILES", [])
         mocker.patch(M_PATH + "INSTALLER_APPORT_SENSITIVE_FILES", [])
         logs.collect_logs(output_tarfile, include_userdata=False)
@@ -155,7 +154,7 @@ class TestCollectLogs:
         fake_stderr.write.assert_any_call("Wrote %s\n" % output_tarfile)
 
     def test_collect_logs_includes_optional_userdata(
-        self, m_getuid, mocker, tmpdir
+        self, m_getuid, mocker, tmpdir, m_log_paths
     ):
         """collect-logs include userdata when --include-userdata is set."""
         m_getuid.return_value = 0
@@ -163,12 +162,12 @@ class TestCollectLogs:
         write_file(log1, "cloud-init-log")
         log2 = tmpdir.join("cloud-init-output.log")
         write_file(log2, "cloud-init-output-log")
-        userdata = tmpdir.join("user-data.txt")
-        write_file(userdata, "user-data")
-        run_dir = tmpdir.join("run")
-        write_file(run_dir.join("results.json"), "results")
+        userdata = m_log_paths.userdata_raw
+        write_file(str(userdata), "user-data")
+        run_dir = m_log_paths.run_dir
+        write_file(str(run_dir / "results.json"), "results")
         write_file(
-            run_dir.join(INSTANCE_JSON_SENSITIVE_FILE),
+            str(m_log_paths.instance_data_sensitive),
             "sensitive",
         )
         output_tarfile = str(tmpdir.join("logs.tgz"))
@@ -223,23 +222,21 @@ class TestCollectLogs:
             M_PATH + "subprocess.call", side_effect=fake_subprocess_call
         )
         mocker.patch(M_PATH + "sys.stderr", fake_stderr)
-        mocker.patch(M_PATH + "CLOUDINIT_RUN_DIR", run_dir)
         mocker.patch(M_PATH + "INSTALLER_APPORT_FILES", [])
         mocker.patch(M_PATH + "INSTALLER_APPORT_SENSITIVE_FILES", [])
-        mocker.patch(M_PATH + "_get_user_data_file", return_value=userdata)
         logs.collect_logs(output_tarfile, include_userdata=True)
         # unpack the tarfile and check file contents
         subp(["tar", "zxvf", output_tarfile, "-C", str(tmpdir)])
         out_logdir = tmpdir.join(date_logdir)
         assert "user-data" == load_text_file(
-            os.path.join(out_logdir, "user-data.txt")
+            os.path.join(out_logdir, userdata.name)
         )
         assert "sensitive" == load_text_file(
             os.path.join(
                 out_logdir,
                 "run",
                 "cloud-init",
-                INSTANCE_JSON_SENSITIVE_FILE,
+                m_log_paths.instance_data_sensitive.name,
             )
         )
         fake_stderr.write.assert_any_call("Wrote %s\n" % output_tarfile)
@@ -400,7 +397,9 @@ class TestCollectInstallerLogs:
 
 
 class TestParser:
-    def test_parser_help_has_userdata_file(self, mocker, tmpdir):
-        userdata = str(tmpdir.join("user-data.txt"))
-        mocker.patch(M_PATH + "_get_user_data_file", return_value=userdata)
-        assert userdata in re.sub(r"\s+", "", logs.get_parser().format_help())
+    def test_parser_help_has_userdata_file(self, m_log_paths, mocker, tmpdir):
+        # userdata = str(tmpdir.join("user-data.txt"))
+        userdata = m_log_paths.userdata_raw
+        assert str(userdata) in re.sub(
+            r"\s+", "", logs.get_parser().format_help()
+        )

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -379,7 +379,7 @@ class TestCollectInstallerLogs:
         mocker.patch(
             M_PATH + "INSTALLER_APPORT_SENSITIVE_FILES", apport_sensitive_files
         )
-        logs.collect_installer_logs(
+        logs._collect_installer_logs(
             log_dir=tmpdir.strpath,
             include_userdata=include_userdata,
             verbosity=0,

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -1,6 +1,7 @@
 import builtins
 import glob
 import os
+import pathlib
 import shutil
 from pathlib import Path
 from unittest import mock
@@ -8,6 +9,7 @@ from unittest import mock
 import pytest
 
 from cloudinit import atomic_helper, log, util
+from cloudinit.cmd.devel import logs
 from cloudinit.gpg import GPG
 from tests.hypothesis import HAS_HYPOTHESIS
 from tests.unittests.helpers import example_netdev, retarget_many_wrapper
@@ -167,3 +169,19 @@ if HAS_HYPOTHESIS:
 
     settings.register_profile("ci", max_examples=1000)
     settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))
+
+
+@pytest.fixture
+def m_log_paths(mocker, tmp_path):
+    """Define logs.LogPaths for testing and mock get_log_paths with it."""
+    paths = logs.LogPaths(
+        userdata_raw=tmp_path / "userdata_raw",
+        cloud_data=tmp_path / "cloud_data",
+        run_dir=tmp_path / "run_dir",
+        instance_data_sensitive=tmp_path
+        / "run_dir"
+        / "instance_data_sensitive",
+    )
+    pathlib.Path(paths.run_dir).mkdir()
+    mocker.patch.object(logs, "get_log_paths", return_value=paths)
+    yield paths

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -21,14 +21,6 @@ Tmpdir = namedtuple("Tmpdir", ["tmpdir", "link_d", "data_d"])
 FakeArgs = namedtuple("FakeArgs", ["action", "local", "mode"])
 
 
-@pytest.fixture()
-def mock_get_user_data_file(mocker, tmpdir):
-    yield mocker.patch(
-        "cloudinit.cmd.devel.logs._get_user_data_file",
-        return_value=tmpdir.join("cloud"),
-    )
-
-
 @pytest.fixture(autouse=True, scope="module")
 def disable_setup_logging():
     # setup_basic_logging can change the logging level to WARNING, so
@@ -255,13 +247,11 @@ class TestCLI:
             "schema",
         ],
     )
-    @mock.patch("cloudinit.stages.Init._read_cfg", return_value={})
     def test_conditional_subcommands_from_entry_point_sys_argv(
         self,
-        m_read_cfg,
         subcommand,
         capsys,
-        mock_get_user_data_file,
+        m_log_paths,
         mock_status_wrapper,
     ):
         """Subcommands from entry-point are properly parsed from sys.argv."""
@@ -284,7 +274,7 @@ class TestCLI:
         ],
     )
     def test_subcommand_parser(
-        self, subcommand, mock_get_user_data_file, mock_status_wrapper
+        self, subcommand, m_log_paths, mock_status_wrapper
     ):
         """cloud-init `subcommand` calls its subparser."""
         # Provide -h param to `subcommand` to avoid having to mock behavior.


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
See individual commits
```

## Additional Context
`tests/unittests/cmd/devel/test_logs.py` would fail if you ran the file on its own due to subp happening on import.

The 2nd commit is just some extra cleanup.

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
