### PR TITLE
fix: Ensure fqdn is always treated as a string in get_hostname_fqdn

### DIFF
--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -1215,7 +1215,7 @@ def get_hostname_fqdn(cfg, cloud, metadata_only=False):
     is_default = False
     if "fqdn" in cfg:
         # user specified a fqdn.  Default hostname then is based off that
-        fqdn = cfg["fqdn"]
+        fqdn = str(cfg["fqdn"])
         hostname = get_cfg_option_str(cfg, "hostname", fqdn.split(".")[0])
     else:
         if "hostname" in cfg and cfg["hostname"].find(".") > 0:

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -799,6 +799,22 @@ class TestGetHostnameFqdn(CiTestCase):
             mock.call(metadata_only=False),
         ] == cloud.get_hostname.call_args_list
 
+    def test_get_hostname_fqdn_from_numeric_fqdn(self):
+        """When cfg fqdn is numeric, ensure it is treated as a string."""
+        hostname, fqdn, _ = util.get_hostname_fqdn(
+            cfg={"fqdn": 12345}, cloud=None
+        )
+        self.assertEqual("12345", hostname)
+        self.assertEqual("12345", fqdn)
+
+    def test_get_hostname_fqdn_from_numeric_fqdn_with_domain(self):
+        """When cfg fqdn is numeric with a domain, ensure correct parsing."""
+        hostname, fqdn, _ = util.get_hostname_fqdn(
+            cfg={"fqdn": "12345.example.com"}, cloud=None
+        )
+        self.assertEqual("12345", hostname)
+        self.assertEqual("12345.example.com", fqdn)
+
     def test_get_hostname_fqdn_from_passes_metadata_only_to_cloud(self):
         """Calls to cloud.get_hostname pass the metadata_only parameter."""
         cloud = mock.MagicMock()

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -133,6 +133,7 @@ ManassehZhou
 manuelisimo
 MarkMielke
 marlluslustosa
+masihkhatibzadeh99
 mathmarchand
 matthewruffell
 maxnet


### PR DESCRIPTION
Fixes #5989 

### Fix
- Explicitly cast `fqdn` to a string before processing.