### PR TITLE
feat: aliyun datasource support crawl metadata at once

### DIFF
--- a/cloudinit/sources/DataSourceAliYun.py
+++ b/cloudinit/sources/DataSourceAliYun.py
@@ -306,8 +306,6 @@ class DataSourceAliYun(sources.DataSource):
 
         @return: The API token or None if unavailable.
         """
-        # if self.cloud_name not in IDMSV2_SUPPORTED_CLOUD_PLATFORMS:
-        #     return None
 
         if seconds is None:
             seconds = self.imdsv2_token_ttl_seconds
@@ -335,9 +333,7 @@ class DataSourceAliYun(sources.DataSource):
         If _api_token is unset on AWS, attempt to refresh the token via a PUT
         and then return the updated token header.
         """
-        # if self.cloud_name not in IDMSV2_SUPPORTED_CLOUD_PLATFORMS:
-        #     return {}
-        # Request a 6 hour token if URL is api_token_route
+
         request_token_header = {
             self.imdsv2_token_req_header: self.imdsv2_token_ttl_seconds
         }

--- a/cloudinit/sources/DataSourceAliYun.py
+++ b/cloudinit/sources/DataSourceAliYun.py
@@ -2,26 +2,42 @@
 
 import copy
 import logging
-from typing import List
+from typing import List, Union
 
 from cloudinit import dmi, sources
+from cloudinit import url_helper as uhelp
+from cloudinit import util
 from cloudinit.event import EventScope, EventType
-from cloudinit.sources import DataSourceEc2 as EC2
-from cloudinit.sources import DataSourceHostname, NicOrder
+from cloudinit.net.dhcp import NoDHCPLeaseError
+from cloudinit.net.ephemeral import EphemeralIPNetwork
+from cloudinit.sources import DataSourceHostname
+from cloudinit.sources.helpers import aliyun, ec2
 
 LOG = logging.getLogger(__name__)
 
 ALIYUN_PRODUCT = "Alibaba Cloud ECS"
 
 
-class DataSourceAliYun(EC2.DataSourceEc2):
+class DataSourceAliYun(sources.DataSource):
 
     dsname = "AliYun"
     metadata_urls = ["http://100.100.100.200"]
 
-    # The minimum supported metadata_version from the ec2 metadata apis
+    # The minimum supported metadata_version from the ecs metadata apis
     min_metadata_version = "2016-01-01"
     extended_metadata_versions: List[str] = []
+
+    # Setup read_url parameters per get_url_params.
+    url_max_wait = 240
+    url_timeout = 50
+
+    # API token for accessing the metadata service
+    _api_token = None
+    # Used to cache calculated network cfg v1
+    _network_config: Union[str, dict] = sources.UNSET
+
+    # Whether we want to get network configuration from the metadata service.
+    perform_dhcp_setup = False
 
     # Aliyun metadata server security enhanced mode overwrite
     @property
@@ -32,11 +48,9 @@ class DataSourceAliYun(EC2.DataSourceEc2):
         super(DataSourceAliYun, self).__init__(sys_cfg, distro, paths)
         self.default_update_events = copy.deepcopy(self.default_update_events)
         self.default_update_events[EventScope.NETWORK].add(EventType.BOOT)
-        self._fallback_nic_order = NicOrder.NIC_NAME
 
     def _unpickle(self, ci_pkl_version: int) -> None:
         super()._unpickle(ci_pkl_version)
-        self._fallback_nic_order = NicOrder.NIC_NAME
 
     def get_hostname(self, fqdn=False, resolve_ip=False, metadata_only=False):
         hostname = self.metadata.get("hostname")
@@ -51,9 +65,319 @@ class DataSourceAliYun(EC2.DataSourceEc2):
 
     def _get_cloud_name(self):
         if _is_aliyun():
-            return EC2.CloudNames.ALIYUN
+            return self.dsname.lower()
+        return "NO_ALIYUN_METADATA"
+
+    @property
+    def platform(self):
+        return self.dsname.lower()
+
+    # IMDSv2 related parameters from the ecs metadata api document
+    @property
+    def api_token_route(self):
+        return "latest/api/token"
+
+    @property
+    def imdsv2_token_ttl_seconds(self):
+        return "21600"
+
+    @property
+    def imdsv2_token_redact(self):
+        return [self.imdsv2_token_put_header, self.imdsv2_token_req_header]
+
+    @property
+    def imdsv2_token_req_header(self):
+        return self.imdsv2_token_put_header + "-ttl-seconds"
+
+    @property
+    def network_config(self):
+        """Return a network config dict for rendering ENI or netplan files."""
+        if self._network_config != sources.UNSET:
+            return self._network_config
+
+        result = {}
+        iface = self.distro.fallback_interface
+        net_md = self.metadata.get("network")
+        if isinstance(net_md, dict):
+            result = aliyun.convert_ecs_metadata_network_config(
+                net_md,
+                fallback_nic=iface,
+                full_network_config=util.get_cfg_option_bool(
+                    self.ds_cfg, "apply_full_imds_network_config", True
+                ),
+            )
         else:
