### PR TITLE
fix: Render bridges correctly for v2 on sysconfig with set-name

### DIFF
--- a/cloudinit/net/eni.py
+++ b/cloudinit/net/eni.py
@@ -5,6 +5,7 @@ import glob
 import logging
 import os
 import re
+from contextlib import suppress
 from typing import Optional
 
 from cloudinit import subp, util
@@ -421,6 +422,11 @@ class Renderer(renderer.Renderer):
         return content
 
     def _render_iface(self, iface, render_hwaddress=False):
+        iface = copy.deepcopy(iface)
+
+        # Remove irrelevant keys
+        with suppress(KeyError):
+            iface.pop("config_id")
         sections = []
         subnets = iface.get("subnets", {})
         accept_ra = iface.pop("accept-ra", None)

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -804,12 +804,12 @@ class NetworkStateInterpreter:
         LOG.debug("v2_common: handling config:\n%s", cfg)
         for iface, dev_cfg in cfg.items():
             if "nameservers" in dev_cfg:
-                search = dev_cfg.get("nameservers").get("search", [])
-                dns = dev_cfg.get("nameservers").get("addresses", [])
+                search = dev_cfg.get("nameservers").get("search")
+                dns = dev_cfg.get("nameservers").get("addresses")
                 name_cmd = {"type": "nameserver"}
-                if len(search) > 0:
+                if search:
                     name_cmd["search"] = search
-                if len(dns) > 0:
+                if dns:
                     name_cmd["address"] = dns
 
                 self._handle_individual_nameserver(name_cmd, iface)

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -6,7 +6,7 @@ import io
 import logging
 import os
 import re
-from typing import Mapping, Optional
+from typing import Dict, Optional
 
 from cloudinit import subp, util
 from cloudinit.distros.parsers import networkmanager_conf, resolv_conf
@@ -705,7 +705,7 @@ class Renderer(renderer.Renderer):
     ):
         physical_filter = renderer.filter_by_physical
         for iface in network_state.iter_interfaces(physical_filter):
-            iface_name = iface["name"]
+            iface_name = iface.get("config_id") or iface["name"]
             iface_subnets = iface.get("subnets", [])
             iface_cfg = iface_contents[iface_name]
             route_cfg = iface_cfg.routes
@@ -910,7 +910,9 @@ class Renderer(renderer.Renderer):
         return out
 
     @classmethod
-    def _render_bridge_interfaces(cls, network_state, iface_contents, flavor):
+    def _render_bridge_interfaces(
+        cls, network_state: NetworkState, iface_contents, flavor
+    ):
         bridge_key_map = {
             old_k: new_k
             for old_k, new_k in cls.cfg_key_maps[flavor].items()
@@ -991,23 +993,29 @@ class Renderer(renderer.Renderer):
 
     @classmethod
     def _render_sysconfig(
-        cls, base_sysconf_dir, network_state, flavor, templates=None
+        cls,
+        base_sysconf_dir,
+        network_state: NetworkState,
+        flavor,
+        templates=None,
     ):
         """Given state, return /etc/sysconfig files + contents"""
         if not templates:
             templates = cls.templates
-        iface_contents: Mapping[str, NetInterface] = {}
+        iface_contents: Dict[str, NetInterface] = {}
         for iface in network_state.iter_interfaces():
             if iface["type"] == "loopback":
                 continue
-            iface_name = iface["name"]
-            iface_cfg = NetInterface(iface_name, base_sysconf_dir, templates)
+            config_id: str = iface.get("config_id") or iface["name"]
+            iface_cfg = NetInterface(
+                iface["name"], base_sysconf_dir, templates
+            )
             if flavor == "suse":
                 iface_cfg.drop("DEVICE")
                 # If type detection fails it is considered a bug in SUSE
                 iface_cfg.drop("TYPE")
             cls._render_iface_shared(iface, iface_cfg, flavor)
-            iface_contents[iface_name] = iface_cfg
+            iface_contents[config_id] = iface_cfg
         cls._render_physical_interfaces(network_state, iface_contents, flavor)
         cls._render_bond_interfaces(network_state, iface_contents, flavor)
         cls._render_vlan_interfaces(network_state, iface_contents, flavor)

--- a/tests/unittests/net/network_configs.py
+++ b/tests/unittests/net/network_configs.py
@@ -4912,4 +4912,89 @@ iface bond0 inet6 static
             """
         ),
     },
+    "v2-bridges-set-name": {
+        "yaml": textwrap.dedent(
+            """\
+            version: 2
+            ethernets:
+              baremetalport:
+                match:
+                  macaddress: 52:54:00:bd:8f:cb
+                set-name: baremetal0
+              provisioningport:
+                match:
+                  macaddress: 52:54:00:25:ae:12
+                set-name: provisioning0
+            bridges:
+              baremetal:
+                addresses:
+                  - fc00:1:1::2/64
+                interfaces:
+                  - baremetalport
+              provisioning:
+                addresses:
+                  - fc00:1:2::2/64
+                interfaces:
+                  - provisioningport
+            """
+        ),
+        "expected_sysconfig_rhel": {
+            "ifcfg-baremetal": textwrap.dedent(
+                """\
+                # Created by cloud-init automatically, do not edit.
+                #
+                BOOTPROTO=none
+                DEVICE=baremetal
+                IPV6ADDR=fc00:1:1::2/64
+                IPV6INIT=yes
+                IPV6_AUTOCONF=no
+                IPV6_FORCE_ACCEPT_RA=no
+                ONBOOT=yes
+                TYPE=Bridge
+                USERCTL=no
+                """
+            ),
+            "ifcfg-baremetal0": textwrap.dedent(
+                """\
+                # Created by cloud-init automatically, do not edit.
+                #
+                BOOTPROTO=none
+                BRIDGE=baremetal
+                DEVICE=baremetal0
+                HWADDR=52:54:00:bd:8f:cb
+                ONBOOT=yes
+                TYPE=Ethernet
+                USERCTL=no
+                """
+            ),
+            "ifcfg-provisioning": textwrap.dedent(
+                """\
+                # Created by cloud-init automatically, do not edit.
+                #
+                BOOTPROTO=none
+                DEVICE=provisioning
+                IPV6ADDR=fc00:1:2::2/64
+                IPV6INIT=yes
+                IPV6_AUTOCONF=no
+                IPV6_FORCE_ACCEPT_RA=no
+                ONBOOT=yes
+                TYPE=Bridge
+                USERCTL=no
+                """
+            ),
+            "ifcfg-provisioning0": textwrap.dedent(
+                """\
+                # Created by cloud-init automatically, do not edit.
+                #
+                BOOTPROTO=none
+                BRIDGE=provisioning
+                DEVICE=provisioning0
+                HWADDR=52:54:00:25:ae:12
+                ONBOOT=yes
+                TYPE=Ethernet
+                USERCTL=no
+                """
+            ),
+        },
+    },
 }

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -2098,6 +2098,7 @@ USERCTL=no
             ("dhcpv6_stateful", "yaml"),
             ("wakeonlan_disabled", "yaml_v2"),
             ("wakeonlan_enabled", "yaml_v2"),
+            ("v2-bridges-set-name", "yaml"),
             pytest.param(
                 "v1-dns",
                 "yaml",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Render bridges correctly for v2 on sysconfig with set-name

When listing interfaces in v2 format, we should expect to be able to
reference other interfaces using the name in the configuration, not
the name the interface will eventually take. This was broken when
using `set-name`.

To fix this, we now store the configuration id alongside the eventual
name, and reference that instead of the name.

Fixes GH-5574
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
