### PR TITLE
fix(scaleway): Don't override IPv6 routes when IPv4 is not primary

### DIFF
--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -367,9 +367,11 @@ class DataSourceScaleway(sources.DataSource):
                 if ip["address"] == self.ephemeral_fixed_address:
                     ip_cfg["dhcp4"] = True
                     # Force addition of a route to the metadata API
-                    ip_cfg["routes"] = [
-                        {"to": "169.254.42.42/32", "via": "62.210.0.1"}
-                    ]
+                    route = {"to": "169.254.42.42/32", "via": "62.210.0.1"}
+                    if "routes" in ip_cfg.keys():
+                        ip_cfg["routes"] += [route]
+                    else:
+                        ip_cfg["routes"] = [route]
                 else:
                     if "addresses" in ip_cfg.keys():
                         ip_cfg["addresses"] += (

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -1030,11 +1030,11 @@ class TestDataSourceScaleway(ResponsesTestCase):
                 fallback_nic.return_value: {
                     "dhcp4": True,
                     "routes": [
-                        {"to": "169.254.42.42/32", "via": "62.210.0.1"},
                         {
                             "via": "fe80::ffff:ffff:ffff:fff1",
                             "to": "::/0",
                         },
+                        {"to": "169.254.42.42/32", "via": "62.210.0.1"},
                     ],
                     "addresses": ("2001:aaa:aaaa:a:aaaa:aaaa:aaaa:1/64",),
                 },

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -955,7 +955,7 @@ class TestDataSourceScaleway(ResponsesTestCase):
         self, m_get_cmdline, fallback_nic
     ):
         """
-        Generate network_config with only IPv6
+        Generate network_config with IPv4+IPv6
         """
         m_get_cmdline.return_value = "scaleway"
         fallback_nic.return_value = "ens2"
@@ -973,6 +973,53 @@ class TestDataSourceScaleway(ResponsesTestCase):
                 "netmask": "64",
                 "gateway": "fe80::ffff:ffff:ffff:fff1",
                 "family": "inet6",
+            },
+        ]
+
+        netcfg = self.datasource.network_config
+        resp = {
+            "version": 2,
+            "ethernets": {
+                fallback_nic.return_value: {
+                    "dhcp4": True,
+                    "routes": [
+                        {"to": "169.254.42.42/32", "via": "62.210.0.1"},
+                        {
+                            "via": "fe80::ffff:ffff:ffff:fff1",
+                            "to": "::/0",
+                        },
+                    ],
+                    "addresses": ("2001:aaa:aaaa:a:aaaa:aaaa:aaaa:1/64",),
+                },
+            },
+        }
+
+        self.assertEqual(netcfg, resp)
+
+    @mock.patch("cloudinit.distros.net.find_fallback_nic")
+    @mock.patch("cloudinit.util.get_cmdline")
+    def test_ipmob_primary_ipv6_v4_config_ok(
+        self, m_get_cmdline, fallback_nic
+    ):
+        """
+        Generate network_config with IPv6+IPv4
+        """
+        m_get_cmdline.return_value = "scaleway"
+        fallback_nic.return_value = "ens2"
+        self.datasource.metadata["private_ip"] = None
+        self.datasource.metadata["ipv6"] = None
+        self.datasource.ephemeral_fixed_address = "10.10.10.10"
+        self.datasource.metadata["public_ips"] = [
+            {
+                "address": "2001:aaa:aaaa:a:aaaa:aaaa:aaaa:1",
+                "netmask": "64",
+                "gateway": "fe80::ffff:ffff:ffff:fff1",
+                "family": "inet6",
+            },
+            {
+                "address": "10.10.10.10",
+                "netmask": "32",
+                "family": "inet",
             },
         ]
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -137,6 +137,7 @@ nicolasbock
 nishigori
 nkukard
 nmeyerhans
+NoSuchCommand
 ogayot
 olivierlemasle
 omBratteng


### PR DESCRIPTION
## Proposed Commit Message
```
fix(scaleway): Don't override IPv6 routes when IPv4 is not primary

If an instance in _routed-ip_ mode uses both IPv4 **and** IPv6, but the IPv6 is listed (attached) first, the default IPv6 route may be absent from the final network configuration for systems that do not accept Router Advertisements.

This changes fixes the problem by making sure that routes are appended, not overwritten.
```

## Test Steps

1. Create an instance with `routed-ip-enabled=true` but no IP address
2. Create a `routed_ipv6` Flexible IP and attach it to the instance
3. Create a `routed_ipv4` Flexible IP and attach it to the instance
4. Start the instance
5. Once fully booted, connect to the instance and ensure it has the expected network configuration, and especially a default IPv6 route


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
