### PR TITLE
Fix daily recipe: ubuntu/focal

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: "Checkout #1"
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: "Checkout #2 (for tools/read-version)"
         run: |
@@ -46,10 +46,10 @@ jobs:
     strategy:
       fail-fast: false
     name: Check json format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout #1"
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: "Test format"
         run: |
@@ -61,19 +61,19 @@ jobs:
     strategy:
       fail-fast: false
     name: Check docs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout #1"
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: "Checkout #2 (for tools/read-version)"
         run: |
           git fetch --unshallow
           git remote add upstream https://git.launchpad.net/cloud-init
       - name: "Install Python 3.10"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10.8'
+          python-version: '3.11.9'
       - name: "Install dependencies"
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
@@ -91,10 +91,10 @@ jobs:
 
   shell-lint:
     name: Shell Lint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: Install ShellCheck
         run: |
@@ -106,9 +106,9 @@ jobs:
           shellcheck ./tools/ds-identify
 
   check-cla-signers:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v3.0.0
+      - uses: actions/checkout@v4
 
       - name: Check CLA signers file
         run: tools/check-cla-signers

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,11 +20,11 @@ env:
   RELEASE: focal
 
 jobs:
-  package-build:
-    runs-on: ubuntu-22.04
+  build-package-and-run-tests:
+    runs-on: ubuntu-24.04
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
@@ -32,58 +32,45 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y install \
-            debhelper \
-            dh-python \
             fakeroot \
-            python3-setuptools \
             sbuild \
-            ubuntu-dev-tools
+            ubuntu-dev-tools \
+            tox \
+            wireguard \
+            $(\
+              ./tools/read-dependencies                   \
+                --requirements-file requirements.txt      \
+                --requirements-file test-requirements.txt \
+                --distro ubuntu                           \
+                --system-pkg-names 2> /dev/null           \
+                | tr '\n' ' '                             \
+            )
           sudo sbuild-adduser $USER
           cp /usr/share/doc/sbuild/examples/example.sbuildrc /home/$USER/.sbuildrc
-          # Install all build and test dependencies
-          ./tools/read-dependencies -r requirements.txt -r test-requirements.txt -d ubuntu -s -i
       - name: Build package
         run: |
           ./packages/bddeb -S -d --release ${{ env.RELEASE }}
           sudo -E su $USER -c 'mk-sbuild ${{ env.RELEASE }}'
           sudo -E su $USER -c 'DEB_BUILD_OPTIONS=nocheck sbuild --nolog --no-run-lintian --no-run-autopkgtest --verbose --dist=${{ env.RELEASE }} --build-dir=${{ runner.temp }} cloud-init_*.dsc'
       - name: Archive debs as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: 'cloud-init-${{ env.RELEASE }}-deb'
           path: '${{ runner.temp }}/cloud-init*.deb'
           retention-days: 3
-
-  integration-tests:
-    needs: package-build
-    runs-on: ubuntu-22.04
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v3
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
         with:
-          # Fetch all tags for tools/read-version
-          fetch-depth: 0
-      - name: Retrieve cloud-init package
-        uses: actions/download-artifact@v3
-        with:
-          name: 'cloud-init-${{ env.RELEASE }}-deb'
+          channel: latest/candidate
       - name: Verify deb package
         run: |
-          ls -hal cloud-init*.deb
-      - name: Prepare test tools
-        run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -y update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install tox wireguard
-      - name: Initialize LXD
+          ls -hal '${{ runner.temp }}'
+          echo ${{ runner.temp }}/cloud-init*.deb || true
+          ls -hal ${{ runner.temp }}/cloud-init*.deb || true
+      - name: Set up Pycloudlib
         run: |
           ssh-keygen -P "" -q -f ~/.ssh/id_rsa
           echo "[lxd]" > /home/$USER/.config/pycloudlib.toml
-          sudo adduser $USER lxd
-          # Jammy GH Action runners have docker installed, which edits iptables
-          # in a way that is incompatible with lxd.
-          # https://documentation.ubuntu.com/lxd/en/latest/howto/network_bridge_firewalld/#prevent-connectivity-issues-with-lxd-and-docker
-          sudo iptables -I DOCKER-USER -j ACCEPT
-          sudo lxd init --auto
       - name: Run integration Tests
         run: |
-          sg lxd -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls cloud-init*.deb)" tox -e integration-tests-ci'
+          sh -c 'CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls ${{ runner.temp }}/cloud-init*.deb)" tox -e integration-tests-ci'

--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -8,15 +8,15 @@ concurrency:
 
 jobs:
   linkcheck:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.failOnError == 'true') }}
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3.0.0
+        uses: actions/checkout@v4
 
       - name: "Install Python 3.10"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10.8'
 

--- a/.github/workflows/packaging-tests.yml
+++ b/.github/workflows/packaging-tests.yml
@@ -18,10 +18,10 @@ env:
 
 jobs:
   check-patches:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Fetch all branches for merging
           fetch-depth: 0
@@ -42,6 +42,7 @@ jobs:
           git fetch upstream main
           git checkout upstream/main
           git merge ${{ github.sha }}
