### PR TITLE
Doc module render fixes

### DIFF
--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -131,7 +131,7 @@
           "properties": {
             "disable_auto_attach": {
               "type": "boolean",
-              "description": "Optional boolean for controlling if ua-auto-attach.service (in Ubuntu Pro instances) will be attempted each boot. Default: ``false``",
+              "description": "Optional boolean for controlling if ua-auto-attach.service (in Ubuntu Pro instances) will be attempted each boot. Default: ``false``.",
               "default": false
             }
           }
@@ -163,7 +163,7 @@
                 "null"
               ],
               "format": "uri",
-              "description": "HTTP Proxy URL used for all APT repositories on a system or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
+              "description": "HTTP Proxy URL used for all APT repositories on a system or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``."
             },
             "global_apt_https_proxy": {
               "type": [
@@ -171,7 +171,7 @@
                 "null"
               ],
               "format": "uri",
-              "description": "HTTPS Proxy URL used for all APT repositories on a system or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
+              "description": "HTTPS Proxy URL used for all APT repositories on a system or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``."
             },
             "ua_apt_http_proxy": {
               "type": [
@@ -179,7 +179,7 @@
                 "null"
               ],
               "format": "uri",
-              "description": "HTTP Proxy URL used only for Ubuntu Pro APT repositories or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
+              "description": "HTTP Proxy URL used only for Ubuntu Pro APT repositories or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``."
             },
             "ua_apt_https_proxy": {
               "type": [
@@ -187,7 +187,7 @@
                 "null"
               ],
               "format": "uri",
-              "description": "HTTPS Proxy URL used only for Ubuntu Pro APT repositories or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``"
+              "description": "HTTPS Proxy URL used only for Ubuntu Pro APT repositories or null to unset. Stored at ``/etc/apt/apt.conf.d/90ubuntu-advantage-aptproxy``."
             }
           }
         }
@@ -198,7 +198,7 @@
       "patternProperties": {
         "^.+$": {
           "label": "<group_name>",
-          "description": "Optional string of single username or a list of usernames to add to the group",
+          "description": "Optional string of single username or a list of usernames to add to the group.",
           "type": [
             "string",
             "array"
@@ -239,12 +239,12 @@
         },
         "expiredate": {
           "default": null,
-          "description": "Optional. Date on which the user's account will be disabled. Default: ``null``",
+          "description": "Optional. Date on which the user's account will be disabled. Default: ``null``.",
           "type": "string",
           "format": "date"
         },
         "gecos": {
-          "description": "Optional comment about the user, usually a comma-separated string of real name and contact information",
+          "description": "Optional comment about the user, usually a comma-separated string of real name and contact information.",
           "type": "string"
         },
         "groups": {
@@ -283,12 +283,12 @@
           ]
         },
         "homedir": {
-          "description": "Optional home dir for user. Default: ``/home/<username>``",
+          "description": "Optional home dir for user. Default: ``/home/<username>``.",
           "default": "``/home/<username>``",
           "type": "string"
         },
         "inactive": {
-          "description": "Optional string representing the number of days until the user is disabled. ",
+          "description": "Optional string representing the number of days until the user is disabled.",
           "type": "string"
         },
         "lock-passwd": {
@@ -299,7 +299,7 @@
         },
         "lock_passwd": {
           "default": true,
-          "description": "Disable password login. Default: ``true``",
+          "description": "Disable password login. Default: ``true``.",
           "type": "boolean"
         },
         "no-create-home": {
@@ -310,7 +310,7 @@
         },
         "no_create_home": {
           "default": false,
-          "description": "Do not create home directory. Default: ``false``",
+          "description": "Do not create home directory. Default: ``false``.",
           "type": "boolean"
         },
         "no-log-init": {
@@ -321,7 +321,7 @@
         },
         "no_log_init": {
           "default": false,
-          "description": "Do not initialize lastlog and faillog for user. Default: ``false``",
+          "description": "Do not initialize lastlog and faillog for user. Default: ``false``.",
           "type": "boolean"
         },
         "no-user-group": {
@@ -332,7 +332,7 @@
         },
         "no_user_group": {
           "default": false,
-          "description": "Do not create group named after user. Default: ``false``",
+          "description": "Do not create group named after user. Default: ``false``.",
           "type": "boolean"
         },
         "passwd": {
@@ -378,7 +378,7 @@
         },
         "primary_group": {
           "default": "``<username>``",
-          "description": "Primary group for user. Default: ``<username>``",
+          "description": "Primary group for user. Default: ``<username>``.",
           "type": "string"
         },
         "selinux-user": {
@@ -400,7 +400,7 @@
           "type": "string"
         },
         "ssh_authorized_keys": {
-          "description": "List of SSH keys to add to user's authkeys file. Can not be combined with ``ssh_redirect_user``",
+          "description": "List of SSH keys to add to user's authkeys file. Can not be combined with ``ssh_redirect_user``.",
           "type": "array",
           "items": {
             "type": "string"
@@ -428,7 +428,7 @@
           "deprecated_description": "Use ``ssh_import_id`` instead."
         },
         "ssh_import_id": {
-          "description": "List of ssh ids to import for user. Can not be combined with ``ssh_redirect_user``. See the man page[1] for more details. [1] https://manpages.ubuntu.com/manpages/noble/en/man1/ssh-import-id.1.html",
+          "description": "List of ssh ids to import for user. Can not be combined with ``ssh_redirect_user``. See the man page[1] for more details. [1] https://manpages.ubuntu.com/manpages/noble/en/man1/ssh-import-id.1.html.",
           "type": "array",
           "items": {
             "type": "string"
@@ -478,7 +478,7 @@
           ]
         },
         "uid": {
-          "description": "The user's ID. Default value [system default]",
+          "description": "The user's ID. Default value [system default].",
           "oneOf": [
             {
               "type": "integer"
@@ -548,7 +548,7 @@
           "deprecated_description": "Use ``remove_defaults`` instead."
         },
         "remove_defaults": {
-          "description": "Remove default CA certificates if true. Default: ``false``",
+          "description": "Remove default CA certificates if true. Default: ``false``.",
           "type": "boolean",
           "default": false
         },
@@ -670,7 +670,7 @@
       "type": "object",
       "properties": {
         "autoinstall": {
-          "description": "Opaque autoinstall schema definition for Ubuntu autoinstall. Full schema processed by live-installer. See: https://ubuntu.com/server/docs/install/autoinstall-reference",
+          "description": "Opaque autoinstall schema definition for Ubuntu autoinstall. Full schema processed by live-installer. See: https://ubuntu.com/server/docs/install/autoinstall-reference.",
           "type": "object",
           "properties": {
             "version": {
@@ -713,7 +713,7 @@
                 "distro",
                 "pip"
               ],
-              "description": "The type of installation for ansible. It can be one of the following values:\n-  ``distro``\n-  ``pip``"
+              "description": "The type of installation for ansible. It can be one of the following values:\n-  ``distro``\n-  ``pip``."
             },
             "run_user": {
               "type": "string",
@@ -973,7 +973,7 @@
                 "base_url": {
                   "type": "string",
                   "default": "https://alpine.global.ssl.fastly.net/alpine",
-                  "description": "The base URL of an Alpine repository, or mirror, to download official packages from. If not specified then it defaults to ``https://alpine.global.ssl.fastly.net/alpine``"
+                  "description": "The base URL of an Alpine repository, or mirror, to download official packages from. If not specified then it defaults to ``https://alpine.global.ssl.fastly.net/alpine``."
                 },
                 "community_enabled": {
                   "type": "boolean",
@@ -987,7 +987,7 @@
                 },
                 "version": {
                   "type": "string",
-                  "description": "The Alpine version to use (e.g. ``v3.12`` or ``edge``)"
+                  "description": "The Alpine version to use (e.g. ``v3.12`` or ``edge``)."
                 }
               },
               "required": [
@@ -997,7 +997,7 @@
             },
             "local_repo_base_url": {
               "type": "string",
-              "description": "The base URL of an Alpine repository containing unofficial packages"
+              "description": "The base URL of an Alpine repository containing unofficial packages."
             }
           }
         }
@@ -1026,16 +1026,16 @@
             },
             "primary": {
               "$ref": "#/$defs/apt_configure.mirror",
-              "description": "The primary and security archive mirrors can be specified using the ``primary`` and ``security`` keys, respectively. Both the ``primary`` and ``security`` keys take a list of configs, allowing mirrors to be specified on a per-architecture basis. Each config is a dictionary which must have an entry for ``arches``, specifying which architectures that config entry is for. The keyword ``default`` applies to any architecture not explicitly listed. The mirror url can be specified with the ``uri`` key, or a list of mirrors to check can be provided in order, with the first mirror that can be resolved being selected. This allows the same configuration to be used in different environment, with different hosts used for a local APT mirror. If no mirror is provided by ``uri`` or ``search``, ``search_dns`` may be used to search for dns names in the format ``<distro>-mirror`` in each of the following:\n- fqdn of this host per cloud metadata,\n- localdomain,\n- domains listed in ``/etc/resolv.conf``.\n\nIf there is a dns entry for ``<distro>-mirror``, then it is assumed that there is a distro mirror at ``http://<distro>-mirror.<domain>/<distro>``. If the ``primary`` key is defined, but not the ``security`` key, then then configuration for ``primary`` is also used for ``security``. If ``search_dns`` is used for the ``security`` key, the search pattern will be ``<distro>-security-mirror``.\n\nEach mirror may also specify a key to import via any of the following optional keys:\n- ``keyid``: a key to import via shortid or fingerprint.\n- ``key``: a raw PGP key.\n- ``keyserver``: alternate keyserver to pull ``keyid`` key from.\n\nIf no mirrors are specified, or all lookups fail, then default mirrors defined in the datasource are used. If none are present in the datasource either the following defaults are used:\n- ``primary`` => ``http://archive.ubuntu.com/ubuntu``.\n- ``security`` => ``http://security.ubuntu.com/ubuntu``"
+              "description": "The primary and security archive mirrors can be specified using the ``primary`` and ``security`` keys, respectively. Both the ``primary`` and ``security`` keys take a list of configs, allowing mirrors to be specified on a per-architecture basis. Each config is a dictionary which must have an entry for ``arches``, specifying which architectures that config entry is for. The keyword ``default`` applies to any architecture not explicitly listed. The mirror url can be specified with the ``uri`` key, or a list of mirrors to check can be provided in order, with the first mirror that can be resolved being selected. This allows the same configuration to be used in different environment, with different hosts used for a local APT mirror. If no mirror is provided by ``uri`` or ``search``, ``search_dns`` may be used to search for dns names in the format ``<distro>-mirror`` in each of the following:\n- fqdn of this host per cloud metadata,\n- localdomain,\n- domains listed in ``/etc/resolv.conf``.\n\nIf there is a dns entry for ``<distro>-mirror``, then it is assumed that there is a distro mirror at ``http://<distro>-mirror.<domain>/<distro>``. If the ``primary`` key is defined, but not the ``security`` key, then then configuration for ``primary`` is also used for ``security``. If ``search_dns`` is used for the ``security`` key, the search pattern will be ``<distro>-security-mirror``.\n\nEach mirror may also specify a key to import via any of the following optional keys:\n- ``keyid``: a key to import via shortid or fingerprint.\n- ``key``: a raw PGP key.\n- ``keyserver``: alternate keyserver to pull ``keyid`` key from.\n\nIf no mirrors are specified, or all lookups fail, then default mirrors defined in the datasource are used. If none are present in the datasource either the following defaults are used:\n- ``primary`` => ``http://archive.ubuntu.com/ubuntu``.\n- ``security`` => ``http://security.ubuntu.com/ubuntu``."
             },
             "security": {
               "$ref": "#/$defs/apt_configure.mirror",
-              "description": "Please refer to the primary config documentation"
+              "description": "Please refer to the primary config documentation."
             },
             "add_apt_repo_match": {
               "type": "string",
               "default": "^[\\w-]+:\\w",
-              "description": "All source entries in ``apt-sources`` that match regex in ``add_apt_repo_match`` will be added to the system using ``add-apt-repository``. If ``add_apt_repo_match`` is not specified, it defaults to ``^[\\w-]+:\\w``"
+              "description": "All source entries in ``apt-sources`` that match regex in ``add_apt_repo_match`` will be added to the system using ``add-apt-repository``. If ``add_apt_repo_match`` is not specified, it defaults to ``^[\\w-]+:\\w``."
             },
             "debconf_selections": {
               "type": "object",
@@ -1046,7 +1046,7 @@
                   "type": "string"
                 }
               },
-              "description": "Debconf additional configurations can be specified as a dictionary under the ``debconf_selections`` config key, with each key in the dict representing a different set of configurations. The value of each key must be a string containing all the debconf configurations that must be applied. We will bundle all of the values and pass them to ``debconf-set-selections``. Therefore, each value line must be a valid entry for ``debconf-set-selections``, meaning that they must possess for distinct fields:\n\n``pkgname question type answer``\n\nWhere:\n- ``pkgname`` is the name of the package.\n- ``question`` the name of the questions.\n- ``type`` is the type of question.\n- ``answer`` is the value used to answer the question.\n\nFor example: ``ippackage ippackage/ip string 127.0.01``"
+              "description": "Debconf additional configurations can be specified as a dictionary under the ``debconf_selections`` config key, with each key in the dict representing a different set of configurations. The value of each key must be a string containing all the debconf configurations that must be applied. We will bundle all of the values and pass them to ``debconf-set-selections``. Therefore, each value line must be a valid entry for ``debconf-set-selections``, meaning that they must possess for distinct fields:\n\n``pkgname question type answer``\n\nWhere:\n- ``pkgname`` is the name of the package.\n- ``question`` the name of the questions.\n- ``type`` is the type of question.\n- ``answer`` is the value used to answer the question.\n\nFor example: ``ippackage ippackage/ip string 127.0.01``."
             },
             "sources_list": {
               "type": "string",
@@ -1228,12 +1228,12 @@
             "validation_key": {
               "type": "string",
               "default": "/etc/chef/validation.pem",
-              "description": "Optional path for validation_cert. default to ``/etc/chef/validation.pem``"
+              "description": "Optional path for validation_cert. Default: ``/etc/chef/validation.pem``."
             },
             "firstboot_path": {
               "type": "string",
               "default": "/etc/chef/firstboot.json",
-              "description": "Path to write run_list and initial_attributes keys that should also be present in this configuration, defaults to ``/etc/chef/firstboot.json``"
+              "description": "Path to write run_list and initial_attributes keys that should also be present in this configuration. Default: ``/etc/chef/firstboot.json``."
             },
             "exec": {
               "type": "boolean",
@@ -1305,12 +1305,12 @@
             },
             "server_url": {
               "type": "string",
-              "description": "The URL for the chef server"
+              "description": "The URL for the chef server."
             },
             "show_time": {
               "type": "boolean",
               "default": true,
-              "description": "Show time in chef logs"
+              "description": "Show time in chef logs."
             },
             "ssl_verify_mode": {
               "type": "string",
@@ -1352,7 +1352,7 @@
             },
             "chef_license": {
               "type": "string",
-              "description": "string that indicates if user accepts or not license related to some of chef products. See https://docs.chef.io/licensing/accept/",
+              "description": "string that indicates if user accepts or not license related to some of chef products. See https://docs.chef.io/licensing/accept/.",
               "enum": [
                 "accept",
                 "accept-silent",
@@ -1368,7 +1368,7 @@
       "properties": {
         "disable_ec2_metadata": {
           "default": false,
-          "description": "Set true to disable IPv4 routes to EC2 metadata. Default: ``false``",
+          "description": "Set true to disable IPv4 routes to EC2 metadata. Default: ``false``.",
           "type": "boolean"
         }
       }
@@ -1448,7 +1448,7 @@
                 "overwrite": {
                   "type": "boolean",
                   "default": false,
-                  "description": "Controls whether this module tries to be safe about writing partition tables or not. If ``overwrite: false`` is set, the device will be checked for a partition table and for a file system and if either is found, the operation will be skipped. If ``overwrite: true`` is set, no checks will be performed. Using ``overwrite: true`` is **dangerous** and can lead to data loss, so double check that the correct device has been specified if using this option. Default: ``false``"
+                  "description": "Controls whether this module tries to be safe about writing partition tables or not. If ``overwrite: false`` is set, the device will be checked for a partition table and for a file system and if either is found, the operation will be skipped. If ``overwrite: true`` is set, no checks will be performed. Using ``overwrite: true`` is **dangerous** and can lead to data loss, so double check that the correct device has been specified if using this option. Default: ``false``."
                 }
               }
             }
@@ -1466,7 +1466,7 @@
               },
               "filesystem": {
                 "type": "string",
-                "description": "Filesystem type to create. E.g., ``ext4`` or ``btrfs``"
+                "description": "Filesystem type to create. E.g., ``ext4`` or ``btrfs``."
               },
               "device": {
                 "type": "string",
@@ -1491,7 +1491,7 @@
               },
               "overwrite": {
                 "type": "boolean",
-                "description": "If ``true``, overwrite any existing filesystem. Using ``overwrite: true`` for filesystems is **dangerous** and can lead to data loss, so double check the entry in ``fs_setup``. Default: ``false``"
+                "description": "If ``true``, overwrite any existing filesystem. Using ``overwrite: true`` for filesystems is **dangerous** and can lead to data loss, so double check the entry in ``fs_setup``. Default: ``false``."
               },
               "replace_fs": {
                 "type": "string",
@@ -1534,12 +1534,12 @@
           "properties": {
             "config": {
               "type": "string",
-              "description": "The fan configuration to use as a single multi-line string"
+              "description": "The fan configuration to use as a single multi-line string."
             },
             "config_path": {
               "type": "string",
               "default": "/etc/network/fan",
-              "description": "The path to write the fan configuration to. Default: ``/etc/network/fan``"
+              "description": "The path to write the fan configuration to. Default: ``/etc/network/fan``."
             }
           }
         }
@@ -1550,7 +1550,7 @@
       "properties": {
         "final_message": {
           "type": "string",
-          "description": "The message to display at the end of the run"
+          "description": "The message to display at the end of the run."
         }
       }
     },
