### PR TITLE
feat(password): support type=RANDOM_FRIENDLY

### DIFF
--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -261,7 +261,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         raise errors[-1]
 
 
-def _friendly_characters(input: str) -> str:
+def _friendly_characters(input: str) -> list[str]:
     return [x for x in input if x not in _unfriendly_characters]
 
 

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -261,7 +261,7 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         raise errors[-1]
 
 
-def _friendly_characters(input: str) -> list[str]:
+def _friendly_characters(input: str) -> List[str]:
     return [x for x in input if x not in _unfriendly_characters]
 
 

--- a/cloudinit/config/cc_set_passwords.py
+++ b/cloudinit/config/cc_set_passwords.py
@@ -261,8 +261,8 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         raise errors[-1]
 
 
-def _friendly_characters(input: str) -> List[str]:
-    return [x for x in input if x not in _unfriendly_characters]
+def _friendly_characters(input: str) -> str:
+    return "".join([x for x in input if x not in _unfriendly_characters])
 
 
 def rand_user_password(pwlen=20, type="RANDOM") -> str:

--- a/doc/module-docs/cc_set_passwords/data.yaml
+++ b/doc/module-docs/cc_set_passwords/data.yaml
@@ -43,6 +43,10 @@ cc_set_passwords:
       - Set the password for user2 to a pre-hashed password.
       - Set the password for user3 to be a randomly generated password, which
         will be written to the system console.
+      - Set the password for user4 to be a randomly generated password.
+        This "friendly" style of random password will be generated without
+        punctuation or characters which are likely to be ambiguous to
+        human readers and will be written to the system console.
     file: cc_set_passwords/example2.yaml
   - comment: |
       Example 3: Disable SSH password authentication and PAM interactive

--- a/doc/module-docs/cc_set_passwords/example2.yaml
+++ b/doc/module-docs/cc_set_passwords/example2.yaml
@@ -5,4 +5,5 @@ chpasswd:
   - {name: user1, password: password1, type: text}
   - {name: user2, password: $6$rounds=4096$5DJ8a9WMTEzIo5J4$Yms6imfeBvf3Yfu84mQBerh18l7OR1Wm1BJXZqFSpJ6BVas0AYJqIjP7czkOaAZHZi1kxQ5Y1IhgWN8K9NgxR1}
   - {name: user3, type: RANDOM}
+  - {name: user4, type: RANDOM_FRIENDLY}
 ssh_pwauth: false

--- a/tests/unittests/config/test_cc_set_passwords.py
+++ b/tests/unittests/config/test_cc_set_passwords.py
@@ -586,7 +586,8 @@ class TestRandUserPassword:
             (20, 4),
         ],
     )
-    def test_rand_user_password(self, strlen, expected_result):
+    @pytest.mark.parametrize("type", ["RANDOM", "R", "RANDOM_FRIENDLY"])
+    def test_rand_user_password(self, strlen, expected_result, type):
         if expected_result is ValueError:
             with pytest.raises(
                 expected_result,
@@ -594,7 +595,12 @@ class TestRandUserPassword:
             ):
                 setpass.rand_user_password(strlen)
         else:
-            rand_password = setpass.rand_user_password(strlen)
+            rand_password = setpass.rand_user_password(strlen, type=type)
+            if type == "RANDOM_FRIENDLY":
+                expected_result -= 1
+                for c in rand_password:
+                    assert c not in setpass._unfriendly_characters
+                    assert c not in string.punctuation
             assert len(rand_password) == strlen
             assert self._get_str_class_num(rand_password) == expected_result
 


### PR DESCRIPTION
In GH PR #5815, the previous random password schema was enhanced to support generation of stronger passwords.  These passwords can however be challenging for a human to read due to excessive punctuation and ambiguous characters. (quick - lI1 - which character is which?  Your results here will vary depending on the display font)

Add a new password type RANDOM_FRIENDLY that generates passwords like the pre-PR5815 scheme, with no punctuation and excluding the same set of ambiguous characters.

LP: #[2118989](https://bugs.launchpad.net/ubuntu/+source/subiquity/+bug/2118989)
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(password): support type=RANDOM_FRIENDLY

In GH PR #5815, the previous random password schema was enhanced to
support generation of stronger passwords.  These passwords can however
be challenging for a human to read due to excessive punctuation and
ambiguous characters. (quick - lI1 - which character is which?  Your
results here will vary depending on the display font)

Add a new password type RANDOM_FRIENDLY that generates passwords like
the pre-PR5815 scheme, with no punctuation and excluding the same set of
ambiguous characters.

LP: #2118989
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
