### PR TITLE
doc: do not document user.meta-data key

### DIFF
--- a/doc/rtd/explanation/format.rst
+++ b/doc/rtd/explanation/format.rst
@@ -166,6 +166,8 @@ will not be read.
 Jinja template
 ==============
 
+.. _jinja-config:
+
 Example cloud-config
 --------------------
 
@@ -175,6 +177,8 @@ Example cloud-config
    #cloud-config
    runcmd:
      - echo 'Running on {{ v1.cloud_name }}' > /var/tmp/cloud_name
+
+.. _jinja-script:
 
 Example user data script
 ------------------------

--- a/doc/rtd/explanation/instancedata.rst
+++ b/doc/rtd/explanation/instancedata.rst
@@ -13,11 +13,9 @@ Instance metadata
 What is ``instance-data?``
 ==========================
 
-Each cloud provider presents unique configuration metadata to a launched cloud
-instance. ``Cloud-init`` crawls this metadata and then caches and exposes this
-information as a standardised and versioned JSON object known as
-``instance-data``. This ``instance-data`` may then be queried or later used
-by ``cloud-init`` in templated configuration and scripts.
+``instance-data`` is a JSON object which contains instance-specific variables
+in a standardized format. These variables may be used in ``cloud-init``
+templated cloud-init configurations.
 
 An example of a small subset of instance-data on a launched EC2 instance:
 
@@ -42,10 +40,9 @@ An example of a small subset of instance-data on a launched EC2 instance:
 Discovery
 =========
 
-One way to easily explore which ``instance-data`` variables are available on
-your machine is to use the :ref:`cloud-init query<cli_query>` tool.
-Warnings or exceptions will be raised on invalid ``instance-data`` keys,
-paths or invalid syntax.
+``instance-data`` can be inspected on a launched instance using
+:ref:`cloud-init query<cli_query>`. Warnings or exceptions will be raised
+on invalid ``instance-data`` keys, paths, or invalid syntax.
 
 The :command:`query` command also publishes ``userdata`` and ``vendordata``
 keys to the root user which will contain the decoded user and vendor data

--- a/doc/rtd/reference/datasources/lxd.rst
+++ b/doc/rtd/reference/datasources/lxd.rst
@@ -11,7 +11,6 @@ running LXD container and VM as ``/dev/lxd/sock`` and represents all
 instance-metadata as versioned HTTP routes such as:
 
   - 1.0/meta-data
-  - 1.0/config/user.meta-data
   - 1.0/config/user.vendor-data
   - 1.0/config/user.user-data
   - 1.0/config/user.<any-custom-key>
@@ -37,25 +36,28 @@ launched container, use either LXD profiles or
 ``lxc launch ... -c <key>="<value>"`` at initial container launch, by setting
 one of the following keys:
 
-- ``user.meta-data``: YAML metadata which will be appended to base metadata.
-- ``user.vendor-data``: YAML which overrides any metadata values.
-- ``user.network-config``: YAML representing either :ref:`network_config_v1` or
-  :ref:`network_config_v2` format.
-- ``user.user-data``: YAML which takes precedence and overrides both metadata
-  and vendor data values.
-- ``user.any-key``: Custom user configuration key and value pairs, which can be
-  passed to ``cloud-init``. Those keys/values will be present in instance-data
-  which can be used by both `#template: jinja` #cloud-config templates and
-  the :command:`cloud-init query` command.
+- ``cloud-init.vendor-data``: YAML which overrides any metadata values.
+- ``cloud-init.network-config``: YAML representing either
+  :ref:`network_config_v1` or :ref:`network_config_v2` format.
+- ``cloud-init.user-data``: YAML which takes precedence and overrides both
+  metadata and vendor data values.
+- ``user.<any-key>``: Keys prefixed with ``user.`` are included in
+  :ref:`instance data<instance_metadata>` under the ``ds.config`` key. These
+  key value pairs are used in jinja :ref:`cloud-config<jinja-config>`
+  and :ref:`user data scripts<jinja-script>`. These key-value pairs may be
+  inspected on a launched instance using ``cloud-init query ds.config``.
 
 .. note::
-   LXD version 4.22 introduced a new scope of config keys prefaced by
-   ``cloud-init.``, which are preferred above the related ``user.*`` keys:
 
-   - ``cloud-init.meta-data``
-   - ``cloud-init.vendor-data``
-   - ``cloud-init.network-config``
-   - ``cloud-init.user-data``
+    Periods (.) and hyphens (-) in Jinja2 have special meaning. Keys which contain a
+    period or hyphen cannot use dot notation to access nested values. To support dot
+    notation, cloud-init provides an alias by converting each hyphen (-) and period (.)
+    character to an underscore (_). This means that an instance launched with
+    ``-c user.special-key=1FE321`` can be queried using standard jinja notation,
+    ``cloud-init query --format "{{ds.config['user.special-key']}}"`` or may use the alias
+    notation ``cloud-init query --format "{{ds.config.user_special_key}}"`` or
+    ``cloud-init query ds.config.user_special_key``.
+
 
 Configuration
 =============


### PR DESCRIPTION

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
```
doc: do not document user.meta-data key

This key is not documented by lxd and will likely be removed.
Also prefer cloud-init prefixes.
```

## Additional Context
https://github.com/canonical/lxd/issues/13853#issuecomment-2374472140

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
