### PR TITLE
fix: nocloud no fail when network-config absent

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -481,7 +481,8 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.DEBUG)
     seedfrom = argv[1]
-    md_seed, ud, vd = util.read_seeded(seedfrom)
+    md_seed, ud, vd, network = util.read_seeded(seedfrom)
     print(f"seeded: {md_seed}")
     print(f"ud: {ud}")
     print(f"vd: {vd}")
+    print(f"network: {network}")

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1069,12 +1069,16 @@ def read_seeded(base="", ext="", timeout=5, retries=10):
         vd_url = "%s%s%s" % (base, "vendor-data", ext)
         md_url = "%s%s%s" % (base, "meta-data", ext)
         network_url = "%s%s%s" % (base, "network-config", ext)
-    network_resp = url_helper.read_file_or_url(
-        network_url, timeout=timeout, retries=retries
-    )
     network = None
-    if network_resp.ok():
-        network = load_yaml(network_resp.contents)
+    try:
+        network_resp = url_helper.read_file_or_url(
+            network_url, timeout=timeout, retries=retries
+        )
+    except url_helper.UrlError as e:
+        LOG.debug("No network config provided: %s", e)
+    else:
+        if network_resp.ok():
+            network = load_yaml(network_resp.contents)
     md_resp = url_helper.read_file_or_url(
         md_url, timeout=timeout, retries=retries
     )


### PR DESCRIPTION
## Proposed Commit Message
```
Commit 5322dca2 introduced an assumption to read_seeded that
network-config must always be present for NoCloud datasource.
Since it is still considered and optional supplemental configuration
allow the read_seeed calls to succeed in the absence of network-config.

Avoids failures seen in tests/integration-tests/datasources/test_nocloud.py::
  test_nocloud_seedfrom_vendordata
```

## Additional Context

## Test Steps
Failing integration test without this changeset
```
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_PLATFORM=lxd_container tox -e integration-tests -- tests/integration_tests/datasources/test_nocloud.py::test_nocloud_seedfrom_vendordata
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
