### PR TITLE
perf(set_passwords): Run module in Network stage

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -137,6 +137,7 @@ cloud_init_modules:
   - rsyslog
   - users_groups
   - ssh
+  - set_passwords
 
 # The modules that run in the 'config' stage
 cloud_config_modules:
@@ -156,7 +157,6 @@ cloud_config_modules:
 {% endif %}
   - locale
 {% endif %}
-  - set_passwords
 {% if variant == "alpine" %}
   - apk_configure
 {% elif variant in ["debian", "ubuntu", "unknown"] %}

--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -3,7 +3,6 @@
 # https://cloudinit.readthedocs.io/en/latest/explanation/boot.html
 Description=Cloud-init: Config Stage
 After=network-online.target cloud-config.target
-Before=systemd-user-sessions.service
 Wants=network-online.target cloud-config.target
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled

--- a/systemd/cloud-init.service.tmpl
+++ b/systemd/cloud-init.service.tmpl
@@ -30,6 +30,7 @@ After=dbus.service
 Before=network-online.target
 Before=sshd-keygen.service
 Before=sshd.service
+Before=systemd-user-sessions.service
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 Before=sysinit.target
 Before=shutdown.target


### PR DESCRIPTION
## Proposed Commit Message
```
perf(set_passwords): Run module in Network stage

Cloud-init blocks login until Config stage completes[1] to prevent users
from connecting to the instance via ssh prior to user configuration[2].
To enable faster ssh, cloud-init can simply move the set_passwords
module sooner in boot. This follows precedent of previous races of this
kind[3], and it effectively reverts b3c9b6a79c85e and while moving the set_passwords
module into Network stage.

The snap and grub_dpkg modules take a significant amount of time due to
runtime of external commands. This should improve time to ssh for all
users of those modules.

This will make both chpasswd and passwd run earlier in boot than before.
This should be safe, since chpasswd and passwd both use PAM, which to my
knowledge just requires r/w access to /etc/.

Probably the biggest noticeable effect will be for snapd users, which will
no longer have to wait an extra ~13s for snapd to start before they can ssh
into the instance.

graphical.target @27.796s
└─multi-user.target @27.796s
  └─snapd.seeded.service @14.658s +13.135s
    └─basic.target @14.207s
      └─sockets.target @14.197s
        └─snapd.socket @14.121s +61ms
          └─sysinit.target @14.006s
            └─cloud-init.service @11.135s +2.506s
              └─systemd-networkd-wait-online.service @9.670s +1.448s
                └─systemd-networkd.service @9.575s +71ms
                  └─network-pre.target @9.561s
                    └─cloud-init-local.service @5.564s +3.983s
                      └─systemd-remount-fs.service @1.581s +150ms
                        └─systemd-fsck-root.service @1.299s +195ms
                          └─systemd-journald.socket @1.011s
                            └─-.mount @880ms
                              └─-.slice @880ms.

[1] https://github.com/canonical/cloud-init/pull/2111
[2] https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2013403
[3] https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/781101
```

# Additional details




## Test Steps
```
tox -e integration-tests -- tests/integration_tests/modules/test_set_password.py                          
```