@@ -1563,7 +1563,7 @@
           "properties": {
             "mode": {
               "default": "auto",
-              "description": "The utility to use for resizing. Default: ``auto``\n\nPossible options:\n\n* ``auto`` - Use any available utility\n\n* ``growpart`` - Use growpart utility\n\n* ``gpart`` - Use BSD gpart utility\n\n* ``'off'`` - Take no action",
+              "description": "The utility to use for resizing. Default: ``auto``\n\nPossible options:\n\n* ``auto`` - Use any available utility\n\n* ``growpart`` - Use growpart utility\n\n* ``gpart`` - Use BSD gpart utility\n\n* ``'off'`` - Take no action.",
               "oneOf": [
                 {
                   "enum": [
@@ -1591,12 +1591,12 @@
               "items": {
                 "type": "string"
               },
-              "description": "The devices to resize. Each entry can either be the path to the device's mountpoint in the filesystem or a path to the block device in '/dev'. Default: ``[/]``"
+              "description": "The devices to resize. Each entry can either be the path to the device's mountpoint in the filesystem or a path to the block device in '/dev'. Default: ``[/]``."
             },
             "ignore_growroot_disabled": {
               "type": "boolean",
               "default": false,
-              "description": "If ``true``, ignore the presence of ``/etc/growroot-disabled``. If ``false`` and the file exists, then don't resize. Default: ``false``"
+              "description": "If ``true``, ignore the presence of ``/etc/growroot-disabled``. If ``false`` and the file exists, then don't resize. Default: ``false``."
             }
           }
         }
@@ -1612,14 +1612,14 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Whether to configure which device is used as the target for grub installation. Default: ``true``"
+              "description": "Whether to configure which device is used as the target for grub installation. Default: ``true``."
             },
             "grub-pc/install_devices": {
               "type": "string",
-              "description": "Device to use as target for grub installation. If unspecified, ``grub-probe`` of ``/boot`` will be used to find the device"
+              "description": "Device to use as target for grub installation. If unspecified, ``grub-probe`` of ``/boot`` will be used to find the device."
             },
             "grub-pc/install_devices_empty": {
-              "description": "Sets values for ``grub-pc/install_devices_empty``. If unspecified, will be set to ``true`` if ``grub-pc/install_devices`` is empty, otherwise ``false``",
+              "description": "Sets values for ``grub-pc/install_devices_empty``. If unspecified, will be set to ``true`` if ``grub-pc/install_devices`` is empty, otherwise ``false``.",
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1634,7 +1634,7 @@
             },
             "grub-efi/install_devices": {
               "type": "string",
-              "description": "Partition to use as target for grub installation. If unspecified, ``grub-probe`` of ``/boot/efi`` will be used to find the partition"
+              "description": "Partition to use as target for grub installation. If unspecified, ``grub-probe`` of ``/boot/efi`` will be used to find the partition."
             }
           }
         },
@@ -1825,11 +1825,11 @@
       "properties": {
         "locale": {
           "type": "string",
-          "description": "The locale to set as the system's locale (e.g. ar_PS)"
+          "description": "The locale to set as the system's locale (e.g. ar_PS)."
         },
         "locale_configfile": {
           "type": "string",
-          "description": "The file in which to write the locale configuration (defaults to the distro's default location)"
+          "description": "The file in which to write the locale configuration (defaults to the distro's default location)."
         }
       }
     },
@@ -1848,7 +1848,7 @@
               "properties": {
                 "network_address": {
                   "type": "string",
-                  "description": "IP address for LXD to listen on"
+                  "description": "IP address for LXD to listen on."
                 },
                 "network_port": {
                   "type": "integer",
@@ -1867,19 +1867,19 @@
                 },
                 "storage_create_device": {
                   "type": "string",
-                  "description": "Setup device based storage using DEVICE"
+                  "description": "Setup device based storage using DEVICE."
                 },
                 "storage_create_loop": {
                   "type": "integer",
-                  "description": "Setup loop based storage with SIZE in GB"
+                  "description": "Setup loop based storage with SIZE in GB."
                 },
                 "storage_pool": {
                   "type": "string",
-                  "description": "Name of storage pool to use or create"
+                  "description": "Name of storage pool to use or create."
                 },
                 "trust_password": {
                   "type": "string",
-                  "description": "The password required to add new clients"
+                  "description": "The password required to add new clients."
                 }
               }
             },
@@ -1907,7 +1907,7 @@
                 },
                 "mtu": {
                   "type": "integer",
-                  "description": "Bridge MTU, defaults to LXD's default value",
+                  "description": "Bridge MTU, defaults to LXD's default value.",
                   "default": -1,
                   "minimum": -1
                 },
