### PR TITLE
chore(actions): add packaging label for any branches modifying debian/*

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,3 +5,9 @@ documentation:
       - 'doc/**'
       - 'cloudinit/config/schemas/**'
   - base-branch: ['main']
+packaging:
+- any:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'debian/**'
+  - base-branch: ['ubuntu/**']


### PR DESCRIPTION
Minor update to auto-label any packaging branches with the label 'packaging'.

Test run here https://github.com/blackboxsw/cloud-init/pull/31