+          test -f debian/patches/series || echo "no patches, skipping" && exit 0
           quilt push -a
           tox -e py3
           quilt pop -a

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Python 3.13-dev
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.13-dev
           check-latest: true
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           sudo apt-get -qy update

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v1
+    - uses: actions/stale@v9
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 14

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -28,7 +28,7 @@ jobs:
             check-latest: false
             experimental: false
     name: Python ${{matrix.python-version}} ${{ matrix.slug }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: "Checkout"
@@ -37,7 +37,7 @@ jobs:
           # Fetch all tags for tools/read-version
           fetch-depth: 0
       - name: Install Python ${{matrix.python-version}}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
           check-latest: ${{matrix.check-latest}}

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -1318,8 +1318,4 @@ def sub_main(args):
 
 
 if __name__ == "__main__":
-    if "TZ" not in os.environ:
-        os.environ["TZ"] = ":/etc/localtime"
-    return_value = main(sys.argv)
-    if return_value:
-        sys.exit(return_value)
+    sys.exit(main(sys.argv))

--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -35,12 +35,12 @@ meta: MetaSchema = {
 
 LOG = logging.getLogger(__name__)
 # phone_home:
-#  url: http://my.foo.bar/$INSTANCE/
+#  url: http://my.foo.bar/{{ v1.instance_id }}/
 #  post: all
 #  tries: 10
 #
 # phone_home:
-#  url: http://my.foo.bar/$INSTANCE_ID/
+#  url: http://my.foo.bar/{{ v1.instance_id }}/
 #  post: [ pub_key_rsa, pub_key_ecdsa, instance_id, hostname,
 #          fqdn ]
 #

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -88,7 +88,7 @@ class DataSourceEc2(sources.DataSource):
     ]
 
     # Setup read_url parameters per get_url_params.
-    url_max_wait = 120
+    url_max_wait = 240
     url_timeout = 50
 
     _api_token = None  # API token for accessing the metadata service

--- a/cloudinit/sources/DataSourceScaleway.py
+++ b/cloudinit/sources/DataSourceScaleway.py
@@ -367,9 +367,11 @@ class DataSourceScaleway(sources.DataSource):
                 if ip["address"] == self.ephemeral_fixed_address:
                     ip_cfg["dhcp4"] = True
                     # Force addition of a route to the metadata API
-                    ip_cfg["routes"] = [
-                        {"to": "169.254.42.42/32", "via": "62.210.0.1"}
-                    ]
+                    route = {"to": "169.254.42.42/32", "via": "62.210.0.1"}
+                    if "routes" in ip_cfg.keys():
+                        ip_cfg["routes"] += [route]
+                    else:
+                        ip_cfg["routes"] = [route]
                 else:
                     if "addresses" in ip_cfg.keys():
                         ip_cfg["addresses"] += (

--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -31,8 +31,6 @@ import random
 import re
 import socket
 
-import serial
-
 from cloudinit import atomic_helper, dmi, sources, subp, util
 from cloudinit.event import EventScope, EventType
 
@@ -576,6 +574,12 @@ class JoyentMetadataSerialClient(JoyentMetadataClient):
 
     def open_transport(self):
         if self.fp is None:
+            try:
+                import serial
+            except ImportError as e:
+                raise NotImplementedError(
+                    "serial support is not available"
+                ) from e
             ser = serial.Serial(self.device, timeout=self.timeout)
             if not ser.isOpen():
                 raise SystemError("Unable to open %s" % self.device)

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -9,7 +9,7 @@ import traceback
 from datetime import datetime
 from io import StringIO
 from typing import Any, Dict, List, Optional, Tuple
-from xml.etree import ElementTree  # nosec B405
+from xml.etree import ElementTree as ET  # nosec B405
 
 import requests
 
@@ -177,7 +177,7 @@ class ReportableErrorOvfInvalidMetadata(ReportableError):
 
 
 class ReportableErrorOvfParsingException(ReportableError):
-    def __init__(self, *, exception: ElementTree.ParseError) -> None:
+    def __init__(self, *, exception: ET.ParseError) -> None:
         message = exception.msg
         super().__init__(f"error parsing ovf-env.xml: {message}")
 

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from time import sleep, time
 from typing import Callable, List, Optional, TypeVar, Union
-from xml.etree import ElementTree  # nosec B405
+from xml.etree import ElementTree as ET  # nosec B405
 from xml.sax.saxutils import escape  # nosec B406
 
 from cloudinit import distros, subp, temp_utils, url_helper, util, version
@@ -363,8 +363,8 @@ class GoalState:
         self.azure_endpoint_client = azure_endpoint_client
 
         try:
-            self.root = ElementTree.fromstring(unparsed_xml)  # nosec B314
-        except ElementTree.ParseError as e:
+            self.root = ET.fromstring(unparsed_xml)  # nosec B314
+        except ET.ParseError as e:
             report_diagnostic_event(
                 "Failed to parse GoalState XML: %s" % e,
                 logger_func=LOG.warning,
@@ -496,9 +496,7 @@ class OpenSSLManager:
         """Decrypt the certificates XML document using the our private key;
         return the list of certs and private keys contained in the doc.
         """
-        tag = ElementTree.fromstring(certificates_xml).find(  # nosec B314
-            ".//Data"
-        )
+        tag = ET.fromstring(certificates_xml).find(".//Data")  # nosec B314
         certificates_content = tag.text
         lines = [
             b"MIME-Version: 1.0",
@@ -1006,8 +1004,8 @@ class OvfEnvXml:
                 unparsable or invalid.
         """
         try:
-            root = ElementTree.fromstring(ovf_env_xml)  # nosec B314
-        except ElementTree.ParseError as e:
+            root = ET.fromstring(ovf_env_xml)  # nosec B314
+        except ET.ParseError as e:
             raise errors.ReportableErrorOvfParsingException(exception=e) from e
 
         # If there's no provisioning section, it's not Azure ovf-env.xml.

--- a/cloudinit/sources/helpers/cloudsigma.py
+++ b/cloudinit/sources/helpers/cloudsigma.py
@@ -22,8 +22,6 @@ API Docs: http://cloudsigma-docs.readthedocs.org/en/latest/server_context.html
 import json
 import platform
 
-import serial
-
 # these high timeouts are necessary as read may read a lot of data.
 READ_TIMEOUT = 60
 WRITE_TIMEOUT = 10
@@ -67,6 +65,11 @@ class CepkoResult:
         self.result = self._marshal(self.raw_result)
 
     def _execute(self):
+        try:
+            import serial
+        except ImportError as e:
+            raise NotImplementedError("serial support is not available") from e
+
         connection = serial.Serial(
             port=SERIAL_PORT, timeout=READ_TIMEOUT, writeTimeout=WRITE_TIMEOUT
         )

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -640,15 +640,21 @@ class Init:
         # TODO(harlowja) Hmmm, should we dynamically import these??
         cloudconfig_handler = CloudConfigPartHandler(**opts)
         shellscript_handler = ShellScriptPartHandler(**opts)
+        boothook_handler = BootHookPartHandler(**opts)
         def_handlers = [
             cloudconfig_handler,
             shellscript_handler,
             ShellScriptByFreqPartHandler(PER_ALWAYS, **opts),
             ShellScriptByFreqPartHandler(PER_INSTANCE, **opts),
             ShellScriptByFreqPartHandler(PER_ONCE, **opts),
-            BootHookPartHandler(**opts),
+            boothook_handler,
             JinjaTemplatePartHandler(
-                **opts, sub_handlers=[cloudconfig_handler, shellscript_handler]
+                **opts,
+                sub_handlers=[
+                    cloudconfig_handler,
+                    shellscript_handler,
+                    boothook_handler,
+                ],
             ),
         ]
         return def_handlers

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -171,7 +171,7 @@ cloud_config_modules:
 {% if is_rhel %}
   - rh_subscription
 {% endif %}
-{% if variant not in ["mariner", "photon"] %}
+{% if variant not in ["azurelinux", "mariner", "photon"] %}
   - spacewalk
 {% endif %}
   - yum_add_repo
@@ -180,7 +180,9 @@ cloud_config_modules:
 {% endif %}
   - ntp
   - timezone
+{% if variant not in ["azurelinux"] %}
   - disable_ec2_metadata
+{% endif %}
   - runcmd
 {% if variant in ["debian", "ubuntu", "unknown"] %}
   - byobu
@@ -198,12 +200,16 @@ cloud_final_modules:
   - ubuntu_drivers
 {% endif %}
   - write_files_deferred
+{% if variant not in ["azurelinux"] %}
   - puppet
   - chef
+{% endif %}
   - ansible
+{% if variant not in ["azurelinux"] %}
   - mcollective
   - salt_minion
   - reset_rmc
+{% endif %}
   - scripts_vendor
   - scripts_per_once
   - scripts_per_boot

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cloud-init (24.3.1-0ubuntu0~20.04.2) UNRELEASED; urgency=medium
+
+  * refresh patches:
+    - d/p/keep-dhclient-as-priority-client.patch
+    - d/p/no-single-process.patch
+  * Upstream snapshot based on upstream/main at 313390f8.
+
+ -- Chad Smith <chad.smith@canonical.com>  Tue, 10 Sep 2024 21:42:49 -0600
+
 cloud-init (24.3.1-0ubuntu0~20.04.1) focal; urgency=medium
 
   * d/p/no-nocloud-network.patch: Remove nocloud network feature

--- a/debian/patches/keep-dhclient-as-priority-client.patch
+++ b/debian/patches/keep-dhclient-as-priority-client.patch
@@ -4,7 +4,7 @@ Last-Update: 2024-02-20
 
 --- a/config/cloud.cfg.tmpl
 +++ b/config/cloud.cfg.tmpl
-@@ -303,7 +303,7 @@ system_info:
+@@ -309,7 +309,7 @@ system_info:
  {% elif variant in ["ubuntu", "unknown"] %}
  {# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
    network:

--- a/debian/patches/no-single-process.patch
+++ b/debian/patches/no-single-process.patch
@@ -6,7 +6,7 @@ Last-Update: 2024-08-02
 
 --- a/systemd/cloud-config.service.tmpl
 +++ b/systemd/cloud-config.service.tmpl
-@@ -10,14 +10,7 @@
+@@ -9,14 +9,7 @@
  
  [Service]
  Type=oneshot
@@ -24,7 +24,7 @@ Last-Update: 2024-08-02
  
 --- a/systemd/cloud-final.service.tmpl
 +++ b/systemd/cloud-final.service.tmpl
-@@ -15,16 +15,10 @@
+@@ -14,16 +14,10 @@
  
  [Service]
  Type=oneshot
@@ -53,7 +53,7 @@ Last-Update: 2024-08-02
  {% if variant in ["almalinux", "cloudlinux", "rhel"] %}
  Requires=dbus.socket
  After=dbus.socket
-@@ -37,14 +38,7 @@
+@@ -36,14 +37,7 @@
  ExecStartPre=/sbin/restorecon /run/cloud-init
  ExecStartPre=/usr/bin/touch /run/cloud-init/enabled
  {% endif %}
@@ -71,7 +71,7 @@ Last-Update: 2024-08-02
  
 --- a/systemd/cloud-init-main.service.tmpl
 +++ /dev/null
-@@ -1,52 +0,0 @@
+@@ -1,51 +0,0 @@
 -## template:jinja
 -# systemd ordering resources
 -# ==========================
@@ -91,16 +91,15 @@ Last-Update: 2024-08-02
 -After=dbus.socket
 -Before=network.service
 -Before=firewalld.target
--Conflicts=shutdown.target
 -{% endif %}
 -{% if variant in ["ubuntu", "unknown", "debian"] %}
 -Before=sysinit.target
--Conflicts=shutdown.target
 -{% endif %}
 -
 -After=systemd-remount-fs.service
 -Before=sysinit.target
 -Before=cloud-init-local.service
+-Before=shutdown.target
 -Conflicts=shutdown.target
 -RequiresMountsFor=/var/lib/cloud
 -ConditionPathExists=!/etc/cloud/cloud-init.disabled
@@ -253,7 +252,7 @@ Last-Update: 2024-08-02
 +WantedBy=cloud-init.target
 --- a/cloudinit/cmd/status.py
 +++ b/cloudinit/cmd/status.py
-@@ -318,9 +318,8 @@
+@@ -321,9 +321,8 @@
      for service in [
          "cloud-final.service",
          "cloud-config.service",

--- a/doc/examples/cloud-config-boot-cmds.txt
+++ b/doc/examples/cloud-config-boot-cmds.txt
@@ -5,7 +5,6 @@
 # This is very similar to runcmd, but commands run very early
 # in the boot process, only slightly after a 'boothook' would run.
 # - bootcmd will run on every boot
-# - INSTANCE_ID variable will be set to the current instance ID
 # - 'cloud-init-per' command can be used to make bootcmd run exactly once
 bootcmd:
   - echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts

--- a/doc/examples/cloud-config-datasources.txt
+++ b/doc/examples/cloud-config-datasources.txt
@@ -9,7 +9,7 @@ datasource:
     # The length in seconds to wait before giving up on the metadata
     # service.  The actual total wait could be up to 
     #   len(resolvable_metadata_urls)*timeout
-    max_wait : 120
+    max_wait : 240
 
     #metadata_url: a list of URLs to check for metadata services
     metadata_urls:

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -117,7 +117,6 @@ runcmd:
 # This is very similar to runcmd above, but commands run very early
 # in the boot process, only slightly after a 'boothook' would run.
 #  - bootcmd will run on every boot
-#  - INSTANCE_ID variable will be set to the current instance ID
 #  - 'cloud-init-per' command can be used to make bootcmd run exactly once
 bootcmd:
  - echo 192.168.1.130 us.archive.ubuntu.com > /etc/hosts
@@ -315,15 +314,15 @@ final_message: "The system is finally up, after $UPTIME seconds"
 
 # phone_home: if this dictionary is present, then the phone_home
 # cloud-config module will post specified data back to the given
-# url
+# url. Note that this example requires a `## template: jinja` header
 # default: none
 # phone_home:
-#  url: http://my.foo.bar/$INSTANCE/
+#  url: http://my.foo.bar/{{ v1.instance_id }}/
 #  post: all
 #  tries: 10
 #
 phone_home:
-  url: http://my.example.com/$INSTANCE_ID/
+  url: http://my.example.com/{{ v1.instance_id }}/
   post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]
 
 # timezone: set the timezone for this instance

--- a/doc/man/cloud-init-per.1
+++ b/doc/man/cloud-init-per.1
@@ -25,7 +25,7 @@ This can be one of the following values:
 run only once and do not re-run for new instance-id
 
 .BR "instance" ":"
-run only the first boot for a given instance-id
+run only once for a given instance-id and re-run for new instance-id
 
 .BR "always" ":"
 run every boot

--- a/doc/module-docs/cc_bootcmd/data.yaml
+++ b/doc/module-docs/cc_bootcmd/data.yaml
@@ -2,8 +2,7 @@ cc_bootcmd:
   description: |
     This module runs arbitrary commands very early in the boot process, only
     slightly after a boothook would run. This is very similar to a boothook,
-    but more user friendly. The environment variable ``INSTANCE_ID`` will be
-    set to the current instance ID for all run commands. Commands can be
+    but more user friendly. Commands can be
     specified either as lists or strings. For invocation details, see
     ``runcmd``.
 
@@ -14,6 +13,10 @@ cc_bootcmd:
     .. note::
        When writing files, do not use ``/tmp`` dir as it races with
        ``systemd-tmpfiles-clean`` (LP: #1707222). Use ``/run/somedir`` instead.
+    .. warning::
+         Use of ``INSTANCE_ID`` variable within this module is deprecated.
+         Use :ref:`jinja templates<user_data_formats-jinja>` with
+         :ref:`v1.instance_id<v1_instance_id>` instead.
   examples:
   - comment: |
       Example 1:

--- a/doc/module-docs/cc_phone_home/data.yaml
+++ b/doc/module-docs/cc_phone_home/data.yaml
@@ -1,34 +1,38 @@
 cc_phone_home:
   description: |
     This module can be used to post data to a remote host after boot is
-    complete. If the post URL contains the string ``$INSTANCE_ID`` it will be
-    replaced with the ID of the current instance.
+    complete.
 
     Either all data can be posted, or a list of keys to post.
 
     Available keys are:
-    
+
     - ``pub_key_rsa``
     - ``pub_key_ecdsa``
     - ``pub_key_ed25519``
     - ``instance_id``
     - ``hostname``
     - ``fdqn``
-    
+
     Data is sent as ``x-www-form-urlencoded`` arguments.
-    
+
     **Example HTTP POST**:
-    
+
     .. code-block:: http
-       
+
        POST / HTTP/1.1
        Content-Length: 1337
        User-Agent: Cloud-Init/21.4
        Accept-Encoding: gzip, deflate
        Accept: */*
        Content-Type: application/x-www-form-urlencoded
-       
+
        pub_key_rsa=rsa_contents&pub_key_ecdsa=ecdsa_contents&pub_key_ed25519=ed25519_contents&instance_id=i-87018aed&hostname=myhost&fqdn=myhost.internal
+
+    .. warning::
+         Use of ``INSTANCE_ID`` variable within this module is deprecated.
+         Use :ref:`jinja templates<user_data_formats-jinja>` with
+         :ref:`v1.instance_id<v1_instance_id>` instead.
   examples:
   - comment: |
       Example 1:

--- a/doc/module-docs/cc_phone_home/example1.yaml
+++ b/doc/module-docs/cc_phone_home/example1.yaml
@@ -1,2 +1,3 @@
+## template: jinja
 #cloud-config
-phone_home: {post: all, url: 'http://example.com/$INSTANCE_ID/'}
+phone_home: {post: all, url: 'http://example.com/{{ v1.instance_id }}/'}

--- a/doc/module-docs/cc_phone_home/example2.yaml
+++ b/doc/module-docs/cc_phone_home/example2.yaml
@@ -1,5 +1,6 @@
+## template: jinja
 #cloud-config
 phone_home:
   post: [pub_key_rsa, pub_key_ecdsa, pub_key_ed25519, instance_id, hostname, fqdn]
   tries: 5
-  url: http://example.com/$INSTANCE_ID/
+  url: http://example.com/{{ v1.instance_id }}/

--- a/doc/rtd/explanation/events.rst
+++ b/doc/rtd/explanation/events.rst
@@ -71,13 +71,6 @@ addition or removal of network interfaces to the system. In addition to
 fetching and updating the system metadata, ``cloud-init`` will also bring
 up/down the newly added interface.
 
-.. warning::
-   Due to its use of ``systemd`` sockets, ``hotplug`` functionality is
-   currently incompatible with SELinux on Linux distributions using systemd.
-   This issue is being `tracked in GitHub #3890`_. Additionally, ``hotplug``
-   support is considered experimental for non-Alpine and non-Debian-based
-   systems.
-
 Example
 =======
 

--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -88,9 +88,12 @@ Explanation
 A user data script is a single script to be executed once per instance.
 User data scripts are run relatively late in the boot process, during
 cloud-init's :ref:`final stage<boot-Final>` as part of the
-:ref:`cc_scripts_user<mod_cc_scripts_user>` module. When run,
-the environment variable ``INSTANCE_ID`` is set to the current instance ID
-for use within the script.
+:ref:`cc_scripts_user<mod_cc_scripts_user>` module.
+
+.. warning::
+    Use of ``INSTANCE_ID`` variable within user data scripts is deprecated.
+    Use :ref:`jinja templates<user_data_formats-jinja>` with
+    :ref:`v1.instance_id<v1_instance_id>` instead.
 
 .. _user_data_formats-cloud_boothook:
 
@@ -114,16 +117,10 @@ Example of once-per-instance script
    #cloud-boothook
    #!/bin/sh
 
-   PERSIST_ID=/var/lib/cloud/first-instance-id
-   _id=""
-   if [ -r $PERSIST_ID ]; then
-     _id=$(cat /var/lib/cloud/first-instance-id)
-   fi
-
-   if [ -z $_id ]  || [ $INSTANCE_ID != $_id ]; then
-     echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts
-   fi
-   sudo echo $INSTANCE_ID > $PERSIST_ID
+   # Early exit 0 when script has already run for this instance-id,
+   # continue if new instance boot.
+   cloud-init-per instance do-hosts /bin/false && exit 0
+   echo 192.168.1.130 us.archive.ubuntu.com >> /etc/hosts
 
 Explanation
 -----------
@@ -138,6 +135,11 @@ The boothook is different in that:
 * It is run very early in boot, during the :ref:`network<boot-Network>` stage,
   before any cloud-init modules are run.
 * It is run on every boot
+
+.. warning::
+    Use of ``INSTANCE_ID`` variable within boothooks is deprecated.
+    Use :ref:`jinja templates<user_data_formats-jinja>` with
+    :ref:`v1.instance_id<v1_instance_id>` instead.
 
 Include file
 ============
@@ -158,6 +160,8 @@ An include file contains a list of URLs, one per line. Each of the URLs will
 be read and their content can be any kind of user data format, both base
 config and meta config. If an error occurs reading a file the remaining files
 will not be read.
+
+.. _user_data_formats-jinja:
 
 Jinja template
 ==============
@@ -191,8 +195,8 @@ as jinja template variables. Any jinja templated configuration must contain
 the original header along with the new jinja header above it.
 
 .. note::
-    Use of Jinja templates is ONLY supported for cloud-config and user data
-    scripts. Jinja templates are not supported for cloud-boothooks or
+    Use of Jinja templates is supported for cloud-config, user data
+    scripts, and cloud-boothooks. Jinja templates are not supported for
     meta configs.
 
 .. _user_data_formats-mime_archive:

--- a/doc/rtd/explanation/instancedata.rst
+++ b/doc/rtd/explanation/instancedata.rst
@@ -310,6 +310,8 @@ Example output:
   - sles, 12.3, x86_64
   - ubuntu, 20.04, focal
 
+.. _v1_instance_id:
+
 ``v1.instance_id``
 ^^^^^^^^^^^^^^^^^^
 

--- a/doc/rtd/howto/module_run_frequency.rst
+++ b/doc/rtd/howto/module_run_frequency.rst
@@ -34,7 +34,8 @@ Then your user data could then be:
 
 .. code-block:: yaml
 
+        ## template: jinja
         #cloud-config
         phone_home:
-            url: http://example.com/$INSTANCE_ID/
+            url: http://example.com/{{ v1.instance_id }}/
             post: all

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -3,6 +3,16 @@
 CLI commands
 ************
 
+Cloud-init ships multiple executables that are intended for user interaction.
+
+These executables include:
+
+- `cloud-init`_
+- `cloud-init-per`_
+
+cloud-init
+==========
+
 For the latest list of subcommands and arguments use ``cloud-init``'s
 ``--help`` option. This can be used against ``cloud-init`` itself, or on any
 of its subcommands.
@@ -44,7 +54,7 @@ The rest of this document will give an overview of each of the subcommands.
 .. _cli_analyze:
 
 :command:`analyze`
-==================
+------------------
 
 Get detailed reports of where ``cloud-init`` spends its time during the boot
 process. For more complete reference see :ref:`analyze`.
@@ -62,7 +72,7 @@ Possible subcommands include:
 .. _cli_clean:
 
 :command:`clean`
-================
+----------------
 
 Remove ``cloud-init`` artifacts from :file:`/var/lib/cloud` and config files
 (best effort) to simulate a clean instance. On reboot, ``cloud-init`` will
@@ -89,7 +99,7 @@ re-run all stages as it did on first boot.
 .. _cli_collect_logs:
 
 :command:`collect-logs`
-=======================
+-----------------------
 
 Collect and tar ``cloud-init``-generated logs, data files, and system
 information for triage. This subcommand is integrated with apport.
@@ -111,7 +121,7 @@ Logs collected include:
 .. _cli_devel:
 
 :command:`devel`
-================
+----------------
 
 Collection of development tools under active development. These tools will
 likely be promoted to top-level subcommands when stable.
@@ -144,18 +154,18 @@ for debugging purposes.
 
 
 :command:`query`
-^^^^^^^^^^^^^^^^
+----------------
 
 Query if hotplug is enabled for a given subsystem.
 
 :command:`handle`
-^^^^^^^^^^^^^^^^^
+-----------------
 
 Respond to newly added system devices by retrieving updated system metadata
 and bringing up/down the corresponding device.
 
 :command:`enable`
-^^^^^^^^^^^^^^^^^
+-----------------
 
 Enable hotplug for a given subsystem. This is a last resort command for
 administrators to enable hotplug in running instances. The recommended
@@ -165,7 +175,7 @@ datasource.
 .. _cli_features:
 
 :command:`features`
-===================
+-------------------
 
 Print out each feature supported. If ``cloud-init`` does not have the
 :command:`features` subcommand, it also does not support any features
@@ -186,7 +196,7 @@ Example output:
 .. _cli_init:
 
 :command:`init` (deprecated)
-============================
+----------------------------
 
 Generally run by OS init systems to execute ``cloud-init``'s stages:
 *init* and *init-local*. See :ref:`boot_stages` for more info.
@@ -201,7 +211,7 @@ generally gated to run only once due to semaphores in
 .. _cli_modules:
 
 :command:`modules` (deprecated)
-===============================
+-------------------------------
 
 Generally run by OS init systems to execute ``modules:config`` and
 ``modules:final`` boot stages. This executes cloud config :ref:`modules`
@@ -231,7 +241,7 @@ run only once due to semaphores in :file:`/var/lib/cloud/`.
 .. _cli_query:
 
 :command:`query`
-================
+----------------
 
 Query standardised cloud instance metadata crawled by ``cloud-init`` and stored
 in :file:`/run/cloud-init/instance-data.json`. This is a convenience
@@ -332,7 +342,7 @@ and region:
 .. _cli_schema:
 
 :command:`schema`
-=================
+-----------------
 
 Validate cloud-config files using jsonschema.
 
@@ -359,7 +369,7 @@ errors on :file:`stdout`.
 .. _cli_single:
 
 :command:`single`
-=================
+-----------------
 
 Attempt to run a single, named, cloud config module.
 
@@ -384,7 +394,7 @@ module default frequency of ``instance``:
 .. _cli_status:
 
 :command:`status`
-=================
+-----------------
 
 Report cloud-init's current status.
 
@@ -486,5 +496,30 @@ Which would produce the following example output:
       "stage": null,
       "status": "done"
     }
+
+.. _cloud-init-per:
+
+cloud-init-per
+==============
+
+``cloud-init-per`` will run a command with arguments at a specific frequency.
+
+For example, with the following command:
+
+.. code-block:: shell-session
+
+   $ cloud-init-per once hello bash -c 'echo "Hello, world!" >> /tmp/hello'
+
+You will find 'Hello, world!' in the file :file:`/tmp/hello`.
+
+If we run the same command again, it will not run, as it has already run once.
+:file:`/tmp/hello` still only contains one line rather than two.
+
+See the
+`cloud-init-per man page <https://manpages.ubuntu.com/manpages/noble/en/man1/cloud-init-per.1.html>`_
+for more details.
+
+
+
 
 .. _More details on machine-id: https://www.freedesktop.org/software/systemd/man/machine-id.html

--- a/doc/userdata.txt
+++ b/doc/userdata.txt
@@ -1,11 +1,11 @@
 === Overview ===
 Userdata is data provided by the entity that launches an instance.
 The cloud provider makes this data available to the instance via in one
-way or another.  
+way or another.
 
 In EC2, the data is provided by the user via the '--user-data' or
 'user-data-file' argument to ec2-run-instances.  The EC2 cloud makes the
-data available to the instance via its meta-data service at 
+data available to the instance via its meta-data service at
 http://169.254.169.254/latest/user-data
 
 cloud-init can read this input and act on it in different ways.
@@ -15,7 +15,7 @@ cloud-init will download and cache to filesystem any user-data that it
 finds.  However, certain types of user-data are handled specially.
 
  * Gzip Compressed Content
-   content found to be gzip compressed will be uncompressed, and 
+   content found to be gzip compressed will be uncompressed, and
    these rules applied to the uncompressed data
 
  * Mime Multi Part archive
@@ -52,17 +52,15 @@ finds.  However, certain types of user-data are handled specially.
    This content is "cloud-config" data.  See the examples for a
    commented example of supported config formats.
 
- * Cloud Boothook 
+ * Cloud Boothook
    begins with #cloud-boothook or Content-Type: text/cloud-boothook
 
    This content is "boothook" data.  It is stored in a file under
-   /var/lib/cloud and then executed immediately.
+   ``/var/lib/cloud`` and then executed immediately.
 
    This is the earliest "hook" available.  Note, that there is no
    mechanism provided for running only once.  The boothook must take
-   care of this itself.  It is provided with the instance id in the
-   environment variable "INSTANCE_ID".  This could be made use of to
-   provide a 'once-per-instance'
+   care of this itself.
 
 === Examples ===
 There are examples in the examples subdirectory.

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -1,0 +1,2 @@
+# This one is currently used only by the CloudSigma and SmartOS datasources.
+pyserial

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,13 +7,8 @@ jinja2
 # reporting feature when configured to use webhooks.
 oauthlib
 
-# This one is currently used only by the CloudSigma and SmartOS datasources.
-# If these datasources are removed, this is no longer needed.
-#
-pyserial
-
 # This is only needed for places where we need to support configs in a manner
-# that the built-in config parser is not sufficent (ie
+# that the built-in config parser is not sufficient (ie
 # when we need to preserve comments, or do not have a top-level
 # section)...
 configobj>=5.0.2

--- a/systemd/cloud-init-main.service.tmpl
+++ b/systemd/cloud-init-main.service.tmpl
@@ -17,16 +17,15 @@ Requires=dbus.socket
 After=dbus.socket
 Before=network.service
 Before=firewalld.target
-Conflicts=shutdown.target
 {% endif %}
 {% if variant in ["ubuntu", "unknown", "debian"] %}
 Before=sysinit.target
-Conflicts=shutdown.target
 {% endif %}
 
 After=systemd-remount-fs.service
 Before=sysinit.target
 Before=cloud-init-local.service
+Before=shutdown.target
 Conflicts=shutdown.target
 RequiresMountsFor=/var/lib/cloud
 ConditionPathExists=!/etc/cloud/cloud-init.disabled

--- a/tests/data/merge_sources/expected9.yaml
+++ b/tests/data/merge_sources/expected9.yaml
@@ -1,5 +1,6 @@
+## template: jinja
 #cloud-config
 
 phone_home:
- url: http://my.example.com/$INSTANCE_ID/$BLAH_BLAH
+ url: http://my.example.com/{{ v1.instance_id }}/$BLAH_BLAH
  post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]

--- a/tests/data/merge_sources/source9-1.yaml
+++ b/tests/data/merge_sources/source9-1.yaml
@@ -1,5 +1,6 @@
+## template: jinja
 #cloud-config
 
 phone_home:
- url: http://my.example.com/$INSTANCE_ID/
+ url: http://my.example.com/{{ v1.instance_id }}/
  post: [ pub_key_rsa, pub_key_ecdsa, instance_id ]

--- a/tests/integration_tests/bugs/test_gh632.py
+++ b/tests/integration_tests/bugs/test_gh632.py
@@ -8,7 +8,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 
 # With some datasource hacking, we can run this on a NoCloud instance
@@ -30,6 +30,7 @@ def test_datasource_rbx_no_stacktrace(client: IntegrationInstance):
 
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     assert "Failed to load metadata and userdata" not in log
     assert (
         "Getting data from <class 'cloudinit.sources.DataSourceRbxCloud."

--- a/tests/integration_tests/bugs/test_gh868.py
+++ b/tests/integration_tests/bugs/test_gh868.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USERDATA = """\
 #cloud-config
@@ -24,3 +24,4 @@ chef:
 def test_chef_license(client: IntegrationInstance):
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)

--- a/tests/integration_tests/bugs/test_lp1813396.py
+++ b/tests/integration_tests/bugs/test_lp1813396.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import (
+    verify_clean_boot,
     verify_clean_log,
     verify_ordered_items_in_text,
 )
@@ -33,6 +34,7 @@ def test_gpg_no_tty(client: IntegrationInstance):
     ]
     verify_ordered_items_in_text(to_verify, log)
     verify_clean_log(log)
+    verify_clean_boot(client)
     control_groups = client.execute(
         "systemd-cgls -u cloud-config.service 2>/dev/null | wc -l"
     ).stdout

--- a/tests/integration_tests/bugs/test_lp1886531.py
+++ b/tests/integration_tests/bugs/test_lp1886531.py
@@ -12,7 +12,7 @@ https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/1886531
 
 import pytest
 
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -26,3 +26,4 @@ class TestLp1886531:
     def test_lp1886531(self, client):
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)

--- a/tests/integration_tests/bugs/test_lp1898997.py
+++ b/tests/integration_tests/bugs/test_lp1898997.py
@@ -15,7 +15,7 @@ import pytest
 from tests.integration_tests import random_mac_address
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 MAC_ADDRESS = random_mac_address()
 
@@ -74,6 +74,7 @@ class TestInterfaceListingWithOpenvSwitch:
 
         # Confirm that the network configuration was applied successfully
         verify_clean_log(cloudinit_output)
+        verify_clean_boot(client)
         # Confirm that the applied network config created the OVS bridge
         assert "ovs-br" in client.execute("ip addr")
 

--- a/tests/integration_tests/cmd/test_schema.py
+++ b/tests/integration_tests/cmd/test_schema.py
@@ -9,6 +9,7 @@ from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.releases import CURRENT_RELEASE, MANTIC
 from tests.integration_tests.util import (
     get_feature_flag_value,
+    verify_clean_boot,
     verify_clean_log,
 )
 
@@ -70,16 +71,20 @@ class TestSchemaDeprecations:
         version_boundary = get_feature_flag_value(
             class_client, "DEPRECATION_INFO_BOUNDARY"
         )
+        boundary_message = "Deprecated cloud-config provided:"
+        messages = [
+            "apt_reboot_if_required:  Deprecated ",
+            "apt_update:  Deprecated in version",
+            "apt_upgrade:  Deprecated in version",
+        ]
         # the deprecation_version is 22.2 in schema for apt_* keys in
         # user-data. Pass 22.2 in against the client's version_boundary.
         if lifecycle.should_log_deprecation("22.2", version_boundary):
-            log_level = "DEPRECATED"
+            messages += boundary_message
+            verify_clean_boot(class_client, require_deprecations=messages)
         else:
-            log_level = "INFO"
-        assert f"{log_level}]: Deprecated cloud-config provided:" in log
-        assert "apt_reboot_if_required:  Deprecated " in log
-        assert "apt_update:  Deprecated in version" in log
-        assert "apt_upgrade:  Deprecated in version" in log
+            verify_clean_boot(class_client, require_deprecations=messages)
+            assert boundary_message in log
 
     def test_network_config_schema_validation(
         self, class_client: IntegrationInstance

--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -6,7 +6,11 @@ import yaml
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
-from tests.integration_tests.util import lxd_has_nocloud, verify_clean_log
+from tests.integration_tests.util import (
+    lxd_has_nocloud,
+    verify_clean_boot,
+    verify_clean_log,
+)
 
 
 def _customize_environment(client: IntegrationInstance):
@@ -75,6 +79,7 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
     } == netplan_cfg
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     result = client.execute("cloud-id")
     if result.stdout != "lxd":
         raise AssertionError(

--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -198,15 +198,18 @@ class TestSmbios:
         version_boundary = get_feature_flag_value(
             client, "DEPRECATION_INFO_BOUNDARY"
         )
+        message = (
+            "The 'nocloud-net' datasource name is "
+            'deprecated" /var/log/cloud-init.log'
+        )
         # nocloud-net deprecated in version 24.1
         if lifecycle.should_log_deprecation("24.1", version_boundary):
-            log_level = "DEPRECATED"
+            verify_clean_boot(client, require_deprecations=[message])
         else:
-            log_level = "INFO"
-        client.execute(
-            rf"grep \"{log_level}]: The 'nocloud-net' datasource name is"
-            ' deprecated" /var/log/cloud-init.log'
-        ).ok
+            client.execute(
+                r"grep \"INFO]: The 'nocloud-net' datasource name is"
+                ' deprecated" /var/log/cloud-init.log'
+            ).ok
 
 
 @pytest.mark.skipif(PLATFORM != "lxd_vm", reason="Modifies grub config")

--- a/tests/integration_tests/datasources/test_none.py
+++ b/tests/integration_tests/datasources/test_none.py
@@ -3,7 +3,7 @@
 import json
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 DS_NONE_BASE_CFG = """\
 datasource_list: [None]
@@ -26,6 +26,7 @@ def test_datasource_none_discovery(client: IntegrationInstance):
     """
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     # Limit datasource detection to DataSourceNone.
     client.write_to_file(
         "/etc/cloud/cloud.cfg.d/99-force-dsnone.cfg", DS_NONE_BASE_CFG
@@ -65,4 +66,5 @@ def test_datasource_none_discovery(client: IntegrationInstance):
         )
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client, require_warnings=expected_warnings)
     assert client.execute("test -f /var/tmp/success-with-datasource-none").ok

--- a/tests/integration_tests/datasources/test_oci_networking.py
+++ b/tests/integration_tests/datasources/test_oci_networking.py
@@ -7,7 +7,7 @@ import yaml
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 DS_CFG = """\
 datasource:
@@ -52,6 +52,7 @@ def test_oci_networking_iscsi_instance(client: IntegrationInstance, tmpdir):
 
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
 
     assert (
         "opc/v2/vnics/" not in log

--- a/tests/integration_tests/datasources/test_tmp_noexec.py
+++ b/tests/integration_tests/datasources/test_tmp_noexec.py
@@ -2,7 +2,7 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 
 def customize_client(client: IntegrationInstance):
@@ -30,3 +30,4 @@ def test_dhcp_tmp_noexec(client: IntegrationInstance):
         not in log
     )
     verify_clean_log(log)
+    verify_clean_boot(client)

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -5,6 +5,7 @@ from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
 from tests.integration_tests.util import (
     push_and_enable_systemd_unit,
+    verify_clean_boot,
     verify_clean_log,
 )
 
@@ -267,6 +268,7 @@ def _test_ansible_pull_from_local_server(my_client):
     my_client.restart()
     log = my_client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(my_client)
     output_log = my_client.read_from_file("/var/log/cloud-init-output.log")
     assert "ok=3" in output_log
     assert "SUCCESS: config-ansible ran successfully" in log
@@ -320,6 +322,7 @@ def test_ansible_pull_distro(client):
 def test_ansible_controller(client):
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     content_ansible = client.execute(
         "lxc exec lxd-container-00 -- cat /home/ansible/ansible.txt"
     )

--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -13,6 +13,7 @@ from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
 from tests.integration_tests.util import (
     get_feature_flag_value,
+    verify_clean_boot,
     verify_clean_log,
 )
 
@@ -489,4 +490,5 @@ def test_install_missing_deps(setup_image, session_cloud: IntegrationCloud):
     ) as minimal_client:
         log = minimal_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(minimal_client)
         assert re.search(RE_GPG_SW_PROPERTIES_INSTALLED, log)

--- a/tests/integration_tests/modules/test_boothook.py
+++ b/tests/integration_tests/modules/test_boothook.py
@@ -4,15 +4,16 @@ import re
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
+## template: jinja
 #cloud-boothook
 #!/bin/sh
 # Error below will generate stderr
 BOOTHOOK/0
 echo BOOTHOOKstdout
-echo "BOOTHOOK: $INSTANCE_ID: is called every boot." >> /boothook.txt
+echo "BOOTHOOK: {{ v1.instance_id }}: is called every boot." >> /boothook.txt
 """
 
 
@@ -25,6 +26,7 @@ def test_boothook_header_runs_part_per_instance(client: IntegrationInstance):
     RE_BOOTHOOK = f"BOOTHOOK: {instance_id}: is called every boot"
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     output = client.read_from_file("/boothook.txt")
     assert 1 == len(re.findall(RE_BOOTHOOK, output))
     client.restart()

--- a/tests/integration_tests/modules/test_ca_certs.py
+++ b/tests/integration_tests/modules/test_ca_certs.py
@@ -14,7 +14,11 @@ import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.releases import IS_UBUNTU
-from tests.integration_tests.util import get_inactive_modules, verify_clean_log
+from tests.integration_tests.util import (
+    get_inactive_modules,
+    verify_clean_boot,
+    verify_clean_log,
+)
 
 CERT_CONTENT = """\
 -----BEGIN CERTIFICATE-----
@@ -106,6 +110,7 @@ class TestCaCerts:
         """
         log = class_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log, ignore_deprecations=False)
