### PR TITLE
fix(packaging):  drop unsupported ConditionEnvironment from cloud-init units on systemd < 246

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,9 @@ cloud-init (24.1.3-0ubuntu1~20.04.4) UNRELEASED; urgency=medium
   * d/cloud-init.logrotate: add logrotate config for cloud-init
   * d/cloud-init.templates: enable WSL datasource by default
   * d/control: remove netifaces
+  * d/p/drop-unsupported-systemd-condition-environment.patch
+    - Drop ConditionEnvironment from unit files because systemd 245.4 ignores
+      those keys and emits warnings at systemctl status
   * d/p/keep-dhclient-as-priority-client.patch
   * d/p/revert-551f560d-cloud-config-after-snap-seeding.patch
     - Retain systemd ordering cloud-config.service After=snapd.seeded.service

--- a/debian/patches/drop-unsupported-systemd-condition-environment.patch
+++ b/debian/patches/drop-unsupported-systemd-condition-environment.patch
@@ -1,0 +1,57 @@
+Description: Drop systemd ignored ConditionEnvironment keys from units on Focal
+ The systemd ConditionEnvironment config key was introduced in systemd
+ version 246, yet Ubuntu Focal contains only systemd v. 245.4. This setting
+ is otherwise ignored by systemd on Focal, but drop the config to avoid
+ warnings from systemctl status cloud-init.
+Origin: backport
+Author: Chad Smith <chad.smith@canonical.com>
+Last-Update: 2024-05-21
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/systemd/cloud-config.service.tmpl
++++ b/systemd/cloud-config.service.tmpl
+@@ -6,7 +6,6 @@
+ Wants=network-online.target cloud-config.target
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+-ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
+ 
+ [Service]
+ Type=oneshot
+--- a/systemd/cloud-final.service.tmpl
++++ b/systemd/cloud-final.service.tmpl
+@@ -9,7 +9,6 @@
+ Wants=network-online.target cloud-config.service
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+-ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
+ 
+ 
+ [Service]
+--- a/systemd/cloud-init-local.service.tmpl
++++ b/systemd/cloud-init-local.service.tmpl
+@@ -28,7 +28,6 @@
+ RequiresMountsFor=/var/lib/cloud
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+-ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
+ 
+ [Service]
+ Type=oneshot
+--- a/systemd/cloud-init.service.tmpl
++++ b/systemd/cloud-init.service.tmpl
+@@ -41,7 +41,6 @@
+ Before=systemd-user-sessions.service
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+-ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
+ 
+ [Service]
+ Type=oneshot
+--- a/systemd/cloud-init.target
++++ b/systemd/cloud-init.target
+@@ -12,4 +12,3 @@
+ After=multi-user.target
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+-ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -11,3 +11,4 @@ retain-apt-pre-deb822.patch
 status-retain-recoverable-error-exit-code.patch
 retain-ec2-default-net-update-events.patch
 cli-retain-file-argument-as-main-cmd-arg.patch
+drop-unsupported-systemd-condition-environment.patch


### PR DESCRIPTION
Focal's systemd 245.4 doesn't have support for ConditionEnvironment keys in units, it was introduced in systemd 246. Drop these keys from cloud-init units/targets to avoid warnings from systemctl status and journalctl about systemd ignoring those keys.

## rebase merge individual commits

### primary funtional commit
```
    fix(packaging): drop unsupported ConditionEnvironment keys from units
    
    Focal is based on systemd 245.5 which doesn't support
    ConditionEnvironment keys in Units. This feature was introduced in
    systemd 246. As a result, journalctl and systemctl status cloud-init
    will show warnings about systemd ignoring this key in various cloud-init
    units. Apply a quilt patch for focal-only which will drop this ignored
    key from our units/targets.
```

## Additional Context


## Test Steps
```
lxc launch ubuntu-daily/focal test-f 
lxc exec test-f -- cloud-init status --wait
# See warning messages from systemd about unsupported config keys 
lxc exex test-f -- journalctl -b 0 | grep ConditionEnvironment
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