-            return EC2.CloudNames.NO_EC2_METADATA
+            LOG.warning("Metadata 'network' key not valid: %s.", net_md)
+            return result
+        self._network_config = result
+        return self._network_config
+
+    def _maybe_fetch_api_token(self, mdurls):
+        """Get an API token for ECS Instance Metadata Service.
+
+        On ECS. IMDS will always answer an API token, set
+        HttpTokens=optional (default) when create instance will not forcefully
+        use the security-enhanced mode (IMDSv2).
+
+        https://api.alibabacloud.com/api/Ecs/2014-05-26/RunInstances
+        """
+
+        urls = []
+        url2base = {}
+        url_path = self.api_token_route
+        request_method = "PUT"
+        for url in mdurls:
+            cur = "{0}/{1}".format(url, url_path)
+            urls.append(cur)
+            url2base[cur] = url
+
+        # use the self._imds_exception_cb to check for Read errors
+        LOG.debug("Fetching Ecs IMDSv2 API Token")
+
+        response = None
+        url = None
+        url_params = self.get_url_params()
+        try:
+            url, response = uhelp.wait_for_url(
+                urls=urls,
+                max_wait=url_params.max_wait_seconds,
+                timeout=url_params.timeout_seconds,
+                status_cb=LOG.warning,
+                headers_cb=self._get_headers,
+                exception_cb=self._imds_exception_cb,
+                request_method=request_method,
+                headers_redact=self.imdsv2_token_redact,
+                connect_synchronously=False,
+            )
+        except uhelp.UrlError:
+            # We use the raised exception to interupt the retry loop.
+            # Nothing else to do here.
+            pass
+
+        if url and response:
+            self._api_token = response
+            return url2base[url]
+
+        # If we get here, then wait_for_url timed out, waiting for IMDS
+        # or the IMDS HTTP endpoint is disabled
+        return None
+
+    def wait_for_metadata_service(self):
+        mcfg = self.ds_cfg
+        mdurls = mcfg.get("metadata_urls", self.metadata_urls)
+
+        # try the api token path first
+        metadata_address = self._maybe_fetch_api_token(mdurls)
+
+        if metadata_address:
+            self.metadata_address = metadata_address
+            LOG.debug("Using metadata source: '%s'", self.metadata_address)
+        else:
+            LOG.warning("IMDS's HTTP endpoint is probably disabled")
+        return bool(metadata_address)
+
+    def crawl_metadata(self):
+        """Crawl metadata service when available.
+
+        @returns: Dictionary of crawled metadata content containing the keys:
+          meta-data, user-data, vendor-data and dynamic.
+        """
+        if not self.wait_for_metadata_service():
+            return {}
+        redact = self.imdsv2_token_redact
+        crawled_metadata = {}
+        exc_cb = self._refresh_stale_aliyun_token_cb
+        exc_cb_ud = self._skip_or_refresh_stale_aliyun_token_cb
+        skip_cb = None
+        exe_cb_whole_meta = self._skip_json_path_meta_path_aliyun_cb
+        try:
+            crawled_metadata["user-data"] = aliyun.get_instance_data(
+                self.min_metadata_version,
+                self.metadata_address,
+                headers_cb=self._get_headers,
+                headers_redact=redact,
+                exception_cb=exc_cb_ud,
+                item_name="user-data",
+            )
+            crawled_metadata["vendor-data"] = aliyun.get_instance_data(
+                self.min_metadata_version,
+                self.metadata_address,
+                headers_cb=self._get_headers,
+                headers_redact=redact,
+                exception_cb=exc_cb_ud,
+                item_name="vendor-data",
+            )
+            try:
+                result = aliyun.get_instance_meta_data(
+                    self.min_metadata_version,
+                    self.metadata_address,
+                    headers_cb=self._get_headers,
+                    headers_redact=redact,
+                    exception_cb=exe_cb_whole_meta,
+                )
+                crawled_metadata["meta-data"] = result
+            except Exception:
+                util.logexc(
+                    LOG,
+                    "Faild read json meta-data from %s "
+                    "fall back directory tree style",
+                    self.metadata_address,
+                )
+                crawled_metadata["meta-data"] = ec2.get_instance_metadata(
+                    self.min_metadata_version,
+                    self.metadata_address,
+                    headers_cb=self._get_headers,
+                    headers_redact=redact,
+                    exception_cb=exc_cb,
+                    retrieval_exception_ignore_cb=skip_cb,
+                )
+        except Exception:
+            util.logexc(
+                LOG,
+                "Failed reading from metadata address %s",
+                self.metadata_address,
+            )
+            return {}
+        return crawled_metadata
+
+    def _refresh_stale_aliyun_token_cb(self, msg, exception):
+        """Exception handler for Ecs to refresh token if token is stale."""
+        if isinstance(exception, uhelp.UrlError) and exception.code == 401:
+            # With _api_token as None, _get_headers will _refresh_api_token.
+            LOG.debug("Clearing cached Ecs API token due to expiry")
+            self._api_token = None
+        return True  # always retry
+
+    def _skip_retry_on_codes(self, status_codes, cause):
+        """Returns False if cause.code is in status_codes."""
+        return cause.code not in status_codes
+
+    def _skip_or_refresh_stale_aliyun_token_cb(self, msg, exception):
+        """Callback will not retry on SKIP_USERDATA_VENDORDATA_CODES or
+        if no token is available."""
+        retry = self._skip_retry_on_codes(ec2.SKIP_USERDATA_CODES, exception)
+        if not retry:
+            return False  # False raises exception
+        return self._refresh_stale_aliyun_token_cb(msg, exception)
+
+    def _skip_json_path_meta_path_aliyun_cb(self, msg, exception):
+        """Callback will not retry of whole meta_path is not found"""
+        if isinstance(exception, uhelp.UrlError) and exception.code == 404:
+            LOG.warning("whole meta_path is not found, skipping")
+            return False
+        return self._refresh_stale_aliyun_token_cb(msg, exception)
+
+    def _get_data(self):
+        if self.cloud_name != self.dsname.lower():
+            return False
+        if self.perform_dhcp_setup:  # Setup networking in init-local stage.
+            if util.is_FreeBSD():
+                LOG.debug("FreeBSD doesn't support running dhclient with -sf")
+                return False
+            try:
+                with EphemeralIPNetwork(
+                    self.distro,
+                    self.distro.fallback_interface,
+                    ipv4=True,
+                    ipv6=False,
+                ) as netw:
+                    self._crawled_metadata = self.crawl_metadata()
+                    LOG.debug(
+                        "Crawled metadata service%s",
+                        f" {netw.state_msg}" if netw.state_msg else "",
+                    )
+
+            except NoDHCPLeaseError:
+                return False
+        else:
+            self._crawled_metadata = self.crawl_metadata()
+        if not self._crawled_metadata or not isinstance(
+            self._crawled_metadata, dict
+        ):
+            return False
+        self.metadata = self._crawled_metadata.get("meta-data", {})
+        self.userdata_raw = self._crawled_metadata.get("user-data", {})
+        self.vendordata_raw = self._crawled_metadata.get("vendor-data", {})
+        return True
+
+    def _refresh_api_token(self, seconds=None):
+        """Request new metadata API token.
+        @param seconds: The lifetime of the token in seconds
+
+        @return: The API token or None if unavailable.
+        """
+        # if self.cloud_name not in IDMSV2_SUPPORTED_CLOUD_PLATFORMS:
+        #     return None
+
+        if seconds is None:
+            seconds = self.imdsv2_token_ttl_seconds
+
+        LOG.debug("Refreshing Ecs metadata API token")
+        request_header = {self.imdsv2_token_req_header: seconds}
+        token_url = "{}/{}".format(self.metadata_address, self.api_token_route)
+        try:
+            response = uhelp.readurl(
+                token_url,
+                headers=request_header,
+                headers_redact=self.imdsv2_token_redact,
+                request_method="PUT",
+            )
+        except uhelp.UrlError as e:
+            LOG.warning(
+                "Unable to get API token: %s raised exception %s", token_url, e
+            )
+            return None
+        return response.contents
+
+    def _get_headers(self, url=""):
+        """Return a dict of headers for accessing a url.
+
+        If _api_token is unset on AWS, attempt to refresh the token via a PUT
+        and then return the updated token header.
+        """
+        # if self.cloud_name not in IDMSV2_SUPPORTED_CLOUD_PLATFORMS:
+        #     return {}
+        # Request a 6 hour token if URL is api_token_route
+        request_token_header = {
+            self.imdsv2_token_req_header: self.imdsv2_token_ttl_seconds
+        }
+        if self.api_token_route in url:
+            return request_token_header
+        if not self._api_token:
+            # If we don't yet have an API token, get one via a PUT against
+            # api_token_route. This _api_token may get unset by a 403 due
+            # to an invalid or expired token
+            self._api_token = self._refresh_api_token()
+            if not self._api_token:
+                return {}
+        return {self.imdsv2_token_put_header: self._api_token}
+
+    def _imds_exception_cb(self, msg, exception=None):
+        """Fail quickly on proper AWS if IMDSv2 rejects API token request
+
+        Guidance from Amazon is that if IMDSv2 had disabled token requests
+        by returning a 403, or cloud-init malformed requests resulting in
+        other 40X errors, we want the datasource detection to fail quickly
+        without retries as those symptoms will likely not be resolved by
+        retries.
+
+        Exceptions such as requests.ConnectionError due to IMDS being
+        temporarily unroutable or unavailable will still retry due to the
+        callsite wait_for_url.
+        """
+        if isinstance(exception, uhelp.UrlError):
+            # requests.ConnectionError will have exception.code == None
+            if exception.code and exception.code >= 400:
+                if exception.code == 403:
+                    LOG.warning(
+                        "Ecs IMDS endpoint returned a 403 error. "
+                        "HTTP endpoint is disabled. Aborting."
+                    )
+                else:
+                    LOG.warning(
+                        "Fatal error while requesting Ecs IMDSv2 API tokens"
+                    )
+                raise exception
 
 
 def _is_aliyun():

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -34,7 +34,6 @@ STRICT_ID_DEFAULT = "warn"
 
 
 class CloudNames:
