### PR TITLE
Various mypy fixes

### DIFF
--- a/cloudinit/config/__init__.py
+++ b/cloudinit/config/__init__.py
@@ -1,1 +1,3 @@
 Config = dict
+Netv1 = dict
+Netv2 = dict

--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -30,9 +30,7 @@ meta: MetaSchema = {
 }  # type: ignore
 
 
-def supplemental_schema_validation(
-    init_cfg: dict, bridge_cfg: dict, preseed_str: str
-):
+def supplemental_schema_validation(init_cfg, bridge_cfg, preseed_str):
     """Validate user-provided lxd network and bridge config option values.
 
     @raises: ValueError describing invalid values provided.

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -78,8 +78,8 @@ def check_condition(cond):
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     try:
-        (args, timeout, condition) = load_power_state(cfg, cloud.distro)
-        if args is None:
+        (arg_list, timeout, condition) = load_power_state(cfg, cloud.distro)
+        if arg_list is None:
             LOG.debug("no power_state provided. doing nothing")
             return
     except Exception as e:
@@ -99,7 +99,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     devnull_fp = open(os.devnull, "w")
 
-    LOG.debug("After pid %s ends, will execute: %s", mypid, " ".join(args))
+    LOG.debug("After pid %s ends, will execute: %s", mypid, " ".join(arg_list))
 
     util.fork_cb(
         run_after_pid_gone,
@@ -108,7 +108,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         timeout,
         condition,
         execmd,
-        [args, devnull_fp],
+        [arg_list, devnull_fp],
     )
 
 

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -939,16 +939,6 @@ class _Annotator:
         if not schema_errors and not schema_deprecations:
             return self._original_content
         lines = self._original_content.split("\n")
-        if not isinstance(self._cloudconfig, dict):
-            # Return a meaningful message on empty cloud-config
-            return "\n".join(
-                lines
-                + [
-                    self._build_footer(
-                        "Errors", ["# E1: Cloud-config is not a YAML dict."]
-                    )
-                ]
-            )
         errors_by_line = self._build_errors_by_line(schema_errors)
         deprecations_by_line = self._build_errors_by_line(schema_deprecations)
         annotated_content = self._annotate_content(

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -127,7 +127,7 @@ if TYPE_CHECKING:
         title: str
         description: str
         distros: typing.List[str]
-        examples: typing.List[str]
+        examples: typing.List[Union[dict, str]]
         frequency: str
         activate_by_schema_keys: NotRequired[List[str]]
 

--- a/cloudinit/config/schemas/schema-network-config-v2.json
+++ b/cloudinit/config/schemas/schema-network-config-v2.json
@@ -10,43 +10,43 @@
       ]
     },
     "dhcp-overrides": {
-        "type": "object",
-        "description": "DHCP behaviour overrides. Overrides will only have an effect if the corresponding DHCP type is enabled.",
-        "additionalProperties": false,
-        "properties": {
-          "hostname": {
-            "type": "string",
-            "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
-          },
-          "route-metric": {
-            "type": "integer",
-            "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
-          },
-          "send-hostname": {
-            "type": "boolean",
-            "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
-          },
-          "use-dns": {
-            "type": "boolean"
-          },
-          "use-domains": {
-            "type": "string"
-          },
-          "use-hostname": {
-            "type": "boolean"
-          },
-          "use-mtu": {
-            "type": "boolean",
-            "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
-          },
-          "use-ntp": {
-            "type": "boolean"
-          },
-          "use-routes": {
-            "type": "boolean",
-            "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
-          }
+      "type": "object",
+      "description": "DHCP behaviour overrides. Overrides will only have an effect if the corresponding DHCP type is enabled.",
+      "additionalProperties": false,
+      "properties": {
+        "hostname": {
+          "type": "string",
+          "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
+        },
+        "route-metric": {
+          "type": "integer",
+          "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
+        },
+        "send-hostname": {
+          "type": "boolean",
+          "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
+        },
+        "use-dns": {
+          "type": "boolean"
+        },
+        "use-domains": {
+          "type": "string"
+        },
+        "use-hostname": {
+          "type": "boolean"
+        },
+        "use-mtu": {
+          "type": "boolean",
+          "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
+        },
+        "use-ntp": {
+          "type": "boolean"
+        },
+        "use-routes": {
+          "type": "boolean",
+          "description": "Unsupported  for dhcp6-overrides when used with the networkd renderer."
         }
+      }
     },
     "gateway": {
       "type": "string",
@@ -56,17 +56,33 @@
       "type": "object",
       "properties": {
         "renderer": {
-            "$ref": "#/$defs/renderer"
+          "$ref": "#/$defs/renderer"
         },
         "dhcp4": {
-          "type": ["boolean", "string"],
+          "type": [
+            "boolean",
+            "string"
+          ],
           "description": "Enable DHCP for IPv4. Off by default.",
-          "enum": ["yes", "no", true, false]
+          "enum": [
+            "yes",
+            "no",
+            true,
+            false
+          ]
         },
         "dhcp6": {
-          "type": ["boolean", "string"],
+          "type": [
+            "boolean",
+            "string"
+          ],
           "description": "Enable DHCP for IPv6. Off by default.",
-          "enum": ["yes", "no", true, false]
+          "enum": [
+            "yes",
+            "no",
+            true,
+            false
+          ]
         },
         "dhcp4-overrides": {
           "$ref": "#/$defs/dhcp-overrides"
@@ -89,7 +105,7 @@
         },
         "mtu": {
           "type": "integer",
-          "description": "The MTU key represents a device’s Maximum Transmission Unit, the largest size packet or frame, specified in octets (eight-bit bytes), that can be sent in a packet- or frame-based network. Specifying mtu is optional."
+          "description": "The MTU key represents a device\u2019s Maximum Transmission Unit, the largest size packet or frame, specified in octets (eight-bit bytes), that can be sent in a packet- or frame-based network. Specifying mtu is optional."
         },
         "nameservers": {
           "type": "object",
@@ -152,7 +168,7 @@
             },
             "macaddress": {
               "type": "string",
-              "description": "Device’s MAC address in the form xx:xx:xx:xx:xx:xx. Globs are not allowed. Letters must be lowercase."
+              "description": "Device\u2019s MAC address in the form xx:xx:xx:xx:xx:xx. Globs are not allowed. Letters must be lowercase."
             },
             "driver": {
               "type": "string",
@@ -162,7 +178,7 @@
         },
         "set-name": {
           "type": "string",
-          "description": "When matching on unique properties such as path or MAC, or with additional assumptions such as ''there will only ever be one wifi device'', match rules can be written so that they only match one device. Then this property can be used to give that device a more specific/desirable/nicer name than the default from udev’s ifnames. Any additional device that satisfies the match rules will then fail to get renamed and keep the original kernel name (and dmesg will show an error)."
+          "description": "When matching on unique properties such as path or MAC, or with additional assumptions such as ''there will only ever be one wifi device'', match rules can be written so that they only match one device. Then this property can be used to give that device a more specific/desirable/nicer name than the default from udev\u2019s ifnames. Any additional device that satisfies the match rules will then fail to get renamed and keep the original kernel name (and dmesg will show an error)."
         },
         "wakeonlan": {
           "type": "boolean",
@@ -257,7 +273,7 @@
               "description": "Configure how ARP replies are to be validated when using ARP link monitoring.",
               "enum": [
                 "none",
-                "active", 
+                "active",
                 "backup",
                 "all"
               ]
@@ -356,7 +372,7 @@
             },
             "stp": {
               "type": "boolean",
-              "description": "Define whether the bridge should use Spanning Tree Protocol. The default value is “true”, which means that Spanning Tree should be used."
+              "description": "Define whether the bridge should use Spanning Tree Protocol. The default value is \u201ctrue\u201d, which means that Spanning Tree should be used."
             }
           }
         }
@@ -393,13 +409,13 @@
           ]
         },
         "renderer": {
-            "$ref": "#/$defs/renderer"
+          "$ref": "#/$defs/renderer"
         },
         "ethernets": {
           "type": "object",
           "additionalProperties": {
             "$ref": "#/$defs/mapping_physical"
-          } 
+          }
         },
         "bonds": {
           "type": "object",

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -50,6 +50,7 @@ from cloudinit.distros.package_management.utils import known_package_managers
 from cloudinit.distros.parsers import hosts
 from cloudinit.features import ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES
 from cloudinit.net import activators, dhcp, renderers
+from cloudinit.net.netops import NetOps
 from cloudinit.net.network_state import parse_net_config_data
 from cloudinit.net.renderer import Renderer
 
@@ -142,7 +143,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     # This is used by self.shutdown_command(), and can be overridden in
     # subclasses
     shutdown_options_map = {"halt": "-H", "poweroff": "-P", "reboot": "-r"}
-    net_ops = iproute2.Iproute2
+    net_ops: Type[NetOps] = iproute2.Iproute2
 
     _ci_pkl_version = 1
     prefer_fqdn = False

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -28,7 +28,7 @@ class BSD(distros.Distro):
     # There is no update/upgrade on OpenBSD
     pkg_cmd_update_prefix: Optional[List[str]] = None
     pkg_cmd_upgrade_prefix: Optional[List[str]] = None
-    net_ops = bsd_netops.BsdNetOps  # type: ignore
+    net_ops = bsd_netops.BsdNetOps
 
     def __init__(self, name, cfg, paths):
         super().__init__(name, cfg, paths)

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -82,7 +82,9 @@ class NoDHCPLeaseMissingDhclientError(NoDHCPLeaseError):
     """Raised when unable to find dhclient."""
 
 
-def maybe_perform_dhcp_discovery(distro, nic=None, dhcp_log_func=None):
+def maybe_perform_dhcp_discovery(
+    distro, nic=None, dhcp_log_func=None
+) -> Dict[str, Any]:
     """Perform dhcp discovery if nic valid and dhclient command exists.
 
     If the nic is invalid or undiscoverable or dhclient command is not found,

