### PR TITLE
Wait for udev

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -771,7 +771,11 @@ def convert_net_json(network_json=None, known_macs=None):
             if not mac:
                 raise ValueError("No mac_address or name entry for %s" % d)
             if mac not in known_macs:
-                raise ValueError("Unable to find a system nic for %s" % d)
+                # Let's give udev a chance to catch up
+                util.udevadm_settle()
+                known_macs = net.get_interfaces_by_mac()
+                if mac not in known_macs:
+                    raise ValueError("Unable to find a system nic for %s" % d)
             d["name"] = known_macs[mac]
 
         for cfg, key, fmt, targets in link_updates:

--- a/tests/unittests/sources/test_configdrive.py
+++ b/tests/unittests/sources/test_configdrive.py
@@ -389,7 +389,6 @@ class TestConfigDriveDataSource(CiTestCase):
             M_PATH + "util.find_devs_with", "m_find_devs_with", return_value=[]
         )
         self.tmp = self.tmp_dir()
-        self.allowed_subp = True
 
     def test_ec2_metadata(self):
         populate_dir(self.tmp, CFG_DRIVE_FILES_V2)
@@ -870,7 +869,6 @@ class TestConvertNetworkData(CiTestCase):
     def setUp(self):
         super(TestConvertNetworkData, self).setUp()
         self.tmp = self.tmp_dir()
-        self.allowed_subp = True
 
     def _getnames_in_config(self, ncfg):
         return set(
@@ -898,12 +896,15 @@ class TestConvertNetworkData(CiTestCase):
 
     def test_convert_raises_value_error_on_missing_name(self):
         macs = {"aa:aa:aa:aa:aa:00": "ens1"}
-        self.assertRaises(
-            ValueError,
-            openstack.convert_net_json,
-            NETWORK_DATA,
-            known_macs=macs,
-        )
+        with mock.patch(
+            "cloudinit.sources.helpers.openstack.util.udevadm_settle"
+        ):
+            self.assertRaises(
+                ValueError,
+                openstack.convert_net_json,
+                NETWORK_DATA,
+                known_macs=macs,
+            )
 
     def test_conversion_with_route(self):
         ncfg = openstack.convert_net_json(

--- a/tests/unittests/sources/test_configdrive.py
+++ b/tests/unittests/sources/test_configdrive.py
@@ -389,6 +389,7 @@ class TestConfigDriveDataSource(CiTestCase):
             M_PATH + "util.find_devs_with", "m_find_devs_with", return_value=[]
         )
         self.tmp = self.tmp_dir()
+        self.allowed_subp = True
 
     def test_ec2_metadata(self):
         populate_dir(self.tmp, CFG_DRIVE_FILES_V2)
@@ -869,6 +870,7 @@ class TestConvertNetworkData(CiTestCase):
     def setUp(self):
         super(TestConvertNetworkData, self).setUp()
         self.tmp = self.tmp_dir()
+        self.allowed_subp = True
 
     def _getnames_in_config(self, ncfg):
         return set(


### PR DESCRIPTION


<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message

It is possible that we outrun udev and when we try to enumerate the macs any given mac may not yet be present. If we detect the condition give udev a chance to catch up and check the system macs again before triggering an error.

Fixes #4125

## Additional Context
This mostly addresses the issue observed in #4125. There are still corner cases where this change would not totally prevent the problem. 

## Test Steps
Customer running into this condition has verified that this change addresses their issue on SLE.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
