### PR TITLE
fix(akamai): handle non-string user data in base64 decoding

### DIFF
--- a/cloudinit/sources/DataSourceAkamai.py
+++ b/cloudinit/sources/DataSourceAkamai.py
@@ -276,7 +276,7 @@ class DataSourceAkamai(sources.DataSource):
             )
             self.userdata_raw = str(userdata)
             try:
-                self.userdata_raw = b64decode(self.userdata_raw).decode()
+                self.userdata_raw = b64decode(self.userdata_raw)
             except binascii.Error as e:
                 LOG.warning("Failed to base64 decode userdata due to %s", e)
         except url_helper.UrlError as e:

--- a/tests/unittests/sources/test_akamai.py
+++ b/tests/unittests/sources/test_akamai.py
@@ -261,14 +261,43 @@ class TestDataSourceAkamai:
                 assert rv6 == ev6
 
     @pytest.mark.parametrize(
-        "use_v6",
+        "use_v6,userdata,decoded_userdata,case",
         (
-            False,
-            True,
+            (
+                False,
+                "dGVzdGluZyBlbmNvZGVkIHVzZXJkYXRh",
+                b"testing encoded userdata",
+                "base64-encoded ASCII plaintext, IPv4 request",
+            ),
+            (
+                True,
+                "dGVzdGluZyBlbmNvZGVkIHVzZXJkYXRh",
+                b"testing encoded userdata",
+                "base64-encoded ASCII plaintext, IPv6 request",
+            ),
+            (
+                False,
+                "H4sIAAAAAAACAytJLS7hAgDGNbk7BQAAAA==",
+                b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x02\x03+I-.\xe1\x02\x00\xc65\xb9;\x05\x00\x00\x00",
+                "base64-encoded gzipped data",
+            ),
+            (
+                False,
+                "dGVzdDHwn4yKdGVzdDI=",
+                "test1\N{WATER WAVE}test2".encode("utf-8"),
+                "base64-encoded Unicode text",
+            ),
         ),
     )
     @mock.patch("cloudinit.url_helper.readurl")
-    def test_fetch_metadata(self, readurl, use_v6: bool):
+    def test_fetch_metadata(
+        self,
+        readurl,
+        use_v6: bool,
+        userdata: str,
+        decoded_userdata: str,
+        case: str,
+    ):
         """
         Tests that making requests sends the expected requests in the expected
         order
@@ -280,7 +309,7 @@ class TestDataSourceAkamai:
             # to GET /v1/instance; truncated for brevity
             '{"id": 123}',
             # to GET /v1/user-data
-            "",
+            userdata,
         ]
 
         # if we're asked to force using v6, we should see the hostname of the
@@ -292,7 +321,7 @@ class TestDataSourceAkamai:
 
         assert readurl.call_count == 3
         assert ds.metadata == {"id": 123}
-        assert ds.userdata_raw == ""
+        assert ds.userdata_raw == decoded_userdata, f"Failed to decode {case}"
 
         assert readurl.mock_calls == [
             mock.call(

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -89,8 +89,10 @@ izzyleung
 j5awry
 jacobsalmela
 jamesottinger
+jberner12
 jcmoore3
 Jehops
+jessealter
 jf
 jfroche
 jgrassler


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [X] I have signed the CLA: https://ubuntu.com/legal/contributors
- [X] I have added my Github username to ``tools/.github-cla-signers``
- [X] I have included a comprehensive commit message using the guide below
- [X] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [X] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(akamai): handle non-string user data in base64 decoding

Previously, user data that was base64-encoded was decoded as a string,
causing non-string data (e.g., gzipped user data) to raise an exception.
This change ensures that the output of b64decode is not decoded to a
string, passing along the decoded bytes unchanged.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
1. Deploy a Linode instance while supplying user-data that is gzipped and then base64 encoded. You may use any cloudconfig you like or the one provided which will set the hostname to `it-worked-gzip`, write to `/root/proof.txt`, and write to the "final_message".

```shell
curl -H "Content-Type: application/json" \
     -H "Authorization: Bearer $LINODE_API_TOKEN" \
     -X POST -d '{
       "region": "us-east",
       "type": "g6-nanode-1",
       "image": "linode/ubuntu22.04",
       "label": "cloud-init-test",
       "root_pass": "'"$PASS"'",
       "metadata": {
         "user_data": "H4sIAA759mYAAzWPwQ7CIBBE73zFWK9W71xN/AEPxlNDYEFiCwS2qRo/XrB62cxmX2Zmt3qMs+l1DNY7IbY4E+MWCwc1kfgLCc/9EvOdTO9ePjXwkj0TFKwfSSxtGZosUgA9kuKbxCHHyIdUp93zg+sFqFFMgSXe3xW4UtlVf6z+++Z98kGNmKgU5WqGZcpYi/pQSR2nNBJTEbaBww+U6I7tjzz54PCMc0Yrm8igsowya01kyGw6IT6RMgJw+QAAAA=="
       }
     }' \
     https://api.linode.com/v4/linode/instances
```

2. You will see an exception is raised in `/var/log/cloud-init.log` when cloud-init attempts to decode the gzipped user data.

3. Replace the installed cloud-init package with a patched release, or simply patch `DataSourceAkamai.py`.

4. Run `cloud-init clean`, followed by `cloud-init init`.

5. You should observe the cloudconfig being successfully decoded, decompressed, and applied.



## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
