### PR TITLE
feat(rh_subscription): new release_version field

### DIFF
--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -69,10 +69,10 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
             return_stat = sm.update_repos()
             if not return_stat:
                 raise SubscriptionError("Unable to add or remove repos")
-            if sm.releasever:
-                sm._set_releasever()
+            if sm.release_version:
+                sm._set_release_version()
                 sm._delete_packagemanager_cache(
-                    additional_error_message="Already set the releasever"
+                    additional_error_message="Already set the release_version"
                     " in the subscription manager but"
                 )
 
@@ -101,7 +101,7 @@ class SubscriptionManager:
         "server-hostname",
         "auto-attach",
         "service-level",
-        "releasever",
+        "release_version",
     ]
 
     def __init__(self, cfg, log=None):
@@ -121,7 +121,7 @@ class SubscriptionManager:
         self.enable_repo = self.rhel_cfg.get("enable-repo")
         self.disable_repo = self.rhel_cfg.get("disable-repo")
         self.servicelevel = self.rhel_cfg.get("service-level")
-        self.releasever = self.rhel_cfg.get("releasever")
+        self.release_version = self.rhel_cfg.get("release_version")
 
     def log_success(self, msg):
         """Simple wrapper for logging info messages. Useful for unittests"""
@@ -165,12 +165,12 @@ class SubscriptionManager:
             )
             return False, no_auto
 
-        # Not verifying the releasever statically in _verify_keys
+        # Not verifying the release_version statically in _verify_keys
         # (by verifying the key is in the output of
         # `subscription-manager release --list`) because sometimes
         # the release will become available only after enabling some repos
         # (which is executed after verify_keys). So we will catch this error
-        # during "subscription-manager release --set=<releasever>"
+        # during "subscription-manager release --set=<release_version>"
         return True, None
 
     def is_registered(self):
@@ -462,23 +462,23 @@ class SubscriptionManager:
     def is_configured(self):
         return bool((self.userid and self.password) or self.activation_key)
 
-    def _set_releasever(self):
+    def _set_release_version(self):
         """
-        Execute "subscription-manager release --set=<releasever>"
+        Execute "subscription-manager release --set=<release_version>"
         Raises Subscription error if the command fails
-        or if releasever is not passed in the config
+        or if release_version is not passed in the config
         """
-        if not self.releasever:
+        if not self.release_version:
             raise SubscriptionError(
-                "Tried to set releasever while"
+                "Tried to set release_version while"
                 "it was not passed in cloud-config"
             )
 
-        cmd = ["release", f"--set={self.releasever}"]
+        cmd = ["release", f"--set={self.release_version}"]
         try:
             _sub_man_cli(cmd)
         except subp.ProcessExecutionError as e:
-            raise SubscriptionError("Unable to set releasever") from e
+            raise SubscriptionError("Unable to set release_version") from e
 
         self.log.debug("Executed the release --set command successfully.")
 

--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -463,7 +463,6 @@ class SubscriptionManager:
         """
         Execute "subscription-manager release --set=<release_version>"
         Raises Subscription error if the command fails
-        or if release_version is not passed in the config
         """
 
         cmd = ["release", f"--set={self.release_version}"]

