### PR TITLE
IBM/RMC: check for IBM cloud platform before enabling reset_rmc logic

### DIFF
--- a/cloudinit/config/cc_reset_rmc.py
+++ b/cloudinit/config/cc_reset_rmc.py
@@ -33,6 +33,7 @@ from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
 from cloudinit.distros import ALL_DISTROS
 from cloudinit.settings import PER_INSTANCE
+from cloudinit.sources.DataSourceIBMCloud import get_ibm_platform
 
 meta: MetaSchema = {
     "id": "cc_reset_rmc",
@@ -61,6 +62,11 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     # Ensuring node id has to be generated only once during first boot
     if cloud.datasource.platform_type == "none":
         LOG.debug("Skipping creation of new ct_node_id node")
+        return
+
+    ibm_platform, _ = get_ibm_platform()
+    if not ibm_platform:
+        LOG.debug("module disabled: not IBM platform")
         return
 
     if not os.path.isdir(RSCT_PATH):


### PR DESCRIPTION



## Proposed Commit Message
cc_reset_rmc module is only for IBM PowerVM Hypervisor. The module should check if its actually running on IBM cloud platform. The change adds that check.

fixes: GH-6154
fixes: f99d4f96b00a ("Add config modules for controlling IBM PowerVM RMC. (#584)")



## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