+        verify_clean_boot(class_client)
 
         expected_inactive = {
             "apt_pipelining",

--- a/tests/integration_tests/modules/test_disk_setup.py
+++ b/tests/integration_tests/modules/test_disk_setup.py
@@ -9,7 +9,7 @@ from cloudinit.subp import subp
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL, IS_UBUNTU
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 DISK_PATH = "/tmp/test_disk_setup_{}".format(uuid4())
 
@@ -69,6 +69,7 @@ class TestDeviceAliases:
         assert "changed my_alias.1 => /dev/sdb1" in log
         assert "changed my_alias.2 => /dev/sdb2" in log
         verify_clean_log(log)
+        verify_clean_boot(client)
 
         lsblk = json.loads(client.execute("lsblk --json"))
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]
@@ -143,6 +144,7 @@ class TestPartProbeAvailability:
 
     def _verify_first_disk_setup(self, client, log):
         verify_clean_log(log)
+        verify_clean_boot(client)
         lsblk = json.loads(client.execute("lsblk --json"))
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]
         assert len(sdb["children"]) == 2
@@ -200,6 +202,7 @@ class TestPartProbeAvailability:
 
         # Assert new setup works as expected
         verify_clean_log(log)
+        verify_clean_boot(client)
 
         lsblk = json.loads(client.execute("lsblk --json"))
         sdb = [x for x in lsblk["blockdevices"] if x["name"] == "sdb"][0]

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -16,6 +16,7 @@ from tests.integration_tests.releases import (
 )
 from tests.integration_tests.util import (
     push_and_enable_systemd_unit,
+    verify_clean_boot,
     verify_clean_log,
     wait_for_cloud_init,
 )
