### PR TITLE
fix(raspberry-pi-os): Remove netplan renderer support

### DIFF
--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -315,8 +315,8 @@ system_info:
     renderers: ['network-manager', 'networkd']
 {% elif variant == "raspberry-pi-os" %}
   network:
-    renderers: ['netplan', 'network-manager']
-    activators: ['netplan', 'network-manager']
+    renderers: ['network-manager']
+    activators: ['network-manager']
 {% elif variant in ["ubuntu", "unknown"] %}
 {# SRU_BLOCKER: do not ship network renderers on Xenial, Bionic or Eoan #}
   network:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(raspberry-pi-os): Remove netplan renderer support

Go back to network config v1 via NM to avoid netplan
NetworkManager interop issues.
```

## Additional Context
On systems where cloud-init renders netplan with renderer: NetworkManager, editing Wi-Fi properties (e.g., password, security) via the NetworkManager GUI correctly creates /etc/netplan/90-NM-<uuid>.yaml, and those changes take effect. However, as soon as the SSID itself is modified, /etc/netplan/50-cloud-init.yaml is re-applied on boot and consistently overrides the 90-NM-* file, reverting to the cloud-init SSID. In other words, non-SSID changes persist, but any SSID change causes 50-cloud-init.yaml to win over 90-NM-* instead of being overridden or creating a separate connection.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
