### PR TITLE
Docs module generation from YAML instead of python meta dicts

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -6,61 +6,23 @@ import re
 import sys
 import sysconfig
 from copy import deepcopy
-from textwrap import dedent
 from typing import Optional
 
 from cloudinit import subp
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
-from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.config.schema import MetaSchema
 from cloudinit.distros import ALL_DISTROS, Distro
 from cloudinit.settings import PER_INSTANCE
 from cloudinit.util import Version, get_cfg_by_path
 
 meta: MetaSchema = {
     "id": "cc_ansible",
-    "name": "Ansible",
-    "title": "Configure ansible for instance",
     "frequency": PER_INSTANCE,
     "distros": [ALL_DISTROS],
     "activate_by_schema_keys": ["ansible"],
-    "description": dedent(
-        """\
-        This module provides ``ansible`` integration for
-        augmenting cloud-init's configuration of the local
-        node.
+}  # type: ignore
 
-
-        This module installs ansible during boot and
-        then uses ``ansible-pull`` to run the playbook
-        repository at the remote URL.
-        """
-    ),
-    "examples": [
-        dedent(
-            """\
-            ansible:
-              package_name: ansible-core
-              install_method: distro
-              pull:
-                url: "https://github.com/holmanb/vmboot.git"
-                playbook_name: ubuntu.yml
-            """
-        ),
-        dedent(
-            """\
-            ansible:
-              package_name: ansible-core
-              install_method: pip
-              pull:
-                url: "https://github.com/holmanb/vmboot.git"
-                playbook_name: ubuntu.yml
-            """
-        ),
-    ],
-}
-
-__doc__ = get_meta_doc(meta)
 LOG = logging.getLogger(__name__)
 CFG_OVERRIDE = "ansible_config"
 

--- a/cloudinit/config/cc_apk_configure.py
+++ b/cloudinit/config/cc_apk_configure.py
@@ -7,12 +7,11 @@
 """Apk Configure: Configures apk repositories file."""
 
 import logging
-from textwrap import dedent
 
 from cloudinit import temp_utils, templater, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
-from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.config.schema import MetaSchema
 from cloudinit.settings import PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
@@ -52,60 +51,12 @@ REPOSITORIES_TEMPLATE = """\
 
 """
 
-
-frequency = PER_INSTANCE
-distros = ["alpine"]
 meta: MetaSchema = {
     "id": "cc_apk_configure",
-    "name": "APK Configure",
-    "title": "Configure apk repositories file",
-    "description": dedent(
-        """\
-        This module handles configuration of the /etc/apk/repositories file.
-
-        .. note::
-          To ensure that apk configuration is valid yaml, any strings
-          containing special characters, especially ``:`` should be quoted.
-    """
-    ),
-    "distros": distros,
-    "examples": [
-        dedent(
-            """\
-        # Keep the existing /etc/apk/repositories file unaltered.
-        apk_repos:
-            preserve_repositories: true
-        """
-        ),
-        dedent(
-            """\
-        # Create repositories file for Alpine v3.12 main and community
-        # using default mirror site.
-        apk_repos:
-            alpine_repo:
-                community_enabled: true
-                version: 'v3.12'
-        """
-        ),
-        dedent(
-            """\
-        # Create repositories file for Alpine Edge main, community, and
-        # testing using a specified mirror site and also a local repo.
-        apk_repos:
-            alpine_repo:
-                base_url: 'https://some-alpine-mirror/alpine'
-                community_enabled: true
-                testing_enabled: true
-                version: 'edge'
-            local_repo_base_url: 'https://my-local-server/local-alpine'
-        """
-        ),
-    ],
-    "frequency": frequency,
+    "distros": ["alpine"],
+    "frequency": PER_INSTANCE,
     "activate_by_schema_keys": ["apk_repos"],
-}
-
-__doc__ = get_meta_doc(meta)
+}  # type: ignore
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:

--- a/cloudinit/config/cc_apt_pipelining.py
+++ b/cloudinit/config/cc_apt_pipelining.py
@@ -7,18 +7,15 @@
 """Apt Pipelining: configure apt pipelining."""
 
 import logging
-from textwrap import dedent
 
 from cloudinit import util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
