### PR TITLE
chore: eliminate calls at import time

### DIFF
--- a/cloudinit/config/cc_chef.py
+++ b/cloudinit/config/cc_chef.py
@@ -23,21 +23,15 @@ from cloudinit.settings import PER_ALWAYS
 
 RUBY_VERSION_DEFAULT = "1.8"
 
-CHEF_DIRS = tuple(
-    [
-        "/etc/chef",
-        "/var/log/chef",
-        "/var/lib/chef",
-        "/var/cache/chef",
-        "/var/backups/chef",
-        "/var/run/chef",
-    ]
+CHEF_DIRS = (
+    "/etc/chef",
+    "/var/log/chef",
+    "/var/lib/chef",
+    "/var/cache/chef",
+    "/var/backups/chef",
+    "/var/run/chef",
 )
-REQUIRED_CHEF_DIRS = tuple(
-    [
-        "/etc/chef",
-    ]
-)
+REQUIRED_CHEF_DIRS = ("/etc/chef",)
 
 # Used if fetching chef from a omnibus style package
 OMNIBUS_URL = "https://www.chef.io/chef/install.sh"
@@ -74,22 +68,20 @@ CHEF_RB_TPL_PATH_KEYS = frozenset(
     ]
 )
 CHEF_RB_TPL_KEYS = frozenset(
-    itertools.chain(
-        CHEF_RB_TPL_DEFAULTS.keys(),
-        CHEF_RB_TPL_BOOL_KEYS,
-        CHEF_RB_TPL_PATH_KEYS,
-        [
-            "server_url",
-            "node_name",
-            "environment",
-            "validation_name",
-            "chef_license",
-        ],
-    )
+    [
+        *CHEF_RB_TPL_DEFAULTS.keys(),
+        *CHEF_RB_TPL_BOOL_KEYS,
+        *CHEF_RB_TPL_PATH_KEYS,
+        "server_url",
+        "node_name",
+        "environment",
+        "validation_name",
+        "chef_license",
+    ]
 )
 CHEF_RB_PATH = "/etc/chef/client.rb"
 CHEF_EXEC_PATH = "/usr/bin/chef-client"
