### PR TITLE
fix(test): convert p.gce.instance.instance_id to str

### DIFF
--- a/integration-requirements.txt
+++ b/integration-requirements.txt
@@ -2,7 +2,7 @@
 # PyPI requirements for cloud-init integration testing
 # https://docs.cloud-init.io/en/latest/development/integration_tests.html
 #
-pycloudlib>=1!9.1.0,<1!10
+pycloudlib>=1!9.1.0,<1!11
 
 # Avoid breaking change in `testpaths` treatment forced
 # test/unittests/conftest.py to be loaded by our integration-tests tox env

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -514,7 +514,7 @@ class TestCombined:
         # attributes
         assert isinstance(client.instance, GceInstance)
         assert v1_data["availability_zone"] == client.instance.zone
-        assert v1_data["instance_id"] == client.instance.instance_id
+        assert v1_data["instance_id"] == client.instance.id
         assert v1_data["local_hostname"] == client.instance.name
 
     @pytest.mark.skipif(


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(test): convert p.gce.instance.instance_id to str

Sdk changes surface instance_id as integer rather than as str.

Convert it appropiately and adopt pycloudlib's public API, rather than
directly accessing instance_id on the GCE SDK underliying instance
object.
```

## Additional Context
<!-- If relevant -->
* Being fixed here: https://github.com/canonical/pycloudlib/pull/437
* Failing test: https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-gce/lastCompletedBuild/testReport/tests.integration_tests.modules.test_combined/TestCombined/test_instance_json_gce/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```
export CLOUD_INIT_CLOUD_INIT_SOURCE=NONE
export CLOUD_INIT_PLATFORM=gce
export CLOUD_INIT_OS_IMAGE=jammy

tox -v -e integration-tests-jenkins -- -vvv --pdb \
        tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_gce
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
