### PR TITLE
Optionalize bash completion.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,16 +28,18 @@ install_subdir(
 )
 
 # Binaries and script entrypoints
-bash_completions_dir = dependency('bash-completion').get_variable(
-  pkgconfig: 'completionsdir',
-  default_value: get_option('datadir') / 'bash-completion' / 'completions',
-)
-install_data(
-  'bash_completion/cloud-init',
-  install_dir: bash_completions_dir,
-  install_mode: 'rw-r--r--',
-  install_tag: 'bin',
-)
+if get_option('bash-completion')
+  bash_completions_dir = dependency('bash-completion').get_variable(
+    pkgconfig: 'completionsdir',
+    default_value: get_option('datadir') / 'bash-completion' / 'completions',
+  )
+  install_data(
+    'bash_completion/cloud-init',
+    install_dir: bash_completions_dir,
+    install_mode: 'rw-r--r--',
+    install_tag: 'bin',
+  )
+endif
 
 install_data(
   [

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ install_subdir(
 )
 
 # Binaries and script entrypoints
-if get_option('bash-completion')
+if get_option('bash_completion')
   bash_completions_dir = dependency('bash-completion').get_variable(
     pkgconfig: 'completionsdir',
     default_value: get_option('datadir') / 'bash-completion' / 'completions',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,4 @@
 option('init_system', type: 'string', value: 'systemd', description: 'Set target init system.')
 option('distro_templates', type: 'array', value: [], description: 'Distro template files to install. WARNING: Templates may change in the future. If using this option, be sure to check new releases for template file changes.')
 option('disable_sshd_keygen', type: 'boolean', value: false, description: 'Provide systemd service to disable sshd-keygen if present to avoid races with cloud-init.')
-option('bash-completion', type: 'boolean', value: true, description: 'Bash completion for cloud-init.')
+option('bash_completion', type: 'boolean', value: true, description: 'Bash completion for cloud-init.')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('init_system', type: 'string', value: 'systemd', description: 'Set target init system.')
 option('distro_templates', type: 'array', value: [], description: 'Distro template files to install. WARNING: Templates may change in the future. If using this option, be sure to check new releases for template file changes.')
 option('disable_sshd_keygen', type: 'boolean', value: false, description: 'Provide systemd service to disable sshd-keygen if present to avoid races with cloud-init.')
+option('bash-completion', type: 'boolean', value: true, description: 'Bash completion for cloud-init.')


### PR DESCRIPTION
To allow for a low-dependency installation of cloud-init, optionalize the bash-completion dependency, defaulted to true. This means behaviorally nothing changes, but that the bash-completion features can be easily turned off if not desired.

## Proposed Commit Message
```
feat: Optionalize bash completion.

To allow for a low-dependency installation of cloud-init, optionalize the
bash-completion dependency, defaulted to true. This means behaviorally
nothing changes, but that the bash-completion features can be easily
turned off if not desired.
```

## Additional Context
n/a

## Test Steps
* Testing: with bash-completion not installed, `meson build -Dbash-completion=false ...` runs successfully, `meson build -Dbash-completion=true ...` and with -D option omitted displays error.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
