### PR TITLE
test(distros): Convert test_alpine.py from unittest to pytest

### DIFF
--- a/tests/unittests/distros/test_alpine.py
+++ b/tests/unittests/distros/test_alpine.py
@@ -5,7 +5,6 @@ from unittest import mock
 import pytest
 
 from cloudinit import distros, util
-from tests.unittests.helpers import TestCase
 
 
 class TestAlpineBusyboxUserGroup:
@@ -50,7 +49,7 @@ class TestAlpineBusyboxUserGroup:
         assert contents == expected
 
 
-class TestAlpineShadowUserGroup(TestCase):
+class TestAlpineShadowUserGroup:
     distro = distros.fetch("alpine")("alpine", {}, None)
 
     @mock.patch("cloudinit.distros.alpine.subp.subp")


### PR DESCRIPTION
Refactored tests/unittests/distros/test_alpine.py to use pytest instead of unittest.TestCase as part of the pytest migration effort.

  - Removed TestCase inheritance
  - Maintained all original test functionality

  Related: canonical#6427
