### PR TITLE
fix: Check renderer for netplan-specific code

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -349,7 +349,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
         except activators.NoActivatorException:
             return None
 
-    def _get_renderer(self) -> Renderer:
+    @property
+    def network_renderer(self) -> Renderer:
         priority = util.get_cfg_by_path(
             self._cfg, ("network", "renderers"), None
         )
@@ -442,7 +443,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
         Returns True if any devices failed to come up, otherwise False.
         """
-        renderer = self._get_renderer()
+        renderer = self.network_renderer
         network_state = parse_net_config_data(netconfig, renderer=renderer)
         self._write_network_state(network_state, renderer)
 

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -21,7 +21,7 @@ from cloudinit import url_helper as uhelp
 from cloudinit import util, warnings
 from cloudinit.distros import Distro
 from cloudinit.event import EventScope, EventType
-from cloudinit.net import activators
+from cloudinit.net import netplan
 from cloudinit.net.dhcp import NoDHCPLeaseError
 from cloudinit.net.ephemeral import EphemeralIPNetwork
 from cloudinit.sources import NicOrder
@@ -1077,7 +1077,7 @@ def convert_ec2_metadata_network_config(
         netcfg["ethernets"][nic_name] = dev_config
         return netcfg
     # Apply network config for all nics and any secondary IPv4/v6 addresses
-    is_netplan = distro.network_activator == activators.NetplanActivator
+    is_netplan = distro.network_renderer == netplan.Renderer
     nic_order = _build_nic_order(
         macs_metadata, macs_to_nics, fallback_nic_order
     )

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -12,7 +12,7 @@ import requests
 import responses
 
 from cloudinit import helpers
-from cloudinit.net import activators
+from cloudinit.net import netplan
 from cloudinit.sources import DataSourceEc2 as ec2
 from cloudinit.sources import NicOrder
 from tests.unittests.helpers import example_netdev
@@ -1546,7 +1546,7 @@ class TestConvertEc2MetadataNetworkConfig:
             },
         }
         distro = mock.Mock()
-        distro.network_activator = activators.NetplanActivator
+        distro.network_renderer = netplan.Renderer
         distro.dhcp_client.dhcp_discovery.return_value = {
             "routers": "172.31.1.0"
         }
@@ -1620,7 +1620,7 @@ class TestConvertEc2MetadataNetworkConfig:
             },
         }
         distro = mock.Mock()
-        distro.network_activator = activators.NetplanActivator
+        distro.network_renderer = netplan.Renderer
         distro.dhcp_client.dhcp_discovery.return_value = {
             "routers": "172.31.1.0"
         }


### PR DESCRIPTION
Draft PR as this has not been tested in a real environment yet.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Check renderer for netplan-specific code

DataSourceEc2 has netplan-specific code that was gated by the
selected activator. However, in practice, the activators are rarely
used. Somebody may have selected a non-netplan renderer without
selecting the proper activator with it. Since this involves rendering
configuration, we should gate on the renderer instead.

Fixes GH-5318
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
