### PR TITLE
Improve verify_clean_boot()

### DIFF
--- a/tests/integration_tests/bugs/test_gh632.py
+++ b/tests/integration_tests/bugs/test_gh632.py
@@ -8,7 +8,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 
 # With some datasource hacking, we can run this on a NoCloud instance
@@ -30,6 +30,7 @@ def test_datasource_rbx_no_stacktrace(client: IntegrationInstance):
 
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     assert "Failed to load metadata and userdata" not in log
     assert (
         "Getting data from <class 'cloudinit.sources.DataSourceRbxCloud."

--- a/tests/integration_tests/bugs/test_gh868.py
+++ b/tests/integration_tests/bugs/test_gh868.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USERDATA = """\
 #cloud-config
@@ -24,3 +24,4 @@ chef:
 def test_chef_license(client: IntegrationInstance):
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import (
+    verify_clean_boot,
     verify_clean_log,
     verify_ordered_items_in_text,
 )
@@ -33,6 +34,7 @@ def test_gpg_no_tty(client: IntegrationInstance):
     ]
     verify_ordered_items_in_text(to_verify, log)
     verify_clean_log(log)
+    verify_clean_boot(client)
     control_groups = client.execute(
         "systemd-cgls -u cloud-config.service 2>/dev/null | wc -l"
     ).stdout

--- a/tests/integration_tests/bugs/test_lp1886531.py
+++ b/tests/integration_tests/bugs/test_lp1886531.py
@@ -12,7 +12,7 @@ https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1886531
 
 import pytest
 
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -26,3 +26,4 @@ class TestLp1886531:
     def test_lp1886531(self, client):
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)

--- a/tests/integration_tests/bugs/test_lp1898997.py
+++ b/tests/integration_tests/bugs/test_lp1898997.py
@@ -15,7 +15,7 @@ import pytest
 from tests.integration_tests import random_mac_address
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 MAC_ADDRESS = random_mac_address()
 
@@ -74,6 +74,7 @@ class TestInterfaceListingWithOpenvSwitch:
 
         # Confirm that the network configuration was applied successfully
         verify_clean_log(cloudinit_output)
+        verify_clean_boot(client)
         # Confirm that the applied network config created the OVS bridge
         assert "ovs-br" in client.execute("ip addr")
 

--- a/tests/integration_tests/cmd/test_schema.py
+++ b/tests/integration_tests/cmd/test_schema.py
@@ -9,6 +9,7 @@ from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.releases import CURRENT_RELEASE, MANTIC
 from tests.integration_tests.util import (
     get_feature_flag_value,
+    verify_clean_boot,
     verify_clean_log,
 )
 
@@ -70,16 +71,20 @@ class TestSchemaDeprecations:
         version_boundary = get_feature_flag_value(
             class_client, "DEPRECATION_INFO_BOUNDARY"
         )
+        boundary_message = "Deprecated cloud-config provided:"
+        messages = [
+            "apt_reboot_if_required:  Deprecated ",
+            "apt_update:  Deprecated in version",
+            "apt_upgrade:  Deprecated in version",
+        ]
         # the deprecation_version is 22.2 in schema for apt_* keys in
         # user-data. Pass 22.2 in against the client's version_boundary.
         if lifecycle.should_log_deprecation("22.2", version_boundary):
-            log_level = "DEPRECATED"
+            messages += boundary_message
+            verify_clean_boot(class_client, require_deprecations=messages)
         else:
-            log_level = "INFO"
-        assert f"{log_level}]: Deprecated cloud-config provided:" in log
-        assert "apt_reboot_if_required:  Deprecated " in log
-        assert "apt_update:  Deprecated in version" in log
-        assert "apt_upgrade:  Deprecated in version" in log
+            verify_clean_boot(class_client, require_deprecations=messages)
+            assert boundary_message in log
 
     def test_network_config_schema_validation(
         self, class_client: IntegrationInstance

--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -6,7 +6,11 @@ import yaml
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
-from tests.integration_tests.util import lxd_has_nocloud, verify_clean_log
+from tests.integration_tests.util import (
+    lxd_has_nocloud,
+    verify_clean_boot,
+    verify_clean_log,
+)
 
 
 def _customize_environment(client: IntegrationInstance):
@@ -75,6 +79,7 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
     } == netplan_cfg
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     result = client.execute("cloud-id")
     if result.stdout != "lxd":
         raise AssertionError(

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -198,15 +198,18 @@ class TestSmbios:
         version_boundary = get_feature_flag_value(
             client, "DEPRECATION_INFO_BOUNDARY"
         )
+        message = (
+            "The 'nocloud-net' datasource name is "
+            'deprecated" /var/log/cloud-init.log'
+        )
         # nocloud-net deprecated in version 24.1
         if lifecycle.should_log_deprecation("24.1", version_boundary):
-            log_level = "DEPRECATED"
+            verify_clean_boot(client, require_deprecations=[message])
         else:
-            log_level = "INFO"
-        client.execute(
-            rf"grep \"{log_level}]: The 'nocloud-net' datasource name is"
-            ' deprecated" /var/log/cloud-init.log'
-        ).ok
+            client.execute(
+                r"grep \"INFO]: The 'nocloud-net' datasource name is"
+                ' deprecated" /var/log/cloud-init.log'
+            ).ok
 
 
 @pytest.mark.skipif(PLATFORM != "lxd_vm", reason="Modifies grub config")

--- a/tests/integration_tests/datasources/test_none.py
+++ b/tests/integration_tests/datasources/test_none.py
@@ -3,7 +3,7 @@
 import json
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 DS_NONE_BASE_CFG = """\
 datasource_list: [None]
@@ -26,6 +26,7 @@ def test_datasource_none_discovery(client: IntegrationInstance):
     """
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     # Limit datasource detection to DataSourceNone.
     client.write_to_file(
         "/etc/cloud/cloud.cfg.d/99-force-dsnone.cfg", DS_NONE_BASE_CFG
@@ -65,4 +66,5 @@ def test_datasource_none_discovery(client: IntegrationInstance):
         )
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client, require_warnings=expected_warnings)
     assert client.execute("test -f /var/tmp/success-with-datasource-none").ok

--- a/tests/integration_tests/datasources/test_oci_networking.py
+++ b/tests/integration_tests/datasources/test_oci_networking.py
@@ -7,7 +7,7 @@ import yaml
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 DS_CFG = """\
 datasource:
@@ -52,6 +52,7 @@ def test_oci_networking_iscsi_instance(client: IntegrationInstance, tmpdir):
 
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
 
     assert (
         "opc/v2/vnics/" not in log

--- a/tests/integration_tests/datasources/test_tmp_noexec.py
+++ b/tests/integration_tests/datasources/test_tmp_noexec.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 
 def customize_client(client: IntegrationInstance):
@@ -30,3 +30,4 @@ def test_dhcp_tmp_noexec(client: IntegrationInstance):
         not in log
     )
     verify_clean_log(log)
+    verify_clean_boot(client)

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -5,6 +5,7 @@ from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
 from tests.integration_tests.util import (
     push_and_enable_systemd_unit,
+    verify_clean_boot,
     verify_clean_log,
 )
 
@@ -267,6 +268,7 @@ def _test_ansible_pull_from_local_server(my_client):
     my_client.restart()
     log = my_client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(my_client)
     output_log = my_client.read_from_file("/var/log/cloud-init-output.log")
     assert "ok=3" in output_log
     assert "SUCCESS: config-ansible ran successfully" in log
@@ -320,6 +322,7 @@ def test_ansible_pull_distro(client):
 def test_ansible_controller(client):
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     content_ansible = client.execute(
         "lxc exec lxd-container-00 -- cat /home/ansible/ansible.txt"
     )

--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -13,6 +13,7 @@ from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
 from tests.integration_tests.util import (
     get_feature_flag_value,
+    verify_clean_boot,
     verify_clean_log,
 )
 
@@ -489,4 +490,5 @@ def test_install_missing_deps(setup_image, session_cloud: IntegrationCloud):
     ) as minimal_client:
         log = minimal_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(minimal_client)
         assert re.search(RE_GPG_SW_PROPERTIES_INSTALLED, log)

