### PR TITLE
Ubuntu/plucky 25.1.x: fix passlib dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-cloud-init (25.1-0ubuntu2) UNRELEASED; urgency=medium
+cloud-init (25.1-0ubuntu2) plucky; urgency=medium
 
   * d/control: add python3-passlib dependency to cloud-init
     metapackage. (LP: #2098988)
 
- -- James Falcon <james.falcon@canonical.com>  Tue, 25 Feb 2025 08:14:10 -0600
+ -- James Falcon <james.falcon@canonical.com>  Tue, 25 Feb 2025 08:16:55 -0600
 
 cloud-init (25.1-0ubuntu1) plucky; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (25.1-0ubuntu2) UNRELEASED; urgency=medium
+
+  * d/control: add python3-passlib dependency to cloud-init
+    metapackage. (LP: #2098988)
+
+ -- James Falcon <james.falcon@canonical.com>  Tue, 25 Feb 2025 08:14:10 -0600
+
 cloud-init (25.1-0ubuntu1) plucky; urgency=medium
 
   * Upstream snapshot based on 25.1.

--- a/debian/control
+++ b/debian/control
@@ -71,6 +71,7 @@ Package: cloud-init
 Architecture: all
 Depends: cloud-init-base,
          python3-serial,
+         python3-passlib,
          ${misc:Depends},
 Description: initialization and customization tool for cloud instances
  Cloud-init is the industry standard multi-distribution method for


### PR DESCRIPTION
Since plucky is past feature freeze, let's just fix the bug rather than add a new metapackage now.

See: https://bugs.launchpad.net/ubuntu/+source/cloud-init/+bug/2098988