### PR TITLE
fix(oracle): properly detect ipv6 only for private ULA addresses

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -364,7 +364,7 @@ class DataSourceOracle(sources.DataSource):
             is_primary = set_primary and index == 0
             mac_address = vnic_dict["macAddr"].lower()
             is_ipv6_only = vnic_dict.get(
-                "ipv6SubnetCidrBlock", False
+                "ipv6VirtualRouterIp", False
             ) and not vnic_dict.get("privateIp", False)
             if mac_address not in interfaces_by_mac:
                 LOG.warning(


### PR DESCRIPTION
When a VNIC is attached to a private subnet and has a ULA address, the VNIC data given by the IMDS does not contain the "ipv6SubnetCidrBlock" entry and instead has a "subnetCidrBlock" entry set to null. To properly detect if we should configure a VNIC as ipv6 single stack, the key "ipv6VirtualRouterIp" must be present and the key "privateIp" must not be present. Previously, the key "ipv6SubnetCidrBlock" was assumed to be present on all VNICs configured for ipv6 single stack or dual stack, but that is not the case when using a private subnet with ULA addresses.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
N/A

## Additional Context
<!-- If relevant -->
Oracle raised an issue a customer had where cloud-init hit a `KeyError` on an ipv6 only instance with ULA addresses. This change addresses this bug.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Tested against various instance configurations that had prefixes for ULA only, GUA only, and both GUA & ULA. The new `ipv6VirtualRouterIp` key was present on all 3 configurations.

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [X] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
