### PR TITLE
chore: drop broken optimization

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -1318,8 +1318,4 @@ def sub_main(args):
 
 
 if __name__ == "__main__":
-    if "TZ" not in os.environ:
-        os.environ["TZ"] = ":/etc/localtime"
-    return_value = main(sys.argv)
-    if return_value:
-        sys.exit(return_value)
+    sys.exit(main(sys.argv))


### PR DESCRIPTION

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
chore: drop broken optimization

Setting TZ environment variable was introduced as a performance optimization in 2016[1].
However, this optimization never worked, because it introduced code which only runs when
__name__ is "__main__". This never happens when installed via setuptools - it gets imported
and executed by the "cloud-init" script.

The underlying issue was fixed at some point between Trusty and Bionic, presumably in
cPython or in glibc. The following reproducer of the original issue will print multiple
lines on an affected system.

strace /usr/bin/python3 -c 'import os; from datetime import datetime; print([datetime.now() for i in range(10)])' |& grep -e localt -e zonei

[1] https://code.launchpad.net/~raharper/cloud-init/+git/cloud-init/+merge/307722
```
## Additional Context

I also checked a few other distros, including alpine (which doesn't use glibc) and fedora. Trusty was the latest that I could find that was affected.

https://code.launchpad.net/~raharper/cloud-init/+git/cloud-init/+merge/307722

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
