### PR TITLE
fix: add OpenRC support to Meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -157,6 +157,33 @@ if init_system == 'systemd'
     install_mode: 'rw-r--r--',
     install_tag: 'systemd',
   )
+elif init_system == 'sysvinit_openrc'
+  openrc = dependency('openrc')
+  udev = dependency('udev')
+  openrc_initd_dir = '/etc/init.d'
+  udev_dir = udev.get_variable(pkgconfig: 'udevdir')
+  install_data(
+    'udev/66-azure-ephemeral.rules',
+    install_dir: udev_dir / 'rules.d',
+    install_mode: 'rw-r--r--',
+    install_tag: 'openrc',
+  )
+
+  install_data(
+    run_command(find, 'sysvinit/openrc', '-type', 'f', check: true).stdout().strip().split('\n'),
+    install_dir: openrc_initd_dir,
+    install_mode: 'rwxr-xr-x',
+    install_tag: 'openrc',
+  )
+
+  install_data(
+    [
+      'tools/cloud-init-hotplugd',
+    ],
+    install_dir: lib_exec_dir,
+    install_mode: 'rwxr-xr-x',
+    install_tag: 'bin',
+  )
 endif
 
 custom_target(

--- a/sysvinit/openrc/cloud-init-ds-identify
+++ b/sysvinit/openrc/cloud-init-ds-identify
@@ -15,7 +15,7 @@ start() {
     ewarn "$RC_SVCNAME is disabled via cloud-init.disabled file"
   else
     ebegin "$description"
-    /usr/lib/cloud-init/ds-identify
+    /usr/libexec/cloud-init/ds-identify
     eend $?
   fi
 }

--- a/sysvinit/openrc/cloud-init-hotplug
+++ b/sysvinit/openrc/cloud-init-hotplug
@@ -2,7 +2,7 @@
 
 description="cloud-init hotplug daemon"
 
-command="/usr/lib/cloud-init/cloud-init-hotplugd"
+command="/usr/libexec/cloud-init/cloud-init-hotplugd"
 pidfile="/run/$RC_SVCNAME.pid"
 
 depend() {


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: add OpenRC support to Meson build

Modify meson.build to install relevant files when OpenRC rather than
Systemd is used.

Also modify 2 OpenRC scripts to run required scripts from
/usr/libexec path rather than /usr/lib.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
