### PR TITLE
fix(wsl): Special handling Landscape client config tags

### DIFF
--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -328,16 +328,12 @@ class DataSourceWSL(sources.DataSource):
         # provides them instead.
         # That's the reason for not using util.mergemanydict().
         merged: dict = {}
+        user_tags: str = ""
         overridden_keys: typing.List[str] = []
-        # We've already checked, this is just to please mypy.
-        assert user_data is not None
-        user_tags = (
-            user_data.get("landscape", {}).get("client", {}).get("tags")
-        )
         if user_data:
             merged = user_data
             user_tags = (
-                merged.get("landscape", {}).get("client", {}).get("tags")
+                merged.get("landscape", {}).get("client", {}).get("tags", "")
             )
         if agent_data:
             if user_data:

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -353,14 +353,13 @@ class DataSourceWSL(sources.DataSource):
                         ", ".join(overridden_keys)
                     )
                 )
-            if user_tags:
+            if user_tags and merged.get("landscape", {}).get("client"):
                 LOG.debug(
-                    " Landscape client conf updated with user-data"
+                    "Landscape client conf updated with user-data"
                     " landscape.client.tags: %s",
                     user_tags,
                 )
-                if merged.get("landscape", {}).get("client"):
-                    merged["landscape"]["client"]["tags"] = user_tags
+                merged["landscape"]["client"]["tags"] = user_tags
 
         self.userdata_raw = "#cloud-config\n%s" % yaml.dump(merged)
         return True

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -329,8 +329,12 @@ class DataSourceWSL(sources.DataSource):
         # That's the reason for not using util.mergemanydict().
         merged: dict = {}
         overridden_keys: typing.List[str] = []
+        user_tags = None
         if user_data:
             merged = user_data
+            user_tags = (
+                merged.get("landscape", {}).get("client", {}).get("tags")
+            )
         if agent_data:
             if user_data:
                 LOG.debug("Merging both user_data and agent.yaml configs.")
@@ -344,6 +348,15 @@ class DataSourceWSL(sources.DataSource):
                         " agent.yaml overrides config keys: "
                         ", ".join(overridden_keys)
                     )
+                )
+            if user_tags:
+                LOG.debug(
+                    " Landscape client conf updated with user-data tags: %s",
+                    user_tags,
+                )
+                # Does nothing if there is no "landscape"."client" key.
+                merged.get("landscape", {}).get("client", {}).update(
+                    {"tags": user_tags}
                 )
 
         self.userdata_raw = "#cloud-config\n%s" % yaml.dump(merged)

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -329,7 +329,9 @@ class DataSourceWSL(sources.DataSource):
         # That's the reason for not using util.mergemanydict().
         merged: dict = {}
         overridden_keys: typing.List[str] = []
-        user_tags = None
+        user_tags = (
+            user_data.get("landscape", {}).get("client", {}).get("tags")
+        )
         if user_data:
             merged = user_data
             user_tags = (
@@ -351,13 +353,12 @@ class DataSourceWSL(sources.DataSource):
                 )
             if user_tags:
                 LOG.debug(
-                    " Landscape client conf updated with user-data tags: %s",
+                    " Landscape client conf updated with user-data"
+                    " landscape.client.tags: %s",
                     user_tags,
                 )
-                # Does nothing if there is no "landscape"."client" key.
-                merged.get("landscape", {}).get("client", {}).update(
-                    {"tags": user_tags}
-                )
+                if merged.get("landscape", {}).get("client"):
+                    merged["landscape"]["client"]["tags"] = user_tags
 
         self.userdata_raw = "#cloud-config\n%s" % yaml.dump(merged)
         return True

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -329,6 +329,8 @@ class DataSourceWSL(sources.DataSource):
         # That's the reason for not using util.mergemanydict().
         merged: dict = {}
         overridden_keys: typing.List[str] = []
+        # We've already checked, this is just to please mypy.
+        assert user_data is not None
         user_tags = (
             user_data.get("landscape", {}).get("client", {}).get("tags")
         )

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -67,8 +67,9 @@ following paths:
    merged with (1), overriding any conflicting modules. If (1) is not provided,
    then this file will be merged with any valid user-provided configuration
    instead. Exception is made for Landscape client config computer tags. If
-   user provided data contains a value for that subkey it will be used instead
-   of the one provided by the ``agent.yaml``, which is treated as a default.
+   user provided data contains a value for ``landscape.client.tags`` it will be
+   used instead of the one provided by the ``agent.yaml``, which is treated as
+   a default.
 
 Then, if a file from (1) is not found, a user-provided configuration will be
 looked for instead in the following order:

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -66,7 +66,9 @@ following paths:
    the Ubuntu Pro for WSL agent. If this file is present, its modules will be
    merged with (1), overriding any conflicting modules. If (1) is not provided,
    then this file will be merged with any valid user-provided configuration
