### PR TITLE
Fix: Add Ephemeral Network for CloudStackLocal DS

### DIFF
--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -1,156 +1,99 @@
 # This file is part of cloud-init. See LICENSE file for license information.
+from socket import gaierror
 from textwrap import dedent
 
 import pytest
 
 from cloudinit import helpers
-from cloudinit.distros import rhel, ubuntu
 from cloudinit.net.dhcp import NoDHCPLeaseError
 from cloudinit.sources import DataSourceHostname
 from cloudinit.sources.DataSourceCloudStack import (
+    CLOUD_STACK_DMI_NAME,
     DataSourceCloudStack,
     DataSourceCloudStackLocal,
+    get_data_server,
+    get_vr_address,
 )
-from tests.unittests.helpers import (
-    CiTestCase,
-    ExitStack,
-    ResponsesTestCase,
-    mock,
-)
+from tests.unittests.helpers import mock
 from tests.unittests.util import MockDistro
 
 SOURCES_PATH = "cloudinit.sources"
 MOD_PATH = SOURCES_PATH + ".DataSourceCloudStack"
 DS_PATH = MOD_PATH + ".DataSourceCloudStack"
 DHCP_MOD_PATH = "cloudinit.net.dhcp"
+FAKE_LEASE = {
+    "interface": "eth0",
+    "fixed-address": "192.168.0.1",
+    "subnet-mask": "255.255.255.0",
+    "routers": "192.168.0.1",
+    "domain-name": "dhclient.local",
+    "renew": "4 2017/07/27 18:02:30",
+    "expire": "5 2017/07/28 07:08:15",
+}
+
+FAKE_LEASE_WITH_SERVER_IDENT = """\
+lease {
+  interface "eth0";
+  fixed-address 10.0.0.5;
+  server-name "DSM111070915004";
+  option subnet-mask 255.255.255.0;
+  option dhcp-lease-time 4294967295;
+  option routers 10.0.0.1;
+  option dhcp-message-type 5;
+  option dhcp-server-identifier 168.63.129.16;
+  option domain-name-servers 168.63.129.16;
+  option dhcp-renewal-time 4294967295;
+  option rfc3442-classless-static-routes 0,10,0,0,1,32,168,63,129,16,10,0,0,1,32,169,254,169,254,10,0,0,1;
+  option unknown-245 a8:3f:81:10;
+  option dhcp-rebinding-time 4294967295;
+  renew 0 2160/02/17 02:22:33;
+  rebind 0 2160/02/17 02:22:33;
+  expire 0 2160/02/17 02:22:33;
+}
+"""  # noqa: E501
+
+
+@pytest.fixture
+def cloudstack_ds(request, paths):
+    yield DataSourceCloudStack(sys_cfg={}, distro=MockDistro(), paths=paths)
 
 
 @pytest.mark.usefixtures("dhclient_exists")
-class TestCloudStackHostname(CiTestCase):
-    def setUp(self):
-        super(TestCloudStackHostname, self).setUp()
-        self.patches = ExitStack()
-        self.addCleanup(self.patches.close)
+class TestCloudStackHostname:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker, tmp_path):
         self.hostname = "vm-hostname"
         self.networkd_domainname = "networkd.local"
         self.isc_dhclient_domainname = "dhclient.local"
 
-        # Mock the parent class get_hostname() method to return
-        # a non-fqdn hostname
         get_hostname_parent = mock.MagicMock(
             return_value=DataSourceHostname(self.hostname, True)
         )
-        self.patches.enter_context(
-            mock.patch(
-                SOURCES_PATH + ".DataSource.get_hostname", get_hostname_parent
-            )
+        mocker.patch(
+            SOURCES_PATH + ".DataSource.get_hostname", get_hostname_parent
         )
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".util.load_text_file",
-                return_value=dedent(
-                    """
-                    lease {
-                      interface "eth0";
-                      fixed-address 10.0.0.5;
-                      server-name "DSM111070915004";
-                      option subnet-mask 255.255.255.0;
-                      option dhcp-lease-time 4294967295;
-                      option routers 10.0.0.1;
-                      option dhcp-message-type 5;
-                      option dhcp-server-identifier 168.63.129.16;
-                      option domain-name-servers 168.63.129.16;
-                      option dhcp-renewal-time 4294967295;
-                      option rfc3442-classless-static-routes """
-                    """0,10,0,0,1,32,168,63,129,16,10,0,0,1,32,169,254,"""
-                    """169,254,10,0,0,1;
-                      option unknown-245 a8:3f:81:10;
-                      option dhcp-rebinding-time 4294967295;
-                    """
-                    """renew 0 2160/02/17 02:22:33;
-                      rebind 0 2160/02/17 02:22:33;
-                      expire 0 2160/02/17 02:22:33;
-                    }
-                    """
-                ),
-            )
+        mocker.patch(
+            DHCP_MOD_PATH + ".util.load_text_file",
+            return_value=FAKE_LEASE_WITH_SERVER_IDENT,
         )
