### PR TITLE
fix: cloud-init-hotplugd: remove use of "exec" and unnecessary exit

### DIFF
--- a/tools/cloud-init-hotplugd
+++ b/tools/cloud-init-hotplugd
@@ -11,13 +11,12 @@
 
 PIPE="/run/cloud-init/share/hook-hotplug-cmd"
 
-mkfifo -m700 $PIPE
+[ -p $PIPE ] || mkfifo -m700 $PIPE
 
 while true; do
   # shellcheck disable=SC2162
-  read args < $PIPE
-  # shellcheck disable=SC2086
-  exec /usr/bin/cloud-init devel hotplug-hook $args
+  if read args < $PIPE; then
+    # shellcheck disable=SC2086
+    /usr/bin/cloud-init devel hotplug-hook $args
+  fi
 done
-
-exit


### PR DESCRIPTION

## Proposed Commit Message

```
fix: cloud-init-hotplugd: remove use of "exec" and unnecessary exit

"exec" should not have been used to call cloud-init so remove it, also
only call "cloud-init devel hotplug-hook" when there are arguments to
pass to it.

The "exit" at the end of the script is unnecessary, so remove it.

Fixes GH-6351
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