--- a/tests/integration_tests/modules/test_boothook.py
+++ b/tests/integration_tests/modules/test_boothook.py
@@ -4,7 +4,7 @@ import re
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
 #cloud-boothook
@@ -25,6 +25,7 @@ def test_boothook_header_runs_part_per_instance(client: IntegrationInstance):
     RE_BOOTHOOK = f"BOOTHOOK: {instance_id}: is called every boot"
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     output = client.read_from_file("/boothook.txt")
     assert 1 == len(re.findall(RE_BOOTHOOK, output))
     client.restart()

--- a/tests/integration_tests/modules/test_ca_certs.py
+++ b/tests/integration_tests/modules/test_ca_certs.py
@@ -14,7 +14,11 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.releases import IS_UBUNTU
-from tests.integration_tests.util import get_inactive_modules, verify_clean_log
+from tests.integration_tests.util import (
+    get_inactive_modules,
+    verify_clean_boot,
+    verify_clean_log,
+)
 
 CERT_CONTENT = """\
 -----BEGIN CERTIFICATE-----
@@ -106,6 +110,7 @@ class TestCaCerts:
         """
         log = class_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log, ignore_deprecations=False)
+        verify_clean_boot(class_client)
 
         expected_inactive = {
             "apt_pipelining",

--- a/tests/integration_tests/modules/test_disk_setup.py
+++ b/tests/integration_tests/modules/test_disk_setup.py
@@ -9,7 +9,7 @@ from cloudinit.subp import subp
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL, IS_UBUNTU
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 DISK_PATH = "/tmp/test_disk_setup_{}".format(uuid4())
 
@@ -69,6 +69,7 @@ class TestDeviceAliases:
         assert "changed my_alias.1 => /dev/sdb1" in log
         assert "changed my_alias.2 => /dev/sdb2" in log
         verify_clean_log(log)
+        verify_clean_boot(client)
 
         lsblk = json.loads(client.execute("lsblk --json"))
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]
@@ -143,6 +144,7 @@ class TestPartProbeAvailability:
 
     def _verify_first_disk_setup(self, client, log):
         verify_clean_log(log)
