### PR TITLE
fix(NetworkManager): Fix network activator

### DIFF
--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -184,6 +184,30 @@ class NetworkManagerActivator(NetworkActivator):
         cmd = ["nmcli", "device", "disconnect", device_name]
         return _alter_interface(cmd, device_name)
 
+    @classmethod
+    def bring_up_interfaces(cls, device_names: Iterable[str]) -> bool:
+        """Activate network
+
+        Return True on success
+        """
+        state = subp.subp(
+            [
+                "systemctl",
+                "show",
+                "--property=SubState",
+                "NetworkManager.service",
+            ]
+        ).stdout.rstrip()
+        if "SubState=running" != state:
+            LOG.warning(
+                "Expected NetworkManager SubState=running, but detected: %s",
+                state,
+            )
+        return _alter_interface(
+            ["systemctl", "reload-or-try-restart", "NetworkManager.service"],
+            "all",
+        )
+
 
 class NetplanActivator(NetworkActivator):
     NETPLAN_CMD = ["netplan", "apply"]

--- a/systemd/cloud-final.service.tmpl
+++ b/systemd/cloud-final.service.tmpl
@@ -25,16 +25,7 @@ Type=oneshot
 ExecStart=sh -c 'echo "start" | netcat -Uu -W1 /run/cloud-init/share/final.sock -s /run/cloud-init/share/final-return.sock | sh'
 RemainAfterExit=yes
 TimeoutSec=0
-{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
-# Restart NetworkManager if it is present and running.
-ExecStartPost=/bin/sh -c 'u=NetworkManager.service; \
- out=$(systemctl show --property=SubState $u) || exit; \
- [ "$out" = "SubState=running" ] || exit 0; \
- systemctl reload-or-try-restart $u'
-{% else %}
 TasksMax=infinity
-{% endif %}
-
 
 # Output needs to appear in instance console output
 StandardOutput=journal+console

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
+from cloudinit import subp
 from cloudinit.net.activators import (
     DEFAULT_PRIORITY,
     NAME_TO_ACTIVATOR,
@@ -234,6 +235,21 @@ NETWORK_MANAGER_BRING_UP_CALL_LIST: list = [
     ),
 ]
 
+NETWORK_MANAGER_BRING_UP_ALL_CALL_LIST: list = [
+    (
+        (
+            [
+                "systemctl",
+                "show",
+                "--property=SubState",
+                "NetworkManager.service",
+            ],
+        ),
+        {},
+    ),
+    ((["systemctl", "reload-or-try-restart", "NetworkManager.service"],), {}),
+]
+
 NETWORKD_BRING_UP_CALL_LIST: list = [
     ((["ip", "link", "set", "dev", "eth0", "up"],), {}),
     ((["ip", "link", "set", "dev", "eth1", "up"],), {}),
@@ -278,7 +294,18 @@ class TestActivatorsBringUp:
             assert call == expected_call_list[index]
             index += 1
 
-    @patch("cloudinit.subp.subp", return_value=("", ""))
+
+@pytest.mark.parametrize(
+    "activator, expected_call_list",
+    [
+        (IfUpDownActivator, IF_UP_DOWN_BRING_UP_CALL_LIST),
+        (NetplanActivator, NETPLAN_CALL_LIST),
+        (NetworkManagerActivator, NETWORK_MANAGER_BRING_UP_ALL_CALL_LIST),
+        (NetworkdActivator, NETWORKD_BRING_UP_CALL_LIST),
+    ],
+)
+class TestActivatorsBringUpAll:
+    @patch("cloudinit.subp.subp", return_value=subp.SubpResult("", ""))
     def test_bring_up_interfaces(
         self, m_subp, activator, expected_call_list, available_mocks
     ):
@@ -288,7 +315,7 @@ class TestActivatorsBringUp:
             assert call == expected_call_list[index]
             index += 1
 
-    @patch("cloudinit.subp.subp", return_value=("", ""))
+    @patch("cloudinit.subp.subp", return_value=subp.SubpResult("", ""))
     def test_bring_up_all_interfaces_v1(
         self, m_subp, activator, expected_call_list, available_mocks
     ):
@@ -297,7 +324,7 @@ class TestActivatorsBringUp:
         for call in m_subp.call_args_list:
             assert call in expected_call_list
 
-    @patch("cloudinit.subp.subp", return_value=("", ""))
+    @patch("cloudinit.subp.subp", return_value=subp.SubpResult("", ""))
     def test_bring_up_all_interfaces_v2(
         self, m_subp, activator, expected_call_list, available_mocks
     ):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(NetworkManager): Fix network activator

Reload NetworkManager configuration rather than bringing up interfaces.

This enables NetworkManager to configure interfaces which are not yet available in userspace, and fixes a race that was previously worked around in a service file.
```

## Additional Context
https://github.com/canonical/cloud-init/issues/5512