-   instead.
+   instead. Exception is made for Landscape client config computer tags. If
+   user provided data contains a value for that subkey it will be used instead
+   of the one provided by the ``agent.yaml``, which is treated as a default.
 
 Then, if a file from (1) is not found, a user-provided configuration will be
 looked for instead in the following order:

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -420,9 +420,13 @@ class TestWSLDataSource:
         agent_file.write(
             """#cloud-config
 landscape:
+    host:
+        url: landscape.canonical.com:6554
     client:
-      account_name: agenttest
-      tags: wsl
+        account_name: agenttest
+        url: https://landscape.canonical.com/message-system
+        ping_url: https://landscape.canonical.com/ping
+        tags: wsl
 ubuntu_pro:
     token: testtoken"""
         )
@@ -462,9 +466,14 @@ ubuntu_pro:
         user_file.write(
             """#cloud-config
 landscape:
-  client:
-    account_name: user
-    tags: usertags
+    host:
+        url: landscape.canonical.com:6554
+    client:
+        computer_title: MLMachine
+        account_name: user
+        url: https://landscape.canonical.com/message-system
+        ping_url: https://landscape.canonical.com/ping
+        tags: usertags
 package_update: true"""
         )
 
@@ -475,9 +484,14 @@ package_update: true"""
         agent_file.write(
             """#cloud-config
 landscape:
+    host:
+        url: hosted.com:6554
     client:
-      account_name: agenttest
-      tags: wsl
+        account_name: agenttest
+        url: https://hosted.com/message-system
+        ping_url: https://hosted.com/ping
+        ssl_public_key: C:\\Users\\User\\server.pem
+        tags: wsl
 ubuntu_pro:
     token: testtoken"""
         )
@@ -544,9 +558,13 @@ package_update: true"""
         agent_file.write(
             """#cloud-config
 landscape:
+    host:
+        url: landscape.canonical.com:6554
     client:
-      account_name: agenttest
-      tags: wsl
+        account_name: agenttest
+        url: https://landscape.canonical.com/message-system
+        ping_url: https://landscape.canonical.com/ping
+        tags: wsl
 ubuntu_pro:
     token: testtoken"""
         )

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -413,7 +413,7 @@ landscape:
     client:
       account_name: agenttest
       tags: wsl
-ubuntu_advantage:
+ubuntu_pro:
     token: testtoken"""
         )
 
@@ -437,7 +437,7 @@ ubuntu_advantage:
         )
         assert "wsl.conf" in userdata
         assert "packages" not in userdata
-        assert "ubuntu_advantage" in userdata
+        assert "ubuntu_pro" in userdata
         assert "landscape" in userdata
         assert "agenttest" in userdata
 
@@ -473,7 +473,7 @@ package_update: true"""
 
         assert "wsl.conf" not in userdata
         assert "packages" not in userdata
-        assert "ubuntu_advantage" in userdata
+        assert "ubuntu_pro" in userdata
         assert "package_update" in userdata, (
             "package_update entry should not be overriden by agent data"
             " nor ignored"
@@ -524,7 +524,7 @@ package_update: true"""
         # Make sure we don't crash if there are no tags anywhere.
         agent_file.write(
             """#cloud-config
-ubuntu_advantage:
+ubuntu_pro:
     token: up4w_token"""
         )
         # Run the datasource
@@ -556,7 +556,7 @@ ubuntu_advantage:
 landscape:
     server:
         port: 6554
-ubuntu_advantage:
+ubuntu_pro:
     token: up4w_token"""
         )
         # Run the datasource

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -478,7 +478,7 @@ package_update: true"""
 landscape:
   client:
     account_name: landscapetest
-    tags: tag_aiml, tag_dev
+    tags: tag_aiml,tag_dev
 locale: en_GB.UTF-8"""
         )
 
@@ -537,7 +537,7 @@ ubuntu_pro:
 landscape:
   client:
     account_name: landscapetest
-    tags: tag_aiml, tag_dev
+    tags: tag_aiml,tag_dev
 package_update: true"""
         )
 
@@ -572,6 +572,7 @@ package_update: true"""
         assert (
             "tag_aiml" in userdata and "tag_dev" in userdata
         ), "User-data should override agent data's Landscape computer tags"
+        assert "wsl" not in userdata
 
     @mock.patch("cloudinit.util.get_linux_distro")
     def test_with_landscape_no_tags(self, m_get_linux_dist, tmpdir, paths):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(wsl): Special handling Landscape client config tags

UP4W business logic is so that its data overrides user at a key (module) 
level.
That means the entire Landscape config is overriden if both agent data
and user data contains config for that module.
Yet, for better usability, computer tags must be assignable per instance.
That's not possible with agent.yaml, because it's meant to be global.
Its config data affects all Ubuntu WSL instances.

Thus this aims to make a special case for landscape.client.tags,
if present in user provided data (either Landscape or local user -
  whatever is picked up before merging with agent.yaml)
its value overwrites any tags set by agent.yaml.

Only landscape.client.tags are treated specially.
The pre-existing merge rules still apply for any other value present in
both agent.yaml and user provided data.

Fixes UDENG-2464
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Fixes UDENG-2464
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
