### PR TITLE
fix: Integration tests

### DIFF
--- a/tests/integration_tests/test_instance_id.py
+++ b/tests/integration_tests/test_instance_id.py
@@ -6,6 +6,7 @@ from pycloudlib.lxd.instance import LXDInstance
 from cloudinit import subp
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
+from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
 
 _INSTANCE_ID = 0
 
@@ -26,7 +27,7 @@ def setup_meta_data(instance: LXDInstance):
 
 # class TestInstanceID:
 @pytest.mark.skipif(
-    PLATFORM not in ["lxd_container", "lxd_vm"],
+    PLATFORM not in ["lxd_container", "lxd_vm"] or CURRENT_RELEASE == FOCAL,
     reason="Uses lxd-specific behavior.",
 )
 @pytest.mark.lxd_setup.with_args(setup_meta_data)

--- a/tests/integration_tests/test_kernel_command_line_match.py
+++ b/tests/integration_tests/test_kernel_command_line_match.py
@@ -104,8 +104,8 @@ def test_lxd_datasource_kernel_override_nocloud_net(
         )
         assert url_val in client.execute("cloud-init query subplatform").stdout
         assert (
-            "Detected platform: DataSourceNoCloudNet [seed=None]"
-            "[dsmode=net]. Checking for active instance data"
+            "Detected platform: DataSourceNoCloudNet. Checking for active"
+            "instance data"
         ) in logs
 
 


### PR DESCRIPTION
String output changed in 7703634ec0.
Instance-id doesn't change on LXD / Focal.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Integration tests

String output changed in 7703634ec0.
Instance-id doesn't change on LXD / Focal.
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-lxd_container/lastCompletedBuild/testReport/tests.integration_tests/test_instance_id/test_instance_id_changes/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
