### PR TITLE
fix: drop udev remove action in hotplug

### DIFF
--- a/cloudinit/cmd/devel/hotplug_hook.py
+++ b/cloudinit/cmd/devel/hotplug_hook.py
@@ -68,7 +68,7 @@ def get_parser(parser=None):
         "--udevaction",
         required=True,
         help="Specify action to take.",
-        choices=["add", "remove"],
+        choices=["add"],
     )
 
     subparsers.add_parser(
@@ -103,8 +103,6 @@ class UeventHandler(abc.ABC):
         detect_presence = None
         if self.action == "add":
             detect_presence = True
-        elif self.action == "remove":
-            detect_presence = False
         else:
             raise ValueError("Unknown action: %s" % self.action)
 
@@ -145,11 +143,6 @@ class NetHandler(UeventHandler):
             if not activator.bring_up_interface(interface_name):
                 raise RuntimeError(
                     "Failed to bring up device: {}".format(self.devpath)
-                )
-        elif self.action == "remove":
-            if not activator.bring_down_interface(interface_name):
-                raise RuntimeError(
-                    "Failed to bring down device: {}".format(self.devpath)
                 )
 
     @property

--- a/cloudinit/config/cc_install_hotplug.py
+++ b/cloudinit/config/cc_install_hotplug.py
@@ -27,7 +27,7 @@ LOG = logging.getLogger(__name__)
 HOTPLUG_UDEV_PATH = "/etc/udev/rules.d/90-cloud-init-hook-hotplug.rules"
 HOTPLUG_UDEV_RULES_TEMPLATE = """\
 # Installed by cloud-init due to network hotplug userdata
-ACTION!="add|remove", GOTO="cloudinit_end"{extra_rules}
+ACTION!="add", GOTO="cloudinit_end"{extra_rules}
 LABEL="cloudinit_hook"
 SUBSYSTEM=="net", RUN+="{libexecdir}/hook-hotplug"
 LABEL="cloudinit_end"

--- a/tests/unittests/cmd/devel/test_hotplug_hook.py
+++ b/tests/unittests/cmd/devel/test_hotplug_hook.py
@@ -119,22 +119,6 @@ class TestHotplug:
         mocks.m_activator.bring_down_interface.assert_not_called()
         init._write_to_cache.assert_called_once_with()
 
-    def test_successful_remove(self, mocks):
-        init = mocks.m_init
-        mocks.m_network_state.iter_interfaces.return_value = [{}]
-        handle_hotplug(
-            hotplug_init=init,
-            devpath="/dev/fake",
-            udevaction="remove",
-            subsystem="net",
-        )
-        init.datasource.update_metadata_if_supported.assert_called_once_with(
-            [EventType.HOTPLUG]
-        )
-        mocks.m_activator.bring_down_interface.assert_called_once_with("fake")
-        mocks.m_activator.bring_up_interface.assert_not_called()
-        init._write_to_cache.assert_called_once_with()
-
     @mock.patch(
         "cloudinit.cmd.devel.hotplug_hook.NetHandler.detect_hotplugged_device"
     )
@@ -158,7 +142,7 @@ class TestHotplug:
             handle_hotplug(
                 hotplug_init=init,
                 devpath="/dev/fake",
-                udevaction="remove",
+                udevaction="add",
                 subsystem="net",
             )
         assert "hotplug not enabled for event of type" in caplog.text
@@ -177,7 +161,7 @@ class TestHotplug:
             handle_hotplug(
                 hotplug_init=mocks.m_init,
                 devpath="/dev/fake",
-                udevaction="remove",
+                udevaction="add",
                 subsystem="net",
             )
 
@@ -191,22 +175,6 @@ class TestHotplug:
                 hotplug_init=mocks.m_init,
                 devpath="/dev/fake",
                 udevaction="add",
-                subsystem="net",
-            )
-
-    def test_detect_hotplugged_device_detected_on_remove(self, mocks):
-        mocks.m_network_state.iter_interfaces.return_value = [
-            {
-                "mac_address": FAKE_MAC,
-            }
-        ]
-        with pytest.raises(
-            RuntimeError, match="Failed to detect .* in updated metadata"
-        ):
-            handle_hotplug(
-                hotplug_init=mocks.m_init,
-                devpath="/dev/fake",
-                udevaction="remove",
                 subsystem="net",
             )
 
@@ -224,19 +192,6 @@ class TestHotplug:
                 hotplug_init=mocks.m_init,
                 devpath="/dev/fake",
                 udevaction="add",
-                subsystem="net",
-            )
-
-    def test_apply_failed_on_remove(self, mocks):
-        mocks.m_network_state.iter_interfaces.return_value = [{}]
-        mocks.m_activator.bring_down_interface.return_value = False
-        with pytest.raises(
-            RuntimeError, match="Failed to bring down device: /dev/fake"
-        ):
-            handle_hotplug(
-                hotplug_init=mocks.m_init,
-                devpath="/dev/fake",
-                udevaction="remove",
                 subsystem="net",
             )
 

--- a/tests/unittests/config/test_cc_install_hotplug.py
+++ b/tests/unittests/config/test_cc_install_hotplug.py
@@ -146,7 +146,7 @@ class TestInstallHotplug:
 
         udev_rules = """\
 # Installed by cloud-init due to network hotplug userdata
-ACTION!="add|remove", GOTO="cloudinit_end"
+ACTION!="add", GOTO="cloudinit_end"
 
 ENV{ID_NET_DRIVER}=="vif|ena|ixgbevf", GOTO="cloudinit_hook"
 GOTO="cloudinit_end"


### PR DESCRIPTION
This patch removes the handling of the udev remove action in the hotplug process to prevent the call trace shown below from being generated:
```
2025-03-21 19:38:43,116 - hotplug_hook.py[ERROR]: Received fatal exception handling hotplug!
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 334, in handle_args
    handle_hotplug(
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 224, in handle_hotplug
    try_hotplug(subsystem, event_handler, datasource)
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 257, in try_hotplug
    raise last_exception
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 246, in try_hotplug
    event_handler.detect_hotplugged_device()
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 112, in detect_hotplugged_device
    raise RuntimeError(
RuntimeError: Failed to detect 02:24:50:39:e7:ef in updated metadata
Traceback (most recent call last):
  File "/usr/bin/cloud-init", line 33, in <module>
    sys.exit(load_entry_point('cloud-init==24.4.1', 'console_scripts', 'cloud-init')())
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 1273, in main
    return sub_main(args)
            ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 1394, in sub_main
    retval = functor(name, args)
              ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 334, in handle_args
    handle_hotplug(
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 224, in handle_hotplug
    try_hotplug(subsystem, event_handler, datasource)
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 257, in try_hotplug
    raise last_exception
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 246, in try_hotplug
    event_handler.detect_hotplugged_device()
  File "/usr/lib/python3/dist-packages/cloudinit/cmd/devel/hotplug_hook.py", line 112, in detect_hotplugged_device
    raise RuntimeError(
RuntimeError: Failed to detect 02:24:50:39:e7:ef in updated metadata
cloud-init-hotplugd.service: Main process exited, code=exited, status=1/FAILURE
cloud-init-hotplugd.service: Failed with result 'exit-code'.
Failed to start cloud-init-hotplugd.service - Cloud-init: Hotplug Hook.
```
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: drop udev remove action in hotplug

When `modprobe --remove ena` is executed, the kernel triggers a udev
remove event. This causes cloud-init to refetch datasource information,
expecting the NIC to be gone. However, since IMDS updates asynchronously,
cloud-init's hotplug logic may wait and retry if the NIC still appears
present. Monitoring the udev remove action may not be necessary. Once the
device is removed, its configurations become inactive, and explicitly
updating them might be redundant.

Fixes: GH-5706
```

## Additional Context
<!-- If relevant -->
[SF#00395673](https://canonical.lightning.force.com/lightning/r/Case/500N100000IBbWYIA1/view)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run `sudo modprobe -r ena && sudo modprobe ena` to verify that the call trace no longer appears.
