### PR TITLE
fix(d/cloud-init-base.preinst): avoid sed of /etc/fstab when absent

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ cloud-init (25.2~1gxxxxxxxx-0ubuntu1) UNRELEASED; urgency=medium
   * d/control: add Azure metapackage
     + New Azure binary package depending on cloud-init-base and
       python3-passlib.
+  * d/cloud-init-base.preinst: avoid sed of /etc/fstab when absent
 
  -- James Falcon <james.falcon@canonical.com>  Tue, 25 Feb 2025 10:19:24 -0600
 

--- a/debian/cloud-init-base.preinst
+++ b/debian/cloud-init-base.preinst
@@ -44,9 +44,10 @@ move_sem() {
 fix_ephemeral0_micro() {
    # make ephemeral0 entries in /etc/fstab written by cloudconfig
    # 'nobootwait', so they do not block subsequent boots (LP: #634102)
-   local out="" oldver=$1 dev="" adop="nobootwait"
+   local out="" dev="" adop="nobootwait"
    local s="[[:space:]]" ns="[^[:space:]]" # space and "not space"
    local remain="${s}\+.*" first4=""
+   [ -f /etc/fstab ] || return 0
    for dev in /dev/sda2 /dev/sdb; do
       first4="${dev}$s\+$ns\+$s\+$ns\+$s\+$ns\+"
       out=$(awk '$1 == dev && $4 ~ /cloudconfig/ &&  $4 !~ op { print $1 ; }' \


### PR DESCRIPTION
## Proposed Commit Message
```
Some environments will not have an /etc/fstab (LXC). Return early instead of leaking fatal awk messages and catching non-zero exit codes.

Also fix shellcheck: drop unused $oldver from fix_ephemeral0_micro

GH: #6148
```

## Additional Context
Found error messages from packaging preinst during testing installs of cloud-init-base when no cloud-init package is present in the image.

## Test Steps
```
lxc launch ubuntu-daily:plucky dev-p
lxc exec dev-p -- apt remove cloud-init cloud-init-base --assume-yes
lxc exec dev-p -- apt install cloud-init --assume-yes | grep fstab
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
