### PR TITLE
Refactored tests/unittests/config/test_apt_conf_v1.py to use pytest i…

### DIFF
--- a/tests/unittests/config/test_apt_conf_v1.py
+++ b/tests/unittests/config/test_apt_conf_v1.py
@@ -3,50 +3,49 @@
 import copy
 import os
 import re
-import shutil
-import tempfile
+
+import pytest
 
 from cloudinit import util
 from cloudinit.config import cc_apt_configure
-from tests.unittests.helpers import TestCase
 
 
-class TestAptProxyConfig(TestCase):
-    def setUp(self):
-        super(TestAptProxyConfig, self).setUp()
-        self.tmp = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, self.tmp)
-        self.pfile = os.path.join(self.tmp, "proxy.cfg")
-        self.cfile = os.path.join(self.tmp, "config.cfg")
+def _search_apt_config(contents, ptype, value):
+    return re.search(
+        r"acquire::%s::proxy\s+[\"']%s[\"'];\n" % (ptype, value),
+        contents,
+        flags=re.IGNORECASE,
+    )
 
-    def _search_apt_config(self, contents, ptype, value):
-        return re.search(
-            r"acquire::%s::proxy\s+[\"']%s[\"'];\n" % (ptype, value),
-            contents,
-            flags=re.IGNORECASE,
-        )
 
-    def test_apt_proxy_written(self):
+class TestAptProxyConfig:
+    def test_apt_proxy_written(self, tmpdir):
+        pfile = tmpdir.join("proxy.cfg")
+        cfile = tmpdir.join("config.cfg")
         cfg = {"proxy": "myproxy"}
-        cc_apt_configure.apply_apt_config(cfg, self.pfile, self.cfile)
+        cc_apt_configure.apply_apt_config(cfg, str(pfile), str(cfile))
 
-        self.assertTrue(os.path.isfile(self.pfile))
-        self.assertFalse(os.path.isfile(self.cfile))
+        assert os.path.isfile(str(pfile))
+        assert not os.path.isfile(str(cfile))
 
-        contents = util.load_text_file(self.pfile)
-        self.assertTrue(self._search_apt_config(contents, "http", "myproxy"))
+        contents = util.load_text_file(str(pfile))
+        assert _search_apt_config(contents, "http", "myproxy")
 
-    def test_apt_http_proxy_written(self):
+    def test_apt_http_proxy_written(self, tmpdir):
+        pfile = tmpdir.join("proxy.cfg")
+        cfile = tmpdir.join("config.cfg")
         cfg = {"http_proxy": "myproxy"}
-        cc_apt_configure.apply_apt_config(cfg, self.pfile, self.cfile)
+        cc_apt_configure.apply_apt_config(cfg, str(pfile), str(cfile))
 
-        self.assertTrue(os.path.isfile(self.pfile))
-        self.assertFalse(os.path.isfile(self.cfile))
+        assert os.path.isfile(str(pfile))
+        assert not os.path.isfile(str(cfile))
 
-        contents = util.load_text_file(self.pfile)
-        self.assertTrue(self._search_apt_config(contents, "http", "myproxy"))
+        contents = util.load_text_file(str(pfile))
+        assert _search_apt_config(contents, "http", "myproxy")
 
-    def test_apt_all_proxy_written(self):
+    def test_apt_all_proxy_written(self, tmpdir):
+        pfile = tmpdir.join("proxy.cfg")
+        cfile = tmpdir.join("config.cfg")
         cfg = {
             "http_proxy": "myproxy_http_proxy",
             "https_proxy": "myproxy_https_proxy",
@@ -59,76 +58,84 @@ class TestAptProxyConfig(TestCase):
             "ftp": cfg["ftp_proxy"],
         }
 
-        cc_apt_configure.apply_apt_config(cfg, self.pfile, self.cfile)
+        cc_apt_configure.apply_apt_config(cfg, str(pfile), str(cfile))
 
-        self.assertTrue(os.path.isfile(self.pfile))
-        self.assertFalse(os.path.isfile(self.cfile))
+        assert os.path.isfile(str(pfile))
+        assert not os.path.isfile(str(cfile))
 
-        contents = util.load_text_file(self.pfile)
+        contents = util.load_text_file(str(pfile))
 
         for ptype, pval in values.items():
-            self.assertTrue(self._search_apt_config(contents, ptype, pval))
+            assert _search_apt_config(contents, ptype, pval)
 
-    def test_proxy_deleted(self):
-        util.write_file(self.cfile, "content doesnt matter")
-        cc_apt_configure.apply_apt_config({}, self.pfile, self.cfile)
-        self.assertFalse(os.path.isfile(self.pfile))
-        self.assertFalse(os.path.isfile(self.cfile))
+    def test_proxy_deleted(self, tmpdir):
+        pfile = tmpdir.join("proxy.cfg")
+        cfile = tmpdir.join("config.cfg")
+        util.write_file(str(cfile), "content doesnt matter")
+        cc_apt_configure.apply_apt_config({}, str(pfile), str(cfile))
+        assert not os.path.isfile(str(pfile))
+        assert not os.path.isfile(str(cfile))
 
