### PR TITLE
typos in documentation

### DIFF
--- a/doc/rtd/howto/rerun_cloud_init.rst
+++ b/doc/rtd/howto/rerun_cloud_init.rst
@@ -23,8 +23,8 @@ Remove the logs and cache, then reboot
 --------------------------------------
 
 This method will reboot the system as if cloud-init never ran. This
-command does not remove all cloud-init artefacts from previous runs of
-cloud-init, but it will clean enough artefacts to allow cloud-init to
+command does not remove all cloud-init artifacts from previous runs of
+cloud-init, but it will clean enough artifacts to allow cloud-init to
 think that it hasn't run yet. It will then re-run after a reboot.
 
 .. code-block:: shell-session

--- a/doc/rtd/howto/ubuntu_test_prerelease.rst
+++ b/doc/rtd/howto/ubuntu_test_prerelease.rst
@@ -49,7 +49,7 @@ Do this to avoid unintentionally installing other unreleased packages.
     rm -f /etc/apt/sources.list.d/proposed.list
     apt update
 
-Remove artefacts and reboot
+Remove artifacts and reboot
 ---------------------------
 
 This will cause cloud-init to rerun as if it is a first boot.


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
