### PR TITLE
fix: when get_session_cloud() fails, _SESSION_CLOUD isn't set

### DIFF
--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -483,6 +483,11 @@ def pytest_sessionstart(session) -> None:
     log.info("starting session")
     try:
         _SESSION_CLOUD = get_session_cloud()
+    except Exception as e:
+        pytest.exit(
+            f"{type(e).__name__} in session setup: {str(e)}", returncode=2
+        )
+    try:
         setup_image(_SESSION_CLOUD)
         REAPER = reaper._Reaper()
         REAPER.start()


### PR DESCRIPTION


<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: when get_session_cloud() fails, _SESSION_CLOUD isn't set

Which causes this secondary failure:

INTERNALERROR> During handling of the above exception, another exception occurred: INTERNALERROR>
<snip>
INTERNALERROR>   File "/home/holmanb/ci/tests/integration_tests/conftest.py", line 490, in pytest_sessionstart
INTERNALERROR>     if _SESSION_CLOUD:
INTERNALERROR>        ^^^^^^^^^^^^^^
INTERNALERROR> NameError: name '_SESSION_CLOUD' is not defined
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
