### PR TITLE
fix(aosc): add hosts template for AOSC OS

### DIFF
--- a/templates/hosts.aosc.tmpl
+++ b/templates/hosts.aosc.tmpl
@@ -1,0 +1,23 @@
+## template:jinja
+{#
+This file (/etc/cloud/templates/hosts.aosc.tmpl) is only utilized
+if enabled in cloud-config.  Specifically, in order to enable it
+you need to add the following to config:
+   manage_etc_hosts: True
+-#}
+# Your system has configured 'manage_etc_hosts' as True.
+# As a result, if you wish for changes to this file to persist
+# then you will need to either
+# a.) make changes to the master file in /etc/cloud/templates/hosts.aosc.tmpl
+# b.) change or remove the value of 'manage_etc_hosts' in
+#     /etc/cloud/cloud.cfg or cloud-config from user-data
+#
+#<ip-address>   <hostname.domain.org>   <hostname>
+{# The value '{{hostname}}' will be replaced with the local-hostname -#}
+127.0.0.1       {{fqdn}} {{hostname}}
+127.0.0.1       localhost
+
+# The following lines are desirable for IPv6 capable hosts
+::1             localhost ip6-localhost ip6-loopback
+ff02::1         ip6-allnodes
+ff02::2         ip6-allrouters


### PR DESCRIPTION
## Proposed Commit Message

```
fix(aosc): add hosts template for AOSC OS
```
## Additional Context

Fixed the [issue](https://github.com/AOSC-Dev/aosc-os-abbs/pull/6927) encountered in AOSC OS, which highlighted the missing hosts template for AOSC OS.

## Test Steps

This fix has been verified in the latest AOSC package and has been merged into the AOSC OS repository.

![cloud-init-24-2-fixed](https://github.com/user-attachments/assets/1196194a-e8c3-4e7e-858c-828131b0f5a8)

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
