### PR TITLE
ci: fix post-merge packaging CI

### DIFF
--- a/.github/workflows/packaging-upstream.yml
+++ b/.github/workflows/packaging-upstream.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           # Fetch all history for merging
           fetch-depth: 0
-          ref: origin/main
+          ref: main
 
       - name: Setup - install dependencies
         run: |


### PR DESCRIPTION


## Additional Context
https://github.com/canonical/cloud-init/actions/runs/13439618723/job/37550455311#step:2:857

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
