### PR TITLE
Improve qemu cmdline

### DIFF
--- a/doc/rtd/howto/run_cloud_init_locally.rst
+++ b/doc/rtd/howto/run_cloud_init_locally.rst
@@ -71,10 +71,10 @@ Download an Ubuntu image to run:
     wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 
 .. note::
-   The example is written for x86. It works on non-x86 but is slower as it
-   will need to be emulated. You can change the image type and
-   :spelling:ignore:`qemu-system-<arch>` to your architecture to make it
-   faster for you.
+   This example uses emulated CPU instructions on non-x86 hosts, so it may be
+   slow. To make it faster on non-x86 architectures, one can change the image
+   type and :spelling:ignore:`qemu-system-<arch>` command name to match the
+   architecture of your host machine.
 
 Boot the image with the ISO attached
 ------------------------------------

--- a/doc/rtd/howto/run_cloud_init_locally.rst
+++ b/doc/rtd/howto/run_cloud_init_locally.rst
@@ -77,9 +77,10 @@ Boot the cloud image with our configuration, :file:`seed.img`, to QEMU:
 
 .. code-block:: shell-session
 
-    $ qemu-system-x86_64 -m 1024 -net nic -net user \
+    $ sudo qemu-system-x86_64 -m 1024 -net nic -net user \
         -drive file=jammy-server-cloudimg-amd64.img,index=0,format=qcow2,media=disk \
-        -drive file=seed.img,index=1,media=cdrom
+        -drive file=seed.img,index=1,media=cdrom \
+        -machine ubuntu,accel=kvm:tcg
 
 The now-booted image will allow for login using the password provided above.
 

--- a/doc/rtd/howto/run_cloud_init_locally.rst
+++ b/doc/rtd/howto/run_cloud_init_locally.rst
@@ -71,9 +71,10 @@ Download an Ubuntu image to run:
     wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 
 .. note::
-   Please be aware, the example is written for x86. It works on non-x86 but
-   is slower as it will need to be emulated. You can change the image type and
-   qemu-system variant to your architecture to make it faster for you.
+   The example is written for x86. It works on non-x86 but is slower as it
+   will need to be emulated. You can change the image type and
+   :spelling:ignore:`qemu-system-<arch>` to your architecture to make it
+   faster for you.
 
 Boot the image with the ISO attached
 ------------------------------------

--- a/doc/rtd/howto/run_cloud_init_locally.rst
+++ b/doc/rtd/howto/run_cloud_init_locally.rst
@@ -78,8 +78,8 @@ Boot the cloud image with our configuration, :file:`seed.img`, to QEMU:
 .. code-block:: shell-session
 
     $ qemu-system-x86_64 -m 1024 -net nic -net user \
-        -hda jammy-server-cloudimg-amd64.img \
-        -hdb seed.img
+        -drive file=jammy-server-cloudimg-amd64.img,index=0,format=qcow2,media=disk \
+        -drive file=seed.img,index=1,media=cdrom
 
 The now-booted image will allow for login using the password provided above.
 

--- a/doc/rtd/howto/run_cloud_init_locally.rst
+++ b/doc/rtd/howto/run_cloud_init_locally.rst
@@ -77,10 +77,10 @@ Boot the cloud image with our configuration, :file:`seed.img`, to QEMU:
 
 .. code-block:: shell-session
 
-    $ sudo qemu-system-x86_64 -m 1024 -net nic -net user \
+    $ qemu-system-x86_64 -m 1024 -net nic -net user \
         -drive file=jammy-server-cloudimg-amd64.img,index=0,format=qcow2,media=disk \
         -drive file=seed.img,index=1,media=cdrom \
-        -machine ubuntu,accel=kvm:tcg
+        -machine accel=kvm:tcg
 
 The now-booted image will allow for login using the password provided above.
 

--- a/doc/rtd/howto/run_cloud_init_locally.rst
+++ b/doc/rtd/howto/run_cloud_init_locally.rst
@@ -70,6 +70,11 @@ Download an Ubuntu image to run:
 
     wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 
+.. note::
+   Please be aware, the example is written for x86. It works on non-x86 but
+   is slower as it will need to be emulated. You can change the image type and
+   qemu-system variant to your architecture to make it faster for you.
+
 Boot the image with the ISO attached
 ------------------------------------
 

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -81,9 +81,10 @@ server image using :command:`wget`:
     $ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 
 .. note::
-   Please be aware, the example is written for x86. It works on non-x86 but
-   is slower as it will need to be emulated. You can change the image type and
-   :spelling:ignore:`qemu-system-<arch>` to your architecture to make it faster for you.
+   This example uses emulated CPU instructions on non-x86 hosts, so it may be
+   slow. To make it faster on non-x86 architectures, one can change the image
+   type and :spelling:ignore:`qemu-system-<arch>` command name to match the
+   architecture of your host machine.
 
 Define our user data
 ====================

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -203,7 +203,6 @@ take a few moments to complete.
         -net nic                                                    \
         -net user                                                   \
         -machine accel=kvm:tcg                                      \
-        -cpu host                                                   \
         -m 512                                                      \
         -nographic                                                  \
         -hda jammy-server-cloudimg-amd64.img                        \

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -83,7 +83,7 @@ server image using :command:`wget`:
 .. note::
    Please be aware, the example is written for x86. It works on non-x86 but
    is slower as it will need to be emulated. You can change the image type and
-   qemu-system variant to your architecture to make it faster for you.
+   :spelling:ignore:`qemu-system-<arch>` to your architecture to make it faster for you.
 
 Define our user data
 ====================

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -80,6 +80,11 @@ server image using :command:`wget`:
 
     $ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
 
+.. note::
+   Please be aware, the example is written for x86. It works on non-x86 but
+   is slower as it will need to be emulated. You can change the image type and
+   qemu-system variant to your architecture to make it faster for you.
+
 Define our user data
 ====================
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -143,6 +143,7 @@ onitake
 orndorffgrant
 Oursin
 outscale-mdr
+paelzer
 philsphicas
 phsm
 phunyguy

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -42,6 +42,7 @@ citrus-it
 cjp256
 CodeBleu
 Conan-Kudo
+cpaelzer
 cvstealth
 dankenigsberg
 dankm
@@ -143,7 +144,6 @@ onitake
 orndorffgrant
 Oursin
 outscale-mdr
-paelzer
 philsphicas
 phsm
 phunyguy


### PR DESCRIPTION
- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [n/a] I have added unit tests to cover the new behavior under ``tests/unittests/``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message
- [n/a] I have updated the documentation with the changed behavior.

## Proposed Commit Message
```
docs: improve qemu command line

The suggested qemu command line in our local execution example
is rather old.

Change the discouraged -hd* options to the new
-device instead.

Further add a chance to use KVM acceleration to speed up the
example.

Finally we had several occasions to be working on x86 only.
We dropped arguments that can not work on cross-arch and
furthermore added a hint at how one could again native
performance on these platforms.

Fixes GH-5050
```

## Additional Context

n/a

## Test Steps

Use the "How to run cloud-init locally" example

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
