### PR TITLE
fix(eni): ensure that a "dns" entry is not rendered in interfaces file

### DIFF
--- a/cloudinit/net/eni.py
+++ b/cloudinit/net/eni.py
@@ -104,6 +104,7 @@ def _iface_add_attrs(iface, index, ipv4_subnet_mtu):
     ignore_map = [
         "control",
         "device_id",
+        "dns",
         "driver",
         "index",
         "inet",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(eni): ensure that a "dns" entry is not rendered in interfaces file

When either a v1 or v2 network-config that contain DNS-related
entries is rendered to eni format then the resultant interfaces file
generated contains a "dns {...}" entry that should not be present,
in addition to the expected "dns-nameservers" and/or
"dns-search" entries.

Fix: change the eni rendering code to ignore any "dns" section present
in cloud-init's internal JSON network config representation.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

Create either a v1 or v2 network config YAML file that contains "dns_nameservers" or "dns_search" subnet entries (network v1 file) or a "nameservers" section with "addresses" or "search" entries (network v2 file". Then use "cloud-init devel net-convert" to convert to eni format.

The generated interfaces file will contain an entry that should not be present:

```
    dns {'nameservers': ['1.2.3.4], 'search': ['test.lan', 'lan']}
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
