### PR TITLE
set USR_LIB_EXEC for openEuler

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,9 @@ LIB = "lib"
 if os.uname()[0] in ["FreeBSD", "DragonFly", "OpenBSD"]:
     USR = "usr/local"
     USR_LIB_EXEC = "usr/local/lib"
-elif os.path.isfile("/etc/redhat-release"):
+elif os.path.isfile("/etc/redhat-release") or os.path.isfile(
+    "/etc/openEuler-release"
+):
     USR_LIB_EXEC = "usr/libexec"
 elif os.path.isfile("/etc/system-release-cpe"):
     with open("/etc/system-release-cpe") as f:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message

set USR_LIB_EXEC for openEuler in setup.py

Fixes: [GH-6329](https://github.com/canonical/cloud-init/issues/6329)

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