-from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.config.schema import MetaSchema
 from cloudinit.settings import PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
-frequency = PER_INSTANCE
-distros = ["ubuntu", "debian"]
 DEFAULT_FILE = "/etc/apt/apt.conf.d/90cloud-init-pipelining"
 APT_PIPE_TPL = (
     "//Written by cloud-init per 'apt_pipelining'\n"
@@ -31,32 +28,10 @@ APT_PIPE_TPL = (
 
 meta: MetaSchema = {
     "id": "cc_apt_pipelining",
-    "name": "Apt Pipelining",
-    "title": "Configure apt pipelining",
-    "description": dedent(
-        """\
-        This module configures apt's ``Acquire::http::Pipeline-Depth`` option,
-        which controls how apt handles HTTP pipelining. It may be useful for
-        pipelining to be disabled, because some web servers, such as S3 do not
-        pipeline properly (LP: #948461).
-
-        Value configuration options for this module are:
-
-        * ``os``: (Default) use distro default
-        * ``false`` disable pipelining altogether
-        * ``<number>``: Manually specify pipeline depth. This is not recommended."""  # noqa: E501
-    ),
-    "distros": distros,
-    "frequency": frequency,
-    "examples": [
-        "apt_pipelining: false",
-        "apt_pipelining: os",
-        "apt_pipelining: 3",
-    ],
+    "distros": ["ubuntu", "debian"],
+    "frequency": PER_INSTANCE,
     "activate_by_schema_keys": ["apt_pipelining"],
-}
-
-__doc__ = get_meta_doc(meta)
+}  # type: ignore
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:

--- a/cloudinit/config/cc_bootcmd.py
+++ b/cloudinit/config/cc_bootcmd.py
@@ -10,58 +10,24 @@
 """Bootcmd: run arbitrary commands early in the boot process."""
 
 import logging
-from textwrap import dedent
 
 from cloudinit import subp, temp_utils, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
-from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.config.schema import MetaSchema
 from cloudinit.settings import PER_ALWAYS
 
 LOG = logging.getLogger(__name__)
 
 frequency = PER_ALWAYS
 
-distros = ["all"]
 
 meta: MetaSchema = {
     "id": "cc_bootcmd",
-    "name": "Bootcmd",
-    "title": "Run arbitrary commands early in the boot process",
-    "description": dedent(
-        """\
-        This module runs arbitrary commands very early in the boot process,
-        only slightly after a boothook would run. This is very similar to a
-        boothook, but more user friendly. The environment variable
-        ``INSTANCE_ID`` will be set to the current instance id for all run
-        commands. Commands can be specified either as lists or strings. For
-        invocation details, see ``runcmd``.
-
-        .. note::
-            bootcmd should only be used for things that could not be done later
-            in the boot process.
-
-        .. note::
-
-          when writing files, do not use /tmp dir as it races with
-          systemd-tmpfiles-clean LP: #1707222. Use /run/somedir instead.
-    """
-    ),
-    "distros": distros,
-    "examples": [
-        dedent(
-            """\
-        bootcmd:
-            - echo 192.168.1.130 us.archive.ubuntu.com > /etc/hosts
-            - [ cloud-init-per, once, mymkfs, mkfs, /dev/vdb ]
-    """
-        )
-    ],
+    "distros": ["all"],
     "frequency": PER_ALWAYS,
     "activate_by_schema_keys": ["bootcmd"],
-}
-
-__doc__ = get_meta_doc(meta)
+}  # type: ignore
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:

--- a/cloudinit/config/cc_byobu.py
+++ b/cloudinit/config/cc_byobu.py
@@ -13,46 +13,18 @@ import logging
 from cloudinit import subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
-from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.config.schema import MetaSchema
 from cloudinit.distros import ug_util
 from cloudinit.settings import PER_INSTANCE
