### PR TITLE
test: Fix test_failing_userdata_modules_exit_codes

### DIFF
--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -117,8 +117,18 @@ def test_invalid_userdata_schema(client: IntegrationInstance):
 
 @pytest.mark.user_data(FAILING_USER_DATA)
 def test_failing_userdata_modules_exit_codes(client: IntegrationInstance):
-    """Test failing in modules representd in exit status"""
+    """Test failing in modules representd in exit status.
+
+    To ensure we don't miss any errors or warnings if a service happens
+    to be restarted, any further module invocations will exit with error
+    on the same boot if a previous invocation exited with error.
+
+    In this test, both bootcmd and runcmd will exit with error the first time.
+    The second time, runcmd will run cleanly, but still exit with error.
+    Since bootcmd runs in init timeframe, and runcmd runs in final timeframe,
+    expect error from those two modes.
+    """
     for mode in ("init", "config", "final"):
         result = client.execute(f"cloud-init modules --mode {mode}")
-        assert result.failed if mode == "init" else result.ok
+        assert result.ok if mode == "config" else result.failed
         assert f"'modules:{mode}'" in result.stdout.strip()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Fix test_failing_userdata_modules_exit_codes

In f24ecef8b, we persist error state across mode invocations during
the same boot. Fix the integration testing accordingly.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
