### PR TITLE
fix(systemd): add Before=shutdown.target to cloud-init-main.service.tmpl

### DIFF
--- a/systemd/cloud-init-main.service.tmpl
+++ b/systemd/cloud-init-main.service.tmpl
@@ -17,16 +17,15 @@ Requires=dbus.socket
 After=dbus.socket
 Before=network.service
 Before=firewalld.target
-Conflicts=shutdown.target
 {% endif %}
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 Before=sysinit.target
-Conflicts=shutdown.target
 {% endif %}
 
 After=systemd-remount-fs.service
 Before=sysinit.target
 Before=cloud-init-local.service
+Before=shutdown.target
 Conflicts=shutdown.target
 RequiresMountsFor=/var/lib/cloud
 ConditionPathExists=!/etc/cloud/cloud-init.disabled


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(systemd): add Before=shutdown.target to cloud-init-main.service.tmpl

Fixes lintian warning systemd-service-file-shutdown-problems.
See [1, 2].

Remove superflous conditional additions of Conflicts=shutdown.target as
it is unconditionally added for every target.

[1] https://salsa.debian.org/lintian/lintian/-/blob/2.118.0/tags/s/systemd-service-file-shutdown-problems.tag
[2] https://github.com/systemd/systemd/issues/11821
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
$ DEB_BUILD_OPTIONS=nocheck make deb
$ lintian cloud-init_all.deb 
...
W: cloud-init: systemd-service-file-shutdown-problems [usr/lib/systemd/system/cloud-init-main.service]
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
