### PR TITLE
fix(raspberry-pi-os): Fix user creation to allow for a preseeded user

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -1,11 +1,13 @@
 # Copyright (C) 2012 Canonical Ltd.
 # Copyright (C) 2012, 2013 Hewlett-Packard Development Company, L.P.
 # Copyright (C) 2012 Yahoo! Inc.
+# Copyright (C) 2025 Raspberry Pi Ltd.
 #
 # Author: Scott Moser <scott.moser@canonical.com>
 # Author: Juerg Haefliger <juerg.haefliger@hp.com>
 # Author: Joshua Harlow <harlowja@yahoo-inc.com>
 # Author: Ben Howard <ben.howard@canonical.com>
+# Author: Paul Oberosler <paul.oberosler@raspberrypi.com>
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
@@ -1368,6 +1370,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 "reload": ["reload-or-restart", service],
                 "try-reload": ["try-reload-or-restart", service],
                 "status": ["status", service],
+                "mask": ["mask", service],
+                "unmask": ["unmask", service],
             }
         else:
             cmds = {
@@ -1379,6 +1383,8 @@ class Distro(persistence.CloudInitPickleMixin, metaclass=abc.ABCMeta):
                 "reload": [service, "restart"],
                 "try-reload": [service, "restart"],
                 "status": [service, "status"],
+                "mask": [service, "stop"],
+                "unmask": [service, "stop"],
             }
         cmd = init_cmd + cmds[action] + list(extra_args)
         return subp.subp(cmd, capture=True, rcs=rcs)

--- a/cloudinit/distros/raspberry_pi_os.py
+++ b/cloudinit/distros/raspberry_pi_os.py
@@ -101,6 +101,9 @@ class Distro(debian.Distro):
             if plain:
                 self.set_passwd(name, plain, hashed=False)
 
+        # Mask userconfig.service
+        self.manage_service("mask", "userconfig.service", "--now")
+
         # honor all other options that would otherwise
         # add_user have taken care of
 

--- a/cloudinit/distros/raspberry_pi_os.py
+++ b/cloudinit/distros/raspberry_pi_os.py
@@ -89,11 +89,7 @@ class Distro(debian.Distro):
 
         if pw_hash:
             subp.subp(
-                [
-                    "/usr/lib/userconf-pi/userconf",
-                    name,
-                    pw_hash
-                ],
+                ["/usr/lib/userconf-pi/userconf", name, pw_hash],
             )
         else:
             subp.subp(
@@ -105,7 +101,8 @@ class Distro(debian.Distro):
             if plain:
                 self.set_passwd(name, plain, hashed=False)
 
-        # honor all other options that would otherwise add_user have taken care of
+        # honor all other options that would otherwise
+        # add_user have taken care of
 
         # Ensure groups exist if requested
         create_groups = kwargs.get("create_groups", True)
@@ -142,9 +139,13 @@ class Distro(debian.Distro):
             if os.path.exists(homedir):
                 for root, dirs, files in os.walk(homedir):
                     for d in dirs:
-                        util.chownbyid(os.path.join(root, d), uid=new_uid, gid=-1)
+                        util.chownbyid(
+                            os.path.join(root, d), uid=new_uid, gid=-1
+                        )
                     for f in files:
-                        util.chownbyid(os.path.join(root, f), uid=new_uid, gid=-1)
+                        util.chownbyid(
+                            os.path.join(root, f), uid=new_uid, gid=-1
+                        )
                 util.chownbyid(homedir, uid=new_uid, gid=-1)
         if kwargs.get("homedir"):
             subp.subp(["usermod", "-d", kwargs["homedir"], "-m", name])

--- a/cloudinit/distros/raspberry_pi_os.py
+++ b/cloudinit/distros/raspberry_pi_os.py
@@ -101,7 +101,15 @@ class Distro(debian.Distro):
             if plain:
                 self.set_passwd(name, plain, hashed=False)
 
-        # Mask userconfig.service
+        # Mask userconfig.service to ensure it does not start the
+        # first-run setup wizard on Raspberry Pi OS Lite images.
+        # The 'systemctl disable' call performed by the userconf tool
+        # only takes effect after a reboot, so masking it ensures the
+        # service stays inactive immediately.
+        #
+        # On desktop images, userconf alone is sufficient to prevent
+        # the graphical first-run wizard, but masking the service here
+        # adds consistency and causes no harm.
         self.manage_service("mask", "userconfig.service", "--now")
 
         # honor all other options that would otherwise

--- a/cloudinit/distros/raspberry_pi_os.py
+++ b/cloudinit/distros/raspberry_pi_os.py
@@ -112,8 +112,8 @@ class Distro(debian.Distro):
         # adds consistency and causes no harm.
         self.manage_service("mask", "userconfig.service", "--now")
 
-        # honor all other options that would otherwise
-        # add_user have taken care of
+        # Continue handling any remaining options
+        # that the base add_user() implementation would normally process.
 
         # Ensure groups exist if requested
         create_groups = kwargs.get("create_groups", True)

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -35,6 +35,7 @@ syslog_fix_perms: root:wheel
 syslog_fix_perms: root:root
 {% endif %}
 
+{% if variant != "raspberry-pi-os" %}
 # A set of users which may be applied and/or used by various modules
 # when a 'default' entry is found it will reference the 'default_user'
 # from the distro configuration specified below
@@ -46,6 +47,7 @@ users:
   - default
 {% endif %}
 
+{% endif %}
 {% if variant == "photon" %}
 # VMware guest customization.
 disable_vmware_customization: true

--- a/tests/unittests/distros/test_raspberry_pi_os.py
+++ b/tests/unittests/distros/test_raspberry_pi_os.py
@@ -129,7 +129,7 @@ class TestRaspberryPiOS:
         args, kwargs = m_subp.call_args
         assert args[0][0] in (
             "/usr/lib/userconf-pi/userconf",
-            "/lib/userconf-pi/userconf"
+            "/lib/userconf-pi/userconf",
         )
         assert args[0][1] == "pi"
         # No env expected
@@ -152,9 +152,7 @@ class TestRaspberryPiOS:
         M_PATH + "subp.subp",
         side_effect=ProcessExecutionError("userconf failed"),
     )
