### PR TITLE
docs: ensure proper 'sudo' representation

### DIFF
--- a/doc/examples/cloud-config-ansible-controller.txt
+++ b/doc/examples/cloud-config-ansible-controller.txt
@@ -19,7 +19,7 @@ users:
   gecos: Ansible User
   shell: /bin/bash
   groups: users,admin,wheel,lxd
-  sudo: ALL=(ALL) NOPASSWD:ALL
+  sudo: "ALL=(ALL) NOPASSWD:ALL"
 
 # Initialize lxd using cloud-init.
 # --------------------------------

--- a/doc/examples/cloud-config-ansible-managed.txt
+++ b/doc/examples/cloud-config-ansible-managed.txt
@@ -13,7 +13,7 @@ users:
 - name: ansible
   gecos: Ansible User
   groups: users,admin,wheel
-  sudo: ALL=(ALL) NOPASSWD:ALL
+  sudo: "ALL=(ALL) NOPASSWD:ALL"
   shell: /bin/bash
   lock_passwd: true
   ssh_authorized_keys:

--- a/doc/examples/cloud-config-user-groups.txt
+++ b/doc/examples/cloud-config-user-groups.txt
@@ -27,7 +27,7 @@ users:
     passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
   - name: barfoo
     gecos: Bar B. Foo
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
     groups: users, admin
     ssh_import_id:
       - lp:falcojr
@@ -44,7 +44,6 @@ users:
     inactive: '5'
     system: true
   - name: fizzbuzz
-    sudo: false
     shell: /bin/bash
     ssh_authorized_keys:
       - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSL7uWGj8cgWyIOaspgKdVy0cKJ+UTjfv7jBOjG2H/GN8bJVXy72XAvnhM0dUM+CCs8FOf0YlPX+Frvz2hKInrmRhZVwRSL129PasD12MlI3l44u6IwS1o/W86Q+tkQYEljtqDOo0a+cOsaZkvUNzUyEXUwz/lmYa6G4hMKZH4NBj7nbAAF96wsMCoyNwbWryBnDYUr6wMbjRR1J9Pw7Xh7WRC73wy4Va2YuOgbD3V/5ZrFPLbWZW/7TFXVrql04QVbyei4aiFR5n//GvoqwQDNe58LmbzX/xvxyKJYdny2zXmdAhMxbrpFQsfpkJ9E/H5w0yOdSvnWbUoG5xNGoOB csmith@fringe
@@ -103,17 +102,14 @@ users:
 #         strings or False to explicitly deny sudo usage. Examples:
 #
 #         Allow a user unrestricted sudo access.
-#             sudo:  ALL=(ALL) NOPASSWD:ALL
+#             sudo:  "ALL=(ALL) NOPASSWD:ALL"
 #                       or
 #             sudo: ["ALL=(ALL) NOPASSWD:ALL"]
 #
 #         Adding multiple sudo rule strings.
 #             sudo:
-#               - ALL=(ALL) NOPASSWD:/bin/mysql
-#               - ALL=(ALL) ALL
-#
-#         Prevent sudo access for a user.
-#             sudo: False
+#               - "ALL=(ALL) NOPASSWD:/bin/mysql"
+#               - "ALL=(ALL) ALL"
 #
 #         Note: Please double check your syntax and make sure it is valid.
 #               cloud-init does not parse/check the syntax of the sudo

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -411,10 +411,10 @@ ssh_pwauth: True
 # syslog being taken down while cloud-init is running.
 #
 # delay: form accepted by shutdown.  default is 'now'. other format
-#        accepted is '+m' (m in minutes)
+#        accepted is an integer for the number of minutes to delay
 # mode: required. must be one of 'poweroff', 'halt', 'reboot'
 # message: provided as the message argument to 'shutdown'. default is none.
 power_state:
-  delay: '+30'
+  delay: 30
   mode: poweroff
   message: Bye Bye

