### PR TITLE
fix: force sftp cleanup when done with instance

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -315,6 +315,15 @@ def _client(
         yield instance
         test_failed = request.session.testsfailed - previous_failures > 0
         _collect_artifacts(instance, request.node.nodeid, test_failed)
+    # conflicting requirements:
+    # - pytest thinks that it can cleanup loggers after tests run
+    # - pycloudlib thinks that at garbage collection is a good place to tear
+    #   down sftp connections
+    # After the final test runs, pytest might clean up loggers which will cause
+    # paramiko to barf when it logs that the connection is being closed.
+    #
+    # Manually run __del__() to prevent this teardown mess.
+    instance.instance.__del__()
 
 
 @pytest.fixture


### PR DESCRIPTION


<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
```
fix: force sftp cleanup when done with instance

Force inline sftp closure rather than on garbage collection.
Without this, pytest causes tracebacks because it cleans up the logger
before the final sftp connection is closed, which causes tracebacks
after tests exit.
```

## Additional Context
https://github.com/pytest-dev/pytest/issues/5282
https://github.com/pytest-dev/pytest/issues/5502
https://github.com/canonical/pycloudlib/issues/415

## Test steps
I tested the `client` and `class_client` fixtures manually by introducing two new classes, with one failing test each, and didn't see any tracebacks nor unexpected failures. 