+        verify_clean_boot(client)
         lsblk = json.loads(client.execute("lsblk --json"))
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]
         assert len(sdb["children"]) == 2
@@ -200,6 +202,7 @@ class TestPartProbeAvailability:
 
         # Assert new setup works as expected
         verify_clean_log(log)
+        verify_clean_boot(client)
 
         lsblk = json.loads(client.execute("lsblk --json"))
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -16,6 +16,7 @@ from tests.integration_tests.releases import (
 )
 from tests.integration_tests.util import (
     push_and_enable_systemd_unit,
+    verify_clean_boot,
     verify_clean_log,
     wait_for_cloud_init,
 )
@@ -256,6 +257,7 @@ def test_multi_nic_hotplug(setup_image, session_cloud: IntegrationCloud):
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
         ips_after_add = _get_ip_addr(client)
 
@@ -297,6 +299,7 @@ def test_multi_nic_hotplug(setup_image, session_cloud: IntegrationCloud):
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
 
 @pytest.mark.skipif(CURRENT_RELEASE <= FOCAL, reason="See LP: #2055397")
@@ -317,6 +320,7 @@ def test_multi_nic_hotplug_vpc(setup_image, session_cloud: IntegrationCloud):
         _wait_till_hotplug_complete(client)
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
         netplan_cfg = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
         config = yaml.safe_load(netplan_cfg)
@@ -359,6 +363,7 @@ def test_multi_nic_hotplug_vpc(setup_image, session_cloud: IntegrationCloud):
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
 
 @pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")

--- a/tests/integration_tests/modules/test_jinja_templating.py
+++ b/tests/integration_tests/modules/test_jinja_templating.py
@@ -4,6 +4,7 @@ import pytest
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.util import (
+    verify_clean_boot,
     verify_clean_log,
     verify_ordered_items_in_text,
 )
@@ -72,6 +73,7 @@ def test_substitution_in_etc_cloud(client: IntegrationInstance):
 
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
 
     # Ensure /etc/cloud/cloud.cfg template works as expected
     hostname = client.execute("hostname").stdout.strip()

--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -13,7 +13,7 @@ from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 BRIDGE_USER_DATA = """\
 #cloud-config
@@ -166,6 +166,7 @@ class TestLxdBridge:
         """Check that the given bridge is configured"""
         cloud_init_log = class_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(cloud_init_log)
+        verify_clean_boot(class_client)
 
         # The bridge should exist
         assert class_client.execute("ip addr show lxdbr0").ok
@@ -178,6 +179,7 @@ class TestLxdBridge:
 def validate_storage(validate_client, pkg_name, command):
     log = validate_client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log, ignore_deprecations=False)
+    verify_clean_boot(validate_client)
     return log
 
 
@@ -289,6 +291,7 @@ def test_basic_preseed(client):
     preseed_cfg = yaml.safe_load(preseed_cfg)
     cloud_init_log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(cloud_init_log)
+    verify_clean_boot(client)
     validate_preseed_profiles(client, preseed_cfg)
     validate_preseed_storage_pools(client, preseed_cfg)
     validate_preseed_projects(client, preseed_cfg)

--- a/tests/integration_tests/modules/test_package_update_upgrade_install.py
+++ b/tests/integration_tests/modules/test_package_update_upgrade_install.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -146,6 +146,7 @@ def test_versioned_packages_are_installed(session_cloud: IntegrationCloud):
         user_data=VERSIONED_USER_DATA.format(pkg_version=pkg_version)
     ) as client:
         verify_clean_log(client.read_from_file("/var/log/cloud-init.log"))
+        verify_clean_boot(client)
         assert f"hello	{pkg_version}" == client.execute(
             "dpkg-query -W hello"
         ), (

--- a/tests/integration_tests/modules/test_puppet.py
+++ b/tests/integration_tests/modules/test_puppet.py
@@ -3,7 +3,7 @@
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 SERVICE_DATA = """\
 #cloud-config
