### PR TITLE
    tests: ibm logged message is Invalid schema: vendor-data

### DIFF
--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -52,7 +52,7 @@ class TestValidUserData:
         """
         result = class_client.execute("cloud-init schema --system")
         if PLATFORM == "ibm":
-            assert "Invalid vendor-data" in result.stderr
+            assert "Invalid schema: vendor-data" in result.stderr
             assert not result.ok
         else:
             assert result.ok

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -389,7 +389,7 @@ def _verify_clean_boot(
     schema = instance.execute("cloud-init schema --system --annotate")
     if "ibm" == PLATFORM:
         # IBM provides invalid vendor-data resulting in schema errors
-        assert "Invalid vendor-data" in schema.stderr
+        assert "Invalid schema: vendor-data" in schema.stderr
         assert not schema.ok, (
             f"Expected IBM schema validation errors due to vendor-data, did "
             f"IBM images resolve this?\nstdout: {schema.stdout}\n"


### PR DESCRIPTION
Verified testing locally with the correct full `Invalid schema: vendor-data` message 
##  To test
```
 CLOUD_INIT_PLATFORM=ibm CLOUD_INIT_OS_IMAGE=focal  CLOUD_INIT_CLOUD_INIT_SOURCE=NONE tox -e integration-tests -- tests/integration_tests/modules/test_cli.py 
```