### PR TITLE
feat: Add subnet metric support for netplan

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -545,6 +545,10 @@
         "ipv6": {
           "type": "boolean",
           "description": "Indicate if the subnet is IPv6. If not specified, it will be inferred from the subnet type or address. This is exists for compatibility with OpenStack's ``network_data.json`` when rendered through sysconfig."
+        },
+        "metric": {
+          "type": "boolean",
+          "description": "Specify default metric for interface and routes of this subnet. "
         }
       }
     },

--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -547,8 +547,8 @@
           "description": "Indicate if the subnet is IPv6. If not specified, it will be inferred from the subnet type or address. This is exists for compatibility with OpenStack's ``network_data.json`` when rendered through sysconfig."
         },
         "metric": {
-          "type": "boolean",
-          "description": "Specify default metric for interface and routes of this subnet. "
+          "type": "integer",
+          "description": "Specify metric cost for interface and routes of this subnet. "
         }
       }
     },

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -164,14 +164,12 @@ def _extract_addresses(config: dict, entry: dict, ifname, features: Callable):
                     "via": route.get("gateway"),
                     "to": to_net,
                 }
-                # Priority for metric: 1. route's metric, 2. subnet's metric, 3. default 100
+                # Priority for metric: 1. route's metric, 2. subnet's metric
                 route_metric = route.get("metric")
                 if route_metric is not None:
                     new_route["metric"] = route_metric
                 elif sn_metric is not None:
                     new_route["metric"] = sn_metric
-                else:
-                    new_route["metric"] = 100
                 routes.append(new_route)
 
             addresses.append(addr)

--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -146,7 +146,7 @@ def _extract_addresses(config: dict, entry: dict, ifname, features: Callable):
                     )
                     new_route["on-link"] = True
                 if sn_metric is not None:
-                    # Add metric to the default route if specified in the subnet
+                    # Add metric to default route if specified in the subnet
                     new_route["metric"] = sn_metric
                 routes.append(new_route)
             if "dns_nameservers" in subnet:

--- a/doc/examples/network-config-v1-subnet-routes.yaml
+++ b/doc/examples/network-config-v1-subnet-routes.yaml
@@ -6,7 +6,9 @@ network:
       mac_address: '00:11:22:33:44:55'
       subnets:
         - type: dhcp
+          metric: 200
         - type: static
+          metric: 100
           address: 10.184.225.122
           netmask: 255.255.255.252
           routes:

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -310,6 +310,7 @@ Valid keys for ``subnets`` include the following:
 - ``dns_nameservers``: Specify a list of IPv4 DNS server IPs.
 - ``dns_search``: Specify a list of DNS search paths.
 - ``routes``: Specify a list of routes for a given interface.
+- ``metric``: Integer which sets the metric cost of routes within this subnet.
 
 Subnet types are one of the following:
 

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -1814,15 +1814,9 @@ class TestNetworkSchema:
                                 "type": "physical",
                                 "name": "eth0",
                                 "subnets": [
-                                    {
-                                        "type": "dhcp4",
-                                        "metric": 100
-                                    },
-                                    {
-                                        "type": "dhcp6",
-                                        "metric": 1000
-                                    }
-                                ]
+                                    {"type": "dhcp4", "metric": 100},
+                                    {"type": "dhcp6", "metric": 1000},
+                                ],
                             }
                         ],
                     }

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -1805,6 +1805,33 @@ class TestNetworkSchema:
                 "",
                 id="GH-4710_mtu_none_and_str_address",
             ),