@@ -256,6 +257,7 @@ def test_multi_nic_hotplug(setup_image, session_cloud: IntegrationCloud):
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
         ips_after_add = _get_ip_addr(client)
 
@@ -297,6 +299,7 @@ def test_multi_nic_hotplug(setup_image, session_cloud: IntegrationCloud):
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
 
 @pytest.mark.skipif(CURRENT_RELEASE <= FOCAL, reason="See LP: #2055397")
@@ -317,6 +320,7 @@ def test_multi_nic_hotplug_vpc(setup_image, session_cloud: IntegrationCloud):
         _wait_till_hotplug_complete(client)
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
         netplan_cfg = client.read_from_file("/etc/netplan/50-cloud-init.yaml")
         config = yaml.safe_load(netplan_cfg)
@@ -359,6 +363,7 @@ def test_multi_nic_hotplug_vpc(setup_image, session_cloud: IntegrationCloud):
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
 
 @pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")

--- a/tests/integration_tests/modules/test_jinja_templating.py
+++ b/tests/integration_tests/modules/test_jinja_templating.py
@@ -4,6 +4,7 @@ import pytest
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.util import (
+    verify_clean_boot,
     verify_clean_log,
     verify_ordered_items_in_text,
 )
@@ -72,6 +73,7 @@ def test_substitution_in_etc_cloud(client: IntegrationInstance):
 
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
 
     # Ensure /etc/cloud/cloud.cfg template works as expected
     hostname = client.execute("hostname").stdout.strip()

