### PR TITLE
chore: clean up pytest warnings

### DIFF
--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -33,13 +33,12 @@ def disable_setup_logging():
 def mock_status_wrapper(mocker, tmpdir):
     link_d = os.path.join(tmpdir, "link")
     data_d = os.path.join(tmpdir, "data")
-    with mocker.patch(
+    mocker.patch(
         "cloudinit.cmd.main.read_cfg_paths",
         return_value=mock.Mock(get_cpath=lambda _: data_d),
-    ), mocker.patch(
-        "cloudinit.cmd.main.os.path.normpath", return_value=link_d
-    ):
-        yield Tmpdir(tmpdir, link_d, data_d)
+    )
+    mocker.patch("cloudinit.cmd.main.os.path.normpath", return_value=link_d)
+    yield Tmpdir(tmpdir, link_d, data_d)
 
 
 class TestCLI:

--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -753,7 +753,7 @@ class TestDsIdentify(DsIdentifyBase):
             m for m in data["mocks"] if m["name"] == "is_ibm_provisioning"
         ][0]
         isprov_m["ret"] = shell_true
-        return self._check_via_dict(data, RC_NOT_FOUND)
+        self._check_via_dict(data, RC_NOT_FOUND)
 
     def test_ibmcloud_template_userdata(self):
         """Template provisioned with user-data first boot.
@@ -770,7 +770,7 @@ class TestDsIdentify(DsIdentifyBase):
         data["mocks"].append(
             {"name": "is_ibm_provisioning", "ret": shell_true}
         )
-        return self._check_via_dict(data, RC_NOT_FOUND)
+        self._check_via_dict(data, RC_NOT_FOUND)
 
     def test_ibmcloud_template_no_userdata(self):
         """Template provisioned with no user-data first boot.
@@ -1179,7 +1179,7 @@ class TestDsIdentify(DsIdentifyBase):
         open64 = "usr/lib64/open-vm-tools/plugins/vmsvc/libdeployPkgPlugin.so"
         cust64["files"][open64] = cust64["files"][p32]
         del cust64["files"][p32]
-        return self._check_via_dict(
+        self._check_via_dict(
             cust64, RC_FOUND, dslist=[cust64.get("ds"), DS_NONE]
         )
 
@@ -1194,7 +1194,7 @@ class TestDsIdentify(DsIdentifyBase):
         )
         cust64["files"][x86] = cust64["files"][p32]
         del cust64["files"][p32]
-        return self._check_via_dict(
+        self._check_via_dict(
             cust64, RC_FOUND, dslist=[cust64.get("ds"), DS_NONE]
         )
 
@@ -1209,7 +1209,7 @@ class TestDsIdentify(DsIdentifyBase):
         )
         cust64["files"][aarch64] = cust64["files"][p32]
         del cust64["files"][p32]
-        return self._check_via_dict(
+        self._check_via_dict(
             cust64, RC_FOUND, dslist=[cust64.get("ds"), DS_NONE]
         )
 
@@ -1224,7 +1224,7 @@ class TestDsIdentify(DsIdentifyBase):
         )
         cust64["files"][i386] = cust64["files"][p32]
         del cust64["files"][p32]
-        return self._check_via_dict(
+        self._check_via_dict(
             cust64, RC_FOUND, dslist=[cust64.get("ds"), DS_NONE]
         )
 
@@ -1400,7 +1400,7 @@ class TestWSL(DsIdentifyBase):
                 "RET": "\r\n",
             },
         )
-        return self._check_via_dict(data, RC_NOT_FOUND)
+        self._check_via_dict(data, RC_NOT_FOUND)
 
     def test_no_cloudinitdir_in_userprofile(self):
         """Negative test by not finding %USERPROFILE%/.cloud-init."""
@@ -1413,7 +1413,7 @@ class TestWSL(DsIdentifyBase):
                 "RET": userprofile,
             },
         )
-        return self._check_via_dict(data, RC_NOT_FOUND)
+        self._check_via_dict(data, RC_NOT_FOUND)
 
     def test_empty_cloudinitdir(self):
         """Negative test by lack of host filesystem mount points."""
@@ -1428,7 +1428,7 @@ class TestWSL(DsIdentifyBase):
         )
         cloudinitdir = os.path.join(userprofile, ".cloud-init")
         os.mkdir(cloudinitdir)
-        return self._check_via_dict(data, RC_NOT_FOUND)
+        self._check_via_dict(data, RC_NOT_FOUND)
 
     def test_found_fail_due_instance_name_parsing(self):
         """WSL datasource detection fail due parsing error even though the file
@@ -1524,7 +1524,7 @@ class TestWSL(DsIdentifyBase):
             Path(filename).unlink()
 
         # Until there is none, making the datasource no longer viable.
-        return self._check_via_dict(data, RC_NOT_FOUND)
+        self._check_via_dict(data, RC_NOT_FOUND)
 
 
 def blkid_out(disks=None):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
chore: clean up pytest warnings
```

## Additional Context
Pytest warns about incorrect usage of mocker and returning from test methods. Clean it up

