### PR TITLE
test(config): Convert test_schema.py from unittest to pytest

### DIFF
--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 import sys
-import unittest
 from collections import namedtuple
 from copy import deepcopy
 from errno import EACCES
@@ -152,7 +151,7 @@ class TestVersionedSchemas:
             )
 
 
-class TestCheckSchema(unittest.TestCase):
+class TestCheckSchema:
     def test_schema_bools_have_dates(self):
         """ensure that new/changed/deprecated keys have an associated
         version key


### PR DESCRIPTION
Refactored tests/unittests/config/test_schema.py to use pytest instead of unittest.TestCase as part of the pytest migration effort.

  - Removed unittest.TestCase inheritance
  - Maintained all original test functionality

 Related: canonical#6427