### PR TITLE
Tests fix clean boot changes

### DIFF
--- a/tests/integration_tests/cmd/test_schema.py
+++ b/tests/integration_tests/cmd/test_schema.py
@@ -83,8 +83,11 @@ class TestSchemaDeprecations:
             messages += boundary_message
             verify_clean_boot(class_client, require_deprecations=messages)
         else:
-            verify_clean_boot(class_client, require_deprecations=messages)
-            assert boundary_message in log
+            verify_clean_boot(class_client)
+            assert f"INFO]: {boundary_message}" in log
+            assert "apt_reboot_if_required:  Deprecated " in log
+            assert "apt_update:  Deprecated in version" in log
+            assert "apt_upgrade:  Deprecated in version" in log
 
     def test_network_config_schema_validation(
         self, class_client: IntegrationInstance

--- a/tests/integration_tests/datasources/test_none.py
+++ b/tests/integration_tests/datasources/test_none.py
@@ -49,22 +49,10 @@ def test_datasource_none_discovery(client: IntegrationInstance):
     client.restart()
     status = json.loads(client.execute("cloud-init status --format=json"))
     assert [] == status["errors"]
-    expected_warnings = [
-        "Used fallback datasource",
+    ignore_warnings = [
         "Falling back to a hard restart of systemd-networkd.service",
     ]
-    unexpected_warnings = []
-    for current_warning in status["recoverable_errors"].get("WARNING", []):
-        if [w for w in expected_warnings if w in current_warning]:
-            # Found a matching expected_warning substring in current_warning
-            continue
-        unexpected_warnings.append(current_warning)
-
-    if unexpected_warnings:
-        raise AssertionError(
-            f"Unexpected recoverable errors: {list(unexpected_warnings)}"
-        )
     log = client.read_from_file("/var/log/cloud-init.log")
     verify_clean_log(log)
-    verify_clean_boot(client, require_warnings=expected_warnings)
+    verify_clean_boot(client, ignore_warnings=ignore_warnings)
     assert client.execute("test -f /var/tmp/success-with-datasource-none").ok


### PR DESCRIPTION
Fix a couple of integration test failures due to shift to verify_clean_boot in commit 313390f81f44be0e52d5447b4112209b282ddb87

See individual commits

## Additional Context
Failed jenkins jobs resolved by this PR: [tests.integration_tests.cmd.test_schema.TestSchemaDeprecations.test_clean_log](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-gce/513/testReport/junit/tests.integration_tests.cmd.test_schema/TestSchemaDeprecations/test_clean_log/)
[tests.integration_tests.datasources.test_none.test_datasource_none_discovery](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-gce/513/testReport/junit/tests.integration_tests.datasources/test_none/test_datasource_none_discovery/)
## Test Steps


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