-
-MODULE_DESCRIPTION = """\
-This module controls whether byobu is enabled or disabled system wide and for
-the default system user. If byobu is to be enabled, this module will ensure it
-is installed. Likewise, if it is to be disabled, it will be removed if
-installed.
-
-Valid configuration options for this module are:
-
-  - ``enable-system``: enable byobu system wide
-  - ``enable-user``: enable byobu for the default user
-  - ``disable-system``: disable byobu system wide
-  - ``disable-user``: disable byobu for the default user
-  - ``enable``: enable byobu both system wide and for default user
-  - ``disable``: disable byobu for all users
-  - ``user``: alias for ``enable-user``
-  - ``system``: alias for ``enable-system``
-"""
-distros = ["ubuntu", "debian"]
 
 LOG = logging.getLogger(__name__)
 
 meta: MetaSchema = {
     "id": "cc_byobu",
-    "name": "Byobu",
-    "title": "Enable/disable byobu system wide and for default user",
-    "description": MODULE_DESCRIPTION,
-    "distros": distros,
+    "distros": ["ubuntu", "debian"],
     "frequency": PER_INSTANCE,
-    "examples": [
-        "byobu_by_default: enable-user",
-        "byobu_by_default: disable-system",
-    ],
     "activate_by_schema_keys": [],
-}
-
-__doc__ = get_meta_doc(meta)
+}  # type: ignore
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -1,6 +1,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 """schema.py: Set of module functions for processing cloud-config schema."""
 import argparse
+import glob
 import json
 import logging
 import os
@@ -40,6 +41,7 @@ from cloudinit.util import (
     error,
     get_modules_from_dir,
     load_text_file,
+    load_yaml,
     write_file,
 )
 
@@ -1459,6 +1461,8 @@ def _get_property_doc(schema: dict, defs: dict, prefix="   ") -> str:
 
 def _get_examples(meta: MetaSchema) -> str:
     """Return restructured text describing the meta examples if present."""
+    paths = read_cfg_paths()
+    module_docs_dir = os.path.join(paths.docs_dir, "module-docs")
     examples = meta.get("examples")
     if not examples:
         return ""
@@ -1467,6 +1471,15 @@ def _get_examples(meta: MetaSchema) -> str:
         rst_content += SCHEMA_EXAMPLES_SPACER_TEMPLATE.format(
             example_count=count
         )
+        # FIXME(no conditional needed when all modules in module-doc.yaml)
+        if isinstance(example, dict):
+            if example["comment"]:
+                comment = f"# {example['comment']}\n"
+            else:
+                comment = ""
+            example = comment + load_text_file(
+                os.path.join(module_docs_dir, example["file"])
+            )
         indented_lines = textwrap.indent(example, "   ").split("\n")
         rst_content += "\n".join(indented_lines)
     return rst_content
@@ -1576,19 +1589,36 @@ def load_doc(requested_modules: list) -> str:
             ),
             sys_exit=True,
         )
-    for mod_name in all_modules:
+    module_docs = get_module_docs()
+    schema = get_schema()
+    for mod_name in sorted(all_modules):
         if "all" in requested_modules or mod_name in requested_modules:
             (mod_locs, _) = importer.find_module(
                 mod_name, ["cloudinit.config"], ["meta"]
             )
             if mod_locs:
                 mod = importer.import_module(mod_locs[0])
-                docs += mod.__doc__ or ""
+                if module_docs.get(mod.meta["id"]):
+                    # Include docs only when module id is in module_docs
+                    mod.meta.update(module_docs.get(mod.meta["id"], {}))
+                    docs += get_meta_doc(mod.meta, schema) or ""
+                else:
+                    docs += mod.__doc__ or ""
     return docs
 
 
 def get_schema_dir() -> str:
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas")
+
+
+def get_module_docs() -> dict:
+    """Return a dict keyed on cc_<mod_name> with documentation info"""
+    paths = read_cfg_paths()
+    mod_docs = {}
+    module_docs_dir = os.path.join(paths.docs_dir, "module-docs")
+    for mod_doc in glob.glob(f"{module_docs_dir}/*/data.yaml"):
+        mod_docs.update(load_yaml(load_text_file(mod_doc)))
+    return mod_docs
 
 
 def get_schema(schema_type: SchemaType = SchemaType.CLOUD_CONFIG) -> dict:

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -649,7 +649,7 @@
                 "distro",
                 "pip"
               ],
