### PR TITLE
6141 fix bddeb running with root

### DIFF
--- a/cloudinit/net/netplan.py
+++ b/cloudinit/net/netplan.py
@@ -243,7 +243,9 @@ def _clean_default(target=None):
         os.unlink(f)
 
 
-def netplan_api_write_yaml_file(net_config_content: str) -> bool:
+def netplan_api_write_yaml_file(
+    net_config_content: str, target: Optional[str] = None
+) -> bool:
     """Use netplan.State._write_yaml_file to write netplan config
 
     Where netplan python API exists, prefer to use of the private
@@ -281,9 +283,11 @@ def netplan_api_write_yaml_file(net_config_content: str) -> bool:
             # determine default root-dir /etc/netplan and/or specialized
             # filenames or read permissions based on whether this config
             # contains secrets.
-            state_output_file._write_yaml_file(
-                os.path.basename(CLOUDINIT_NETPLAN_FILE)
-            )
+            if not target:
+                file = os.path.basename(CLOUDINIT_NETPLAN_FILE)
+            else:
+                file = target
+            state_output_file._write_yaml_file(file)
     except Exception as e:
         LOG.warning(
             "Unable to render network config using netplan python module."
@@ -392,7 +396,7 @@ class Renderer(renderer.Renderer):
         content = header + content
 
         netplan_config_changed = has_netplan_config_changed(fpnplan, content)
-        if not netplan_api_write_yaml_file(content):
+        if not netplan_api_write_yaml_file(content, target=fpnplan):
             fallback_write_netplan_yaml(fpnplan, content)
 
         if self.clean_default:

--- a/packages/bddeb
+++ b/packages/bddeb
@@ -306,7 +306,7 @@ def main():
         "release_suffix": get_release_suffix(args.release),
     }
 
-    with temp_utils.tempdir() as tdir:
+    with temp_utils.tempdir(needs_exe=True) as tdir:
 
         # output like 0.7.6-1022-g36e92d3
         ver_data = read_version()


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->

See individual commits.

## Additional Context
<!-- If relevant -->
https://github.com/canonical/cloud-init/issues/6141

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

!! Note: Without this PR, running the tests will write to `/etc/netplan/50-cloud-init.yaml`
Run `pytest test/unittest` with the root user. 


## Merge type

- [ ] Squash merge using "Proposed Commit Message"
- [x] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
