### PR TITLE
tests: fix ibm expected warnings on invalid vendor-data schema

### DIFF
--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -51,7 +51,11 @@ class TestValidUserData:
         PR #575
         """
         result = class_client.execute("cloud-init schema --system")
-        assert result.ok
+        if PLATFORM == "ibm":
+            assert "Invalid vendor-data" in result.stdout
+            assert not result.ok
+        else:
+            assert result.ok
         assert "Valid schema user-data" in result.stdout.strip()
         result = class_client.execute("cloud-init status --long")
         assert 0 == result.return_code, (

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -310,6 +310,7 @@ class TestCombined:
                 "azure": "DataSourceAzure [seed=/dev/sr0]",
                 "ec2": "DataSourceEc2Local",
                 "gce": "DataSourceGCELocal",
+                "ibm": "DataSourceNoCloud [seed=/dev/vdb]",
                 "oci": "DataSourceOracle",
                 "openstack": "DataSourceOpenStackLocal [net,ver=2]",
                 "qemu": "DataSourceNoCloud [seed=/dev/vda][dsmode=net]",

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -387,10 +387,19 @@ def _verify_clean_boot(
             f"{out.stdout}\nstderr: {out.stderr}"
         )
     schema = instance.execute("cloud-init schema --system --annotate")
-    assert schema.ok, (
-        f"Schema validation failed\nstdout:{schema.stdout}"
-        f"\nstderr:\n{schema.stderr}"
-    )
+    if "ibm" == PLATFORM:
+        # IBM provides invalid vendor-data resulting in schema errors
+        assert "Invalid vendor-data" in schema.stdout
+        assert not schema.ok, (
+            f"Expected IBM schema validation errors due to vendor-data, did "
+            f"IBM images resolve this?\nstdout: {schema.stdout}\n"
+            f"stderr:\n{schema.stderr}"
+        )
+    else:
+        assert schema.ok, (
+            f"Schema validation failed\nstdout:{schema.stdout}"
+            f"\nstderr:\n{schema.stderr}"
+        )
 
 
 def verify_clean_log(log: str, ignore_deprecations: bool = True):


### PR DESCRIPTION
## Proposed Commit Message
```
tests: fix ibm expected warnings on invalid vendor-data schema

- also test_combined expects IBM datasource NoCloud [seed=/dev/vda]
```

## Additional Context
Want to reduce the amount of IBM test failures seen given that we know the vendor-data schema delivered in IBM images uses deprecated schema.

## Test Steps
Kick any IBM jenkins job and see 40 repeated test failures, a good portion of which fail due to verify_clean_boot getting a non-zero exit code on `cloud-init schema --system --annotate` because of deprecated vendor-data https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-ibm-generic

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
