### PR TITLE
test: refactor test_data.py to use only pytest

### DIFF
--- a/tests/unittests/test_data.py
+++ b/tests/unittests/test_data.py
@@ -23,7 +23,6 @@ from cloudinit import user_data as ud
 from cloudinit import util
 from cloudinit.config.modules import Modules
 from cloudinit.settings import DEFAULT_RUN_DIR, PER_INSTANCE
-from tests.unittests import helpers
 from tests.unittests.util import FakeDataSource
 
 MPATH = "cloudinit.stages"
@@ -790,29 +789,29 @@ class TestUDProcess:
         assert count_messages(message) == 1
 
 
-class TestConvertString(helpers.TestCase):
+class TestConvertString:
     def test_handles_binary_non_utf8_decodable(self):
         """Printable unicode (not utf8-decodable) is safely converted."""
         blob = b"#!/bin/bash\necho \xc3\x84\n"
         msg = ud.convert_string(blob)
-        self.assertEqual(blob, msg.get_payload(decode=True))
+        assert blob == msg.get_payload(decode=True)
 
     def test_handles_binary_utf8_decodable(self):
         blob = b"\x32\x32"
         msg = ud.convert_string(blob)
-        self.assertEqual(blob, msg.get_payload(decode=True))
+        assert blob == msg.get_payload(decode=True)
 
     def test_handle_headers(self):
         text = "hi mom"
         msg = ud.convert_string(text)
-        self.assertEqual(text, msg.get_payload(decode=False))
+        assert text == msg.get_payload(decode=False)
 
     def test_handle_mime_parts(self):
         """Mime parts are properly returned as a mime message."""
         message = MIMEBase("text", "plain")
         message.set_payload("Just text")
         msg = ud.convert_string(str(message))
-        self.assertEqual("Just text", msg.get_payload(decode=False))
+        assert "Just text" == msg.get_payload(decode=False)
 
 
 class TestFetchBaseConfig:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: refactor test_data.py to use only pytest

Remove helpers.TestCase inheritance and replace self.assert methods with bare assert statements. 
This change is a refactor only. Test behavior and coverage remains exactly the same.

Fixes GH-6427
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Run the specific unit tests to verify they still pass:
```bash
tox -e py3 -- tests/unittests/test_data.py

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
