### PR TITLE
Update pylint version in order to support python 3.12

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -304,6 +304,10 @@ def create_swapfile(fname: str, size: str) -> None:
                 "bs=1M",
                 "count=%s" % size,
             ]
+        else:
+            raise subp.ProcessExecutionError(
+                "Missing dependency: 'dd' and 'fallocate' are not available"
+            )
 
         try:
             subp.subp(cmd, capture=True)

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -121,6 +121,8 @@ class BSD(distros.Distro):
             if not self.pkg_cmd_upgrade_prefix:
                 return
             cmd = self.pkg_cmd_upgrade_prefix
+        else:
+            cmd = []
 
         if args and isinstance(args, str):
             cmd.append(args)

--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -12,7 +12,7 @@ import cloudinit.distros.bsd
 from cloudinit import subp, util
 
 try:
-    import crypt
+    import crypt  # pylint: disable=W4901
 
     salt = crypt.METHOD_BLOWFISH  # pylint: disable=E1101
     blowfish_hash: Any = functools.partial(

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -49,7 +49,7 @@ from cloudinit.sources.helpers.azure import (
 from cloudinit.url_helper import UrlError
 
 try:
-    import crypt
+    import crypt  # pylint: disable=W4901
 
     blowfish_hash: Any = functools.partial(
         crypt.crypt, salt=f"$6${util.rand_str(strlen=16)}"

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -336,6 +336,8 @@ class DataSourceEc2(sources.DataSource):
         return None
 
     def wait_for_metadata_service(self):
+        urls = []
+        start_time = 0
         mcfg = self.ds_cfg
 
         url_params = self.get_url_params()
@@ -369,7 +371,6 @@ class DataSourceEc2(sources.DataSource):
             and self.cloud_name not in IDMSV2_SUPPORTED_CLOUD_PLATFORMS
         ):
             # if we can't get a token, use instance-id path
-            urls = []
             url2base = {}
             url_path = "{ver}/meta-data/instance-id".format(
                 ver=self.min_metadata_version

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -332,7 +332,7 @@ class MetaDataKeys(Flag):
     CONFIG = auto()
     DEVICES = auto()
     META_DATA = auto()
-    ALL = CONFIG | DEVICES | META_DATA
+    ALL = CONFIG | DEVICES | META_DATA  # pylint: disable=E1131
 
 
 class _MetaDataReader:

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -284,6 +284,7 @@ class DataSourceWSL(sources.DataSource):
             return False
 
         seed_dir = cloud_init_data_dir(user_home)
+        agent_data = None
         user_data: Optional[Union[dict, bytes]] = None
 
         # Load any metadata

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3127,7 +3127,6 @@ class Version(namedtuple("Version", ["major", "minor", "patch", "rev"])):
     :raises ValueError: If invalid arguments are given.
 
     Examples:
-
         >>> Version(2, 9) == Version.from_str("2.9")
         True
         >>> Version(2, 9, 1) > Version.from_str("2.9.1")

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -318,7 +318,7 @@ def _client(
 
 
 @pytest.fixture
-def client(
+def client(  # pylint: disable=W0135
     request, fixture_utils, session_cloud, setup_image
 ) -> Iterator[IntegrationInstance]:
     """Provide a client that runs for every test."""
@@ -327,7 +327,7 @@ def client(
 
 
 @pytest.fixture(scope="module")
-def module_client(
+def module_client(  # pylint: disable=W0135
     request, fixture_utils, session_cloud, setup_image
 ) -> Iterator[IntegrationInstance]:
     """Provide a client that runs once per module."""
@@ -336,7 +336,7 @@ def module_client(
 
 
 @pytest.fixture(scope="class")
-def class_client(
+def class_client(  # pylint: disable=W0135
     request, fixture_utils, session_cloud, setup_image
 ) -> Iterator[IntegrationInstance]:
     """Provide a client that runs once per class."""

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -319,7 +319,7 @@ def wait_for_cloud_init(client: "IntegrationInstance", num_retries: int = 30):
         except Exception as e:
             last_exception = e
         time.sleep(1)
-    raise Exception(
+    raise Exception(  # pylint: disable=W0719
         "cloud-init status did not return successfully."
     ) from last_exception
 

--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -249,6 +249,7 @@ class TestNtp(FilesystemMockingTestCase):
                     )
 
     def _get_expected_pools(self, pools, distro, client):
+        expected_pools = None
         if client in ["ntp", "chrony"]:
             if client == "ntp" and distro == "alpine":
                 # NTP for Alpine Linux is Busybox's ntp which does not
@@ -264,6 +265,7 @@ class TestNtp(FilesystemMockingTestCase):
         return expected_pools
 
     def _get_expected_servers(self, servers, distro, client):
+        expected_servers = None
         if client in ["ntp", "chrony"]:
             if client == "ntp" and distro == "alpine":
                 # NTP for Alpine Linux is Busybox's ntp which only supports

--- a/tests/unittests/sources/test_gce.py
+++ b/tests/unittests/sources/test_gce.py
@@ -101,6 +101,7 @@ class TestDataSourceGCE(test_helpers.ResponsesTestCase):
             gce_meta = GCE_META
 
         def _request_callback(request):
+            recursive = False
             url_path = urlparse(request.url).path
             if url_path.startswith("/computeMetadata/v1/"):
                 path = url_path.split("/computeMetadata/v1/")[1:][0]

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1725,6 +1725,8 @@ class TestRedirectOutputPreexecFn:
             args = (test_string, None)
         elif request.param == "errfmt":
             args = (None, test_string)
+        else:
+            args = (None, None)
         with mock.patch(M_PATH + "subprocess.Popen") as m_popen:
             util.redirect_output(*args)
 

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ hypothesis==6.31.6
 hypothesis_jsonschema==0.20.1
 isort==5.10.1
 mypy==0.950
-pylint==2.13.9
+pylint==3.2.0
 pytest==7.0.1
 ruff==0.4.3
 types-jsonschema==4.4.2


### PR DESCRIPTION
Fedora 39 and above comes with python version 3.12. When running `tox -e pylint` on cloud-init, we may experience issue such as the one reported here: https://github.com/pylint-dev/pylint/issues/8782

Minimum version of pylint required in order to support python 3.12 is 3.0.2. Please see https://github.com/pylint-dev/astroid/issues/2201 . Upon further experimentation, it is seen that we need minimum pylint version 3.2.0 for cloud-init. Update tox.ini in order to use this pylint version.

