### PR TITLE
tests: update nocloud deprecation test for boundary version

### DIFF
--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -6,10 +6,12 @@ import pytest
 from pycloudlib.lxd.instance import LXDInstance
 
 from cloudinit.subp import subp
+from cloudinit.util import should_log_deprecation
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
 from tests.integration_tests.util import (
+    get_feature_flag_value,
     override_kernel_command_line,
     verify_clean_boot,
     verify_clean_log,
@@ -193,9 +195,18 @@ class TestSmbios:
         assert client.execute("cloud-init clean --logs").ok
         client.restart()
         assert client.execute("test -f /var/tmp/smbios_test_file").ok
-        assert "'nocloud-net' datasource name is deprecated" in client.execute(
-            "cloud-init status --format json"
+        version_boundary = get_feature_flag_value(
+            client, "DEPRECATION_INFO_BOUNDARY"
         )
+        # nocloud-net deprecated in version 24.1
+        if should_log_deprecation("24.1", version_boundary):
+            log_level = "DEPRECATED"
+        else:
+            log_level = "INFO"
+        client.execute(
+            rf"grep \"{log_level}]: The 'nocloud-net' datasource name is"
+            ' deprecated" /var/log/cloud-init.log'
+        ).ok
 
 
 @pytest.mark.skipif(PLATFORM != "lxd_vm", reason="Modifies grub config")


### PR DESCRIPTION


## Proposed Commit Message
```
tests: update nocloud deprecation test for boundary version (#PR)
```
## Additional Context
<!-- If relevant -->
Failing jenkins test 
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-lxd_vm/469/testReport/junit/tests.integration_tests.datasources.test_nocloud/TestSmbios/test_smbios_seed_network/

## Test Steps
```
CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests -- tests/integration_tests/datasources/test_nocloud.py::TestSmbios::test_smbios_seed_local
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
