### PR TITLE
fix[analyze-boot]: use monotonic clock for containers

### DIFF
--- a/tests/integration_tests/cmd/test_analyze.py
+++ b/tests/integration_tests/cmd/test_analyze.py
@@ -1,0 +1,36 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+"""Tests for `cloud-init analyze`"""
+import pytest
+
+from cloudinit.distros import uses_systemd
+from tests.integration_tests.integration_settings import PLATFORM
+from tests.integration_tests.util import get_datetime_from_string
+
+
+class TestAnalyzeCommand:
+    @pytest.mark.skipif(not uses_systemd(), reason="Relies on systemd output")
+    @pytest.mark.skipif(
+        PLATFORM != "lxd_container",
+        reason="Testing lxdcontainer-specific behavior",
+    )
+    def test_analyze_boot_ordered_timestamps(self, module_client):
+        """
+        Confirm that analyze boot is working correctly in lxd containers
+        and that the correct zero-point is used for the monotonic clock used
+        to determine when cloud-init was activated by systemd
+        """
+        assert module_client.execute("cloud-init status --wait --long").ok
+        result = module_client.execute("cloud-init analyze boot")
+        assert result.stderr == "container"
+
+        container_start_time = get_datetime_from_string(
+            result.stdout, "^\\s*Container started at: (.+?)$"
+        )
+        cloudinit_activation_time = get_datetime_from_string(
+            result.stdout, "^\\s*Cloud-init activated by systemd at: (.+?)$"
+        )
+        cloudinit_start_time = get_datetime_from_string(
+            result.stdout, "^\\s*Cloud-init start: (.+?)$"
+        )
+        assert container_start_time < cloudinit_activation_time
+        assert cloudinit_activation_time < cloudinit_start_time

--- a/tests/integration_tests/util.py
+++ b/tests/integration_tests/util.py
@@ -6,6 +6,7 @@ import re
 import time
 from collections import namedtuple
 from contextlib import contextmanager
+from datetime import datetime
 from functools import lru_cache
 from itertools import chain
 from pathlib import Path
@@ -663,3 +664,31 @@ def network_wait_logged(log: str) -> bool:
         "Running command "
         "['systemctl', 'start', 'systemd-networkd-wait-online.service']"
     ) in log
+
+
+def get_datetime_from_string(
+    str, regex, datetime_strformat="%Y-%m-%d %H:%M:%S.%f%z"
+):
+    """
+    Extract datetime from a given line in a string
+    """
+    matched = re.search(regex, str, re.M)
+    assert matched, (
+        f"Unable to find the datetime using the regex {regex}",
+        f"inside the string {str}",
+    )
+
+    try:
+        converted_datetime = datetime.strptime(
+            matched.group(1), datetime_strformat
+        )
+    except ValueError:
+        pytest.fail(
+            " ".join(
+                (
+                    f"Unable to parse the datetime {matched.group(1)}",
+                    f"using the format {datetime_strformat}",
+                )
+            )
+        )
+    return converted_datetime

--- a/tests/unittests/analyze/test_boot.py
+++ b/tests/unittests/analyze/test_boot.py
@@ -192,55 +192,6 @@ class TestAnalyzeBoot:
         self.remove_dummy_file(path, log_path)
         assert CONTAINER_CODE == finish_code
 
