### PR TITLE
feat: Support URI sources in `write_files` module

### DIFF
--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -90,13 +90,17 @@ def write_files(name, files, owner: str, ssl_details: Optional[dict] = None):
         path = os.path.abspath(path)
         # Read content from provided URL, if any, or decode from inline
         contents = read_url_or_decode(
-            f_info.get("source", None), ssl_details,
-            f_info.get("content", None), f_info.get("encoding", None)
+            f_info.get("source", None),
+            ssl_details,
+            f_info.get("content", None),
+            f_info.get("encoding", None),
         )
         if contents == None:
             LOG.warning(
                 "No content could be loaded for entry %s in module %s;"
-                " skipping", i + 1, name
+                " skipping",
+                i + 1,
+                name,
             )
             continue
         # Only create the file if content exists. This will not happen, for
@@ -149,8 +153,10 @@ def read_url_or_decode(source, ssl_details, content, encoding):
             ).contents
         except Exception:
             util.logexc(
-                LOG, 'Failed to retrieve contents from source "%s";'
-                ' falling back to data from "contents" key', url
+                LOG,
+                'Failed to retrieve contents from source "%s"; falling back to'
+                ' data from "contents" key',
+                url,
             )
             use_url = False
     # If inline content is provided, and URL is not provided or is

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -14,7 +14,6 @@ from cloudinit import url_helper, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
-from cloudinit.helpers import Paths
 from cloudinit.settings import PER_INSTANCE
 
 DEFAULT_PERMS = 0o644
@@ -45,7 +44,8 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             name,
         )
         return
-    write_files(name, filtered_files, cloud.distro.default_owner, cloud.paths)
+    ssl_details = util.fetch_ssl_details(cloud.paths)
+    write_files(name, filtered_files, cloud.distro.default_owner, ssl_details)
 
 
 def canonicalize_extraction(encoding_type):
@@ -73,7 +73,7 @@ def canonicalize_extraction(encoding_type):
     return [TEXT_PLAIN_ENC]
 
 
-def write_files(name, files, owner: str, paths: Paths):
+def write_files(name, files, owner: str, ssl_details: dict|None = None):
     if not files:
         return
 
@@ -98,7 +98,7 @@ def write_files(name, files, owner: str, paths: Paths):
                     url,
                     retries=3,
                     sec_between=3,
-                    ssl_details=util.fetch_ssl_details(paths),
+                    ssl_details=ssl_details,
                 )
             except Exception:
                 util.logexc(

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -94,12 +94,12 @@ def write_files(name, files, owner: str, ssl_details: dict|None = None):
         if use_url:
             # TODO: URL templating, probably. See cloudinit/config/cc_phone_home.py:126
             try:
-                contents = url_helper.read_file_or_url(
+                contents = str(url_helper.read_file_or_url(
                     url,
                     retries=3,
                     sec_between=3,
                     ssl_details=ssl_details,
-                )
+                ))
             except Exception:
                 util.logexc(
                     LOG, "Failed to retrieve contents from source \"%s\";"

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -9,6 +9,7 @@
 import base64
 import logging
 import os
+from typing import Optional
 
 from cloudinit import url_helper, util
 from cloudinit.cloud import Cloud
@@ -73,7 +74,7 @@ def canonicalize_extraction(encoding_type):
     return [TEXT_PLAIN_ENC]
 
 
-def write_files(name, files, owner: str, ssl_details: dict|None = None):
+def write_files(name, files, owner: str, ssl_details: Optional[dict] = None):
     if not files:
         return
 

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -92,6 +92,14 @@ def write_files(name, files, owner: str, ssl_details: dict|None = None):
             f_info.get("source", None), ssl_details,
             f_info.get("content", None), f_info.get("encoding", None)
         )
+        if contents == None:
+            LOG.warning(
+                "No content could be loaded for entry %s in module %s;"
+                " skipping", i + 1, name
+            )
+            continue
+        # Only create the file if content exists. This will not happen, for
+        # example, if the URL fails and no inline content was provided
         (u, g) = util.extract_usergroup(f_info.get("owner", owner))
         perms = decode_perms(f_info.get("permissions"), DEFAULT_PERMS)
         omode = "ab" if util.get_cfg_option_bool(f_info, "append") else "wb"
@@ -142,8 +150,9 @@ def read_url_or_decode(url, ssl_details, content, encoding):
                 ' falling back to data from "contents" key', url
             )
             use_url = False
