### PR TITLE
Improve schema validator warning messages on initialization

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -679,15 +679,16 @@ def netplan_validate_network_schema(
             message = _format_schema_problems(
                 errors,
                 prefix=(
-                    f"Invalid {SchemaType.NETWORK_CONFIG.value} provided:\n"
+                    f"{SchemaType.NETWORK_CONFIG.value} failed "
+                    "schema validation!\n"
                 ),
                 separator="\n",
             )
         else:
             message = (
-                f"Invalid {SchemaType.NETWORK_CONFIG.value} provided: "
-                "Please run 'sudo cloud-init schema --system' to "
-                "see the schema errors."
+                f"{SchemaType.NETWORK_CONFIG.value} failed schema validation! "
+                "You may run 'sudo cloud-init schema --system' to "
+                "check the details."
             )
         LOG.warning(message)
     return True
@@ -807,14 +808,14 @@ def validate_cloudconfig_schema(
         if log_details:
             details = _format_schema_problems(
                 errors,
-                prefix=f"Invalid {schema_type.value} provided:\n",
+                prefix=f"{schema_type.value} failed schema validation!\n",
                 separator="\n",
             )
         else:
             details = (
-                f"Invalid {schema_type.value} provided: "
-                "Please run 'sudo cloud-init schema --system' to "
-                "see the schema errors."
+                f"{schema_type.value} failed schema validation! "
+                "You may run 'sudo cloud-init schema --system' to "
+                "check the details."
             )
         LOG.warning(details)
     return True

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -448,8 +448,9 @@ class TestNetplanValidateNetworkSchema:
                     column=12,
                     message="incorrect YAML value: yes for dhcp value",
                 ),
-                r"Invalid network-config provided:.*format-l1.c12: Invalid"
-                " netplan schema. incorrect YAML value: yes for dhcp value",
+                r"network-config failed schema validation!.*format-l1.c12: "
+                "Invalid netplan schema. incorrect YAML value: yes for dhcp "
+                "value",
             ),
         ),
     )
@@ -513,8 +514,8 @@ class TestValidateCloudConfigSchema:
         assert "cloudinit.config.schema" == module
         assert logging.WARNING == log_level
         assert (
-            "Invalid cloud-config provided:\np1: -1 is not of type 'string'"
-            == log_msg
+            "cloud-config failed schema validation!\n"
+            "p1: -1 is not of type 'string'" == log_msg
         )
 
     @skipUnlessJsonSchema()
@@ -534,8 +535,9 @@ class TestValidateCloudConfigSchema:
         assert "cloudinit.config.schema" == module
         assert logging.WARNING == log_level
         assert (
-            "Invalid cloud-config provided: Please run 'sudo cloud-init "
-            "schema --system' to see the schema errors." == log_msg
+            "cloud-config failed schema validation! You may run "
+            "'sudo cloud-init schema --system' to check the details."
+            == log_msg
         )
 
     @skipUnlessJsonSchema()


### PR DESCRIPTION
During initialization, schema validator may throw warning messages if it finds
the provided configuration does not agree with the schema definition:

schema.py[WARNING]: Invalid cloud-config provided

In reality, even if the configuration does not agree with the schema, it may
sometimes still work. Improve the error message to make it more factual instead
of broadly claiming that the config is broken.

fixes: GH-5399

