### PR TITLE
chore(formatting): fix squashed commit test formatting

### DIFF
--- a/tests/integration_tests/datasources/test_caching.py
+++ b/tests/integration_tests/datasources/test_caching.py
@@ -10,9 +10,7 @@ def setup_custom_datasource(client: IntegrationInstance, datasource_name: str):
         f"datasource_list: [ {datasource_name}, None ]\n"
         "datasource_pkg_list: [ cisources ]",
     )
-    assert client.execute(
-        "mkdir -p /usr/lib/python3/dist-packages/cisources"
-    )
+    assert client.execute("mkdir -p /usr/lib/python3/dist-packages/cisources")
     client.push_file(
         util.ASSETS_DIR / f"DataSource{datasource_name}.py",
         "/usr/lib/python3/dist-packages/cisources/"


### PR DESCRIPTION
Fix squashmerged test changes that required extra formatting in commit 550c685c98551f65c30832b186fe091721b48477

Issue introduced by applying minor changes to existing tests in review and merging it before CI finished running the formatting validation job.