### PR TITLE
chore: avoid flaky ntp test on devel ubuntu releases

### DIFF
--- a/tests/integration_tests/releases.py
+++ b/tests/integration_tests/releases.py
@@ -98,6 +98,7 @@ LUNAR = Release("ubuntu", "lunar", "23.04")
 MANTIC = Release("ubuntu", "mantic", "23.10")
 NOBLE = Release("ubuntu", "noble", "24.04")
 ORACULAR = Release("ubuntu", "oracular", "24.10")
+UBUNTU_DEVEL = ORACULAR
 
 UBUNTU_STABLE = (FOCAL, JAMMY, MANTIC, NOBLE)
 


### PR DESCRIPTION
## Proposed Commit Message

```
The ntp package (via ntpsec) occasionally has dependency resolution issues in Ubuntu development releases when new versions of systemd-timesyncd or ntp are released into the archive and cloud images are launched from build serial numbers which do not yet contain the updated systemd-timesyncd package.

Update tests/integration_tests/modules/test_ntp_servers.py on UBUNTU_DEVEL series by providing additional bootcmd to ensure systemd-timesyncd is up to date before any cc_ntp operations take place.

This avoids apt package resolution conflicts when stale ubuntu cloudimages do not yet have knowledge of systemd-timesyncd packages when trying to install ntp/ntpsec.
```

## Additional Context

Intermittent yet repeated ntp error on ubuntu devel releases
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_container/48/
```
tests.integration_tests.modules.test_ntp_servers.TestNtpServers.test_ntp_installed (from pytest)
Failing for the past 3 builds (Since Unstable
[#46](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_container/46/) )
[Took 20 sec.](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_container/48/testReport/junit/tests.integration_tests.modules.test_ntp_servers/TestNtpServers/test_ntp_installed/history)
Error Message

AssertionError: assert False
 +  where False = ''.ok
 +    where '' = execute('ntpd --version')
 +      where execute = <tests.integration_tests.instances.IntegrationInstance object at 0x7fb95540a0b0>.execute
```

## Test Steps
```
CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers
CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers
```
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