--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -285,8 +285,8 @@ class EphemeralDHCPv4:
         dhcp_log_func=None,
     ):
         self.iface = iface
-        self._ephipv4 = None
-        self.lease = None
+        self._ephipv4: Optional[EphemeralIPv4Network] = None
+        self.lease: Optional[Dict[str, Any]] = None
         self.dhcp_log_func = dhcp_log_func
         self.connectivity_url_data = connectivity_url_data
         self.distro = distro

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -331,7 +331,7 @@ class DataSourceAzure(sources.DataSource):
         )
         self._iso_dev = None
         self._network_config = None
-        self._ephemeral_dhcp_ctx = None
+        self._ephemeral_dhcp_ctx: Optional[EphemeralDHCPv4] = None
         self._route_configured_for_imds = False
         self._route_configured_for_wireserver = False
         self._wireserver_endpoint = DEFAULT_WIRESERVER_ENDPOINT
@@ -426,7 +426,7 @@ class DataSourceAzure(sources.DataSource):
             dhcp_log_func=dhcp_log_cb,
         )
 
-        lease = None
+        lease: Optional[Dict[str, Any]] = None
         start_time = monotonic()
         deadline = start_time + timeout_minutes * 60
         with events.ReportEventStack(
@@ -1252,7 +1252,7 @@ class DataSourceAzure(sources.DataSource):
     def _poll_imds(self) -> bytes:
         """Poll IMDs for reprovisiondata XML document data."""
         dhcp_attempts = 0
-        reprovision_data = None
+        reprovision_data: Optional[bytes] = None
         while not reprovision_data:
             if not self._is_ephemeral_networking_up():
                 dhcp_attempts += 1

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -213,10 +213,6 @@ class DataSourceLXD(sources.DataSource):
             user_metadata = _raw_instance_data_to_dict(
                 "user.meta-data", user_metadata
             )
-        if not isinstance(self.metadata, dict):
-            self.metadata = util.mergemanydict(
-                [util.load_yaml(self.metadata), user_metadata]
-            )
         if "user-data" in self._crawled_metadata:
             self.userdata_raw = self._crawled_metadata["user-data"]
         if "network-config" in self._crawled_metadata:

--- a/cloudinit/sources/DataSourceNWCS.py
+++ b/cloudinit/sources/DataSourceNWCS.py
@@ -45,6 +45,11 @@ class DataSourceNWCS(sources.DataSource):
         self.dsmode = sources.DSMODE_NETWORK
         self.metadata_full = None
 
+    def _unpickle(self, ci_pkl_version: int) -> None:
+        super()._unpickle(ci_pkl_version)
+        if not self._network_config:
+            self._network_config = sources.UNSET
+
     def _get_data(self):
         md = self.get_metadata()
 
@@ -94,13 +99,6 @@ class DataSourceNWCS(sources.DataSource):
     @property
     def network_config(self):
         LOG.debug("Attempting network configuration")
-
-        if self._network_config is None:
-            LOG.warning(
-                "Found None as cached _network_config, resetting to %s",
-                sources.UNSET,
-            )
-            self._network_config = sources.UNSET
 
         if self._network_config != sources.UNSET:
             return self._network_config

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -375,7 +375,6 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 )
                 raise DatasourceUnpickleUserDataError() from e
 
