### PR TITLE
Fix test warnings

### DIFF
--- a/tests/unittests/config/test_cc_runcmd.py
+++ b/tests/unittests/config/test_cc_runcmd.py
@@ -91,7 +91,7 @@ class TestRunCmdSchema:
                         {"a": "n"},
                     ]
                 },
-                "",
+                "is not of type",
             ),
         ),
     )

--- a/tests/unittests/runs/test_merge_run.py
+++ b/tests/unittests/runs/test_merge_run.py
@@ -11,7 +11,6 @@ from tests.unittests import helpers
 from tests.unittests.helpers import replicate_test_root
 
 
-@pytest.mark.usefixtures("fake_filesystem_hook")
 @pytest.fixture(autouse=True)
 def user_data(tmp_path):
     replicate_test_root("simple_ubuntu", str(tmp_path))

--- a/tests/unittests/runs/test_simple_run.py
+++ b/tests/unittests/runs/test_simple_run.py
@@ -12,7 +12,6 @@ from cloudinit.sources import NetworkConfigSource
 from tests.unittests.helpers import replicate_test_root
 
 
-@pytest.mark.usefixtures("fake_filesystem_hook")
 @pytest.fixture(autouse=True)
 def replicate_root(tmp_path):
     replicate_test_root("simple_ubuntu", str(tmp_path))

--- a/tests/unittests/sources/test_smartos.py
+++ b/tests/unittests/sources/test_smartos.py
@@ -1427,7 +1427,6 @@ class TestNetworkConversion:
         assert expected == found
 
 
-@pytest.mark.allow_subp_for("mdata-get")
 @pytest.fixture
 def mdata_proc():
     mdata_proc = multiprocessing.Process(target=start_mdata_loop)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->

## Additional Context

This doesn't fix all warnings. Other valid ones exist which can be seen running `tox -e py3-fast`. Those will have to be fixed separately. Specifically:

```python3
tests/unittests/analyze/test_dump.py::TestParseCILogLine::test_parse_logline_returns_event_for_amazon_linux_2_line
  /home/holmanb/ci-b/tests/unittests/analyze/test_dump.py:201: DeprecationWarning: Parsing dates involving a day of month without a year specified is ambiguious
  and fails to parse leap day. The default behavior will change in Python 3.15
  to either always raise an exception or to use a different default year (TBD).
  To avoid trouble, add a specific year to the input & format.
  See https://github.com/python/cpython/issues/70647.
    datetime.strptime("Apr 30 19:39:11", "%b %d %H:%M:%S")

tests/unittests/config/test_cc_snap.py: 4 warnings
tests/unittests/config/test_cc_rsyslog.py: 3 warnings
tests/unittests/config/test_cc_package_update_upgrade_install.py: 2 warnings
tests/unittests/config/test_cc_power_state_change.py: 5 warnings
  /home/holmanb/ci-b/.tox/py3-fast/lib/python3.13/site-packages/_pytest/raises.py:624: PytestWarning: matching against an empty string will *always* pass. If you want to check for an empty message you need to pass '^$'. If you don't want to match you should pass `None` or leave out the parameter.
    super().__init__(match=match, check=check)

```



## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
