### PR TITLE
tests: integration tests aware of features.DEPRECATION_INFO_BOUNDARY

### DIFF
--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -31,7 +31,7 @@ from typing import (
 
 import yaml
 
-from cloudinit import importer, safeyaml
+from cloudinit import features, importer, safeyaml
 from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.handlers import INCLUSION_TYPES_MAP, type_from_starts_with
 from cloudinit.helpers import Paths
@@ -796,7 +796,7 @@ def validate_cloudconfig_schema(
             schema_error, SchemaDeprecationError
         ):  # pylint: disable=W1116
             if schema_error.version == "devel" or should_log_deprecation(
-                schema_error.version
+                schema_error.version, features.DEPRECATION_INFO_BOUNDARY
             ):
                 deprecations.append(SchemaProblem(path, schema_error.message))
             else:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3210,16 +3210,17 @@ class Version(namedtuple("Version", ["major", "minor", "patch", "rev"])):
         return -1
 
 
-def should_log_deprecation(version: str) -> bool:
+def should_log_deprecation(version: str, boundary_version: str) -> bool:
     """Determine if a deprecation message should be logged.
 
     :param version: The version in which the thing was deprecated.
+    :param boundary_version: The version at which deprecation level is logged.
 
     :return: True if the message should be logged, else False.
     """
-    return features.DEPRECATION_INFO_BOUNDARY == "devel" or Version.from_str(
+    return boundary_version == "devel" or Version.from_str(
         version
-    ) <= Version.from_str(features.DEPRECATION_INFO_BOUNDARY)
+    ) <= Version.from_str(boundary_version)
 
 
 def deprecate(
@@ -3263,7 +3264,9 @@ def deprecate(
         f"{deprecated_version} and scheduled to be removed in "
         f"{version_removed}. {message}"
     ).rstrip()
-    if not should_log_deprecation(deprecated_version):
+    if not should_log_deprecation(
+        deprecated_version, features.DEPRECATION_INFO_BOUNDARY
+    ):
         level = logging.INFO
     elif hasattr(LOG, "deprecated"):
         level = log.DEPRECATED

--- a/tests/integration_tests/cmd/test_schema.py
+++ b/tests/integration_tests/cmd/test_schema.py
@@ -3,9 +3,13 @@ from textwrap import dedent
 
 import pytest
 
+from cloudinit.util import should_log_deprecation
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.releases import CURRENT_RELEASE, MANTIC
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import (
+    get_feature_flag_value,
+    verify_clean_log,
+)
 
 USER_DATA = """\
 #cloud-config
@@ -62,10 +66,19 @@ class TestSchemaDeprecations:
     def test_clean_log(self, class_client: IntegrationInstance):
         log = class_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log, ignore_deprecations=True)
-        assert "DEPRECATED]: Deprecated cloud-config provided:" in log
-        assert "apt_reboot_if_required: Default: ``false``. Deprecated " in log
-        assert "apt_update: Default: ``false``. Deprecated in version" in log
-        assert "apt_upgrade: Default: ``false``. Deprecated in version" in log
+        version_boundary = get_feature_flag_value(
+            class_client, "DEPRECATION_INFO_BOUNDARY"
+        )
+        # the deprecation_version is 22.2 in schema for apt_* keys in
+        # user-data. Pass 22.2 in against the client's version_boundary.
+        if should_log_deprecation("22.2", version_boundary):
+            log_level = "DEPRECATED"
+        else:
+            log_level = "INFO"
+        assert f"{log_level}]: Deprecated cloud-config provided:" in log
+        assert "apt_reboot_if_required:  Deprecated " in log
+        assert "apt_update:  Deprecated in version" in log
+        assert "apt_upgrade:  Deprecated in version" in log
 
     def test_network_config_schema_validation(
         self, class_client: IntegrationInstance
@@ -139,17 +152,10 @@ class TestSchemaDeprecations:
         ), "`schema` cmd must return 0 even with deprecated configs"
         assert not result.stderr
         assert "Cloud config schema deprecations:" in result.stdout
+        assert "apt_update:  Deprecated in version" in result.stdout
+        assert "apt_upgrade:  Deprecated in version" in result.stdout
         assert (
-            "apt_update: Default: ``false``. Deprecated in version"
-            in result.stdout
-        )
-        assert (
-            "apt_upgrade: Default: ``false``. Deprecated in version"
-            in result.stdout
-        )
-        assert (
-            "apt_reboot_if_required: Default: ``false``. Deprecated in version"
-            in result.stdout
+            "apt_reboot_if_required:  Deprecated in version" in result.stdout
         )
 
         annotated_result = class_client.execute(
@@ -167,9 +173,9 @@ class TestSchemaDeprecations:
             apt_reboot_if_required: false\t\t# D3
 
             # Deprecations: -------------
-            # D1: Default: ``false``. Deprecated in version 22.2. Use ``package_update`` instead.
-            # D2: Default: ``false``. Deprecated in version 22.2. Use ``package_upgrade`` instead.
-            # D3: Default: ``false``. Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
+            # D1:  Deprecated in version 22.2. Use ``package_update`` instead.
+            # D2:  Deprecated in version 22.2. Use ``package_upgrade`` instead.
+            # D3:  Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
 
 
             Valid schema /root/user-data"""  # noqa: E501

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import pytest
 
 import cloudinit.config
-from cloudinit.util import is_true
+from cloudinit.util import is_true, should_log_deprecation
 from tests.integration_tests.decorators import retry
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
@@ -131,8 +131,20 @@ class TestCombined:
         """Check that deprecated key produces a log warning"""
         client = class_client
         log = client.read_from_file("/var/log/cloud-init.log")
-        assert "Deprecated cloud-config provided" in log
-        assert "The value of 'false' in user craig's 'sudo' config is " in log
+        version_boundary = get_feature_flag_value(
+            class_client, "DEPRECATION_INFO_BOUNDARY"
+        )
+        # the deprecation_version is 22.2 in schema for apt_* keys in
+        # user-data. Pass 22.2 in against the client's version_boundary.
+        if should_log_deprecation("22.2", version_boundary):
+            log_level = "DEPRECATED"
+        else:
+            log_level = "INFO"
+
+        assert (
+            f"[{log_level}]: The value of 'false' in user craig's 'sudo'"
+            " config is deprecated" in log
+        )
         assert 2 == log.count("DEPRECATE")
 
     def test_ntp_with_apt(self, class_client: IntegrationInstance):

--- a/tests/unittests/distros/test_create_users.py
+++ b/tests/unittests/distros/test_create_users.py
@@ -4,7 +4,7 @@ from typing import List
 
 import pytest
 
-from cloudinit import distros, ssh_util
+from cloudinit import distros, features, ssh_util
 from cloudinit.util import should_log_deprecation
 from tests.unittests.helpers import mock
 from tests.unittests.util import abstract_to_concrete
@@ -145,7 +145,9 @@ class TestCreateUser:
 
         expected_levels = (
             ["WARNING", "DEPRECATED"]
-            if should_log_deprecation("23.1")
+            if should_log_deprecation(
+                "23.1", features.DEPRECATION_INFO_BOUNDARY
+            )
             else ["INFO"]
         )
         assert caplog.records[0].levelname in expected_levels
@@ -178,7 +180,9 @@ class TestCreateUser:
 
         expected_levels = (
             ["WARNING", "DEPRECATED"]
-            if should_log_deprecation("22.3")
+            if should_log_deprecation(
+                "22.3", features.DEPRECATION_INFO_BOUNDARY
+            )
             else ["INFO"]
         )
         assert caplog.records[1].levelname in expected_levels


### PR DESCRIPTION
## Proposed Commit Message
```
tests: integration tests aware of features.DEPRECATION_INFO_BOUNDARY
```

## Additional Context
<!-- If relevant -->
Failed jenkins jobs represented deprecation message errors in integration tests https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-lxd_container/454/ .

## Test Steps
```
CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests -- tests/integration_tests/cmd/test_schema.py::TestSchemaDeprecations::test_clean_log tests/integration_tests/cmd/test_schema.py::TestSchemaDeprecations::test_schema_deprecations tests/integration_tests/cmd/test_status.py::test_status_json_errors tests/integration_tests/modules/test_combined.py::TestCombined::test_deprecated_message
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
