### PR TITLE
docs: Remove mention of resolv.conf

### DIFF
--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -259,8 +259,7 @@ Users can specify a ``nameserver`` type. Nameserver dictionaries include
 the following keys:
 
 - ``address``: List of IPv4 or IPv6 address of nameservers.
-- ``search``: Optional. List of hostnames to include in the :file:`resolv.conf`
-  search path.
+- ``search``: Optional. List of hostnames to include in the search path.
 - ``interface``: Optional. Ties the nameserver definition to the specified
   interface. The value specified here must match the ``name`` of an interface
   defined in this config. If unspecified, this nameserver will be considered
@@ -306,10 +305,8 @@ Valid keys for ``subnets`` include the following:
 - ``broadcast`` : IPv4 broadcast address in dotted format. This is
   only rendered if :file:`/etc/network/interfaces` is used.
 - ``gateway``: IPv4 address of the default gateway for this subnet.
-- ``dns_nameservers``: Specify a list of IPv4 dns server IPs to end up in
-  :file:`resolv.conf`.
-- ``dns_search``: Specify a list of search paths to be included in
-  :file:`resolv.conf`.
+- ``dns_nameservers``: Specify a list of IPv4 DNS server IPs.
+- ``dns_search``: Specify a list of DNS search paths.
 - ``routes``: Specify a list of routes for a given interface.
 
 Subnet types are one of the following:


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
docs: Remove mention of resolv.conf

Use of resolv.conf is renderer-specific.
Not every renderer uses it.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
