### PR TITLE
fix: do not log ppid when ppid is undefined

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -110,7 +110,7 @@ def log_ppid(distro, bootstage_name):
                 deprecated_version="24.3",
                 extra_message=DEPRECATE_BOOT_STAGE_MESSAGE,
             )
-    LOG.info("PID [%s] started cloud-init '%s'.", ppid, bootstage_name)
+        LOG.info("PID [%s] started cloud-init '%s'.", ppid, bootstage_name)
 
 
 def welcome(action, msg=None):


### PR DESCRIPTION
This fixes a bug introduced in the function `log_ppid` by the commit 75add5c72aa575d373825deddcb685f725e290d8 which renders cloud-init unusable on all non-linux systems.

With this commit, cloud-init tried to log the ppid even if it was undefined, because ppid is only collected on linux distros. Here is the output of cloud-init 24.3 on OpenBSD:

```
Cloud-init v. 24.3 running 'init-local' at Thu, 03 Oct 2024 20:24:37 +0000. Up 39.569653034210205 seconds.
2024-10-03 20:24:38,050 - main.py[ERROR]: failed stage init-local
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/cloud_init-24.3-py3.10.egg/cloudinit/cmd/main.py", line 831, in status_wrapper
    ret = functor(name, args)
  File "/usr/local/lib/python3.10/site-packages/cloud_init-24.3-py3.10.egg/cloudinit/cmd/main.py", line 395, in main_init
    log_ppid(init.distro, bootstage_name)
  File "/usr/local/lib/python3.10/site-packages/cloud_init-24.3-py3.10.egg/cloudinit/cmd/main.py", line 112, in log_ppid
    LOG.info("PID [%s] started cloud-init '%s'.", ppid, bootstage_name)
UnboundLocalError: local variable 'ppid' referenced before assignment
failed run of stage init-local
```

This PR is an attempt to fix this issue by restoring the previous behavior of log_ppid from the  commits dc7c48b9b3fbeb8548d796ae8f0e2b15246eb903 and 4abdd5a7066c322163579d8d91a44426ac705172 

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: do not log ppid when ppid is undefined

This fixes a bug introduced in 75add5c72aa575d373825deddcb685f725e290d8
which renders cloud-init unusable on all non-linux systems.
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
