### PR TITLE
feat(digitalocean): Add support for base64-encoded user-data

### DIFF
--- a/cloudinit/sources/DataSourceDigitalOcean.py
+++ b/cloudinit/sources/DataSourceDigitalOcean.py
@@ -91,7 +91,7 @@ class DataSourceDigitalOcean(sources.DataSource):
         self.metadata["public-keys"] = md.get("public_keys")
         self.metadata["availability_zone"] = md.get("region", "default")
         self.vendordata_raw = md.get("vendor_data", None)
-        self.userdata_raw = md.get("user_data", None)
+        self.userdata_raw = util.maybe_b64decode(md.get("user_data", None))
 
         if ipv4LL_nic:
             do_helper.del_ipv4_link_local(self.distro, ipv4LL_nic)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(digitalocean): Add support for base64-encoded user-data

Updated DataSourceDigitalOcean to decode user_data using `util.maybe_b64decode()`. A unit test was added to verify the correct handling of base64-encoded user data.
```

## Additional Context

Trying to use user-data provided by Terraform with `base64_encode = true`, I received the following error:

```
# /var/log/cloud-init-output.log
2025-06-24 13:37:13,389 - __init__.py[WARNING]: Unhandled non-multipart (text/x-not-multipart) userdata: 'b'Q29udGVudC1UeXBlOiBtdWx0'...'
```

This PR uses `util.maybe_b64decode()` similar to EC2 and Hetzner, to "potentially" decode base64-encoded user data.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
