### PR TITLE
Add 'to: default' support in network state

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -16,6 +16,7 @@ from cloudinit.net import (
     ipv4_mask_to_net_prefix,
     ipv6_mask_to_net_prefix,
     is_ip_network,
+    is_ipv4_address,
     is_ipv4_network,
     is_ipv6_address,
     is_ipv6_network,
@@ -991,6 +992,22 @@ def _normalize_net_keys(network, address_keys=()):
         raise ValueError(message)
 
     addr = str(net.get(addr_key))
+    if addr == "default":
+        gw_ip = str(net.get("gateway"))
+        if not gw_ip:
+            message = "Gateway IP is empty"
+            LOG.error(message)
+            raise ValueError(message)
+
+        if is_ipv4_address(gw_ip):
+            addr = "0.0.0.0/0"
+        elif is_ipv6_address(gw_ip):
+            addr = "::/0"
+        else:
+            message = f"Invalid Gateway IP: '{gw_ip}'"
+            LOG.error(message)
+            raise ValueError(message)
+
     if not is_ip_network(addr):
         LOG.error("Address %s is not a valid ip network", addr)
         raise ValueError(f"Address {addr} is not a valid ip address")

--- a/doc/rtd/reference/network-config-format-v2.rst
+++ b/doc/rtd/reference/network-config-format-v2.rst
@@ -296,12 +296,15 @@ Example: ::
 -----------------------------------
 
 Add device specific routes. Each mapping includes a ``to``, ``via`` key
-with an IPv4 or IPv6 address as value. ``metric`` is an optional value.
+with an IPv4 or IPv6 address as value. ``to: default`` may be used to
+configure the default route. ``metric`` is an optional value.
+``table`` is an optional numeric ID or name of the routing table for
+policy-based routing.
 
 Example: ::
 
   routes:
-   - to: 0.0.0.0/0
+   - to: default  # could be 0.0.0.0/0 optionally
      via: 10.23.2.1
      metric: 3
 

--- a/tests/unittests/net/artifacts/photon_net_config_v2.yaml
+++ b/tests/unittests/net/artifacts/photon_net_config_v2.yaml
@@ -10,11 +10,11 @@ network:
       mtu: 1500
       addresses: [192.0.2.10/24]
       routes:
-        - to: 0.0.0.0/0
+        - to: default
           via: 192.168.14.1
           metric: 50
           table: 10
-        - to: ::/0
+        - to: default
           via: 2001:1::2
           metric: 100
       routing-policy:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(network_state): add 'to: default' support in network state

Add `to: default` support during routes configuration from network config v2
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
