### PR TITLE
chore: Prefer other methods over $INSTANCE_ID

### DIFF
--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -35,12 +35,12 @@ meta: MetaSchema = {
 
 LOG = logging.getLogger(__name__)
 # phone_home:
-#  url: http://my.foo.bar/$INSTANCE/
+#  url: http://my.foo.bar/{{ v1.instance_id }}/
 #  post: all
 #  tries: 10
 #
 # phone_home:
-#  url: http://my.foo.bar/$INSTANCE_ID/
+#  url: http://my.foo.bar/{{ v1.instance_id }}/
 #  post: [ pub_key_rsa, pub_key_ecdsa, instance_id, hostname,
 #          fqdn ]
 #

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -640,15 +640,20 @@ class Init:
         # TODO(harlowja) Hmmm, should we dynamically import these??
         cloudconfig_handler = CloudConfigPartHandler(**opts)
         shellscript_handler = ShellScriptPartHandler(**opts)
+        boothook_handler = BootHookPartHandler(**opts)
         def_handlers = [
             cloudconfig_handler,
             shellscript_handler,
             ShellScriptByFreqPartHandler(PER_ALWAYS, **opts),
             ShellScriptByFreqPartHandler(PER_INSTANCE, **opts),
             ShellScriptByFreqPartHandler(PER_ONCE, **opts),
-            BootHookPartHandler(**opts),
             JinjaTemplatePartHandler(
-                **opts, sub_handlers=[cloudconfig_handler, shellscript_handler]
+                **opts,
+                sub_handlers=[
+                    cloudconfig_handler,
+                    shellscript_handler,
+                    boothook_handler,
+                ],
             ),
         ]
         return def_handlers

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -647,6 +647,7 @@ class Init:
             ShellScriptByFreqPartHandler(PER_ALWAYS, **opts),
             ShellScriptByFreqPartHandler(PER_INSTANCE, **opts),
             ShellScriptByFreqPartHandler(PER_ONCE, **opts),
+            boothook_handler,
             JinjaTemplatePartHandler(
                 **opts,
                 sub_handlers=[

--- a/doc/examples/cloud-config-boot-cmds.txt
+++ b/doc/examples/cloud-config-boot-cmds.txt
@@ -5,7 +5,6 @@
 # This is very similar to runcmd, but commands run very early
 # in the boot process, only slightly after a 'boothook' would run.
 # - bootcmd will run on every boot
-# - INSTANCE_ID variable will be set to the current instance ID
 # - 'cloud-init-per' command can be used to make bootcmd run exactly once
 bootcmd:
   - echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -117,7 +117,6 @@ runcmd:
 # This is very similar to runcmd above, but commands run very early
 # in the boot process, only slightly after a 'boothook' would run.
 #  - bootcmd will run on every boot
-#  - INSTANCE_ID variable will be set to the current instance ID
 #  - 'cloud-init-per' command can be used to make bootcmd run exactly once
 bootcmd:
  - echo 192.168.1.130 us.archive.ubuntu.com > /etc/hosts
@@ -315,15 +314,15 @@ final_message: "The system is finally up, after $UPTIME seconds"
 
 # phone_home: if this dictionary is present, then the phone_home
 # cloud-config module will post specified data back to the given
-# url
+# url. Note that this example requires a `## template: jinja` header
 # default: none
 # phone_home:
-#  url: http://my.foo.bar/$INSTANCE/
+#  url: http://my.foo.bar/{{ v1.instance_id }}/
 #  post: all
 #  tries: 10
 #
 phone_home:
-  url: http://my.example.com/$INSTANCE_ID/
+  url: http://my.example.com/{{ v1.instance_id }}/
   post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]
 
 # timezone: set the timezone for this instance

--- a/doc/man/cloud-init-per.1
+++ b/doc/man/cloud-init-per.1
@@ -25,7 +25,7 @@ This can be one of the following values:
 run only once and do not re-run for new instance-id
 
 .BR "instance" ":"
-run only the first boot for a given instance-id
+run only once for a given instance-id and re-run for new instance-id
 
 .BR "always" ":"
 run every boot

--- a/doc/module-docs/cc_bootcmd/data.yaml
+++ b/doc/module-docs/cc_bootcmd/data.yaml
@@ -2,8 +2,7 @@ cc_bootcmd:
   description: |
     This module runs arbitrary commands very early in the boot process, only
     slightly after a boothook would run. This is very similar to a boothook,
-    but more user friendly. The environment variable ``INSTANCE_ID`` will be
-    set to the current instance ID for all run commands. Commands can be
+    but more user friendly. Commands can be
     specified either as lists or strings. For invocation details, see
     ``runcmd``.
 
@@ -14,6 +13,10 @@ cc_bootcmd:
     .. note::
        When writing files, do not use ``/tmp`` dir as it races with
        ``systemd-tmpfiles-clean`` (LP: #1707222). Use ``/run/somedir`` instead.
+    .. warning::
+         Use of ``INSTANCE_ID`` variable within this module is deprecated.
+         Use :ref:`jinja templates<user_data_formats-jinja>` with
+         :ref:`v1.instance_id<v1_instance_id>` instead.
   examples:
   - comment: |
       Example 1:

--- a/doc/module-docs/cc_phone_home/data.yaml
+++ b/doc/module-docs/cc_phone_home/data.yaml
@@ -1,34 +1,38 @@
 cc_phone_home:
   description: |
     This module can be used to post data to a remote host after boot is
-    complete. If the post URL contains the string ``$INSTANCE_ID`` it will be
-    replaced with the ID of the current instance.
+    complete.
 
     Either all data can be posted, or a list of keys to post.
 
     Available keys are:
-    
+
     - ``pub_key_rsa``
     - ``pub_key_ecdsa``
     - ``pub_key_ed25519``
     - ``instance_id``
     - ``hostname``
     - ``fdqn``
-    
+
     Data is sent as ``x-www-form-urlencoded`` arguments.
-    
+
     **Example HTTP POST**:
-    
+
     .. code-block:: http
-       
+
        POST / HTTP/1.1
        Content-Length: 1337
        User-Agent: Cloud-Init/21.4
        Accept-Encoding: gzip, deflate
        Accept: */*
        Content-Type: application/x-www-form-urlencoded
-       
+
        pub_key_rsa=rsa_contents&pub_key_ecdsa=ecdsa_contents&pub_key_ed25519=ed25519_contents&instance_id=i-87018aed&hostname=myhost&fqdn=myhost.internal
+
+    .. warning::
+         Use of ``INSTANCE_ID`` variable within this module is deprecated.
+         Use :ref:`jinja templates<user_data_formats-jinja>` with
+         :ref:`v1.instance_id<v1_instance_id>` instead.
   examples:
   - comment: |
       Example 1:

--- a/doc/module-docs/cc_phone_home/example1.yaml
+++ b/doc/module-docs/cc_phone_home/example1.yaml
@@ -1,2 +1,3 @@
+## template: jinja
 #cloud-config
-phone_home: {post: all, url: 'http://example.com/$INSTANCE_ID/'}
+phone_home: {post: all, url: 'http://example.com/{{ v1.instance_id }}/'}

--- a/doc/module-docs/cc_phone_home/example2.yaml
+++ b/doc/module-docs/cc_phone_home/example2.yaml
@@ -1,5 +1,6 @@
+## template: jinja
 #cloud-config
 phone_home:
   post: [pub_key_rsa, pub_key_ecdsa, pub_key_ed25519, instance_id, hostname, fqdn]
   tries: 5
-  url: http://example.com/$INSTANCE_ID/
+  url: http://example.com/{{ v1.instance_id }}/

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -117,6 +117,8 @@ Example of once-per-instance script
    #cloud-boothook
    #!/bin/sh
 
+   # Early exit 0 when script has already run for this instance-id,
+   # continue if new instance boot.
    cloud-init-per instance do-hosts /bin/false && exit 0
    echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts
 

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -88,9 +88,11 @@ Explanation
 A user data script is a single script to be executed once per instance.
 User data scripts are run relatively late in the boot process, during
 cloud-init's :ref:`final stage<boot-Final>` as part of the
-:ref:`cc_scripts_user<mod_cc_scripts_user>` module. When run,
-the environment variable ``INSTANCE_ID`` is set to the current instance ID
-for use within the script.
+:ref:`cc_scripts_user<mod_cc_scripts_user>` module.
+
+.. warning::
+    Use of ``INSTANCE_ID`` variable within boothooks is deprecated.
+    Use :ref:`cloud-init-per` instead.
 
 .. _user_data_formats-cloud_boothook:
 
@@ -114,16 +116,8 @@ Example of once-per-instance script
    #cloud-boothook
    #!/bin/sh
 
-   PERSIST_ID=/var/lib/cloud/first-instance-id
-   _id=""
-   if [ -r $PERSIST_ID ]; then
-     _id=$(cat /var/lib/cloud/first-instance-id)
-   fi
-
-   if [ -z $_id ]  || [ $INSTANCE_ID != $_id ]; then
-     echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts
-   fi
-   sudo echo $INSTANCE_ID > $PERSIST_ID
+   cloud-init-per instance do-hosts /bin/false && exit 0
+   echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts
 
 Explanation
 -----------
@@ -138,6 +132,10 @@ The boothook is different in that:
 * It is run very early in boot, during the :ref:`network<boot-Network>` stage,
   before any cloud-init modules are run.
 * It is run on every boot
+
+.. warning::
+    Use of ``INSTANCE_ID`` variable within boothooks is deprecated.
+    Use :ref:`cloud-init-per` instead.
 
 Include file
 ============

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -91,8 +91,9 @@ cloud-init's :ref:`final stage<boot-Final>` as part of the
 :ref:`cc_scripts_user<mod_cc_scripts_user>` module.
 
 .. warning::
-    Use of ``INSTANCE_ID`` variable within boothooks is deprecated.
-    Use :ref:`cloud-init-per` instead.
+    Use of ``INSTANCE_ID`` variable within user data scripts is deprecated.
+    Use :ref:`jinja templates<user_data_formats-jinja>` with
+    :ref:`v1.instance_id<v1_instance_id>` instead.
 
 .. _user_data_formats-cloud_boothook:
 
@@ -135,7 +136,8 @@ The boothook is different in that:
 
 .. warning::
     Use of ``INSTANCE_ID`` variable within boothooks is deprecated.
-    Use :ref:`cloud-init-per` instead.
+    Use :ref:`jinja templates<user_data_formats-jinja>` with
+    :ref:`v1.instance_id<v1_instance_id>` instead.
 
 Include file
 ============
@@ -156,6 +158,8 @@ An include file contains a list of URLs, one per line. Each of the URLs will
 be read and their content can be any kind of user data format, both base
 config and meta config. If an error occurs reading a file the remaining files
 will not be read.
+
+.. _user_data_formats-jinja:
 
 Jinja template
 ==============
@@ -189,8 +193,8 @@ as jinja template variables. Any jinja templated configuration must contain
 the original header along with the new jinja header above it.
 
 .. note::
-    Use of Jinja templates is ONLY supported for cloud-config and user data
-    scripts. Jinja templates are not supported for cloud-boothooks or
+    Use of Jinja templates is supported for cloud-config, user data
+    scripts, and cloud-boothooks. Jinja templates are not supported for
     meta configs.
 
 .. _user_data_formats-mime_archive:

--- a/doc/rtd/explanation/instancedata.rst
+++ b/doc/rtd/explanation/instancedata.rst
@@ -310,6 +310,8 @@ Example output:
   - sles, 12.3, x86_64
   - ubuntu, 20.04, focal
 
+.. _v1_instance_id:
+
 ``v1.instance_id``
 ^^^^^^^^^^^^^^^^^^
 

--- a/doc/rtd/howto/module_run_frequency.rst
+++ b/doc/rtd/howto/module_run_frequency.rst
@@ -34,7 +34,8 @@ Then your user data could then be:
 
 .. code-block:: yaml
 
+        ## template: jinja
         #cloud-config
         phone_home:
-            url: http://example.com/$INSTANCE_ID/
+            url: http://example.com/{{ v1.instance_id }}/
             post: all

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -5,10 +5,9 @@ CLI commands
 
 Cloud-init ships multiple executables that are intended for user interaction.
 
-These executables are:
+These executables include:
 
 - `cloud-init`_
-- `cloud-id`_
 - `cloud-init-per`_
 
 cloud-init
@@ -497,29 +496,6 @@ Which would produce the following example output:
       "stage": null,
       "status": "done"
     }
-
-cloud-id
-========
-
-``cloud-id`` reports the canonical cloud-id for the instance.
-
-For example, on LXD, we'll see:
-
-.. code-block:: shell-session
-
-   $ cloud-id
-   lxd
-
-Whereas on AWS, we'll see:
-
-.. code-block:: shell-session
-
-   $ cloud-id
-   aws
-
-See the
-`cloud-id man page <https://manpages.ubuntu.com/manpages/noble/en/man1/cloud-id.1.html>`_
-for more details.
 
 .. _cloud-init-per:
 

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -3,9 +3,9 @@
 CLI commands
 ************
 
-Cloud-init ships multiple binaries that are intended for user interaction.
+Cloud-init ships multiple executables that are intended for user interaction.
 
-These binaries are:
+These executables are:
 
 - `cloud-init`_
 - `cloud-id`_

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -3,6 +3,17 @@
 CLI commands
 ************
 
+Cloud-init ships multiple binaries that are intended for user interaction.
+
+These binaries are:
+
+- `cloud-init`_
+- `cloud-id`_
+- `cloud-init-per`_
+
+cloud-init
+==========
+
 For the latest list of subcommands and arguments use ``cloud-init``'s
 ``--help`` option. This can be used against ``cloud-init`` itself, or on any
 of its subcommands.
@@ -44,7 +55,7 @@ The rest of this document will give an overview of each of the subcommands.
 .. _cli_analyze:
 
 :command:`analyze`
-==================
+------------------
 
 Get detailed reports of where ``cloud-init`` spends its time during the boot
 process. For more complete reference see :ref:`analyze`.
@@ -62,7 +73,7 @@ Possible subcommands include:
 .. _cli_clean:
 
 :command:`clean`
-================
+----------------
 
 Remove ``cloud-init`` artifacts from :file:`/var/lib/cloud` and config files
 (best effort) to simulate a clean instance. On reboot, ``cloud-init`` will
@@ -89,7 +100,7 @@ re-run all stages as it did on first boot.
 .. _cli_collect_logs:
 
 :command:`collect-logs`
-=======================
+-----------------------
 
 Collect and tar ``cloud-init``-generated logs, data files, and system
 information for triage. This subcommand is integrated with apport.
@@ -111,7 +122,7 @@ Logs collected include:
 .. _cli_devel:
 
 :command:`devel`
-================
+----------------
 
 Collection of development tools under active development. These tools will
 likely be promoted to top-level subcommands when stable.
@@ -144,18 +155,18 @@ for debugging purposes.
 
 
 :command:`query`
-^^^^^^^^^^^^^^^^
+----------------
 
 Query if hotplug is enabled for a given subsystem.
 
 :command:`handle`
-^^^^^^^^^^^^^^^^^
+-----------------
 
 Respond to newly added system devices by retrieving updated system metadata
 and bringing up/down the corresponding device.
 
 :command:`enable`
-^^^^^^^^^^^^^^^^^
+-----------------
 
 Enable hotplug for a given subsystem. This is a last resort command for
 administrators to enable hotplug in running instances. The recommended
@@ -165,7 +176,7 @@ datasource.
 .. _cli_features:
 
 :command:`features`
-===================
+-------------------
 
 Print out each feature supported. If ``cloud-init`` does not have the
 :command:`features` subcommand, it also does not support any features
@@ -186,7 +197,7 @@ Example output:
 .. _cli_init:
 
 :command:`init` (deprecated)
-============================
+----------------------------
 
 Generally run by OS init systems to execute ``cloud-init``'s stages:
 *init* and *init-local*. See :ref:`boot_stages` for more info.
@@ -201,7 +212,7 @@ generally gated to run only once due to semaphores in
 .. _cli_modules:
 
 :command:`modules` (deprecated)
-===============================
+-------------------------------
 
 Generally run by OS init systems to execute ``modules:config`` and
 ``modules:final`` boot stages. This executes cloud config :ref:`modules`
@@ -231,7 +242,7 @@ run only once due to semaphores in :file:`/var/lib/cloud/`.
 .. _cli_query:
 
 :command:`query`
-================
+----------------
 
 Query standardised cloud instance metadata crawled by ``cloud-init`` and stored
 in :file:`/run/cloud-init/instance-data.json`. This is a convenience
@@ -332,7 +343,7 @@ and region:
 .. _cli_schema:
 
 :command:`schema`
-=================
+-----------------
 
 Validate cloud-config files using jsonschema.
 
@@ -359,7 +370,7 @@ errors on :file:`stdout`.
 .. _cli_single:
 
 :command:`single`
-=================
+-----------------
 
 Attempt to run a single, named, cloud config module.
 
@@ -384,7 +395,7 @@ module default frequency of ``instance``:
 .. _cli_status:
 
 :command:`status`
-=================
+-----------------
 
 Report cloud-init's current status.
 
@@ -486,5 +497,53 @@ Which would produce the following example output:
       "stage": null,
       "status": "done"
     }
+
+cloud-id
+========
+
+``cloud-id`` reports the canonical cloud-id for the instance.
+
+For example, on LXD, we'll see:
+
+.. code-block:: shell-session
+
+   $ cloud-id
+   lxd
+
+Whereas on AWS, we'll see:
+
+.. code-block:: shell-session
+
+   $ cloud-id
+   aws
+
+See the
+`cloud-id man page <https://manpages.ubuntu.com/manpages/noble/en/man1/cloud-id.1.html>`_
+for more details.
+
+.. _cloud-init-per:
+
+cloud-init-per
+==============
+
+``cloud-init-per`` will run a command with arguments at a specific frequency.
+
+For example, with the following command:
+
+.. code-block:: shell-session
+
+   $ cloud-init-per once hello bash -c 'echo "Hello, world!" >> /tmp/hello'
+
+You will find 'Hello, world!' in the file :file:`/tmp/hello`.
+
+If we run the same command again, it will not run, as it has already run once.
+:file:`/tmp/hello` still only contains one line rather than two.
+
+See the
+`cloud-init-per man page <https://manpages.ubuntu.com/manpages/noble/en/man1/cloud-init-per.1.html>`_
+for more details.
+
+
+
 
 .. _More details on machine-id: https://www.freedesktop.org/software/systemd/man/machine-id.html

--- a/doc/userdata.txt
+++ b/doc/userdata.txt
@@ -56,7 +56,7 @@ finds.  However, certain types of user-data are handled specially.
    begins with #cloud-boothook or Content-Type: text/cloud-boothook
 
    This content is "boothook" data.  It is stored in a file under
-   /var/lib/cloud and then executed immediately.
+   ``/var/lib/cloud`` and then executed immediately.
 
    This is the earliest "hook" available.  Note, that there is no
    mechanism provided for running only once.  The boothook must take

--- a/doc/userdata.txt
+++ b/doc/userdata.txt
@@ -1,11 +1,11 @@
 === Overview ===
 Userdata is data provided by the entity that launches an instance.
 The cloud provider makes this data available to the instance via in one
-way or another.  
+way or another.
 
 In EC2, the data is provided by the user via the '--user-data' or
 'user-data-file' argument to ec2-run-instances.  The EC2 cloud makes the
-data available to the instance via its meta-data service at 
+data available to the instance via its meta-data service at
 http://169.254.169.254/latest/user-data
 
 cloud-init can read this input and act on it in different ways.
@@ -15,7 +15,7 @@ cloud-init will download and cache to filesystem any user-data that it
 finds.  However, certain types of user-data are handled specially.
 
  * Gzip Compressed Content
-   content found to be gzip compressed will be uncompressed, and 
+   content found to be gzip compressed will be uncompressed, and
    these rules applied to the uncompressed data
 
  * Mime Multi Part archive
@@ -52,7 +52,7 @@ finds.  However, certain types of user-data are handled specially.
    This content is "cloud-config" data.  See the examples for a
    commented example of supported config formats.
 
- * Cloud Boothook 
+ * Cloud Boothook
    begins with #cloud-boothook or Content-Type: text/cloud-boothook
 
    This content is "boothook" data.  It is stored in a file under
@@ -60,9 +60,7 @@ finds.  However, certain types of user-data are handled specially.
 
    This is the earliest "hook" available.  Note, that there is no
    mechanism provided for running only once.  The boothook must take
-   care of this itself.  It is provided with the instance id in the
-   environment variable "INSTANCE_ID".  This could be made use of to
-   provide a 'once-per-instance'
+   care of this itself.
 
 === Examples ===
 There are examples in the examples subdirectory.

--- a/tests/data/merge_sources/expected9.yaml
+++ b/tests/data/merge_sources/expected9.yaml
@@ -1,5 +1,6 @@
+## template: jinja
 #cloud-config
 
 phone_home:
- url: http://my.example.com/$INSTANCE_ID/$BLAH_BLAH
+ url: http://my.example.com/{{ v1.instance_id }}/$BLAH_BLAH
  post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]

--- a/tests/data/merge_sources/source9-1.yaml
+++ b/tests/data/merge_sources/source9-1.yaml
@@ -1,5 +1,6 @@
+## template: jinja
 #cloud-config
 
 phone_home:
- url: http://my.example.com/$INSTANCE_ID/
+ url: http://my.example.com/{{ v1.instance_id }}/
  post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]

--- a/tests/integration_tests/modules/test_boothook.py
+++ b/tests/integration_tests/modules/test_boothook.py
@@ -7,12 +7,13 @@ from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import verify_clean_log
 
 USER_DATA = """\
+## template: jinja
 #cloud-boothook
 #!/bin/sh
 # Error below will generate stderr
 BOOTHOOK/0
 echo BOOTHOOKstdout
-echo "BOOTHOOK: $INSTANCE_ID: is called every boot." >> /boothook.txt
+echo "BOOTHOOK: {{ v1.instance_id }}: is called every boot." >> /boothook.txt
 """
 
 

--- a/tests/integration_tests/test_multi_part_user_data_handling.py
+++ b/tests/integration_tests/test_multi_part_user_data_handling.py
@@ -73,7 +73,7 @@ CLOUD_CONFIG_ARCHIVE = """
 - type: 'text/cloud-config'
   content: |
     bootcmd:
-     - [sh, -c, 'echo "BOOTCMD: $(date -R): $INSTANCE_ID" | tee /run/bootcmd.txt']
+     - [sh, -c, 'echo "BOOTCMD: $(date -R): from cloud-config" | tee /run/bootcmd.txt']
 """  # noqa: E501
 
 

--- a/tests/unittests/config/test_cc_bootcmd.py
+++ b/tests/unittests/config/test_cc_bootcmd.py
@@ -84,22 +84,6 @@ class TestBootcmd(CiTestCase):
             str(context_manager.exception),
         )
 
-    def test_handler_creates_and_runs_bootcmd_script_with_instance_id(self):
-        """Valid schema runs a bootcmd script with INSTANCE_ID in the env."""
-        cc = get_cloud()
-        out_file = self.tmp_path("bootcmd.out", self.new_root)
-        my_id = "b6ea0f59-e27d-49c6-9f87-79f19765a425"
-        valid_config = {
-            "bootcmd": ["echo {0} $INSTANCE_ID > {1}".format(my_id, out_file)]
-        }
-
-        with mock.patch(self._etmpfile_path, FakeExtendedTempFile):
-            with self.allow_subp(["/bin/sh"]):
-                handle("cc_bootcmd", valid_config, cc, [])
-        self.assertEqual(
-            my_id + " iid-datasource-none\n", util.load_text_file(out_file)
-        )
-
     def test_handler_runs_bootcmd_script_with_error(self):
         """When a valid script generates an error, that error is raised."""
         cc = get_cloud()


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
chore: Prefer other methods over $INSTANCE_ID

$INSTANCE_ID is an environment variable that contains a reference
to the current instance id. Its use is no longer needed now that
we can use jinja templates with {{ v1.instance_id }}. Furthermore,
`cloud-init-per` is a better replacement for running scripts once
per instance.

In particular, this commit does the following:
- Add jinja templating functionality to boothooks to be consistent
  with other core user data types
- Document cloud-id and cloud-init-per as they were previously
  undocumented
- Replace all $INSTANCE_ID references in docs to either use
  {{ v1.instance_id }} or the `cloud-init-per` script
- Update documentation of $INSTANCE_ID to now be deprecated
- Update tests as necessary
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
