### PR TITLE
test: assert that schema is valid by default

### DIFF
--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -266,6 +266,11 @@ def _verify_clean_boot(
         f"{traceback_count - expected_traceback_count} unexpected traceback(s)"
         " found in /var/log/cloud-init.log"
     )
+    schema = instance.execute("cloud-init schema --system --annotate")
+    assert schema.ok, (
+        f"Schema validation failed\nstdout:{schema.stdout}"
+        f"\nstderr:\n{schema.stderr}"
+    )
 
 
 def verify_clean_log(log: str, ignore_deprecations: bool = True):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: assert that schema is valid by default
```

## Additional Context
This should increase our test coverage of `cloud-init schema` by running it by default in `verify_clean_boot()`. This command has had numerous tracebacks over the years (I just [reported another](https://github.com/canonical/cloud-init/issues/5656)), so additional coverage should hopefully help prevent this type of thing from getting hit by users.

My plan is to fix any new test failures caused by this new addition prior to adding `verify_clean_boot()` next to our `verify_clean_log()` calls - which should pave the way for eventually replacing `verify_clean_log()`.

Note: In a followup PR I plan to add new flags (`ignore_deprecations` and `require_deprecations`) to allow skipping deprecation on tests which we intend to continue using deprecated keys and requiring a deprecation to be reported in the case where it should be.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
