### PR TITLE
fix(cc_write_files): preserve special permission bits

### DIFF
--- a/cloudinit/config/cc_write_files.py
+++ b/cloudinit/config/cc_write_files.py
@@ -112,6 +112,9 @@ def write_files(name, files, owner: str, ssl_details: Optional[dict] = None):
             path, contents, omode=omode, mode=perms, user=u, group=g
         )
         util.chownbyname(path, u, g)
+        if util.get_permissions(path) != perms:
+            # Original setuid bit permissions were cleared due to chown
+            util.chmod(path, perms)
 
 
 def decode_perms(perm, default):

--- a/tests/unittests/config/test_cc_write_files.py
+++ b/tests/unittests/config/test_cc_write_files.py
@@ -115,6 +115,29 @@ class TestWriteFiles:
             mock.call(mock.ANY, USER, GROUP)
         ] == m_chownbyname.call_args_list
 
+    def test_special_permission_bits(self, m_chownbyname, tmp_path):
+        expected = "hello world\n"
+        filename = str(tmp_path / "special.file")
+        permissions = 0o4711
+        write_files(
+            "test_permission",
+            [
+                {
+                    "content": expected,
+                    "path": filename,
+                    "permissions": permissions,
+                }
+            ],
+            OWNER,
+        )
+        assert util.load_text_file(filename) == expected
+        assert [
+            mock.call(mock.ANY, USER, GROUP)
+        ] == m_chownbyname.call_args_list
+        assert util.get_permissions(filename) == decode_perms(
+            permissions, None
+        )
+
     def test_yaml_binary(self, m_chownbyname):
         data_wrong_paths = util.load_yaml(YAML_TEXT)
         data = []


### PR DESCRIPTION
feat(config): preserve special permission bits on write_files

Fix: GH-6225