### PR TITLE
fix: lxd do not check for thinpool kernel module

### DIFF
--- a/tests/unittests/config/test_cc_lxd.py
+++ b/tests/unittests/config/test_cc_lxd.py
@@ -89,10 +89,6 @@ class TestLxd(t_help.CiTestCase):
                 self.assertEqual(
                     [
                         mock.call(sem_file),
-                        mock.call(
-                            "/lib/modules/mykernel/"
-                            "kernel/drivers/md/dm-thin-pool.ko"
-                        ),
                     ],
                     exists.call_args_list,
                 )


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: lxd do not check for thinpool kernel module

Rather than checking for kernel module file before running lxd, just
fall back to disabling thinpool and retrying with thinpool disabled
when subp() fails and it is using lvm as backing storage.

On some Ubuntu releases, the kernel module is compressed which causes
this check to fail and this warning to erroneously be logged. Making
this logic only run in the failure path and avoiding file matches on
kernel driver files should be less error prone.

BREAKING_CHANGE: On some Ubuntu series this changes behavior causing
lxd to now use lxd thinpool, which is the current lxd default.
```

## Additional Context
Some images ship compressed kernel modules. On Jammy, GCE, we ship: `/lib/modules/6.8.0-1014-gcp/kernel/drivers/md/dm-thin-pool.ko.zst`

https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-gce/lastCompletedBuild/testReport/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
