### PR TITLE
24.3.x

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+24.3.1
+ - test: add test coverage for iproute2 commands (#5651)
+ - fix(netops): fix ip addr flush command (#5651) (GH: 5648)
+
 24.3
  - docs: Clarify v2 set-name behavior (#5639)
  - fix: properly handle blank lines in fstab (#5643)

--- a/cloudinit/net/netops/iproute2.py
+++ b/cloudinit/net/netops/iproute2.py
@@ -130,7 +130,6 @@ class Iproute2(NetOps):
                 "dev",
                 interface,
             ],
-            update_env={"LANG": "C"},
         )
 
     @staticmethod
@@ -141,4 +140,4 @@ class Iproute2(NetOps):
 
     @staticmethod
     def flush_addr(interface: str):
-        subp.subp(["ip", "flush", "dev", interface])
+        subp.subp(["ip", "addr", "flush", "dev", interface])

--- a/cloudinit/version.py
+++ b/cloudinit/version.py
@@ -4,7 +4,7 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-__VERSION__ = "24.3"
+__VERSION__ = "24.3.1"
 _PACKAGED_VERSION = "@@PACKAGED_VERSION@@"
 
 FEATURES = [

--- a/tests/unittests/net/netops/test_iproute2.py
+++ b/tests/unittests/net/netops/test_iproute2.py
@@ -1,0 +1,203 @@
+from unittest import mock
+
+from cloudinit.net.netops import iproute2
+from cloudinit.subp import SubpResult
+
+
+class TestOps:
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_link_up(self, m_subp):
+        iproute2.Iproute2.link_up("eth0")
+        iproute2.Iproute2.link_up("eth0", "inet6")
+        assert m_subp.call_args_list == [
+            mock.call(["ip", "link", "set", "dev", "eth0", "up"]),
+            mock.call(
+                ["ip", "-family", "inet6", "link", "set", "dev", "eth0", "up"]
+            ),
+        ]
+
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_link_down(self, m_subp):
+        iproute2.Iproute2.link_down("enp24s0")
+        iproute2.Iproute2.link_down("eno1", "inet6")
+        assert m_subp.call_args_list == [
+            mock.call(["ip", "link", "set", "dev", "enp24s0", "down"]),
+            mock.call(
+                [
+                    "ip",
+                    "-family",
+                    "inet6",
+                    "link",
+                    "set",
+                    "dev",
+                    "eno1",
+                    "down",
+                ]
+            ),
+        ]
+
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_link_rename(self, m_subp):
+        iproute2.Iproute2.link_rename("ens1", "ego1")
+        assert m_subp.call_args_list == [
+            mock.call(["ip", "link", "set", "ens1", "name", "ego1"])
+        ]
+
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_add_route(self, m_subp):
+        iproute2.Iproute2.add_route("wlan0", "102.42.42.0/24")
+        iproute2.Iproute2.add_route(
+            "ens2",
+            "102.42.0.0/16",
+            gateway="192.168.2.254",
+            source_address="192.168.2.1",
+        )
+        assert m_subp.call_args_list == [
+            mock.call(
+                [
+                    "ip",
+                    "-4",
+                    "route",
+                    "replace",
+                    "102.42.42.0/24",
+                    "dev",
+                    "wlan0",
+                ]
+            ),
+            mock.call(
+                [
+                    "ip",
+                    "-4",
+                    "route",
+                    "replace",
+                    "102.42.0.0/16",
+                    "via",
+                    "192.168.2.254",
+                    "dev",
+                    "ens2",
+                    "src",
+                    "192.168.2.1",
+                ]
+            ),
+        ]
+
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_del_route(self, m_subp):
+        iproute2.Iproute2.del_route("wlan0", "102.42.42.0/24")
+        iproute2.Iproute2.del_route(
+            "ens2",
+            "102.42.0.0/16",
+            gateway="192.168.2.254",
+            source_address="192.168.2.1",
+        )
+        assert m_subp.call_args_list == [
+            mock.call(
+                ["ip", "-4", "route", "del", "102.42.42.0/24", "dev", "wlan0"]
+            ),
+            mock.call(
+                [
+                    "ip",
+                    "-4",
+                    "route",
+                    "del",
+                    "102.42.0.0/16",
+                    "via",
+                    "192.168.2.254",
+                    "dev",
+                    "ens2",
+                    "src",
+                    "192.168.2.1",
+                ]
+            ),
+        ]
+
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_append_route(self, m_subp):
+        iproute2.Iproute2.append_route("wlan0", "102.42.42.0/24", "10.0.4.254")
+        assert m_subp.call_args_list == [
+            mock.call(
+                [
+                    "ip",
+                    "-4",
+                    "route",
+                    "append",
+                    "102.42.42.0/24",
+                    "via",
+                    "10.0.4.254",
+                    "dev",
+                    "wlan0",
+                ]
+            )
+        ]
+
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_add_addr(self, m_subp):
+        iproute2.Iproute2.add_addr("wlan0", "10.0.17.0", "10.0.17.255")
+        assert m_subp.call_args_list == [
+            mock.call(
+                [
+                    "ip",
+                    "-family",
+                    "inet",
+                    "addr",
+                    "add",
+                    "10.0.17.0",
+                    "broadcast",
+                    "10.0.17.255",
+                    "dev",
+                    "wlan0",
+                ],
+            ),
+        ]
+
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_del_addr(self, m_subp):
+        iproute2.Iproute2.del_addr("eth0", "10.0.8.3")
+        assert m_subp.call_args_list == [
+            mock.call(
+                [
+                    "ip",
+                    "-family",
+                    "inet",
+                    "addr",
+                    "del",
+                    "10.0.8.3",
+                    "dev",
+                    "eth0",
+                ],
+            ),
+        ]
+
+    @mock.patch.object(iproute2.subp, "subp")
+    def test_flush_addr(self, m_subp):
+        iproute2.Iproute2.flush_addr("eth0")
+        assert m_subp.call_args_list == [
+            mock.call(
+                ["ip", "addr", "flush", "dev", "eth0"],
+            ),
+        ]
+
+    @mock.patch.object(
+        iproute2.subp,
+        "subp",
+        return_value=SubpResult(
+            "default via 192.168.0.1 dev enp2s0 proto dhcp src 192.168.0.104"
+            " metric 100",
+            "",
+        ),
+    )
+    def test_add_default_route(self, m_subp):
+        assert iproute2.Iproute2.get_default_route() == (
+            "default via 192.168.0.1 dev enp2s0 proto dhcp src"
+            " 192.168.0.104 metric 100"
+        )
+        assert m_subp.call_args_list == [
+            mock.call(
+                [
+                    "ip",
+                    "route",
+                    "show",
+                    "0.0.0.0/0",
+                ],
+            ),
+        ]

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -836,7 +836,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                update_env={"LANG": "C"},
             ),
         ]
         expected_teardown_calls = [
@@ -973,7 +972,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                         "dev",
                         "eth0",
                     ],
-                    update_env={"LANG": "C"},
                 )
             ]
         )