-
     def __str__(self):
         return type_utils.obj_name(self)
 

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -317,7 +317,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         self.sys_cfg = sys_cfg
         self.distro = distro
         self.paths = paths
-        self.userdata = None
+        self.userdata: Optional[Any] = None
         self.metadata: dict = {}
         self.userdata_raw: Optional[str] = None
         self.vendordata = None
@@ -359,7 +359,6 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
         if not hasattr(self, "check_if_fallback_is_allowed"):
             setattr(self, "check_if_fallback_is_allowed", lambda: False)
-
         if hasattr(self, "userdata") and self.userdata is not None:
             # If userdata stores MIME data, on < python3.6 it will be
             # missing the 'policy' attribute that exists on >=python3.6.
@@ -375,6 +374,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
                     e,
                 )
                 raise DatasourceUnpickleUserDataError() from e
+
 
     def __str__(self):
         return type_utils.obj_name(self)
@@ -484,6 +484,12 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         """
         self._dirty_cache = True
         return_value = self._check_and_get_data()
+        # TODO: verify that datasource types are what they are expected to be
+        # each datasource uses different logic to get userdata, metadata, etc
+        # and then the rest of the codebase assumes the types of this data
+        # it would be prudent to have a type check here that warns, when the
+        # datatype is incorrect, rather than assuming types and throwing
+        # exceptions later if/when they get used incorrectly.
         if not return_value:
             return return_value
         self.persist_instance_data()

--- a/cloudinit/temp_utils.py
+++ b/cloudinit/temp_utils.py
@@ -10,7 +10,6 @@ import tempfile
 from cloudinit import util
 
 LOG = logging.getLogger(__name__)
-_TMPDIR = None
 _ROOT_TMPDIR = "/run/cloud-init/tmp"
 _EXE_ROOT_TMPDIR = "/var/tmp/cloud-init"
 
@@ -20,8 +19,6 @@ def get_tmp_ancestor(odir=None, needs_exe: bool = False):
         return odir
     if needs_exe:
         return _EXE_ROOT_TMPDIR
-    if _TMPDIR:
-        return _TMPDIR
     if os.getuid() == 0:
         return _ROOT_TMPDIR
     return os.environ.get("TMPDIR", "/tmp")
@@ -53,18 +50,11 @@ def _tempfile_dir_arg(odir=None, needs_exe: bool = False):
                 " mounted as noexec",
                 tdir,
             )
-
-    if odir is None and not needs_exe:
-        global _TMPDIR
-        _TMPDIR = tdir
-
     return tdir
 
 
 def ExtendedTemporaryFile(**kwargs):
-    kwargs["dir"] = _tempfile_dir_arg(
-        kwargs.pop("dir", None), kwargs.pop("needs_exe", False)
-    )
+    kwargs["dir"] = _tempfile_dir_arg()
     fh = tempfile.NamedTemporaryFile(**kwargs)
     # Replace its unlink with a quiet version
     # that does not raise errors when the

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -279,7 +279,8 @@ class UrlResponse:
     @property
     def contents(self) -> bytes:
         if self._response.content is None:
-            return b""
+            # typeshed bug: https://github.com/python/typeshed/pull/12180
+            return b""  # type: ignore
         return self._response.content
 
     @property

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -560,7 +560,7 @@ def dual_stack(
     """
     return_result = None
     returned_address = None
-    last_exception = None
+    last_exception: Optional[BaseException] = None
     exceptions = []
     is_done = threading.Event()
 
