### PR TITLE
fix(tests): use instance.clean/restart instead of clean --reboot

### DIFF
--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -19,9 +19,8 @@ def _remove_nocloud_dir_and_reboot(client: IntegrationInstance):
     # On Impish and below, NoCloud will be detected on an LXD container.
     # If we remove this directory, it will no longer be detected.
     client.execute("rm -rf /var/lib/cloud/seed/nocloud-net")
-    old_boot_id = client.instance.get_boot_id()
-    client.execute("cloud-init clean --logs --reboot")
-    client.instance._wait_for_execute(old_boot_id=old_boot_id)
+    client.instance.clean()
+    client.instance.restart()
 
 
 @retry(tries=30, delay=1)
@@ -157,7 +156,8 @@ def test_status_block_through_all_boot_status(client):
     push_and_enable_systemd_unit(
         client, "before-cloud-init-local.service", BEFORE_CLOUD_INIT_LOCAL
     )
-    client.execute("cloud-init clean --logs --reboot")
+    client.instance.clean()
+    client.instance.restart()
     wait_for_cloud_init(client).stdout.strip()
     client.execute("cloud-init status --wait")
 


### PR DESCRIPTION
## Proposed Commit Message

```
fix(tests): use instance.clean/restart instead of clean --reboot

Directly calling execute("cloud-init clean --logs --reboot") on
an integration instances also involves awaiting a new boot id upon
next interaction with with instance to ensure a reboot has actually
taken place already on this target machine.

Slow responding test instances/platforms may not completed the shutdown
restart sequence yet when trying to iteract with an immediate blocking
call to execut("cloud-init status --wait") which may exit early if accessing
the prior instance boot before the reboot occurred.

It is preferable to use inspect /proc/sys/kernel/random/boot_id before
issuing a reboot request and block until a delta is seen in boot_id.
This blocking wait on reboot and new boot_id is encapsulated inside
pycloudlib.BaseInstance.restart which will inspect
/proc/sys/kernel/random/boot_id before restart and block until a delta
in boot_id across the requested restart.

Fix test_status_block_through_all_boot_status to call instance.clean()
and restart() to ensure we do not beat the instance reboot race with
our post-boot assertions.
```

## Additional Context
Jenkins failures in oracular
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_vm/53/testReport/junit/tests.integration_tests.cmd/test_status/test_status_block_through_all_boot_status/
Noble: https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_vm/152/testReport/junit/tests.integration_tests.cmd/test_status/test_status_block_through_all_boot_status/

```
OSError: Failed reading remote file via cat: /before-local.start-nostatusjson
Return code: 1
Stderr: cat: /before-local.start-nostatusjson: No such file or directory
Stdout:
```
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```

PYCLOUDLIB_CONFIG=pycloudlib.toml CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_PLATFORM=lxd_vm tox -e integration-tests -- tests/integration_tests/cmd/test_status.py::test_status_block_through_all_boot_status --pdb
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
