### PR TITLE
Enable the sysv init scripts in OpenBSD build script

### DIFF
--- a/sysvinit/openbsd/cloudconfig.tmpl
+++ b/sysvinit/openbsd/cloudconfig.tmpl
@@ -13,7 +13,6 @@ daemon_user=root
 
 . /etc/rc.d/rc.subr
 
-rc_bg="YES" # (undefined or "YES")
 rc_usercheck="YES" # (undefined or "NO")
 
 rc_start() {

--- a/sysvinit/openbsd/cloudfinal.tmpl
+++ b/sysvinit/openbsd/cloudfinal.tmpl
@@ -11,7 +11,6 @@ daemon_user=root
 
 . /etc/rc.d/rc.subr
 
-rc_bg="YES" # (undefined or "YES")
 rc_usercheck="YES" # (undefined or "NO")
 
 rc_start() {

--- a/sysvinit/openbsd/cloudinit.tmpl
+++ b/sysvinit/openbsd/cloudinit.tmpl
@@ -11,7 +11,6 @@ daemon_user=root
 
 . /etc/rc.d/rc.subr
 
-rc_bg="YES" # (undefined or "YES")
 rc_usercheck="YES" # (undefined or "NO")
 
 rc_start() {

--- a/sysvinit/openbsd/cloudinitlocal.tmpl
+++ b/sysvinit/openbsd/cloudinitlocal.tmpl
@@ -14,7 +14,6 @@ daemon_user=root
 
 . /etc/rc.d/rc.subr
 
-rc_bg="YES" # (undefined or "YES")
 rc_usercheck="YES"
 
 rc_start() {

--- a/tools/build-on-openbsd
+++ b/tools/build-on-openbsd
@@ -43,24 +43,9 @@ else
     python3 setup.py install -O1 --distro openbsd --skip-build --init-system sysvinit_openbsd
 
     echo "Installation completed."
-    RC_LOCAL="/etc/rc.local"
-    RC_LOCAL_CONTENT="
 
-rm -rf /var/run/cloud-init
-/usr/local/lib/cloud-init/ds-identify
-
-cloud-init init --local
-
-cloud-init init
-
-cloud-init modules --mode config
-
-cloud-init modules --mode final
-"
-    if ! test -e $RC_LOCAL; then
-        echo "export PATH=$PATH:/usr/local/sbin:/usr/local/bin" >> $RC_LOCAL
-        echo "$RC_LOCAL_CONTENT" >> $RC_LOCAL
-    elif ! grep -Fq "cloud-init" $RC_LOCAL; then
-        echo "$RC_LOCAL_CONTENT" >> $RC_LOCAL
-    fi
+    rcctl enable cloudinitlocal
+    rcctl enable cloudinit
+    rcctl enable cloudconfig
+    rcctl enable cloudfinal
 fi


### PR DESCRIPTION
## Proposed Commit Message
```
<type>fix(openbsd)</type>: Enable sysv init scripts in OpenBSD build script

This replaces the use of `/etc/rc.local` in the OpenBSD build script by the sysv init scripts provided with cloud-init.

Fixes GH-4036
LP: #1992853
```

## Additional Context

I've fixed a bug in the sysv init scripts by disabling `rc_bg="YES"`, otherwise it would fail to execute correctly with this error at boot:

```
rcctl start cloudconfig 
cloudconfig/etc/rc.d/cloudconfig: kill: 66598: No such process
(ok)
```

Also, `/etc/rc.local` is not needed anymore, `/var/run` is managed by the system and does not have to be cleaned up manually.

## Test Steps

My own CI: https://github.com/hcartiaux/openbsd-cloud-image/actions/

* Generate an OpenBSD 7.6 image with cloud-init 24.3.1
* Apply the diff with the post-install script `install.site`
* Generate a minimal iso with a ssh key
* Boot the previously generated image and wait until the VM is back

I've also tested manually to have a closer look at the output.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
