### PR TITLE
cloud-config user-data:  ntp to provide ntp_client: ntpsec support

### DIFF
--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -20,6 +20,7 @@ LOG = logging.getLogger(__name__)
 
 frequency = PER_INSTANCE
 NTP_CONF = "/etc/ntp.conf"
+NTPSEC_CONF = "/etc/ntpsec/ntp.conf"
 NR_POOL_SERVERS = 4
 distros = [
     "almalinux",
@@ -79,6 +80,14 @@ NTP_CLIENT_CONFIG = {
         "template_name": "ntp.conf.{distro}",
         "template": None,
     },
+    "ntpsec": {
+        "check_exe": "ntpd",
+        "confpath": NTPSEC_CONF,
+        "packages": ["ntpsec"],
+        "service_name": "ntpsec",
+        "template_name": "ntpsec.conf.{distro}",
+        "template": None,
+    },
     "openntpd": {
         "check_exe": "ntpd",
         "confpath": "/etc/ntpd.conf",
@@ -105,9 +114,14 @@ DISTRO_CLIENT_CONFIG = {
             "service_name": "chronyd",
         },
         "ntp": {
-            "confpath": "/etc/ntp.conf",
+            "confpath": NTP_CONF,
             "packages": [],
             "service_name": "ntpd",
+        },
+        "ntpsec": {
+            "confpath": NTP_CONF,
+            "packages": [],
+            "service_name": "ntpsec",
         },
     },
     "aosc": {
@@ -129,6 +143,7 @@ DISTRO_CLIENT_CONFIG = {
         "ntp": {
             "service_name": "ntpd",
         },
+        "ntpsec": {"service_name": "ntpd", "confpath": NTP_CONF},
         "chrony": {
             "service_name": "chronyd",
         },
@@ -146,7 +161,7 @@ DISTRO_CLIENT_CONFIG = {
     },
     "freebsd": {
         "ntp": {
-            "confpath": "/etc/ntp.conf",
+            "confpath": NTP_CONF,
             "service_name": "ntpd",
             "template_name": "ntp.conf.{distro}",
         },
@@ -181,7 +196,7 @@ DISTRO_CLIENT_CONFIG = {
             "service_name": "chronyd",
         },
         "ntp": {
-            "confpath": "/etc/ntp.conf",
+            "confpath": NTP_CONF,
             "service_name": "ntpd",
         },
         "systemd-timesyncd": {
@@ -193,9 +208,10 @@ DISTRO_CLIENT_CONFIG = {
             "service_name": "chronyd",
         },
         "ntp": {
-            "confpath": "/etc/ntp.conf",
+            "confpath": NTP_CONF,
             "service_name": "ntpd",
         },
+        "ntpsec": {"service_name": "ntpd", "confpath": NTP_CONF},
         "systemd-timesyncd": {
             "check_exe": "/usr/lib/systemd/systemd-timesyncd",
         },
@@ -204,7 +220,8 @@ DISTRO_CLIENT_CONFIG = {
         "chrony": {
             "service_name": "chronyd",
         },
-        "ntp": {"service_name": "ntpd", "confpath": "/etc/ntp.conf"},
+        "ntp": {"service_name": "ntpd", "confpath": NTP_CONF},
+        "ntpsec": {"service_name": "ntpd", "confpath": NTP_CONF},
         "systemd-timesyncd": {
             "check_exe": "/usr/lib/systemd/systemd-timesyncd",
             "confpath": "/etc/systemd/timesyncd.conf",
@@ -214,6 +231,7 @@ DISTRO_CLIENT_CONFIG = {
         "ntp": {
             "service_name": "ntpd",
         },
+        "ntpsec": {"service_name": "ntpd", "confpath": NTP_CONF},
         "chrony": {
             "service_name": "chronyd",
         },
@@ -223,9 +241,10 @@ DISTRO_CLIENT_CONFIG = {
             "service_name": "chronyd",
         },
         "ntp": {
-            "confpath": "/etc/ntp.conf",
+            "confpath": NTP_CONF,
             "service_name": "ntpd",
         },
+        "ntpsec": {"service_name": "ntpd", "confpath": NTP_CONF},
         "systemd-timesyncd": {
             "check_exe": "/usr/lib/systemd/systemd-timesyncd",
         },

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2133,6 +2133,15 @@
             "ntp_client": {
               "type": "string",
               "default": "auto",
+              "enum": [
+                "auto",
+                "chrony",
+                "ntp",
+                "ntpdate",
+                "ntpsec",
+                "openntpd",
+                "systemd-timesyncd"
+              ],
               "description": "Name of an NTP client to use to configure system NTP. When unprovided or 'auto' the default client preferred by the distribution will be used. The following built-in client names can be used to override existing configuration defaults: chrony, ntp, openntpd, ntpdate, systemd-timesyncd."
             },
             "enabled": {

--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -179,16 +179,21 @@ class BSDNetworking(Networking):
 
     def __init__(self):
         self.ifc = ifconfig.Ifconfig()
-        self.ifs = {}
-        self._update_ifs()
+        self._ifs = {}
         super().__init__()
+
+    @property
+    def ifs(self):
+        if not self._ifs:
+            self._update_ifs()
+        return self._ifs
 
     def _update_ifs(self):
         ifconf = subp.subp(["ifconfig", "-a"])
         # ``ifconfig -a`` always returns at least ``lo0``.
         # So this ``if`` is really just to make testing/mocking easier
         if ifconf[0]:
-            self.ifs = self.ifc.parse(ifconf[0])
+            self._ifs = self.ifc.parse(ifconf[0])
 
     def apply_network_config_names(self, netcfg: NetworkConfig) -> None:
         LOG.debug("Cannot rename network interface.")

--- a/templates/ntpsec.conf.alpine.tmpl
+++ b/templates/ntpsec.conf.alpine.tmpl
@@ -1,0 +1,69 @@
+# /etc/ntp.conf
+# Sensible default NTPsec configuration file.
+# See ntp.conf(5) man page for help.
+# More examples can be found at https://gitlab.com/NTPsec/ntpsec/-/tree/master/etc/ntp.d
+
+# If you have no other local chimers to help NTP perform sanity checks
+# then you can use some public chimers from the NTP public pool:
+# http://www.pool.ntp.org/en/
+#
+# iburst tells it to send the first few requests at 2 second intervals rather
+# than wait for the poll interval, which defaults to 64 seconds. That greatly
+# speeds up the time for ntpd to set the system time and start responding to
+# requests.
+#
+# You can speed up initialization, and spread the load better, by
+# using a country-specific potion of the pool, e.g. something like
+#
+# us.pool.ntp.org
+#
+# If you are not in the USA, then it will probably work to
+# change the 'us' to your two letter country code.
+#
+# Major Internet-using countries with pools include:
+# us de fr uk nl ch ru ca au cn za br
+#
+# If you don't know your country code, find it at
+#
+# https://en.wikipedia.org/wiki/ISO_3166-1
+#
+# and then try prepending it to ".pool.ntp.org" and pinging that.
+# hostname. If you get a response, you can use it.
+#
+# Alternatively, if you are running Linux your distribution may have
+# a designated pool disparcher, e.g. ubuntu.pool.ntp.org
+#
+{% if pools %}# pools
+{% endif %}
+{% for pool in pools -%}
+pool {{pool}} iburst
+{% endfor %}
+{%- if servers %}# servers
+{% endif %}
+{% for server in servers -%}
+server {{server}} iburst
+{% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+
+# The following setting reduces the maximum number of sources to not use more
+# than four servers from the pool.ntp.org pool.  If you have specified other
+# servers, you can increase the maxclock number accordingly.
+tos maxclock 5
+
+# Exchange time with everybody, but don't allow configuration.
+# This is the right security setup for 99% of deployments.
+restrict default kod limited nomodify noquery
+restrict -6 default kod limited nomodify noquery
+
+# Local users may interrogate the NTP server more closely.
+restrict 127.0.0.1
+restrict -6 ::1
+
+# Minimal logging - we declare a drift file and that's it.
+driftfile /var/lib/ntp/ntp.drift
+
+# We don't log any statistics by default, but the directory
+# still needs to exist
+statsdir /var/log/ntpstats/

--- a/templates/ntpsec.conf.debian.tmpl
+++ b/templates/ntpsec.conf.debian.tmpl
@@ -1,0 +1,62 @@
+## template:jinja
+
+# /etc/ntpsec/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
+
+driftfile /var/lib/ntpsec/ntp.drift
+leapfile /usr/share/zoneinfo/leap-seconds.list
+
+# To enable Network Time Security support as a server, obtain a certificate
+# (e.g. with Let's Encrypt), configure the paths below, and uncomment:
+# nts cert CERT_FILE
+# nts key KEY_FILE
+# nts enable
+
+# You must create /var/log/ntpsec (owned by ntpsec:ntpsec) to enable logging.
+#statsdir /var/log/ntpsec/
+#statistics loopstats peerstats clockstats
+#filegen loopstats file loopstats type day enable
+#filegen peerstats file peerstats type day enable
+#filegen clockstats file clockstats type day enable
+
+# This should be maxclock 7, but the pool entries count towards maxclock.
+tos maxclock 11
+
+# Comment this out if you have a refclock and want it to be able to discipline
+# the clock by itself (e.g. if the system is not connected to the network).
+tos minclock 4 minsane 3
+
+# Specify one or more NTP servers.
+
+# Public NTP servers supporting Network Time Security:
+# server time.cloudflare.com nts
+
+# pool.ntp.org maps to about 1000 low-stratum NTP servers.  Your server will
+# pick a different set every time it starts up.  Please consider joining the
+# pool: <https://www.pool.ntp.org/join.html>
+{% if pools %}# pools
+{% endif %}
+{% for pool in pools -%}
+pool {{pool}} iburst
+{% endfor %}
+{%- if servers %}# servers
+{% endif %}
+{% for server in servers -%}
+server {{server}} iburst
+{% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+
+# Access control configuration; see /usr/share/doc/ntpsec-doc/html/accopt.html
+# for details.
+#
+# Note that "restrict" applies to both servers and clients, so a configuration
+# that might be intended to block requests from certain clients could also end
+# up blocking replies from your own upstream servers.
+
+# By default, exchange time with everybody, but don't allow configuration.
+restrict default kod nomodify nopeer noquery limited
+
+# Local users may interrogate the ntp server more closely.
+restrict 127.0.0.1
+restrict ::1

--- a/templates/ntpsec.conf.rhel.tmpl
+++ b/templates/ntpsec.conf.rhel.tmpl
@@ -1,0 +1,35 @@
+## template:jinja
+
+# For more information about this file, see the ntp.conf(5) man page.
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (https://www.pool.ntp.org/join.html).
+{% if pools %}# pools
+{% endif %}
+{% for pool in pools -%}
+pool {{pool}} iburst
+{% endfor %}
+{%- if servers %}# servers
+{% endif %}
+{% for server in servers -%}
+server {{server}} iburst
+{% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+
+# Reduce the maximum number of servers used from the pool.
+tos maxclock 5
+
+# Record the frequency of the system clock.
+driftfile /var/lib/ntp/drift
+
+# Disable configuration and monitoring access by default.
+restrict default nomodify noquery
+
+# Enable all access for localhost.
+restrict 127.0.0.1
+restrict ::1
+
+# Enable writing of statistics records.
+#statistics clockstats cryptostats loopstats peerstats

--- a/templates/ntpsec.conf.sles.tmpl
+++ b/templates/ntpsec.conf.sles.tmpl
@@ -1,0 +1,122 @@
+## template:jinja
+
+# /etc/ntpsec/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
+
+driftfile /var/lib/ntpsec/ntp.drift
+leapfile /usr/share/zoneinfo/leap-seconds.list
+
+# To enable Network Time Security support as a server, obtain a certificate
+# (e.g. with Let's Encrypt), configure the paths below, and uncomment:
+# nts cert CERT_FILE
+# nts key KEY_FILE
+# nts enable
+
+# You must create /var/log/ntpsec (owned by ntpsec:ntpsec) to enable logging.
+#statsdir /var/log/ntpsec/
+#statistics loopstats peerstats clockstats
+#filegen loopstats file loopstats type day enable
+#filegen peerstats file peerstats type day enable
+#filegen clockstats file clockstats type day enable
+
+# This should be maxclock 7, but the pool entries count towards maxclock.
+tos maxclock 11
+################################################################################
+## /etc/ntp.conf
+##
+## Sample NTP configuration file.
+## See package 'ntp-doc' for documentation, Mini-HOWTO and FAQ.
+## Copyright (c) 2017 SUSE LINUX GmbH, Nuernberg, Germany.
+##
+## Author: Michael Andres,  <ma@suse.de>
+##         Michael Skibbe,  <mskibbe@suse.de>
+##
+################################################################################
+
+##
+## Radio and modem clocks by convention have addresses in the
+## form 127.127.t.u, where t is the clock type and u is a unit
+## number in the range 0-3.
+##
+## Most of these clocks require support in the form of a
+## serial port or special bus peripheral. The particular
+## device is normally specified by adding a soft link
+## /dev/device-u to the particular hardware device involved,
+## where u correspond to the unit number above.
+##
+## Generic DCF77 clock on serial port (Conrad DCF77)
+## Address:     127.127.8.u
+## Serial Port: /dev/refclock-u
+##
+## (create soft link /dev/refclock-0 to the particular ttyS?)
+##
+# server 127.127.8.0 mode 5 prefer
+
+##
+## Undisciplined Local Clock. This is a fake driver intended for backup
+## and when no outside source of synchronized time is available.
+##
+# server 127.127.1.0		# local clock (LCL)
+# fudge  127.127.1.0 stratum 10	# LCL is unsynchronized
+
+##
+## Add external Servers using
+## # rcntpd addserver <yourserver>
+## The servers will only be added to the currently running instance, not
+## to /etc/ntp.conf.
+##
+{% if pools %}# pools
+{% endif %}
+{% for pool in pools -%}
+pool {{pool}} iburst
+{% endfor %}
+{%- if servers %}# servers
+{% endif %}
+{% for server in servers -%}
+server {{server}} iburst
+{% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+
+# Access control configuration; see /usr/share/doc/packages/ntp/html/accopt.html for
+# details.  The web page <http://support.ntp.org/bin/view/Support/AccessRestrictions>
+# might also be helpful.
+#
+# Note that "restrict" applies to both servers and clients, so a configuration
+# that might be intended to block requests from certain clients could also end
+# up blocking replies from your own upstream servers.
+
+# By default, exchange time with everybody, but don't allow configuration.
+restrict -4 default notrap nomodify nopeer noquery
+restrict -6 default notrap nomodify nopeer noquery
+
+# Local users may interrogate the ntp server more closely.
+restrict 127.0.0.1
+restrict ::1
+
+# Clients from this (example!) subnet have unlimited access, but only if
+# cryptographically authenticated.
+#restrict 192.168.123.0 mask 255.255.255.0 notrust
+
+##
+## Miscellaneous stuff
+##
+
+driftfile /var/lib/ntp/drift/ntp.drift # path for drift file
+
+logfile   /var/log/ntp		# alternate log file
+# logconfig =syncstatus + sysevents
+# logconfig =all
+
+# statsdir /tmp/		# directory for statistics files
+# filegen peerstats  file peerstats  type day enable
+# filegen loopstats  file loopstats  type day enable
+# filegen clockstats file clockstats type day enable
+
+#
+# Authentication stuff
+#
+keys /etc/ntp.keys		# path for keys file
+trustedkey 1			# define trusted keys
+requestkey 1			# key (7) for accessing server variables
+controlkey 1			# key (6) for accessing server variables

--- a/templates/ntpsec.conf.ubuntu.tmpl
+++ b/templates/ntpsec.conf.ubuntu.tmpl
@@ -1,0 +1,65 @@
+## template:jinja
+
+# /etc/ntpsec/ntp.conf, configuration for ntpd; see ntp.conf(5) for help
+
+driftfile /var/lib/ntpsec/ntp.drift
+leapfile /usr/share/zoneinfo/leap-seconds.list
+
+# To enable Network Time Security support as a server, obtain a certificate
+# (e.g. with Let's Encrypt), configure the paths below, and uncomment:
+# nts cert CERT_FILE
+# nts key KEY_FILE
+# nts enable
+
+# You must create /var/log/ntpsec (owned by ntpsec:ntpsec) to enable logging.
+#statsdir /var/log/ntpsec/
+#statistics loopstats peerstats clockstats
+#filegen loopstats file loopstats type day enable
+#filegen peerstats file peerstats type day enable
+#filegen clockstats file clockstats type day enable
+
+# This should be maxclock 7, but the pool entries count towards maxclock.
+tos maxclock 11
+
+# Comment this out if you have a refclock and want it to be able to discipline
+# the clock by itself (e.g. if the system is not connected to the network).
+tos minclock 4 minsane 3
+
+# Specify one or more NTP servers.
+
+# Public NTP servers supporting Network Time Security:
+# server time.cloudflare.com nts
+
+# Use servers from the NTP Pool Project. Approved by Ubuntu Technical Board
+# on 2011-02-08 (LP: #104525). See https://www.pool.ntp.org/join.html for
+# more information.
+{% if pools %}# pools
+{% endif %}
+{% for pool in pools -%}
+pool {{pool}} iburst
+{% endfor %}
+{%- if servers %}# servers
+{% endif %}
+{% for server in servers -%}
+server {{server}} iburst
+{% endfor %}
+{% for peer in peers -%}
+peer {{peer}}
+{% endfor %}
+
+# Use Ubuntu's ntp server as a fallback.
+# server ntp.ubuntu.com
+
+# Access control configuration; see /usr/share/doc/ntpsec-doc/html/accopt.html
+# for details.
+#
+# Note that "restrict" applies to both servers and clients, so a configuration
+# that might be intended to block requests from certain clients could also end
+# up blocking replies from your own upstream servers.
+
+# By default, exchange time with everybody, but don't allow configuration.
+restrict default kod nomodify noquery limited
+
+# Local users may interrogate the ntp server more closely.
+restrict 127.0.0.1
+restrict ::1

--- a/tests/integration_tests/modules/test_ntp_servers.py
+++ b/tests/integration_tests/modules/test_ntp_servers.py
@@ -18,7 +18,7 @@ from tests.integration_tests.instances import IntegrationInstance
 USER_DATA = """\
 #cloud-config
 ntp:
-  ntp_client: ntp
+  ntp_client: ntpsec
   servers:
       - 172.16.15.14
       - 172.16.17.18
@@ -46,13 +46,17 @@ class TestNtpServers:
         (This test is skipped on all currently supported Ubuntu releases, so
         may not actually be needed any longer.)
         """
-        if class_client.execute("test -e /etc/ntp.conf.dist").failed:
-            pytest.skip("/etc/ntp.conf.dist does not exist")
-        dist_file = class_client.read_from_file("/etc/ntp.conf.dist")
+        if class_client.execute(
+            "test -e /etc/ntpsec/ntp.conf.dpkg-dist"
+        ).failed:
+            pytest.skip("/etc/ntpsec/ntp.conf.dpkg-dist does not exist")
+        dist_file = class_client.read_from_file(
+            "/etc/ntpsec/ntp.conf.dpkg-dist"
+        )
         assert 0 == len(dist_file.strip().splitlines())
 
     def test_ntp_entries(self, class_client: IntegrationInstance):
-        ntp_conf = class_client.read_from_file("/etc/ntp.conf")
+        ntp_conf = class_client.read_from_file("/etc/ntpsec/ntp.conf")
         for expected_server in EXPECTED_SERVERS:
             assert re.search(
                 r"^server {} iburst".format(expected_server),
@@ -114,7 +118,7 @@ def test_timesyncd(client: IntegrationInstance):
 EMPTY_NTP = """\
 #cloud-config
 ntp:
-  ntp_client: ntp
+  ntp_client: ntpsec
   pools: []
   servers: []
 """
@@ -123,7 +127,7 @@ ntp:
 @pytest.mark.user_data(EMPTY_NTP)
 def test_empty_ntp(client: IntegrationInstance):
     assert client.execute("ntpd --version").ok
-    assert client.execute("test -f /etc/ntp.conf.dist").failed
+    assert client.execute("test -f /etc/ntpsec/ntp.conf.dist").failed
     assert "pool.ntp.org iburst" in client.execute(
-        'grep -v "^#" /etc/ntp.conf'
+        'grep -v "^#" /etc/ntpsec/ntp.conf'
     )

--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -265,7 +265,9 @@ class TestNtp:
 
         return expected_servers
 
-    @pytest.mark.parametrize("client", ("ntp", "systemd-timesyncd", "chrony"))
+    @pytest.mark.parametrize(
+        "client", ("ntp", "ntpsec", "systemd-timesyncd", "chrony")
+    )
     def test_ntp_handler_real_distro_ntp_templates(self, client, tmpdir):
         """Test ntp handler renders the shipped distro ntp client templates."""
         pools = ["0.mycompany.pool.ntp.org", "3.mycompany.pool.ntp.org"]
@@ -858,6 +860,18 @@ class TestNTPSchema:
                 "Cloud config schema errors: "
                 "ntp.allow.1: None is not of type 'string',*"
                 ", ntp.peers.0: 123 is not of type 'string'",
+            ),
+            (
+                {
+                    "ntp": {
+                        "ntp_client": "bogus",
+                    }
+                },
+                re.escape(
+                    "Cloud config schema errors: ntp.ntp_client: 'bogus' is"
+                    " not one of ['auto', 'chrony', 'ntp', 'ntpdate',"
+                    " 'ntpsec', 'openntpd', 'systemd-timesyncd']"
+                ),
             ),
         ),
     )


### PR DESCRIPTION
Due to the ntp being a transitional package in may install ntpd or ntpsec on different distributions, it may be preferred 
to specify ntpsec as the preferred ntp_client in general to strictly define the client that an admin wishes to install/enable.  Provide a mechanism to directly prefer a specific  `ntp_client: ntpsec` instead of the ntp transitional package.

Also, in Ubuntu, daily integration tests against development Ubuntu series will occasionally hit issues with APT dependency resolution when trying to provide user-data declaring a preference for ntp transitional package when systemd-timesyncd packages in Ubuntu cloud images are out of date with latest published packages in the <release>-updates pocket. APT is unable to resolve a stale systemd-timesyncd package as it `Provides: time-daemon` which conflicts with `ntpsec` which also `Provides: time-daemon`.


## Proposed Commit Message
 see individual commits
* pytestify tests/unittests/config/test_cc_ntp.py
* Add `ntp_client: ntpsec` support to #cloud-config

## Additional Context

Intermittent yet repeated ntp error on ubuntu devel releases
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_container/48/
```
tests.integration_tests.modules.test_ntp_servers.TestNtpServers.test_ntp_installed (from pytest)
Failing for the past 3 builds (Since Unstable
[#46](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_container/46/) )
[Took 20 sec.](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_container/48/testReport/junit/tests.integration_tests.modules.test_ntp_servers/TestNtpServers/test_ntp_installed/history)
Error Message

AssertionError: assert False
 +  where False = ''.ok
 +    where '' = execute('ntpd --version')
 +      where execute = <tests.integration_tests.instances.IntegrationInstance object at 0x7fb95540a0b0>.execute
```

## Test Steps
```
CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers
CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_ntp_servers.py::TestNtpServers
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
