### PR TITLE
tests: reduce deprecation count when below deprecation info boundary

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -847,7 +847,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 util.deprecate(
                     deprecated=f"The value of 'false' in user {name}'s "
                     "'sudo' config",
-                    deprecated_version="22.3",
+                    deprecated_version="22.2",
                     extra_message="Use 'null' instead.",
                 )
 

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -136,18 +136,23 @@ class TestCombined:
         version_boundary = get_feature_flag_value(
             class_client, "DEPRECATION_INFO_BOUNDARY"
         )
-        # the deprecation_version is 22.2 in schema for apt_* keys in
+        # the changed_version is 22.2 in schema for user.sudo key in
         # user-data. Pass 22.2 in against the client's version_boundary.
         if should_log_deprecation("22.2", version_boundary):
             log_level = "DEPRECATED"
+            deprecation_count = 2
         else:
+            # Expect the distros deprecated call to be redacted.
+            # jsonschema still emits deprecation log due to changed_version
+            # instead of deprecated_version
             log_level = "INFO"
+            deprecation_count = 1
 
         assert (
             f"[{log_level}]: The value of 'false' in user craig's 'sudo'"
             " config is deprecated" in log
         )
-        assert 2 == log.count("DEPRECATE")
+        assert deprecation_count == log.count("DEPRECATE")
 
     def test_ntp_with_apt(self, class_client: IntegrationInstance):
         """LP #1628337.

--- a/tests/unittests/distros/test_create_users.py
+++ b/tests/unittests/distros/test_create_users.py
@@ -181,15 +181,15 @@ class TestCreateUser:
         expected_levels = (
             ["WARNING", "DEPRECATED"]
             if should_log_deprecation(
-                "22.3", features.DEPRECATION_INFO_BOUNDARY
+                "22.2", features.DEPRECATION_INFO_BOUNDARY
             )
             else ["INFO"]
         )
         assert caplog.records[1].levelname in expected_levels
         assert (
             "The value of 'false' in user foo_user's 'sudo' "
-            "config is deprecated in 22.3 and scheduled to be removed"
-            " in 27.3. Use 'null' instead."
+            "config is deprecated in 22.2 and scheduled to be removed"
+            " in 27.2. Use 'null' instead."
         ) in caplog.text
 
     def test_explicit_sudo_none(self, m_subp, dist, caplog):


### PR DESCRIPTION
## Proposed Commit Message
```
tests: reduce deprecation count when below deprecation info boundary
```

## Additional Context
Jenkins failure https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-gce/lastSuccessfulBuild/testReport/junit/tests.integration_tests.modules.test_combined/TestCombined/test_deprecated_message/

## Test Steps
```
for REL in focal jammy noble mantic oracular; do 
CLOUD_INIT_OS_IMAGE=$REL CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined::test_deprecated_message;
done
```
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
