### PR TITLE
test: decouple netplan integrations from libnetplan SRU

### DIFF
--- a/tests/integration_tests/cmd/test_schema.py
+++ b/tests/integration_tests/cmd/test_schema.py
@@ -6,9 +6,9 @@ import pytest
 
 from cloudinit import lifecycle
 from tests.integration_tests.instances import IntegrationInstance
-from tests.integration_tests.releases import CURRENT_RELEASE, JAMMY
 from tests.integration_tests.util import (
     get_feature_flag_value,
+    has_netplanlib,
     verify_clean_boot,
     verify_clean_log,
 )
@@ -103,7 +103,7 @@ class TestSchemaDeprecations:
                 "annotate": NET_V1_ANNOTATED,
             },
         }
-        if CURRENT_RELEASE >= JAMMY:
+        if has_netplanlib(class_client):
             # Support for netplan API available
             content_responses[NET_CFG_V2] = {
                 "out": "Valid schema /root/net.yaml"

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -26,10 +26,11 @@ from tests.integration_tests.integration_settings import (
     OS_IMAGE_TYPE,
     PLATFORM,
 )
-from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, JAMMY
+from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
 from tests.integration_tests.util import (
     get_feature_flag_value,
     get_inactive_modules,
+    has_netplanlib,
     lxd_has_nocloud,
     network_wait_logged,
     verify_clean_boot,
@@ -99,13 +100,13 @@ class TestCombined:
         Test that netplan config file is generated with proper permissions
         """
         log = class_client.read_from_file("/var/log/cloud-init.log")
-        if CURRENT_RELEASE < JAMMY:
+        if has_netplanlib(class_client):
+            assert "Rendered netplan config using netplan python API" in log
+        else:
             assert (
                 "No netplan python module. Fallback to write"
                 " /etc/netplan/50-cloud-init.yaml" in log
             )
-        else:
-            assert "Rendered netplan config using netplan python API" in log
         file_perms = class_client.execute(
             "stat -c %a /etc/netplan/50-cloud-init.yaml"
         )

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -590,6 +590,11 @@ def get_feature_flag_value(client: "IntegrationInstance", key):
     return value
 
 
+def has_netplanlib(client: "IntegrationInstance") -> bool:
+    """Return True if netplan python3 pkg is installed on the instance."""
+    return client.execute("dpkg-query -W python3-netplan").ok
+
+
 def override_kernel_command_line(ds_str: str, instance: "IntegrationInstance"):
     """set the kernel command line and reboot, return after boot done
 


### PR DESCRIPTION
## Proposed Commit Message
```
test: decouple netplan integrations from libnetplan SRU

The netplan.io SRU on Jammy is in an unresolved publication state for 140 days. Avoid hard-coding cloud-init integration tests to expect a specific series to contain libnetplan and instead check the instance under test to confirm python3-netplan is installed before validating cloud-init behavior.
```

## Additional Context
Jammy integration tests should not expect libnetplan yet (until netplan.io version 0.107 gets SRU''d)

https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-azure-generic/lastSuccessfulBuild/testReport/junit/tests.integration_tests.modules.test_combined/TestCombined/test_netplan_permissions/


## Test Steps
```
CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily CLOUD_INIT_OS_IMAGE=noble tox -e integration-tests -- --last-failed  tests/integration_tests/cmd/test_schema.py tests/integration-tests/modules/test_combined.py::TestCombined::test_netplan_permissions
```
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
