### PR TITLE
ci: fix labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,7 @@
+# Changes to labeler do not run in pull requests because this only runs against
+# the base branch by default
+#
+# https://github.com/actions/labeler/tree/main?tab=readme-ov-file#initial-set-up-of-the-labeler-action
 documentation:
 - all:
   - changed-files:
@@ -10,4 +14,5 @@ packaging:
   - changed-files:
     - any-glob-to-any-file:
       - 'debian/**'
-  - base-branch: ['ubuntu/**']
+  - base-branch: ['ubuntu/*']
+


### PR DESCRIPTION
## Proposed Commit Message
```
ci: fix labeler
```

## Additional Context

The failed job shows this output:

```yaml
Run actions/labeler@v5
  with:
    repo-token: ***
    configuration-path: .github/labeler.yml
    sync-labels: false
    dot: true
The configuration file (path: .github/labeler.yml) was not found locally, fetching via the api
Error: SyntaxError: Invalid regular expression: /ubuntu/**/: Nothing to repeat
Error: Invalid regular expression: /ubuntu/**/: Nothing to repeat
```

This PR removes the offending line, which was redundant anyways 


So I'm not really sure how to test this, because unlike normal workflows, the base branch runs [the labeler job](https://github.com/actions/labeler/tree/main?tab=readme-ov-file#initial-set-up-of-the-labeler-action). Per the docs:

> When submitting an initial pull request to a repository using the pull_request_target event, the labeler workflow will not run on that pull request because the pull_request_target execution runs off the base branch instead of the pull request's branch


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
