### PR TITLE
tests(pro): bump pycloudlib add noble release to pro tests

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -2,7 +2,7 @@
 # PyPI requirements for cloud-init integration testing
 # https://cloudinit.readthedocs.io/en/latest/topics/integration_tests.html
 #
-pycloudlib>=1!6.7.0,<1!8
+pycloudlib>=1!6.7.0,<1!9.3
 
 # Avoid breaking change in `testpaths` treatment forced
 # test/unittests/conftest.py to be loaded by our integration-tests tox env

--- a/tests/integration_tests/modules/test_ubuntu_pro.py
+++ b/tests/integration_tests/modules/test_ubuntu_pro.py
@@ -19,6 +19,7 @@ from tests.integration_tests.releases import (
     FOCAL,
     IS_UBUNTU,
     JAMMY,
+    NOBLE,
 )
 from tests.integration_tests.util import (
     get_feature_flag_value,
@@ -236,7 +237,7 @@ def maybe_install_cloud_init(session_cloud: IntegrationCloud):
 
 
 @pytest.mark.skipif(
-    not all([IS_UBUNTU, CURRENT_RELEASE in [BIONIC, FOCAL, JAMMY]]),
+    CURRENT_RELEASE not in [BIONIC, FOCAL, JAMMY, NOBLE],
     reason="Test runs on Ubuntu LTS releases only",
 )
 @pytest.mark.skipif(


### PR DESCRIPTION
## Proposed Commit Message

```
tests(pro): bump pycloudlib add noble release to pro tests

Since Noble is an LTS which supports Ubuntu Pro add integration
test coverage for that feature.

Bump pycloudlib dependency to 1!9.2 which allows cloud-init integration
tests to obtain service_account_email configuration from
the .config/pycloudlib.toml:

[gce]
credentials_path = <path>

without the need to also provide `service_account_email` in
pycloudlib.toml.
```

## Additional Context
Fixes jenkins failures about service account https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-gce/lastSuccessfulBuild/testReport/junit/tests.integration_tests.modules.test_ubuntu_pro/TestUbuntuAdvantagePro/test_custom_services/

## Test Steps
```
# setup .config/pycloudlib.toml with GCE credentials file
CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_PLATFORM=gce tox -e integration-tests --  tests/integration_tests/modules/test_ubuntu_pro.py::TestUbuntuAdvantagePro::test_custom_services
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
