### PR TITLE
feat(azure): add interface to dhcp_log_func

### DIFF
--- a/cloudinit/net/ephemeral.py
+++ b/cloudinit/net/ephemeral.py
@@ -283,7 +283,7 @@ class EphemeralDHCPv4:
         distro,
         iface=None,
         connectivity_urls_data: Optional[List[Dict[str, Any]]] = None,
-        dhcp_log_func=None,
+        dhcp_log_func: Optional[Callable[[str, str, str], None]] = None,
     ):
         self.iface = iface
         self._ephipv4: Optional[EphemeralIPv4Network] = None

--- a/cloudinit/sources/helpers/azure.py
+++ b/cloudinit/sources/helpers/azure.py
@@ -968,12 +968,14 @@ def report_failure_to_fabric(endpoint: str, error: "errors.ReportableError"):
         shim.clean_up()
 
 
-def dhcp_log_cb(out, err):
+def dhcp_log_cb(interface: str, out: str, err: str) -> None:
     report_diagnostic_event(
-        "dhclient output stream: %s" % out, logger_func=LOG.debug
+        f"dhcp client stdout for interface={interface}: {out}",
+        logger_func=LOG.debug,
     )
     report_diagnostic_event(
-        "dhclient error stream: %s" % err, logger_func=LOG.debug
+        f"dhcp client stderr for interface={interface}: {err}",
+        logger_func=LOG.debug,
     )
 
 

--- a/tests/unittests/net/test_dhcp.py
+++ b/tests/unittests/net/test_dhcp.py
@@ -686,7 +686,8 @@ class TestDHCPDiscoveryClean:
         my_pid = 1
         write_file(pid_file, "%d\n" % my_pid)
 
-        def dhcp_log_func(out, err):
+        def dhcp_log_func(interface, out, err):
+            assert interface == "eth9"
             assert out == dhclient_out
             assert err == dhclient_err
 


### PR DESCRIPTION
- Fixup "dhclient" -> "dhcp client" in diagnostic message as client may be dhclient, dhcpcd, or others.

- Expand callback to include interface name which can be used in the diagnostic log.

- Add type definitions for callback function.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->

## Test Steps

- Create VM on Azure.
- Verify DHCP diagnostic logs.

Should see something like this example output:

```
2025-05-27 22:27:38,366 - performance.py[DEBUG]: Running ['dhcpcd', '--ipv4only', '--waitip', '--persistent', '--noarp', '--script=/bin/true', 'eth0'] took 4.287 seconds
2025-05-27 22:27:38,366 - azure.py[DEBUG]: dhcp client stdout for interface=eth0:
2025-05-27 22:27:38,366 - azure.py[DEBUG]: dhcp client stderr for interface=eth0: dhcpcd-10.0.6 starting
DUID 00:01:00:01:2f:c8:f8:d6:60:45:bd:79:d7:b8
eth0: IAID bd:79:d7:b8
eth0: carrier lost
eth0: carrier acquired
eth0: IAID bd:79:d7:b8
eth0: soliciting a DHCP lease
eth0: offered 10.0.0.19 from 168.63.129.16 LVL041062410020SOC
eth0: leased 10.0.0.19 for infinity
eth0: adding route to 10.0.0.0/24
eth0: adding default route via 10.0.0.1
eth0: adding host route to 168.63.129.16 via 10.0.0.1
eth0: adding host route to 169.254.169.254 via 10.0.0.1
...
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
