### PR TITLE
Support encrypted and signed user data

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -1111,7 +1111,7 @@ def apt_key(
                 )
         return file_name
 
-    def apt_key_list(gpg_context):
+    def apt_key_list(gpg_context: GPG):
         """apt-key list
 
         returns string of all trusted keys (in /etc/apt/trusted.gpg and

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -55,7 +55,6 @@ INCLUSION_TYPES_MAP = {
     "text/x-shellscript-per-boot": "text/x-shellscript-per-boot",
     "text/x-shellscript-per-instance": "text/x-shellscript-per-instance",
     "text/x-shellscript-per-once": "text/x-shellscript-per-once",
-    "-----begin pgp message-----": "text/x-pgp-armored",
 }
 
 # Sorted longest first

--- a/cloudinit/handlers/__init__.py
+++ b/cloudinit/handlers/__init__.py
@@ -55,6 +55,7 @@ INCLUSION_TYPES_MAP = {
     "text/x-shellscript-per-boot": "text/x-shellscript-per-boot",
     "text/x-shellscript-per-instance": "text/x-shellscript-per-instance",
     "text/x-shellscript-per-once": "text/x-shellscript-per-once",
+    "-----begin pgp message-----": "text/x-pgp-armored",
 }
 
 # Sorted longest first

--- a/cloudinit/settings.py
+++ b/cloudinit/settings.py
@@ -79,3 +79,4 @@ PER_ONCE = "once"
 FREQUENCIES = [PER_INSTANCE, PER_ALWAYS, PER_ONCE]
 
 HOTPLUG_ENABLED_FILE = "/var/lib/cloud/hotplug.enabled"
+KEY_DIR = "/etc/cloud/keys"

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -646,34 +646,34 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         return URLParams(max_wait, timeout, retries, sec_between_retries)
 
     def get_userdata(self, apply_filter=False):
-        require_pgp = self.sys_cfg.get("user_data", {}).get(
-            "require_pgp", False
+        require_signature = self.sys_cfg.get("user_data", {}).get(
+            "require_signature", False
         )
         if self.userdata is None:
             self.userdata = self.ud_proc.process(
-                self.get_userdata_raw(), require_pgp
+                self.get_userdata_raw(), require_signature
             )
         if apply_filter:
             return self._filter_xdata(self.userdata)
         return self.userdata
 
     def get_vendordata(self):
-        require_pgp = self.sys_cfg.get("vendor_data", {}).get(
-            "require_pgp", False
+        require_signature = self.sys_cfg.get("vendor_data", {}).get(
+            "require_signature", False
         )
         if self.vendordata is None:
             self.vendordata = self.ud_proc.process(
-                self.get_vendordata_raw(), require_pgp
+                self.get_vendordata_raw(), require_signature
             )
         return self.vendordata
 
     def get_vendordata2(self):
-        require_pgp = self.sys_cfg.get("vendor_data2", {}).get(
-            "require_pgp", False
+        require_signature = self.sys_cfg.get("vendor_data2", {}).get(
+            "require_signature", False
         )
         if self.vendordata2 is None:
             self.vendordata2 = self.ud_proc.process(
-                self.get_vendordata2_raw(), require_pgp
+                self.get_vendordata2_raw(), require_signature
             )
         return self.vendordata2
 

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -646,34 +646,34 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         return URLParams(max_wait, timeout, retries, sec_between_retries)
 
     def get_userdata(self, apply_filter=False):
-        require_signature = self.sys_cfg.get("user_data", {}).get(
-            "require_signature", False
-        )
         if self.userdata is None:
             self.userdata = self.ud_proc.process(
-                self.get_userdata_raw(), require_signature
+                self.get_userdata_raw(),
+                require_signature=self.sys_cfg.get("user_data", {}).get(
+                    "require_signature", False
+                ),
             )
         if apply_filter:
             return self._filter_xdata(self.userdata)
         return self.userdata
 
     def get_vendordata(self):
-        require_signature = self.sys_cfg.get("vendor_data", {}).get(
-            "require_signature", False
-        )
         if self.vendordata is None:
             self.vendordata = self.ud_proc.process(
-                self.get_vendordata_raw(), require_signature
+                self.get_vendordata_raw(),
+                require_signature=self.sys_cfg.get("vendor_data", {}).get(
+                    "require_signature", False
+                ),
             )
         return self.vendordata
 
     def get_vendordata2(self):
-        require_signature = self.sys_cfg.get("vendor_data2", {}).get(
-            "require_signature", False
-        )
         if self.vendordata2 is None:
             self.vendordata2 = self.ud_proc.process(
-                self.get_vendordata2_raw(), require_signature
+                self.get_vendordata2_raw(),
+                require_signature=self.sys_cfg.get("vendor_data2", {}).get(
+                    "require_signature", False
+                ),
             )
         return self.vendordata2
 

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -646,20 +646,35 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         return URLParams(max_wait, timeout, retries, sec_between_retries)
 
     def get_userdata(self, apply_filter=False):
+        require_pgp = self.sys_cfg.get("user_data", {}).get(
+            "require_pgp", False
+        )
         if self.userdata is None:
-            self.userdata = self.ud_proc.process(self.get_userdata_raw())
+            self.userdata = self.ud_proc.process(
+                self.get_userdata_raw(), require_pgp
+            )
         if apply_filter:
             return self._filter_xdata(self.userdata)
         return self.userdata
 
     def get_vendordata(self):
+        require_pgp = self.sys_cfg.get("vendor_data", {}).get(
+            "require_pgp", False
+        )
         if self.vendordata is None:
-            self.vendordata = self.ud_proc.process(self.get_vendordata_raw())
+            self.vendordata = self.ud_proc.process(
+                self.get_vendordata_raw(), require_pgp
+            )
         return self.vendordata
 
     def get_vendordata2(self):
+        require_pgp = self.sys_cfg.get("vendor_data2", {}).get(
+            "require_pgp", False
+        )
         if self.vendordata2 is None:
-            self.vendordata2 = self.ud_proc.process(self.get_vendordata2_raw())
+            self.vendordata2 = self.ud_proc.process(
+                self.get_vendordata2_raw(), require_pgp
+            )
         return self.vendordata2
 
     @property

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -799,7 +799,7 @@ class Init:
         Base config can have a definition like:
           user_data:
             enabled: false
-            require_pgp: true
+            require_signature: true
         or a deprecated `allow_userdata` key.
 
         Parse them and maybe consume userdata accordingly.

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -7,7 +7,7 @@ import os
 import subprocess
 from errno import ENOEXEC
 from io import TextIOWrapper
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from cloudinit import performance
 
@@ -170,7 +170,7 @@ def subp(
     capture=True,
     shell=False,
     logstring=False,
-    decode="replace",
+    decode: Literal[False, "strict", "ignore", "replace"] = "replace",
     update_env=None,
     cwd=None,
     timeout=None,

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -11,12 +11,13 @@
 import email
 import logging
 import os
+import pathlib
 from email.message import Message
 from email.mime.base import MIMEBase
 from email.mime.multipart import MIMEMultipart
 from email.mime.nonmultipart import MIMENonMultipart
 from email.mime.text import MIMEText
-import pathlib
+from typing import Union
 
 from cloudinit import features, gpg, handlers, subp, util
 from cloudinit.settings import KEY_DIR
@@ -402,10 +403,14 @@ def message_from_string(string) -> Message:
     return email.message_from_string(string)
 
 
-# Coverts a raw string into a mime message
-def convert_string(raw_data, content_type=NOT_MULTIPART_TYPE) -> Message:
-    """convert a string (more likely bytes) or a message into
-    a mime message."""
+def convert_string(
+    raw_data: Union[str, bytes], content_type=NOT_MULTIPART_TYPE
+) -> Message:
+    """Convert the raw data into a mime message.
+
+    'raw_data' is the data as it was received from the user-data source.
+    It could be a string, bytes, or a gzip compressed version of either.
+    """
     if not raw_data:
         raw_data = b""
 

--- a/cloudinit/user_data.py
+++ b/cloudinit/user_data.py
@@ -403,10 +403,6 @@ def is_skippable(part):
     return False
 
 
-def message_from_string(string) -> Message:
-    return email.message_from_string(string)
-
-
 def convert_string(
     raw_data: Union[str, bytes], content_type=NOT_MULTIPART_TYPE
 ) -> Message:
@@ -430,7 +426,7 @@ def convert_string(
         bdata = raw_data
     bdata = util.decomp_gzip(bdata, decode=False)
     if b"mime-version:" in bdata[0:4096].lower():
-        msg = message_from_string(bdata.decode("utf-8"))
+        msg = email.message_from_string(bdata.decode("utf-8"))
     else:
         msg = create_binmsg(bdata, content_type)
 

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -24,6 +24,7 @@ Formats that directly configure the instance:
 
 Formats that deal with other user data formats:
 
+- `PGP Message`_
 - `Include file`_
 - `Jinja template`_
 - `MIME multi-part archive`_
@@ -140,6 +141,64 @@ The boothook is different in that:
     Use of ``INSTANCE_ID`` variable within boothooks is deprecated.
     Use :ref:`jinja templates<user_data_formats-jinja>` with
     :ref:`v1.instance_id<v1_instance_id>` instead.
+
+.. _user_data_formats-pgp:
+
+PGP Message
+===========
+
+Example
+-------
+
+.. code-block:: text
+
+    -----BEGIN PGP MESSAGE-----
+
+    hF4DoKS6K1guBqsSAQdAE8bD7gGuKcGN91zGzW7SR+u6nnq9pyqjR8qJZl2sJRow
+    MgfxFaFaIw232BJvqwuoa0HGsmCaVyXmj6PFVJceBn2X7s8hXgHutlQxQf1Mju63
+    1OkBCQIQxJJj1X4dpQs44tcCjkGOWOO9XrSyAPhcR5sHIUYcsrd3cW9OUp6PUMb2
+    Ci2Lmz8gG+Z1pEAxJD6TdCIFy/+Emf6UaDPWbg6CRuWmu3BtagUmVVK8+yXZBa6j
+    hdy0a9FZDpZsemWwsGxHJg0HRcClE/AebMtjczftIosPFfn68/fUgwGcuQ28wWGn
+    HG9h09fgXoO1tlOjpz/pqDou465pDMk43gxOUoCtdBaOSgkHWUiD2s9WxoAi83OY
+    9uTdQCZ1EmaUQE7W/VFlcjapCtoiph/sBmQyumcMfUjJd5CCTK8q3iNcFnkulXl+
+    yRMFhm1w1SBogfKeo8bv0wO9SJZ4dBq0cDSXYGzFkWOzm1k0o7rJ4pghuU3EUFk+
+    Sr3QDTBlOz83BI2NPHLO+MqAwCwtao29YXA9iDYD3Cyz8fRLsWL0gLGE887s0W0Y
+    dh2fIhLR+5uufQWF6xj7Am3UBTbidgMmEch9FdSYZYpPamiWojMFg45jLyBBETIq
+    C2AAfHUYOkwZzf55yxwLEW4qyj9q+9rHF/M/XfI7t+RgBqODmNWoww4SOixEun1X
+    tP3W8DSp9p+PMqdfztf8Uo7HzijsolLlt4cxsUx5tN0Bz9UYtQ9VMog5IN1Oe5Vu
+    Wec6bO9qWdZUNV5Ty32DFycXvgmzI6w/9v4R7YKgKE/2AWOito4E3WpZZlj2mVJW
+    M9ZoSf3O9I3jqyCpI/pZ/F1egrydwLskM71FCx/3kkAHRRB4436TpQe0OpMFcfOp
+    6qflwEWygx9EzqEsfZJ4vYgXf2ivgsSpxGVE+5Tcg90Te+0of3E=
+    =T2Fh
+    -----END PGP MESSAGE-----
+
+Explanation
+-----------
+
+A PGP message is a message that has been encrypted and/or signed with one or
+multiple `PGP keys <https://datatracker.ietf.org/doc/html/rfc4880>`_, and then
+`ASCII armored <https://www.gnupg.org/gph/en/manual/r1290.html>`_. The message
+is decrypted and/or verified with keys contained in the image.
+The decrypted message is then processed as any other user data format.
+
+To support such data, cloud-init requires the decryption and signing keys
+to be present in the `/etc/cloud/keys` directory. To decrypt encrypted
+data, the private key corresponding to the public key that encrypted the data
+must be present. To verify signed data, the public key that corresponds
+to the private key that signed the data must be present.
+
+To ensure authenticity, cloud-init can restrict user data to be a PGP
+message only. To do so, the following
+:ref:`base configuration<base_config_user_data>` can be used:
+
+.. code-block:: yaml
+
+    user_data:
+      require_pgp: true
+
+
+For a detailed guide to creating the PGP message and image necessary for this
+user data format, see the :ref:`Use encrypted or signed user data<pgp>` page.
 
 Include file
 ============
@@ -383,6 +442,8 @@ as binary data and so may be processed automatically.
 |User data script    |#!                           |text/x-shellscript       |
 +--------------------+-----------------------------+-------------------------+
 |Cloud boothook      |#cloud-boothook              |text/cloud-boothook      |
++--------------------+-----------------------------+-------------------------+
+| PGP Message        |-----BEGIN PGP MESSAGE-----  |text/x-pgp-armored       |
 +--------------------+-----------------------------+-------------------------+
 |MIME multi-part     |Content-Type: multipart/mixed|multipart/mixed          |
 +--------------------+-----------------------------+-------------------------+

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -194,7 +194,7 @@ message only. To do so, the following
 .. code-block:: yaml
 
     user_data:
-      require_pgp: true
+      require_signature: true
 
 
 For a detailed guide to creating the PGP message and image necessary for this

--- a/doc/rtd/howto/index.rst
+++ b/doc/rtd/howto/index.rst
@@ -22,6 +22,7 @@ How do I...?
    Re-run cloud-init <rerun_cloud_init.rst>
    Change how often a module runs <module_run_frequency.rst>
    Validate my user data <debug_user_data.rst>
+   Use encrypted or signed user data <pgp.rst>
    Debug cloud-init <debugging.rst>
    Check the status of cloud-init <status.rst>
    Report a bug <bugs.rst>

--- a/doc/rtd/howto/pgp.rst
+++ b/doc/rtd/howto/pgp.rst
@@ -136,7 +136,7 @@ using the existing key ring in the snapshot, we do this for a few reasons:
 * Users may not want these keys in any key ring by default on a new instance
 * Exporting keys is easier than copying key rings
 
-Note that on launch, cloud-init will import there keys into a temporary
+Note that on launch, cloud-init will import these keys into a temporary
 key ring that is removed after the user data is processed. The default
 key ring will not be read or modified.
 

--- a/doc/rtd/howto/pgp.rst
+++ b/doc/rtd/howto/pgp.rst
@@ -93,8 +93,8 @@ cloud-config file:
 
 Save this file to your working directory as `cloud-config.yaml`.
 
-Encrypt the user data using the public key of the encrypting user and the
-private key of the signing user:
+Encrypt the user data using the public key of the encrypting user and
+sign it using the private key of the signing user:
 
 .. code-block:: bash
 
@@ -134,8 +134,7 @@ While it is more steps to export the keys in this way as opposed to
 using the existing key ring in the snapshot, we do this for a few reasons:
 
 * Users may not want these keys in any key ring by default on a new instance
-* Keys may be exported from any system without needing to be concerned with
-  the implementation details of the gpg implementation
+* Exporting keys is easier than copying key rings
 
 Note that on launch, cloud-init will import there keys into a temporary
 key ring that is removed after the user data is processed. The default
@@ -151,7 +150,7 @@ require that cloud-init only process PGP messages. To do so, create a file
 .. code-block:: text
 
     user_data:
-      require_pgp: true
+      require_signature: true
 
 Retrieve our encrypted and signed user data
 ===========================================

--- a/doc/rtd/howto/pgp.rst
+++ b/doc/rtd/howto/pgp.rst
@@ -127,6 +127,18 @@ Export the private key of the encrypting user:
 
     $ gpg --export-secret-keys encrypting_user > /etc/cloud/keys/encrypting_user.gpg
 
+Remove key ring
+---------------
+
+.. note::
+    This step is optional but recommended for a clean image.
+
+Remove the keyring that was generated upon creating our first key:
+
+.. code-block:: bash
+
+    $ rm -r ~/.gnupg/
+
 Why export keys?
 ----------------
 
@@ -151,6 +163,15 @@ require that cloud-init only process PGP messages. To do so, create a file
 
     user_data:
       require_signature: true
+
+Clean cloud-init
+================
+
+This is to ensure that cloud-init runs as if it were first boot:
+
+.. code-block:: bash
+
+    $ cloud-init clean --logs
 
 Retrieve our encrypted and signed user data
 ===========================================

--- a/doc/rtd/howto/pgp.rst
+++ b/doc/rtd/howto/pgp.rst
@@ -1,0 +1,201 @@
+.. _pgp:
+
+Use encrypted or signed user data
+*********************************
+
+Overview
+========
+
+This guide will show you how to use PGP encryption to secure your
+:ref:`user data<user_data_formats-pgp>`
+when using cloud-init. This will be accomplished with the following steps:
+
+1. Launch a cloud instance
+2. Generate PGP key pairs
+3. Encrypt and sign the user data
+4. Export the keys
+5. Restrict user data to require PGP message
+6. Retrieve our encrypted and signed user data
+7. Create a custom image containing the keys
+8. Launch an instance with the encrypted user data
+
+We will be using the `gpg` command to for all PGP-related operations. This
+guide will add new keys to the default key ring while later providing
+instructions for removing them. These keys are generated for instructive
+purposes only and are not intended for production use.
+
+.. note::
+    This guide is NOT intended to be a comprehensive guide to PGP encryption or
+    best practices when using the `gpg` command or gpg key rings. Please
+    consult the `GnuPG documentation <https://gnupg.org/>`_ for documentation
+    and best practices.
+
+Prerequisites
+=============
+
+This guide also assumes you have the ability to launch cloud instances
+with root permissions and can create snapshots or custom images from
+those instances. This guide will demonstrate this using LXD, but
+commands to achieve the same result will vary by cloud provider.
+
+The launched instance must contain the `GNU Privacy Guard` software
+which provides the `gpg` command.
+
+Launch a cloud instance
+=======================
+
+We will use LXD to launch an Ubuntu instance, but you can use any cloud
+provider and OS that supports `gpg` and cloud-init.
+
+Launch the instance and connect to it:
+
+.. code-block:: bash
+
+    $ lxc launch ubuntu:noble pgp-demo
+    $ lxc shell pgp-demo
+
+You should now be inside the LXD instance in the "/root" directory.
+The remaining steps will be performed inside this instance in the "/root"
+directory until otherwise noted.
+
+Generate PGP key pairs
+======================
+
+.. note::
+
+    If you already have PGP key pairs you would like to use, you can skip this
+    step. However, we do NOT recommend reusing or sharing any personal
+    private keys.
+
+First, generate a new key pair to be used for signing:
+
+.. code-block:: bash
+
+    $ gpg --quick-generate-key --batch --passphrase "" signing_user
+
+Next, generate a new key pair to be used for encryption:
+
+.. code-block:: bash
+
+    $ gpg --quick-generate-key --batch --passphrase "" encrypting_user
+
+Encrypt and sign the user data
+==============================
+
+Create a file with your user data. For this example, we will use a simple
+cloud-config file:
+
+.. code-block:: yaml
+
+    #cloud-config
+    runcmd:
+      - echo 'Hello, World!' > /var/tmp/hello-world.txt
+
+Save this file to your working directory as `cloud-config.yaml`.
+
+Encrypt the user data using the public key of the encrypting user and the
+private key of the signing user:
+
+.. code-block:: bash
+
+    $ gpg --batch --output cloud-config.yaml.asc --sign --local-user signing_user --encrypt --recipient encrypting_user --armor cloud-config.yaml
+
+Our encrypted and signed user data is now saved in `cloud-config.yaml.asc`.
+
+Export the keys
+===============
+
+In order to use this user data, we will need to create a custom image
+containing the public key of the encrypting user and the private key
+of the signing user.
+
+Create the key directory:
+
+.. code-block:: bash
+
+    $ mkdir /etc/cloud/keys
+
+Export the public key of the signing user:
+
+.. code-block:: bash
+
+    $ gpg --export signing_user > /etc/cloud/keys/signing_user.gpg
+
+Export the private key of the encrypting user:
+
+.. code-block:: bash
+
+    $ gpg --export-secret-keys encrypting_user > /etc/cloud/keys/encrypting_user.gpg
+
+Why export keys?
+----------------
+
+While it is more steps to export the keys in this way as opposed to
+using the existing key ring in the snapshot, we do this for a few reasons:
+
+* Users may not want these keys in any key ring by default on a new instance
+* Keys may be exported from any system without needing to be concerned with
+  the implementation details of the gpg implementation
+
+Note that on launch, cloud-init will import there keys into a temporary
+key ring that is removed after the user data is processed. The default
+key ring will not be read or modified.
+
+Restrict user data to require PGP message
+=========================================
+
+To ensure that our message hasn't been replaced or tampered with, we can
+require that cloud-init only process PGP messages. To do so, create a file
+`/etc/cloud/cloud.cfg.d/99_pgp.cfg` with the following contents:
+
+.. code-block:: text
+
+    user_data:
+      require_pgp: true
+
+Retrieve our encrypted and signed user data
+===========================================
+
+Before running
+these commands, copy the encrypted and signed user data
+that we created earlier to the host system.
+
+From the host system, run:
+
+.. code-block:: bash
+
+    $ lxc file pull pgp-demo/root/cloud-config.yaml.asc .
+
+
+Create a custom image containing the keys
+=========================================
+
+.. note::
+    Before creating the image, you may want to remove the original user data
+    and created key ring from the instance. This is not strictly necessary
+    but is recommended for a clean image.
+
+Now that we have our instance configured, we can create a custom image from
+it. This step will vary depending on your cloud provider.
+
+Using LXD, from the host system, run:
+
+.. code-block:: bash
+
+    $ lxc stop pgp-demo
+    $ lxc publish pgp-demo --alias pgp-demo-image
+
+Launch an instance with the encrypted user data
+===============================================
+
+Now that we have our custom image with the keys, we can launch a
+new instance with the encrypted user data. With your encrypted and signed
+user data in the current working directory, run:
+
+.. code-block:: bash
+
+    $ lxc launch pgp-demo-image pgp-demo-encrypted \
+      --config user.user-data="$(cat cloud-config.yaml.asc)"
+
+On the launched system, you should see the file `/var/tmp/hello-world.txt`
+containing the text `Hello, World!`.

--- a/doc/rtd/reference/base_config_reference.rst
+++ b/doc/rtd/reference/base_config_reference.rst
@@ -267,8 +267,9 @@ Format is a dict with the following keys:
 * ``enabled``: A boolean value to enable or disable the use of user data.
   One use case is to prevent users from accidentally breaking closed
   appliances. Default: ``true``.
-* ``require_pgp``: A boolean indicating whether to require PGP verification
-  of the user data. Default: ``false``. This should be true if
+* ``require_signature``: A boolean indicating whether to require a PGP
+  signed message for user data. Default: ``false``.
+  This should be true if
   using :ref:`signed user data<user_data_formats-pgp>`.
 
 ``vendor_data``/``vendor_data2``
@@ -281,8 +282,8 @@ Format is a dict with the following keys:
 
 * ``enabled``: A boolean indicating whether to enable or disable the vendor
   data. Default: ``true``.
-* ``require_pgp``: A boolean indicating whether to require PGP verification
-  of the vendor data. Default: ``false``.
+* ``require_signature``: A boolean indicating whether to require a PGP
+  signed message for vendor data. Default: ``false``.
 * ``prefix``: A path to a binary to prefix to any executed scripts.
   An example of usage would be to prefix a script with ``strace`` to
   debug a script.

--- a/doc/rtd/reference/base_config_reference.rst
+++ b/doc/rtd/reference/base_config_reference.rst
@@ -255,25 +255,37 @@ There are a few reasons to modify the ``datasource_list``:
    that the key and its contents, a list, must share a single line - no
    newlines.
 
+.. _base_config_user_data:
+
+``user_data``
+^^^^^^^^^^^^^
+
+Allows the user to set options for processing user data.
+
+Format is a dict with the following keys:
+
+* ``enabled``: A boolean value to enable or disable the use of user data.
+  One use case is to prevent users from accidentally breaking closed
+  appliances. Default: ``true``.
+* ``require_pgp``: A boolean indicating whether to require PGP verification
+  of the user data. Default: ``false``. This should be true if
+  using :ref:`signed user data<user_data_formats-pgp>`.
+
 ``vendor_data``/``vendor_data2``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Allows the user to disable ``vendor_data`` or ``vendor_data2`` along with
 providing a prefix for any executed scripts.
 
-Format is a dict with ``enabled`` and ``prefix`` keys:
+Format is a dict with the following keys:
 
-* ``enabled``: A boolean indicating whether to enable or disable the
-  ``vendor_data``.
-* ``prefix``: A path to prepend to any ``vendor_data``-provided script.
-
-``allow_userdata``
-^^^^^^^^^^^^^^^^^^
-
-A boolean value to disable the use of user data.
-This allows custom images to prevent users from accidentally breaking closed
-appliances. Setting ``allow_userdata: false`` in the configuration will disable
-``cloud-init`` from processing user data.
+* ``enabled``: A boolean indicating whether to enable or disable the vendor
+  data. Default: ``true``.
+* ``require_pgp``: A boolean indicating whether to require PGP verification
+  of the vendor data. Default: ``false``.
+* ``prefix``: A path to a binary to prefix to any executed scripts.
+  An example of usage would be to prefix a script with ``strace`` to
+  debug a script.
 
 ``manual_cache_clean``
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/rtd/spelling_word_list.txt
+++ b/doc/rtd/spelling_word_list.txt
@@ -167,6 +167,7 @@ passno
 passthrough
 passw
 pem
+pgp
 pid
 pipelining
 pki

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -83,10 +83,10 @@ class IntegrationInstance:
         log.info("Restarting instance and waiting for boot")
         self.instance.restart()
 
-    def execute(self, command, *, use_sudo=True) -> Result:
+    def execute(self, command, *, use_sudo=True, **kwargs) -> Result:
         if self.instance.username == "root" and use_sudo is False:
             raise RuntimeError("Root user cannot run unprivileged")
-        return self.instance.execute(command, use_sudo=use_sudo)
+        return self.instance.execute(command, use_sudo=use_sudo, **kwargs)
 
     def pull_file(
         self,

--- a/tests/integration_tests/userdata/test_pgp.py
+++ b/tests/integration_tests/userdata/test_pgp.py
@@ -1,4 +1,5 @@
 """Test PGP signed and encrypted userdata."""
+
 import pytest
 
 from cloudinit import subp

--- a/tests/integration_tests/userdata/test_pgp.py
+++ b/tests/integration_tests/userdata/test_pgp.py
@@ -329,7 +329,7 @@ def test_signature_required(client: IntegrationInstance):
     assert result.failed
     assert (
         "'require_signature' was set true in cloud-init's base configuration, "
-        "but content type is text/cloud-config"
+        "but content is not signed"
     ) in result.stdout
 
 

--- a/tests/integration_tests/userdata/test_pgp.py
+++ b/tests/integration_tests/userdata/test_pgp.py
@@ -353,7 +353,4 @@ def test_encrypted_message_but_required_signature(
 
     result = client.execute("cloud-init status --format=json")
     assert result.failed
-    assert (
-        "Signature verification required, but no signature found"
-        in result.stdout
-    )
+    assert "Signature verification failed" in result.stdout

--- a/tests/integration_tests/userdata/test_pgp.py
+++ b/tests/integration_tests/userdata/test_pgp.py
@@ -1,0 +1,331 @@
+"""Test PGP signed and encrypted userdata."""
+import pytest
+
+from cloudinit import subp
+from tests.integration_tests.clouds import IntegrationCloud
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.integration_settings import PLATFORM
+from tests.integration_tests.util import verify_clean_boot
+
+USER_DATA = """\
+#cloud-config
+bootcmd:
+ - touch /var/tmp/{0}
+"""
+
+
+@pytest.fixture(scope="module")
+def gpg_dir(tmp_path_factory):
+    yield tmp_path_factory.mktemp("gpg_dir")
+
+
+@pytest.fixture(scope="module")
+def public_key(gpg_dir):
+    subp.subp(
+        [
+            "gpg",
+            "--homedir",
+            str(gpg_dir),
+            "--quick-generate-key",
+            "--batch",
+            # "loopback",
+            "--passphrase",
+            "",
+            "signing_user",
+        ]
+    )
+    yield subp.subp(
+        [
+            "gpg",
+            "--homedir",
+            str(gpg_dir),
+            "--export",
+            "--armor",
+            "signing_user",
+        ]
+    ).stdout
+
+
+@pytest.fixture(scope="module")
+def private_key(gpg_dir):
+    subp.subp(
+        [
+            "gpg",
+            "--homedir",
+            str(gpg_dir),
+            "--quick-generate-key",
+            "--batch",
+            "--passphrase",
+            "",
+            "encrypting_user",
+        ]
+    )
+    yield subp.subp(
+        [
+            "gpg",
+            "--homedir",
+            str(gpg_dir),
+            "--batch",
+            "--export-secret-keys",
+            "--armor",
+            "encrypting_user",
+        ]
+    ).stdout
+
+
+@pytest.fixture(scope="module")
+def signed_and_encrypted_userdata(gpg_dir, public_key, private_key):
+    return subp.subp(
+        [
+            "gpg",
+            "--homedir",
+            str(gpg_dir),
+            "--batch",
+            "--sign",
+            "--local-user",
+            "signing_user",
+            "--encrypt",
+            "--recipient",
+            "encrypting_user",
+            "--armor",
+        ],
+        data=USER_DATA.format("signed_and_encrypted"),
+    ).stdout
+
+
+@pytest.fixture(scope="module")
+def signed_userdata(gpg_dir, public_key):
+    return subp.subp(
+        [
+            "gpg",
+            "--homedir",
+            str(gpg_dir),
+            "--batch",
+            "--sign",
+            "--local-user",
+            "signing_user",
+            "--armor",
+        ],
+        data=USER_DATA.format("signed"),
+    ).stdout
+
+
+@pytest.fixture(scope="module")
+def encrypted_userdata(gpg_dir, private_key):
+    return subp.subp(
+        [
+            "gpg",
+            "--homedir",
+            str(gpg_dir),
+            "--batch",
+            "--encrypt",
+            "--recipient",
+            "encrypting_user",
+            "--armor",
+        ],
+        data=USER_DATA.format("encrypted"),
+    ).stdout
+
+
+@pytest.fixture(scope="module")
+def valid_keys_image(
+    public_key,
+    private_key,
+    session_cloud: IntegrationCloud,
+):
+    with session_cloud.launch() as client:
+        client.execute("mkdir /etc/cloud/keys")
+        client.write_to_file("/etc/cloud/keys/pub_key", public_key)
+        client.write_to_file("/etc/cloud/keys/priv_key", private_key)
+        client.execute("cloud-init clean --logs")
+        image_id = client.snapshot()
+        yield image_id
+        client.cloud.cloud_instance.delete_image(image_id)
+
+
+@pytest.fixture(scope="module")
+def valid_pub_key_image(
+    public_key,
+    session_cloud: IntegrationCloud,
+):
+    with session_cloud.launch() as client:
+        client.execute("mkdir /etc/cloud/keys")
+        client.write_to_file("/etc/cloud/keys/pub_key", public_key)
+        client.execute("cloud-init clean --logs")
+        image_id = client.snapshot()
+        yield image_id
+        client.cloud.cloud_instance.delete_image(image_id)
+
+
+@pytest.fixture(scope="module")
+def valid_priv_key_image(
+    private_key,
+    session_cloud: IntegrationCloud,
+):
+    with session_cloud.launch() as client:
+        client.execute("mkdir /etc/cloud/keys")
+        client.write_to_file("/etc/cloud/keys/priv_key", private_key)
+        client.execute("cloud-init clean --logs")
+        image_id = client.snapshot()
+        yield image_id
+        client.cloud.cloud_instance.delete_image(image_id)
+
+
+@pytest.fixture
+def pgp_client(session_cloud: IntegrationCloud, request):
+    user_data_fixture, image_id_fixture = request.param
+    user_data = request.getfixturevalue(user_data_fixture)
+    launch_kwargs = {"image_id": request.getfixturevalue(image_id_fixture)}
+    with session_cloud.launch(
+        user_data=user_data, launch_kwargs=launch_kwargs
+    ) as client:
+        yield client
+
+
+def _invalidate_key(client, key_path):
+    pub_key = client.read_from_file(key_path)
+    midde_index = len(pub_key) // 2
+    bad_pub_key = f"{pub_key[:midde_index]}a{pub_key[midde_index:]}"
+    client.write_to_file(key_path, bad_pub_key)
+
+
+@pytest.mark.parametrize(
+    "pgp_client",
+    [("signed_and_encrypted_userdata", "valid_keys_image")],
+    indirect=True,
+)
+def test_signed_and_encrypted(pgp_client: IntegrationInstance):
+    client = pgp_client
+    assert client.execute("test -f /var/tmp/signed_and_encrypted")
+    verify_clean_boot(client)
+
+    # Invalidate our public key and ensure we fail
+    client.execute("cp /etc/cloud/keys/pub_key /var/tmp/pub_key")
+    _invalidate_key(client, "/etc/cloud/keys/pub_key")
+    client.execute("cloud-init clean --logs")
+    client.execute("rm /var/tmp/signed_and_encrypted")
+    client.restart()
+    assert not client.execute("test -f /var/tmp/signed_and_encrypted")
+    result = client.execute("cloud-init status --format=json")
+    assert result.failed
+    assert "Failed decrypting user data" in result.stdout
+
+    # Restore the public key, invalidate the private key, and ensure we fail
+    client.execute("cp /var/tmp/pub_key /etc/cloud/keys/pub_key")
+    client.execute("cp /etc/cloud/keys/priv_key /var/tmp/priv_key")
+    _invalidate_key(client, "/etc/cloud/keys/priv_key")
+    client.execute("cloud-init clean --logs")
+    client.execute("rm /var/tmp/signed_and_encrypted")
+    client.restart()
+    assert not client.execute("test -f /var/tmp/signed_and_encrypted")
+    result = client.execute("cloud-init status --format=json")
+    assert result.failed
+    assert "Failed decrypting user data" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "pgp_client",
+    [("encrypted_userdata", "valid_priv_key_image")],
+    indirect=True,
+)
+def test_encrypted(pgp_client: IntegrationInstance):
+    client = pgp_client
+    assert client.execute("test -f /var/tmp/encrypted")
+    verify_clean_boot(client)
+
+    # Invalidate our private key and ensure we fail
+    _invalidate_key(client, "/etc/cloud/keys/priv_key")
+    client.execute("cloud-init clean --logs")
+    client.execute("rm /var/tmp/encrypted")
+    client.restart()
+    assert not client.execute("test -f /var/tmp/encrypted")
+    result = client.execute("cloud-init status --format=json")
+    assert result.failed
+    assert "Failed decrypting user data" in result.stdout
+
+
+@pytest.mark.parametrize(
+    "pgp_client",
+    [("signed_userdata", "valid_pub_key_image")],
+    indirect=True,
+)
+def test_signed(pgp_client: IntegrationInstance):
+    client = pgp_client
+    assert client.execute("test -f /var/tmp/signed")
+    verify_clean_boot(client)
+
+    # Invalidate our public key and ensure we fail
+    _invalidate_key(client, "/etc/cloud/keys/pub_key")
+    client.execute("cloud-init clean --logs")
+    client.execute("rm /var/tmp/signed")
+    client.restart()
+    assert not client.execute("test -f /var/tmp/signed")
+    result = client.execute("cloud-init status --format=json")
+    assert result.failed
+    assert "Failed decrypting user data" in result.stdout
+
+
+@pytest.fixture
+def lxd_pgp_client(session_cloud: IntegrationCloud, request):
+    user_data_fixture, image_id_fixture = request.param
+    user_data = request.getfixturevalue(user_data_fixture)
+    launch_kwargs = {
+        "execute_via_ssh": False,
+        "username": "root",
+    }
+    if image_id_fixture:
+        launch_kwargs["image_id"] = request.getfixturevalue(image_id_fixture)
+
+    with session_cloud.launch(
+        user_data=user_data, launch_kwargs=launch_kwargs
+    ) as client:
+        yield client
+
+
+@pytest.mark.skipif(
+    PLATFORM not in ["lxd_container", "lxd_vm"],
+    reason=(
+        "failed user data means no ssh or 'ubuntu' user creation, "
+        "so we need special LXD options"
+    ),
+)
+@pytest.mark.parametrize(
+    "lxd_pgp_client",
+    [
+        pytest.param(
+            ("encrypted_userdata", "valid_pub_key_image"),
+            id="encrypted_with_no_priv_key",
+        ),
+        pytest.param(
+            ("signed_userdata", "valid_priv_key_image"),
+            id="signed_with_no_pub_key",
+        ),
+        pytest.param(
+            ("signed_and_encrypted_userdata", None),
+            id="signed_and_encrypted_with_no_keys",
+        ),
+    ],
+    indirect=True,
+)
+def test_unparseable_userdata(
+    lxd_pgp_client: IntegrationInstance,
+):
+    result = lxd_pgp_client.execute("cloud-init status --format=json")
+    assert result.failed
+    assert "Failed decrypting user data" in result.stdout
+
+
+@pytest.mark.user_data(USER_DATA.format("no"))
+def test_pgp_required(client: IntegrationInstance):
+    client.write_to_file(
+        "/etc/cloud/cloud.cfg.d/99_pgp.cfg", "user_data:\n  require_pgp: true"
+    )
+    client.execute("cloud-init clean --logs")
+    client.restart()
+
+    result = client.execute("cloud-init status --format=json")
+    assert result.failed
+    assert (
+        "'require_pgp' was set true in cloud-init's base configuration, but "
+        "content type is text/cloud-config"
+    ) in result.stdout

--- a/tests/unittests/cloudinit/test_user_data.py
+++ b/tests/unittests/cloudinit/test_user_data.py
@@ -126,3 +126,12 @@ class TestPgpData:
         ud_proc = user_data.UserDataProcessor({})
         with pytest.raises(RuntimeError, match="content is not signed"):
             ud_proc.process(CLOUD_CONFIG, require_signature=True)
+
+    def test_pgp_in_list_disallowed(self, mocker):
+        mocker.patch("cloudinit.subp.subp", side_effect=my_subp)
+        ud_proc = user_data.UserDataProcessor({})
+        with pytest.raises(
+            RuntimeError,
+            match="PGP message must encompass entire user data or vendor data",
+        ):
+            ud_proc.process([GOOD_MESSAGE, GOOD_MESSAGE])

--- a/tests/unittests/cloudinit/test_user_data.py
+++ b/tests/unittests/cloudinit/test_user_data.py
@@ -108,7 +108,7 @@ class TestPgpData:
         mocker.patch("cloudinit.subp.subp", side_effect=my_subp)
         ud_proc = user_data.UserDataProcessor({})
         with pytest.raises(
-            RuntimeError, match="payload of type text/x-pgp-armored"
+            RuntimeError, match="Failed decrypting user data payload"
         ):
             ud_proc.process(BAD_MESSAGE)
 
@@ -124,7 +124,5 @@ class TestPgpData:
     def test_pgp_required_with_no_pgp_message(self, mocker):
         mocker.patch("cloudinit.subp.subp", side_effect=my_subp)
         ud_proc = user_data.UserDataProcessor({})
-        with pytest.raises(
-            RuntimeError, match="content type is text/cloud-config"
-        ):
+        with pytest.raises(RuntimeError, match="content is not signed"):
             ud_proc.process(CLOUD_CONFIG, require_signature=True)

--- a/tests/unittests/cloudinit/test_user_data.py
+++ b/tests/unittests/cloudinit/test_user_data.py
@@ -114,7 +114,7 @@ class TestPgpData:
     def test_pgp_required(self, mocker):
         mocker.patch("cloudinit.subp.subp", side_effect=my_subp)
         ud_proc = user_data.UserDataProcessor({})
-        message = ud_proc.process(GOOD_MESSAGE, require_pgp=True)
+        message = ud_proc.process(GOOD_MESSAGE, require_signature=True)
         parts = [p for p in message.walk() if not user_data.is_skippable(p)]
         assert len(parts) == 1
         part = parts[0]
@@ -126,4 +126,4 @@ class TestPgpData:
         with pytest.raises(
             RuntimeError, match="content type is text/cloud-config"
         ):
-            ud_proc.process(CLOUD_CONFIG, require_pgp=True)
+            ud_proc.process(CLOUD_CONFIG, require_signature=True)

--- a/tests/unittests/cloudinit/test_user_data.py
+++ b/tests/unittests/cloudinit/test_user_data.py
@@ -1,0 +1,129 @@
+"""These tests are for code in the cloudinit.user_data module.
+
+These are NOT general tests for user data processing.
+"""
+
+from email.mime.base import MIMEBase
+
+import pytest
+
+from cloudinit import subp, user_data
+from tests.unittests.util import gzip_text
+
+
+def count_messages(root):
+    return sum(not user_data.is_skippable(m) for m in root.walk())
+
+
+class TestMessageFromString:
+    def test_unicode_not_messed_up(self):
+        roundtripped = user_data.message_from_string("\n").as_string()
+        assert "\x00" not in roundtripped
+
+
+class TestUDProcess:
+    @pytest.mark.parametrize(
+        "msg",
+        [
+            pytest.param("#cloud-config\napt_update: True\n", id="str"),
+            pytest.param(b"#cloud-config\napt_update: True\n", id="bytes"),
+            pytest.param(
+                gzip_text("#cloud-config\napt_update: True\n"),
+                id="compressed",
+            ),
+        ],
+    )
+    def test_type_in_userdata(self, msg):
+        ud_proc = user_data.UserDataProcessor({})
+        message = ud_proc.process(msg)
+        assert count_messages(message)
+
+
+class TestConvertString:
+    @pytest.mark.parametrize(
+        "blob,decode",
+        [
+            pytest.param("hi mom", False, id="str"),
+            pytest.param(b"#!/bin/bash\necho \xc3\x84\n", True, id="bytes"),
+            pytest.param(b"\x32\x32", True, id="binary"),
+        ],
+    )
+    def test_mime_conversion_preserves_content(self, blob, decode):
+        """Ensure for each type of input, the content is preserved."""
+        assert (
+            user_data.convert_string(blob).get_payload(decode=decode) == blob
+        )
+
+    def test_handle_mime_parts(self):
+        """Mime parts are properly returned as a mime message."""
+        message = MIMEBase("text", "plain")
+        message.set_payload("Just text")
+        msg = user_data.convert_string(str(message))
+        assert "Just text" == msg.get_payload(decode=False)
+
+
+GOOD_MESSAGE = """\
+-----BEGIN PGP MESSAGE-----
+
+Pass:AMockWillDecryptMeIntoACloudConfig
+-----END PGP MESSAGE-----
+"""
+
+CLOUD_CONFIG = """\
+#cloud-config
+password: password
+"""
+
+BAD_MESSAGE = """\
+-----BEGIN PGP MESSAGE-----
+
+Fail:AMockWillFailToDecryptMe
+-----END PGP MESSAGE-----
+"""
+
+
+def my_subp(*args, **kwargs):
+    if args[0][0] == "gpg":
+        if "Pass:" in kwargs["data"]:
+            return subp.SubpResult(CLOUD_CONFIG, "")
+        elif "Fail:" in kwargs["data"]:
+            raise subp.ProcessExecutionError(
+                "", "gpg: public key decryption failed", 2, args[0]
+            )
+    return subp.SubpResult("", "")
+
+
+class TestPgpData:
+    def test_pgp_decryption(self, mocker):
+        mocker.patch("cloudinit.subp.subp", side_effect=my_subp)
+        ud_proc = user_data.UserDataProcessor({})
+        message = ud_proc.process(GOOD_MESSAGE)
+        parts = [p for p in message.walk() if not user_data.is_skippable(p)]
+        assert len(parts) == 1
+        part = parts[0]
+        assert part.get_payload() == CLOUD_CONFIG
+
+    def test_pgp_decryption_failure(self, mocker):
+        mocker.patch("cloudinit.subp.subp", side_effect=my_subp)
+        ud_proc = user_data.UserDataProcessor({})
+        with pytest.raises(
+            RuntimeError, match="payload of type text/x-pgp-armored"
+        ):
+            ud_proc.process(BAD_MESSAGE)
+
+    def test_pgp_required(self, mocker):
+        mocker.patch("cloudinit.subp.subp", side_effect=my_subp)
+        ud_proc = user_data.UserDataProcessor({})
+        message = ud_proc.process(GOOD_MESSAGE, require_pgp=True)
+        parts = [p for p in message.walk() if not user_data.is_skippable(p)]
+        assert len(parts) == 1
+        part = parts[0]
+        assert part.get_payload() == CLOUD_CONFIG
+
+    def test_pgp_required_with_no_pgp_message(self, mocker):
+        mocker.patch("cloudinit.subp.subp", side_effect=my_subp)
+        ud_proc = user_data.UserDataProcessor({})
+        with pytest.raises(
+            RuntimeError, match="content type is text/cloud-config"
+        ):
+            ud_proc.process(CLOUD_CONFIG, require_pgp=True)

--- a/tests/unittests/cloudinit/test_user_data.py
+++ b/tests/unittests/cloudinit/test_user_data.py
@@ -85,7 +85,7 @@ Fail:AMockWillFailToDecryptMe
 def my_subp(*args, **kwargs):
     if args[0][0] == "gpg":
         if "Pass:" in kwargs["data"]:
-            return subp.SubpResult(CLOUD_CONFIG, "")
+            return subp.SubpResult(CLOUD_CONFIG, "gpg: Good signature")
         elif "Fail:" in kwargs["data"]:
             raise subp.ProcessExecutionError(
                 "", "gpg: public key decryption failed", 2, args[0]

--- a/tests/unittests/cloudinit/test_user_data.py
+++ b/tests/unittests/cloudinit/test_user_data.py
@@ -3,6 +3,7 @@
 These are NOT general tests for user data processing.
 """
 
