### PR TITLE
fix: ensure MAAS datasource retries on failure

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -1097,7 +1097,7 @@ class OauthUrlHelper:
         return self._wrapped(readurl, args, kwargs)
 
     def _exception_cb(self, extra_exception_cb, exception):
-        ret = None
+        ret = True
         try:
             if extra_exception_cb:
                 ret = extra_exception_cb(exception)

--- a/tests/unittests/sources/test_maas.py
+++ b/tests/unittests/sources/test_maas.py
@@ -224,7 +224,7 @@ class TestMAASDataSource:
         assert expected == ds.get_data()
 
     @responses.activate
-    def test_get_data_with_retry(self, mocker, tmp_path):
+    def test_get_data_with_retry(self, mocker, tmp_path, caplog):
         """Ensure we can get data from IMDS even if some attempts fail."""
         mocker.patch("time.sleep")
         metadata_url = "http://169.254.169.254/MAAS/metadata"
@@ -269,6 +269,9 @@ class TestMAASDataSource:
         assert ds.metadata["public-keys"] == "ssh-rsa AAAAB...yc2E= keyname"
         assert ds.vendordata_raw == "my-vendordata"
         assert ds.userdata_raw == b"my-userdata"
+        assert (
+            "Please wait 1 seconds while we wait to try again" in caplog.text
+        )
 
 
 @mock.patch("cloudinit.sources.DataSourceMAAS.url_helper.OauthUrlHelper")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: ensure MAAS datasource retries on failure

All MAAS requests get an `exception_cb` added dynamically via the
`OauthUrlHelper`. Ensure these callbacks adhere to the requirement
added in 1a515532 that an `exception_cb` return True if the exception
is not to be raised from the handler.

LP: #2106671
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
