### PR TITLE
fix: bug #6082, get the network card information multiple times, to avoid errors because the network card is not ready.

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -758,51 +758,46 @@ def convert_net_json(network_json=None, known_macs=None):
         d for d in config if d.get("type") == "physical" and "name" not in d
     ]
 
+    # fix bug#6082: get the network card information multiple times,
+    # to avoid errors because the network card is not ready.
     if need_names or link_updates:
-        # fix bug#6082: get the network card information multiple times,
-        # to avoid errors because the network card is not ready.
-        flag = True
-        start = time.time()
-        while flag:
-            time.sleep(0.1)
-            if known_macs is None:
-                known_macs = net.get_interfaces_by_mac()
+        if known_macs is None:
+            known_macs = net.get_interfaces_by_mac()
 
-            # go through and fill out the link_id_info with names
-            for _link_id, info in link_id_info.items():
-                if info.get("name"):
-                    continue
-                if info.get("mac") in known_macs:
-                    info["name"] = known_macs[info["mac"]]
+        # go through and fill out the link_id_info with names
+        for _link_id, info in link_id_info.items():
+            if info.get("name"):
+                continue
+            if info.get("mac") in known_macs:
+                info["name"] = known_macs[info["mac"]]
 
-            flag = False
-            for d in need_names:
-                mac = d.get("mac_address")
-                if not mac:
-                    raise ValueError("No mac_address or name entry for %s" % d)
-                if mac not in known_macs:
-                    # Let's give udev a chance to catch up
-                    util.udevadm_settle()
+        for d in need_names:
+            mac = d.get("mac_address")
+            if not mac:
+                raise ValueError("No mac_address or name entry for %s" % mac)
+            if mac not in known_macs:
+                # Let's give udev a chance to catch up
+                util.udevadm_settle()
+                start = time.monotonic()
+                while True:
                     known_macs = net.get_interfaces_by_mac()
                     if mac not in known_macs:
-                        if time.time() - start > FIND_MAC_TIMEOUT:
-                            raise ValueError("Unable to find a system nic for %s" % d)
-                        LOG.debug("Unable to find a system nic for %s, try again." % d)
-                        flag = True
-                        known_macs = None
-                        break
-                d["name"] = known_macs[mac]
+                        _msg = "Unable to find a system nic for mac(%s)" % mac
+                        if time.monotonic() - start > FIND_MAC_TIMEOUT:
+                            raise ValueError(_msg)
+                        time.sleep(0.1)
+                        LOG.debug(_msg)
+                        continue
+                    break
+            d["name"] = known_macs[mac]
 
-            if flag:
-                continue
-
-            for cfg, key, fmt, targets in link_updates:
-                if isinstance(targets, (list, tuple)):
-                    cfg[key] = [
-                        fmt % link_id_info[target]["name"] for target in targets
-                    ]
-                else:
-                    cfg[key] = fmt % link_id_info[targets]["name"]
+        for cfg, key, fmt, targets in link_updates:
+            if isinstance(targets, (list, tuple)):
+                cfg[key] = [
+                    fmt % link_id_info[target]["name"] for target in targets
+                ]
+            else:
+                cfg[key] = fmt % link_id_info[targets]["name"]
 
     # Infiniband interfaces may be referenced in network_data.json by a 6 byte
     # Ethernet MAC-style address, and we use that address to look up the

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -18,7 +18,6 @@ andrewbogott
 andrewlukoshko
 andy191x
 ani-sinha
-Ankele
 antonyc
 apollo13
 ashuntu

--- a/tools/.github-cla-signers
+++ b/tools/.github-cla-signers
@@ -18,6 +18,7 @@ andrewbogott
 andrewlukoshko
 andy191x
 ani-sinha
+Ankele
 antonyc
 apollo13
 ashuntu


### PR DESCRIPTION
…errors because the network card is not ready.


This patch fixes bug #6082, get the network card information multiple times to avoid errors because the network card is not ready， which deploy bare metal server with cloud-init in image through OpenStack Ironic.
Fill in any shell scripts in runcmd, and call OpenStack API with ConfigDrive user-data, after the server has deployed, runcmd scripts was not executed (/var/log/cloud-init.log), all the modules after INIT stage while failed, because the cloud data is not stored correctly.
Now, let's try to get the MAC address again a few more times before concluding that the MAC address does not match, because network_data.json contains network card information that cannot be recognized immediately after boot( or cloud-init.service start).

Fixes #6082 
