### PR TITLE
feat: Return error in `cloud-init status` if stage not run

### DIFF
--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from cloudinit import safeyaml, subp
 from cloudinit.cmd.devel import read_cfg_paths
+from cloudinit.cmd.main import STAGE_NAME
 from cloudinit.distros import uses_systemd
 from cloudinit.helpers import Paths
 from cloudinit.util import get_cmdline, load_json, load_text_file
@@ -430,6 +431,15 @@ def get_latest_event(status_v1):
     return latest_event
 
 
+def get_not_started_errors(status_v1) -> List[str]:
+    """Return a list of errors from status_v1 that are not started."""
+    return [
+        f"Failed to start stage: {stage_name}"
+        for stage_name, stage_info in status_v1.items()
+        if stage_name in STAGE_NAME.keys() and stage_info.get("start") is None
+    ]
+
+
 def get_errors(status_v1) -> Tuple[List, Dict]:
     """Return a list of errors and recoverable_errors from status_v1."""
     errors = []
@@ -451,6 +461,7 @@ def get_errors(status_v1) -> Tuple[List, Dict]:
                     recoverable_errors[err_type].extend(
                         current_recoverable_errors[err_type]
                     )
+    errors.extend(get_not_started_errors(status_v1)) 
     return errors, recoverable_errors
 
 

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -355,10 +355,12 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                         "blah": {"finished": 123.456},
                         "init": {
                             "errors": [],
-                            "start": 124.567,
-                            "finished": 125.678,
+                            "start": 12.3,
+                            "finished": 12.4,
                         },
-                        "init-local": {"start": 123.45, "finished": 123.46},
+                        "init-local": {"start": 12.1, "finished": 12.2},
+                        "modules-config": {"start": 12.5, "finished": 12.6},
+                        "modules-final": {"start": 12.7, "finished": 12.8},
                     }
                 },
                 None,
@@ -379,8 +381,10 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                             "[seed=/var/.../seed/nocloud-net]"
                             "[dsmode=net]"
                         ),
-                        "init": {"start": 124.567, "finished": 125.678},
-                        "init-local": {"start": 123.45, "finished": 123.46},
+                        "init": {"start": 12.3, "finished": 12.4},
+                        "init-local": {"start": 12.1, "finished": 12.2},
+                        "modules-config": {"start": 12.5, "finished": 12.6},
+                        "modules-final": {"start": 12.7, "finished": 12.8},
                     }
                 },
                 None,
@@ -391,7 +395,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     status: done
                     extended_status: done
                     boot_status_code: enabled-by-generator
-                    last_update: Thu, 01 Jan 1970 00:02:05 +0000
+                    last_update: Thu, 01 Jan 1970 00:00:12 +0000
                     detail: DataSourceNoCloud [seed=/var/.../seed/nocloud-net][dsmode=net]
                     errors: []
                     recoverable_errors: {}
@@ -409,10 +413,12 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                         "blah": {"errors": [], "finished": 123.456},
                         "init": {
                             "errors": ["error1"],
-                            "start": 124.567,
-                            "finished": 125.678,
+                            "start": 12.3,
+                            "finished": 12.4,
                         },
-                        "init-local": {"start": 123.45, "finished": 123.46},
+                        "init-local": {"start": 12.1, "finished": 12.2},
+                        "modules-config": {"start": 12.5, "finished": 12.6},
+                        "modules-final": {"start": 12.7, "finished": 12.8},
                     }
                 },
                 None,
@@ -420,6 +426,29 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 1,
                 "status: error\n",
                 id="on_errors",