@@ -18,6 +18,7 @@ def test_puppet_service(client: IntegrationInstance):
     """Basic test that puppet gets installed and runs."""
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     puppet_ok = client.execute("systemctl is-active puppet.service").ok
     puppet_agent_ok = client.execute(
         "systemctl is-active puppet-agent.service"

--- a/tests/integration_tests/modules/test_ubuntu_drivers.py
+++ b/tests/integration_tests/modules/test_ubuntu_drivers.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -24,6 +24,7 @@ def test_ubuntu_drivers_installed(session_cloud: IntegrationCloud):
     ) as client:
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
         assert 1 == log.count(
             "Installing and activating NVIDIA drivers "
             "(nvidia/license-accepted=True, version=latest)"

--- a/tests/integration_tests/modules/test_ubuntu_pro.py
+++ b/tests/integration_tests/modules/test_ubuntu_pro.py
@@ -22,6 +22,7 @@ from tests.integration_tests.releases import (
 )
 from tests.integration_tests.util import (
     get_feature_flag_value,
+    verify_clean_boot,
     verify_clean_log,
 )
 
@@ -142,21 +143,22 @@ class TestUbuntuAdvantage:
         version_boundary = get_feature_flag_value(
             client, "DEPRECATION_INFO_BOUNDARY"
         )
+        boundary_message = (
+            "Module has been renamed from cc_ubuntu_advantage "
+            "to cc_ubuntu_pro /var/log/cloud-init.log"
+        )
         # ubuntu_advantage key is deprecated in version 24.1
         if lifecycle.should_log_deprecation("24.1", version_boundary):
-            log_level = "DEPRECATED"
+            verify_clean_boot(client, require_deprecations=[boundary_message])
         else:
-            log_level = "INFO"
-        client.execute(
-            rf"grep \"{log_level}]: Module has been renamed from"
-            " cc_ubuntu_advantage to cc_ubuntu_pro /var/log/cloud-init.log"
-        ).ok
+            client.execute(rf"grep \"INFO]: {boundary_message}").ok
         assert is_attached(client)
 
     @pytest.mark.user_data(ATTACH.format(token=CLOUD_INIT_UA_TOKEN))
     def test_idempotency(self, client: IntegrationInstance):
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
         assert is_attached(client)
 
         # Clean reboot to change instance-id and trigger cc_ua in next boot
@@ -165,6 +167,7 @@ class TestUbuntuAdvantage:
 
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
         assert is_attached(client)
 
         # Assert service-already-enabled handling for esm-infra.
@@ -178,6 +181,7 @@ class TestUbuntuAdvantage:
         client.restart()
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
         assert "Service `esm-infra` already enabled" in log
 
 
@@ -209,6 +213,7 @@ def maybe_install_cloud_init(session_cloud: IntegrationCloud):
     ) as client:
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
 
         assert not is_attached(
             client
@@ -247,6 +252,7 @@ class TestUbuntuAdvantagePro:
         ) as client:
             log = client.read_from_file("/var/log/cloud-init.log")
             verify_clean_log(log)
+            verify_clean_boot(client)
             assert_ua_service_noop(client)
             assert is_attached(client)
             services_status = get_services_status(client)

--- a/tests/integration_tests/net/test_dhcp.py
+++ b/tests/integration_tests/net/test_dhcp.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, NOBLE
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 
 @pytest.mark.skipif(not IS_UBUNTU, reason="ubuntu-specific tests")
@@ -23,6 +23,7 @@ class TestDHCP:
         log = client.read_from_file("/var/log/cloud-init.log")
         assert "DHCP client selected: dhclient" in log
         verify_clean_log(log)
