### PR TITLE
Ubuntu/devel

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,11 +2,7 @@ cloud-init (24.4~3+really24.3.1-0ubuntu1) oracular; urgency=medium
 
   * d/cloud-init.lintian-overrides:
     + Remove alien disabled tag:
-      E: cloud-init: alien-tag package-supports-alternative-init-but-no-init.d-script
-    + Fix disabled warning tag:
-      systemd-service-file-refers-to-unusual-wantedby-target,
-      to point to the correct path under /usr/lib instead of /lib and add
-      cloud-init-main.service.
+      alien-tag package-supports-alternative-init-but-no-init.d-script
   * Upstream snapshot based on 24.3.1.
     List of changes from upstream can be found at
     https://raw.githubusercontent.com/canonical/cloud-init/24.3.1/ChangeLog

--- a/debian/cloud-init.lintian-overrides
+++ b/debian/cloud-init.lintian-overrides
@@ -1,6 +1,5 @@
 # cloud-init.target should not be considered as unusual
-cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-config.service]
-cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-final.service]
-cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-init-local.service]
-cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-init-main.service]
-cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-init-network.service]
+cloud-init binary: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-config.service]
+cloud-init binary: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-final.service]
+cloud-init binary: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-init-local.service]
+cloud-init binary: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-init.service]


### PR DESCRIPTION
Fix lintian issues seen on latest build. 

- Shorten the debian/changelog line that is greater than 80 characters
- Revert the lintian /usr/lib overrides vs /lib for systemd units. We can address this separately when we properly determine why pkg-config is setting /usr/lib/ in some sbuild environments and /lib in others.


```

W: cloud-init: debian-changelog-line-too-long [usr/share/doc/cloud-init/changelog.Debian.gz:5]
W: cloud-init: mismatched-override systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-config.service] [usr/share/lintian/overrides/cloud-init:2]
W: cloud-init: mismatched-override systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-final.service] [usr/share/lintian/overrides/cloud-init:3]
W: cloud-init: mismatched-override systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-init-local.service] [usr/share/lintian/overrides/cloud-init:4]
W: cloud-init: mismatched-override systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-init-main.service] [usr/share/lintian/overrides/cloud-init:5]
W: cloud-init: mismatched-override systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [usr/lib/systemd/system/cloud-init-network.service] [usr/share/lintian/overrides/cloud-init:6]
W: cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-config.service]
W: cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-final.service]
W: cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-init-local.service]
W: cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-init-main.service]
W: cloud-init: systemd-service-file-refers-to-unusual-wantedby-target cloud-init.target [lib/systemd/system/cloud-init-network.service]
```
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
