### PR TITLE
doc: Update references to older keys

### DIFF
--- a/doc/rtd/reference/datasources/lxd.rst
+++ b/doc/rtd/reference/datasources/lxd.rst
@@ -11,8 +11,8 @@ running LXD container and VM as ``/dev/lxd/sock`` and represents all
 instance-meta-data as versioned HTTP routes such as:
 
   - 1.0/meta-data
-  - 1.0/config/user.vendor-data
-  - 1.0/config/user.user-data
+  - 1.0/config/cloud-init.vendor-data
+  - 1.0/config/cloud-init.user-data
   - 1.0/config/user.<any-custom-key>
 
 The LXD socket device ``/dev/lxd/sock`` is only present on containers and VMs

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -81,6 +81,7 @@ gilbsgilbs
 glyg
 halfdime-code
 hamalq
+hamistao
 hcartiaux
 holmanb
 impl


### PR DESCRIPTION
All other references to old `user.vendor-data` and `user.user-data` were replaced by their newer counterparts `cloud-init.vendor-data` and `cloud-init.user-data`, but apparentely these ones were lingering still.