@@ -992,7 +990,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                         "dev",
                         "eth0",
                     ],
-                    update_env={"LANG": "C"},
                 )
             ]
         )
@@ -1023,7 +1020,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                update_env={"LANG": "C"},
             ),
             mock.call(["ip", "route", "show", "0.0.0.0/0"]),
             mock.call(
@@ -1104,7 +1100,6 @@ class TestEphemeralIPV4Network(CiTestCase):
                     "dev",
                     "eth0",
                 ],
-                update_env={"LANG": "C"},
             ),
             mock.call(
                 [


### PR DESCRIPTION
Cherry-pick changes from PR #5651 as hotfix candidates (regressed in 24.2, but 24.3 just cut so let's fix it)

git cherry-pick 3e74d5e670c4324b1655133a97e9267e1001a10f
git cherry-pick 30addd2f38c69ce9404d2eab1ad29574a494d284 
update ChangeLog and bump release for hotfix of 24.2 regresssion #5648

## Proposed Commit Messages: see separate commits, expect merge from command line, not github UI


## Additional Context
#5648 affected 24.2, but best to include it in 24.3.1 given latest upstream snapshot was just cut.

To generate changelog https://github.com/canonical/uss-tableflip/pull/123 was used to document GH issues fixed in ChangeLog entries

## Test Steps


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
- [x] Merge on command-line
