### PR TITLE
Revert "fix(vmware): Set IPv6 to dhcp when there is no IPv6 addr (#54…

### DIFF
--- a/cloudinit/sources/helpers/vmware/imc/config_nic.py
+++ b/cloudinit/sources/helpers/vmware/imc/config_nic.py
@@ -207,7 +207,7 @@ class NicConfigurator:
         """
 
         if not nic.staticIpv6:
-            return ([{"type": "dhcp6"}], [])
+            return ([], [])
 
         subnet_list = []
         # Static Ipv6

--- a/tests/unittests/sources/vmware/test_vmware_config_file.py
+++ b/tests/unittests/sources/vmware/test_vmware_config_file.py
@@ -241,45 +241,27 @@ class TestVmwareConfigFile(CiTestCase):
             elif cfg.get("name") == nic2.get("name"):
                 nic2.update(cfg)
 
-        # Test NIC1
         self.assertEqual("physical", nic1.get("type"), "type of NIC1")
         self.assertEqual("NIC1", nic1.get("name"), "name of NIC1")
         self.assertEqual(
             "00:50:56:a6:8c:08", nic1.get("mac_address"), "mac address of NIC1"
         )
         subnets = nic1.get("subnets")
-        self.assertEqual(2, len(subnets), "number of subnets for NIC1")
-        subnet_ipv4 = subnets[0]
-        self.assertEqual(
-            "dhcp", subnet_ipv4.get("type"), "Ipv4 DHCP type for NIC1"
-        )
-        self.assertEqual(
-            "auto", subnet_ipv4.get("control"), "NIC1 Control type"
-        )
-        subnet_ipv6 = subnets[1]
-        self.assertEqual(
-            "dhcp6", subnet_ipv6.get("type"), "Ipv6 DHCP type for NIC1"
-        )
+        self.assertEqual(1, len(subnets), "number of subnets for NIC1")
+        subnet = subnets[0]
+        self.assertEqual("dhcp", subnet.get("type"), "DHCP type for NIC1")
+        self.assertEqual("auto", subnet.get("control"), "NIC1 Control type")
 
-        # Test NIC2
         self.assertEqual("physical", nic2.get("type"), "type of NIC2")
         self.assertEqual("NIC2", nic2.get("name"), "name of NIC2")
         self.assertEqual(
             "00:50:56:a6:5a:de", nic2.get("mac_address"), "mac address of NIC2"
         )
         subnets = nic2.get("subnets")
-        self.assertEqual(2, len(subnets), "number of subnets for NIC2")
-        subnet_ipv4 = subnets[0]
-        self.assertEqual(
-            "dhcp", subnet_ipv4.get("type"), "Ipv4 DHCP type for NIC2"
-        )
-        self.assertEqual(
-            "auto", subnet_ipv4.get("control"), "NIC2 Control type"
-        )
-        subnet_ipv6 = subnets[1]
-        self.assertEqual(
-            "dhcp6", subnet_ipv6.get("type"), "Ipv6 DHCP type for NIC2"
-        )
+        self.assertEqual(1, len(subnets), "number of subnets for NIC2")
+        subnet = subnets[0]
+        self.assertEqual("dhcp", subnet.get("type"), "DHCP type for NIC2")
+        self.assertEqual("auto", subnet.get("control"), "NIC2 Control type")
 
     def test_get_nics_list_static(self):
         """Tests if NicConfigurator properly calculates network subnets
@@ -304,7 +286,6 @@ class TestVmwareConfigFile(CiTestCase):
                 elif cfg.get("name") == nic2.get("name"):
                     nic2.update(cfg)
 
-        # Test NIC1
         self.assertEqual("physical", nic1.get("type"), "type of NIC1")
         self.assertEqual("NIC1", nic1.get("name"), "name of NIC1")
         self.assertEqual(
@@ -364,7 +345,6 @@ class TestVmwareConfigFile(CiTestCase):
             else:
                 self.assertEqual(True, False, "invalid gateway %s" % (gateway))
 
-        # Test NIC2
         self.assertEqual("physical", nic2.get("type"), "type of NIC2")
         self.assertEqual("NIC2", nic2.get("name"), "name of NIC2")
         self.assertEqual(
@@ -372,18 +352,16 @@ class TestVmwareConfigFile(CiTestCase):
         )
 
         subnets = nic2.get("subnets")
-        self.assertEqual(2, len(subnets), "Number of subnets for NIC2")
+        self.assertEqual(1, len(subnets), "Number of subnets for NIC2")
 
-        subnet_ipv4 = subnets[0]
-        self.assertEqual("static", subnet_ipv4.get("type"), "Subnet type")
+        subnet = subnets[0]
+        self.assertEqual("static", subnet.get("type"), "Subnet type")
         self.assertEqual(
-            "192.168.6.102", subnet_ipv4.get("address"), "Subnet address"
+            "192.168.6.102", subnet.get("address"), "Subnet address"
         )
         self.assertEqual(
-            "255.255.0.0", subnet_ipv4.get("netmask"), "Subnet netmask"
+            "255.255.0.0", subnet.get("netmask"), "Subnet netmask"
         )
-        subnet_ipv6 = subnets[1]
-        self.assertEqual("dhcp6", subnet_ipv6.get("type"), "Subnet type")
 
     def test_custom_script(self):
         cf = ConfigFile("tests/data/vmware/cust-dhcp-2nic.cfg")
@@ -470,10 +448,7 @@ class TestVmwareNetConfig(CiTestCase):
                             "type": "static",
                             "address": "10.20.87.154",
                             "netmask": "255.255.252.0",
-                        },
-                        {
-                            "type": "dhcp6",
-                        },
+                        }
                     ],
                 }
             ],
@@ -524,10 +499,7 @@ class TestVmwareNetConfig(CiTestCase):
                                     "metric": 10000,
                                 }
                             ],
-                        },
-                        {
-                            "type": "dhcp6",
-                        },
+                        }
                     ],
                 }
             ],
@@ -587,10 +559,7 @@ class TestVmwareNetConfig(CiTestCase):
                                     "metric": 10000,
                                 }
                             ],
-                        },
-                        {
-                            "type": "dhcp6",
-                        },
+                        }
                     ],
                 }
             ],
@@ -635,10 +604,7 @@ class TestVmwareNetConfig(CiTestCase):
                             "address": "10.20.87.154",
                             "netmask": "255.255.252.0",
                             "gateway": "10.20.87.253",
-                        },
-                        {
-                            "type": "dhcp6",
-                        },
+                        }
                     ],
                 }
             ],


### PR DESCRIPTION
This reverts commit 2b6fe6403db769de14f7c7b7e4aa65f5bea8f3e0.

When there is no IPv6 set to dhcp explicitly, NetworkManager keyfile defaults to method=auto, may-fail=true.
When there is Ipv6 set to dhcp explictily, NetworkManager keyfile will be set to method=auto, may-fail=false.
The default settings are what we want, so revert the previous change to keep IPv6 not set explicitly.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
Revert "fix(vmware): Set IPv6 to dhcp when there is no IPv6 addr (#5471)"

When there is no IPv6 set to dhcp explicitly, NetworkManager keyfile defaults to method=auto, may-fail=true.
When there is Ipv6 set to dhcp explictily, NetworkManager keyfile will be set to method=auto, may-fail=false.
The default settings are what we want, so revert the previous change to keep IPv6 not set explicitly.

```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
