### PR TITLE
Support networkd RequiredForOnline option

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v2.json
+++ b/cloudinit/config/schemas/schema-network-config-v2.json
@@ -103,6 +103,10 @@
         "gateway6": {
           "$ref": "#/$defs/gateway"
         },
+        "optional": {
+          "type": "boolean",
+          "description": "Not required for online, false by default"
+        },
         "mtu": {
           "type": "integer",
           "description": "The MTU key represents a device\u2019s Maximum Transmission Unit, the largest size packet or frame, specified in octets (eight-bit bytes), that can be sent in a packet- or frame-based network. Specifying mtu is optional."

--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -47,6 +47,7 @@ NETWORK_V2_KEY_FILTER = [
     "set-name",
     "wakeonlan",
     "accept-ra",
+    "optional",
 ]
 
 NET_CONFIG_TO_V2: Dict[str, Dict[str, Any]] = {
@@ -409,6 +410,9 @@ class NetworkStateInterpreter:
         wakeonlan = command.get("wakeonlan", None)
         if wakeonlan is not None:
             wakeonlan = util.is_true(wakeonlan)
+        optional = command.get("optional", None)
+        if optional is not None:
+            optional = util.is_true(optional)
         iface.update(
             {
                 "config_id": command.get("config_id"),
@@ -423,6 +427,7 @@ class NetworkStateInterpreter:
                 "subnets": subnets,
                 "accept-ra": accept_ra,
                 "wakeonlan": wakeonlan,
+                "optional": optional,
             }
         )
         iface_key = command.get("config_id", command.get("name"))
@@ -747,7 +752,7 @@ class NetworkStateInterpreter:
             driver = match.get("driver", None)
             if driver:
                 phy_cmd["params"] = {"driver": driver}
-            for key in ["mtu", "match", "wakeonlan", "accept-ra"]:
+            for key in ["mtu", "match", "wakeonlan", "accept-ra", "optional"]:
                 if key in cfg:
                     phy_cmd[key] = cfg[key]
 

--- a/cloudinit/net/networkd.py
+++ b/cloudinit/net/networkd.py
@@ -122,6 +122,9 @@ class Renderer(renderer.Renderer):
         if "mtu" in iface and iface["mtu"]:
             cfg.update_section(sec, "MTUBytes", iface["mtu"])
 
+        if "optional" in iface and iface["optional"]:
+            cfg.update_section(sec, "RequiredForOnline", "no")
+
     def parse_routes(self, rid, conf, cfg: CfgParser):
         """
         Parse a route and use rid as a key in order to isolate the route from

--- a/doc/rtd/reference/network-config-format-v2.rst
+++ b/doc/rtd/reference/network-config-format-v2.rst
@@ -264,6 +264,14 @@ The MTU key represents a device's Maximum Transmission Unit, the largest size
 packet or frame, specified in octets (eight-bit bytes), that can be sent in a
 packet- or frame-based network. Specifying ``mtu`` is optional.
 
+``optional: <(bool)>``
+------------------------
+
+Mark a device as not required for booting. By default networkd will wait for
+all configured interfaces to be configured before continuing to boot. This
+option causes networkd to not wait for the interface. This is only supported
+by networkd. The default is false.
+
 ``nameservers: <(mapping)>``
 ----------------------------
 


### PR DESCRIPTION
Implement the "optional" ethernet interface property from NetPlan for the networkd renderer. Marks an interface as not required for the network-online target using the RequiredForOnline=no Link property.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(networkd): Support RequiredForOnline link option

This allows an administrator to specify that an interface may not be available at
boot time, so we can avoid hanging while we wait for a configuration that might
never happen.

```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Using the networkd renderer, add an optional: true property to an interface. See that networkd no longer blocks the boot waiting for it to be configured.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
