### PR TITLE
fix: cc_user_groups incorrectly assumes "useradd" never locks password field

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -136,6 +136,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     doas_fn = "/etc/doas.conf"
     ci_sudoers_fn = "/etc/sudoers.d/90-cloud-init-users"
     hostname_conf_fn = "/etc/hostname"
+    shadow_fn = "/etc/shadow"
     tz_zone_dir = "/usr/share/zoneinfo"
     default_owner = "root:root"
     init_cmd = ["service"]  # systemctl, service etc
@@ -655,19 +656,21 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     def get_default_user(self):
         return self.get_option("default_user")
 
-    def add_user(self, name, **kwargs):
+    def add_user(self, name, **kwargs) -> bool:
         """
         Add a user to the system using standard GNU tools
 
         This should be overridden on distros where useradd is not desirable or
         not available.
+
+        Returns False if user already exists, otherwise True.
         """
         # XXX need to make add_user idempotent somehow as we
         # still want to add groups or modify SSH keys on pre-existing
         # users in the image.
         if util.is_user(name):
             LOG.info("User %s already exists, skipping.", name)
-            return
+            return False
 
         if "create_groups" in kwargs:
             create_groups = kwargs.pop("create_groups")
@@ -771,6 +774,9 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             util.logexc(LOG, "Failed to create user %s", name)
             raise e
 
+        # Indicate that a new user was created
+        return True
+
     def add_snap_user(self, name, **kwargs):
         """
         Add a snappy user to the system using snappy tools
@@ -798,6 +804,62 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
 
         return username
 
+    def _check_if_password_field_matches(
+        self, username, pattern1, pattern2, pattern3=None, check_file=None
+    ) -> bool:
+        """
+        Check whether ``username`` user has a hashed password matching
+        either pattern.
+
+        FreeBSD, NetBSD, and OpenBSD use 3 patterns, others only use
+        2 patterns.
+
+        Returns either 'True' to indicate a match, otherwise 'False'.
+        """
+
+        if not check_file:
+            check_file = self.shadow_fn
+
+        cmd = [
+            "grep",
+            "-q",
+            "-e",
+            "^%s%s" % (username, pattern1),
+            "-e",
+            "^%s%s" % (username, pattern2),
+        ]
+        if pattern3 is not None:
+            cmd.extend(["-e", "^%s%s" % (username, pattern3)])
+        cmd.append(check_file)
+        try:
+            subp.subp(cmd)
+        except subp.ProcessExecutionError as e:
+            if e.exit_code == 1:
+                # Exit code 1 means 'grep' didn't find empty password
+                return True
+            else:
+                util.logexc(
+                    LOG,
+                    "Failed to check the status of password for user %s",
+                    username,
+                )
+                raise e
+        return False
+
+    def _check_if_existing_password(self, username, shadow_file=None) -> bool:
+        """
+        Check whether ``username`` user has an existing password (regardless
+        of whether locked or not).
+
+        Returns either 'True' to indicate a password present, or 'False'
+        for no password set.
+        """
+
+        status = not self._check_if_password_field_matches(
+            username, "::", ":!:", check_file=shadow_file
+        )
+        return status
+
     def create_user(self, name, **kwargs):
         """
         Creates or partially updates the ``name`` user in the system.
@@ -824,20 +886,103 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             return self.add_snap_user(name, **kwargs)
 
         # Add the user
-        self.add_user(name, **kwargs)
+        pre_existing_user = not self.add_user(name, **kwargs)
 
-        # Set password if plain-text password provided and non-empty
-        if "plain_text_passwd" in kwargs and kwargs["plain_text_passwd"]:
-            self.set_passwd(name, kwargs["plain_text_passwd"])
+        has_existing_password = False
+        ud_blank_password_specified = False
+        ud_password_specified = False
+        password_key = None
 
-        # Set password if hashed password is provided and non-empty
-        if "hashed_passwd" in kwargs and kwargs["hashed_passwd"]:
-            self.set_passwd(name, kwargs["hashed_passwd"], hashed=True)
+        if "plain_text_passwd" in kwargs:
+            ud_password_specified = True
+            password_key = "plain_text_passwd"
+            if kwargs["plain_text_passwd"]:
+                # Set password if plain-text password provided and non-empty
+                self.set_passwd(name, kwargs["plain_text_passwd"])
+            else:
+                ud_blank_password_specified = True
 