--- a/cloudinit/config/cc_rh_subscription.py
+++ b/cloudinit/config/cc_rh_subscription.py
@@ -489,8 +489,8 @@ class SubscriptionManager:
         """
         self.log.debug("Deleting the package manager cache")
         try:
-            util.del_dir("/var/cache/dnf", ignore_FileNotFoundError=True)
-            util.del_dir("/var/cache/yum", ignore_FileNotFoundError=True)
+            util.del_dir("/var/cache/dnf")
+            util.del_dir("/var/cache/yum")
         except Exception as e:
             raise SubscriptionError(
                 f"{additional_error_message}"

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2635,7 +2635,7 @@
             },
             "release_version": {
               "type": "string",
-              "description": "Sets the release_version via``subscription-manager release --set=<release_version>`` then deletes the package manager cache ``/var/cache/{dnf,yum}`` . These steps are applied after any pool attachement and/or enabling/disabling repos. For more information about this key, check https://access.redhat.com/solutions/238533 ."
+              "description": "Sets the release_version via``subscription-manager release --set=<release_version>`` then deletes the package manager cache ``/var/cache/{dnf,yum}`` . These steps are applied after any pool attachment and/or enabling/disabling repos. For more information about this key, check https://access.redhat.com/solutions/238533 ."
             },
             "rhsm-baseurl": {
               "type": "string",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2633,9 +2633,9 @@
                 "type": "string"
               }
             },
-            "releasever": {
+            "release_version": {
               "type": "string",
-              "description": "Sets the releasever via``subscription-manager release --set=<releasever>`` then deletes the package manager cache ``/var/cache/{dnf,yum}`` . These steps are applied after any pool attachement and/or enabling/disabling repos. For more information about this key, check https://access.redhat.com/solutions/238533 ."
+              "description": "Sets the release_version via``subscription-manager release --set=<release_version>`` then deletes the package manager cache ``/var/cache/{dnf,yum}`` . These steps are applied after any pool attachement and/or enabling/disabling repos. For more information about this key, check https://access.redhat.com/solutions/238533 ."
             },
             "rhsm-baseurl": {
               "type": "string",

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -2633,6 +2633,10 @@
                 "type": "string"
               }
             },
+            "releasever": {
+              "type": "string",
+              "description": "Sets the releasever via``subscription-manager release --set=<releasever>`` then deletes the package manager cache ``/var/cache/{dnf,yum}`` . These steps are applied after any pool attachement and/or enabling/disabling repos. For more information about this key, check https://access.redhat.com/solutions/238533 ."
+            },
             "rhsm-baseurl": {
               "type": "string",
               "description": "Sets the baseurl in ``/etc/rhsm/rhsm.conf``."

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -913,9 +913,21 @@ def center(text, fill, max_len):
     )
 
 
-def del_dir(path):
+def del_dir(path, ignore_FileNotFoundError=False):
+    '''
+    Deletes a directory and all its contents by calling shutil.rmtree
+
+    @param path: The path of the directory.
+    @param ignore_FileNotFoundError (default False):
+        ignore FileNotFoundError raised by shutil.rmtree
+    """
+    '''
     LOG.debug("Recursively deleting %s", path)
-    shutil.rmtree(path)
+    try:
+        shutil.rmtree(path)
+    except FileNotFoundError as e:
+        if not ignore_FileNotFoundError:
+            raise e
 
 
 def read_optional_seed(fill, base="", ext="", timeout=5):

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -913,21 +913,19 @@ def center(text, fill, max_len):
     )
 
 
-def del_dir(path, ignore_FileNotFoundError=False):
+def del_dir(path):
     '''
     Deletes a directory and all its contents by calling shutil.rmtree
+    Will ignore FileNotFoundError
 
     @param path: The path of the directory.
