### PR TITLE
fix(openbsd): fix mtu on newline in hostname files

### DIFF
--- a/cloudinit/net/openbsd.py
+++ b/cloudinit/net/openbsd.py
@@ -27,7 +27,7 @@ class Renderer(cloudinit.net.bsd.BSDRenderer):
                     )
                 mtu = v.get("mtu")
                 if mtu:
-                    content += " mtu %d" % mtu
+                    content += "\nmtu %d" % mtu
                 content += "\n" + self.interface_routes
             util.write_file(fn, content)
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -173,6 +173,7 @@ TheRealFalcon
 thetoolsmith
 timothegenzmer
 tnt-dev
+tobias-urdin
 tomponline
 tsanghan
 tSU-RooT


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs #1234, Closes #1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message

```
fix(openbsd): fix mtu on newline in hostname files

The /etc/hostname.* files should have the mtu on
a separate line otherwise it gives error:

  ifconfig: mtu: bad value

The lines are executed in order by ifconfig and
mtu should be on it's own line.

Fixes: GH-5413
```

## Additional Context
<!-- If relevant -->

## Test Steps
use cloud-init with a config drive instead of dhcp


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)