### PR TITLE
docs: include missing --seed datasource flags in cloud-init clean CLI

### DIFF
--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -92,7 +92,7 @@ re-run all stages as it did on first boot.
   config files for network. Argument `datasource` removes files and/or configs
   written by current datasource. `all` removes config files of all types.
 * :command:`--seed`: Remove the cloud-init seed directory (e.g., :file:`/var/lib/cloud/seed/`) 
-  which stores instance metadata used for simulating a cloud environment. 
+  which stores instance metadata used initializing a datasource. 
   Useful when regenerating metadata from a new or updated seed source.
   
 .. note::

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -91,7 +91,10 @@ re-run all stages as it did on first boot.
   cleans config files for ssh daemon. Argument `network` removes all generated
   config files for network. Argument `datasource` removes files and/or configs
   written by current datasource. `all` removes config files of all types.
-
+* :command:`--seed`: Remove the cloud-init seed directory (e.g., :file:`/var/lib/cloud/seed/`) 
+  which stores instance metadata used for simulating a cloud environment. 
+  Useful when regenerating metadata from a new or updated seed source.
+  
 .. note::
 
    The operations performed by `clean` can be supplemented / customized. See:

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -91,10 +91,11 @@ re-run all stages as it did on first boot.
   cleans config files for ssh daemon. Argument `network` removes all generated
   config files for network. Argument `datasource` removes files and/or configs
   written by current datasource. `all` removes config files of all types.
-* :command:`--seed`: Remove the cloud-init seed directory (e.g., :file:`/var/lib/cloud/seed/`) 
-  which stores instance metadata used initializing a datasource. 
+* :command:`--seed`: Remove the cloud-init seed directory
+  (e.g., :file:`/var/lib/cloud/seed/`)
+  which stores instance metadata used initializing a datasource.
   Useful when regenerating metadata from a new or updated seed source.
-  
+
 .. note::
 
    The operations performed by `clean` can be supplemented / customized. See:


### PR DESCRIPTION
Hey @TheRealFalcon 
## Proposed Commit Message

docs: include missing --seed datasource flags in cloud-init clean CLI doc. Addresses missing flags in clean.py reference documentation.

### screenshot
![Screenshot from 2025-06-01 00-26-41](https://github.com/user-attachments/assets/f7d14d7c-a658-458d-816a-043e5b0e7000)

## Additional Context
## Test Steps
## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
