### PR TITLE
typing: add no_implicit_optional lint

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -994,7 +994,7 @@ def process_merged_cloud_config_part_problems(
 def _get_config_type_and_rendered_userdata(
     config_path: str,
     content: str,
-    instance_data_path: str = None,
+    instance_data_path: Optional[str] = None,
 ) -> UserDataTypeAndDecodedContent:
     """
     Return tuple of user-data-type and rendered content.
@@ -1065,7 +1065,7 @@ def validate_cloudconfig_file(
     schema: dict,
     schema_type: SchemaType = SchemaType.CLOUD_CONFIG,
     annotate: bool = False,
-    instance_data_path: str = None,
+    instance_data_path: Optional[str] = None,
 ) -> bool:
     """Validate cloudconfig file adheres to a specific jsonschema.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ module = [
     "uaclient.*",
 ]
 ignore_missing_imports = true
+no_implicit_optional = true
 
 [tool.ruff]
 target-version = "py37"

--- a/tests/unittests/sources/test_akamai.py
+++ b/tests/unittests/sources/test_akamai.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pytest
 
@@ -17,7 +17,7 @@ class TestDataSourceAkamai:
     """
 
     def _get_datasource(
-        self, ds_cfg: Dict[str, Any] = None, local: bool = False
+        self, ds_cfg: Optional[Dict[str, Any]] = None, local: bool = False
     ) -> Union[DataSourceAkamai, DataSourceAkamaiLocal]:
         """
         Creates a test DataSource configured as provided


### PR DESCRIPTION


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
typing: add no_implicit_optional lint

Explicit optional types are preferred and the default in mypy >= 0.980[1].

Add the config to check for this and fix any instance of the lint error.

References:
[1] https://mypy.readthedocs.io/en/stable/config_file.html#confval-implicit_optional
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
