### PR TITLE
Ubuntu/focal sort patch order

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,9 +4,13 @@ cloud-init (25.1-0ubuntu1~20.04.1) UNRELEASED; urgency=medium
     - d/p/cpick-d75840be-fix-retry-AWS-hotplug-for-async-IMDS-5995
     - d/p/cpick-84806336-chore-Add-feature-flag-for-manual-network-waiting
   * refresh patches
+    - d/p/cli-retain-file-argument-as-main-cmd-arg.patch
     - d/p/deprecation-version-boundary.patch
+    - d/p/drop-unsupported-systemd-condition-environment.patch
     - d/p/expire-on-hashed-users.patch
+    - d/p/grub-dpkg-support.patch
     - d/p/netplan99-cannot-use-default.patch
+    - d/p/no-nocloud-network.patch
     - d/p/no-single-process.patch
     - d/p/retain-ec2-default-net-update-events.patch
     - d/p/retain-netplan-world-readable.patch

--- a/debian/patches/cli-retain-file-argument-as-main-cmd-arg.patch
+++ b/debian/patches/cli-retain-file-argument-as-main-cmd-arg.patch
@@ -21,7 +21,7 @@ Last-Update: 2024-04-30 <YYYY-MM-DD, last update of the meta-information, option
      if args.files:
          for fh in args.files:
              # The realpath is more useful in logging
