### PR TITLE
Ubuntu/devel 25.1.x

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (25.1.1-0ubuntu2) UNRELEASED; urgency=medium
+
+  * d/control: Fix how cloud-init-base overwrites cloud-init files.
+    (LP: #2092333)
+
+ -- James Falcon <james.falcon@canonical.com>  Fri, 28 Mar 2025 16:41:08 -0500
+
 cloud-init (25.1.1-0ubuntu1) plucky; urgency=medium
 
   * Upstream bug fix release based on upstream bugfix 25.1.1.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-cloud-init (25.1.1-0ubuntu2) UNRELEASED; urgency=medium
+cloud-init (25.1.1-0ubuntu2) plucky; urgency=medium
 
   * d/control: Fix how cloud-init-base overwrites cloud-init files.
     (LP: #2092333)
 
- -- James Falcon <james.falcon@canonical.com>  Fri, 28 Mar 2025 16:41:08 -0500
+ -- James Falcon <james.falcon@canonical.com>  Fri, 28 Mar 2025 16:43:14 -0500
 
 cloud-init (25.1.1-0ubuntu1) plucky; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -43,8 +43,8 @@ Depends: cloud-guest-utils | cloud-utils,
          ${python3:Depends}
 Recommends: eatmydata, gdisk, gnupg, python3-apt, software-properties-common
 Suggests: openssh-server, ssh-import-id
-Replaces: cloud-init (<= 24.4~3+really24.3.1-0ubuntu4)
-Breaks: cloud-init (<= 24.4~3+really24.3.1-0ubuntu4)
+Replaces: cloud-init (<< 25.1.1-0ubuntu2~), cloud-init-base 
+Breaks: cloud-init (<< 25.1.1-0ubuntu2~), cloud-init-base
 Description: initialization and customization tool for cloud instances
  Cloud-init with minimal dependencies, refer to cloud-init for more
  information.


### PR DESCRIPTION
Should be reviewed alongside https://github.com/canonical/cloud-init/pull/6139
```
Fix how cloud-init-base overwrites cloud-init files

Cloud-init is currently broken on `do-release-upgrade` to plucky. In
plucky, cloud-init's packaging has been broken out into multiple binary
packages:
- cloud-init-base contains almost all of what used to be cloud-init
  minus some dependencies that aren't needed everywhere
- Additional cloud-specific packages will be made that contain
  cloud-init-base + the dependencies needed for that cloud
- cloud-init now depends on cloud-init-base + all extra cloud-specific
  dependencies.

This allows the cloud-init package to be essentially identical to what
the cloud-init package contained before with the advantage of being
able to install only `cloud-init-base` on systems that don't need
everything required by `cloud-init`'s full dependencies.

When making this change, the following was initially added to
`cloud-init-base` package on plucky:

Breaks: cloud-init (<= 24.4~3+really24.3.1-0ubuntu4)
Replaces: cloud-init (<= 24.4~3+really24.3.1-0ubuntu4)

However, this doesn't work. Since cloud-init get's SRUed in full, the
version numbers will always need to increase. Futhermore, this means
`cloud-init-base` can potentially break and replace the version of
cloud-init on plucky being upgraded.

Instead, this commit changes the `Replaces:` line to:
`Replaces: cloud-init`. This allows cloud-init-base to overwrite any
files previously owned by `cloud-init`, but allows various versions of
the two packages to live side-by-side.
```

## Additional context
Without this change, during `do-release-upgrade`, we get errors about essentially every cloud-init file:
```
apt-term.log:Selecting previously unselected package cloud-init-base.
apt-term.log:Preparing to unpack .../098-cloud-init-base_25.1-0ubuntu3_all.deb ...
apt-term.log:Unpacking cloud-init-base (25.1-0ubuntu3) ...
apt-term.log:dpkg: warning: trying to overwrite '/etc/cloud/cloud.cfg', which is also in package cloud-init (24.4.1-0ubuntu0~24.10.1)
apt-term.log:dpkg: warning: trying to overwrite '/etc/cloud/cloud.cfg.d/05_logging.cfg', which is also in package cloud-init (24.4.1-0ubuntu0~24.10.1)
apt-term.log:dpkg: warning: trying to overwrite '/etc/cloud/cloud.cfg.d/README', which is also in package cloud-init (24.4.1-0ubuntu0~24.10.1)
apt-term.log:dpkg: warning: trying to overwrite '/etc/cloud/templates/chef_client.rb.tmpl', which is also in package cloud-init (24.4.1-0ubuntu0~24.10.1)
apt-term.log:dpkg: warning: trying to overwrite '/etc/cloud/templates/chrony.conf.almalinux.tmpl', which is also in package cloud-init (24.4.1-0ubuntu0~24.10.1)
apt-term.log:dpkg: warning: trying to overwrite '/etc/cloud/templates/chrony.conf.alpine.tmpl', which is also in package cloud-init (24.4.1-0ubuntu0~24.10.1)
...
```
Then we see no cloud-init files on disk.

With this change, the errors disappear from the logs, cloud-init works as expected, I can see the new cloud-init version in plucky, and we have files in the expected packages:
```
# dpkg -L cloud-init
/.
/usr
/usr/share
/usr/share/doc
/usr/share/doc/cloud-init
/usr/share/doc/cloud-init/NEWS.Debian.gz
/usr/share/doc/cloud-init/changelog.Debian.gz
/usr/share/doc/cloud-init/copyright
/etc/logrotate.d/cloud-init
#
#
# dpkg -L cloud-init-base
/.
/etc
/etc/cloud
/etc/cloud/clean.d
/etc/cloud/cloud.cfg
/etc/cloud/cloud.cfg.d
/etc/cloud/cloud.cfg.d/05_logging.cfg
/etc/cloud/cloud.cfg.d/README
/etc/cloud/templates
/etc/cloud/templates/chef_client.rb.tmpl
/etc/cloud/templates/chrony.conf.almalinux.tmpl
...
```

This was tested using the ppa at https://launchpad.net/~falcojr/+archive/ubuntu/cloud-init-dev

## Merge type

- [] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
