### PR TITLE
chore: make ansible test serial

### DIFF
--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -330,6 +330,7 @@ class TestAnsible:
         """assert exception not raised if package installed"""
         cc_ansible.AnsiblePullDistro(get_cloud().distro).check_deps()
 
+    @mark.serial
     @mock.patch(M_PATH + "subp.subp", return_value=("stdout", "stderr"))
     @mock.patch(M_PATH + "subp.which", return_value=False)
     def test_pip_bootstrap(self, m_which, m_subp):


### PR DESCRIPTION
```
chore: make ansible test serial
```

## Additional Context
Arguably we should modify the test, but for now just mark it as serial to fix the py3-fast tox env.

```
tox -e py3-fast
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
