### PR TITLE
feat(ec2): support not materialize meta data item in cfg

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -545,6 +545,9 @@ class DataSourceEc2(sources.DataSource):
         """
         if not self.wait_for_metadata_service():
             return {}
+        ignore_items_meta_data = util.get_cfg_by_path(
+            self.sys_cfg, ("ignore_items_meta_data",), []
+        )
         api_version = self.get_metadata_api_version()
         redact = self.imdsv2_token_redact
         crawled_metadata = {}
@@ -573,6 +576,7 @@ class DataSourceEc2(sources.DataSource):
                 headers_redact=redact,
                 exception_cb=exc_cb,
                 retrieval_exception_ignore_cb=skip_cb,
+                ignore_items=ignore_items_meta_data,
             )
             if self.cloud_name == CloudNames.AWS:
                 identity = ec2.get_instance_identity(


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(ec2): configure meta data item in cfg to not materialize

Cloud vendors provide a lot of information in meta data,but some of the
information may not be needed by cloudinit. When iterating through the 
materialization function (helpers/ec2.py), it may need to be ignored,
such as security-credentials in the previous code. We would like to
provide a configuration item to configure the allowable field name to
be ignored. This can save cloudinit startup time when there is a large
amount of data that can be ignored. One case is that in the meta data
provided by Alibaba Cloud, there is a disks item that contains
information about the disks on the instance, but cloudinit does not use
it. When there are a large number of disks in the metadata data, this
can cause many unnecessary HTTP access. This feature allows users to 
ignore accessing some unused data
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
