### PR TITLE
tests: fix integration tests for ubuntu pro 32.3 release

### DIFF
--- a/cloudinit/config/modules.py
+++ b/cloudinit/config/modules.py
@@ -208,7 +208,7 @@ class Modules:
                 util.deprecate(
                     deprecated=(
                         f"Module has been renamed from {mod_name} to "
-                        f"{RENAMED_MODULES[mod_name][1]}. Update any"
+                        f"{RENAMED_MODULES[mod_name]}. Update any"
                         " references in /etc/cloud/cloud.cfg"
                     ),
                     deprecated_version="24.1",

--- a/tests/integration_tests/modules/test_ubuntu_pro.py
+++ b/tests/integration_tests/modules/test_ubuntu_pro.py
@@ -43,14 +43,6 @@ ubuntu_pro:
 
 PRO_AUTO_ATTACH_DISABLED = """\
 #cloud-config
-# ubuntu_advantage config kept as duplication until the release of this
-# commit in proclient (ubuntu-advantage-tools v. 32):
-# https://github.com/canonical/ubuntu-pro-client/commit/7bb69e3ad
-# Without a top-level ubuntu_advantage key Pro will automatically attach
-# instead of defer to cloud-init for all attach operations.
-ubuntu_advantage:
-  features:
-    disable_auto_attach: true
 ubuntu_pro:
   features:
     disable_auto_attach: true
@@ -59,10 +51,6 @@ ubuntu_pro:
 PRO_DAEMON_DISABLED = """\
 #cloud-config
 # Disable Pro daemon (only needed in GCE)
-# Drop ubuntu_advantage key once ubuntu-advantage-tools v. 32 is SRU'd
-ubuntu_advantage:
-  features:
-    disable_auto_attach: true
 ubuntu_pro:
   features:
     disable_auto_attach: true
@@ -72,21 +60,18 @@ bootcmd:
 
 AUTO_ATTACH_CUSTOM_SERVICES = """\
 #cloud-config
-# Drop ubuntu_advantage key once ubuntu-advantage-tools v. 32 is SRU'd
-ubuntu_advantage:
-  enable:
-  - esm-infra
 ubuntu_pro:
   enable:
   - esm-infra
 """
 
 
-def did_ua_service_noop(client: IntegrationInstance) -> bool:
-    ua_log = client.read_from_file("/var/log/ubuntu-advantage.log")
-    return (
+def assert_ua_service_noop(client: IntegrationInstance):
+    status_resp = client.execute("systemctl status ua-auto-attach.service")
+    assert status_resp.return_code == 3  # Due to being skipped
+    assert (
         "Skipping auto-attach and deferring to cloud-init to setup and"
-        " configure auto-attach" in ua_log
+        " configure auto-attach" in status_resp.stdout
     )
 
 
@@ -212,16 +197,8 @@ def maybe_install_cloud_init(session_cloud: IntegrationCloud):
         user_data=user_data,
         launch_kwargs=launch_kwargs,
     ) as client:
-        # TODO: Re-enable this check after cloud images contain
-        # cloud-init 23.4.
-        # Explanation: We have to include something under
-        # user-data.ubuntu_pro to skip the automatic auto-attach
-        # (driven by ua-auto-attach.service and/or ubuntu-advantage.service)
-        # while customizing the instance but in cloud-init < 23.4,
-        # user-data.ubuntu_pro requires a token key.
-
-        # log = client.read_from_file("/var/log/cloud-init.log")
-        # verify_clean_log(log)
+        log = client.read_from_file("/var/log/cloud-init.log")
+        verify_clean_log(log)
 
         assert not is_attached(
             client
@@ -260,7 +237,7 @@ class TestUbuntuAdvantagePro:
         ) as client:
             log = client.read_from_file("/var/log/cloud-init.log")
             verify_clean_log(log)
-            assert did_ua_service_noop(client)
+            assert_ua_service_noop(client)
             assert is_attached(client)
             services_status = get_services_status(client)
             assert services_status.pop(


### PR DESCRIPTION
## Proposed Commit Message
```
tests: fix integration tests for ubuntu pro 32.3 release

Now that pro 32.3 is published, drop duplicated ubuntu_advantage
alias keys from test user-data because pro 32.3 can now react to
ubuntu_pro keys.

Also, pro v. 32.3 changed how it logs some messages for various
systemd services. To obtain ua-auto-attach.service logs we now
invoke systemctl status ua-auto-attach.service instead of looking
at /var/log/ubuntu-advantage.log.

Additionally fix bug in clipped log message which didn't log the
full name of the renamed module:
 Module has been renamed from cc_old_name to c.
```

## Additional Context
Failed jenkins jobs representing this failure to discover Skip logs in /var/log/ubuntu-advantage.log
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-azure/451/testReport/tests.integration_tests.modules.test_ubuntu_pro/TestUbuntuAdvantagePro/test_custom_services/


## Test Steps
```
CLOUD_INIT_UA_TOKEN=<REDACTED> CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_PLATFORM=ec2 .tox/integration-tests/bin/pytest tests/integration_tests/modules/test_ubuntu_pro.py
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
