### PR TITLE
fix: avoid deprecation logs for calling cli stages

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -98,21 +98,6 @@ DEPRECATE_BOOT_STAGE_MESSAGE = (
 )
 
 
-def log_ppid(distro, bootstage_name):
-    if distro.is_linux:
-        ppid = os.getppid()
-        if 1 != ppid and distro.uses_systemd():
-            lifecycle.deprecate(
-                deprecated=(
-                    "Unsupported configuration: boot stage called "
-                    f"by PID [{ppid}] outside of systemd"
-                ),
-                deprecated_version="24.3",
-                extra_message=DEPRECATE_BOOT_STAGE_MESSAGE,
-            )
-    LOG.info("PID [%s] started cloud-init '%s'.", ppid, bootstage_name)
-
-
 def welcome(action, msg=None):
     if not msg:
         msg = welcome_format(action)
@@ -394,7 +379,7 @@ def main_init(name, args):
     # config applied.  We send the welcome message now, as stderr/out have
     # been redirected and log now configured.
     welcome(name, msg=w_msg)
-    log_ppid(init.distro, bootstage_name)
+    LOG.info("PID [%s] started cloud-init '%s'.", os.getppid(), bootstage_name)
 
     # re-play early log messages before logging was setup
     for lvl, msg in early_logs:
@@ -662,7 +647,7 @@ def main_modules(action_name, args):
 
     # now that logging is setup and stdout redirected, send welcome
     welcome(name, msg=w_msg)
-    log_ppid(init.distro, bootstage_name)
+    LOG.info("PID [%s] started cloud-init '%s'.", os.getppid(), bootstage_name)
 
     if name == "init":
         lifecycle.deprecate(

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -938,17 +938,14 @@ def main(sysv_args=None):
         "--debug",
         "-d",
         action="store_true",
-        help=(
-            "DEPRECATED: Show additional pre-action "
-            "logging (default: %(default)s)."
-        ),
+        help="Show additional pre-action logging (default: %(default)s).",
         default=False,
     )
     parser.add_argument(
         "--force",
         action="store_true",
         help=(
-            "DEPRECATED: Force running even if no datasource is"
+            "Force running even if no datasource is"
             " found (use at your own risk)."
         ),
         dest="force",
@@ -971,10 +968,7 @@ def main(sysv_args=None):
 
     # Each action and its sub-options (if any)
     parser_init = subparsers.add_parser(
-        "init",
-        help=(
-            "DEPRECATED: Initialize cloud-init and perform initial modules."
-        ),
+        "init", help="Initialize cloud-init and perform initial modules."
     )
     parser_init.add_argument(
         "--local",
@@ -997,8 +991,7 @@ def main(sysv_args=None):
 
     # These settings are used for the 'config' and 'final' stages
     parser_mod = subparsers.add_parser(
-        "modules",
-        help=("DEPRECATED: Activate modules using a given configuration key."),
+        "modules", help="Activate modules using a given configuration key."
     )
     extra_help = lifecycle.deprecate(
         deprecated="`init`",
@@ -1029,11 +1022,7 @@ def main(sysv_args=None):
 
     # This subcommand allows you to run a single module
     parser_single = subparsers.add_parser(
-        "single",
-        help=(
-            "Manually run a single module. Useful for "
-            "testing during development."
-        ),
+        "single", help="Run a single module."
     )
     parser_single.add_argument(
         "--name",

--- a/tests/integration_tests/reporting/test_webhook_reporting.py
+++ b/tests/integration_tests/reporting/test_webhook_reporting.py
@@ -6,11 +6,9 @@ import json
 
 import pytest
 
-from cloudinit import lifecycle
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import (
     ASSETS_DIR,
-    get_feature_flag_value,
     verify_clean_boot,
     verify_clean_log,
 )
@@ -53,18 +51,7 @@ def test_webhook_reporting(client: IntegrationInstance):
         "cloud-init status --wait"
     )
     verify_clean_log(client.read_from_file("/var/log/cloud-init.log"))
-    version_boundary = get_feature_flag_value(
-        client, "DEPRECATION_INFO_BOUNDARY"
-    )
-    message = "Unsupported configuration: boot stage called by PID"
-    deprecation_messages = []
-    if lifecycle.should_log_deprecation("24.3", version_boundary):
-        deprecation_messages.append(message)
-    else:
-        assert client.execute(
-            f"grep 'INFO]: {message}' /var/log/cloud-init.log"
-        ).stdout.strip(), f"Did not find expected log: {message}"
-    verify_clean_boot(client, require_deprecations=deprecation_messages)
+    verify_clean_boot(client)
 
     server_output = client.read_from_file(
         "/var/tmp/echo_server_output"


### PR DESCRIPTION
Includes a git revert of bd6cd1fbee12ac81ff6c46cc5f979cfdf76e5e13.

## Proposed Commit Message

```
fix: avoid deprecation logs for calling cli stages
    
Avoid deprecating command line calls to cloud-init boot.

When cloud-init's boot stages are invoked directly on the command line
is typically an attempt to add suppplemental configuration to a
system after initial boot has completed.
Although direct calls to cloud-init boot stages could lead to
misconfiguration if boot stages are called out of sequence
of customized /etc/cloud/cloud.cfg altering which config modules are
run during the boot stage, the support of such uses or custom
environments is out of scope for this feature. It remains a simple
tool to apply additional configuration via user-data onto an existing
system after initial boot.

At some point in the future, a new subcommand may be provided by
cloud-init tooling to allow for supplemental configuration of user-data
post-boot, in that event this --file feature will become deprecated in
favor of a cleaner/simpler alternative.

Fixes GH-5726
```

## Additional Context
This fix will be backported to Ubuntu Oracular as a bug fix as well, avoiding exit 2 from cloud-init status and DEPRECATION or INFO level logs for users or tooling which call cloud-init boot stages with the `--file` param.
#5726 

## Test Steps
```
CLOUD_INIT_OS_IMAGE=oracular CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/cmd/test_stages.py

# Test stable series non-deprecation level logs by modifying cloudint/features.py locally before running against focal
sed -i 's/devel/22.1/' cloudinit/features.py 
CLOUD_INIT_OS_IMAGE=focal CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/cmd/test_stages.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
