### PR TITLE
tests(lxd): avoid failure on multiple calls to --show-log

### DIFF
--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -126,7 +126,8 @@ def verify_clean_boot(
             maybe_list = [value]
         return maybe_list
 
-    traceback_texts = []
+    if ignore_tracebacks is None:
+        ignore_tracebacks = []
     # Define exceptions by matrix of platform and Ubuntu release
     if "azure" == PLATFORM:
         # Consistently on all Azure launches:
@@ -147,17 +148,19 @@ def verify_clean_boot(
         ignore_errors = append_or_create_list(
             ignore_warnings, "Stderr: RTNETLINK answers: File exists"
         )
-        traceback_texts.append("Stderr: RTNETLINK answers: File exists")
+        if isinstance(ignore_tracebacks, list):
+            ignore_tracebacks.append("Stderr: RTNETLINK answers: File exists")
         # LP: #1833446
         ignore_warnings = append_or_create_list(
             ignore_warnings,
             "UrlError: 404 Client Error: Not Found for url: "
             "http://169.254.169.254/latest/meta-data/",
         )
-        traceback_texts.append(
-            "UrlError: 404 Client Error: Not Found for url: "
-            "http://169.254.169.254/latest/meta-data/"
-        )
+        if isinstance(ignore_tracebacks, list):
+            ignore_tracebacks.append(
+                "UrlError: 404 Client Error: Not Found for url: "
+                "http://169.254.169.254/latest/meta-data/"
+            )
         # Oracle has a file in /etc/cloud/cloud.cfg.d that contains
         # users:
         # - default
@@ -168,7 +171,7 @@ def verify_clean_boot(
             ignore_warnings,
             "Unable to disable SSH logins for opc given ssh_redirect_user",
         )
-
+    # Preserve platform-specific tracebacks expected
     _verify_clean_boot(
         instance,
         ignore_deprecations=ignore_deprecations,


### PR DESCRIPTION
Rebase as separate commits

## Proposed Commit Message

```
*  tests(minimal): rsyslog not in minimal images expect warning
    
    Adapt test_no_problems to use verify_clean_boot instead of
    verify_clean_log.
    
    Fix verify_clean_boot to retain platform-specific ignored tracebacks
    before passing it into _verify_clean_boot.

* tests(lxd): avoid failure on multiple calls to --show-log

Cope with repeated calls to lxc console --show-log which exits 1
with the error "no such file or directory" when the log entries
have already been processed and no new log entries exist.

Preserve lxc_log on the client instance and return former log content
on lxd platforms when "no such file or directory" runtime errors are raised
```

## Additional Context
Resolves test_keys_to_console errors seen in https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_container-minimal/lastSuccessfulBuild/#showFailuresLink


## Test Steps
```
 CLOUD_INIT_OS_IMAGE_TYPE=minimal CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_OS_IMAGE_TYPE=minimal CLOUD_INIT_OS_IMAGE=jammy tox -e integration-tests -- --last-failed tests/integration_tests/modules/test_keys_to_console.py
```
## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
