### PR TITLE
test: exit on pytest session fixture failure

### DIFF
--- a/tests/integration_tests/bugs/test_gh671.py
+++ b/tests/integration_tests/bugs/test_gh671.py
@@ -21,7 +21,7 @@ def _check_password(instance, unhashed_password):
 
 
 @pytest.mark.skipif(PLATFORM != "azure", reason="Test is Azure specific")
-def test_update_default_password(setup_image, session_cloud: IntegrationCloud):
+def test_update_default_password(session_cloud: IntegrationCloud):
     os_profile = {
         "os_profile": {
             "admin_password": "",

--- a/tests/integration_tests/bugs/test_lp1835584.py
+++ b/tests/integration_tests/bugs/test_lp1835584.py
@@ -92,8 +92,5 @@ def test_azure_kernel_upgrade_case_insensitive_uuid(
             )
         }
     ) as instance:
-        # We can't use setup_image fixture here because we want to avoid
-        # taking a snapshot or cleaning the booted machine after cloud-init
-        # upgrade.
         instance.install_new_cloud_init(source, clean=False)
         _check_iid_insensitive_across_kernel_upgrade(instance)

--- a/tests/integration_tests/bugs/test_lp1901011.py
+++ b/tests/integration_tests/bugs/test_lp1901011.py
@@ -20,7 +20,7 @@ from tests.integration_tests.integration_settings import PLATFORM
     ],
 )
 def test_ephemeral(
-    instance_type, is_ephemeral, session_cloud: IntegrationCloud, setup_image
+    instance_type, is_ephemeral, session_cloud: IntegrationCloud
 ):
     if is_ephemeral:
         expected_log = (

--- a/tests/integration_tests/bugs/test_lp1910835.py
+++ b/tests/integration_tests/bugs/test_lp1910835.py
@@ -29,7 +29,7 @@ ssh_authorized_keys:
 
 
 @pytest.mark.skipif(PLATFORM != "azure", reason="Test is Azure specific")
-def test_crlf_in_azure_metadata_ssh_keys(session_cloud, setup_image):
+def test_crlf_in_azure_metadata_ssh_keys(session_cloud):
     authorized_keys_path = "/home/{}/.ssh/authorized_keys".format(
         session_cloud.cloud_instance.username
     )

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -7,7 +7,7 @@ import re
 import string
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Type
+from typing import Type, Optional
 from uuid import UUID
 
 from pycloudlib import (
@@ -65,7 +65,7 @@ class IntegrationCloud(ABC):
         self.settings = settings
         self.cloud_instance = self._get_cloud_instance()
         self.initial_image_id = self._get_initial_image()
-        self.snapshot_id = None
+        self.snapshot_id: Optional[str] = None
 
     @property
     def image_id(self):

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -7,7 +7,7 @@ import re
 import string
 from abc import ABC, abstractmethod
 from copy import deepcopy
-from typing import Type, Optional
+from typing import Optional, Type
 from uuid import UUID
 
 from pycloudlib import (
@@ -182,7 +182,7 @@ class IntegrationCloud(ABC):
 
     def delete_snapshot(self):
         if self.snapshot_id:
-            if self.settings.KEEP_IMAGE:  # type: ignore
+            if self.settings.KEEP_IMAGE:
                 log.info(
                     "NOT deleting snapshot image created for this testrun "
                     "because KEEP_IMAGE is True: %s",

--- a/tests/integration_tests/cmd/test_status.py
+++ b/tests/integration_tests/cmd/test_status.py
@@ -34,7 +34,7 @@ def retry_read_from_file(client: IntegrationInstance, path: str):
     PLATFORM != "lxd_container",
     reason="Test is LXD specific",
 )
-def test_wait_when_no_datasource(session_cloud: IntegrationCloud, setup_image):
+def test_wait_when_no_datasource(session_cloud: IntegrationCloud):
     """Ensure that when no datasource is found, we get status: disabled
 
     LP: #1966085

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -310,28 +310,31 @@ def _client(
             pytest.skip("lxd_setup requires LXD")
         local_launch_kwargs["lxd_setup"] = lxd_setup
 
-    with session_cloud.launch(
-        user_data=user_data, launch_kwargs=launch_kwargs, **local_launch_kwargs
-    ) as instance:
-        if lxd_use_exec is not None and isinstance(
-            instance.instance, LXDInstance
-        ):
-            # Existing instances are not affected by the launch kwargs, so
-            # ensure it here; we still need the launch kwarg so waiting works
-            instance.instance.execute_via_ssh = False
-        previous_failures = request.session.testsfailed
-        yield instance
-        test_failed = request.session.testsfailed - previous_failures > 0
-        _collect_artifacts(instance, request.node.nodeid, test_failed)
-    # conflicting requirements:
-    # - pytest thinks that it can cleanup loggers after tests run
-    # - pycloudlib thinks that at garbage collection is a good place to tear
-    #   down sftp connections
-    # After the final test runs, pytest might clean up loggers which will cause
-    # paramiko to barf when it logs that the connection is being closed.
-    #
-    # Manually run __del__() to prevent this teardown mess.
-    instance.instance.__del__()
+    try:
+        with session_cloud.launch(
+            user_data=user_data, launch_kwargs=launch_kwargs, **local_launch_kwargs
+        ) as instance:
+            if lxd_use_exec is not None and isinstance(
+                instance.instance, LXDInstance
+            ):
+                # Existing instances are not affected by the launch kwargs, so
+                # ensure it here; we still need the launch kwarg so waiting works
+                instance.instance.execute_via_ssh = False
+            previous_failures = request.session.testsfailed
+            yield instance
+            test_failed = request.session.testsfailed - previous_failures > 0
+            _collect_artifacts(instance, request.node.nodeid, test_failed)
+        # conflicting requirements:
+        # - pytest thinks that it can cleanup loggers after tests run
+        # - pycloudlib thinks that at garbage collection is a good place to tear
+        #   down sftp connections
+        # After the final test runs, pytest might clean up loggers which will cause
+        # paramiko to barf when it logs that the connection is being closed.
+        #
+        # Manually run __del__() to prevent this teardown mess.
+        instance.instance.__del__()
+    except Exception as e:
+        pytest.exit(f"Failed to set up pytest session: {e}", returncode=1)
 
 
 @pytest.fixture

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -74,7 +74,7 @@ def disable_subp_usage(request):
     pass
 
 
-_SESSION: IntegrationCloud
+_SESSION_CLOUD: IntegrationCloud
 
 
 @pytest.fixture(scope="session")
@@ -83,8 +83,8 @@ def session_cloud() -> Generator[IntegrationCloud, None, None]:
 
     yield this shared session
     """
-    global _SESSION
-    yield _SESSION
+    global _SESSION_CLOUD
+    yield _SESSION_CLOUD
 
 
 def get_session_cloud() -> IntegrationCloud:
@@ -471,10 +471,10 @@ def _generate_profile_report() -> None:
 # https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_sessionstart
 def pytest_sessionstart(session) -> None:
     """do session setup"""
-    global _SESSION
+    global _SESSION_CLOUD
     try:
-        _SESSION = get_session_cloud()
-        setup_image(_SESSION)
+        _SESSION_CLOUD = get_session_cloud()
+        setup_image(_SESSION_CLOUD)
     except Exception as e:
         pytest.exit(
             f"{type(e).__name__} in session setup: {str(e)}", returncode=2
@@ -488,7 +488,7 @@ def pytest_sessionfinish(session, exitstatus) -> None:
     elif integration_settings.INCLUDE_PROFILE:
         _generate_profile_report()
     try:
-        _SESSION.delete_snapshot()
-        _SESSION.destroy()
+        _SESSION_CLOUD.delete_snapshot()
+        _SESSION_CLOUD.destroy()
     except Exception as e:
         log.warning("%s in session fixture teardown: %s", type(e), e)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -81,7 +81,9 @@ def session_cloud() -> Generator[IntegrationCloud, None, None]:
         yield cloud
         cloud.destroy()
     except Exception as e:
-        pytest.exit(f"{type(e)} in session fixture setup: {str(e)}", returncode=2)
+        pytest.exit(
+            f"{type(e)} in session fixture setup: {str(e)}", returncode=2
+        )
 
 
 def _session_cloud() -> IntegrationCloud:
@@ -174,7 +176,9 @@ def setup_image(session_cloud: IntegrationCloud):
         # during setup so use a finalizer instead.
         return session_cloud
     except Exception as e:
-        pytest.exit(f"{type(e)} in session fixture setup: {str(e)}", returncode=2)
+        pytest.exit(
+            f"{type(e)} in session fixture setup: {str(e)}", returncode=2
+        )
 
 
 def _collect_logs(instance: IntegrationInstance, log_dir: Path):
@@ -352,7 +356,9 @@ def _client(
         # Manually run __del__() to prevent this teardown mess.
         instance.instance.__del__()
     except Exception as e:
-        pytest.exit(f"{type(e)} in session fixture setup: {str(e)}", returncode=2)
+        pytest.exit(
+            f"{type(e)} in session fixture setup: {str(e)}", returncode=2
+        )
 
 
 @pytest.fixture

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -477,6 +477,7 @@ def pytest_sessionstart(session) -> None:
     try:
         SESSION = get_session_cloud()
         setup_image(SESSION)
+        raise ValueError("huh")
     except Exception as e:
         pytest.exit(
             f"{type(e)} in session fixture setup: {str(e)}", returncode=2
@@ -494,6 +495,4 @@ def pytest_sessionfinish(session, exitstatus) -> None:
         SESSION.delete_snapshot()
         SESSION.destroy()
     except Exception as e:
-        log.warning(
-            "%s in session fixture teardown: %s", type(e), e
-        )
+        log.warning("%s in session fixture teardown: %s", type(e), e)

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -130,6 +130,7 @@ def setup_image(session_cloud: IntegrationCloud, request):
         or integration_settings.INCLUDE_COVERAGE
         or integration_settings.INCLUDE_PROFILE
     ):
+        yield
         return
     log.info("Setting up source image")
     client = session_cloud.launch()
@@ -161,7 +162,8 @@ def setup_image(session_cloud: IntegrationCloud, request):
     # For some reason a yield here raises a
     # ValueError: setup_image did not yield a value
     # during setup so use a finalizer instead.
-    request.addfinalizer(session_cloud.delete_snapshot)
+    yield session_cloud
+    session_cloud.delete_snapshot()
 
 
 def _collect_logs(instance: IntegrationInstance, log_dir: Path):

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -477,10 +477,10 @@ def pytest_sessionstart(session) -> None:
     try:
         SESSION = get_session_cloud()
         setup_image(SESSION)
-        raise ValueError("huh")
     except Exception as e:
         pytest.exit(
-            f"{type(e)} in session fixture setup: {str(e)}", returncode=2
+            f"{type(e).__name__} in session setup: {str(e)}",
+            returncode=2
         )
 
 

--- a/tests/integration_tests/datasources/test_azure.py
+++ b/tests/integration_tests/datasources/test_azure.py
@@ -78,9 +78,7 @@ def parse_resolvectl_dns(output: str) -> dict:
 @pytest.mark.skipif(
     CURRENT_RELEASE < BIONIC, reason="Easier to test on Bionic+"
 )
-def test_azure_multi_nic_setup(
-    setup_image, session_cloud: IntegrationCloud
-) -> None:
+def test_azure_multi_nic_setup(session_cloud: IntegrationCloud) -> None:
     """Integration test for https://warthogs.atlassian.net/browse/CPC-3999.
 
     Azure should have the primary NIC only route to DNS.

--- a/tests/integration_tests/decorators.py
+++ b/tests/integration_tests/decorators.py
@@ -27,7 +27,7 @@ def retry(*, tries: int = 30, delay: int = 1):
                     time.sleep(delay)
             else:
                 if last_error:
-                    raise last_error
+                    raise TimeoutError from last_error
             return retval
 
         return wrapper

--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -478,7 +478,7 @@ runcmd:
 
 
 @pytest.mark.skipif(not IS_UBUNTU, reason="Apt usage")
-def test_install_missing_deps(setup_image, session_cloud: IntegrationCloud):
+def test_install_missing_deps(session_cloud: IntegrationCloud):
     # Two stage install: First stage:  remove gpg noninteractively from image
     instance1 = session_cloud.launch(user_data=REMOVE_GPG_USERDATA)
     snapshot_id = instance1.snapshot()

--- a/tests/integration_tests/modules/test_hotplug.py
+++ b/tests/integration_tests/modules/test_hotplug.py
@@ -309,7 +309,7 @@ def test_multi_nic_hotplug(client: IntegrationInstance):
 
 @pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")
 @pytest.mark.skip(reason="IMDS race, see GH-5373. Unskip when fixed.")
-def test_multi_nic_hotplug_vpc(setup_image, session_cloud: IntegrationCloud):
+def test_multi_nic_hotplug_vpc(session_cloud: IntegrationCloud):
     """Tests that additional secondary NICs are routable from local
     networks after the hotplug hook is executed when network updates
     are configured on the HOTPLUG event."""

--- a/tests/integration_tests/modules/test_lxd.py
+++ b/tests/integration_tests/modules/test_lxd.py
@@ -247,7 +247,7 @@ def test_storage_btrfs(client):
 @pytest.mark.skipif(
     CURRENT_RELEASE < FOCAL, reason="tested on Focal and later"
 )
-def test_storage_preseed_btrfs(setup_image, session_cloud: IntegrationCloud):
+def test_storage_preseed_btrfs(session_cloud: IntegrationCloud):
     # TODO: If test is marked as not bionic, why is there a bionic section?
     if CURRENT_RELEASE.series in ("bionic",):
         nictype = "nictype: bridged"
@@ -311,7 +311,7 @@ def test_storage_zfs(client):
 @pytest.mark.skipif(
     CURRENT_RELEASE < FOCAL, reason="Tested on focal and later"
 )
-def test_storage_preseed_zfs(setup_image, session_cloud: IntegrationCloud):
+def test_storage_preseed_zfs(session_cloud: IntegrationCloud):
     # TODO: If test is marked as not bionic, why is there a bionic section?
     if CURRENT_RELEASE.series in ("bionic",):
         nictype = "nictype: bridged"

--- a/tests/integration_tests/test_networking.py
+++ b/tests/integration_tests/test_networking.py
@@ -182,9 +182,7 @@ ethernets:
         pytest.param(NET_V2_MATCH_CONFIG, id="v2"),
     ),
 )
-def test_netplan_rendering(
-    net_config, session_cloud: IntegrationCloud, setup_image
-):
+def test_netplan_rendering(net_config, session_cloud: IntegrationCloud):
     mac_addr = random_mac_address()
     launch_kwargs = {
         "config_dict": {
@@ -222,9 +220,7 @@ version: 1
     reason="Test requires custom networking provided by LXD",
 )
 @pytest.mark.parametrize("net_config", (NET_V1_NAME_TOO_LONG,))
-def test_schema_warnings(
-    net_config, session_cloud: IntegrationCloud, setup_image
-):
+def test_schema_warnings(net_config, session_cloud: IntegrationCloud):
     # TODO: This test takes a lot more time than it needs to.
     # The default launch wait will wait until cloud-init done, but the
     # init network stage will wait 2 minutes for network timeout.
@@ -266,9 +262,7 @@ def test_schema_warnings(
     PLATFORM not in ("lxd_vm", "lxd_container"),
     reason="Test requires lxc exec feature due to broken network config",
 )
-def test_invalid_network_v2_netplan(
-    session_cloud: IntegrationCloud, setup_image
-):
+def test_invalid_network_v2_netplan(session_cloud: IntegrationCloud):
     mac_addr = random_mac_address()
 
     if PLATFORM == "lxd_vm":
@@ -316,7 +310,7 @@ def test_invalid_network_v2_netplan(
 
 
 @pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")
-def test_ec2_multi_nic_reboot(setup_image, session_cloud: IntegrationCloud):
+def test_ec2_multi_nic_reboot(session_cloud: IntegrationCloud):
     """Tests that additional secondary NICs and secondary IPs on them are
     routable from non-local networks after a reboot event when network updates
     are configured on every boot."""
@@ -347,7 +341,7 @@ def test_ec2_multi_nic_reboot(setup_image, session_cloud: IntegrationCloud):
 
 @pytest.mark.adhoc  # costly instance not available in all regions / azs
 @pytest.mark.skipif(PLATFORM != "ec2", reason="test is ec2 specific")
-def test_ec2_multi_network_cards(setup_image, session_cloud: IntegrationCloud):
+def test_ec2_multi_network_cards(session_cloud: IntegrationCloud):
     """
     Tests that with an interface type with multiple network cards (non unique
     device indexes).


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: improve test initialization error path

- eliminated vestigial setup_image() fixture use
- make setup_image() a function not a fixture
- move one-time setup into pytest_sessionstart()
- use a global variable to store the session for cleanup
- any failure in pytest_sessionstart() triggers pytest.exit()
- make failure warnings more descriptive
```

## Additional Context

If a session fixture fails in pre-configuring our image, there is no point in reporting many test failures. One failure with a better message would be preferred.

Example output:
```
!!! _pytest.outcomes.Exit: <class 'TimeoutError'> in session fixture setup: !!!!
================ 203 deselected, 1 warning in 130.94s (0:02:10) ================
integration-tests-ci: exit 2 (133.56 seconds) /home/runner/work/cloud-init/cloud-init> .tox/integration-tests-ci/bin/python -m pytest --log-cli-level=INFO --color=yes tests/integration_tests/ pid=9908
  integration-tests-ci: FAIL code 2 (200.28=setup[66.73]+cmd[133.56] seconds)
  evaluation failed :( (200.52 seconds)
Process completed with exit code 2.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
