### PR TITLE
Ubuntu/oracular 25.1.x

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,9 @@
-cloud-init (25.1.1-0ubuntu2~24.10.1) UNRELEASED; urgency=medium
+cloud-init (25.1.1-0ubuntu2~24.10.1) oracular; urgency=medium
 
   * d/control: Fix how cloud-init-base overwrites cloud-init files.
     (LP: #2092333)
 
- -- James Falcon <james.falcon@canonical.com>  Fri, 28 Mar 2025 16:48:22 -0500
+ -- James Falcon <james.falcon@canonical.com>  Fri, 28 Mar 2025 16:50:53 -0500
 
 cloud-init (25.1.1-0ubuntu1~24.10.1) oracular; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (25.1.1-0ubuntu2~24.10.1) UNRELEASED; urgency=medium
+
+  * d/control: Fix how cloud-init-base overwrites cloud-init files.
+    (LP: #2092333)
+
+ -- James Falcon <james.falcon@canonical.com>  Fri, 28 Mar 2025 16:48:22 -0500
+
 cloud-init (25.1.1-0ubuntu1~24.10.1) oracular; urgency=medium
 
   * Drop cpicks which are now upstream:

--- a/debian/control
+++ b/debian/control
@@ -44,6 +44,7 @@ Depends: cloud-guest-utils | cloud-utils,
          ${python3:Depends}
 Recommends: eatmydata, gdisk, gnupg, python3-apt, software-properties-common
 Suggests: openssh-server, ssh-import-id
+Provides: cloud-init-base
 Description: initialization and customization tool for cloud instances
  Cloud-init is the industry standard multi-distribution method for
  cross-platform cloud instance initialization. It is supported across all major


### PR DESCRIPTION
Should be reviewed alongside https://github.com/canonical/cloud-init/pull/6137

```
Fix how cloud-init-base overwrites cloud-init files

Cloud-init is currently broken on `do-release-upgrade` to plucky. In
plucky, cloud-init's packaging has been broken out into multiple binary
packages:
- cloud-init-base contains almost all of what used to be cloud-init
  minus some dependencies that aren't needed everywhere
- Additional cloud-specific packages will be made that contain
  cloud-init-base + the dependencies needed for that cloud
- cloud-init now depends on cloud-init-base + all extra cloud-specific
  dependencies.

This allows the cloud-init package to be essentially identical to what
the cloud-init package contained before with the advantage of being
able to install only `cloud-init-base` on systems that don't need
everything required by `cloud-init`'s full dependencies.

When making this change, the following was initially added to
`cloud-init-base` package on plucky:

Breaks: cloud-init (<= 24.4~3+really24.3.1-0ubuntu4)
Replaces: cloud-init (<= 24.4~3+really24.3.1-0ubuntu4)

However, this doesn't work. Since cloud-init get's SRUed in full, the
version numbers will always need to increase. Futhermore, this means
`cloud-init-base` can potentially break and replace the version of
cloud-init on plucky being upgraded.

Instead, this commit changes the `Replaces:` line to:
`Replaces: cloud-init`. This allows cloud-init-base to overwrite any
files previously owned by `cloud-init`, but allows various versions of
the two packages to live side-by-side.
```

If approved, these same changes will go into noble, jammy, and focal.