### PR TITLE
test(distros): Convert test_sysconfig.py from unittest to pytest

### DIFF
--- a/tests/unittests/distros/test_sysconfig.py
+++ b/tests/unittests/distros/test_sysconfig.py
@@ -9,13 +9,6 @@ from cloudinit.distros.parsers.sys_conf import SysConf
 
 
 class TestSysConfHelper:
-    # This function was added in 2.7, make it work for 2.6
-    def assertRegMatches(self, text, regexp):
-        regexp = re.compile(regexp)
-        assert regexp.search(text), "%s must match %s!" % (
-            text,
-            regexp.pattern,
-        )
 
     def test_parse_no_change(self):
         contents = """# A comment


### PR DESCRIPTION
Refactored tests/unittests/distros/test_sysconfig.py to use pytest instead of unittest.TestCase as part of the pytest migration effort.

  - Removed TestCase inheritance
  - Converted self.assert* methods to bare assert statements
  - Maintained all original test functionality

  Related: #6427