-    @param ignore_FileNotFoundError (default False):
-        ignore FileNotFoundError raised by shutil.rmtree
     """
     '''
     LOG.debug("Recursively deleting %s", path)
     try:
         shutil.rmtree(path)
-    except FileNotFoundError as e:
-        if not ignore_FileNotFoundError:
-            raise e
+    except FileNotFoundError:
+        pass
 
 
 def read_optional_seed(fill, base="", ext="", timeout=5):

--- a/doc/module-docs/cc_rh_subscription/example3.yaml
+++ b/doc/module-docs/cc_rh_subscription/example3.yaml
@@ -19,4 +19,4 @@ rh_subscription:
   server-hostname: foo.bar.com
   # Set `subscription-manager release --set=6Server` then
   # delete /var/cache/{dnf,yum}
-  releasever: 6Server
+  release_version: 6Server

--- a/doc/module-docs/cc_rh_subscription/example3.yaml
+++ b/doc/module-docs/cc_rh_subscription/example3.yaml
@@ -17,3 +17,6 @@ rh_subscription:
   rhsm-baseurl: http://url
   # Alter the server hostname in /etc/rhsm/rhsm.conf
   server-hostname: foo.bar.com
+  # Set `subscription-manager release --set=6Server` then
+  # delete /var/cache/{dnf,yum}
+  releasever: 6Server

--- a/doc/rtd/spelling_word_list.txt
+++ b/doc/rtd/spelling_word_list.txt
@@ -173,6 +173,7 @@ rc
 rd
 readinessprobes
 regex
+releasever
 repodata
 resizefs
 resolv

--- a/doc/rtd/spelling_word_list.txt
+++ b/doc/rtd/spelling_word_list.txt
@@ -173,7 +173,6 @@ rc
 rd
 readinessprobes
 regex
-releasever
 repodata
 resizefs
 resolv

--- a/tests/unittests/config/test_cc_rh_subscription.py
+++ b/tests/unittests/config/test_cc_rh_subscription.py
@@ -316,9 +316,13 @@ class TestBadInput:
         )
         assert m_sman_cli.call_count == 3
         assert m_delete_pm_cache.call_count == 0
+        expected_cmd = [
+            "release",
+            f"--set={self.CONFIG_BAD_RELEASE_VERSION["rh_subscription"]["release_version"]}",
+        ]
         self.assert_logged_warnings(
             (
-                "Unable to set release_version",
+                f"Unable to set release_version using: {expected_cmd}",
                 "rh_subscription plugin did not complete successfully",
             ),
             caplog,
@@ -347,8 +351,7 @@ class TestBadInput:
         assert m_rmtree.call_args_list == [mock.call("/var/cache/dnf")]
         self.assert_logged_warnings(
             (
-                "Already set the release_version in the subscription manager"
-                " but unable to delete the package manager cache",
+                "Unable to delete the package manager cache",
                 "rh_subscription plugin did not complete successfully",
             ),
             caplog,

--- a/tests/unittests/config/test_cc_rh_subscription.py
+++ b/tests/unittests/config/test_cc_rh_subscription.py
@@ -318,7 +318,7 @@ class TestBadInput:
         assert m_delete_pm_cache.call_count == 0
         expected_cmd = [
             "release",
-            f"--set={self.CONFIG_BAD_RELEASE_VERSION["rh_subscription"]["release_version"]}",
+            f"--set={self.CONFIG_BAD_RELEASE_VERSION['rh_subscription']['release_version']}",
         ]
         self.assert_logged_warnings(
             (

--- a/tests/unittests/config/test_cc_rh_subscription.py
+++ b/tests/unittests/config/test_cc_rh_subscription.py
@@ -40,6 +40,7 @@ class TestHappyPath:
             "add-pool": ["pool1", "pool2", "pool3"],
             "enable-repo": ["repo1", "repo2", "repo3"],
             "disable-repo": ["repo4", "repo5"],
+            "releasever": "7.6b",
         }
     }
 
@@ -52,7 +53,10 @@ class TestHappyPath:
         assert m_sman_cli.call_count == 1
         assert "System is already registered" in caplog.text
 
-    def test_simple_registration(self, m_sman_cli, caplog):
+    @mock.patch.object(
+        cc_rh_subscription.SubscriptionManager, "_set_releasever"
+    )
+    def test_simple_registration(self, m_set_releasever, m_sman_cli, caplog):
         """
         Simple registration with username and password
         """
@@ -76,6 +80,7 @@ class TestHappyPath:
         )
         assert "rh_subscription plugin completed successfully" in caplog.text
         assert m_sman_cli.call_count == 2
+        assert m_set_releasever.call_count == 0
 
     @mock.patch.object(cc_rh_subscription.SubscriptionManager, "_getRepos")
     def test_update_repos_disable_with_none(self, m_get_repos, m_sman_cli):
@@ -94,7 +99,7 @@ class TestHappyPath:
     def test_full_registration(self, m_sman_cli, caplog):
         """
         Registration with auto-attach, service-level, adding pools,
