### PR TITLE
migrate away from deprecation warnings

### DIFF
--- a/cloudinit/analyze/__init__.py
+++ b/cloudinit/analyze/__init__.py
@@ -5,7 +5,7 @@
 import argparse
 import re
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import IO
 
 from cloudinit.analyze import dump, show
@@ -128,9 +128,11 @@ def analyze_boot(name, args):
     infh, outfh = configure_io(args)
     kernel_info = show.dist_check_timestamp()
     status_code, kernel_start, kernel_end, ci_sysd_start = kernel_info
-    kernel_start_timestamp = datetime.utcfromtimestamp(kernel_start)
-    kernel_end_timestamp = datetime.utcfromtimestamp(kernel_end)
-    ci_sysd_start_timestamp = datetime.utcfromtimestamp(ci_sysd_start)
+    kernel_start_timestamp = datetime.fromtimestamp(kernel_start, timezone.utc)
+    kernel_end_timestamp = datetime.fromtimestamp(kernel_end, timezone.utc)
+    ci_sysd_start_timestamp = datetime.fromtimestamp(
+        ci_sysd_start, timezone.utc
+    )
     try:
         last_init_local = [
             e
@@ -138,7 +140,9 @@ def analyze_boot(name, args):
             if e["name"] == "init-local"
             and "starting search" in e["description"]
         ][-1]
-        ci_start = datetime.utcfromtimestamp(last_init_local["timestamp"])
+        ci_start = datetime.fromtimestamp(
+            last_init_local["timestamp"], timezone.utc
+        )
     except IndexError:
         ci_start = "Could not find init-local log-line in cloud-init.log"
         status_code = show.FAIL_CODE

--- a/cloudinit/analyze/show.py
+++ b/cloudinit/analyze/show.py
@@ -85,7 +85,9 @@ def event_timestamp(event):
 
 
 def event_datetime(event):
-    return datetime.datetime.utcfromtimestamp(event_timestamp(event))
+    return datetime.datetime.fromtimestamp(
+        event_timestamp(event), datetime.timezone.utc
+    )
 
 
 def delta_seconds(t1, t2):

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -10,7 +10,7 @@ import struct
 import threading
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from threading import Event
 from typing import Union
 
@@ -375,7 +375,9 @@ class HyperVKvpReportingHandler(ReportingHandler):
             "name": event.name,
             "type": event.event_type,
             "ts": (
-                datetime.utcfromtimestamp(event.timestamp).isoformat() + "Z"
+                datetime.fromtimestamp(
+                    event.timestamp, timezone.utc
+                ).isoformat()
             ),
         }
         if hasattr(event, self.RESULT_KEY):

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -213,14 +213,14 @@ def _has_expired(public_key):
         return False
 
     expire_str = json_obj["expireOn"]
-    format_str = "%Y-%m-%dT%H:%M:%S+0000"
+    format_str = "%Y-%m-%dT%H:%M:%S%z"
     try:
         expire_time = datetime.datetime.strptime(expire_str, format_str)
     except ValueError:
         return False
 
     # Expire the key if and only if we have exceeded the expiration timestamp.
-    return datetime.datetime.utcnow() > expire_time
+    return datetime.datetime.now(datetime.timezone.utc) > expire_time
 
 
 def _parse_public_keys(public_keys_data, default_user=None):

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -6,7 +6,7 @@ import base64
 import csv
 import logging
 import traceback
-from datetime import datetime
+from datetime import datetime, timezone
 from io import StringIO
 from typing import Any, Dict, List, Optional, Tuple
 from xml.etree import ElementTree as ET  # nosec B405
@@ -52,7 +52,7 @@ class ReportableError(Exception):
         else:
             self.supporting_data = {}
 
-        self.timestamp = datetime.utcnow()
+        self.timestamp = datetime.now(timezone.utc)
 
         try:
             self.vm_id = identity.query_vm_id()

--- a/cloudinit/sources/azure/kvp.py
+++ b/cloudinit/sources/azure/kvp.py
@@ -3,7 +3,7 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 from cloudinit import version
@@ -49,7 +49,7 @@ def report_success_to_host() -> bool:
         [
             "result=success",
             f"agent=Cloud-Init/{version.version_string()}",
-            f"timestamp={datetime.utcnow().isoformat()}",
+            f"timestamp={datetime.now(timezone.utc).isoformat()}",
             f"vm_id={vm_id}",
         ]
     )

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -1013,7 +1013,7 @@ class OvfEnvXml:
             raise errors.ReportableErrorOvfParsingException(exception=e) from e
 
         # If there's no provisioning section, it's not Azure ovf-env.xml.
-        if not root.find("./wa:ProvisioningSection", cls.NAMESPACES):
+        if root.find("./wa:ProvisioningSection", cls.NAMESPACES) is None:
             raise NonAzureDataSource(
                 "Ignoring non-Azure ovf-env.xml: ProvisioningSection not found"
             )

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -10,7 +10,7 @@ import re
 import textwrap
 import zlib
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from time import sleep, time
 from typing import Callable, List, Optional, TypeVar, Union
 from xml.etree import ElementTree as ET  # nosec B405
