### PR TITLE
fix: don't deadlock when starting network service with systemctl

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -45,11 +45,9 @@ def get_users_by_type(users_list: list, pw_type: str) -> list:
     )
 
 
-def _restart_ssh_daemon(distro: Distro, service: str):
+def _restart_ssh_daemon(distro: Distro, service: str, *extra_args: str):
     try:
-        distro.manage_service(
-            "restart", service, "--job-mode=ignore-dependencies"
-        )
+        distro.manage_service("restart", service, *extra_args)
         LOG.debug("Restarted the SSH daemon.")
     except subp.ProcessExecutionError as e:
         LOG.warning(
@@ -118,7 +116,9 @@ def handle_ssh_pwauth(pw_auth, distro: Distro):
             # for backwards compatibility so that users who think that they
             # need to manually start cloud-init (why?) with systemd (again,
             # why?) can do so.
-            _restart_ssh_daemon(distro, service)
+            _restart_ssh_daemon(
+                distro, service, "--job-mode=ignore-dependencies"
+            )
     else:
         _restart_ssh_daemon(distro, service)
 

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -48,7 +48,7 @@ def get_users_by_type(users_list: list, pw_type: str) -> list:
 def _restart_ssh_daemon(distro: Distro, service: str):
     try:
         distro.manage_service(
-            "restart", service, "--job-mode='ignore-dependencies'"
+            "restart", service, "--job-mode=ignore-dependencies"
         )
         LOG.debug("Restarted the SSH daemon.")
     except subp.ProcessExecutionError as e:

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -138,7 +138,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
     shadow_empty_locked_passwd_patterns = ["^{username}::", "^{username}:!:"]
     tz_zone_dir = "/usr/share/zoneinfo"
     default_owner = "root:root"
-    init_cmd = ["service"]  # systemctl, service etc
+    init_cmd: List[str] = ["service"]  # systemctl, service etc
     renderer_configs: Mapping[str, MutableMapping[str, Any]] = {}
     _preferred_ntp_clients = None
     networking_cls: Type[Networking] = LinuxNetworking
@@ -1369,7 +1369,7 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 "try-reload": [service, "restart"],
                 "status": [service, "status"],
             }
-        cmd = list(init_cmd) + list(cmds[action])
+        cmd = init_cmd + cmds[action] + list(extra_args)
         return subp.subp(cmd, capture=True, rcs=rcs)
 
     def set_keymap(self, layout: str, model: str, variant: str, options: str):

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -27,7 +27,9 @@ SYSTEMD_CHECK_CALL = mock.call(
     ["systemctl", "show", "--property", "ActiveState", "--value", "ssh"]
 )
 SYSTEMD_RESTART_CALL = mock.call(
-    ["systemctl", "restart", "ssh", "--job-mode='ignore-dependencies'"], capture=True, rcs=None
+    ["systemctl", "restart", "ssh", "--job-mode=ignore-dependencies"],
+    capture=True,
+    rcs=None,
 )
 SERVICE_RESTART_CALL = mock.call(
     ["service", "ssh", "restart"], capture=True, rcs=None

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -27,7 +27,7 @@ SYSTEMD_CHECK_CALL = mock.call(
     ["systemctl", "show", "--property", "ActiveState", "--value", "ssh"]
 )
 SYSTEMD_RESTART_CALL = mock.call(
-    ["systemctl", "restart", "ssh"], capture=True, rcs=None
+    ["systemctl", "restart", "ssh", "--job-mode='ignore-dependencies'"], capture=True, rcs=None
 )
 SERVICE_RESTART_CALL = mock.call(
     ["service", "ssh", "restart"], capture=True, rcs=None


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: don't deadlock when starting network service with systemctl
```

## Additional Context

https://github.com/canonical/cloud-init/issues/5930

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
