### PR TITLE
fix(net): ignore udevadm failures when enumerating nics

### DIFF
--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -486,7 +486,17 @@ def find_candidate_nics_on_linux() -> List[str]:
                 "Found unstable nic names: %s; calling udevadm settle",
                 unstable,
             )
-            util.udevadm_settle()
+            try:
+                util.udevadm_settle()
+            except subp.ProcessExecutionError as error:
+                LOG.error(
+                    "udevadm failed to settle: "
+                    "cmd=%r stderr=%r stdout=%r exit_code=%s",
+                    error.cmd,
+                    error.stderr,
+                    error.stdout,
+                    error.exit_code,
+                )
 
     # sort into interfaces with carrier, interfaces which could have carrier,
     # and ignore interfaces that are definitely disconnected

--- a/cloudinit/net/__init__.py
+++ b/cloudinit/net/__init__.py
@@ -489,7 +489,7 @@ def find_candidate_nics_on_linux() -> List[str]:
             try:
                 util.udevadm_settle()
             except subp.ProcessExecutionError as error:
-                LOG.error(
+                LOG.warning(
                     "udevadm failed to settle: "
                     "cmd=%r stderr=%r stdout=%r exit_code=%s",
                     error.cmd,

--- a/tests/unittests/net/test_init.py
+++ b/tests/unittests/net/test_init.py
@@ -606,7 +606,7 @@ class TestNetFindCandidateNics:
             cmd="xcmd", stderr="xstderr", stdout="xstdout", exit_code=1
         )
 
-        with caplog.at_level(logging.ERROR):
+        with caplog.at_level(logging.WARNING):
             result = net.find_candidate_nics_on_linux()
             assert (
                 "udevadm failed to settle: cmd='xcmd' "


### PR DESCRIPTION
udevadm settle may fail due to circumstances outside of cloud-init's control.  We regularly see reports of udevadm settle timeouts due to a deadlock between a udev action waiting on something that happens after cloud-init-local.service.  While it can be considered misconfiguration, cloud-init should treat the outcome as best-effort and move on.

Fixes #6184