### PR TITLE
test: fix no ds cache tests

### DIFF
--- a/tests/integration_tests/datasources/test_caching.py
+++ b/tests/integration_tests/datasources/test_caching.py
@@ -25,7 +25,7 @@ def verify_no_cache_boot(client: IntegrationInstance):
             "No local datasource found",
             "running 'init'",
             "no cache found",
-            "Detected platform",
+            "Detected DataSource",
             "TEST _get_data called",
         ],
         text=log,
@@ -83,7 +83,7 @@ def test_no_cache_with_fallback(client: IntegrationInstance):
     util.verify_ordered_items_in_text(
         [
             "no cache found",
-            "Detected platform",
+            "Detected DataSource",
             "TEST _get_data called",
             "running 'init'",
             "restored from cache with run check",
@@ -102,7 +102,7 @@ def test_no_cache_with_fallback(client: IntegrationInstance):
     util.verify_ordered_items_in_text(
         [
             "cache invalid in datasource",
-            "Detected platform",
+            "Detected DataSource",
             "Restored fallback datasource from checked cache",
             "running 'init'",
             "restored from cache with run check",

--- a/tests/integration_tests/test_kernel_command_line_match.py
+++ b/tests/integration_tests/test_kernel_command_line_match.py
@@ -22,7 +22,7 @@ log = logging.getLogger("integration_testing")
     (
         (
             "ds=nocloud;s=http://my-url/;h=hostname",
-            "DataSourceNoCloud [seed=None][dsmode=net]",
+            "DataSourceNoCloud",
             True,
         ),
         ("ci.ds=openstack", "DataSourceOpenStack", True),
@@ -49,17 +49,14 @@ def test_lxd_datasource_kernel_override(
     override_kernel_command_line(ds_str, client)
     if cmdline_configured:
         assert (
-            "Machine is configured by the kernel command line to run on single"
+            "Kernel command line set to use a single"
             f" datasource {configured}"
         ) in client.execute("cat /var/log/cloud-init.log")
     else:
         # verify that no plat
         log = client.execute("cat /var/log/cloud-init.log")
-        assert (f"Detected platform: {configured}") in log
-        assert (
-            "Machine is configured by the kernel "
-            "command line to run on single "
-        ) not in log
+        assert f"Detected {configured}" in log
+        assert "Kernel command line set to use a single" not in log
 
 
 GH_REPO_PATH = "https://raw.githubusercontent.com/canonical/cloud-init/main/"


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
See individual commits
```

## Additional Context
<!-- If relevant -->
7703634ec048aa00ddf6ef7a5d552004a84c4f04
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-lxd_container/470/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_vm/469/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```sh
CLOUD_INIT_PLATFORM=lxd_container tox -e integration-tests -- \
  tests/integration_tests/datasources/test_caching.py::test_no_cache_network_only \
  tests/integration_tests/datasources/test_caching.py::test_no_cache_with_fallback

CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=focal tox -e integration-tests -- tests/integration_tests/test_kernel_command_line_match.py::test_lxd_datasource_kernel_override
```

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
