### PR TITLE
docs: fix typo in generated file usage for launch_lxd doc

### DIFF
--- a/doc/rtd/howto/launch_lxd.rst
+++ b/doc/rtd/howto/launch_lxd.rst
@@ -30,14 +30,14 @@ we just created:
 .. code-block:: shell-session
 
     $ lxc init ubuntu-daily:jammy test-container
-    $ lxc config set test-container user.user-data - < userdata.yaml
+    $ lxc config set test-container user.user-data - < user-data.yaml
     $ lxc start test-container
 
 To avoid the extra commands this can also be done at launch:
 
 .. code-block:: shell-session
 
-    $ lxc launch ubuntu-daily:jammy test-container --config=user.user-data="$(cat userdata.yaml)"
+    $ lxc launch ubuntu-daily:jammy test-container --config=user.user-data="$(cat user-data.yaml)"
 
 Finally, a profile can be set up with the specific data if you need to
 launch this multiple times:
@@ -72,4 +72,3 @@ custom network config and using LXD with cloud-init.
 .. _LXD: https://ubuntu.com/lxd
 .. _Instance Configuration: https://documentation.ubuntu.com/lxd/en/latest/instances/
 .. _Custom Network Configuration: https://documentation.ubuntu.com/lxd/en/latest/cloud-init/
-

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -179,6 +179,7 @@ scorpion44
 shaardie
 shell-skrimp
 shi2wei3
+ShPakvel
 simondeziel
 slingamn
 slyon


### PR DESCRIPTION
## Proposed Commit Message

```
docs: fix typo in generated file usage for launch_lxd doc 

File was created with name "user-data.yaml".
But later it was used several times with typo in it.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
