### PR TITLE
test: update regex for rust-coreutils stat -c output using double quotes

### DIFF
--- a/tests/integration_tests/modules/test_wireguard.py
+++ b/tests/integration_tests/modules/test_wireguard.py
@@ -76,7 +76,7 @@ class TestWireguard:
             # test if file was written for wg0
             (
                 "stat -c '%N' /etc/wireguard/wg0.conf",
-                r"['\"]/etc/wireguard/wg0.conf['\"]",
+                re.compile(r"['\"]/etc/wireguard/wg0.conf['\"]"),
             ),
             # check permissions for wg0
             ("stat -c '%U %a' /etc/wireguard/wg0.conf", r"root 600"),
@@ -112,7 +112,10 @@ class TestWireguard:
     ):
         result = class_client.execute(cmd)
         assert result.ok
-        assert re.search(expected_out, result.stdout)
+        if isinstance(expected_out, re.Pattern):
+            assert re.search(expected_out, result.stdout)
+            return
+        assert expected_out in result.stdout
 
     def test_wireguard_tools_installed(
         self, class_client: IntegrationInstance


### PR DESCRIPTION
## Proposed Commit Message
```
test: update regex for rust-coreutils stat -c output using double quotes

Will be fixed in upstream rust-coreutils per
https://github.com/uutils/coreutils/issues/8789. But,
this may take a bit to SRU to Ubuntu Questing.
```


## Additional Context
Unhappy Jenkins job representing this failure only on Questing
https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-questing-ec2-generic/lastSuccessfulBuild/testReport/junit/tests.integration_tests.modules.test_wireguard/TestWireguard/test_wireguard_stat__c___N___etc_wireguard_wg0_conf___etc_wireguard_wg0_conf__/

## Test Steps
```
# single quote test case
CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=plucky  tox -e integration-tests -- tests/integration_tests/modules/test_wireguard::TestWireguard::test_wireguard

# double quote test case

CLOUD_INIT_PLATFORM=lxd_vm CLOUD_INIT_OS_IMAGE=questing tox -e integration-tests -- tests/integration_tests/modules/test_wireguard::TestWireguard::test_wireguard
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
