### PR TITLE
fix: avoid dependency cycle on Fedora

### DIFF
--- a/systemd/cloud-init-local.service.tmpl
+++ b/systemd/cloud-init-local.service.tmpl
@@ -2,7 +2,7 @@
 [Unit]
 # https://docs.cloud-init.io/en/latest/explanation/boot.html
 Description=Cloud-init: Local Stage (pre-network)
-{% if variant in ["almalinux", "cloudlinux", "ubuntu", "unknown", "debian", "raspberry-pi-os", "rhel"] %}
+{% if variant in ["almalinux", "cloudlinux", "ubuntu", "unknown", "debian", "raspberry-pi-os", "rhel", "fedora"] %}
 DefaultDependencies=no
 {% endif %}
 Wants=network-pre.target
@@ -23,7 +23,7 @@ ConditionEnvironment=!KERNEL_CMDLINE=cloud-init=disabled
 
 [Service]
 Type=oneshot
-{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
+{% if variant in ["almalinux", "cloudlinux", "rhel", "fedora"] %}
 ExecStartPre=/sbin/restorecon /run/cloud-init
 {% endif %}
 # This service is a shim which preserves systemd ordering while allowing a

--- a/systemd/cloud-init-main.service.tmpl
+++ b/systemd/cloud-init-main.service.tmpl
@@ -8,7 +8,7 @@
 # https://www.freedesktop.org/software/systemd/man/latest/systemd-remount-fs.service.html
 [Unit]
 Description=Cloud-init: Single Process
-{% if variant in ["almalinux", "cloudlinux", "ubuntu", "unknown", "debian", "raspberry-pi-os", "rhel"] %}
+{% if variant in ["almalinux", "cloudlinux", "ubuntu", "unknown", "debian", "raspberry-pi-os", "rhel", "fedora"] %}
 DefaultDependencies=no
 {% endif %}
 {% if variant in ["almalinux", "cloudlinux", "rhel"] %}
@@ -31,7 +31,7 @@ ExecStart=/usr/bin/cloud-init --all-stages
 KillMode=process
 TasksMax=infinity
 TimeoutStartSec=infinity
-{% if variant in ["almalinux", "cloudlinux", "rhel"] %}
+{% if variant in ["almalinux", "cloudlinux", "rhel", "fedora"] %}
 ExecStartPre=/sbin/restorecon /run/cloud-init
 {% endif %}
 

--- a/systemd/cloud-init-network.service.tmpl
+++ b/systemd/cloud-init-network.service.tmpl
@@ -2,7 +2,7 @@
 [Unit]
 # https://docs.cloud-init.io/en/latest/explanation/boot.html
 Description=Cloud-init: Network Stage
-{% if variant not in ["almalinux", "cloudlinux", "photon", "raspberry-pi-os", "rhel"] %}
+{% if variant not in ["almalinux", "cloudlinux", "photon", "raspberry-pi-os", "rhel", "fedora"] %}
 DefaultDependencies=no
 {% endif %}
 Wants=cloud-init-local.service


### PR DESCRIPTION
Starting with 25.2, Fedora's automated test suite began failing for Cloud images[0] due to a dependency loop. This was due to the `Before=auditd.service` directive added to cloud-init-local.service - auditd.service in Fedora is configured with `DefaultDependencies=no` and `Before=sysinit.target`, but cloud-init-local.service does not include `DefaultDependencies=no`.

This patch adds Fedora to most of the if blocks that include its derivative distributions. The exceptions are the one waiting for firewalld.service, since currently Fedora Cloud doesn't include it, and the one that requires dbus.socket, as that runs after sysinit.target.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=2390898

Fixes: cc8d1b4c464d ("chore: make auditd wait for cloud-init-local.service (#6138)")

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: avoid dependency cycle on Fedora

Starting with 25.2, Fedora's automated test suite began failing for
Cloud images[0] due to a dependency loop. This was due to the
`Before=auditd.service` directive added to cloud-init-local.service -
auditd.service in Fedora is configured with `DefaultDependencies=no` and
`Before=sysinit.target`, but cloud-init-local.service does not include
`DefaultDependencies=no`.

This patch adds Fedora to most of the if blocks that include its
derivative distributions. The exceptions are the one waiting for
firewalld.service, since currently Fedora Cloud doesn't include it,
and the one that requires dbus.socket, as that runs after
sysinit.target.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=2390898

Fixes: cc8d1b4c464d ("chore: make auditd wait for cloud-init-local.service (#6138)")
Signed-off-by: Jeremy Cline <jeremycline@linux.microsoft.com>
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
