### PR TITLE
test: Allow unknown size in growpart test

### DIFF
--- a/tests/integration_tests/modules/test_growpart.py
+++ b/tests/integration_tests/modules/test_growpart.py
@@ -62,7 +62,7 @@ class TestGrowPart:
         log = client.read_from_file("/var/log/cloud-init.log")
         assert (
             "cc_growpart.py[INFO]: '/dev/sdb1' resized:"
-            " changed (/dev/sdb1) from" in log
+            " changed (/dev/sdb1)" in log
         )
 
         lsblk = json.loads(client.execute("lsblk --json"))


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: Allow unknown size in growpart test
```

## Additional Context
The test occasionally fails because it could not properly determine the sizes.

Relevant logs:
```
2024-11-14 20:57:53,534 - handlers.py[DEBUG]: start: init-network/config-growpart: running config-growpart with frequency always
2024-11-14 20:57:53,534 - helpers.py[DEBUG]: Running config-growpart using lock (<cloudinit.helpers.DummyLock object at 0x7fa841cbdeb0>)
2024-11-14 20:57:53,535 - subp.py[DEBUG]: Running command ['growpart', '--help'] with allowed return codes [0] (shell=False, capture=True)
2024-11-14 20:57:53,546 - performance.py[DEBUG]: Running ['growpart', '--help'] took 0.011 seconds
2024-11-14 20:57:53,547 - util.py[DEBUG]: Reading from /proc/505/mountinfo (quiet=False)
2024-11-14 20:57:53,547 - util.py[DEBUG]: Reading 3422 bytes from /proc/505/mountinfo
2024-11-14 20:57:53,547 - cc_growpart.py[DEBUG]: growpart found fs=ext4
2024-11-14 20:57:53,547 - util.py[DEBUG]: Reading from /sys/class/block/sda1/partition (quiet=False)
2024-11-14 20:57:53,547 - util.py[DEBUG]: Reading 2 bytes from /sys/class/block/sda1/partition
2024-11-14 20:57:53,547 - util.py[DEBUG]: Reading from /sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/virtio6/host0/target0:0:0/0:0:0:1/block/sda/dev (quiet=False)
2024-11-14 20:57:53,547 - util.py[DEBUG]: Reading 4 bytes from /sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/virtio6/host0/target0:0:0/0:0:0:1/block/sda/dev
2024-11-14 20:57:53,548 - util.py[DEBUG]: Reading from /proc/505/mountinfo (quiet=False)
2024-11-14 20:57:53,548 - util.py[DEBUG]: Reading 3422 bytes from /proc/505/mountinfo
2024-11-14 20:57:53,548 - util.py[DEBUG]: Reading from /proc/505/mountinfo (quiet=False)
2024-11-14 20:57:53,548 - util.py[DEBUG]: Reading 3422 bytes from /proc/505/mountinfo
2024-11-14 20:57:53,552 - subp.py[DEBUG]: Running command ['growpart', '--dry-run', '/dev/sda', '1'] with allowed return codes [0] (shell=False, capture=True)
2024-11-14 20:57:53,600 - performance.py[DEBUG]: Running ['growpart', '--dry-run', '/dev/sda', '1'] took 0.048 seconds
2024-11-14 20:57:53,601 - cc_growpart.py[DEBUG]: growpart found fs=None
2024-11-14 20:57:53,604 - util.py[DEBUG]: Reading from /sys/class/block/sdb1/partition (quiet=False)
2024-11-14 20:57:53,604 - util.py[DEBUG]: Reading 2 bytes from /sys/class/block/sdb1/partition
2024-11-14 20:57:53,604 - util.py[DEBUG]: Reading from /sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/virtio6/host0/target0:0:1/0:0:1:1/block/sdb/dev (quiet=False)
2024-11-14 20:57:53,604 - util.py[DEBUG]: Reading 5 bytes from /sys/devices/pci0000:00/0000:00:01.1/0000:02:00.0/virtio6/host0/target0:0:1/0:0:1:1/block/sdb/dev
2024-11-14 20:57:53,604 - util.py[DEBUG]: Reading from /proc/505/mountinfo (quiet=False)
2024-11-14 20:57:53,604 - util.py[DEBUG]: Reading 3422 bytes from /proc/505/mountinfo
2024-11-14 20:57:53,605 - util.py[DEBUG]: Reading from /proc/505/mountinfo (quiet=False)
2024-11-14 20:57:53,605 - util.py[DEBUG]: Reading 3422 bytes from /proc/505/mountinfo
2024-11-14 20:57:53,606 - subp.py[DEBUG]: Running command ['growpart', '--dry-run', '/dev/sdb', '1'] with allowed return codes [0] (shell=False, capture=True)
2024-11-14 20:57:53,655 - performance.py[DEBUG]: Running ['growpart', '--dry-run', '/dev/sdb', '1'] took 0.048 seconds
2024-11-14 20:57:53,655 - subp.py[DEBUG]: Running command ['growpart', '/dev/sdb', '1'] with allowed return codes [0] (shell=False, capture=True)
2024-11-14 20:57:53,976 - performance.py[DEBUG]: Running ['growpart', '/dev/sdb', '1'] took 0.320 seconds
2024-11-14 20:57:53,976 - performance.py[DEBUG]: Resizing devices took 0.430 seconds
2024-11-14 20:57:53,977 - cc_growpart.py[DEBUG]: '/' NOCHANGE: no change necessary (/dev/sda, 1)
2024-11-14 20:57:53,977 - cc_growpart.py[INFO]: '/dev/sdb1' resized: changed (/dev/sdb1) size, new size is unknown
2024-11-14 20:57:53,977 - handlers.py[DEBUG]: finish: init-network/config-growpart: SUCCESS: config-growpart ran successfully and took 0.442 seconds
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
