### PR TITLE
fix(btrfs): Version parsing

### DIFF
--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -58,7 +58,10 @@ def _resize_btrfs(mount_point, devpth):
     # the resize operation can be queued
     btrfs_with_queue = lifecycle.Version.from_str("5.10")
     system_btrfs_ver = lifecycle.Version.from_str(
-        subp.subp(["btrfs", "--version"])[0].split("v")[-1].strip()
+        subp.subp(["btrfs", "--version"])
+        .stdout.split("\n")[0]
+        .split("v")[-1]
+        .strip()
     )
     if system_btrfs_ver >= btrfs_with_queue:
         idx = cmd.index("resize")

--- a/tests/unittests/config/test_cc_resizefs.py
+++ b/tests/unittests/config/test_cc_resizefs.py
@@ -495,11 +495,11 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
     @mock.patch("cloudinit.config.cc_resizefs.os.path.isdir")
     @mock.patch("cloudinit.subp.subp")
     def test_resize_btrfs_version(self, m_subp, m_is_dir, m_is_rw):
-        """Queue the resize request if btrfs >= 5.10"""
+        """Queue the resize request if btrfs >= 6.10"""
         m_is_rw.return_value = True
         m_is_dir.return_value = True
         m_subp.return_value = SubpResult(
-            "btrfs-progs v5.10 \n\n-EXPERIMENTAL -INJECT -STATIC +LZO +ZSTD "
+            "btrfs-progs v6.10 \n\n-EXPERIMENTAL -INJECT -STATIC +LZO +ZSTD "
             "+UDEV +FSVERITY +ZONED CRYPTO=libgcrypt",
             "",
         )

--- a/tests/unittests/config/test_cc_resizefs.py
+++ b/tests/unittests/config/test_cc_resizefs.py
@@ -22,7 +22,7 @@ from cloudinit.config.schema import (
     get_schema,
     validate_cloudconfig_schema,
 )
-from cloudinit.subp import ProcessExecutionError
+from cloudinit.subp import ProcessExecutionError, SubpResult
 from tests.unittests.helpers import (
     CiTestCase,
     mock,
@@ -62,7 +62,7 @@ class TestResizefs(CiTestCase):
         fs_type = "ufs"
         resize_what = "/"
         devpth = "/dev/da0p2"
-        m_subp.return_value = (
+        m_subp.return_value = SubpResult(
             "stdout: super-block backups (for fsck_ffs -b #) at:\n\n",
             "growfs: no room to allocate last cylinder group; "
             "leaving 364KB unused\n",
@@ -457,7 +457,7 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
         """Do not resize / directly if it is read-only. (LP: #1734787)."""
         m_is_rw.return_value = False
         m_is_dir.return_value = True
-        m_subp.return_value = ("btrfs-progs v4.19 \n", "")
+        m_subp.return_value = SubpResult("btrfs-progs v4.19 \n", "")
         self.assertEqual(
             ("btrfs", "filesystem", "resize", "max", "//.snapshots"),
             _resize_btrfs("/", "/dev/sda1"),
@@ -470,7 +470,7 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
         """Do not resize / directly if it is read-only. (LP: #1734787)."""
         m_is_rw.return_value = True
         m_is_dir.return_value = True
-        m_subp.return_value = ("btrfs-progs v4.19 \n", "")
+        m_subp.return_value = SubpResult("btrfs-progs v4.19 \n", "")
         self.assertEqual(
             ("btrfs", "filesystem", "resize", "max", "/"),
             _resize_btrfs("/", "/dev/sda1"),
@@ -485,7 +485,24 @@ class TestMaybeGetDevicePathAsWritableBlock(CiTestCase):
         """Queue the resize request if btrfs >= 5.10"""
         m_is_rw.return_value = True
         m_is_dir.return_value = True
-        m_subp.return_value = ("btrfs-progs v5.10 \n", "")
+        m_subp.return_value = SubpResult("btrfs-progs v5.10 \n", "")
+        self.assertEqual(
+            ("btrfs", "filesystem", "resize", "--enqueue", "max", "/"),
+            _resize_btrfs("/", "/dev/sda1"),
+        )
+
+    @mock.patch("cloudinit.util.mount_is_read_write")
+    @mock.patch("cloudinit.config.cc_resizefs.os.path.isdir")
+    @mock.patch("cloudinit.subp.subp")
+    def test_resize_btrfs_version(self, m_subp, m_is_dir, m_is_rw):
+        """Queue the resize request if btrfs >= 5.10"""
+        m_is_rw.return_value = True
+        m_is_dir.return_value = True
+        m_subp.return_value = SubpResult(
+            "btrfs-progs v5.10 \n\n-EXPERIMENTAL -INJECT -STATIC +LZO +ZSTD "
+            "+UDEV +FSVERITY +ZONED CRYPTO=libgcrypt",
+            "",
+        )
         self.assertEqual(
             ("btrfs", "filesystem", "resize", "--enqueue", "max", "/"),
             _resize_btrfs("/", "/dev/sda1"),
@@ -555,12 +572,12 @@ class TestZpool:
 
     @mock.patch(M_PATH + "os")
     @mock.patch("cloudinit.subp.subp")
-    def test_get_device_info_from_zpool_on_error(self, zpool_output, m_os):
+    def test_get_device_info_from_zpool_on_error(self, m_subp, m_os):
         # mock /dev/zfs exists
         m_os.path.exists.return_value = True
 
         # mock subp command from get_mount_info_fs_on_zpool
-        zpool_output.return_value = (
+        m_subp.return_value = SubpResult(
             readResource("zpool_status_simple.txt"),
             "error",
         )


### PR DESCRIPTION


<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(btrfs): Version parsing

Fixes GH-5614
```

## Additional Context
#5614