### PR TITLE
test: allow relative path in apt-get test

### DIFF
--- a/tests/integration_tests/modules/test_package_update_upgrade_install.py
+++ b/tests/integration_tests/modules/test_package_update_upgrade_install.py
@@ -65,7 +65,7 @@ class TestPackageUpdateUpgradeInstall:
             "grep ^Commandline: /var/log/apt/history.log"
         )
         assert re.search(
-            "Commandline: /usr/bin/apt-get --option=Dpkg::Options"
+            "Commandline: (/usr/bin/)?apt-get --option=Dpkg::Options"
             "::=--force-confold --option=Dpkg::options::=--force-unsafe-io "
             r"--assume-yes --quiet install (sl|tree) (tree|sl)",
             out,


### PR DESCRIPTION
## Proposed Commit Message
```
test: allow relative path in apt-get test

Minimal Ubuntu images don't show full path
```

## Additional Context
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_container-minimal/18/testReport/tests.integration_tests.modules.test_package_update_upgrade_install/TestPackageUpdateUpgradeInstall/test_apt_packages_were_updated/

/var/log/apt/history.log (snippet):
```
Start-Date: 2024-11-20  15:11:45
Commandline: apt-get --option=Dpkg::Options::=--force-confold --option=Dpkg::options::=--force-unsafe-io --assume-yes --quiet install tree sl
Install: libgpm2:amd64 (1.20.7-11, automatic), sl:amd64 (5.02-1), tree:amd64 (2.1.1-2ubuntu3), libncurses6:amd64 (6.4+20240113-1ubuntu2, automatic)
End-Date: 2024-11-20  15:11:46
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
