### PR TITLE
Fix metric setting of nmconnection for rhel

### DIFF
--- a/cloudinit/net/network_manager.py
+++ b/cloudinit/net/network_manager.py
@@ -237,6 +237,10 @@ class NMConnection:
         value = subnet["address"] + "/" + str(subnet["prefix"])
         self._add_numbered(family, "address", value)
 
+    def _is_default_route(self, route):
+        default_nets = ("::", "0.0.0.0")
+        return route["prefix"] == 0 and route["network"] in default_nets
+
     def _add_route(self, route):
         """Adds a ipv[46].route<n> property."""
         # Because network v2 route definitions can have mixed v4 and v6
@@ -245,6 +249,11 @@ class NMConnection:
         value = f'{route["network"]}/{route["prefix"]}'
         if "gateway" in route:
             value += f',{route["gateway"]}'
+        if "metric" in route:
+            if self._is_default_route(route):
+                self.config[family]["route-metric"] = f'{route["metric"]}'
+            else:
+                value += f',{route["metric"]}'
         route_key = self._get_next_numbered_section(family, "route")
         self.config[family][route_key] = value
         if "mtu" in route:

--- a/tests/unittests/net/network_configs.py
+++ b/tests/unittests/net/network_configs.py
@@ -249,6 +249,7 @@ NETWORK_CONFIGS = {
                 method=auto
                 may-fail=false
                 address1=192.168.21.3/24
+                route-metric=10000
                 route1=0.0.0.0/0,65.61.151.37
                 dns=8.8.8.8;8.8.4.4;
                 dns-search=barley.maas;sach.maas;
@@ -420,6 +421,7 @@ NETWORK_CONFIGS = {
                 [ipv4]
                 method=auto
                 may-fail=false
+                route-metric=10000
                 route1=0.0.0.0/0,65.61.151.37
                 address1=192.168.21.3/24
                 dns=8.8.8.8;8.8.4.4;
@@ -3372,7 +3374,7 @@ iface bond0 inet6 static
                 may-fail=false
                 address1=2001:1::1/92
                 route1=2001:67c::/32,2001:67c:1562::1
-                route2=3001:67c::/32,3001:67c:15::1
+                route2=3001:67c::/32,3001:67c:15::1,10000
 
                 [ethernet]
                 mtu=9000
@@ -3725,7 +3727,7 @@ iface bond0 inet6 static
 
                 [ipv6]
                 route1=2001:67c::/32,2001:67c:1562::1
-                route2=3001:67c::/32,3001:67c:15::1
+                route2=3001:67c::/32,3001:67c:15::1,10000
                 method=manual
                 may-fail=false
                 address1=2001:1::1/92


### PR DESCRIPTION
Most RHEL systems use network manager to bring up manage network connections. 
Network Manager uses route-metric for the default route and route/plen[,gateway,metric] for the additional static routes, please see
https://networkmanager.dev/docs/api/latest/nm-settings-nmcli.html 
https://networkmanager.dev/docs/api/latest/nm-settings-keyfile.html

This changes ensures that cloud-init generates nmconnection files with route metric settings that are compatible with RHEL and network manager.

Fixes: GH-5877

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->

## Test steps

For the config data
```
#cloud-config

network:
  version: 1
  config:
    - type: physical
      name: enp1s0
      subnets:
      - type: static
        address: 10.0.2.2/24
        gateway: 10.0.2.1
        routes:
          - destination: 0.0.0.0/0
            gateway: 10.0.2.1
            metric: 99
          - destination: 192.168.122.1/24
            gateway: 10.0.2.1
            metric: 98
```
After this changes the nmconnetion file looks as below
```
# cat /etc/NetworkManager/system-connections/cloud-init-enp1s0.nmconnection
# Generated by cloud-init. Changes will be lost.

[connection]
id=cloud-init enp1s0
uuid=a41601f3-3acc-5f60-ac5f-9d9011ab7c25
autoconnect-priority=120
type=ethernet
interface-name=enp1s0

[user]
org.freedesktop.NetworkManager.origin=cloud-init

[ethernet]

[ipv4]
method=manual
may-fail=false
address1=10.0.2.2/24
gateway=10.0.2.1
route-metric=99
route1=0.0.0.0/0,10.0.2.1
route2=192.168.122.1/24,10.0.2.1,98
``` 

and the routes are configured with metric

```
$ ip r show
default via 10.0.2.1 dev enp1s0 proto static metric 99 
10.0.2.0/24 dev enp1s0 proto kernel scope link src 10.0.2.2 metric 99 
192.168.122.0/24 via 10.0.2.1 dev enp1s0 proto static metric 98 

```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
