### PR TITLE
feat(Gentoo): Netifrc network rendering support

### DIFF
--- a/cloudinit/distros/gentoo.py
+++ b/cloudinit/distros/gentoo.py
@@ -17,10 +17,20 @@ from cloudinit.settings import PER_ALWAYS, PER_INSTANCE
 
 LOG = logging.getLogger(__name__)
 
+NETWORK_FILE_HEADER = """\
+# This file is generated from information provided by the datasource. Changes
+# to it will not persist across an instance reboot. To disable cloud-init's
+# network configuration capabilities, write a file
+# /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg with the following:
+# network: {config: disabled}
+
+"""
+
 
 class Distro(distros.Distro):
     locale_gen_fn = "/etc/locale.gen"
     default_locale = "en_US.UTF-8"
+    renderer_configs = {"netifrc": {"netifrc_header": NETWORK_FILE_HEADER}}
 
     # C.UTF8 makes sense to generate, but is not selected
     # Add /etc/locale.gen entries to this list to support more locales

--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -315,6 +315,24 @@ class NetworkdActivator(NetworkActivator):
         )
 
 
+class NetifrcActivator(NetworkActivator):
+    @staticmethod
+    def available(target: Optional[str] = None) -> bool:
+        expected = "rc-service"
+        search = ["/sbin"]
+        return bool(subp.which(expected, search=search, target=target))
+
+    @staticmethod
+    def bring_up_interface(device_name: str) -> bool:
+        cmd = ["rc-service", "net." + device_name, "start"]
+        return _alter_interface(cmd, device_name)
+
+    @staticmethod
+    def bring_down_interface(device_name: str) -> bool:
+        cmd = ["rc-service", "net." + device_name, "stop"]
+        return _alter_interface(cmd, device_name)
+
+
 # This section is mostly copied and pasted from renderers.py. An abstract
 # version to encompass both seems overkill at this point
 DEFAULT_PRIORITY = [
@@ -323,6 +341,7 @@ DEFAULT_PRIORITY = [
     "network-manager",
     "networkd",
     "ifconfig",
+    "netifrc",
 ]
 
 NAME_TO_ACTIVATOR: Dict[str, Type[NetworkActivator]] = {
@@ -331,6 +350,7 @@ NAME_TO_ACTIVATOR: Dict[str, Type[NetworkActivator]] = {
     "network-manager": NetworkManagerActivator,
     "networkd": NetworkdActivator,
     "ifconfig": IfConfigActivator,
+    "netifrc": NetifrcActivator,
 }
 
 

--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -324,12 +324,12 @@ class NetifrcActivator(NetworkActivator):
 
     @staticmethod
     def bring_up_interface(device_name: str) -> bool:
-        cmd = ["rc-service", "net." + device_name, "start"]
+        cmd = ["rc-service", "net-ci." + device_name, "start"]
         return _alter_interface(cmd, device_name)
 
     @staticmethod
     def bring_down_interface(device_name: str) -> bool:
-        cmd = ["rc-service", "net." + device_name, "stop"]
+        cmd = ["rc-service", "-s", "net-ci." + device_name, "stop"]
         return _alter_interface(cmd, device_name)
 
 

--- a/cloudinit/net/activators.py
+++ b/cloudinit/net/activators.py
@@ -324,12 +324,12 @@ class NetifrcActivator(NetworkActivator):
 
     @staticmethod
     def bring_up_interface(device_name: str) -> bool:
-        cmd = ["rc-service", "net-ci." + device_name, "start"]
+        cmd = ["rc-service", "net." + device_name, "start"]
         return _alter_interface(cmd, device_name)
 
     @staticmethod
     def bring_down_interface(device_name: str) -> bool:
-        cmd = ["rc-service", "-s", "net-ci." + device_name, "stop"]
+        cmd = ["rc-service", "-s", "net." + device_name, "stop"]
         return _alter_interface(cmd, device_name)
 
 

--- a/cloudinit/net/netifrc.py
+++ b/cloudinit/net/netifrc.py
@@ -194,13 +194,13 @@ class Renderer(renderer.Renderer):
         self.netifrc_header = config.get("netifrc_header", "")
         self.netifrc_path = config.get("netifrc_path", "etc/conf.d/net")
         self.initd_net_prefix = config.get(
-            "initd_net_prefix", "etc/init.d/net-ci."
+            "initd_net_prefix", "etc/init.d/net."
         )
         self.initd_netlo_path = config.get(
             "initd_netlo_path", "etc/init.d/net.lo"
         )
         self.runlevel_default_prefix = config.get(
-            "runlevel_default_prefix", "etc/runlevels/default/net-ci."
+            "runlevel_default_prefix", "etc/runlevels/default/net."
         )
 
     def _render_routes(self, name, routes, lines):

--- a/cloudinit/net/netifrc.py
+++ b/cloudinit/net/netifrc.py
@@ -1,0 +1,506 @@
+# Copyright 2025 David Timber
+#
+# Author: David Timber <dxdt@dev.snart.me>
+# Gentoo Netifrc net renderer
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+r"""
+List of implemented vars:
+  General:
+    - config_
+    - dhcp_ (release nodns nontp nonis nogateway nosendhost)
+    - dhcpcd_ (dhcpv4 only "-4" and dhcpv6 only "-6")
+    - routes_
+    - dns_search_
+    - dns_servers_
+    - mtu_
+    - mac_
+
+  Bridge support:
+    - bridge_
+    - bridge_forward_delay_
+    - bridge_hello_time_
+    - bridge_stp_state_
+
+  Bond support:
+    - mode_
+    - fail_over_mac_
+    - arp_validate_
+    - arp_interval_
+    - arp_ip_target_
+    - downdelay_
+    - updelay_
+    - lacp_rate_
+    - ad_select_
+    - xmit_hash_policy_
+    - num_grat_arp_
+    - miimon_
+    - primary_
+    - primary_reselect_
+    - all_slaves_active_
+    - min_links_
+
+  VLAN support:
+    - _vlanN_
+    - vlans_
+    - _vlanN_name
+
+  Wake on LAN support:
+    - ethtool_change_
+
+To list all prefixes that appear in the examples, from /netifrc/doc, run:
+
+  grep -hoP '\K(\w+)_(?=[\w_]+=)' *.example.* | sort | uniq
+
+No metric support:
+Netifrc only supports per-interface link through metric_. There's no
+counterpart config in Netifrc, so subnet metric settings will be ignored. Use
+route metric instead.
+
+  routes:
+   - to: 0.0.0.0/0
+     via: 10.23.2.1
+     metric: 3
+
+IPv6 support:
+
+Netifrc can use both dhcpcd and dhclient backends.As dhcpcd is "Gentoo's long
+time default" according to the handbook, the module will assume dhcpcd.
+The kernel's accept_ra implementation has a range of issues on modern systems
+such as Gentoo. The module WOULD NOT use sysctl to set kernel's accept_ra and
+expect that the DHCP client backend will do router solicitation and processing
+of RA messages. Currently, it is not possible to implement accept-ra option as
+neither dhcpcd or dhclient does not offer an option to disable SLAAC.
+dhcp[46]-overrides:
+
+https://cloudinit.readthedocs.io/en/latest/reference/network-config-format-v2.html#dhcp4-overrides-and-dhcp6-overrides-mapping
+https://wiki.gentoo.org/wiki/Handbook:X86/Networking/Modular/en#DHCP
+
+NOTE: they're currently not defined in the schema!
+
+These options are originally intended for Netplan, but the Netifrc module
+honours them when passed. However, the module expects them to be an array, not
+a mapping. Currently, it is not possible to specify separate DHCP overrides
+for DHCPv4 and DHCPv6. This is a bug in Netifrc dhcpcd module.
+Example:
+  dhcp4-overrides:
+    - release
+    - nodns
+    - nontp
+    - nonis
+  dhcp6-overrides:
+    - nogateway
+    - nosendhost
+will be rendered as
+`dhcp_IFACE="release nodns nontp nonis nogateway nosendhost"`
+DHCPv4 or DHCPv6 only:
+It is possible to disable IPv4 or IPv6 like so:
+  dhcp4: true
+  dhcp6: false
+will be rendered as `dhcpcd_IFACE="-4"` to disable IPv6 configuration.
+"""
+
+import copy
+import logging
+import os
+from typing import Optional
+
+from cloudinit import subp, util
+from cloudinit.net import ipv4_mask_to_net_prefix, renderer
+from cloudinit.net.network_state import NetworkState
+
+LOG = logging.getLogger(__name__)
+
+
+def _str_list(lst):
+    return [str(s) for s in lst]
+
+
+def _iface_var(name):
+    r"""
+    https://gitweb.gentoo.org/proj/netifrc.git/tree/doc/net.example.Linux.in#n701
+
+    #config_eth0.1="dhcp" - does not work
+    #config_eth0_1="dhcp" - does work
+
+    https://gitweb.gentoo.org/proj/netifrc.git/tree/doc/net.example.Linux.in#n670
+
+    #vlan1_name="vlan1"
+    #eth0_vlan2_name="eth0.2"
+    #eth1_vlan2_name="eth1.2"
+    """
+    return name.replace(".", "_")
+
+
+class Renderer(renderer.Renderer):
+    """Renders network information in a /etc/conf.d/net format."""
+
+    _bond_opts = {
+        "bond_mode": '''mode_%s="%s"''',
+        "bond_xmit_hash_policy": '''xmit_hash_policy_%s="%s"''',
+        "bond_miimon": '''miimon_%s="%s"''',
+        "bond_min_links": '''min_links_%s="%s"''',
+        "bond_arp_interval": '''arp_interval_%s="%s"''',
+        "bond_arp_ip_target": '''arp_ip_target_%s="%s"''',
+        "bond_arp_validate": '''arp_validate_%s="%s"''',
+        "bond_ad_select": '''ad_select_%s="%s"''',
+        "bond_num_grat_arp": '''num_grat_arp_%s="%s"''',
+        "bond_downdelay": '''downdelay_%s="%s"''',
+        "bond_updelay": '''updelay_%s="%s"''',
+        "bond_lacp_rate": '''lacp_rate_%s="%s"''',
+        "bond_fail_over_mac": '''fail_over_mac_%s="%s"''',
+        "bond_primary": '''primary_%s="%s"''',
+        "bond_primary_reselect": '''primary_reselect_%s="%s"''',
+        "bond_all_slaves_active": '''all_slaves_active_%s="%s"''',
+        # missing from schema: active_slave, queue_id, num_unsol_na,
+        # use_carrier, resend_igmp
+    }
+
+    def __init__(self, config=None):
+        if not config:
+            config = {}
+        self.netifrc_header = config.get("netifrc_header", "")
+        self.netifrc_path = config.get("netifrc_path", "etc/conf.d/net")
+        self.initd_net_prefix = config.get(
+            "initd_net_prefix", "etc/init.d/net."
+        )
+        self.initd_netlo_path = config.get(
+            "initd_netlo_path", self.initd_net_prefix + "lo"
+        )
+        self.resolv_conf_path = config.get(
+            "resolv_conf_path", "etc/resolv.conf.head"
+        )
+
+    def _render_routes(self, name, routes, lines):
+        out = []
+        for r in routes:
+            if "prefix" in r:
+                pl = r["prefix"]
+                pfx = "/%d" % (pl,)
+            elif "netmask" in r:
+                pl = ipv4_mask_to_net_prefix(r["netmask"])
+                pfx = "/%d" % (pl,)
+            else:
+                pl = 0
+                pfx = ""
+
+            if "network" not in r or (
+                pl == 0 and r["network"] in ["0.0.0.0", "::"]
+            ):
+                dst = "default"
+            else:
+                dst = """%s%s""" % (r["network"], pfx)
+
+            if "metric" in r:
+                metric = "metric " + str(r["metric"]) + " "
+            else:
+                metric = ""
+
+            # "gateway" = next hop
+            out.append("""%s %svia %s""" % (dst, metric, r["gateway"]))
+
+        lines.append(
+            '''routes_%s="\n%s"''' % (_iface_var(name), "\n".join(out))
+        )
+
+    def _render_iface(self, name, iface, lines):
+        routes = []
+        dns_ns = []
+        dns_search = []
+        subnet_config = []
+        dhcp4_opts = []
+        dhcp6_opts = []
+
+        accept_ra = iface.get("accept-ra")
+        ethernet_wol = iface.get("wakeonlan")
+        mtu = iface.get("mtu")
+        mac = iface.get("mac_address")
+
+        dhcpv4 = False
+        dhcpv6 = False
+
+        for subnet in iface.get("subnets", []):
+            stype = subnet["type"]
+            addr = subnet.get("address")
+            gw = subnet.get("gateway")
+
+            if subnet.get("metric"):
+                # no per-subnet metric support in Netifrc
+                LOG.warning(
+                    "Network config: %s: subnet level metric not supported",
+                    name,
+                )
+
+            dhcp4_opts += subnet.get("dhcp4-overrides", [])
+            dhcp6_opts += subnet.get("dhcp6-overrides", [])
+            dns_ns += subnet.get("dns_nameservers", [])
+            dns_search += subnet.get("dns_search", [])
+
+            if stype == "dhcp":
+                dhcpv4 = dhcpv6 = True
+            elif stype == "dhcp4":
+                dhcpv4 = True
+            elif stype == "dhcp6":
+                # "Configure this interface with IPv6 dhcp."
+                dhcpv6 = True
+
+            # v1 compat
+            # These are not possible with the current Netifrc w/ dhcpcd
+            # backend.
+
+            elif stype == "ipv6_dhcpv6-stateful":
+                # "Configure this interface with dhcp6."
+                # so, no SLAAC? (ipv6ra_noautoconf)
+                dhcpv6 = True
+            elif stype == "ipv6_dhcpv6-stateless":
+                # "Configure this interface with SLAAC and DHCP."
+                # same as "dhcp6"
+                dhcpv6 = True
+            elif stype == "ipv6_slaac":
+                # "Configure this interface with dhcp6."
+                # (nodhcp6)
+                dhcpv6 = True
+
+            elif addr:
+                prefix = subnet.get("prefix")
+                if prefix:
+                    subnet_config.append("%s/%d" % (addr, prefix))
+                else:
+                    nm = subnet.get("netmask")
+                    subnet_config.append("%s netmask %s" % (addr, nm))
+
+            if gw:
+                routes.append({"gateway": gw})
+
+            routes += subnet.get("routes", [])
+
+        # config_IFACE="..."
+
+        if dhcpv4 or dhcpv6:
+            subnet_config.append("dhcp")
+        if not subnet_config:
+            subnet_config.append("null")
+        lines.append(
+            '''config_%s="%s"''' % (_iface_var(name), "\n".join(subnet_config))
+        )
+
+        # dhcp(v6)?_IFACE="..."
+
+        if accept_ra is not None:  # no support
+            # this is `ipv6ra_noautoconf`. Again, can't do this w/
+            # Netifrc+dhcpdc.
+            LOG.warning("Network config: %s accept-ra: not supported", name)
+
+        # dhcpv6_ is a dhclient module dialect. As this module assumes dhcpcd,
+        # the lists are eventually combined here. Split them up when
+        # implementing dhclient in the future.
+        #
+        # This could cause some issues. If it really did, sadly, Netifrc is not
+        # for you.
+        dhcp_opts = dhcp4_opts + dhcp6_opts
+        if dhcp_opts:
+            dhcp_opts = _str_list(dhcp_opts)
+            lines.append(
+                '''dhcp_%s="%s"''' % (_iface_var(name), " ".join(dhcp_opts))
+            )
+
+        if dhcpv4 ^ dhcpv6:
+            if dhcpv4:
+                lines.append('''dhcpcd_%s="-4"''' % (_iface_var(name),))
+            else:
+                lines.append('''dhcpcd_%s="-6"''' % (_iface_var(name),))
+
+        # routes_IFACE="..."
+        if routes:
+            self._render_routes(name, routes, lines)
+
+        if dns_ns:
+            lines.append(
+                '''dns_servers_%s="%s"'''
+                % (_iface_var(name), " ".join(dns_ns))
+            )
+        if dns_search:
+            lines.append(
+                '''dns_search_%s="%s"'''
+                % (_iface_var(name), " ".join(dns_search))
+            )
+
+        if mtu:
+            lines.append('''mtu_%s="%s"''' % (_iface_var(name), mtu))
+
+        if mac:
+            lines.append('''mac_%s="%s"''' % (_iface_var(name), mac))
+
+        # FIXME: metric_*="..." ?
+
+        if ethernet_wol:
+            lines.append('''ethtool_change_%s="wol g"''' % (_iface_var(name),))
+
+    def _emit_bond_params(self, iface, name, lines):
+        for k, v in iface.items():
+            k = k.replace("-", "_")  # what a mess
+            if not k.startswith("bond_"):
+                continue
+            fmt = self._bond_opts.get(k)
+            if fmt is None:
+                continue
+
+            if v is list:
+                v = " ".join([str(e) for e in v])
+            elif v is bool:
+                v = str(int(v))
+            else:
+                v = str(v)
+
+            lines.append(fmt % (_iface_var(name), v))
+
+    def _render_interfaces(self, network_state):
+        lines = []
+        all_bridged_ports = []
+        bond_map = dict[str, set]()
+        vlan_map = dict[str, list]()
+
+        for iface in network_state.iter_interfaces():
+            name = iface["name"]
+            type = iface.get("type")
+            bond_master = iface.get("bond-master")
+
+            # `config_lo="..."` is completely valid and works
+            # if name == "lo":
+            # continue
+
+            iface = copy.deepcopy(iface)
+
+            if bond_master:
+                ports = bond_map.setdefault(bond_master, set())
+                ports.add(name)
+
+            if type == "vlan":
+                link = iface["vlan-raw-device"]
+                vlan_id = iface["vlan_id"]
+                vlan_list = vlan_map.setdefault(link, [])
+                vlan_list.append(str(vlan_id))
+                lines.append('''%s_vlan%d_name="%s"''' % (link, vlan_id, name))
+            elif type == "bridge":
+                # params
+
+                bridge_fd = iface.get("bridge_fd")
+                if bridge_fd:
+                    lines.append(
+                        '''bridge_forward_delay_%s="%d"'''
+                        % (_iface_var(name), bridge_fd)
+                    )
+                bridge_stp = iface.get("bridge_stp")
+                if bridge_stp:
+                    lines.append(
+                        '''bridge_stp_state_%s="%d"'''
+                        % (_iface_var(name), bridge_stp)
+                    )
+                bridge_hello = iface.get("bridge_hello")
+                if bridge_hello:
+                    lines.append(
+                        '''bridge_hello_time_%s="%d"'''
+                        % (_iface_var(name), bridge_hello)
+                    )
+
+                bridge_ports = iface["bridge_ports"]
+                all_bridged_ports += bridge_ports
+                lines.append(
+                    '''bridge_%s="%s"'''
+                    % (_iface_var(name), " ".join(bridge_ports))
+                )
+            elif type == "bond":
+                self._emit_bond_params(iface, name, lines)
+
+            if bond_master and iface.pop("subnets", None):
+                # if it's a bond slave but had subnets
+                LOG.warning(
+                    "Network config: %s: subnets in bond slave removed", name
+                )
+
+            iface.pop(
+                "name", None
+            )  # make sure it's not referenced in the tail
+            self._render_iface(name, iface, lines)
+            lines.append("")
+        lines.append("")
+
+        if all_bridged_ports:
+            # "nullify" all_bridged_ports
+            # (Netifrc requires slave interfaces to be "null")
+            for name in all_bridged_ports:
+                lines.append('''config_%s="null"''' % (_iface_var(name),))
+            lines.append("")
+
+        if bond_map:
+            # construct slaves_*="..."
+            for name, ports in bond_map.items():
+                lines.append(
+                    '''slaves_%s="%s"''' % (_iface_var(name), " ".join(ports))
+                )
+            lines.append("")
+
+        if vlan_map:
+            # construct vlans_*="..."
+            for name, vlan_list in vlan_map.items():
+                lines.append(
+                    '''vlans_%s="%s"'''
+                    % (_iface_var(name), " ".join(vlan_list))
+                )
+            # lines.append("")
+
+        return self.netifrc_header + "\n".join(lines)
+
+    def _render_global_dns(
+        self,
+        network_state: NetworkState,
+    ):
+        # OpenRC says: keep it old fashioned and simple
+        # Render global DNS in resolv.conf
+
+        resolv = ["# Generated by cloud-init netifrc module"]
+        if network_state.dns_nameservers:
+            for ns in network_state.dns_nameservers:
+                resolv.append("nameserver " + ns)
+        if network_state.dns_searchdomains:
+            for s in network_state.dns_searchdomains:
+                resolv.append("search " + s)
+
+        return self.netifrc_header + "\n".join(resolv)
+
+    def render_network_state(
+        self,
+        network_state: NetworkState,
+        templates: Optional[dict] = None,
+        target=None,
+    ) -> None:
+        fp = subp.target_path(target, self.netifrc_path)
+        util.ensure_dir(os.path.dirname(fp))
+        util.write_file(fp, self._render_interfaces(network_state))
+
+        # create symlinks
+        # TODO: unit test
+
+        for iface in network_state.iter_interfaces():
+            name = iface["name"]
+            if name == "lo":
+                # don't link the original script to itself
+                continue
+            src = subp.target_path(target, self.initd_netlo_path)
+            dst = subp.target_path(target, self.initd_net_prefix + name)
+            util.sym_link(src, dst, True)
+
+        # resolv.conf
+        # TODO: unit test
+
+        fp = subp.target_path(target, self.resolv_conf_path)
+        util.write_file(fp, self._render_global_dns(network_state))
+
+
+def available(target=None):
+    rc = subp.target_path(target, "etc/init.d/net.lo")
+    if not os.path.isfile(rc):
+        return False
+
+    return True

--- a/cloudinit/net/renderers.py
+++ b/cloudinit/net/renderers.py
@@ -7,6 +7,7 @@ from cloudinit.net import (
     eni,
     freebsd,
     netbsd,
+    netifrc,
     netplan,
     network_manager,
     networkd,
@@ -24,6 +25,7 @@ NAME_TO_RENDERER = {
     "networkd": networkd,
     "openbsd": openbsd,
     "sysconfig": sysconfig,
+    "netifrc": netifrc,
 }
 
 DEFAULT_PRIORITY = [
@@ -35,6 +37,7 @@ DEFAULT_PRIORITY = [
     "netbsd",
     "openbsd",
     "networkd",
+    "netifrc",
 ]
 
 

--- a/doc/rtd/reference/network-config.rst
+++ b/doc/rtd/reference/network-config.rst
@@ -212,6 +212,12 @@ calls something akin to `FreeBSD.start_services`_ which will invoke applicable
 network services to setup the network, making network activators unneeded
 for BSD flavors at the moment.
 
+Netifrc
+-------
+
+netifrc is Gentoo's default framework for configuring and managing network
+interfaces on systems running OpenRC.
+
 Network output policy
 =====================
 
@@ -231,6 +237,7 @@ preference) is as follows:
 - NetBSD
 - OpenBSD
 - Networkd
+- Netifrc
 
 The default policy for selecting a network ``activator`` (in order of
 preference) is as follows:
@@ -239,6 +246,7 @@ preference) is as follows:
 - **Netplan**: using ``netplan apply`` to manage device setup/teardown
 - **NetworkManager**: using ``nmcli`` to manage device setup/teardown
 - **Networkd**: using ``ip`` to manage device setup/teardown
+- **Netifrc**: using ``rc-service`` to manage device setup/teardown
 
 When applying the policy, ``cloud-init`` checks if the current instance has the
 correct binaries and paths to support the renderer. The first renderer that
@@ -247,8 +255,8 @@ supplying an updated configuration in cloud-config. ::
 
   system_info:
     network:
-      renderers: ['netplan', 'network-manager', 'eni', 'sysconfig', 'freebsd', 'netbsd', 'openbsd']
-      activators: ['eni', 'netplan', 'network-manager', 'networkd']
+      renderers: ['netplan', 'network-manager', 'eni', 'sysconfig', 'netifrc', 'freebsd', 'netbsd', 'openbsd']
+      activators: ['eni', 'netplan', 'network-manager', 'networkd', 'netifrc']
 
 Network configuration tools
 ===========================
@@ -271,7 +279,7 @@ Example output:
 
    usage: /usr/bin/cloud-init devel net-convert [-h] -p PATH -k {eni,network_data.json,yaml,azure-imds,vmware-imc} -d PATH -D
                                                   {alpine,arch,azurelinux,debian,ubuntu,freebsd,dragonfly,gentoo,cos,netbsd,openbsd,almalinux,amazon,centos,cloudlinux,eurolinux,fedora,mariner,miraclelinux,openmandriva,photon,rhel,rocky,virtuozzo,opensuse,sles,openEuler,raspberry-pi-os}
-                                                  [-m name,mac] [--debug] -O {eni,netplan,networkd,sysconfig,network-manager}
+                                                  [-m name,mac] [--debug] -O {eni,netplan,networkd,sysconfig,network-manager,netifrc}
 
    options:
      -h, --help            show this help message and exit
@@ -285,7 +293,7 @@ Example output:
      -m name,mac, --mac name,mac
                            interface name to mac mapping
      --debug               enable debug logging to stderr.
-     -O {eni,netplan,networkd,sysconfig,network-manager}, --output-kind {eni,netplan,networkd,sysconfig,network-manager}
+     -O {eni,netplan,networkd,sysconfig,network-manager,netifrc}, --output-kind {eni,netplan,networkd,sysconfig,network-manager,netifrc}
                            The network config format to emit
 
 Example of converting V2 to sysconfig:
@@ -327,3 +335,4 @@ Example output:
 .. _Vultr JSON meta-data: https://www.vultr.com/metadata/
 .. _cloudinit.net.activators.select_activator: https://github.com/canonical/cloud-init/blob/main/cloudinit/net/activators.py#L249
 .. _FreeBSD.start_services: https://github.com/canonical/cloud-init/blob/main/cloudinit/net/freebsd.py#L46
+.. _Netifrc: https://wiki.gentoo.org/wiki/Netifrc

--- a/tests/unittests/net/network_configs.py
+++ b/tests/unittests/net/network_configs.py
@@ -257,6 +257,16 @@ NETWORK_CONFIGS = {
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_eth99="192.168.21.3/24\ndhcp"',
+            'dhcpcd_eth99="-4"',
+            'dns_servers_eth99="8.8.8.8 8.8.4.4"',
+            'dns_search_eth99="barley.maas sach.maas"',
+            'routes_eth99="\ndefault metric 10000 via 65.61.151.37"',
+            'config_eth1="null"',
+            'dns_servers_lo="1.2.3.4 5.6.7.8"',
+            'dns_search_lo="wark.maas"',
+        },
         "yaml": textwrap.dedent(
             """
             version: 1
@@ -430,6 +440,14 @@ NETWORK_CONFIGS = {
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_eth1="null"',
+            'config_eth99="192.168.21.3/24\ndhcp"',
+            'dhcpcd_eth99="-4"',
+            'dns_servers_eth99="8.8.8.8 8.8.4.4"',
+            'dns_search_eth99="barley.maas sach.maas"',
+            'routes_eth99="\ndefault metric 10000 via 65.61.151.37"',
+        },
         "yaml": textwrap.dedent(
             """
             version: 2
@@ -525,6 +543,9 @@ NETWORK_CONFIGS = {
 
                 """
             ),
+        },
+        "expected_netifrc": {
+            'config_iface0="dhcp"',
         },
         "yaml_v1": textwrap.dedent(
             """\
@@ -669,6 +690,10 @@ NETWORK_CONFIGS = {
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_iface0="192.168.14.2/24\n2001:1::1/64"',
+            'mtu_iface0="8999"',
+        },
     },
     "v2_ipv4_and_ipv6_static": {
         "yaml_v2": textwrap.dedent(
@@ -783,6 +808,10 @@ NETWORK_CONFIGS = {
 
                 """
             ),
+        },
+        "expected_netifrc": {
+            'config_iface0="192.168.14.2/24\n2001:1::1/64"',
+            'mtu_iface0="9000"',
         },
     },
     "v6_and_v4": {
@@ -927,6 +956,10 @@ NETWORK_CONFIGS = {
 
                 """
             ),
+        },
+        "expected_netifrc": {
+            'config_iface0="dhcp"',
+            'dhcpcd_iface0="-6"',
         },
     },
     "dhcpv6_accept_ra": {
@@ -1161,6 +1194,10 @@ NETWORK_CONFIGS = {
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_iface0="dhcp"',
+            'dhcpcd_iface0="-6"',
+        },
     },
     "static6": {
         "yaml_v1": textwrap.dedent(
@@ -1286,6 +1323,10 @@ NETWORK_CONFIGS = {
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_iface0="dhcp"',
+            'dhcpcd_iface0="-6"',
+        },
     },
     "dhcpv6_stateful": {
         "expected_eni": textwrap.dedent(
@@ -1345,6 +1386,10 @@ NETWORK_CONFIGS = {
             USERCTL=no
             """
             ),
+        },
+        "expected_netifrc": {
+            'config_iface0="dhcp"',
+            'dhcpcd_iface0="-6"',
         },
     },
     "wakeonlan_disabled": {
@@ -1409,6 +1454,10 @@ NETWORK_CONFIGS = {
 
                 """
             ),
+        },
+        "expected_netifrc": {
+            'config_iface0="dhcp"',
+            'dhcpcd_iface0="-4"',
         },
         "yaml_v2": textwrap.dedent(
             """\
@@ -1486,6 +1535,11 @@ NETWORK_CONFIGS = {
 
                 """
             ),
+        },
+        "expected_netifrc": {
+            'config_iface0="dhcp"',
+            'dhcpcd_iface0="-4"',
+            'ethtool_change_iface0="wol g"',
         },
         "yaml_v2": textwrap.dedent(
             """\
@@ -2933,6 +2987,49 @@ pre-down route del -net 10.0.0.0/8 gw 11.0.0.1 metric 3 || true
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_eth0="null"',
+            'config_eth1="null"',
+            'config_eth2="null"',
+            'config_eth3="null"',
+            'config_eth4="null"',
+            'config_eth5="dhcp"',
+            'dhcpcd_eth5="-4"',
+            'vlans_eth0="101"',
+            'eth0_vlan101_name="eth0.101"',
+            'mtu_eth0_101="1500"',
+            'config_eth0_101="192.168.0.2/24\n192.168.2.10/24"',
+            'routes_eth0_101="\ndefault via 192.168.0.1"',
+            'dns_servers_eth0_101="192.168.0.10 10.23.23.134"',
+            'dns_search_eth0_101="barley.maas sacchromyces.maas '
+            'brettanomyces.maas"',
+            'slaves_bond0="eth1 eth2"',
+            'xmit_hash_policy_bond0="layer3+4"',
+            'miimon_bond0="100"',
+            'mode_bond0="active-backup"',
+            'config_bond0="dhcp"',
+            'dhcpcd_bond0="-6"',
+            'vlans_bond0="200"',
+            'bond0_vlan200_name="bond0.200"',
+            'config_bond0_200="dhcp"',
+            'dhcpcd_bond0_200="-4"',
+            'bridge_br0="eth3 eth4"',
+            'bridge_br0="eth3 eth4"',
+            'bridge_ageing_time_br0="250"',
+            'bridge_forward_delay_br0="1"',
+            'bridge_hello_time_br0="1"',
+            'bridge_max_age_br0="10"',
+            'brport_path_cost_eth3="50"',
+            'brport_path_cost_eth4="75"',
+            'brport_priority_eth3="28"',
+            'brport_priority_eth4="14"',
+            'bridge_priority_br0="22"',
+            'bridge_stp_state_br0="0"',
+            'config_br0="192.168.14.2/24\n2001:1::1/64"',
+            'routes_br0="\ndefault via 2001:4800:78ff:1b::1"',
+            'dns_servers_br0="8.8.8.8 4.4.4.4 8.8.4.4"',
+            'dns_search_br0="barley.maas wark.maas foobar.maas"',
+        },
         "yaml": textwrap.dedent(
             """
             version: 2
@@ -3382,6 +3479,25 @@ iface bond0 inet6 static
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_bond0s0="null"',
+            'config_bond0s1="null"',
+            'config_bond0="192.168.0.2/24\n192.168.1.2/24\n2001:1::1/92"',
+            'routes_bond0="\ndefault via 192.168.0.1\n10.1.3.0/24 via '
+            "192.168.0.3\n2001:67c::/32 via 2001:67c:1562::1\n"
+            '3001:67c::/32 metric 10000 via 3001:67c:15::1"',
+            'mtu_bond0="9000"',
+            'slaves_bond0="bond0s0 bond0s1"',
+            'mode_bond0="active-backup"',
+            'miimon_bond0="100"',
+            'xmit_hash_policy_bond0="layer3+4"',
+            'num_grat_arp_bond0="5"',
+            'downdelay_bond0="10"',
+            'updelay_bond0="20"',
+            'fail_over_mac_bond0="active"',
+            'primary_bond0="bond0s0"',
+            'primary_reselect_bond0="always"',
+        },
     },
     "bond_v2": {
         "yaml": textwrap.dedent(
@@ -3735,6 +3851,25 @@ iface bond0 inet6 static
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_bond0s0="null"',
+            'config_bond0s1="null"',
+            'config_bond0="192.168.0.2/24\n192.168.1.2/24\n2001:1::1/92"',
+            'routes_bond0="\ndefault via 192.168.0.1\n10.1.3.0/24 via '
+            "192.168.0.3\n2001:67c::/32 via 2001:67c:1562::1\n3001:67c::/32 "
+            'metric 10000 via 3001:67c:15::1"',
+            'mtu_bond0="9000"',
+            'slaves_bond0="bond0s0 bond0s1"',
+            'mode_bond0="active-backup"',
+            'miimon_bond0="100"',
+            'xmit_hash_policy_bond0="layer3+4"',
+            'num_grat_arp_bond0="5"',
+            'downdelay_bond0="10"',
+            'updelay_bond0="20"',
+            'fail_over_mac_bond0="active"',
+            'primary_bond0="bond0s0"',
+            'primary_reselect_bond0="always"',
+        },
     },
     "vlan_v1": {
         "yaml": textwrap.dedent(
@@ -3871,6 +4006,14 @@ iface bond0 inet6 static
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_en0="null"',
+            'vlans_en0="99"',
+            'en0_vlan99_name="en0.99"',
+            'mtu_en0_99="2222"',
+            'config_en0_99="192.168.2.2/24 192.168.1.2/24 2001:1::bbbb/96"',
+            'routes_en0_99="\ndefault via 192.168.1.1\ndefault via 2001:1::1"',
+        },
     },
     "vlan_v2": {
         "yaml": textwrap.dedent(
@@ -4005,6 +4148,14 @@ iface bond0 inet6 static
 
                 """
             ),
+        },
+        "expected_netifrc": {
+            'config_en0="null"',
+            'vlans_en0="99"',
+            'en0_vlan99_name="en0.99"',
+            'mtu_en0_99="2222"',
+            'config_en0_99="192.168.2.2/24 192.168.1.2/24 2001:1::bbbb/96"',
+            'routes_en0_99="\ndefault via 192.168.1.1\ndefault via 2001:1::1"',
         },
     },
     "bridge": {
@@ -4217,6 +4368,14 @@ iface bond0 inet6 static
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_eth0="2001:1::100/96"',
+            'config_eth1="2001:1::101/96"',
+            'config_br0="192.168.2.2/24"',
+            'bridge_br0="eth0 eth1"',
+            'bridge_priority_br0="22"',
+            'bridge_stp_state_br0="0"',
+        },
     },
     "manual": {
         "yaml": textwrap.dedent(
@@ -4415,6 +4574,12 @@ iface bond0 inet6 static
                 """
             ),
         },
+        "expected_netifrc": {
+            'config_eth0="192.168.1.2/24"',
+            'config_eth1="null"',
+            'mtu_eth1="1480"',
+            'config_eth2="null"',
+        },
     },
     "v1-dns": {
         "expected_networkd": textwrap.dedent(
@@ -4548,6 +4713,14 @@ iface bond0 inet6 static
 
             """
             )
+        },
+        "expected_netifrc": {
+            'config_interface0="192.168.1.20/16"',
+            'routes_interface0="\ndefault via 192.168.1.1"',
+            'dns_search_interface0="cccc"',
+            'dns_servers_lo="2.2.2.2 FEDC::1"',
+            'dns_search_lo="bbbb"',
+            'dns_servers_interface0="3.3.3.3"',
         },
         "yaml": textwrap.dedent(
             """\
@@ -4784,6 +4957,12 @@ iface bond0 inet6 static
 
             """
             )
+        },
+        "expected_netifrc": {
+            'config_eth0="192.168.1.20/16\n'
+            '2001:bc8:1210:232:dc00:ff:fe20:185/64"',
+            'dns_servers_eth0="8.8.8.8 FEDC::1"',
+            'dns_search_eth0="lab home"',
         },
         "yaml": textwrap.dedent(
             """\

--- a/tests/unittests/test_net.py
+++ b/tests/unittests/test_net.py
@@ -4984,7 +4984,11 @@ class TestNetifrcNetRendering:
         renderer.render_network_state(ns, target=render_dir)
 
         initd_net_prefix = os.path.join(render_dir, renderer.initd_net_prefix)
+        runlevel_default_prefix = os.path.join(
+            render_dir, renderer.runlevel_default_prefix
+        )
         assert os.path.exists(initd_net_prefix + "eth1000")
+        assert os.path.exists(runlevel_default_prefix + "eth1000")
 
         contents = _extract_netifrc_lines(
             os.path.join(render_dir, renderer.netifrc_path)


### PR DESCRIPTION
## Proposed Commit Message
```
feat(Gentoo): Netifrc net config rendering support

Fixes GH-6359
```

## Additional Context
https://bugs.gentoo.org/961141

> On Gentoo, Netifrc and dhcpcd are the only option on musl-only systems. dhcpcd is limited by the protocol itself and some cloud service providers rely on the IMDS entirely for net config. Adding Netifrc support to Cloud-init fixes this.

https://github.com/gentoo/gentoo/pull/43323

> For most cases, running Cloud-init without network rendering is okay as long as
only one address of each IP version(4, 6) on one network interface is involved.
Anything more than that, for example, multiple addresses, pushing routes, DNS
servers and so on cannot be achieved by simply running dhcpcd due to the
limitation of DHCP as well as provider's architectural design.
>
>As Netifrc and standalone dhcpcd were the only options with Musl, complex cloud
network setup on cloud instances was not possible.
>
>The patches add the experimental Netifrc network renderer support. Musl Gentoo
users can now enjoy cloud-init's network rendering.

https://wiki.gentoo.org/wiki/Google_Summer_of_Code/2017/Ideas/Better_Gentoo_Support_in_cloud-init

> cloud-init currently uses a deprecated network back end for Gentoo. This proposal seeks to convert cloud-init's Gentoo back end to the new back end. A possible further goal would be to extend systemd support for cloud-init on Gentoo, mainly on the network side. 

#6359 
#4810 

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
