### PR TITLE
fix install location of systemd drop-in configs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -312,7 +312,7 @@ if not platform.system().endswith("BSD"):
         [
             (RULES_PATH + "/rules.d", [f for f in glob("udev/*.rules")]),
             (
-                ETC + "/systemd/system/sshd-keygen@.service.d/",
+                INITSYS_ROOTS["systemd"] + "/sshd-keygen@.service.d/",
                 ["systemd/disable-sshd-keygen-if-cloud-init-active.conf"],
             ),
         ]


### PR DESCRIPTION
Fixes #5613

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<fix>(systemd) Correct location of installed drop-in files

As noted in the systemd documentation, /etc is reserved for "System
units created by the administrator" while the lib directory should be
used by "System units installed by the distribution package manager".

Fixes GH-5613

```

## Additional Context
<!-- If relevant -->

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1078180
https://manpages.debian.org/bookworm/systemd/systemd.unit.5.en.html

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Validate that cloud-init installations currently include `/etc/systemd/system/sshd-keygen@.service.d/disable-sshd-keygen-if-cloud-init-active.conf`.  After this change, the file is installed as `/usr/lib/systemd/system/sshd-keygen@.service.d/disable-sshd-keygen-if-cloud-init-active.conf`

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
