### PR TITLE
chore: bump ci dependency versions

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout #1"
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: "Checkout #2 (for tools/read-version)"
         run: |
@@ -46,10 +46,10 @@ jobs:
     strategy:
       fail-fast: false
     name: Check json format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout #1"
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: "Test format"
         run: |
@@ -61,17 +61,17 @@ jobs:
     strategy:
       fail-fast: false
     name: Check docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout #1"
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: "Checkout #2 (for tools/read-version)"
         run: |
           git fetch --unshallow
           git remote add upstream https://git.launchpad.net/cloud-init
       - name: "Install Python 3.10"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10.8'
       - name: "Install dependencies"
@@ -91,10 +91,10 @@ jobs:
 
   shell-lint:
     name: Shell Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: Install ShellCheck
         run: |
@@ -106,9 +106,9 @@ jobs:
           shellcheck ./tools/ds-identify
 
   check-cla-signers:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v4
 
       - name: Check CLA signers file
         run: tools/check-cla-signers

--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -73,7 +73,7 @@ jobs:
       - name: "Install Python 3.10"
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10.8'
+          python-version: '3.11.9'
       - name: "Install dependencies"
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -33,6 +33,7 @@ jobs:
           free -h
           cat /proc/mounts
           df -h
+          sudo du -sh /var/lib/schroot | true
       - name: Prepare dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
@@ -52,6 +53,15 @@ jobs:
             )
           sudo sbuild-adduser $USER
           cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
+      - name: Create tmpfs for schroot
+        run: |
+          sudo tee -a /etc/fstab<<EOF
+          # for schroots overlay
+          none /var/lib/schroot/session        tmpfs uid=root,gid=root,mode=0755 0 0
+          none /var/lib/schroot/union/overlay  tmpfs uid=root,gid=root,mode=0755,size=85% 0 0
+          none /var/lib/sbuild/build           tmpfs uid=sbuild,gid=sbuild,mode=2770 0 0
+          EOF
+          sudo mount -a
       - name: Build package
         run: |
           ./packages/bddeb -S -d --release ${{ env.RELEASE }}
@@ -67,13 +77,6 @@ jobs:
         uses: canonical/setup-lxd@v0.1.1
         with:
           channel: latest/candidate
-
-      # this is really dumb, but I'm out of time for now
-      #      - name: Retrieve cloud-init package
-      #        uses: actions/download-artifact@v3
-      #        with:
-      #          name: 'cloud-init-${{ env.RELEASE }}-deb'
-
       - name: Verify deb package
         run: |
           ls -hal '${{ runner.temp }}'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -63,6 +63,10 @@ jobs:
         with:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/candidate
       - name: Retrieve cloud-init package
         uses: actions/download-artifact@v4
         with:
@@ -74,16 +78,13 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y install tox wireguard
-      - name: Initialize LXD
+      - name: Initialize pycloudlib
         run: |
           ssh-keygen -P "" -q -f ~/.ssh/id_rsa
           echo "[lxd]" > /home/$USER/.config/pycloudlib.toml
-          sudo adduser $USER lxd
           # Jammy GH Action runners have docker installed, which edits iptables
           # in a way that is incompatible with lxd.
           # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-          sudo iptables -I DOCKER-USER -j ACCEPT
-          sudo lxd init --auto
       - name: Run integration Tests
         run: |
-          sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls cloud-init*.deb)" tox -e integration-tests-ci'
+          'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls cloud-init*.deb)" tox -e integration-tests-ci'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
+      - name: Inspect
+        run: |
+          free -h
+          cat /proc/mounts
+          df -h
       - name: Prepare dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
@@ -64,7 +69,9 @@ jobs:
           channel: latest/candidate
       - name: Verify deb package
         run: |
-          ls -hal '${{ runner.temp }}/cloud-init*.deb'
+          ls -hal '${{ runner.temp }}'
+          echo '${{ runner.temp }}/cloud-init*.deb || true
+          ls -hal '${{ runner.temp }}/cloud-init*.deb' || true
       - name: Set up Pycloudlib
         run: |
           ssh-keygen -P "" -q -f ~/.ssh/id_rsa

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,10 +21,10 @@ env:
 
 jobs:
   package-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
@@ -48,7 +48,7 @@ jobs:
           sudo -E su $USER -c 'mk-sbuild ${{ env.RELEASE }}'
           sudo -E su $USER -c 'DEB_BUILD_OPTIONS=nocheck sbuild --nolog --no-run-lintian --no-run-autopkgtest --verbose --dist=${{ env.RELEASE }} --build-dir=${{ runner.temp }} cloud-init_*.dsc'
       - name: Archive debs as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'cloud-init-${{ env.RELEASE }}-deb'
           path: '${{ runner.temp }}/cloud-init*.deb'
@@ -56,15 +56,15 @@ jobs:
 
   integration-tests:
     needs: package-build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
       - name: Retrieve cloud-init package
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: 'cloud-init-${{ env.RELEASE }}-deb'
       - name: Verify deb package

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,7 +20,7 @@ env:
   RELEASE: focal
 
 jobs:
-  package-build:
+  build-package-and-run-tests:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
@@ -47,15 +47,6 @@ jobs:
             )
           sudo sbuild-adduser $USER
           cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
