### PR TITLE
doc: remove misleading warning

### DIFF
--- a/doc/rtd/explanation/events.rst
+++ b/doc/rtd/explanation/events.rst
@@ -71,13 +71,6 @@ addition or removal of network interfaces to the system. In addition to
 fetching and updating the system metadata, ``cloud-init`` will also bring
 up/down the newly added interface.
 
-.. warning::
-   Due to its use of ``systemd`` sockets, ``hotplug`` functionality is
-   currently incompatible with SELinux on Linux distributions using systemd.
-   This issue is being `tracked in GitHub #3890`_. Additionally, ``hotplug``
-   support is considered experimental for non-Alpine and non-Debian-based
-   systems.
-
 Example
 =======
 


### PR DESCRIPTION
## Additional Context


tl;dr: documenting downstream bugs rather than filing them against downstream bug trackers is not the best approach.

It may be better to let users use the features that they want to, and if an issue is uncovered direct bug reports to the proper support channels.

>   Due to its use of ``systemd`` sockets, ``hotplug`` functionality is
>   currently incompatible with SELinux on Linux distributions using systemd.

This isn't true. No incompatibility with SELinux exists. An SELinux rule just needs to be updated on the affected distro to allow this access.

>   This issue is being tracked in GitHub #3890.

This is a downstream issue. Why wasn't it reported downstream for them to fix?

>   Additionally, ``hotplug``
>   support is considered experimental for non-Alpine and non-Debian-based
>   systems.

It's been around for a while. I'd like to stop calling this experimental. 

Related to https://github.com/canonical/cloud-init/issues/3890


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
