### PR TITLE
Ubuntu/focal: fix invalid quilt patch for daily recipe builds

### DIFF
--- a/debian/patches/no-single-process.patch
+++ b/debian/patches/no-single-process.patch
@@ -193,7 +193,7 @@ Last-Update: 2024-08-02
 -WantedBy=cloud-init.target
 --- /dev/null
 +++ b/systemd/cloud-init.service.tmpl
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,56 @@
 +## template:jinja
 +[Unit]
 +# https://cloudinit.readthedocs.io/en/latest/explanation/boot.html


### PR DESCRIPTION
## Proposed Commit Message
```
    fix: invalid quilt patch no-single-process.patch
    
    Patch diff was invalid representing a 57 line diff for cloud-init.service
    in the diff header. But, the actual diff context was only 56 lines.
    
    This broke the ability to apply all quilt patches with quilt push -a.
    
    Resulting in broken daily build recipe for focal with the following
    error message:
      patch: **** malformed patch at line 252:
    
      Patch no-single-process.patch does not apply (enforce with -f)
```

## Additional Context
Failing daily build https://launchpadlibrarian.net/742766914/buildlog.txt.gz

## Test Steps
```
-- Before this PR
quilt push -a  # will fail in the same way as daily recipe
-- After this PR
quilt push -a  # will succeed
tox -e py3 # success
quilt pop -a # succeed
```

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
