### PR TITLE
fix for python3-requests 2.32.2

### DIFF
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -134,7 +134,9 @@ class LXDSocketAdapter(HTTPAdapter):
 
     # Fix for requests 2.32.2+:
     # https://github.com/psf/requests/pull/6710
-    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+    def get_connection_with_tls_context(
+        self, request, verify, proxies=None, cert=None
+    ):
         return self.get_connection(request.url, proxies)
 
 

--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -132,6 +132,11 @@ class LXDSocketAdapter(HTTPAdapter):
     def get_connection(self, url, proxies=None):
         return SocketConnectionPool(LXD_SOCKET_PATH)
 
+    # Fix for requests 2.32.2+:
+    # https://github.com/psf/requests/pull/6710
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+        return self.get_connection(request.url, proxies)
+
 
 def _raw_instance_data_to_dict(metadata_type: str, metadata_value) -> dict:
     """Convert raw instance data from str, bytes, YAML to dict

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -54,6 +54,7 @@ dermotbradley
 dhalturin
 dhensby
 Dorthu
+eaglegai
 eandersson
 eb3095
 ederst


### PR DESCRIPTION
Fix for requests 2.32.2+:
Add get_connection_with_tls_context() for requests 2.32.2 as suggests:  https://github.com/psf/requests/pull/6710

