### PR TITLE
feat(wsl): Reuse metadata as Landscape installation_request_id

### DIFF
--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -241,8 +241,8 @@ def load_ubuntu_pro_data(
     Read .ubuntupro user-data if present and return a tuple of agent and
     landscape user-data.
     """
-    pro_dir = os.path.join(user_home, ".ubuntupro/.cloud-init")
-    if not os.path.isdir(pro_dir):
+    pro_dir = cloud_init_data_dir(user_home / ".ubuntupro")
+    if pro_dir is None:
         return None, None
 
     landscape_path = PurePath(

--- a/cloudinit/sources/DataSourceWSL.py
+++ b/cloudinit/sources/DataSourceWSL.py
@@ -220,7 +220,7 @@ def load_instance_metadata(
 
 
 def load_ubuntu_pro_data(
-    user_home: PurePath,
+    user_home: PurePath, instance_id: str
 ) -> Tuple[Optional[ConfigData], Optional[ConfigData]]:
     """
     Read .ubuntupro user-data if present and return a tuple of agent and
@@ -241,12 +241,12 @@ def load_ubuntu_pro_data(
             landscape_path,
             cloud_init_data_dir(user_home),
         )
-        landscape_data = ConfigData(landscape_path)
+        landscape_data = ConfigData(landscape_path, instance_id)
 
     agent_path = PurePath(os.path.join(pro_dir, AGENT_DATA_FILE))
     agent_data = None
     if os.path.isfile(agent_path):
-        agent_data = ConfigData(agent_path)
+        agent_data = ConfigData(agent_path, instance_id)
 
     return agent_data, landscape_data
 
@@ -420,14 +420,15 @@ class DataSourceWSL(sources.DataSource):
             LOG.error("Unable to load metadata: %s", str(err))
             return False
 
+        iid = self.metadata["instance-id"]
         # # Load Ubuntu Pro configs only on Ubuntu distros
         if self.distro.name == "ubuntu":
-            agent_data, user_data = load_ubuntu_pro_data(user_home)
+            agent_data, user_data = load_ubuntu_pro_data(user_home, iid)
 
         # Load regular user configs
         try:
             if user_data is None and seed_dir is not None:
-                user_data = ConfigData(self.find_user_data_file(seed_dir))
+                user_data = ConfigData(self.find_user_data_file(seed_dir), iid)
 
         except (ValueError, IOError) as err:
             log = LOG.info if agent_data else LOG.error

--- a/doc/rtd/reference/datasources/wsl.rst
+++ b/doc/rtd/reference/datasources/wsl.rst
@@ -135,14 +135,15 @@ the case to the best of our knowledge at the time of this writing.
 Most of what ``meta-data`` is intended for is not applicable under WSL, such as
 setting a hostname. Yet, the knowledge of ``meta-data.instance-id`` is vital
 for cloud-init. So, this datasource provides a default value but also supports
-optionally sourcing meta-data from a per-instance specific configuration file:
-``%USERPROFILE%\.cloud-init\<InstanceName>.meta-data``. If that file exists, it
-is a YAML-formatted file minimally providing a value for instance ID
-such as: ``instance-id: x-y-z``. Advanced users looking to share
-snapshots or relaunch a snapshot where cloud-init is re-triggered, must run
-``sudo cloud-init clean --logs`` on the instance before snapshot/export, or
-create the appropriate ``.meta-data`` file containing ``instance-id:
-some-new-instance-id``.
+optionally sourcing meta-data from a per-instance specific configuration file
+located either at ``%USERPROFILE%\.cloud-init\<InstanceName>.meta-data`` or
+``%USERPROFILE%\.ubuntupro\.cloud-init\<InstanceName>.meta-data``. When both
+files exist, only the second will be loaded. The file must be a YAML-formatted
+file minimally providing a value for instance ID such as: ``instance-id:
+x-y-z``. Advanced users looking to share snapshots or relaunch a snapshot where
+cloud-init is re-triggered, must run ``sudo cloud-init clean --logs`` on the
+instance before snapshot/export, or create the appropriate ``.meta-data`` file
+containing ``instance-id: some-new-instance-id``.
 
 Unsupported or restricted modules and features
 ===============================================

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -182,10 +182,11 @@ class TestWSLHelperFunctions:
         assert files == wsl.candidate_user_data_file_names(INSTANCE_NAME)
 
     @pytest.mark.parametrize(
-        "md_content,raises,errors,warnings,md_expected",
+        "md_content,is_from_pro,raises,errors,warnings,md_expected",
         (
             pytest.param(
                 None,
+                False,
                 does_not_raise(),
                 [],
                 [],
@@ -194,6 +195,7 @@ class TestWSLHelperFunctions:
             ),
             pytest.param(
                 "{}",
+                False,
                 pytest.raises(
                     ValueError,
                     match=(
@@ -207,6 +209,7 @@ class TestWSLHelperFunctions:
             ),
             pytest.param(
                 "{",
+                True,
                 pytest.raises(
                     ValueError,
                     match=(
@@ -221,12 +224,24 @@ class TestWSLHelperFunctions:
         ),
     )
     def test_load_instance_metadata(
-        self, md_content, raises, errors, warnings, md_expected, tmpdir, caplog
+        self,
+        md_content,
+        is_from_pro,
+        raises,
+        errors,
+        warnings,
+        md_expected,
+        tmpdir,
+        caplog,
     ):
         """meta-data file is optional. Errors are raised on invalid content."""
+        path = ".cloud-init"
+        if is_from_pro:
+            path = ".ubuntupro/.cloud-init"
+
         if md_content is not None:
-            dir = tmpdir.join(".cloud-init")
-            dir.mkdir()
+            dir = tmpdir.join(path)
+            os.makedirs(dir)
             dir.join("myinstance.meta-data").write(md_content)
         with caplog.at_level(logging.WARNING):
             with raises:

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -317,11 +317,11 @@ class TestMergeAgentLandscapeData:
         if agent_yaml is not None:
             agent_path = tmpdir.join("agent.yaml")
             agent_path.write(agent_yaml)
-            agent_data = wsl.ConfigData(agent_path)
+            agent_data = wsl.ConfigData(agent_path, "")
         if landscape_user_data is not None:
             landscape_ud_path = tmpdir.join("instance_name.user_data")
             landscape_ud_path.write(landscape_user_data)
-            user_data = wsl.ConfigData(landscape_ud_path)
+            user_data = wsl.ConfigData(landscape_ud_path, "")
         assert expected == wsl.merge_agent_landscape_data(
             agent_data, user_data
         )

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -225,7 +225,9 @@ class TestWSLHelperFunctions:
     ):
         """meta-data file is optional. Errors are raised on invalid content."""
         if md_content is not None:
-            tmpdir.join("myinstance.meta-data").write(md_content)
+            dir = tmpdir.join(".cloud-init")
+            dir.mkdir()
+            dir.join("myinstance.meta-data").write(md_content)
         with caplog.at_level(logging.WARNING):
             with raises:
                 assert md_expected == wsl.load_instance_metadata(

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -194,6 +194,15 @@ class TestWSLHelperFunctions:
                 id="default_md_on_no_md_file",
             ),
             pytest.param(
+                '{"instance-id":"iid-load-from-pro"}',
+                True,
+                does_not_raise(),
+                [],
+                [],
+                {"instance-id": "iid-load-from-pro"},
+                id="metadata_from_pro",
+            ),
+            pytest.param(
                 "{}",
                 False,
                 pytest.raises(
@@ -592,6 +601,11 @@ landscape:
 ubuntu_pro:
     token: testtoken"""
         )
+        SAMPLE_ID = "Nice-ID"
+        agent_metadata_path = ubuntu_pro_tmp.join(f"{INSTANCE_NAME}.meta-data")
+        agent_metadata_path.write(
+            f'{{"instance-id":"{SAMPLE_ID}"}}',
+        )
 
         # Run the datasource
         ds = wsl.DataSourceWSL(
@@ -613,6 +627,8 @@ ubuntu_pro:
         assert "ubuntu_pro" in userdata
         assert "landscape" in userdata
         assert "agenttest" in userdata
+        assert "installation_request_id" in userdata
+        assert SAMPLE_ID in userdata
 
     @mock.patch("cloudinit.util.get_linux_distro")
     def test_landscape_vs_local_user(self, m_get_linux_dist, tmpdir, paths):

--- a/tests/unittests/sources/test_wsl.py
+++ b/tests/unittests/sources/test_wsl.py
@@ -231,7 +231,7 @@ class TestWSLHelperFunctions:
         with caplog.at_level(logging.WARNING):
             with raises:
                 assert md_expected == wsl.load_instance_metadata(
-                    PurePath(tmpdir), "myinstance"
+                    tmpdir, "myinstance"
                 )
             warning_logs = "\n".join(
                 [


### PR DESCRIPTION
### Checklist:

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.


### Proposed commit message

```
feat(wsl): Reuse metadata as Landscape installation_request_id

Recently the Landscape server started tracking the status of commands
delivered to clients that run on parent instances, notably the Ubuntu
Pro for WSL agent, by assigning request IDs which the pro agent refers
to when replying with the command completion status. For the case of
the Install command, which results in a new WSL instance being created
on the parent Windows machine and registered with Landscape, the
server also expects the same value to be part of the landscape-client
registration message. For that we need the `installation_request_id`
to be added to the client.conf file. We found that synergic to the concept
of `metadata.instance-id`, thus this refactoring in the WSL datasource aims
to allow:
- the pro agent to write a per-instance metadata file
- the WSL data source to use the `metadata.instance-id` as `installation_request_id`
   - if the landscape.client config exists
   - if doesn't contain that field.

Details were discussed in the specification document
"WS042 - Handle Landscape request_id in command Install via cloud-init"

```


### Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)

---
UDENG-6773