### PR TITLE
fix: resolve the issue (#3398)

### DIFF
--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -318,6 +318,12 @@ def read_md(address=None, url_params=None, platform_check=True):
             LOG.warning("unknown user-data-encoding: %s, ignoring", encoding)
         ret["user-data"] = ud
 
+    # Update md with parsed instance-data
+    md["instance-data"] = instance_data
+
+    # Update md with parsed project-data
+    md["project-data"] = project_data    
+    
     ret["meta-data"] = md
     ret["success"] = True
 

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -323,7 +323,7 @@ def read_md(address=None, url_params=None, platform_check=True):
 
     # Update md with parsed project-data
     md["project-data"] = project_data    
-    
+
     ret["meta-data"] = md
     ret["success"] = True
 


### PR DESCRIPTION
Fix the computeMetadata subkey format to allow to query things like: ds.meta_data.instance-data.foo that wasn't possible before.