### PR TITLE
Ubuntu/oracular bug fix release systemd ordering

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cloud-init (24.4~3+really24.3.1-0ubuntu4) UNRELEASED; urgency=medium
+
+  * Bug fix release (LP: #2081124):
+    d/p/cpick-hotplugd-systemd-ordering-fix.patch: fix systemd ordering cycle
+    issues with network cloud-init-hotplugd.socket, NetworkManager and
+    dbus.socket by adding DefaultDependencies=no to cloud-init-hotplugd.socket.
+
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 20 Sep 2024 15:31:13 -0600
+
 cloud-init (24.4~3+really24.3.1-0ubuntu3) oracular; urgency=medium
 
   * Bug fix release (LP: #2080688):

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (24.4~3+really24.3.1-0ubuntu4) UNRELEASED; urgency=medium
+cloud-init (24.4~3+really24.3.1-0ubuntu4) oracular; urgency=medium
 
   * Bug fix release (LP: #2081124):
     d/p/cpick-hotplugd-systemd-ordering-fix.patch: fix systemd ordering cycle

--- a/debian/patches/cpick-hotplugd-systemd-ordering-fix.patch
+++ b/debian/patches/cpick-hotplugd-systemd-ordering-fix.patch
@@ -1,0 +1,24 @@
+Description: remove DefaultDependencies from cloud-init-hotplug.socket (#5722)
+ Shifting systemd ordering earlier in boot for cloud-init-hotplugd.socket
+ introduced a systemd ordering cycle due to After=sysinit.target being pulled
+ carried along witu cloud-init-hotplugd.socket in earlier boot. This caused
+ conflicts in only Ubuntu Live Desktop images which have a custom dropin from
+ livecd-rootfs which also orders cloud-init-network.service
+ After=NetworkManager.service. The livecd-rootfs override is documented in
+ LP: #2081325. This bug is not seen on Ubuntu Server images.
+Author: Chad Smith <chad.smith@canonical.com>
+Origin: upstream
+Bug: https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2081124
+Last-Update: 2024-09-20
+--- a/systemd/cloud-init-hotplugd.socket
++++ b/systemd/cloud-init-hotplugd.socket
+@@ -5,6 +5,9 @@
+ # Known bug with an enforcing SELinux policy: LP: #1936229
+ [Unit]
+ Description=cloud-init hotplug hook socket
++DefaultDependencies=no
++Before=shutdown.target
++Conflicts=shutdown.target
+ After=cloud-config.target
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 cpick-nocloudnet-seedfrom-sysconfig-fix.patch
+cpick-hotplugd-systemd-ordering-fix.patch


### PR DESCRIPTION
sync bugfix cherry pick into oracular for release during beta freeze
See individual commits 


## procedure to create this branch
```
git fetch upstream
git checkout upstream/ubuntu/oracular -B ubuntu/oracular
quilt push -a
quilt new cpick-fhotplugd-systemd-ordering-fix.patch
quilt add systemd/cloud-init-hotplugd.socket
git show upstream/main:systemd/cloud-init-hotplugd.socket > systemd/cloud-init-hotplugd.socket
quilt refresh
quilt edit --dep3 -e # setup the header of the cpick quilt patch
quilt pop -a
git add debian
git commit -am 'Add d/p/cpick-hotplugd-systemd-ordering-fix.patch'
dch -i  # manually add debian/changelog entry
git commit -am 'update changelog'
vi debian/changelog # bump UNRELEASED to oracular'
git commit -am 'releasing cloud-init version 24.4~3+really24.3.1-0ubuntu4'
```

## testing 
```
quilt push -a
tox -e py3 
quilt pop -a
build-package

$ sbuild --dist=oracular --arch=amd64  --arch-all ../out/cloud-init_*.dsc
```


## test results
confirmed no new lintian build issues, sbuild success as well.