### PR TITLE
Ubuntu/devel: ensure binary versions match

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+cloud-init (25.3-~1gxxxxxxxx-0ubuntu1) UNRELEASED; urgency=medium
+
+  * d/control: Ensure binary packages depend on same version of
+    cloud-init-base.
+
+ -- James Falcon <james.falcon@canonical.com>  Fri, 15 Aug 2025 14:44:27 -0500
+
 cloud-init (25.2-0ubuntu1) questing; urgency=medium
 
   * Upstream snapshot based on 25.2.

--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,7 @@ Description: initialization and customization tool for cloud instances
 
 Package: cloud-init-azure
 Architecture: all
-Depends: cloud-init-base,
+Depends: cloud-init-base (= ${binary:Version}),
          python3-passlib,
          ${misc:Depends},
 Description: Azure specific cloud-init
@@ -60,7 +60,7 @@ Description: Azure specific cloud-init
 
 Package: cloud-init-cloud-sigma
 Architecture: all
-Depends: cloud-init-base,
+Depends: cloud-init-base (= ${binary:Version}),
          python3-serial,
          ${misc:Depends},
 Description: Cloud Sigma specific cloud-init
@@ -69,7 +69,7 @@ Description: Cloud Sigma specific cloud-init
 
 Package: cloud-init-smart-os
 Architecture: all
-Depends: cloud-init-base,
+Depends: cloud-init-base (= ${binary:Version}),
          python3-serial,
          ${misc:Depends},
 Description: Smart OS specific cloud-init
@@ -78,7 +78,7 @@ Description: Smart OS specific cloud-init
 
 Package: cloud-init
 Architecture: all
-Depends: cloud-init-base,
+Depends: cloud-init-base (= ${binary:Version}),
          python3-serial,
          python3-passlib,
          ${misc:Depends},


### PR DESCRIPTION
Without this, one can manually `apt install cloud-init` and receive an updated version of `cloud-init` without the corresponding updated `cloud-init-base`. Since all of the functionality is contained within `cloud-init-base`, this wouldn't be what anybody wants.