### PR TITLE
tests: ec2 check status exit code instead of cloud-init init --local

### DIFF
--- a/tests/integration_tests/datasources/test_ec2_ipv6.py
+++ b/tests/integration_tests/datasources/test_ec2_ipv6.py
@@ -2,22 +2,13 @@ import re
 
 import pytest
 
-from cloudinit.util import should_log_deprecation
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import get_feature_flag_value
 
 
-def _test_crawl(client: IntegrationInstance, ip: str):
-    return_code = (
-        2
-        if should_log_deprecation(
-            "24.3", get_feature_flag_value(client, "DEPRECATION_INFO_BOUNDARY")
-        )
-        else 0
-    )
-    assert client.execute("cloud-init clean --logs")
-    assert return_code == client.execute("cloud-init init --local").return_code
+def _test_crawl(client, ip):
+    assert client.execute("cloud-init clean --logs").ok
+    assert client.execute("cloud-init init --local").ok
     log = client.read_from_file("/var/log/cloud-init.log")
     assert f"Using metadata source: '{ip}'" in log
     result = re.findall(r"Crawl of metadata service.* (\d+.\d+) seconds", log)


### PR DESCRIPTION
## Proposed Commit Message
```
    tests: revert expectation of exit 2 from cloud-init init --local
    
    Commit 604d80eb introduced assertions expecting exit 2 from the
    CLI when calling cloud-init init --local. Revert this test assertion
    as only cloud-init status command exits (2) on deprecations/warnings.
    
    Invoking cloud-init's boot stages on the commmand line will only exit
    1 if critical errors are encountered to avoid degrading overall
    systemd health as seen from cloud-init systemd units. When cloud-init
    boot stages encounter recoverable_errors of any type, there is no
    need to exit non-zero as those deprecation logs are not-critical to
    the health of the system as a whole.
```

## Additional Context

Expected integration test failure on ec2 with daily PPA tomorrow because cloud-init init --local (or any direct call to cloud-init stage  doesn't actually exit non-zero because we didn't want cloud-init systemd units/services to degrade overall systemd health based on recoverable_errors. 

## Test Steps
```
# 1. build the deb locally from tip of main (or wait for daily PPA build publishing in +2 hours)

# test where DEPRECATION_INFO_BOUNDARY is 22.1 <= "24.3" defined for deprecation/info level message about invoking cloud-init from the CLI
CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_PLATFORM=ec2 CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_24.2~6gee44a4e2-0ubuntu1~22.04.1_all.deb tox -e integration-tests -- tests/integration_tests/datasources/test_ec2_ipv6.py  --pdb

# test where DEPRECATION_INFO_BOUNDARY=devel (oracular)
CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_PLATFORM=ec2 CLOUD_INIT_CLOUD_INIT_SOURCE=cloud-init_24.2~6gee44a4e2-0ubuntu1_all.deb tox -e integration-tests -- tests/integration_tests/datasources/test_ec2_ipv6.py  --pdb
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
