### PR TITLE
fix: Fix integration test failures

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -140,6 +140,8 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     user=user,
                     passwd=url_parts.password or "",
                 )
+                LOG.debug("Creating a secure connection")
+                ftp_tls.prot_p()
             except ftplib.error_perm as e:
                 LOG.warning(
                     "Attempted to connect to an insecure ftp server but used "
@@ -156,26 +158,13 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     headers=None,
                     url=url,
                 ) from e
-            LOG.debug("Creating a secure connection")
-            ftp_tls.prot_p()
-            LOG.debug("Reading file: %s", url_parts.path)
-            ftp_tls.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
-
-            response = FtpResponse(buffer.getvalue(), url)
-            LOG.debug("Closing connection")
-            ftp_tls.close()
-            return response
-        else:
             try:
-                ftp = ftplib.FTP()
-                LOG.debug(
-                    "Attempting to connect to %s via port %s.", url, port
+                LOG.debug("Reading file: %s", url_parts.path)
+                ftp_tls.retrbinary(
+                    f"RETR {url_parts.path}", callback=buffer.write
                 )
-                ftp.connect(
-                    host=url_parts.hostname,
-                    port=port,
-                    timeout=timeout or 5.0,  # uses float internally
-                )
+
+                return FtpResponse(buffer.getvalue(), url)
             except ftplib.all_errors as e:
                 code = ftp_get_return_code_from_exception(e)
                 raise UrlError(
@@ -187,17 +176,42 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     headers=None,
                     url=url,
                 ) from e
-            LOG.debug("Attempting to login with user [%s]", user)
-            ftp.login(
-                user=user,
-                passwd=url_parts.password or "",
-            )
-            LOG.debug("Reading file: %s", url_parts.path)
-            ftp.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
-            response = FtpResponse(buffer.getvalue(), url)
-            LOG.debug("Closing connection")
-            ftp.close()
-            return response
+            finally:
+                LOG.debug("Closing connection")
+                ftp_tls.close()
+        else:
+            try:
+                ftp = ftplib.FTP()
+                LOG.debug(
+                    "Attempting to connect to %s via port %s.", url, port
+                )
+                ftp.connect(
+                    host=url_parts.hostname,
+                    port=port,
+                    timeout=timeout or 5.0,  # uses float internally
+                )
+                LOG.debug("Attempting to login with user [%s]", user)
+                ftp.login(
+                    user=user,
+                    passwd=url_parts.password or "",
+                )
+                LOG.debug("Reading file: %s", url_parts.path)
+                ftp.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
+                return FtpResponse(buffer.getvalue(), url)
+            except ftplib.all_errors as e:
+                code = ftp_get_return_code_from_exception(e)
+                raise UrlError(
+                    cause=(
+                        "Reading file from ftp server"
+                        f" failed for url {url} [{code}]"
+                    ),
+                    code=code,
+                    headers=None,
+                    url=url,
+                ) from e
+            finally:
+                LOG.debug("Closing connection")
+                ftp.close()
 
 
 def _read_file(path: str, **kwargs) -> "FileResponse":

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -267,6 +267,8 @@ class TestFTP:
                 #!/usr/bin/python3
                 import logging
 
+                from systemd.daemon import notify
+
                 from pyftpdlib.authorizers import DummyAuthorizer
                 from pyftpdlib.handlers import FTPHandler, TLS_FTPHandler
                 from pyftpdlib.servers import FTPServer
@@ -297,6 +299,9 @@ class TestFTP:
                 handler.authorizer = authorizer
                 handler.abstracted_fs = UnixFilesystem
                 server = FTPServer(("localhost", 2121), handler)
+
+                # tell systemd to proceed
+                notify("READY=1")
 
                 # start the ftp server
                 server.serve_forever()
@@ -357,7 +362,7 @@ class TestFTP:
                 Before=cloud-init-network.service
 
                 [Service]
-                Type=exec
+                Type=notify
                 ExecStart=/server.py
 
                 [Install]

--- a/tests/integration_tests/test_kernel_command_line_match.py
+++ b/tests/integration_tests/test_kernel_command_line_match.py
@@ -103,10 +103,7 @@ def test_lxd_datasource_kernel_override_nocloud_net(
             == client.execute("cloud-init query platform").stdout.strip()
         )
         assert url_val in client.execute("cloud-init query subplatform").stdout
-        assert (
-            "Detected platform: DataSourceNoCloudNet. Checking for active"
-            "instance data"
-        ) in logs
+        assert "Detected DataSourceNoCloudNet" in logs
 
 
 @pytest.mark.skipif(PLATFORM != "lxd_vm", reason="Modifies grub config")
@@ -116,7 +113,7 @@ def test_lxd_disable_cloud_init_cmdline(client: IntegrationInstance):
 
     override_kernel_command_line("cloud-init=disabled", client)
     assert "Active: inactive (dead)" in client.execute(
-        "systemctl status cloud-init"
+        "systemctl status cloud-init.target"
     )
 
 
@@ -128,7 +125,7 @@ def test_lxd_disable_cloud_init_file(client: IntegrationInstance):
     client.execute("cloud-init --clean")
     client.restart()
     assert "Active: inactive (dead)" in client.execute(
-        "systemctl status cloud-init"
+        "systemctl status cloud-init.target"
     )
 
 
@@ -142,5 +139,5 @@ def test_lxd_disable_cloud_init_env(client: IntegrationInstance):
     client.execute("cloud-init --clean")
     client.restart()
     assert "Active: inactive (dead)" in client.execute(
-        "systemctl status cloud-init"
+        "systemctl status cloud-init.target"
     )


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->


## Additional Context

tests fixed:

https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests/test_kernel_command_line_match/test_lxd_datasource_kernel_override_nocloud_net_ds_nocloud_net_s_https___raw_githubusercontent_com_canonical_cloud_init_main_tests_data_kernel_cmdline_match__/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests.datasources.test_nocloud/TestFTP/test_nocloud_ftp_unencrypted_server_succeeds/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests.datasources.test_nocloud/TestFTP/test_nocloud_ftps_encrypted_server_succeeds/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests.datasources.test_nocloud/TestFTP/test_nocloud_ftp_encrypted_server_fails/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests/test_kernel_command_line_match/test_lxd_disable_cloud_init_cmdline/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests/test_kernel_command_line_match/test_lxd_disable_cloud_init_file/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests/test_kernel_command_line_match/test_lxd_disable_cloud_init_env/
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/lastCompletedBuild/testReport/tests.integration_tests.datasources.test_nocloud/TestFTP/test_nocloud_ftps_unencrypted_server_fails/              

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
