### PR TITLE
test(distros): Convert test_ifconfig.py from unittest to pytest

### DIFF
--- a/tests/unittests/distros/test_ifconfig.py
+++ b/tests/unittests/distros/test_ifconfig.py
@@ -6,55 +6,55 @@ from tests.unittests.helpers import readResource
 
 
 @pytest.fixture
-def ifs_txt_freebsd():
+def ifs_freebsd():
     return readResource("netinfo/freebsd-ifconfig-output")
 
 
 @pytest.fixture
-def ifs_text_freebsd_cidr():
+def ifs_freebsd_cidr():
     return readResource("netinfo/freebsd-ifconfig-cidr-output")
 
 
 @pytest.fixture
-def ifs_txt_openbsd():
+def ifs_openbsd():
     return readResource("netinfo/openbsd-ifconfig-output")
 
 
 class TestIfconfigParserFreeBSD:
-    def test_parse_freebsd(self, ifs_txt_freebsd):
+    def test_parse_freebsd(self, ifs_freebsd):
         """assert parsing works without any exceptions"""
-        Ifconfig().parse(ifs_txt_freebsd)
+        Ifconfig().parse(ifs_freebsd)
 
-    def test_is_bridge(self, ifs_txt_freebsd):
+    def test_is_bridge(self, ifs_freebsd):
         """assert bridge0 is_bridge"""
-        ifs = Ifconfig().parse(ifs_txt_freebsd)
+        ifs = Ifconfig().parse(ifs_freebsd)
         assert ifs["bridge0"].is_bridge
 
-    def test_index(self, ifs_txt_freebsd):
+    def test_index(self, ifs_freebsd):
         """assert vtnet0 index is 1"""
-        ifs = Ifconfig().parse(ifs_txt_freebsd)
+        ifs = Ifconfig().parse(ifs_freebsd)
         assert ifs["vtnet0"].index == 1
 
-    def test_is_vlan(self, ifs_txt_freebsd):
+    def test_is_vlan(self, ifs_freebsd):
         """assert re0.33 is_vlan"""
-        ifs = Ifconfig().parse(ifs_txt_freebsd)
+        ifs = Ifconfig().parse(ifs_freebsd)
         assert ifs["re0.33"].is_vlan
 
-    def test_netmask(self, ifs_txt_freebsd):
-        ifs = Ifconfig().parse(ifs_txt_freebsd)
+    def test_netmask(self, ifs_freebsd):
+        ifs = Ifconfig().parse(ifs_freebsd)
         # netmasks are Normalized from non-contiguous hex bitmasks to
         # contiguous decimal bitmasks
         assert ifs["bridge0"].inet["192.168.1.1"]["netmask"] == "255.255.255.0"
         assert ifs["lo0"].inet["127.0.0.1"]["netmask"] == "255.0.0.0"
 
-    def test_description(self, ifs_txt_freebsd):
+    def test_description(self, ifs_freebsd):
         """assert vnet0:11 is associated with jail: webirc"""
-        ifs = Ifconfig().parse(ifs_txt_freebsd)
+        ifs = Ifconfig().parse(ifs_freebsd)
         assert ifs["vnet0:11"].description == "'associated with jail: webirc'"
 
-    def test_vtnet_options(self, ifs_txt_freebsd):
+    def test_vtnet_options(self, ifs_freebsd):
         """assert vtnet has TXCSUM"""
-        ifs = Ifconfig().parse(ifs_txt_freebsd)
+        ifs = Ifconfig().parse(ifs_freebsd)
         assert "txcsum" in ifs["vtnet0"].options
 
     def test_duplicate_mac(self):
@@ -75,12 +75,12 @@ class TestIfconfigParserFreeBSD:
 
 
 class TestIfconfigParserFreeBSDCIDR:
-    def test_parse_freebsd(self, ifs_text_freebsd_cidr):
+    def test_parse_freebsd(self, ifs_freebsd_cidr):
         """assert parsing works without any exceptions"""
-        Ifconfig().parse(ifs_text_freebsd_cidr)
+        Ifconfig().parse(ifs_freebsd_cidr)
 
-    def test_netmask(self, ifs_text_freebsd_cidr):
-        ifs = Ifconfig().parse(ifs_text_freebsd_cidr)
+    def test_netmask(self, ifs_freebsd_cidr):
+        ifs = Ifconfig().parse(ifs_freebsd_cidr)
         # netmasks are Normalized from CIDR to contiguous decimal bitmasks
         assert (
             ifs["vtnet0"].inet["198.51.100.13"]["netmask"] == "255.255.255.255"
@@ -89,28 +89,28 @@ class TestIfconfigParserFreeBSDCIDR:
 
 
 class TestIfconfigParserOpenBSD:
-    def test_parse_openbsd(self, ifs_txt_openbsd):
+    def test_parse_openbsd(self, ifs_openbsd):
         """assert parsing works without any exceptions"""
-        Ifconfig().parse(ifs_txt_openbsd)
+        Ifconfig().parse(ifs_openbsd)
 
-    def test_is_not_physical(self, ifs_txt_openbsd):
+    def test_is_not_physical(self, ifs_openbsd):
         """assert enc0 is not physical"""
-        ifs = Ifconfig().parse(ifs_txt_openbsd)
+        ifs = Ifconfig().parse(ifs_openbsd)
         assert not ifs["enc0"].is_physical
 
-    def test_is_physical(self, ifs_txt_openbsd):
-        """assert enc0 is not physical"""
-        ifs = Ifconfig().parse(ifs_txt_openbsd)
+    def test_is_physical(self, ifs_openbsd):
+        """assert vio0 is not physical"""
+        ifs = Ifconfig().parse(ifs_openbsd)
         assert ifs["vio0"].is_physical
 
-    def test_index(self, ifs_txt_openbsd):
+    def test_index(self, ifs_openbsd):
         """assert vio0 index is 1"""
-        ifs = Ifconfig().parse(ifs_txt_openbsd)
+        ifs = Ifconfig().parse(ifs_openbsd)
         assert ifs["vio0"].index == 1
 
-    def test_gif_ipv6(self, ifs_txt_openbsd):
+    def test_gif_ipv6(self, ifs_openbsd):
         """assert that we can parse a gif inet6 address, despite the -->"""
-        ifs = Ifconfig().parse(ifs_txt_openbsd)
+        ifs = Ifconfig().parse(ifs_openbsd)
         assert ifs["gif0"].inet6["fe80::be30:5bff:fed0:471"] == {
             "prefixlen": "64",
             "scope": "link-local",


### PR DESCRIPTION
Refactored tests/unittests/distros/test_ifconfig.py to use pytest instead of unittest.TestCase as part of the pytest migration effort.

  - Removed TestCase inheritance
  - Refactored tests to use pytest fixtures instead of unittest setUp methods
  - updated tests to receive fixtures as function arguments
  - Maintained all original test functionality

  Related: #6427
