### PR TITLE
fix(pytest): Fix broken pytest gdb flag

### DIFF
--- a/tests/unittests/config/test_cc_disk_setup.py
+++ b/tests/unittests/config/test_cc_disk_setup.py
@@ -1,4 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+# pylint: disable=attribute-defined-outside-init
 
 import random
 import tempfile

--- a/tests/unittests/config/test_cc_disk_setup.py
+++ b/tests/unittests/config/test_cc_disk_setup.py
@@ -14,15 +14,13 @@ from cloudinit.config.schema import (
 from tests.unittests.helpers import (
     CiTestCase,
     ExitStack,
-    TestCase,
     mock,
     skipUnlessJsonSchema,
 )
 
 
-class TestIsDiskUsed(TestCase):
-    def setUp(self):
-        super(TestIsDiskUsed, self).setUp()
+class TestIsDiskUsed:
+    def setup_method(self):
         self.patches = ExitStack()
         mod_name = "cloudinit.config.cc_disk_setup"
         self.enumerate_disk = self.patches.enter_context(
@@ -32,14 +30,13 @@ class TestIsDiskUsed(TestCase):
             mock.patch("{0}.check_fs".format(mod_name))
         )
 
-    def tearDown(self):
-        super().tearDown()
+    def teardown_method(self):
         self.patches.close()
 
     def test_multiple_child_nodes_returns_true(self):
         self.enumerate_disk.return_value = (mock.MagicMock() for _ in range(2))
         self.check_fs.return_value = (mock.MagicMock(), None, mock.MagicMock())
-        self.assertTrue(cc_disk_setup.is_disk_used(mock.MagicMock()))
+        assert cc_disk_setup.is_disk_used(mock.MagicMock())
 
     def test_valid_filesystem_returns_true(self):
         self.enumerate_disk.return_value = (mock.MagicMock() for _ in range(1))
@@ -48,44 +45,29 @@ class TestIsDiskUsed(TestCase):
             "ext4",
             mock.MagicMock(),
         )
-        self.assertTrue(cc_disk_setup.is_disk_used(mock.MagicMock()))
+        assert cc_disk_setup.is_disk_used(mock.MagicMock())
 
     def test_one_child_nodes_and_no_fs_returns_false(self):
         self.enumerate_disk.return_value = (mock.MagicMock() for _ in range(1))
         self.check_fs.return_value = (mock.MagicMock(), None, mock.MagicMock())
-        self.assertFalse(cc_disk_setup.is_disk_used(mock.MagicMock()))
+        assert not cc_disk_setup.is_disk_used(mock.MagicMock())
 
 
-class TestGetMbrHddSize(TestCase):
-    def setUp(self):
-        super(TestGetMbrHddSize, self).setUp()
-        self.patches = ExitStack()
-        self.subp = self.patches.enter_context(
-            mock.patch.object(cc_disk_setup.subp, "subp")
-        )
-
-    def tearDown(self):
-        super().tearDown()
-        self.patches.close()
-
-    def _configure_subp_mock(self, hdd_size_in_bytes, sector_size_in_bytes):
-        def _subp(cmd, *args, **kwargs):
-            self.assertEqual(3, len(cmd))
-            if "--getsize64" in cmd:
-                return hdd_size_in_bytes, None
-            elif "--getss" in cmd:
-                return sector_size_in_bytes, None
-            raise RuntimeError("Unexpected blockdev command called")
-
-        self.subp.side_effect = _subp
-
+class TestGetMbrHddSize:
     def _test_for_sector_size(self, sector_size):
         size_in_bytes = random.randint(10000, 10000000) * 512
         size_in_sectors = size_in_bytes / sector_size
-        self._configure_subp_mock(size_in_bytes, sector_size)
-        self.assertEqual(
-            size_in_sectors, cc_disk_setup.get_hdd_size("/dev/sda1")
-        )
+
+        def _subp(cmd, *args, **kwargs):
+            assert 3 == len(cmd)
+            if "--getsize64" in cmd:
+                return size_in_bytes, None
+            elif "--getss" in cmd:
+                return sector_size, None
+            raise RuntimeError("Unexpected blockdev command called")
+
+        with mock.patch.object(cc_disk_setup.subp, "subp", _subp):
+            assert size_in_sectors == cc_disk_setup.get_hdd_size("/dev/sda1")
 
     def test_size_for_512_byte_sectors(self):
         self._test_for_sector_size(512)
