### PR TITLE
Schema support deprecated users groups hyphenated keys

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -267,9 +267,9 @@
               "patternProperties": {
                 "^.+$": {
                   "label": "<group_name>",
-                  "description": "When providing an object for users.groups the ``<group_name>`` keys are the groups to add this user to",
                   "deprecated": true,
                   "deprecated_version": "23.1",
+                  "deprecated_description": "The use of ``object`` type is deprecated. Use ``string`` or ``array`` of ``string`` instead.",
                   "type": [
                     "null"
                   ],
@@ -292,9 +292,7 @@
           "type": "string"
         },
         "lock-passwd": {
-          "default": true,
           "type": "boolean",
-          "description": "Default: ``true``",
           "deprecated": true,
           "deprecated_version": "22.3",
           "deprecated_description": "Use ``lock_passwd`` instead."
@@ -304,15 +302,33 @@
           "description": "Disable password login. Default: ``true``",
           "type": "boolean"
         },
+        "no-create-home": {
+          "type": "boolean",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``no_create_home`` instead."
+        },
         "no_create_home": {
           "default": false,
           "description": "Do not create home directory. Default: ``false``",
           "type": "boolean"
         },
+        "no-log-init": {
+          "type": "boolean",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``no_log_init`` instead."
+        },
         "no_log_init": {
           "default": false,
           "description": "Do not initialize lastlog and faillog for user. Default: ``false``",
           "type": "boolean"
+        },
+        "no-user-group": {
+          "type": "boolean",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``no_user_group`` instead."
         },
         "no_user_group": {
           "default": false,
@@ -323,23 +339,53 @@
           "description": "Hash of user password applied when user does not exist. This will NOT be applied if the user already exists. To generate this hash, run: ``mkpasswd --method=SHA-512 --rounds=500000`` **Note:** Your password might possibly be visible to unprivileged users on your system, depending on your cloud's security model. Check if your cloud's IMDS server is visible from an unprivileged user to evaluate risk.",
           "type": "string"
         },
+        "hashed-passwd": {
+          "type": "string",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``hashed_passwd`` instead."
+        },
         "hashed_passwd": {
           "description": "Hash of user password to be applied. This will be applied even if the user is preexisting. To generate this hash, run: ``mkpasswd --method=SHA-512 --rounds=500000``. **Note:** Your password might possibly be visible to unprivileged users on your system, depending on your cloud's security model. Check if your cloud's IMDS server is visible from an unprivileged user to evaluate risk.",
           "type": "string"
         },
+        "plain-text-passwd": {
+          "type": "string",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``plain_text_passwd`` instead."
+        },
         "plain_text_passwd": {
           "description": "Clear text of user password to be applied. This will be applied even if the user is preexisting. **Note:** SSH keys or certificates are a safer choice for logging in to your system. For local escalation, supplying a hashed password is a safer choice than plain text. Your password might possibly be visible to unprivileged users on your system, depending on your cloud's security model. An exposed plain text password is an immediate security concern. Check if your cloud's IMDS server is visible from an unprivileged user to evaluate risk.",
           "type": "string"
+        },
+        "create-groups": {
+          "type": "boolean",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``create_groups`` instead."
         },
         "create_groups": {
           "default": true,
           "description": "Boolean set ``false`` to disable creation of specified user ``groups``. Default: ``true``.",
           "type": "boolean"
         },
+        "primary-group": {
+          "type": "string",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``primary_group`` instead."
+        },
         "primary_group": {
           "default": "``<username>``",
           "description": "Primary group for user. Default: ``<username>``",
           "type": "string"
+        },
+        "selinux-user": {
+          "type": "string",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``selinux_user`` instead."
         },
         "selinux_user": {
           "description": "SELinux user for user's login. Default: the default SELinux user.",
@@ -362,20 +408,24 @@
           "minItems": 1
         },
         "ssh-authorized-keys": {
-          "allOf": [
-            {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "minItems": 1
-            },
-            {
-              "deprecated": true,
-              "deprecated_version": "18.3",
-              "deprecated_description": "Use ``ssh_authorized_keys`` instead."
-            }
-          ]
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "deprecated": true,
+          "deprecated_version": "18.3",
+          "deprecated_description": "Use ``ssh_authorized_keys`` instead."
+        },
+        "ssh-import-id": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``ssh_import_id`` instead."
         },
         "ssh_import_id": {
           "description": "List of ssh ids to import for user. Can not be combined with ``ssh_redirect_user``. See the man page[1] for more details. [1] https://manpages.ubuntu.com/manpages/noble/en/man1/ssh-import-id.1.html",
@@ -384,6 +434,12 @@
             "type": "string"
           },
           "minItems": 1
