### PR TITLE
fix(raspberry-pi-os): Systemd network service template fix

### DIFF
--- a/systemd/cloud-init-network.service.tmpl
+++ b/systemd/cloud-init-network.service.tmpl
@@ -2,21 +2,21 @@
 [Unit]
 # https://docs.cloud-init.io/en/latest/explanation/boot.html
 Description=Cloud-init: Network Stage
-{% if variant not in ["almalinux", "cloudlinux", "photon", "raspberry-pi-os", "rhel"] %}
+{% if variant not in ["almalinux", "cloudlinux", "photon", "rhel"] %}
 DefaultDependencies=no
 {% endif %}
 Wants=cloud-init-local.service
 Wants=sshd-keygen.service
 Wants=sshd.service
 After=cloud-init-local.service
-{% if variant not in ["ubuntu"] %}
+{% if variant not in ["ubuntu", "raspberry-pi-os"] %}
 After=systemd-networkd-wait-online.service
 {% endif %}
 {% if variant in ["ubuntu", "unknown", "debian", "raspberry-pi-os"] %}
 After=networking.service
 {% endif %}
 {% if variant in ["almalinux", "centos", "cloudlinux", "eurolinux", "fedora",
-                  "miraclelinux", "openeuler", "OpenCloudOS", "openmandriva", "raspberry-pi-os", 
+                  "miraclelinux", "openeuler", "OpenCloudOS", "openmandriva",
                   "rhel", "rocky", "suse", "TencentOS", "virtuozzo"] %}
 After=NetworkManager.service
 After=NetworkManager-wait-online.service
@@ -28,13 +28,10 @@ After=wicked.service
 After=dbus.service
 {% endif %}
 Before=network-online.target
-{% if variant == "raspberry-pi-os" %}
-Before=avahi-daemon.service
-{% endif %}
 Before=sshd-keygen.service
 Before=sshd.service
 Before=systemd-user-sessions.service
-{% if variant in ["ubuntu", "unknown", "debian"] %}
+{% if variant in ["ubuntu", "unknown", "debian", "raspberry-pi-os"] %}
 Before=sysinit.target
 Before=shutdown.target
 Conflicts=shutdown.target


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [X] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(raspberry-pi-os): adjust systemd network ordering; drop obsolete deps

Align systemd network ordering with current Raspberry Pi OS behavior.
The previous sequencing was designed around older cloud-init and
setup-wizard requirements, but recent upstream and downstream
changes make those workarounds unnecessary. The updated ordering
matches default expectations and works reliably with newer
NetworkManager/Netplan fixes.

Remove the no-longer-needed Before=avahi-daemon.service dependency,
simplifying the unit and bringing it closer to other distros.

Run the network units before sysinit.target, which is consistent with how
RPi OS boots and has been validated in current downstream images.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)

@tdewey-rpi