-
         # Mock cloudinit.net.dhcp.networkd_get_option_from_leases() method \
         # result since we don't have a DHCP client running
         networkd_get_option_from_leases = mock.MagicMock(
             return_value=self.networkd_domainname
         )
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".networkd_get_option_from_leases",
-                networkd_get_option_from_leases,
-            )
+        mocker.patch(
+            DHCP_MOD_PATH + ".networkd_get_option_from_leases",
+            networkd_get_option_from_leases,
         )
 
-        # Mock cloudinit.net.dhcp.get_newest_lease_file_from_distro() method \
-        # result since we don't have a DHCP client running
-        isc_dhclient_get_newest_lease_file_from_distro = mock.MagicMock(
-            return_value="/var/lib/NetworkManager/dhclient-u-u-i-d-eth0.lease"
-        )
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH
-                + ".IscDhclient.get_newest_lease_file_from_distro",
-                isc_dhclient_get_newest_lease_file_from_distro,
-            )
-        )
-
-        # Mock cloudinit.net.dhcp.networkd_get_option_from_leases() method \
-        # result since we don't have a DHCP client running
-        lease = {
-            "interface": "eth0",
-            "fixed-address": "192.168.0.1",
-            "subnet-mask": "255.255.255.0",
-            "routers": "192.168.0.1",
-            "domain-name": self.isc_dhclient_domainname,
-            "renew": "4 2017/07/27 18:02:30",
-            "expire": "5 2017/07/28 07:08:15",
-        }
-        get_newest_lease = mock.MagicMock(return_value=lease)
-
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".IscDhclient.get_newest_lease",
-                get_newest_lease,
-            )
-        )
-
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".IscDhclient.parse_leases",
-                mock.MagicMock(return_value=[lease]),
-            )
-        )
-
-        # Mock get_vr_address() method as it relies to
-        # parsing DHCP/networkd files
-        self.patches.enter_context(
-            mock.patch(
-                MOD_PATH + ".get_vr_address",
-                mock.MagicMock(return_value="192.168.0.1"),
-            )
-        )
-
-        self.tmp = self.tmp_dir()
-
-    def test_get_domainname_networkd(self):
+    def test_get_domainname_networkd(self, cloudstack_ds):
         """
         Test if DataSourceCloudStack._get_domainname()
         gets domain name from systemd-networkd leases.
         """
-        ds = DataSourceCloudStack(
-            {}, ubuntu.Distro, helpers.Paths({"run_dir": self.tmp})
-        )
-        result = ds._get_domainname()
-        self.assertEqual(self.networkd_domainname, result)
+        assert self.networkd_domainname == cloudstack_ds._get_domainname()
 
-    def test_get_domainname_isc_dhclient(self):
+    def test_get_domainname_isc_dhclient(self, cloudstack_ds, mocker):
         """
         Test if DataSourceCloudStack._get_domainname()
         gets domain name from isc-dhcp-client leases
@@ -159,17 +102,12 @@ class TestCloudStackHostname(CiTestCase):
         # Override systemd-networkd reply mock to None
         # to force the code to fallback to IscDhclient
         get_networkd_domain = mock.MagicMock(return_value=None)
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".networkd_get_option_from_leases",
-                get_networkd_domain,
-            )
+        mocker.patch(
+            DHCP_MOD_PATH + ".networkd_get_option_from_leases",
+            get_networkd_domain,
         )
 
-        ds = DataSourceCloudStack(
-            {}, rhel.Distro, helpers.Paths({"run_dir": self.tmp})
-        )
-        with mock.patch(
+        with mocker.patch(
             MOD_PATH + ".util.load_text_file",
             return_value=dedent(
                 """
@@ -198,10 +136,10 @@ class TestCloudStackHostname(CiTestCase):
                 """
             ),
         ):
-            result = ds._get_domainname()
-        self.assertEqual(self.isc_dhclient_domainname, result)
+            result = cloudstack_ds._get_domainname()
+        assert self.isc_dhclient_domainname == result
 
-    def test_get_hostname_non_fqdn(self):
+    def test_get_hostname_non_fqdn(self, cloudstack_ds):
         """
         Test get_hostname() method implementation
         with fqdn parameter=False.
@@ -209,14 +147,10 @@ class TestCloudStackHostname(CiTestCase):
         return its response intact.
         """
         expected = DataSourceHostname(self.hostname, True)
+        result = cloudstack_ds.get_hostname(fqdn=False)
+        assert expected == result
 
-        ds = DataSourceCloudStack(
-            {}, ubuntu.Distro, helpers.Paths({"run_dir": self.tmp})
-        )
-        result = ds.get_hostname(fqdn=False)
-        self.assertTupleEqual(expected, result)
-
-    def test_get_hostname_fqdn(self):
+    def test_get_hostname_fqdn(self, cloudstack_ds):
         """
         Test get_hostname() method implementation
         with fqdn parameter=True.
