### PR TITLE
Render vlan, bond, bridge device mac address properly in network state

### DIFF
--- a/cloudinit/net/network_state.py
+++ b/cloudinit/net/network_state.py
@@ -432,6 +432,10 @@ class NetworkStateInterpreter:
                 "keep_configuration": command.get("keep_configuration"),
             }
         )
+
+        if iface["mac_address"]:
+            iface["mac_address"] = iface["mac_address"].lower()
+
         iface_key = command.get("config_id", command.get("name"))
         self._network_state["interfaces"].update({iface_key: iface})
         self.dump_network_state()
@@ -791,6 +795,7 @@ class NetworkStateInterpreter:
                 "name": vlan,
                 "vlan_id": cfg.get("id"),
                 "vlan_link": cfg.get("link"),
+                "mac_address": cfg.get("macaddress"),
             }
             if "mtu" in cfg:
                 vlan_cmd["mtu"] = cfg["mtu"]
@@ -848,8 +853,11 @@ class NetworkStateInterpreter:
                 cmd_type + "_interfaces": item_cfg.get("interfaces"),
                 "params": dict((v2key_to_v1[k], v) for k, v in params.items()),
             }
+
             if "mtu" in item_cfg:
                 v1_cmd["mtu"] = item_cfg["mtu"]
+            if "macaddress" in item_cfg:
+                v1_cmd["mac_address"] = item_cfg["macaddress"]
 
             warn_deprecated_all_devices(item_cfg)
             subnets = self._v2_to_v1_ipcfg(item_cfg)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
feat(network_state): render vlan, bond, bridge device mac address properly in network state

Currently mac_address given through config yaml is ignored and mac address is not accessible
while iterating through interfaces.
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
