### PR TITLE
fix: re-add variant support for templates

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ init_system = get_option('init_system')
 
 lib_exec_dir = get_option('prefix') / get_option('libexecdir') / 'cloud-init'
 render_tmpl = './tools/render-template'
+distro = get_option('distro')
 
 pymod = import('python')
 python = pymod.find_installation('python3')
@@ -107,6 +108,7 @@ if init_system == 'systemd'
     output: '@BASENAME@',
     command: [
       render_tmpl,
+      '--variant', distro,
       '@INPUT@',
       meson.current_build_dir() / '@OUTPUT@',
     ],
@@ -130,6 +132,7 @@ if init_system == 'systemd'
       output: '@BASENAME@',
       command: [
         render_tmpl,
+        '--variant', distro,
         '@INPUT@',
         meson.current_build_dir() / '@OUTPUT@',
       ],
@@ -192,6 +195,7 @@ custom_target(
   output: 'cloud.cfg',
   command: [
     render_tmpl,
+    '--variant', distro,
     '--is-yaml', '@INPUT@',
     meson.current_build_dir() / '@OUTPUT@',
   ],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('init_system', type: 'string', value: 'systemd', description: 'Set target init system.')
+option('distro', type: 'string', value: 'auto', description: 'The distro variant to use when rendering templates')
 option('distro_templates', type: 'array', value: [], description: 'Distro template files to install. WARNING: Templates may change in the future. If using this option, be sure to check new releases for template file changes.')
 option('disable_sshd_keygen', type: 'boolean', value: false, description: 'Provide systemd service to disable sshd-keygen if present to avoid races with cloud-init.')
 option('bash_completion', type: 'boolean', value: true, description: 'Bash completion for cloud-init.')

--- a/tools/render-template
+++ b/tools/render-template
@@ -50,7 +50,7 @@ def main():
         default=platform["variant"],
         action="store",
         help="define the variant.",
-        choices=VARIANTS,
+        choices=VARIANTS + [ "auto" ],
     )
     parser.add_argument(
         "--prefix",
@@ -83,8 +83,14 @@ def main():
     )
 
     args = parser.parse_args(sys.argv[1:])
+    # Use the detected variant if the variant is "auto".
+    # This is done this way so meson doesn't need conditionals
+    # every time it calls this script.
+    variant = args.variant
+    if args.variant == "auto":
+        variant = platform["variant"]
     templater.render_template(
-        args.variant, args.template, args.output, args.is_yaml, prefix=args.prefix
+        variant, args.template, args.output, args.is_yaml, prefix=args.prefix
     )
 
 


### PR DESCRIPTION
Restore the previous support for specifying the variant used in
template rendering instead of always depending on the host.
Before #5027 this was configured with the --distro option to setup.py,
so use the distro meson option.

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: re-add variant support for templates

Restore the previous support for specifying the variant used in template rendering instead of always depending on the host. Before #5027 this was configured with the --distro option to setup.py, so use the distro meson option.

Fixes GH-5027
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
