### PR TITLE
test: fix integration for PROPOSED to run apt update prior to install

### DIFF
--- a/tests/integration_tests/instances.py
+++ b/tests/integration_tests/instances.py
@@ -215,6 +215,7 @@ class IntegrationInstance:
             '$(lsb_release -sc)-proposed main" >> '
             "/etc/apt/sources.list.d/proposed.list"
         ).ok
+        assert self.execute("apt-get update").ok
         assert self.execute(
             f"apt-get install -qy {pkg} -t=$(lsb_release -sc)-proposed"
         ).ok


### PR DESCRIPTION
CLOUD_INIT_CLOUD_INIT_SOURCE=PROPOSED gets and exit 1 from `apt-get install -qy {pkg} -t=$(lsb_release -sc)-proposed` when local apt cache files on disk do not have a known suite yet for jammy-proposed. This exit 1 results  test teardown  during base image creation and failure to run any integration tests.

https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-jammy-gce-generic/648/artifact/pytest.log

## Proposed Commit Message
```
test: fix integration for PROPOSED to run apt update prior to install
```


## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
