### PR TITLE
fix: cli: incorrect top-level usage output when subcommand provides invalid optional parameter

### DIFF
--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -278,6 +278,22 @@ class TestCLI:
         assert f"usage: cloud-init {subcommand}" in out.getvalue()
 
     @pytest.mark.parametrize(
+        "subcommand",
+        [
+            "clean",
+            "collect-logs",
+            "status",
+        ],
+    )
+    def test_subcommand_parser_shows_usage(self, subcommand, capsys):
+        """cloud-init `subcommand` shows usage on error."""
+        # Provide --invalid-arg to `subcommand` to trigger error.
+        exit_code = self._call_main(["cloud-init", subcommand, "--invalid"])
+        _out, err = capsys.readouterr()
+        assert f"usage: cloud-init {subcommand}" in err
+        assert 2 == exit_code
+
+    @pytest.mark.parametrize(
         "args,expected_subcommands",
         [
             ([], ["schema"]),


### PR DESCRIPTION
This change ensures that a subcommand's usage information is provided to the user when an invalid argument is passed to the subcommand.

Fixes #4609 

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ x ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have added my Github username to ``tools/.github-cla-signers``
- [ ] I have included a comprehensive commit message using the guide below
- [ x ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ x ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ x ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ x ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: CLI shows incorrect usage when subcommand used erroneously

When a subcommand is provided with an invalid parameter, the CLI
outputs the top-level usage information. This change modifies this
behaviour such that the usage information of the respective
subcommand is displayed instead.

Fixes GH-4609
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

From issue:

Expected:
Providing and invalid optional parameter --invalid to a cloud-init sub-command should generate a usage statement for that sub-command

$ cloud-init clean --invalid

usage: /usr/bin/cloud-init clean [-h] [-l] [--machine-id] [-r] [-s] [-c {all,ssh_config,network} [{all,ssh_config,network} ...]]
/usr/bin/cloud-init clean: error: unrecognized arguments: --invalid

Actual:
Providing and invalid optional parameter --invalid to a cloud-init sub-command actually generates a usage statement from the base-command which doesn't provide helpful context on viable parameters for that sub-command

usage: /usr/bin/cloud-init [-h] [--version] [--file FILES] [--debug] [--force] {init,modules,single,query,features,analyze,devel,collect-logs,clean,status,schema} ...
/usr/bin/cloud-init: error: unrecognized arguments: --invalid

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
