### PR TITLE
Ubuntu/focal: wait for mounts

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 cloud-init (25.1-0ubuntu1~20.04.1) UNRELEASED; urgency=medium
 
   * Update d/p/no-single-process.patch
+    - This patch missed waiting for mounts (LP: #2097441)
+    - Fix upstream conflict
 
  -- Brett Holman <brett.holman@canonical.com>  Mon, 06 Jan 2024 17:39:42 -0700
 

--- a/debian/patches/no-single-process.patch
+++ b/debian/patches/no-single-process.patch
@@ -54,7 +54,15 @@ Last-Update: 2024-08-02
  Before=network-pre.target
  Before=shutdown.target
  {% if variant in ["almalinux", "cloudlinux", "rhel"] %}
-@@ -25,14 +26,7 @@ Type=oneshot
+@@ -16,6 +17,7 @@
+ Before=sysinit.target
+ {% endif %}
+ Conflicts=shutdown.target
++RequiresMountsFor=/var/lib/cloud
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+ ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
+@@ -25,14 +27,7 @@
  {% if variant in ["almalinux", "cloudlinux", "rhel"] %}
  ExecStartPre=/sbin/restorecon /run/cloud-init
  {% endif %}


### PR DESCRIPTION
https://github.com/canonical/cloud-init/issues/6001