### PR TITLE
fix(sources/wsl): no error with empty .cloud-init dir (SC-1862)

### DIFF
--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -318,7 +318,7 @@ class DataSourceWSL(sources.DataSource):
         super().__init__(sys_cfg, distro, paths, ud_proc)
         self.instance_name = ""
 
-    def find_user_data_file(self, seed_dir: PurePath) -> Optional[PurePath]:
+    def find_user_data_file(self, seed_dir: PurePath) -> PurePath:
         """
         Finds the most precendent of the candidate files that may contain
         user-data, if any, or None otherwise.
@@ -334,8 +334,7 @@ class DataSourceWSL(sources.DataSource):
             ef.name.casefold(): ef.path for ef in os.scandir(seed_dir)
         }
         if not existing_files:
-            LOG.debug("%s directory is empty", seed_dir)
-            return None
+            raise IOError("%s directory is empty" % seed_dir)
 
         folded_names = [
             f.casefold()
@@ -345,10 +344,9 @@ class DataSourceWSL(sources.DataSource):
             if filename in existing_files.keys():
                 return PurePath(existing_files[filename])
 
-        LOG.debug(
-            "%s doesn't contain any of the expected user-data files", seed_dir
+        raise IOError(
+            "%s doesn't contain any of the expected user-data files" % seed_dir
         )
-        return None
 
     def check_instance_id(self, sys_cfg) -> bool:
         # quickly (local check only) if self.metadata['instance_id']
@@ -404,9 +402,8 @@ class DataSourceWSL(sources.DataSource):
         # Load regular user configs
         try:
             if user_data is None and seed_dir is not None:
-                user_data_file = self.find_user_data_file(seed_dir)
-                if user_data_file is not None:
-                    user_data = ConfigData(user_data_file)
+                user_data = ConfigData(self.find_user_data_file(seed_dir))
+
         except (ValueError, IOError) as err:
             LOG.error(
                 "Unable to load any user-data file in %s: %s",

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -405,7 +405,8 @@ class DataSourceWSL(sources.DataSource):
                 user_data = ConfigData(self.find_user_data_file(seed_dir))
 
         except (ValueError, IOError) as err:
-            LOG.error(
+            log = LOG.info if agent_data else LOG.error
+            log(
                 "Unable to load any user-data file in %s: %s",
                 seed_dir,
                 str(err),

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -52,6 +52,8 @@ User data can be supplied in any
 cloud-config files or shell scripts. At runtime, the WSL datasource looks for
 user data in the following locations inside the Windows host filesystem, in the
 order specified below.
+The WSL datasource will be enabled if cloud-init discovers at least one of the
+applicable config files described below.
 
 First, configurations from Ubuntu Pro/Landscape are checked for in the
 following paths:
@@ -71,8 +73,8 @@ following paths:
    used instead of the one provided by the ``agent.yaml``, which is treated as
    a default.
 
-Then, if a file from (1) is not found, a user-provided configuration will be
-looked for instead in the following order:
+Then, if a file from (1) is not found, optional user-provided configuration
+will be looked for in the following order:
 
 1. ``%USERPROFILE%\.cloud-init\<InstanceName>.user-data`` holds user data for a
    specific instance configuration. The datasource resolves the name attributed

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -477,9 +477,7 @@ write_files:
             ubuntu_pro_tmp = tmpdir.join(".ubuntupro", ".cloud-init")
             os.makedirs(ubuntu_pro_tmp, exist_ok=True)
             agent_path = ubuntu_pro_tmp.join("agent.yaml")
-            agent_path.write(
-                "#cloud-config\nlandscape:\n client: {account_name: agent}\n"
-            )
+            agent_path.write(AGENT_SAMPLE)
 
         ds = wsl.DataSourceWSL(
             sys_cfg=SAMPLE_CFG,
@@ -488,8 +486,10 @@ write_files:
         )
 
         assert ds.get_data() is with_agent_data
-        ud = ds.get_userdata(True)
-        print(ud)
+        if with_agent_data:
+            assert ds.userdata_raw == AGENT_SAMPLE
+        else:
+            assert ds.userdata_raw is None
 
         expected_log_level = logging.INFO if with_agent_data else logging.ERROR
         regex = (
@@ -506,7 +506,6 @@ write_files:
         ), "Expected log message matching '{}' with log level '{}'".format(
             regex, expected_log_level
         )
-        assert ud is not None
 
     @mock.patch("cloudinit.util.get_linux_distro")
     def test_data_precedence(self, m_get_linux_dist, tmpdir, paths):

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -5,6 +5,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 import logging
 import os
+import re
 from copy import deepcopy
 from email.mime.multipart import MIMEMultipart
 from pathlib import PurePath
@@ -459,6 +460,53 @@ write_files:
         assert "write_files" not in join_payloads_from_content_type(
             cast(MIMEMultipart, ud), "text/cloud-config"
         ), "No cloud-config part should exist"
+
+    @pytest.mark.parametrize("with_agent_data", [True, False])
+    @mock.patch("cloudinit.util.lsb_release")
+    def test_get_data_x(
+        self, m_lsb_release, with_agent_data, caplog, paths, tmpdir
+    ):
+        """
+        Assert behavior of empty .cloud-config dir with and without agent data
+        """
+        m_lsb_release.return_value = SAMPLE_LINUX_DISTRO
+        data_path = tmpdir.join(".cloud-init", f"{INSTANCE_NAME}.user-data")
+        data_path.dirpath().mkdir()
+
+        if with_agent_data:
+            ubuntu_pro_tmp = tmpdir.join(".ubuntupro", ".cloud-init")
+            os.makedirs(ubuntu_pro_tmp, exist_ok=True)
+            agent_path = ubuntu_pro_tmp.join("agent.yaml")
+            agent_path.write(
+                "#cloud-config\nlandscape:\n client: {account_name: agent}\n"
+            )
+
+        ds = wsl.DataSourceWSL(
+            sys_cfg=SAMPLE_CFG,
+            distro=_get_distro("ubuntu"),
+            paths=paths,
+        )
+
+        assert ds.get_data() is with_agent_data
+        ud = ds.get_userdata(True)
+        print(ud)
+
+        expected_log_level = logging.INFO if with_agent_data else logging.ERROR
+        regex = (
+            "Unable to load any user-data file in /[^:]*/.cloud-init:"
+            " /.*/.cloud-init directory is empty"
+        )
+        messages = [
+            x.message
+            for x in caplog.records
+            if x.levelno == expected_log_level and re.match(regex, x.message)
+        ]
+        assert (
+            len(messages) > 0
+        ), "Expected log message matching '{}' with log level '{}'".format(
+            regex, expected_log_level
+        )
+        assert ud is not None
 
     @mock.patch("cloudinit.util.get_linux_distro")
     def test_data_precedence(self, m_get_linux_dist, tmpdir, paths):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(sources/wsl): no error with empty .cloud-init dir (SC-1862)

Do not treat the emptiness of .cloud-init/ as an error in the logs
if agent.yaml is present.

Fixes GH-5632
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