@@ -620,7 +620,7 @@ def dual_stack(
             "Timed out waiting for addresses: %s, "
             "exception(s) raised while waiting: %s",
             " ".join(addresses),
-            " ".join(exceptions),  # type: ignore
+            " ".join(map(str, exceptions)),
         )
     finally:
         executor.shutdown(wait=False)

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3250,8 +3250,8 @@ def deprecate(
 
     Note: uses keyword-only arguments to improve legibility
     """
-    if not hasattr(deprecate, "_log"):
-        deprecate._log = set()  # type: ignore
+    if not hasattr(deprecate, "log"):
+        setattr(deprecate, "log", set())
     message = extra_message or ""
     dedup = hash(deprecated + message + deprecated_version + str(schedule))
     version = Version.from_str(deprecated_version)
@@ -3267,8 +3267,9 @@ def deprecate(
         level = log.DEPRECATED
     else:
         level = logging.WARN
-    if not skip_log and dedup not in deprecate._log:  # type: ignore
-        deprecate._log.add(dedup)  # type: ignore
+    log_cache = getattr(deprecate, "log")
+    if not skip_log and dedup not in log_cache:
+        log_cache.add(dedup)
         LOG.log(level, deprecate_msg)
     return DeprecationLog(level, deprecate_msg)
 

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -357,8 +357,6 @@ def read_conf(fname, *, instance_data_file=None) -> Dict:
                 config_file,
                 repr(e),
             )
-    if config_file is None:
-        return {}
     return load_yaml(config_file, default={})  # pyright: ignore
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ follow_imports = "silent"
 check_untyped_defs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+warn_unreachable = true
 exclude = []
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ exclude = []
 module = [
     "apport.*",
     "BaseHTTPServer",
-    "cloudinit.feature_overrides",
     "configobj",
     "debconf",
     "httplib",
@@ -33,7 +32,6 @@ module = [
     "paramiko.*",
     "pip.*",
     "pycloudlib.*",
-    "responses",
     "serial",
     "tests.integration_tests.user_settings",
     "uaclient.*",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 # isort: off
 from setup_utils import (  # noqa: E402
     get_version,
-    in_virtualenv,
     is_f,
     is_generator,
     pkg_config_read,
@@ -266,13 +265,12 @@ class InitsysInstallData(install):
         self.distribution.reinitialize_command("install_data", True)
 
 
-if not in_virtualenv():
-    USR = "/" + USR
-    ETC = "/" + ETC
-    USR_LIB_EXEC = "/" + USR_LIB_EXEC
-    LIB = "/" + LIB
-    for k in INITSYS_ROOTS.keys():
-        INITSYS_ROOTS[k] = "/" + INITSYS_ROOTS[k]
+USR = "/" + USR
+ETC = "/" + ETC
+USR_LIB_EXEC = "/" + USR_LIB_EXEC
+LIB = "/" + LIB
+for k in INITSYS_ROOTS.keys():
+    INITSYS_ROOTS[k] = "/" + INITSYS_ROOTS[k]
 
 data_files = [
     (ETC + "/cloud", [render_tmpl("config/cloud.cfg.tmpl", is_yaml=True)]),
@@ -308,8 +306,7 @@ data_files = [
 ]
 if not platform.system().endswith("BSD"):
     RULES_PATH = pkg_config_read("udev", "udevdir")
-    if not in_virtualenv():
-        RULES_PATH = "/" + RULES_PATH
+    RULES_PATH = "/" + RULES_PATH
 
     data_files.extend(
         [

--- a/setup_utils.py
+++ b/setup_utils.py
@@ -35,15 +35,6 @@ def pkg_config_read(library: str, var: str) -> str:
     return path
 
 
-def in_virtualenv() -> bool:
-    # TODO: sys.real_prefix doesn't exist on any currently supported
-    # version of python. This function can never return True
-    try:
-        return sys.real_prefix != sys.prefix
-    except AttributeError:
-        return False
-
-
 def version_to_pep440(version: str) -> str:
     # read-version can spit out something like 22.4-15-g7f97aee24
     # which is invalid under PEP 440. If we replace the first - with a +

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -21,7 +21,7 @@ from pycloudlib import (
     Openstack,
     Qemu,
 )
-from pycloudlib.cloud import BaseCloud, ImageType
+from pycloudlib.cloud import ImageType
 from pycloudlib.ec2.instance import EC2Instance
 from pycloudlib.lxd.cloud import _BaseLXD
 from pycloudlib.lxd.instance import BaseInstance, LXDInstance
@@ -55,7 +55,6 @@ def _get_ubuntu_series() -> list:
 
 class IntegrationCloud(ABC):
     datasource: str
-    cloud_instance: BaseCloud
 
     def __init__(
         self,
@@ -64,7 +63,7 @@ class IntegrationCloud(ABC):
     ):
         self._image_type = image_type
         self.settings = settings
-        self.cloud_instance: BaseCloud = self._get_cloud_instance()
+        self.cloud_instance = self._get_cloud_instance()
         self.initial_image_id = self._get_initial_image()
         self.snapshot_id = None
 
@@ -183,7 +182,7 @@ class IntegrationCloud(ABC):
 
     def delete_snapshot(self):
         if self.snapshot_id:
-            if self.settings.KEEP_IMAGE:
+            if self.settings.KEEP_IMAGE:  # type: ignore
                 log.info(
                     "NOT deleting snapshot image created for this testrun "
                     "because KEEP_IMAGE is True: %s",
@@ -200,7 +199,7 @@ class IntegrationCloud(ABC):
 class Ec2Cloud(IntegrationCloud):
     datasource = "ec2"
 
-    def _get_cloud_instance(self):
+    def _get_cloud_instance(self) -> EC2:
         return EC2(tag="ec2-integration-test")
 
     def _get_initial_image(self, **kwargs) -> str:
@@ -228,7 +227,7 @@ class Ec2Cloud(IntegrationCloud):
 class GceCloud(IntegrationCloud):
     datasource = "gce"
 
-    def _get_cloud_instance(self):
+    def _get_cloud_instance(self) -> GCE:
         return GCE(
             tag="gce-integration-test",
         )
@@ -243,7 +242,7 @@ class AzureCloud(IntegrationCloud):
     datasource = "azure"
     cloud_instance: Azure
 
-    def _get_cloud_instance(self):
+    def _get_cloud_instance(self) -> Azure:
         return Azure(tag="azure-integration-test")
 
     def _get_initial_image(self, **kwargs) -> str:
@@ -265,7 +264,7 @@ class AzureCloud(IntegrationCloud):
 class OciCloud(IntegrationCloud):
     datasource = "oci"
 
-    def _get_cloud_instance(self):
+    def _get_cloud_instance(self) -> OCI:
         return OCI(
             tag="oci-integration-test",
         )
@@ -276,11 +275,7 @@ class _LxdIntegrationCloud(IntegrationCloud):
     instance_tag: str
     cloud_instance: _BaseLXD
 
-    def _get_cloud_instance(self):
-        return self.pycloudlib_instance_cls(tag=self.instance_tag)
-
-    @staticmethod
-    def _get_or_set_profile_list(release):
+    def _get_or_set_profile_list(self, release):
         return None
 
     @staticmethod
@@ -355,15 +350,21 @@ class LxdContainerCloud(_LxdIntegrationCloud):
     pycloudlib_instance_cls = LXDContainer
     instance_tag = "lxd-container-integration-test"
 
+    def _get_cloud_instance(self) -> LXDContainer:
+        return self.pycloudlib_instance_cls(tag=self.instance_tag)
+
 
 class LxdVmCloud(_LxdIntegrationCloud):
     datasource = "lxd_vm"
     cloud_instance: LXDVirtualMachine
     pycloudlib_instance_cls = LXDVirtualMachine
     instance_tag = "lxd-vm-integration-test"
-    _profile_list = None
+    _profile_list: list = []
 
-    def _get_or_set_profile_list(self, release):
+    def _get_cloud_instance(self) -> LXDVirtualMachine:
+        return self.pycloudlib_instance_cls(tag=self.instance_tag)
+
+    def _get_or_set_profile_list(self, release) -> list:
         if self._profile_list:
             return self._profile_list
         self._profile_list = self.cloud_instance.build_necessary_profiles(

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Union
 
-from pycloudlib.lxd.instance import LXDInstance
 from pycloudlib.gce.instance import GceInstance
 from pycloudlib.instance import BaseInstance
+from pycloudlib.lxd.instance import LXDInstance
 from pycloudlib.result import Result
 
 from tests.helpers import cloud_init_project_dir

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Union
 
+from pycloudlib.lxd.instance import LXDInstance
 from pycloudlib.gce.instance import GceInstance
 from pycloudlib.instance import BaseInstance
 from pycloudlib.result import Result
@@ -289,7 +290,7 @@ class IntegrationInstance:
         try:
             # in some cases that ssh is not used, an address is not assigned
             if (
-                hasattr(self.instance, "execute_via_ssh")
+                isinstance(self.instance, LXDInstance)
                 and self.instance.execute_via_ssh
             ):
                 self._ip = self.instance.ip

--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -152,10 +152,10 @@ class TestApt:
         keys = class_client.execute(list_cmd + cc_apt_configure.APT_LOCAL_KEYS)
         files = class_client.execute(
             "ls " + cc_apt_configure.APT_TRUSTED_GPG_DIR
-        )
+        ).stdout
         for file in files.split():
             path = cc_apt_configure.APT_TRUSTED_GPG_DIR + file
-            keys += class_client.execute(list_cmd + path) or ""
+            keys += class_client.execute(list_cmd + path).stdout
         class_client.execute("gpgconf --homedir /root/tmpdir --kill all")
         return keys
 

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -13,6 +13,8 @@ import uuid
 from pathlib import Path
 
 import pytest
+from pycloudlib.ec2.instance import EC2Instance
+from pycloudlib.gce.instance import GceInstance
 
 import cloudinit.config
 from cloudinit.util import is_true
@@ -461,6 +463,9 @@ class TestCombined:
             "/run/cloud-init/cloud-id-aws"
         )
         assert v1_data["subplatform"].startswith("metadata")
+
+        # type narrow since availability_zone is not a BaseInstance attribute
+        assert isinstance(client.instance, EC2Instance)
         assert (
             v1_data["availability_zone"] == client.instance.availability_zone
         )
@@ -483,6 +488,9 @@ class TestCombined:
             "/run/cloud-init/cloud-id-gce"
         )
         assert v1_data["subplatform"].startswith("metadata")
+        # type narrow since zone and instance_id are not BaseInstance
+        # attributes
+        assert isinstance(client.instance, GceInstance)
         assert v1_data["availability_zone"] == client.instance.zone
         assert v1_data["instance_id"] == client.instance.instance_id
         assert v1_data["local_hostname"] == client.instance.name

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -62,7 +62,6 @@ def test_clean_boot_of_upgraded_package(session_cloud: IntegrationCloud):
     source = get_validated_source(session_cloud)
     if not source.installs_new_version():
         pytest.skip(UNSUPPORTED_INSTALL_METHOD_MSG.format(source))
-        return  # type checking doesn't understand that skip raises
     launch_kwargs = {
         "image_id": session_cloud.initial_image_id,
     }
@@ -194,7 +193,6 @@ def test_subsequent_boot_of_upgraded_package(session_cloud: IntegrationCloud):
             pytest.fail(UNSUPPORTED_INSTALL_METHOD_MSG.format(source))
         else:
             pytest.skip(UNSUPPORTED_INSTALL_METHOD_MSG.format(source))
-        return  # type checking doesn't understand that skip raises
 
     launch_kwargs = {"image_id": session_cloud.initial_image_id}
 

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -746,7 +746,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
         assert_file,
         cmdargs: MyArgs,
         expected_retcode: int,
-        expected_status: str,
+        expected_status: Union[str, dict],
         config: Config,
         capsys,
     ):

--- a/tests/unittests/config/test_cc_apk_configure.py
+++ b/tests/unittests/config/test_cc_apk_configure.py
@@ -10,7 +10,7 @@ import textwrap
 
 import pytest
 
-from cloudinit import cloud, helpers, temp_utils, util
+from cloudinit import cloud, helpers, util
 from cloudinit.config import cc_apk_configure
 from cloudinit.config.schema import (
     SchemaValidationError,
@@ -51,7 +51,7 @@ class TestNoConfig(FilesystemMockingTestCase):
 
 class TestConfig(FilesystemMockingTestCase):
     def setUp(self):
-        super(TestConfig, self).setUp()
+        super().setUp()
         self.new_root = self.tmp_dir()
         self.new_root = self.reRoot(root=self.new_root)
         for dirname in ["tmp", "etc/apk"]:
@@ -60,11 +60,14 @@ class TestConfig(FilesystemMockingTestCase):
         self.name = "apk_configure"
         self.cloud = cloud.Cloud(None, self.paths, None, None, None)
         self.args = []
-        temp_utils._TMPDIR = self.new_root
+        self.mock = mock.patch(
+            "cloudinit.temp_utils.get_tmp_ancestor", lambda *_: self.new_root
+        )
+        self.mock.start()
 
     def tearDown(self):
+        self.mock.stop()
         super().tearDown()
-        temp_utils._TMPDIR = None
 
     @mock.patch(CC_APK + "._write_repositories_file")
     def test_no_repo_settings(self, m_write_repos):

--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -138,16 +138,14 @@ class TestNtp(FilesystemMockingTestCase):
         servers = []
         pools = ["10.0.0.1", "10.0.0.2"]
         (confpath, template_fn) = self._generate_template()
-        mock_path = "cloudinit.config.cc_ntp.temp_utils._TMPDIR"
-        with mock.patch(mock_path, self.new_root):
-            cc_ntp.write_ntp_config_template(
-                "ubuntu",
-                servers=servers,
-                pools=pools,
-                path=confpath,
-                template_fn=template_fn,
-                template=None,
-            )
+        cc_ntp.write_ntp_config_template(
+            "ubuntu",
+            servers=servers,
+            pools=pools,
+            path=confpath,
+            template_fn=template_fn,
+            template=None,
+        )
         self.assertEqual(
             "servers []\npools ['10.0.0.1', '10.0.0.2']\n",
             util.load_text_file(confpath),
@@ -163,16 +161,14 @@ class TestNtp(FilesystemMockingTestCase):
         pools = cc_ntp.generate_server_names(distro)
         servers = []
         (confpath, template_fn) = self._generate_template()
-        mock_path = "cloudinit.config.cc_ntp.temp_utils._TMPDIR"
-        with mock.patch(mock_path, self.new_root):
-            cc_ntp.write_ntp_config_template(
-                distro,
-                servers=servers,
-                pools=pools,
-                path=confpath,
-                template_fn=template_fn,
-                template=None,
-            )
+        cc_ntp.write_ntp_config_template(
+            distro,
+            servers=servers,
+            pools=pools,
+            path=confpath,
+            template_fn=template_fn,
+            template=None,
+        )
         self.assertEqual(
             "servers []\npools {0}\n".format(pools),
             util.load_text_file(confpath),
@@ -672,8 +668,8 @@ class TestNtp(FilesystemMockingTestCase):
         }
         for distro in cc_ntp.distros:
             mycloud = self._get_cloud(distro)
-            mock_path = "cloudinit.config.cc_ntp.temp_utils._TMPDIR"
-            with mock.patch(mock_path, self.new_root):
+            mock_path = "cloudinit.config.cc_ntp.temp_utils.get_tmp_ancestor"
+            with mock.patch(mock_path, lambda *_: self.new_root):
                 cc_ntp.handle("notimportant", cfg, mycloud, None)
             self.assertEqual(
                 "servers []\npools ['mypool.org']\n%s" % custom,
@@ -712,8 +708,8 @@ class TestNtp(FilesystemMockingTestCase):
             )
             confpath = ntpconfig["confpath"]
             m_select.return_value = ntpconfig
-            mock_path = "cloudinit.config.cc_ntp.temp_utils._TMPDIR"
-            with mock.patch(mock_path, self.new_root):
+            mock_path = "cloudinit.config.cc_ntp.temp_utils.get_tmp_ancestor"
+            with mock.patch(mock_path, lambda *_: self.new_root):
                 cc_ntp.handle("notimportant", {"ntp": cfg}, mycloud, None)
             self.assertEqual(
                 "servers []\npools ['mypool.org']\n%s" % custom,

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -1767,29 +1767,6 @@ class TestAnnotatedCloudconfigFile:
             schema_errors=[],
         )
 
-    def test_annotated_cloudconfig_file_with_non_dict_cloud_config(self):
-        """Error when empty non-dict cloud-config is provided.
-
-        OurJSON validation when user-data is None type generates a bunch
-        schema validation errors of the format:
-        ('', "None is not of type 'object'"). Ignore those symptoms and
-        report the general problem instead.
-        """
-        content = "\n\n\n"
-        expected = "\n".join(
-            [
-                content,
-                "# Errors: -------------",
-                "# E1: Cloud-config is not a YAML dict.\n\n",
-            ]
-        )
-        assert expected == annotated_cloudconfig_file(
-            None,
-            content,
-            schemamarks={},
-            schema_errors=[SchemaProblem("", "None is not of type 'object'")],
-        )
-
     def test_annotated_cloudconfig_file_schema_annotates_and_adds_footer(self):
         """With schema_errors, error lines are annotated and a footer added."""
         content = dedent(

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -152,7 +152,7 @@ def clear_deprecation_log():
     # Since deprecations are de-duped, the existance (or non-existance) of
     # a deprecation warning in a previous test can cause the next test to
     # fail.
-    util.deprecate._log = set()
+    setattr(util.deprecate, "log", set())
 
 
 PYTEST_VERSION_TUPLE = tuple(map(int, pytest.__version__.split(".")))

--- a/tests/unittests/net/test_network_state.py
+++ b/tests/unittests/net/test_network_state.py
@@ -215,7 +215,7 @@ class TestNetworkStateParseConfigV2:
         In netplan targets we perform a passthrough and the warning is not
         needed.
         """
-        util.deprecate._log = set()  # type: ignore
+        util.deprecate.__dict__["log"] = set()
         ncfg = yaml.safe_load(
             cfg.format(
                 gateway4="gateway4: 10.54.0.1",

--- a/tests/unittests/sources/test_akamai.py
+++ b/tests/unittests/sources/test_akamai.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Union
 
 import pytest
 
@@ -224,7 +224,7 @@ class TestDataSourceAkamai:
         get_interfaces_by_mac,
         local_stage: bool,
         ds_cfg: Dict[str, Any],
-        expected_manager_config: List[Tuple[Tuple[bool, bool], bool]],
+        expected_manager_config: List,
         expected_interface: str,
     ):
         """

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -63,8 +63,7 @@ class TestCloudInitLogger(CiTestCase):
 
 class TestDeprecatedLogs:
     def test_deprecated_log_level(self, caplog):
-        logger = logging.getLogger()
-        logger.deprecated("deprecated message")
+        logging.getLogger().deprecated("deprecated message")
         assert "DEPRECATED" == caplog.records[0].levelname
         assert "deprecated message" in caplog.text
 
@@ -116,7 +115,6 @@ class TestDeprecatedLogs:
         )
 
     def test_log_deduplication(self, caplog):
-        log.define_deprecation_logger()
         util.deprecate(
             deprecated="stuff",
             deprecated_version="19.1",
@@ -139,6 +137,5 @@ class TestDeprecatedLogs:
 def test_logger_prints_to_stderr(capsys):
     message = "to stdout"
     log.setup_basic_logging()
-    LOG = logging.getLogger()
-    LOG.warning(message)
+    logging.getLogger().warning(message)
     assert message in capsys.readouterr().err

--- a/tests/unittests/test_temp_utils.py
+++ b/tests/unittests/test_temp_utils.py
@@ -25,7 +25,6 @@ class TestTempUtils(CiTestCase):
             {
                 "os.getuid": 1000,
                 "tempfile.mkdtemp": {"side_effect": fake_mkdtemp},
-                "_TMPDIR": {"new": None},
                 "os.path.isdir": True,
             },
             mkdtemp,
@@ -46,7 +45,6 @@ class TestTempUtils(CiTestCase):
             {
                 "os.getuid": 1000,
                 "tempfile.mkdtemp": {"side_effect": fake_mkdtemp},
-                "_TMPDIR": {"new": None},
                 "os.path.isdir": True,
                 "util.has_mount_opt": True,
             },
@@ -69,7 +67,6 @@ class TestTempUtils(CiTestCase):
             {
                 "os.getuid": 0,
                 "tempfile.mkdtemp": {"side_effect": fake_mkdtemp},
-                "_TMPDIR": {"new": None},
                 "os.path.isdir": True,
             },
             mkdtemp,
@@ -90,7 +87,6 @@ class TestTempUtils(CiTestCase):
             {
                 "os.getuid": 1000,
                 "tempfile.mkstemp": {"side_effect": fake_mkstemp},
-                "_TMPDIR": {"new": None},
                 "os.path.isdir": True,
             },
             mkstemp,
@@ -111,7 +107,6 @@ class TestTempUtils(CiTestCase):
             {
                 "os.getuid": 0,
                 "tempfile.mkstemp": {"side_effect": fake_mkstemp},
-                "_TMPDIR": {"new": None},
                 "os.path.isdir": True,
             },
             mkstemp,

--- a/tox.ini
+++ b/tox.ini
@@ -45,31 +45,33 @@ version = cloudinit/config/schemas/versions.schema.cloud-config.json
 [testenv:ruff]
 deps =
     ruff=={[format_deps]ruff}
-commands = {envpython} -m ruff check .
+commands = {envpython} -m ruff check {posargs:.}
 
 [testenv:pylint]
 deps =
     pylint=={[format_deps]pylint}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
-commands = {envpython} -m pylint {posargs:cloudinit/ tests/ tools/ conftest.py setup.py}
+commands = {envpython} -m pylint {posargs:.}
 
 [testenv:black]
 deps =
     black=={[format_deps]black}
-commands = {envpython} -m black . --check
+commands = {envpython} -m black --check {posargs:.}
 
 [testenv:isort]
 deps =
     isort=={[format_deps]isort}
-commands = {envpython} -m isort . --check-only --diff
+commands = {envpython} -m isort --check-only --diff {posargs:.}
 
 [testenv:mypy]
 deps =
+    -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/integration-requirements.txt
+    -r{toxinidir}/doc-requirements.txt
     hypothesis=={[format_deps]hypothesis}
     hypothesis_jsonschema=={[format_deps]hypothesis_jsonschema}
     mypy=={[format_deps]mypy}
-    pytest=={[format_deps]pytest}
     types-jsonschema=={[format_deps]types-jsonschema}
     types-Jinja2=={[format_deps]types-Jinja2}
     types-passlib=={[format_deps]types-passlib}
@@ -78,7 +80,7 @@ deps =
     types-requests=={[format_deps]types-requests}
     types-setuptools=={[format_deps]types-setuptools}
     typing-extensions=={[format_deps]typing-extensions}
-commands = {envpython} -m mypy cloudinit/ tests/ tools/
+commands = {envpython} -m mypy {posargs:cloudinit/ tests/ tools/}
 
 [testenv:check_format]
 deps =
@@ -89,16 +91,18 @@ deps =
     isort=={[format_deps]isort}
     mypy=={[format_deps]mypy}
     pylint=={[format_deps]pylint}
-    pytest=={[format_deps]pytest}
     types-jsonschema=={[format_deps]types-jsonschema}
+    types-Jinja2=={[format_deps]types-Jinja2}
     types-oauthlib=={[format_deps]types-oauthlib}
     types-passlib=={[format_deps]types-passlib}
     types-pyyaml=={[format_deps]types-PyYAML}
+    types-oauthlib=={[format_deps]types-oauthlib}
     types-requests=={[format_deps]types-requests}
     types-setuptools=={[format_deps]types-setuptools}
     typing-extensions=={[format_deps]typing-extensions}
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
+    -r{toxinidir}/doc-requirements.txt
 commands =
     {[testenv:black]commands}
     {[testenv:ruff]commands}
@@ -115,15 +119,17 @@ deps =
     isort
     mypy
     pylint
-    pytest
     types-jsonschema
+    types-Jinja2
     types-oauthlib
+    types-passlib
     types-pyyaml
+    types-oauthlib
     types-requests
     types-setuptools
-    typing-extensions
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
+    -r{toxinidir}/doc-requirements.txt
 commands =
     {[testenv:check_format]commands}
 
@@ -151,7 +157,8 @@ commands = {envpython} -m pytest \
             -vvvv --showlocals \
             --durations 10 \
             -m "not hypothesis_slow" \
-            {posargs:--cov=cloudinit --cov-branch tests/unittests}
+            --cov=cloudinit --cov-branch \
+            {posargs:tests/unittests}
 
 # experimental
 [testenv:py3-fast]
@@ -168,15 +175,16 @@ deps =
     -r{toxinidir}/test-requirements.txt
 commands = {envpython} -m pytest \
             -m hypothesis_slow \
-            {posargs:--hypothesis-show-statistics tests/unittests}
+            --hypothesis-show-statistics \
+            {posargs:tests/unittests}
 
 #commands = {envpython} -X tracemalloc=40 -Werror::ResourceWarning:cloudinit -m pytest \
 [testenv:py3-leak]
 deps = {[testenv:py3]deps}
 commands = {envpython} -X tracemalloc=40 -Wall -m pytest \
             --durations 10 \
-            {posargs:--cov=cloudinit --cov-branch \
-            tests/unittests}
+            --cov=cloudinit --cov-branch \
+            {posargs:tests/unittests}
 
 
 [testenv:lowest-supported]
@@ -242,16 +250,24 @@ commands = {[testenv:ruff]commands}
 
 [testenv:tip-mypy]
 deps =
+    -r{toxinidir}/test-requirements.txt
+    -r{toxinidir}/integration-requirements.txt
+    -r{toxinidir}/doc-requirements.txt
     hypothesis
     hypothesis_jsonschema
     mypy
     pytest
+    types-Jinja2
     types-jsonschema
     types-oauthlib
     types-PyYAML
+    types-passlib
+    types-pyyaml
+    types-oauthlib
     types-requests
     types-setuptools
-commands = {[testenv:mypy]commands}
+    typing-extensions
+commands = {envpython} -m mypy {posargs:cloudinit/ tests/ tools/}
 
 [testenv:tip-pylint]
 deps =
@@ -260,7 +276,8 @@ deps =
     # test-requirements
     -r{toxinidir}/test-requirements.txt
     -r{toxinidir}/integration-requirements.txt
-commands = {[testenv:pylint]commands}
+commands = {envpython} -m pylint {posargs:.}
+
 
 [testenv:tip-black]
 deps = black

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,8 @@ typing-extensions==4.1.1
 [files]
 schema = cloudinit/config/schemas/schema-cloud-config-v1.json
 version = cloudinit/config/schemas/versions.schema.cloud-config.json
+network_v1 = cloudinit/config/schemas/schema-network-config-v1.json
+network_v2 = cloudinit/config/schemas/schema-network-config-v2.json
 
 [testenv:ruff]
 deps =
@@ -142,6 +144,8 @@ commands =
     {envpython} -m black .
     {envpython} -m json.tool --indent 2 {[files]schema} {[files]schema}
     {envpython} -m json.tool --indent 2 {[files]version} {[files]version}
+    {envpython} -m json.tool --indent 2 {[files]network_v1} {[files]network_v1}
+    {envpython} -m json.tool --indent 2 {[files]network_v2} {[files]network_v2}
 
 [testenv:do_format_tip]
 deps =


### PR DESCRIPTION
## Additional Context
See individual commits.

This work enables using more of mypy's static analysis features.

This PR does various cleanups including:

- remove unnecessary type ignore comments
- add missing type annotations
- remove invalid type annotations
- minor refactors to eliminate the need for type annotations
- eliminate unused code
- auto-format network jsonschema
- tox: fix minor issues
- tox: add stub libraries


Note to reviewers:

Most of the changes here are no-ops. That said, please pay special attention to the commit titled `refactor(typing): Remove unused code paths`. Invalid type annotations can lead mypy to warn incorrectly that a code path is unused (this is how I found many of the type errors in this commit series). I do believe that I was thorough in verifying this commit, but this one carries the most risk of the series.