### PR TITLE
chore(actions): add doc label for any doc related subdir file matches

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,6 +2,6 @@ documentation:
 - all:
   - changed-files:
     - any-glob-to-any-file:
-      - 'doc/*'
-      - 'cloudinit/config/schemas/*'
+      - 'doc/**'
+      - 'cloudinit/config/schemas/**'
   - base-branch: ['main']


### PR DESCRIPTION
## Proposed Commit Message

```
chore(actions): add doc label for any doc related subdir file matches

Recently noticed that doc file changes in nested subdirs were not triggering documentation auto label.

Example of subdir match at
https://github.com/actions/labeler?tab=readme-ov-file#basic-examples
```

## Additional Context
documentation PR that didn't auto-label 
https://github.com/canonical/cloud-init/pull/5595

## Test Steps


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
