### PR TITLE
doc: update examples to reflect alternative ways to provide `sudo` option

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -405,6 +405,15 @@
               "description": "Sudo rule to use or false. Absence of a sudo value or ``null`` will result in no sudo rules added for this user."
             },
             {
+              "type": "array",
+              "items": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            {
               "type": "boolean",
               "changed": true,
               "changed_version": "22.2",

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -35,6 +35,10 @@ users:
     lock_passwd: true
     ssh_authorized_keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSL7uWGj8cgWyIOaspgKdVy0cKJ+UTjfv7jBOjG2H/GN8bJVXy72XAvnhM0dUM+CCs8FOf0YlPX+Frvz2hKInrmRhZVwRSL129PasD12MlI3l44u6IwS1o/W86Q+tkQYEljtqDOo0a+cOsaZkvUNzUyEXUwz/lmYa6G4hMKZH4NBj7nbAAF96wsMCoyNwbWryBnDYUr6wMbjRR1J9Pw7Xh7WRC73wy4Va2YuOgbD3V/5ZrFPLbWZW/7TFXVrql04QVbyei4aiFR5n//GvoqwQDNe58LmbzX/xvxyKJYdny2zXmdAhMxbrpFQsfpkJ9E/H5w0yOdSvnWbUoG5xNGoOB csmith@fringe
+  - name: testuser
+    gecos: Mr. Test
+    homedir: /local/testdir
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
   - name: cloudy
     gecos: Magic Cloud App Daemon User
     inactive: '5'
@@ -100,6 +104,8 @@ users:
 #
 #         Allow a user unrestricted sudo access.
 #             sudo:  ALL=(ALL) NOPASSWD:ALL
+#                       or
+#             sudo: ["ALL=(ALL) NOPASSWD:ALL"]
 #
 #         Adding multiple sudo rule strings.
 #             sudo:


### PR DESCRIPTION
 For creating users and groups, it is possible to pass a `sudo` option to the
 config file that accepts a sudo rule. The option can be a sudo rule string,
 a list of sudo rule strings or `False` to explicitly deny sudo usage. Update
 examples to show how a list of strings can be used with `sudo` option.