-    def test_proxy_replaced(self):
-        util.write_file(self.cfile, "content doesnt matter")
+    def test_proxy_replaced(self, tmpdir):
+        pfile = tmpdir.join("proxy.cfg")
+        cfile = tmpdir.join("config.cfg")
+        util.write_file(str(cfile), "content doesnt matter")
         cc_apt_configure.apply_apt_config(
-            {"proxy": "foo"}, self.pfile, self.cfile
+            {"proxy": "foo"}, str(pfile), str(cfile)
         )
-        self.assertTrue(os.path.isfile(self.pfile))
-        contents = util.load_text_file(self.pfile)
-        self.assertTrue(self._search_apt_config(contents, "http", "foo"))
+        assert os.path.isfile(str(pfile))
+        contents = util.load_text_file(str(pfile))
+        assert _search_apt_config(contents, "http", "foo")
 
-    def test_config_written(self):
+    def test_config_written(self, tmpdir):
+        pfile = tmpdir.join("proxy.cfg")
+        cfile = tmpdir.join("config.cfg")
         payload = "this is my apt config"
         cfg = {"conf": payload}
 
-        cc_apt_configure.apply_apt_config(cfg, self.pfile, self.cfile)
+        cc_apt_configure.apply_apt_config(cfg, str(pfile), str(cfile))
 
-        self.assertTrue(os.path.isfile(self.cfile))
-        self.assertFalse(os.path.isfile(self.pfile))
+        assert os.path.isfile(str(cfile))
+        assert not os.path.isfile(str(pfile))
 
-        self.assertEqual(util.load_text_file(self.cfile), payload)
+        assert util.load_text_file(str(cfile)) == payload
 
-    def test_config_replaced(self):
-        util.write_file(self.pfile, "content doesnt matter")
+    def test_config_replaced(self, tmpdir):
+        pfile = tmpdir.join("proxy.cfg")
+        cfile = tmpdir.join("config.cfg")
+        util.write_file(str(pfile), "content doesnt matter")
         cc_apt_configure.apply_apt_config(
-            {"conf": "foo"}, self.pfile, self.cfile
+            {"conf": "foo"}, str(pfile), str(cfile)
         )
-        self.assertTrue(os.path.isfile(self.cfile))
-        self.assertEqual(util.load_text_file(self.cfile), "foo")
+        assert os.path.isfile(str(cfile))
+        assert util.load_text_file(str(cfile)) == "foo"
 
-    def test_config_deleted(self):
+    def test_config_deleted(self, tmpdir):
+        pfile = tmpdir.join("proxy.cfg")
+        cfile = tmpdir.join("config.cfg")
         # if no 'conf' is provided, delete any previously written file
-        util.write_file(self.pfile, "content doesnt matter")
-        cc_apt_configure.apply_apt_config({}, self.pfile, self.cfile)
-        self.assertFalse(os.path.isfile(self.pfile))
-        self.assertFalse(os.path.isfile(self.cfile))
+        util.write_file(str(pfile), "content doesnt matter")
+        cc_apt_configure.apply_apt_config({}, str(pfile), str(cfile))
+        assert not os.path.isfile(str(pfile))
+        assert not os.path.isfile(str(cfile))
 
 
-class TestConversion(TestCase):
+class TestConversion:
     def test_convert_with_apt_mirror_as_empty_string(self):
         # an empty apt_mirror is the same as no apt_mirror
         empty_m_found = cc_apt_configure.convert_to_v3_apt_format(
             {"apt_mirror": ""}
         )
         default_found = cc_apt_configure.convert_to_v3_apt_format({})
-        self.assertEqual(default_found, empty_m_found)
+        assert default_found == empty_m_found
 
     def test_convert_with_apt_mirror(self):
         mirror = "http://my.mirror/ubuntu"
         f = cc_apt_configure.convert_to_v3_apt_format({"apt_mirror": mirror})
-        self.assertIn(mirror, set(m["uri"] for m in f["apt"]["primary"]))
+        assert mirror in set(m["uri"] for m in f["apt"]["primary"])
 
     def test_no_old_content(self):
         mirror = "http://my.mirror/ubuntu"
         mydata = {"apt": {"primary": {"arches": ["default"], "uri": mirror}}}
         expected = copy.deepcopy(mydata)
-        self.assertEqual(
-            expected, cc_apt_configure.convert_to_v3_apt_format(mydata)
-        )
+        assert expected == cc_apt_configure.convert_to_v3_apt_format(mydata)


### PR DESCRIPTION
Refactored tests/unittests/config/test_apt_conf_v1.py to use pytest instead of unittest.TestCase as part of the pytest migration effort.

- Removed TestCase inheritance and replaced with pytest fixtures
- Converted self.assert* methods to bare assert statements  
- Used tmpdir fixture for temporary file handling instead of manual setup/teardown
- Maintained all original test functionality
- Followed cloud-init pytest guidelines
