### PR TITLE
doc(autoinstall): Remove incorrect statements, be more direct

### DIFF
--- a/doc/rtd/reference/faq.rst
+++ b/doc/rtd/reference/faq.rst
@@ -20,7 +20,7 @@ Having trouble? We would like to help!
 
 Other projects, such as `Subiquity autoinstaller`_, use cloud-init to implement
 a subset of their features and have a YAML configuration format which combines
-``cloud-init``'s cloud-config with additional autoinstall-specific keys.
+``cloud-init``'s cloud-config with additional keys.
 
 If you are an autoinstall user, please direct questions to their IRC channel
 (``#ubuntu-server`` on Libera) or Discourse.

--- a/doc/rtd/reference/faq.rst
+++ b/doc/rtd/reference/faq.rst
@@ -77,7 +77,6 @@ Whitepapers:
 
 .. _mailing list: https://launchpad.net/~cloud-init
 .. _IRC channel on Libera: https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init
-.. _Juju: https://ubuntu.com/blog/topics/juju
 .. _discourse page: https://discourse.charmhub.io
 .. _do: https://github.com/canonical/ubuntu-pro-client/blob/9b46480b9e4b88e918bac5ced0d4b8edb3cbbeab/lib/auto_attach.py#L35
 
@@ -100,5 +99,4 @@ Whitepapers:
 .. _cloud-init Summit 2018: https://powersj.io/post/cloud-init-summit18/
 .. _cloud-init Summit 2017: https://powersj.io/post/cloud-init-summit17/
 .. _Subiquity autoinstaller: https://ubuntu.com/server/docs/install/autoinstall
-.. _juju_project: https://discourse.charmhub.io/t/model-config-cloudinit-userdata/512
 .. _discourse page: https://discourse.charmhub.io

--- a/doc/rtd/reference/faq.rst
+++ b/doc/rtd/reference/faq.rst
@@ -23,7 +23,7 @@ a subset of their features and have a YAML configuration format which combines
 ``cloud-init``'s cloud-config with additional keys.
 
 If you are an autoinstall user, please direct questions to their IRC channel
-(``#ubuntu-server`` on Libera) or Discourse.
+(``#ubuntu-server`` on Libera).
 
 Can I use cloud-init as a library?
 ==================================
@@ -77,7 +77,6 @@ Whitepapers:
 
 .. _mailing list: https://launchpad.net/~cloud-init
 .. _IRC channel on Libera: https://kiwiirc.com/nextclient/irc.libera.chat/cloud-init
-.. _discourse page: https://discourse.charmhub.io
 .. _do: https://github.com/canonical/ubuntu-pro-client/blob/9b46480b9e4b88e918bac5ced0d4b8edb3cbbeab/lib/auto_attach.py#L35
 
 .. _cloud-init - The Good Parts: https://www.youtube.com/watch?v=2_m6EUo6VOI
@@ -99,4 +98,3 @@ Whitepapers:
 .. _cloud-init Summit 2018: https://powersj.io/post/cloud-init-summit18/
 .. _cloud-init Summit 2017: https://powersj.io/post/cloud-init-summit17/
 .. _Subiquity autoinstaller: https://ubuntu.com/server/docs/install/autoinstall
-.. _discourse page: https://discourse.charmhub.io

--- a/doc/rtd/reference/faq.rst
+++ b/doc/rtd/reference/faq.rst
@@ -15,21 +15,15 @@ Having trouble? We would like to help!
 - Find a bug? Check out the :ref:`reporting_bugs` topic to find out how to
   report one
 
-``autoinstall``, ``preruncmd``, ``postruncmd``
-==============================================
+``autoinstall``
+===============
 
-Since ``cloud-init`` ignores top level user data ``cloud-config`` keys, other
-projects such as `Juju`_ and `Subiquity autoinstaller`_ use a YAML-formatted
-config that combines ``cloud-init``'s user data cloud-config YAML format with
-their custom YAML keys. Since ``cloud-init`` ignores unused top level keys,
-these combined YAML configurations may be valid ``cloud-config`` files,
-however keys such as ``autoinstall``, ``preruncmd``, and ``postruncmd`` are
-not used by ``cloud-init`` to configure anything.
+Other projects, such as `Subiquity autoinstaller`_, use cloud-init to implement
+a subset of their features and have a YAML configuration format which combines
+``cloud-init``'s cloud-config with additional autoinstall-specific keys.
 
-Please direct bugs and questions about other projects that use ``cloud-init``
-to their respective support channels. For Subiquity autoinstaller that is via
-IRC (``#ubuntu-server`` on Libera) or Discourse. For Juju support see their
-`discourse page`_.
+If you are an autoinstall user, please direct questions to their IRC channel
+(``#ubuntu-server`` on Libera) or Discourse.
 
 Can I use cloud-init as a library?
 ==================================


### PR DESCRIPTION
## Commit message
```
doc(autoinstall): Remove incorrect statements, be more direct
```

## Additional Context
Top level keys are no longer ignored, so drop this incorrect statement.

Tailor this section more directly toward subiquity / autoinstall, since
that is where the frequently asked questions come from.
