### PR TITLE
feat(azure): improve handling for reading VM ID

### DIFF
--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -332,24 +332,28 @@ class DataSourceAzure(sources.DataSource):
         self._iso_dev = None
         self._network_config = None
         self._ephemeral_dhcp_ctx: Optional[EphemeralDHCPv4] = None
-        self._route_configured_for_imds = False
-        self._route_configured_for_wireserver = False
-        self._wireserver_endpoint = DEFAULT_WIRESERVER_ENDPOINT
         self._reported_ready_marker_file = os.path.join(
             paths.cloud_dir, "data", "reported_ready"
         )
+        self._route_configured_for_imds = False
+        self._route_configured_for_wireserver = False
+        self._system_uuid = None
+        self._vm_id = None
+        self._wireserver_endpoint = DEFAULT_WIRESERVER_ENDPOINT
 
     def _unpickle(self, ci_pkl_version: int) -> None:
         super()._unpickle(ci_pkl_version)
 
         self._ephemeral_dhcp_ctx = None
         self._iso_dev = None
-        self._route_configured_for_imds = False
-        self._route_configured_for_wireserver = False
-        self._wireserver_endpoint = DEFAULT_WIRESERVER_ENDPOINT
         self._reported_ready_marker_file = os.path.join(
             self.paths.cloud_dir, "data", "reported_ready"
         )
+        self._route_configured_for_imds = False
+        self._route_configured_for_wireserver = False
+        self._system_uuid = None
+        self._vm_id = None
+        self._wireserver_endpoint = DEFAULT_WIRESERVER_ENDPOINT
 
     def __str__(self):
         root = sources.DataSource.__str__(self)
@@ -620,6 +624,13 @@ class DataSourceAzure(sources.DataSource):
         @raise: InvalidMetaDataException when the expected metadata service is
             unavailable, broken or disabled.
         """
+        self._query_vm_id()
+        report_diagnostic_event(
+            "Azure VM ID: %s System UUID: %s"
+            % (self._vm_id, self._system_uuid),
+            logger_func=LOG.info,
+        )
+
         crawled_data = {}
         # azure removes/ejects the cdrom containing the ovf-env.xml
         # file on reboot.  So, in order to successfully reboot we
@@ -1037,22 +1048,46 @@ class DataSourceAzure(sources.DataSource):
         # quickly (local check only) if self.instance_id is still valid
         return sources.instance_id_matches_system_uuid(self.get_instance_id())
 
+    def _query_vm_id(self):
+        """Query the system UUID and VM IDs, if needed.
+
+        They are initialized to None, check only if they are unset.
+
+        Raise as reportable error on failure.
+        """
+        if not self._system_uuid:
+            try:
+                self._system_uuid = identity.query_system_uuid()
+            except RuntimeError as error:
+                raise errors.ReportableErrorVmIdentification(exception=error)
+
+        if not self._vm_id:
+            try:
+                self._vm_id = identity.convert_system_uuid_to_vm_id(
+                    self._system_uuid
+                )
+            except ValueError as error:
+                raise errors.ReportableErrorVmIdentification(
+                    exception=error, system_uuid=self._system_uuid
+                )
+
     def _iid(self, previous=None):
+        self._query_vm_id()
+
         prev_iid_path = os.path.join(
             self.paths.get_cpath("data"), "instance-id"
         )
-        system_uuid = identity.query_system_uuid()
         if os.path.exists(prev_iid_path):
             previous = util.load_text_file(prev_iid_path).strip()
-            swapped_id = identity.byte_swap_system_uuid(system_uuid)
+            swapped_id = identity.byte_swap_system_uuid(self._system_uuid)
 
             # Older kernels than 4.15 will have UPPERCASE product_uuid.
             # We don't want Azure to react to an UPPER/lower difference as
             # a new instance id as it rewrites SSH host keys.
             # LP: #1835584
-            if previous.lower() in [system_uuid, swapped_id]:
+            if previous.lower() in [self._system_uuid, swapped_id]:
                 return previous
-        return system_uuid
+        return self._system_uuid
 
     @azure_ds_telemetry_reporter
     def _wait_for_nic_detach(self, nl_sock):
@@ -1353,6 +1388,7 @@ class DataSourceAzure(sources.DataSource):
         @param host_only: Only report to host (error may be recoverable).
         @return: The success status of sending the failure signal.
         """