-    # If URL is not provided or fails, parse inline content
-    if not use_url:
+    # If inline content is provided, and URL is not provided or is
+    # inaccessible, parse the former
+    if content != None and not use_url:
         # NOTE: This is not simply an "else"! Notice that `use_url` can change
         # in the previous "if" block
         extractions = canonicalize_extraction(encoding)

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -136,10 +136,13 @@ def decode_perms(perm, default):
 
 
 def read_url_or_decode(source, ssl_details, content, encoding):
-    result = None
-    # Fetch file content from source URL, if provided
     url = None if source is None else source.get("uri", None)
     use_url = bool(url)
+    # Special case: empty URL and content. Write a blank file
+    if content is None and not use_url:
+        return ""
+    # Fetch file content from source URL, if provided
+    result = None
     if use_url:
         try:
             # NOTE: These retry parameters are arbitrarily chosen defaults.

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -95,7 +95,7 @@ def write_files(name, files, owner: str, ssl_details: Optional[dict] = None):
             f_info.get("content", None),
             f_info.get("encoding", None),
         )
-        if contents == None:
+        if contents is None:
             LOG.warning(
                 "No content could be loaded for entry %s in module %s;"
                 " skipping",
@@ -138,7 +138,7 @@ def decode_perms(perm, default):
 def read_url_or_decode(source, ssl_details, content, encoding):
     contents = None
     # Fetch file content from source URL, if provided
-    url = None if source == None else source.get("uri", None)
+    url = None if source is None else source.get("uri", None)
     use_url = bool(url)
     if use_url:
         try:
@@ -161,7 +161,7 @@ def read_url_or_decode(source, ssl_details, content, encoding):
             use_url = False
     # If inline content is provided, and URL is not provided or is
     # inaccessible, parse the former
-    if content != None and not use_url:
+    if content is not None and not use_url:
         # NOTE: This is not simply an "else"! Notice that `use_url` can change
         # in the previous "if" block
         extractions = canonicalize_extraction(encoding)

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -136,7 +136,7 @@ def decode_perms(perm, default):
 
 
 def read_url_or_decode(source, ssl_details, content, encoding):
-    contents = None
+    result = None
     # Fetch file content from source URL, if provided
     url = None if source is None else source.get("uri", None)
     use_url = bool(url)
@@ -144,7 +144,7 @@ def read_url_or_decode(source, ssl_details, content, encoding):
         try:
             # NOTE: These retry parameters are arbitrarily chosen defaults.
             # They have no significance, and may be changed if appropriate
-            contents = url_helper.read_file_or_url(
+            result = url_helper.read_file_or_url(
                 url,
                 headers=source.get("headers", None),
                 retries=3,
@@ -165,8 +165,8 @@ def read_url_or_decode(source, ssl_details, content, encoding):
         # NOTE: This is not simply an "else"! Notice that `use_url` can change
         # in the previous "if" block
         extractions = canonicalize_extraction(encoding)
-        contents = extract_contents(content, extractions)
-    return contents
+        result = extract_contents(content, extractions)
+    return result
 
 
 def extract_contents(contents, extraction_types):

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -92,14 +92,15 @@ def write_files(name, files, owner: str, ssl_details: dict|None = None):
         url = f_info.get("source", "")
         use_url = bool(url)
         if use_url:
-            # TODO: URL templating, probably. See cloudinit/config/cc_phone_home.py:126
             try:
-                contents = str(url_helper.read_file_or_url(
+                # NOTE: These retry parameters are arbitrarily chosen defaults.
+                # They have no significance, and may be changed if appropriate
+                contents = url_helper.read_file_or_url(
                     url,
                     retries=3,
                     sec_between=3,
                     ssl_details=ssl_details,
-                ))
+                ).contents
             except Exception:
                 util.logexc(
                     LOG, "Failed to retrieve contents from source \"%s\";"

--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -130,9 +130,10 @@ def decode_perms(perm, default):
         return default
 
 
-def read_url_or_decode(url, ssl_details, content, encoding):
+def read_url_or_decode(source, ssl_details, content, encoding):
     contents = None
     # Fetch file content from source URL, if provided
+    url = None if source == None else source.get("uri", None)
     use_url = bool(url)
     if use_url:
         try:
@@ -140,6 +141,7 @@ def read_url_or_decode(url, ssl_details, content, encoding):
             # They have no significance, and may be changed if appropriate
             contents = url_helper.read_file_or_url(
                 url,
+                headers=source.get("headers", None),
                 retries=3,
                 sec_between=3,
                 ssl_details=ssl_details,

--- a/cloudinit/config/cc_write_files_deferred.py
+++ b/cloudinit/config/cc_write_files_deferred.py
@@ -39,4 +39,4 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             name,
         )
         return
-    write_files(name, filtered_files, cloud.distro.default_owner)
+    write_files(name, filtered_files, cloud.distro.default_owner, cloud.paths)

--- a/cloudinit/config/cc_write_files_deferred.py
+++ b/cloudinit/config/cc_write_files_deferred.py
@@ -39,4 +39,5 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             name,
         )
         return
-    write_files(name, filtered_files, cloud.distro.default_owner, cloud.paths)
+    ssl_details = util.fetch_ssl_details(cloud.paths)
+    write_files(name, filtered_files, cloud.distro.default_owner, ssl_details)

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -3399,7 +3399,9 @@
                   "headers": {
                     "type": "object",
                     "description": "Optional HTTP headers to accompany load request, if applicable",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                      "type": "string"
+                    }
                   }
                 },
                 "required": [

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -3384,7 +3384,7 @@
               "content": {
                 "type": "string",
                 "default": "''",
-                "description": "Content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``"
+                "description": "Optional content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``"
               },
               "source": {
                 "type": "object",
@@ -3397,13 +3397,9 @@
                     "description": "URI from which to load file content. If loading fails repeatedly, ``content`` is used instead."
                   },
                   "headers": {
-                    "type": "array",
+                    "type": "object",
                     "description": "Optional HTTP headers to accompany load request, if applicable",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": true
-                    },
-                    "minItems": 1
+                    "additionalProperties": true
                   }
                 },
                 "required": [

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -3386,6 +3386,11 @@
                 "default": "''",
                 "description": "Optional content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``"
               },
