### PR TITLE
docs: network-config v2 ethernets are of type object

### DIFF
--- a/doc/rtd/reference/network-config-format-v2.rst
+++ b/doc/rtd/reference/network-config-format-v2.rst
@@ -37,7 +37,7 @@ For example the following could be present in
 
   network:
     version: 2
-    ethernets: []
+    ethernets: {}
 
 It may also be provided in other locations including the
 :ref:`datasource_nocloud`. See :ref:`network_config` for other places.


### PR DESCRIPTION
## Proposed Commit Message
docs: network-config v2 ethernets are of type object

The schema (cloudinit/config/schemas/schema-network-config-v2.json) and most other examples show that the `ethernets` field should contain an object with a map of type:
  configuration id -> definition

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
