### PR TITLE
fix: bddeb tool needs distro debian param for package dependency lookup

### DIFF
--- a/packages/bddeb
+++ b/packages/bddeb
@@ -102,7 +102,13 @@ def write_debian_folder(root, templ_data, cloud_util_deps):
     reqs = reqs_output.splitlines()
     test_reqs = run_helper(
         "read-dependencies",
-        ["--requirements-file", "test-requirements.txt", "--system-pkg-names"],
+        [
+            "--distro",
+            "debian",
+            "--requirements-file",
+            "test-requirements.txt",
+            "--system-pkg-names",
+        ],
     ).splitlines()
 
     requires = ["cloud-utils | cloud-guest-utils"] if cloud_util_deps else []


### PR DESCRIPTION

## Proposed Commit Message
```
fix: bddeb tool needs distro debian param for package dependency lookup

Use debian distro package renames and lookups when determining
system package names for test-requirements.txt.

Otherwise, pyserial dependency gets translated to invalid
system package name python3-pyserial.
```

## Additional Context

Without this change current `make deb` target results in the following debuild errors:
```
make deb
...
        dpkg-checkbuilddeps: error: Unmet build dependencies: python3-pyserial
```
## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
