### PR TITLE
fix(test): Fix ip printer for non-lxd

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -294,6 +294,8 @@ class IntegrationInstance:
                 and self.instance.execute_via_ssh
             ):
                 self._ip = self.instance.ip
+            elif not isinstance(self.instance, LXDInstance):
+                self._ip = self.instance.ip
         except NotImplementedError:
             self._ip = "Unknown"
         return self._ip


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(test): Fix ip printer for non-lxd
```

## Additional Context


https://github.com/canonical/cloud-init/commit/343d2c72f32db8fbe47eb8afa98c15987e9ffba6 gave us a  log with the IP address of an instance, if `KEEP_INSTANCE = True`, which allows on to ssh into an instance immediately after a test finishes, useful for debugging and developing tests.

https://github.com/canonical/cloud-init/commit/937e84c4def1e8c88e27d7e270529403b9a63dcc worked around [a pycloudlib bug](https://github.com/canonical/pycloudlib/issues/316) in this logic which caused some lxd instances to hang/fail, but broke the IP printer logic for all non-lxd platforms.

This brings back the IP printer logic. I tested this on ec2 and lxd.

## Test Steps
Run integration test with `KEEP_INSTANCE=True`, check for `Keeping Instance, public ip: x.x.x.x` in the "live log teardown" pytest section.