-        and enabling and disabling yum repos
+        enabling and disabling yum repos and setting releasever
         """
         call_lists = []
         call_lists.append(["attach", "--pool=pool1", "--pool=pool3"])
@@ -102,6 +107,7 @@ class TestHappyPath:
             ["repos", "--disable=repo5", "--enable=repo2", "--enable=repo3"]
         )
         call_lists.append(["attach", "--auto", "--servicelevel=self-support"])
+        call_lists.append(["release", "--set=7.6b"])
         reg = (
             "The system has been registered with ID:"
             " 12345678-abde-abcde-1234-1234567890abc"
@@ -116,9 +122,15 @@ class TestHappyPath:
             ("Repo ID: repo1\nRepo ID: repo5\n", ""),
             ("Repo ID: repo2\nRepo ID: repo3\nRepo ID: repo4", ""),
             ("", ""),
+            ("Release set to: 7.6b", ""),
         ]
+        # to avoid deleting the actual cache files
+        # (triggered by the presence of the releasever key)
+        # on the host running the tests
+        mock.patch("shutil.rmtree")
+
         cc_rh_subscription.handle(NAME, self.CONFIG_FULL, None, [])
-        assert m_sman_cli.call_count == 9
+        assert m_sman_cli.call_count == 10
         for call in call_lists:
             assert mock.call(call) in m_sman_cli.call_args_list
         assert "rh_subscription plugin completed successfully" in caplog.text
@@ -167,6 +179,13 @@ class TestBadInput:
             "activation-key": "abcdef1234",
             "fookey": "bar",
             "org": "ABC",
+        }
+    }
+    CONFIG_BADRELEASEVER = {
+        "rh_subscription": {
+            "username": "scooby@do.com",
+            "password": "scooby-snacks",
+            "releasever": "badreleasever",
         }
     }
 
@@ -272,7 +291,58 @@ class TestBadInput:
                 "fookey is not a valid key for rh_subscription. Valid keys"
                 " are: org, activation-key, username, password, disable-repo,"
                 " enable-repo, add-pool, rhsm-baseurl, server-hostname,"
-                " auto-attach, service-level",
+                " auto-attach, service-level, releasever",
+                "rh_subscription plugin did not complete successfully",
+            ),
+            caplog,
+        )
+
+    @mock.patch.object(
+        cc_rh_subscription.SubscriptionManager, "_delete_packagemanager_cache"
+    )
+    def test_bad_releasever(self, m_delete_pm_cache, m_sman_cli, caplog):
+        """
+        Failure at setting releasever
+        """
+        m_sman_cli.side_effect = [
+            subp.ProcessExecutionError,
+            (self.REG, "bar"),
+            subp.ProcessExecutionError,
+        ]
+        cc_rh_subscription.handle(NAME, self.CONFIG_BADRELEASEVER, None, [])
+        assert m_sman_cli.call_count == 3
+        assert m_delete_pm_cache.call_count == 0
+        self.assert_logged_warnings(
+            (
+                "Unable to set releasever",
+                "rh_subscription plugin did not complete successfully",
+            ),
+            caplog,
+        )
+
+    @mock.patch("shutil.rmtree", side_effect=[PermissionError])
+    def test_pm_cache_deletion_after_setting_releasever(
+        self, m_rmtree, m_sman_cli, caplog
+    ):
+        """
+        Failure at deleting package manager cache
+        after setting releasever
+        """
+        good_release_ver_cfg = copy.deepcopy(self.CONFIG_BADRELEASEVER)
+        good_release_ver_cfg["rh_subscription"]["releasever"] = "1.2Server"
+        m_sman_cli.side_effect = [
+            subp.ProcessExecutionError,
+            (self.REG, "bar"),
+            ("Release set to: 1.2Server", ""),
+        ]
+        cc_rh_subscription.handle(NAME, good_release_ver_cfg, None, [])
+        # assert "rh_subscription plugin completed successfully" in caplog.text
+        assert m_sman_cli.call_count == 3
+        assert m_rmtree.call_args_list == [mock.call("/var/cache/dnf")]
+        self.assert_logged_warnings(
+            (
+                "Already set the releasever in the subscription manager but "
+                "unable to delete the package manager cache",
                 "rh_subscription plugin did not complete successfully",
             ),
             caplog,
@@ -298,6 +368,10 @@ class TestRhSubscriptionSchema:
             (
                 {"rh_subscription": {"disable-repo": "name"}},
                 "'name' is not of type 'array'",
+            ),
+            (
+                {"rh_subscription": {"releasever": [10]}},
+                r"\[10\] is not of type 'string'",
             ),
             (
                 {

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2042,28 +2042,17 @@ class TestDelDir:
             util.del_dir(tmpdir)
         assert not os.path.exists(tmpdir)
 
-    @pytest.mark.parametrize(
-        "ignore_FileNotFoundError,expected_error",
-        ((False, pytest.raises(FileNotFoundError)), (True, does_not_raise())),
-    )
-    def test_del_dir_ignoreFileNotFound(
-        self, ignore_FileNotFoundError, expected_error
-    ):
+    def test_del_dir_ignoreFileNotFound(self):
         """
