### PR TITLE
fix(smartos): Add `addrconf` IPv6 support

### DIFF
--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -927,6 +927,8 @@ def convert_smartos_network_data(
         for ip in nic.get("ips", []):
             if ip == "dhcp":
                 subnet = {"type": "dhcp4"}
+            elif ip == "addrconf":
+                subnet = {"type": "dhcp6"}
             else:
                 routeents = []
                 subnet = dict(

--- a/tests/unittests/sources/test_smartos.py
+++ b/tests/unittests/sources/test_smartos.py
@@ -1384,7 +1384,7 @@ class TestNetworkConversion(CiTestCase):
                     ],
                     "type": "physical",
                 }
-		],
+            ],
             "version": 1,
         }
         found = convert_net(SDC_NICS_ADDRCONF)

--- a/tests/unittests/sources/test_smartos.py
+++ b/tests/unittests/sources/test_smartos.py
@@ -327,6 +327,30 @@ SDC_NICS_SINGLE_GATEWAY = json.loads(
 """
 )
 
+SDC_NICS_ADDRCONF = json.loads(
+    """
+[
+        {
+          "gateway": "10.64.1.129",
+          "gateways": [
+            "10.64.1.129"
+          ],
+          "interface": "net0",
+          "ip": "10.64.1.130",
+          "ips": [
+            "10.64.1.130/26",
+            "addrconf"
+          ],
+          "mac": "e2:7f:c1:50:eb:99",
+          "model": "virtio",
+          "netmask": "255.255.255.192",
+          "nic_tag": "external",
+          "primary": true,
+          "vlan_id": 20
+        }
+]
+"""
+)
 
 MOCK_RETURNS = {
     "hostname": "test-host",
@@ -1341,6 +1365,29 @@ class TestNetworkConversion(CiTestCase):
             ],
         }
         found = convert_net(SDC_NICS_SINGLE_GATEWAY, routes=routes)
+        self.maxDiff = None
+        self.assertEqual(expected, found)
+
+    def test_ipv6_addrconf(self):
+        expected = {
+            "config": [
+                {
+                    "mac_address": "e2:7f:c1:50:eb:99",
+                    "name": "net0",
+                    "subnets": [
+                        {
+                            "address": "10.64.1.130/26",
+                            "gateway": "10.64.1.129",
+                            "type": "static",
+                        },
+                        {"type": "dhcp6"},
+                    ],
+                    "type": "physical",
+                }
+		],
+            "version": 1,
+        }
+        found = convert_net(SDC_NICS_ADDRCONF)
         self.maxDiff = None
         self.assertEqual(expected, found)
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -27,6 +27,7 @@ berolinux
 bin456789
 bipinbachhao
 BirknerAlex
+blackhelicoptersdotnet
 bmhughes
 brianphaley
 BrinKe-dev


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(smartos): Add `addrconf` IPv6 support

SmartOS uses `addrconf` as a special value to indicate that an IPv6
address should be obtained via DHCPv6 or SLAAC. cloud-init does not
know how to handle this.

Added logic to DataSourceSmartOS.py to properly recognise and handle
this value.
```

## Additional Context
<!-- If relevant -->
The vendor's documentation describes how this is supposed to work.

https://docs.smartos.org/setting-up-ipv6-in-a-zone/

This works fine for native and lx-branded zones (where network configuration is handled by other means), but not for KVM or Bhyve zones in which `cloud-init` is expected to perform the appropriate configuration. 

Before this change, `addrconf` would be passed through to `cloud-init` as a static address, causing errors.

```
# cloud-init status -l
status: error
extended_status: error
boot_status_code: enabled-by-generator
last_update: Mon, 21 Oct 2024 00:52:15 +0000
detail:
Cloud-init enabled by systemd cloud-init-generator
errors:
	- Address addrconf is not a valid ip address
	- Address addrconf is not a valid ip address
recoverable_errors:
ERROR:
	- Address addrconf is not a valid ip network
	- Address addrconf is not a valid ip network
WARNING:
	- failed stage init
	- failed stage init-local
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

1. On a SmartOS host, follow the [vendor's documentation](https://docs.smartos.org/setting-up-ipv6-in-a-zone/) to create a `bhyve` or `kvm` zone with the `addrconf` keyword in the NIC configuration.

2. On the guest, check to see that an IPv6 address was autoconfigured. 

```
# ip addr
[...]
2: net0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether e2:7f:c1:50:eb:99 brd ff:ff:ff:ff:ff:ff
    altname enp0s6
    inet 10.64.1.130/26 brd 10.64.1.191 scope global noprefixroute net0
       valid_lft forever preferred_lft forever
    inet6 2001:0db8::a8ac:2e5d:33d9:fdcd/128 scope global noprefixroute
       valid_lft forever preferred_lft forever
    inet6 2001:0db8::e07f:c1ff:fe50:eb99/64 scope global dynamic noprefixroute
       valid_lft 2591950sec preferred_lft 604750sec
    inet6 fe80::e07f:c1ff:fe50:eb99/64 scope link noprefixroute
       valid_lft forever preferred_lft forever
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
