### PR TITLE
fix: rh_subscription org value

### DIFF
--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -47,14 +47,14 @@ meta: MetaSchema = {
             """\
             rh_subscription:
                 activation-key: foobar
-                org: 12345
+                org: 'ABC'
             """
         ),
         dedent(
             """\
             rh_subscription:
                 activation-key: foobar
-                org: 12345
+                org: 'ABC'
                 auto-attach: true
                 service-level: self-support
                 add-pool:

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2478,8 +2478,8 @@
               "description": "The activation key to use. Must be used with ``org``. Should not be used with ``username`` or ``password``"
             },
             "org": {
-              "type": "integer",
-              "description": "The organization number to use. Must be used with ``activation-key``. Should not be used with ``username`` or ``password``"
+              "type": "string",
+              "description": "The organization name to use. Must be used with ``activation-key``. Should not be used with ``username`` or ``password``"
             },
             "auto-attach": {
               "type": "boolean",

--- a/tests/unittests/config/test_cc_rh_subscription.py
+++ b/tests/unittests/config/test_cc_rh_subscription.py
@@ -184,7 +184,7 @@ class TestBadInput(CiTestCase):
         "rh_subscription": {
             "activation-key": "abcdef1234",
             "fookey": "bar",
-            "org": "123",
+            "org": "ABC",
         }
     }
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -140,6 +140,7 @@ outscale-mdr
 philsphicas
 phsm
 phunyguy
+pneigel-ca
 qubidt
 r00ta
 RedKrieg


### PR DESCRIPTION
Update `org` type from `integer` to `string`, updated unit test that references `org`.

Fixes GH-5382

## Proposed Commit Message
```
fix: rh_subscription org value

Update org value type

Fixes GH-5382
```

## Additional Context
The original issue identified schema errors for values that were determined to be appropriate using underlying tools.

## Test Steps
Provide sample configuration for `rh_subscription` using a `string` for the value of `org` and it should be free of schema errors when validated, ie: `cloud-init schema --system`

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [X] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [X] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
