### PR TITLE
fix: Do not filter netdevs using addr_assign_type

### DIFF
--- a/WIP-ONGOING-REFACTORIZATION.rst
+++ b/WIP-ONGOING-REFACTORIZATION.rst
@@ -146,7 +146,6 @@ categories:
 
   * ``get_ib_interface_hwaddr``
   * ``get_interface_mac``
-  * ``interface_has_own_mac``
   * ``is_bond``
   * ``is_bridge``
   * ``is_physical``

--- a/cloudinit/distros/networking.py
+++ b/cloudinit/distros/networking.py
@@ -71,11 +71,6 @@ class Networking(metaclass=abc.ABCMeta):
     def get_master(self, devname: DeviceName):
         return net.get_master(devname)
 
-    def interface_has_own_mac(
-        self, devname: DeviceName, *, strict: bool = False
-    ) -> bool:
-        return net.interface_has_own_mac(devname, strict=strict)
-
     def is_bond(self, devname: DeviceName) -> bool:
         return net.is_bond(devname)
 

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -730,34 +730,6 @@ class TestGetInterfaceMAC(CiTestCase):
         )
 
 
-class TestInterfaceHasOwnMAC(CiTestCase):
-    def setUp(self):
-        super(TestInterfaceHasOwnMAC, self).setUp()
-        sys_mock = mock.patch("cloudinit.net.get_sys_class_path")
-        self.m_sys_path = sys_mock.start()
-        self.sysdir = self.tmp_dir() + "/"
-        self.m_sys_path.return_value = self.sysdir
-        self.addCleanup(sys_mock.stop)
-
-    def test_interface_has_own_mac_false_when_stolen(self):
-        """Return False from interface_has_own_mac when address is stolen."""
-        write_file(os.path.join(self.sysdir, "eth1", "addr_assign_type"), "2")
-        self.assertFalse(net.interface_has_own_mac("eth1"))
-
-    def test_interface_has_own_mac_true_when_not_stolen(self):
-        """Return False from interface_has_own_mac when mac isn't stolen."""
-        valid_assign_types = ["0", "1", "3"]
-        assign_path = os.path.join(self.sysdir, "eth1", "addr_assign_type")
-        for _type in valid_assign_types:
-            write_file(assign_path, _type)
-            self.assertTrue(net.interface_has_own_mac("eth1"))
-
-    def test_interface_has_own_mac_strict_errors_on_absent_assign_type(self):
-        """When addr_assign_type is absent, interface_has_own_mac errors."""
-        with self.assertRaises(ValueError):
-            net.interface_has_own_mac("eth1", strict=True)
-
-
 @mock.patch("cloudinit.net.subp.subp")
 @pytest.mark.usefixtures("disable_netdev_info")
 class TestEphemeralIPV4Network(CiTestCase):


### PR DESCRIPTION
Fixes #6110 

~~Marking this as a draft until I have confirmation from the user that disabling MAC passthrough works around the bug.~~ The user has verified that MAC passthrough was the cause of #6110. Ready for feedback.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers`` (N/A?)
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Do not filter netdevs using addr_assign_type

This filter was originally introduced in bf7723e to prevent bonds and
vlans being included in `get_interfaces`. However, specific filtering
for vlans was implemented in ebc9ecb and the same was added for bonds
in e5f5421.

As of kernel commit cb6cf08, some USB NICs which use passthrough MAC
addresses will also report their MAC address as stolen. While MAC
passthrough makes it possible for more than one interface to use the
same MAC, removing the filter for stolen MACs allows cloud-init to
succeed in the more common case where only one NIC exists with a
stolen MAC.

Fixes GH-6110
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Without a lot of fiddling, properly testing this requires access to hardware that supports MAC passthrough via the `r8152` driver and has it enabled in the firmware. Kernel 6.11 is required to reproduce the bug. Stolen from the test plan in [LP#1682871](https://bugs.launchpad.net/cloud-init/+bug/1682871), this one-liner should return a list that includes the device with the stolen MAC:
```
python3 -c 'from cloudinit.net import get_interfaces_by_mac; print(get_interfaces_by_mac())'
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
