### PR TITLE
test(ec2-dual-stack): fix int-test

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -159,8 +159,12 @@ class DataSourceEc2(sources.DataSource):
                     self.distro.fallback_interface,
                     ipv4=True,
                     ipv6=True,
-                ):
+                ) as netw:
                     self._crawled_metadata = self.crawl_metadata()
+                    LOG.debug(
+                        "Crawled metadata service%s",
+                        f" {netw.state_msg}" if netw.state_msg else "",
+                    )
 
             except NoDHCPLeaseError:
                 return False

--- a/tests/integration_tests/datasources/test_ec2_ipv6.py
+++ b/tests/integration_tests/datasources/test_ec2_ipv6.py
@@ -11,7 +11,7 @@ def _test_crawl(client, ip):
     assert client.execute("cloud-init init --local").ok
     log = client.read_from_file("/var/log/cloud-init.log")
     assert f"Using metadata source: '{ip}'" in log
-    result = re.findall(r"Crawl of metadata service.* (\d+.\d+) seconds", log)
+    result = re.findall(r"Getting metadata took (\d+.\d+) seconds", log)
     if len(result) != 1:
         pytest.fail(f"Expected 1 metadata crawl time, got {result}")
     # 20 would still be a crazy long time for metadata service to crawl,
@@ -51,4 +51,4 @@ def test_dual_stack(client: IntegrationInstance):
 
     client.restart()
     log = client.read_from_file("/var/log/cloud-init.log")
-    assert "Crawl of metadata service using link-local ipv6 took" in log
+    assert "Crawled metadata service using link-local ipv6" in log


### PR DESCRIPTION
Bring back log messages about link-local being used during ephemeral net setup at init-local time to make it testable.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test(ec2-dual-stack): fix int-test

Bring back log messages about link-local being used during ephemeral net
setup at init-local time to make it testable.
```

## Additional Context
<!-- If relevant -->
* Logs changed as part of: https://github.com/canonical/cloud-init/pull/5672
* Failing test: https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-ec2/496

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
```
export CLOUD_INIT_CLOUD_INIT_SOURCE=./cloud-init_all.deb
export CLOUD_INIT_PLATFORM=ec2
export CLOUD_INIT_OS_IMAGE=focal

tox -re integration-tests -- -vvv --pdb tests/integration_tests/datasources/test_ec2_ipv6.py::test_dual_stack
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