-    # @mock.patch("time.time", return_value=100)
-    # @mock.patch("cloudinit.util.uptime", return_value=96)
-    # @mock.patch("time.monotonic", return_value=97)
-    # @mock.patch("cloudinit.analyze.show.SystemctlReader")
-    # @pytest.mark.parametrize(
-    #     (
-    #         "is_container_returnvalue",
-    #         "time_mock_expected_callcount",
-    #         "monotonic_mock_expected_callcount",
-    #         "expected_return",
-    #     ),
-    #     (
-    #         (True, 2, 1, (CONTAINER_CODE, 4, 33, 43)),
-    #         (False, 1, 0, (SUCCESS_CODE, 4, 34, 44)),
-    #     ),
-    # )
-    # def test_gather_timestamps_using_systemd(
-    #     self,
-    #     mock_SystemctlReader,
-    #     monotonic_mock,
-    #     uptime_mock,
-    #     time_mock,
-    #     is_container_returnvalue,
-    #     time_mock_expected_callcount,
-    #     monotonic_mock_expected_callcount,
-    #     expected_return,
-    #     mocker,
-    # ):
-    #     """
-    #     Testing the behavior based on whether or not the
-    #     instance is a container
-    #     """
-    #     mocker.patch(
-    #         "cloudinit.util.is_container",
-    #         return_value=is_container_returnvalue,
-    #     )
-    #     systemctlReader_mocks = [
-    #         mock.Mock(name="UserspaceTimestampMonotonic"),
-    #         mock.Mock(name="InactiveExitTimestampMonotonic"),
-    #     ]
-    #     systemctlReader_mocks[0].convert_val_to_float.return_value = 30
-    #     systemctlReader_mocks[1].convert_val_to_float.return_value = 40
-    #     mock_SystemctlReader.side_effect = systemctlReader_mocks
-    #     assert gather_timestamps_using_systemd() == expected_return
-
-    #     assert time_mock.call_count == time_mock_expected_callcount
-    #     assert uptime_mock.call_count == 1
-    #     assert monotonic_mock.call_count == monotonic_mock_expected_callcount
-
     @mock.patch("cloudinit.analyze.show.SystemctlReader")
     @pytest.mark.parametrize(
         (
@@ -290,16 +241,11 @@ class TestAnalyzeBoot:
 
         # Mocking the return values of the 4 calls to convert_val_to_float
         # in gather_timestamps_using_systemd
-        mock_SystemctlReader_instances = [
-            mock.Mock(),
-            mock.Mock(),
-            mock.Mock(),
-            mock.Mock(),
-        ]
-        for i in range(len(mock_SystemctlReader_instances)):
-            mock_SystemctlReader_instances[
-                i
-            ].convert_val_to_float.return_value = m_returns_of_convert_call[i]
+        mock_SystemctlReader_instances = [mock.Mock() for _ in range(4)]
+        for instance, value in zip(
+            mock_SystemctlReader_instances, m_returns_of_convert_call
+        ):
+            instance.convert_val_to_float.return_value = value
         mock_SystemctlReader.side_effect = mock_SystemctlReader_instances
 
         assert expected_return == gather_timestamps_using_systemd()

--- a/tests/unittests/analyze/test_boot.py
+++ b/tests/unittests/analyze/test_boot.py
@@ -39,28 +39,36 @@ class TestSystemCtlReader:
         )
         reader = SystemctlReader("dont", "care")
         with pytest.raises(RuntimeError):
-            reader.parse_epoch_as_float()
+            reader.convert_val_to_float()
 
     @mock.patch("cloudinit.subp.subp", return_value=("U=1000000", None))
     def test_systemctl_works_correctly_threshold(self, m_subp):
         reader = SystemctlReader("dummyProperty", "dummyParameter")
-        assert 1.0 == reader.parse_epoch_as_float()
-        thresh = 1.0 - reader.parse_epoch_as_float()
+        assert 1.0 == reader.convert_val_to_float()
+        thresh = 1.0 - reader.convert_val_to_float()
         assert thresh < 1e-6
         assert thresh > (-1 * 1e-6)
 
     @mock.patch("cloudinit.subp.subp", return_value=("U=0", None))
     def test_systemctl_succeed_zero(self, m_subp):
         reader = SystemctlReader("dummyProperty", "dummyParameter")
-        assert 0.0 == reader.parse_epoch_as_float()
+        assert 0.0 == reader.convert_val_to_float()
+
+    @mock.patch(
+        "cloudinit.subp.subp",
+        return_value=("U=Fri 1970-01-02 00:01:15.123 UTC", None),
+    )
+    def test_systemctl_succeed_human_readable_date(self, m_subp):
+        reader = SystemctlReader("dummyProperty", "dummyParameter")
+        assert 86475.123 == reader.convert_val_to_float()
 
     @mock.patch("cloudinit.subp.subp", return_value=("U=1", None))
     def test_systemctl_succeed_distinct(self, m_subp):
         reader = SystemctlReader("dummyProperty", "dummyParameter")
-        val1 = reader.parse_epoch_as_float()
+        val1 = reader.convert_val_to_float()
         m_subp.return_value = ("U=2", None)
         reader2 = SystemctlReader("dummyProperty", "dummyParameter")
-        val2 = reader2.parse_epoch_as_float()
+        val2 = reader2.convert_val_to_float()
         assert val1 != val2
 
     @pytest.mark.parametrize(
@@ -79,7 +87,7 @@ class TestSystemCtlReader:
         m_subp.return_value = return_value
         reader = SystemctlReader("dummyProperty", "dummyParameter")
         with pytest.raises(exception):
-            reader.parse_epoch_as_float()
+            reader.convert_val_to_float()
 
 
 class TestAnalyzeBoot:
@@ -184,31 +192,90 @@ class TestAnalyzeBoot:
         self.remove_dummy_file(path, log_path)
         assert CONTAINER_CODE == finish_code
 
-    @mock.patch("time.time", return_value=100)
-    @mock.patch("cloudinit.util.uptime", return_value=96)
-    @mock.patch("time.monotonic", return_value=97)
+    # @mock.patch("time.time", return_value=100)
+    # @mock.patch("cloudinit.util.uptime", return_value=96)
+    # @mock.patch("time.monotonic", return_value=97)
+    # @mock.patch("cloudinit.analyze.show.SystemctlReader")
+    # @pytest.mark.parametrize(
+    #     (
+    #         "is_container_returnvalue",
+    #         "time_mock_expected_callcount",
+    #         "monotonic_mock_expected_callcount",
+    #         "expected_return",
+    #     ),
+    #     (
+    #         (True, 2, 1, (CONTAINER_CODE, 4, 33, 43)),
+    #         (False, 1, 0, (SUCCESS_CODE, 4, 34, 44)),
+    #     ),
+    # )
+    # def test_gather_timestamps_using_systemd(
+    #     self,
+    #     mock_SystemctlReader,
+    #     monotonic_mock,
+    #     uptime_mock,
+    #     time_mock,
+    #     is_container_returnvalue,
+    #     time_mock_expected_callcount,
+    #     monotonic_mock_expected_callcount,
+    #     expected_return,
+    #     mocker,
+    # ):
+    #     """
+    #     Testing the behavior based on whether or not the
+    #     instance is a container
+    #     """
+    #     mocker.patch(
+    #         "cloudinit.util.is_container",
+    #         return_value=is_container_returnvalue,
+    #     )
+    #     systemctlReader_mocks = [
+    #         mock.Mock(name="UserspaceTimestampMonotonic"),
+    #         mock.Mock(name="InactiveExitTimestampMonotonic"),
+    #     ]
+    #     systemctlReader_mocks[0].convert_val_to_float.return_value = 30
+    #     systemctlReader_mocks[1].convert_val_to_float.return_value = 40
+    #     mock_SystemctlReader.side_effect = systemctlReader_mocks
+    #     assert gather_timestamps_using_systemd() == expected_return
+
+    #     assert time_mock.call_count == time_mock_expected_callcount
+    #     assert uptime_mock.call_count == 1
+    #     assert monotonic_mock.call_count == monotonic_mock_expected_callcount
+
     @mock.patch("cloudinit.analyze.show.SystemctlReader")
     @pytest.mark.parametrize(
         (
             "is_container_returnvalue",
-            "time_mock_expected_callcount",
-            "monotonic_mock_expected_callcount",
+            "expected_first_2_constructors_call_list",
+            "m_returns_of_convert_call",
             "expected_return",
         ),
         (
-            (True, 2, 1, (CONTAINER_CODE, 4, 33, 43)),
-            (False, 1, 0, (SUCCESS_CODE, 4, 34, 44)),
+            (
+                True,
+                [
+                    mock.call("UserspaceTimestamp"),
+                    mock.call("UserspaceTimestampMonotonic"),
+                ],
+                [1500, 7, 7, 18],
+                (CONTAINER_CODE, 1500, 1500, 1511),
+            ),
+            (
+                False,
+                [
+                    mock.call("KernelTimestamp"),
+                    mock.call("KernelTimestampMonotonic"),
+                ],
+                [1000, 1, 3, 8],
+                (SUCCESS_CODE, 1000, 1002, 1007),
+            ),
         ),
     )
     def test_gather_timestamps_using_systemd(
         self,
         mock_SystemctlReader,
-        monotonic_mock,
-        uptime_mock,
-        time_mock,
         is_container_returnvalue,
-        time_mock_expected_callcount,
-        monotonic_mock_expected_callcount,
+        expected_first_2_constructors_call_list,
+        m_returns_of_convert_call,
         expected_return,
         mocker,
     ):
@@ -220,25 +287,41 @@ class TestAnalyzeBoot:
             "cloudinit.util.is_container",
             return_value=is_container_returnvalue,
         )
-        systemctlReader_mocks = [
-            mock.Mock(name="UserspaceTimestampMonotonic"),
-            mock.Mock(name="InactiveExitTimestampMonotonic"),
-        ]
-        systemctlReader_mocks[0].parse_epoch_as_float.return_value = 30
-        systemctlReader_mocks[1].parse_epoch_as_float.return_value = 40
-        mock_SystemctlReader.side_effect = systemctlReader_mocks
-        assert gather_timestamps_using_systemd() == expected_return
 
-        assert time_mock.call_count == time_mock_expected_callcount
-        assert uptime_mock.call_count == 1
-        assert monotonic_mock.call_count == monotonic_mock_expected_callcount
+        # Mocking the return values of the 4 calls to convert_val_to_float
+        # in gather_timestamps_using_systemd
+        mock_SystemctlReader_instances = [
+            mock.Mock(),
+            mock.Mock(),
+            mock.Mock(),
+            mock.Mock(),
+        ]
+        for i in range(len(mock_SystemctlReader_instances)):
+            mock_SystemctlReader_instances[
+                i
+            ].convert_val_to_float.return_value = m_returns_of_convert_call[i]
+        mock_SystemctlReader.side_effect = mock_SystemctlReader_instances
+
+        assert expected_return == gather_timestamps_using_systemd()
+
+        # Verifying that the 4 constructor calls of SystemctlReader in
+        # gather_timestamps_using_systemd were with the expected arguments
+        assert (
+            mock_SystemctlReader.call_args_list[:2]
+            == expected_first_2_constructors_call_list
+        )
+        assert mock_SystemctlReader.call_args_list[2:] == [
+            mock.call("UserspaceTimestampMonotonic"),
+            mock.call("InactiveExitTimestampMonotonic", "cloud-init-local"),
+        ]
 
     @mock.patch(
         "cloudinit.analyze.show.SystemctlReader",
         side_effect=Exception("ARandomError"),
     )
+    @mock.patch("cloudinit.subp.subp")
     def test_gather_timestamps_using_systemd_with_SystemctlReader_exception(
-        self, systemctlReader_mock
+        self, m_subp, systemctlReader_mock
     ):
         """
         Confirm the function returns the error code when SystemctlReader


### PR DESCRIPTION


## Proposed Commit Message
```
fix[analyze-boot]: use monotonic clock for containers
Fixes GH-5773
```

## Test Steps
### Reproducing the bug
Spin an lxd container and run `cloud-init analyze boot` . You will notice that the `Cloud-init activated by systemd at` timestamp is higher (should be lower) than the `Cloud-init start` timestamp

###Verifying the fix
`CLOUD_INIT_PLATFORM='lxd_container' CLOUD_INIT_OS_IMAGE='noble' tox -e integration-tests -- tests/integration_tests/cmd/test_analyze.py` using this source branch (which has the fix and the new integration test)


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
