### PR TITLE
docs: Fix misleading GitHub link on homepage

### DIFF
--- a/doc/rtd/index.rst
+++ b/doc/rtd/index.rst
@@ -77,7 +77,8 @@ projects, contributions, suggestions, fixes and constructive feedback.
 * Read our `Code of Conduct`_
 * Ask questions in the ``#cloud-init`` `room on Matrix <Matrix_>`_
 * Follow announcements or ask a question on `GitHub Discussions`_
-* :ref:`Contribute on GitHub<contributing>`
+* `Contribute on GitHub <GH repo_>`
+* :ref:`Contribution Guidelines <contributing>`
 * `Release schedule`_
 
 .. toctree::


### PR DESCRIPTION
- Change 'Contribute on GitHub' to point directly to GitHub repository
- Rename contributing guidelines reference for clarity

Fixes #6057