@@ -1976,11 +1976,11 @@
               "properties": {
                 "public-cert": {
                   "type": "string",
-                  "description": "Optional value of server public certificate which will be written to ``/etc/mcollective/ssl/server-public.pem``"
+                  "description": "Optional value of server public certificate which will be written to ``/etc/mcollective/ssl/server-public.pem``."
                 },
                 "private-cert": {
                   "type": "string",
-                  "description": "Optional value of server private certificate which will be written to ``/etc/mcollective/ssl/server-private.pem``"
+                  "description": "Optional value of server private certificate which will be written to ``/etc/mcollective/ssl/server-private.pem``."
                 }
               },
               "patternProperties": {
@@ -2022,7 +2022,7 @@
         },
         "mount_default_fields": {
           "type": "array",
-          "description": "Default mount configuration for any mount entry with less than 6 options provided. When specified, 6 items are required and represent ``/etc/fstab`` entries. Default: ``defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev``",
+          "description": "Default mount configuration for any mount entry with less than 6 options provided. When specified, 6 items are required and represent ``/etc/fstab`` entries. Default: ``defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev``.",
           "default": [
             null,
             null,
@@ -2050,10 +2050,10 @@
           "properties": {
             "filename": {
               "type": "string",
-              "description": "Path to the swap file to create"
+              "description": "Path to the swap file to create."
             },
             "size": {
-              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. **WARNING: Attempts to use IEC prefixes in your configuration prior to cloud-init version 23.1 will result in unexpected behavior. SI prefixes names (KB, MB) are required on pre-23.1 cloud-init, however IEC values are used. In summary, assume 1KB == 1024B, not 1000B**",
+              "description": "The size in bytes of the swap file, 'auto' or a human-readable size abbreviation of the format <float_size><units> where units are one of B, K, M, G or T. **WARNING: Attempts to use IEC prefixes in your configuration prior to cloud-init version 23.1 will result in unexpected behavior. SI prefixes names (KB, MB) are required on pre-23.1 cloud-init, however IEC values are used. In summary, assume 1KB == 1024B, not 1000B**.",
               "oneOf": [
                 {
                   "enum": [
@@ -2079,7 +2079,7 @@
                   "pattern": "^([0-9]+)?\\.?[0-9]+[BKMGT]$"
                 }
               ],
-              "description": "The maxsize in bytes of the swap file"
+              "description": "The maxsize in bytes of the swap file."
             }
           }
         }
@@ -2128,7 +2128,7 @@
                 "type": "string"
               },
               "uniqueItems": true,
-              "description": "List of CIDRs to allow"
+              "description": "List of CIDRs to allow."
             },
             "ntp_client": {
               "type": "string",
@@ -2138,7 +2138,7 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "Attempt to enable ntp clients if set to True.  If set to ``false``, ntp client will not be configured or installed"
+              "description": "Attempt to enable ntp clients if set to True.  If set to ``false``, ntp client will not be configured or installed."
             },
             "config": {
               "description": "Configuration settings or overrides for the ``ntp_client`` specified.",
@@ -2212,17 +2212,17 @@
         "package_update": {
           "type": "boolean",
           "default": false,
-          "description": "Set ``true`` to update packages. Happens before upgrade or install. Default: ``false``"
+          "description": "Set ``true`` to update packages. Happens before upgrade or install. Default: ``false``."
         },
         "package_upgrade": {
           "type": "boolean",
           "default": false,
-          "description": "Set ``true`` to upgrade packages. Happens before install. Default: ``false``"
+          "description": "Set ``true`` to upgrade packages. Happens before install. Default: ``false``."
         },
         "package_reboot_if_required": {
           "type": "boolean",
           "default": false,
-          "description": "Set ``true`` to reboot the system if required by presence of `/var/run/reboot-required`. Default: ``false``"
+          "description": "Set ``true`` to reboot the system if required by presence of `/var/run/reboot-required`. Default: ``false``."
         },
         "apt_update": {
           "type": "boolean",
@@ -2260,7 +2260,7 @@
               "description": "The URL to send the phone home data to."
             },
             "post": {
-              "description": "A list of keys to post or ``all``. Default: ``all``",
+              "description": "A list of keys to post or ``all``. Default: ``all``.",
               "oneOf": [
                 {
                   "enum": [
@@ -2285,7 +2285,7 @@
             },
             "tries": {
               "type": "integer",
-              "description": "The number of times to try sending the phone home data. Default: ``10``",
+              "description": "The number of times to try sending the phone home data. Default: ``10``.",
               "default": 10
             }
           }
@@ -2303,7 +2303,7 @@
           "additionalProperties": false,
           "properties": {
             "delay": {
-              "description": "Time in minutes to delay after cloud-init has finished. Can be ``now`` or an integer specifying the number of minutes to delay. Default: ``now``",
+              "description": "Time in minutes to delay after cloud-init has finished. Can be ``now`` or an integer specifying the number of minutes to delay. Default: ``now``.",
               "default": "now",
               "oneOf": [
                 {
@@ -2338,12 +2338,12 @@
               "type": "string"
             },
             "timeout": {
-              "description": "Time in seconds to wait for the cloud-init process to finish before executing shutdown. Default: ``30``",
+              "description": "Time in seconds to wait for the cloud-init process to finish before executing shutdown. Default: ``30``.",
               "type": "integer",
               "default": 30
             },
             "condition": {
-              "description": "Apply state change only if condition is met. May be boolean true (always met), false (never met), or a command string or list to be executed. For command formatting, see the documentation for ``cc_runcmd``. If exit code is 0, condition is met, otherwise not. Default: ``true``",
+              "description": "Apply state change only if condition is met. May be boolean true (always met), false (never met), or a command string or list to be executed. For command formatting, see the documentation for ``cc_runcmd``. If exit code is 0, condition is met, otherwise not. Default: ``true``.",
               "default": true,
               "oneOf": [
                 {
@@ -2371,7 +2371,7 @@
             "install": {
               "type": "boolean",
               "default": true,
-              "description": "Whether or not to install puppet. Setting to ``false`` will result in an error if puppet is not already present on the system. Default: ``true``"
+              "description": "Whether or not to install puppet. Setting to ``false`` will result in an error if puppet is not already present on the system. Default: ``true``."
             },
             "version": {
               "type": "string",
@@ -2379,7 +2379,7 @@
             },
             "install_type": {
               "type": "string",
-              "description": "Valid values are ``packages`` and ``aio``. Agent packages from the puppetlabs repositories can be installed by setting ``aio``. Based on this setting, the default config/SSL/CSR paths will be adjusted accordingly. Default: ``packages``",
+              "description": "Valid values are ``packages`` and ``aio``. Agent packages from the puppetlabs repositories can be installed by setting ``aio``. Based on this setting, the default config/SSL/CSR paths will be adjusted accordingly. Default: ``packages``.",
               "enum": [
                 "packages",
                 "aio"
@@ -2397,32 +2397,32 @@
             "cleanup": {
               "type": "boolean",
               "default": true,
-              "description": "Whether to remove the puppetlabs repo after installation if ``install_type`` is ``aio`` Default: ``true``"
+              "description": "Whether to remove the puppetlabs repo after installation if ``install_type`` is ``aio`` Default: ``true``."
             },
             "conf_file": {
               "type": "string",
-              "description": "The path to the puppet config file. Default depends on ``install_type``"
+              "description": "The path to the puppet config file. Default depends on ``install_type``."
             },
             "ssl_dir": {
               "type": "string",
-              "description": "The path to the puppet SSL directory. Default depends on ``install_type``"
+              "description": "The path to the puppet SSL directory. Default depends on ``install_type``."
             },
             "csr_attributes_path": {
               "type": "string",
-              "description": "The path to the puppet csr attributes file. Default depends on ``install_type``"
+              "description": "The path to the puppet csr attributes file. Default depends on ``install_type``."
             },
             "package_name": {
               "type": "string",
-              "description": "Name of the package to install if ``install_type`` is ``packages``. Default: ``puppet``"
+              "description": "Name of the package to install if ``install_type`` is ``packages``. Default: ``puppet``."
             },
             "exec": {
               "type": "boolean",
               "default": false,
-              "description": "Whether or not to run puppet after configuration finishes. A single manual run can be triggered by setting ``exec`` to ``true``, and additional arguments can be passed to ``puppet agent`` via the ``exec_args`` key (by default the agent will execute with the ``--test`` flag). Default: ``false``"
+              "description": "Whether or not to run puppet after configuration finishes. A single manual run can be triggered by setting ``exec`` to ``true``, and additional arguments can be passed to ``puppet agent`` via the ``exec_args`` key (by default the agent will execute with the ``--test`` flag). Default: ``false``."
             },
             "exec_args": {
               "type": "array",
-              "description": "A list of arguments to pass to 'puppet agent' if 'exec' is true Default: ``['--test']``",
+              "description": "A list of arguments to pass to 'puppet agent' if 'exec' is true Default: ``['--test']``.",
               "items": {
                 "type": "string"
               }
@@ -2430,7 +2430,7 @@
             "start_service": {
               "type": "boolean",
               "default": true,
-              "description": "By default, the puppet service will be automatically enabled after installation and set to automatically start on boot. To override this in favor of manual puppet execution set ``start_service`` to ``false``"
+              "description": "By default, the puppet service will be automatically enabled after installation and set to automatically start on boot. To override this in favor of manual puppet execution set ``start_service`` to ``false``."
             },
             "conf": {
               "type": "object",
@@ -2456,7 +2456,7 @@
             },
             "csr_attributes": {
               "type": "object",
-              "description": "create a ``csr_attributes.yaml`` file for CSR attributes and certificate extension requests. See https://puppet.com/docs/puppet/latest/config_file_csr_attributes.html",
+              "description": "create a ``csr_attributes.yaml`` file for CSR attributes and certificate extension requests. See https://puppet.com/docs/puppet/latest/config_file_csr_attributes.html.",
               "additionalProperties": false,
               "properties": {
                 "custom_attributes": {
@@ -2480,7 +2480,7 @@
             false,
             "noblock"
           ],
-          "description": "Whether to resize the root partition. ``noblock`` will resize in the background. Default: ``true``"
+          "description": "Whether to resize the root partition. ``noblock`` will resize in the background. Default: ``true``."
         }
       }
     },
@@ -2490,7 +2490,7 @@
         "manage_resolv_conf": {
           "type": "boolean",
           "default": false,
-          "description": "Whether to manage the resolv.conf file. ``resolv_conf`` block will be ignored unless this is set to ``true``. Default: ``false``"
+          "description": "Whether to manage the resolv.conf file. ``resolv_conf`` block will be ignored unless this is set to ``true``. Default: ``false``."
         },
         "resolv_conf": {
           "type": "object",
@@ -2498,23 +2498,23 @@
           "properties": {
             "nameservers": {
               "type": "array",
-              "description": "A list of nameservers to use to be added as ``nameserver`` lines"
+              "description": "A list of nameservers to use to be added as ``nameserver`` lines."
             },
             "searchdomains": {
               "type": "array",
-              "description": "A list of domains to be added ``search`` line"
+              "description": "A list of domains to be added ``search`` line."
             },
             "domain": {
               "type": "string",
-              "description": "The domain to be added as ``domain`` line"
+              "description": "The domain to be added as ``domain`` line."
             },
             "sortlist": {
               "type": "array",
-              "description": "A list of IP addresses to be added to ``sortlist`` line"
+              "description": "A list of IP addresses to be added to ``sortlist`` line."
             },
             "options": {
               "type": "object",
-              "description": "Key/value pairs of options to go under ``options`` heading. A unary option should be specified as ``true``"
+              "description": "Key/value pairs of options to go under ``options`` heading. A unary option should be specified as ``true``."
             }
           }
         }
@@ -2529,18 +2529,18 @@
           "properties": {
             "username": {
               "type": "string",
-              "description": "The username to use. Must be used with password. Should not be used with ``activation-key`` or ``org``"
+              "description": "The username to use. Must be used with password. Should not be used with ``activation-key`` or ``org``."
             },
             "password": {
               "type": "string",
-              "description": "The password to use. Must be used with username. Should not be used with ``activation-key`` or ``org``"
+              "description": "The password to use. Must be used with username. Should not be used with ``activation-key`` or ``org``."
             },
             "activation-key": {
               "type": "string",
-              "description": "The activation key to use. Must be used with ``org``. Should not be used with ``username`` or ``password``"
+              "description": "The activation key to use. Must be used with ``org``. Should not be used with ``username`` or ``password``."
             },
             "org": {
-              "description": "The organization to use. Must be used with ``activation-key``. Should not be used with ``username`` or ``password``",
+              "description": "The organization to use. Must be used with ``activation-key``. Should not be used with ``username`` or ``password``.",
               "oneOf": [
                 {
                   "type": "string"
@@ -2555,40 +2555,40 @@
             },
             "auto-attach": {
               "type": "boolean",
-              "description": "Whether to attach subscriptions automatically"
+              "description": "Whether to attach subscriptions automatically."
             },
             "service-level": {
               "type": "string",
-              "description": "The service level to use when subscribing to RH repositories. ``auto-attach`` must be true for this to be used"
+              "description": "The service level to use when subscribing to RH repositories. ``auto-attach`` must be true for this to be used."
             },
             "add-pool": {
               "type": "array",
-              "description": "A list of pools ids add to the subscription",
+              "description": "A list of pools ids add to the subscription.",
               "items": {
                 "type": "string"
               }
             },
             "enable-repo": {
               "type": "array",
-              "description": "A list of repositories to enable",
+              "description": "A list of repositories to enable.",
               "items": {
                 "type": "string"
               }
             },
             "disable-repo": {
               "type": "array",
-              "description": "A list of repositories to disable",
+              "description": "A list of repositories to disable.",
               "items": {
                 "type": "string"
               }
             },
             "rhsm-baseurl": {
               "type": "string",
-              "description": "Sets the baseurl in ``/etc/rhsm/rhsm.conf``"
+              "description": "Sets the baseurl in ``/etc/rhsm/rhsm.conf``."
             },
             "server-hostname": {
               "type": "string",
-              "description": "Sets the serverurl in ``/etc/rhsm/rhsm.conf``"
+              "description": "Sets the serverurl in ``/etc/rhsm/rhsm.conf``."
             }
           }
         }
@@ -2603,11 +2603,11 @@
           "properties": {
             "config_dir": {
               "type": "string",
-              "description": "The directory where rsyslog configuration files will be written. Default: ``/etc/rsyslog.d``"
+              "description": "The directory where rsyslog configuration files will be written. Default: ``/etc/rsyslog.d``."
             },
             "config_filename": {
               "type": "string",
-              "description": "The name of the rsyslog configuration file. Default: ``20-cloud-config.conf``"
+              "description": "The name of the rsyslog configuration file. Default: ``20-cloud-config.conf``."
             },
             "configs": {
               "type": "array",
@@ -2657,12 +2657,12 @@
             },
             "install_rsyslog": {
               "default": false,
-              "description": "Install rsyslog. Default: ``false``",
+              "description": "Install rsyslog. Default: ``false``.",
               "type": "boolean"
             },
             "check_exe": {
               "type": "string",
-              "description": "The executable name for the rsyslog daemon.\nFor example, ``rsyslogd``, or ``/opt/sbin/rsyslogd`` if the rsyslog binary is in an unusual path. This is only used if ``install_rsyslog`` is ``true``. Default: ``rsyslogd``"
+              "description": "The executable name for the rsyslog daemon.\nFor example, ``rsyslogd``, or ``/opt/sbin/rsyslogd`` if the rsyslog binary is in an unusual path. This is only used if ``install_rsyslog`` is ``true``. Default: ``rsyslogd``."
             },
             "packages": {
               "type": "array",
@@ -2670,7 +2670,7 @@
                 "type": "string"
               },
               "uniqueItems": true,
-              "description": "List of packages needed to be installed for rsyslog. This is only used if ``install_rsyslog`` is ``true``. Default: ``[rsyslog]``"
+              "description": "List of packages needed to be installed for rsyslog. This is only used if ``install_rsyslog`` is ``true``. Default: ``[rsyslog]``."
             }
           }
         }
@@ -2710,35 +2710,35 @@
           "properties": {
             "pkg_name": {
               "type": "string",
-              "description": "Package name to install. Default: ``salt-minion``"
+              "description": "Package name to install. Default: ``salt-minion``."
             },
             "service_name": {
               "type": "string",
-              "description": "Service name to enable. Default: ``salt-minion``"
+              "description": "Service name to enable. Default: ``salt-minion``."
             },
             "config_dir": {
               "type": "string",
-              "description": "Directory to write config files to. Default: ``/etc/salt``"
+              "description": "Directory to write config files to. Default: ``/etc/salt``."
             },
             "conf": {
               "type": "object",
-              "description": "Configuration to be written to `config_dir`/minion"
+              "description": "Configuration to be written to `config_dir`/minion."
             },
             "grains": {
               "type": "object",
-              "description": "Configuration to be written to `config_dir`/grains"
+              "description": "Configuration to be written to `config_dir`/grains."
             },
             "public_key": {
               "type": "string",
-              "description": "Public key to be used by the salt minion"
+              "description": "Public key to be used by the salt minion."
             },
             "private_key": {
               "type": "string",
-              "description": "Private key to be used by salt minion"
+              "description": "Private key to be used by salt minion."
             },
             "pki_dir": {
               "type": "string",
-              "description": "Directory to write key files. Default: `config_dir`/pki/minion"
+              "description": "Directory to write key files. Default: `config_dir`/pki/minion."
             }
           }
         }
@@ -2752,7 +2752,7 @@
           "additionalProperties": false,
           "properties": {
             "enabled": {
-              "description": "Whether vendor data is enabled or not. Default: ``true``",
+              "description": "Whether vendor data is enabled or not. Default: ``true``.",
               "oneOf": [
                 {
                   "type": "boolean",
@@ -2777,7 +2777,7 @@
                   "integer"
                 ]
               },
-              "description": "The command to run before any vendor scripts. Its primary use case is for profiling a script, not to prevent its run"
+              "description": "The command to run before any vendor scripts. Its primary use case is for profiling a script, not to prevent its run."
             }
           }
         }
@@ -2793,11 +2793,11 @@
             "file": {
               "type": "string",
               "default": "/dev/urandom",
-              "description": "File to write random data to. Default: ``/dev/urandom``"
+              "description": "File to write random data to. Default: ``/dev/urandom``."
             },
             "data": {
               "type": "string",
-              "description": "This data will be written to ``file`` before data from the datasource. When using a multi-line value or specifying binary data, be sure to follow YAML syntax and use the ``|`` and ``!binary`` YAML format specifiers when appropriate"
+              "description": "This data will be written to ``file`` before data from the datasource. When using a multi-line value or specifying binary data, be sure to follow YAML syntax and use the ``|`` and ``!binary`` YAML format specifiers when appropriate."
             },
             "encoding": {
               "type": "string",
@@ -2809,7 +2809,7 @@
                 "gzip",
                 "gz"
               ],
-              "description": "Used to decode ``data`` provided. Allowed values are ``raw``, ``base64``, ``b64``, ``gzip``, or ``gz``.  Default: ``raw``"
+              "description": "Used to decode ``data`` provided. Allowed values are ``raw``, ``base64``, ``b64``, ``gzip``, or ``gz``.  Default: ``raw``."
             },
             "command": {
               "type": "array",
@@ -2821,7 +2821,7 @@
             "command_required": {
               "type": "boolean",
               "default": false,
-              "description": "If true, and ``command`` is not available to be run then an exception is raised and cloud-init will record failure. Otherwise, only debug error is mentioned. Default: ``false``"
+              "description": "If true, and ``command`` is not available to be run then an exception is raised and cloud-init will record failure. Otherwise, only debug error is mentioned. Default: ``false``."
             }
           }
         }
@@ -2833,24 +2833,24 @@
         "preserve_hostname": {
           "type": "boolean",
           "default": false,
-          "description": "If true, the hostname will not be changed. Default: ``false``"
+          "description": "If true, the hostname will not be changed. Default: ``false``."
         },
         "hostname": {
           "type": "string",
-          "description": "The hostname to set"
+          "description": "The hostname to set."
         },
         "fqdn": {
           "type": "string",
-          "description": "The fully qualified domain name to set"
+          "description": "The fully qualified domain name to set."
         },
         "prefer_fqdn_over_hostname": {
           "type": "boolean",
-          "description": "If true, the fqdn will be used if it is set. If false, the hostname will be used. If unset, the result is distro-dependent"
+          "description": "If true, the fqdn will be used if it is set. If false, the hostname will be used. If unset, the result is distro-dependent."
         },
         "create_hostname_file": {
           "type": "boolean",
           "default": true,
-          "description": "If ``false``, the hostname file (e.g. /etc/hostname) will not be created if it does not exist. On systems that use systemd, setting create_hostname_file to ``false`` will set the hostname transiently. If ``true``, the hostname file will always be created and the hostname will be set statically on systemd systems. Default: ``true``"
+          "description": "If ``false``, the hostname file (e.g. /etc/hostname) will not be created if it does not exist. On systems that use systemd, setting create_hostname_file to ``false`` will set the hostname transiently. If ``true``, the hostname file will always be created and the hostname will be set statically on systemd systems. Default: ``true``."
         }
       }
     },
@@ -2878,7 +2878,7 @@
             "expire": {
               "type": "boolean",
               "default": true,
-              "description": "Whether to expire all user passwords such that a password will need to be reset on the user's next login. Default: ``true``"
+              "description": "Whether to expire all user passwords such that a password will need to be reset on the user's next login. Default: ``true``."
             },
             "users": {
               "description": "This key represents a list of existing users to set passwords for. Each item under users contains the following required keys: ``name`` and ``password`` or in the case of a randomly generated password, ``name`` and ``type``. The ``type`` key has a default value of ``hash``, and may alternatively be set to ``text`` or ``RANDOM``. Randomly generated passwords may be insecure, use at your own risk.",
@@ -2953,7 +2953,7 @@
         },
         "password": {
           "type": "string",
-          "description": "Set the default user's password. Ignored if ``chpasswd`` ``list`` is used"
+          "description": "Set the default user's password. Ignored if ``chpasswd`` ``list`` is used."
         }
       }
     },
@@ -2987,7 +2987,7 @@
                 "object",
                 "array"
               ],
-              "description": "Snap commands to run on the target system",
+              "description": "Snap commands to run on the target system.",
               "items": {
                 "oneOf": [
                   {
@@ -3031,15 +3031,15 @@
           "properties": {
             "server": {
               "type": "string",
-              "description": "The Spacewalk server to use"
+              "description": "The Spacewalk server to use."
             },
             "proxy": {
               "type": "string",
-              "description": "The proxy to use when connecting to Spacewalk"
+              "description": "The proxy to use when connecting to Spacewalk."
             },
             "activation_key": {
               "type": "string",
-              "description": "The activation key to use when registering with Spacewalk"
+              "description": "The activation key to use when registering with Spacewalk."
             }
           }
         }
@@ -3051,12 +3051,12 @@
         "no_ssh_fingerprints": {
           "type": "boolean",
           "default": false,
-          "description": "If true, SSH fingerprints will not be written. Default: ``false``"
+          "description": "If true, SSH fingerprints will not be written. Default: ``false``."
         },
         "authkey_hash": {
           "type": "string",
           "default": "sha256",
-          "description": "The hash type to use when generating SSH fingerprints. Default: ``sha256``"
+          "description": "The hash type to use when generating SSH fingerprints. Default: ``sha256``."
         }
       }
     },
@@ -3067,7 +3067,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "description": "The SSH public key to import"
+            "description": "The SSH public key to import."
           }
         }
       }
