### PR TITLE
fix: Make _should_wait_via_user_data() handle non-dict data

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -330,8 +330,10 @@ def _should_wait_via_user_data(
     if not raw_config:
         return False, "no configuration found"
 
+    # Since we can get a header like #cloud-config-archive, make sure
+    # we grab enough text to correctly distinguish our type
     if (
-        handlers.type_from_starts_with(raw_config.strip()[:13])
+        handlers.type_from_starts_with(raw_config.strip()[:42])
         != "text/cloud-config"
     ):
         return True, "non-cloud-config user data found"

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -348,6 +348,9 @@ def _should_wait_via_user_data(
         )
         return True, "failed to parse user data as yaml"
 
+    if not isinstance(parsed_yaml, dict):
+        return True, "parsed config not in cloud-config format"
+
     # These all have the potential to require network access, so we should wait
     if "write_files" in parsed_yaml:
         for item in parsed_yaml["write_files"]:

--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -330,8 +330,10 @@ def _should_wait_via_user_data(
     if not raw_config:
         return False, "no configuration found"
 
+    # Since this could be some arbitrarily large blob of binary data,
+    # such as a gzipped file, only grab enough to inspect the header.
     # Since we can get a header like #cloud-config-archive, make sure
-    # we grab enough text to correctly distinguish our type
+    # we grab enough to not be incorrectly identified as cloud-config.
     if (
         handlers.type_from_starts_with(raw_config.strip()[:42])
         != "text/cloud-config"

--- a/tests/integration_tests/modules/test_cloud_config_archive.py
+++ b/tests/integration_tests/modules/test_cloud_config_archive.py
@@ -16,6 +16,7 @@ USER_DATA = """\
 """
 
 
+@pytest.mark.ci
 @pytest.mark.user_data(USER_DATA)
 def test_cloud_config_archive(client: IntegrationInstance):
     """Basic correctness test for #cloud-config-archive."""

--- a/tests/integration_tests/modules/test_cloud_config_archive.py
+++ b/tests/integration_tests/modules/test_cloud_config_archive.py
@@ -1,0 +1,30 @@
+import pytest
+
+from tests.integration_tests.instances import IntegrationInstance
+from tests.integration_tests.util import verify_clean_boot, verify_clean_log
+
+USER_DATA = """\
+#cloud-config-archive
+- type: "text/cloud-boothook"
+  content: |
+    #!/bin/sh
+    echo "this is from a boothook." > /var/tmp/boothook.txt
+- type: "text/cloud-config"
+  content: |
+    bootcmd:
+    - echo "this is from a cloud-config." > /var/tmp/bootcmd.txt
+"""
+
+
+@pytest.mark.user_data(USER_DATA)
+def test_cloud_config_archive(client: IntegrationInstance):
+    """Basic correctness test for #cloud-config-archive."""
+    log = client.read_from_file("/var/log/cloud-init.log")
+    assert "this is from a boothook." in client.read_from_file(
+        "/var/tmp/boothook.txt"
+    )
+    assert "this is from a cloud-config." in client.read_from_file(
+        "/var/tmp/bootcmd.txt"
+    )
+    verify_clean_log(log)
+    verify_clean_boot(client)

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -18,6 +18,19 @@ MyArgs = namedtuple(
 )
 
 
+CLOUD_CONFIG_ARCHIVE = """\
+#cloud-config-archive
+- type: "text/cloud-boothook"
+  content: |
+    #!/bin/sh
+    echo "this is from a boothook." > /var/tmp/boothook.txt
+- type: "text/cloud-config"
+  content: |
+    bootcmd:
+    - echo "this is from a cloud-config." > /var/tmp/bootcmd.txt
+"""
+
+
 EXTRA_CLOUD_CONFIG = """\
 #cloud-config
 write_files
@@ -264,6 +277,8 @@ class TestMain:
             ),
             # Not parseable as yaml
             (mock.Mock(), "#cloud-config\nbootcmd:\necho hello", True),
+            # Yaml that parses to list
+            (mock.Mock(), CLOUD_CONFIG_ARCHIVE, True),
             # Non-cloud-config
             (mock.Mock(), "#!/bin/bash\n  - echo hello", True),
             # Something that after processing won't decode to utf-8


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Ensure _should_wait_via_user_data() handles all user data types

The function "_should_wait_via_user_data()" wasn't properly
handling user data that has a header that starts with
#cloud-config, but isn't cloud-config, like #cloud-config-archive

Fixes GH-5975
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