+              "source": {
+                "type": "string",
+                "default": "''",
+                "description": "Optional URI from which to fetch file content. If fetching fails repeatedly, ``content`` is used instead."
+              },
               "owner": {
                 "type": "string",
                 "default": "root:root",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -3384,12 +3384,31 @@
               "content": {
                 "type": "string",
                 "default": "''",
-                "description": "Optional content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``"
+                "description": "Content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``"
               },
               "source": {
-                "type": "string",
-                "default": "''",
-                "description": "Optional URI from which to fetch file content. If fetching fails repeatedly, ``content`` is used instead."
+                "type": "object",
+                "description": "Optional specification for content loading from an arbitrary URI",
+                "additionalProperties": false,
+                "properties": {
+                  "uri": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URI from which to load file content. If loading fails repeatedly, ``content`` is used instead."
+                  },
+                  "headers": {
+                    "type": "array",
+                    "description": "Optional HTTP headers to accompany load request, if applicable",
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "minItems": 1
+                  }
+                },
+                "required": [
+                  "uri"
+                ]
               },
               "owner": {
                 "type": "string",

--- a/doc/module-docs/cc_runcmd/example1.yaml
+++ b/doc/module-docs/cc_runcmd/example1.yaml
@@ -4,4 +4,3 @@ runcmd:
 - [sh, -xc, 'echo $(date) '': hello world!''']
 - [sh, -c, echo "=========hello world'========="]
 - ls -l /root
-- [wget, 'http://example.org', -O, /tmp/index.html]

--- a/doc/module-docs/cc_write_files/data.yaml
+++ b/doc/module-docs/cc_write_files/data.yaml
@@ -3,8 +3,9 @@ cc_write_files:
     Write out arbitrary content to files, optionally setting permissions.
     Parent folders in the path are created if absent. Content can be specified
     in plain text or binary. Data encoded with either base64 or binary gzip
-    data can be specified and will be decoded before being written. For empty
-    file creation, content can be omitted.
+    data can be specified and will be decoded before being written. Data can
+    also be loaded from an arbitrary URI. For empty file creation, content can
+    be omitted.
 
     .. note::
        If multi-line data is provided, care should be taken to ensure it
@@ -36,5 +37,10 @@ cc_write_files:
       Example 5: Defer writing the file until after the package (Nginx) is
       installed and its user is created.
     file: cc_write_files/example5.yaml
+  - comment: >
+      Example 6: Retrieve file contents from a URI source, rather than inline.
+      Especially useful with an external config-management repo, or for large
+      binaries.
+    file: cc_write_files/example6.yaml
   name: Write Files
   title: Write arbitrary files

--- a/doc/module-docs/cc_write_files/example6.yaml
+++ b/doc/module-docs/cc_write_files/example6.yaml
@@ -1,5 +1,9 @@
 #cloud-config
 write_files:
-- source: https://gitlab.example.com/some_ci_job/artifacts/hello
+- source:
+    uri: https://gitlab.example.com/some_ci_job/artifacts/hello
+    headers:
+      Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
+      User-Agent: cloud-init on myserver.example.com
   path: /usr/bin/hello
   permissions: '0755'

--- a/doc/module-docs/cc_write_files/example6.yaml
+++ b/doc/module-docs/cc_write_files/example6.yaml
@@ -1,0 +1,5 @@
+#cloud-config
+write_files:
+- source: https://gitlab.example.com/some_ci_job/artifacts/hello
+  path: /usr/bin/hello
+  permissions: '0755'

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -85,6 +85,16 @@ class TestWriteFiles(FilesystemMockingTestCase):
         )
         self.assertEqual(util.load_text_file(filename), expected)
 
