### PR TITLE
test: Add ds-identify integration test coverage

### DIFF
--- a/tests/integration_tests/test_ds_identify.py
+++ b/tests/integration_tests/test_ds_identify.py
@@ -1,7 +1,5 @@
 """test that ds-identify works as expected"""
 
-import json
-
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import OS_IMAGE, PLATFORM
 from tests.integration_tests.util import verify_clean_log, wait_for_cloud_init

--- a/tests/integration_tests/test_ds_identify.py
+++ b/tests/integration_tests/test_ds_identify.py
@@ -11,6 +11,8 @@ MAP_PLATFORM_TO_DATASOURCE = {
     "lxd_container": "lxd",
     "lxd_vm": "lxd",
     "qemu": "nocloud",
+    "ec2": "aws",
+    "oci": "oracle",
 }
 
 
@@ -28,9 +30,9 @@ def test_ds_identify(client: IntegrationInstance):
     verify_clean_log(client.execute("cat /var/log/cloud-init.log"))
     assert client.execute("cloud-init status --wait")
 
-    datasource = MAP_PLATFORM_TO_DATASOURCE.get(PLATFORM)
+    datasource = MAP_PLATFORM_TO_DATASOURCE.get(PLATFORM, PLATFORM)
     if "lxd" == datasource and "focal" == OS_IMAGE:
         datasource = "nocloud"
-    assert datasource == json.loads(
-        client.execute("cloud-init status --format json").stdout
-    ).get("datasource")
+    cloud_id = client.execute("cloud-id")
+    assert cloud_id.ok
+    assert datasource == cloud_id.stdout.rstrip()

--- a/tests/integration_tests/test_ds_identify.py
+++ b/tests/integration_tests/test_ds_identify.py
@@ -19,9 +19,9 @@ MAP_PLATFORM_TO_DATASOURCE = {
 def test_ds_identify(client: IntegrationInstance):
     """Verify that ds-identify works correctly
 
-    Deb packaging often a datasource_list with a single datasource, which
-    bypasses ds-identify. This tests works by removing this file and verifying
-    that cloud-init doesn't experience issues.
+    Deb packaging often a defines datasource_list with a single datasource,
+    which bypasses ds-identify logic. This tests works by removing this file
+    and verifying that cloud-init doesn't experience issues.
     """
     assert client.execute(f"rm {DATASOURCE_LIST_FILE}")
     assert client.execute("cloud-init clean --logs")

--- a/tests/integration_tests/test_ds_identify.py
+++ b/tests/integration_tests/test_ds_identify.py
@@ -1,0 +1,21 @@
+"""test that ds-identify works as expected"""
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_log, wait_for_cloud_init
+
+DATASOURCE_LIST_FILE = "/etc/cloud/cloud.cfg.d/90_dpkg.cfg"
+
+
+def test_ds_identify(client: IntegrationInstance):
+    """Verify that ds-identify works correctly
+
+    Deb packaging often a datasource_list with a single datasource, which
+    bypasses ds-identify. This tests works by removing this file and verifying
+    that cloud-init doesn't experience issues.
+    """
+    assert client.execute(f"rm {DATASOURCE_LIST_FILE}")
+    assert client.execute("cloud-init clean --logs")
+    client.restart()
+    wait_for_cloud_init(client)
+    verify_clean_log(client.execute("cat /var/log/cloud-init.log"))
+    assert client.execute("cloud-init status --wait")


### PR DESCRIPTION
## Proposed Commit Message
```
test: Add ds-identify integration test coverage

LXD instances don't have a defined datasource_list and therefore
implicitly exercise ds-identify. Add coverage for all other platforms.
```

## Additional Context
Currently LXD integration tests exercise ds-identify, but I don't know of any others that do - just some [unit tests](https://github.com/canonical/cloud-init/blob/main/tests/unittests/test_ds_identify.py).
