### PR TITLE
docs: Clarify v2 set-name behavior

### DIFF
--- a/doc/rtd/reference/network-config-format-v2.rst
+++ b/doc/rtd/reference/network-config-format-v2.rst
@@ -151,13 +151,19 @@ Example: ::
 ``set-name: <(scalar)>``
 ------------------------
 
-When matching on unique properties such as path or MAC, or with additional
-assumptions such as "there will only ever be one wifi device", match rules
-can be written so that they only match one device. Then this property can be
+When matching on unique properties such as MAC, match rules
+can be written so that they match only one device. Then this property can be
 used to give that device a more specific/desirable/nicer name than the default
 from udev’s ``ifnames``. Any additional device that satisfies the match rules
 will then fail to get renamed and keep the original kernel name (and dmesg
 will show an error).
+
+While multiple properties can be used in a match, ``macaddress`` is
+**required** for cloud-init to perform the rename.
+
+.. note::
+    On a netplan-based system, cloud-init will perform the rename
+    independently and prior to netplan.
 
 ``wakeonlan: <(bool)>``
 -----------------------


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
docs: Clarify v2 set-name behavior
```

## Additional Context
https://github.com/canonical/cloud-init/blob/8bc3e42543d6be2624a439fe0b72b4546928667e/cloudinit/net/__init__.py#L613

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
