### PR TITLE
chore: cleanup `len' usage

### DIFF
--- a/cloudinit/config/cc_apt_configure.py
+++ b/cloudinit/config/cc_apt_configure.py
@@ -241,7 +241,7 @@ def apply_debconf_selections(cfg):
     LOG.debug("pkgs_cfgd: %s", pkgs_cfgd)
     need_reconfig = pkgs_cfgd.intersection(pkgs_installed)
 
-    if len(need_reconfig) == 0:
+    if not need_reconfig:
         LOG.debug("no need for reconfig")
         return
 

--- a/cloudinit/config/cc_byobu.py
+++ b/cloudinit/config/cc_byobu.py
@@ -28,7 +28,7 @@ meta: MetaSchema = {
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
-    if len(args) != 0:
+    if args:
         value = args[0]
     else:
         value = util.get_cfg_option_str(cfg, "byobu_by_default", "")

--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -377,7 +377,7 @@ def check_partition_mbr_layout(device, layout):
     found_layout = []
     for line in out.splitlines():
         _line = line.split()
-        if len(_line) == 0:
+        if not _line:
             continue
 
         if device in _line[0]:
@@ -500,7 +500,7 @@ def get_partition_mbr_layout(size, layout):
         # Create a single partition, default to Linux
         return ",,83"
 
-    if (len(layout) == 0 and isinstance(layout, list)) or not isinstance(
+    if ((not layout) and isinstance(layout, list)) or not isinstance(
         layout, list
     ):
         raise RuntimeError("Partition layout is invalid")

--- a/cloudinit/config/cc_final_message.py
+++ b/cloudinit/config/cc_final_message.py
@@ -38,7 +38,7 @@ FINAL_MESSAGE_DEF = (
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
 
     msg_in = ""
-    if len(args) != 0:
+    if args:
         msg_in = str(args[0])
     else:
         msg_in = util.get_cfg_option_str(cfg, "final_message", "")

--- a/cloudinit/config/cc_locale.py
+++ b/cloudinit/config/cc_locale.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger(__name__)
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
-    if len(args) != 0:
+    if args:
         locale = args[0]
     else:
         locale = util.get_cfg_option_str(cfg, "locale", cloud.get_locale())

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -548,7 +548,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     if swapfile:
         updated_cfg.append([swapfile, "none", "swap", "sw", "0", "0"])
 
-    if len(updated_cfg) == 0:
+    if not updated_cfg:
         # This will only be true if there is no mount configuration at all
         # Even if fstab has no functional changes, we'll get past this point
         # as we remove any 'comment=cloudconfig' lines and then add them back

--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -427,18 +427,14 @@ def write_ntp_config_template(
     if not peers:
         peers = []
 
-    if len(servers) == 0 and len(pools) == 0 and distro_name == "cos":
+    if not servers and not pools and distro_name == "cos":
         return
-    if (
-        len(servers) == 0
-        and distro_name == "alpine"
-        and service_name == "ntpd"
-    ):
+    if not servers and distro_name == "alpine" and service_name == "ntpd":
         # Alpine's Busybox ntpd only understands "servers" configuration
         # and not "pool" configuration.
         servers = generate_server_names(distro_name)
         LOG.debug("Adding distro default ntp servers: %s", ",".join(servers))
-    elif len(servers) == 0 and len(pools) == 0:
+    elif not (servers) and not (pools):
         pools = generate_server_names(distro_name)
         LOG.debug(
             "Adding distro default ntp pool servers: %s", ",".join(pools)

--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -47,7 +47,7 @@ LOG = logging.getLogger(__name__)
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
-    if len(args) != 0:
+    if args:
         ph_cfg = util.read_conf(args[0])
     else:
         if "phone_home" not in cfg:

--- a/cloudinit/config/cc_resizefs.py
+++ b/cloudinit/config/cc_resizefs.py
@@ -249,7 +249,7 @@ def maybe_get_writable_device_path(devpath, info):
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
-    if len(args) != 0:
+    if args:
         resize_root = args[0]
     else:
         resize_root = util.get_cfg_option_str(cfg, "resize_rootfs", True)

--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -330,7 +330,7 @@ class SubscriptionManager:
         """
 
         # An empty list was passed
-        if len(pools) == 0:
+        if not pools:
             self.log.debug("No pools to attach")
             return True
 
@@ -379,7 +379,7 @@ class SubscriptionManager:
             return False
 
         # Bail if both lists are not populated
-        if (len(erepos) == 0) and (len(drepos) == 0):
+        if not (erepos) and not (drepos):
             self.log.debug("No repo IDs to enable or disable")
             return True
 

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -47,7 +47,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         return
 
     # import for "user: XXXXX"
-    if len(args) != 0:
+    if args:
         user = args[0]
         ids = []
         if len(args) > 1:

--- a/cloudinit/config/cc_timezone.py
+++ b/cloudinit/config/cc_timezone.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger(__name__)
 
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
-    if len(args) != 0:
+    if args:
         timezone = args[0]
     else:
         timezone = util.get_cfg_option_str(cfg, "timezone", False)

--- a/cloudinit/distros/aosc.py
+++ b/cloudinit/distros/aosc.py
@@ -135,7 +135,7 @@ def update_locale_conf(sys_path, locale_cfg):
         if v is None:
             continue
         v = str(v)
-        if len(v) == 0:
+        if not v:
             continue
         contents[k] = v
         updated_am += 1

--- a/cloudinit/distros/parsers/ifconfig.py
+++ b/cloudinit/distros/parsers/ifconfig.py
@@ -102,7 +102,7 @@ class Ifconfig:
         ifs_by_mac = defaultdict(list)
         dev = None
         for line in text.splitlines():
-            if len(line) == 0:
+            if not line:
                 continue
             if line[0] not in ("\t", " "):
                 # We hit the start of a device block in the ifconfig output

--- a/cloudinit/distros/parsers/sys_conf.py
+++ b/cloudinit/distros/parsers/sys_conf.py
@@ -65,7 +65,7 @@ class SysConf(configobj.ConfigObj):
     def _quote(self, value, multiline=False):
         if not isinstance(value, str):
             raise ValueError('Value "%s" is not a string' % (value))
-        if len(value) == 0:
+        if not value:
             return ""
         quot_func = None
         if value[0] in ['"', "'"] and value[-1] in ['"', "'"]:

--- a/cloudinit/distros/rhel_util.py
+++ b/cloudinit/distros/rhel_util.py
@@ -26,7 +26,7 @@ def update_sysconfig_file(fn, adjustments, allow_empty=False):
         if v is None:
             continue
         v = str(v)
-        if len(v) == 0 and not allow_empty:
+        if (not v) and (not allow_empty):
             continue
         contents[k] = v
         updated_am += 1

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -828,7 +828,7 @@ def _rename_interfaces(
         "up": Iproute2.link_up,
     }
 
-    if len(ops) + len(ups) == 0:
+    if not (ops) and not (ups):
         if len(errors):
             LOG.warning(
                 "Unable to rename interfaces: %s due to errors: %s",

--- a/cloudinit/net/dhcp.py
+++ b/cloudinit/net/dhcp.py
@@ -237,7 +237,7 @@ class IscDhclient(DhcpClient):
         """
         lease_regex = re.compile(r"lease {(?P<lease>.*?)}\n", re.DOTALL)
         dhcp_leases: List[Dict] = []
-        if len(lease_content) == 0:
+        if not lease_content:
             return []
         for lease in lease_regex.findall(lease_content):
             lease_options = []

--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -938,7 +938,7 @@ class Renderer(renderer.Renderer):
         ):
             content.set_section_keypair("main", "dns", "none")
 
-        if len(content) == 0:
+        if not content:
             return None
         out = "".join([_make_header(), "\n", "\n".join(content.write()), "\n"])
         return out

--- a/cloudinit/netinfo.py
+++ b/cloudinit/netinfo.py
@@ -189,7 +189,7 @@ def _netdev_info_ifconfig_netbsd(ifconfig_data):
     # fields that need to be returned in devs for each dev
     devs = {}
     for line in ifconfig_data.splitlines():
-        if len(line) == 0:
+        if not line:
             continue
         if line[0] not in ("\t", " "):
             curdev = line.split()[0]
@@ -237,7 +237,7 @@ def _netdev_info_ifconfig(ifconfig_data):
     # fields that need to be returned in devs for each dev
     devs = {}
     for line in ifconfig_data.splitlines():
-        if len(line) == 0:
+        if not line:
             continue
         if line[0] not in ("\t", " "):
             curdev = line.split()[0]
@@ -587,7 +587,8 @@ def netdev_pformat():
         fields = ["Device", "Up", "Address", "Mask", "Scope", "Hw-Address"]
         tbl = SimpleTable(fields)
         for dev, data in sorted(netdev.items()):
-            for addr in data.get("ipv4"):
+            ipv4_addrs = data.get("ipv4")
+            for addr in ipv4_addrs:
                 tbl.add_row(
                     (
                         dev,
@@ -598,7 +599,9 @@ def netdev_pformat():
                         data["hwaddr"],
                     )
                 )
-            for addr in data.get("ipv6"):
+
+            ipv6_addrs = data.get("ipv6")
+            for addr in ipv6_addrs:
                 tbl.add_row(
                     (
                         dev,
@@ -609,7 +612,7 @@ def netdev_pformat():
                         data["hwaddr"],
                     )
                 )
-            if len(data.get("ipv6")) + len(data.get("ipv4")) == 0:
+            if not (ipv4_addrs) and not (ipv6_addrs):
                 tbl.add_row(
                     (dev, data["up"], empty, empty, empty, data["hwaddr"])
                 )

--- a/cloudinit/reporting/handlers.py
+++ b/cloudinit/reporting/handlers.py
@@ -345,7 +345,7 @@ class HyperVKvpReportingHandler(ReportingHandler):
             result_array.append(self._encode_kvp_item(subkey, value))
             i += 1
             des_in_json = des_in_json[room_for_desc:]
-            if len(des_in_json) == 0:
+            if not des_in_json:
                 break
         return result_array
 

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1733,15 +1733,18 @@ def can_dev_be_reformatted(devpath, preserve_ntfs):
     # devpath of /dev/sd[a-z] or /dev/disk/cloud/azure_resource
     # where partitions are "<devpath>1" or "<devpath>-part1" or "<devpath>p1"
     partitions = _partitions_on_device(devpath)
-    if len(partitions) == 0:
+    if not partitions:
         return False, "device %s was not partitioned" % devpath
-    elif len(partitions) > 2:
+
+    partition_len = len(partitions)
+    if partition_len > 2:
         msg = "device %s had 3 or more partitions: %s" % (
             devpath,
             " ".join([p[1] for p in partitions]),
         )
         return False, msg
-    elif len(partitions) == 2:
+
+    if partition_len == 2:
         cand_part, cand_path = partitions[1]
     else:
         cand_part, cand_path = partitions[0]

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -895,7 +895,7 @@ def _build_nic_order(
     @return: Dictionary with macs as keys and nic orders as values.
     """
     nic_order: Dict[str, int] = {}
-    if len(macs_to_nics) == 0 or len(macs_metadata) == 0:
+    if (not macs_to_nics) or (not macs_metadata):
         return nic_order
 
     valid_macs_metadata = filter(

--- a/cloudinit/sources/DataSourceMAAS.py
+++ b/cloudinit/sources/DataSourceMAAS.py
@@ -197,7 +197,7 @@ def get_id_from_ds_cfg(ds_cfg):
 def read_maas_seed_dir(seed_d):
     if seed_d.startswith("file://"):
         seed_d = seed_d[7:]
-    if not os.path.isdir(seed_d) or len(os.listdir(seed_d)) == 0:
+    if not os.path.isdir(seed_d) or not os.listdir(seed_d):
         raise MAASSeedDirNone("%s: not a directory")
 
     # seed_dir looks in seed_dir, not seed_dir/VERSION
@@ -283,7 +283,7 @@ def check_seed_contents(content, seed):
         else:
             ret[dpath] = content[spath]
 
-    if len(ret) == 0:
+    if not ret:
         raise MAASSeedDirNone("%s: no data files found" % seed)
 
     if missing:

--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -167,7 +167,7 @@ class DataSourceNoCloud(sources.DataSource):
 
         # There was no indication on kernel cmdline or data
         # in the seeddir suggesting this handler should be used.
-        if len(found) == 0:
+        if not found:
             return False
 
         # The special argument "seedfrom" indicates we should

--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -78,7 +78,7 @@ class DataSourceOVF(sources.DataSource):
                 found.append(name)
 
         # There was no OVF transports found
-        if len(found) == 0:
+        if not found:
             return False
 
         if "seedfrom" in md and md["seedfrom"]:
@@ -372,7 +372,7 @@ def get_properties(contents):
         dom.documentElement, lambda n: n.localName == "PropertySection"
     )
 
-    if len(propSections) == 0:
+    if not propSections:
         raise XmlError("No 'PropertySection's")
 
     props = {}

--- a/cloudinit/sources/DataSourceSmartOS.py
+++ b/cloudinit/sources/DataSourceSmartOS.py
@@ -438,7 +438,7 @@ class JoyentMetadataClient:
         while True:
             try:
                 byte = self.fp.read(1)
-                if len(byte) == 0:
+                if not byte:
                     raise JoyentMetadataTimeoutException(msg % as_ascii())
                 if byte == b"\n":
                     return as_ascii()

--- a/cloudinit/sources/DataSourceVMware.py
+++ b/cloudinit/sources/DataSourceVMware.py
@@ -500,7 +500,7 @@ def get_none_if_empty_val(val):
     # simplify the rest of this function's logic.
     val = util.decode_binary(val)
     val = val.rstrip()
-    if len(val) == 0 or val == GUESTINFO_EMPTY_YAML_VAL:
+    if (not val) or (val == GUESTINFO_EMPTY_YAML_VAL):
         return None
     return val
 

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -237,14 +237,14 @@ def merge_agent_landscape_data(
     cloud-init to merge separate parts.
     """
     # Ignore agent_data if None or empty
-    if agent_data is None or len(agent_data.raw) == 0:
-        if user_data is None or len(user_data.raw) == 0:
+    if (agent_data is None) or (not agent_data.raw):
+        if (user_data is None) or (not user_data.raw):
             return None
         return user_data.raw
 
     # Ignore user_data if None or empty
-    if user_data is None or len(user_data.raw) == 0:
-        if agent_data is None or len(agent_data.raw) == 0:
+    if (user_data is None) or (not user_data.raw):
+        if (agent_data is None) or (not agent_data.raw):
             return None
         return agent_data.raw
 

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -1034,7 +1034,7 @@ class OvfEnvXml:
         matches = node.findall(
             "./%s:%s" % (namespace, name), OvfEnvXml.NAMESPACES
         )
-        if len(matches) == 0:
+        if not matches:
             msg = "missing configuration for %r" % name
             LOG.debug(msg)
             if required:
@@ -1058,13 +1058,14 @@ class OvfEnvXml:
         default=None,
     ):
         matches = node.findall("./wa:" + name, OvfEnvXml.NAMESPACES)
-        if len(matches) == 0:
+        if not matches:
             msg = "missing configuration for %r" % name
             LOG.debug(msg)
             if required:
                 raise errors.ReportableErrorOvfInvalidMetadata(msg)
             return default
-        elif len(matches) > 1:
+
+        if len(matches) > 1:
             raise errors.ReportableErrorOvfInvalidMetadata(
                 "multiple configuration matches for %r (%d)"
                 % (name, len(matches))

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -408,7 +408,7 @@ class ConfigDriveReader(BaseReader):
             path = self._path_join(self.base_path, name)
             if os.path.exists(path):
                 found[name] = path
-        if len(found) == 0:
+        if not found:
             raise NonReadable("%s: no files found" % (self.base_path))
 
         md = {}

--- a/cloudinit/sources/helpers/vultr.py
+++ b/cloudinit/sources/helpers/vultr.py
@@ -78,7 +78,7 @@ def get_interface_list():
     except Exception as e:
         LOG.error("find_candidate_nics script exception: %s", e)
 
-    if len(ifaces) == 0:
+    if not ifaces:
         for iface in net.find_candidate_nics():
             # Skip dummy
             if "dummy" in iface:

--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -312,7 +312,7 @@ def check_permissions(username, current_path, full_path, is_file, strictmodes):
 
     # 3. no write permission (w) is given to group and world users (022)
     # Group and world user can still have +rx.
-    if strictmodes and parent_permission & 0o022 != 0:
+    if strictmodes and (parent_permission & 0o022):
         LOG.debug(
             "Path %s in %s must not give write"
             "permission to group or world users. Ignoring key.",

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -125,7 +125,7 @@ def lsb_release():
             if fname in fmap:
                 data[fmap[fname]] = val.strip()
         missing = [k for k in fmap.values() if k not in data]
-        if len(missing):
+        if missing:
             LOG.warning(
                 "Missing fields in lsb_release --all output: %s",
                 ",".join(missing),
@@ -1627,11 +1627,11 @@ def pipe_in_out(in_fh, out_fh, chunk_size=1024, chunk_cb=None):
         data = in_fh.read(chunk_size)
         if len(data) == 0:
             break
-        else:
-            out_fh.write(data)
-            bytes_piped += len(data)
-            if chunk_cb:
-                chunk_cb(bytes_piped)
+        out_fh.write(data)
+        bytes_piped += len(data)
+        if chunk_cb:
+            chunk_cb(bytes_piped)
+
     out_fh.flush()
     return bytes_piped
 
@@ -2991,7 +2991,7 @@ def wait_for_files(flist, maxwait, naplen=0.5, log_pre=""):
     waited = 0
     while True:
         need -= set([f for f in need if os.path.exists(f)])
-        if len(need) == 0:
+        if not need:
             LOG.debug(
                 "%sAll files appeared after %s seconds: %s",
                 log_pre,

--- a/setup.py
+++ b/setup.py
@@ -242,13 +242,11 @@ class InitsysInstallData(install):
         if self.init_system and isinstance(self.init_system, str):
             self.init_system = self.init_system.split(",")
 
-        if len(self.init_system) == 0 and not platform.system().endswith(
-            "BSD"
-        ):
+        if not self.init_system and not platform.system().endswith("BSD"):
             self.init_system = ["systemd"]
 
         bad = [f for f in self.init_system if f not in INITSYS_TYPES]
-        if len(bad) != 0:
+        if bad:
             raise DistutilsError("Invalid --init-system: %s" % ",".join(bad))
 
         for system in self.init_system:

--- a/tests/unittests/runs/test_merge_run.py
+++ b/tests/unittests/runs/test_merge_run.py
@@ -66,7 +66,7 @@ class TestMergeRun(helpers.FilesystemMockingTestCase):
         self.assertEqual(mirror["arches"], ["i386", "amd64", "blah"])
         mods = Modules(initer)
         (which_ran, failures) = mods.run_section("cloud_init_modules")
-        self.assertTrue(len(failures) == 0)
+        self.assertFalse(failures)
         self.assertTrue(os.path.exists("/etc/blah.ini"))
         self.assertIn("write_files", which_ran)
         contents = util.load_text_file("/etc/blah.ini")

--- a/tests/unittests/runs/test_simple_run.py
+++ b/tests/unittests/runs/test_simple_run.py
@@ -97,7 +97,7 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
 
         mods = Modules(initer)
         (which_ran, failures) = mods.run_section("cloud_init_modules")
-        self.assertTrue(len(failures) == 0)
+        self.assertFalse(failures)
         self.assertTrue(os.path.exists("/etc/blah.ini"))
         self.assertIn("write_files", which_ran)
         contents = util.load_text_file("/etc/blah.ini")
@@ -125,7 +125,7 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
 
         mods = Modules(initer)
         (which_ran, failures) = mods.run_section("cloud_init_modules")
-        self.assertTrue(len(failures) == 0)
+        self.assertFalse(failures)
         self.assertIn(
             "Skipping modules 'spacewalk' because they are not verified on"
             " distro 'ubuntu'",
@@ -154,7 +154,7 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
 
         mods = Modules(initer)
         (which_ran, failures) = mods.run_section("cloud_init_modules")
-        self.assertTrue(len(failures) == 0)
+        self.assertFalse(failures)
         self.assertIn("runcmd", which_ran)
         self.assertNotIn(
             "Skipping modules 'runcmd' because they are not verified on"
@@ -189,7 +189,7 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
 
         mods = Modules(initer)
         (which_ran, failures) = mods.run_section("cloud_init_modules")
-        self.assertTrue(len(failures) == 0)
+        self.assertFalse(failures)
         self.assertIn("spacewalk", which_ran)
         self.assertIn(
             "running unverified_modules: 'spacewalk'", self.logs.getvalue()
@@ -223,5 +223,5 @@ class TestSimpleRun(helpers.FilesystemMockingTestCase):
 
         mods = Modules(initer)
         (which_ran, failures) = mods.run_section("cloud_init_modules")
-        self.assertTrue(len(failures) == 0)
+        self.assertFalse(failures)
         self.assertEqual([], which_ran)

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3843,8 +3843,8 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 0
-        assert len(self.mock_azure_report_failure_to_fabric.mock_calls) == 0
+        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_azure_report_failure_to_fabric.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
         # Verify dmesg reported via KVP.
@@ -3928,8 +3928,8 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 0
-        assert len(self.mock_azure_report_failure_to_fabric.mock_calls) == 0
+        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_azure_report_failure_to_fabric.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
         # Verify dmesg reported via KVP.
@@ -4014,7 +4014,7 @@ class TestProvisioning:
         # Verify reports via KVP.
         assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 1
         assert len(self.mock_azure_report_failure_to_fabric.mock_calls) == 1
-        assert len(self.mock_kvp_report_success_to_host.mock_calls) == 0
+        assert not self.mock_kvp_report_success_to_host.mock_calls
 
         # Verify dmesg reported via KVP.
         assert len(self.mock_report_dmesg_to_kvp.mock_calls) == 1
@@ -4197,7 +4197,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 0
+        assert not self.mock_kvp_report_failure_to_host.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
         # Verify dmesg reported via KVP.
@@ -4324,7 +4324,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 0
+        assert not self.mock_kvp_report_failure_to_host.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
         # Verify dmesg reported via KVP.
@@ -4453,7 +4453,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 0
+        assert not self.mock_kvp_report_failure_to_host.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
         # Verify dmesg reported via KVP.
@@ -4589,7 +4589,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 0
+        assert not self.mock_kvp_report_failure_to_host.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
         # Verify dmesg reported via KVP.
@@ -4830,7 +4830,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 0
+        assert not self.mock_kvp_report_failure_to_host.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
     @pytest.mark.parametrize("pps_type", ["Savable", "Running", "Unknown"])
@@ -4863,7 +4863,7 @@ class TestProvisioning:
 
         # Verify reports via KVP.
         assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 2
-        assert len(self.mock_kvp_report_success_to_host.mock_calls) == 0
+        assert not self.mock_kvp_report_success_to_host.mock_calls
 
     @pytest.mark.parametrize(
         "subp_side_effect",
@@ -4979,7 +4979,7 @@ class TestProvisioning:
 
         # Verify reports via KVP.
         assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 1
-        assert len(self.mock_kvp_report_success_to_host.mock_calls) == 0
+        assert not self.mock_kvp_report_success_to_host.mock_calls
 
 
 class TestCheckAzureProxyAgent:

--- a/tests/unittests/sources/test_configdrive.py
+++ b/tests/unittests/sources/test_configdrive.py
@@ -597,7 +597,7 @@ class TestConfigDriveDataSource(CiTestCase):
         devs_with_answers = {}
 
         def my_devs_with(*args, **kwargs):
-            criteria = args[0] if len(args) else kwargs.pop("criteria", None)
+            criteria = args[0] if args else kwargs.pop("criteria", None)
             return devs_with_answers.get(criteria, [])
 
         def my_is_partition(dev):

--- a/tests/unittests/sources/test_maas.py
+++ b/tests/unittests/sources/test_maas.py
@@ -105,7 +105,7 @@ class TestMAASDataSource:
         return what read_maas_seed_url returns."""
 
         def my_readurl(*args, **kwargs):
-            if len(args):
+            if args:
                 url = args[0]
             else:
                 url = kwargs["url"]

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -92,7 +92,7 @@ def _register_uris(version, ec2_files, ec2_meta, os_files, *, responses_mock):
 
     def match_ec2_url(uri, headers):
         path = uri.path.strip("/")
-        if len(path) == 0:
+        if not path:
             return (200, headers, "\n".join(EC2_VERSIONS))
         path = uri.path.lstrip("/")
         if path in ec2_files:

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5085,7 +5085,7 @@ class TestGetInterfaces:
 
         assert "tun0" in self._se_get_devicelist()
         found = [ent for ent in ret if "tun0" in ent]
-        assert len(found) == 0
+        assert not found
 
     def test_gi_excludes_stolen_macs(self, mocks):
         ret = net.get_interfaces()


### PR DESCRIPTION
In most cases there is need to calculate length of list of string values to do something else, just ensuring list or string is not empty is enough. This will also give a slight performance gain.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [] I have signed the CLA: https://ubuntu.com/legal/contributors
- [] I have added my Github username to ``tools/.github-cla-signers``
- [] I have included a comprehensive commit message using the guide below
- [] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!--
chore: cleanup `len' usage

In most cases there is need to calculate length of list of string values
to do something else, just ensuring list or string is not empty is
enough. This will also give a slight performance gain.
-->
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
