### PR TITLE
feat(vultr): add override for network interface detection

### DIFF
--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -77,7 +77,6 @@ def get_interface_list():
                     ifaces.append(iface)
     except Exception as e:
         LOG.error("find_candidate_nics script exception: %s", e)
-        pass
 
     if len(ifaces) == 0:
         for iface in net.find_candidate_nics():

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -4,6 +4,7 @@
 
 import json
 import logging
+import os
 from functools import lru_cache
 
 from requests import exceptions
@@ -60,12 +61,30 @@ def refactor_metadata(metadata):
 
 # Get interface list, sort, and clean
 def get_interface_list():
+    # Check for the presence of a "find_candidate_nics.sh" shell script on the
+    # running guest image. Use that as an optional source of truth before
+    # falling back to "net.find_candidate_nics()". This allows the Vultr team
+    # to provision machines with niche hardware configurations at the same
+    # cadence as image rollouts.
     ifaces = []
-    for iface in net.find_candidate_nics():
-        # Skip dummy
-        if "dummy" in iface:
-            continue
-        ifaces.append(iface)
+    try:
+        nic_script = "/opt/vultr/find_candidate_nics.sh"
+        if os.path.exists(nic_script):
+            out = subp.subp(nic_script, capture=True, shell=True)
+            for line in out.stdout.splitlines():
+                iface = line.strip()
+                if len(iface) > 0:
+                    ifaces.append(iface)
+    except Exception as e:
+        LOG.error("find_candidate_nics script exception: %s", e)
+        pass
+
+    if len(ifaces) == 0:
+        for iface in net.find_candidate_nics():
+            # Skip dummy
+            if "dummy" in iface:
+                continue
+            ifaces.append(iface)
 
     return ifaces
 

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -15,6 +15,7 @@ andgein
 andrew-lee-metaswitch
 andrewbogott
 andrewlukoshko
+andy191x
 ani-sinha
 antonyc
 apollo13


### PR DESCRIPTION
## Proposed Commit Message

```
feat(vultr): add override for network interface detection (#5847)
```

## Additional Context

The purpose of this feature is to provide the Vultr team with a way to define custom NIC lists to scan for metadata. This is particularly useful when dealing with niche hardware deployments.

The feature checks for the presence of an `/opt/vultr/find_candidate_nics.sh` shell script on the running guest image. If detected, DataSourceVultr uses that as an optional source of truth before falling back to `net.find_candidate_nics()`.

## Test Steps

This feature was tested manually on Vultr's Ubuntu 22.04 and Ubuntu 24.04 images (as of 10/2024).

The added functionality is low risk, as it is both opt-in and limited to the Vultr cloud.

```
cp vultr.py /usr/lib/python3/dist-packages/cloudinit/sources/helpers/vultr.py
cloud-init clean -r
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
