### PR TITLE
Allow to set mac_address for VLAN subinterface

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -384,6 +384,10 @@
           "items": {
             "$ref": "#/$defs/config_type_subnet"
           }
+        },
+        "mac_address": {
+          "type": "string",
+          "description": "When specifying MAC Address on a VLAN subinterface this value will be assigned to the vlan subinterface device and may be different than the MAC address of the physical interface. Specifying a MAC Address is optional. If ``mac_address`` is not present, then the VLAN subinterface will use the MAC Address values from one of the physical interface."
         }
       }
     },

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -732,6 +732,7 @@ def convert_net_json(network_json=None, known_macs=None):
                 {
                     "name": name,
                     "vlan_id": link["vlan_id"],
+                    "mac_address": link["vlan_mac_address"],
                 }
             )
             link_updates.append((cfg, "vlan_link", "%s", link["vlan_link"]))

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -231,6 +231,8 @@ Type ``vlan`` requires the following keys:
 - ``name``: Set the name of the VLAN
 - ``vlan_link``: Specify the underlying link via its ``name``.
 - ``vlan_id``: Specify the VLAN numeric id.
+- ``mac_address``: Optional, specify VLAN subinterface MAC address. If not
+  set MAC address from physical interface is used.
 
 The following optional keys are supported:
 

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -219,6 +219,7 @@ class TestConvertNetJson:
                     "type": "vlan",
                     "vlan_id": 123,
                     "vlan_link": "bond0",
+                    "mac_address": "xx:xx:xx:xx:xx:00",
                 },
                 {"address": "1.1.1.1", "type": "nameserver"},
             ],
@@ -346,6 +347,7 @@ class TestConvertNetJson:
                     ],
                     "vlan_id": 123,
                     "vlan_link": "bond0",
+                    "mac_address": "xx:xx:xx:xx:xx:00",
                 },
             ],
         }

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -110,6 +110,7 @@ jordimassaguerpla
 jqueuniet
 jsf9k
 jshen28
+jumpojoy
 kadiron
 kaiwalyakoparkar
 kallioli


### PR DESCRIPTION
This patch fixes regression caused by [0]
when setting mac_address for vlan subinterface is no longer propagated to netplan. The patch [0] changed behaviour of cloud-init between Bionic and Focal which on first glance looked like fixing only warning. But it was affecting netplan configuration.

This patch adds optional mac_address field to vlan subinterface.

[0] https://github.com/canonical/cloud-init/pull/5365

Related: #5364
