### PR TITLE
Single cherry-pick fix into noble on top of what's queued in SRU verification.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-cloud-init (24.3.1-0ubuntu0~24.04.2) UNRELEASED; urgency=medium
+cloud-init (24.3.1-0ubuntu0~24.04.2) noble; urgency=medium
 
   * Bug fix release (LP: #2081124):
     d/p/cpick-hotplugd-systemd-ordering-fix.patch: fix systemd ordering cycle

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+cloud-init (24.3.1-0ubuntu0~24.04.2) UNRELEASED; urgency=medium
+
+  * Bug fix release (LP: #2081124):
+    d/p/cpick-hotplugd-systemd-ordering-fix.patch: fix systemd ordering cycle
+    issues with network cloud-init-hotplugd.socket, NetworkManager and
+    dbus.socket by adding DefaultDependencies=no to cloud-init-hotplugd.socket.
+
+ -- Chad Smith <chad.smith@canonical.com>  Fri, 20 Sep 2024 16:07:14 -0600
+
 cloud-init (24.3.1-0ubuntu0~24.04.1) noble; urgency=medium
 
   * d/p/no-single-process.patch: Remove single process optimization

--- a/debian/patches/cpick-hotplugd-systemd-ordering-fix.patch
+++ b/debian/patches/cpick-hotplugd-systemd-ordering-fix.patch
@@ -1,0 +1,24 @@
+Description: remove DefaultDependencies from cloud-init-hotplug.socket (#5722)
+ Shifting systemd ordering earlier in boot for cloud-init-hotplugd.socket
+ introduced a systemd ordering cycle due to After=sysinit.target being pulled
+ carried along witu cloud-init-hotplugd.socket in earlier boot. This caused
+ conflicts in only Ubuntu Live Desktop images which have a custom dropin from
+ livecd-rootfs which also orders cloud-init-network.service
+ After=NetworkManager.service. The livecd-rootfs override is documented in
+ LP: #2081325. This bug is not seen on Ubuntu Server images.
+Author: Chad Smith <chad.smith@canonical.com>
+Origin: upstream
+Bug: https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2081124
+Last-Update: 2024-09-20
+--- a/systemd/cloud-init-hotplugd.socket
++++ b/systemd/cloud-init-hotplugd.socket
+@@ -5,6 +5,9 @@
+ # Known bug with an enforcing SELinux policy: LP: #1936229
+ [Unit]
+ Description=cloud-init hotplug hook socket
++DefaultDependencies=no
++Before=shutdown.target
++Conflicts=shutdown.target
+ After=cloud-config.target
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 deprecation-version-boundary.patch
 no-single-process.patch
 no-nocloud-network.patch
+cpick-hotplugd-systemd-ordering-fix.patch


### PR DESCRIPTION
Sync single cherry-pick from upstream #5722 for release. Lay this cherry-pick down as a single quilt patch. Preferred to use the ubuntu/noble-24.3.x branch because we already have performed a new_upstream_snapshot.py against ubuntu/noble to fix daily recipes.


## Proposed Commit Message
See individual commits

### Procedure to create this branch
```
git fetch upstream
git checkout upstream/ubuntu/noble -B ubuntu/noble-24.3.x
# Start from the version of cloud-init in noble-proposed
git reset --hard ubuntu/24.3.1-0ubuntu0_24.04.1
# cherry-pick the ubuntu/oracular pending commit in review to get the quilt patch
git cherry-pick82b4b7e1436f3da2ae8285c7e9ef6815030a6ccd
# resolve minor merge conflict
vi debian/patches/series
git add debian/patches/series
git cherry-pick --continue
dch -i # manually add same d/changelog from oracular/ fix verson 24.04.2
git commit -am 'update changelog'

vi debian/changelog # set UNRELEASED to noble
git commit -am 'releasing cloud-init version 24.3.1-0ubuntu0~24.04.2'
```

## Additional Context
 Preferred to use the ubuntu/noble-24.3.x branch because we already have performed a new_upstream_snapshot.py against ubuntu/noble to fix daily recipes. The alternative could have been `git reset --hard ubuntu/24.3.1-0ubuntu0_24.04.1` on `ubutu/noble` and push that back up to upstream before creating this PR.


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