-        # Default locking down the account.  'lock_passwd' defaults to True.
-        # lock account unless lock_password is False.
+        if "hashed_passwd" in kwargs:
+            ud_password_specified = True
+            password_key = "hashed_passwd"
+            if kwargs["hashed_passwd"]:
+                # Set password if hashed password is provided and non-empty
+                self.set_passwd(name, kwargs["hashed_passwd"], hashed=True)
+            else:
+                ud_blank_password_specified = True
+
+        if pre_existing_user:
+            if not ud_password_specified:
+                if "passwd" in kwargs:
+                    password_key = "passwd"
+                    # Only "plain_text_passwd" and "hashed_passwd"
+                    # are valid for an existing user.
+                    LOG.warning(
+                        "'passwd' in user-data is ignored for existing "
+                        "user %s",
+                        name,
+                    )
+
+                # As no password specified for the existing user in user-data
+                # then check if the existing user's hashed password value is
+                # blank (whether locked or not).
+                if util.system_is_snappy():
+                    has_existing_password = self._check_if_existing_password(
+                        name, "/var/lib/extrausers/shadow"
+                    )
+                    if not has_existing_password:
+                        # Check /etc/shadow also
+                        has_existing_password = (
+                            self._check_if_existing_password(name)
+                        )
+                else:
+                    has_existing_password = self._check_if_existing_password(
+                        name
+                    )
+        else:
+            if "passwd" in kwargs:
+                ud_password_specified = True
+                password_key = "passwd"
+                if not kwargs["passwd"]:
+                    ud_blank_password_specified = True
+
+        # Default locking down the account. 'lock_passwd' defaults to True.
+        # Lock account unless lock_password is False in which case unlock
+        # account as long as a password (blank or otherwise) was specified.
         if kwargs.get("lock_passwd", True):
             self.lock_passwd(name)
+        elif has_existing_password or ud_password_specified:
+            # 'lock_passwd: False' and either existing account already with
+            # non-blank password or else existing/new account with password
+            # explicitly set in user-data.
+            if ud_blank_password_specified:
+                LOG.debug(
+                    "Allowing unlocking empty password for %s based on empty"
+                    " '%s' in user-data",
+                    name,
+                    password_key,
+                )
+
+            # Unlock the existing/new account
+            self.unlock_passwd(name)
+        elif pre_existing_user:
+            # Pre-existing user with no existing password and none
+            # explicitly set in user-data.
+            LOG.warning(
+                "Not unlocking blank password for existing user %s."
+                " 'lock_passwd: false' present in user-data but no existing"
+                " password set and no 'plain_text_passwd'/'hashed_passwd'"
+                " provided in user-data",
+                name,
+            )
+        else:
+            # No password (whether blank or otherwise) explicitly set
+            LOG.warning(
+                "Not unlocking password for user %s. 'lock_passwd: false'"
+                " present in user-data but no 'passwd'/'plain_text_passwd'/"
+                "'hashed_passwd' provided in user-data",
+                name,
+            )
 
         # Configure doas access
         if "doas" in kwargs:
@@ -914,6 +1059,50 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             util.logexc(LOG, "Failed to disable password for user %s", name)
             raise e
 
+    def unlock_passwd(self, name: str):
+        """
+        Unlock the password of a user, i.e., enable password logins
+        """
+        # passwd must use short '-u' due to SLES11 lacking long form '--unlock'
+        unlock_tools = (["passwd", "-u", name], ["usermod", "--unlock", name])
+        try:
+            cmd = next(tool for tool in unlock_tools if subp.which(tool[0]))
+        except StopIteration as e:
+            raise RuntimeError(
+                "Unable to unlock user account '%s'. No tools available. "
+                "  Tried: %s." % (name, [c[0] for c in unlock_tools])
+            ) from e
+        try:
+            _, err = subp.subp(cmd, rcs=[0, 3])
+        except Exception as e:
+            util.logexc(LOG, "Failed to enable password for user %s", name)
+            raise e
+        if err:
+            # if "passwd" or "usermod" are unable to unlock an account with
+            # an empty password then they display a message on stdout. In
+            # that case then instead set a blank password.
+            passwd_set_tools = (
+                ["passwd", "-d", name],
+                ["usermod", "--password", "''", name],
+            )
+            try:
+                cmd = next(
+                    tool for tool in passwd_set_tools if subp.which(tool[0])
+                )
+            except StopIteration as e:
+                raise RuntimeError(
+                    "Unable to set blank password for user account '%s'. "
+                    "No tools available. "
+                    "  Tried: %s." % (name, [c[0] for c in unlock_tools])
+                ) from e
+            try:
+                subp.subp(cmd)
+            except Exception as e:
+                util.logexc(
+                    LOG, "Failed to set blank password for user %s", name
+                )
+                raise e
+
     def expire_passwd(self, user):
         try:
             subp.subp(["passwd", "--expire", user])