+        verify_clean_boot(client)
 
     @pytest.mark.xfail(
         reason=(
@@ -41,6 +42,7 @@ class TestDHCP:
             ", DHCP is still running" not in log
         ), "cloud-init leaked a dhcp daemon that is still running"
         verify_clean_log(log)
+        verify_clean_boot(client)
 
     @pytest.mark.skipif(
         CURRENT_RELEASE < NOBLE,
@@ -89,3 +91,4 @@ class TestDHCP:
             ), "Failed to get unknown option 245"
             assert "'unknown-245'" in log, "Failed to get unknown option 245"
         verify_clean_log(log)
+        verify_clean_boot(client)

--- a/tests/integration_tests/reporting/test_webhook_reporting.py
+++ b/tests/integration_tests/reporting/test_webhook_reporting.py
@@ -7,7 +7,11 @@ import json
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import ASSETS_DIR, verify_clean_log
+from tests.integration_tests.util import (
+    ASSETS_DIR,
+    verify_clean_boot,
+    verify_clean_log,
+)
 
 URL = "http://127.0.0.1:55555"
 
@@ -47,6 +51,7 @@ def test_webhook_reporting(client: IntegrationInstance):
         "cloud-init status --wait"
     )
     verify_clean_log(client.read_from_file("/var/log/cloud-init.log"))
+    verify_clean_boot(client)
 
     server_output = client.read_from_file(
         "/var/tmp/echo_server_output"

--- a/tests/integration_tests/test_ds_identify.py
+++ b/tests/integration_tests/test_ds_identify.py
@@ -2,7 +2,11 @@
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log, wait_for_cloud_init
+from tests.integration_tests.util import (
+    verify_clean_boot,
+    verify_clean_log,
+    wait_for_cloud_init,
+)
 
 DATASOURCE_LIST_FILE = "/etc/cloud/cloud.cfg.d/90_dpkg.cfg"
 MAP_PLATFORM_TO_DATASOURCE = {
@@ -26,6 +30,7 @@ def test_ds_identify(client: IntegrationInstance):
     client.restart()
     wait_for_cloud_init(client)
     verify_clean_log(client.execute("cat /var/log/cloud-init.log"))
+    verify_clean_boot(client)
     assert client.execute("cloud-init status --wait")
 
     datasource = MAP_PLATFORM_TO_DATASOURCE.get(PLATFORM, PLATFORM)

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -18,7 +18,7 @@ from tests.integration_tests.releases import (
     MANTIC,
     NOBLE,
 )
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 # Older Ubuntu series didn't read cloud-init.* config keys
 LXD_NETWORK_CONFIG_KEY = (
@@ -339,6 +339,7 @@ def test_ec2_multi_nic_reboot(setup_image, session_cloud: IntegrationCloud):
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
         # SSH over primary and secondary NIC works
         for ip in public_ips:
@@ -459,6 +460,7 @@ def test_ec2_multi_network_cards(setup_image, session_cloud: IntegrationCloud):
 
             log_content = client.read_from_file("/var/log/cloud-init.log")
             verify_clean_log(log_content)
+            verify_clean_boot(client)
 
             # SSH over secondary NICs works
             subp("nc -w 5 -zv " + allocation_1["PublicIp"] + " 22", shell=True)

--- a/tests/integration_tests/test_paths.py
+++ b/tests/integration_tests/test_paths.py
@@ -10,7 +10,7 @@ from cloudinit.cmd.devel.logs import (
 )
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 DEFAULT_CLOUD_DIR = "/var/lib/cloud"
 NEW_CLOUD_DIR = "/new-cloud-dir"
@@ -39,6 +39,7 @@ class TestHonorCloudDir:
     def verify_log_and_files(self, custom_client):
         log_content = custom_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(custom_client)
         assert NEW_CLOUD_DIR in log_content
         assert DEFAULT_CLOUD_DIR not in log_content
         assert custom_client.execute(f"test ! -d {DEFAULT_CLOUD_DIR}").ok

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -198,3 +198,4 @@ def test_subsequent_boot_of_upgraded_package(session_cloud: IntegrationCloud):
         log = instance.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
         assert instance.execute("cloud-init status --wait --long").ok
+        verify_clean_boot(instance)


### PR DESCRIPTION
## Additional Context
See commit messages for details. 

`verify_clean_boot()`
- add support for deprecated calls
- verify `cloud-init status` return code

Also add `verify_clean_boot()` alongside each `verify_clean_log()` call.


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
