### PR TITLE
NM activator/bring_up_interfaces: reload and bring up individual network conns

### DIFF
--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -206,9 +206,9 @@ class NetworkManagerActivator(NetworkActivator):
                 state,
             )
         return _alter_interface(
-            ["systemctl", "reload-or-try-restart", "NetworkManager.service"],
+            ["systemctl", "try-reload-or-restart", "NetworkManager.service"],
             "all",
-        )
+        ) and all(cls.bring_up_interface(device) for device in device_names)
 
 
 class NetplanActivator(NetworkActivator):

--- a/tests/unittests/test_net_activators.py
+++ b/tests/unittests/test_net_activators.py
@@ -247,8 +247,8 @@ NETWORK_MANAGER_BRING_UP_ALL_CALL_LIST: list = [
         ),
         {},
     ),
-    ((["systemctl", "reload-or-try-restart", "NetworkManager.service"],), {}),
-]
+    ((["systemctl", "try-reload-or-restart", "NetworkManager.service"],), {}),
+] + NETWORK_MANAGER_BRING_UP_CALL_LIST
 
 NETWORKD_BRING_UP_CALL_LIST: list = [
     ((["ip", "link", "set", "dev", "eth0", "up"],), {}),


### PR DESCRIPTION
## Proposed Commit Message
Reloading the network manager service is equivalent to "nmcli reload" and this command only reloads the global .conf files and DNS config, not connections. This means changes to connection files will not take effect. For those to take effect, we need "nmcli conn load/reload" and then "nmcli conn up". Thus, reloading network manager as well as reloading the connections are required to cover all cases.

Also see https://github.com/canonical/cloud-init/issues/5512#issuecomment-2298371744

While at it, rename "reload-or-try-restart" -> "try-reload-or-restart" since the former is legacy and the later is the officially documented sub-command.

Fixes: GH-6064
Fixes: bde913ae242 ("fix(NetworkManager): Fix network activator")


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
