### PR TITLE
fix(freebsd): correct configuration of IPv6 routes

### DIFF
--- a/cloudinit/net/bsd.py
+++ b/cloudinit/net/bsd.py
@@ -18,6 +18,7 @@ class BSDRenderer(renderer.Renderer):
     rc_conf_fn = "etc/rc.conf"
     interface_routes = ""
     route_names = ""
+    route6_names = ""
 
     def get_rc_config_value(self, key):
         fn = subp.target_path(self.target, self.rc_conf_fn)

--- a/cloudinit/net/freebsd.py
+++ b/cloudinit/net/freebsd.py
@@ -76,10 +76,20 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
             self.set_rc_config_value("ipv6_defaultrouter", gateway)
         else:
             route_name = f"net{self._route_cpt}"
-            route_cmd = f"-net {network} -netmask {netmask} {gateway}"
-            self.set_rc_config_value("route_" + route_name, route_cmd)
-            self.route_names = f"{self.route_names} {route_name}"
-            self.set_rc_config_value("static_routes", self.route_names.strip())
+            if ":" in network:
+                route_cmd = f"-net {network}/{netmask} {gateway}"
+                self.set_rc_config_value("ipv6_route_" + route_name, route_cmd)
+                self.route6_names = f"{self.route6_names} {route_name}"
+                self.set_rc_config_value(
+                    "ipv6_static_routes", self.route6_names.strip()
+                )
+            else:
+                route_cmd = f"-net {network} -netmask {netmask} {gateway}"
+                self.set_rc_config_value("route_" + route_name, route_cmd)
+                self.route_names = f"{self.route_names} {route_name}"
+                self.set_rc_config_value(
+                    "static_routes", self.route_names.strip()
+                )
             self._route_cpt += 1
 
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -64,6 +64,7 @@ eslerm
 esposem
 fionn
 frantisekz
+frikilax
 GabrielNagy
 garzdin
 giggsoff


### PR DESCRIPTION
## Proposed Commit Message
```
fix(freebsd): correct configuration of IPv6 routes

the generation of IPv6 routes on FreeBSD were not correct.
This commit keeps the generation of IPv4 routes as they were, but introduces a change to parameter names and separate handling of IPv6 routes
```

## Additional Context
This only impacts **Networking Config v1** on **FreeBSD**, and nothing was changed regarding other *BSD distros.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