@@ -3089,7 +3089,7 @@
         "ssh_authorized_keys": {
           "type": "array",
           "minItems": 1,
-          "description": "The SSH public keys to add ``.ssh/authorized_keys`` in the default user's home directory",
+          "description": "The SSH public keys to add ``.ssh/authorized_keys`` in the default user's home directory.",
           "items": {
             "type": "string"
           }
@@ -3097,11 +3097,11 @@
         "ssh_deletekeys": {
           "type": "boolean",
           "default": true,
-          "description": "Remove host SSH keys. This prevents re-use of a private host key from an image with default host SSH keys. Default: ``true``"
+          "description": "Remove host SSH keys. This prevents re-use of a private host key from an image with default host SSH keys. Default: ``true``."
         },
         "ssh_genkeytypes": {
           "type": "array",
-          "description": "The SSH key types to generate. Default: ``[rsa, ecdsa, ed25519]``",
+          "description": "The SSH key types to generate. Default: ``[rsa, ecdsa, ed25519]``.",
           "default": [
             "ecdsa",
             "ed25519",
@@ -3120,22 +3120,22 @@
         "disable_root": {
           "type": "boolean",
           "default": true,
-          "description": "Disable root login. Default: ``true``"
+          "description": "Disable root login. Default: ``true``."
         },
         "disable_root_opts": {
           "type": "string",
           "default": "``no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command=\"echo 'Please login as the user \\\"$USER\\\" rather than the user \\\"$DISABLE_USER\\\".';echo;sleep 10;exit 142\"``",
-          "description": "Disable root login options.  If ``disable_root_opts`` is specified and contains the string ``$USER``, it will be replaced with the username of the default user. Default: ``no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command=\"echo 'Please login as the user \\\"$USER\\\" rather than the user \\\"$DISABLE_USER\\\".';echo;sleep 10;exit 142\"``"
+          "description": "Disable root login options.  If ``disable_root_opts`` is specified and contains the string ``$USER``, it will be replaced with the username of the default user. Default: ``no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command=\"echo 'Please login as the user \\\"$USER\\\" rather than the user \\\"$DISABLE_USER\\\".';echo;sleep 10;exit 142\"``."
         },
         "allow_public_ssh_keys": {
           "type": "boolean",
           "default": true,
-          "description": "If ``true``, will import the public SSH keys from the datasource's metadata to the user's ``.ssh/authorized_keys`` file. Default: ``true``"
+          "description": "If ``true``, will import the public SSH keys from the datasource's metadata to the user's ``.ssh/authorized_keys`` file. Default: ``true``."
         },
         "ssh_quiet_keygen": {
           "type": "boolean",
           "default": false,
-          "description": "If ``true``, will suppress the output of key generation to the console. Default: ``false``"
+          "description": "If ``true``, will suppress the output of key generation to the console. Default: ``false``."
         },
         "ssh_publish_hostkeys": {
           "type": "object",
@@ -3144,11 +3144,11 @@
             "enabled": {
               "type": "boolean",
               "default": true,
-              "description": "If true, will read host keys from ``/etc/ssh/*.pub`` and publish them to the datasource (if supported). Default: ``true``"
+              "description": "If true, will read host keys from ``/etc/ssh/*.pub`` and publish them to the datasource (if supported). Default: ``true``."
             },
             "blacklist": {
               "type": "array",
-              "description": "The SSH key types to ignore when publishing. Default: ``[]`` to publish all SSH key types",
+              "description": "The SSH key types to ignore when publishing. Default: ``[]`` to publish all SSH key types.",
               "items": {
                 "type": "string"
               }
@@ -3162,7 +3162,7 @@
       "properties": {
         "timezone": {
           "type": "string",
-          "description": "The timezone to use as represented in /usr/share/zoneinfo"
+          "description": "The timezone to use as represented in /usr/share/zoneinfo."
         }
       }
     },
@@ -3213,7 +3213,7 @@
       "properties": {
         "manage_etc_hosts": {
           "default": false,
-          "description": "Whether to manage ``/etc/hosts`` on the system. If ``true``, render the hosts file using ``/etc/cloud/templates/hosts.tmpl`` replacing ``$hostname`` and ``$fdqn``. If ``localhost``, append a ``127.0.1.1`` entry that resolves from FQDN and hostname every boot. Default: ``false``",
+          "description": "Whether to manage ``/etc/hosts`` on the system. If ``true``, render the hosts file using ``/etc/cloud/templates/hosts.tmpl`` replacing ``$hostname`` and ``$fdqn``. If ``localhost``, append a ``127.0.1.1`` entry that resolves from FQDN and hostname every boot. Default: ``false``.",
           "oneOf": [
             {
               "enum": [
@@ -3258,7 +3258,7 @@
         "create_hostname_file": {
           "type": "boolean",
           "default": true,
-          "description": "If ``false``, the hostname file (e.g. /etc/hostname) will not be created if it does not exist. On systems that use systemd, setting create_hostname_file to ``false`` will set the hostname transiently. If ``true``, the hostname file will always be created and the hostname will be set statically on systemd systems. Default: ``true``"
+          "description": "If ``false``, the hostname file (e.g. /etc/hostname) will not be created if it does not exist. On systems that use systemd, setting create_hostname_file to ``false`` will set the hostname transiently. If ``true``, the hostname file will always be created and the hostname will be set statically on systemd systems. Default: ``true``."
         }
       }
     },
@@ -3294,7 +3294,7 @@
               "$ref": "#/$defs/users_groups.user"
             }
           ],
-          "description": "The ``user`` dictionary values override the ``default_user`` configuration from ``/etc/cloud/cloud.cfg``. The `user` dictionary keys supported for the default_user are the same as the ``users`` schema."
+          "description": "The ``user`` dictionary values override the ``default_user`` configuration from ``/etc/cloud/cloud.cfg``. The ``user`` dictionary keys supported for the default_user are the same as the ``users`` schema."
         },
         "users": {
           "type": [
@@ -3338,11 +3338,11 @@
                 "properties": {
                   "name": {
                     "type": "string",
-                    "description": "Name of the interface. Typically wgx (example: wg0)"
+                    "description": "Name of the interface. Typically wgx (example: wg0)."
                   },
                   "config_path": {
                     "type": "string",
-                    "description": "Path to configuration file of Wireguard interface"
+                    "description": "Path to configuration file of Wireguard interface."
                   },
                   "content": {
                     "type": "string",
@@ -3384,16 +3384,16 @@
             "properties": {
               "path": {
                 "type": "string",
-                "description": "Path of the file to which ``content`` is decoded and written"
+                "description": "Path of the file to which ``content`` is decoded and written."
               },
               "content": {
                 "type": "string",
                 "default": "''",
-                "description": "Optional content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``"
+                "description": "Optional content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``."
               },
               "source": {
                 "type": "object",
-                "description": "Optional specification for content loading from an arbitrary URI",
+                "description": "Optional specification for content loading from an arbitrary URI.",
                 "additionalProperties": false,
                 "properties": {
                   "uri": {
@@ -3403,7 +3403,7 @@
                   },
                   "headers": {
                     "type": "object",
-                    "description": "Optional HTTP headers to accompany load request, if applicable",
+                    "description": "Optional HTTP headers to accompany load request, if applicable.",
                     "additionalProperties": {
                       "type": "string"
                     }
@@ -3416,12 +3416,12 @@
               "owner": {
                 "type": "string",
                 "default": "root:root",
-                "description": "Optional owner:group to chown on the file and new directories. Default: ``root:root``"
+                "description": "Optional owner:group to chown on the file and new directories. Default: ``root:root``."
               },
               "permissions": {
                 "type": "string",
                 "default": "'0o644'",
-                "description": "Optional file permissions to set on ``path`` represented as an octal string '0###'. Default: ``0o644``"
+                "description": "Optional file permissions to set on ``path`` represented as an octal string '0###'. Default: ``0o644``."
               },
               "encoding": {
                 "type": "string",
@@ -3437,7 +3437,7 @@
                   "base64",
                   "text/plain"
                 ],
-                "description": "Optional encoding type of the content. Default: ``text/plain``. No decoding is performed by default. Supported encoding types are: gz, gzip, gz+base64, gzip+base64, gz+b64, gzip+b64, b64, base64"
+                "description": "Optional encoding type of the content. Default: ``text/plain``. No decoding is performed by default. Supported encoding types are: gz, gzip, gz+base64, gzip+base64, gz+b64, gzip+b64, b64, base64."
               },
               "append": {
                 "type": "boolean",
@@ -3461,7 +3461,7 @@
         "yum_repo_dir": {
           "type": "string",
           "default": "/etc/yum.repos.d",
-          "description": "The repo parts directory where individual yum repo config files will be written. Default: ``/etc/yum.repos.d``"
+          "description": "The repo parts directory where individual yum repo config files will be written. Default: ``/etc/yum.repos.d``."
         },
         "yum_repos": {
           "type": "object",
@@ -3477,17 +3477,17 @@
                 "baseurl": {
                   "type": "string",
                   "format": "uri",
-                  "description": "URL to the directory where the yum repository's 'repodata' directory lives"
+                  "description": "URL to the directory where the yum repository's 'repodata' directory lives."
                 },
                 "metalink": {
                   "type": "string",
                   "format": "uri",
-                  "description": "Specifies a URL to a metalink file for the repomd.xml"
+                  "description": "Specifies a URL to a metalink file for the repomd.xml."
                 },
                 "mirrorlist": {
                   "type": "string",
                   "format": "uri",
-                  "description": "Specifies a URL to a file containing a baseurls list"
+                  "description": "Specifies a URL to a file containing a baseurls list."
                 },
                 "name": {
                   "type": "string",
@@ -3513,7 +3513,7 @@
                       "type": "string"
                     }
                   ],
-                  "description": "Any supported yum repository configuration options will be written to the yum repo config file. See: man yum.conf"
+                  "description": "Any supported yum repository configuration options will be written to the yum repo config file. See: man yum.conf."
                 }
               },
               "anyOf": [
@@ -3559,7 +3559,7 @@
                   "baseurl": {
                     "type": "string",
                     "format": "uri",
-                    "description": "The base repositoy URL"
+                    "description": "The base repositoy URL."
                   }
                 },
                 "required": [
@@ -3571,7 +3571,7 @@
             },
             "config": {
               "type": "object",
-              "description": "Any supported zypo.conf key is written to ``/etc/zypp/zypp.conf``"
+              "description": "Any supported zypo.conf key is written to ``/etc/zypp/zypp.conf``."
             }
           }
         }
@@ -3585,7 +3585,7 @@
         },
         {
           "type": "array",
-          "description": "A list specifying filepath operation configuration for stdout and stderror",
+          "description": "A list specifying filepath operation configuration for stdout and stderror.",
           "items": {
             "type": [
               "string"

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -295,7 +295,7 @@
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "22.3",
-          "deprecated_description": "Use ``lock_passwd`` instead."
+          "deprecated_description": "Use **lock_passwd** instead."
         },
         "lock_passwd": {
           "default": true,
@@ -306,7 +306,7 @@
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``no_create_home`` instead."
+          "deprecated_description": "Use **no_create_home** instead."
         },
         "no_create_home": {
           "default": false,
@@ -317,7 +317,7 @@
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``no_log_init`` instead."
+          "deprecated_description": "Use **no_log_init** instead."
         },
         "no_log_init": {
           "default": false,
@@ -328,7 +328,7 @@
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``no_user_group`` instead."
+          "deprecated_description": "Use **no_user_group** instead."
         },
         "no_user_group": {
           "default": false,
@@ -343,7 +343,7 @@
           "type": "string",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``hashed_passwd`` instead."
+          "deprecated_description": "Use **hashed_passwd** instead."
         },
         "hashed_passwd": {
           "description": "Hash of user password to be applied. This will be applied even if the user is preexisting. To generate this hash, run: ``mkpasswd --method=SHA-512 --rounds=500000``. **Note:** Your password might possibly be visible to unprivileged users on your system, depending on your cloud's security model. Check if your cloud's IMDS server is visible from an unprivileged user to evaluate risk.",
@@ -353,7 +353,7 @@
           "type": "string",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``plain_text_passwd`` instead."
+          "deprecated_description": "Use **plain_text_passwd** instead."
         },
         "plain_text_passwd": {
           "description": "Clear text of user password to be applied. This will be applied even if the user is preexisting. **Note:** SSH keys or certificates are a safer choice for logging in to your system. For local escalation, supplying a hashed password is a safer choice than plain text. Your password might possibly be visible to unprivileged users on your system, depending on your cloud's security model. An exposed plain text password is an immediate security concern. Check if your cloud's IMDS server is visible from an unprivileged user to evaluate risk.",
@@ -363,7 +363,7 @@
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``create_groups`` instead."
+          "deprecated_description": "Use **create_groups** instead."
         },
         "create_groups": {
           "default": true,
@@ -374,7 +374,7 @@
           "type": "string",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``primary_group`` instead."
+          "deprecated_description": "Use **primary_group** instead."
         },
         "primary_group": {
           "default": "``<username>``",
@@ -385,7 +385,7 @@
           "type": "string",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``selinux_user`` instead."
+          "deprecated_description": "Use **selinux_user** instead."
         },
         "selinux_user": {
           "description": "SELinux user for user's login. Default: the default SELinux user.",
@@ -400,7 +400,7 @@
           "type": "string"
         },
         "ssh_authorized_keys": {
-          "description": "List of SSH keys to add to user's authkeys file. Can not be combined with ``ssh_redirect_user``.",
+          "description": "List of SSH keys to add to user's authkeys file. Can not be combined with **ssh_redirect_user**.",
           "type": "array",
           "items": {
             "type": "string"
@@ -415,7 +415,7 @@
           "minItems": 1,
           "deprecated": true,
           "deprecated_version": "18.3",
-          "deprecated_description": "Use ``ssh_authorized_keys`` instead."
+          "deprecated_description": "Use **ssh_authorized_keys** instead."
         },
         "ssh-import-id": {
           "type": "array",
@@ -425,10 +425,10 @@
           "minItems": 1,
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``ssh_import_id`` instead."
+          "deprecated_description": "Use **ssh_import_id** instead."
         },
         "ssh_import_id": {
-          "description": "List of ssh ids to import for user. Can not be combined with ``ssh_redirect_user``. See the man page[1] for more details. [1] https://manpages.ubuntu.com/manpages/noble/en/man1/ssh-import-id.1.html.",
+          "description": "List of ssh ids to import for user. Can not be combined with **ssh_redirect_user**. See the man page[1] for more details. [1] https://manpages.ubuntu.com/manpages/noble/en/man1/ssh-import-id.1.html.",
           "type": "array",
           "items": {
             "type": "string"
@@ -439,12 +439,12 @@
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "24.2",
-          "deprecated_description": "Use ``ssh_redirect_user`` instead."
+          "deprecated_description": "Use **ssh_redirect_user** instead."
         },
         "ssh_redirect_user": {
           "type": "boolean",
           "default": false,
-          "description": "Boolean set to true to disable SSH logins for this user. When specified, all cloud meta-data public SSH keys will be set up in a disabled state for this username. Any SSH login as this username will timeout and prompt with a message to login instead as the ``default_username`` for this instance. Default: ``false``. This key can not be combined with ``ssh_import_id`` or ``ssh_authorized_keys``."
+          "description": "Boolean set to true to disable SSH logins for this user. When specified, all cloud meta-data public SSH keys will be set up in a disabled state for this username. Any SSH login as this username will timeout and prompt with a message to login instead as the **default_username** for this instance. Default: ``false``. This key can not be combined with **ssh_import_id** or **ssh_authorized_keys**."
         },
         "system": {
           "description": "Optional. Create user as system user with no home directory. Default: ``false``.",
@@ -545,7 +545,7 @@
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "22.3",
-          "deprecated_description": "Use ``remove_defaults`` instead."
+          "deprecated_description": "Use **remove_defaults** instead."
         },
         "remove_defaults": {
           "description": "Remove default CA certificates if true. Default: ``false``.",
@@ -961,7 +961,7 @@
             "preserve_repositories": {
               "type": "boolean",
               "default": false,
-              "description": "By default, cloud-init will generate a new repositories file ``/etc/apk/repositories`` based on any valid configuration settings specified within a apk_repos section of cloud config. To disable this behavior and preserve the repositories file from the pristine image, set ``preserve_repositories`` to ``true``.\nThe ``preserve_repositories`` option overrides all other config keys that would alter ``/etc/apk/repositories``."
+              "description": "By default, cloud-init will generate a new repositories file ``/etc/apk/repositories`` based on any valid configuration settings specified within a apk_repos section of cloud config. To disable this behavior and preserve the repositories file from the pristine image, set **preserve_repositories** to ``true``.\nThe **preserve_repositories** option overrides all other config keys that would alter ``/etc/apk/repositories``."
             },
             "alpine_repo": {
               "type": [
@@ -1013,7 +1013,7 @@
             "preserve_sources_list": {
               "type": "boolean",
               "default": false,
-              "description": "By default, cloud-init will generate a new sources list in ``/etc/apt/sources.list.d`` based on any changes specified in cloud config. To disable this behavior and preserve the sources list from the pristine image, set ``preserve_sources_list`` to ``true``.\n\nThe ``preserve_sources_list`` option overrides all other config keys that would alter ``sources.list`` or ``sources.list.d``, **except** for additional sources to be added to ``sources.list.d``."
+              "description": "By default, cloud-init will generate a new sources list in ``/etc/apt/sources.list.d`` based on any changes specified in cloud config. To disable this behavior and preserve the sources list from the pristine image, set **preserve_sources_list** to ``true``.\n\nThe **preserve_sources_list** option overrides all other config keys that would alter ``sources.list`` or ``sources.list.d``, **except** for additional sources to be added to ``sources.list.d``."
             },
             "disable_suites": {
               "type": "array",
@@ -1022,11 +1022,11 @@
               },
               "minItems": 1,
               "uniqueItems": true,
-              "description": "Entries in the sources list can be disabled using ``disable_suites``, which takes a list of suites to be disabled. If the string ``$RELEASE`` is present in a suite in the ``disable_suites`` list, it will be replaced with the release name. If a suite specified in ``disable_suites`` is not present in ``sources.list`` it will be ignored. For convenience, several aliases are provided for`` disable_suites``:\n- ``updates`` => ``$RELEASE-updates``\n- ``backports`` => ``$RELEASE-backports``\n- ``security`` => ``$RELEASE-security``\n- ``proposed`` => ``$RELEASE-proposed``\n- ``release`` => ``$RELEASE``.\n\nWhen a suite is disabled using ``disable_suites``, its entry in ``sources.list`` is not deleted; it is just commented out."
+              "description": "Entries in the sources list can be disabled using **disable_suites**, which takes a list of suites to be disabled. If the string ``$RELEASE`` is present in a suite in the **disable_suites** list, it will be replaced with the release name. If a suite specified in **disable_suites** is not present in ``sources.list`` it will be ignored. For convenience, several aliases are provided for **disable_suites**:\n- ``updates`` => ``$RELEASE-updates``\n- ``backports`` => ``$RELEASE-backports``\n- ``security`` => ``$RELEASE-security``\n- ``proposed`` => ``$RELEASE-proposed``\n- ``release`` => ``$RELEASE``.\n\nWhen a suite is disabled using **disable_suites**, its entry in ``sources.list`` is not deleted; it is just commented out."
             },
             "primary": {
               "$ref": "#/$defs/apt_configure.mirror",
-              "description": "The primary and security archive mirrors can be specified using the ``primary`` and ``security`` keys, respectively. Both the ``primary`` and ``security`` keys take a list of configs, allowing mirrors to be specified on a per-architecture basis. Each config is a dictionary which must have an entry for ``arches``, specifying which architectures that config entry is for. The keyword ``default`` applies to any architecture not explicitly listed. The mirror url can be specified with the ``uri`` key, or a list of mirrors to check can be provided in order, with the first mirror that can be resolved being selected. This allows the same configuration to be used in different environment, with different hosts used for a local APT mirror. If no mirror is provided by ``uri`` or ``search``, ``search_dns`` may be used to search for dns names in the format ``<distro>-mirror`` in each of the following:\n- fqdn of this host per cloud metadata,\n- localdomain,\n- domains listed in ``/etc/resolv.conf``.\n\nIf there is a dns entry for ``<distro>-mirror``, then it is assumed that there is a distro mirror at ``http://<distro>-mirror.<domain>/<distro>``. If the ``primary`` key is defined, but not the ``security`` key, then then configuration for ``primary`` is also used for ``security``. If ``search_dns`` is used for the ``security`` key, the search pattern will be ``<distro>-security-mirror``.\n\nEach mirror may also specify a key to import via any of the following optional keys:\n- ``keyid``: a key to import via shortid or fingerprint.\n- ``key``: a raw PGP key.\n- ``keyserver``: alternate keyserver to pull ``keyid`` key from.\n\nIf no mirrors are specified, or all lookups fail, then default mirrors defined in the datasource are used. If none are present in the datasource either the following defaults are used:\n- ``primary`` => ``http://archive.ubuntu.com/ubuntu``.\n- ``security`` => ``http://security.ubuntu.com/ubuntu``."
+              "description": "The primary and security archive mirrors can be specified using the **primary** and **security** keys, respectively. Both the **primary** and **security** keys take a list of configs, allowing mirrors to be specified on a per-architecture basis. Each config is a dictionary which must have an entry for **arches**, specifying which architectures that config entry is for. The keyword ``default`` applies to any architecture not explicitly listed. The mirror url can be specified with the **uri** key, or a list of mirrors to check can be provided in order, with the first mirror that can be resolved being selected. This allows the same configuration to be used in different environment, with different hosts used for a local APT mirror. If no mirror is provided by **uri** or **search**, **search_dns** may be used to search for dns names in the format ``<distro>-mirror`` in each of the following:\n- fqdn of this host per cloud metadata,\n- localdomain,\n- domains listed in ``/etc/resolv.conf``.\n\nIf there is a dns entry for ``<distro>-mirror``, then it is assumed that there is a distro mirror at ``http://<distro>-mirror.<domain>/<distro>``. If the **primary** key is defined, but not the **security** key, then then configuration for **primary** is also used for **security**. If **search_dns** is used for the **security** key, the search pattern will be ``<distro>-security-mirror``.\n\nEach mirror may also specify a key to import via any of the following optional keys:\n- **keyid**: a key to import via shortid or fingerprint.\n- **key**: a raw PGP key.\n- **keyserver**: alternate keyserver to pull **keyid** key from.\n\nIf no mirrors are specified, or all lookups fail, then default mirrors defined in the datasource are used. If none are present in the datasource either the following defaults are used:\n- **primary** => ``http://archive.ubuntu.com/ubuntu``.\n- **security** => ``http://security.ubuntu.com/ubuntu``."
             },
             "security": {
               "$ref": "#/$defs/apt_configure.mirror",
@@ -1035,7 +1035,7 @@
             "add_apt_repo_match": {
               "type": "string",
               "default": "^[\\w-]+:\\w",
-              "description": "All source entries in ``apt-sources`` that match regex in ``add_apt_repo_match`` will be added to the system using ``add-apt-repository``. If ``add_apt_repo_match`` is not specified, it defaults to ``^[\\w-]+:\\w``."
+              "description": "All source entries in ``apt-sources`` that match regex in **add_apt_repo_match** will be added to the system using ``add-apt-repository``. If **add_apt_repo_match** is not specified, it defaults to ``^[\\w-]+:\\w``."
             },
             "debconf_selections": {
               "type": "object",
@@ -1046,11 +1046,11 @@
                   "type": "string"
                 }
               },
-              "description": "Debconf additional configurations can be specified as a dictionary under the ``debconf_selections`` config key, with each key in the dict representing a different set of configurations. The value of each key must be a string containing all the debconf configurations that must be applied. We will bundle all of the values and pass them to ``debconf-set-selections``. Therefore, each value line must be a valid entry for ``debconf-set-selections``, meaning that they must possess for distinct fields:\n\n``pkgname question type answer``\n\nWhere:\n- ``pkgname`` is the name of the package.\n- ``question`` the name of the questions.\n- ``type`` is the type of question.\n- ``answer`` is the value used to answer the question.\n\nFor example: ``ippackage ippackage/ip string 127.0.01``."
+              "description": "Debconf additional configurations can be specified as a dictionary under the **debconf_selections** config key, with each key in the dict representing a different set of configurations. The value of each key must be a string containing all the debconf configurations that must be applied. We will bundle all of the values and pass them to **debconf-set-selections**. Therefore, each value line must be a valid entry for ``debconf-set-selections``, meaning that they must possess for distinct fields:\n\n``pkgname question type answer``\n\nWhere:\n- ``pkgname`` is the name of the package.\n- ``question`` the name of the questions.\n- ``type`` is the type of question.\n- ``answer`` is the value used to answer the question.\n\nFor example: ``ippackage ippackage/ip string 127.0.01``."
             },
             "sources_list": {
               "type": "string",
-              "description": "Specifies a custom template for rendering ``sources.list`` . If no ``sources_list`` template is given, cloud-init will use sane default. Within this template, the following strings will be replaced with the appropriate values:\n- ``$MIRROR``\n- ``$RELEASE``\n- ``$PRIMARY``\n- ``$SECURITY``\n- ``$KEY_FILE``"
+              "description": "Specifies a custom template for rendering ``sources.list`` . If no **sources_list** template is given, cloud-init will use sane default. Within this template, the following strings will be replaced with the appropriate values:\n- ``$MIRROR``\n- ``$RELEASE``\n- ``$PRIMARY``\n- ``$SECURITY``\n- ``$KEY_FILE``"
             },
             "conf": {
               "type": "string",
@@ -1103,7 +1103,7 @@
                   "minProperties": 1
                 }
               },
-              "description": "Source list entries can be specified as a dictionary under the ``sources`` config key, with each key in the dict representing a different source file. The key of each source entry will be used as an id that can be referenced in other config entries, as well as the filename for the source's configuration under ``/etc/apt/sources.list.d``. If the name does not end with ``.list``, it will be appended. If there is no configuration for a key in ``sources``, no file will be written, but the key may still be referred to as an id in other ``sources`` entries.\n\nEach entry under ``sources`` is a dictionary which may contain any of the following optional keys:\n- ``source``: a sources.list entry (some variable replacements apply).\n- ``keyid``: a key to import via shortid or fingerprint.\n- ``key``: a raw PGP key.\n- ``keyserver``: alternate keyserver to pull ``keyid`` key from.\n- ``filename``: specify the name of the list file.\n- ``append``: If ``true``, append to sources file, otherwise overwrite it. Default: ``true``.\n\nThe ``source`` key supports variable replacements for the following strings:\n- ``$MIRROR``\n- ``$PRIMARY``\n- ``$SECURITY``\n- ``$RELEASE``\n- ``$KEY_FILE``"
+              "description": "Source list entries can be specified as a dictionary under the **sources** config key, with each key in the dict representing a different source file. The key of each source entry will be used as an id that can be referenced in other config entries, as well as the filename for the source's configuration under ``/etc/apt/sources.list.d``. If the name does not end with ``.list``, it will be appended. If there is no configuration for a key in **sources**, no file will be written, but the key may still be referred to as an id in other **sources** entries.\n\nEach entry under **sources** is a dictionary which may contain any of the following optional keys:\n- **source**: a sources.list entry (some variable replacements apply).\n- **keyid**: a key to import via shortid or fingerprint.\n- **key**: a raw PGP key.\n- **keyserver**: alternate keyserver to pull **keyid** key from.\n- **filename**: specify the name of the list file.\n- **append**: If ``true``, append to sources file, otherwise overwrite it. Default: ``true``.\n\nThe **source** key supports variable replacements for the following strings:\n- ``$MIRROR``\n- ``$PRIMARY``\n- ``$SECURITY``\n- ``$RELEASE``\n- ``$KEY_FILE``"
             }
           }
         }
@@ -1131,7 +1131,7 @@
                 {
                   "deprecated": true,
                   "deprecated_version": "22.4",
-                  "deprecated_description": "Use ``os`` instead.",
+                  "deprecated_description": "Use **os** instead.",
                   "enum": [
                     "none",
                     "unchanged"
@@ -1198,7 +1198,7 @@
             {
               "deprecated": true,
               "deprecated_version": "22.3",
-              "deprecated_description": "Use ``ca_certs`` instead."
+              "deprecated_description": "Use **ca_certs** instead."
             }
           ]
         }
@@ -1470,7 +1470,7 @@
               },
               "device": {
                 "type": "string",
-                "description": "Specified either as a path or as an alias in the format ``<alias name>.<y>`` where ``<y>`` denotes the partition number on the device. If specifying device using the ``<alias name>.<partition number>`` format, the value of ``partition`` will be overwritten."
+                "description": "Specified either as a path or as an alias in the format ``<alias name>.<y>`` where ``<y>`` denotes the partition number on the device. If specifying device using the ``<alias name>.<partition number>`` format, the value of **partition** will be overwritten."
               },
               "partition": {
                 "type": [
@@ -1487,15 +1487,15 @@
                     ]
                   }
                 ],
-                "description": "The partition can be specified by setting ``partition`` to the desired partition number. The ``partition`` option may also be set to ``auto``, in which this module will search for the existence of a filesystem matching the ``label``, ``filesystem`` and ``device`` of the ``fs_setup`` entry and will skip creating the filesystem if one is found. The ``partition`` option may also be set to ``any``, in which case any filesystem that matches ``filesystem`` and ``device`` will cause this module to skip filesystem creation for the ``fs_setup`` entry, regardless of ``label`` matching or not. To write a filesystem directly to a device, use ``partition: none``. ``partition: none`` will **always** write the filesystem, even when the ``label`` and ``filesystem`` are matched, and ``overwrite`` is ``false``."
+                "description": "The partition can be specified by setting **partition** to the desired partition number. The **partition** option may also be set to ``auto``, in which this module will search for the existence of a filesystem matching the **label**, **filesystem** and **device** of the **fs_setup** entry and will skip creating the filesystem if one is found. The **partition** option may also be set to ``any``, in which case any filesystem that matches **filesystem** and **device** will cause this module to skip filesystem creation for the **fs_setup** entry, regardless of **label** matching or not. To write a filesystem directly to a device, use ``partition: none``. ``partition: none`` will **always** write the filesystem, even when the **label** and **filesystem** are matched, and ``overwrite`` is ``false``."
               },
               "overwrite": {
                 "type": "boolean",
-                "description": "If ``true``, overwrite any existing filesystem. Using ``overwrite: true`` for filesystems is **dangerous** and can lead to data loss, so double check the entry in ``fs_setup``. Default: ``false``."
+                "description": "If ``true``, overwrite any existing filesystem. Using ``overwrite: true`` for filesystems is **dangerous** and can lead to data loss, so double check the entry in **fs_setup**. Default: ``false``."
               },
               "replace_fs": {
                 "type": "string",
-                "description": "Ignored unless ``partition`` is ``auto`` or ``any``. Default ``false``."
+                "description": "Ignored unless **partition** is ``auto`` or ``any``. Default ``false``."
               },
               "extra_opts": {
                 "type": [
@@ -1505,7 +1505,7 @@
                 "items": {
                   "type": "string"
                 },
-                "description": "Optional options to pass to the filesystem creation command. Ignored if you using ``cmd`` directly."
+                "description": "Optional options to pass to the filesystem creation command. Ignored if you using **cmd** directly."
               },
               "cmd": {
                 "type": [
@@ -1515,7 +1515,7 @@
                 "items": {
                   "type": "string"
                 },
-                "description": "Optional command to run to create the filesystem. Can include string substitutions of the other ``fs_setup`` config keys. This is only necessary if you need to override the default command."
+                "description": "Optional command to run to create the filesystem. Can include string substitutions of the other **fs_setup** config keys. This is only necessary if you need to override the default command."
               }
             }
           }
@@ -1579,7 +1579,7 @@
                   ],
                   "changed": true,
                   "changed_version": "22.3",
-                  "changed_description": "Specifying a boolean ``false`` value for ``mode`` is deprecated. Use the string ``'off'`` instead."
+                  "changed_description": "Specifying a boolean ``false`` value for **mode** is deprecated. Use the string ``'off'`` instead."
                 }
               ]
             },
@@ -1619,7 +1619,7 @@
               "description": "Device to use as target for grub installation. If unspecified, ``grub-probe`` of ``/boot`` will be used to find the device."
             },
             "grub-pc/install_devices_empty": {
-              "description": "Sets values for ``grub-pc/install_devices_empty``. If unspecified, will be set to ``true`` if ``grub-pc/install_devices`` is empty, otherwise ``false``.",
+              "description": "Sets values for **grub-pc/install_devices_empty**. If unspecified, will be set to ``true`` if **grub-pc/install_devices** is empty, otherwise ``false``.",
               "oneOf": [
                 {
                   "type": "boolean"
@@ -1642,7 +1642,7 @@
           "type": "object",
           "deprecated": true,
           "deprecated_version": "22.2",
-          "deprecated_description": "Use ``grub_dpkg`` instead."
+          "deprecated_description": "Use **grub_dpkg** instead."
         }
       }
     },