@@ -100,36 +82,32 @@ class TestGetMbrHddSize(TestCase):
         self._test_for_sector_size(4096)
 
 
-class TestGetPartitionMbrLayout(TestCase):
+class TestGetPartitionMbrLayout:
     def test_single_partition_using_boolean(self):
-        self.assertEqual(
-            ",,83", cc_disk_setup.get_partition_mbr_layout(1000, True)
-        )
+        assert ",,83" == cc_disk_setup.get_partition_mbr_layout(1000, True)
 
     def test_single_partition_using_list(self):
         disk_size = random.randint(1000000, 1000000000000)
-        self.assertEqual(
-            ",,83", cc_disk_setup.get_partition_mbr_layout(disk_size, [100])
+        assert ",,83" == cc_disk_setup.get_partition_mbr_layout(
+            disk_size, [100]
         )
 
     def test_half_and_half(self):
         disk_size = random.randint(1000000, 1000000000000)
         expected_partition_size = int(float(disk_size) / 2)
-        self.assertEqual(
-            ",{0},83\n,,83".format(expected_partition_size),
-            cc_disk_setup.get_partition_mbr_layout(disk_size, [50, 50]),
-        )
+        assert ",{0},83\n,,83".format(
+            expected_partition_size
+        ) == cc_disk_setup.get_partition_mbr_layout(disk_size, [50, 50])
 
     def test_thirds_with_different_partition_type(self):
         disk_size = random.randint(1000000, 1000000000000)
         expected_partition_size = int(float(disk_size) * 0.33)
-        self.assertEqual(
-            ",{0},83\n,,82".format(expected_partition_size),
-            cc_disk_setup.get_partition_mbr_layout(disk_size, [33, [66, 82]]),
-        )
+        assert ",{0},83\n,,82".format(
+            expected_partition_size
+        ) == cc_disk_setup.get_partition_mbr_layout(disk_size, [33, [66, 82]])
 
 
-class TestUpdateFsSetupDevices(TestCase):
+class TestUpdateFsSetupDevices:
     def test_regression_1634678(self):
         # Cf. https://bugs.launchpad.net/cloud-init/+bug/1634678
         fs_setup = {
@@ -144,17 +122,14 @@ class TestUpdateFsSetupDevices(TestCase):
             [fs_setup], lambda device: device
         )
 
-        self.assertEqual(
-            {
-                "_origname": "/dev/xvdb1",
-                "partition": "auto",
-                "device": "/dev/xvdb1",
-                "overwrite": False,
-                "label": "test",
-                "filesystem": "ext4",
-            },
-            fs_setup,
-        )
+        assert {
+            "_origname": "/dev/xvdb1",
+            "partition": "auto",
+            "device": "/dev/xvdb1",
+            "overwrite": False,
+            "label": "test",
+            "filesystem": "ext4",
+        } == fs_setup
 
     def test_dotted_devname(self):
         fs_setup = {
@@ -168,17 +143,14 @@ class TestUpdateFsSetupDevices(TestCase):
             [fs_setup], lambda device: device
         )
 
-        self.assertEqual(
-            {
-                "_origname": "ephemeral0.0",
-                "_partition": "auto",
-                "partition": "0",
-                "device": "ephemeral0",
-                "label": "test2",
-                "filesystem": "xfs",
-            },
-            fs_setup,
-        )
+        assert {
+            "_origname": "ephemeral0.0",
+            "_partition": "auto",
+            "partition": "0",
+            "device": "ephemeral0",
+            "label": "test2",
+            "filesystem": "xfs",
+        } == fs_setup
 
     def test_dotted_devname_populates_partition(self):
         fs_setup = {
@@ -189,19 +161,16 @@ class TestUpdateFsSetupDevices(TestCase):
         cc_disk_setup.update_fs_setup_devices(
             [fs_setup], lambda device: device
         )
-        self.assertEqual(
-            {
-                "_origname": "ephemeral0.1",
-                "device": "ephemeral0",
-                "partition": "1",
-                "label": "test2",
-                "filesystem": "xfs",
-            },
-            fs_setup,
-        )
+        assert {
+            "_origname": "ephemeral0.1",
+            "device": "ephemeral0",
+            "partition": "1",
+            "label": "test2",
+            "filesystem": "xfs",
+        } == fs_setup
 
 
-class TestPurgeDisk(TestCase):
+class TestPurgeDisk:
     @mock.patch(
         "cloudinit.config.cc_disk_setup.read_parttbl", return_value=None
     )
@@ -215,7 +184,7 @@ class TestPurgeDisk(TestCase):
 
         expected = b"\0" * (1024 * 1024)
 
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
 
 @mock.patch(
@@ -245,17 +214,15 @@ class TestMkfsCommandHandling(CiTestCase):
             }
         )
 
-        self.assertIn(
+        assert (
             "extra_opts "
             "ignored because cmd was specified: mkfs -t ext4 -L with_cmd "
-            "/dev/xdb1",
-            self.logs.getvalue(),
+            "/dev/xdb1" in self.logs.getvalue()
         )
-        self.assertIn(
+        assert (
             "overwrite "
             "ignored because cmd was specified: mkfs -t ext4 -L with_cmd "
-            "/dev/xdb1",
-            self.logs.getvalue(),
+            "/dev/xdb1" in self.logs.getvalue()
         )
 
         subp.assert_called_once_with(
@@ -304,10 +271,10 @@ class TestMkfsCommandHandling(CiTestCase):
             }
         )
 
-        self.assertEqual(
-            [mock.call("mkfs.swap"), mock.call("mkswap")],
-            m_which.call_args_list,
-        )
+        assert [
+            mock.call("mkfs.swap"),
+            mock.call("mkswap"),
+        ] == m_which.call_args_list
         subp.assert_called_once_with(
             ["/sbin/mkswap", "-L", "swap", "-f", "/dev/xdb1"], shell=False
         )

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -21,15 +21,14 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
-from tests.unittests.helpers import TestCase, skipUnlessJsonSchema
+from tests.unittests.helpers import skipUnlessJsonSchema
 from tests.unittests.util import get_cloud
 
 LOG = logging.getLogger(__name__)
 
 
-class TestRandomSeed(TestCase):
-    def setUp(self):
-        super(TestRandomSeed, self).setUp()
+class TestRandomSeed:
+    def setup_method(self):
         self._seed_file = tempfile.mktemp()
         self.unapply = []
 
@@ -39,10 +38,9 @@ class TestRandomSeed(TestCase):
         self.subp_called = []
         self.whichdata = {}
 
-    def tearDown(self):
+    def teardown_method(self):
         apply_patches([i for i in reversed(self.unapply)])
         util.del_file(self._seed_file)
-        super().tearDown()
 
     def apply_patches(self, patches):
         ret = apply_patches(patches)
@@ -74,7 +72,7 @@ class TestRandomSeed(TestCase):
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_text_file(self._seed_file)
-        self.assertEqual("tiny-tim-was-here", contents)
+        assert "tiny-tim-was-here" == contents
 
     def test_append_random_unknown_encoding(self):
         data = self._compress(b"tiny-toe")
@@ -85,7 +83,7 @@ class TestRandomSeed(TestCase):
                 "encoding": "special_encoding",
             }
         }
