### PR TITLE
Handle zero byte ssh key files

### DIFF
--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -264,9 +264,20 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
         for keytype in key_names:
             keyfile = KEY_FILE_TPL % (keytype)
-            if os.path.exists(keyfile):
+            if os.path.exists(keyfile) and os.path.getsize(keyfile) != 0:
+                # no need to generate keys if the keyfile exists and
+                # is not an empty file.
                 continue
             util.ensure_dir(os.path.dirname(keyfile))
+            if os.path.exists(keyfile) and os.path.getsize(keyfile) == 0:
+                # remove empty ssh key files.
+                try:
+                    util.del_file(keyfile)
+                except Exception:
+                    util.logexc(
+                        LOG, "Failed deleting empty key file %s", keyfile
+                    )
+
             cmd = ["ssh-keygen", "-t", keytype, "-N", "", "-f", keyfile]
 
             # TODO(harlowja): Is this guard needed?


### PR DESCRIPTION

## Proposed Commit Message
Sometimes, due to file system corruption from a linux kernel crash or for some other reasons, the system may be left with zero byte ssh keyfiles. These zero byte files are of no use and generate errors like the following upon next reboot:
sshd[1454]: Unable to load host key: /etc/ssh/ssh_host_rsa_key sshd[1454]: Unable to load host key "/etc/ssh/ssh_host_ecdsa_key": invalid format

Therefore, we should check for the presence of zero-byte files and if found delete and regenerate the key files in order to recover from the error.

Fixes: GH-5305

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