@@ -122,9 +122,11 @@ def get_boot_telemetry():
         "boot-telemetry",
         "kernel_start=%s user_start=%s cloudinit_activation=%s"
         % (
-            datetime.utcfromtimestamp(kernel_start).isoformat() + "Z",
-            datetime.utcfromtimestamp(user_start).isoformat() + "Z",
-            datetime.utcfromtimestamp(cloudinit_activation).isoformat() + "Z",
+            datetime.fromtimestamp(kernel_start, timezone.utc).isoformat(),
+            datetime.fromtimestamp(user_start, timezone.utc).isoformat(),
+            datetime.fromtimestamp(
+                cloudinit_activation, timezone.utc
+            ).isoformat(),
         ),
         events.DEFAULT_EVENT_ORIGIN,
     )

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -330,7 +330,9 @@ class _LxdIntegrationCloud(IntegrationCloud):
         except KeyError:
             profile_list = self._get_or_set_profile_list(release)
 
-        prefix = datetime.datetime.utcnow().strftime("cloudinit-%m%d-%H%M%S")
+        prefix = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "cloudinit-%m%d-%H%M%S"
+        )
         default_name = prefix + "".join(
             random.choices(string.ascii_lowercase + string.digits, k=8)
         )

--- a/tests/integration_tests/test_paths.py
+++ b/tests/integration_tests/test_paths.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Iterator
 
 import pytest
@@ -66,7 +66,11 @@ class TestHonorCloudDir:
         found_logs = custom_client.execute(
             "tar -tf cloud-init.tar.gz"
         ).stdout.splitlines()
-        dirname = datetime.utcnow().date().strftime("cloud-init-logs-%Y-%m-%d")
+        dirname = (
+            datetime.now(timezone.utc)
+            .date()
+            .strftime("cloud-init-logs-%Y-%m-%d")
+        )
         expected_logs = [
             f"{dirname}/",
             f"{dirname}/dmesg.txt",
@@ -98,7 +102,11 @@ class TestHonorCloudDir:
         found_logs = custom_client.execute(
             "tar -tf cloud-init.tar.gz"
         ).stdout.splitlines()
-        dirname = datetime.utcnow().date().strftime("cloud-init-logs-%Y-%m-%d")
+        dirname = (
+            datetime.now(timezone.utc)
+            .date()
+            .strftime("cloud-init-logs-%Y-%m-%d")
+        )
         assert f"{dirname}/new-cloud-dir/data/result.json" in found_logs
 
     # LXD inserts some agent setup code into VMs on Bionic under

--- a/tests/unittests/cmd/devel/test_logs.py
+++ b/tests/unittests/cmd/devel/test_logs.py
@@ -3,6 +3,7 @@
 import glob
 import os
 import pathlib
+import sys
 import tarfile
 from datetime import datetime, timezone
 
@@ -140,8 +141,12 @@ class TestCollectLogs:
         )
         extract_to = tmp_path / "extracted"
         extract_to.mkdir()
+
+        tar_kwargs = {}
+        if sys.version_info > (3, 11):
+            tar_kwargs = {"filter": "fully_trusted"}
         with tarfile.open(tmp_path / "cloud-init.tar.gz") as tar:
-            tar.extractall(extract_to)
+            tar.extractall(extract_to, **tar_kwargs)  # type: ignore[arg-type]
         extracted_dir = extract_to / f"cloud-init-logs-{today}"
 
         for name in to_collect:

--- a/tests/unittests/config/test_cc_ubuntu_pro.py
+++ b/tests/unittests/config/test_cc_ubuntu_pro.py
@@ -1,4 +1,5 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+import importlib.metadata
 import json
 import logging
 import re
@@ -447,13 +448,10 @@ class TestUbuntuProSchema:
                         " Use **ubuntu_pro** instead"
                     ),
                 ),
