### PR TITLE
fix(actions): doc labeler needs all clause instead of default any

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,7 @@
 documentation:
-- changed-files:
-  - any-glob-to-any-file:
-    - 'doc/*'
-    - 'cloudinit/config/schema/*'
-- base-branch: 'main'
+- all:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'doc/*'
+      - 'cloudinit/config/schema/*'
+  - base-branch: 'main'


### PR DESCRIPTION
## Proposed Commit Message

```
fix(actions): doc labeler needs all clause instead of default any

Unspecified base match in labeler assumes 'any' for each match
clause. When specifying base-branch and --any-glob-to-any-file either
one of these cases would result in a successful match which would label
all PRs again main as documentation. We need to explicitly specify
'all:' in our labeler match config to ensure BOTH:

- matching file paths related to documentation
      -AND-
- targeting a merge against 'main' branch
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

labeler github action appears to have when being triggered by 'old' repo .github/workflow state which results in this PR's documentation label being added. To test this without concern for interaction with prior .github/workflow state, I was able to change the `documentation:` label in .github/labeler.yml to some other label `invalid:` and put up a pull request again my local repo's `main` to ensure invalid was only added when my PR also included a change to cloudinit/config/schemas/schema-cloud-config-v1.json.



## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
