### PR TITLE
fix(ovf): no warning should be logged when rpctool found no value

### DIFF
--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -322,10 +322,11 @@ def transport_vmware_guestinfo():
         # If the first attempt at getting the data was with vmtoolsd, then
         # no second attempt is made.
         if vmtoolsd and rpctool == vmtoolsd:
-            # The fallback failed, log the error.
-            util.logexc(
-                LOG, "vmtoolsd failed to get guestinfo.ovfEnv: %s", error
-            )
+            # The fallback failed and exit code is not 1, log the error.
+            if error.exit_code != 1:
+                util.logexc(
+                    LOG, "vmtoolsd failed to get guestinfo.ovfEnv: %s", error
+                )
             return None
 
         if not vmtoolsd:
@@ -336,10 +337,11 @@ def transport_vmware_guestinfo():
             LOG.info("fallback to vmtoolsd")
             return query_guestinfo(vmtoolsd, exec_vmtoolsd)
         except subp.ProcessExecutionError as error:
-            # The fallback failed, log the error.
-            util.logexc(
-                LOG, "vmtoolsd failed to get guestinfo.ovfEnv: %s", error
-            )
+            # The fallback failed and exit code is not 1, log the error.
+            if error.exit_code != 1:
+                util.logexc(
+                    LOG, "vmtoolsd failed to get guestinfo.ovfEnv: %s", error
+                )
 
     return None
 

--- a/tests/unittests/sources/test_ovf.py
+++ b/tests/unittests/sources/test_ovf.py
@@ -537,6 +537,11 @@ class TestTransportVmwareGuestinfo(CiTestCase):
         ]
         self.assertEqual(NOT_FOUND, dsovf.transport_vmware_guestinfo())
         self.assertEqual(2, m_subp.call_count)
+        self.assertNotIn(
+            "WARNING",
+            self.logs.getvalue(),
+            "exit code of 1 by rpctool and vmtoolsd should not cause warning.",
+        )
 
     def test_vmware_rpctool_fails_and_vmtoolsd_success(self, m_subp, m_which):
         """When vmware-rpctool fails but vmtoolsd succeeds"""


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(ovf): no warning should be logged when rpctool found no value

When both rpctool binaries found no value with exit code 1, no warning should be logged.

Fixes GH-5914
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
