### PR TITLE
Simplify maas check

### DIFF
--- a/tests/unittests/test_ds_identify.py
+++ b/tests/unittests/test_ds_identify.py
@@ -526,21 +526,6 @@ class TestDsIdentify(DsIdentifyBase):
         for var in expected_vars:
             self.assertIn("{0}=".format(var), err)
 
-    @pytest.mark.xfail(reason="GH-4796")
-    def test_maas_not_detected_1(self):
-        """Don't incorrectly identify maas
-
-        In ds-identify the function check_config() attempts to parse yaml keys
-        in bash, but it sometimes introduces false positives. The maas
-        datasource uses check_config() and the existence of a "MAAS" key to
-        identify itself (which is a very poor identifier - clouds should have
-        stricter identifiers). Since the MAAS datasource is at the begining of
-        the list, this is particularly troublesome and more concerning than
-        NoCloud false positives, for example.
-        """
-        config = "LXD-kvm-not-MAAS-1"
-        self._test_ds_found(config)
-
     def test_maas_not_detected_2(self):
         """Don't incorrectly identify maas
 
@@ -556,24 +541,6 @@ class TestDsIdentify(DsIdentifyBase):
         NoCloud false positives, for example.
         """
         config = "LXD-kvm-not-MAAS-2"
-        self._test_ds_found(config)
-
-    @pytest.mark.xfail(reason="GH-4796")
-    def test_maas_not_detected_3(self):
-        """Don't incorrectly identify maas
-
-        The bug reported in 4794 combined with the previously existing bug
-        reported in 4796 made for very loose MAAS false-positives.
-
-        In ds-identify the function check_config() attempts to parse yaml keys
-        in bash, but it sometimes introduces false positives. The maas
-        datasource uses check_config() and the existence of a "MAAS" key to
-        identify itself (which is a very poor identifier - clouds should have
-        stricter identifiers). Since the MAAS datasource is at the begining of
-        the list, this is particularly troublesome and more concerning than
-        NoCloud false positives, for example.
-        """
-        config = "LXD-kvm-not-MAAS-3"
         self._test_ds_found(config)
 
     def test_flow_sequence_control(self):

--- a/tools/ds-identify
+++ b/tools/ds-identify
@@ -951,11 +951,6 @@ dscheck_MAAS() {
             return ${DS_FOUND}
             ;;
     esac
-
-    # check config files written by maas for installed system.
-    if check_config "MAAS"; then
-        return "${DS_FOUND}"
-    fi
     return ${DS_NOT_FOUND}
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->

## Additional Context

I don’t think that the MAAS datasource specifically requires custom cloud.cfg parsing.

#### Justification:

MAAS uses curtin to set debconf selections [1][2]
Curtin uses cloud-init’s postinst to write out MAAS preseed[3], which is what that ds-identify `check_config()` call[4] is checking for.
Before cloud-init’s postinst writes out the MAAS preseed, it writes out `/etc/cloud/cloud.cfg.d/90_dpkg.cfg` with a `datasource_list: [ <values> ]`, which is the generic (non-maas specific) way of setting MAAS as the datasource.

I don’t think we need the custom MAAS config parsing code that currently exists in cloud-init - it is redundant.

Removing this eliminates known false positives: known cloud-init platform miss-identifications.

Related to https://github.com/canonical/cloud-init/issues/4796

[1] https://github.com/canonical/maas/blob/790c72a3b8a3fe14465319203df4e951d0197dab/src/maasserver/compose_preseed.py#L431
[2] https://github.com/canonical/curtin/blame/3a123215d1f0e47901686c63a5d12c8a1393ecf3/curtin/commands/apt_config.py#L344
[3] https://github.com/canonical/cloud-init/blob/ff9a14a04a5607931d7f9d998cb8f46931f3140a/debian/cloud-init-base.postinst#L298
[4] https://github.com/canonical/cloud-init/blob/main/tools/ds-identify#L956

## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