+        },
+        "ssh-redirect-user": {
+          "type": "boolean",
+          "deprecated": true,
+          "deprecated_version": "24.2",
+          "deprecated_description": "Use ``ssh_redirect_user`` instead."
         },
         "ssh_redirect_user": {
           "type": "boolean",
@@ -487,7 +543,6 @@
       "properties": {
         "remove-defaults": {
           "type": "boolean",
-          "default": false,
           "deprecated": true,
           "deprecated_version": "22.3",
           "deprecated_description": "Use ``remove_defaults`` instead."
@@ -605,9 +660,9 @@
         },
         "system_info": {
           "type": "object",
-          "description": "System and/or distro specific settings. This is not intended to be overridden by user data or vendor data.",
           "deprecated": true,
-          "deprecated_version": "24.2"
+          "deprecated_version": "24.2",
+          "deprecated_description": "System and/or distro specific settings. This is not intended to be overridden by user data or vendor data."
         }
       }
     },
@@ -1580,7 +1635,6 @@
         },
         "grub-dpkg": {
           "type": "object",
-          "description": "An alias for ``grub_dpkg``",
           "deprecated": true,
           "deprecated_version": "22.2",
           "deprecated_description": "Use ``grub_dpkg`` instead."
@@ -2167,24 +2221,18 @@
         },
         "apt_update": {
           "type": "boolean",
-          "default": false,
-          "description": "Default: ``false``.",
           "deprecated": true,
           "deprecated_version": "22.2",
           "deprecated_description": "Use ``package_update`` instead."
         },
         "apt_upgrade": {
           "type": "boolean",
-          "default": false,
-          "description": "Default: ``false``.",
           "deprecated": true,
           "deprecated_version": "22.2",
           "deprecated_description": "Use ``package_upgrade`` instead."
         },
         "apt_reboot_if_required": {
           "type": "boolean",
-          "default": false,
-          "description": "Default: ``false``.",
           "deprecated": true,
           "deprecated_version": "22.2",
           "deprecated_description": "Use ``package_reboot_if_required`` instead."
@@ -2882,7 +2930,6 @@
                 }
               ],
               "minItems": 1,
-              "description": "List of ``username:password`` pairs. Each user will have the corresponding password set. A password can be randomly generated by specifying ``RANDOM`` or ``R`` as a user's password. A hashed password, created by a tool like ``mkpasswd``, can be specified. A regex (``r'\\$(1|2a|2y|5|6)(\\$.+){2}'``) is used to determine if a password value should be treated as a hash.",
               "deprecated": true,
               "deprecated_version": "22.2",
               "deprecated_description": "Use ``users`` instead."

--- a/tests/unittests/config/test_cc_grub_dpkg.py
+++ b/tests/unittests/config/test_cc_grub_dpkg.py
@@ -300,8 +300,8 @@ class TestGrubDpkgSchema:
                 pytest.raises(
                     SchemaValidationError,
                     match=(
-                        "Cloud config schema deprecations: grub-dpkg: An alias"
-                        " for ``grub_dpkg`` Deprecated in version 22.2. Use "
+                        "Cloud config schema deprecations: grub-dpkg:"
+                        "  Deprecated in version 22.2. Use "
                         "``grub_dpkg`` instead."
                     ),
                 ),

--- a/tests/unittests/config/test_cc_package_update_upgrade_install.py
+++ b/tests/unittests/config/test_cc_package_update_upgrade_install.py
@@ -300,16 +300,16 @@ class TestPackageUpdateUpgradeSchema:
             (
                 {"apt_update": False},
                 (
-                    "Cloud config schema deprecations: apt_update: "
-                    "Default: ``false``. Deprecated in version 22.2. "
+                    "Cloud config schema deprecations: apt_update:  "
+                    "Deprecated in version 22.2. "
                     "Use ``package_update`` instead."
                 ),
             ),
             (
                 {"apt_upgrade": False},
                 (
-                    "Cloud config schema deprecations: apt_upgrade: "
-                    "Default: ``false``. Deprecated in version 22.2. "
+                    "Cloud config schema deprecations: apt_upgrade:  "
+                    "Deprecated in version 22.2. "
                     "Use ``package_upgrade`` instead."
                 ),
             ),
@@ -317,8 +317,7 @@ class TestPackageUpdateUpgradeSchema:
                 {"apt_reboot_if_required": False},
                 (
                     "Cloud config schema deprecations: "
-                    "apt_reboot_if_required: Default: ``false``. "
-                    "Deprecated in version 22.2. Use "
+                    "apt_reboot_if_required:  Deprecated in version 22.2. Use "
                     "``package_reboot_if_required`` instead."
                 ),
             ),

