### PR TITLE
tests: fix expect logging from growpart on devent with partition

### DIFF
--- a/tests/integration_tests/modules/test_growpart.py
+++ b/tests/integration_tests/modules/test_growpart.py
@@ -62,7 +62,7 @@ class TestGrowPart:
         log = client.read_from_file("/var/log/cloud-init.log")
         assert (
             "cc_growpart.py[INFO]: '/dev/sdb1' resized:"
-            " changed (/dev/sdb, 1) from" in log
+            " changed (/dev/sdb1) from" in log
         )
 
         lsblk = json.loads(client.execute("lsblk --json"))


### PR DESCRIPTION
## Commit message

```
tests: fix expect logging from growpart on devent with partition

Commit e520c944e changed resize logging by altering providing the
device path which includes the partition number instead of a tuple
when both device and partiiton number of set.

Fix expected log message.
```
CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_growpart.py::TestGrowPart::test_grow_part
```
## Additional Context
Jenkins test failure showing inability to match expected log
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_vm/8/testReport/junit/tests.integration_tests.modules.test_growpart/TestGrowPart/test_grow_part/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
