### PR TITLE
tests: ibm expect invalid vendor-data in stderr

### DIFF
--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -52,7 +52,7 @@ class TestValidUserData:
         """
         result = class_client.execute("cloud-init schema --system")
         if PLATFORM == "ibm":
-            assert "Invalid vendor-data" in result.stdout
+            assert "Invalid vendor-data" in result.stderr
             assert not result.ok
         else:
             assert result.ok


### PR DESCRIPTION
The error `Invalid vendor-data` is sent to stderr not stdout.

## Proposed commit message
```
tests: ibm expect invalid vendor-data in stderr
```

## Additional context
[Failing Jenkins job showing lack of match for `Invalid vendor-data` in stdout](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-focal-ibm-generic/lastSuccessfulBuild/testReport/junit/tests.integration_tests/test_signal_handler/test_no_warnings/)
