### PR TITLE
fix(wsl): Put back the "path" argument to wsl_path in ds-identify

### DIFF
--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1776,7 +1776,7 @@ dscheck_WSL() {
 
     # Then we can check for any .cloud-init folders for the user
     if [ ! -d "$profile_dir/.cloud-init/" ] && [ ! -d "$profile_dir/.ubuntupro/.cloud-init/" ]; then
-        debug 1 "No .cloud-init directories found"
+        debug 1 "No .cloud-init directories found in $profile_dir"
         return "${DS_NOT_FOUND}"
     fi
 

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -1696,7 +1696,7 @@ dscheck_VMware() {
 
 WSL_path() {
     local params="$1" path="$2" val=""
-    val="$(wslpath "$params" "$1")"
+    val="$(wslpath "$params" "$path")"
     _RET="$val"
 }
 


### PR DESCRIPTION

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(wsl): Put back the "path" argument to wsl_path in ds-identify

Got swallowed by 
https://github.com/canonical/cloud-init/pull/5116/commits/da6b5c437a799bb934c89545c1b077a84d34a51d

The way it is results in wrong invocation of wslpath binary,
thus we never find WSL specific data, disabling cloud-init.
```

## Additional Context
<!-- If relevant -->

## Test Steps
1. Have a WSL instance with  `datasources_list=[WSL, NoCloud] # could be something else,as long as there is one more real datasource meant to be not activated`
2. Run cloud-init normally.
3. Look at `/run/ds-identify.log`. It should contain the message "No .cloud-init directories found".

We compute the `.cloud-init` directory correctly but when translating that into a Linux path using `wslpath` then things don't go well.

Unfortunately that's a function built to be mocked, so I don't see how to properly test this in the current repository practices.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
