### PR TITLE
fix(grub_dpkg): Don't set grub install target by default

### DIFF
--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -21,9 +21,9 @@ from cloudinit.subp import ProcessExecutionError
 
 MODULE_DESCRIPTION = """\
 Configure which device is used as the target for grub installation. This module
-can be enabled/disabled using the ``enabled`` config key in the ``grub_dpkg``
-config dict. This module automatically selects a disk using ``grub-probe`` if
-no installation device is specified.
+can be enabled using the ``enabled`` config key in the ``grub_dpkg``
+config dict. This module selects a disk with ``grub-probe`` if no installation
+device is specified.
 
 The value which is placed into the debconf database is in the format which the
 grub postinstall script expects. Normally, this is a /dev/disk/by-id/ value,
@@ -53,7 +53,7 @@ meta: MetaSchema = {
             """
         )
     ],
-    "activate_by_schema_keys": [],
+    "activate_by_schema_keys": ["grub_dpkg", "grub-dpkg"],
 }
 
 __doc__ = get_meta_doc(meta)
@@ -145,7 +145,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if not mycfg:
         mycfg = {}
 
-    enabled = mycfg.get("enabled", True)
+    enabled = mycfg.get("enabled", False)
     if util.is_false(enabled):
         LOG.debug("%s disabled by config grub_dpkg/enabled=%s", name, enabled)
         return

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1541,8 +1541,8 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Whether to configure which device is used as the target for grub installation. Default: ``true``"
+              "default": false,
+              "description": "Whether to configure which device is used as the target for grub installation. Default: ``false``"
             },
             "grub-pc/install_devices": {
               "type": "string",

--- a/tests/unittests/config/test_cc_grub_dpkg.py
+++ b/tests/unittests/config/test_cc_grub_dpkg.py
@@ -247,7 +247,7 @@ class TestHandle:
         """Test setting of correct debconf database entries"""
         m_is_efi_booted.return_value = is_uefi
         m_fetch_idevs.return_value = fetch_idevs_output
-        cfg = {"grub_dpkg": {}}
+        cfg = {"grub_dpkg": {"enabled": True}}
         if cfg_idevs is not None:
             cfg["grub_dpkg"]["grub-pc/install_devices"] = cfg_idevs
         if cfg_idevs_empty is not None:


### PR DESCRIPTION
```
fix(grub_dpkg): Don't set grub install target by default

This is no longer the best default behavior for all use cases.
Since some users may be use this we want to keep this feature
available by opt-in.

Reasons:
- This is no longer required by default.
- This has broken some cloud users.
- This behavior can be slow.

Related to LP: #2054103

BREAKING_CHANGE: Change the default value for grub_dpkg.enabled to False.
```
Note: The impetus of this PR was correctness, but a side-effect is performance. This module sometimes takes absurd amounts of time to run, a recently launched Noble image took ~5s run this module (which is not uncommon). See the logs below.
```
2024-06-07 17:41:31,205 - modules.py[DEBUG]: Running module grub_dpkg (<module 'cloudinit.config.cc_grub_d
pkg' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_grub_dpkg.py'>) with frequency once-per-inst
ance
2024-06-07 17:41:31,205 - handlers.py[DEBUG]: start: modules-config/config-grub_dpkg: running config-grub_
dpkg with frequency once-per-instance
2024-06-07 17:41:31,205 - util.py[DEBUG]: Writing to /var/lib/cloud/instances/6638723470694742222/sem/config_grub_dpkg - wb: [644] 24 bytes
2024-06-07 17:41:31,206 - helpers.py[DEBUG]: Running config-grub_dpkg using lock (<FileLock using file '/var/lib/cloud/instances/6638723470694742222/sem/config_grub_dpkg'>)
2024-06-07 17:41:31,206 - subp.py[DEBUG]: Running command ['grub-probe', '-t', 'device', '/boot/efi'] with allowed return codes [0] (shell=False, capture=True)
2024-06-07 17:41:31,611 - subp.py[DEBUG]: command ['grub-probe', '-t', 'device', '/boot/efi'] took 0.4s to run
2024-06-07 17:41:31,612 - subp.py[DEBUG]: Running command ['udevadm', 'info', '--root', '--query=symlink', '/dev/sda15'] with allowed return codes [0] (shell=False, capture=True)
2024-06-07 17:41:31,617 - cc_grub_dpkg.py[DEBUG]: considering these device symlinks: /dev/disk/by-id/google-persistent-disk-0-part15,/dev/disk/by-diskseq/9-part15,/dev/disk/by-id/scsi-0Google_PersistentDisk_persistent-disk-0-part15,/dev/disk/by-label/UEFI,/dev/disk/by-partuuid/6f30e8db-9171-4c49-8ced-4f63a2c18d35,/dev/disk/by-path/pci-0000:00:03.0-scsi-0:0:1:0-part15,/dev/disk/by-uuid/A3EC-8A73
2024-06-07 17:41:31,617 - cc_grub_dpkg.py[DEBUG]: filtered to these disk/by-id symlinks: /dev/disk/by-id/google-persistent-disk-0-part15,/dev/disk/by-id/scsi-0Google_PersistentDisk_persistent-disk-0-part15
2024-06-07 17:41:31,617 - cc_grub_dpkg.py[DEBUG]: selected /dev/disk/by-id/google-persistent-disk-0-part15
2024-06-07 17:41:31,617 - cc_grub_dpkg.py[DEBUG]: Setting grub debconf-set-selections with 'grub-pc grub-efi/install_devices string /dev/disk/by-id/google-persistent-disk-0-part15
'
2024-06-07 17:41:31,617 - subp.py[DEBUG]: Running command ['debconf-set-selections'] with allowed return codes [0] (shell=False, capture=True)
2024-06-07 17:41:35,929 - subp.py[DEBUG]: command ['debconf-set-selections'] took 4.3s to run
2024-06-07 17:41:35,930 - handlers.py[DEBUG]: finish: modules-config/config-grub_dpkg: SUCCESS: config-grub_dpkg ran successfully
```