### PR TITLE
feat(azure): format ReportableErrorImdsInvalidMetadata's value without repr()

### DIFF
--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -156,7 +156,7 @@ class ReportableErrorImdsInvalidMetadata(ReportableError):
         super().__init__(f"invalid IMDS metadata for key={key}")
 
         self.supporting_data["key"] = key
-        self.supporting_data["value"] = repr(value)
+        self.supporting_data["value"] = value
 
 
 class ReportableErrorImdsMetadataParsingException(ReportableError):

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -157,6 +157,7 @@ class ReportableErrorImdsInvalidMetadata(ReportableError):
 
         self.supporting_data["key"] = key
         self.supporting_data["value"] = value
+        self.supporting_data["type"] = type(value).__name__
 
 
 class ReportableErrorImdsMetadataParsingException(ReportableError):

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -250,7 +250,8 @@ def test_unhandled_exception():
 @pytest.mark.parametrize(
     "value",
     [
-        "Running" "None",
+        "Running",
+        "None",
         None,
     ],
 )

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -255,3 +255,4 @@ def test_imds_invalid_metadata():
     assert error.reason == "invalid IMDS metadata for key=compute"
     assert error.supporting_data["key"] == key
     assert error.supporting_data["value"] == value
+    assert error.supporting_data["type"] == type(value).__name__

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -246,11 +246,11 @@ def test_unhandled_exception():
     quoted_value = quote_csv_value(f"exception={source_error!r}")
     assert f"|{quoted_value}|" in error.as_encoded_report()
 
+
 @pytest.mark.parametrize(
     "value",
     [
-        "Running"
-        "None",
+        "Running" "None",
         None,
     ],
 )

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -246,10 +246,16 @@ def test_unhandled_exception():
     quoted_value = quote_csv_value(f"exception={source_error!r}")
     assert f"|{quoted_value}|" in error.as_encoded_report()
 
-
-def test_imds_invalid_metadata():
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Running"
+        "None",
+        None,
+    ],
+)
+def test_imds_invalid_metadata(value):
     key = "compute"
-    value = "Running"
     error = errors.ReportableErrorImdsInvalidMetadata(key=key, value=value)
 
     assert error.reason == "invalid IMDS metadata for key=compute"

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -254,4 +254,4 @@ def test_imds_invalid_metadata():
 
     assert error.reason == "invalid IMDS metadata for key=compute"
     assert error.supporting_data["key"] == key
-    assert error.supporting_data["value"] == repr(value)
+    assert error.supporting_data["value"] == value


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(azure): format ReportableErrorImdsInvalidMetadata's value without repr()

repr() is used to capture the value, and value is later formatted with str().  The
conversion with repr() maintains most accurate output, but the quote handling
causes confusion for the typical case.  Drop repr usage and add additional
supporting data indicating type.

Current error example:

\```
Azure datasource failure occurred: result=error|reason=invalid IMDS metadata for
key=extended.compute.ppsType|agent=Cloud-Init/24.4
0ubuntu1~20.04.1|key=extended.compute.ppsType|'value=''Running'''|vm_id=dd9d1a15-9289-4a87-a338
3caf2d8df7e0|timestamp=2025-02-09T10:17:46.481069+00:00|documentation_url=https://aka.ms/linuxprovisioningerror
\```

Proposed output example:
\```
Azure datasource failure occurred: result=error|reason=invalid IMDS metadata for
key=extended.compute.ppsType|agent=Cloud-Init/24.4
0ubuntu1~20.04.1|key=extended.compute.ppsType|value=Running|type=str|vm_id=dd9d1a15-9289-4a87-a338
3caf2d8df7e0|timestamp=2025-02-09T10:17:46.481069+00:00|documentation_url=https://aka.ms/linuxprovisioningerror
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
