### PR TITLE
docs: Use Noble for examples instead of Jammy

### DIFF
--- a/doc/rtd/howto/launch_lxd.rst
+++ b/doc/rtd/howto/launch_lxd.rst
@@ -29,7 +29,7 @@ we just created:
 
 .. code-block:: shell-session
 
-    $ lxc init ubuntu-daily:jammy test-container
+    $ lxc init ubuntu-daily:noble test-container
     $ lxc config set test-container user.user-data - < user-data.yaml
     $ lxc start test-container
 
@@ -37,7 +37,7 @@ To avoid the extra commands this can also be done at launch:
 
 .. code-block:: shell-session
 
-    $ lxc launch ubuntu-daily:jammy test-container --config=user.user-data="$(cat user-data.yaml)"
+    $ lxc launch ubuntu-daily:noble test-container --config=user.user-data="$(cat user-data.yaml)"
 
 Finally, a profile can be set up with the specific data if you need to
 launch this multiple times:
@@ -46,7 +46,7 @@ launch this multiple times:
 
     $ lxc profile create dev-user-data
     $ lxc profile set dev-user-data user.user-data - < cloud-init-config.yaml
-    $ lxc launch ubuntu-daily:jammy test-container -p default -p dev-user-data
+    $ lxc launch ubuntu-daily:noble test-container -p default -p dev-user-data
 
 LXD configuration types
 -----------------------

--- a/doc/rtd/howto/launch_qemu.rst
+++ b/doc/rtd/howto/launch_qemu.rst
@@ -49,7 +49,7 @@ Boot the cloud image with our configuration, ``seed.img``, to QEMU:
 .. code-block:: shell-session
 
     $ qemu-system-x86_64 -m 1024 -net nic -net user \
-        -drive file=jammy-server-cloudimg-amd64.img,index=0,format=qcow2,media=disk \
+        -drive file=noble-server-cloudimg-amd64.img,index=0,format=qcow2,media=disk \
         -drive file=seed.img,index=1,media=cdrom \
         -machine accel=kvm:tcg
 

--- a/doc/rtd/howto/shared/download_image.txt
+++ b/doc/rtd/howto/shared/download_image.txt
@@ -2,4 +2,4 @@ Download an Ubuntu image to run:
 
 .. code-block:: shell-session
 
-    wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+    wget https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img

--- a/doc/rtd/tutorial/qemu-script.sh
+++ b/doc/rtd/tutorial/qemu-script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 TEMP_DIR=temp
-IMAGE_URL="https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
+IMAGE_URL="https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
 
 # setup
 mkdir "$TEMP_DIR" && cd "$TEMP_DIR" || {
@@ -36,7 +36,7 @@ qemu-system-x86_64                                              \
     -cpu host                                                   \
     -m 512                                                      \
     -nographic                                                  \
-    -hda jammy-server-cloudimg-amd64.img                        \
+    -hda noble-server-cloudimg-amd64.img                        \
     -smbios type=1,serial=ds='nocloud;s=http://10.0.2.2:8000/'
 
 echo -e "\nTo reuse the image and config files, start the python webserver and "

--- a/doc/rtd/tutorial/qemu.rst
+++ b/doc/rtd/tutorial/qemu.rst
@@ -60,7 +60,7 @@ server image using :command:`wget`:
 
 .. code-block:: bash
 
-    $ wget https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img
+    $ wget https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
 
 .. note::
    This example uses emulated CPU instructions on non-x86 hosts, so it may be
@@ -189,7 +189,7 @@ take a few moments to complete.
         -machine accel=kvm:tcg                                      \
         -m 512                                                      \
         -nographic                                                  \
-        -hda jammy-server-cloudimg-amd64.img                        \
+        -hda noble-server-cloudimg-amd64.img                        \
         -smbios type=1,serial=ds='nocloud;s=http://10.0.2.2:8000/'
 
 .. note::
@@ -201,7 +201,7 @@ line. Many things may be configured: memory size, graphical output, networking
 information, hard drives and more.
 
 Let us examine the final two lines of our previous command. The first of them,
-:command:`-hda jammy-server-cloudimg-amd64.img`, tells QEMU to use the cloud
+:command:`-hda noble-server-cloudimg-amd64.img`, tells QEMU to use the cloud
 image as a virtual hard drive. This will cause the virtual machine to
 boot Ubuntu, which already has cloud-init installed.
 


### PR DESCRIPTION
## Proposed Commit Message
```
docs: Use Noble for examples instead of Jammy
```

## Additional Context

The docs refer to "the latest Ubuntu LTS", which is Noble these days, not Jammy.

I tested that `https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img` is indeed a working URL as well.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits.
