### PR TITLE
fix: cloud-init.postinst for maas preseed provisioning

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+cloud-init (24.4~3+really24.3.1-0ubuntu2) UNRELEASED; urgency=medium
+
+  * d/cloud-init.postinst: fix MAAS preseed provisioning by replacing
+    handle_preseed_maas and handle_preseed_local_cloud_config functions
+    which were removed in commit cf13fd126 (GH-5685)
+
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 10 Sep 2024 13:41:14 -0600
+
 cloud-init (24.4~3+really24.3.1-0ubuntu1) oracular; urgency=medium
 
   * d/cloud-init.lintian-overrides:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (24.4~3+really24.3.1-0ubuntu2) UNRELEASED; urgency=medium
+cloud-init (24.4~3+really24.3.1-0ubuntu2) oracular; urgency=medium
 
   * d/cloud-init.postinst: fix MAAS preseed provisioning by replacing
     handle_preseed_maas and handle_preseed_local_cloud_config functions

--- a/debian/cloud-init.postinst
+++ b/debian/cloud-init.postinst
@@ -51,6 +51,80 @@ with open(fname, "w") as fp:
     fp.write(yaml.dump(cfg))' "$@"
 }
 
+handle_preseed_maas() {
+   local cfg_file="/etc/cloud/cloud.cfg.d/90_dpkg_maas.cfg"
+   local md_url="" creds_all="" c_key="" t_key="" t_sec="" c_sec="";
+
+   db_get "cloud-init/maas-metadata-url" && md_url="$RET" || :
+   db_get "cloud-init/maas-metadata-credentials" && creds_all="$RET" || :
+
+   # nothing to do
+   [ -n "$md_url" -o -n "$creds_all" ] || return 0
+
+   # change a url query string format into : delimited
+   if [ -n "$creds_all" -a "${creds_all#*&}" != "${creds_all}" ]; then
+      # the command here ends up looking like:
+      # python3 -c '...' 'oauth_consumer_key=v1&oauth_token_key=v2...' \
+      #   oauth_consumer_key oauth_token_key oauth_token_secret
+      creds_all=$(python3 -c 'from six.moves.urllib.parse import parse_qs;
+import sys;
+keys = parse_qs(sys.argv[1])
+for k in sys.argv[2:]:
+   sys.stdout.write("%s:" % keys.get(k,[""])[0])' "$creds_all" \
+   oauth_consumer_key oauth_token_key oauth_token_secret
+)
+   fi
+
+   # now, if non-empty creds_all is: consumer_key:token_key:token_secret
+   if [ -n "$creds_all" ]; then
+      OIFS="$IFS"; IFS=:; set -- $creds_all; IFS="$OIFS"
+      c_key=$1; t_key=$2; t_sec=$3
+   fi
+
+   if [ "$md_url" = "_" -a "${c_key}:${t_key}:${t_sec}" = "_:_:_" ]; then
+      # if all these values were '_', the delete value, just delete the file.
+      rm -f "$cfg_file"
+   else
+      local header="# written by cloud-init debian package per preseed entries
+# cloud-init/{maas-metadata-url,/maas-metadata-credentials}"
+
+      local pair="" k="" v="" pload="" orig_umask=""
+      for pair in "metadata_url:$md_url" "consumer_key:${c_key}" \
+         "token_key:${t_key}" "token_secret:$t_sec"; do
+         k=${pair%%:*}
+         v=${pair#${k}:}
+         [ -n "$v" ] && pload="${pload} $k: \"$v\","
+      done
+
+      # '_' would indicate "delete", otherwise, existing entries are left
+      orig_umask=$(umask)
+      umask 066
+      : >> "$cfg_file" && chmod 600 "$cfg_file"
+      update_cfg "$cfg_file" "$header" "datasource: { MAAS: { ${pload%,} } }" _
+      umask ${orig_umask}
+   fi
+
+   # now clear the database of the values, as they've been consumed
+   db_unregister "cloud-init/maas-metadata-url" || :
+   db_unregister "cloud-init/maas-metadata-credentials" || :
+}
+
+handle_preseed_local_cloud_config() {
+   local ccfg="" debconf_name="cloud-init/local-cloud-config"
+   local cfg_file="/etc/cloud/cloud.cfg.d/90_dpkg_local_cloud_config.cfg"
+   local header="# written by cloud-init debian package per preseed entry
+# $debconf_name"
+
+   db_get "${debconf_name}" && ccfg="$RET" || :
+
+   if [ "$ccfg" = "_" ]; then
+      rm -f "$cfg_file"
+   elif [ -n "$ccfg" ]; then
+      { echo "$header"; echo "$ccfg"; } > "$cfg_file"
+   fi
+   db_unregister "${debconf_name}" || :
+}
+
 fix_1336855() {
   ### Begin fix for LP: 1336855
   # fix issue where cloud-init misidentifies the location of grub and
@@ -190,6 +264,12 @@ if [ "$1" = "configure" ]; then
 datasource_list: [ $values ]
 EOF
    fi
+
+   # if there are maas settings pre-seeded apply them
+   handle_preseed_maas
+
+   # if there is generic cloud-config preseed, apply them
+   handle_preseed_local_cloud_config
 
    # fix issue where cloud-init misidentifies the location of grub
    fix_1336855


### PR DESCRIPTION
## Merge as separate commits

## Proposed Commit Message
- see separate commits

Functional change
```
fix(d/postinst): retain handle_preseed functions for MAAS provision

Commit cf13fd12 removed support for MAAS preseed functions from
debian/cloud-init.postinst which is the only operation which
allows MAAS to send preseed config to cloud-init.

Fixes GH-5685
```

## Additional Context
https://github.com/canonical/cloud-init/issues/5685

The other functions in postinst that were removed by commit cf13fd12 were already version gated to be skipped on any recent supported LTS.  So, the other dropped postinst functions in that commit do not need to be reverted. Just active MAAS preseed support utility functions.


## Test Steps


## Merge type

- [x] merge as separate commits from git command line 
- [ ] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
