### PR TITLE
fix: Reorder iface filters & warn on inherited MAC

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -1044,8 +1044,6 @@ def get_interfaces(
     # 16 somewhat arbitrarily chosen.  Normally a mac is 6 '00:' tokens.
     zero_mac = ":".join(("00",) * 16)
     for name in devs:
-        if filter_without_own_mac and not interface_has_own_mac(name):
-            continue
         if is_bridge(name):
             filtered_logger("Ignoring bridge interface: %s", name)
             continue
@@ -1053,6 +1051,9 @@ def get_interfaces(
             continue
         if is_bond(name):
             filtered_logger("Ignoring bond interface: %s", name)
+            continue
+        if filter_without_own_mac and not interface_has_own_mac(name):
+            filtered_logger("Ignoring interface with inherited MAC: %s", name)
             continue
         if (
             filter_slave_if_master_not_bridge_bond_openvswitch

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -5090,7 +5090,7 @@ class TestGetInterfaces:
     def test_gi_excludes_stolen_macs(self, mocks):
         ret = net.get_interfaces()
         mocks["interface_has_own_mac"].assert_has_calls(
-            [mock.call("enp0s1"), mock.call("bond1")], any_order=True
+            [mock.call("enp0s1")], any_order=True
         )
         expected = [
             ("enp0s2", "aa:aa:aa:aa:aa:02", "e1000", "0x5"),


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] ~~I have updated the documentation with the changed behavior.~~
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->
Warn when interfaces are ignored based on `addr_assign_type`. See #6110 and #6111

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Reorder iface filters & warn on inherited MAC

This filter was originally introduced in bf7723e to prevent bonds and
vlans being included in `get_interfaces`. However, specific filtering
for vlans was implemented in ebc9ecb and the same was added for bonds
in e5f5421.

As of kernel commit cb6cf08, some USB NICs which use passthrough MAC
addresses will also report their MAC address as stolen. MAC
passthrough makes it possible for more than one physical interface to
use the same MAC, so provide a warning to make it clear what
is going on.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
