### PR TITLE
fix: Run ansible with run_user instead of root for distro install_method

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -124,6 +124,10 @@ class AnsiblePullPip(AnsiblePull):
 
 
 class AnsiblePullDistro(AnsiblePull):
+    def __init__(self, distro: Distro, user: Optional[str]):
+        super().__init__(distro)
+        self.run_user = user
+
     def install(self, pkg_name: str):
         if not self.is_installed():
             self.distro.install_packages([pkg_name])
@@ -151,7 +155,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         if install_method == "pip":
             ansible = AnsiblePullPip(distro, ansible_user)
         else:
-            ansible = AnsiblePullDistro(distro)
+            ansible = AnsiblePullDistro(distro, ansible_user)
         ansible.install(package_name)
         ansible.check_deps()
         ansible_config = ansible_cfg.get("ansible_config", "")

--- a/tests/unittests/config/test_cc_ansible.py
+++ b/tests/unittests/config/test_cc_ansible.py
@@ -323,12 +323,16 @@ class TestAnsible:
     def test_deps_not_installed(self, m_which):
         """assert exception raised if package not installed"""
         with raises(ValueError):
-            cc_ansible.AnsiblePullDistro(get_cloud().distro).check_deps()
+            cc_ansible.AnsiblePullDistro(
+                get_cloud().distro, "root"
+            ).check_deps()
 
     @mock.patch(M_PATH + "subp.which", return_value=True)
     def test_deps(self, m_which):
         """assert exception not raised if package installed"""
-        cc_ansible.AnsiblePullDistro(get_cloud().distro).check_deps()
+        cc_ansible.AnsiblePullDistro(
+            get_cloud().distro, "ansible"
+        ).check_deps()
 
     @mark.serial
     @mock.patch(M_PATH + "subp.subp", return_value=("stdout", "stderr"))
@@ -390,7 +394,7 @@ class TestAnsible:
         ansible_pull = (
             cc_ansible.AnsiblePullPip(distro, "ansible")
             if pull_type == "pip"
-            else cc_ansible.AnsiblePullDistro(distro)
+            else cc_ansible.AnsiblePullDistro(distro, "")
         )
         cc_ansible.run_ansible_pull(
             ansible_pull, deepcopy(cfg["ansible"]["pull"])
@@ -415,7 +419,7 @@ class TestAnsible:
     def test_parse_version_distro(self, m_subp):
         """Verify that the expected version is returned"""
         assert cc_ansible.AnsiblePullDistro(
-            get_cloud().distro
+            get_cloud().distro, ""
         ).get_version() == lifecycle.Version(2, 10, 8)
 
     @mock.patch("cloudinit.subp.subp", side_effect=[(pip_version, "")])

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -178,6 +178,7 @@ sbraz
 scorpion44
 SeanSith
 shaardie
+shaerpour
 shell-skrimp
 shi2wei3
 ShPakvel


### PR DESCRIPTION
## Proposed Commit Message
```
fix: Run ansible with run_user instead of root for distro install_method

Added constructor for AnsiblePullDistro that handels which user to run
playbook with
```

## Additional Context
## Test Steps
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)

Fixes GH-4092