### PR TITLE
fix: stop reporting error if cloud-init receives signal

### DIFF
--- a/cloudinit/config/cc_ansible.py
+++ b/cloudinit/config/cc_ansible.py
@@ -9,7 +9,7 @@ import sysconfig
 from copy import deepcopy
 from typing import Optional
 
-from cloudinit import lifecycle, signal_handler, subp
+from cloudinit import lifecycle, subp
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -63,8 +63,7 @@ class AnsiblePull(abc.ABC):
         return self.distro.do_as(command, self.run_user, **kwargs)
 
     def subp(self, command, **kwargs):
-        with signal_handler.suspend_crash():
-            return subp.subp(command, update_env=self.env, **kwargs)
+        return subp.subp(command, update_env=self.env, **kwargs)
 
     @abc.abstractmethod
     def is_installed(self):

--- a/cloudinit/config/cc_bootcmd.py
+++ b/cloudinit/config/cc_bootcmd.py
@@ -11,7 +11,7 @@
 
 import logging
 
-from cloudinit import signal_handler, subp, temp_utils, util
+from cloudinit import subp, temp_utils, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -50,10 +50,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         try:
             iid = cloud.get_instance_id()
             env = {"INSTANCE_ID": str(iid)} if iid else {}
-            with signal_handler.suspend_crash():
-                subp.subp(
-                    ["/bin/sh", tmpf.name], update_env=env, capture=False
-                )
+            subp.subp(["/bin/sh", tmpf.name], update_env=env, capture=False)
         except Exception:
             util.logexc(LOG, "Failed to run bootcmd module %s", name)
             raise

--- a/cloudinit/config/cc_package_update_upgrade_install.py
+++ b/cloudinit/config/cc_package_update_upgrade_install.py
@@ -10,7 +10,7 @@ import logging
 import os
 import time
 
-from cloudinit import signal_handler, subp, util
+from cloudinit import subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -48,10 +48,7 @@ def _fire_reboot(
     wait_attempts: int = 6, initial_sleep: int = 1, backoff: int = 2
 ):
     """Run a reboot command and panic if it doesn't happen fast enough."""
-    # systemd will kill cloud-init with a signal
-    # this is expected so don't behave as if this is a failure state
-    with signal_handler.suspend_crash():
-        subp.subp(REBOOT_CMD)
+    subp.subp(REBOOT_CMD)
     start = time.monotonic()
     wait_time = initial_sleep
     for _i in range(wait_attempts):

--- a/cloudinit/config/cc_power_state_change.py
+++ b/cloudinit/config/cc_power_state_change.py
@@ -13,7 +13,7 @@ import re
 import subprocess
 import time
 
-from cloudinit import signal_handler, subp, util
+from cloudinit import subp, util
 from cloudinit.cloud import Cloud
 from cloudinit.config import Config
 from cloudinit.config.schema import MetaSchema
@@ -220,7 +220,4 @@ def run_after_pid_gone(pid, pidcmdline, timeout, condition, func, args):
     except Exception as e:
         fatal("Unexpected Exception when checking condition: %s" % e)
 
-    # systemd could kill this process with a signal before it exits
-    # this is expected, so don't crash
-    with signal_handler.suspend_crash():
-        func(*args)
+    func(*args)

--- a/cloudinit/signal_handler.py
+++ b/cloudinit/signal_handler.py
@@ -5,15 +5,13 @@
 # Author: Joshua Harlow <harlowja@yahoo-inc.com>
 #
 # This file is part of cloud-init. See LICENSE file for license information.
-import contextlib
 import inspect
 import logging
 import signal
 import sys
-import threading
 import types
 from io import StringIO
-from typing import Callable, Dict, Final, NamedTuple, Union
+from typing import Callable, Dict, Final, Union
 
 from cloudinit import version as vr
 from cloudinit.log import log_util
@@ -27,17 +25,6 @@ SIGNALS: Final[Dict[int, str]] = {
     signal.SIGTERM: "Cloud-init %(version)s received SIGTERM, exiting",
     signal.SIGABRT: "Cloud-init %(version)s received SIGABRT, exiting",
 }
-
-
-class ExitBehavior(NamedTuple):
-    exit_code: int
-    log_level: int
-
-
-SIGNAL_EXIT_BEHAVIOR_CRASH: Final = ExitBehavior(1, logging.ERROR)
-SIGNAL_EXIT_BEHAVIOR_QUIET: Final = ExitBehavior(0, logging.INFO)
-_SIGNAL_EXIT_BEHAVIOR = SIGNAL_EXIT_BEHAVIOR_CRASH
-_SUSPEND_WRITE_LOCK = threading.RLock()
 
 
 def inspect_handler(sig: Union[int, Callable, None]) -> None:
@@ -83,9 +70,9 @@ def _handle_exit(signum, frame):
         f"Received signal {name} resulting in exit. Cause:\n"
         + contents.getvalue(),
         log=LOG,
-        log_level=_SIGNAL_EXIT_BEHAVIOR.log_level,
+        log_level=logging.INFO,
     )
-    sys.exit(_SIGNAL_EXIT_BEHAVIOR.exit_code)
+    sys.exit(0)
 
 
 def attach_handlers():
@@ -95,23 +82,3 @@ def attach_handlers():
         inspect_handler(signal.signal(signum, _handle_exit))
     sigs_attached += len(SIGNALS)
     return sigs_attached
-
-
-@contextlib.contextmanager
-def suspend_crash():
-    """suspend_crash() allows signals to be received without exiting 1
-
-    This allow signal handling without a crash where it is expected. The
-    call stack is still printed if signal is received during this context, but
-    the return code is 0 and no traceback is printed.
-
-    Threadsafe.
-    """
-    global _SIGNAL_EXIT_BEHAVIOR
-
-    # If multiple threads simultaneously were to modify this
-    # global state, this function would not behave as expected.
-    with _SUSPEND_WRITE_LOCK:
-        _SIGNAL_EXIT_BEHAVIOR = SIGNAL_EXIT_BEHAVIOR_QUIET
-        yield
-        _SIGNAL_EXIT_BEHAVIOR = SIGNAL_EXIT_BEHAVIOR_CRASH

--- a/cloudinit/subp.py
+++ b/cloudinit/subp.py
@@ -9,7 +9,7 @@ from errno import ENOEXEC
 from io import TextIOWrapper
 from typing import List, Optional, Union
 
-from cloudinit import performance, signal_handler
+from cloudinit import performance
 
 LOG = logging.getLogger(__name__)
 
@@ -368,8 +368,7 @@ def runparts(dirp, skip_no_exist=True, exe_prefix=None):
         if is_exe(exe_path):
             attempted.append(exe_path)
             try:
-                with signal_handler.suspend_crash():
-                    subp(prefix + [exe_path], capture=False)
+                subp(prefix + [exe_path], capture=False)
             except ProcessExecutionError as e:
                 LOG.debug(e)
                 failed.append(exe_name)


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: stop reporting error if cloud-init receives signal

It's too hard to predict when exactly cloud-init might receive a
legitimate signal (such as reboot), and even if we correctly predicted
it, the handling of it can still be racy.

Instead, log the current state and exit 0.

Fixes GH-6151
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
