### PR TITLE
fix: remove cloud-final.service regression

### DIFF
--- a/systemd/cloud-final.service
+++ b/systemd/cloud-final.service
@@ -1,8 +1,11 @@
+## template:jinja
 [Unit]
 # https://docs.cloud-init.io/en/latest/explanation/boot.html
 Description=Cloud-init: Final Stage
 After=network-online.target time-sync.target cloud-config.service rc-local.service
+{% if variant in ["ubuntu", "unknown", "debian"] %}
 After=multi-user.target
+{% endif %}
 Before=apt-daily.service
 Wants=network-online.target cloud-config.service
 ConditionPathExists=!/etc/cloud/cloud-init.disabled


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: remove cloud-final.service regression

After=multi-user.target can cause issues on non-debian systems,
so ensure it is templated

Fixes GH-6245
```

## Additional Context
https://github.com/canonical/cloud-init/issues/6245#issuecomment-2979800496

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