@@ -1844,7 +1844,7 @@
             "init": {
               "type": "object",
               "additionalProperties": false,
-              "description": "LXD init configuration values to provide to `lxd init --auto` command. Can not be combined with ``lxd.preseed``.",
+              "description": "LXD init configuration values to provide to `lxd init --auto` command. Can not be combined with **lxd.preseed**.",
               "properties": {
                 "network_address": {
                   "type": "string",
@@ -1889,11 +1889,11 @@
                 "mode"
               ],
               "additionalProperties": false,
-              "description": "LXD bridge configuration provided to setup the host lxd bridge. Can not be combined with ``lxd.preseed``.",
+              "description": "LXD bridge configuration provided to setup the host lxd bridge. Can not be combined with **lxd.preseed**.",
               "properties": {
                 "mode": {
                   "type": "string",
-                  "description": "Whether to setup LXD bridge, use an existing bridge by ``name`` or create a new bridge. `none` will avoid bridge setup, `existing` will configure lxd to use the bring matching ``name`` and `new` will create a new bridge.",
+                  "description": "Whether to setup LXD bridge, use an existing bridge by **name** or create a new bridge. `none` will avoid bridge setup, `existing` will configure lxd to use the bring matching **name** and `new` will create a new bridge.",
                   "enum": [
                     "none",
                     "existing",
@@ -1913,19 +1913,19 @@
                 },
                 "ipv4_address": {
                   "type": "string",
-                  "description": "IPv4 address for the bridge. If set, ``ipv4_netmask`` key required."
+                  "description": "IPv4 address for the bridge. If set, **ipv4_netmask** key required."
                 },
                 "ipv4_netmask": {
                   "type": "integer",
-                  "description": "Prefix length for the ``ipv4_address`` key. Required when ``ipv4_address`` is set."
+                  "description": "Prefix length for the **ipv4_address** key. Required when **ipv4_address** is set."
                 },
                 "ipv4_dhcp_first": {
                   "type": "string",
-                  "description": "First IPv4 address of the DHCP range for the network created. This value will combined with ``ipv4_dhcp_last`` key to set LXC ``ipv4.dhcp.ranges``."
+                  "description": "First IPv4 address of the DHCP range for the network created. This value will combined with **ipv4_dhcp_last** key to set LXC **ipv4.dhcp.ranges**."
                 },
                 "ipv4_dhcp_last": {
                   "type": "string",
-                  "description": "Last IPv4 address of the DHCP range for the network created. This value will combined with ``ipv4_dhcp_first`` key to set LXC ``ipv4.dhcp.ranges``."
+                  "description": "Last IPv4 address of the DHCP range for the network created. This value will combined with **ipv4_dhcp_first** key to set LXC **ipv4.dhcp.ranges**."
                 },
                 "ipv4_dhcp_leases": {
                   "type": "integer",
@@ -1938,11 +1938,11 @@
                 },
                 "ipv6_address": {
                   "type": "string",
-                  "description": "IPv6 address for the bridge (CIDR notation). When set, ``ipv6_netmask`` key is required. When absent, no IPv6 will be configured."
+                  "description": "IPv6 address for the bridge (CIDR notation). When set, **ipv6_netmask** key is required. When absent, no IPv6 will be configured."
                 },
                 "ipv6_netmask": {
                   "type": "integer",
-                  "description": "Prefix length for ``ipv6_address`` provided. Required when ``ipv6_address`` is set."
+                  "description": "Prefix length for **ipv6_address** provided. Required when **ipv6_address** is set."
                 },
                 "ipv6_nat": {
                   "type": "boolean",
@@ -1957,7 +1957,7 @@
             },
             "preseed": {
               "type": "string",
-              "description": "Opaque LXD preseed YAML config passed via stdin to the command: lxd init --preseed. See: https://documentation.ubuntu.com/lxd/en/latest/howto/initialize/#non-interactive-configuration or lxd init --dump for viable config. Can not be combined with either ``lxd.init`` or ``lxd.bridge``."
+              "description": "Opaque LXD preseed YAML config passed via stdin to the command: lxd init --preseed. See: https://documentation.ubuntu.com/lxd/en/latest/howto/initialize/#non-interactive-configuration or lxd init --dump for viable config. Can not be combined with either **lxd.init** or **lxd.bridge**."
             }
           }
         }
@@ -2017,7 +2017,7 @@
             "minItems": 1,
             "maxItems": 6
           },
-          "description": "List of lists. Each inner list entry is a list of ``/etc/fstab`` mount declarations of the format: [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno ]. A mount declaration with less than 6 items will get remaining values from ``mount_default_fields``. A mount declaration with only `fs_spec` and no `fs_file` mountpoint will be skipped.",
+          "description": "List of lists. Each inner list entry is a list of ``/etc/fstab`` mount declarations of the format: [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno ]. A mount declaration with less than 6 items will get remaining values from **mount_default_fields**. A mount declaration with only `fs_spec` and no `fs_file` mountpoint will be skipped.",
           "minItems": 1
         },
         "mount_default_fields": {
@@ -2141,18 +2141,18 @@
               "description": "Attempt to enable ntp clients if set to True.  If set to ``false``, ntp client will not be configured or installed."
             },
             "config": {
-              "description": "Configuration settings or overrides for the ``ntp_client`` specified.",
+              "description": "Configuration settings or overrides for the **ntp_client** specified.",
               "type": "object",
               "minProperties": 1,
               "additionalProperties": false,
               "properties": {
                 "confpath": {
                   "type": "string",
-                  "description": "The path to where the ``ntp_client`` configuration is written."
+                  "description": "The path to where the **ntp_client** configuration is written."
                 },
                 "check_exe": {
                   "type": "string",
-                  "description": "The executable name for the ``ntp_client``. For example, ntp service ``check_exe`` is 'ntpd' because it runs the ntpd binary."
+                  "description": "The executable name for the **ntp_client**. For example, ntp service **check_exe** is 'ntpd' because it runs the ntpd binary."
                 },
                 "packages": {
                   "type": "array",
@@ -2160,15 +2160,15 @@
                     "type": "string"
                   },
                   "uniqueItems": true,
-                  "description": "List of packages needed to be installed for the selected ``ntp_client``."
+                  "description": "List of packages needed to be installed for the selected **ntp_client**."
                 },
                 "service_name": {
                   "type": "string",
-                  "description": "The systemd or sysvinit service name used to start and stop the ``ntp_client`` service."
+                  "description": "The systemd or sysvinit service name used to start and stop the **ntp_client** service."
                 },
                 "template": {
                   "type": "string",
-                  "description": "Inline template allowing users to customize their ``ntp_client`` configuration with the use of the Jinja templating engine. The template content should start with ``## template:jinja``. Within the template, you can utilize any of the following ntp module config keys: ``servers``, ``pools``, ``allow``, and ``peers``. Each cc_ntp schema config key and expected value type is defined above."
+                  "description": "Inline template allowing users to customize their **ntp_client** configuration with the use of the Jinja templating engine. The template content should start with ``## template:jinja``. Within the template, you can utilize any of the following ntp module config keys: **servers**, **pools**, **allow**, and **peers**. Each cc_ntp schema config key and expected value type is defined above."
                 }
               }
             }