--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -13,7 +13,7 @@ from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 BRIDGE_USER_DATA = """\
 #cloud-config
@@ -166,6 +166,7 @@ class TestLxdBridge:
         """Check that the given bridge is configured"""
         cloud_init_log = class_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(cloud_init_log)
+        verify_clean_boot(class_client)
 
         # The bridge should exist
         assert class_client.execute("ip addr show lxdbr0").ok
@@ -178,6 +179,7 @@ class TestLxdBridge:
 def validate_storage(validate_client, pkg_name, command):
     log = validate_client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log, ignore_deprecations=False)
+    verify_clean_boot(validate_client)
     return log
 
 
@@ -289,6 +291,7 @@ def test_basic_preseed(client):
     preseed_cfg = yaml.safe_load(preseed_cfg)
     cloud_init_log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(cloud_init_log)
+    verify_clean_boot(client)
     validate_preseed_profiles(client, preseed_cfg)
     validate_preseed_storage_pools(client, preseed_cfg)
     validate_preseed_projects(client, preseed_cfg)

--- a/tests/integration_tests/modules/test_package_update_upgrade_install.py
+++ b/tests/integration_tests/modules/test_package_update_upgrade_install.py
@@ -12,7 +12,7 @@ import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -146,6 +146,7 @@ def test_versioned_packages_are_installed(session_cloud: IntegrationCloud):
         user_data=VERSIONED_USER_DATA.format(pkg_version=pkg_version)
     ) as client:
         verify_clean_log(client.read_from_file("/var/log/cloud-init.log"))
+        verify_clean_boot(client)
         assert f"hello	{pkg_version}" == client.execute(
             "dpkg-query -W hello"
         ), (

--- a/tests/integration_tests/modules/test_puppet.py
+++ b/tests/integration_tests/modules/test_puppet.py
@@ -3,7 +3,7 @@
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 SERVICE_DATA = """\
 #cloud-config