-    def test_add_user_rename_fails_logs_error(
-        self, m_subp, caplog
-    ):
+    def test_add_user_rename_fails_logs_error(self, m_subp, caplog):
         cls = fetch("raspberry_pi_os")
         distro = cls("raspberry-pi-os", {}, None)
 

--- a/tests/unittests/distros/test_raspberry_pi_os.py
+++ b/tests/unittests/distros/test_raspberry_pi_os.py
@@ -1,7 +1,8 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import logging
 from typing import cast
+
+import pytest
 
 from cloudinit.distros import fetch
 from cloudinit.distros.raspberry_pi_os import Distro as RpiDistro
@@ -154,13 +155,12 @@ class TestRaspberryPiOS:
         M_PATH + "subp.subp",
         side_effect=ProcessExecutionError("userconf failed"),
     )
-    def test_add_user_rename_fails_logs_error(self, m_subp, caplog):
+    def test_add_user_rename_fails_logs_error(self, m_subp):
         cls = fetch("raspberry_pi_os")
         distro = cls("raspberry-pi-os", {}, None)
 
-        with caplog.at_level(logging.ERROR):
-            assert distro.add_user("pi") is False
-            assert "Failed to setup user" in caplog.text
+        with pytest.raises(ProcessExecutionError, match="userconf failed"):
+            distro.add_user("pi")
 
     @mock.patch(
         "cloudinit.net.generate_fallback_config",

--- a/tests/unittests/distros/test_raspberry_pi_os.py
+++ b/tests/unittests/distros/test_raspberry_pi_os.py
@@ -125,7 +125,10 @@ class TestRaspberryPiOS:
         cls = fetch("raspberry_pi_os")
         distro = cls("raspberry-pi-os", {}, None)
 
-        assert distro.add_user("pi") is True
+        with mock.patch(
+            "cloudinit.distros.Distro.manage_service", return_value=True
+        ):
+            assert distro.add_user("pi") is True
         m_subp.assert_called_once()
 
         # Accept both common locations for userconf

--- a/tests/unittests/distros/test_raspberry_pi_os.py
+++ b/tests/unittests/distros/test_raspberry_pi_os.py
@@ -1,8 +1,10 @@
 # This file is part of cloud-init. See LICENSE file for license information.
 
 import logging
+from typing import cast
 
 from cloudinit.distros import fetch
+from cloudinit.distros.raspberry_pi_os import Distro as RpiDistro
 from cloudinit.subp import ProcessExecutionError
 from tests.unittests.helpers import mock
 
@@ -138,7 +140,7 @@ class TestRaspberryPiOS:
     @mock.patch(M_PATH + "subp.subp")
     def test_add_user_existing_user(self, m_subp):
         cls = fetch("raspberry_pi_os")
-        distro = cls("raspberry-pi-os", {}, None)
+        distro = cast(RpiDistro, cls("raspberry-pi-os", {}, None))
 
         distro.default_user_renamed = True
         with mock.patch(


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(raspberry-pi-os): Fix user creation to allow for a preseeded user

Updates user creation on rpios to support renaming existing users
for the first user to create and after that default to GNU tools.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->
Updated the unit-tests to cover the changes.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)

@tdewey-rpi
