### PR TITLE
add INSTANCE_TYPE integration settings and lessen integration log spams

### DIFF
--- a/doc/rtd/development/integration_tests.rst
+++ b/doc/rtd/development/integration_tests.rst
@@ -237,6 +237,30 @@ on of:
             PLATFORM = 'lxd_container'
 
 
+Selecting Instance Type
+-----------------------
+
+To select a specific instance type, modify the ``INSTANCE_TYPE`` variable to be
+the desired instance type. This value is cloud-specific, so refer to the
+cloud's documentation for the available instance types. If you specify an
+instance type, be sure to also specify respective cloud platform you are
+testing against.
+
+.. tab-set::
+
+    .. tab-item:: Inline environment variable
+
+        .. code-block:: bash
+
+            CLOUD_INIT_PLATFORM=ec2 CLOUD_INIT_INSTANCE_TYPE='t2.micro' tox -e integration_tests
+
+    .. tab-item:: user_settings.py file
+
+        .. code-block:: python
+
+            PLATFORM = 'ec2'  # need to specify the cloud in order to use the instance type setting
+            INSTANCE_TYPE = 't2.micro'
+
 Image selection
 ===============
 

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -132,6 +132,10 @@ class IntegrationCloud(ABC):
             "user_data": user_data,
             "username": DISTRO_TO_USERNAME[CURRENT_RELEASE.os],
         }
+        if self.settings.INSTANCE_TYPE:
+            default_launch_kwargs["instance_type"] = (
+                self.settings.INSTANCE_TYPE
+            )
         launch_kwargs = {**default_launch_kwargs, **launch_kwargs}
         display_launch_kwargs = deepcopy(launch_kwargs)
         if display_launch_kwargs.get("user_data") is not None:


### PR DESCRIPTION
## Proposed Commit Message
N/A

Separate commits, plz rebase :blue_heart: 

## Additional Context
This will allow for manually specifying instance types when needing to reproduce certain bugs or test certain instance types (like Baremetal!)

Also, put some duct tape over the metaphorical mouths of urllib3 and botocore for integration tests to lessen log spam.

## Test Steps
Run an integration test locally with INSTANCE_TYPE specified:
```
CLOUD_INIT_INSTANCE_TYPE="m6in.32xlarge" tox -e integration-tests -- tests/integration_tests/modules/test_hotplug.py::test_multi_nic_hotplug_vpc
```

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [X] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
