### PR TITLE
feat(ca_certs): Add CentOS support

### DIFF
--- a/cloudinit/config/cc_ca_certs.py
+++ b/cloudinit/config/cc_ca_certs.py
@@ -72,6 +72,7 @@ for distro in (
 
 for distro in (
     "almalinux",
+    "centos",
     "cloudlinux",
     "rocky",
 ):
@@ -80,6 +81,7 @@ for distro in (
 distros = [
     "almalinux",
     "aosc",
+    "centos",
     "cloudlinux",
     "alpine",
     "debian",


### PR DESCRIPTION
## Proposed Commit Message
```txt
feat(ca_certs): Add CentOS support

CentOS is using the same PKI paths as RHEL.
```
## Additional Context

In PR #5264 the `ca_certs` support of AlmaLinux and CloudLinux was added, both are configured as a derivation of RHEL.

The new PR adds CentOS as well, in the same manner.

## Test Steps

Basically the same as for PR #5264

```yaml
#cloud-config
ca_certs:
  remove_defaults: true
  trusted:
    - single_line_cert
    - |
      -----BEGIN CERTIFICATE-----
      YOUR-ORGS-TRUSTED-CA-CERT-HERE
      -----END CERTIFICATE-----
```

## Checklist

[x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/development/index.html)
[ ] I have updated or added any [unit tests](https://cloudinit.readthedocs.io/en/latest/development/testing.html) accordingly
[ ] I have updated or added any [documentation](https://cloudinit.readthedocs.io/en/latest/development/contribute_docs.html) accordingly

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
