### PR TITLE
test: correctly mock fallback nic in openstack tests

### DIFF
--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -85,6 +85,13 @@ def mock_is_resolvable():
         yield
 
 
+def mock_distro():
+    distro = mock.MagicMock(spec=Distro)
+    distro.is_virtual = True
+    distro.fallback_interface = "eth9"
+    return distro
+
+
 # TODO _register_uris should leverage test_ec2.register_mock_metaserver.
 def _register_uris(version, ec2_files, ec2_meta, os_files, *, responses_mock):
     """Registers a set of url patterns into responses that will mimic the
@@ -301,9 +308,10 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
             OS_FILES,
             responses_mock=self.responses,
         )
-        distro = mock.MagicMock(spec=Distro)
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN,
+            mock_distro(),
+            helpers.Paths({"run_dir": self.tmp}),
         )
         self.assertIsNone(ds_os.version)
         with mock.patch.object(ds_os, "override_ds_detect", return_value=True):
@@ -373,10 +381,10 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         _register_uris(
             self.VERSION, {}, {}, os_files, responses_mock=self.responses
         )
-        distro = mock.MagicMock(spec=Distro)
-        distro.is_virtual = True
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN,
+            mock_distro(),
+            helpers.Paths({"run_dir": self.tmp}),
         )
         self.assertIsNone(ds_os.version)
         with test_helpers.mock.patch.object(
@@ -400,10 +408,10 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         _register_uris(
             self.VERSION, {}, {}, os_files, responses_mock=self.responses
         )
-        distro = mock.MagicMock(spec=Distro)
-        distro.is_virtual = True
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN,
+            mock_distro(),
+            helpers.Paths({"run_dir": self.tmp}),
         )
         ds_os.ds_cfg = {
             "max_wait": 0,
@@ -476,10 +484,10 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         _register_uris(
             self.VERSION, {}, {}, os_files, responses_mock=self.responses
         )
-        distro = mock.MagicMock(spec=Distro)
-        distro.is_virtual = True
         ds_os = ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN,
+            mock_distro(),
+            helpers.Paths({"run_dir": self.tmp}),
         )
         ds_os.ds_cfg = {
             "max_wait": 0,
@@ -505,7 +513,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         )
         ds_os = ds.DataSourceOpenStack(
             settings.CFG_BUILTIN,
-            test_util.MockDistro(),
+            mock_distro(),
             helpers.Paths({"run_dir": self.tmp}),
         )
         crawled_data = ds_os._crawl_metadata()

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -583,10 +583,10 @@ class TestDetectOpenStack(test_helpers.CiTestCase):
         self.tmp = self.tmp_dir()
 
     def _fake_ds(self) -> ds.DataSourceOpenStack:
-        distro = mock.MagicMock(spec=Distro)
-        distro.is_virtual = True
         return ds.DataSourceOpenStack(
-            settings.CFG_BUILTIN, distro, helpers.Paths({"run_dir": self.tmp})
+            settings.CFG_BUILTIN,
+            test_util.MockDistro(),
+            helpers.Paths({"run_dir": self.tmp}),
         )
 
     def test_ds_detect_non_intel_x86(self, m_is_x86):

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -85,13 +85,6 @@ def mock_is_resolvable():
         yield
 
 
-def mock_distro():
-    distro = mock.MagicMock(spec=Distro)
-    distro.is_virtual = True
-    distro.fallback_interface = "eth9"
-    return distro
-
-
 # TODO _register_uris should leverage test_ec2.register_mock_metaserver.
 def _register_uris(version, ec2_files, ec2_meta, os_files, *, responses_mock):
     """Registers a set of url patterns into responses that will mimic the
@@ -310,7 +303,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         )
         ds_os = ds.DataSourceOpenStack(
             settings.CFG_BUILTIN,
-            mock_distro(),
+            test_util.MockDistro(),
             helpers.Paths({"run_dir": self.tmp}),
         )
         self.assertIsNone(ds_os.version)
@@ -383,7 +376,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         )
         ds_os = ds.DataSourceOpenStack(
             settings.CFG_BUILTIN,
-            mock_distro(),
+            test_util.MockDistro(),
             helpers.Paths({"run_dir": self.tmp}),
         )
         self.assertIsNone(ds_os.version)
@@ -410,7 +403,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         )
         ds_os = ds.DataSourceOpenStack(
             settings.CFG_BUILTIN,
-            mock_distro(),
+            test_util.MockDistro(),
             helpers.Paths({"run_dir": self.tmp}),
         )
         ds_os.ds_cfg = {
@@ -486,7 +479,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         )
         ds_os = ds.DataSourceOpenStack(
             settings.CFG_BUILTIN,
-            mock_distro(),
+            test_util.MockDistro(),
             helpers.Paths({"run_dir": self.tmp}),
         )
         ds_os.ds_cfg = {
@@ -513,7 +506,7 @@ class TestOpenStackDataSource(test_helpers.ResponsesTestCase):
         )
         ds_os = ds.DataSourceOpenStack(
             settings.CFG_BUILTIN,
-            mock_distro(),
+            test_util.MockDistro(),
             helpers.Paths({"run_dir": self.tmp}),
         )
         crawled_data = ds_os._crawl_metadata()

--- a/tests/unittests/sources/test_openstack.py
+++ b/tests/unittests/sources/test_openstack.py
@@ -14,7 +14,6 @@ import pytest
 import responses
 
 from cloudinit import helpers, settings, util
-from cloudinit.distros import Distro
 from cloudinit.sources import UNSET, BrokenMetadata
 from cloudinit.sources import DataSourceOpenStack as ds
 from cloudinit.sources import convert_vendordata

--- a/tests/unittests/util.py
+++ b/tests/unittests/util.py
@@ -72,6 +72,8 @@ def abstract_to_concrete(abclass):
 
 
 class MockDistro(distros.Distro):
+    fallback_interface = "eth9"
+
     # MockDistro is here to test base Distro class implementations
     def __init__(self, name="testingdistro", cfg=None, paths=None):
         self._client = None


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: correctly mock fallback nic in openstack tests

Previously, the mock distro would present a mock fallback interface
resulting in invalid IP addresses that would look something like:
fe80::a9fe:a9fe%25<MagicMock name='mock.fallback_interface' id='138716823174880'>
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
