### PR TITLE
tests: hard-code curtin-dev ppa instead of canonical-kernel-team

### DIFF
--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -48,9 +48,10 @@ apt:
     deb-src $SECURITY $RELEASE-security multiverse
   sources:
     test_keyserver:
-      keyid: 110E21D8B0E2A1F0243AF6820856F197B892ACEA
+      keyid: 1BC30F715A3B861247A81A5E55FE7C8C0165013E
       keyserver: keyserver.ubuntu.com
-      source: "deb http://ppa.launchpad.net/canonical-kernel-team/ppa/ubuntu $RELEASE main"
+      # Hard-code noble as devel releases may not see new packages for some time
+      source: "deb http://ppa.launchpad.net/curtin-dev/daily/ubuntu noble main"
     test_ppa:
       keyid: 441614D8
       keyserver: keyserver.ubuntu.com
@@ -249,7 +250,7 @@ class TestApt:
         )
 
         assert (
-            "http://ppa.launchpad.net/canonical-kernel-team/ppa/ubuntu"
+            "http://ppa.launchpad.net/curtin-dev/daily/ubuntu"
             in test_keyserver_contents
         )
 
@@ -452,9 +453,10 @@ INSTALL_ANY_MISSING_RECOMMENDED_DEPENDENCIES = """\
 apt:
   sources:
     test_keyserver:
-      keyid: 110E21D8B0E2A1F0243AF6820856F197B892ACEA
+      keyid: 1BC30F715A3B861247A81A5E55FE7C8C0165013E
       keyserver: keyserver.ubuntu.com
-      source: "deb http://ppa.launchpad.net/canonical-kernel-team/ppa/ubuntu $RELEASE main"
+      # Hard-code noble as devel releases may not see new packages for some time
+      source: "deb http://ppa.launchpad.net/curtin-dev/daily/ubuntu noble main"
     test_ppa:
       keyid: 441614D8
       keyserver: keyserver.ubuntu.com


### PR DESCRIPTION
## Proposed Commit Message
```
    tests: hard-code curtin-dev ppa instead of canonical-kernel-team
    
    Avoid integration test dependencies on PPAs that we don't own.
    
    The canonical-kernel-team PPA will trail publication of packages
    to the devel series sometimes by many weeks. Also, their process
    may change in the future and the daily canonical-kernel-team PPA
    may not be used at some point in the future.
    
    Some of our apt-related integration tests are only asserting that
    different formats of user-data can setup and assert valid PPA
    signing keys to 3 separate PPAs on a single instance launch to avoid
    the costs of launching three separate instances to test different
    user-data formats.
    
    For these tests, we can hard-code a known series and PPA without
    degrading the value of the simple test.
    
    Shift our canonical-kernel-team PPA reference to curtin-dev daily
    PPA for two reasons:
    - we have tighter coupling with the curtin dev team to keep in step
      with any process changes
    - ppa:curtin-dev/daily already has a 4096-bit signing key istead of
      the stale 1024-bit key in canonical-kernel-team's PPA which may
      change in the near future.
```

## Additional Context

The canonical-kernel-team PPA doesn't currently publish oracular series packages as it is a development release. 
https://launchpad.net/~canonical-kernel-team/+archive/ubuntu/ppa.  It also has a stale 1024-bit signing key which will be changed in the future to avoid apt errors on oracular.

Given that oracular/devel builds may trail the opening of a devel release for an undetermined bit of time, and signing keys may change, we will move to a PPA that already has 4096-bit keys to avoid a future test failure.


## Test Steps
```
CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_apt_functionality.py::test_install_missing_deps

CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_apt_functionality.py::test_install_missing_deps
````

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)