### PR TITLE
fix: make tools/tox-venv with current versions of tox.

### DIFF
--- a/tools/tox-venv
+++ b/tools/tox-venv
@@ -22,7 +22,7 @@ get_env_dirs() {
             key=${key%%=*}
             val=${equal}
         fi
-        [ "$key" = "envdir" ] || continue
+        [ "$key" = "envdir" ] || [ "$key" = "env_dir" ] || continue
         out="${out:+${out}${CR}}${curenv}:$val"
     done
     echo "$out"


### PR DESCRIPTION
## Proposed Commit Message

```
fix: make tools/tox-venv with current versions of tox.

At some point in the past, 'tox --showconfig' would output 'envdir' 
for the directory of the virtual environment. current versions use `env_dir`.

The change here makes ./tools/tox-venv work as it expects. 
Now './tools/tox-venv --list' will show the environments available.

    $ ./tools/tox-venv --list
    py3*
    black
    ruff
    isort
    mypy
    pylint
```
