### PR TITLE
Ubuntu/jammy

### DIFF
--- a/cloudinit/distros/package_management/snap.py
+++ b/cloudinit/distros/package_management/snap.py
@@ -35,4 +35,23 @@ class Snap(PackageManager):
 
     @staticmethod
     def upgrade_packages():
-        subp.subp(["snap", "refresh"])
+        command = ["snap", "get", "system", "-d"]
+        snap_hold = None
+        try:
+            result = subp.subp(command)
+            snap_hold = (
+                util.load_json(result.stdout).get("refresh", {}).get("hold")
+            )
+        except subp.ProcessExecutionError as e:
+            LOG.info(
+                "Continuing to snap refresh. Unable to run command: %s: %s",
+                command,
+                e,
+            )
+        if snap_hold == "forever":
+            LOG.info(
+                "Skipping snap refresh because refresh.hold is set to '%s'",
+                snap_hold,
+            )
+        else:
+            subp.subp(["snap", "refresh"])

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -140,6 +140,8 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     user=user,
                     passwd=url_parts.password or "",
                 )
+                LOG.debug("Creating a secure connection")
+                ftp_tls.prot_p()
             except ftplib.error_perm as e:
                 LOG.warning(
                     "Attempted to connect to an insecure ftp server but used "
@@ -156,26 +158,13 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     headers=None,
                     url=url,
                 ) from e
-            LOG.debug("Creating a secure connection")
-            ftp_tls.prot_p()
-            LOG.debug("Reading file: %s", url_parts.path)
-            ftp_tls.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
-
-            response = FtpResponse(buffer.getvalue(), url)
-            LOG.debug("Closing connection")
-            ftp_tls.close()
-            return response
-        else:
             try:
