### PR TITLE
Scaleway: Force on-link: true for static networks (#5523)

### DIFF
--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -367,7 +367,11 @@ class DataSourceScaleway(sources.DataSource):
                 if ip["address"] == self.ephemeral_fixed_address:
                     ip_cfg["dhcp4"] = True
                     # Force addition of a route to the metadata API
-                    route = {"to": "169.254.42.42/32", "via": "62.210.0.1"}
+                    route = {
+                        "on-link": True,
+                        "to": "169.254.42.42/32",
+                        "via": "62.210.0.1",
+                    }
                     if "routes" in ip_cfg.keys():
                         ip_cfg["routes"] += [route]
                     else:

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -860,7 +860,11 @@ class TestDataSourceScaleway(ResponsesTestCase):
             "ethernets": {
                 fallback_nic.return_value: {
                     "routes": [
-                        {"to": "169.254.42.42/32", "via": "62.210.0.1"}
+                        {
+                            "on-link": True,
+                            "to": "169.254.42.42/32",
+                            "via": "62.210.0.1",
+                        }
                     ],
                     "dhcp4": True,
                 },
@@ -903,7 +907,11 @@ class TestDataSourceScaleway(ResponsesTestCase):
                 fallback_nic.return_value: {
                     "dhcp4": True,
                     "routes": [
-                        {"to": "169.254.42.42/32", "via": "62.210.0.1"}
+                        {
+                            "on-link": True,
+                            "to": "169.254.42.42/32",
+                            "via": "62.210.0.1",
+                        }
                     ],
                     "addresses": ("20.20.20.20/32",),
                 },
@@ -983,7 +991,11 @@ class TestDataSourceScaleway(ResponsesTestCase):
                 fallback_nic.return_value: {
                     "dhcp4": True,
                     "routes": [
-                        {"to": "169.254.42.42/32", "via": "62.210.0.1"},
+                        {
+                            "on-link": True,
+                            "to": "169.254.42.42/32",
+                            "via": "62.210.0.1",
+                        },
                         {
                             "via": "fe80::ffff:ffff:ffff:fff1",
                             "to": "::/0",
@@ -1034,7 +1046,11 @@ class TestDataSourceScaleway(ResponsesTestCase):
                             "via": "fe80::ffff:ffff:ffff:fff1",
                             "to": "::/0",
                         },
-                        {"to": "169.254.42.42/32", "via": "62.210.0.1"},
+                        {
+                            "on-link": True,
+                            "to": "169.254.42.42/32",
+                            "via": "62.210.0.1",
+                        },
                     ],
                     "addresses": ("2001:aaa:aaaa:a:aaaa:aaaa:aaaa:1/64",),
                 },


### PR DESCRIPTION
On some distributions like focal (See LP: #2073869) systemd fails to add a route which is not in the subnet of the NIC if onlink is not explicitely specified.

Force on-link to true to avoid those situations.
Fixes: GH-5523

## Proposed Commit Message
Scaleway: Force on-link: true for static networks (#5523)

```
<type>(optional scope): <summary>  Force use of on-link: true not working on Ubuntu Focal

The version of systemd on Ubuntu Focal does not support subnets outside
of the NIC network without addition of on-link. This is not the case with other Ubuntu
distributions.

Fixes GH-5523
LP: #2073869

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
