### PR TITLE
test: fix lru_cache test wrapper

### DIFF
--- a/tests/unittests/early_patches.py
+++ b/tests/unittests/early_patches.py
@@ -6,8 +6,15 @@ cached_functions = []
 
 
 def wrapped_lru_cache(*args, **kwargs):
-    def wrapper(func: Callable, *a, **k):
-        new_func = old_lru_cache(*args, **kwargs)(func, *a, **k)
+    def wrapper(*a, **k):
+        func: Callable
+        if len(args) > 0 and callable(args[0]):
+            func = args[0]
+        elif len(a) > 0 and callable(a[0]):
+            func = a[0]
+        else:
+            raise NotImplementedError("cannot find cached func")
+        new_func = old_lru_cache(*args, **kwargs)(*a, **k)
 
         # Without this check, we'll also store stdlib functions with @lru_cache
         if "cloudinit" in func.__module__:


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
test: fix lru_cache test wrapper

The position of the cached func in the decorator and decorated
signatures varies depending on how the decorator is called (with or
without args). Fix the latter case.

Fixes tox -e hypothesis-slow.

Fixes GH-5869
```

## Additional Context
<!-- If relevant -->

https://github.com/canonical/cloud-init/actions/runs/17380029255/job/49335144582

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

tox -e hypothesis-slow


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
