### PR TITLE
fix (openstack): Append interface / scope_id for IPv6 link-local metadata address

### DIFF
--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -17,7 +17,6 @@ from cloudinit.sources.helpers import openstack
 LOG = logging.getLogger(__name__)
 
 # Various defaults/constants...
-DEF_MD_URLS = ["http://[fe80::a9fe:a9fe]", "http://169.254.169.254"]
 DEFAULT_IID = "iid-dsopenstack"
 DEFAULT_METADATA = {
     "instance-id": DEFAULT_IID,
@@ -73,6 +72,12 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
         return mstr
 
     def wait_for_metadata_service(self):
+        DEF_MD_URLS = [
+            "http://[fe80::a9fe:a9fe%25{iface}]".format(
+                iface=self.distro.fallback_interface
+            ),
+            "http://169.254.169.254",
+        ]
         urls = self.ds_cfg.get("metadata_urls", DEF_MD_URLS)
         filtered = [x for x in urls if util.is_resolvable_url(x)]
         if set(filtered) != set(urls):

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -20,6 +20,7 @@ from cloudinit.sources import DataSourceOpenStack as ds
 from cloudinit.sources import convert_vendordata
 from cloudinit.sources.helpers import openstack
 from tests.unittests import helpers as test_helpers
+from tests.unittests import util as test_util
 from tests.unittests.helpers import mock
 
 BASE_URL = "http://169.254.169.254"
@@ -503,7 +504,9 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             responses_mock=self.responses,
         )
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, None, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN,
+            test_util.MockDistro(),
+            helpers.Paths({"run_dir": self.tmp}),
         )
         crawled_data = ds_os._crawl_metadata()
         self.assertEqual(UNSET, ds_os.ec2_metadata)

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -65,6 +65,7 @@ esposem
 fionn
 frantisekz
 frikilax
+frittentheke
 GabrielNagy
 garzdin
 giggsoff


### PR DESCRIPTION
## Proposed Commit Message
```
 OpenStack: Append interface for IPv6 link-local metadata address

Link-Local IPv6 addresses (fe80::/10) without a scope_id or interface are invalid,
see [1]. This made urllib3 reject an URL of `http://[fe80::a9fe:a9fe]` as invalid
argument.
This change now appends an interface in the proper URL-encoded format ([2]).

[1] https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/netinet_in.h.html
[2] https://datatracker.ietf.org/doc/html/rfc6874

Fixes GH-5422
```


## Additional Context
* see https://github.com/canonical/cloud-init/pull/1805#issuecomment-2177441491
* Fixes GH-5422

## Test Steps
Start VM on OpenStack with only IPv6.
https://github.com/canonical/cloud-init/pull/1805#issuecomment-2177441491

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
