### PR TITLE
Quick LXD integration fix

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -29,6 +29,7 @@ from cloudinit import (
     util,
 )
 from cloudinit.config import Netv1, Netv2
+from cloudinit.distros.ubuntu import Distro as Ubuntu
 from cloudinit.event import EventScope, EventType, userdata_to_events
 
 # Default handlers (used if not overridden)
@@ -1101,11 +1102,14 @@ class Init:
                 log_details=False,  # May have wifi passwords in net cfg
                 log_deprecations=True,
             )
-        # ensure all physical devices in config are present
-        self.distro.networking.wait_for_physdevs(netcfg)
 
-        # apply renames from config
-        self._apply_netcfg_names(netcfg)
+        if not isinstance(self.distro, Ubuntu):
+
+            # ensure all physical devices in config are present
+            self.distro.networking.wait_for_physdevs(netcfg)
+
+            # apply renames from config
+            self._apply_netcfg_names(netcfg)
 
         # rendering config
         LOG.info(

--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -29,7 +29,6 @@ from cloudinit import (
     util,
 )
 from cloudinit.config import Netv1, Netv2
-from cloudinit.distros.ubuntu import Distro as Ubuntu
 from cloudinit.event import EventScope, EventType, userdata_to_events
 
 # Default handlers (used if not overridden)
@@ -1102,14 +1101,11 @@ class Init:
                 log_details=False,  # May have wifi passwords in net cfg
                 log_deprecations=True,
             )
+        # ensure all physical devices in config are present
+        self.distro.networking.wait_for_physdevs(netcfg)
 
-        if not isinstance(self.distro, Ubuntu):
-
-            # ensure all physical devices in config are present
-            self.distro.networking.wait_for_physdevs(netcfg)
-
-            # apply renames from config
-            self._apply_netcfg_names(netcfg)
+        # apply renames from config
+        self._apply_netcfg_names(netcfg)
 
         # rendering config
         LOG.info(

--- a/tests/integration_tests/datasources/test_lxd_discovery.py
+++ b/tests/integration_tests/datasources/test_lxd_discovery.py
@@ -119,7 +119,7 @@ def test_lxd_datasource_discovery(client: IntegrationInstance):
     assert {"public-keys": v1["public_ssh_keys"][0]} == (
         yaml.safe_load(ds_cfg["config"]["user.meta-data"])
     )
-    assert "#cloud-config\ninstance-id" in ds_cfg["meta-data"]
+    assert "instance-id" in ds_cfg["meta-data"]
 
     # Some series no longer provide nocloud-net seed files (LP: #1958460)
     if lxd_has_nocloud(client):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: fix integration test on new lxd versions
```

## Additional Context
Observed on lxd version 6.3:
```bash
>       assert "#cloud-config\ninstance-id" in ds_cfg["meta-data"]
E       AssertionError: assert '#cloud-config\ninstance-id' in 'instance-id: 31115406-0687-4110-9af1-0f5597e62919\nlocal-hostname: cloudinit-0411-223256hhan8767\npublic-keys: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCqpCozNyoIR4yR5UGrjUg4HzfDs0voCchtGzRcYc1HO83rgPJGHMSFi5WuiLCZtWMtLShnZBxwouXo03mnYPe1dC1QBas2QZIEgJ9Piq+c3kS/YxIf0R2UNg/laYeRNpNtz5zuC+gBQpz5BWLGL39PUHyW6eBtIdpl2CrOASN56pK6Hk285ZphFVWDc+GyxqM1s1E1qH8NmtX2RKl9/LV/LWcPqwkwWMaV9PmdoiwKekJb9xNJiE0HEwdgE55FCSVzMMxJtGZaSHfva8qDamW/IK5JB7RM5u2aC71yWZI8DOXEPHFxKBWBJO4eMQPLQp4ACq8fEWqzci3Ieu9AzmGBa4PCiWA70flPoU09U8daqoYjZei/az1H0CAObaWeDo/pU8bN4CUX8ap3+RU3UzD5JMcZs9jy2VG1nbrM5CYM9EO4Mt6yT+/vQQbXd9Qvg3KkLM8IUVNUf0yPRb/yqJ3QknQ11LVdhJI8GPFzxC5JxbaqngAoqqE5Da2lHb+60vVXIJdwPgKQCXnD9E40Ej8XwmE3DJciZN8zFl1eNsAQF/wJIdoR7+uKnayMu6DcoOBwNwc2MjPJochkicLz7slpzslAE78XM2AzTZg5z8t4bAN+IWeOdiqlyvBFOVEBuzyVmhbkedvzj/SKciU8RFHup6STEH++ujOgIkBdqJYLPQ== **holmanb@arc\n'
```


LXD no longer erroneously includes #cloud-config in instance data, so don't assert that it does. 

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

```bash
$ tox -e integration-tests -- tests/integration_tests/datasources/test_lxd_discovery.py::test_lxd_datasource_discovery
```

Tests pass locally.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
