### PR TITLE
ci: fix tox.ini pytest cmd to use cloudinit dir for coverage reporting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -132,7 +132,7 @@ commands =
     {envpython} -m json.tool --indent 2 {[files]network_v2} {[files]network_v2}
 
 [testenv:py3]
-commands = {envpython} -m pytest -m "not hypothesis_slow" --cov=cloud-init --cov-branch {posargs:tests/unittests}
+commands = {envpython} -m pytest -m "not hypothesis_slow" --cov=cloudinit --cov-branch {posargs:tests/unittests}
 
 [testenv:py3-fast]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -151,6 +151,15 @@ commands = {envpython} -m pytest \
 [testenv:py3-leak]
 commands = {envpython} -X tracemalloc=40 -Wall -m pytest {posargs:tests/unittests}
 
+# generates html coverage report from the most recent pytest run
+[testenv:coverage-html]
+deps = {[testenv]deps}
+commands = coverage html -i
+
+# prints out the coverage report "table" from the most recent pytest run
+[testenv:coverage-report]
+deps = {[testenv]deps}
+commands = coverage report -i
 
 [testenv:lowest-supported]
 # Tox is going to install requirements from pip. This is fine for


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
```
ci: fix tox.ini pytest cmd to use cloudinit dir for coverage reporting
```

## Additional Context
<!-- If relevant -->

## Test Steps
Run the following locally to run pytest and ensure that the coverage report table appears at the end of the pytest results:
```
tox -e py3
```

Then, run the following new tox command to re-print the table to console:
```
tox -e coverage-report
```

Then, run the following new tox command to generate the html coverage site.
```
tox -e converage-html
```

Optional: Open automagically with xdg-open:
```
xdg-open htmlcov/index.html
```

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
