### PR TITLE
fix(jsonschema): Add missing sudo definition

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -405,6 +405,15 @@
               "description": "Sudo rule to use or false. Absence of a sudo value or ``null`` will result in no sudo rules added for this user."
             },
             {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
               "type": "boolean",
               "changed": true,
               "changed_version": "22.2",


### PR DESCRIPTION
```
fix(jsonschema): Add missing sudo definition

This configuration:

users:
  - name: osadmin
    lock_passwd: false
    sudo: ["ALL=(ALL) NOPASSWD:ALL"]

Is valid syntax but is missing from the jsonschema definition.

Fixes GH-5399
```

https://github.com/canonical/cloud-init/issues/5399