### PR TITLE
test (config): Convert test_apt_conf_v1.py from unittest to  pytest

### DIFF
--- a/tests/unittests/config/test_apt_conf_v1.py
+++ b/tests/unittests/config/test_apt_conf_v1.py
@@ -65,14 +65,14 @@ class TestAptProxyConfig:
 
     def test_proxy_deleted(self, p_c_files):
         pfile, cfile = p_c_files
-        util.write_file(cfile, "content doesnt matter")
+        util.write_file(cfile, "content doesn't matter")
         cc_apt_configure.apply_apt_config({}, pfile, cfile)
         assert not os.path.isfile(pfile)
         assert not os.path.isfile(cfile)
 
     def test_proxy_replaced(self, p_c_files):
         pfile, cfile = p_c_files
-        util.write_file(cfile, "content doesnt matter")
+        util.write_file(cfile, "content doesn't matter")
         cc_apt_configure.apply_apt_config({"proxy": "foo"}, pfile, cfile)
         assert os.path.isfile(pfile)
         contents = util.load_text_file(pfile)
@@ -92,7 +92,7 @@ class TestAptProxyConfig:
 
     def test_config_replaced(self, p_c_files):
         pfile, cfile = p_c_files
-        util.write_file(pfile, "content doesnt matter")
+        util.write_file(pfile, "content doesn't matter")
         cc_apt_configure.apply_apt_config({"conf": "foo"}, pfile, cfile)
         assert os.path.isfile(cfile)
         assert util.load_text_file(cfile) == "foo"
@@ -100,7 +100,7 @@ class TestAptProxyConfig:
     def test_config_deleted(self, p_c_files):
         # if no 'conf' is provided, delete any previously written file
         pfile, cfile = p_c_files
-        util.write_file(pfile, "content doesnt matter")
+        util.write_file(pfile, "content doesn't matter")
         cc_apt_configure.apply_apt_config({}, pfile, cfile)
         assert not os.path.isfile(pfile)
         assert not os.path.isfile(cfile)


### PR DESCRIPTION
Refactored tests/unittests/config/test_apt_conf_v1.py to use pytest instead of unittest.TestCase as part of the pytest migration effort.

  - Removed unittest.TestCase inheritance
  - Converted setUp() to pytest fixture for temporary files
  - Parameterized proxy-related tests for cleaner duplication removal
  - Replaced unittest assertions with plain pytest `assert` statements
  - Replaced `_search_apt_config` as standalone helper function
  - Maintained all original test functionality

 Related: canonical#6427


