### PR TITLE
feat(snap): avoid refresh on package_upgrade: true and refresh.hold

### DIFF
--- a/cloudinit/distros/package_management/snap.py
+++ b/cloudinit/distros/package_management/snap.py
@@ -35,4 +35,23 @@ class Snap(PackageManager):
 
     @staticmethod
     def upgrade_packages():
-        subp.subp(["snap", "refresh"])
+        command = ["snap", "get", "system", "-d"]
+        snap_hold = None
+        try:
+            result = subp.subp(command)
+            snap_hold = (
+                util.load_json(result.stdout).get("refresh", {}).get("hold")
+            )
+        except subp.ProcessExecutionError as e:
+            LOG.info(
+                "Continuing to snap refresh. Unable to run command: %s: %s",
+                command,
+                e,
+            )
+        if snap_hold == "forever":
+            LOG.info(
+                "Skipping snap refresh because refresh.hold is set to '%s'",
+                snap_hold,
+            )
+        else:
+            subp.subp(["snap", "refresh"])

--- a/doc/module-docs/cc_package_update_upgrade_install/data.yaml
+++ b/doc/module-docs/cc_package_update_upgrade_install/data.yaml
@@ -9,5 +9,7 @@ cc_package_update_upgrade_install:
   - comment: |
       Example 1:
     file: cc_package_update_upgrade_install/example1.yaml
+  - comment: "By default, `package_upgrade: true` will trigger upgrades on any installed package manager. To avoid calling `snap refresh` in images with snap installed, set snap refresh.hold to `forever` will prevent cloud-init's snap interaction during any boot"
+    file: cc_package_update_upgrade_install/example2.yaml
   name: Package Update Upgrade Install
   title: Update, upgrade, and install packages

--- a/doc/module-docs/cc_package_update_upgrade_install/data.yaml
+++ b/doc/module-docs/cc_package_update_upgrade_install/data.yaml
@@ -1,15 +1,16 @@
 cc_package_update_upgrade_install:
   description: |
     This module allows packages to be updated, upgraded or installed during
-    boot. If any packages are to be installed or an upgrade is to be performed
-    then the package cache will be updated first. If a package installation or
-    upgrade requires a reboot, then a reboot can be performed if
-    ``package_reboot_if_required`` is specified.
+    boot using any available package manager present on a system such as apt,
+    pkg, snap, yum or zypper. If any packages are to be installed or an upgrade
+    is to be performed then the package cache will be updated first. If a
+    package installation or upgrade requires a reboot, then a reboot can be
+    performed if ``package_reboot_if_required`` is specified.
   examples:
   - comment: |
       Example 1:
     file: cc_package_update_upgrade_install/example1.yaml
-  - comment: "By default, `package_upgrade: true` will trigger upgrades on any installed package manager. To avoid calling `snap refresh` in images with snap installed, set snap refresh.hold to `forever` will prevent cloud-init's snap interaction during any boot"
+  - comment: "By default, ``package_upgrade: true`` performs upgrades on any installed package manager. To avoid calling ``snap refresh`` in images with snap installed, set snap refresh.hold to ``forever`` will prevent cloud-init's snap interaction during any boot"
     file: cc_package_update_upgrade_install/example2.yaml
   name: Package Update Upgrade Install
   title: Update, upgrade, and install packages

--- a/doc/module-docs/cc_package_update_upgrade_install/example2.yaml
+++ b/doc/module-docs/cc_package_update_upgrade_install/example2.yaml
@@ -1,0 +1,7 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+snap:
+  commands:
+    00: snap refresh --hold=forever
+package_reboot_if_required: true

--- a/tests/unittests/config/test_cc_package_update_upgrade_install.py
+++ b/tests/unittests/config/test_cc_package_update_upgrade_install.py
@@ -122,7 +122,7 @@ class TestRebootIfRequired:
 
         caplog.set_level(logging.WARNING)
         with mock.patch(
-            "cloudinit.subp.subp", return_value=("fakeout", "fakeerr")
+            "cloudinit.subp.subp", return_value=SubpResult("{}", "fakeerr")
         ) as m_subp:
             with mock.patch("os.path.isfile", side_effect=_isfile):
                 with mock.patch(M_PATH + "time.sleep") as m_sleep:

--- a/tests/unittests/distros/test_ubuntu.py
+++ b/tests/unittests/distros/test_ubuntu.py
@@ -1,7 +1,10 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+import logging
+
 import pytest
 
 from cloudinit.distros import fetch
+from cloudinit.subp import SubpResult
 
 
 class TestPackageCommand:
@@ -14,7 +17,7 @@ class TestPackageCommand:
             "cloudinit.distros.ubuntu.Snap.available",
             return_value=snap_available,
         )
-        m_snap_upgrade_packges = mocker.patch(
+        m_snap_upgrade_packages = mocker.patch(
             "cloudinit.distros.ubuntu.Snap.upgrade_packages",
             return_value=snap_available,
         )
@@ -27,6 +30,81 @@ class TestPackageCommand:
         m_apt_run_package_command.assert_called_once_with("upgrade")
         m_snap_available.assert_called_once()
         if snap_available:
-            m_snap_upgrade_packges.assert_called_once()
+            m_snap_upgrade_packages.assert_called_once()
         else:
-            m_snap_upgrade_packges.assert_not_called()
+            m_snap_upgrade_packages.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "subp_side_effect,expected_log",
+        (
+            pytest.param(
+                [
+                    SubpResult(
+                        stdout='{"refresh": {"hold": "forever"}}', stderr=None
+                    )
+                ],
+                "Skipping snap refresh because refresh.hold is set to"
+                " 'forever'",
+                id="skip_snap_refresh_due_to_global_hold_forever",
+            ),
+            pytest.param(
+                [
+                    SubpResult(
+                        stdout=(
+                            '{"refresh": {"hold":'
+                            ' "2024-07-08T15:38:20-06:00"}}'
+                        ),
+                        stderr=None,
+                    ),
+                    SubpResult(stdout="All snaps up to date.", stderr=""),
+                ],
+                "",
+                id="perform_snap_refresh_due_to_temporary_global_hold",
+            ),
+            pytest.param(
+                [
+                    SubpResult(
+                        stdout="{}",
+                        stderr=(
+                            'error: snap "core" has no "refresh.hold" '
+                            "configuration option"
+                        ),
+                    ),
+                    SubpResult(stdout="All snaps up to date.", stderr=""),
+                ],
+                "",
+                id="snap_refresh_performed_when_no_global_hold_is_set",
+            ),
+        ),
+    )
+    def test_package_command_avoids_snap_refresh_when_refresh_hold_is_forever(
+        self, subp_side_effect, expected_log, caplog, mocker
+    ):
+        """Do not call snap refresh when snap refresh.hold is forever.
+
+        This indicates an environment where snaps refreshes are not preferred
+        for whatever reason.
+        """
+        m_snap_available = mocker.patch(
+            "cloudinit.distros.ubuntu.Snap.available",
+            return_value=True,
+        )
+        m_subp = mocker.patch(
+            "cloudinit.subp.subp",
+            side_effect=subp_side_effect,
+        )
+        m_apt_run_package_command = mocker.patch(
+            "cloudinit.distros.package_management.apt.Apt.run_package_command",
+        )
+        cls = fetch("ubuntu")
+        distro = cls("ubuntu", {}, None)
+        with caplog.at_level(logging.INFO):
+            distro.package_command("upgrade")
+        m_apt_run_package_command.assert_called_once_with("upgrade")
+        m_snap_available.assert_called_once()
+        expected_calls = [mocker.call(["snap", "get", "system", "-d"])]
+        if expected_log:
+            assert expected_log in caplog.text
+        else:
+            expected_calls.append(mocker.call(["snap", "refresh"]))
+        assert m_subp.call_args_list == expected_calls


### PR DESCRIPTION
-- 07102024: updated proposed commit message, reverted behavior to only honor refresh.hold=forever and updated example doc for temporary snap hold.

## Proposed Commit Message
```
    feat(snap): avoid refresh on package_upgrade: true and refresh.hold
    
    When snap refresh.hold is set to forever, an admin is saying they do
    not want generic automated refreshes of snaps performed by default.
    
    This should be an indicator to cloud-init to avoid calling snap refresh
    on such systems due to a `package_upgrade: true` present in user-data.
    
    For network-limited environments with images which have the snap package
    manager but don't want to wait and timeout on snap refresh, the following
    user-data can be provided to still allow for package_upgrade: true,
    and avoid a 20-30 second wait on snaps being unable to access certain
    snap URLs.
    
       #cloud-config
       package_upgrade: true
       snap:
         commands:
           00: snap refresh --hold=forever
    
    cloud-init now interrogates the state refresh.hold value by calling
      snap get system -d
    
    If snap refresh --hold was called in that environment to set 'forever',
    cloud-init will skip calling refresh and log the reason for skipping.
    
    We cannot honor short time-based refresh.holds because the snap
    services place a short hold in early boot anyway as systemd units
    startup.
    
    Fixes: GH-5290
```
## Additional Context

#5290 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [x] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