-    ALIYUN = "aliyun"
     AWS = "aws"
     BRIGHTBOX = "brightbox"
     ZSTACK = "zstack"
@@ -54,7 +53,7 @@ def skip_404_tag_errors(exception):
 
 
 # Cloud platforms that support IMDSv2 style metadata server
-IDMSV2_SUPPORTED_CLOUD_PLATFORMS = [CloudNames.AWS, CloudNames.ALIYUN]
+IDMSV2_SUPPORTED_CLOUD_PLATFORMS = [CloudNames.AWS]
 
 # Only trigger hook-hotplug on NICs with Ec2 drivers. Avoid triggering
 # it on docker virtual NICs and the like. LP: #1946003
@@ -768,11 +767,6 @@ def warn_if_necessary(cfgval, cfg):
     warnings.show_warning("non_ec2_md", cfg, mode=True, sleep=sleep)
 
 
-def identify_aliyun(data):
-    if data["product_name"] == "Alibaba Cloud ECS":
-        return CloudNames.ALIYUN
-
-
 def identify_aws(data):
     # data is a dictionary returned by _collect_platform_data.
     uuid_str = data["uuid"]
@@ -821,7 +815,6 @@ def identify_platform():
         identify_zstack,
         identify_e24cloud,
         identify_outscale,
