### PR TITLE
feat: Eliminate redundant configuration reads

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -506,7 +506,10 @@ class Init:
 
         self._write_to_cache()
         if already_instancified and previous_ds == ds:
-            LOG.info("Not re-loading configuration, instance id and datasource have not changed.")
+            LOG.info(
+                "Not re-loading configuration, instance "
+                "id and datasource have not changed."
+            )
             # Ensure needed components are regenerated
             # after change of instance which may cause
             # change of configuration

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -11,6 +11,7 @@ import os
 import sys
 from collections import namedtuple
 from contextlib import suppress
+from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
 from cloudinit import (
@@ -459,8 +460,13 @@ class Init:
         # Remove the old symlink and attach a new one so
         # that further reads/writes connect into the right location
         idir = self._get_ipath()
-        util.del_file(self.paths.instance_link)
-        util.sym_link(idir, self.paths.instance_link)
+        destination = Path(self.paths.instance_link).resolve().absolute()
+        already_instancified = destination == Path(idir).absolute()
+        if already_instancified:
+            LOG.info("Instance link already exists, not recreating it.")
+        else:
+            util.del_file(self.paths.instance_link)
+            util.sym_link(idir, self.paths.instance_link)
 
         # Ensures these dirs exist
         dir_list = []
@@ -499,10 +505,13 @@ class Init:
         )
 
         self._write_to_cache()
-        # Ensure needed components are regenerated
-        # after change of instance which may cause
-        # change of configuration
-        self._reset()
+        if already_instancified and previous_ds == ds:
+            LOG.info("Not re-loading configuration, instance id and datasource have not changed.")
+            # Ensure needed components are regenerated
+            # after change of instance which may cause
+            # change of configuration
+        else:
+            self._reset()
         return iid
 
     def previous_iid(self):

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -37,7 +37,7 @@ INSTANCE_TYPE: Optional[str] = None
 # <image_id>[::<os>::<release>::<version>].  If given, os and release should
 # describe the image specified by image_id.  (Ubuntu releases are converted
 # to this format internally; in this case, to "None::ubuntu::focal::20.04".)
-OS_IMAGE = "jammy"
+OS_IMAGE = "focal"
 
 # Populate if you want to use a pre-launched instance instead of
 # creating a new one. The exact contents will be platform dependent
@@ -69,7 +69,7 @@ EXISTING_INSTANCE_ID: Optional[str] = None
 #   Install from a PPA. It MUST start with 'ppa:'
 # <file path>
 #   A path to a valid package to be uploaded and installed
-CLOUD_INIT_SOURCE = "IN_PLACE"
+CLOUD_INIT_SOURCE = "NONE"
 
 # Before an instance is torn down, we run `cloud-init collect-logs`
 # and transfer them locally. These settings specify when to collect these

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -37,7 +37,7 @@ INSTANCE_TYPE: Optional[str] = None
 # <image_id>[::<os>::<release>::<version>].  If given, os and release should
 # describe the image specified by image_id.  (Ubuntu releases are converted
 # to this format internally; in this case, to "None::ubuntu::focal::20.04".)
-OS_IMAGE = "focal"
+OS_IMAGE = "jammy"
 
 # Populate if you want to use a pre-launched instance instead of
 # creating a new one. The exact contents will be platform dependent
@@ -69,7 +69,7 @@ EXISTING_INSTANCE_ID: Optional[str] = None
 #   Install from a PPA. It MUST start with 'ppa:'
 # <file path>
 #   A path to a valid package to be uploaded and installed
-CLOUD_INIT_SOURCE = "NONE"
+CLOUD_INIT_SOURCE = "IN_PLACE"
 
 # Before an instance is torn down, we run `cloud-init collect-logs`
 # and transfer them locally. These settings specify when to collect these

--- a/tests/integration_tests/test_instance_id.py
+++ b/tests/integration_tests/test_instance_id.py
@@ -1,0 +1,97 @@
+from typing import cast
+
+import pytest
+from pycloudlib.lxd.instance import LXDInstance
+
+from cloudinit import subp
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.integration_settings import PLATFORM
+
+_INSTANCE_ID = 0
+
+
+def setup_meta_data(instance: LXDInstance):
+    """Increment the instance id and apply it to the instance."""
+    global _INSTANCE_ID
+    _INSTANCE_ID += 1
+    command = [
+        "lxc",
+        "config",
+        "set",
+        instance.name,
+        f"user.meta-data=instance-id: test_{_INSTANCE_ID}",
+    ]
+    subp.subp(command)
+
+
+# class TestInstanceID:
+@pytest.mark.skipif(
+    PLATFORM not in ["lxd_container", "lxd_vm"],
+    reason="Uses lxd-specific behavior.",
+)
+@pytest.mark.lxd_setup.with_args(setup_meta_data)
+@pytest.mark.lxd_use_exec
+def test_instance_id_changes(client: IntegrationInstance):
+    """Verify instance id change behavior
+
+    If the id from the datasource changes, cloud-init should update the
+    instance id link.
+    """
+    client.execute("cloud-init status --wait")
+    # check that instance id is the one we set
+    assert (
+        "test_1"
+        == client.execute("cloud-init query instance-id").stdout.rstrip()
+    )
+    assert (
+        "/var/lib/cloud/instances/test_1"
+        == client.execute(
+            "readlink -f /var/lib/cloud/instance"
+        ).stdout.rstrip()
+    )
+
+    instance = cast(LXDInstance, client.instance)
+    setup_meta_data(instance)
+    client.restart()
+    client.execute("cloud-init status --wait")
+    # check that instance id is the one we reset
+    assert (
+        "test_2"
+        == client.execute("cloud-init query instance-id").stdout.rstrip()
+    )
+    assert (
+        "/var/lib/cloud/instances/test_2"
+        == client.execute(
+            "readlink -f /var/lib/cloud/instance"
+        ).stdout.rstrip()
+    )
+
+
+@pytest.mark.lxd_use_exec
+def test_instance_id_no_changes(client: IntegrationInstance):
+    """Verify instance id no change behavior
+
+    If the id from the datasource does not change, cloud-init should not
+    update the instance id link.
+    """
+    instance_id = client.execute(
+        "cloud-init query instance-id"
+    ).stdout.rstrip()
+    assert (
+        f"/var/lib/cloud/instances/{instance_id}"
+        == client.execute(
+            "readlink -f /var/lib/cloud/instance"
+        ).stdout.rstrip()
+    )
+    client.restart()
+    client.execute("cloud-init status --wait")
+    assert (
+        instance_id
+        == client.execute("cloud-init query instance-id").stdout.rstrip()
+    )
+    assert (
+        f"/var/lib/cloud/instances/{instance_id}"
+        == client.execute(
+            "readlink -f /var/lib/cloud/instance"
+        ).stdout.rstrip()
+    )


### PR DESCRIPTION

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat: Eliminate redundant configuration reads

When instance id hasn't changed and datasource hasn't changed, don't
forcibly reload configuration.
```

## Additional Context
On a test system, this avoids reloading the configuration on the second `instancify()`

See the new messages in logs: 
[no-reload.log](https://github.com/user-attachments/files/16351318/no-reload.txt)