-              "description": "The type of installation for ansible. It can be one of the following values:\n\n - ``distro``\n - ``pip``"
+              "description": "The type of installation for ansible. It can be one of the following values:\n-  ``distro``\n-  ``pip``"
             },
             "run_user": {
               "type": "string",
@@ -685,6 +685,7 @@
                 "run_ansible": {
                   "type": "array",
                   "items": {
+                    "type": "object",
                     "properties": {
                       "playbook_name": {
                         "type": "string"

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -897,7 +897,7 @@
             "preserve_repositories": {
               "type": "boolean",
               "default": false,
-              "description": "By default, cloud-init will generate a new repositories file ``/etc/apk/repositories`` based on any valid configuration settings specified within a apk_repos section of cloud config. To disable this behavior and preserve the repositories file from the pristine image, set ``preserve_repositories`` to ``true``.\n\n The ``preserve_repositories`` option overrides all other config keys that would alter ``/etc/apk/repositories``."
+              "description": "By default, cloud-init will generate a new repositories file ``/etc/apk/repositories`` based on any valid configuration settings specified within a apk_repos section of cloud config. To disable this behavior and preserve the repositories file from the pristine image, set ``preserve_repositories`` to ``true``.\nThe ``preserve_repositories`` option overrides all other config keys that would alter ``/etc/apk/repositories``."
             },
             "alpine_repo": {
               "type": [

--- a/cloudinit/helpers.py
+++ b/cloudinit/helpers.py
@@ -307,6 +307,9 @@ class Paths(persistence.CloudInitPickleMixin):
         self.cfgs = path_cfgs
         # Populate all the initial paths
         self.cloud_dir: str = path_cfgs.get("cloud_dir", "/var/lib/cloud")
+        self.docs_dir: str = path_cfgs.get(
+            "docs_dir", "/usr/share/doc/cloud-init/"
+        )
         self.run_dir: str = path_cfgs.get("run_dir", settings.DEFAULT_RUN_DIR)
         self.instance_link: str = os.path.join(self.cloud_dir, "instance")
         self.boot_finished: str = os.path.join(

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -59,6 +59,7 @@ CFG_BUILTIN = {
     "system_info": {
         "paths": {
             "cloud_dir": "/var/lib/cloud",
+            "docs_dir": "/usr/share/doc/cloud-init/",
             "templates_dir": "/etc/cloud/templates/",
         },
         "distro": "ubuntu",

--- a/conftest.py
+++ b/conftest.py
@@ -205,6 +205,7 @@ def paths(tmpdir):
     """
     dirs = {
         "cloud_dir": tmpdir.mkdir("cloud_dir").strpath,
+        "docs_dir": tmpdir.mkdir("docs_dir").strpath,
         "run_dir": tmpdir.mkdir("run_dir").strpath,
     }
     return helpers.Paths(dirs)

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -8,4 +8,5 @@ sphinx==7.1.2
 sphinx-design
 sphinx-copybutton
 sphinx-notfound-page
+sphinxcontrib.datatemplates
 sphinxcontrib-spelling

--- a/doc/module-docs/cc_ansible/data.yaml
+++ b/doc/module-docs/cc_ansible/data.yaml
@@ -1,0 +1,17 @@
+cc_ansible:
+  name: Ansible
+  title: Configure ansible for instance
+  description:
+     This module provides ``ansible`` integration for
+     augmenting cloud-init's configuration of the local
+     node.
+
+
+     This module installs ansible during boot and
+     then uses ``ansible-pull`` to run the playbook
+     repository at the remote URL.
+  examples:
+  - comment: ""
+    file: cc_ansible/example1.yaml
+  - comment: ""
+    file: cc_ansible/example2.yaml

--- a/doc/module-docs/cc_ansible/example1.yaml
+++ b/doc/module-docs/cc_ansible/example1.yaml
@@ -1,0 +1,7 @@
+#cloud-config
+ansible:
+  package_name: ansible-core
+  install_method: distro
+  pull:
+    url: https://github.com/holmanb/vmboot.git
+    playbook_name: ubuntu.yml

--- a/doc/module-docs/cc_ansible/example2.yaml
+++ b/doc/module-docs/cc_ansible/example2.yaml
@@ -1,0 +1,7 @@
+#cloud-config
+ansible:
+  package_name: ansible-core
+  install_method: pip
+  pull:
+    url: https://github.com/holmanb/vmboot.git
+    playbook_name: ubuntu.yml

--- a/doc/module-docs/cc_apk_configure/data.yaml
+++ b/doc/module-docs/cc_apk_configure/data.yaml
@@ -1,0 +1,16 @@
+cc_apk_configure:
+  name: APK Configure
+  title: Configure apk repositories file
+  description: |
+     This module handles configuration of the /etc/apk/repositories file.
+
+     .. note::
+       To ensure that apk configuration is valid yaml, any strings
+       containing special characters, especially ``:`` should be quoted.
+  examples:
+  - comment: Keep the existing /etc/apk/repositories file unaltered.
+    file: cc_apk_configure/example1.yaml
+  - comment: Create repositories file for Alpine v3.12 main and community using default mirror site.
+    file: cc_apk_configure/example2.yaml
+  - comment: Create repositories file for Alpine Edge main, community, and testing using a specified mirror site and also a local repo.
+    file: cc_apk_configure/example3.yaml

--- a/doc/module-docs/cc_apk_configure/example1.yaml
+++ b/doc/module-docs/cc_apk_configure/example1.yaml
@@ -1,0 +1,3 @@
+#cloud-config
+apk_repos:
+  preserve_repositories: true

--- a/doc/module-docs/cc_apk_configure/example2.yaml
+++ b/doc/module-docs/cc_apk_configure/example2.yaml
@@ -1,0 +1,5 @@
+#cloud-config
+apk_repos:
+  alpine_repo:
+    community_enabled: true
+    version: 'v3.12'

--- a/doc/module-docs/cc_apk_configure/example3.yaml
+++ b/doc/module-docs/cc_apk_configure/example3.yaml
@@ -1,0 +1,8 @@
+#cloud-config
+apk_repos:
+  alpine_repo:
+    base_url: https://some-alpine-mirror/alpine
+    community_enabled: true
+    testing_enabled: true
+    version: edge
+  local_repo_base_url: https://my-local-server/local-alpine

--- a/doc/module-docs/cc_apt_pipelining/data.yaml
+++ b/doc/module-docs/cc_apt_pipelining/data.yaml
@@ -1,0 +1,21 @@
+cc_apt_pipelining:
+  name: Apt Pipelining
+  title: Configure apt pipelining
+  description: |
+     This module configures apt's ``Acquite::http::Pipeline-Depth`` option,
+     which controls how apt handles HTTP pipelining. It may be useful for
+     pipelining to be disabled, because some web servers, such as S3 do not
+     pipeline properly (LP: #948461).
+
+     Value configuration options for this module are:
+
+     * ``os``: (Default) use distro default
+     * ``false`` disable pipelining altogether
+     * ``<number>``: Manually specify pipeline depth. This is not recommended.
+  examples:
+  - comment: ""
+    file: cc_apt_pipelining/example1.yaml
+  - comment: ""
+    file: cc_apt_pipelining/example2.yaml
+  - comment: ""
+    file: cc_apt_pipelining/example3.yaml

--- a/doc/module-docs/cc_apt_pipelining/example1.yaml
+++ b/doc/module-docs/cc_apt_pipelining/example1.yaml
@@ -1,0 +1,2 @@
+#cloud-config
+apt_pipelining: false

--- a/doc/module-docs/cc_apt_pipelining/example2.yaml
+++ b/doc/module-docs/cc_apt_pipelining/example2.yaml
@@ -1,0 +1,2 @@
+#cloud-config
+apt_pipelining: os

--- a/doc/module-docs/cc_apt_pipelining/example3.yaml
+++ b/doc/module-docs/cc_apt_pipelining/example3.yaml
@@ -1,0 +1,2 @@
+#cloud-config
+apt_pipelining: 3

--- a/doc/module-docs/cc_bootcmd/data.yaml
+++ b/doc/module-docs/cc_bootcmd/data.yaml
@@ -1,0 +1,23 @@
+cc_bootcmd:
+  name: Bootcmd
+  title: Run arbitrary commands early in the boot process
+  description: |
+    This module runs arbitrary commands very early in the boot process,
+    only slightly after a boothook would run. This is very similar to a
+    boothook, but more user friendly. The environment variable
+    ``INSTANCE_ID`` will be set to the current instance id for all run
+    commands. Commands can be specified either as lists or strings. For
+    invocation details, see ``runcmd``.
+
+    .. note::
+
+        bootcmd should only be used for things that could not be done later
+        in the boot process.
+
+    .. note::
+
+       when writing files, do not use /tmp dir as it races with
+       systemd-tmpfiles-clean LP: #1707222. Use /run/somedir instead.
+  examples:
+  - comment: ""
+    file: cc_bootcmd/example1.yaml

--- a/doc/module-docs/cc_bootcmd/example1.yaml
+++ b/doc/module-docs/cc_bootcmd/example1.yaml
@@ -1,0 +1,4 @@
+#cloud-config
+bootcmd:
+- echo 192.168.1.130 us.archive.ubuntu.com > /etc/hosts
+- [ cloud-init-per, once, mymkfs, mkfs, /dev/vdb ]

--- a/doc/module-docs/cc_byobu/data.yaml
+++ b/doc/module-docs/cc_byobu/data.yaml
@@ -1,0 +1,24 @@
+cc_byobu:
+  name: Byobu
+  title: Enable/disable byobu system wide and for default user
+  description: |
+    This module controls whether byobu is enabled or disabled system wide and
+    for the default system user. If byobu is to be enabled, this module wil
+    ensure it is installed. Likewise, if it is to be disabled, it will be
+    removed if installed.
+
+    Valid configuration options for this module are:
+
+    - ``enable-system``: enable byobu system wide
+    - ``enable-user``: enable byobu for the default user
+    - ``disable-system``: disable byobu system wide
+    - ``disable-user``: disable byobu for the default user
+    - ``enable``: enable byobu both system wide and for default user
+    - ``disable``: disable byobu for all users
+    - ``user``: alias for ``enable-user``
+    - ``system``: alias for ``enable-system``
+  examples:
+  - comment: ""
+    file: cc_byobu/example1.yaml
+  - comment: ""
+    file: cc_byobu/example2.yaml

--- a/doc/module-docs/cc_byobu/example1.yaml
+++ b/doc/module-docs/cc_byobu/example1.yaml
@@ -1,0 +1,2 @@
+#cloud-config
+byobu_by_default: enable-user

--- a/doc/module-docs/cc_byobu/example2.yaml
+++ b/doc/module-docs/cc_byobu/example2.yaml
@@ -1,0 +1,2 @@
+#cloud-config
+byobu_by_default: disable-system

--- a/doc/rtd/reference/modules.rst
+++ b/doc/rtd/reference/modules.rst
@@ -26,7 +26,8 @@ date. A 5 year timeline may also be expected for changed keys.
    :template: modules.tmpl
 .. datatemplate:yaml:: ../../module-docs/cc_bootcmd/data.yaml
    :template: modules.tmpl
-.. automodule:: cloudinit.config.cc_byobu
+.. datatemplate:yaml:: ../../module-docs/cc_byobu/data.yaml
+   :template: modules.tmpl
 .. automodule:: cloudinit.config.cc_ca_certs
 .. automodule:: cloudinit.config.cc_chef
 .. automodule:: cloudinit.config.cc_disable_ec2_metadata

--- a/doc/rtd/reference/modules.rst
+++ b/doc/rtd/reference/modules.rst
@@ -19,11 +19,11 @@ date. A 5 year timeline may also be expected for changed keys.
 
 .. datatemplate:yaml:: ../../module-docs/cc_ansible/data.yaml
    :template: modules.tmpl
-
-
-.. automodule:: cloudinit.config.cc_apk_configure
+.. datatemplate:yaml:: ../../module-docs/cc_apk_configure/data.yaml
+   :template: modules.tmpl
 .. automodule:: cloudinit.config.cc_apt_configure
-.. automodule:: cloudinit.config.cc_apt_pipelining
+.. datatemplate:yaml:: ../../module-docs/cc_apt_pipelining/data.yaml
+   :template: modules.tmpl
 .. automodule:: cloudinit.config.cc_bootcmd
 .. automodule:: cloudinit.config.cc_byobu
 .. automodule:: cloudinit.config.cc_ca_certs

--- a/doc/rtd/reference/modules.rst
+++ b/doc/rtd/reference/modules.rst
@@ -24,7 +24,8 @@ date. A 5 year timeline may also be expected for changed keys.
 .. automodule:: cloudinit.config.cc_apt_configure
 .. datatemplate:yaml:: ../../module-docs/cc_apt_pipelining/data.yaml
    :template: modules.tmpl
-.. automodule:: cloudinit.config.cc_bootcmd
+.. datatemplate:yaml:: ../../module-docs/cc_bootcmd/data.yaml
+   :template: modules.tmpl
 .. automodule:: cloudinit.config.cc_byobu
 .. automodule:: cloudinit.config.cc_ca_certs
 .. automodule:: cloudinit.config.cc_chef

--- a/doc/rtd/reference/modules.rst
+++ b/doc/rtd/reference/modules.rst
@@ -17,7 +17,10 @@ deprecated keys may cause warnings in the logs. In the case that a
 key's expected value changes, the key will be marked ``changed`` with a
 date. A 5 year timeline may also be expected for changed keys.
 
-.. automodule:: cloudinit.config.cc_ansible
+.. datatemplate:yaml:: ../../module-docs/cc_ansible/data.yaml
+   :template: modules.tmpl
+
+
 .. automodule:: cloudinit.config.cc_apk_configure
 .. automodule:: cloudinit.config.cc_apt_configure
 .. automodule:: cloudinit.config.cc_apt_pipelining

--- a/doc/rtd/templates/module_property.tmpl
+++ b/doc/rtd/templates/module_property.tmpl
@@ -1,0 +1,12 @@
+{% macro print_prop(name, types, description, prefix) -%}
+{% set descr_suffix = description.splitlines()[0]|d('') -%}
+{% set descr_lines = description.splitlines()[1:]|d([]) -%}
+{{prefix}}* **{{name}}:** ({{types}}){{ descr_suffix }}
+{% for line in descr_lines -%}
+{{prefix ~ '  '}}{{ line }}
+{% endfor -%}
+{%- endmacro -%}
+{% if prop_cfg.get('items', {}).get('type') == 'object' %}
+{% set description = description ~ " Each object in **" ~ name ~ "** list supports the following keys:" %}
+{% endif %}
+{{ print_prop(name, types, description, prefix ) }}

--- a/doc/rtd/templates/modules.tmpl
+++ b/doc/rtd/templates/modules.tmpl
@@ -1,0 +1,46 @@
+.. -*- mode: rst -*-
+{% for mod_id, mod_cfg in data.items() %}
+{% set mod_meta = config.html_context[mod_id]['meta'] -%}
+{{ mod_cfg['name'] }}{% set name_len = mod_cfg['name']|length %}
+{{ '~' * name_len }}
+
+{{ mod_cfg['title'] }}
+
+.. tab-set::
+
+   .. tab-item:: Summary
+
+{% for line in mod_cfg['description'].splitlines() %}
+      {{ line -}}
+{% endfor %}
+
+      **Internal name:** ``{{ mod_id }}``
+
+      **Module frequency:** {{ mod_meta['frequency'] }}
+
+      **Supported distros:** {{ mod_meta['distros']|join(', ') }}
+
+{% if mod_meta['activate_by_schema_keys'] %}
+      **Activate only on keys:** ``{{ mod_meta['activate_by_schema_keys']|join('``, ``') }}``
+
+{% endif %}
+   .. tab-item:: Config schema
+
+{% for line2 in config.html_context[mod_id]['schema_doc'].splitlines() %}
+      {{ line2 }}
+{% endfor %}
+
+   .. tab-item:: Examples
+
+   {% for example in mod_cfg['examples'] %}
+      {% for line in example["comment"].splitlines() %}
+      {{ line }}
+      {% endfor %}
+
+      .. literalinclude:: ../../module-docs/{{ example["file"] }}
+          :language: yaml
+
+   {% endfor %}
+
+
+{% endfor %}

--- a/setup.py
+++ b/setup.py
@@ -301,6 +301,10 @@ data_files = [
         USR + "/share/doc/cloud-init/examples/seed",
         [f for f in glob("doc/examples/seed/*") if is_f(f)],
     ),
+    (
+        USR + "/share/doc/cloud-init/module-docs",
+        [f for f in glob("doc/module-docs/*", recursive=True) if is_f(f)],
+    ),
 ]
 if not platform.system().endswith("BSD"):
     RULES_PATH = pkg_config_read("udev", "udevdir")

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -292,6 +292,10 @@ class _LxdIntegrationCloud(IntegrationCloud):
                 os.path.join(cloudinit_path, "..", "templates"),
                 "/etc/cloud/templates",
             ),
+            (
+                os.path.join(cloudinit_path, "..", "doc", "module-docs"),
+                "/usr/share/doc/cloud-init/module-docs",
+            ),
         ]
         for n, (source_path, target_path) in enumerate(mounts):
             format_variables = {

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -136,7 +136,9 @@ class TestCLI:
         """When running in init-local mode, status_wrapper honors cloud_dir."""
         cloud_dir = mock_status_wrapper.tmpdir.join("cloud")
         paths = helpers.Paths({"cloud_dir": str(cloud_dir)})
-        mocker.patch(M_PATH + "read_cfg_paths", return_value=paths)
+        mocker.patch(
+            "cloudinit.config.schema.read_cfg_paths", return_value=paths
+        )
         data_d = mock_status_wrapper.data_d
         link_d = mock_status_wrapper.link_d
 
@@ -368,7 +370,13 @@ class TestCLI:
     )
     @mock.patch("cloudinit.stages.Init._read_cfg", return_value={})
     def test_wb_schema_subcommand(
-        self, m_read_cfg, args, expected_doc_sections, is_error
+        self,
+        m_read_cfg,
+        args,
+        expected_doc_sections,
+        is_error,
+        mocker,
+        request,
     ):
         """Validate that doc content has correct values."""
 
@@ -381,6 +389,12 @@ class TestCLI:
             contextlib.redirect_stderr
             if is_error
             else contextlib.redirect_stdout
+        )
+        paths = helpers.Paths(
+            {"docs_dir": os.path.join(request.config.rootdir, "doc")}
+        )
+        mocker.patch(
+            "cloudinit.config.schema.read_cfg_paths", return_value=paths
         )
         with redirecter(out_or_err):
             self._call_main(["cloud-init", "schema", "--docs"] + args)


### PR DESCRIPTION
## rebase individual commits

Primary functional commit with cc_ansible doc template migration followed by minor integration test helper and doc migrations of apt_configure/apt_pipelining, bootcmd and byobu. The intent and migration will be basically the same for every cc_ module once this lands. I expect 3 more branches of just cc_<module> refactors to templates, the thing to be wary of is that our json schema inline RST syntax doesn't get rendered with poor formatting in the generated docs, or disappear from output of the `cloud-init schema --docs cc_<mod_name>`

```
    feat(docs): generate rtd module schema from rtd/module-docs
    
    Add a new doc/rtd/templates and doc/module-docs directory for
    which use sphinxcontrib.datatemplates to render schema documentation
    instead of automodule documentation.
    
    The refactor allows moving doc-related keys out of each cc_* module's
    meta dictionary: examples, descripton, name and title.
    
    Move doc-related metadata keys into
    doc/module-docs/<module_id>/data.yaml and supporting examples into
    doc/module-docs/<module_id>/example*.yaml.
    
    This allows us to simplify cc_<module> documentation by allowing
    doc authors to manipulate either sphinx jinja templates, RST files or
    YAML example files instead of having to dedent and encode RST or MD
    markup in python "meta" dictionarties.
    
    To support doc generation for both readthedocs(sphinx) and cloud-init
    schema --docs command, schema.py grows a get_module_docs function to
    source the specific module-docs/*/data.yaml files for examples, names
    and titles.
```

The intent with this draft is to start a conversation about relocating RST templates out of `cloudinit.config.schema` and into official templates in doct/rtd/templates that could be more easily updated if we change skins.

This only sets up common logic for generating RTD docs and sharing the module-docs/*.yaml with `cloud-init schema --doc` command line. If we decide this is a reasonable approach, this branch will likely adapt a few cc_<modules> at a time to ease reviewing.

Benefits:
 - move docs into YAML data files so module developers don't have to encode RST in python dicts for examples/descriptions/titles etc
 - python cc_<module>s longer do work of load for setting `__doc__ = get_meta_doc()` on module load which reads cloud-config-schema.json

