### PR TITLE
doc: change `jammy` to `noble` in libvirt instance creation

### DIFF
--- a/doc/rtd/howto/launch_libvirt.rst
+++ b/doc/rtd/howto/launch_libvirt.rst
@@ -21,8 +21,8 @@ Create an instance
 .. code-block:: shell-session
 
     virt-install --name cloud-init-001 --memory 4000 --noreboot \
-        --os-variant detect=on,name=ubuntujammy \
-        --disk=size=10,backing_store="$(pwd)/jammy-server-cloudimg-amd64.img" \
+        --os-variant detect=on,name=ubuntunoble \
+        --disk=size=10,backing_store="$(pwd)/noble-server-cloudimg-amd64.img" \
         --cloud-init user-data="$(pwd)/user-data,meta-data=$(pwd)/meta-data,network-config=$(pwd)/network-config"
 
 .. LINKS


### PR DESCRIPTION
## Proposed Commit Message
```
doc: change `jammy` to `noble` in libvirt instance creation
```

## Additional Context
URL: https://docs.cloud-init.io/en/latest/howto/launch_libvirt.html

User downloads `noble` image in [Download a cloud image](https://docs.cloud-init.io/en/latest/howto/launch_libvirt.html#download-a-cloud-image) section but [Create an instance](https://docs.cloud-init.io/en/latest/howto/launch_libvirt.html#create-an-instance) is using `jammy-server-cloudimg-amd64.img` image.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
