### PR TITLE
fix: read_optional_seed to set network-config when present

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -973,7 +973,7 @@ def read_optional_seed(fill, base="", ext="", timeout=5):
         fill["user-data"] = ud
         fill["vendor-data"] = vd
         fill["meta-data"] = md
-        fill["network-config"] = md
+        fill["network-config"] = network
         return True
     except url_helper.UrlError as e:
         if e.code == url_helper.NOT_FOUND:


### PR DESCRIPTION
## Proposed Commit Message

```
    fix: read_optional_seed to set network-config when present
    
    Commit 5322dca2f added network-config support to nocloud's
    read_optional_seed function. It persisted meta-data as
    network-config. Add tests and fix to track network-config value.
```

## Additional Context

## Test Steps


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