@@ -2228,19 +2228,19 @@
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "22.2",
-          "deprecated_description": "Use ``package_update`` instead."
+          "deprecated_description": "Use **package_update** instead."
         },
         "apt_upgrade": {
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "22.2",
-          "deprecated_description": "Use ``package_upgrade`` instead."
+          "deprecated_description": "Use **package_upgrade** instead."
         },
         "apt_reboot_if_required": {
           "type": "boolean",
           "deprecated": true,
           "deprecated_version": "22.2",
-          "deprecated_description": "Use ``package_reboot_if_required`` instead."
+          "deprecated_description": "Use **package_reboot_if_required** instead."
         }
       }
     },
@@ -2388,37 +2388,37 @@
             },
             "collection": {
               "type": "string",
-              "description": "Puppet collection to install if ``install_type`` is ``aio``. This can be set to one of ``puppet`` (rolling release), ``puppet6``, ``puppet7`` (or their nightly counterparts) in order to install specific release streams."
+              "description": "Puppet collection to install if **install_type** is ``aio``. This can be set to one of ``puppet`` (rolling release), ``puppet6``, ``puppet7`` (or their nightly counterparts) in order to install specific release streams."
             },
             "aio_install_url": {
               "type": "string",
-              "description": "If ``install_type`` is ``aio``, change the url of the install script."
+              "description": "If **install_type** is ``aio``, change the url of the install script."
             },
             "cleanup": {
               "type": "boolean",
               "default": true,
-              "description": "Whether to remove the puppetlabs repo after installation if ``install_type`` is ``aio`` Default: ``true``."
+              "description": "Whether to remove the puppetlabs repo after installation if **install_type** is ``aio`` Default: ``true``."
             },
             "conf_file": {
               "type": "string",
-              "description": "The path to the puppet config file. Default depends on ``install_type``."
+              "description": "The path to the puppet config file. Default depends on **install_type**."
             },
             "ssl_dir": {
               "type": "string",
-              "description": "The path to the puppet SSL directory. Default depends on ``install_type``."
+              "description": "The path to the puppet SSL directory. Default depends on **install_type**."
             },
             "csr_attributes_path": {
               "type": "string",
-              "description": "The path to the puppet csr attributes file. Default depends on ``install_type``."
+              "description": "The path to the puppet csr attributes file. Default depends on **install_type**."
             },
             "package_name": {
               "type": "string",
-              "description": "Name of the package to install if ``install_type`` is ``packages``. Default: ``puppet``."
+              "description": "Name of the package to install if **install_type** is ``packages``. Default: ``puppet``."
             },
             "exec": {
               "type": "boolean",
               "default": false,
-              "description": "Whether or not to run puppet after configuration finishes. A single manual run can be triggered by setting ``exec`` to ``true``, and additional arguments can be passed to ``puppet agent`` via the ``exec_args`` key (by default the agent will execute with the ``--test`` flag). Default: ``false``."
+              "description": "Whether or not to run puppet after configuration finishes. A single manual run can be triggered by setting **exec** to ``true``, and additional arguments can be passed to ``puppet agent`` via the **exec_args** key (by default the agent will execute with the ``--test`` flag). Default: ``false``."
             },
             "exec_args": {
               "type": "array",
@@ -2430,7 +2430,7 @@
             "start_service": {
               "type": "boolean",
               "default": true,
-              "description": "By default, the puppet service will be automatically enabled after installation and set to automatically start on boot. To override this in favor of manual puppet execution set ``start_service`` to ``false``."
+              "description": "By default, the puppet service will be automatically enabled after installation and set to automatically start on boot. To override this in favor of manual puppet execution set **start_service** to ``false``."
             },
             "conf": {
               "type": "object",
@@ -2490,7 +2490,7 @@
         "manage_resolv_conf": {
           "type": "boolean",
           "default": false,
-          "description": "Whether to manage the resolv.conf file. ``resolv_conf`` block will be ignored unless this is set to ``true``. Default: ``false``."
+          "description": "Whether to manage the resolv.conf file. **resolv_conf** block will be ignored unless this is set to ``true``. Default: ``false``."
         },
         "resolv_conf": {
           "type": "object",
@@ -2529,18 +2529,18 @@
           "properties": {
             "username": {
               "type": "string",
-              "description": "The username to use. Must be used with password. Should not be used with ``activation-key`` or ``org``."
+              "description": "The username to use. Must be used with password. Should not be used with **activation-key** or **org**."
             },
             "password": {
               "type": "string",
-              "description": "The password to use. Must be used with username. Should not be used with ``activation-key`` or ``org``."
+              "description": "The password to use. Must be used with username. Should not be used with **activation-key** or **org**."
             },
             "activation-key": {
               "type": "string",
-              "description": "The activation key to use. Must be used with ``org``. Should not be used with ``username`` or ``password``."
+              "description": "The activation key to use. Must be used with **org**. Should not be used with **username** or **password**."
             },
             "org": {
-              "description": "The organization to use. Must be used with ``activation-key``. Should not be used with ``username`` or ``password``.",
+              "description": "The organization to use. Must be used with **activation-key**. Should not be used with **username** or **password**.",
               "oneOf": [
                 {
                   "type": "string"
@@ -2611,7 +2611,7 @@
             },
             "configs": {
               "type": "array",
-              "description": "Each entry in ``configs`` is either a string or an object. Each config entry contains a configuration string and a file to write it to. For config entries that are an object, ``filename`` sets the target filename and ``content`` specifies the config string to write. For config entries that are only a string, the string is used as the config string to write. If the filename to write the config to is not specified, the value of the ``config_filename`` key is used. A file with the selected filename will be written inside the directory specified by ``config_dir``.",
+              "description": "Each entry in **configs** is either a string or an object. Each config entry contains a configuration string and a file to write it to. For config entries that are an object, **filename** sets the target filename and **content** specifies the config string to write. For config entries that are only a string, the string is used as the config string to write. If the filename to write the config to is not specified, the value of the **config_filename** key is used. A file with the selected filename will be written inside the directory specified by **config_dir**.",
               "items": {
                 "oneOf": [
                   {
@@ -2670,7 +2670,7 @@
                 "type": "string"
               },
               "uniqueItems": true,
-              "description": "List of packages needed to be installed for rsyslog. This is only used if ``install_rsyslog`` is ``true``. Default: ``[rsyslog]``."
+              "description": "List of packages needed to be installed for rsyslog. This is only used if **install_rsyslog** is ``true``. Default: ``[rsyslog]``."
             }
           }
         }
@@ -2797,7 +2797,7 @@
             },
             "data": {
               "type": "string",
-              "description": "This data will be written to ``file`` before data from the datasource. When using a multi-line value or specifying binary data, be sure to follow YAML syntax and use the ``|`` and ``!binary`` YAML format specifiers when appropriate."
+              "description": "This data will be written to **file** before data from the datasource. When using a multi-line value or specifying binary data, be sure to follow YAML syntax and use the ``|`` and ``!binary`` YAML format specifiers when appropriate."
             },
             "encoding": {
               "type": "string",
@@ -2809,19 +2809,19 @@
                 "gzip",
                 "gz"
               ],
-              "description": "Used to decode ``data`` provided. Allowed values are ``raw``, ``base64``, ``b64``, ``gzip``, or ``gz``.  Default: ``raw``."
+              "description": "Used to decode **data** provided. Allowed values are ``raw``, ``base64``, ``b64``, ``gzip``, or ``gz``.  Default: ``raw``."
             },
             "command": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "Execute this command to seed random. The command will have RANDOM_SEED_FILE in its environment set to the value of ``file`` above."
+              "description": "Execute this command to seed random. The command will have RANDOM_SEED_FILE in its environment set to the value of **file** above."
             },
             "command_required": {
               "type": "boolean",
               "default": false,
-              "description": "If true, and ``command`` is not available to be run then an exception is raised and cloud-init will record failure. Otherwise, only debug error is mentioned. Default: ``false``."
+              "description": "If true, and **command** is not available to be run then an exception is raised and cloud-init will record failure. Otherwise, only debug error is mentioned. Default: ``false``."
             }
           }
         }
@@ -2881,7 +2881,7 @@
               "description": "Whether to expire all user passwords such that a password will need to be reset on the user's next login. Default: ``true``."
             },
             "users": {
-              "description": "This key represents a list of existing users to set passwords for. Each item under users contains the following required keys: ``name`` and ``password`` or in the case of a randomly generated password, ``name`` and ``type``. The ``type`` key has a default value of ``hash``, and may alternatively be set to ``text`` or ``RANDOM``. Randomly generated passwords may be insecure, use at your own risk.",
+              "description": "This key represents a list of existing users to set passwords for. Each item under users contains the following required keys: **name** and **password** or in the case of a randomly generated password, **name** and **type**. The **type** key has a default value of ``hash``, and may alternatively be set to ``text`` or ``RANDOM``. Randomly generated passwords may be insecure, use at your own risk.",
               "type": "array",
               "items": {
                 "minItems": 1,
@@ -2947,13 +2947,13 @@
               "minItems": 1,
               "deprecated": true,
               "deprecated_version": "22.2",
-              "deprecated_description": "Use ``users`` instead."
+              "deprecated_description": "Use **users** instead."
             }
           }
         },
         "password": {
           "type": "string",
-          "description": "Set the default user's password. Ignored if ``chpasswd`` ``list`` is used."
+          "description": "Set the default user's password. Ignored if **chpasswd** ``list`` is used."
         }
       }
     },