--- a/doc/rtd/reference/datasources/vmware.rst
+++ b/doc/rtd/reference/datasources/vmware.rst
@@ -426,7 +426,7 @@ this datasource using the GuestInfo keys transport:
        - default
        - name: akutz
          primary_group: akutz
-         sudo: ALL=(ALL) NOPASSWD:ALL
+         sudo: "ALL=(ALL) NOPASSWD:ALL"
          groups: sudo, wheel
          lock_passwd: true
          ssh_authorized_keys:
@@ -555,4 +555,3 @@ the meta-data key ``network``. Valid encodings are ``base64`` and
 .. _VMware vSphere Product Documentation: https://docs.vmware.com/en/VMware-vSphere/8.0/vsphere-vm-administration/GUID-EB5F090E-723C-4470-B640-50B35D1EC016.html#GUID-9A5093A5-C54F-4502-941B-3F9C0F573A39__GUID-40C60643-A2EB-4B05-8927-B51AF7A6CC5E
 .. _property: https://vdc-repo.vmware.com/vmwb-repository/dcr-public/723e7f8b-4f21-448b-a830-5f22fd931b01/5a8257bd-7f41-4423-9a73-03307535bd42/doc/vim.vm.ConfigInfo.html
 .. _govc: https://github.com/vmware/govmomi/blob/master/govc
-

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -204,7 +204,7 @@ include file.
     - name: j
       gecos: Agent J
       groups: users,sudo,netdev,audio
-      sudo: ALL=(ALL) NOPASSWD:ALL
+      sudo: "ALL=(ALL) NOPASSWD:ALL"
       shell: /bin/bash
       lock_passwd: true
 

--- a/doc/rtd/reference/yaml_examples/ansible_controller.rst
+++ b/doc/rtd/reference/yaml_examples/ansible_controller.rst
@@ -28,7 +28,7 @@ For a full list of keys, refer to the `Ansible module`_ schema.
       gecos: Ansible User
       shell: /bin/bash
       groups: users,admin,wheel,lxd
-      sudo: ALL=(ALL) NOPASSWD:ALL
+      sudo: "ALL=(ALL) NOPASSWD:ALL"
 
     # Initialize LXD using cloud-init
     # -------------------------------

--- a/doc/rtd/reference/yaml_examples/ansible_managed.rst
+++ b/doc/rtd/reference/yaml_examples/ansible_managed.rst
@@ -20,7 +20,7 @@ schema.
     - name: ansible
       gecos: Ansible User
       groups: users,admin,wheel
-      sudo: ALL=(ALL) NOPASSWD:ALL
+      sudo: "ALL=(ALL) NOPASSWD:ALL"
       shell: /bin/bash
       lock_passwd: true
       ssh_authorized_keys:
@@ -66,4 +66,3 @@ schema.
     # Ok11rJYIe7+e9B0lhku0AFwGyqlWQmS/MhIpnjHIk5tP4heHGSmzKQWJDbTskNWd6aq1G7
     # 6HWfDpX4HgoM8AAAALaG9sbWFuYkBhcmM=
     # -----END OPENSSH PRIVATE KEY-----
-

--- a/doc/rtd/reference/yaml_examples/user_groups.rst
+++ b/doc/rtd/reference/yaml_examples/user_groups.rst
@@ -64,7 +64,7 @@ exceptions and can be applied to already-existing users:
       passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
     - name: barfoo
       gecos: Bar B. Foo
-      sudo: ALL=(ALL) NOPASSWD:ALL
+      sudo: "ALL=(ALL) NOPASSWD:ALL"
       groups: users, admin
       ssh_import_id:
         - lp:falcojr
@@ -77,7 +77,6 @@ exceptions and can be applied to already-existing users:
       inactive: '5'
       system: true
     - name: fizzbuzz
-      sudo: false
       shell: /bin/bash
       ssh_authorized_keys:
         - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDSL7uWGj8cgWsp... csmith@fringe