@@ -18,6 +18,7 @@ def test_puppet_service(client: IntegrationInstance):
     """Basic test that puppet gets installed and runs."""
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
+    verify_clean_boot(client)
     puppet_ok = client.execute("systemctl is-active puppet.service").ok
     puppet_agent_ok = client.execute(
         "systemctl is-active puppet-agent.service"

--- a/tests/integration_tests/modules/test_ubuntu_drivers.py
+++ b/tests/integration_tests/modules/test_ubuntu_drivers.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.integration_tests.clouds import IntegrationCloud
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 USER_DATA = """\
 #cloud-config
@@ -24,6 +24,7 @@ def test_ubuntu_drivers_installed(session_cloud: IntegrationCloud):
     ) as client:
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
         assert 1 == log.count(
             "Installing and activating NVIDIA drivers "
             "(nvidia/license-accepted=True, version=latest)"

--- a/tests/integration_tests/modules/test_ubuntu_pro.py
+++ b/tests/integration_tests/modules/test_ubuntu_pro.py
@@ -22,6 +22,7 @@ from tests.integration_tests.releases import (
 )
 from tests.integration_tests.util import (
     get_feature_flag_value,
+    verify_clean_boot,
     verify_clean_log,
 )
 
@@ -142,21 +143,22 @@ class TestUbuntuAdvantage:
         version_boundary = get_feature_flag_value(
             client, "DEPRECATION_INFO_BOUNDARY"
         )
+        boundary_message = (
+            "Module has been renamed from cc_ubuntu_advantage "
+            "to cc_ubuntu_pro /var/log/cloud-init.log"
+        )
         # ubuntu_advantage key is deprecated in version 24.1
         if lifecycle.should_log_deprecation("24.1", version_boundary):
-            log_level = "DEPRECATED"
+            verify_clean_boot(client, require_deprecations=[boundary_message])
         else:
-            log_level = "INFO"
-        client.execute(
-            rf"grep \"{log_level}]: Module has been renamed from"
-            " cc_ubuntu_advantage to cc_ubuntu_pro /var/log/cloud-init.log"
-        ).ok
+            client.execute(rf"grep \"INFO]: {boundary_message}").ok
         assert is_attached(client)
 
     @pytest.mark.user_data(ATTACH.format(token=CLOUD_INIT_UA_TOKEN))
     def test_idempotency(self, client: IntegrationInstance):
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
         assert is_attached(client)
 
         # Clean reboot to change instance-id and trigger cc_ua in next boot
@@ -165,6 +167,7 @@ class TestUbuntuAdvantage:
 
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
         assert is_attached(client)
 
         # Assert service-already-enabled handling for esm-infra.
@@ -178,6 +181,7 @@ class TestUbuntuAdvantage:
         client.restart()
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
         assert "Service `esm-infra` already enabled" in log
 
 
@@ -209,6 +213,7 @@ def maybe_install_cloud_init(session_cloud: IntegrationCloud):
     ) as client:
         log = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
+        verify_clean_boot(client)
 
         assert not is_attached(
             client
@@ -247,6 +252,7 @@ class TestUbuntuAdvantagePro:
         ) as client:
             log = client.read_from_file("/var/log/cloud-init.log")
             verify_clean_log(log)
+            verify_clean_boot(client)
             assert_ua_service_noop(client)
             assert is_attached(client)
             services_status = get_services_status(client)

--- a/tests/integration_tests/net/test_dhcp.py
+++ b/tests/integration_tests/net/test_dhcp.py
@@ -4,7 +4,7 @@ import pytest
 
 from tests.integration_tests.integration_settings import PLATFORM
 from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, NOBLE
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 
 @pytest.mark.skipif(not IS_UBUNTU, reason="ubuntu-specific tests")
@@ -23,6 +23,7 @@ class TestDHCP:
         log = client.read_from_file("/var/log/cloud-init.log")
         assert "DHCP client selected: dhclient" in log
         verify_clean_log(log)
+        verify_clean_boot(client)
 
     @pytest.mark.xfail(
         reason=(
@@ -41,6 +42,7 @@ class TestDHCP:
             ", DHCP is still running" not in log
         ), "cloud-init leaked a dhcp daemon that is still running"
         verify_clean_log(log)
+        verify_clean_boot(client)
 
     @pytest.mark.skipif(
         CURRENT_RELEASE < NOBLE,
@@ -89,3 +91,4 @@ class TestDHCP:
             ), "Failed to get unknown option 245"
             assert "'unknown-245'" in log, "Failed to get unknown option 245"
         verify_clean_log(log)
+        verify_clean_boot(client)

--- a/tests/integration_tests/reporting/test_webhook_reporting.py
+++ b/tests/integration_tests/reporting/test_webhook_reporting.py
@@ -7,7 +7,11 @@ import json
 import pytest
 
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.util import ASSETS_DIR, verify_clean_log
+from tests.integration_tests.util import (
+    ASSETS_DIR,
+    verify_clean_boot,
+    verify_clean_log,
+)
 
 URL = "http://127.0.0.1:55555"
 
@@ -47,6 +51,7 @@ def test_webhook_reporting(client: IntegrationInstance):
         "cloud-init status --wait"
     )
     verify_clean_log(client.read_from_file("/var/log/cloud-init.log"))
+    verify_clean_boot(client)
 
     server_output = client.read_from_file(
         "/var/tmp/echo_server_output"

--- a/tests/integration_tests/test_ds_identify.py
+++ b/tests/integration_tests/test_ds_identify.py
@@ -2,7 +2,11 @@
 
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.integration_settings import PLATFORM
-from tests.integration_tests.util import verify_clean_log, wait_for_cloud_init
+from tests.integration_tests.util import (
+    verify_clean_boot,
+    verify_clean_log,
+    wait_for_cloud_init,
+)
 
 DATASOURCE_LIST_FILE = "/etc/cloud/cloud.cfg.d/90_dpkg.cfg"
 MAP_PLATFORM_TO_DATASOURCE = {
@@ -26,6 +30,7 @@ def test_ds_identify(client: IntegrationInstance):
     client.restart()
     wait_for_cloud_init(client)
     verify_clean_log(client.execute("cat /var/log/cloud-init.log"))
+    verify_clean_boot(client)
     assert client.execute("cloud-init status --wait")
 
     datasource = MAP_PLATFORM_TO_DATASOURCE.get(PLATFORM, PLATFORM)

--- a/tests/integration_tests/test_multi_part_user_data_handling.py
+++ b/tests/integration_tests/test_multi_part_user_data_handling.py
@@ -73,7 +73,7 @@ CLOUD_CONFIG_ARCHIVE = """
 - type: 'text/cloud-config'
   content: |
     bootcmd:
-     - [sh, -c, 'echo "BOOTCMD: $(date -R): $INSTANCE_ID" | tee /run/bootcmd.txt']
+     - [sh, -c, 'echo "BOOTCMD: $(date -R): from cloud-config" | tee /run/bootcmd.txt']
 """  # noqa: E501
 
 

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -18,7 +18,7 @@ from tests.integration_tests.releases import (
     MANTIC,
     NOBLE,
 )
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 # Older Ubuntu series didn't read cloud-init.* config keys
 LXD_NETWORK_CONFIG_KEY = (
@@ -339,6 +339,7 @@ def test_ec2_multi_nic_reboot(setup_image, session_cloud: IntegrationCloud):
 
         log_content = client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(client)
 
         # SSH over primary and secondary NIC works
         for ip in public_ips:
@@ -459,6 +460,7 @@ def test_ec2_multi_network_cards(setup_image, session_cloud: IntegrationCloud):
 
             log_content = client.read_from_file("/var/log/cloud-init.log")
             verify_clean_log(log_content)
+            verify_clean_boot(client)
 
             # SSH over secondary NICs works
             subp("nc -w 5 -zv " + allocation_1["PublicIp"] + " 22", shell=True)

--- a/tests/integration_tests/test_paths.py
+++ b/tests/integration_tests/test_paths.py
@@ -10,7 +10,7 @@ from cloudinit.cmd.devel.logs import (
 )
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.releases import CURRENT_RELEASE, FOCAL
-from tests.integration_tests.util import verify_clean_log
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
 
 DEFAULT_CLOUD_DIR = "/var/lib/cloud"
 NEW_CLOUD_DIR = "/new-cloud-dir"
@@ -39,6 +39,7 @@ class TestHonorCloudDir:
     def verify_log_and_files(self, custom_client):
         log_content = custom_client.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log_content)
+        verify_clean_boot(custom_client)
         assert NEW_CLOUD_DIR in log_content
         assert DEFAULT_CLOUD_DIR not in log_content
         assert custom_client.execute(f"test ! -d {DEFAULT_CLOUD_DIR}").ok

--- a/tests/integration_tests/test_upgrade.py
+++ b/tests/integration_tests/test_upgrade.py
@@ -198,3 +198,4 @@ def test_subsequent_boot_of_upgraded_package(session_cloud: IntegrationCloud):
         log = instance.read_from_file("/var/log/cloud-init.log")
         verify_clean_log(log)
         assert instance.execute("cloud-init status --wait --long").ok
+        verify_clean_boot(instance)

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -64,16 +64,20 @@ def _format_found(header: str, items: list) -> str:
 
 def verify_clean_boot(
     instance: "IntegrationInstance",
+    *,
+    ignore_deprecations: Optional[Union[List[str], bool]] = None,
     ignore_warnings: Optional[Union[List[str], bool]] = None,
     ignore_errors: Optional[Union[List[str], bool]] = None,
     ignore_tracebacks: Optional[Union[List[str], bool]] = None,
+    require_deprecations: Optional[list] = None,
     require_warnings: Optional[list] = None,
     require_errors: Optional[list] = None,
 ):
-    """raise assertions if the client experienced unexpected warnings or errors
+    """Raise exception if the client experienced unexpected conditions.
 
-    Fail when a required error isn't found.
-    Expected warnings and errors are defined in this function.
+    Fail when a required error, warning, or deprecation isn't found.
+
+    Platform-specific conditions are defined in this function.
 
     This function is similar to verify_clean_log, hence the similar name.
 
@@ -84,13 +88,17 @@ def verify_clean_boot(
     - less resource intensive (no log copying required)
     - nice error formatting
 
-    instance: test instance
-    ignored_warnings: list of expected warnings to ignore,
-        or true to ignore all
-    ignored_errors: list of expected errors to ignore, or true to ignore all
-    require_warnings: Optional[list] = None,
-    require_errors: Optional[list] = None,
-    fail_when_expected_not_found: optional list of expected errors
+    :param instance: test instance
+    :param ignored_deprecations: list of deprecation messages to ignore, or
+        true to ignore all
+    :param ignored_warnings: list of expected warnings to ignore, or true to
+        ignore all
+    :param ignored_errors: list of expected errors to ignore, or true to ignore
+        all
+    :param require_deprecations: list of expected deprecation messages to
+        require
+    :param require_warnings: list of expected warning messages to require
+    :param require_errors: list of expected error messages to require
     """
 
     def append_or_create_list(
@@ -150,9 +158,11 @@ def verify_clean_boot(
 
     _verify_clean_boot(
         instance,
+        ignore_deprecations=ignore_deprecations,
         ignore_warnings=ignore_warnings,
         ignore_errors=ignore_errors,
         ignore_tracebacks=ignore_tracebacks,
+        require_deprecations=require_deprecations,
         require_warnings=require_warnings,
         require_errors=require_errors,
     )
@@ -160,21 +170,27 @@ def verify_clean_boot(
 
 def _verify_clean_boot(
     instance: "IntegrationInstance",
+    ignore_deprecations: Optional[Union[List[str], bool]] = None,
     ignore_warnings: Optional[Union[List[str], bool]] = None,
     ignore_errors: Optional[Union[List[str], bool]] = None,
     ignore_tracebacks: Optional[Union[List[str], bool]] = None,
+    require_deprecations: Optional[list] = None,
     require_warnings: Optional[list] = None,
     require_errors: Optional[list] = None,
 ):
+    ignore_deprecations = ignore_deprecations or []
     ignore_errors = ignore_errors or []
     ignore_warnings = ignore_warnings or []
+    require_deprecations = require_deprecations or []
     require_errors = require_errors or []
     require_warnings = require_warnings or []
     status = json.loads(instance.execute("cloud-init status --format=json"))
 
+    unexpected_deprecations = set()
     unexpected_errors = set()
     unexpected_warnings = set()
 
+    required_deprecations_found = set()
     required_warnings_found = set()
     required_errors_found = set()
 
@@ -211,16 +227,42 @@ def _verify_clean_boot(
         else:
             unexpected_warnings.add(current_warning)
 
+    # check for unexpected deprecations
+    for current_deprecation in status["recoverable_errors"].get(
+        "DEPRECATED", []
+    ):
+
+        # check for required deprecations
+        for expected in require_deprecations:
+            if expected in current_deprecation:
+                required_deprecations_found.add(expected)
+
+        if ignore_deprecations is True:
+            continue
+        # check for unexpected deprecations
+        for expected in [*ignore_deprecations, *require_deprecations]:
+            if expected in current_deprecation:
+                break
+        else:
+            unexpected_deprecations.add(current_deprecation)
+
     required_errors_not_found = set(require_errors) - required_errors_found
     required_warnings_not_found = (
         set(require_warnings) - required_warnings_found
     )
+    required_deprecations_not_found = (
+        set(require_deprecations) - required_deprecations_found
+    )
 
+    # ordered from most severe to least severe
+    # this allows the first message printed to be the most significant
     errors = [
         *unexpected_errors,
         *required_errors_not_found,
         *unexpected_warnings,
         *required_warnings_not_found,
+        *unexpected_deprecations,
+        *required_deprecations_not_found,
     ]
     if errors:
         message = ""
@@ -243,28 +285,83 @@ def _verify_clean_boot(
         message += _format_found(
             "Required warnings not found", list(required_warnings_not_found)
         )
+        message += _format_found(
+            "Required deprecations not found",
+            list(required_deprecations_not_found),
+        )
         assert not errors, message
 
-    if ignore_tracebacks is True:
-        return
     # assert no unexpected Tracebacks
-    expected_traceback_count = 0
-    traceback_count = int(
-        instance.execute(
-            "grep --count Traceback /var/log/cloud-init.log"
-        ).stdout.strip()
-    )
-    if ignore_tracebacks:
-        for expected_traceback in ignore_tracebacks:
-            expected_traceback_count += int(
-                instance.execute(
-                    f"grep --count '{expected_traceback}'"
-                    " /var/log/cloud-init.log"
-                ).stdout.strip()
-            )
-    assert expected_traceback_count == traceback_count, (
-        f"{traceback_count - expected_traceback_count} unexpected traceback(s)"
-        " found in /var/log/cloud-init.log"
+    if ignore_tracebacks is not True:
+        expected_traceback_count = 0
+        traceback_count = int(
+            instance.execute(
+                "grep --count Traceback /var/log/cloud-init.log"
+            ).stdout.strip()
+        )
+        if ignore_tracebacks:
+            for expected_traceback in ignore_tracebacks:
+                expected_traceback_count += int(
+                    instance.execute(
+                        f"grep --count '{expected_traceback}'"
+                        " /var/log/cloud-init.log"
+                    ).stdout.strip()
+                )
+        assert expected_traceback_count == traceback_count, (
+            f"{traceback_count - expected_traceback_count} unexpected "
+            "traceback(s) found in /var/log/cloud-init.log"
+        )
+
+    # check that the return code of cloud-init status is expected
+    if not any(
+        [
+            ignore_deprecations,
+            ignore_warnings,
+            ignore_errors,
+            ignore_tracebacks,
+            require_deprecations,
+            require_warnings,
+            require_errors,
+        ]
+    ):
+        # make sure that return code is 0 when all was good
+        out = instance.execute("cloud-init status --long")
+        assert out.ok, (
+            "Unexpected non-zero return code from "
+            f"`cloud-init status`: {out.return_code}\nstdout: "
+            f"{out.stdout}\nstderr: {out.stderr}"
+        )
+    elif any(
+        [
+            ignore_deprecations,
+            ignore_warnings,
+            ignore_errors,
+            ignore_tracebacks,
+        ]
+    ):
+        # Ignore is optional, so we can't be sure whether we will got a return
+        # code of 0 or 2. This makes this function more useful when writing
+        # tests that run on series with different behavior. In this case we
+        # cannot be sure whether it will return 0 or 2, but we never want to
+        # see a return code of 1, so assert that it isn't 1.
+        out = instance.execute("cloud-init status --long")
+        assert 1 != out.return_code, (
+            f"Unexpected return code from `cloud-init status`. Expected rc=0 "
+            f"or rc=2, received rc={out.return_code}\nstdout: "
+            f"{out.stdout}\nstderr: {out.stderr}"
+        )
+    else:
+        # we know that we should have a return code of 2
+        out = instance.execute("cloud-init status --long")
+        assert 2 == out.return_code, (
+            f"Unexpected return code from `cloud-init status`. "
+            f"Expected rc=2, received rc={out.return_code}\nstdout: "
+            f"{out.stdout}\nstderr: {out.stderr}"
+        )
+    schema = instance.execute("cloud-init schema --system --annotate")
+    assert schema.ok, (
+        f"Schema validation failed\nstdout:{schema.stdout}"
+        f"\nstderr:\n{schema.stderr}"
     )
 
 

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -330,6 +330,7 @@ class TestAnsible:
         """assert exception not raised if package installed"""
         cc_ansible.AnsiblePullDistro(get_cloud().distro).check_deps()
 
+    @mark.serial
     @mock.patch(M_PATH + "subp.subp", return_value=("stdout", "stderr"))
     @mock.patch(M_PATH + "subp.which", return_value=False)
     def test_pip_bootstrap(self, m_which, m_subp):

--- a/tests/unittests/config/test_cc_bootcmd.py
+++ b/tests/unittests/config/test_cc_bootcmd.py
@@ -84,22 +84,6 @@ class TestBootcmd(CiTestCase):
             str(context_manager.exception),
         )
 
-    def test_handler_creates_and_runs_bootcmd_script_with_instance_id(self):
-        """Valid schema runs a bootcmd script with INSTANCE_ID in the env."""
-        cc = get_cloud()
-        out_file = self.tmp_path("bootcmd.out", self.new_root)
-        my_id = "b6ea0f59-e27d-49c6-9f87-79f19765a425"
-        valid_config = {
-            "bootcmd": ["echo {0} $INSTANCE_ID > {1}".format(my_id, out_file)]
-        }
-
-        with mock.patch(self._etmpfile_path, FakeExtendedTempFile):
-            with self.allow_subp(["/bin/sh"]):
-                handle("cc_bootcmd", valid_config, cc, [])
-        self.assertEqual(
-            my_id + " iid-datasource-none\n", util.load_text_file(out_file)
-        )
-
     def test_handler_runs_bootcmd_script_with_error(self):
         """When a valid script generates an error, that error is raised."""
         cc = get_cloud()

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -3,7 +3,7 @@
 import base64
 import datetime
 from unittest import mock
-from xml.etree import ElementTree
+from xml.etree import ElementTree as ET
 
 import pytest
 import requests
@@ -211,8 +211,8 @@ def test_imds_metadata_parsing_exception():
 def test_ovf_parsing_exception():
     error = None
     try:
-        ElementTree.fromstring("<badxml")
-    except ElementTree.ParseError as exception:
+        ET.fromstring("<badxml")
+    except ET.ParseError as exception:
         error = errors.ReportableErrorOvfParsingException(exception=exception)
 
     assert (

--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -5,7 +5,7 @@ import os
 import re
 import unittest
 from textwrap import dedent
-from xml.etree import ElementTree
+from xml.etree import ElementTree as ET
 from xml.sax.saxutils import escape, unescape
 
 import pytest
@@ -231,7 +231,7 @@ class TestGoalStateParsing(CiTestCase):
 
     def test_invalid_goal_state_xml_raises_parse_error(self):
         xml = "random non-xml data"
-        with self.assertRaises(ElementTree.ParseError):
+        with self.assertRaises(ET.ParseError):
             azure_helper.GoalState(xml, mock.MagicMock())
 
     def test_missing_container_id_in_goal_state_xml_raises_exc(self):
@@ -717,7 +717,7 @@ class TestGoalStateHealthReporter(CiTestCase):
 
         self.assertEqual(health_document, generated_health_document)
 
-        generated_xroot = ElementTree.fromstring(generated_health_document)
+        generated_xroot = ET.fromstring(generated_health_document)
         self.assertEqual(
             self._text_from_xpath_in_xroot(
                 generated_xroot, "./GoalStateIncarnation"
@@ -780,7 +780,7 @@ class TestGoalStateHealthReporter(CiTestCase):
 
         self.assertEqual(health_document, generated_health_document)
 
-        generated_xroot = ElementTree.fromstring(generated_health_document)
+        generated_xroot = ET.fromstring(generated_health_document)
         self.assertEqual(
             self._text_from_xpath_in_xroot(
                 generated_xroot, "./GoalStateIncarnation"
@@ -923,7 +923,7 @@ class TestGoalStateHealthReporter(CiTestCase):
             description=long_err_msg,
         )
 
-        generated_xroot = ElementTree.fromstring(generated_health_document)
+        generated_xroot = ET.fromstring(generated_health_document)
         generated_health_report_description = self._text_from_xpath_in_xroot(
             generated_xroot,
             "./Container/RoleInstanceList/Role/Health/Details/Description",
@@ -976,7 +976,7 @@ class TestGoalStateHealthReporter(CiTestCase):
             description=long_err_msg,
         )
 
-        generated_xroot = ElementTree.fromstring(generated_health_document)
+        generated_xroot = ET.fromstring(generated_health_document)
         generated_health_report_description = self._text_from_xpath_in_xroot(
             generated_xroot,
             "./Container/RoleInstanceList/Role/Health/Details/Description",

--- a/tests/unittests/sources/test_scaleway.py
+++ b/tests/unittests/sources/test_scaleway.py
@@ -955,7 +955,7 @@ class TestDataSourceScaleway(ResponsesTestCase):
         self, m_get_cmdline, fallback_nic
     ):
         """
-        Generate network_config with only IPv6
+        Generate network_config with IPv4+IPv6
         """
         m_get_cmdline.return_value = "scaleway"
         fallback_nic.return_value = "ens2"
@@ -988,6 +988,53 @@ class TestDataSourceScaleway(ResponsesTestCase):
                             "via": "fe80::ffff:ffff:ffff:fff1",
                             "to": "::/0",
                         },
+                    ],
+                    "addresses": ("2001:aaa:aaaa:a:aaaa:aaaa:aaaa:1/64",),
+                },
+            },
+        }
+
+        self.assertEqual(netcfg, resp)
+
+    @mock.patch("cloudinit.distros.net.find_fallback_nic")
+    @mock.patch("cloudinit.util.get_cmdline")
+    def test_ipmob_primary_ipv6_v4_config_ok(
+        self, m_get_cmdline, fallback_nic
+    ):
+        """
+        Generate network_config with IPv6+IPv4
+        """
+        m_get_cmdline.return_value = "scaleway"
+        fallback_nic.return_value = "ens2"
+        self.datasource.metadata["private_ip"] = None
+        self.datasource.metadata["ipv6"] = None
+        self.datasource.ephemeral_fixed_address = "10.10.10.10"
+        self.datasource.metadata["public_ips"] = [
+            {
+                "address": "2001:aaa:aaaa:a:aaaa:aaaa:aaaa:1",
+                "netmask": "64",
+                "gateway": "fe80::ffff:ffff:ffff:fff1",
+                "family": "inet6",
+            },
+            {
+                "address": "10.10.10.10",
+                "netmask": "32",
+                "family": "inet",
+            },
+        ]
+
+        netcfg = self.datasource.network_config
+        resp = {
+            "version": 2,
+            "ethernets": {
+                fallback_nic.return_value: {
+                    "dhcp4": True,
+                    "routes": [
+                        {
+                            "via": "fe80::ffff:ffff:ffff:fff1",
+                            "to": "::/0",
+                        },
+                        {"to": "169.254.42.42/32", "via": "62.210.0.1"},
                     ],
                     "addresses": ("2001:aaa:aaaa:a:aaaa:aaaa:aaaa:1/64",),
                 },

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -74,6 +74,7 @@ garzdin
 giggsoff
 gilbsgilbs
 glyg
+halfdime-code
 hamalq
 hcartiaux
 holmanb
@@ -137,6 +138,7 @@ nicolasbock
 nishigori
 nkukard
 nmeyerhans
+NoSuchCommand
 ogayot
 olivierlemasle
 omBratteng

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ passenv =
     PYTEST_ADDOPTS
     HYPOTHESIS_PROFILE
 deps =
+    -r{toxinidir}/requirements-all.txt
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 
@@ -44,7 +45,7 @@ deps =
     isort==5.13.2
     mypy==1.11.1
     pylint==3.2.6
-    ruff==0.5.7
+    ruff==0.6.4
 
 [latest_versions]
 deps =


### PR DESCRIPTION
Perform new_upstream_snapshot,py to sync unreleased tip of main into ubuntu/focal in order to fix daily recipe builds which are failing due to commit 9cc458c drift in systemd files which no-singleprocess.patch removes.


## Proposed Commit Message
-- see top three most recent separate commits



## Additional Context
[failed build recipe logs](https://launchpadlibrarian.net/748388415/buildlog.txt.gz) 
the error:
```

patching file systemd/cloud-init-main.service.tmpl
Hunk #1 FAILED at 1.
Not deleting file systemd/cloud-init-main.service.tmpl as content differs from patch
```

### steps to create this branch
```
new_upstream_snapshot.py # expect failure
quilt push -a
quilt push -f
rm systemd/cloud-init-main.service.tmpl
quilt refresh
quilt pop -a 
git commit -am 'refresh patches....'
new_upstream_snapshot.py -p quilt
# enter no SRU bug to leave UNRELEASED state
# manually add refreshed patches to d/changelog
```

## Test Steps
```
git checkout main
git pull
git reset --hard upstream/main
git merge ubuntu/focal
quilt push -a
tox -e py3
quilt pop -a
````

## Merge type
- [x] git push upstream ubuntu/focal from command line once approved
- [ ] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