+            ),
+            # Reports error when any stage not present.
+            pytest.param(
+                lambda config: config.result_file,
+                status.EnabledStatus.ENABLED_BY_GENERATOR,
+                {
+                    "v1": {
+                        "stage": None,
+                        "init": {
+                            "errors": [],
+                            "start": None,
+                            "finished": None,
+                        },
+                        "init-local": {"start": 12.1, "finished": 12.2},
+                        "modules-config": {"start": 12.5, "finished": 12.6},
+                        "modules-final": {"start": 12.7, "finished": 12.8},
+                    }
+                },
+                None,
+                MyArgs(long=False, wait=False, format="tabular"),
+                1,
+                "status: error\n",
+                id="missing_stage_error",
             ),
             # Long format of error status includes all error messages.
             pytest.param(
@@ -797,6 +826,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 "stage": None,
                 "init": {"start": 124.456, "finished": 125.678},
                 "init-local": {"start": 123.45, "finished": 123.46},
+                "modules-config": {"start": 123.56, "finished": 123.57},
+                "modules-final": {"start": 123.67, "finished": 123.68},
             }
         }
 


### PR DESCRIPTION
In draft state as I'm looking for feedback and still needs test updates.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat: Return error in `cloud-init status` if stage not run

Fixes GH-5304
```

## Additional Context
The original issue in `GH-5304` was not reproducible on current versions of cloud-init. Since that version of cloud-init, we've updated our status checking to only be running if [`status.json` exists but `results.json` doesn't exist](https://github.com/canonical/cloud-init/blob/d15a7704b6e1317b1fa186667085372c69e6f586/cloudinit/cmd/status.py#L374), and checking systemd status can only change cloud-init status [from RUNNING to ERROR](https://github.com/canonical/cloud-init/blob/d15a7704b6e1317b1fa186667085372c69e6f586/cloudinit/cmd/status.py#L501) rather than the previous code that [could change status back to RUNNING](https://github.com/canonical/cloud-init/blob/781f77c2f673189bba81df2d0d9acd231972bc78/cloudinit/cmd/status.py#L362).

So instead I addressed this comment:
`Long term cloud-init status should return a fatal error code and indicate this issue`

Thinking about it more though, I'm not actually sure we want this behavior, and if we do it probably shouldn't be applied to existing releases. While the supported cloud-init path is to run all 4 services, we have seen numerous use cases where people do things we wouldn't endorse. Amazon Linux completely removing cloud-init-local.service comes to mind. I'm not proposing we officially support those use cases, but I'm also not sure it makes sense to declare there was an error when the lack of a service running may have been intended behavior and technically nothing "bad" happened.

This PR makes it error to have not run one of the stages. After masking cloud-init-local.service and cloud-init.service, I get these results:
```
root@me:~# cloud-init status --long
status: error
extended_status: error - done
boot_status_code: enabled-by-generator
last_update: Thu, 01 Jan 1970 00:00:02 +0000
detail: Cloud-init enabled by systemd cloud-init-generator
errors:
	- Failed to start stage: init
	- Failed to start stage: init-local
recoverable_errors:
WARNING:
	- Failed to write boot finished file /var/lib/cloud/instance/boot-finished
	- Used fallback datasource
```

```
root@me:~# cloud-init status --format json
{
  "boot_status_code": "enabled-by-generator",
  "datasource": null,
  "detail": "Cloud-init enabled by systemd cloud-init-generator",
  "errors": [
    "Failed to start stage: init",
    "Failed to start stage: init-local"
  ],
  "extended_status": "error - done",
  "init": {
    "errors": [],
    "finished": null,
    "recoverable_errors": {},
    "start": null
  },
  "init-local": {
    "errors": [],
    "finished": null,
    "recoverable_errors": {},
    "start": null
  },
  "last_update": "Thu, 01 Jan 1970 00:00:02 +0000",
  "modules-config": {
    "errors": [],
    "finished": 2.23,
    "recoverable_errors": {},
    "start": 2.12
  },
  "modules-final": {
    "errors": [],
    "finished": 2.5,
    "recoverable_errors": {
      "WARNING": [
        "Failed to write boot finished file /var/lib/cloud/instance/boot-finished",
        "Used fallback datasource"
      ]
    },
    "start": 2.44
  },
  "recoverable_errors": {
    "WARNING": [
      "Failed to write boot finished file /var/lib/cloud/instance/boot-finished",
      "Used fallback datasource"
    ]
  },
  "stage": null,
  "status": "error"
}
```
(the timestamps are related to my environment and not an issue)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
