### PR TITLE
fix: Update default LXD meta-data with user meta-data

### DIFF
--- a/cloudinit/sources/DataSourceLXD.py
+++ b/cloudinit/sources/DataSourceLXD.py
@@ -210,8 +210,8 @@ class DataSourceLXD(sources.DataSource):
         config = self._crawled_metadata.get("config", {})
         user_metadata = config.get("user.meta-data", {})
         if user_metadata:
-            user_metadata = _raw_instance_data_to_dict(
-                "user.meta-data", user_metadata
+            self.metadata.update(
+                _raw_instance_data_to_dict("user.meta-data", user_metadata)
             )
         if "user-data" in self._crawled_metadata:
             self.userdata_raw = self._crawled_metadata["user-data"]


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Update default LXD meta-data with user meta-data

This was previously unnecessary because:

a. LXD automatically appends the user.meta-data key to default meta-data.
b. In the presence of duplicate keys, PyYAML uses the last key.

This change is part of a series of changes that will enable cloud-init to
avoid depending on undefined behavior. In the future LXD may stop appending
user-defined meta-data to its default meta-data. This change makes
cloud-init forward compatible to LXD for when that change is implemented.

GH-5575
```

## Additional context

Fixes https://github.com/canonical/cloud-init/issues/5575.
Should make cloud-init forward compatible with LXD changes which might be made to address https://github.com/canonical/lxd/issues/13853


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