-@@ -1051,6 +1056,17 @@ def main(sysv_args=None):
+@@ -1053,6 +1058,17 @@ def main(sysv_args=None):
          default=False,
      )
      parser.add_argument(

--- a/debian/patches/drop-unsupported-systemd-condition-environment.patch
+++ b/debian/patches/drop-unsupported-systemd-condition-environment.patch
@@ -8,33 +8,6 @@ Author: Chad Smith <chad.smith@canonical.com>
 Last-Update: 2024-05-21
 ---
 This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
---- a/systemd/cloud-init-local.service.tmpl
-+++ b/systemd/cloud-init-local.service.tmpl
-@@ -20,7 +20,6 @@
- RequiresMountsFor=/var/lib/cloud
- ConditionPathExists=!/etc/cloud/cloud-init.disabled
- ConditionKernelCommandLine=!cloud-init=disabled
--ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
-
- [Service]
- Type=oneshot
---- a/systemd/cloud-init.target
-+++ b/systemd/cloud-init.target
-@@ -12,4 +12,3 @@ Description=Cloud-init target
- After=multi-user.target
- ConditionPathExists=!/etc/cloud/cloud-init.disabled
- ConditionKernelCommandLine=!cloud-init=disabled
--ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
---- a/systemd/cloud-init-hotplugd.service
-+++ b/systemd/cloud-init-hotplugd.service
-@@ -16,7 +16,6 @@ After=cloud-init.target
- Requires=cloud-init-hotplugd.socket
- ConditionPathExists=!/etc/cloud/cloud-init.disabled
- ConditionKernelCommandLine=!cloud-init=disabled
--ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
- 
- [Service]
- Type=oneshot
 --- a/systemd/cloud-config.service
 +++ b/systemd/cloud-config.service
 @@ -5,7 +5,6 @@ After=network-online.target cloud-config
@@ -55,10 +28,10 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  
  
  [Service]
---- a/systemd/cloud-init.service.tmpl
-+++ b/systemd/cloud-init.service.tmpl
-@@ -44,7 +44,6 @@ Conflicts=shutdown.target
- {% endif %}
+--- a/systemd/cloud-init-hotplugd.service
++++ b/systemd/cloud-init-hotplugd.service
+@@ -16,7 +16,6 @@ After=cloud-init.target
+ Requires=cloud-init-hotplugd.socket
  ConditionPathExists=!/etc/cloud/cloud-init.disabled
  ConditionKernelCommandLine=!cloud-init=disabled
 -ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
@@ -72,6 +45,33 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
  ConditionPathExists=!/etc/cloud/cloud-init.disabled
  ConditionKernelCommandLine=!cloud-init=disabled
 -ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
-
+ 
  [Socket]
  ListenFIFO=/run/cloud-init/hook-hotplug-cmd
+--- a/systemd/cloud-init-local.service.tmpl
++++ b/systemd/cloud-init-local.service.tmpl
+@@ -20,7 +20,6 @@ Conflicts=shutdown.target
+ RequiresMountsFor=/var/lib/cloud
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+-ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
+ 
+ [Service]
+ Type=oneshot
+--- a/systemd/cloud-init.service.tmpl
++++ b/systemd/cloud-init.service.tmpl
+@@ -44,7 +44,6 @@ Conflicts=shutdown.target
+ {% endif %}
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+-ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
+ 
+ [Service]
+ Type=oneshot
+--- a/systemd/cloud-init.target
++++ b/systemd/cloud-init.target
+@@ -12,4 +12,3 @@ Description=Cloud-init target
+ After=multi-user.target
+ ConditionPathExists=!/etc/cloud/cloud-init.disabled
+ ConditionKernelCommandLine=!cloud-init=disabled
+-ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled

--- a/debian/patches/grub-dpkg-support.patch
+++ b/debian/patches/grub-dpkg-support.patch
@@ -28,7 +28,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
          return
 --- a/cloudinit/config/schemas/schema-cloud-config-v1.json
 +++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
-@@ -1611,8 +1611,8 @@
+@@ -1616,8 +1616,8 @@
            "properties": {
              "enabled": {
                "type": "boolean",

--- a/debian/patches/netplan99-cannot-use-default.patch
+++ b/debian/patches/netplan99-cannot-use-default.patch
@@ -20,6 +20,55 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
                  }
                  # If the gateway is not contained within the subnet's
                  # network, mark it as on-link so that it can still be
+--- a/tests/unittests/distros/test_netconfig.py
++++ b/tests/unittests/distros/test_netconfig.py
+@@ -193,7 +193,7 @@ network:
+             addresses:
+             - 192.168.1.5/24
+             routes:
+-            -   to: default
++            -   to: 0.0.0.0/0
+                 via: 192.168.1.254
+         eth1:
+             dhcp4: true
+@@ -212,7 +212,7 @@ network:
+             addresses:
+             - 2607:f0d0:1002:0011::2/64
+             routes:
+-            -   to: default
++            -   to: ::/0
+                 via: 2607:f0d0:1002:0011::1
+         eth1:
+             dhcp4: true
+@@ -1078,7 +1078,7 @@ class TestNetCfgDistroArch(TestNetCfgDis
+                             addresses:
+                             - 192.168.1.5/24
+                             routes:
+-                            -   to: default
++                            -   to: 0.0.0.0/0
+                                 via: 192.168.1.254
+                         eth1:
+                             dhcp4: true
+--- a/tests/unittests/net/network_configs.py
++++ b/tests/unittests/net/network_configs.py
+@@ -1686,7 +1686,7 @@ pre-down route del -net 10.0.0.0/8 gw 11
+                             - sacchromyces.maas
+                             - brettanomyces.maas
+                         routes:
+-                        -   to: default
++                        -   to: 0.0.0.0/0
+                             via: 192.168.0.1
+         """
+         ).rstrip(" "),
+@@ -3119,7 +3119,7 @@ pre-down route del -net 10.0.0.0/8 gw 11
+                          transmit-hash-policy: layer3+4
+                          up-delay: 20
+                      routes:
+-                     -   to: default
++                     -   to: 0.0.0.0/0
+                          via: 192.168.0.1
+                      -   to: 10.1.3.0/24
+                          via: 192.168.0.3
 --- a/tests/unittests/test_net.py
 +++ b/tests/unittests/test_net.py
 @@ -433,7 +433,7 @@ network:
@@ -119,52 +168,3 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
                            via: 2001:ffff::1
                            on-link: true
                        set-name: interface0
---- a/tests/unittests/distros/test_netconfig.py
-+++ b/tests/unittests/distros/test_netconfig.py
-@@ -193,7 +193,7 @@ network:
-             addresses:
-             - 192.168.1.5/24
-             routes:
--            -   to: default
-+            -   to: 0.0.0.0/0
-                 via: 192.168.1.254
-         eth1:
-             dhcp4: true
-@@ -212,7 +212,7 @@ network:
-             addresses:
-             - 2607:f0d0:1002:0011::2/64
-             routes:
--            -   to: default
-+            -   to: ::/0
-                 via: 2607:f0d0:1002:0011::1
-         eth1:
-             dhcp4: true
-@@ -1078,7 +1078,7 @@ class TestNetCfgDistroArch(TestNetCfgDis
-                             addresses:
-                             - 192.168.1.5/24
-                             routes:
--                            -   to: default
-+                            -   to: 0.0.0.0/0
-                                 via: 192.168.1.254
-                         eth1:
-                             dhcp4: true
---- a/tests/unittests/net/network_configs.py
-+++ b/tests/unittests/net/network_configs.py
-@@ -1686,7 +1686,7 @@ pre-down route del -net 10.0.0.0/8 gw 11
-                             - sacchromyces.maas
-                             - brettanomyces.maas
-                         routes:
--                        -   to: default
-+                        -   to: 0.0.0.0/0
-                             via: 192.168.0.1
-         """
-         ).rstrip(" "),
-@@ -3119,7 +3119,7 @@ pre-down route del -net 10.0.0.0/8 gw 11
-                          transmit-hash-policy: layer3+4
-                          up-delay: 20
-                      routes:
--                     -   to: default
-+                     -   to: 0.0.0.0/0
-                          via: 192.168.0.1
-                      -   to: 10.1.3.0/24
-                          via: 192.168.0.3

--- a/debian/patches/no-nocloud-network.patch
+++ b/debian/patches/no-nocloud-network.patch
@@ -26,7 +26,7 @@ Last-Update: 2024-08-02
          # Now that we have exhausted any other places merge in the defaults
 --- a/cloudinit/util.py
 +++ b/cloudinit/util.py
-@@ -1011,7 +1011,6 @@ def read_seeded(base="", ext="", timeout
+@@ -1012,7 +1012,6 @@ def read_seeded(base="", ext="", timeout
          ud_url = base.replace("%s", "user-data" + ext)
          vd_url = base.replace("%s", "vendor-data" + ext)
          md_url = base.replace("%s", "meta-data" + ext)
@@ -34,7 +34,7 @@ Last-Update: 2024-08-02
      else:
          if features.NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH:
              if base[-1] != "/" and parse.urlparse(base).query == "":
-@@ -1020,17 +1019,7 @@ def read_seeded(base="", ext="", timeout
+@@ -1021,17 +1020,7 @@ def read_seeded(base="", ext="", timeout
          ud_url = "%s%s%s" % (base, "user-data", ext)
          vd_url = "%s%s%s" % (base, "vendor-data", ext)
          md_url = "%s%s%s" % (base, "meta-data", ext)
@@ -54,7 +54,7 @@ Last-Update: 2024-08-02
      )
 --- a/tests/unittests/test_util.py
 +++ b/tests/unittests/test_util.py
-@@ -2482,7 +2482,7 @@ class TestReadOptionalSeed:
+@@ -2498,7 +2498,7 @@ class TestReadOptionalSeed:
                  {
                      "meta-data": {"md": "val"},
                      "user-data": b"ud",
@@ -63,7 +63,7 @@ Last-Update: 2024-08-02
                      "vendor-data": None,
                  },
                  True,
-@@ -2537,7 +2537,7 @@ class TestReadSeeded:
+@@ -2553,7 +2553,7 @@ class TestReadSeeded:
          assert found_md == {"key1": "val1"}
          assert found_ud == ud
          assert found_vd == vd
@@ -72,7 +72,7 @@ Last-Update: 2024-08-02
  
      @pytest.mark.parametrize(
          "base, feature_flag, req_urls",
-@@ -2546,7 +2546,6 @@ class TestReadSeeded:
+@@ -2562,7 +2562,6 @@ class TestReadSeeded:
                  "http://10.0.0.1/%s?qs=1",
                  True,
                  [
@@ -80,7 +80,7 @@ Last-Update: 2024-08-02
                      "http://10.0.0.1/meta-data?qs=1",
                      "http://10.0.0.1/user-data?qs=1",
                      "http://10.0.0.1/vendor-data?qs=1",
-@@ -2557,7 +2556,6 @@ class TestReadSeeded:
+@@ -2573,7 +2572,6 @@ class TestReadSeeded:
                  "https://10.0.0.1:8008/",
                  True,
                  [
@@ -88,7 +88,7 @@ Last-Update: 2024-08-02
                      "https://10.0.0.1:8008/meta-data",
                      "https://10.0.0.1:8008/user-data",
                      "https://10.0.0.1:8008/vendor-data",
-@@ -2568,7 +2566,6 @@ class TestReadSeeded:
+@@ -2584,7 +2582,6 @@ class TestReadSeeded:
                  "https://10.0.0.1:8008",
                  True,
                  [
@@ -96,7 +96,7 @@ Last-Update: 2024-08-02
                      "https://10.0.0.1:8008/meta-data",
                      "https://10.0.0.1:8008/user-data",
                      "https://10.0.0.1:8008/vendor-data",
-@@ -2579,7 +2576,6 @@ class TestReadSeeded:
+@@ -2595,7 +2592,6 @@ class TestReadSeeded:
                  "https://10.0.0.1:8008",
                  False,
                  [
@@ -104,7 +104,7 @@ Last-Update: 2024-08-02
                      "https://10.0.0.1:8008meta-data",
                      "https://10.0.0.1:8008user-data",
                      "https://10.0.0.1:8008vendor-data",
-@@ -2590,7 +2586,6 @@ class TestReadSeeded:
+@@ -2606,7 +2602,6 @@ class TestReadSeeded:
                  "https://10.0.0.1:8008?qs=",
                  True,
                  [
@@ -112,7 +112,7 @@ Last-Update: 2024-08-02
                      "https://10.0.0.1:8008?qs=meta-data",
                      "https://10.0.0.1:8008?qs=user-data",
                      "https://10.0.0.1:8008?qs=vendor-data",
-@@ -2629,7 +2624,7 @@ class TestReadSeeded:
+@@ -2645,7 +2640,7 @@ class TestReadSeeded:
          # user-data, vendor-data read raw. It could be scripts or other format
          assert found_ud == "/user-data: 1"
          assert found_vd == "/vendor-data: 1"
@@ -121,7 +121,7 @@ Last-Update: 2024-08-02
          assert [
              mock.call(req_url, timeout=5, retries=10) for req_url in req_urls
          ] == m_read.call_args_list
-@@ -2659,7 +2654,7 @@ class TestReadSeededWithoutVendorData(he
+@@ -2675,7 +2670,7 @@ class TestReadSeededWithoutVendorData(he
          self.assertEqual(found_md, {"key1": "val1"})
          self.assertEqual(found_ud, ud)
          self.assertEqual(found_vd, vd)

--- a/debian/patches/no-single-process.patch
+++ b/debian/patches/no-single-process.patch
@@ -5,6 +5,47 @@ Author: Brett Holman <brett.holman@canonical.com>
 Last-Update: 2024-08-02
 
 
+--- a/cloudinit/cmd/status.py
++++ b/cloudinit/cmd/status.py
+@@ -321,9 +321,8 @@ def systemd_failed(wait: bool) -> bool:
+     for service in [
+         "cloud-final.service",
+         "cloud-config.service",
+-        "cloud-init-network.service",
++        "cloud-init.service",
+         "cloud-init-local.service",
+-        "cloud-init-main.service",
+     ]:
+         try:
+             stdout = query_systemctl(
+--- a/cloudinit/config/cc_mounts.py
++++ b/cloudinit/config/cc_mounts.py
+@@ -519,7 +519,7 @@ def handle(name: str, cfg: Config, cloud
+     # fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno
+     uses_systemd = cloud.distro.uses_systemd()
+     default_mount_options = (
+-        "defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev"
++        "defaults,nofail,x-systemd.after=cloud-init.service,_netdev"
+         if uses_systemd
+         else "defaults,nobootwait"
+     )
+--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
++++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
+@@ -2034,12 +2034,12 @@
+         },
+         "mount_default_fields": {
+           "type": "array",
+-          "description": "Default mount configuration for any mount entry with less than 6 options provided. When specified, 6 items are required and represent ``/etc/fstab`` entries. Default: ``defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev``.",
++          "description": "Default mount configuration for any mount entry with less than 6 options provided. When specified, 6 items are required and represent ``/etc/fstab`` entries. Default: ``defaults,nofail,x-systemd.after=cloud-init.service,_netdev``.",
+           "default": [
+             null,
+             null,
+             "auto",
+-            "defaults,nofail,x-systemd.after=cloud-init-network.service",
++            "defaults,nofail,x-systemd.after=cloud-init.service",
+             "0",
+             "2"
+           ],
 --- a/systemd/cloud-config.service
 +++ b/systemd/cloud-config.service
 @@ -9,14 +9,7 @@ ConditionEnvironment=!KERNEL_CMDLINE=clo
@@ -23,6 +64,16 @@ Last-Update: 2024-08-02
  RemainAfterExit=yes
  TimeoutSec=0
  
+--- a/systemd/cloud-config.target
++++ b/systemd/cloud-config.target
+@@ -14,5 +14,5 @@
+ 
+ [Unit]
+ Description=Cloud-config availability
+-Wants=cloud-init-local.service cloud-init-network.service
+-After=cloud-init-local.service cloud-init-network.service
++Wants=cloud-init-local.service cloud-init.service
++After=cloud-init-local.service cloud-init.service
 --- a/systemd/cloud-final.service
 +++ b/systemd/cloud-final.service
 @@ -12,16 +12,10 @@ ConditionEnvironment=!KERNEL_CMDLINE=clo
@@ -123,133 +174,6 @@ Last-Update: 2024-08-02
 -
 -[Install]
 -WantedBy=cloud-init.target
---- /dev/null
-+++ b/systemd/cloud-init.service.tmpl
-@@ -0,0 +1,59 @@
-+## template:jinja
-+[Unit]
-+# https://docs.cloud-init.io/en/latest/explanation/boot.html
-+Description=Cloud-init: Network Stage
-+{% if variant not in ["almalinux", "cloudlinux", "photon", "rhel"] %}
-+DefaultDependencies=no
-+{% endif %}
-+Wants=cloud-init-local.service
-+Wants=sshd-keygen.service
-+Wants=sshd.service
-+After=cloud-init-local.service
-+{% if variant not in ["ubuntu"] %}
-+After=systemd-networkd-wait-online.service
-+{% endif %}
-+{% if variant in ["ubuntu", "unknown", "debian"] %}
-+After=networking.service
-+{% endif %}
-+{% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora",
-+                  "miraclelinux", "openeuler", "OpenCloudOS", "openmandriva", "rhel", "rocky",
-+                  "suse", "TencentOS", "virtuozzo"] %}
-+
-+After=network.service
-+After=NetworkManager.service
-+After=NetworkManager-wait-online.service
-+{% endif %}
-+{% if variant in ["suse"] %}
-+After=wicked.service
-+# setting hostname via hostnamectl depends on dbus, which otherwise
-+# would not be guaranteed at this point.
-+After=dbus.service
-+{% endif %}
-+Before=network-online.target
-+Before=sshd-keygen.service
-+Before=sshd.service
-+Before=systemd-user-sessions.service
-+{% if variant in ["ubuntu", "unknown", "debian"] %}
-+Before=sysinit.target
-+Before=shutdown.target
-+Conflicts=shutdown.target
-+{% endif %}
-+{% if variant in ["suse"] %}
-+Before=shutdown.target
-+Conflicts=shutdown.target
-+{% endif %}
-+ConditionPathExists=!/etc/cloud/cloud-init.disabled
-+ConditionKernelCommandLine=!cloud-init=disabled
-+ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
-+
-+[Service]
-+Type=oneshot
-+ExecStart=/usr/bin/cloud-init init
-+RemainAfterExit=yes
-+TimeoutSec=0
-+
-+# Output needs to appear in instance console output
-+StandardOutput=journal+console
-+
-+[Install]
-+WantedBy=cloud-init.target
---- a/cloudinit/cmd/status.py
-+++ b/cloudinit/cmd/status.py
-@@ -321,9 +321,8 @@ def systemd_failed(wait: bool) -> bool:
-     for service in [
-         "cloud-final.service",
-         "cloud-config.service",
--        "cloud-init-network.service",
-+        "cloud-init.service",
-         "cloud-init-local.service",
--        "cloud-init-main.service",
-     ]:
-         try:
-             stdout = query_systemctl(
---- a/cloudinit/config/cc_mounts.py
-+++ b/cloudinit/config/cc_mounts.py
-@@ -519,7 +519,7 @@ def handle(name: str, cfg: Config, cloud
-     # fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno
-     uses_systemd = cloud.distro.uses_systemd()
-     default_mount_options = (
--        "defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev"
-+        "defaults,nofail,x-systemd.after=cloud-init.service,_netdev"
-         if uses_systemd
-         else "defaults,nobootwait"
-     )
---- a/cloudinit/config/schemas/schema-cloud-config-v1.json
-+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
-@@ -2034,12 +2034,12 @@
-         },
-         "mount_default_fields": {
-           "type": "array",
--          "description": "Default mount configuration for any mount entry with less than 6 options provided. When specified, 6 items are required and represent ``/etc/fstab`` entries. Default: ``defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev``.",
-+          "description": "Default mount configuration for any mount entry with less than 6 options provided. When specified, 6 items are required and represent ``/etc/fstab`` entries. Default: ``defaults,nofail,x-systemd.after=cloud-init.service,_netdev``.",
-           "default": [
-             null,
-             null,
-             "auto",
--            "defaults,nofail,x-systemd.after=cloud-init-network.service",
-+            "defaults,nofail,x-systemd.after=cloud-init.service",
-             "0",
-             "2"
-           ],
---- a/systemd/cloud-config.target
-+++ b/systemd/cloud-config.target
-@@ -14,5 +14,5 @@
- 
- [Unit]
- Description=Cloud-config availability
--Wants=cloud-init-local.service cloud-init-network.service
--After=cloud-init-local.service cloud-init-network.service
-+Wants=cloud-init-local.service cloud-init.service
-+After=cloud-init-local.service cloud-init.service
---- a/tests/unittests/config/test_cc_mounts.py
-+++ b/tests/unittests/config/test_cc_mounts.py
-@@ -566,9 +566,9 @@ class TestFstabHandling:
-             LABEL=keepme	none	ext4	defaults	0	0
-             LABEL=UEFI
-             /dev/sda4	/mnt2	auto	nofail,comment=cloudconfig	1	2
--            /dev/sda5	/mnt3	auto	defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev,comment=cloudconfig	0	2
-+            /dev/sda5	/mnt3	auto	defaults,nofail,x-systemd.after=cloud-init.service,_netdev,comment=cloudconfig	0	2
-             /dev/sda1	/mnt	xfs	auto,comment=cloudconfig	0	2
--            /dev/sda3	/mnt4	btrfs	defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev,comment=cloudconfig	0	2
-+            /dev/sda3	/mnt4	btrfs	defaults,nofail,x-systemd.after=cloud-init.service,_netdev,comment=cloudconfig	0	2
-             /dev/sdb1	none	swap	sw,comment=cloudconfig	0	0
-             """  # noqa: E501
-             ).strip()
 --- a/systemd/cloud-init-network.service.tmpl
 +++ /dev/null
 @@ -1,64 +0,0 @@
@@ -317,3 +241,79 @@ Last-Update: 2024-08-02
 -
 -[Install]
 -WantedBy=cloud-init.target
+--- /dev/null
++++ b/systemd/cloud-init.service.tmpl
+@@ -0,0 +1,59 @@
++## template:jinja
++[Unit]
++# https://docs.cloud-init.io/en/latest/explanation/boot.html
++Description=Cloud-init: Network Stage
++{% if variant not in ["almalinux", "cloudlinux", "photon", "rhel"] %}
++DefaultDependencies=no
++{% endif %}
++Wants=cloud-init-local.service
++Wants=sshd-keygen.service
++Wants=sshd.service
++After=cloud-init-local.service
++{% if variant not in ["ubuntu"] %}
++After=systemd-networkd-wait-online.service
++{% endif %}
++{% if variant in ["ubuntu", "unknown", "debian"] %}
++After=networking.service
++{% endif %}
++{% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora",
++                  "miraclelinux", "openeuler", "OpenCloudOS", "openmandriva", "rhel", "rocky",
++                  "suse", "TencentOS", "virtuozzo"] %}
++
++After=network.service
++After=NetworkManager.service
++After=NetworkManager-wait-online.service
++{% endif %}
++{% if variant in ["suse"] %}
++After=wicked.service
++# setting hostname via hostnamectl depends on dbus, which otherwise
++# would not be guaranteed at this point.
++After=dbus.service
++{% endif %}
++Before=network-online.target
++Before=sshd-keygen.service
++Before=sshd.service
++Before=systemd-user-sessions.service
++{% if variant in ["ubuntu", "unknown", "debian"] %}
++Before=sysinit.target
++Before=shutdown.target
++Conflicts=shutdown.target
++{% endif %}
++{% if variant in ["suse"] %}
++Before=shutdown.target
++Conflicts=shutdown.target
++{% endif %}
++ConditionPathExists=!/etc/cloud/cloud-init.disabled
++ConditionKernelCommandLine=!cloud-init=disabled
++ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
++
++[Service]
++Type=oneshot
++ExecStart=/usr/bin/cloud-init init
++RemainAfterExit=yes
++TimeoutSec=0
++
++# Output needs to appear in instance console output
++StandardOutput=journal+console
++
++[Install]
++WantedBy=cloud-init.target
+--- a/tests/unittests/config/test_cc_mounts.py
++++ b/tests/unittests/config/test_cc_mounts.py
+@@ -566,9 +566,9 @@ class TestFstabHandling:
+             LABEL=keepme	none	ext4	defaults	0	0
+             LABEL=UEFI
+             /dev/sda4	/mnt2	auto	nofail,comment=cloudconfig	1	2
+-            /dev/sda5	/mnt3	auto	defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev,comment=cloudconfig	0	2
++            /dev/sda5	/mnt3	auto	defaults,nofail,x-systemd.after=cloud-init.service,_netdev,comment=cloudconfig	0	2
+             /dev/sda1	/mnt	xfs	auto,comment=cloudconfig	0	2
+-            /dev/sda3	/mnt4	btrfs	defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev,comment=cloudconfig	0	2
++            /dev/sda3	/mnt4	btrfs	defaults,nofail,x-systemd.after=cloud-init.service,_netdev,comment=cloudconfig	0	2
+             /dev/sdb1	none	swap	sw,comment=cloudconfig	0	0
+             """  # noqa: E501
+             ).strip()


### PR DESCRIPTION
## Additional Info

Effectively a no-op, but should make it easier to review PRs going forward by reducing diff size when refreshing. Another PR (incoming shortly) will include a CI check for this behavior.

Validated programatically:

```
# set QUILT_REFRESH_ARGS="-p ab --no-timestamps --no-index --sort" in ~/.quiltrc
quilt push -a
git diff > before
quilt pop -a --refresh
quilt push -a
git diff > after.debian
git diff -- . :^debian > after.nodebian
quilt pop -a
md5sum before after.*
```
The final 3 lines of output show this:
```
b22e493d8a2a4e7acffddc354ca58048  before
e0c5d33934c5b131052c6a1e0b539e17  after.debian
b22e493d8a2a4e7acffddc354ca58048  after.nodebian
```
This is the expected outcome: the diff excluding patches is identical, but since patches were updated (refreshed), they have changed.

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
