### PR TITLE
Translate key names for OpenStack bond properties

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -672,7 +672,14 @@ def convert_net_json(network_json=None, known_macs=None):
                 if k == "bond_links":
                     continue
                 elif k.startswith("bond"):
-                    params.update({k: v})
+                    # There is a difference in key name formatting for
+                    # bond parameters in the cloudinit and OpenStack
+                    # network schemas. The keys begin with 'bond-' in the
+                    # cloudinit schema but 'bond_' in OpenStack
+                    # network_data.json schema. Translate them to what
+                    # is expected by cloudinit.
+                    translated_key = "bond-{}".format(k.split("bond_", 1)[-1])
+                    params.update({translated_key: v})
 
             # openstack does not provide a name for the bond.
             # they do provide an 'id', but that is possibly non-sensical.

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -200,7 +200,6 @@ class TestConvertNetJson:
                     "type": "bond",
                 },
                 {
-                    "mac_address": "xx:xx:xx:xx:xx:00",
                     "name": "bond0.123",
                     "subnets": [
                         {

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -192,9 +192,9 @@ class TestConvertNetJson:
                     "name": "bond0",
                     "mac_address": "xx:xx:xx:xx:xx:00",
                     "params": {
-                        "bond_miimon": 100,
-                        "bond_mode": "802.3ad",
-                        "bond_xmit_hash_policy": "layer3+4",
+                        "bond-miimon": 100,
+                        "bond-mode": "802.3ad",
+                        "bond-xmit_hash_policy": "layer3+4",
                     },
                     "subnets": [],
                     "type": "bond",


### PR DESCRIPTION
Ensure that properties for bonded interfaces are translated properly from the OpenStack network_config.json format.

Fixes #5366

## Proposed Commit Message
```
fix: Ensure properties for bonded interfaces are properly translated

There is a discrepancy between the properties key name formatting in
the OpenStack network_data.json and cloudinit network-config.json
specifications. Ensure `bond_` is translated to `bond-` when the
OpenStack configuration is parsed by cloudinit.

Fixes GH-5366
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
