### PR TITLE
schema: add schema rules for 'baseurl' and 'metalink' in yum repo config

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -3452,6 +3452,11 @@
                   "format": "uri",
                   "description": "URL to the directory where the yum repository's 'repodata' directory lives"
                 },
+                "metalink": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Specifies a URL to a metalink file for the repomd.xml"
+                },
                 "name": {
                   "type": "string",
                   "description": "Optional human-readable name of the yum repo."
@@ -3479,8 +3484,17 @@
                   "description": "Any supported yum repository configuration options will be written to the yum repo config file. See: man yum.conf"
                 }
               },
-              "required": [
-                "baseurl"
+              "anyOf": [
+                {
+                  "required": [
+                    "baseurl"
+                  ]
+                },
+                {
+                  "required": [
+                    "metalink"
+                  ]
+                }
               ]
             }
           }


### PR DESCRIPTION
## Proposed Commit Message

At least one of (or both) 'baseurl' or 'metalink' should be provided for yum repository specification. Add schema changes to enforce it. Without this, with just 'metalink' property set, one would get the schema validator error

\---
Error: Cloud config schema errors: yum_repos.epel-release: 'baseurl' is a required property \---





## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