-                # If __version__ no longer exists on jsonschema, that means
-                # we're using a high enough version of jsonschema to not need
-                # to skip this test.
                 (
                     JSONSCHEMA_SKIP_REASON
                     if lifecycle.Version.from_str(
-                        getattr(jsonschema, "__version__", "999")
+                        importlib.metadata.version("jsonschema")
                     )
                     < lifecycle.Version(4)
                     else ""

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -20,9 +20,9 @@ def agent_string():
 
 @pytest.fixture()
 def fake_utcnow():
-    timestamp = datetime.datetime.utcnow()
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
     with mock.patch.object(errors, "datetime", autospec=True) as m:
-        m.utcnow.return_value = timestamp
+        m.now.return_value = timestamp
         yield timestamp
 
 

--- a/tests/unittests/sources/azure/test_kvp.py
+++ b/tests/unittests/sources/azure/test_kvp.py
@@ -1,6 +1,6 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest import mock
 
 import pytest
@@ -11,9 +11,9 @@ from cloudinit.sources.azure import errors, kvp
 
 @pytest.fixture()
 def fake_utcnow():
-    timestamp = datetime.utcnow()
+    timestamp = datetime.now(timezone.utc)
     with mock.patch.object(kvp, "datetime", autospec=True) as m:
-        m.utcnow.return_value = timestamp
+        m.now.return_value = timestamp
         yield timestamp
 
 

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -315,7 +315,7 @@ def mock_subp_subp():
 
 @pytest.fixture
 def mock_timestamp():
-    timestamp = datetime.datetime.utcnow()
+    timestamp = datetime.datetime.now(datetime.timezone.utc)
     with mock.patch.object(errors, "datetime", autospec=True) as m:
         m.utcnow.return_value = timestamp
         yield timestamp

--- a/tests/unittests/sources/test_gce.py
+++ b/tests/unittests/sources/test_gce.py
@@ -341,8 +341,8 @@ class TestDataSourceGCE(test_helpers.ResponsesTestCase):
 
     def test_has_expired(self):
         def _get_timestamp(days):
-            format_str = "%Y-%m-%dT%H:%M:%S+0000"
-            today = datetime.datetime.now()
+            format_str = "%Y-%m-%dT%H:%M:%S%z"
+            today = datetime.datetime.now(datetime.timezone.utc)
             timestamp = today + datetime.timedelta(days=days)
             return timestamp.strftime(format_str)
 

--- a/tests/unittests/test_log.py
+++ b/tests/unittests/test_log.py
@@ -45,9 +45,22 @@ class TestCloudInitLogger(CiTestCase):
         # parsed dt : 2017-08-23 14:19:43.069000
         # utc_after : 2017-08-23 14:19:43.570064
 
-        utc_before = datetime.datetime.utcnow() - datetime.timedelta(0, 0.5)
+        def remove_tz(_dt: datetime.datetime) -> datetime.datetime:
+            """
+            Removes the timezone object from an aware datetime dt without
+            conversion of date and time data
+            """
+            return _dt.replace(tzinfo=None)
+
+        utc_before = remove_tz(
+            datetime.datetime.now(datetime.timezone.utc)
+            - datetime.timedelta(0, 0.5)
+        )
         self.LOG.error("Test message")
-        utc_after = datetime.datetime.utcnow() + datetime.timedelta(0, 0.5)
+        utc_after = remove_tz(
+            datetime.datetime.now(datetime.timezone.utc)
+            + datetime.timedelta(0, 0.5)
+        )
 
         # extract timestamp from log:
         # 2017-08-23 14:19:43,069 - test_log.py[ERROR]: Test message


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->

<!--
## Proposed Commit Message
 Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore

```
<type>(optional scope): <summary>  # no more than 72 characters

A description of what the change being made is and why it is being
made if the summary line is insufficient.  This should be wrapped at
72 characters.

If you need to write multiple paragraphs, feel free.

Fixes GH-NNNNN (GitHub Issue number. Remove line if irrelevant)
LP: #NNNNNN (Launchpad bug number. Remove line if irrelevant)
```
-->
## Rebase & merge
See individual commits

Fixes GH-5175


## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/issues/5855 was discovered while working on this issue. I decided to split it as a separate work item, because it requires a broader discussion.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
make deb

export CLOUD_INIT_KEEP_INSTANCE=true
export CLOUD_INIT_CLOUD_INIT_SOURCE=./cloud-init_all.deb

export CLOUD_INIT_PLATFORM=lxd_vm
export CLOUD_INIT_OS_IMAGE=oracular
tox -v -e integration-tests-jenkins -- -vvv --pdb tests/integration_tests/test_paths.py

export CLOUD_INIT_PLATFORM=lxd_vm
export CLOUD_INIT_OS_IMAGE=focal
tox -v -e integration-tests-jenkins -- -vvv --pdb tests/integration_tests/test_paths.py

export CLOUD_INIT_PLATFORM=gce
export CLOUD_INIT_OS_IMAGE=focal
tox -v -e integration-tests-jenkins -- -vvv --pdb tests/integration_tests/modules/test_combined.py

export CLOUD_INIT_PLATFORM=gce
export CLOUD_INIT_OS_IMAGE=oracular
tox -v -e integration-tests-jenkins -- -vvv --pdb tests/integration_tests/modules/test_combined.py

export CLOUD_INIT_PLATFORM=azure
export CLOUD_INIT_OS_IMAGE=focal
tox -v -e integration-tests-jenkins -- -vvv --pdb tests/integration_tests/modules/test_combined.py

export CLOUD_INIT_PLATFORM=azure
export CLOUD_INIT_OS_IMAGE=oracular
tox -v -e integration-tests-jenkins -- -vvv --pdb tests/integration_tests/modules/test_combined.py
```

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
