### PR TITLE
Add support for network interfaces in requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,9 +19,6 @@ pyyaml
 # Requests handles ssl correctly!
 requests
 
-# Add support for network interfaces in requests
-requests-toolbelt
-
 # For patching pieces of cloud-config together
 jsonpatch
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,9 @@ pyyaml
 # Requests handles ssl correctly!
 requests
 
+# Add support for network interfaces in requests
+requests-toolbelt
+
 # For patching pieces of cloud-config together
 jsonpatch
 


### PR DESCRIPTION
This change modifies the metadata retrieval logic to handle IPv6 link-local
addresses that require a specific network interface (scope_id). Previously,
cloud-init failed to connect when using addresses like [fe80::a9fe:a9fe%25{iface}] due
to improper handling in the underlying requests layer.

By introducing a scoped connection handling approach, this fix enables
cloud-init to operate correctly in IPv6-only OpenStack environments
and similar setups where metadata services are accessible via
scoped link-local addresses.

**Summary of Patch Fixes:**

1. **Interface in URL:** Added proper support for link-local IPv6 addresses with network interface identifiers (e.g., `%eth0`), enabling reliable socket binding using `SO_BINDTODEVICE`.

2. **Enhanced URL Parsing:** Improved URL parser to correctly handle hostnames, ports (with defaults), interfaces, and support for both `%` and `%25` encoded formats across various schemes including `http`, `https`, `ftp`, `sftp`, and `file`.

**Fixes  #6205**


