### PR TITLE
net/sysconfig: do not remove all existing settings of /etc/sysconfig/network

### DIFF
--- a/cloudinit/net/sysconfig.py
+++ b/cloudinit/net/sysconfig.py
@@ -1119,6 +1119,24 @@ class Renderer(renderer.Renderer):
             if network_state.use_ipv6:
                 netcfg.append("NETWORKING_IPV6=yes")
                 netcfg.append("IPV6_AUTOCONF=no")
+
+            # if sysconfig file exists and is not empty, append rest of the
+            # file content, do not remove the exsisting customizations.
+            if os.path.exists(sysconfig_path):
+                for line in util.load_text_file(sysconfig_path).splitlines():
+                    if (
+                        not any(
+                            setting in line
+                            for setting in [
+                                "NETWORKING",
+                                "NETWORKING_IPV6",
+                                "IPV6_AUTOCONF",
+                            ]
+                        )
+                        and line not in _make_header().splitlines()
+                    ):
+                        netcfg.append(line)
+
             util.write_file(
                 sysconfig_path, "\n".join(netcfg) + "\n", file_mode
             )


### PR DESCRIPTION
## Proposed Commit Message

In some distros, `/etc/sysconfig/network` may have important configurations that are necessary for the instance to come up. For example, centos based distros write `NOZEROCONF=yes` in `/etc/sysconfig/network` for some instances that require zeroconf to be disabled. Removing these customizations would prevent the instance to come up. So leave the customizations in `/etc/sysconfig/network` intact except those that we are interested in.

Fixes GH-5990
Signed-off-by: Ani Sinha <anisinha@redhat.com>

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
