### PR TITLE
chore: log URL when retrying 503s

### DIFF
--- a/cloudinit/url_helper.py
+++ b/cloudinit/url_helper.py
@@ -433,7 +433,8 @@ def _handle_error(
     if error.code and error.code == 503:
         LOG.warning(
             "Endpoint returned a 503 error. "
-            "HTTP endpoint is overloaded. Retrying."
+            "HTTP endpoint is overloaded. Retrying URL (%s).",
+            error.url,
         )
         if error.headers:
             return _get_retry_after(error.headers.get("Retry-After", "1"))


### PR DESCRIPTION
## Proposed Commit Message
```
chore: log URL when retrying 503s

In GH-6062 there were opaque logs from OpenStack launches which provided unhelpful warnings "Ec2 IMDS endpoint returned a 503" which didn't provide context of what URLs were being retried.

Provide parameterized warnings which include the URL generating 503s.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