-        self.assertRaises(
+        pytest.raises(
             IOError,
             cc_seed_random.handle,
             "test",
@@ -105,7 +103,7 @@ class TestRandomSeed(TestCase):
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_text_file(self._seed_file)
-        self.assertEqual("tiny-toe", contents)
+        assert "tiny-toe" == contents
 
     def test_append_random_gz(self):
         data = self._compress(b"big-toe")
@@ -118,7 +116,7 @@ class TestRandomSeed(TestCase):
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_text_file(self._seed_file)
-        self.assertEqual("big-toe", contents)
+        assert "big-toe" == contents
 
     def test_append_random_base64(self):
         data = atomic_helper.b64e("bubbles")
@@ -131,7 +129,7 @@ class TestRandomSeed(TestCase):
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_text_file(self._seed_file)
-        self.assertEqual("bubbles", contents)
+        assert "bubbles" == contents
 
     def test_append_random_b64(self):
         data = atomic_helper.b64e("kit-kat")
@@ -144,7 +142,7 @@ class TestRandomSeed(TestCase):
         }
         cc_seed_random.handle("test", cfg, get_cloud("ubuntu"), [])
         contents = util.load_text_file(self._seed_file)
-        self.assertEqual("kit-kat", contents)
+        assert "kit-kat" == contents
 
     def test_append_random_metadata(self):
         cfg = {
@@ -156,7 +154,7 @@ class TestRandomSeed(TestCase):
         c = get_cloud("ubuntu", metadata={"random_seed": "-so-was-josh"})
         cc_seed_random.handle("test", cfg, c, [])
         contents = util.load_text_file(self._seed_file)
-        self.assertEqual("tiny-tim-was-here-so-was-josh", contents)
+        assert "tiny-tim-was-here-so-was-josh" == contents
 
     def test_seed_command_provided_and_available(self):
         c = get_cloud("ubuntu")
@@ -165,7 +163,7 @@ class TestRandomSeed(TestCase):
         cc_seed_random.handle("test", cfg, c, [])
 
         subp_args = [f["args"] for f in self.subp_called]
-        self.assertIn(["pollinate", "-q"], subp_args)
+        assert ["pollinate", "-q"] in subp_args
 
     def test_seed_command_not_provided(self):
         c = get_cloud("ubuntu")
@@ -173,7 +171,7 @@ class TestRandomSeed(TestCase):
         cc_seed_random.handle("test", {}, c, [])
 
         # subp should not have been called as which would say not available
-        self.assertFalse(self.subp_called)
+        assert not self.subp_called
 
     def test_unavailable_seed_command_and_required_raises_error(self):
         c = get_cloud("ubuntu")
@@ -184,9 +182,7 @@ class TestRandomSeed(TestCase):
                 "command_required": True,
             }
         }