@@ -2966,7 +2966,7 @@
           "additionalProperties": false,
           "properties": {
             "assertions": {
-              "description": "Properly-signed snap assertions which will run before and snap ``commands``.",
+              "description": "Properly-signed snap assertions which will run before and snap **commands**.",
               "type": [
                 "object",
                 "array"
@@ -3077,7 +3077,7 @@
       "properties": {
         "ssh_keys": {
           "type": "object",
-          "description": "A dictionary entries for the public and private host keys of each desired key type. Entries in the ``ssh_keys`` config dict should have keys in the format ``<key type>_private``, ``<key type>_public``, and, optionally, ``<key type>_certificate``, e.g. ``rsa_private: <key>``, ``rsa_public: <key>``, and ``rsa_certificate: <key>``. Not all key types have to be specified, ones left unspecified will not be used. If this config option is used, then separate keys will not be automatically generated. In order to specify multi-line private host keys and certificates, use YAML multi-line syntax. **Note:** Your ssh keys might possibly be visible to unprivileged users on your system, depending on your cloud's security model.",
+          "description": "A dictionary entries for the public and private host keys of each desired key type. Entries in the **ssh_keys** config dict should have keys in the format ``<key type>_private``, ``<key type>_public``, and, optionally, ``<key type>_certificate``, e.g. ``rsa_private: <key>``, ``rsa_public: <key>``, and ``rsa_certificate: <key>``. Not all key types have to be specified, ones left unspecified will not be used. If this config option is used, then separate keys will not be automatically generated. In order to specify multi-line private host keys and certificates, use YAML multi-line syntax. **Note:** Your ssh keys might possibly be visible to unprivileged users on your system, depending on your cloud's security model.",
           "additionalProperties": false,
           "patternProperties": {
             "^(ecdsa|ed25519|rsa)_(public|private|certificate)$": {
@@ -3125,7 +3125,7 @@
         "disable_root_opts": {
           "type": "string",
           "default": "``no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command=\"echo 'Please login as the user \\\"$USER\\\" rather than the user \\\"$DISABLE_USER\\\".';echo;sleep 10;exit 142\"``",
-          "description": "Disable root login options.  If ``disable_root_opts`` is specified and contains the string ``$USER``, it will be replaced with the username of the default user. Default: ``no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command=\"echo 'Please login as the user \\\"$USER\\\" rather than the user \\\"$DISABLE_USER\\\".';echo;sleep 10;exit 142\"``."
+          "description": "Disable root login options.  If **disable_root_opts** is specified and contains the string ``$USER``, it will be replaced with the username of the default user. Default: ``no-port-forwarding,no-agent-forwarding,no-X11-forwarding,command=\"echo 'Please login as the user \\\"$USER\\\" rather than the user \\\"$DISABLE_USER\\\".';echo;sleep 10;exit 142\"``."
         },
         "allow_public_ssh_keys": {
           "type": "boolean",
@@ -3204,7 +3204,7 @@
           "$ref": "#/$defs/ubuntu_pro.properties",
           "deprecated": true,
           "deprecated_version": "24.1",
-          "deprecated_description": "Use ``ubuntu_pro`` instead."
+          "deprecated_description": "Use **ubuntu_pro** instead."
         }
       }
     },
@@ -3226,7 +3226,7 @@
               "enum": [
                 "template"
               ],
-              "changed_description": "Use of ``template`` is deprecated, use ``true`` instead.",
+              "changed_description": "Use of **template** is deprecated, use ``true`` instead.",
               "changed": true,
               "changed_version": "22.3"
             }
@@ -3234,11 +3234,11 @@
         },
         "fqdn": {
           "type": "string",
-          "description": "Optional fully qualified domain name to use when updating ``/etc/hosts``. Preferred over ``hostname`` if both are provided. In absence of ``hostname`` and ``fqdn`` in cloud-config, the ``local-hostname`` value will be used from datasource metadata."
+          "description": "Optional fully qualified domain name to use when updating ``/etc/hosts``. Preferred over **hostname** if both are provided. In absence of **hostname** and **fqdn** in cloud-config, the ``local-hostname`` value will be used from datasource metadata."
         },
         "hostname": {
           "type": "string",
-          "description": "Hostname to set when rendering ``/etc/hosts``. If ``fqdn`` is set, the hostname extracted from ``fqdn`` overrides ``hostname``."
+          "description": "Hostname to set when rendering ``/etc/hosts``. If **fqdn** is set, the hostname extracted from **fqdn** overrides **hostname**."
         }
       }
     },
@@ -3253,7 +3253,7 @@
         "prefer_fqdn_over_hostname": {
           "type": "boolean",
           "default": null,
-          "description": "By default, it is distro-dependent whether cloud-init uses the short hostname or fully qualified domain name when both ``local-hostname` and ``fqdn`` are both present in instance metadata. When set ``true``, use fully qualified domain name if present as hostname instead of short hostname. When set ``false``, use ``hostname`` config value if present, otherwise fallback to ``fqdn``."
+          "description": "By default, it is distro-dependent whether cloud-init uses the short hostname or fully qualified domain name when both ``local-hostname` and ``fqdn`` are both present in instance metadata. When set ``true``, use fully qualified domain name if present as hostname instead of short hostname. When set ``false``, use **hostname** config value if present, otherwise fallback to **fqdn**."
         },
         "create_hostname_file": {
           "type": "boolean",
@@ -3294,7 +3294,7 @@
               "$ref": "#/$defs/users_groups.user"
             }
           ],
