### PR TITLE
feat(byobu/locale): install necessary packages when absent in images and cloud-config user-data wants to setup 

### DIFF
--- a/cloudinit/config/cc_byobu.py
+++ b/cloudinit/config/cc_byobu.py
@@ -37,6 +37,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         LOG.debug("Skipping module named %s, no 'byobu' values found", name)
         return
 
+    if not subp.which("byobu"):
+        cloud.distro.install_packages(["byobu"])
+
     if value == "user" or value == "system":
         value = "enable-%s" % value
 

--- a/tests/unittests/config/test_cc_byobu.py
+++ b/tests/unittests/config/test_cc_byobu.py
@@ -1,15 +1,90 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import re
+from unittest import mock
 
 import pytest
 
+from cloudinit.config import cc_byobu
 from cloudinit.config.schema import (
     SchemaValidationError,
     get_schema,
     validate_cloudconfig_schema,
 )
 from tests.unittests.helpers import skipUnlessJsonSchema
+from tests.unittests.util import get_cloud
+
+M_PATH = "cloudinit.config.cc_byobu."
+
+
+class TestHandleByobu:
+    """Validate behavior of cc_byobu.handle function."""
+
+    def test_handle_no_cfg(self, caplog):
+        """Exit early when no applicable config."""
+        cloud = get_cloud(distro="ubuntu")
+        cc_byobu.handle("byobu", cfg={}, cloud=cloud, args=[])
+        assert "Skipping module named byobu, no 'byobu' values" in caplog.text
+
+    @pytest.mark.parametrize(
+        "cfg, which_response, expected_cmds",
+        (
+            pytest.param(
+                {"byobu_by_default": "disable-system"},
+                "",  # byobu command not installed
+                [
+                    mock.call(
+                        [
+                            "/bin/sh",
+                            "-c",
+                            'X=0; echo "byobu byobu/launch-by-default boolean'
+                            ' false" | debconf-set-selections &&'
+                            " dpkg-reconfigure byobu --frontend=noninteractive"
+                            " || X=$(($X+1));  exit $X",
+                        ],
+                        capture=False,
+                    )
+                ],
+                id="install_byobu_pkg_when_absent_and_setup",
+            ),
+            pytest.param(
+                {"byobu_by_default": "disable-system"},
+                "/usr/bin/byobu",  # byobu command not installed
+                [
+                    mock.call(
+                        [
+                            "/bin/sh",
+                            "-c",
+                            'X=0; echo "byobu byobu/launch-by-default'
+                            ' boolean false" | debconf-set-selections &&'
+                            " dpkg-reconfigure byobu --frontend=noninteractive"
+                            " || X=$(($X+1));  exit $X",
+                        ],
+                        capture=False,
+                    )
+                ],
+                id="setup_byobu_pkg_when_present",
+            ),
+        ),
+    )
+    @mock.patch(f"{M_PATH}subp.which")
+    @mock.patch(f"{M_PATH}subp.subp", return_value=("", ""))
+    def test_handle_install_byobu_if_needed(
+        self, subp, subp_which, cfg, which_response, expected_cmds, caplog
+    ):
+        """Perform expected commands and install byobu on byobu user-data."""
+        subp_which.return_value = which_response
+        cloud = get_cloud(distro="ubuntu")
+        with mock.patch.object(
+            cloud.distro, "install_packages"
+        ) as install_pkgs:
+            cc_byobu.handle("byobu", cfg=cfg, cloud=cloud, args=[])
+        assert expected_cmds == subp.call_args_list
+        subp_which.assert_called_with("byobu")
+        if which_response:
+            install_pkgs.assert_not_called()
+        else:
+            install_pkgs.assert_called_once_with(["byobu"])
 
 
 class TestByobuSchema:

--- a/tests/unittests/config/test_cc_locale.py
+++ b/tests/unittests/config/test_cc_locale.py
@@ -111,15 +111,20 @@ class TestLocale:
             with mock.patch(
                 "cloudinit.distros.debian.LOCALE_CONF_FN", locale_conf.strpath
             ):
-                cc_locale.handle("cc_locale", cfg, cc, [])
-                m_subp.assert_called_with(
-                    [
-                        "update-locale",
-                        "--locale-file=%s" % locale_conf.strpath,
-                        "LANG=C.UTF-8",
-                    ],
-                    capture=False,
-                )
+                with mock.patch(
+                    "cloudinit.distros.debian.subp.which",
+                    return_value="/usr/sbin/update-locale",
+                ) as m_which:
+                    cc_locale.handle("cc_locale", cfg, cc, [])
+        m_subp.assert_called_with(
+            [
+                "update-locale",
+                "--locale-file=%s" % locale_conf.strpath,
+                "LANG=C.UTF-8",
+            ],
+            capture=False,
+        )
+        m_which.assert_called_once_with("update-locale")
 
 
 class TestLocaleSchema:


### PR DESCRIPTION
### rebase as separate commits

Install the necessary package dependencies (byobu or locales) when cloud-config directives provide configuration requesting setup and config of byobu or locales.


Addresses issues with minimal images not containing byobu or locales packages, yet user-data requests that specific setup and configuration.

## Proposed Commit Message(s)
```
* feat(locale): support locales install on minimal images when cfg requests-


*  feat(byobu): support byobu install on minimal images when cfg requests
```

## Additional Context
Failed jenkins job on ubuntu minimal
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_container-minimal/lastSuccessfulBuild/

## Test Steps
```
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_OS_IMAGE_TYPE=minimal tox -e integration-tests -- --last-failed tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale
```
## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
