### PR TITLE
fix(alpine): do not enable cc_reset_rmc for Alpine Linux

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -207,7 +207,9 @@ cloud_final_modules:
 {% if variant not in ["azurelinux"] %}
   - mcollective
   - salt_minion
+{% if variant not in ["alpine"] %}
   - reset_rmc
+{% endif %}
 {% endif %}
   - scripts_vendor
   - scripts_per_once


### PR DESCRIPTION

## Proposed Commit Message

```
fix(alpine): do not enable cc_reset_rmc for Alpine Linux

cc_reset_rmc module relies upon binaries from IBM Power Tools which
IBM only provides for Enterprise Linux distros. These binaries are
almost certainly compiled using glibc, whereas Alpine uses musl.

Therefore remove reset_rmc from the list of cloud_final_modules in
the cloud.cfg generated for Alpine from the template.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
