### PR TITLE
fix: Stop attempting to resize ZFS in cc_growpart on Linux

### DIFF
--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -503,7 +503,7 @@ def resize_devices(resizer: Resizer, devices, distro: Distro):
         # Ideally we would grow the FS for both OSes in the same module.
         if fs == "zfs" and isinstance(resizer, ResizeGrowFS):
             info += _call_resizer(resizer, devent, disk, ptnum, blockdev, fs)
-            return info
+            continue
 
         try:
             statret = os.stat(blockdev)

--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -118,36 +118,6 @@ class RESIZE:
 LOG = logging.getLogger(__name__)
 
 
-def resizer_factory(mode: str, distro: Distro, devices: list):
-    resize_class = None
-    if mode == "auto":
-        for _name, resizer in RESIZERS:
-            cur = resizer(distro)
-            if cur.available(devices=devices):
-                resize_class = cur
-                break
-
-        if not resize_class:
-            raise ValueError("No resizers available")
-
-    else:
-        mmap = {}
-        for k, v in RESIZERS:
-            mmap[k] = v
-
-        if mode not in mmap:
-            raise TypeError("unknown resize mode %s" % mode)
-
-        mclass = mmap[mode](distro)
-        if mclass.available(devices=devices):
-            resize_class = mclass
-
-        if not resize_class:
-            raise ValueError("mode %s not available" % mode)
-
-    return resize_class
-
-
 class ResizeFailedException(Exception):
     pass
 
@@ -278,6 +248,36 @@ class ResizeGpart(Resizer):
             raise ResizeFailedException(e) from e
 
         return (before, get_size(partdev, fs))
+
+
+def resizer_factory(mode: str, distro: Distro, devices: list) -> Resizer:
+    resize_class = None
+    if mode == "auto":
+        for _name, resizer in RESIZERS:
+            cur = resizer(distro)
+            if cur.available(devices=devices):
+                resize_class = cur
+                break
+
+        if not resize_class:
+            raise ValueError("No resizers available")
+
+    else:
+        mmap = {}
+        for k, v in RESIZERS:
+            mmap[k] = v
+
+        if mode not in mmap:
+            raise TypeError("unknown resize mode %s" % mode)
+
+        mclass = mmap[mode](distro)
+        if mclass.available(devices=devices):
+            resize_class = mclass
+
+        if not resize_class:
+            raise ValueError("mode %s not available" % mode)
+
+    return resize_class
 
 
 def get_size(filename, fs) -> Optional[int]:
@@ -473,7 +473,7 @@ def _call_resizer(resizer, devent, disk, ptnum, blockdev, fs):
     return info
 
 
-def resize_devices(resizer, devices, distro: Distro):
+def resize_devices(resizer: Resizer, devices, distro: Distro):
     # returns a tuple of tuples containing (entry-in-devices, action, message)
     devices = copy.copy(devices)
     info = []
@@ -496,7 +496,12 @@ def resize_devices(resizer, devices, distro: Distro):
             continue
 
         LOG.debug("growpart found fs=%s", fs)
-        if fs == "zfs":
+        # TODO: This seems to be the wrong place for this. On Linux, we the
+        # `os.stat(blockdev)` call below will fail on a ZFS filesystem.
+        # We then delay resizing the FS until calling cc_resizefs. Yet
+        # the code here is to accommodate the FreeBSD `growfs` service.
+        # Ideally we would grow the FS for both OSes in the same module.
+        if fs == "zfs" and isinstance(resizer, ResizeGrowFS):
             info += _call_resizer(resizer, devent, disk, ptnum, blockdev, fs)
             return info
 

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -440,21 +440,27 @@ class TestResizeZFS:
     def test_zroot(self, dev, expected, common_mocks):
         resize_calls = []
 
-        class myresizer:
+        class MyResizer(cc_growpart.ResizeGrowFS):
             def resize(self, diskdev, partnum, partdev, fs):
                 resize_calls.append((diskdev, partnum, partdev, fs))
                 if partdev == "zroot/ROOT/changed":
                     return (1024, 2048)
                 return (1024, 1024)  # old size, new size
 
-        def find(name, res):
-            for f in res:
-                if f[0] == name:
-                    return f
-            return None
+        def get_status_from_device(device_name, resize_results):
+            for result in resize_results:
+                if result[0] == device_name:
+                    return result[1]
+            raise ValueError(
+                f"Device {device_name} not found in {resize_results}"
+            )
 
-        resized = cc_growpart.resize_devices(myresizer(), [dev], self.distro)
-        assert expected == find(dev, resized)[1]
+        resized = cc_growpart.resize_devices(
+            resizer=MyResizer(distro=self.distro),
+            devices=[dev],
+            distro=self.distro,
+        )
+        assert expected == get_status_from_device(dev, resized)
 
 
 class TestGetSize:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Stop attempting to resize ZFS in cc_growpart on Linux

In e520c944, growing ZFS was added to cc_growpart to support BSD
systems. However, this left Linux in a state where it will fail to
resize and log a warning anytime it encounters ZFS. This commit
ensures that the cc_growpart resize is only attempted on BSD (or any
other system that uses `growfs`). This leaves cc_resizefs to grow the
filesystem on Linux.

This is admittedly a hack solution and long term, we should ensure
that ZFS gets grown in one module, and find a better long-term
abstraction for volume managers.


```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
