### PR TITLE
test: add option to keep instance on error

### DIFF
--- a/doc/rtd/development/integration_tests.rst
+++ b/doc/rtd/development/integration_tests.rst
@@ -95,6 +95,23 @@ to ``True``.
 
             KEEP_INSTANCE = True
 
+To keep the instance only if the test was unsuccessful, set ``KEEP_INSTANCE``
+variable to ``ON_ERROR``.
+
+.. tab-set::
+
+    .. tab-item:: Inline environment variable
+
+        .. code-block:: bash
+
+            CLOUD_INIT_KEEP_INSTANCE=ON_ERROR tox -e integration_tests
+
+    .. tab-item:: user_settings.py file
+
+        .. code-block:: python
+
+            KEEP_INSTANCE = "ON_ERROR"
+
 
 Use in-place cloud-init source code
 -------------------------------------

--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -66,6 +66,7 @@ class IntegrationCloud(ABC):
         self.cloud_instance = self._get_cloud_instance()
         self.initial_image_id = self._get_initial_image()
         self.snapshot_id: Optional[str] = None
+        self.has_failed_test = False
 
     @property
     def image_id(self):
@@ -173,7 +174,14 @@ class IntegrationCloud(ABC):
         return IntegrationInstance(self, cloud_instance, settings)
 
     def destroy(self):
-        if self.settings.KEEP_IMAGE or self.settings.KEEP_INSTANCE:
+        if (
+            self.settings.KEEP_IMAGE
+            or self.settings.KEEP_INSTANCE is True
+            or (
+                self.settings.KEEP_INSTANCE == "ON_ERROR"
+                and self.has_failed_test
+            )
+        ):
             log.info(
                 "NOT cleaning cloud instance because KEEP_IMAGE or "
                 "KEEP_INSTANCE is True"

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -337,6 +337,10 @@ def _client(
         yield instance
         test_failed = request.session.testsfailed - previous_failures > 0
         _collect_artifacts(instance, request.node.nodeid, test_failed)
+        instance.test_failed = test_failed
+        if test_failed:
+            session_cloud.has_failed_test = True
+
     # conflicting requirements:
     # - pytest thinks that it can cleanup loggers after tests run
     # - pycloudlib thinks that at garbage collection is a good place to

--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -68,6 +68,7 @@ class IntegrationInstance:
         self.cloud = cloud
         self.instance = instance
         self.settings = settings
+        self.test_failed = False
         self._ip = ""
 
     def destroy(self):
@@ -348,7 +349,9 @@ Pin-Priority: 1001"""
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if not self.settings.KEEP_INSTANCE:
-            conftest.REAPER.reap(self)
-        else:
+        if self.settings.KEEP_INSTANCE is True or (
+            self.settings.KEEP_INSTANCE == "ON_ERROR" and self.test_failed
+        ):
             log.info("Keeping Instance, public ip: %s", self.ip())
+        else:
+            conftest.REAPER.reap(self)

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -8,7 +8,9 @@ from cloudinit.util import is_false, is_true
 # LAUNCH SETTINGS
 ##################################################################
 
-# Keep instance (mostly for debugging) when test is finished
+# Keep instance (mostly for debugging) when test is finished.
+# Can be True, False, or "ON_ERROR" to keep the instance only if the test
+# fails.
 KEEP_INSTANCE = False
 # Keep snapshot image (mostly for debugging) when test is finished
 KEEP_IMAGE = False


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: add option to keep instance on error

Co-authored-by: Brett Holman <brett.holman@canonical.com>
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
