### PR TITLE
Handle ssh_config being /usr and inheriting user configuration from sshd_config.d

### DIFF
--- a/cloudinit/ssh_util.py
+++ b/cloudinit/ssh_util.py
@@ -544,6 +544,10 @@ def parse_ssh_config_map(fname):
 
 
 def _includes_dconf(fname: str) -> bool:
+    # Handle cases where sshd_config is handled in /usr/etc/ssh/sshd_config
+    # so /etc/ssh/sshd_config.d/ exists but /etc/ssh/sshd_config doesn't
+    if not os.path.exists(fname) and os.path.exists(f"{fname}.d"):
+        return True
     if not os.path.isfile(fname):
         return False
     for line in util.load_text_file(fname).splitlines():

--- a/tests/unittests/test_ssh_util.py
+++ b/tests/unittests/test_ssh_util.py
@@ -561,6 +561,18 @@ class TestUpdateSshConfig:
         expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
         assert not os.path.isfile(expected_conf_file)
 
+    def test_without_sshd_config(self, tmpdir):
+        """In some cases /etc/ssh/sshd_config.d exists but /etc/ssh/sshd_config
+        doesn't. In this case we shouldn't create /etc/ssh/sshd_config but make
+        /etc/ssh/sshd_config.d/50-cloud-init.conf."""
+        mycfg = tmpdir.join("sshd_config")
+        os.mkdir(os.path.join(tmpdir, "sshd_config.d"))
+        assert ssh_util.update_ssh_config({"key": "value"}, mycfg)
+        expected_conf_file = f"{mycfg}.d/50-cloud-init.conf"
+        assert os.path.isfile(expected_conf_file)
+        assert not os.path.isfile(mycfg)
+        assert "key value\n" == util.load_text_file(expected_conf_file)
+
     @pytest.mark.parametrize(
         "cfg",
         ["Include {mycfg}.d/*.conf", "Include {mycfg}.d/*.conf # comment"],


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<type>fix: ensure system sshd_config is not overwritten<summary>  # no more than 72 characters

In some systems, Tumbleweed for instance, the system sshd_config is
stored in /usr/etc/ssh/sshd_config which is then set to inherit user
changes from /etc/ssh/sshd_config.d/*.conf to neatly handle updating
of system configuration without overwriting user configuration

However, previously we would check for /etc/ssh/sshd_config and if it
does not exist cloud-init would then write it's changes to
/etc/ssh/sshd_config instead of the 
/etc/ssh/sshd_config.d/50-cloud-init.conf that's used for all other
instances

To handle this if the sshd_config file does not exist, lets also check
for sshd_config.d. If the later then exists we know it's safe to use
write sshd_config.d/50-cloud-init.conf
```

## Additional Context
<!-- If relevant -->

This originally came out of https://github.com/cockpit-project/bots/issues/7448

If run on Tumbleweed and you provide the `ssh_pwauth: True` option, it will overwrite the system defaults for sshd_config since it writes the change to `/etc/ssh/sshd_config` instead of `/etc/ssh/sshd_config.d/50-cloud-init.conf`

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

This is pretty easy to recreate, on any system that lacks `/etc/ssh/sshd_config` and instead includes user configuration from `/etc/ssh/sshd_config.d/*`. I ran all my tests through the Tumbleweed cloud image from [here](https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-Cloud.qcow2)

```yaml
#cloud-config
users:
  - default
  - name: root
    lock_passwd: false
    # $ mkpasswd --method=sha256crypt --salt=CockpitCloudInit foobar
    hashed_passwd: '$5$CockpitCloudInit$Iw89f.aPgqHPXAHC2Zs9h9335n3E1FQDFvR6MLqwPK9'
    groups: users,wheel
    ssh_authorized_keys:
      - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDUOtNJdBEXyKxBB898rdT54ULjMGuO6v4jLXmRsdRhR5Id/lKNc9hsdioPWUePgYlqML2iSV72vKQoVhkyYkpcsjr3zvBny9+5xej3+TBLoEMAm2hmllKPmxYJDU8jQJ7wJuRrOVOnk0iSNF+FcY/yaQ0owSF02Nphx47j2KWc0IjGGlt4fl0fmHJuZBA2afN/4IYIIsEWZziDewVtaEjWV3InMRLllfdqGMllhFR+ed2hQz9PN2QcapmEvUR4UCy/mJXrke5htyFyHi8ECfyMMyYeHwbWLFQIve4CWix9qtksvKjcetnxT+WWrutdr3c9cfIj/c0v/Zg/c4zETxtp cockpit-test
ssh_pwauth: True
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
