### PR TITLE
Make pytest more verbose for easier debugging

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -132,7 +132,7 @@ commands =
     {envpython} -m json.tool --indent 2 {[files]network_v2} {[files]network_v2}
 
 [testenv:py3]
-commands = {envpython} -m pytest -m "not hypothesis_slow" --cov=cloudinit --cov-branch {posargs:tests/unittests}
+commands = {envpython} -m pytest -vv -m "not hypothesis_slow" --cov=cloudinit --cov-branch {posargs:tests/unittests}
 
 [testenv:py3-fast]
 deps =


### PR DESCRIPTION
When the pytest fails, its easier to debug if pytest is run in verbose mode. Enable it.



## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
