### PR TITLE
chore: allow custom pkg-config binary path

### DIFF
--- a/setup_utils.py
+++ b/setup_utils.py
@@ -13,6 +13,11 @@ def is_generator(p: str) -> bool:
 
 
 def pkg_config_read(library: str, var: str) -> str:
+    pkg_config = "pkg-config"
+
+    if os.getenv("PKG_CONFIG"):
+        pkg_config = os.getenv("PKG_CONFIG")
+
     fallbacks = {
         "systemd": {
             "systemdsystemconfdir": "/etc/systemd/system",
@@ -23,7 +28,7 @@ def pkg_config_read(library: str, var: str) -> str:
             "udevdir": "/usr/lib/udev",
         },
     }
-    cmd = ["pkg-config", f"--variable={var}", library]
+    cmd = [pkg_config, f"--variable={var}", library]
     try:
         path = subprocess.check_output(cmd).decode("utf-8")  # nosec B603
         path = path.strip()


### PR DESCRIPTION
This commit adds the possibility to specify a custom pkg-config binary path in build scripts using the PKG_CONFIG environment variable. Packages managers might use different pkg-config depending on the target platform.

Fixes GH-6099

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
(Removed by #6116: - [ ] I have added my Github username to ``tools/.github-cla-signers``)
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
    chore: allow custom pkg-config binary path

    This commit adds the possibility to specify a custom pkg-config binary path
    in build scripts using the PKG_CONFIG environment variable. Packages
    managers might use different pkg-config depending on the target platform.

    Fixes GH-6099
```

## Additional Context

Specific package managers might not define `pkg-config`, but rather `pkg-config-x86` (and so on for various arch) in  multi arch build systems.

## Test Steps

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
