### PR TITLE
perf(netplan): Improve network v1 -> network v2 performance

### DIFF
--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -6,7 +6,7 @@ import logging
 import os
 import textwrap
 from tempfile import SpooledTemporaryFile
-from typing import Optional, cast
+from typing import Callable, List, Optional, cast
 
 from cloudinit import features, safeyaml, subp, util
 from cloudinit.net import (
@@ -48,7 +48,7 @@ def _get_params_dict_by_match(config, match):
     )
 
 
-def _extract_addresses(config: dict, entry: dict, ifname, features=None):
+def _extract_addresses(config: dict, entry: dict, ifname, features: Callable):
     """This method parse a cloudinit.net.network_state dictionary (config) and
        maps netstate keys/values into a dictionary (entry) to represent
        netplan yaml. (config v1 -> netplan)
@@ -98,8 +98,6 @@ def _extract_addresses(config: dict, entry: dict, ifname, features=None):
                 obj,
             ]
 
-    if features is None:
-        features = []
     addresses = []
     routes = []
     nameservers = []
@@ -142,7 +140,7 @@ def _extract_addresses(config: dict, entry: dict, ifname, features=None):
                 searchdomains += _listify(subnet.get("dns_search", []))
             if "mtu" in subnet:
                 mtukey = "mtu"
-                if subnet_is_ipv6(subnet) and "ipv6-mtu" in features:
+                if subnet_is_ipv6(subnet) and "ipv6-mtu" in features():
                     mtukey = "ipv6-mtu"
                 entry.update({mtukey: subnet.get("mtu")})
             for route in subnet.get("routes", []):
@@ -311,11 +309,10 @@ class Renderer(renderer.Renderer):
         self.netplan_header = config.get("netplan_header", None)
         self._postcmds = config.get("postcmds", False)
         self.clean_default = config.get("clean_default", True)
-        self._features = config.get("features", None)
+        self._features = config.get("features") or []
 
-    @property
-    def features(self):
-        if self._features is None:
+    def features(self) -> List[str]:
+        if not self._features:
             try:
                 info_blob, _err = subp.subp(self.NETPLAN_INFO, capture=True)
                 info = util.load_yaml(info_blob)
@@ -408,7 +405,6 @@ class Renderer(renderer.Renderer):
             ) from last_exception
 
     def _render_content(self, network_state: NetworkState) -> str:
-
         # if content already in netplan format, pass it back
         if network_state.version == 2:
             LOG.debug("V2 to V2 passthrough")
@@ -464,7 +460,7 @@ class Renderer(renderer.Renderer):
                 # by using `Literal` when supported.
                 for match in ["bond_", "bond-"]:
                     bond_params = _get_params_dict_by_match(ifcfg, match)
-                    for (param, value) in bond_params.items():
+                    for param, value in bond_params.items():
                         newname = v2_bond_map.get(param.replace("_", "-"))
                         if newname is None:
                             continue
@@ -500,7 +496,7 @@ class Renderer(renderer.Renderer):
                 # Previous cast is needed to help mypy to know that the key is
                 # present in `NET_CONFIG_TO_V2`. This could probably be removed
                 # by using `Literal` when supported.
-                for (param, value) in params.items():
+                for param, value in params.items():
                     newname = v2_bridge_map.get(param)
                     if newname is None:
                         continue

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -3499,13 +3499,11 @@ class TestNetplanPostcommands:
         )
         mock_subp.side_effect = iter(
             [
-                subp.ProcessExecutionError,
                 ("", ""),
                 ("", ""),
             ]
         )
         expected = [
-            mock.call(["netplan", "info"], capture=True),
             mock.call(["netplan", "generate"], capture=True),
             mock.call(
                 [


### PR DESCRIPTION
## Commit message
```
feat(netplan): Improve network v1 -> network v2 performance

When converting network v1 to network v2, cloud-init might need to
know whether the backend network system supports ipv6 mtu. Previously
cloud-init was always calling `netplan info` when converting from v1
to v2 to know whether this feature is supported. With this change,
cloud-init only calls `netplan info` if it is required to render the
configuration (i.e. if MTU needs to be configured for ipv6).

This code change works by changing a property which always gets
referenced into a function which only gets referenced when it is
needed.

This removes ~0.2s from network render time on all Ubuntu platforms
that require converting from network v1 to network v2.

On a local LXD VM running Ubuntu Noble (24.04), this removes 0.2 seconds
from time to ssh - and cuts cloud-init's reported time in Network stage
down from 0.501 to 0.301.
```
