### PR TITLE
fix(tests): handle TMPDIR != "/tmp"

### DIFF
--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -119,9 +119,11 @@ def fake_filesystem(mocker, tmpdir, fake_filesystem_hook):
     """
     # This allows fake_filesystem to be used with production code that
     # creates temporary directories. Functions like TemporaryDirectory()
-    # attempt to create a directory under "/tmp" assuming that it already
-    # exists, but then it fails because of the retargeting that happens here.
-    tmpdir.mkdir("tmp")
+    # attempt to create a directory under $TMPDIR (among other locations)
+    # assuming that it already exists, but then it fails because of the
+    # retargeting that happens here.
+    TMPDIR = os.getenv("TMPDIR", "/tmp")
+    Path(tmpdir, TMPDIR[1:]).mkdir(exist_ok=True)
 
     for mod, funcs in FS_FUNCS.items():
         for f, nargs in funcs:


### PR DESCRIPTION
Fix an issue in an environment where TMPDIR is not set to /tmp where 22 tests fail. These tests have codepaths that use TemporaryDirectory(). Create a TMPDIR equivalent under the fake_filesystem.

I'm looking at a different problem (LP: #[2118989](https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2118989)) and found this when simply trying to unittest main branch.
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(tests): handle TMPDIR != "/tmp"

Fix an issue in an environment where TMPDIR is not set to /tmp where 22
tests fail. These tests have codepaths that use TemporaryDirectory().
Create a TMPDIR equivalent under the fake_filesystem.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
