### PR TITLE
fix: disable grub-dpkg by default

### DIFF
--- a/cloudinit/config/cc_grub_dpkg.py
+++ b/cloudinit/config/cc_grub_dpkg.py
@@ -24,7 +24,7 @@ meta: MetaSchema = {
     "id": "cc_grub_dpkg",
     "distros": ["ubuntu", "debian"],
     "frequency": PER_INSTANCE,
-    "activate_by_schema_keys": [],
+    "activate_by_schema_keys": ["grub_dpkg", "grub-dpkg"],
 }
 
 LOG = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if not mycfg:
         mycfg = {}
 
-    enabled = mycfg.get("enabled", True)
+    enabled = mycfg.get("enabled", False)
     if util.is_false(enabled):
         LOG.debug("%s disabled by config grub_dpkg/enabled=%s", name, enabled)
         return

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1611,8 +1611,8 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "default": true,
-              "description": "Whether to configure which device is used as the target for grub installation. Default: ``true``."
+              "default": false,
+              "description": "Whether to configure which device is used as the target for grub installation. Default: ``false``."
             },
             "grub-pc/install_devices": {
               "type": "string",

--- a/tests/unittests/config/test_cc_grub_dpkg.py
+++ b/tests/unittests/config/test_cc_grub_dpkg.py
@@ -248,7 +248,7 @@ class TestHandle:
         """Test setting of correct debconf database entries"""
         m_is_efi_booted.return_value = is_uefi
         m_fetch_idevs.return_value = fetch_idevs_output
-        cfg = {"grub_dpkg": {}}
+        cfg = {"grub_dpkg": {"enabled": True}}
         if cfg_idevs is not None:
             cfg["grub_dpkg"]["grub-pc/install_devices"] = cfg_idevs
         if cfg_idevs_empty is not None:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
```
fix: disable grub-dpkg by default
```

## Additional Context
It is no longer used by grub packaging.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
