### PR TITLE
fix: allow downstreams to strip invalid MTU

### DIFF
--- a/cloudinit/features.py
+++ b/cloudinit/features.py
@@ -98,6 +98,16 @@ Note that in addition to this flag, downstream patches are also likely needed
 to modify the systemd unit files.
 """
 
+STRIP_INVALID_MTU = False
+"""
+If ``STRIP_INVALID_MTU`` is True, then cloud-init will strip invalid MTU
+values from rendered v2 netplan configuration. Cloud-init allowed these values
+prior to 24.2, so this flag is used to maintain compatibility with
+previously generated network configurations.
+
+(This flag can be removed when Noble is no longer supported.)
+"""
+
 DEPRECATION_INFO_BOUNDARY = "devel"
 """
 DEPRECATION_INFO_BOUNDARY is used by distros to configure at which upstream

--- a/tests/unittests/test_features.py
+++ b/tests/unittests/test_features.py
@@ -11,8 +11,8 @@ from cloudinit import features
 class TestGetFeatures:
     def test_feature_without_override(self):
         # Since features are intended to be overridden downstream, mock them
-        # all here so new feature flags don't require a new change to this
-        # unit test.
+        # all here so that downstream changes to features do not require
+        # changes to this test.
         with mock.patch.multiple(
             "cloudinit.features",
             ERROR_ON_USER_DATA_FAILURE=True,
@@ -23,6 +23,7 @@ class TestGetFeatures:
             NOCLOUD_SEED_URL_APPEND_FORWARD_SLASH=False,
             APT_DEB822_SOURCE_LIST_FILE=True,
             MANUAL_NETWORK_WAIT=False,
+            STRIP_INVALID_MTU=False,
         ):
             assert {
                 "ERROR_ON_USER_DATA_FAILURE": True,
@@ -33,4 +34,5 @@ class TestGetFeatures:
                 "APT_DEB822_SOURCE_LIST_FILE": True,
                 "DEPRECATION_INFO_BOUNDARY": "devel",
                 "MANUAL_NETWORK_WAIT": False,
+                "STRIP_INVALID_MTU": False,
             } == features.get_features()


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: allow downstreams to strip invalid MTU

mtu: 0 is an invalid value within neptlan configuration, but cloud-init
allowed it in previous releases. This commit adds a flag to allow
cloud-init to strip it from downstreams to keep backwards compatibility.

Fixes GH-6239
```

## Additional Context
If merged, we can add Ubuntu quilt patches for Jammy and Noble

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