-        identify_aliyun,
         lambda x: CloudNames.UNKNOWN,
     )
     for checker in checks:

--- a/cloudinit/sources/helpers/aliyun.py
+++ b/cloudinit/sources/helpers/aliyun.py
@@ -1,0 +1,211 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+import logging
+from typing import MutableMapping
+
+from cloudinit import net, url_helper, util
+from cloudinit.sources.helpers import ec2
+
+LOG = logging.getLogger(__name__)
+
+
+def get_instance_meta_data(
+    api_version="latest",
+    metadata_address="http://100.100.100.200",
+    ssl_details=None,
+    timeout=5,
+    retries=5,
+    headers_cb=None,
+    headers_redact=None,
+    exception_cb=None,
+):
+    ud_url = url_helper.combine_url(metadata_address, api_version)
+    ud_url = url_helper.combine_url(ud_url, "meta-data/all")
+    response = url_helper.read_file_or_url(
+        ud_url,
+        ssl_details=ssl_details,
+        timeout=timeout,
+        retries=retries,
+        exception_cb=exception_cb,
+        headers_cb=headers_cb,
+        headers_redact=headers_redact,
+    )
+    meta_data_raw: object = util.load_json(response.contents)
+
+    # meta_data_raw is a json object with the following format get
+    # by`meta-data/all`
+    # {
+    #   "sub-private-ipv4-list": "",
+    #   "dns-conf": {
+    #     "nameservers": "100.100.2.136\r\n100.100.2.138"
+    #   },
+    #   "zone-id": "cn-hangzhou-i",
+    #   "instance": {
+    #     "instance-name": "aliyun_vm_test",
+    #     "instance-type": "ecs.g7.xlarge"
+    #   },
+    #   "disks": {
+    #     "bp1cikh4di1xxxx": {
+    #       "name": "disk_test",
+    #       "id": "d-bp1cikh4di1lf7pxxxx"
+    #     }
+    #   },
+    #   "instance-id": "i-bp123",
+    #   "eipv4": "47.99.152.7",
+    #   "private-ipv4": "192.168.0.9",
+    #   "hibernation": {
+    #     "configured": "false"
+    #   },
+    #   "vpc-id": "vpc-bp1yeqg123",
+    #   "mac": "00:16:3e:30:3e:ca",
+    #   "source-address": "http://mirrors.cloud.aliyuncs.com",
+    #   "vswitch-cidr-block": "192.168.0.0/24",
+    #   "network": {
+    #     "interfaces": {
+    #       "macs": {
+    #         "00:16:3e:30:3e:ca": {
+    #           "vpc-cidr-block": "192.168.0.0/16",
+    #           "netmask": "255.255.255.0"
+    #         }
+    #       }
+    #     }
+    #   },
+    #   "network-type": "vpc",
+    #   "hostname": "aliyun_vm_test",
+    #   "region-id": "cn-hangzhou",
+    #   "ntp-conf": {
+    #     "ntp-servers": "ntp1.aliyun.com\r\nntp2.aliyun.com"
+    #   },
+    # }
+    # Note: For example, in the values of dns conf: the `nameservers`
+    # key is a string, the format is the same as the response from the
+    # `meta-data/dns-conf/nameservers` endpoint. we use the same
+    # serialization method to ensure consistency between
+    # the two methods (directory tree and json path).
+    def _process_dict_values(d):
+        if isinstance(d, dict):
+            return {k: _process_dict_values(v) for k, v in d.items()}
+        elif isinstance(d, list):
+            return [_process_dict_values(item) for item in d]
+        else:
+            return ec2.MetadataLeafDecoder()("", d)
+
+    return _process_dict_values(meta_data_raw)
+
+
+def get_instance_data(
+    api_version="latest",
+    metadata_address="http://100.100.100.200",
+    ssl_details=None,
+    timeout=5,
+    retries=5,
+    headers_cb=None,
+    headers_redact=None,
+    exception_cb=None,
+    item_name=None,
+):
+    ud_url = url_helper.combine_url(metadata_address, api_version)
+    ud_url = url_helper.combine_url(ud_url, item_name)
+    data = b""
+    support_items_list = ["user-data", "vendor-data"]
+    if item_name not in support_items_list:
+        LOG.error(
+            "aliyun datasource not support the item  %s",
+            item_name,
+        )
+        return data
+    try:
+        response = url_helper.read_file_or_url(
+            ud_url,
+            ssl_details=ssl_details,
+            timeout=timeout,
+            retries=retries,
+            exception_cb=exception_cb,
+            headers_cb=headers_cb,
+            headers_redact=headers_redact,
+        )
+        data = response.contents
+    except Exception:
+        util.logexc(LOG, "Failed fetching %s from url %s", item_name, ud_url)
+    return data
+
+
+def convert_ecs_metadata_network_config(
+    network_md,
+    macs_to_nics=None,
+    fallback_nic=None,
+    full_network_config=True,
+):
+    """Convert ecs metadata to network config version 2 data dict.
+
+    @param: network_md: 'network' portion of ECS metadata.
+    generally formed as {"interfaces": {"macs": {}} where
+    'macs' is a dictionary with mac address as key:
+    @param: macs_to_nics: Optional dict of mac addresses and nic names. If
+    not provided, get_interfaces_by_mac is called to get it from the OS.
+    @param: fallback_nic: Optionally provide the primary nic interface name.
+    This nic will be guaranteed to minimally have a dhcp4 configuration.
+    @param: full_network_config: Boolean set True to configure all networking
+    presented by IMDS. This includes rendering secondary IPv4 and IPv6
+    addresses on all NICs and rendering network config on secondary NICs.
+    If False, only the primary nic will be configured and only with dhcp
+    (IPv4/IPv6).
+
+    @return A dict of network config version 2 based on the metadata and macs.
+    """
+    netcfg: MutableMapping = {"version": 2, "ethernets": {}}
+    if not macs_to_nics:
+        macs_to_nics = net.get_interfaces_by_mac()
+    macs_metadata = network_md["interfaces"]["macs"]
+
+    if not full_network_config:
+        for mac, nic_name in macs_to_nics.items():
+            if nic_name == fallback_nic:
+                break
+        dev_config: MutableMapping = {
+            "dhcp4": True,
+            "dhcp6": False,
+            "match": {"macaddress": mac.lower()},
+            "set-name": nic_name,
+        }
+        nic_metadata = macs_metadata.get(mac)
+        if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
+            dev_config["dhcp6"] = True
+        netcfg["ethernets"][nic_name] = dev_config
+        return netcfg
+    nic_name_2_mac_map = dict()
+    for mac, nic_name in macs_to_nics.items():
+        nic_metadata = macs_metadata.get(mac)
+        if not nic_metadata:
+            continue  # Not a physical nic represented in metadata
+        nic_name_2_mac_map[nic_name] = mac
+
+    # sorted by nic_name
+    orderd_nic_name_list = sorted(
+        nic_name_2_mac_map.keys(), key=net.natural_sort_key
+    )
+    for nic_idx, nic_name in enumerate(orderd_nic_name_list):
+        nic_mac = nic_name_2_mac_map[nic_name]
+        nic_metadata = macs_metadata.get(nic_mac)
+        dhcp_override = {"route-metric": (nic_idx + 1) * 100}
+        dev_config = {
+            "dhcp4": True,
+            "dhcp4-overrides": dhcp_override,
+            "dhcp6": False,
+            "match": {"macaddress": nic_mac.lower()},
+            "set-name": nic_name,
+        }
+        if nic_metadata.get("ipv6s"):  # Any IPv6 addresses configured
+            dev_config["dhcp6"] = True
+            dev_config["dhcp6-overrides"] = dhcp_override
+
+        netcfg["ethernets"][nic_name] = dev_config
+    # Remove route-metric dhcp overrides and routes / routing-policy if only
+    # one nic configured
+    if len(netcfg["ethernets"]) == 1:
+        for nic_name in netcfg["ethernets"].keys():
+            netcfg["ethernets"][nic_name].pop("dhcp4-overrides")
+            netcfg["ethernets"][nic_name].pop("dhcp6-overrides", None)
+            netcfg["ethernets"][nic_name].pop("routes", None)
+            netcfg["ethernets"][nic_name].pop("routing-policy", None)
+    return netcfg