-                ftp = ftplib.FTP()
-                LOG.debug(
-                    "Attempting to connect to %s via port %s.", url, port
+                LOG.debug("Reading file: %s", url_parts.path)
+                ftp_tls.retrbinary(
+                    f"RETR {url_parts.path}", callback=buffer.write
                 )
-                ftp.connect(
-                    host=url_parts.hostname,
-                    port=port,
-                    timeout=timeout or 5.0,  # uses float internally
-                )
+
+                return FtpResponse(buffer.getvalue(), url)
             except ftplib.all_errors as e:
                 code = ftp_get_return_code_from_exception(e)
                 raise UrlError(
@@ -187,17 +176,42 @@ def read_ftps(url: str, timeout: float = 5.0, **kwargs: dict) -> "FtpResponse":
                     headers=None,
                     url=url,
                 ) from e
-            LOG.debug("Attempting to login with user [%s]", user)
-            ftp.login(
-                user=user,
-                passwd=url_parts.password or "",
-            )
-            LOG.debug("Reading file: %s", url_parts.path)
-            ftp.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
-            response = FtpResponse(buffer.getvalue(), url)
-            LOG.debug("Closing connection")
-            ftp.close()
-            return response
+            finally:
+                LOG.debug("Closing connection")
+                ftp_tls.close()
+        else:
+            try:
+                ftp = ftplib.FTP()
+                LOG.debug(
+                    "Attempting to connect to %s via port %s.", url, port
+                )
+                ftp.connect(
+                    host=url_parts.hostname,
+                    port=port,
+                    timeout=timeout or 5.0,  # uses float internally
+                )
+                LOG.debug("Attempting to login with user [%s]", user)
+                ftp.login(
+                    user=user,
+                    passwd=url_parts.password or "",
+                )
+                LOG.debug("Reading file: %s", url_parts.path)
+                ftp.retrbinary(f"RETR {url_parts.path}", callback=buffer.write)
+                return FtpResponse(buffer.getvalue(), url)
+            except ftplib.all_errors as e:
+                code = ftp_get_return_code_from_exception(e)
+                raise UrlError(
+                    cause=(
+                        "Reading file from ftp server"
+                        f" failed for url {url} [{code}]"
+                    ),
+                    code=code,
+                    headers=None,
+                    url=url,
+                ) from e
+            finally:
+                LOG.debug("Closing connection")
+                ftp.close()
 
 
 def _read_file(path: str, **kwargs) -> "FileResponse":

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -973,7 +973,7 @@ def read_optional_seed(fill, base="", ext="", timeout=5):
         fill["user-data"] = ud
         fill["vendor-data"] = vd
         fill["meta-data"] = md
-        fill["network-config"] = md
+        fill["network-config"] = network
         return True
     except url_helper.UrlError as e:
         if e.code == url_helper.NOT_FOUND:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,12 +1,10 @@
 cloud-init (24.2-0ubuntu1~22.04.2) UNRELEASED; urgency=medium
 
-  * Upstream snapshot based on upstream/main at f93a6b5a.
+  * d/p/no-single-process.patch: Remove single process optimization
+  * d/p/no-nocloud-network.patch: Remove nocloud network feature
   * refresh patches:
     - d/p/cli-retain-file-argument-as-main-cmd-arg.patch
     - d/p/revert-551f560d-cloud-config-after-snap-seeding.patch
-  * refresh patches:
-    - d/p/no-nocloud-network.patch
-    - d/p/no-single-process.patch
   * Upstream snapshot based on upstream/main at edd92b71.
 
  -- Chad Smith <chad.smith@canonical.com>  Wed, 07 Aug 2024 16:36:13 -0600
@@ -15,8 +13,6 @@ cloud-init (24.2-0ubuntu1~22.04.1) jammy; urgency=medium
 
   * d/control: remove netifaces due to GH-4634
   * d/p/deprecation-version-boundary.patch: Pin deprecation version to 22.1
-  * d/p/no-single-process.patch: Remove single process optimization
-  * d/p/no-nocloud-network.patch: Remove nocloud network feature
   * drop d/p/do-not-block-user-login.patch: upstream 4981ea9 now orders
     cloud-init.service Before=systemd-user-sessions.service
   * refresh patches:

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,8 +4,12 @@ cloud-init (24.2-0ubuntu1~22.04.2) UNRELEASED; urgency=medium
   * refresh patches:
     - d/p/cli-retain-file-argument-as-main-cmd-arg.patch
     - d/p/revert-551f560d-cloud-config-after-snap-seeding.patch
+  * refresh patches:
+    - d/p/no-nocloud-network.patch
+    - d/p/no-single-process.patch
+  * Upstream snapshot based on upstream/main at edd92b71.
 
- -- James Falcon <james.falcon@canonical.com>  Tue, 06 Aug 2024 12:36:24 -0500
+ -- Chad Smith <chad.smith@canonical.com>  Wed, 07 Aug 2024 16:36:13 -0600
 
 cloud-init (24.2-0ubuntu1~22.04.1) jammy; urgency=medium
 

--- a/debian/patches/no-nocloud-network.patch
+++ b/debian/patches/no-nocloud-network.patch
@@ -7,20 +7,118 @@ Last-Update: 2024-08-02
 
 --- a/cloudinit/sources/DataSourceNoCloud.py
 +++ b/cloudinit/sources/DataSourceNoCloud.py
-@@ -190,7 +190,7 @@ class DataSourceNoCloud(sources.DataSour
- 
-             # This could throw errors, but the user told us to do it
-             # so if errors are raised, let them raise
--            md_seed, ud, vd, network = util.read_seeded(seedfrom, timeout=None)
-+            md_seed, ud, vd, _ = util.read_seeded(seedfrom, timeout=None)
-             LOG.debug("Using seeded cache data from %s", seedfrom)
- 
-             # Values in the command line override those from the seed
-@@ -199,7 +199,6 @@ class DataSourceNoCloud(sources.DataSour
+@@ -199,7 +199,7 @@
              )
              mydata["user-data"] = ud
              mydata["vendor-data"] = vd
 -            mydata["network-config"] = network
++            mydata["network-config"] = None
              found.append(seedfrom)
  
          # Now that we have exhausted any other places merge in the defaults
+--- a/cloudinit/util.py
++++ b/cloudinit/util.py
+@@ -1059,7 +1059,6 @@
+         ud_url = base.replace("%s", "user-data" + ext)
+         vd_url = base.replace("%s", "vendor-data" + ext)
+         md_url = base.replace("%s", "meta-data" + ext)
+-        network_url = base.replace("%s", "network-config" + ext)
+     else:
+         if features.NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH:
+             if base[-1] != "/" and parse.urlparse(base).query == "":
+@@ -1068,17 +1067,7 @@
+         ud_url = "%s%s%s" % (base, "user-data", ext)
+         vd_url = "%s%s%s" % (base, "vendor-data", ext)
+         md_url = "%s%s%s" % (base, "meta-data", ext)
+-        network_url = "%s%s%s" % (base, "network-config", ext)
+     network = None
+-    try:
+-        network_resp = url_helper.read_file_or_url(
+-            network_url, timeout=timeout, retries=retries
+-        )
+-    except url_helper.UrlError as e:
+-        LOG.debug("No network config provided: %s", e)
+-    else:
+-        if network_resp.ok():
+-            network = load_yaml(network_resp.contents)
+     md_resp = url_helper.read_file_or_url(
+         md_url, timeout=timeout, retries=retries
+     )
+--- a/tests/unittests/test_util.py
++++ b/tests/unittests/test_util.py
+@@ -2481,7 +2481,7 @@
+                 {
+                     "meta-data": {"md": "val"},
+                     "user-data": b"ud",
+-                    "network-config": {"net": "cfg"},
++                    "network-config": None,
+                     "vendor-data": None,
+                 },
+                 True,
+@@ -2536,7 +2536,7 @@
+         assert found_md == {"key1": "val1"}
+         assert found_ud == ud
+         assert found_vd == vd
+-        assert found_network == {"test": "true"}
++        assert found_network is None
+ 
+     @pytest.mark.parametrize(
+         "base, feature_flag, req_urls",
+@@ -2545,7 +2545,6 @@
+                 "http://10.0.0.1/%s?qs=1",
+                 True,
+                 [
+-                    "http://10.0.0.1/network-config?qs=1",
+                     "http://10.0.0.1/meta-data?qs=1",
+                     "http://10.0.0.1/user-data?qs=1",
+                     "http://10.0.0.1/vendor-data?qs=1",
+@@ -2556,7 +2555,6 @@
+                 "https://10.0.0.1:8008/",
+                 True,
+                 [
+-                    "https://10.0.0.1:8008/network-config",
+                     "https://10.0.0.1:8008/meta-data",
+                     "https://10.0.0.1:8008/user-data",
+                     "https://10.0.0.1:8008/vendor-data",
+@@ -2567,7 +2565,6 @@
+                 "https://10.0.0.1:8008",
+                 True,
+                 [
+-                    "https://10.0.0.1:8008/network-config",
+                     "https://10.0.0.1:8008/meta-data",
+                     "https://10.0.0.1:8008/user-data",
+                     "https://10.0.0.1:8008/vendor-data",
+@@ -2578,7 +2575,6 @@
+                 "https://10.0.0.1:8008",
+                 False,
+                 [
+-                    "https://10.0.0.1:8008network-config",
+                     "https://10.0.0.1:8008meta-data",
+                     "https://10.0.0.1:8008user-data",
+                     "https://10.0.0.1:8008vendor-data",
+@@ -2589,7 +2585,6 @@
+                 "https://10.0.0.1:8008?qs=",
+                 True,
+                 [
+-                    "https://10.0.0.1:8008?qs=network-config",
+                     "https://10.0.0.1:8008?qs=meta-data",
+                     "https://10.0.0.1:8008?qs=user-data",
+                     "https://10.0.0.1:8008?qs=vendor-data",
+@@ -2628,7 +2623,7 @@
+         # user-data, vendor-data read raw. It could be scripts or other format
+         assert found_ud == "/user-data: 1"
+         assert found_vd == "/vendor-data: 1"
+-        assert found_network == {"/network-config": 1}
++        assert found_network is None
+         assert [
+             mock.call(req_url, timeout=5, retries=10) for req_url in req_urls
+         ] == m_read.call_args_list
+@@ -2658,7 +2653,7 @@
+         self.assertEqual(found_md, {"key1": "val1"})
+         self.assertEqual(found_ud, ud)
+         self.assertEqual(found_vd, vd)
+-        self.assertEqual(found_network, {"test": "true"})
++        self.assertIsNone(found_network)
+ 
+ 
+ class TestEncode(helpers.TestCase):

--- a/debian/patches/no-nocloud-network.patch
+++ b/debian/patches/no-nocloud-network.patch
@@ -7,7 +7,7 @@ Last-Update: 2024-08-02
 
 --- a/cloudinit/sources/DataSourceNoCloud.py
 +++ b/cloudinit/sources/DataSourceNoCloud.py
-@@ -190,7 +190,7 @@
+@@ -190,7 +190,7 @@ class DataSourceNoCloud(sources.DataSour
  
              # This could throw errors, but the user told us to do it
              # so if errors are raised, let them raise
@@ -16,7 +16,7 @@ Last-Update: 2024-08-02
              LOG.debug("Using seeded cache data from %s", seedfrom)
  
              # Values in the command line override those from the seed
-@@ -199,7 +199,6 @@
+@@ -199,7 +199,6 @@ class DataSourceNoCloud(sources.DataSour
              )
              mydata["user-data"] = ud
              mydata["vendor-data"] = vd

--- a/debian/patches/no-single-process.patch
+++ b/debian/patches/no-single-process.patch
@@ -6,7 +6,7 @@ Last-Update: 2024-08-02
 
 --- a/systemd/cloud-config.service.tmpl
 +++ b/systemd/cloud-config.service.tmpl
-@@ -10,14 +10,7 @@
+@@ -10,14 +10,7 @@ ConditionEnvironment=!KERNEL_CMDLINE=clo
  
  [Service]
  Type=oneshot
@@ -24,7 +24,7 @@ Last-Update: 2024-08-02
  
 --- a/systemd/cloud-final.service.tmpl
 +++ b/systemd/cloud-final.service.tmpl
-@@ -15,16 +15,10 @@
+@@ -15,16 +15,10 @@ ConditionEnvironment=!KERNEL_CMDLINE=clo
  
  [Service]
  Type=oneshot
@@ -45,7 +45,7 @@ Last-Update: 2024-08-02
  ExecStartPost=/bin/sh -c 'u=NetworkManager.service; \
 --- a/systemd/cloud-init-local.service.tmpl
 +++ b/systemd/cloud-init-local.service.tmpl
-@@ -7,6 +7,7 @@
+@@ -7,6 +7,7 @@ DefaultDependencies=no
  {% endif %}
  Wants=network-pre.target
  After=hv_kvp_daemon.service
@@ -53,7 +53,7 @@ Last-Update: 2024-08-02
  {% if variant in ["almalinux", "cloudlinux", "rhel"] %}
  Requires=dbus.socket
  After=dbus.socket
-@@ -37,14 +38,7 @@
+@@ -37,14 +38,7 @@ ExecStartPre=/bin/mkdir -p /run/cloud-in
  ExecStartPre=/sbin/restorecon /run/cloud-init
  ExecStartPre=/usr/bin/touch /run/cloud-init/enabled
  {% endif %}

--- a/doc/module-docs/cc_package_update_upgrade_install/data.yaml
+++ b/doc/module-docs/cc_package_update_upgrade_install/data.yaml
@@ -1,13 +1,16 @@
 cc_package_update_upgrade_install:
   description: |
     This module allows packages to be updated, upgraded or installed during
-    boot. If any packages are to be installed or an upgrade is to be performed
-    then the package cache will be updated first. If a package installation or
-    upgrade requires a reboot, then a reboot can be performed if
-    ``package_reboot_if_required`` is specified.
+    boot using any available package manager present on a system such as apt,
+    pkg, snap, yum or zypper. If any packages are to be installed or an upgrade
+    is to be performed then the package cache will be updated first. If a
+    package installation or upgrade requires a reboot, then a reboot can be
+    performed if ``package_reboot_if_required`` is specified.
   examples:
   - comment: |
       Example 1:
     file: cc_package_update_upgrade_install/example1.yaml
+  - comment: "By default, ``package_upgrade: true`` performs upgrades on any installed package manager. To avoid calling ``snap refresh`` in images with snap installed, set snap refresh.hold to ``forever`` will prevent cloud-init's snap interaction during any boot"
+    file: cc_package_update_upgrade_install/example2.yaml
   name: Package Update Upgrade Install
   title: Update, upgrade, and install packages

--- a/doc/module-docs/cc_package_update_upgrade_install/example2.yaml
+++ b/doc/module-docs/cc_package_update_upgrade_install/example2.yaml
@@ -1,0 +1,7 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+snap:
+  commands:
+    00: snap refresh --hold=forever
+package_reboot_if_required: true

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -267,6 +267,8 @@ class TestFTP:
                 #!/usr/bin/python3
                 import logging
 
+                from systemd.daemon import notify
+
                 from pyftpdlib.authorizers import DummyAuthorizer
                 from pyftpdlib.handlers import FTPHandler, TLS_FTPHandler
                 from pyftpdlib.servers import FTPServer
@@ -297,6 +299,9 @@ class TestFTP:
                 handler.authorizer = authorizer
                 handler.abstracted_fs = UnixFilesystem
                 server = FTPServer(("localhost", 2121), handler)
+
+                # tell systemd to proceed
+                notify("READY=1")
 
                 # start the ftp server
                 server.serve_forever()
@@ -357,7 +362,7 @@ class TestFTP:
                 Before=cloud-init-network.service
 
                 [Service]
-                Type=exec
+                Type=notify
                 ExecStart=/server.py
 
                 [Install]

--- a/tests/integration_tests/test_kernel_command_line_match.py
+++ b/tests/integration_tests/test_kernel_command_line_match.py
@@ -103,10 +103,7 @@ def test_lxd_datasource_kernel_override_nocloud_net(
             == client.execute("cloud-init query platform").stdout.strip()
         )
         assert url_val in client.execute("cloud-init query subplatform").stdout
-        assert (
-            "Detected platform: DataSourceNoCloudNet. Checking for active"
-            "instance data"
-        ) in logs
+        assert "Detected DataSourceNoCloudNet" in logs
 
 
 @pytest.mark.skipif(PLATFORM != "lxd_vm", reason="Modifies grub config")
@@ -116,7 +113,7 @@ def test_lxd_disable_cloud_init_cmdline(client: IntegrationInstance):
 
     override_kernel_command_line("cloud-init=disabled", client)
     assert "Active: inactive (dead)" in client.execute(
-        "systemctl status cloud-init"
+        "systemctl status cloud-init.target"
     )
 
 
@@ -128,7 +125,7 @@ def test_lxd_disable_cloud_init_file(client: IntegrationInstance):
     client.execute("cloud-init --clean")
     client.restart()
     assert "Active: inactive (dead)" in client.execute(
-        "systemctl status cloud-init"
+        "systemctl status cloud-init.target"
     )
 
 
@@ -142,5 +139,5 @@ def test_lxd_disable_cloud_init_env(client: IntegrationInstance):
     client.execute("cloud-init --clean")
     client.restart()
     assert "Active: inactive (dead)" in client.execute(
-        "systemctl status cloud-init"
+        "systemctl status cloud-init.target"
     )

--- a/tests/unittests/config/test_cc_package_update_upgrade_install.py
+++ b/tests/unittests/config/test_cc_package_update_upgrade_install.py
@@ -122,7 +122,7 @@ class TestRebootIfRequired:
 
         caplog.set_level(logging.WARNING)
         with mock.patch(
-            "cloudinit.subp.subp", return_value=("fakeout", "fakeerr")
+            "cloudinit.subp.subp", return_value=SubpResult("{}", "fakeerr")
         ) as m_subp:
             with mock.patch("os.path.isfile", side_effect=_isfile):
                 with mock.patch(M_PATH + "time.sleep") as m_sleep:

--- a/tests/unittests/distros/test_ubuntu.py
+++ b/tests/unittests/distros/test_ubuntu.py
@@ -1,7 +1,10 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+import logging
+
 import pytest
 
 from cloudinit.distros import fetch
+from cloudinit.subp import SubpResult
 
 
 class TestPackageCommand:
@@ -14,7 +17,7 @@ class TestPackageCommand:
             "cloudinit.distros.ubuntu.Snap.available",
             return_value=snap_available,
         )
-        m_snap_upgrade_packges = mocker.patch(
+        m_snap_upgrade_packages = mocker.patch(
             "cloudinit.distros.ubuntu.Snap.upgrade_packages",
             return_value=snap_available,
         )
@@ -27,6 +30,81 @@ class TestPackageCommand:
         m_apt_run_package_command.assert_called_once_with("upgrade")
         m_snap_available.assert_called_once()
         if snap_available:
-            m_snap_upgrade_packges.assert_called_once()
+            m_snap_upgrade_packages.assert_called_once()
         else:
-            m_snap_upgrade_packges.assert_not_called()
+            m_snap_upgrade_packages.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "subp_side_effect,expected_log",
+        (
+            pytest.param(
+                [
+                    SubpResult(
+                        stdout='{"refresh": {"hold": "forever"}}', stderr=None
+                    )
+                ],
+                "Skipping snap refresh because refresh.hold is set to"
+                " 'forever'",
+                id="skip_snap_refresh_due_to_global_hold_forever",
+            ),
+            pytest.param(
+                [
+                    SubpResult(
+                        stdout=(
+                            '{"refresh": {"hold":'
+                            ' "2024-07-08T15:38:20-06:00"}}'
+                        ),
+                        stderr=None,
+                    ),
+                    SubpResult(stdout="All snaps up to date.", stderr=""),
+                ],
+                "",
+                id="perform_snap_refresh_due_to_temporary_global_hold",
+            ),
+            pytest.param(
+                [
+                    SubpResult(
+                        stdout="{}",
+                        stderr=(
+                            'error: snap "core" has no "refresh.hold" '
+                            "configuration option"
+                        ),
+                    ),
+                    SubpResult(stdout="All snaps up to date.", stderr=""),
+                ],
+                "",
+                id="snap_refresh_performed_when_no_global_hold_is_set",
+            ),
+        ),
+    )
+    def test_package_command_avoids_snap_refresh_when_refresh_hold_is_forever(
+        self, subp_side_effect, expected_log, caplog, mocker
+    ):
+        """Do not call snap refresh when snap refresh.hold is forever.
+
+        This indicates an environment where snaps refreshes are not preferred
+        for whatever reason.
+        """
+        m_snap_available = mocker.patch(
+            "cloudinit.distros.ubuntu.Snap.available",
+            return_value=True,
+        )
+        m_subp = mocker.patch(
+            "cloudinit.subp.subp",
+            side_effect=subp_side_effect,
+        )
+        m_apt_run_package_command = mocker.patch(
+            "cloudinit.distros.package_management.apt.Apt.run_package_command",
+        )
+        cls = fetch("ubuntu")
+        distro = cls("ubuntu", {}, None)
+        with caplog.at_level(logging.INFO):
+            distro.package_command("upgrade")
+        m_apt_run_package_command.assert_called_once_with("upgrade")
+        m_snap_available.assert_called_once()
+        expected_calls = [mocker.call(["snap", "get", "system", "-d"])]
+        if expected_log:
+            assert expected_log in caplog.text
+        else:
+            expected_calls.append(mocker.call(["snap", "refresh"]))
+        assert m_subp.call_args_list == expected_calls


### PR DESCRIPTION
- New upstream snapshot to pull in tests/unittests/test_util.py changes.
- Fix d/changelog to place new quilt patches into unreleased changelog entry
- disable read_seeded calls to external network-config resource that we disregard in any callsites.