### PR TITLE
chore: setup.py ruff/lints for python 3.12

### DIFF
--- a/tools/read-dependencies
+++ b/tools/read-dependencies
@@ -7,11 +7,11 @@
 
 try:
     from argparse import ArgumentParser
-except ImportError:
+except ImportError as exc:
     raise RuntimeError(
         "Could not import argparse. Please install python3-argparse "
         "package to continue"
-    )
+    ) from exc
 
 import json
 import os
@@ -49,8 +49,8 @@ MAYBE_RELIABLE_YUM_INSTALL = [
         grep -q "^proxy=" /etc/yum.conf || return 0
         error ":: http proxy in use => forcing the use of fixed URLs in /etc/yum.repos.d/*.repo"
         sed -i --regexp-extended '/^#baseurl=/s/#// ; /^(mirrorlist|metalink)=/s/^/#/' /etc/yum.repos.d/*.repo
-        sed -i 's/download\.fedoraproject\.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo
-        sed -i 's/download\.example/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo
+        sed -i 's/download.fedoraproject.org/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo
+        sed -i 's/download.example/dl.fedoraproject.org/g' /etc/yum.repos.d/*.repo
     }
     configure_repos_for_proxy_use
     n=0; max=10;
@@ -68,7 +68,7 @@ MAYBE_RELIABLE_YUM_INSTALL = [
     error ":: running yum install --cacheonly --assumeyes $*"
     yum install --cacheonly --assumeyes "$@"
     configure_repos_for_proxy_use
-    """,
+    """,  # noqa
     "reliable-yum-install",
 ]
 


### PR DESCRIPTION
## Proposed Commit Message
```
chore: setup.py ruff/lints for python 3.12

Correct invalid escape sequences seen when running:
   python3.12 ./tools/read-dependencies

Add noqa for line length for shell script used in CentOS pkg creation.
```
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
