### PR TITLE
feat(oracle): downgrade warning log about falling back to imds

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -297,7 +297,7 @@ class DataSourceOracle(sources.DataSource):
         if self._is_iscsi_root():
             self._network_config = self._get_iscsi_config()
         if not self._has_network_config():
-            LOG.warning(
+            LOG.debug(
                 "Could not obtain network configuration from initramfs. "
                 "Falling back to IMDS."
             )

--- a/tests/unittests/sources/test_oracle.py
+++ b/tests/unittests/sources/test_oracle.py
@@ -675,7 +675,7 @@ class TestNetworkConfigFromOpcImds:
             ) == caplog.record_tuples[-1][1:]
 
         assert (
-            logging.WARNING,
+            logging.DEBUG,
             "Could not obtain network configuration from initramfs."
             " Falling back to IMDS.",
         ) == caplog.record_tuples[log_initramfs_index][1:]


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
```
feat(oracle): downgrade warning log about falling back to IMDS

If an oracle instance does not configure networking in the initramfs and
thus cloud-init does not already have networking, a warning should NOT
be logged since ubuntu oracle images will soon be changed such that
networking will not be configured in initramfs for VMs that do not have
an ISCSI root/boot device.
```

## Additional Context
<!-- If relevant -->
The Canonical Public Cloud team is looking to make a change to the open-iscsi package in the near future that will modify the iscsi initramfs script such that on VMs that do not have iscsi boot or root devices, networking will NOT be configured in the initramfs since:
A) setting up the networking via DHCP is ridiculously slow (~10s) and cloud-init ephemeral network setup is very fast (~2s) 
B) this will allow for oracle VMs to work seamlessly on both IPv4 and IPv6 single stack networking.    
C) this ultimately will lead to boot times on oracle more than HALVING from 20-25s on average all the way down to 10-12s on average

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
