### PR TITLE
fix: Clean cache if no datasource fallback

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -406,6 +406,7 @@ class Init:
                         ds,
                     )
                 else:
+                    util.del_file(self.paths.instance_link)
                     raise e
         self.datasource = ds
         # Ensure we adjust our path members datasource


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Clean cache if no datasource fallback

9929a00 added the ability to used a cached datasource when none is
found. This was supposed to be per-datasource, but the lack of cache
cleaning got applied universally. This commit makes it so cache will be
cleaned as it was before if fallback isn't implemented in datasource.

Fixes GH-5486
```

## Additional Context
To simulate this using the LXD datasource, I did:
```diff
diff --git a/cloudinit/sources/DataSourceLXD.py b/cloudinit/sources/DataSourceLXD.py
index 4f69d90eb..931027a23 100644
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -195,7 +195,7 @@ class DataSourceLXD(sources.DataSource):
     @staticmethod
     def ds_detect() -> bool:
         """Check platform environment to report if this datasource may run."""
-        return is_platform_viable()
+        return False
 
     def _get_data(self) -> bool:
         """Crawl LXD socket API instance data and return True on success"""
@@ -229,13 +229,13 @@ class DataSourceLXD(sources.DataSource):
             ver=LXD_SOCKET_API_VERSION, socket=LXD_SOCKET_PATH
         )
 
-    def check_instance_id(self, sys_cfg) -> str:
-        """Return True if instance_id unchanged."""
-        response = read_metadata(metadata_keys=MetaDataKeys.META_DATA)
-        md = response.get("meta-data", {})
-        if not isinstance(md, dict):
-            md = util.load_yaml(md)
-        return md.get("instance-id") == self.metadata.get("instance-id")
+    # def check_instance_id(self, sys_cfg) -> str:
+    #     """Return True if instance_id unchanged."""
+    #     response = read_metadata(metadata_keys=MetaDataKeys.META_DATA)
+    #     md = response.get("meta-data", {})
+    #     if not isinstance(md, dict):
+    #         md = util.load_yaml(md)
+    #     return md.get("instance-id") == self.metadata.get("instance-id")
 
     @property
     def network_config(self) -> dict:
@@ -271,6 +271,13 @@ class DataSourceLXD(sources.DataSource):
         return cast(dict, self._network_config)
 
 
+class DataSourceLXDNet(DataSourceLXD):
+    @staticmethod
+    def ds_detect() -> bool:
+        """Check platform environment to report if this datasource may run."""
+        return is_platform_viable()
+
+
 def is_platform_viable() -> bool:
     """Return True when this platform appears to have an LXD socket."""
     if os.path.exists(LXD_SOCKET_PATH):
@@ -462,6 +469,7 @@ def read_metadata(
 # Used to match classes to dependencies
 datasources = [
     (DataSourceLXD, (sources.DEP_FILESYSTEM,)),
+    (DataSourceLXDNet, (sources.DEP_FILESYSTEM, sources.DEP_NETWORK)),
 ]
 
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
