### PR TITLE
test: support systemctl try-reload-or-restart messaging alternatives

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -26,7 +26,7 @@ from tests.integration_tests.integration_settings import (
     OS_IMAGE_TYPE,
     PLATFORM,
 )
-from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU
+from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, NOBLE
 from tests.integration_tests.util import (
     get_feature_flag_value,
     get_inactive_modules,
@@ -264,9 +264,13 @@ class TestCombined:
             # Some minimal images may not have an installed rsyslog package
             # Test user-data doesn't provide install_rsyslog: true so expect
             # warnings when not installed.
+            if CURRENT_RELEASE < NOBLE:
+                operation_name = "reload-or-try-restart"
+            else:
+                operation_name = "try-reload-or-restart"
             require_warnings.append(
-                "Failed to try-reload-or-restart rsyslog.service:"
-                " Unit rsyslog.service not found."
+                f"Failed to {operation_name} rsyslog.service: Unit"
+                " rsyslog.service not found."
             )
         # Set ignore_deprecations=True as test_deprecated_message covers this
         verify_clean_boot(


### PR DESCRIPTION
## Proposed Commit Message

```
test: support systemctl try-reload-or-restart messaging alternatives

systemd 251 changed response message text from reload-or-try-restart to
try-reload-or-restart
```

## Additional Context
Jenkins failures seen on Ubuntu noble but not questing due to systemd name changes.
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_container-minimal/116/testReport/junit/tests.integration_tests.modules.test_combined/TestCombined/test_no_problems/


## Test Steps
```
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_OS_IMAGE_TYPE=minimal CLOUD_INIT_OS_IMAGE=questing CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems

# AND
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_OS_IMAGE_TYPE=minimal CLOUD_INIT_OS_IMAGE=noble CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