+            pytest.param(
+                {
+                    "network": {
+                        "version": 1,
+                        "config": [
+                            {
+                                "type": "physical",
+                                "name": "eth0",
+                                "subnets": [
+                                    {
+                                        "type": "dhcp4",
+                                        "metric": 100
+                                    },
+                                    {
+                                        "type": "dhcp6",
+                                        "metric": 1000
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                },
+                SchemaType.NETWORK_CONFIG_V1,
+                does_not_raise(),
+                "",
+                id="subnet_metric_validation",
+            ),
         ),
     )
     @mock.patch("cloudinit.net.netplan.available", return_value=False)

--- a/tests/unittests/net/network_configs.py
+++ b/tests/unittests/net/network_configs.py
@@ -1662,8 +1662,7 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                             priority: 22
                             stp: false
                         routes:
-                        -   metric: 100
-                            to: ::/0
+                        -   to: ::/0
                             via: 2001:4800:78ff:1b::1
                 vlans:
                     bond0.200:
@@ -3122,11 +3121,9 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                      routes:
                      -   to: default
                          via: 192.168.0.1
-                     -   metric: 100
-                         to: 10.1.3.0/24
+                     -   to: 10.1.3.0/24
                          via: 192.168.0.3
-                     -   metric: 100
-                         to: 2001:67c::/32
+                     -   to: 2001:67c::/32
                          via: 2001:67c:1562::1
                      -   metric: 10000
                          to: 3001:67c::/32

--- a/tests/unittests/net/network_configs.py
+++ b/tests/unittests/net/network_configs.py
@@ -1662,7 +1662,8 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                             priority: 22
                             stp: false
                         routes:
-                        -   to: ::/0
+                        -   metric: 100
+                            to: ::/0
                             via: 2001:4800:78ff:1b::1
                 vlans:
                     bond0.200:
@@ -3121,9 +3122,11 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                      routes:
                      -   to: default
                          via: 192.168.0.1
-                     -   to: 10.1.3.0/24
+                     -   metric: 100
+                         to: 10.1.3.0/24
                          via: 192.168.0.3
-                     -   to: 2001:67c::/32
+                     -   metric: 100
+                         to: 2001:67c::/32
                          via: 2001:67c:1562::1
                      -   metric: 10000
                          to: 3001:67c::/32

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -2564,7 +2564,6 @@ USERCTL=no
                 expected, self._render_and_read(network_config=v2data)
             )
 
-
     def test_from_v2_routes(self):
         """verify routes (including IPv6) get rendered using v2 config.
 

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -3708,8 +3708,7 @@ class TestNetplanNetRendering:
                       routes:
                       -   to: default
                           via: 192.168.23.1
-                      -   metric: 100
-                          to: 10.176.0.0/24
+                      -   to: 10.176.0.0/24
                           via: 10.184.225.121
                       set-name: interface0
                 """,
@@ -3744,8 +3743,7 @@ class TestNetplanNetRendering:
                       routes:
                       -   to: default
                           via: 192.168.23.1
-                      -   metric: 100
-                          to: 192.167.225.122/24
+                      -   to: 192.167.225.122/24
                           via: 192.168.23.1
                       set-name: interface0
                 """,

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -3603,7 +3603,8 @@ class TestNetplanNetRendering:
                       routes:
                       -   to: default
                           via: 192.168.23.1
-                      -   to: 10.176.0.0/24
+                      -   metric: 100
+                          to: 10.176.0.0/24
                           via: 10.184.225.121
                       set-name: interface0
                 """,
@@ -3638,7 +3639,8 @@ class TestNetplanNetRendering:
                       routes:
                       -   to: default
                           via: 192.168.23.1
-                      -   to: 192.167.225.122/24
+                      -   metric: 100
+                          to: 192.167.225.122/24
                           via: 192.168.23.1
                       set-name: interface0
                 """,


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat: Add support of subnet metric for netplan

This patch enhances netplan configuration by adding support for subnet metrics. It implements metric handling for DHCP configurations by adding the subnet metric to DHCP overrides with the "route-metric" key. For static routes, it establishes a priority system where the route's metric takes precedence, followed by the subnet's metric, and finally defaulting to 100 if neither is specified. The patch also adds subnet metric support for default gateway routes. These changes provide more flexible network configuration options, allowing for better control over routing priorities in cloud-init generated netplan configurations from network config v1. 
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