@@ -948,6 +1137,9 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
             )
             + "\n"
         )
+        # Need to use the short option name '-e' instead of '--encrypted'
+        # (which would be more descriptive) since Busybox and SLES 11
+        # chpasswd don't know about long names.
         cmd = ["chpasswd"] + (["-e"] if hashed else [])
         subp.subp(cmd, data=payload)
 

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -907,8 +907,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 # As no password specified for the existing user in user-data
                 # then check if the existing user's hashed password value is
                 # empty (whether locked or not).
-                has_existing_password = not self._shadow_file_has_empty_user_password(
-                    name
+                has_existing_password = not (
+                    self._shadow_file_has_empty_user_password(name)
                 )
         else:
             if "passwd" in kwargs:

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -907,8 +907,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 # As no password specified for the existing user in user-data
                 # then check if the existing user's hashed password value is
                 # empty (whether locked or not).
-                has_existing_password = (
-                    not self._shadow_file_has_empty_user_password(name)
+                has_existing_password = not self._shadow_file_has_empty_user_password(
+                    name
                 )
         else:
             if "passwd" in kwargs:

--- a/cloudinit/distros/bsd.py
+++ b/cloudinit/distros/bsd.py
@@ -15,6 +15,7 @@ class BSD(distros.Distro):
     networking_cls = BSDNetworking
     hostname_conf_fn = "/etc/rc.conf"
     rc_conf_fn = "/etc/rc.conf"
+    shadow_fn = "/etc/master.passwd"
     default_owner = "root:wheel"
 
     # This differs from the parent Distro class, which has -P for

--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -47,9 +47,9 @@ class Distro(cloudinit.distros.bsd.BSD):
     # field value of either "*" or "*LOCKED*" indicate differing forms of
     # "locked" but with no password defined.
     shadow_empty_locked_passwd_patterns = [
-        "^{username}::",
-        "^{username}:\*:",
-        "^{username}:\*LOCKED\*:",
+        r"^{username}::",
+        r"^{username}:\*:",
+        r"^{username}:\*LOCKED\*:",
     ]
 
     @classmethod

--- a/cloudinit/distros/netbsd.py
+++ b/cloudinit/distros/netbsd.py
@@ -55,9 +55,9 @@ class NetBSD(cloudinit.distros.bsd.BSD):
     # password, and a password field of "*LOCKED*" followed by 13 "*"
     # indicates a locked and blank password.
     shadow_empty_locked_passwd_patterns = [
-        "^{username}::",
-        "^{username}:\*\*\*\*\*\*\*\*\*\*\*\*\*:",
-        "^{username}:\*LOCKED\*\*\*\*\*\*\*\*\*\*\*\*\*\*:",
+        r"^{username}::",
+        r"^{username}:\*\*\*\*\*\*\*\*\*\*\*\*\*:",
+        r"^{username}:\*LOCKED\*\*\*\*\*\*\*\*\*\*\*\*\*\*:",
     ]
 
     def __init__(self, name, cfg, paths):

--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -179,16 +179,21 @@ class BSDNetworking(Networking):
 
     def __init__(self):
         self.ifc = ifconfig.Ifconfig()
-        self.ifs = {}
-        self._update_ifs()
+        self._ifs = {}
         super().__init__()
+
+    @property
+    def ifs(self) -> dict:
+        if not self._ifs:
+            self._update_ifs()
+        return self._ifs
 
     def _update_ifs(self):
         ifconf = subp.subp(["ifconfig", "-a"])
         # ``ifconfig -a`` always returns at least ``lo0``.
         # So this ``if`` is really just to make testing/mocking easier
         if ifconf[0]:
-            self.ifs = self.ifc.parse(ifconf[0])
+            self._ifs = self.ifc.parse(ifconf[0])
 
     def apply_network_config_names(self, netcfg: NetworkConfig) -> None:
         LOG.debug("Cannot rename network interface.")

--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -19,9 +19,9 @@ class Distro(cloudinit.distros.netbsd.NetBSD):
     # "*" or "*************" (13 "*") indicate differing forms of "locked"
     # but with no password defined.
     shadow_empty_locked_passwd_patterns = [
-        "^{username}::",
-        "^{username}:\*:",
-        "^{username}:\*\*\*\*\*\*\*\*\*\*\*\*\*:",
+        r"^{username}::",
+        r"^{username}:\*:",
+        r"^{username}:\*\*\*\*\*\*\*\*\*\*\*\*\*:",
     ]
 
     def _read_hostname(self, filename, default=None):

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -11,7 +11,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, JAMMY
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -36,6 +36,9 @@ AHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
     sudo: ALL=(ALL) NOPASSWD:ALL
     groups: [cloud-users, secret]
     lock_passwd: true
+  - name: nopassworduser
+    gecos: I do not like passwords
+    lock_passwd: false
   - name: cloudy
     gecos: Magic Cloud App Daemon User
     inactive: '0'
@@ -46,6 +49,10 @@ AHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
   - name: archivist
     uid: 1743
 """
+
+NEW_USER_EMPTY_PASSWD_WARNING = "Not unlocking password for user {username}. 'lock_passwd: false' present in user-data but no 'passwd'/'plain_text_passwd'/'hashed_passwd' provided in user-data"  # noqa: E501
+
+EXISTING_USER_EMPTY_PASSWD_WARNING = "Not unlocking blank password for existing user {username}. 'lock_passwd: false' present in user-data but no existing password set and no 'plain_text_passwd'/'hashed_passwd' provided in user-data"  # noqa E501
 
 
 @pytest.mark.ci
@@ -86,6 +93,8 @@ class TestUsersGroups:
             (["passwd", "eric"], r"eric:x:1742:"),
             # Test int uid
             (["passwd", "archivist"], r"archivist:x:1743:"),
+            # Test int uid
+            (["passwd", "nopassworduser"], r"nopassworduser:x:1744:"),
         ],
     )
     def test_users_groups(self, regex, getent_args, class_client):
@@ -106,6 +115,32 @@ class TestUsersGroups:
         _, groups_str = output.split(":", maxsplit=1)
         groups = groups_str.split()
         assert "secret" in groups
+
+    def test_nopassword_unlock_warnings(self, class_client):
+        """Verify warnings for empty passwords for new and existing users."""
+        verify_clean_boot(
+            class_client,
+            require_warnings=[
+                NEW_USER_EMPTY_PASSWD_WARNING.format(username="nopassworduser")
+            ],
+        )
+
+        # Fake admin clearing and unlocking and empty unlocked password foobar
+        # This will generate additional warnings about not unlocking passwords
+        # for pre-existing users which have an existing empty password
+        class_client.execute("passwd -d foobar")
+        class_client.instance.clean()
+        class_client.restart()
+        verify_clean_boot(
+            class_client,
+            ignore_warnings=True,  # ignore warnings about existing groups
+            require_warnings=[
+                EXISTING_USER_EMPTY_PASSWD_WARNING.format(
+                    username="nopassworduser"
+                ),
+                EXISTING_USER_EMPTY_PASSWD_WARNING.format(username="foobar"),
+            ],
+        )
 
 
 @pytest.mark.user_data(USER_DATA)

--- a/tests/unittests/distros/test_create_users.py
+++ b/tests/unittests/distros/test_create_users.py
@@ -220,7 +220,7 @@ class TestCreateUser:
             ),
             pytest.param(
                 {
-                    "/etc/master.passwd": f"dnsmasq::\n{USER}:*LOCKED**************:"
+                    "/etc/master.passwd": f"dnsmasq::\n{USER}:*LOCKED**************:"  # noqa: E501
                 },
                 "netbsd",
                 False,
@@ -280,7 +280,8 @@ class TestCreateUser:
                 shadow_file.parent.mkdir(parents=True, exist_ok=True)
             else:
                 raise AssertionError(
-                    f"Shadow file path {filename} not defined for distro {dist.name}"
+                    f"Shadow file path {filename} not defined for distro"
+                    f" {dist.name}"
                 )
             shadow_file.write_text(content)
         unlock_passwd = mocker.patch.object(dist, "unlock_passwd")

--- a/tests/unittests/distros/test_create_users.py
+++ b/tests/unittests/distros/test_create_users.py
@@ -6,7 +6,6 @@ from typing import List
 import pytest
 
 from cloudinit import distros, features, lifecycle, ssh_util
-from cloudinit.subp import SubpResult
 from tests.unittests.distros import _get_distro
 from tests.unittests.helpers import mock
 from tests.unittests.util import abstract_to_concrete

--- a/tests/unittests/distros/test_dragonflybsd.py
+++ b/tests/unittests/distros/test_dragonflybsd.py
@@ -1,8 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import cloudinit.util
-from cloudinit.distros.dragonflybsd import Distro
-from cloudinit.distros.freebsd import FreeBSDNetworking
 from tests.unittests.distros import _get_distro
 from tests.unittests.helpers import mock
 
@@ -11,10 +9,9 @@ M_PATH = "cloudinit.distros."
 
 class TestDragonFlyBSD:
     @mock.patch(M_PATH + "subp.subp")
-    def test_add_user(self, m_subp, mocker):
-        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+    def test_add_user(self, m_subp):
         distro = _get_distro("dragonflybsd")
-        user_created = distro.add_user("me2", uid=1234, default=False)
+        assert True is distro.add_user("me2", uid=1234, default=False)
         assert [
             mock.call(
                 [
@@ -30,10 +27,8 @@ class TestDragonFlyBSD:
                 logstring=["pw", "useradd", "-n", "me2", "-d/home/me2", "-m"],
             )
         ] == m_subp.call_args_list
-        assert user_created == True
 
-    def test_unlock_passwd(self, mocker, caplog):
-        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+    def test_unlock_passwd(self, caplog):
         distro = _get_distro("dragonflybsd")
         distro.unlock_passwd("me2")
         assert (

--- a/tests/unittests/distros/test_dragonflybsd.py
+++ b/tests/unittests/distros/test_dragonflybsd.py
@@ -14,7 +14,7 @@ class TestDragonFlyBSD:
     def test_add_user(self, m_subp, mocker):
         mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
         distro = _get_distro("dragonflybsd")
-        distro.add_user("me2", uid=1234, default=False)
+        user_created = distro.add_user("me2", uid=1234, default=False)
         assert [
             mock.call(
                 [
@@ -30,6 +30,7 @@ class TestDragonFlyBSD:
                 logstring=["pw", "useradd", "-n", "me2", "-d/home/me2", "-m"],
             )
         ] == m_subp.call_args_list
+        assert user_created == True
 
     def test_unlock_passwd(self, mocker, caplog):
         mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)

--- a/tests/unittests/distros/test_dragonflybsd.py
+++ b/tests/unittests/distros/test_dragonflybsd.py
@@ -1,7 +1,65 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import cloudinit.util
+from cloudinit.distros.dragonflybsd import Distro
+from cloudinit.distros.freebsd import FreeBSDNetworking
+from tests.unittests.distros import _get_distro
 from tests.unittests.helpers import mock
+
+M_PATH = "cloudinit.distros."
+
+
+class TestDragonFlyBSD:
+    @mock.patch(M_PATH + "subp.subp")
+    def test_add_user(self, m_subp, mocker):
+        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+        distro = _get_distro("dragonflybsd")
+        distro.add_user("me2", uid=1234, default=False)
+        assert [
+            mock.call(
+                [
+                    "pw",
+                    "useradd",
+                    "-n",
+                    "me2",
+                    "-u",
+                    "1234",
+                    "-d/home/me2",
+                    "-m",
+                ],
+                logstring=["pw", "useradd", "-n", "me2", "-d/home/me2", "-m"],
+            )
+        ] == m_subp.call_args_list
+
+    @mock.patch(M_PATH + "subp.subp")
+    def test_check_existing_password_for_user(self, m_subp, mocker):
+        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+        distro = _get_distro("dragonflybsd")
+        distro._check_if_existing_password("me2")
+        assert [
+            mock.call(
+                [
+                    "grep",
+                    "-q",
+                    "-e",
+                    "^me2::",
+                    "-e",
+                    "^me2:*:",
+                    "-e",
+                    "^me2:*LOCKED*:",
+                    "/etc/master.passwd",
+                ]
+            )
+        ] == m_subp.call_args_list
+
+    def test_unlock_passwd(self, mocker, caplog):
+        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+        distro = _get_distro("dragonflybsd")
+        distro.unlock_passwd("me2")
+        assert (
+            "Dragonfly BSD/FreeBSD password lock is not reversible, "
+            "ignoring unlock for user me2" in caplog.text
+        )
 
 
 def test_find_dragonflybsd_part():

--- a/tests/unittests/distros/test_dragonflybsd.py
+++ b/tests/unittests/distros/test_dragonflybsd.py
@@ -31,27 +31,6 @@ class TestDragonFlyBSD:
             )
         ] == m_subp.call_args_list
 
-    @mock.patch(M_PATH + "subp.subp")
-    def test_check_existing_password_for_user(self, m_subp, mocker):
-        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
-        distro = _get_distro("dragonflybsd")
-        distro._check_if_existing_password("me2")
-        assert [
-            mock.call(
-                [
-                    "grep",
-                    "-q",
-                    "-e",
-                    "^me2::",
-                    "-e",
-                    "^me2:*:",
-                    "-e",
-                    "^me2:*LOCKED*:",
-                    "/etc/master.passwd",
-                ]
-            )
-        ] == m_subp.call_args_list
-
     def test_unlock_passwd(self, mocker, caplog):
         mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
         distro = _get_distro("dragonflybsd")

--- a/tests/unittests/distros/test_freebsd.py
+++ b/tests/unittests/distros/test_freebsd.py
@@ -2,7 +2,6 @@
 
 import os
 
-from cloudinit.distros.freebsd import Distro, FreeBSDNetworking
 from cloudinit.util import find_freebsd_part, get_path_dev_freebsd
 from tests.unittests.distros import _get_distro
 from tests.unittests.helpers import CiTestCase, mock
@@ -12,10 +11,9 @@ M_PATH = "cloudinit.distros.freebsd."
 
 class TestFreeBSD:
     @mock.patch(M_PATH + "subp.subp")
-    def test_add_user(self, m_subp, mocker):
-        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+    def test_add_user(self, m_subp):
         distro = _get_distro("freebsd")
-        user_created = distro.add_user("me2", uid=1234, default=False)
+        assert True is distro.add_user("me2", uid=1234, default=False)
         assert [
             mock.call(
                 [
@@ -38,10 +36,8 @@ class TestFreeBSD:
                 ],
             )
         ] == m_subp.call_args_list
-        assert user_created == True
 
-    def test_unlock_passwd(self, mocker, caplog):
-        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+    def test_unlock_passwd(self, caplog):
         distro = _get_distro("freebsd")
         distro.unlock_passwd("me2")
         assert (

--- a/tests/unittests/distros/test_freebsd.py
+++ b/tests/unittests/distros/test_freebsd.py
@@ -39,27 +39,6 @@ class TestFreeBSD:
             )
         ] == m_subp.call_args_list
 
-    @mock.patch(M_PATH + "subp.subp")
-    def test_check_existing_password_for_user(self, m_subp, mocker):
-        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
-        distro = _get_distro("freebsd")
-        distro._check_if_existing_password("me2")
-        assert [
-            mock.call(
-                [
-                    "grep",
-                    "-q",
-                    "-e",
-                    "^me2::",
-                    "-e",
-                    "^me2:*:",
-                    "-e",
-                    "^me2:*LOCKED*:",
-                    "/etc/master.passwd",
-                ]
-            )
-        ] == m_subp.call_args_list
-
     def test_unlock_passwd(self, mocker, caplog):
         mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
         distro = _get_distro("freebsd")

--- a/tests/unittests/distros/test_freebsd.py
+++ b/tests/unittests/distros/test_freebsd.py
@@ -39,6 +39,36 @@ class TestFreeBSD:
             )
         ] == m_subp.call_args_list
 
+    @mock.patch(M_PATH + "subp.subp")
+    def test_check_existing_password_for_user(self, m_subp, mocker):
+        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+        distro = _get_distro("freebsd")
+        distro._check_if_existing_password("me2")
+        assert [
+            mock.call(
+                [
+                    "grep",
+                    "-q",
+                    "-e",
+                    "^me2::",
+                    "-e",
+                    "^me2:*:",
+                    "-e",
+                    "^me2:*LOCKED*:",
+                    "/etc/master.passwd",
+                ]
+            )
+        ] == m_subp.call_args_list
+
+    def test_unlock_passwd(self, mocker, caplog):
+        mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
+        distro = _get_distro("freebsd")
+        distro.unlock_passwd("me2")
+        assert (
+            "Dragonfly BSD/FreeBSD password lock is not reversible, "
+            "ignoring unlock for user me2" in caplog.text
+        )
+
 
 class TestDeviceLookUp(CiTestCase):
     @mock.patch("cloudinit.subp.subp")

--- a/tests/unittests/distros/test_freebsd.py
+++ b/tests/unittests/distros/test_freebsd.py
@@ -15,7 +15,7 @@ class TestFreeBSD:
     def test_add_user(self, m_subp, mocker):
         mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)
         distro = _get_distro("freebsd")
-        distro.add_user("me2", uid=1234, default=False)
+        user_created = distro.add_user("me2", uid=1234, default=False)
         assert [
             mock.call(
                 [
@@ -38,6 +38,7 @@ class TestFreeBSD:
                 ],
             )
         ] == m_subp.call_args_list
+        assert user_created == True
 
     def test_unlock_passwd(self, mocker, caplog):
         mocker.patch.object(Distro, "networking_cls", spec=FreeBSDNetworking)

--- a/tests/unittests/distros/test_netbsd.py
+++ b/tests/unittests/distros/test_netbsd.py
@@ -2,10 +2,7 @@ import unittest.mock as mock
 
 import pytest
 
-from cloudinit.distros.bsd import BSDNetworking
-from cloudinit.distros.netbsd import Distro
 from tests.unittests.distros import _get_distro
-from tests.unittests.helpers import mock
 
 try:
     # Blowfish not available in < 3.7, so this has never worked. Ignore failure
@@ -20,20 +17,17 @@ M_PATH = "cloudinit.distros.netbsd."
 
 class TestNetBSD:
     @mock.patch(M_PATH + "subp.subp")
-    def test_add_user(self, m_subp, mocker):
-        mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
+    def test_add_user(self, m_subp):
         distro = _get_distro("netbsd")
-        user_created = distro.add_user("me2", uid=1234, default=False)
+        assert True is distro.add_user("me2", uid=1234, default=False)
         assert [
             mock.call(
                 ["useradd", "-m", "me2"], logstring=["useradd", "-m", "me2"]
             )
         ] == m_subp.call_args_list
-        assert user_created == True
 
     @mock.patch(M_PATH + "subp.subp")
-    def test_unlock_passwd(self, m_subp, mocker, caplog):
-        mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
+    def test_unlock_passwd(self, m_subp, caplog):
         distro = _get_distro("netbsd")
         distro.unlock_passwd("me2")
         assert [

--- a/tests/unittests/distros/test_openbsd.py
+++ b/tests/unittests/distros/test_openbsd.py
@@ -1,0 +1,51 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from cloudinit.distros.bsd import BSDNetworking
+from cloudinit.distros.openbsd import Distro
+from tests.unittests.distros import _get_distro
+from tests.unittests.helpers import mock
+
+M_PATH = "cloudinit.distros.openbsd."
+
+
+class TestOpenBSD:
+    @mock.patch(M_PATH + "subp.subp")
+    def test_add_user(self, m_subp, mocker):
+        mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
+        distro = _get_distro("openbsd")
+        distro.add_user("me2", uid=1234, default=False)
+        assert [
+            mock.call(
+                ["useradd", "-m", "me2"], logstring=["useradd", "-m", "me2"]
+            )
+        ] == m_subp.call_args_list
+
+    @mock.patch(M_PATH + "subp.subp")
+    def test_check_existing_password_for_user(self, m_subp, mocker):
+        mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
+        distro = _get_distro("openbsd")
+        distro._check_if_existing_password("me2")
+        assert [
+            mock.call(
+                [
+                    "grep",
+                    "-q",
+                    "-e",
+                    "^me2::",
+                    "-e",
+                    "^me2:*:",
+                    "-e",
+                    "^me2:*************:",
+                    "/etc/master.passwd",
+                ]
+            )
+        ] == m_subp.call_args_list
+
+    def test_unlock_passwd(self, mocker, caplog):
+        mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
+        distro = _get_distro("openbsd")
+        distro.unlock_passwd("me2")
+        assert (
+            "OpenBSD password lock is not reversible, "
+            "ignoring unlock for user me2" in caplog.text
+        )

--- a/tests/unittests/distros/test_openbsd.py
+++ b/tests/unittests/distros/test_openbsd.py
@@ -13,12 +13,13 @@ class TestOpenBSD:
     def test_add_user(self, m_subp, mocker):
         mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
         distro = _get_distro("openbsd")
-        distro.add_user("me2", uid=1234, default=False)
+        user_created = distro.add_user("me2", uid=1234, default=False)
         assert [
             mock.call(
                 ["useradd", "-m", "me2"], logstring=["useradd", "-m", "me2"]
             )
         ] == m_subp.call_args_list
+        assert user_created == True
 
     def test_unlock_passwd(self, mocker, caplog):
         mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)

--- a/tests/unittests/distros/test_openbsd.py
+++ b/tests/unittests/distros/test_openbsd.py
@@ -20,27 +20,6 @@ class TestOpenBSD:
             )
         ] == m_subp.call_args_list
 
-    @mock.patch(M_PATH + "subp.subp")
-    def test_check_existing_password_for_user(self, m_subp, mocker):
-        mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
-        distro = _get_distro("openbsd")
-        distro._check_if_existing_password("me2")
-        assert [
-            mock.call(
-                [
-                    "grep",
-                    "-q",
-                    "-e",
-                    "^me2::",
-                    "-e",
-                    "^me2:*:",
-                    "-e",
-                    "^me2:*************:",
-                    "/etc/master.passwd",
-                ]
-            )
-        ] == m_subp.call_args_list
-
     def test_unlock_passwd(self, mocker, caplog):
         mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
         distro = _get_distro("openbsd")

--- a/tests/unittests/distros/test_openbsd.py
+++ b/tests/unittests/distros/test_openbsd.py
@@ -1,7 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from cloudinit.distros.bsd import BSDNetworking
-from cloudinit.distros.openbsd import Distro
 from tests.unittests.distros import _get_distro
 from tests.unittests.helpers import mock
 
@@ -10,19 +8,16 @@ M_PATH = "cloudinit.distros.openbsd."
 
 class TestOpenBSD:
     @mock.patch(M_PATH + "subp.subp")
-    def test_add_user(self, m_subp, mocker):
-        mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
+    def test_add_user(self, m_subp):
         distro = _get_distro("openbsd")
-        user_created = distro.add_user("me2", uid=1234, default=False)
+        assert True is distro.add_user("me2", uid=1234, default=False)
         assert [
             mock.call(
                 ["useradd", "-m", "me2"], logstring=["useradd", "-m", "me2"]
             )
         ] == m_subp.call_args_list
-        assert user_created == True
 
-    def test_unlock_passwd(self, mocker, caplog):
-        mocker.patch.object(Distro, "networking_cls", spec=BSDNetworking)
+    def test_unlock_passwd(self, caplog):
         distro = _get_distro("openbsd")
         distro.unlock_passwd("me2")
         assert (


### PR DESCRIPTION
## Proposed Commit Message

```
fix: cc_user_groups incorrectly assumes "useradd" never locks password

Currently cc_user_groups assumes that "useradd" never locks the password
field of newly created users. This is an incorrect assumption.

From the useradd manpage:

'-p, --password PASSWORD
The encrypted password, as returned by crypt(3). The default is to
disable the password.'

That is, if cloud-init runs 'useradd' but does not pass it the "-p"
option (with an encrypted password) then the new user's password field
will be locked by "useradd".

cloud-init only passes the "-p" option when calling "useradd" when
user-data specifies the "passwd" option for a new user. For user-data
that specifies either the "hashed_passwd" or "plain_text_passwd"
options instead then cloud-init calls "useradd" without the "-p" option
and so the password field of such a user will be locked by "useradd".

For user-data that specifies "hash_passwd" for a new user then "useradd"
is called with no "-p" option, so causing "useradd" to lock the
password field, however then cloud-init calls "chpasswd -e" to set the
encrypted password which also results in the password field being
unlocked.

For user-data that specifies either "plain_text_passwd" for a new user
then "useradd" is called with no "-p" option, so causing "useradd" to
lock the password. cloud-init then calls "chpasswd" to set the password
which also results in the password field being unlocked.

For user-data that specifies no password at all for a new user then
"useradd" is called with no "-p" option, so causing "useradd" to lock
the password. The password field is left locked.

In all the above scenarios "passwd -l" may be called later by
cloud-init to enforce "lock_passwd: true").

Conversely where "lock_passwd: false" applies the above "usermod"
situation (for "hash_passwd", "plain_text_passwd" or no
password) means that newly created users may have password
fields locked when they should be unlocked.

For Alpine, "adduser" does not support any form of password being
passed and it always locks the password field (the same point
applies about password field being unlocked when/if "chpasswd" is
called). Therefore in some situations (i.e. no password specified
in user-data) the password needs to be unlocked if
"lock_passwd: false".

This PR changes add_user (in both __init__.py and alpine.py) to
explicitly call either lock_passwd or unlock_passwd at all times to
achieve the desired final result.
```

## Additional Context
<!-- If relevant -->

## Test Steps

User-data:

```
users:
  - name: hash
    hash_passwd: $6$nonsense
    locked_passd: false
  - name: password
    passwd: $6$nonsense
    locked_passd: false
  - name: plain
    plain_text_passwd: test
    locked_passd: false
  - name: none
    locked_passd: false
```

Then check /etc/shadow to see if all the above users have locked or unlocked password fields.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
