### PR TITLE
ubuntu: don't rename interfaces

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -29,6 +29,7 @@ from cloudinit import (
     util,
 )
 from cloudinit.config import Netv1, Netv2
+from cloudinit.distros.ubuntu import Distro as Ubuntu
 from cloudinit.event import EventScope, EventType, userdata_to_events
 
 # Default handlers (used if not overridden)
@@ -1101,11 +1102,14 @@ class Init:
                 log_details=False,  # May have wifi passwords in net cfg
                 log_deprecations=True,
             )
-        # ensure all physical devices in config are present
-        self.distro.networking.wait_for_physdevs(netcfg)
 
-        # apply renames from config
-        self._apply_netcfg_names(netcfg)
+        if not isinstance(self.distro, Ubuntu):
+
+            # ensure all physical devices in config are present
+            self.distro.networking.wait_for_physdevs(netcfg)
+
+            # apply renames from config
+            self._apply_netcfg_names(netcfg)
 
         # rendering config
         LOG.info(


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: don't bring up or rename interfaces on Ubuntu

This behavior was required with eni network configuration.
This code is a duplication of behavior that netplan is capable of
with both networkd and NetworkManager.

Bringing up and renaming interfaces at runtime is known to cause bugs
which cloud-init does not handle gracefully.
```

## Additional Context

Related: https://github.com/canonical/cloud-init/issues/6110

#### TODO: link other related bugs

A secondary effect of skipping logic which does slow operations like waiting for devices and renaming devices is a faster boot, but correctness is the primary motivator for this change.

Doing Ubuntu-specific operations in shared code paths is not the cleanest approach, but it is quite simple for the sake of evaluation. A better approach might be explored later, if we decide to make this change.

## Test Steps

Already tested on LXD containers.

This should be thoroughly vetted on various platforms.

This PPA for noble can be used for evaluation: https://launchpad.net/~holmanb/+archive/ubuntu/cloud-init-no-interface-rename

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
