### PR TITLE
fix(netplan): Fix predictable interface rename issue

### DIFF
--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -381,6 +381,9 @@ class Renderer(renderer.Renderer):
         if not run:
             LOG.debug("netplan net_setup_link postcmd disabled")
             return
+        elif "net.ifnames=0" in util.get_cmdline():
+            LOG.debug("Predictable interface names disabled.")
+            return
         setup_lnk = ["udevadm", "test-builtin", "net_setup_link"]
 
         # It's possible we can race a udev rename and attempt to run

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -3397,10 +3397,13 @@ class TestNetplanPostcommands:
         mock_netplan_generate.assert_called_with(run=True, config_changed=True)
         mock_net_setup_link.assert_called_with(run=True)
 
+    @mock.patch("cloudinit.util.get_cmdline")
     @mock.patch("cloudinit.util.SeLinuxGuard")
     @mock.patch.object(netplan, "get_devicelist")
     @mock.patch("cloudinit.subp.subp")
-    def test_netplan_postcmds(self, mock_subp, mock_devlist, mock_sel):
+    def test_netplan_postcmds(
+        self, mock_subp, mock_devlist, mock_sel, m_get_cmdline
+    ):
         mock_sel.__enter__ = mock.Mock(return_value=False)
         mock_sel.__exit__ = mock.Mock()
         mock_devlist.side_effect = [["lo"]]


### PR DESCRIPTION
## Proposed Commit Message
```
fix(netplan): Fix predictable interface rename issue

When predictable naming is disabled, the following command may exit with
a non-zero exit code.

    udevadm test-builtin net_setup_link

This code only ran to check for udev rename races, which cannot happen
when systemd renaming is disabled. Skip when disabled.

Fixes GH-3950
```

## Additional Context
https://github.com/canonical/cloud-init/issues/3950