-          "description": "The ``user`` dictionary values override the ``default_user`` configuration from ``/etc/cloud/cloud.cfg``. The ``user`` dictionary keys supported for the default_user are the same as the ``users`` schema."
+          "description": "The **user** dictionary values override the **default_user** configuration from ``/etc/cloud/cloud.cfg``. The **user** dictionary keys supported for the default_user are the same as the **users** schema."
         },
         "users": {
           "type": [
@@ -3384,12 +3384,12 @@
             "properties": {
               "path": {
                 "type": "string",
-                "description": "Path of the file to which ``content`` is decoded and written."
+                "description": "Path of the file to which **content** is decoded and written."
               },
               "content": {
                 "type": "string",
                 "default": "''",
-                "description": "Optional content to write to the provided ``path``. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``."
+                "description": "Optional content to write to the provided **path**. When content is present and encoding is not 'text/plain', decode the content prior to writing. Default: ``''``."
               },
               "source": {
                 "type": "object",
@@ -3399,7 +3399,7 @@
                   "uri": {
                     "type": "string",
                     "format": "uri",
-                    "description": "URI from which to load file content. If loading fails repeatedly, ``content`` is used instead."
+                    "description": "URI from which to load file content. If loading fails repeatedly, **content** is used instead."
                   },
                   "headers": {
                     "type": "object",
@@ -3421,7 +3421,7 @@
               "permissions": {
                 "type": "string",
                 "default": "'0o644'",
-                "description": "Optional file permissions to set on ``path`` represented as an octal string '0###'. Default: ``0o644``."
+                "description": "Optional file permissions to set on **path** represented as an octal string '0###'. Default: ``0o644``."
               },
               "encoding": {
                 "type": "string",
@@ -3442,7 +3442,7 @@
               "append": {
                 "type": "boolean",
                 "default": false,
-                "description": "Whether to append ``content`` to existing file if ``path`` exists. Default: ``false``."
+                "description": "Whether to append **content** to existing file if **path** exists. Default: ``false``."
               },
               "defer": {
                 "type": "boolean",

--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -256,23 +256,28 @@ def render_property_template(prop_name, prop_cfg, prefix=""):
 
 def render_nested_properties(prop_cfg, defs, prefix):
     prop_str = ""
+    prop_types = set(["properties", "patternProperties"])
     flatten_schema_refs(prop_cfg, defs)
     if "items" in prop_cfg:
         prop_str += render_nested_properties(prop_cfg["items"], defs, prefix)
-    if not set(["properties", "patternProperties"]).intersection(prop_cfg):
-        return prop_str
-    for prop_name, nested_cfg in prop_cfg.get("properties", {}).items():
-        flatten_schema_all_of(nested_cfg)
-        flatten_schema_refs(nested_cfg, defs)
-        prop_str += render_property_template(prop_name, nested_cfg, prefix)
-        prop_str += render_nested_properties(nested_cfg, defs, prefix + "  ")
-    for prop_name, nested_cfg in prop_cfg.get("patternProperties", {}).items():
-        flatten_schema_all_of(nested_cfg)
-        flatten_schema_refs(nested_cfg, defs)
-        if nested_cfg.get("label"):
-            prop_name = nested_cfg.get("label")
-        prop_str += render_property_template(prop_name, nested_cfg, prefix)
-        prop_str += render_nested_properties(nested_cfg, defs, prefix + "  ")
+        for alt_schema in prop_cfg["items"].get("oneOf", []):
+            if prop_types.intersection(alt_schema):
+                prop_str += render_nested_properties(alt_schema, defs, prefix)
+
+    for hidden_key in prop_cfg.get("hidden", []):
+        prop_cfg.pop(hidden_key, None)
+
+    # Render visible property types
+    for prop_type in prop_types.intersection(prop_cfg):
+        for prop_name, nested_cfg in prop_cfg.get(prop_type, {}).items():
+            flatten_schema_all_of(nested_cfg)
+            flatten_schema_refs(nested_cfg, defs)
+            if nested_cfg.get("label"):
+                prop_name = nested_cfg.get("label")
+            prop_str += render_property_template(prop_name, nested_cfg, prefix)
+            prop_str += render_nested_properties(
+                nested_cfg, defs, prefix + "  "
+            )
     return prop_str
 
 

--- a/doc/rtd/templates/module_property.tmpl
+++ b/doc/rtd/templates/module_property.tmpl
@@ -6,7 +6,17 @@
 {{prefix ~ '  '}}{{ line }}
 {% endfor -%}
 {%- endmacro -%}
-{% if prop_cfg.get('items', {}).get('type') == 'object' %}
-{% set description = description ~ " Each object in **" ~ name ~ "** list supports the following keys:" %}
-{% endif %}
-{{ print_prop(name, types, description, prefix ) }}
+{% set ns = namespace(is_obj_type=false) -%}
+{% if ('properties' in prop_cfg or 'patternProperties' in prop_cfg) %}{% set ns.is_obj_type = true -%}{% endif -%}
+{% for key, val in prop_cfg.get('items', {}).items() -%}
+  {% if key in ('properties', 'patternProperties') -%}{% set ns.is_obj_type = true -%}{% endif -%}
+  {% if key == 'oneOf' -%}
+    {% for oneOf in val -%}
+      {% if ('properties' in oneOf or 'patternProperties' in oneOf ) -%}{% set ns.is_obj_type = true -%}{% endif -%}
+    {% endfor -%}
+  {% endif -%}
+{% endfor -%}
+{% if ns.is_obj_type -%}
+{% set description = description ~ " Each object in **" ~ name ~ "** list supports the following keys:" -%}
+{% endif -%}
+{{ print_prop(name, types, description, prefix ) -}}

--- a/doc/rtd/templates/property_deprecation.tmpl
+++ b/doc/rtd/templates/property_deprecation.tmpl
@@ -1,2 +1,2 @@
 
-{{ '*Deprecated in version ' ~ deprecated_version ~ '.' ~ deprecated_description ~ '*' -}}
+{{ '*Deprecated in version ' ~ deprecated_version ~ ':* ' ~ deprecated_description -}}

--- a/tests/unittests/config/test_cc_ca_certs.py
+++ b/tests/unittests/config/test_cc_ca_certs.py
@@ -390,10 +390,12 @@ class TestCACertsSchema:
             # Valid, yet deprecated schemas
             (
                 {"ca-certs": {"remove-defaults": True}},
-                "Cloud config schema deprecations: ca-certs:  "
-                "Deprecated in version 22.3. Use ``ca_certs`` instead.,"
-                " ca-certs.remove-defaults:  Deprecated in version 22.3"
-                ". Use ``remove_defaults`` instead.",
+                re.escape(
+                    "Cloud config schema deprecations: ca-certs:  "
+                    "Deprecated in version 22.3. Use **ca_certs** instead.,"
+                    " ca-certs.remove-defaults:  Deprecated in version 22.3"
+                    ". Use **remove_defaults** instead."
+                ),
             ),
             # Invalid schemas
             (

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -774,11 +774,11 @@ class TestGrowpartSchema:
                 {"growpart": {"mode": False}},
                 pytest.raises(
                     SchemaValidationError,
-                    match=(
+                    match=re.escape(
                         "Cloud config schema deprecations: "
                         "growpart.mode:  Changed in version 22.3. "
                         "Specifying a boolean ``false`` value for "
-                        "``mode`` is deprecated. Use the string ``'off'`` "
+                        "**mode** is deprecated. Use the string ``'off'`` "
                         "instead."
                     ),
                 ),

--- a/tests/unittests/config/test_cc_grub_dpkg.py
+++ b/tests/unittests/config/test_cc_grub_dpkg.py
@@ -1,5 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
+import re
 from unittest import mock
 
 import pytest
@@ -299,10 +300,10 @@ class TestGrubDpkgSchema:
                 {"grub-dpkg": {"grub-pc/install_devices_empty": False}},
                 pytest.raises(
                     SchemaValidationError,
-                    match=(
+                    match=re.escape(
                         "Cloud config schema deprecations: grub-dpkg:"
                         "  Deprecated in version 22.2. Use "
-                        "``grub_dpkg`` instead."
+                        "**grub_dpkg** instead."
                     ),
                 ),
                 False,

--- a/tests/unittests/config/test_cc_package_update_upgrade_install.py
+++ b/tests/unittests/config/test_cc_package_update_upgrade_install.py
@@ -1,5 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import logging
+import re
 from unittest import mock
 
 import pytest
@@ -299,26 +300,26 @@ class TestPackageUpdateUpgradeSchema:
             ({"packages": []}, SCHEMA_EMPTY_ERROR),
             (
                 {"apt_update": False},
-                (
+                re.escape(
                     "Cloud config schema deprecations: apt_update:  "
                     "Deprecated in version 22.2. "
-                    "Use ``package_update`` instead."
+                    "Use **package_update** instead."
                 ),
             ),
             (
                 {"apt_upgrade": False},
-                (
+                re.escape(
                     "Cloud config schema deprecations: apt_upgrade:  "
                     "Deprecated in version 22.2. "
-                    "Use ``package_upgrade`` instead."
+                    "Use **package_upgrade** instead."
                 ),
             ),
             (
                 {"apt_reboot_if_required": False},
-                (
+                re.escape(
                     "Cloud config schema deprecations: "
                     "apt_reboot_if_required:  Deprecated in version 22.2. Use "
-                    "``package_reboot_if_required`` instead."
+                    "**package_reboot_if_required** instead."
                 ),
             ),
         ],

--- a/tests/unittests/config/test_cc_ubuntu_pro.py
+++ b/tests/unittests/config/test_cc_ubuntu_pro.py
@@ -444,7 +444,7 @@ class TestUbuntuProSchema:
                     SchemaValidationError,
                     match=re.escape(
                         "ubuntu_advantage:  Deprecated in version 24.1."
-                        " Use ``ubuntu_pro`` instead"
+                        " Use **ubuntu_pro** instead"
                     ),
                 ),
                 # If __version__ no longer exists on jsonschema, that means

--- a/tests/unittests/config/test_cc_update_etc_hosts.py
+++ b/tests/unittests/config/test_cc_update_etc_hosts.py
@@ -87,10 +87,10 @@ class TestUpdateEtcHosts:
                 {"manage_etc_hosts": "template"},
                 pytest.raises(
                     SchemaValidationError,
-                    match=(
+                    match=re.escape(
                         "Cloud config schema deprecations: "
                         "manage_etc_hosts:  Changed in version 22.3. "
-                        "Use of ``template`` is deprecated, use "
+                        "Use of **template** is deprecated, use "
                         "``true`` instead."
                     ),
                 ),

--- a/tests/unittests/config/test_cc_users_groups.py
+++ b/tests/unittests/config/test_cc_users_groups.py
@@ -372,9 +372,11 @@ class TestUsersGroupsSchema:
                 pytest.raises(
                     SchemaValidationError,
                     match=(
-                        "Cloud config schema deprecations: "
-                        "users.0.lock-passwd:  Deprecated in version 22.3."
-                        " Use ``lock_passwd`` instead."
+                        re.escape(
+                            "Cloud config schema deprecations: "
+                            "users.0.lock-passwd:  Deprecated in version 22.3."
+                            " Use **lock_passwd** instead."
+                        )
                     ),
                 ),
                 False,
@@ -384,9 +386,11 @@ class TestUsersGroupsSchema:
                 pytest.raises(
                     SchemaValidationError,
                     match=(
-                        "Cloud config schema deprecations: "
-                        "users.0.no-create-home:  Deprecated in version 24.2."
-                        " Use ``no_create_home`` instead."
+                        re.escape(
+                            "Cloud config schema deprecations: "
+                            "users.0.no-create-home:  Deprecated in version"
+                            " 24.2. Use **no_create_home** instead."
+                        )
                     ),
                 ),
                 False,
@@ -527,15 +531,17 @@ class TestUsersGroupsSchema:
                 pytest.raises(
                     SchemaValidationError,
                     match=(
-                        "Cloud config schema deprecations: "
-                        "users.0.ssh-authorized-keys: "
-                        " Deprecated in version 18.3."
-                        " Use ``ssh_authorized_keys`` instead."
-                        ", "
-                        "users.0.uid: "
-                        " Changed in version 22.3."
-                        " The use of ``string`` type is deprecated."
-                        " Use an ``integer`` instead."
+                        re.escape(
+                            "Cloud config schema deprecations: "
+                            "users.0.ssh-authorized-keys: "
+                            " Deprecated in version 18.3."
+                            " Use **ssh_authorized_keys** instead."
+                            ", "
+                            "users.0.uid: "
+                            " Changed in version 22.3."
+                            " The use of ``string`` type is deprecated."
+                            " Use an ``integer`` instead."
+                        )
                     ),
                 ),
                 False,

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -2751,9 +2751,9 @@ class TestHandleSchemaArgs:
                     apt_reboot_if_required: true            # D3
 
                     # Deprecations: -------------
-                    # D1: Deprecated in version 22.2. Use ``package_update`` instead.
-                    # D2: Deprecated in version 22.2. Use ``package_upgrade`` instead.
-                    # D3: Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
+                    # D1: Deprecated in version 22.2. Use **package_update** instead.
+                    # D2: Deprecated in version 22.2. Use **package_upgrade** instead.
+                    # D3: Deprecated in version 22.2. Use **package_reboot_if_required** instead.
 
                     Valid schema {cfg_file}
                     """  # noqa: E501
@@ -2773,9 +2773,9 @@ class TestHandleSchemaArgs:
                     apt_reboot_if_required: true            # D3
 
                     # Deprecations: -------------
-                    # D1: Deprecated in version 22.2. Use ``package_update`` instead.
-                    # D2: Deprecated in version 22.2. Use ``package_upgrade`` instead.
-                    # D3: Deprecated in version 22.2. Use ``package_reboot_if_required`` instead.
+                    # D1: Deprecated in version 22.2. Use **package_update** instead.
+                    # D2: Deprecated in version 22.2. Use **package_upgrade** instead.
+                    # D3: Deprecated in version 22.2. Use **package_reboot_if_required** instead.
 
                     Valid schema {cfg_file}
                     """  # noqa: E501
@@ -2789,9 +2789,9 @@ class TestHandleSchemaArgs:
                     """\
                     Cloud config schema deprecations: \
 apt_reboot_if_required: Deprecated in version 22.2. Use\
- ``package_reboot_if_required`` instead., apt_update: Deprecated in version\
- 22.2. Use ``package_update`` instead., apt_upgrade: Deprecated in version\
- 22.2. Use ``package_upgrade`` instead.\
+ **package_reboot_if_required** instead., apt_update: Deprecated in version\
+ 22.2. Use **package_update** instead., apt_upgrade: Deprecated in version\
+ 22.2. Use **package_upgrade** instead.\
                     Valid schema {cfg_file}
                     """  # noqa: E501
                 ),

--- a/tox.ini
+++ b/tox.ini
@@ -184,6 +184,8 @@ deps = -r{toxinidir}/doc-requirements.txt
 commands =
     {envpython} -m sphinx {posargs:-W doc/rtd doc/rtd_html}
     {envpython} -m doc8 doc/rtd
+passenv =
+    CLOUD_INIT_*
 
 [testenv:doc-spelling]
 deps = -r{toxinidir}/doc-requirements.txt


### PR DESCRIPTION
Fix incorrectly redacted module property documentation for `Users and Groups`  and `Rsyslog` for nested JSON schemas which contain alternative `oneOf` schemas.

The bulk of this work was made easier by adding the ability to debug the rendered RST files to see bogus white-space indentation that sphinx was able to smooth out.

When building docs, a developer/reviewer can now look at individually rendered RST content for any config module with the following environment variable:
```
CLOUD_INIT_DEBUG_MODULE_DOC_FILE=/tmp/doc.cc_rsyslog CLOUD_INIT_DEBUG_MODULE_DOC=cc_rsyslog tox -e doc
``` 

To render all module docs `CLOUD_INIT_DEBUG_MODULE_DOC=all` can be provided instead


## Proposed Commit Message
--- See individual commits


## Additional Context
<!-- If relevant -->

## Test Steps
```
tox -e doc
xdg-open doc/rtd_html/reference/modules.html   # Navigate to rsyslog and "users and groups" schema tabs to compare local render versus public docs for the same schema tabs
```

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
