### PR TITLE
tests: assert cloud-init user-data cert is the only root cert

### DIFF
--- a/tests/integration_tests/modules/test_ca_certs.py
+++ b/tests/integration_tests/modules/test_ca_certs.py
@@ -92,8 +92,13 @@ class TestCaCerts:
 
     def test_cert_installed(self, class_client: IntegrationInstance):
         """Test that our specified cert has been installed"""
-        certs = class_client.execute("cat /etc/ssl/certs/ca-certificates.crt")
-        assert CERT_CONTENT in certs
+        checksum = class_client.execute(
+            "sha256sum /etc/ssl/certs/ca-certificates.crt"
+        )
+        assert (
+            "78e875f18c73c1aab9167ae0bd323391e52222cc2dbcda42d129537219300062"
+            in checksum
+        )
 
     def test_clean_log(self, class_client: IntegrationInstance):
         """Verify no errors, no deprecations and correct inactive modules in


### PR DESCRIPTION
## Proposed Commit Message

```
tests: assert cloud-init user-data cert is the only root cert

Reintroduce strict assert that cloud-init's cert in userdata is the
only root cert defined on the platform. Google guest agent was
installed a secondary root cert in ca_certifications.crt for a period of
time and this was determined to be less than ideal practice.

Allow cloud-init's integration tests to remain strict validation of
cert checksum to provide a signal if other platforms or agents
attempt to extend or alter the system-wide CA.

## Additional Context
Google guest agent now intends to install their certs in a separate file for use by their agents so cloud-init's integration tests can retain strict checksum.


## Test Steps
```
CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_PLATFORM=gce .tox/integration-tests-jenkins/bin/pytest tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed

CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_PLATFORM=gce .tox/integration-tests-jenkins/bin/pytest tests/integration_tests/modules/test_ca_certs.py::TestCaCerts::test_cert_installed
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