@@ -225,14 +159,10 @@ class TestCloudStackHostname(CiTestCase):
         expected = DataSourceHostname(
             self.hostname + "." + self.networkd_domainname, True
         )
+        result = cloudstack_ds.get_hostname(fqdn=True)
+        assert expected == result
 
-        ds = DataSourceCloudStack(
-            {}, ubuntu.Distro, helpers.Paths({"run_dir": self.tmp})
-        )
-        result = ds.get_hostname(fqdn=True)
-        self.assertTupleEqual(expected, result)
-
-    def test_get_hostname_fqdn_fallback(self):
+    def test_get_hostname_fqdn_fallback(self, cloudstack_ds, mocker):
         """
         Test get_hostname() when some error happens
         during domainname discovery.
@@ -249,32 +179,23 @@ class TestCloudStackHostname(CiTestCase):
         # Override systemd-networkd reply mock to None
         # to force the code to fallback to IscDhclient
         get_networkd_domain = mock.MagicMock(return_value=None)
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".networkd_get_option_from_leases",
-                get_networkd_domain,
-            )
+        mocker.patch(
+            DHCP_MOD_PATH + ".networkd_get_option_from_leases",
+            get_networkd_domain,
         )
 
-        self.patches.enter_context(
-            mock.patch(
-                "cloudinit.distros.net.find_fallback_nic",
-                return_value="eth0",
-            )
+        mocker.patch(
+            "cloudinit.distros.net.find_fallback_nic",
+            return_value="eth0",
         )
 
-        self.patches.enter_context(
-            mock.patch(
-                MOD_PATH
-                + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
-                return_value=True,
-            )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.get_newest_lease_file_from_distro",
+            return_value=True,
         )
 
-        self.patches.enter_context(
-            mock.patch(
-                MOD_PATH + ".dhcp.IscDhclient.parse_leases", return_value=[]
-            )
+        mocker.patch(
+            MOD_PATH + ".dhcp.IscDhclient.parse_leases", return_value=[]
         )
 
         lease = {
@@ -285,155 +206,165 @@ class TestCloudStackHostname(CiTestCase):
             "renew": "4 2017/07/27 18:02:30",
             "expire": "5 2017/07/28 07:08:15",
         }
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".IscDhclient.get_newest_lease",
-                return_value=lease,
-            )
+        mocker.patch(
+            DHCP_MOD_PATH + ".IscDhclient.get_newest_lease",
+            return_value=lease,
         )
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".Dhcpcd.get_newest_lease", return_value=lease
-            )
+        mocker.patch(
+            DHCP_MOD_PATH + ".Dhcpcd.get_newest_lease", return_value=lease
         )
 
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".util.load_text_file",
-                return_value=dedent(
-                    """
-                    lease {
-                      interface "eth0";
-                      fixed-address 10.0.0.5;
-                      server-name "DSM111070915004";
-                      option subnet-mask 255.255.255.0;
-                      option dhcp-lease-time 4294967295;
-                      option routers 10.0.0.1;
-                      option dhcp-message-type 5;
-                      option dhcp-server-identifier 168.63.129.16;
-                      option domain-name-servers 168.63.129.16;
-                      option dhcp-renewal-time 4294967295;
-                      option rfc3442-classless-static-routes """
-                    """0,10,0,0,1,32,168,63,129,16,10,0,0,1,32,169,254,"""
-                    """169,254,10,0,0,1;
-                      option unknown-245 a8:3f:81:10;
-                      option dhcp-rebinding-time 4294967295;
-                    """
-                    """renew 0 2160/02/17 02:22:33;
-                      rebind 0 2160/02/17 02:22:33;
-                      expire 0 2160/02/17 02:22:33;
-                    }
-                    """
-                ),
-            )
-        )
+        cloudstack_ds.distro.fallback_interface = "eth0"
+        with mocker.patch(MOD_PATH + ".util.load_text_file"):
+            result = cloudstack_ds.get_hostname(fqdn=True)
+            assert expected == result
 
-        ds = DataSourceCloudStack(
-            {}, ubuntu.Distro("", {}, {}), helpers.Paths({"run_dir": self.tmp})
+
+class TestGetDataServer:
+    @pytest.mark.parametrize(
+        "addrinfo,expected,expected_log",
+        (
+            pytest.param(
+                # Fake addrinfo
+                [("_", "_", "_", "_", ("10.1.35.171", 80)), "_"],
+                "10.1.35.171",
+                None,
+                id="success_on_dns_resolution",
+            ),
+            pytest.param(
+                gaierror("Name or service not known"),
+                None,
+                "DNS Entry data-server not found",
+                id="none_on_no_dns_resolution",
+            ),
+        ),
+    )
+    def test_data_server_from_dns(
+        self, addrinfo, expected, expected_log, mocker, caplog
+    ):
+        """Lookup data-server from DNS."""
+        if isinstance(addrinfo, Exception):
+            mocker.patch(MOD_PATH + ".getaddrinfo", side_effect=addrinfo)
+            assert expected == get_data_server()
+        else:
+            mocker.patch(MOD_PATH + ".getaddrinfo", return_value=addrinfo)
+            assert expected is get_data_server()
+        if expected_log:
+            assert expected_log in caplog.text
+
+
+@mock.patch(MOD_PATH + ".get_data_server", return_value="10.1.37.131")
+@mock.patch(
+    MOD_PATH + ".dhcp.networkd_get_option_from_leases",
+    return_value="10.1.37.132",
+)
+class TestGetVrAddress:
+    def test_get_vr_addr_from_dns(
+        self, m_networkd_option_from_leases, m_get_data_server, caplog
+    ):
+        """cloud-init first obtains data-server if resolved by DNS"""
+        assert "10.1.37.131" == get_vr_address(MockDistro())
+        assert (
+            "Found metadata server '10.1.37.131' via data-server DNS entry"
+            in caplog.text
         )
-        ds.distro.fallback_interface = "eth0"
-        with mock.patch(MOD_PATH + ".util.load_text_file"):
-            result = ds.get_hostname(fqdn=True)
-            self.assertTupleEqual(expected, result)
+        assert 0 == m_networkd_option_from_leases.call_count
+
+    def test_get_vr_addr_from_networkd_leases(
+        self, m_networkd_option_from_leases, m_get_data_server, mocker, caplog
+    ):
+        """When no DNS for data-server use networkd dhcp-server-identifier"""
+        mocker.patch(MOD_PATH + ".get_data_server", return_value=None)
+        assert "10.1.37.132" == get_vr_address(MockDistro())
+        assert (
+            "Found SERVER_ADDRESS '10.1.37.132' via networkd_leases"
+            in caplog.text
+        )
+        m_networkd_option_from_leases.assert_called_once_with("SERVER_ADDRESS")
 
 
 @pytest.mark.usefixtures("dhclient_exists")
-class TestCloudStackPasswordFetching(CiTestCase):
-    def setUp(self):
-        super(TestCloudStackPasswordFetching, self).setUp()
-        self.patches = ExitStack()
-        self.addCleanup(self.patches.close)
-        mod_name = MOD_PATH
-        self.patches.enter_context(mock.patch("{0}.ec2".format(mod_name)))
-        self.patches.enter_context(mock.patch("{0}.uhelp".format(mod_name)))
+@mock.patch(MOD_PATH + ".dmi.read_dmi_data", return_value=CLOUD_STACK_DMI_NAME)
+class TestCloudStackPasswordFetching:
+    @pytest.fixture(autouse=True)
+    def setup(self, mocker, tmp_path):
+        mocker.patch(f"{MOD_PATH}.ec2")
+        mocker.patch(f"{MOD_PATH}.uhelp")
         default_gw = "192.201.20.0"
-
+        mocker.patch(
+            DHCP_MOD_PATH + ".IscDhclient.get_newest_lease",
+            return_value={
+                "interface": "eth0",
+                "fixed-address": "192.168.0.1",
+                "subnet-mask": "255.255.255.0",
+                "routers": "192.168.0.1",
+                "renew": "4 2017/07/27 18:02:30",
+                "expire": "5 2017/07/28 07:08:15",
+                "dhcp-server-identifier": "168.63.129.16",
+            },
+        )
         get_newest_lease_file_from_distro = mock.MagicMock(return_value=None)
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH + ".IscDhclient.get_newest_lease",
-                return_value={
-                    "interface": "eth0",
-                    "fixed-address": "192.168.0.1",
-                    "subnet-mask": "255.255.255.0",
-                    "routers": "192.168.0.1",
-                    "renew": "4 2017/07/27 18:02:30",
-                    "expire": "5 2017/07/28 07:08:15",
-                },
-            )
+        mocker.patch(
+            DHCP_MOD_PATH + ".IscDhclient.get_newest_lease",
+            return_value={
+                "interface": "eth0",
+                "fixed-address": "192.168.0.1",
+                "subnet-mask": "255.255.255.0",
+                "routers": "192.168.0.1",
+                "renew": "4 2017/07/27 18:02:30",
+                "expire": "5 2017/07/28 07:08:15",
+                "dhcp-server-identifier": "168.63.129.16",
+            },
         )
-        self.patches.enter_context(
-            mock.patch(
-                DHCP_MOD_PATH
-                + ".IscDhclient.get_newest_lease_file_from_distro",
-                get_newest_lease_file_from_distro,
-            )
+        mocker.patch(
+            DHCP_MOD_PATH + ".IscDhclient.get_newest_lease_file_from_distro",
+            get_newest_lease_file_from_distro,
         )
-
         get_default_gw = mock.MagicMock(return_value=default_gw)
-        self.patches.enter_context(
-            mock.patch(mod_name + ".get_default_gateway", get_default_gw)
-        )
+        mocker.patch(MOD_PATH + ".get_default_gateway", get_default_gw)
 
         get_networkd_server_address = mock.MagicMock(return_value=None)
-        self.patches.enter_context(
-            mock.patch(
-                mod_name + ".dhcp.networkd_get_option_from_leases",
-                get_networkd_server_address,
-            )
+        mocker.patch(
+            MOD_PATH + ".dhcp.networkd_get_option_from_leases",
+            get_networkd_server_address,
         )
         get_data_server = mock.MagicMock(return_value=None)
-        self.patches.enter_context(
-            mock.patch(mod_name + ".get_data_server", get_data_server)
-        )
+        mocker.patch(MOD_PATH + ".get_data_server", get_data_server)
 
-        self.tmp = self.tmp_dir()
-
-    def _set_password_server_response(self, response_string):
+    def _set_password_server_response(self, response_string, mocker):
         subp = mock.MagicMock(return_value=(response_string, ""))
-        self.patches.enter_context(
-            mock.patch(
-                "cloudinit.sources.DataSourceCloudStack.subp.subp", subp
-            )
-        )
+        mocker.patch("cloudinit.sources.DataSourceCloudStack.subp.subp", subp)
         return subp
 
-    def test_empty_password_doesnt_create_config(self):
-        self._set_password_server_response("")
-        ds = DataSourceCloudStack(
-            {}, MockDistro(), helpers.Paths({"run_dir": self.tmp})
-        )
-        ds.get_data()
-        self.assertEqual({}, ds.get_config_obj())
+    def test_empty_password_doesnt_create_config(
+        self, _dmi, cloudstack_ds, mocker
+    ):
+        self._set_password_server_response("", mocker)
+        cloudstack_ds.get_data()
+        assert {} == cloudstack_ds.get_config_obj()
 
-    def test_saved_password_doesnt_create_config(self):
-        self._set_password_server_response("saved_password")
-        ds = DataSourceCloudStack(
-            {}, MockDistro(), helpers.Paths({"run_dir": self.tmp})
-        )
-        ds.get_data()
-        self.assertEqual({}, ds.get_config_obj())
+    def test_saved_password_doesnt_create_config(
+        self, _dmi, cloudstack_ds, mocker
+    ):
+        self._set_password_server_response("saved_password", mocker)
+        cloudstack_ds.get_data()
+        assert {} == cloudstack_ds.get_config_obj()
 
     @mock.patch(DS_PATH + ".wait_for_metadata_service")
-    def test_password_sets_password(self, m_wait):
+    def test_password_sets_password(self, m_wait, _dmi, cloudstack_ds, mocker):
         m_wait.return_value = True
         password = "SekritSquirrel"
-        self._set_password_server_response(password)
-        ds = DataSourceCloudStack(
-            {}, MockDistro(), helpers.Paths({"run_dir": self.tmp})
-        )
-        ds.get_data()
-        self.assertEqual(password, ds.get_config_obj()["password"])
+        self._set_password_server_response(password, mocker)
+        cloudstack_ds.get_data()
+        assert password == cloudstack_ds.get_config_obj()["password"]
 
     @mock.patch(DS_PATH + ".wait_for_metadata_service")
-    def test_bad_request_doesnt_stop_ds_from_working(self, m_wait):
+    def test_bad_request_doesnt_stop_ds_from_working(
+        self, m_wait, _dmi, cloudstack_ds, mocker
+    ):
         m_wait.return_value = True
-        self._set_password_server_response("bad_request")
-        # with mock.patch(DHCP_MOD_PATH + ".util.load_text_file"):
-        ds = DataSourceCloudStack(
-            {}, MockDistro(), helpers.Paths({"run_dir": self.tmp})
-        )
-        self.assertTrue(ds.get_data())
+        self._set_password_server_response("bad_request", mocker)
+        assert cloudstack_ds.get_data() is True
 
     def assertRequestTypesSent(self, subp, expected_request_types):
         request_types = []
@@ -442,68 +373,71 @@ class TestCloudStackPasswordFetching(CiTestCase):
             for arg in args:
                 if arg.startswith("DomU_Request"):
                     request_types.append(arg.split()[1])
-        self.assertEqual(expected_request_types, request_types)
+        assert expected_request_types == request_types
 
     @mock.patch(DS_PATH + ".wait_for_metadata_service")
-    def test_valid_response_means_password_marked_as_saved(self, m_wait):
+    def test_valid_response_means_password_marked_as_saved(
+        self, m_wait, _dmi, cloudstack_ds, mocker
+    ):
         m_wait.return_value = True
         password = "SekritSquirrel"
-        subp = self._set_password_server_response(password)
-        ds = DataSourceCloudStack(
-            {}, MockDistro(), helpers.Paths({"run_dir": self.tmp})
-        )
-        ds.get_data()
+        subp = self._set_password_server_response(password, mocker)
+        cloudstack_ds.get_data()
         self.assertRequestTypesSent(
             subp, ["send_my_password", "saved_password"]
         )
 
-    def _check_password_not_saved_for(self, response_string):
-        subp = self._set_password_server_response(response_string)
-        ds = DataSourceCloudStack(
-            {}, MockDistro(), helpers.Paths({"run_dir": self.tmp})
+    def _check_password_not_saved_for(
+        self, response_string, cloudstack_ds, mocker
+    ):
+        subp = self._set_password_server_response(
+            response_string, mocker=mocker
         )
         with mock.patch(DS_PATH + ".wait_for_metadata_service") as m_wait:
             m_wait.return_value = True
-            ds.get_data()
+            cloudstack_ds.get_data()
         self.assertRequestTypesSent(subp, ["send_my_password"])
 
-    def test_password_not_saved_if_empty(self):
-        self._check_password_not_saved_for("")
+    def test_password_not_saved_if_empty(self, _dmi, cloudstack_ds, mocker):
+        self._check_password_not_saved_for("", cloudstack_ds, mocker)
 
-    def test_password_not_saved_if_already_saved(self):
-        self._check_password_not_saved_for("saved_password")
-
-    def test_password_not_saved_if_bad_request(self):
-        self._check_password_not_saved_for("bad_request")
-
-
-class TestDataSourceCloudStackLocal(ResponsesTestCase, CiTestCase):
-    with_logs = True
-
-    @mock.patch(
-        MOD_PATH + ".EphemeralIPNetwork",
-        autospec=True,
-    )
-    @mock.patch(MOD_PATH + ".net.find_fallback_nic")
-    def test_local_datasource_fails_ephemeral_dhcp(
-        self, m_find_fallback_nic, m_dhcp
+    def test_password_not_saved_if_already_saved(
+        self, _dmi, cloudstack_ds, mocker
     ):
-        self.tmp = self.tmp_dir()
+        self._check_password_not_saved_for(
+            "saved_password", cloudstack_ds, mocker
+        )
+
+    def test_password_not_saved_if_bad_request(
+        self, _dmi, cloudstack_ds, mocker
+    ):
+        self._check_password_not_saved_for(
+            "bad_request", cloudstack_ds, mocker
+        )
+
+
+class TestDataSourceCloudStackLocal:
+
+    @mock.patch(MOD_PATH + ".EphemeralIPNetwork", autospec=True)
+    @mock.patch(MOD_PATH + ".net.find_fallback_nic")
+    @mock.patch(MOD_PATH + ".get_vr_address", return_value="10.1.37.131")
+    def test_local_datasource_fails_ephemeral_dhcp(
+        self, m_get_vr_address, m_find_fallback_nic, m_dhcp, caplog, tmpdir
+    ):
         distro = MockDistro()
         ds = DataSourceCloudStackLocal(
-            {}, distro, helpers.Paths({"run_dir": self.tmp})
+            {}, distro, helpers.Paths({"run_dir": tmpdir})
         )
-        fallback_nic_cases = [None, "enp0s1", "enp0s1"]
-        dhcp_results = [Exception, NoDHCPLeaseError, Exception]
+        fallback_nic_cases = ["enp0s1", "enp0s1"]
+        dhcp_results = [NoDHCPLeaseError, Exception("Something unexpected")]
         expected_logs = [
-            ("Attempting DHCP on: None", "Failed to crawl IMDS with None"),
             (
                 "Attempting DHCP on: enp0s1",
-                "Unable to obtain a DHCP lease for enp0s1",
+                "Unable to obtain a DHCP lease on enp0s1",
             ),
             (
                 "Attempting DHCP on: enp0s1",
-                "Failed to crawl IMDS with enp0s1",
+                "Failed fetching metadata service: Something unexpected",
             ),
         ]
 
@@ -520,10 +454,7 @@ class TestDataSourceCloudStackLocal(ResponsesTestCase, CiTestCase):
             assert m_dhcp.call_count == dhcp_module_call_count - 1
             assert ds._get_data() is False
             for msg in logs:
-                self.assertIn(
-                    msg,
-                    self.logs.getvalue(),
-                )
+                assert msg in caplog.text
 
     @mock.patch(MOD_PATH + ".CloudStackPasswordServerClient.get_password")
     @mock.patch(SOURCES_PATH + ".helpers.ec2.get_instance_metadata")
@@ -534,19 +465,21 @@ class TestDataSourceCloudStackLocal(ResponsesTestCase, CiTestCase):
         autospec=True,
     )
     @mock.patch(MOD_PATH + ".net.find_fallback_nic")
+    # @mock.patch(MOD_PATH + ".get_vr_address", return_value="10.1.37.131")
     def test_local_datasource_success(
         self,
+        # m_get_vr_address,
         m_find_fallback_nic,
         m_dhcp,
         m_wait_for_mds,
         m_get_userdata,
         m_get_metadata,
         m_get_password,
+        tmpdir,
     ):
         distro = MockDistro()
-        self.tmp = self.tmp_dir()
         ds = DataSourceCloudStackLocal(
-            {}, distro, helpers.Paths({"run_dir": self.tmp})
+            {}, distro, helpers.Paths({"run_dir": tmpdir})
         )
 
         m_find_fallback_nic.return_value = "enp0s1"

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -501,7 +501,6 @@ class TestDataSourceCloudStackLocal(ResponsesTestCase, CiTestCase):
         assert ds._get_data() is False
         assert m_dhcp.call_count == 1
         expected_logs = (
-            "Setting up network to reach IMDS",
             "Looking for the primary NIC in: ['enp0s4']",
             "Unable to obtain a DHCP lease for enp0s4",
         )

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -5,9 +5,18 @@ import pytest
 
 from cloudinit import helpers
 from cloudinit.distros import rhel, ubuntu
+from cloudinit.net.dhcp import NoDHCPLeaseError
 from cloudinit.sources import DataSourceHostname
-from cloudinit.sources.DataSourceCloudStack import DataSourceCloudStack
-from tests.unittests.helpers import CiTestCase, ExitStack, mock
+from cloudinit.sources.DataSourceCloudStack import (
+    DataSourceCloudStack,
+    DataSourceCloudStackLocal,
+)
+from tests.unittests.helpers import (
+    CiTestCase,
+    ExitStack,
+    ResponsesTestCase,
+    mock,
+)
 from tests.unittests.util import MockDistro
 
 SOURCES_PATH = "cloudinit.sources"
@@ -466,3 +475,146 @@ class TestCloudStackPasswordFetching(CiTestCase):
 
     def test_password_not_saved_if_bad_request(self):
         self._check_password_not_saved_for("bad_request")
+
+
+class TestDataSourceCloudStackLocal(ResponsesTestCase, CiTestCase):
+    with_logs = True
+
+    @mock.patch(
+        MOD_PATH + ".EphemeralIPNetwork",
+        autospec=True,
+    )
+    @mock.patch(MOD_PATH + ".net.find_candidate_nics")
+    def test_local_datasource_uses_ephemeral_dhcp(
+        self, m_find_candidate_nics, m_dhcp
+    ):
+        self.tmp = self.tmp_dir()
+        distro = MockDistro()
+        ds = DataSourceCloudStackLocal(
+            {}, distro, helpers.Paths({"run_dir": self.tmp})
+        )
+        m_find_candidate_nics.return_value = [
+            "enp0s4",
+        ]
+        m_dhcp.return_value.__enter__.side_effect = (NoDHCPLeaseError,)
+        mock.call(distro, iface="enp0s4"),
+        assert ds._get_data() is False
+        assert m_dhcp.call_count == 1
+        expected_logs = (
+            "Setting up network to reach IMDS",
+            "Looking for the primary NIC in: ['enp0s4']",
+            "Unable to obtain a DHCP lease for enp0s4",
+        )
+        for msg in expected_logs:
+            self.assertIn(
+                msg,
+                self.logs.getvalue(),
+            )
+
+    @mock.patch(
+        MOD_PATH + ".EphemeralIPNetwork",
+        autospec=True,
+    )
+    @mock.patch(MOD_PATH + ".net.find_candidate_nics")
+    def test_local_datasource_tries_on_multi_nic(
+        self,
+        m_find_candidate_nics,
+        m_dhcp,
+    ):
+        self.tmp = self.tmp_dir()
+        distro = MockDistro()
+        ds = DataSourceCloudStackLocal(
+            {}, distro, helpers.Paths({"run_dir": self.tmp})
+        )
+
+        m_find_candidate_nics.return_value = [
+            "ens0p4",
+            "ens0p5",
+            "ens4",
+        ]
+        m_dhcp.return_value.__enter__.side_effect = (
+            NoDHCPLeaseError,
+            NoDHCPLeaseError,
+            Exception,
+        )
+        assert ds._get_data() is False
+        assert m_dhcp.call_args_list == [
+            mock.call(distro, "ens0p4"),
+            mock.call(distro, "ens0p5"),
+            mock.call(distro, "ens4"),
+        ]
+
+    @mock.patch(MOD_PATH + ".CloudStackPasswordServerClient.get_password")
+    @mock.patch(SOURCES_PATH + ".helpers.ec2.get_instance_metadata")
+    @mock.patch(SOURCES_PATH + ".helpers.ec2.get_instance_userdata")
+    @mock.patch(DS_PATH + ".wait_for_metadata_service")
+    @mock.patch(
+        MOD_PATH + ".EphemeralIPNetwork",
+        autospec=True,
+    )
+    @mock.patch(MOD_PATH + ".net.find_candidate_nics")
+    def test_local_datasource_success(
+        self,
+        m_find_candidate_nics,
+        m_dhcp,
+        m_wait_for_mds,
+        m_get_userdata,
+        m_get_metadata,
+        m_get_password,
+    ):
+        distro = MockDistro()
+        self.tmp = self.tmp_dir()
+        ds = DataSourceCloudStackLocal(
+            {}, distro, helpers.Paths({"run_dir": self.tmp})
+        )
+
+        m_find_candidate_nics.return_value = ["enp0s4"]
+        m_dhcp.return_value.__enter__.side_effect = (None,)
+        m_wait_for_mds.return_value = (True,)
+        m_get_userdata.return_value = "ud"
+        m_get_metadata.return_value = "md"
+        m_get_password.return_value = True
+
+        assert ds._get_data() is True
+        assert ds.userdata_raw == "ud"
+        assert ds.metadata == "md"
+
+    @mock.patch(MOD_PATH + ".CloudStackPasswordServerClient.get_password")
+    @mock.patch(SOURCES_PATH + ".helpers.ec2.get_instance_metadata")
+    @mock.patch(SOURCES_PATH + ".helpers.ec2.get_instance_userdata")
+    @mock.patch(DS_PATH + ".wait_for_metadata_service")
+    @mock.patch(
+        MOD_PATH + ".EphemeralIPNetwork",
+        autospec=True,
+    )
+    @mock.patch(MOD_PATH + ".net.find_candidate_nics")
+    def test_local_datasource_success_on_secondary_nic(
+        self,
+        m_find_candidate_nics,
+        m_dhcp,
+        m_wait_for_mds,
+        m_get_userdata,
+        m_get_metadata,
+        m_get_password,
+    ):
+        distro = MockDistro()
+        self.tmp = self.tmp_dir()
+        ds = DataSourceCloudStackLocal(
+            {}, distro, helpers.Paths({"run_dir": self.tmp})
+        )
+
+        m_find_candidate_nics.return_value = ["enp0s4", "ens4"]
+        m_dhcp.return_value.__enter__.side_effect = (
+            NoDHCPLeaseError,
+            None,
+        )
+        m_wait_for_mds.return_value = (
+            False,
+            True,
+        )
+        m_get_userdata.return_value = "ud"
+        m_get_metadata.return_value = "md"
+        m_get_password.return_value = True
+        assert ds._get_data() is True
+        assert ds.userdata_raw == "ud"
+        assert ds.metadata == "md"

--- a/tests/unittests/sources/test_common.py
+++ b/tests/unittests/sources/test_common.py
@@ -63,6 +63,7 @@ DEFAULT_LOCAL = [
     NWCS.DataSourceNWCS,
     Akamai.DataSourceAkamaiLocal,
     WSL.DataSourceWSL,
+    CloudStack.DataSourceCloudStackLocal,
 ]
 
 DEFAULT_NETWORK = [


### PR DESCRIPTION
This commit adds a new local datasource, CloudStackLocal, which supports ephemeral networking and parallels the structure of other cloud provider datasources. In particular this functionality is enabled by performing DHCP setup contingently on the perform_dhcp_setup parameter. Each detected NIC is presented sequentially as a candidate for networking and performs DHCP discovery. If a lease is not obtained, a subsequent NIC is tried. Otherwise upon success, we try to reach the IMDS. If this were to fail for some reason, we continue to the next NIC. Upon successful data retrieval from the IMDS we return. The communication with the IMDS has been wrapped in a new function: _crawl_metadata for improved modularity.

The motivation for this patch is outlined in GH issue #6143, which highlighted the inability to use NetworkManager as a renderer in a CloudStack environment. Symptomatically, cloud-init was unable to discover the IMDS by DNS or reach it as no network had yet been created, and forcing cloud-init to wait on the network resulted in a deadlock where NetworkManager required dbus.sock but could not acquire it until cloud-init.service finished - which could not happen without the network. The ephemeral network in this commit ensures that networking is available at the time that we reach out to the IMDS - ensuring it can be discovered dynamically and avoiding the deadlock.

Fixes GH-6143