### PR TITLE
Allow ability to specify fqdn via metadata

### DIFF
--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -859,6 +859,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
             # if there is an ipv4 address in 'local-hostname', then
             # make up a hostname (LP: #475354) in format ip-xx.xx.xx.xx
             lhost = self.metadata["local-hostname"]
+            metadata_fqdn = self.metadata.get("fqdn", None)
             if net.is_ipv4_address(lhost):
                 toks = []
                 if resolve_ip:
@@ -868,6 +869,9 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
                     toks = str(toks).split(".")
                 else:
                     toks = ["ip-%s" % lhost.replace(".", "-")]
+            elif metadata_fqdn is not None:
+                # Use the fqdn which was specified in the cloud metadata
+                toks = metadata_fqdn.split(".")
             else:
                 toks = lhost.split(".")
 


### PR DESCRIPTION
Similar to hostname, also allow fqdn to be specified via metadata

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Allow ability to specify fqdn via metadata

Similar to hostname, also allow fqdn to be specified via metadata.
In non-DHCP use cases where static IP information is set via network_config and
no search domains are available network_config or DHCP, there is no way to set
the FQDN of the host, except for specifying hostname itself as a FQDN. In many
cases, it is desired to keep hostname as a non-FQDN while also allowing for a
FQDN. Prior to this change, fqdn could be specified via cloud.cfg but this was
not dynamically configurable via meta_data.
```

## Additional Context
In `get_hostname_fqdn()`, it seems that static config is first checked for fqdn and if it is not present, then the cloud information should be queried:
(https://github.com/canonical/cloud-init/blob/e0e6a427fdc6826bf7b11d52157a1c5f9b3dde4d/cloudinit/util.py#L1263-L1279)

This change extends this functionality and will use the fqdn data from the cloud metadata (if provided) before finally falling through to the hostname from the cloud metadata.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
