### PR TITLE
Set MTU for bond parent interface

### DIFF
--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -431,6 +431,10 @@ class NMConnection:
             self.config["vlan"]["parent"] = renderer.con_ref(
                 iface["vlan-raw-device"]
             )
+        if if_type == "bond" and ipv4_mtu is not None:
+            if "ethernet" not in self.config:
+                self.config["ethernet"] = {}
+            self.config["ethernet"]["mtu"] = str(ipv4_mtu)
         if if_type == "bridge":
             # Bridge is ass-backwards compared to bond
             for port in iface["bridge_ports"]:

--- a/tests/unittests/net/network_configs.py
+++ b/tests/unittests/net/network_configs.py
@@ -3385,6 +3385,9 @@ iface bond0 inet6 static
                 route1=2001:67c::/32,2001:67c:1562::1
                 route2=3001:67c::/32,3001:67c:15::1
 
+                [ethernet]
+                mtu=9000
+
                 """
             ),
         },


### PR DESCRIPTION
If an MTU has been provided for the bond interface, ensure it is properly configured. Support for jumbo frames requires that the underlying physical interfaces and the parent bond interface all have the larger MTU configured, not just the physical interfaces. 

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Set MTU for bond parent interface

If an MTU has been provided for the bond interface, ensure it is
properly configured. Support for jumbo frames requires that the
underlying physical interfaces and the parent bond interface all
have the larger MTU configured, not just the physical interfaces.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