+import email
 from email.mime.base import MIMEBase
 
 import pytest
@@ -17,7 +18,7 @@ def count_messages(root):
 
 class TestMessageFromString:
     def test_unicode_not_messed_up(self):
-        roundtripped = user_data.message_from_string("\n").as_string()
+        roundtripped = email.message_from_string("\n").as_string()
         assert "\x00" not in roundtripped
 
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2451,12 +2451,6 @@ class TestMultiLog(helpers.FilesystemMockingTestCase):
         self.assertEqual((log_level, mock.ANY), logger.log.call_args[0])
 
 
-class TestMessageFromString(helpers.TestCase):
-    def test_unicode_not_messed_up(self):
-        roundtripped = util.message_from_string("\n").as_string()
-        self.assertNotIn("\x00", roundtripped)
-
-
 class TestReadOptionalSeed:
     @pytest.mark.parametrize(
         "seed_dir,expected_fill,retval",

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -1,8 +1,10 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+import gzip
+from io import BytesIO
 from typing import Optional, Type
 from unittest import mock
 
-from cloudinit import cloud, distros, helpers
+from cloudinit import cloud, distros, helpers, util
 from cloudinit.config import Config
 from cloudinit.net.dhcp import IscDhclient
 from cloudinit.sources import DataSource, DataSourceHostname
@@ -69,6 +71,15 @@ def abstract_to_concrete(abclass):
 
     concreteCls.__abstractmethods__ = frozenset()
     return type("DummyConcrete" + abclass.__name__, (concreteCls,), {})
+
+
+def gzip_text(text):
+    contents = BytesIO()
+    f = gzip.GzipFile(fileobj=contents, mode="wb")
+    f.write(util.encode_text(text))
+    f.flush()
+    f.close()
+    return contents.getvalue()
 
 
 class MockDistro(distros.Distro):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat: Support encrypted and signed user data

Cloud-init user data often contains user secrets including passwords
and private keys. This data has always been submitted in plain text.
To protect this data's confidentiality and guarantee its authenticity,
add the ability to have this data encrypted and signed.

A new user data format is added allowing for an ASCII armored PGP
MESSAGE. If detected, cloud-init will import into a temporary keyring
any keys provided in /etc/cloud/keys and use these keys to decrypt
and/or verify the provided data.

After decryption, the resulting message will be treated as user data
as before.

Fixes GH-4943
```

## Additional Context
The `squash:` commits are just to make reviewing easier. I plan to squash them before merging.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
