### PR TITLE
fix: use program name of netcat as installed by upstream, "nc"

### DIFF
--- a/systemd/cloud-config.service
+++ b/systemd/cloud-config.service
@@ -16,7 +16,7 @@ Type=oneshot
 # process has completed this stage. The output from the return socket is piped
 # into a shell so that the process can send a completion message (defaults to
 # "done", otherwise includes an error message) and an exit code to systemd.
-ExecStart=sh -c 'echo "start" | netcat -Uu -W1 /run/cloud-init/share/config.sock -s /run/cloud-init/share/config-return.sock | sh'
+ExecStart=sh -c 'echo "start" | nc -Uu -W1 /run/cloud-init/share/config.sock -s /run/cloud-init/share/config-return.sock | sh'
 RemainAfterExit=yes
 TimeoutSec=0
 

--- a/systemd/cloud-final.service
+++ b/systemd/cloud-final.service
@@ -19,7 +19,7 @@ Type=oneshot
 # process has completed this stage. The output from the return socket is piped
 # into a shell so that the process can send a completion message (defaults to
 # "done", otherwise includes an error message) and an exit code to systemd.
-ExecStart=sh -c 'echo "start" | netcat -Uu -W1 /run/cloud-init/share/final.sock -s /run/cloud-init/share/final-return.sock | sh'
+ExecStart=sh -c 'echo "start" | nc -Uu -W1 /run/cloud-init/share/final.sock -s /run/cloud-init/share/final-return.sock | sh'
 RemainAfterExit=yes
 TimeoutSec=0
 TasksMax=infinity

--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -32,7 +32,7 @@ ExecStartPre=/sbin/restorecon /run/cloud-init
 # process has completed this stage. The output from the return socket is piped
 # into a shell so that the process can send a completion message (defaults to
 # "done", otherwise includes an error message) and an exit code to systemd.
-ExecStart=sh -c 'echo "start" | netcat -Uu -W1 /run/cloud-init/share/local.sock -s /run/cloud-init/share/local-return.sock | sh'
+ExecStart=sh -c 'echo "start" | nc -Uu -W1 /run/cloud-init/share/local.sock -s /run/cloud-init/share/local-return.sock | sh'
 RemainAfterExit=yes
 TimeoutSec=0
 

--- a/systemd/cloud-init-network.service.tmpl
+++ b/systemd/cloud-init-network.service.tmpl
@@ -53,7 +53,7 @@ Type=oneshot
 # process has completed this stage. The output from the return socket is piped
 # into a shell so that the process can send a completion message (defaults to
 # "done", otherwise includes an error message) and an exit code to systemd.
-ExecStart=sh -c 'echo "start" | netcat -Uu -W1 /run/cloud-init/share/network.sock -s /run/cloud-init/share/network-return.sock | sh'
+ExecStart=sh -c 'echo "start" | nc -Uu -W1 /run/cloud-init/share/network.sock -s /run/cloud-init/share/network-return.sock | sh'
 RemainAfterExit=yes
 TimeoutSec=0
 


### PR DESCRIPTION
(OpenBSD) netcat installs itself by default only as "nc", *not* as "netcat" (the latter longer name is an ubuntu (or debian?) add-on).
Use the upstream-provided binary name.

## Proposed commit message
fix: use program name of netcat as installed by upstream, "nc" (#5933)

## Merge type
- [x] Squash merge using "Proposed Commit Message"