-        self.assertRaises(
-            ValueError, cc_seed_random.handle, "test", cfg, c, []
-        )
+        pytest.raises(ValueError, cc_seed_random.handle, "test", cfg, c, [])
 
     def test_seed_command_and_required(self):
         c = get_cloud("ubuntu")
@@ -194,7 +190,7 @@ class TestRandomSeed(TestCase):
         cfg = {"random_seed": {"command_required": True, "command": ["foo"]}}
         cc_seed_random.handle("test", cfg, c, [])
 
-        self.assertIn(["foo"], [f["args"] for f in self.subp_called])
+        assert ["foo"] in [f["args"] for f in self.subp_called]
 
     def test_file_in_environment_for_command(self):
         c = get_cloud("ubuntu")
@@ -211,7 +207,7 @@ class TestRandomSeed(TestCase):
         # this just instists that the first time subp was called,
         # RANDOM_SEED_FILE was in the environment set up correctly
         subp_env = [f["update_env"] for f in self.subp_called]
-        self.assertEqual(subp_env[0].get("RANDOM_SEED_FILE"), self._seed_file)
+        assert subp_env[0].get("RANDOM_SEED_FILE") == self._seed_file
 
 
 def apply_patches(patches):

--- a/tests/unittests/config/test_cc_seed_random.py
+++ b/tests/unittests/config/test_cc_seed_random.py
@@ -7,6 +7,7 @@
 #    Based on test_handler_set_hostname.py
 #
 #    This file is part of cloud-init. See LICENSE file for license information.
+# pylint: disable=attribute-defined-outside-init
 import gzip
 import logging
 import tempfile


### PR DESCRIPTION
## Proposed Commit Message
```
fix(pytest): Fix broken pytest gdb flag

When pyest is called with --pdb, some tests fail. The test failure
appears to be due to unittest mocking subp prior to pytest fixtures
being created, which causes autospec to fail on subp, since subp is
already mocked. Fix it by converting these tests to use pytest.
```

## Test Steps

The following:
```
.tox/py3/bin/python -m pytest -vvvv --showlocals --pdb
```
now passes