--- a/tests/unittests/config/test_cc_users_groups.py
+++ b/tests/unittests/config/test_cc_users_groups.py
@@ -373,9 +373,20 @@ class TestUsersGroupsSchema:
                     SchemaValidationError,
                     match=(
                         "Cloud config schema deprecations: "
-                        "users.0.lock-passwd: Default: ``true`` "
-                        "Deprecated in version 22.3. Use "
-                        "``lock_passwd`` instead."
+                        "users.0.lock-passwd:  Deprecated in version 22.3."
+                        " Use ``lock_passwd`` instead."
+                    ),
+                ),
+                False,
+            ),
+            (
+                {"users": [{"name": "bbsw", "no-create-home": True}]},
+                pytest.raises(
+                    SchemaValidationError,
+                    match=(
+                        "Cloud config schema deprecations: "
+                        "users.0.no-create-home:  Deprecated in version 24.2."
+                        " Use ``no_create_home`` instead."
                     ),
                 ),
                 False,
@@ -396,13 +407,10 @@ class TestUsersGroupsSchema:
                     SchemaValidationError,
                     match=(
                         "Cloud config schema deprecations: "
-                        "users.0.groups.adm: When providing an object "
-                        "for users.groups the ``<group_name>`` keys "
-                        "are the groups to add this user to Deprecated"
-                        " in version 23.1., users.0.groups.sudo: When "
-                        "providing an object for users.groups the "
-                        "``<group_name>`` keys are the groups to add "
-                        "this user to Deprecated in version 23.1."
+                        "users.0.groups.adm:  Deprecated in version 23.1. "
+                        "The use of ``object`` type is deprecated. Use "
+                        "``string`` or ``array`` of ``string`` instead., "
+                        "users.0.groups.sudo:  Deprecated in version 23.1."
                     ),
                 ),
                 False,
@@ -458,10 +466,7 @@ class TestUsersGroupsSchema:
                     SchemaValidationError,
                     match=(
                         "Cloud config schema deprecations: "
-                        "user.groups.sbuild: When providing an object "
-                        "for users.groups the ``<group_name>`` keys "
-                        "are the groups to add this user to Deprecated"
-                        " in version 23.1."
+                        "user.groups.sbuild:  Deprecated in version 23.1."
                     ),
                 ),
                 False,

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -2773,9 +2773,9 @@ class TestHandleSchemaArgs:
                     apt_reboot_if_required: true            # D3
 
                     # Deprecations: -------------
-                    # D1: Default: ``false``. Deprecated in version 22.2. Use ``package_update`` instead.
-                    # D2: Default: ``false``. Deprecated in version 22.2. Use ``package_upgrade`` instead.
-                    # D3: Default: ``false``. Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
+                    # D1: Deprecated in version 22.2. Use ``package_update`` instead.
+                    # D2: Deprecated in version 22.2. Use ``package_upgrade`` instead.
+                    # D3: Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
 
                     Valid schema {cfg_file}
                     """  # noqa: E501
@@ -2795,9 +2795,9 @@ class TestHandleSchemaArgs:
                     apt_reboot_if_required: true            # D3
 
                     # Deprecations: -------------
-                    # D1: Default: ``false``. Deprecated in version 22.2. Use ``package_update`` instead.
-                    # D2: Default: ``false``. Deprecated in version 22.2. Use ``package_upgrade`` instead.
-                    # D3: Default: ``false``. Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
+                    # D1: Deprecated in version 22.2. Use ``package_update`` instead.
+                    # D2: Deprecated in version 22.2. Use ``package_upgrade`` instead.
+                    # D3: Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
 
                     Valid schema {cfg_file}
                     """  # noqa: E501
@@ -2810,11 +2810,10 @@ class TestHandleSchemaArgs:
                 dedent(
                     """\
                     Cloud config schema deprecations: \
-apt_reboot_if_required: Default: ``false``. Deprecated in version 22.2.\
- Use ``package_reboot_if_required`` instead., apt_update: Default: \
-``false``. Deprecated in version 22.2. Use ``package_update`` instead.,\
- apt_upgrade: Default: ``false``. Deprecated in version 22.2. Use \
-``package_upgrade`` instead.\
+apt_reboot_if_required: Deprecated in version 22.2. Use\
+ ``package_reboot_if_required`` instead., apt_update: Deprecated in version\
+ 22.2. Use ``package_update`` instead., apt_upgrade: Deprecated in version\
+ 22.2. Use ``package_upgrade`` instead.\
                     Valid schema {cfg_file}
                     """  # noqa: E501
                 ),


### PR DESCRIPTION
## Proposed Commit Message
```
    fix(schema): permit deprecated hyphenated keys under users key
    
    Both hyphenated and underscore delimited key names are permitted
    by cloudinit/distros/ug_util.py#L114 due to magic replacement
    of key names.
    
    Since this is still valid json schema, add the necessary hyphenated
    aliases for all users/groups keys. Because the goal in the future is
    to only support one config key for a given configuraion option, add
    deprecated keys to thos schema definitions.
    
    Also drop the description key from the deprecates lock-passwd schema
    key.
    
    Any deprecated schema key which provides a suggested replacement should
    not provide duplicated key descriptions as the preferred replacement
    will provided the necessary context.
    
    Fixes GH-5454
```

## Additional Context
Expect a supplemental PR which allows downstream stable images which include earlier versions of cloud-init  to pin the cloud-init version which determines whether new schema deprecations introduced will be logged at deprecation level or only at info level. https://github.com/canonical/cloud-init/pull/5411.

This PR will allow downstreams to avoid seeing non-zero exit codes from `cloud-init status` due to new deprecations which can be introduced by upgrading the cloud-init package to a newer version of cloud-init on otherwise stable images.

## Test Steps
```
tox -e py3 -- tests/unittests/config/test_cc_users_groups.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
