### PR TITLE
Adds support for using metalinks instead of baseurl

### DIFF
--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -211,7 +211,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
                 n_repo_config[k] = v
         repo_config = n_repo_config
         missing_required = 0
-        for req_field in ["baseurl"]:
+        for req_field in ["baseurl", "metalink"]:
             if req_field not in repo_config:
                 LOG.warning(
                     "Repository %s does not contain a %s"

--- a/doc/examples/cloud-config-yum-repo.txt
+++ b/doc/examples/cloud-config-yum-repo.txt
@@ -3,8 +3,9 @@
 #
 # Add yum repository configuration to the system
 #
-# The following example adds the file /etc/yum.repos.d/epel_testing.repo
+# The following example adds the file /etc/yum.repos.d/epel.repo
 # which can then subsequently be used by yum for later operations.
+# Either baseurl or metalink can be used but not both
 yum_repos:
   # The name of the repository
   epel-testing:
@@ -12,7 +13,8 @@ yum_repos:
     # See: man yum.conf
     #
     # This one is required!
-    baseurl: http://download.fedoraproject.org/pub/epel/testing/5/$basearch
+    #baseurl: http://download.fedoraproject.org/pub/epel/testing/5/$basearch
+    metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
     enabled: false
     failovermethod: priority
     gpgcheck: true

--- a/doc/rtd/reference/examples.rst
+++ b/doc/rtd/reference/examples.rst
@@ -116,15 +116,15 @@ Additional apt configuration and repositories
 =============================================
 
 .. literalinclude:: ../../examples/cloud-config-apt.txt
-    :language: yaml
-    :linenos:
+   :language: yaml
+   :linenos:
 
 Disk setup
 ==========
 
 .. literalinclude:: ../../examples/cloud-config-disk-setup.txt
-    :language: yaml
-    :linenos:
+   :language: yaml
+   :linenos:
 
 Configure data sources
 ======================

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -22,6 +22,7 @@ aswinrajamannar
 bdrung
 beantaxi
 beezly
+bengaywins
 berolinux
 bin456789
 bipinbachhao


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.



## Additional Context
<!-- If relevant -->
feat(yum): support for using metalinks instead of baseurl (#5359)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Create yum repo using Cloud init with a `metalink` instead of `baseurl`.

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
- [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
- [ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
- [x] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
