### PR TITLE
Fix CI patch test

### DIFF
--- a/.github/workflows/packaging-tests.yml
+++ b/.github/workflows/packaging-tests.yml
@@ -1,4 +1,4 @@
-name: Packaging Tests
+name: Packaging
 
 on:
   pull_request:
@@ -18,6 +18,7 @@ env:
 
 jobs:
   check-patches:
+    name: Check patches
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -25,6 +26,7 @@ jobs:
         with:
           # Fetch all branches for merging
           fetch-depth: 0
+          ref: main
       - name: Prepare dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
@@ -34,15 +36,18 @@ jobs:
           echo 'QUILT_PATCHES=debian/patches' >> ~/.quiltrc
           echo 'QUILT_SERIES=debian/patches/series' >> ~/.quiltrc
 
-      - name: 'Daily recipe: quilt patches apply successfully and tests run'
+      - name: Configure git and merge
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
-          git remote add upstream https://git.launchpad.net/cloud-init
-          git fetch upstream main
-          git checkout upstream/main
           git merge ${{ github.sha }}
-          test -f debian/patches/series || echo "no patches, skipping" && exit 0
+
+      - name: Quilt patches apply successfully and tests run
+        run: |
+          if test -f debian/patches/series; then
+            echo "no patches, skipping"
+            exit 0
+          fi
           quilt push -a
           tox -e py3
           quilt pop -a


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
```
ci: fix packaging patch check

Also:
- simplify checkout logic to use local github main branch
- add human-friendly job name and reduce redundant words
```

## Additional Context
A recent push to fix running against the devel branch broke running against series with patches.

https://github.com/canonical/cloud-init/actions/runs/10909563606/job/30278043196?pr=5712

The patch check job showed this:

```bash
+ test -f debian/patches/series
+ exit 0
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
