### PR TITLE
fix(azure): disable use-dns for secondary nics

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1965,6 +1965,9 @@ def generate_network_config_from_instance_network_metadata(
         # addresses.
         nicname = "eth{idx}".format(idx=idx)
         dhcp_override = {"route-metric": (idx + 1) * 100}
+        # DNS resolution through secondary NICs is not supported, disable it.
+        if idx > 0:
+            dhcp_override["use-dns"] = False
         dev_config: Dict[str, Any] = {
             "dhcp4": True,
             "dhcp4-overrides": dhcp_override,

--- a/tests/integration_tests/datasources/test_azure.py
+++ b/tests/integration_tests/datasources/test_azure.py
@@ -1,11 +1,14 @@
+import datetime
+
 import pytest
+from pycloudlib.azure.util import AzureCreateParams, AzureParams
 from pycloudlib.cloud import ImageType
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.conftest import get_validated_source
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.releases import CURRENT_RELEASE
+from tests.integration_tests.releases import BIONIC, CURRENT_RELEASE
 
 
 def _check_for_eject_errors(
@@ -45,3 +48,70 @@ def test_azure_eject(session_cloud: IntegrationCloud):
                 session_cloud.cloud_instance.delete_image(snapshot_id)
         else:
             _check_for_eject_errors(instance)
+
+
+def parse_resolvectl_dns(output: str) -> dict:
+    """Parses the output of 'resolvectl dns'.
+
+    >>> parse_resolvectl_dns(
+    ...    "Global:",
+    ...    "Link 2 (eth0): 168.63.129.16",
+    ...    "Link 3 (eth1): 168.63.129.16",
+    ... )
+    {'Global': '',
+     'Link 2 (eth0)': '168.63.129.16',
+     'Link 3 (eth1)': '168.63.129.16'}
+    """
+
+    parsed = dict()
+    for line in output.splitlines():
+        if line.isspace():
+            continue
+        splitted = line.split(":")
+        k = splitted.pop(0).strip()
+        v = splitted.pop(0).strip() if splitted else ""
+        parsed[k] = v
+    return parsed
+
+
+@pytest.mark.skipif(PLATFORM != "azure", reason="Test is Azure specific")
+@pytest.mark.skipif(
+    CURRENT_RELEASE < BIONIC, reason="Easier to test on Bionic+"
+)
+def test_azure_multi_nic_setup(
+    setup_image, session_cloud: IntegrationCloud
+) -> None:
+    """Integration test for https://warthogs.atlassian.net/browse/CPC-3999.
+
+    Azure should have the primary NIC only route to DNS.
+    Ensure other NICs do not have route to DNS.
+    """
+    us = datetime.datetime.now().strftime("%f")
+    rg_params = AzureParams(f"ci-test-multi-nic-setup-{us}", None)
+    nic_one = AzureCreateParams(f"ci-nic1-test-{us}", rg_params.name, None)
+    nic_two = AzureCreateParams(f"ci-nic2-test-{us}", rg_params.name, None)
+    with session_cloud.launch(
+        launch_kwargs={
+            "resource_group_params": rg_params,
+            "network_interfaces_params": [nic_one, nic_two],
+        }
+    ) as client:
+        _check_for_eject_errors(client)
+        if CURRENT_RELEASE == BIONIC:
+            ret = client.execute("systemd-resolve --status")
+            assert ret.ok, ret.stderr
+            assert ret.stdout.count("Current Scopes: DNS") == 1
+        else:
+            ret = client.execute("resolvectl dns")
+            assert ret.ok, ret.stderr
+            routes = parse_resolvectl_dns(ret.stdout)
+            routes_devices = list(routes.keys())
+            eth1_dev = [dev for dev in routes_devices if "(eth1)" in dev][0]
+            assert not routes[eth1_dev], (
+                f"Expected eth1 to not have routes to dns."
+                f" Found: {routes[eth1_dev]}"
+            )
+
+        # check the instance can resolve something
+        res = client.execute("resolvectl query google.com")
+        assert res.ok, res.stderr

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -742,14 +742,20 @@ class TestGenerateNetworkConfig:
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
                             "dhcp6": False,
                             "dhcp4": True,
-                            "dhcp4-overrides": {"route-metric": 200},
+                            "dhcp4-overrides": {
+                                "route-metric": 200,
+                                "use-dns": False,
+                            },
                         },
                         "eth2": {
                             "set-name": "eth2",
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
                             "dhcp6": False,
                             "dhcp4": True,
-                            "dhcp4-overrides": {"route-metric": 300},
+                            "dhcp4-overrides": {
+                                "route-metric": 300,
+                                "use-dns": False,
+                            },
                         },
                     },
                     "version": 2,
@@ -976,7 +982,7 @@ class TestNetworkConfig:
                     "dhcp6": False,
                     "match": {"macaddress": "00:0d:3a:04:75:98"},
                     "set-name": "eth0",
-                }
+                },
             },
             "version": 2,
         }
@@ -1557,7 +1563,7 @@ scbus-1 on xpt0 bus 0
                     "dhcp6": False,
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
-                }
+                },
             },
             "version": 2,
         }
@@ -1586,14 +1592,14 @@ scbus-1 on xpt0 bus 0
                     "match": {"macaddress": "22:0d:3a:04:75:98"},
                     "dhcp6": False,
                     "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 200},
+                    "dhcp4-overrides": {"route-metric": 200, "use-dns": False},
                 },
                 "eth2": {
                     "set-name": "eth2",
                     "match": {"macaddress": "33:0d:3a:04:75:98"},
                     "dhcp6": False,
                     "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 300},
+                    "dhcp4-overrides": {"route-metric": 300, "use-dns": False},
                 },
             },
             "version": 2,
@@ -1626,7 +1632,7 @@ scbus-1 on xpt0 bus 0
                     "dhcp6": False,
                     "dhcp4": True,
                     "dhcp4-overrides": {"route-metric": 100},
-                }
+                },
             },
             "version": 2,
         }


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(azure): disable use-dns for secondary nics

DNS resolution through secondary NICs is not supported on Azure. Disable
it.
    
Without this, we see seconds of delay resolving urls in cloud-init logs
from Jammy+, see SF ticket.
    
Per cjp256's comment, the first NIC under metadata.imds.network is ensured
to be the primary one. We use this to determine primary NICs instead of
relying on fragile driver and/or NIC names.
    
Fixes: SF #00380708
    
Co-authored-by: Calvin Mwadime <calvin.mwadime@canonical.com>
```

## Additional Context
<!-- If relevant -->
Supersedes https://github.com/canonical/cloud-init/pull/5180, see comments for more context.
Closes:
- https://warthogs.atlassian.net/browse/CPC-4224
- https://warthogs.atlassian.net/browse/CPC-3999
- https://bootstack.canonical.com/cases/00380708

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
make deb

export CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_all.deb
export CLOUD_INIT_PLATFORM=azure

tox -e integration-tests -- tests/integration_tests/datasources/test_azure.py::test_azure_multi_nic_setup
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
