### PR TITLE
vlan and bond support in networkd

### DIFF
--- a/tests/unittests/cmd/devel/test_net_convert.py
+++ b/tests/unittests/cmd/devel/test_net_convert.py
@@ -54,7 +54,6 @@ Name=eth0
 
 [Network]
 DHCP=ipv4
-
 """
 
 SAMPLE_SYSCONFIG_CONTENT = """\

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-bond.200.netdev
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-bond.200.netdev
@@ -1,0 +1,8 @@
+[NetDev]
+Kind=vlan
+MACAddress=00:11:22:33:44:99
+MTUBytes=111
+Name=bond.200
+
+[VLAN]
+Id=200

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-bond.200.network
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-bond.200.network
@@ -1,0 +1,14 @@
+[Address]
+Address=192.168.200.10/24
+
+[Link]
+MACAddress=00:11:22:33:44:99
+MTUBytes=111
+
+[Match]
+Name=bond.200
+
+[Network]
+DHCP=ipv6
+DNS=1.1.1.1 8.8.4.4
+Domains=bond.vlan.test

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-bond0.netdev
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-bond0.netdev
@@ -1,0 +1,11 @@
+[Bond]
+LACPTransmitRate=fast
+MIIMonitorSec=100ms
+Mode=802.3ad
+TransmitHashPolicy=layer2+3
+
+[NetDev]
+Kind=bond
+MACAddress=00:11:22:33:44:77
+MTUBytes=333
+Name=bond0

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-bond0.network
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-bond0.network
@@ -1,0 +1,10 @@
+[Link]
+MACAddress=00:11:22:33:44:77
+MTUBytes=333
+
+[Match]
+Name=bond0
+
+[Network]
+DHCP=no
+VLAN=bond.200

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-eth0.network
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-eth0.network
@@ -1,0 +1,11 @@
+[Link]
+MTUBytes=1500
+
+[Match]
+MACAddress=00:11:22:33:44:55
+Name=eth0
+
+[Network]
+Bond=bond0
+DHCP=no
+VLAN=vlan100

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-eth1.network
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-eth1.network
@@ -1,0 +1,5 @@
+[Match]
+Name=eth1
+
+[Network]
+DHCP=yes

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-eth2.network
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-eth2.network
@@ -1,0 +1,16 @@
+[Address]
+Address=10.20.30.40/24
+
+[Link]
+MTUBytes=1400
+
+[Match]
+MACAddress=00:aa:bb:cc:dd:ee
+Name=eth2
+
+[Network]
+Bond=bond0
+DHCP=no
+DNS=9.9.9.9 8.8.8.8
+Domains=example.org
+VLAN=vl101

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-vl101.netdev
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-vl101.netdev
@@ -1,0 +1,6 @@
+[NetDev]
+Kind=vlan
+Name=vl101
+
+[VLAN]
+Id=101

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-vl101.network
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-vl101.network
@@ -1,0 +1,5 @@
+[Match]
+Name=vl101
+
+[Network]
+DHCP=no

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-vlan100.netdev
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-vlan100.netdev
@@ -1,0 +1,8 @@
+[NetDev]
+Kind=vlan
+MACAddress=00:11:22:33:44:66
+MTUBytes=901
+Name=vlan100
+
+[VLAN]
+Id=100

--- a/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-vlan100.network
+++ b/tests/unittests/net/artifacts/photon_net_config/etc/systemd/network/10-cloud-init-vlan100.network
@@ -1,0 +1,27 @@
+[Address]
+Address=192.168.100.10/24
+
+[Address]
+Address=192.168.100.11/24
+
+[Link]
+MACAddress=00:11:22:33:44:66
+MTUBytes=901
+
+[Match]
+Name=vlan100
+
+[Network]
+DHCP=ipv6
+DNS=8.8.8.8 1.1.1.1
+Domains=corp.example.com vlan.test
+
+[Route]
+Destination=10.10.200.0/24
+Gateway=192.168.100.1
+Metric=50
+
+[Route]
+Destination=10.10.201.0/24
+Gateway=192.168.100.2
+Metric=150

--- a/tests/unittests/net/artifacts/photon_net_config_v2.yaml
+++ b/tests/unittests/net/artifacts/photon_net_config_v2.yaml
@@ -1,0 +1,86 @@
+network:
+  version: 2
+
+  ethernets:
+    eth0:
+      match:
+        macaddress: "00:11:22:33:44:55"
+      set-name: eth0
+      dhcp4: false
+      mtu: 1500
+
+    eth1:
+      dhcp4: true
+      dhcp6: true
+
+    eth2:
+      match:
+        macaddress: "00:aa:bb:cc:dd:ee"
+      set-name: eth2
+      mtu: 1400
+      dhcp4: false
+      addresses:
+        - 10.20.30.40/24
+      nameservers:
+        addresses:
+          - 9.9.9.9
+          - 8.8.8.8
+        search:
+          - example.org
+
+  bonds:
+    bond0:
+      interfaces: [eth0, eth2]
+      parameters:
+        mode: 802.3ad
+        mii-monitor-interval: 100
+        transmit-hash-policy: layer2+3
+        lacp-rate: fast
+      dhcp4: false
+      dhcp6: false
+      mtu: 333
+      macaddress: "00:11:22:33:44:77"
+
+  vlans:
+    vlan100:
+      id: 100
+      link: eth0
+      addresses:
+        - 192.168.100.10/24
+        - 192.168.100.11/24
+      dhcp6: true
+      mtu: 901
+      macaddress: "00:11:22:33:44:66"
+      nameservers:
+        addresses:
+          - 8.8.8.8
+          - 1.1.1.1
+        search:
+          - corp.example.com
+          - vlan.test
+      routes:
+        - to: 10.10.200.0/24
+          via: 192.168.100.1
+          metric: 50
+        - to: 10.10.201.0/24
+          via: 192.168.100.2
+          metric: 150
+
+    vl101:
+      id: 101
+      link: eth2
+
+    bond.200:
+      id: 200
+      link: bond0
+      macaddress: "00:11:22:33:44:99"
+      addresses:
+        - 192.168.200.10/24
+      nameservers:
+        addresses:
+          - 1.1.1.1
+          - 8.8.4.4
+        search:
+          - bond.vlan.test
+      mtu: 111
+      dhcp6: true

--- a/tests/unittests/net/network_configs.py
+++ b/tests/unittests/net/network_configs.py
@@ -1000,7 +1000,7 @@ NETWORK_CONFIGS = {
                 Name=iface0
                 [Network]
                 DHCP=ipv6
-                IPv6AcceptRA=True
+                IPv6AcceptRA=yes
             """
         ).rstrip(" "),
     },
@@ -1075,7 +1075,7 @@ NETWORK_CONFIGS = {
                 Name=iface0
                 [Network]
                 DHCP=ipv6
-                IPv6AcceptRA=False
+                IPv6AcceptRA=no
             """
         ).rstrip(" "),
     },


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
feat(networkd): support vlan and bond rendering

```
Networkd renderer used in Photon OS doesn't support vlan and bond settings specified through network config yaml.
This is an effort towards supporting the same in networkd renderer.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
