### PR TITLE
fix: setup.py doesn't match CPE releases on RHEL /etc/system-release-cpe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,14 +187,7 @@ elif os.path.isfile("/etc/redhat-release"):
 elif os.path.isfile("/etc/system-release-cpe"):
     with open("/etc/system-release-cpe") as f:
         cpe_data = f.read().rstrip().split(":")
-
-        if cpe_data[1] == "\o":  # noqa: W605
-            # URI formatted CPE
-            inc = 0
-        else:
-            # String formatted CPE
-            inc = 1
-        (cpe_vendor, cpe_product, cpe_version) = cpe_data[2 + inc : 5 + inc]
+        (cpe_vendor, cpe_product, cpe_version) = cpe_data[3:6]
         if cpe_vendor == "amazon":
             USR_LIB_EXEC = "usr/libexec"
 


### PR DESCRIPTION

## Proposed Commit Message
```
fix: setup.py doesn't match CPE releases on RHEL /etc/system-release-cpe

python3.12 setup.py build reports invalid escape sequence '\o'

For years we've had an invalid escape sequence that didn't correctly match CPE images from RHEL.

The correct string match seen in /etc/system-release-cpe format is:
   cpe:/o:redhat:enterprise_linux:9:baseos or
   cpe:/o:fedoraproject:fedora:17

Reference: https://linux.org/docs/man5/os-release.html
```

## Additional Context

## Test Steps

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
