### PR TITLE
docs(mounts): Correct fs-freq reference to fs_freq

### DIFF
--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -516,7 +516,7 @@ def mount_if_needed(
 
 def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     """Handle the mounts configuration."""
-    # fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno
+    # fs_spec, fs_file, fs_vfstype, fs_mntops, fs_freq, fs_passno
     uses_systemd = cloud.distro.uses_systemd()
     default_mount_options = (
         "defaults,nofail,x-systemd.after=cloud-init-network.service,_netdev"

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2068,7 +2068,7 @@
             "minItems": 1,
             "maxItems": 6
           },
-          "description": "List of lists. Each inner list entry is a list of ``/etc/fstab`` mount declarations of the format: [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno ]. A mount declaration with less than 6 items will get remaining values from **mount_default_fields**. A mount declaration with only `fs_spec` and no `fs_file` mountpoint will be skipped.",
+          "description": "List of lists. Each inner list entry is a list of ``/etc/fstab`` mount declarations of the format: [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs_freq, fs_passno ]. A mount declaration with less than 6 items will get remaining values from **mount_default_fields**. A mount declaration with only `fs_spec` and no `fs_file` mountpoint will be skipped.",
           "minItems": 1
         },
         "mount_default_fields": {

--- a/doc/examples/cloud-config-mount-points.txt
+++ b/doc/examples/cloud-config-mount-points.txt
@@ -3,7 +3,7 @@
 # set up mount points
 # 'mounts' contains a list of lists
 #  the inner list are entries for an /etc/fstab line
-#  ie : [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno ]
+#  ie : [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs_freq, fs_passno ]
 #
 # default:
 # mounts:

--- a/doc/examples/cloud-config.txt
+++ b/doc/examples/cloud-config.txt
@@ -22,7 +22,7 @@ packages:
 # set up mount points
 # 'mounts' contains a list of lists
 #  the inner list are entries for an /etc/fstab line
-#  ie : [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno ]
+#  ie : [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs_freq, fs_passno ]
 #
 # default:
 # mounts:

--- a/doc/module-docs/cc_mounts/data.yaml
+++ b/doc/module-docs/cc_mounts/data.yaml
@@ -3,7 +3,7 @@ cc_mounts:
     This module can add or remove mount points from ``/etc/fstab`` as well as
     configure swap. The ``mounts`` config key takes a list of ``fstab`` entries
     to add. Each entry is specified as a list of ``[ fs_spec, fs_file,
-    fs_vfstype, fs_mntops, fs-freq, fs_passno ]``.
+    fs_vfstype, fs_mntops, fs_freq, fs_passno ]``.
     
     For more information on these options, consult the manual for
     ``/etc/fstab``. When specifying the ``fs_spec``, if the device name starts

--- a/doc/rtd/reference/yaml_examples/mounts.rst
+++ b/doc/rtd/reference/yaml_examples/mounts.rst
@@ -44,7 +44,7 @@ contains entries for an ``/etc/fstab`` line, e.g.:
 
 .. code-block:: yaml
 
-   [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs-freq, fs_passno ]
+   [ fs_spec, fs_file, fs_vfstype, fs_mntops, fs_freq, fs_passno ]
 
 With defaults:
 


### PR DESCRIPTION
Corrects the spelling of the fstab 'fs_freq' field from 'fs-freq' to 'fs_freq' in documentation, examples, and comments.

Closes #GH-6210

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [X] I have signed the CLA: https://ubuntu.com/legal/contributors
- [X] I have included a comprehensive commit message using the guide below
- [] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [X] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
docs(mounts): Correct fs-freq reference to fs_freq (#6262)

Corrects the spelling of the fstab 'fs_freq' field from 'fs-freq'
to 'fs_freq' in documentation, examples, and comments.

Fixes GH-6210
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
