### PR TITLE
feat(clean): Add a new clean option to clean fstab entries

### DIFF
--- a/cloudinit/cmd/clean.py
+++ b/cloudinit/cmd/clean.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 from cloudinit import settings, sources
+from cloudinit.config import cc_mounts
 from cloudinit.distros import uses_systemd
 from cloudinit.log import log_util
 from cloudinit.net.netplan import CLOUDINIT_NETPLAN_FILE
@@ -99,6 +100,7 @@ def get_parser(parser=None):
             "ssh_config",
             "network",
             "datasource",
+            "fstab",
         ],
         default=[],
         nargs="+",
@@ -118,7 +120,7 @@ def remove_artifacts(init, remove_logs, remove_seed=False, remove_config=None):
     @param: remove_seed: Boolean. Set True to also delete seed subdir in
         paths.cloud_dir.
     @param: remove_config: List of strings.
-        Can be any of: all, network, ssh_config, datasource.
+        Can be any of: all, network, ssh_config, datasource, fstab.
     @returns: 0 on success, 1 otherwise.
     """
     init.read_cfg()
@@ -134,6 +136,8 @@ def remove_artifacts(init, remove_logs, remove_seed=False, remove_config=None):
     ):
         for conf in GEN_SSH_CONFIG_FILES:
             del_file(conf)
+    if remove_config and set(remove_config).intersection(["all", "fstab"]):
+        cc_mounts.cleanup_fstab()
 
     clean_datasource = remove_config and set(remove_config).intersection(
         ["all", "datasource"]

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -535,7 +535,7 @@ def cleanup_fstab(ds_remove_entries: list = []) -> None:
         if changed:
             with open(FSTAB_PATH, "w") as f:
                 f.writelines(new_lines)
-                LOG.info("Removed resource disk entries from %s", FSTAB_PATH)
+            LOG.info("Removed resource disk entries from %s", FSTAB_PATH)
     except Exception as e:
         LOG.warning("Failed to clean resource disk entries from fstab: %s", e)
 

--- a/cloudinit/config/cc_mounts.py
+++ b/cloudinit/config/cc_mounts.py
@@ -518,7 +518,7 @@ def cleanup_fstab(ds_remove_entries: list = []) -> None:
     if not os.path.exists(FSTAB_PATH):
         return
 
-    base_entry = [f"{MNT_COMMENT}"]
+    base_entry = [MNT_COMMENT]
 
     with open(FSTAB_PATH, "r") as f:
         lines = f.readlines()

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1676,31 +1676,7 @@ class DataSourceAzure(sources.DataSource):
         by cloud-init i.e. lines containing "/dev/disk/cloud/azure_resource"
         and cloudconfig comment.
         """
-        fstab_path = cc_mounts.FSTAB_PATH
-        mnt_comment = cc_mounts.MNT_COMMENT
-        removed_entries = RESOURCE_DISK_PATH
-        if not os.path.exists(fstab_path):
-            return
-
-        with open(fstab_path, "r") as f:
-            lines = f.readlines()
-        new_lines = []
-        changed = False
-        for line in lines:
-            if removed_entries in line and mnt_comment in line:
-                changed = True
-                continue
-            new_lines.append(line)
-        # rewrite fstab
-        try:
-            if changed:
-                with open(fstab_path, "w") as f:
-                    f.writelines(new_lines)
-                LOG.info("Removed resource disk entries from %s", fstab_path)
-        except Exception as e:
-            LOG.warning(
-                "Failed to clean resource disk entries from fstab: %s", e
-            )
+        cc_mounts.cleanup_fstab([f"{RESOURCE_DISK_PATH}"])
 
     def clean(self):
         # Azure-specific cleanup logic for "cloud-init clean -c datasource"

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -1676,7 +1676,7 @@ class DataSourceAzure(sources.DataSource):
         by cloud-init i.e. lines containing "/dev/disk/cloud/azure_resource"
         and cloudconfig comment.
         """
-        cc_mounts.cleanup_fstab([f"{RESOURCE_DISK_PATH}"])
+        cc_mounts.cleanup_fstab([RESOURCE_DISK_PATH])
 
     def clean(self):
         # Azure-specific cleanup logic for "cloud-init clean -c datasource"

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -90,9 +90,11 @@ re-run all stages as it did on first boot.
   Optionally remove all ``cloud-init`` generated config files. Argument
   `ssh_config` cleans config files for ssh daemon. Argument `network` removes
   all generated config files for network. Argument `datasource` removes files
-  and/or configs written by current datasource. Argument `fstab` removes all
-  entries that have been configured by cloud-init. `all` removes
-  config files of all types.
+  and/or configs written by current datasource. It includes `fstab` entries
+  that have been only configured by this datasource leaving aside other entries
+  configured by cloud-init. Argument `fstab` removes all entries that have
+  been configured by cloud-init including those that are configured by various
+  datasources. `all` removes config files of all types.
 * :command:`--seed`: Remove the cloud-init seed directory
   (e.g., :file:`/var/lib/cloud/seed/`)
   which stores instance metadata used initializing a datasource.

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -91,7 +91,7 @@ re-run all stages as it did on first boot.
   `ssh_config` cleans config files for ssh daemon. Argument `network` removes
   all generated config files for network. Argument `datasource` removes files
   and/or configs written by current datasource. Argument `fstab` removes all
-  entries that have the comment `comment=cloudconfig` in them. `all` removes
+  entries that have been configured by cloud-init. `all` removes
   config files of all types.
 * :command:`--seed`: Remove the cloud-init seed directory
   (e.g., :file:`/var/lib/cloud/seed/`)

--- a/doc/rtd/reference/cli.rst
+++ b/doc/rtd/reference/cli.rst
@@ -86,11 +86,13 @@ re-run all stages as it did on first boot.
   remove the file. Best practice when cloning a golden image, to ensure the
   next boot of that image auto-generates a unique machine ID.
   `More details on machine-id`_.
-* :command:`--configs [all | ssh_config | network | datasource ]`: Optionally
-  remove all ``cloud-init`` generated config files. Argument `ssh_config`
-  cleans config files for ssh daemon. Argument `network` removes all generated
-  config files for network. Argument `datasource` removes files and/or configs
-  written by current datasource. `all` removes config files of all types.
+* :command:`--configs [all | ssh_config | network | datasource | fstab ]`:
+  Optionally remove all ``cloud-init`` generated config files. Argument
+  `ssh_config` cleans config files for ssh daemon. Argument `network` removes
+  all generated config files for network. Argument `datasource` removes files
+  and/or configs written by current datasource. Argument `fstab` removes all
+  entries that have the comment `comment=cloudconfig` in them. `all` removes
+  config files of all types.
 * :command:`--seed`: Remove the cloud-init seed directory
   (e.g., :file:`/var/lib/cloud/seed/`)
   which stores instance metadata used initializing a datasource.


### PR DESCRIPTION
## Proposed Commit Message

A new `cloud-init clean -c fstab` option is introduced that would clean all fstab entries that have "comment=cloudconfig" comment. It refactors code already present in DataSourceAzure.clean() method added as a part of the change 08a9dcf34445be572 ("feat(azure): Implement the clean callback for DataSourceAzure (#6321)")

Fixes: GH-6341



## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
