### PR TITLE
dhcp: add option to use NetworkManager for DHCP discovery

### DIFF
--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -12,7 +12,7 @@ After=systemd-remount-fs.service
 Requires=dbus.socket
 After=dbus.socket
 {% endif %}
-Before=NetworkManager.service
+After=NetworkManager.service
 {% if variant in ["almalinux", "cloudlinux", "rhel"] %}
 Before=network.service
 {% endif %}


### PR DESCRIPTION
Many distros nowadays, especially that the ISC DHCP client got abandoned usptream, ship NetworkManager as their only DHCP client. Allow using it for the init stage networking.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.