--- a/tests/unittests/sources/test_ec2.py
+++ b/tests/unittests/sources/test_ec2.py
@@ -1710,16 +1710,6 @@ class TestIdentifyPlatform:
         assert ec2.CloudNames.AWS == ec2.identify_platform()
 
     @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
-    def test_identify_aliyun(self, m_collect):
-        """aliyun should be identified if product name equals to
-        Alibaba Cloud ECS
-        """
-        m_collect.return_value = self.collmock(
-            product_name="Alibaba Cloud ECS"
-        )
-        assert ec2.CloudNames.ALIYUN == ec2.identify_platform()
-
-    @mock.patch("cloudinit.sources.DataSourceEc2._collect_platform_data")
     def test_identify_zstack(self, m_collect):
         """zstack should be identified if chassis-asset-tag
         ends in .zstack.io


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## feat: aliyun datasource support crawl metadata at once
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
In the pr: https://github.com/canonical/cloud-init/pull/5838,
we discussed the optimization of improving the startup
speed of cloudinit, which is to provide a path in the IMDS server
to return all instance metadata information at once. This PR
is mainly due to the support of this feature in the aliyun data
source. We separated the data source from EC2, of course, we also
reused some tool functions of EC2. The benefits of the separation
are obvious. Prior to this, some behaviors of EC2 affected Alibaba
Cloud, such as the device number attribute in network configuration.
https://bugs.launchpad.net/cloud-init/+bug/1917875

The update made this time are as follows
1. Separate the Alibaba Cloud data source from ec2 and make it
   independent
2. Alibaba Cloud data sources will prioritize obtaining metadata
   information from the new path at once. If it fails, it will return
   to the previous directory tree format
3. The network_config in aliyun data sources has streamlined
   the logic in EC2, using network card names to sort routing
   priorities
4. aliyun data sources support vendor data
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