-      - name: Create tmpfs for schroot
-        run: |
-          sudo tee -a /etc/fstab<<EOF
-          # for schroots overlay
-          none /var/lib/schroot/session        tmpfs uid=root,gid=root,mode=0755 0 0
-          none /var/lib/schroot/union/overlay  tmpfs uid=root,gid=root,mode=0755,size=85% 0 0
-          none /var/lib/sbuild/build           tmpfs uid=sbuild,gid=sbuild,mode=2770 0 0
-          EOF
-          sudo mount -a
       - name: Build package
         run: |
           ./packages/bddeb -S -d --release ${{ env.RELEASE }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -32,12 +32,19 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y install \
-            debhelper \
-            dh-python \
             fakeroot \
-            python3-setuptools \
             sbuild \
-            ubuntu-dev-tools
+            ubuntu-dev-tools \
+            tox \
+            wireguard \
+            $(\
+              ./tools/read-dependencies                   \
+                --requirements-file requirements.txt      \
+                --requirements-file test-requirements.txt \
+                --distro ubuntu                           \
+                --system-pkg-names 2> /dev/null           \
+                | tr '\n' ' '                             \
+            )
           sudo sbuild-adduser $USER
           cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
           # Install all build and test dependencies
@@ -60,10 +67,6 @@ jobs:
       - name: Verify deb package
         run: |
           ls -hal cloud-init*.deb
-      - name: Prepare test tools
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install tox wireguard
       - name: Set up Pycloudlib
         run: |
           ssh-keygen -P "" -q -f ~/.ssh/id_rsa

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,24 +53,10 @@ jobs:
           name: 'cloud-init-${{ env.RELEASE }}-deb'
           path: '${{ runner.temp }}/cloud-init*.deb'
           retention-days: 3
-
-  integration-tests:
-    needs: package-build
-    runs-on: ubuntu-24.04
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-        with:
-          # Fetch all tags for tools/read-version
-          fetch-depth: 0
       - name: Setup LXD
         uses: canonical/setup-lxd@v0.1.1
         with:
           channel: latest/candidate
-      - name: Retrieve cloud-init package
-        uses: actions/download-artifact@v4
-        with:
-          name: 'cloud-init-${{ env.RELEASE }}-deb'
       - name: Verify deb package
         run: |
           ls -hal cloud-init*.deb
@@ -78,13 +64,10 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y install tox wireguard
-      - name: Initialize pycloudlib
+      - name: Set up Pycloudlib
         run: |
           ssh-keygen -P "" -q -f ~/.ssh/id_rsa
           echo "[lxd]" > /home/$USER/.config/pycloudlib.toml
-          # Jammy GH Action runners have docker installed, which edits iptables
-          # in a way that is incompatible with lxd.
-          # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
       - name: Run integration Tests
         run: |
-          'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls cloud-init*.deb)" tox -e integration-tests-ci'
+          sh -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls cloud-init*.deb)" tox -e integration-tests-ci'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,8 +47,6 @@ jobs:
             )
           sudo sbuild-adduser $USER
           cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
-          # Install all build and test dependencies
-          ./tools/read-dependencies -r requirements.txt -r test-requirements.txt -d ubuntu -s -i
       - name: Build package
         run: |
           ./packages/bddeb -S -d --release ${{ env.RELEASE }}
@@ -66,11 +64,11 @@ jobs:
           channel: latest/candidate
       - name: Verify deb package
         run: |
-          ls -hal cloud-init*.deb
+          ls -hal '${{ runner.temp }}/cloud-init*.deb'
       - name: Set up Pycloudlib
         run: |
           ssh-keygen -P "" -q -f ~/.ssh/id_rsa
           echo "[lxd]" > /home/$USER/.config/pycloudlib.toml
       - name: Run integration Tests
         run: |
-          sh -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls cloud-init*.deb)" tox -e integration-tests-ci'
+          sh -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls ${{ runner.temp }}/cloud-init*.deb)" tox -e integration-tests-ci'

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,11 +67,18 @@ jobs:
         uses: canonical/setup-lxd@v0.1.1
         with:
           channel: latest/candidate
+
+      # this is really dumb, but I'm out of time for now
+      #      - name: Retrieve cloud-init package
+      #        uses: actions/download-artifact@v3
+      #        with:
+      #          name: 'cloud-init-${{ env.RELEASE }}-deb'
+
       - name: Verify deb package
         run: |
           ls -hal '${{ runner.temp }}'
-          echo '${{ runner.temp }}/cloud-init*.deb || true
-          ls -hal '${{ runner.temp }}/cloud-init*.deb' || true
+          echo ${{ runner.temp }}/cloud-init*.deb || true
+          ls -hal ${{ runner.temp }}/cloud-init*.deb || true
       - name: Set up Pycloudlib
         run: |
           ssh-keygen -P "" -q -f ~/.ssh/id_rsa

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,12 +28,6 @@ jobs:
         with:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
-      - name: Inspect
-        run: |
-          free -h
-          cat /proc/mounts
-          df -h
-          sudo du -sh /var/lib/schroot | true
       - name: Prepare dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -8,15 +8,15 @@ concurrency:
 
 jobs:
   linkcheck:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.failOnError == 'true') }}
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: "Install Python 3.10"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10.8'
 

--- a/.github/workflows/packaging-tests.yml
+++ b/.github/workflows/packaging-tests.yml
@@ -18,10 +18,10 @@ env:
 
 jobs:
   check-patches:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Fetch all branches for merging
           fetch-depth: 0

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Python 3.13-dev
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.13-dev
           check-latest: true
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get -qy update

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 14

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,7 +28,7 @@ jobs:
             check-latest: false
             experimental: false
     name: Python ${{matrix.python-version}} ${{ matrix.slug }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: "Checkout"
@@ -37,7 +37,7 @@ jobs:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
       - name: Install Python ${{matrix.python-version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
           check-latest: ${{matrix.check-latest}}


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
chore: bump ci dependency versions

- use canonical/lxd in integration test
- optimize integration test to run faster
```

## Additional Context
https://github.com/canonical/cloud-init/pull/5658