### PR TITLE
deprecation version boundary

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -236,17 +236,12 @@ def attempt_cmdline_url(path, network=True, cmdline=None) -> Tuple[int, str]:
                 is_cloud_cfg = False
             if is_cloud_cfg:
                 if cmdline_name == "url":
-                    return (
-                        log.DEPRECATED,
-                        str(
-                            util.deprecate(
-                                deprecated="The kernel command line key `url`",
-                                deprecated_version="22.3",
-                                extra_message=" Please use `cloud-config-url` "
-                                "kernel command line parameter instead",
-                                return_log=True,
-                            ),
-                        ),
+                    return util.deprecate(
+                        deprecated="The kernel command line key `url`",
+                        deprecated_version="22.3",
+                        extra_message=" Please use `cloud-config-url` "
+                        "kernel command line parameter instead",
+                        skip_log=True,
                     )
             else:
                 if cmdline_name == "cloud-config-url":
@@ -972,8 +967,8 @@ def main(sysv_args=None):
         deprecated="`init`",
         deprecated_version="24.1",
         extra_message="Use `cloud-init init` instead.",
-        return_log=True,
-    )
+        skip_log=True,
+    ).message
     parser_mod.add_argument(
         "--mode",
         "-m",

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -31,13 +31,14 @@ from typing import (
 
 import yaml
 
-from cloudinit import importer, safeyaml
+from cloudinit import features, importer, safeyaml
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.handlers import INCLUSION_TYPES_MAP, type_from_starts_with
 from cloudinit.helpers import Paths
 from cloudinit.sources import DataSourceNotFoundException
 from cloudinit.temp_utils import mkdtemp
 from cloudinit.util import (
+    Version,
     error,
     get_modules_from_dir,
     load_text_file,
@@ -137,7 +138,14 @@ else:
 
 
 class SchemaDeprecationError(ValidationError):
-    pass
+    def __init__(
+        self,
+        message: str,
+        version: str,
+        **kwargs,
+    ):
+        super().__init__(message, **kwargs)
+        self.version: str = version
 
 
 class SchemaProblem(NamedTuple):
@@ -363,7 +371,7 @@ def _validator(
         msg = _add_deprecated_changed_or_new_msg(
             schema, annotate=True, filter_key=[filter_key]
         )
-        yield error_type(msg)
+        yield error_type(msg, schema.get("deprecated_version", "devel"))
 
 
 _validator_deprecated = partial(_validator, filter_key="deprecated")
@@ -770,6 +778,7 @@ def validate_cloudconfig_schema(
 
     errors: SchemaProblems = []
     deprecations: SchemaProblems = []
+    info_deprecations: SchemaProblems = []
     for schema_error in sorted(
         validator.iter_errors(config), key=lambda e: e.path
     ):
@@ -785,25 +794,39 @@ def validate_cloudconfig_schema(
             )
             if prop_match:
                 path = prop_match["name"]
-        problem = (SchemaProblem(path, schema_error.message),)
         if isinstance(
             schema_error, SchemaDeprecationError
         ):  # pylint: disable=W1116
-            deprecations += problem
+            if (
+                "devel" != features.DEPRECATION_INFO_BOUNDARY
+                and Version.from_str(schema_error.version)
+                > Version.from_str(features.DEPRECATION_INFO_BOUNDARY)
+            ):
+                info_deprecations.append(
+                    SchemaProblem(path, schema_error.message)
+                )
+            else:
+                deprecations.append(SchemaProblem(path, schema_error.message))
         else:
-            errors += problem
+            errors.append(SchemaProblem(path, schema_error.message))
 
-    if log_deprecations and deprecations:
-        message = _format_schema_problems(
-            deprecations,
-            prefix="Deprecated cloud-config provided:\n",
-            separator="\n",
-        )
-        # This warning doesn't fit the standardized util.deprecated() utility
-        # format, but it is a deprecation log, so log it directly.
-        LOG.deprecated(message)  # type: ignore
-    if strict and (errors or deprecations):
-        raise SchemaValidationError(errors, deprecations)
+    if log_deprecations:
+        if info_deprecations:
+            message = _format_schema_problems(
+                info_deprecations,
+                prefix="Deprecated cloud-config provided: ",
+            )
+            LOG.info(message)
+        if deprecations:
+            message = _format_schema_problems(
+                deprecations,
+                prefix="Deprecated cloud-config provided: ",
+            )
+            # This warning doesn't fit the standardized util.deprecated()
+            # utility format, but it is a deprecation log, so log it directly.
+            LOG.deprecated(message)  # type: ignore
+    if strict and (errors or deprecations or info_deprecations):
+        raise SchemaValidationError(errors, deprecations + info_deprecations)
     if errors:
         if log_details:
             details = _format_schema_problems(

--- a/cloudinit/features.py
+++ b/cloudinit/features.py
@@ -87,6 +87,35 @@ On Debian and Ubuntu systems, cc_apt_configure will write a deb822 compatible
 to write /etc/apt/sources.list directly.
 """
 
+DEPRECATION_INFO_BOUNDARY = "devel"
+"""
+DEPRECATION_INFO_BOUNDARY is used by distros to configure at which upstream
+version to start logging deprecations at a level higher than INFO.
+
+The default value "devel" tells cloud-init to log all deprecations higher
+than INFO. This value may be overriden by downstreams in order to maintain
+stable behavior across releases.
+
+Jsonschema key deprecations and inline logger deprecations include a
+deprecated_version key. When the variable below is set to a version,
+cloud-init will use that version as a demarcation point. Deprecations which
+are added after this version will be logged as at an INFO level. Deprecations
+which predate this version will be logged at the higher DEPRECATED level.
+Downstreams that want stable log behavior may set the variable below to the
+first version released in their stable distro. By doing this, they can expect
+that newly added deprecations will be logged at INFO level. The implication of
+the different log levels is that logs at DEPRECATED level result in a return
+code of 2 from `cloud-init status`.
+
+format:
+
+<value> :: = <default> | <version>
+<default> ::= "devel"
+<version> ::= <major> "." <minor> ["." <patch>]
+
+where <major>, <minor>, and <patch> are positive integers
+"""
+
 
 def get_features() -> Dict[str, bool]:
     """Return a dict of applicable features/overrides and their values."""

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -629,7 +629,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"a-b": "asdf"},
-                "Deprecated cloud-config provided:\na-b: <desc> "
+                "Deprecated cloud-config provided: a-b: <desc> "
                 "Deprecated in version 22.1.",
             ),
             (
@@ -650,7 +650,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "+5"},
-                "Deprecated cloud-config provided:\nx: <desc> "
+                "Deprecated cloud-config provided: x: <desc> "
                 "Deprecated in version 22.1.",
             ),
             (
@@ -671,7 +671,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "5"},
-                "Deprecated cloud-config provided:\nx: <desc> "
+                "Deprecated cloud-config provided: x: <desc> "
                 "Deprecated in version 22.1. <dep desc>",
             ),
             (
@@ -692,7 +692,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "5"},
-                "Deprecated cloud-config provided:\nx: <desc> "
+                "Deprecated cloud-config provided: x: <desc> "
                 "Deprecated in version 22.1.",
             ),
             (
@@ -708,7 +708,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "+5"},
-                "Deprecated cloud-config provided:\nx: <desc> "
+                "Deprecated cloud-config provided: x: <desc> "
                 "Deprecated in version 22.1.",
             ),
             (
@@ -745,7 +745,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "+5"},
-                "Deprecated cloud-config provided:\nx: <desc> "
+                "Deprecated cloud-config provided: x: <desc> "
                 "Deprecated in version 32.3.",
             ),
             (
@@ -770,7 +770,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"x": "+5"},
-                "Deprecated cloud-config provided:\nx:  Deprecated in "
+                "Deprecated cloud-config provided: x:  Deprecated in "
                 "version 27.2.",
             ),
             (
@@ -786,7 +786,7 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"a-b": "asdf"},
-                "Deprecated cloud-config provided:\na-b: <desc> "
+                "Deprecated cloud-config provided: a-b: <desc> "
                 "Deprecated in version 27.2.",
             ),
             pytest.param(
@@ -804,8 +804,8 @@ class TestValidateCloudConfigSchema:
                     },
                 },
                 {"a-b": "asdf"},
-                "Deprecated cloud-config provided:\na-b:  Deprecated "
-                "in version 27.2.\na-b:  Changed in version 22.2. "
+                "Deprecated cloud-config provided: a-b:  Deprecated "
+                "in version 27.2., a-b:  Changed in version 22.2. "
                 "Drop ballast.",
                 id="deprecated_pattern_property_without_description",
             ),

--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -482,6 +482,7 @@ c: 4
         ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES=True,
         EXPIRE_APPLIES_TO_HASHED_USERS=False,
         NETPLAN_CONFIG_ROOT_READ_ONLY=True,
+        DEPRECATION_INFO_BOUNDARY="devel",
         NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH=False,
         APT_DEB822_SOURCE_LIST_FILE=True,
     )
@@ -513,6 +514,7 @@ c: 4
                 "ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES": True,
                 "EXPIRE_APPLIES_TO_HASHED_USERS": False,
                 "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
+                "DEPRECATION_INFO_BOUNDARY": "devel",
                 "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": False,
                 "APT_DEB822_SOURCE_LIST_FILE": True,
             },

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -19,6 +19,7 @@ class TestGetFeatures:
             ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES=True,
             EXPIRE_APPLIES_TO_HASHED_USERS=False,
             NETPLAN_CONFIG_ROOT_READ_ONLY=True,
+            DEPRECATION_INFO_BOUNDARY="devel",
             NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH=False,
             APT_DEB822_SOURCE_LIST_FILE=True,
         ):
@@ -29,4 +30,5 @@ class TestGetFeatures:
                 "NETPLAN_CONFIG_ROOT_READ_ONLY": True,
                 "NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH": False,
                 "APT_DEB822_SOURCE_LIST_FILE": True,
+                "DEPRECATION_INFO_BOUNDARY": "devel",
             } == features.get_features()

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -7,6 +7,8 @@ import io
 import logging
 import time
 
+import pytest
+
 from cloudinit import log, util
 from cloudinit.analyze.dump import CLOUD_INIT_ASCTIME_FMT
 from tests.unittests.helpers import CiTestCase
@@ -65,6 +67,48 @@ class TestDeprecatedLogs:
         logger.deprecated("deprecated message")
         assert "DEPRECATED" == caplog.records[0].levelname
         assert "deprecated message" in caplog.text
+
+    @pytest.mark.parametrize(
+        "expected_log_level, deprecation_info_boundary",
+        (
+            pytest.param(
+                "DEPRECATED",
+                "19.2",
+                id="test_same_deprecation_info_boundary_is_deprecated_level",
+            ),
+            pytest.param(
+                "INFO",
+                "19.1",
+                id="test_lower_deprecation_info_boundary_is_info_level",
+            ),
+        ),
+    )
+    def test_deprecate_log_level_based_on_features(
+        self, expected_log_level, deprecation_info_boundary, caplog, mocker
+    ):
+        """Deprecation log level depends on key deprecation_version
+
+        When DEPRECATION_INFO_BOUNDARY is set to a version number, and a key
+        has a deprecated_version with a version greater than the boundary
+        the log level is INFO instead of DEPRECATED. If
+        DEPRECATION_INFO_BOUNDARY is set to the default, "devel", all
+        deprecated keys are logged at level DEPRECATED.
+        """
+        mocker.patch.object(
+            util.features,
+            "DEPRECATION_INFO_BOUNDARY",
+            deprecation_info_boundary,
+        )
+        util.deprecate(
+            deprecated="some key",
+            deprecated_version="19.2",
+            extra_message="dont use it",
+        )
+        assert expected_log_level == caplog.records[0].levelname
+        assert (
+            "some key is deprecated in 19.2 and scheduled to be removed in"
+            " 24.2" in caplog.text
+        )
 
     def test_log_deduplication(self, caplog):
         log.define_deprecation_logger()


### PR DESCRIPTION
## Additional Context

Add deprecation version knob for stable release distros. This allows distros to set an "initial release" version for the cloud-init release on a stable distro, and any newly added deprecation in future releases should log at an INFO level. 

with the following cloud-config:
```yaml
#cloud-config
grub-dpkg:
  enabled:
    false
users:
  - name: osadmin
    lock-passwd: false
    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
    ssh-authorized-keys:
      - ssh-rsa "AAAAB3NzaC1yc2EAAAADAQABAAABAQCc/K1T62elOkJKc94sWovn06RE7D274Fxx5n+eT/oClAwk7632awMtWjO+lIRpzOlEcYCR6wexlmL9mZNEFJoROMMRyCxRilNAiDKOq0X5j1HXY2ky9KjtLxo2b8yXFRBcYKK4W8aHU94NkNek81jdi9lC+L6jUrZ25d7xylqnEbd4TgrBphiowdh5B3RY+j6ePthLWWhHopRcVDgq91yYacelCCIfSDaGBya9iXPZSwoKtPin4n5PdSGmSOA3fIkvV5JjLS1QbuY5tzhXKuH9MdAqrvutF1bprs/GDf0IY8DO7DDoo8rXjhhgGtCdg1i5UitZIAM3hn/Vk5F//5eJ JOOS8312@EB-OR6120158"

```
this PR yields the following schema annotate output:
```yaml
# cloud-init schema --system --annotate
Found cloud-config data types: user-data, network-config

1. user-data at /var/lib/cloud/instances/cb88d1af-f827-4381-bc89-4fad787bcaaf/cloud-config.txt:
#cloud-config

# from 1 files
# part-001

---
grub-dpkg:		# D1
    enabled: false
users:
-   lock-passwd: false		# D2
    name: osadmin
    ssh-authorized-keys:		# D3
    - ssh-rsa "AAAAB3NzaC1yc2EAAAADAQABAAABAQCc/K1T62elOkJKc94sWovn06RE7D274Fxx5n+eT/oClAwk7632awMtWjO+lIRpzOlEcYCR6wexlmL9mZNEFJoROMMRyCxRilNAiDKOq0X5j1HXY2ky9KjtLxo2b8yXFRBcYKK4W8aHU94NkNek81jdi9lC+L6jUrZ25d7xylqnEbd4TgrBphiowdh5B3RY+j6ePthLWWhHopRcVDgq91yYacelCCIfSDaGBya9iXPZSwoKtPin4n5PdSGmSOA3fIkvV5JjLS1QbuY5tzhXKuH9MdAqrvutF1bprs/GDf0IY8DO7DDoo8rXjhhgGtCdg1i5UitZIAM3hn/Vk5F//5eJ
        JOOS8312@EB-OR6120158"
    sudo:
    - ALL=(ALL) NOPASSWD:ALL
...

# Deprecations: -------------
# D1: An alias for ``grub_dpkg`` Deprecated in version 22.2. Use ``grub_dpkg`` instead.
# D2: Default: ``true`` Deprecated in version 22.3. Use ``lock_passwd`` instead.
# D3:  Deprecated in version 18.3. Use ``ssh_authorized_keys`` instead.


  Valid schema user-data

2. network-config at /var/lib/cloud/instances/cb88d1af-f827-4381-bc89-4fad787bcaaf/network-config.json:
  Valid schema network-config
```
and the deprecated key use is logged at level DEPRECATED:

```bash
# cloud-init status  --long
status: done
extended_status: degraded done
boot_status_code: enabled-by-generator
last_update: Thu, 01 Jan 1970 00:00:04 +0000
detail: DataSourceLXD
errors: []
recoverable_errors:
DEPRECATED:
	- Deprecated cloud-config provided:grub-dpkg: An alias for ``grub_dpkg`` Deprecated in version 22.2. Use ``grub_dpkg`` instead., users.0.lock-passwd: Default: ``true`` Deprecated in version 22.3. Use ``lock_passwd`` instead., users.0.ssh-authorized-keys:  Deprecated in version 18.3. Use ``ssh_authorized_keys`` instead.
```
when DEPRECATION_INFO_BOUNDARY is set to 22.2
```diff
diff --git a/cloudinit/features.py b/cloudinit/features.py
index 9d88e138c..7f6900969 100644
--- a/cloudinit/features.py
+++ b/cloudinit/features.py
@@ -87,7 +87,7 @@ On Debian and Ubuntu systems, cc_apt_configure will write a deb822 compatible
 to write /etc/apt/sources.list directly.
 """
 
-DEPRECATION_INFO_BOUNDARY = "devel"
+DEPRECATION_INFO_BOUNDARY = "22.2"
 """
 DEPRECATION_INFO_BOUNDARY is used by distros to configure at which version to
 start logging deprecations at a level higher than INFO.
```

all deprecations are still reported
```
root@me:~# cloud-init schema --annotate --system
Found cloud-config data types: user-data, network-config

1. user-data at /var/lib/cloud/instances/5362d6fe-c68b-4e53-9920-49795eac9c28/cloud-config.txt:
#cloud-config

# from 1 files
# part-001

---
grub-dpkg:		# D1
    enabled: false
users:
-   lock-passwd: false		# D2
    name: osadmin
    ssh-authorized-keys:		# D3
    - ssh-rsa "AAAAB3NzaC1yc2EAAAADAQABAAABAQCc/K1T62elOkJKc94sWovn06RE7D274Fxx5n+eT/oClAwk7632awMtWjO+lIRpzOlEcYCR6wexlmL9mZNEFJoROMMRyCxRilNAiDKOq0X5j1HXY2ky9KjtLxo2b8yXFRBcYKK4W8aHU94NkNek81jdi9lC+L6jUrZ25d7xylqnEbd4TgrBphiowdh5B3RY+j6ePthLWWhHopRcVDgq91yYacelCCIfSDaGBya9iXPZSwoKtPin4n5PdSGmSOA3fIkvV5JjLS1QbuY5tzhXKuH9MdAqrvutF1bprs/GDf0IY8DO7DDoo8rXjhhgGtCdg1i5UitZIAM3hn/Vk5F//5eJ
        JOOS8312@EB-OR6120158"
    sudo:
    - ALL=(ALL) NOPASSWD:ALL
...

# Deprecations: -------------
# D1: An alias for ``grub_dpkg`` Deprecated in version 22.2. Use ``grub_dpkg`` instead.
# D2: Default: ``true`` Deprecated in version 22.3. Use ``lock_passwd`` instead.
# D3:  Deprecated in version 18.3. Use ``ssh_authorized_keys`` instead.


  Valid schema user-data

2. network-config at /var/lib/cloud/instances/5362d6fe-c68b-4e53-9920-49795eac9c28/network-config.json:
  Valid schema network-config
```
however only older deprecations than this version are logged at a `DEPRECATED` level:
```
root@me:~# cloud-init status --long
status: done
extended_status: degraded done
boot_status_code: enabled-by-generator
last_update: Thu, 01 Jan 1970 00:00:03 +0000
detail: DataSourceLXD
errors: []
recoverable_errors:
DEPRECATED:
	- Deprecated cloud-config provided:grub-dpkg: An alias for ``grub_dpkg`` Deprecated in version 22.2. Use ``grub_dpkg`` instead.
```


nice to have:

- [ ] log the release boundary
- [ ] user configurable release boundary


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
