### PR TITLE
fix(azure): fix discrepancy for monotonic() vs time()

### DIFF
--- a/cloudinit/sources/azure/imds.py
+++ b/cloudinit/sources/azure/imds.py
@@ -4,7 +4,7 @@
 
 import logging
 import uuid
-from time import time
+from time import monotonic
 from typing import Dict, Optional, Type, Union
 
 import requests
@@ -31,7 +31,7 @@ class ReadUrlRetryHandler:
     :param logging_backoff: Backoff to limit logging.
     :param max_connection_errors: Number of connection errors to retry on.
     :param retry_codes: Set of http codes to retry on.
-    :param retry_deadline: Optional time()-based deadline to retry until.
+    :param retry_deadline: Optional monotonic()-based deadline to retry until.
     """
 
     def __init__(
@@ -66,7 +66,10 @@ class ReadUrlRetryHandler:
             return False
 
         log = True
-        if self.retry_deadline is not None and time() >= self.retry_deadline:
+        if (
+            self.retry_deadline is not None
+            and monotonic() >= self.retry_deadline
+        ):
             retry = False
         else:
             retry = True

--- a/tests/unittests/sources/azure/test_imds.py
+++ b/tests/unittests/sources/azure/test_imds.py
@@ -60,8 +60,8 @@ def mock_requests_session_request():
 
 
 @pytest.fixture(autouse=True)
-def mock_time():
-    with mock.patch.object(imds, "time", autospec=True) as m:
+def mock_time_monotonic():
+    with mock.patch.object(imds, "monotonic", autospec=True) as m:
         m.time_current = 0.0
         m.time_increment = 1.0
 


### PR DESCRIPTION
Transient failures in fetching metadata from IMDS would not retry. get_metadata_from_imds() is now using time.monotonic() for measuring time instead of time.time() causing the deadline check to fail on first check (monotonic() values will always be less than time()).

Update azure.imds.ReadUrlRetryHandler to use time.monotonic() instead of time.time().