### PR TITLE
fix: Don't log error in wait_for_url

### DIFF
--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -326,6 +326,7 @@ class DataSourceEc2(sources.DataSource):
 
         # If we get here, then wait_for_url timed out, waiting for IMDS
         # or the IMDS HTTP endpoint is disabled
+        LOG.error("Unable to get response from urls: %s", urls)
         return None
 
     def wait_for_metadata_service(self):

--- a/cloudinit/sources/DataSourceExoscale.py
+++ b/cloudinit/sources/DataSourceExoscale.py
@@ -67,6 +67,7 @@ class DataSourceExoscale(sources.DataSource):
             timeout=self.url_timeout,
             status_cb=LOG.critical,
         )
+        LOG.error("Unable to get response from url: %s", metadata_url)
 
         return bool(url)
 

--- a/cloudinit/sources/DataSourceExoscale.py
+++ b/cloudinit/sources/DataSourceExoscale.py
@@ -67,7 +67,6 @@ class DataSourceExoscale(sources.DataSource):
             timeout=self.url_timeout,
             status_cb=LOG.critical,
         )
-        LOG.error("Unable to get response from url: %s", metadata_url)
 
         return bool(url)
 
@@ -80,6 +79,7 @@ class DataSourceExoscale(sources.DataSource):
         metadata_ready = self.wait_for_metadata_service()
 
         if not metadata_ready:
+            LOG.error("Unable to get response from metadata service")
             return {}
 
         return read_metadata(

--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -983,7 +983,6 @@ def wait_for_url(
                 # We've already exceeded our max_wait. Time to bail.
                 break
 
-    LOG.error("Timed out, no response from urls: %s", urls)
     return False, None
 
 

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -733,7 +733,7 @@ class TestWaitForUrl:
         assert response.encode() == response_contents
 
     @responses.activate
-    def test_timeout(self, caplog):
+    def test_timeout(self):
         """If no endpoint responds in time, expect no response"""
 
         self.event.clear()
@@ -761,9 +761,6 @@ class TestWaitForUrl:
         self.event.set()
         assert not url
         assert not response_contents
-        assert re.search(
-            r"open 'https:\/\/sleep1\/'.*Timed out", caplog.text, re.DOTALL
-        )
 
     def test_explicit_arguments(self, retry_mocks):
         """Ensure that explicit arguments are respected"""

--- a/tests/unittests/test_url_helper.py
+++ b/tests/unittests/test_url_helper.py
@@ -2,7 +2,6 @@
 # pylint: disable=attribute-defined-outside-init
 
 import logging
-import re
 from functools import partial
 from threading import Event
 from time import process_time


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Don't log error in wait_for_url

There are use cases where we may want to recover or not treat a failure
of this function as an error. This change lets the caller decide what
to do.

Logging was added to callsites that didn't already have it.

Fixes GH-5971
```

## Additional Context
#5971

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
