### PR TITLE
test(config): Convert test_cc_spacewalk.py from unittest to pytest

### DIFF
--- a/tests/unittests/config/test_cc_spacewalk.py
+++ b/tests/unittests/config/test_cc_spacewalk.py
@@ -5,12 +5,11 @@ from unittest import mock
 
 from cloudinit import subp
 from cloudinit.config import cc_spacewalk
-from tests.unittests import helpers
 
 LOG = logging.getLogger(__name__)
 
 
-class TestSpacewalk(helpers.TestCase):
+class TestSpacewalk:
     space_cfg = {
         "spacewalk": {
             "server": "localhost",
@@ -21,12 +20,12 @@ class TestSpacewalk(helpers.TestCase):
     @mock.patch("cloudinit.config.cc_spacewalk.subp.subp")
     def test_not_is_registered(self, mock_subp):
         mock_subp.side_effect = subp.ProcessExecutionError(exit_code=1)
-        self.assertFalse(cc_spacewalk.is_registered())
+        assert cc_spacewalk.is_registered() is False
 
     @mock.patch("cloudinit.config.cc_spacewalk.subp.subp")
     def test_is_registered(self, mock_subp):
         mock_subp.side_effect = None
-        self.assertTrue(cc_spacewalk.is_registered())
+        assert cc_spacewalk.is_registered() is True
 
     @mock.patch("cloudinit.config.cc_spacewalk.subp.subp")
     def test_do_register(self, mock_subp):


### PR DESCRIPTION
Refactored tests/unittests/config/test_cc_spacewalk.py to use pytest instead of unittest.TestCase as part of the pytest migration effort.

- Removed TestCase inheritance
- Removed unused helpers import
- Converted self.assertFalse() to assert not statement
- Converted self.assertTrue() to assert statement
- Maintained all original test functionality

Related: #6427