### PR TITLE
fix(azure): handle unexpected exceptions during obtain_lease()

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -467,6 +467,12 @@ class DataSourceAzure(sources.DataSource):
                         ),
                         host_only=True,
                     )
+                except FileNotFoundError as error:
+                    report_diagnostic_event(
+                        "File not found during DHCP %r" % error,
+                        logger_func=LOG.error,
+                    )
+                    raise error
                 except subp.ProcessExecutionError as error:
                     # udevadm settle, ip link set dev eth0 up, etc.
                     report_diagnostic_event(

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3424,6 +3424,25 @@ class TestEphemeralNetworking:
         assert azure_ds._wireserver_endpoint == "168.63.129.16"
         assert azure_ds._ephemeral_dhcp_ctx.iface == lease["interface"]
 
+    def test_no_retry_missing_driver(
+        self,
+        azure_ds,
+        caplog,
+        mock_ephemeral_dhcp_v4
+    ):
+        mock_ephemeral_dhcp_v4.return_value.obtain_lease.side_effect = [       
+            FileNotFoundError     
+        ]
+
+        with pytest.raises(FileNotFoundError):
+            azure_ds._setup_ephemeral_networking()
+
+        assert (
+            mock_ephemeral_dhcp_v4.return_value.mock_calls
+            == [mock.call.obtain_lease()]
+        )
+        assert "File not found during DHCP" in caplog.text
+
     def test_no_retry_missing_dhclient_error(
         self,
         azure_ds,

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -3425,22 +3425,18 @@ class TestEphemeralNetworking:
         assert azure_ds._ephemeral_dhcp_ctx.iface == lease["interface"]
 
     def test_no_retry_missing_driver(
-        self,
-        azure_ds,
-        caplog,
-        mock_ephemeral_dhcp_v4
+        self, azure_ds, caplog, mock_ephemeral_dhcp_v4
     ):
-        mock_ephemeral_dhcp_v4.return_value.obtain_lease.side_effect = [       
-            FileNotFoundError     
+        mock_ephemeral_dhcp_v4.return_value.obtain_lease.side_effect = [
+            FileNotFoundError
         ]
 
         with pytest.raises(FileNotFoundError):
             azure_ds._setup_ephemeral_networking()
 
-        assert (
-            mock_ephemeral_dhcp_v4.return_value.mock_calls
-            == [mock.call.obtain_lease()]
-        )
+        assert mock_ephemeral_dhcp_v4.return_value.mock_calls == [
+            mock.call.obtain_lease()
+        ]
         assert "File not found during DHCP" in caplog.text
 
     def test_no_retry_missing_dhclient_error(


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(azure): handle unexpected exceptions during obtain_lease()

During DHCP we have seen various errors arising due to network interfaces being renamed during discovery.
e.g. cloud-init unhandled exception: FileNotFoundError(2, ''No such file or directory'')'
Add a guard to catch any unexpected exception to avoid unexpected propagation of exception, e.g. FileNotFoundError.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
