### PR TITLE
fix: make 'cloud-init --all-stages' work interactively

### DIFF
--- a/cloudinit/socket.py
+++ b/cloudinit/socket.py
@@ -135,6 +135,9 @@ class SocketSync:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Notify the socket that this stage is complete."""
+        if os.isatty(sys.stdin.fileno()):
+            # See corresponding log for __enter__()
+            return
         message = f"Completed socket interaction for boot stage {self.stage}"
         if exc_type:
             # handle exception thrown in context

--- a/tests/unittests/test_cli.py
+++ b/tests/unittests/test_cli.py
@@ -346,6 +346,32 @@ class TestCLI:
         assert False is parseargs.debug
         assert False is parseargs.force
 
+    def test_all_stages_with_tty(self, mocker):
+        """Ensure all stages get called when using a tty."""
+        mocker.patch("cloudinit.cmd.main.os.isatty", return_value=True)
+        mocker.patch("cloudinit.cmd.main.sys.stdin.fileno")
+        mocker.patch("cloudinit.cmd.main.socket.sd_notify")
+        mocker.patch("cloudinit.cmd.main.socket.os.makedirs")
+        mocker.patch("cloudinit.cmd.main.socket.os.remove")
+        mocker.patch("cloudinit.cmd.main.socket.socket")
+        m_sub_main = mocker.patch(
+            "cloudinit.cmd.main.sub_main", return_value=0
+        )
+
+        self._call_main(["cloud-init", "--all-stages"])
+        assert m_sub_main.call_count == 4
+        assert m_sub_main.call_args_list[0][0][0].subcommand == "init"
+        assert m_sub_main.call_args_list[0][0][0].local is True
+
+        assert m_sub_main.call_args_list[1][0][0].subcommand == "init"
+        assert m_sub_main.call_args_list[1][0][0].local is False
+
+        assert m_sub_main.call_args_list[2][0][0].subcommand == "modules"
+        assert m_sub_main.call_args_list[2][0][0].mode == "config"
+
+        assert m_sub_main.call_args_list[3][0][0].subcommand == "modules"
+        assert m_sub_main.call_args_list[3][0][0].mode == "final"
+
 
 class TestSignalHandling:
     @mock.patch("cloudinit.cmd.main.atomic_helper.write_json")


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: make 'cloud-init --all-stages' work interactively
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
