### PR TITLE
Drop noop clean-up of cloud-init/* debconf values

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -20,6 +20,8 @@ cloud-init (24.4~4gc9dce94d-0ubuntu1) UNRELEASED; urgency=medium
     + Add warning about image portability to dpkg-reconfigure.
   * d/NEWS: add news about cloud-specific packages
   * d/po/templates.pot and cloud-init.templates: enable CloudCIX by default.
+  * d/cloud-init-base.{config,postinst}:
+    + Drop noop clean-up of cloud-init/* debconf values
 
  -- Alberto Contreras <alberto.contreras@canonical.com>  Fri, 27 Sep 2024 10:10:16 +0200
 

--- a/debian/cloud-init-base.config
+++ b/debian/cloud-init-base.config
@@ -45,7 +45,6 @@ get_yaml_list() {
 }
 
 # Migrate a debconf value from cloud-init/* to cloud-init-base/*
-# cleaning up the old value.
 #
 # Arguments:
 #   Name of the debconf question
@@ -53,10 +52,6 @@ migrate_debconf_to_cloud_init_base() {
     local old="cloud-init/$1" new="cloud-init-base/$1"
     if db_get "$new"; then
        # cloud-init-base/* win against cloud-init/* values
-       if db_get "$old"; then
-          echo "Removing ${old} in favor of ${new}" 1>&2 || :
-          db_unregister "$old" || :
-       fi
        return 0
     fi
     if db_get "$old"; then

--- a/debian/cloud-init-base.postinst
+++ b/debian/cloud-init-base.postinst
@@ -251,7 +251,6 @@ rename_hook_hotplug_udev_rule() {
 }
 
 # Migrate a debconf value from cloud-init/* to cloud-init-base/*
-# cleaning up the old value.
 #
 # Arguments:
 #   Name of the debconf question
@@ -259,10 +258,6 @@ migrate_debconf_to_cloud_init_base() {
     local old="cloud-init/$1" new="cloud-init-base/$1"
     if db_get "$new"; then
        # cloud-init-base/* win against cloud-init/* values
-       if db_get "$old"; then
-          echo "Removing ${old} in favor of ${new}" 1>&2 || :
-          db_unregister "$old" || :
-       fi
        return 0
     fi
     if db_get "$old"; then


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Do not squash

See individual commits for reference.

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
