### PR TITLE
ci: don't reference PR in post-merged CI

### DIFF
--- a/.github/workflows/packaging-upstream.yml
+++ b/.github/workflows/packaging-upstream.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           # Fetch all history for merging
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: origin/main
 
       - name: Setup - install dependencies
         run: |
@@ -55,7 +55,7 @@ jobs:
             if [ ! -f debian/patches/series ]; then
               echo "no patches, skipping $BRANCH"
               # undo merge - this step is not expected to fail
-              git reset --hard ${{ github.event.pull_request.head.sha }}
+              git reset --hard origin/main
               continue
             fi
             # did patches apply cleanly?
@@ -65,5 +65,5 @@ jobs:
             # a patch didn't un-apply cleanly if this step fails
             quilt pop -a
             # undo merge - this step is not expected to fail
-            git reset --hard ${{ github.event.pull_request.head.sha }}
+            git reset --hard origin/main
           done


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
ci: don't reference PR in post-merged CI
```

## Additional Context
https://github.com/canonical/cloud-init/actions/runs/13292819865/job/37117524229

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
