### PR TITLE
feat(cc_chef): Allow change of Chef configuration file

### DIFF
--- a/cloudinit/config/cc_chef.py
+++ b/cloudinit/config/cc_chef.py
@@ -171,6 +171,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             )
 
     # Create the chef config from template
+    cfg_filename = util.get_cfg_option_str(
+        chef_cfg, "config_path", default=CHEF_RB_PATH
+    )
     template_fn = cloud.get_template_filename("chef_client.rb")
     if template_fn:
         iid = str(cloud.datasource.get_instance_id())
@@ -183,9 +186,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             if k in CHEF_RB_TPL_PATH_KEYS and v:
                 param_paths.add(os.path.dirname(v))
         util.ensure_dirs(param_paths)
-        templater.render_to_file(template_fn, CHEF_RB_PATH, params)
+        templater.render_to_file(template_fn, cfg_filename, params)
     else:
-        LOG.warning("No template found, not rendering to %s", CHEF_RB_PATH)
+        LOG.warning("No template found, not rendering to %s", cfg_filename)
 
     # Set the firstboot json
     fb_filename = util.get_cfg_option_str(

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1221,6 +1221,11 @@
               "uniqueItems": true,
               "description": "Create the necessary directories for chef to run. By default, it creates the following directories:\n- ``/etc/chef``\n- ``/var/log/chef``\n- ``/var/lib/chef``\n- ``/var/cache/chef``\n- ``/var/backups/chef``\n- ``/var/run/chef``"
             },
+            "config_path": {
+              "type": "string",
+              "default": "/etc/chef/client.rb",
+              "description": "Optional path for Chef configuration file. Default: ``/etc/chef/client.rb``"
+            },
             "validation_cert": {
               "type": "string",
               "description": "Optional string to be written to file validation_key. Special value ``system`` means set use existing file."

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -174,6 +174,7 @@ SadeghHayeri
 sarahwzadara
 sbraz
 scorpion44
+SeanSith
 shaardie
 shell-skrimp
 shi2wei3


### PR DESCRIPTION

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
Added `config_path` property to `cc_chef` to enable changing of Chef configuration path. Enables better support of community Chef forks (e.g. [Cinc](https://cinc.sh)).

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
