### PR TITLE
tests: fix test_nocloud message typo introduced by commit 313390f8

### DIFF
--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -198,17 +198,13 @@ class TestSmbios:
         version_boundary = get_feature_flag_value(
             client, "DEPRECATION_INFO_BOUNDARY"
         )
-        message = (
-            "The 'nocloud-net' datasource name is "
-            'deprecated" /var/log/cloud-init.log'
-        )
+        message = "The 'nocloud-net' datasource name is deprecated"
         # nocloud-net deprecated in version 24.1
         if lifecycle.should_log_deprecation("24.1", version_boundary):
             verify_clean_boot(client, require_deprecations=[message])
         else:
             client.execute(
-                r"grep \"INFO]: The 'nocloud-net' datasource name is"
-                ' deprecated" /var/log/cloud-init.log'
+                rf"grep \"INFO]: {message}\" /var/log/cloud-init.log"
             ).ok
 
 


### PR DESCRIPTION
## Proposed Commit Message
```
* tests: fix test_nocloud message typo introduced by commit 313390f8
*  tests: webhook require_deprecation msg on 24.3

```

## Additional Context
Failed job: 
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-oracular-lxd_vm/lastSuccessfulBuild/testReport/junit/tests.integration_tests.datasources.test_nocloud/TestSmbios/test_smbios_seed_network/

## Test Steps
```
CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE .tox/integration-tests/bin/pytest tests/integration_tests/datasources/test_nocloud.py::TestSmbios::test_smbios_seed_network  --pdb
```
## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
