### PR TITLE
Fix arch systemd ordering cycle.

### DIFF
--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -7,10 +7,6 @@ DefaultDependencies=no
 {% endif %}
 Wants=network-pre.target
 After=hv_kvp_daemon.service
-{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
-Requires=dbus.socket
-After=dbus.socket
-{% endif %}
 Before=NetworkManager.service
 {% if variant in ["almalinux", "cloudlinux", "rhel"] %}
 Before=network.service
@@ -25,7 +21,6 @@ Conflicts=shutdown.target
 Before=sysinit.target
 Conflicts=shutdown.target
 {% endif %}
-RequiresMountsFor=/var/lib/cloud
 ConditionPathExists=!/etc/cloud/cloud-init.disabled
 ConditionKernelCommandLine=!cloud-init=disabled
 ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled

--- a/systemd/cloud-init-main.service.tmpl
+++ b/systemd/cloud-init-main.service.tmpl
@@ -23,7 +23,6 @@ Before=sysinit.target
 {% endif %}
 
 After=systemd-remount-fs.service
-Before=sysinit.target
 Before=cloud-init-local.service
 Before=shutdown.target
 Conflicts=shutdown.target

--- a/systemd/cloud-init-main.service.tmpl
+++ b/systemd/cloud-init-main.service.tmpl
@@ -8,18 +8,12 @@
 # https://www.freedesktop.org/software/systemd/man/latest/systemd-remount-fs.service.html
 [Unit]
 Description=Cloud-init: Single Process
-Wants=network-pre.target
 {% if variant in ["almalinux", "cloudlinux", "ubuntu", "unknown", "debian", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
 {% if variant in ["almalinux", "cloudlinux", "rhel"] %}
 Requires=dbus.socket
 After=dbus.socket
-Before=network.service
-Before=firewalld.target
-{% endif %}
-{% if variant in ["ubuntu", "unknown", "debian"] %}
-Before=sysinit.target
 {% endif %}
 
 After=systemd-remount-fs.service


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message

See individual commits. One is a fix for https://github.com/canonical/cloud-init/issues/5755 and the other cleans up redundant dependencies that were introduced in the single process change.


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
