### PR TITLE
feat(ec2): Bump url_max_timeout to 240s from 120s.

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -88,7 +88,7 @@ class DataSourceEc2(sources.DataSource):
     ]
 
     # Setup read_url parameters per get_url_params.
-    url_max_wait = 120
+    url_max_wait = 240
     url_timeout = 50
 
     _api_token = None  # API token for accessing the metadata service

--- a/doc/examples/cloud-config-datasources.txt
+++ b/doc/examples/cloud-config-datasources.txt
@@ -9,7 +9,7 @@ datasource:
     # The length in seconds to wait before giving up on the metadata
     # service.  The actual total wait could be up to 
     #   len(resolvable_metadata_urls)*timeout
-    max_wait : 120
+    max_wait : 240
 
     #metadata_url: a list of URLs to check for metadata services
     metadata_urls:

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -74,6 +74,7 @@ garzdin
 giggsoff
 gilbsgilbs
 glyg
+halfdime-code
 hamalq
 hcartiaux
 holmanb


### PR DESCRIPTION


<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [X] I have signed the CLA: https://ubuntu.com/legal/contributors
- [X] I have added my Github username to ``tools/.github-cla-signers``
- [X] I have included a comprehensive commit message using the guide below
- [N/A] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [X] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [N/A] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [X] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(ec2): Bump url_max_timeout to 240s from 120s.
    
Initialization of IMDS is periodically exceeding the 120s limit on
instance launch. Increase the timeout to allow for this variance.
    
Update docs to reflect change.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
This issue was seen during instance launch testing and is inconsistent and difficult to reproduce.
Most of the time, the current timeout is not reached.

``tox -e py3`` was run before and after this change with only hash naming differences.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