+    def test_empty(self):
+        self.patchUtils(self.tmp)
+        filename = "/tmp/my.file"
+        write_files(
+            "test_empty",
+            [{"path": filename}],
+            self.owner,
+        )
+        self.assertEqual(util.load_text_file(filename), "")
+
     def test_append(self):
         self.patchUtils(self.tmp)
         existing = "hello "

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -176,7 +176,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
         cfg = {
             "write_files": [
                 {
-                    "source": "file://"+src_path,
+                    "source": {"uri": "file://"+src_path},
                     "path": dst_path,
                 }
             ]
@@ -199,7 +199,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
         cfg = {
             "write_files": [
                 {
-                    "source": "file://"+src_path,
+                    "source": {"uri": "file://"+src_path},
                     "content": content,
                     "encoding": "text/plain",
                     "path": dst_path,
@@ -292,7 +292,10 @@ class TestWriteFilesSchema:
                     "write_files": [
                         {
                             "append": False,
-                            "source": "http://a.com/a",
+                            "source": {
+                                "uri": "http://a.com/a",
+                                "headers": [{"Authorization": "Bearer SOME_TOKEN"}],
+                            },
                             "content": "a",
                             "encoding": "text/plain",
                             "owner": "jeff",

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -190,6 +190,26 @@ class TestWriteFiles(FilesystemMockingTestCase):
     #TODO: Should probably test this with an HTTP(S) URL as well, but that's
     # a bit more complicated.
 
+    def test_uri_fallback(self):
+        self.patchUtils(self.tmp)
+        src_path = "/tmp/INVALID"
+        dst_path = "/tmp/uri-fallback-target"
+        content = "asdf"
+        util.del_file(src_path)
+        cfg = {
+            "write_files": [
+                {
+                    "source": "file://"+src_path,
+                    "content": content,
+                    "encoding": "text/plain",
+                    "path": dst_path,
+                }
+            ]
+        }
+        cc = self.tmp_cloud("ubuntu")
+        handle("ignored", cfg, cc, [])
+        self.assertEqual(content, util.load_text_file(dst_path))
+
     def test_deferred(self):
         self.patchUtils(self.tmp)
         file_path = "/tmp/deferred.file"

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -177,7 +177,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
         cfg = {
             "write_files": [
                 {
-                    "source": {"uri": "file://"+src_path},
+                    "source": {"uri": "file://" + src_path},
                     "path": dst_path,
                 }
             ]
@@ -216,7 +216,7 @@ class TestWriteFiles(FilesystemMockingTestCase):
         cfg = {
             "write_files": [
                 {
-                    "source": {"uri": "file://"+src_path},
+                    "source": {"uri": "file://" + src_path},
                     "content": content,
                     "encoding": "text/plain",
                     "path": dst_path,
@@ -311,7 +311,9 @@ class TestWriteFilesSchema:
                             "append": False,
                             "source": {
                                 "uri": "http://a.com/a",
-                                "headers": [{"Authorization": "Bearer SOME_TOKEN"}],
+                                "headers": [
+                                    {"Authorization": "Bearer SOME_TOKEN"}
+                                ],
                             },
                             "content": "a",
                             "encoding": "text/plain",

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -167,6 +167,29 @@ class TestWriteFiles(FilesystemMockingTestCase):
             "Unknown encoding type text/plain", self.logs.getvalue()
         )
 
+    def test_file_uri(self):
+        self.patchUtils(self.tmp)
+        src_path = "/tmp/file-uri"
+        dst_path = "/tmp/file-uri-target"
+        content = "asdf"
+        util.write_file(src_path, content)
+        cfg = {
+            "write_files": [
+                {
+                    "source": "file://"+src_path,
+                    "path": dst_path,
+                }
+            ]
+        }
+        cc = self.tmp_cloud("ubuntu")
+        handle("ignored", cfg, cc, [])
+        self.assertEqual(
+            util.load_text_file(src_path), util.load_text_file(dst_path)
+        )
+
+    #TODO: Should probably test this with an HTTP(S) URL as well, but that's
+    # a bit more complicated.
+
     def test_deferred(self):
         self.patchUtils(self.tmp)
         file_path = "/tmp/deferred.file"
@@ -249,6 +272,7 @@ class TestWriteFilesSchema:
                     "write_files": [
                         {
                             "append": False,
+                            "source": "http://a.com/a",
                             "content": "a",
                             "encoding": "text/plain",
                             "owner": "jeff",

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -198,7 +198,13 @@ class TestWriteFiles(FilesystemMockingTestCase):
         cfg = {
             "write_files": [
                 {
-                    "source": {"uri": url},
+                    "source": {
+                        "uri": url,
+                        "headers": {
+                            "foo": "bar",
+                            "blah": "blah",
+                        },
+                    },
                     "path": path,
                 }
             ]

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -311,9 +311,9 @@ class TestWriteFilesSchema:
                             "append": False,
                             "source": {
                                 "uri": "http://a.com/a",
-                                "headers": [
-                                    {"Authorization": "Bearer SOME_TOKEN"}
-                                ],
+                                "headers": {
+                                    "Authorization": "Bearer SOME_TOKEN"
+                                },
                             },
                             "content": "a",
                             "encoding": "text/plain",

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -110,6 +110,7 @@ licebmi
 linitio
 LKHN
 lkundrak
+LRitzdorf
 lucasmoura
 lucendio
 lungj


### PR DESCRIPTION
## Proposed Commit Message
```
feat(write_files): support URI content sources

This change adds an optional `source` key to the `write_files` module,
allowing users to specify a URI from which to load file contents. This
facilitates more flexible multi-part configurations, as file contents
can be managed via external sources such as independent Git
repositories.

Fixes GH-5500
```

## Additional Context
Resolves #5500

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Unit tests, included, cover:
- `file://` and HTTP URI functionality
- Fallback behavior (i.e. use inline `content` if the provided URI fails to return usable data)
- Updated schema validation

## Merge type
- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
