### PR TITLE
feat(vmware): Support network events

### DIFF
--- a/doc/rtd/reference/datasources/vmware.rst
+++ b/doc/rtd/reference/datasources/vmware.rst
@@ -325,6 +325,76 @@ If either of the above values are true, then the datasource will sleep for a
 second, check the network status, and repeat until one or both addresses from
 the specified families are available.
 
+Update Event support
+--------------------
+
+The VMware datasource supports the following types of update events:
+
+* Network -- ``boot``, ``boot-new-instance``, and ``hotplug``
+
+This means the guest will reconfigure networking from the network
+configuration provided via guestinfo, IMC, etc. each time the guest
+boots or even when a new network interface is added.
+
+It is possible to override the data source's default set of configured
+update events by specifying which events to use via user data.
+For example, the following snippet from user data would disable the
+`hotplug` event:
+
+   .. code-block:: yaml
+
+       #cloud-config
+       updates:
+         network:
+           when: ["boot", "boot-new-instance"]
+
+Determining the supported and enabled update events
+---------------------------------------------------
+
+This datasource also advertises the scope and type of the supported
+and enabled events.
+
+The ``guestinfo`` key ``guestinfo.cloudinit.updates.supported``
+contains a list of the supported scopes and types that adheres to the
+format ``SCOPE=TYPE[;TYPE][,SCOPE=TYPE[;TYPE]]``, for example:
+
+* ``network=boot;hotplug``
+* ``network=boot-new-instance``
+
+The value is based on the events supported by the datasource, whether
+or not the event is enabled. To inspect which events are enabled, use
+``guestinfo.cloudinit.updates.enabled``.
+
+This allows a consumer to determine if different versions of the
+datasource have different supported event types, regardless of which
+events are enabled.
+
+Network drivers and the hotplug update event
+--------------------------------------------
+
+By default, this datasource only responds to hotplug events if the
+driver is one of the following:
+
+* ``e1000``
+* ``e1000e``
+* ``vlance``
+* ``vmxnet2``
+* ``vmxnet3``
+* ``vrdma``
+
+This prevents responding unintentionally to interfaces created by
+Docker or other programs. However, it is also possible to override this
+list by setting ``metadata.network-drivers`` to a list of drivers:
+
+   .. code-block:: yaml
+
+       network-drivers:
+       - vmxnet2
+       - vmxnet3
+
+The above snippet means only NICs that use either the ``vmxnet2`` or
+``vmxnet3`` drivers will respond to hotplug events.
+
 Walkthrough of GuestInfo keys transport
 =======================================
 

--- a/tests/unittests/test_upgrade.py
+++ b/tests/unittests/test_upgrade.py
@@ -156,6 +156,7 @@ class TestUpgrade:
         "Vultr": {"netcfg"},
         "VMware": {
             "data_access_method",
+            "extra_hotplug_udev_rules",
             "rpctool",
             "rpctool_fn",
         },


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message

<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(vmware): Support network events

This patch updates the DataSource for VMware to support network
reconfiguration when the BOOT, BOOT_NEW_INSTANCE, and HOTPLUG
events are received.

Previously the datasource could only reconfigure the network if
a new instance ID was detected. However, due to features like
backup/restore, migrating VMs, etc., it was determined that it is
valuable to support reconfiguring the network without changing the
instance ID. This is because changing the instance ID also means
running the per-instance configuration modules, such as regenerating
the system's SSH host keys, which could lock out automation.
```

## Additional Context

`NA`

## Test Steps

```shell
make clean_pyc && PYTHONPATH="$(pwd)" python3 -m pytest -v tests/unittests/sources/test_vmware.py
```

```shell
make clean_pyc && PYTHONPATH="$(pwd)" python3 -m pytest -v tests/unittests/test_upgrade.py
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)

Fixes #5729 
