### PR TITLE
Support setting mirrorlist in yum repository config

### DIFF
--- a/cloudinit/config/cc_yum_add_repo.py
+++ b/cloudinit/config/cc_yum_add_repo.py
@@ -141,7 +141,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
                 n_repo_config[k] = v
         repo_config = n_repo_config
         missing_required = 0
-        req_fields = ["baseurl", "metalink"]
+        req_fields = ["baseurl", "metalink", "mirrorlist"]
         for req_field in req_fields:
             if req_field not in repo_config:
                 missing_required += 1

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -3457,6 +3457,11 @@
                   "format": "uri",
                   "description": "Specifies a URL to a metalink file for the repomd.xml"
                 },
+                "mirrorlist": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "Specifies a URL to a file containing a baseurls list"
+                },
                 "name": {
                   "type": "string",
                   "description": "Optional human-readable name of the yum repo."
@@ -3493,6 +3498,11 @@
                 {
                   "required": [
                     "metalink"
+                  ]
+                },
+                {
+                  "required": [
+                    "mirrorlist"
                   ]
                 }
               ]

--- a/doc/examples/cloud-config-yum-repo.txt
+++ b/doc/examples/cloud-config-yum-repo.txt
@@ -11,9 +11,10 @@ yum_repos:
     # Any repository configuration options
     # See: man yum.conf
     #
-    # At least one of 'baseurl' or 'metalink' is required!
+    # At least one of 'baseurl' or 'metalink' or 'mirrorlist' is required!
     baseurl: http://download.fedoraproject.org/pub/epel/testing/5/$basearch
     metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
+    mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&
     enabled: false
     failovermethod: priority
     gpgcheck: true

--- a/tests/unittests/config/test_cc_yum_add_repo.py
+++ b/tests/unittests/config/test_cc_yum_add_repo.py
@@ -31,7 +31,8 @@ class TestConfig(helpers.FilesystemMockingTestCase):
             "yum_repos": {
                 "epel-testing": {
                     "name": "Extra Packages for Enterprise Linux 5 - Testing",
-                    # At least one of baseurl or metalink must be present.
+                    # At least one of baseurl or metalink or mirrorlist
+                    # must be present.
                     # Missing this should cause the repo not to be written
                     # 'baseurl': 'http://blah.org/pub/epel/testing/5/$barch',
                     "enabled": False,
@@ -73,6 +74,43 @@ class TestConfig(helpers.FilesystemMockingTestCase):
                 "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL",
                 "enabled": "0",
                 "metalink": "http://blah.org/pub/epel/testing/5/$basearch",
+                "gpgcheck": "1",
+            }
+        }
+        for section in expected:
+            self.assertTrue(
+                parser.has_section(section),
+                "Contains section {0}".format(section),
+            )
+            for k, v in expected[section].items():
+                self.assertEqual(parser.get(section, k), v)
+
+    def test_mirrorlist_config(self):
+        cfg = {
+            "yum_repos": {
+                "epel-testing": {
+                    "name": "Extra Packages for Enterprise Linux 5 - Testing",
+                    "mirrorlist": "http://mirrors.blah.org/metalink?repo=rhel-$releasever",
+                    "enabled": False,
+                    "gpgcheck": True,
+                    "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL",
+                    "failovermethod": "priority",
+                },
+            },
+        }
+        self.patchUtils(self.tmp)
+        self.patchOS(self.tmp)
+        cc_yum_add_repo.handle("yum_add_repo", cfg, None, [])
+        contents = util.load_text_file("/etc/yum.repos.d/epel-testing.repo")
+        parser = configparser.ConfigParser()
+        parser.read_string(contents)
+        expected = {
+            "epel-testing": {
+                "name": "Extra Packages for Enterprise Linux 5 - Testing",
+                "failovermethod": "priority",
+                "gpgkey": "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL",
+                "enabled": "0",
+                "mirrorlist": "http://mirrors.blah.org/metalink?repo=rhel-$releasever",
                 "gpgcheck": "1",
             }
         }


### PR DESCRIPTION
## Proposed Commit Message
'mirrorlist' config can be specified instead or along with 'baseurl' in the yum repository config. Add support for specifying mirrorlist instead of 'baseurl'.

Fixes GH-5520
Signed-off-by: Ani Sinha <anisinha@redhat.com>

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ x] I have added my Github username to ``tools/.github-cla-signers``
- [ x] I have included a comprehensive commit message using the guide below
- [ x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