@@ -136,4 +135,3 @@ supplemental config options. This config will make the default user
 .. literalinclude:: ../../../module-docs/cc_users_groups/example7.yaml
    :language: yaml
    :linenos:
-

--- a/tests/data/merge_sources/expected7.yaml
+++ b/tests/data/merge_sources/expected7.yaml
@@ -13,7 +13,7 @@ users:
     passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
   - name: barfoo
     gecos: Bar B. Foo
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
     groups: users, admin
     ssh_import_id: None
     lock-passwd: true

--- a/tests/data/merge_sources/source7-1.yaml
+++ b/tests/data/merge_sources/source7-1.yaml
@@ -13,7 +13,7 @@ users:
     passwd: $6$j212wezy$7H/1LT4f9/N3wpgNunhsIqtMj62OKiS3nyNwuizouQc3u7MbYCarYeAHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
   - name: barfoo
     gecos: Bar B. Foo
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
     groups: users, admin
     ssh_import_id: None
     lock-passwd: true
@@ -24,4 +24,3 @@ users:
     gecos: Magic Cloud App Daemon User
     inactive: '5'
     system: true
-

--- a/tests/integration_tests/modules/test_ansible.py
+++ b/tests/integration_tests/modules/test_ansible.py
@@ -132,7 +132,7 @@ users:
   gecos: Ansible User
   shell: /bin/bash
   groups: users,admin,wheel,lxd
-  sudo: ALL=(ALL) NOPASSWD:ALL
+  sudo: "ALL=(ALL) NOPASSWD:ALL"
 
 # Initialize lxd using cloud-init.
 # --------------------------------

--- a/tests/integration_tests/modules/test_cli.py
+++ b/tests/integration_tests/modules/test_cli.py
@@ -36,7 +36,7 @@ users:
   - name: newsuper
     gecos: Big Stuff
     groups: users, admin
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
     hashed-password: asdfasdf
     shell: /bin/bash
     lock_passwd: true

--- a/tests/integration_tests/modules/test_users_groups.py
+++ b/tests/integration_tests/modules/test_users_groups.py
@@ -38,7 +38,7 @@ users:
 AHWYPYb2FT.lbioDm2RrkJPb9BZMN1O/
   - name: barfoo
     gecos: Bar B. Foo
-    sudo: ALL=(ALL) NOPASSWD:ALL
+    sudo: "ALL=(ALL) NOPASSWD:ALL"
     groups: [cloud-users, secret]
     lock_passwd: true
   - name: nopassworduser

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -1503,6 +1503,13 @@ class TestSchemaDocExamples:
     def test_cloud_config_schema_doc_examples(self, example_path):
         validate_cloudconfig_file(example_path, self.schema)
 
+        # Assert no use of deprecated keys
+        validate_cloudconfig_schema(
+            config=yaml.safe_load(open(example_path)),
+            schema=self.schema,
+            strict=True,
+        )
+
     @pytest.mark.parametrize(
         "example_path",
         _get_meta_doc_examples(file_glob="network-config-v1*yaml"),


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
docs: ensure proper 'sudo' representation

Some YAML parsers can choke on the ':' character if it isn't quoted,
so ensure all sudo examples are quoted.

Also, remove any `sudo: false` examples as that configuration is
deprecated.

Fixes GH-6195
```

## Additional Context
Running with `sudo: false` results in:
```
2025-05-01 13:39:15,213 - loggers.py[DEPRECATED]: Deprecated cloud-config provided: users.5.sudo:  Changed in version 22.2. The value ``false`` is deprecated for this key, use ``null`` instead.
```
and
```
2025-05-01 13:39:15,612 - lifecycle.py[DEPRECATED]: The value of 'false' in user fizzbuzz's 'sudo' config is deprecated in 22.2 and scheduled to be removed in 27.2. Use 'null' instead.
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