+        error.vm_id = self._vm_id
         report_diagnostic_event(
             f"Azure datasource failure occurred: {error.as_encoded_report()}",
             logger_func=LOG.error,

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1388,13 +1388,13 @@ class DataSourceAzure(sources.DataSource):
         @param host_only: Only report to host (error may be recoverable).
         @return: The success status of sending the failure signal.
         """
-        error.vm_id = self._vm_id
+        encoded_report = error.as_encoded_report(vm_id=self._vm_id)
         report_diagnostic_event(
-            f"Azure datasource failure occurred: {error.as_encoded_report()}",
+            f"Azure datasource failure occurred: {encoded_report}",
             logger_func=LOG.error,
         )
         report_dmesg_to_kvp()
-        reported = kvp.report_failure_to_host(error)
+        reported = kvp.report_via_kvp(encoded_report)
         if host_only:
             return reported
 
@@ -1454,7 +1454,7 @@ class DataSourceAzure(sources.DataSource):
         :returns: List of SSH keys, if requested.
         """
         report_dmesg_to_kvp()
-        kvp.report_success_to_host()
+        kvp.report_success_to_host(vm_id=self._vm_id)
 
         try:
             data = get_metadata_from_fabric(

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1406,7 +1406,8 @@ class DataSourceAzure(sources.DataSource):
                     logger_func=LOG.debug,
                 )
                 report_failure_to_fabric(
-                    endpoint=self._wireserver_endpoint, error=error
+                    endpoint=self._wireserver_endpoint,
+                    encoded_report=encoded_report,
                 )
                 self._negotiated = True
                 return True
@@ -1429,7 +1430,8 @@ class DataSourceAzure(sources.DataSource):
                 # Reporting failure will fail, but it will emit telemetry.
                 pass
             report_failure_to_fabric(
-                endpoint=self._wireserver_endpoint, error=error
+                endpoint=self._wireserver_endpoint,
+                encoded_report=encoded_report,
             )
             self._negotiated = True
             return True

--- a/cloudinit/sources/azure/errors.py
+++ b/cloudinit/sources/azure/errors.py
@@ -37,11 +37,7 @@ def encode_report(
 
 class ReportableError(Exception):
     def __init__(
-        self,
-        reason: str,
-        *,
-        supporting_data: Optional[Dict[str, Any]] = None,
-        vm_id: Optional[str] = None,
+        self, reason: str, *, supporting_data: Optional[Dict[str, Any]] = None
     ) -> None:
         self.agent = f"Cloud-Init/{version.version_string()}"
         self.documentation_url = "https://aka.ms/linuxprovisioningerror"
@@ -53,10 +49,11 @@ class ReportableError(Exception):
             self.supporting_data = {}
 
         self.timestamp = datetime.now(timezone.utc)
-        self.vm_id = vm_id
 
     def as_encoded_report(
         self,
+        *,
+        vm_id: Optional[str],
     ) -> str:
         data = [
             "result=error",
@@ -65,7 +62,7 @@ class ReportableError(Exception):
         ]
         data += [f"{k}={v}" for k, v in self.supporting_data.items()]
         data += [
-            f"vm_id={self.vm_id}",
+            f"vm_id={vm_id}",
             f"timestamp={self.timestamp.isoformat()}",
             f"documentation_url={self.documentation_url}",
         ]

--- a/cloudinit/sources/azure/kvp.py
+++ b/cloudinit/sources/azure/kvp.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from cloudinit import version
 from cloudinit.reporting import handlers, instantiated_handler_registry
-from cloudinit.sources.azure import errors, identity
+from cloudinit.sources.azure import errors
 
 LOG = logging.getLogger(__name__)
 
@@ -35,16 +35,7 @@ def report_via_kvp(report: str) -> bool:
     return True
 
 
-def report_failure_to_host(error: errors.ReportableError) -> bool:
-    return report_via_kvp(error.as_encoded_report())
-
-
-def report_success_to_host() -> bool:
-    try:
-        vm_id = identity.query_vm_id()
-    except Exception as id_error:
-        vm_id = f"failed to read vm id: {id_error!r}"
-
+def report_success_to_host(*, vm_id: Optional[str]) -> bool:
     report = errors.encode_report(
         [
             "result=success",

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -959,11 +959,10 @@ def get_metadata_from_fabric(
 
 
 @azure_ds_telemetry_reporter
-def report_failure_to_fabric(endpoint: str, error: "errors.ReportableError"):
+def report_failure_to_fabric(endpoint: str, *, encoded_report: str):
     shim = WALinuxAgentShim(endpoint=endpoint)
-    description = error.as_encoded_report()
     try:
-        shim.register_with_azure_and_report_failure(description=description)
+        shim.register_with_azure_and_report_failure(description=encoded_report)
     finally:
         shim.clean_up()
 

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -456,6 +456,9 @@ class TestValidateCloudConfigSchema:
         """When strict is False validate_cloudconfig_schema emits warnings."""
         schema = {"properties": {"p1": {"type": "string"}}}
         validate_cloudconfig_schema({"p1": -1}, schema=schema, strict=False)
+        assert (
+            caplog.record_tuples and len(caplog.record_tuples) == 1
+        ), caplog.record_tuples
         [(module, log_level, log_msg)] = caplog.record_tuples
         assert "cloudinit.config.schema" == module
         assert logging.WARNING == log_level

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -106,6 +106,7 @@ def test_reportable_errors(
     error = errors.ReportableError(
         reason=reason,
         supporting_data=supporting_data,
+        vm_id=fake_vm_id,
     )
 
     data = [
@@ -263,3 +264,16 @@ def test_imds_invalid_metadata(value):
     assert error.supporting_data["key"] == key
     assert error.supporting_data["value"] == value
     assert error.supporting_data["type"] == type(value).__name__
+
+
+def test_vm_identification_exception():
+    exception = ValueError("foobar")
+    system_uuid = "1234-5678-90ab-cdef"
+
+    error = errors.ReportableErrorVmIdentification(
+        exception=exception, system_uuid=system_uuid
+    )
+
+    assert error.reason == "failure to identify Azure VM ID"
+    assert error.supporting_data["exception"] == repr(exception)
+    assert error.supporting_data["system_uuid"] == system_uuid

--- a/tests/unittests/sources/azure/test_errors.py
+++ b/tests/unittests/sources/azure/test_errors.py
@@ -106,7 +106,6 @@ def test_reportable_errors(
     error = errors.ReportableError(
         reason=reason,
         supporting_data=supporting_data,
-        vm_id=fake_vm_id,
     )
 
     data = [
@@ -121,7 +120,7 @@ def test_reportable_errors(
         "documentation_url=https://aka.ms/linuxprovisioningerror",
     ]
 
-    assert error.as_encoded_report() == "|".join(data)
+    assert error.as_encoded_report(vm_id=fake_vm_id) == "|".join(data)
 
 
 def test_dhcp_lease(mocker):
@@ -245,7 +244,7 @@ def test_unhandled_exception():
     assert trace.endswith("Traceback (most recent call last):")
 
     quoted_value = quote_csv_value(f"exception={source_error!r}")
-    assert f"|{quoted_value}|" in error.as_encoded_report()
+    assert f"|{quoted_value}|" in error.as_encoded_report(vm_id="test-vm-id")
 
 
 @pytest.mark.parametrize(

--- a/tests/unittests/sources/azure/test_kvp.py
+++ b/tests/unittests/sources/azure/test_kvp.py
@@ -40,19 +40,19 @@ def telemetry_reporter(tmp_path):
 
 
 class TestReportFailureToHost:
-    def test_report_failure_to_host(self, caplog, telemetry_reporter, mocker):
+    def test_report_via_kvp(self, caplog, telemetry_reporter, mocker):
         mocker.patch(
             "cloudinit.sources.azure.identity.query_vm_id", return_value="foo"
         )
         error = errors.ReportableError(reason="test")
-        assert kvp.report_failure_to_host(error) is True
+        assert kvp.report_via_kvp(error) is True
         assert (
             "KVP handler not enabled, skipping host report." not in caplog.text
         )
 
         report = {
             "key": "PROVISIONING_REPORT",
-            "value": error.as_encoded_report(),
+            "value": error.as_encoded_report(vm_id="fake-vm-id"),
         }
         assert report in list(telemetry_reporter._iterate_kvps(0))
 
@@ -62,7 +62,7 @@ class TestReportFailureToHost:
         )
         error = errors.ReportableError(reason="test")
 
-        assert kvp.report_failure_to_host(error) is False
+        assert kvp.report_via_kvp(error) is False
         assert "KVP handler not enabled, skipping host report." in caplog.text
 
 

--- a/tests/unittests/sources/azure/test_kvp.py
+++ b/tests/unittests/sources/azure/test_kvp.py
@@ -40,29 +40,23 @@ def telemetry_reporter(tmp_path):
 
 
 class TestReportFailureToHost:
-    def test_report_via_kvp(self, caplog, telemetry_reporter, mocker):
-        mocker.patch(
-            "cloudinit.sources.azure.identity.query_vm_id", return_value="foo"
-        )
+    def test_report_via_kvp(self, caplog, telemetry_reporter):
         error = errors.ReportableError(reason="test")
-        assert kvp.report_via_kvp(error) is True
+        encoded_report = error.as_encoded_report(vm_id="fake-vm-id")
+
+        assert kvp.report_via_kvp(encoded_report) is True
         assert (
             "KVP handler not enabled, skipping host report." not in caplog.text
         )
 
         report = {
             "key": "PROVISIONING_REPORT",
-            "value": error.as_encoded_report(vm_id="fake-vm-id"),
+            "value": encoded_report,
         }
         assert report in list(telemetry_reporter._iterate_kvps(0))
 
-    def test_report_skipped_without_telemetry(self, caplog, mocker):
-        mocker.patch(
-            "cloudinit.sources.azure.identity.query_vm_id", return_value="foo"
-        )
-        error = errors.ReportableError(reason="test")
-
-        assert kvp.report_via_kvp(error) is False
+    def test_report_skipped_without_telemetry(self, caplog):
+        assert kvp.report_via_kvp("test report") is False
         assert "KVP handler not enabled, skipping host report." in caplog.text
 
 
@@ -70,7 +64,7 @@ class TestReportSuccessToHost:
     def test_report_success_to_host(
         self, caplog, fake_utcnow, fake_vm_id, telemetry_reporter
     ):
-        assert kvp.report_success_to_host() is True
+        assert kvp.report_success_to_host(vm_id=fake_vm_id) is True
         assert (
             "KVP handler not enabled, skipping host report." not in caplog.text
         )
@@ -94,5 +88,5 @@ class TestReportSuccessToHost:
         mocker.patch(
             "cloudinit.sources.azure.identity.query_vm_id", return_value="foo"
         )
-        assert kvp.report_success_to_host() is False
+        assert kvp.report_success_to_host(vm_id="fake") is False
         assert "KVP handler not enabled, skipping host report." in caplog.text

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -209,9 +209,9 @@ def mock_report_dmesg_to_kvp():
 
 
 @pytest.fixture
-def mock_kvp_report_failure_to_host():
+def mock_kvp_report_via_kvp():
     with mock.patch(
-        MOCKPATH + "kvp.report_failure_to_host",
+        MOCKPATH + "kvp.report_via_kvp",
         return_value=True,
         autospec=True,
     ) as m:
@@ -3477,7 +3477,7 @@ class TestEphemeralNetworking:
         self,
         azure_ds,
         mock_ephemeral_dhcp_v4,
-        mock_kvp_report_failure_to_host,
+        mock_kvp_report_via_kvp,
         mock_sleep,
     ):
         lease = {
@@ -3504,8 +3504,7 @@ class TestEphemeralNetworking:
         assert azure_ds._ephemeral_dhcp_ctx.iface == "fakeEth0"
 
         error_reasons = [
-            c[0][0].reason
-            for c in mock_kvp_report_failure_to_host.call_args_list
+            c[0][0].reason for c in mock_kvp_report_via_kvp.call_args_list
         ]
         assert error_reasons == ["failure to find DHCP interface"]
 
@@ -3581,7 +3580,7 @@ class TestEphemeralNetworking:
         self,
         azure_ds,
         mock_ephemeral_dhcp_v4,
-        mock_kvp_report_failure_to_host,
+        mock_kvp_report_via_kvp,
         mock_sleep,
         error_class,
         error_reason,
@@ -3611,8 +3610,7 @@ class TestEphemeralNetworking:
         assert azure_ds._ephemeral_dhcp_ctx.iface == "fakeEth0"
 
         error_reasons = [
-            c[0][0].reason
-            for c in mock_kvp_report_failure_to_host.call_args_list
+            c[0][0].reason for c in mock_kvp_report_via_kvp.call_args_list
         ]
         assert error_reasons == [error_reason] * 10
 
@@ -3627,7 +3625,7 @@ class TestEphemeralNetworking:
         self,
         azure_ds,
         mock_ephemeral_dhcp_v4,
-        mock_kvp_report_failure_to_host,
+        mock_kvp_report_via_kvp,
         mock_sleep,
         mock_time,
         mock_monotonic,
@@ -3659,8 +3657,7 @@ class TestEphemeralNetworking:
         assert azure_ds._ephemeral_dhcp_ctx is None
 
         error_reasons = [
-            c[0][0].reason
-            for c in mock_kvp_report_failure_to_host.call_args_list
+            c[0][0].reason for c in mock_kvp_report_via_kvp.call_args_list
         ]
         assert error_reasons == [error_reason] * 3
 
@@ -3752,7 +3749,7 @@ class TestProvisioning:
         mock_dmi_read_dmi_data,
         mock_get_interfaces,
         mock_get_interface_mac,
-        mock_kvp_report_failure_to_host,
+        mock_kvp_report_via_kvp,
         mock_kvp_report_success_to_host,
         mock_netlink,
         mock_readurl,
@@ -3782,7 +3779,7 @@ class TestProvisioning:
         self.mock_dmi_read_dmi_data = mock_dmi_read_dmi_data
         self.mock_get_interfaces = mock_get_interfaces
         self.mock_get_interface_mac = mock_get_interface_mac
-        self.mock_kvp_report_failure_to_host = mock_kvp_report_failure_to_host
+        self.mock_kvp_report_via_kvp = mock_kvp_report_via_kvp
         self.mock_kvp_report_success_to_host = mock_kvp_report_success_to_host
         self.mock_netlink = mock_netlink
         self.mock_readurl = mock_readurl
@@ -3895,7 +3892,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_kvp_report_via_kvp.mock_calls
         assert not self.mock_azure_report_failure_to_fabric.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
@@ -3980,7 +3977,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_kvp_report_via_kvp.mock_calls
         assert not self.mock_azure_report_failure_to_fabric.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
@@ -4063,7 +4060,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 1
+        assert len(self.mock_kvp_report_via_kvp.mock_calls) == 1
         assert len(self.mock_azure_report_failure_to_fabric.mock_calls) == 1
         assert not self.mock_kvp_report_success_to_host.mock_calls
 
@@ -4125,7 +4122,7 @@ class TestProvisioning:
         # Verify reports via KVP.
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
-        assert self.mock_kvp_report_failure_to_host.mock_calls == [
+        assert self.mock_kvp_report_via_kvp.mock_calls == [
             mock.call(
                 errors.ReportableErrorImdsInvalidMetadata(
                     key="extended.compute.ppsType", value=pps_type
@@ -4247,7 +4244,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_kvp_report_via_kvp.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
         # Verify dmesg reported via KVP.
@@ -4374,7 +4371,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_kvp_report_via_kvp.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
         # Verify dmesg reported via KVP.
@@ -4503,7 +4500,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_kvp_report_via_kvp.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
         # Verify dmesg reported via KVP.
@@ -4639,7 +4636,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_kvp_report_via_kvp.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 2
 
         # Verify dmesg reported via KVP.
@@ -4880,7 +4877,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert not self.mock_kvp_report_failure_to_host.mock_calls
+        assert not self.mock_kvp_report_via_kvp.mock_calls
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
     @pytest.mark.parametrize("pps_type", ["Savable", "Running", "Unknown"])
@@ -4912,7 +4909,7 @@ class TestProvisioning:
         assert self.mock_netlink.mock_calls == []
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 2
+        assert len(self.mock_kvp_report_via_kvp.mock_calls) == 2
         assert not self.mock_kvp_report_success_to_host.mock_calls
 
     @pytest.mark.parametrize(
@@ -4985,7 +4982,7 @@ class TestProvisioning:
         assert self.wrapped_util_write_file.mock_calls == []
 
         # Verify reports via KVP. Ignore failure reported after sleep().
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 1
+        assert len(self.mock_kvp_report_via_kvp.mock_calls) == 1
         assert len(self.mock_kvp_report_success_to_host.mock_calls) == 1
 
     def test_imds_failure_results_in_provisioning_failure(self):
@@ -5028,7 +5025,7 @@ class TestProvisioning:
         assert self.patched_reported_ready_marker_path.exists() is False
 
         # Verify reports via KVP.
-        assert len(self.mock_kvp_report_failure_to_host.mock_calls) == 1
+        assert len(self.mock_kvp_report_via_kvp.mock_calls) == 1
         assert not self.mock_kvp_report_success_to_host.mock_calls
 
 
@@ -5115,7 +5112,7 @@ class TestGetMetadataFromImds:
         exception,
         mock_azure_report_failure_to_fabric,
         mock_imds_fetch_metadata_with_api_fallback,
-        mock_kvp_report_failure_to_host,
+        mock_kvp_report_via_kvp,
         mock_time,
         mock_monotonic,
         monkeypatch,
@@ -5150,10 +5147,10 @@ class TestGetMetadataFromImds:
             == expected_duration
         )
 
-        reported_error = mock_kvp_report_failure_to_host.call_args[0][0]
+        reported_error = mock_kvp_report_via_kvp.call_args[0][0]
         assert isinstance(reported_error, reported_error_type)
         assert reported_error.supporting_data["exception"] == repr(exception)
-        assert mock_kvp_report_failure_to_host.mock_calls == [
+        assert mock_kvp_report_via_kvp.mock_calls == [
             mock.call(reported_error)
         ]
 
@@ -5176,16 +5173,16 @@ class TestReportFailure:
         azure_ds,
         kvp_enabled,
         mock_azure_report_failure_to_fabric,
-        mock_kvp_report_failure_to_host,
+        mock_kvp_report_via_kvp,
         mock_kvp_report_success_to_host,
         mock_report_dmesg_to_kvp,
     ):
-        mock_kvp_report_failure_to_host.return_value = kvp_enabled
+        mock_kvp_report_via_kvp.return_value = kvp_enabled
         error = errors.ReportableError(reason="foo")
 
         assert azure_ds._report_failure(error, host_only=True) == kvp_enabled
 
-        assert mock_kvp_report_failure_to_host.mock_calls == [mock.call(error)]
+        assert mock_kvp_report_via_kvp.mock_calls == [mock.call(error)]
         assert mock_kvp_report_success_to_host.mock_calls == []
         assert mock_azure_report_failure_to_fabric.mock_calls == []
         assert mock_report_dmesg_to_kvp.mock_calls == [mock.call()]

--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -1394,15 +1394,13 @@ class TestGetMetadataGoalStateXMLAndReportFailureToFabric(CiTestCase):
             SentinelException,
             azure_helper.report_failure_to_fabric,
             "test_endpoint",
-            "test-report",
+            encoded_report="test-report",
         )
         self.assertEqual(1, self.m_shim.return_value.clean_up.call_count)
 
     def test_report_failure_to_fabric_calls_shim_report_failure(
         self,
     ):
-        error = errors.ReportableError(reason="test")
-
         azure_helper.report_failure_to_fabric(
             endpoint="test_endpoint",
             encoded_report="test",
@@ -1410,7 +1408,7 @@ class TestGetMetadataGoalStateXMLAndReportFailureToFabric(CiTestCase):
         # default err message description should be shown to the user
         # if an empty description is passed in
         self.m_shim.return_value.register_with_azure_and_report_failure.assert_called_once_with(  # noqa: E501
-            description=error.as_encoded_report(vm_id=None),
+            description="test",
         )
 
     def test_instantiates_shim_with_kwargs(self):

--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -1379,9 +1379,8 @@ class TestGetMetadataGoalStateXMLAndReportFailureToFabric(CiTestCase):
         )
 
     def test_success_calls_clean_up(self):
-        error = errors.ReportableError(reason="test")
         azure_helper.report_failure_to_fabric(
-            endpoint="test_endpoint", error=error
+            endpoint="test_endpoint", encoded_report="test"
         )
         self.assertEqual(1, self.m_shim.return_value.clean_up.call_count)
 
@@ -1395,7 +1394,7 @@ class TestGetMetadataGoalStateXMLAndReportFailureToFabric(CiTestCase):
             SentinelException,
             azure_helper.report_failure_to_fabric,
             "test_endpoint",
-            errors.ReportableError(reason="test"),
+            "test-report",
         )
         self.assertEqual(1, self.m_shim.return_value.clean_up.call_count)
 
@@ -1406,18 +1405,18 @@ class TestGetMetadataGoalStateXMLAndReportFailureToFabric(CiTestCase):
 
         azure_helper.report_failure_to_fabric(
             endpoint="test_endpoint",
-            error=error,
+            encoded_report="test",
         )
         # default err message description should be shown to the user
         # if an empty description is passed in
         self.m_shim.return_value.register_with_azure_and_report_failure.assert_called_once_with(  # noqa: E501
-            description=error.as_encoded_report(),
+            description=error.as_encoded_report(vm_id=None),
         )
 
     def test_instantiates_shim_with_kwargs(self):
         azure_helper.report_failure_to_fabric(
             endpoint="test_endpoint",
-            error=errors.ReportableError(reason="test"),
+            encoded_report="test",
         )
         self.m_shim.assert_called_once_with(
             endpoint="test_endpoint",


### PR DESCRIPTION
- Only read system uuid and convert once.  As can be seen in the test mocks, in some cases it will be read multiple times when reporting error. Initialize IDs to None and save them. This required ReportableError to have its VM ID populated when we report failure instead of re-reading it on initialization.

- Report failure to read or convert into a ReportableError. Today, this failure is reported as unhandled exception.  I expect this happens on images that either restrict/limit DMI or otherwise use some access controls that cause breakage.  This doesn't fix it, but cleans up the reported error.

- Report a diagnostic for the detected VM ID.