### PR TITLE
fix: stop warning on dual-stack request failure

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -697,7 +697,7 @@ def dual_stack(
         # No success, return the last exception but log them all for
         # debugging
         if last_exception:
-            LOG.warning(
+            LOG.debug(
                 "Exception(s) %s during request to "
                 "%s, raising last exception",
                 exceptions,
@@ -710,7 +710,7 @@ def dual_stack(
 
     # when max_wait expires, log but don't throw (retries happen)
     except TimeoutError:
-        LOG.warning(
+        LOG.debug(
             "Timed out waiting for addresses: %s, "
             "exception(s) raised while waiting: %s",
             " ".join(addresses),


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: stop warning on dual-stack request failure

Failure from one or more endpoints may be expected, yet logging
warning means we will return 2.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