-CHEF_EXEC_DEF_ARGS = tuple(["-d", "-i", "1800", "-s", "20"])
+CHEF_EXEC_DEF_ARGS = ("-d", "-i", "1800", "-s", "20")
 
 
 LOG = logging.getLogger(__name__)

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -31,10 +31,8 @@ meta: MetaSchema = {
 
 # Shortname matches 'sda', 'sda1', 'xvda', 'hda', 'sdb', xvdb, vda, vdd1, sr0
 DEVICE_NAME_FILTER = r"^([x]{0,1}[shv]d[a-z][0-9]*|sr[0-9]+)$"
-DEVICE_NAME_RE = re.compile(DEVICE_NAME_FILTER)
 # Name matches 'server:/path'
 NETWORK_NAME_FILTER = r"^.+:.*"
-NETWORK_NAME_RE = re.compile(NETWORK_NAME_FILTER)
 FSTAB_PATH = "/etc/fstab"
 MNT_COMMENT = "comment=cloudconfig"
 MB = 2**20
@@ -57,7 +55,7 @@ def is_meta_device_name(name):
 
 def is_network_device(name):
     # return true if this is a network device
-    if NETWORK_NAME_RE.match(name):
+    if re.compile(NETWORK_NAME_FILTER).match(name):
         return True
     return False
 
@@ -114,7 +112,7 @@ def sanitize_devname(startname, transformer, aliases=None):
             device_path = "/dev/%s" % (device_path,)
         LOG.debug("Mapped metadata name %s to %s", orig, device_path)
     else:
-        if DEVICE_NAME_RE.match(startname):
+        if re.compile(DEVICE_NAME_FILTER).match(startname):
             device_path = "/dev/%s" % (device_path,)
 
     partition_path = None

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -55,7 +55,7 @@ def is_meta_device_name(name):
 
 def is_network_device(name):
     # return true if this is a network device
-    if re.compile(NETWORK_NAME_FILTER).match(name):
+    if re.match(NETWORK_NAME_FILTER, name):
         return True
     return False
 
@@ -112,7 +112,7 @@ def sanitize_devname(startname, transformer, aliases=None):
             device_path = "/dev/%s" % (device_path,)
         LOG.debug("Mapped metadata name %s to %s", orig, device_path)
     else:
-        if re.compile(DEVICE_NAME_FILTER).match(startname):
+        if re.match(DEVICE_NAME_FILTER, startname):
             device_path = "/dev/%s" % (device_path,)
 
     partition_path = None

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -188,7 +188,7 @@ def apply_rsyslog_changes(configs, def_fname, cfg_dir):
 
 def parse_remotes_line(line, name=None):
     try:
-        data, comment = re.compile(r"[ ]*[#]+[ ]*").split(line)
+        data, comment = re.split(r"[ ]*[#]+[ ]*", line)
         comment = comment.strip()
     except ValueError:
         data, comment = (line, None)
@@ -202,11 +202,12 @@ def parse_remotes_line(line, name=None):
     else:
         raise ValueError("line had multiple spaces: %s" % data)
 
-    toks = re.compile(
+    toks = re.match(
         r"^(?P<proto>[@]{0,2})"
         r"(([\[](?P<bracket_addr>[^\]]*)[\]])|(?P<addr>[^:]*))"
-        r"([:](?P<port>[0-9]+))?$"
-    ).match(host_port)
+        r"([:](?P<port>[0-9]+))?$",
+        host_port,
+    )
 
     if not toks:
         raise ValueError("Invalid host specification '%s'" % host_port)

--- a/cloudinit/config/cc_rsyslog.py
+++ b/cloudinit/config/cc_rsyslog.py
@@ -59,13 +59,6 @@ DISTRO_OVERRIDES = {
 
 LOG = logging.getLogger(__name__)
 
-COMMENT_RE = re.compile(r"[ ]*[#]+[ ]*")
-HOST_PORT_RE = re.compile(
-    r"^(?P<proto>[@]{0,2})"
-    r"(([\[](?P<bracket_addr>[^\]]*)[\]])|(?P<addr>[^:]*))"
-    r"([:](?P<port>[0-9]+))?$"
-)
-
 
 def distro_default_rsyslog_config(distro: Distro):
     """Construct a distro-specific rsyslog config dictionary by merging
@@ -195,7 +188,7 @@ def apply_rsyslog_changes(configs, def_fname, cfg_dir):
 
 def parse_remotes_line(line, name=None):
     try:
-        data, comment = COMMENT_RE.split(line)
+        data, comment = re.compile(r"[ ]*[#]+[ ]*").split(line)
         comment = comment.strip()
     except ValueError:
         data, comment = (line, None)
@@ -209,7 +202,11 @@ def parse_remotes_line(line, name=None):
     else:
         raise ValueError("line had multiple spaces: %s" % data)
 
-    toks = HOST_PORT_RE.match(host_port)
+    toks = re.compile(
+        r"^(?P<proto>[@]{0,2})"
+        r"(([\[](?P<bracket_addr>[^\]]*)[\]])|(?P<addr>[^:]*))"
+        r"([:](?P<port>[0-9]+))?$"
+    ).match(host_port)
 
     if not toks:
         raise ValueError("Invalid host specification '%s'" % host_port)

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -110,9 +110,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         cert_config = []
         for key, val in cfg["ssh_keys"].items():
             if key not in CONFIG_KEY_TO_FILE:
-                if re.compile(
-                    "^(ecdsa-sk|ed25519-sk)_(private|public|certificate)$"
-                ).match(key):
+                if re.match(
+                    "^(ecdsa-sk|ed25519-sk)_(private|public|certificate)$", key
+                ):
                     reason = "unsupported"
                 else:
                     reason = "unrecognized"

--- a/cloudinit/config/cc_ssh.py
+++ b/cloudinit/config/cc_ssh.py
@@ -38,9 +38,6 @@ LOG = logging.getLogger(__name__)
 GENERATE_KEY_NAMES = ["rsa", "ecdsa", "ed25519"]
 FIPS_UNSUPPORTED_KEY_NAMES = ["ed25519"]
 
-pattern_unsupported_config_keys = re.compile(
-    "^(ecdsa-sk|ed25519-sk)_(private|public|certificate)$"
-)
 KEY_FILE_TPL = "/etc/ssh/ssh_host_%s_key"
 PUBLISH_HOST_KEYS = True
 # By default publish all supported hostkey types.
@@ -113,7 +110,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         cert_config = []
         for key, val in cfg["ssh_keys"].items():
             if key not in CONFIG_KEY_TO_FILE:
-                if pattern_unsupported_config_keys.match(key):
+                if re.compile(
+                    "^(ecdsa-sk|ed25519-sk)_(private|public|certificate)$"
+                ).match(key):
                     reason = "unsupported"
                 else:
                     reason = "unrecognized"

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -372,10 +372,6 @@ def _validator(
         yield error_type(msg, schema.get("deprecated_version", "devel"))
 
 
-_validator_deprecated = partial(_validator, filter_key="deprecated")
-_validator_changed = partial(_validator, filter_key="changed")
-
-
 def _anyOf(
     validator,
     anyOf,
@@ -521,8 +517,8 @@ def get_jsonschema_validator():
 
     # Add deprecation handling
     validators = dict(Draft4Validator.VALIDATORS)
-    validators[DEPRECATED_KEY] = _validator_deprecated
-    validators["changed"] = _validator_changed
+    validators[DEPRECATED_KEY] = partial(_validator, filter_key="deprecated")
+    validators["changed"] = partial(_validator, filter_key="changed")
     validators["oneOf"] = _oneOf
     validators["anyOf"] = _anyOf
 

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -100,10 +100,6 @@ OSFAMILIES = {
 
 LOG = logging.getLogger(__name__)
 
-# This is a best guess regex, based on current EC2 AZs on 2017-12-11.
-# It could break when Amazon adds new regions and new AZs.
-_EC2_AZ_RE = re.compile("^[a-z][a-z]-(?:[a-z]+-)+[0-9][a-z]$")
-
 # Default NTP Client Configurations
 PREFERRED_NTP_CLIENTS = ["chrony", "systemd-timesyncd", "ntp", "ntpdate"]
 
@@ -1707,7 +1703,11 @@ def _get_package_mirror_info(
 
         # ec2 availability zones are named cc-direction-[0-9][a-d] (us-east-1b)
         # the region is us-east-1. so region = az[0:-1]
-        if _EC2_AZ_RE.match(data_source.availability_zone):
+        # This is a best guess regex, based on current EC2 AZs on 2017-12-11.
+        # It could break when Amazon adds new regions and new AZs.
+        if re.compile("^[a-z][a-z]-(?:[a-z]+-)+[0-9][a-z]$").match(
+            data_source.availability_zone
+        ):
             ec2_region = data_source.availability_zone[0:-1]
 
             if ALLOW_EC2_MIRRORS_ON_NON_AWS_INSTANCE_TYPES:

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1705,8 +1705,9 @@ def _get_package_mirror_info(
         # the region is us-east-1. so region = az[0:-1]
         # This is a best guess regex, based on current EC2 AZs on 2017-12-11.
         # It could break when Amazon adds new regions and new AZs.
-        if re.compile("^[a-z][a-z]-(?:[a-z]+-)+[0-9][a-z]$").match(
-            data_source.availability_zone
+        if re.match(
+            "^[a-z][a-z]-(?:[a-z]+-)+[0-9][a-z]$",
+            data_source.availability_zone,
         ):
             ec2_region = data_source.availability_zone[0:-1]
 

--- a/cloudinit/distros/parsers/sys_conf.py
+++ b/cloudinit/distros/parsers/sys_conf.py
@@ -21,20 +21,19 @@ import configobj
 # or look at the 'param_expand()' function in the subst.c file in the bash
 # source tarball...
 SHELL_VAR_RULE = r"[a-zA-Z_]+[a-zA-Z0-9_]*"
-SHELL_VAR_REGEXES = [
-    # Basic variables
-    re.compile(r"\$" + SHELL_VAR_RULE),
-    # Things like $?, $0, $-, $@
-    re.compile(r"\$[0-9#\?\-@\*]"),
-    # Things like ${blah:1} - but this one
-    # gets very complex so just try the
-    # simple path
-    re.compile(r"\$\{.+\}"),
-]
 
 
 def _contains_shell_variable(text):
-    for r in SHELL_VAR_REGEXES:
+    for r in [
+        # Basic variables
+        re.compile(r"\$" + SHELL_VAR_RULE),
+        # Things like $?, $0, $-, $@
+        re.compile(r"\$[0-9#\?\-@\*]"),
+        # Things like ${blah:1} - but this one
+        # gets very complex so just try the
+        # simple path
+        re.compile(r"\$\{.+\}"),
+    ]:
         if r.search(text):
             return True
     return False

--- a/cloudinit/dmi.py
+++ b/cloudinit/dmi.py
@@ -2,8 +2,7 @@
 import logging
 import os
 import re
-from collections import namedtuple
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from cloudinit import performance, subp
 from cloudinit.util import (
@@ -18,8 +17,12 @@ LOG = logging.getLogger(__name__)
 # Path for DMI Data
 DMI_SYS_PATH = "/sys/class/dmi/id"
 
-KernelNames = namedtuple("KernelNames", ["linux", "freebsd", "openbsd"])
-KernelNames.__new__.__defaults__ = (None, None, None)
+
+class KernelNames(NamedTuple):
+    linux: str
+    freebsd: Optional[str]
+    openbsd: Optional[str]
+
 
 # FreeBSD's kenv(1) and Linux /sys/class/dmi/id/* both use different names from
 # dmidecode. The values are the same, and ultimately what we're interested in.

--- a/cloudinit/handlers/cloud_config.py
+++ b/cloudinit/handlers/cloud_config.py
@@ -36,7 +36,6 @@ MERGE_HEADER = "Merge-Type"
 # a: 22
 #
 # This gets loaded into yaml with final result {'a': 22}
-DEF_MERGERS = mergers.string_extract_mergers("dict(replace)+list()+str()")
 CLOUD_PREFIX = "#cloud-config"
 JSONP_PREFIX = "#cloud-config-jsonp"
 
@@ -103,7 +102,9 @@ class CloudConfigPartHandler(handlers.Handler):
         all_mergers.extend(mergers_yaml)
         all_mergers.extend(mergers_header)
         if not all_mergers:
-            all_mergers = DEF_MERGERS
+            all_mergers = mergers.string_extract_mergers(
+                "dict(replace)+list()+str()"
+            )
         return (payload_yaml, all_mergers)
 
     def _merge_patch(self, payload):

--- a/cloudinit/mergers/__init__.py
+++ b/cloudinit/mergers/__init__.py
@@ -106,9 +106,7 @@ def string_extract_mergers(merge_how):
         m_name = m_name.replace("-", "_")
         if not m_name:
             continue
-        match = re.compile(r"(^[a-zA-Z_][A-Za-z0-9_]*)\((.*?)\)$").match(
-            m_name
-        )
+        match = re.match(r"(^[a-zA-Z_][A-Za-z0-9_]*)\((.*?)\)$", m_name)
         if not match:
             msg = "Matcher identifier '%s' is not in the right format" % (
                 m_name

--- a/cloudinit/mergers/__init__.py
+++ b/cloudinit/mergers/__init__.py
@@ -8,8 +8,6 @@ import re
 
 from cloudinit import importer, type_utils
 
-NAME_MTCH = re.compile(r"(^[a-zA-Z_][A-Za-z0-9_]*)\((.*?)\)$")
-
 DEF_MERGE_TYPE = "list()+dict()+str()"
 MERGER_PREFIX = "m_"
 MERGER_ATTR = "Merger"
@@ -108,7 +106,9 @@ def string_extract_mergers(merge_how):
         m_name = m_name.replace("-", "_")
         if not m_name:
             continue
-        match = NAME_MTCH.match(m_name)
+        match = re.compile(r"(^[a-zA-Z_][A-Za-z0-9_]*)\((.*?)\)$").match(
+            m_name
+        )
         if not match:
             msg = "Matcher identifier '%s' is not in the right format" % (
                 m_name

--- a/cloudinit/net/renderer.py
+++ b/cloudinit/net/renderer.py
@@ -21,9 +21,6 @@ def filter_by_attr(match_name):
     return lambda iface: (match_name in iface and iface[match_name])
 
 
-filter_by_physical = filter_by_type("physical")
-
-
 class Renderer(abc.ABC):
     def __init__(self, config=None):
         pass
@@ -34,7 +31,7 @@ class Renderer(abc.ABC):
         # TODO(harlowja): this seems shared between eni renderer and
         # this, so move it to a shared location.
         content = io.StringIO()
-        for iface in network_state.iter_interfaces(filter_by_physical):
+        for iface in network_state.iter_interfaces(filter_by_type("physical")):
             # for physical interfaces write out a persist net udev rule
             if "name" in iface and iface.get("mac_address"):
                 driver = iface.get("driver", None)

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -718,8 +718,9 @@ class Renderer(renderer.Renderer):
     def _render_physical_interfaces(
         cls, network_state, iface_contents, flavor
     ):
-        physical_filter = renderer.filter_by_physical
-        for iface in network_state.iter_interfaces(physical_filter):
+        for iface in network_state.iter_interfaces(
+            renderer.filter_by_type("physical")
+        ):
             iface_name = iface.get("config_id") or iface["name"]
             iface_subnets = iface.get("subnets", [])
             iface_cfg = iface_contents[iface_name]

--- a/cloudinit/sources/__init__.py
+++ b/cloudinit/sources/__init__.py
@@ -15,9 +15,8 @@ import logging
 import os
 import pickle
 import re
-from collections import namedtuple
 from enum import Enum, unique
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
 
 from cloudinit import (
     atomic_helper,
@@ -177,20 +176,16 @@ def redact_sensitive_keys(metadata, redact_value=REDACT_SENSITIVE_VALUE):
     return md_copy
 
 
-URLParams = namedtuple(
-    "URLParams",
-    [
-        "max_wait_seconds",
-        "timeout_seconds",
-        "num_retries",
-        "sec_between_retries",
-    ],
-)
+class URLParams(NamedTuple):
+    max_wait_seconds: int
+    timeout_seconds: int
+    num_retries: int
+    sec_between_retries: int
 
-DataSourceHostname = namedtuple(
-    "DataSourceHostname",
-    ["hostname", "is_default"],
-)
+
+class DataSourceHostname(NamedTuple):
+    hostname: Optional[str]
+    is_default: bool
 
 
 class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
@@ -827,7 +822,7 @@ class DataSource(CloudInitPickleMixin, metaclass=abc.ABCMeta):
         @param metadata_only: Boolean, set True to avoid looking up hostname
             if meta-data doesn't have local-hostname present.
 
-        @return: a DataSourceHostname namedtuple
+        @return: a DataSourceHostname NamedTuple
             <hostname or qualified hostname>, <is_default> (str, bool).
             is_default is a bool and
             it's true only if hostname is localhost and was

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -40,8 +40,6 @@ except (ImportError, AttributeError):
     JUndefined = object
 
 LOG = logging.getLogger(__name__)
-TYPE_MATCHER = re.compile(r"##\s*template:(.*)", re.I)
-BASIC_MATCHER = re.compile(r"\$\{([A-Za-z0-9_.]+)\}|\$([A-Za-z0-9_.]+)")
 MISSING_JINJA_PREFIX = "CI_MISSING_JINJA_VAR/"
 
 
@@ -140,7 +138,9 @@ def basic_render(content, params):
             )
         return str(selected_params[key])
 
-    return BASIC_MATCHER.sub(replacer, content)
+    return re.compile(r"\$\{([A-Za-z0-9_.]+)\}|\$([A-Za-z0-9_.]+)").sub(
+        replacer, content
+    )
 
 
 def detect_template(text):
@@ -171,7 +171,7 @@ def detect_template(text):
     else:
         ident = text
         rest = ""
-    type_match = TYPE_MATCHER.match(ident)
+    type_match = re.compile(r"##\s*template:(.*)", re.I).match(ident)
     if not type_match:
         return ("basic", basic_render, text)
     else:

--- a/cloudinit/templater.py
+++ b/cloudinit/templater.py
@@ -138,8 +138,8 @@ def basic_render(content, params):
             )
         return str(selected_params[key])
 
-    return re.compile(r"\$\{([A-Za-z0-9_.]+)\}|\$([A-Za-z0-9_.]+)").sub(
-        replacer, content
+    return re.sub(
+        r"\$\{([A-Za-z0-9_.]+)\}|\$([A-Za-z0-9_.]+)", replacer, content
     )
 
 
@@ -171,7 +171,7 @@ def detect_template(text):
     else:
         ident = text
         rest = ""
-    type_match = re.compile(r"##\s*template:(.*)", re.I).match(ident)
+    type_match = re.match(r"##\s*template:(.*)", ident, re.I)
     if not type_match:
         return ("basic", basic_render, text)
     else:

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -34,7 +34,7 @@ import subprocess
 import sys
 import time
 from base64 import b64decode
-from collections import deque, namedtuple
+from collections import deque
 from contextlib import contextmanager, suppress
 from errno import ENOENT
 from functools import lru_cache
@@ -50,6 +50,7 @@ from typing import (
     Generator,
     List,
     Mapping,
+    NamedTuple,
     Optional,
     Sequence,
     Union,
@@ -1188,10 +1189,10 @@ def dos2unix(contents):
     return contents.replace("\r\n", "\n")
 
 
-HostnameFqdnInfo = namedtuple(
-    "HostnameFqdnInfo",
-    ["hostname", "fqdn", "is_default"],
-)
+class HostnameFqdnInfo(NamedTuple):
+    hostname: str
+    fqdn: str
+    is_default: bool
 
 
 def get_hostname_fqdn(cfg, cloud, metadata_only=False):


### PR DESCRIPTION
It is not best practice, and it often adds unnecessary overhead.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
chore: eliminate calls at import time

It is not best practice, and it often adds unnecessary overhead.

Fixes GH-5344
```

## Additional Context
The important part of this is regex compile - that can be done when/if the function is called rather than at import time which will save some cycles.

While `namedtuple()` and `tuple()` aren't truly harmful, there are ways to define similar types statically rather than generating them at runtime, so I modified those in a few places too.

Fixes https://github.com/canonical/cloud-init/issues/5344