-        Should raise FileNotFoundError only if tries to delete non-existing
-        directory with ignore_FileNotFoundError=False
+        Should not raise FileNotFoundError
         """
         non_existing_dir = "/blabla"
         assert not os.path.exists(non_existing_dir)
-        with expected_error:
-            util.del_dir(
-                non_existing_dir,
-                ignore_FileNotFoundError=ignore_FileNotFoundError,
-            )
+        with does_not_raise():
+            util.del_dir(non_existing_dir)
         assert not os.path.exists(non_existing_dir)
 
-    @pytest.mark.parametrize("ignore_FileNotFoundError", (False, True))
-    def test_del_dir_generic_errors(self, ignore_FileNotFoundError, mocker):
+    def test_del_dir_generic_errors(self, mocker):
         """
         If shutil.rmtree raises a non-FileNotFoundError , del_dir should
         raise this error
@@ -2074,9 +2063,7 @@ class TestDelDir:
             side_effect=mocked_side_effect,
         )
         with pytest.raises(mocked_side_effect):
-            util.del_dir(
-                "somedir", ignore_FileNotFoundError=ignore_FileNotFoundError
-            )
+            util.del_dir("somedir")
         assert mock_rmtree.call_count == 1
 
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -2042,7 +2042,7 @@ class TestDelDir:
             util.del_dir(tmpdir)
         assert not os.path.exists(tmpdir)
 
-    def test_del_dir_ignoreFileNotFound(self):
+    def test_del_dir_file_not_found(self):
         """
         Should not raise FileNotFoundError
         """


### PR DESCRIPTION
## Proposed Commit Message
```
feat(rh_subscription): new release_version field
Refs GH-6030
```

## Test Steps
- Run a QEMU RHEL-10 VM with the following user-data (See more details in https://github.com/canonical/cloud-init/issues/6292#issuecomment-3144757542 on where to get the image from)
```
#cloud-config
password: 'somepasswordyouset'
chpasswd:
  expire: False
rh_subscription:
  username: 'yourredhatusername'
  password: 'yourredhatpassword'
```
- Manually modify the cloudinit python script in the VM (under `/usr/lib/python3.12/site-packages/cloudinit`) withe file changes of this PR
- `sudo subscription-manager unregister`
- Add `releasever: 10` under rh_subscription in `/var/lib/cloud/instance/cloud-config.txt`
- `sudo cloud-init single --name cc_rh_subscription --frequency always`

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
