### PR TITLE
fix: Use /usr/lib/ rather than /lib in packaging code

### DIFF
--- a/setup_utils.py
+++ b/setup_utils.py
@@ -16,11 +16,11 @@ def pkg_config_read(library: str, var: str) -> str:
     fallbacks = {
         "systemd": {
             "systemdsystemconfdir": "/etc/systemd/system",
-            "systemdsystemunitdir": "/lib/systemd/system",
-            "systemdsystemgeneratordir": "/lib/systemd/system-generators",
+            "systemdsystemunitdir": "/usr/lib/systemd/system",
+            "systemdsystemgeneratordir": "/usr/lib/systemd/system-generators",
         },
         "udev": {
-            "udevdir": "/lib/udev",
+            "udevdir": "/usr/lib/udev",
         },
     }
     cmd = ["pkg-config", f"--variable={var}", library]


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Use /usr/lib/ rather than /lib in packaging code

Support for unmerged /usr was removed from systemd a while ago:
https://lists.freedesktop.org/archives/systemd-devel/2022-September/048352.html

Furthermore, Debian tooling will now throw lintian errors if files
continue to reference /lib. Since it is no longer supported in upstream
systemd, there is no reason for it to be supported in upstream
cloud-init code that uses systemd.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
