### PR TITLE
fix: install doc files that were previously installed pre-Meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -231,6 +231,16 @@ install_data(
 )
 install_data(
   [
+    'doc/status.txt',
+    'doc/userdata.txt',
+    'doc/var-lib-cloud.txt',
+  ],
+  install_dir: get_option('datadir') / 'doc' / 'cloud-init',
+  install_mode: 'rw-r--r--',
+  install_tag: 'doc',
+)
+install_data(
+  [
     'doc/examples/seed/README',
     'doc/examples/seed/meta-data',
     'doc/examples/seed/user-data',


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message

```
fix: install doc files that were previously installed pre-Meson

The Meson-based installation does not install these text files whereas
the pre-Meson installation did, so reinstate them.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
