### PR TITLE
Raspberry Pi OS ntp client update

### DIFF
--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -213,8 +213,8 @@ DISTRO_CLIENT_CONFIG: Dict[str, Dict] = {
         },
     },
     "raspberry-pi-os": {
-        "chrony": {
-            "confpath": "/etc/chrony/chrony.conf",
+        "systemd-timesyncd": {
+            "check_exe": "/usr/lib/systemd/systemd-timesyncd",
         },
     },
     "rhel": {

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -336,8 +336,6 @@ system_info:
 {% if variant in ["debian", "ubuntu", "unknown"] %}
   # Automatically discover the best ntp_client
   ntp_client: auto
-{% elif variant == "raspberry-pi-os" %}
-  ntp_client: 'systemd-timesyncd'
 {% endif %}
 {% if variant in ["alpine", "amazon", "aosc", "arch", "azurelinux", "debian", "fedora",
                   "gentoo", "mariner", "OpenCloudOS", "openeuler",


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [X] I have signed the CLA: https://ubuntu.com/legal/contributors
- [X] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(raspberry-pi-os): Update ntp client 

Updates the ntp client used on Raspberry Pi OS
to `systemd-timesyncd`.
```

## Additional Context
@tdewey-rpi

## Test Steps
Use the `cc_ntp` on Raspberry Pi OS without the default `ntp_client` option set in `cloud.cfg`.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
