### PR TITLE
Fix configuration of DNS servers via OpenStack

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -661,27 +661,23 @@ def convert_net_json(network_json=None, known_macs=None):
                 )
 
             # Look for either subnet or network specific DNS servers
-            # and add them as subnet level DNS entries. Use a set to
-            # for accumulation to eliminate duplicates.
+            # and add them as subnet level DNS entries.
             # Subnet specific nameservers
-            dns_nameservers = set(
-                [
-                    service["address"]
-                    for route in network.get("routes", [])
-                    for service in route.get("services", [])
-                    if service.get("type") == "dns"
-                ]
-            )
+            dns_nameservers = [
+                service["address"]
+                for route in network.get("routes", [])
+                for service in route.get("services", [])
+                if service.get("type") == "dns"
+            ]
             # Network specific nameservers
-            dns_nameservers.update(
-                [
-                    service["address"]
-                    for service in network.get("services", [])
-                    if service.get("type") == "dns"
-                ]
-            )
+            for service in network.get("services", []):
+                if service.get("type") != "dns":
+                    continue
+                if service["address"] in dns_nameservers:
+                    continue
+                dns_nameservers.append(service["address"])
             if dns_nameservers:
-                subnet["dns_nameservers"] = list(dns_nameservers)
+                subnet["dns_nameservers"] = dns_nameservers
 
             # Enable accept_ra for stateful and legacy ipv6_dhcp types
             if network["type"] in ["ipv6_dhcpv6-stateful", "ipv6_dhcp"]:

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -231,3 +231,129 @@ class TestConvertNetJson:
         assert expected == openstack.convert_net_json(
             network_json=network_json, known_macs=macs
         )
+
+    def test_dns_servers(self):
+        """
+        Verify additional properties under subnet.routes are not rendered
+        """
+        network_json = {
+            "links": [
+                {
+                    "id": "ens1f0np0",
+                    "name": "ens1f0np0",
+                    "type": "phy",
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:00",
+                    "mtu": 9000,
+                },
+                {
+                    "id": "ens1f1np1",
+                    "name": "ens1f1np1",
+                    "type": "phy",
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:01",
+                    "mtu": 9000,
+                },
+                {
+                    "id": "bond0",
+                    "name": "bond0",
+                    "type": "bond",
+                    "bond_links": ["ens1f0np0", "ens1f1np1"],
+                    "mtu": 9000,
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:00",
+                    "bond_mode": "802.3ad",
+                    "bond_xmit_hash_policy": "layer3+4",
+                    "bond_miimon": 100,
+                },
+                {
+                    "id": "bond0.123",
+                    "name": "bond0.123",
+                    "type": "vlan",
+                    "vlan_link": "bond0",
+                    "vlan_id": 123,
+                    "vlan_mac_address": "xx:xx:xx:xx:xx:00",
+                },
+            ],
+            "networks": [
+                {
+                    "id": "publicnet-ipv4",
+                    "type": "ipv4",
+                    "link": "bond0.123",
+                    "ip_address": "x.x.x.x",
+                    "netmask": "255.255.255.0",
+                    "routes": [
+                        {
+                            "network": "0.0.0.0",
+                            "netmask": "0.0.0.0",
+                            "gateway": "x.x.x.1",
+                            "services": [
+                                {"type": "dns", "address": "1.1.1.1"},
+                                {"type": "dns", "address": "8.8.8.8"},
+                            ],
+                        }
+                    ],
+                    "network_id": "00000000-0000-0000-0000-000000000000",
+                }
+            ],
+            "services": [],
+        }
+        expected = {
+            "version": 1,
+            "config": [
+                {
+                    "name": "ens1f0np0",
+                    "type": "physical",
+                    "mtu": 9000,
+                    "subnets": [],
+                    "mac_address": "xx:xx:xx:xx:xx:00",
+                },
+                {
+                    "name": "ens1f1np1",
+                    "type": "physical",
+                    "mtu": 9000,
+                    "subnets": [],
+                    "mac_address": "xx:xx:xx:xx:xx:01",
+                },
+                {
+                    "name": "bond0",
+                    "type": "bond",
+                    "mtu": 9000,
+                    "subnets": [],
+                    "mac_address": "xx:xx:xx:xx:xx:00",
+                    "params": {
+                        "bond-mode": "802.3ad",
+                        "bond-xmit_hash_policy": "layer3+4",
+                        "bond-miimon": 100,
+                    },
+                    "bond_interfaces": ["ens1f0np0", "ens1f1np1"],
+                },
+                {
+                    "name": "bond0.123",
+                    "type": "vlan",
+                    "subnets": [
+                        {
+                            "type": "static",
+                            "netmask": "255.255.255.0",
+                            "routes": [
+                                {
+                                    "network": "0.0.0.0",
+                                    "netmask": "0.0.0.0",
+                                    "gateway": "x.x.x.1",
+                                }
+                            ],
+                            "address": "x.x.x.x",
+                            "dns_nameservers": ["8.8.8.8", "1.1.1.1"],
+                            "ipv4": True,
+                        }
+                    ],
+                    "vlan_id": 123,
+                    "vlan_link": "bond0",
+                },
+            ],
+        }
+        macs = {
+            "xx:xx:xx:xx:xx:00": "ens1f0np0",
+            "xx:xx:xx:xx:xx:01": "ens1f1np1",
+        }
+        netcfg = openstack.convert_net_json(
+            network_json=network_json, known_macs=macs
+        )
+        assert expected == netcfg

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -340,7 +340,7 @@ class TestConvertNetJson:
                                 }
                             ],
                             "address": "x.x.x.x",
-                            "dns_nameservers": ["8.8.8.8", "1.1.1.1"],
+                            "dns_nameservers": ["1.1.1.1", "8.8.8.8"],
                             "ipv4": True,
                         }
                     ],


### PR DESCRIPTION
Ensure DNS server addresses are parsed from the proper location of network_data.json

Fixes #5386 

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Ensure proper configuration of DNS servers via OpenStack json network config

Ensure DNS server addresses are parsed from the proper location
of network_data.json and that the services entry is not propogated
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
