### PR TITLE
test: add regex to cope with stat link output double/single quotes

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -326,12 +326,13 @@ class TestCombined:
 
     def test_cloud_id_file_symlink(self, class_client: IntegrationInstance):
         cloud_id = class_client.execute("cloud-id").stdout
-        expected_link_output = (
-            "'/run/cloud-init/cloud-id' -> "
-            f"'/run/cloud-init/cloud-id-{cloud_id}'"
+        expected_link_regex = (
+            r"['\"]/run/cloud-init/cloud-id['\"] -> "
+            f"['\"]/run/cloud-init/cloud-id-{cloud_id}['\"]"
         )
-        assert expected_link_output == str(
-            class_client.execute("stat -c %N /run/cloud-init/cloud-id")
+        assert re.match(
+            expected_link_regex,
+            class_client.execute("stat -c %N /run/cloud-init/cloud-id"),
         )
 
     def test_run_frequency(self, class_client: IntegrationInstance):


### PR DESCRIPTION
## Additional Context
Failing jenkins tests due to changes in `stat` command output in questing single quotes changed to double quotes.
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-questing-lxd_container-generic/lastSuccessfulBuild/testReport/junit/tests.integration_tests.modules.test_combined/TestCombined/test_cloud_id_file_symlink/

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
