### PR TITLE
fix(schema): allow accept_ra for bond/bridge/VLAN devices

### DIFF
--- a/cloudinit/config/schemas/schema-network-config-v1.json
+++ b/cloudinit/config/schemas/schema-network-config-v1.json
@@ -80,6 +80,10 @@
           "type": "integer",
           "description": "The MTU size in bytes. This ``mtu`` key represents a device's Maximum Transmission Unit, which is the largest size packet or frame, specified in octets (eight-bit bytes), that can be sent in a packet- or frame-based network. Specifying ``mtu`` is optional. Values too small or too large for a device may be ignored by that device."
         },
+        "accept-ra": {
+          "type": "boolean",
+          "description": "Whether to accept IPv6 Router Advertisements (RA) on this interface. If unset, it will not be rendered"
+        },
         "params": {
           "description": "The ``params`` key in a bond holds a dictionary of bonding parameters. This dictionary may be empty. For more details on what the various bonding parameters mean please read the [Linux Kernel Bonding.txt](https://www.kernel.org/doc/Documentation/networking/bonding.txt).",
           "additionalProperties": false,
@@ -272,6 +276,10 @@
             "type": "string"
           }
         },
+        "accept-ra": {
+          "type": "boolean",
+          "description": "Whether to accept IPv6 Router Advertisements (RA) on this interface. If unset, it will not be rendered"
+        },
         "params": {
           "type": "object",
           "additionalProperties": false,
@@ -392,6 +400,10 @@
         "mac_address": {
           "type": "string",
           "description": "When specifying MAC Address on a VLAN subinterface this value will be assigned to the vlan subinterface device and may be different than the MAC address of the physical interface. Specifying a MAC Address is optional. If ``mac_address`` is not present, then the VLAN subinterface will use the MAC Address values from one of the physical interface."
+        },
+        "accept-ra": {
+          "type": "boolean",
+          "description": "Whether to accept IPv6 Router Advertisements (RA) on this interface. If unset, it will not be rendered"
         }
       }
     },

--- a/doc/rtd/reference/network-config-format-v1.rst
+++ b/doc/rtd/reference/network-config-format-v1.rst
@@ -126,6 +126,13 @@ bond interfaces. Specifying a MAC Address is optional. If ``mac_address`` is
 not present, then the bond will use one of the MAC Address values from one of
 the bond interfaces.
 
+``accept-ra: <boolean>``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``accept-ra`` key is a boolean value that specifies whether or not to
+accept Router Advertisements (RA) for this interface. Specifying ``accept-ra``
+is optional.
+
 .. note::
    It is best practice to "quote" all MAC addresses, since an unquoted MAC
    address might be incorrectly interpreted as an integer in `YAML`_.
@@ -226,6 +233,15 @@ Valid keys are:
   - ``bridge_waitport``: Set amount of time in seconds to wait on specific
     ports to become available.
 
+The following optional keys are supported:
+
+``accept-ra: <boolean>``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``accept-ra`` key is a boolean value that specifies whether or not to
+accept Router Advertisements (RA) for this interface. Specifying ``accept-ra``
+is optional.
+
 Bridge example
 ^^^^^^^^^^^^^^
 
@@ -251,6 +267,13 @@ The following optional keys are supported:
 The MTU key represents a device's Maximum Transmission Unit, the largest size
 packet or frame, specified in octets (eight-bit bytes), that can be sent in a
 packet- or frame-based network.  Specifying ``mtu`` is optional.
+
+``accept-ra: <boolean>``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``accept-ra`` key is a boolean value that specifies whether or not to
+accept Router Advertisements (RA) for this interface. Specifying ``accept-ra``
+is optional.
 
 .. note::
    The possible supported values of a device's MTU are not available at

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -233,6 +233,142 @@ class TestConvertNetJson:
             network_json=network_json, known_macs=macs
         )
 
+    def test_bond_ipv6_accept_ra_false(self):
+        """Verify accept-ra is set to False for static IPv6."""
+        network_json = {
+            "links": [
+                {
+                    "id": "ens1f0np0",
+                    "name": "ens1f0np0",
+                    "type": "phy",
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:00",
+                    "mtu": 9000,
+                },
+                {
+                    "id": "ens1f1np1",
+                    "name": "ens1f1np1",
+                    "type": "phy",
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:01",
+                    "mtu": 9000,
+                },
+                {
+                    "id": "bond0",
+                    "name": "bond0",
+                    "type": "bond",
+                    "bond_links": ["ens1f0np0", "ens1f1np1"],
+                    "mtu": 9000,
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:00",
+                    "bond_mode": "802.3ad",
+                    "bond_xmit_hash_policy": "layer3+4",
+                    "bond_miimon": 100,
+                },
+                {
+                    "id": "bond0.123",
+                    "name": "bond0.123",
+                    "type": "vlan",
+                    "vlan_link": "bond0",
+                    "vlan_id": 123,
+                    "vlan_mac_address": "xx:xx:xx:xx:xx:00",
+                },
+            ],
+            "networks": [
+                {
+                    "id": "publicnet-ipv4",
+                    "type": "ipv4",
+                    "link": "bond0.123",
+                    "ip_address": "x.x.x.x",
+                    "netmask": "255.255.255.0",
+                    "routes": [
+                        {
+                            "network": "0.0.0.0",
+                            "netmask": "0.0.0.0",
+                            "gateway": "x.x.x.1",
+                        }
+                    ],
+                    "network_id": "00000000-0000-0000-0000-000000000000",
+                },
+                {
+                    "id": "publicnet-ipv6",
+                    "type": "ipv6",
+                    "link": "bond0.123",
+                    "ip_address": "2001::/56",
+                    "gateway": "fe80::1",
+                    "routes": [],
+                    "network_id": "00000000-0000-0000-0000-000000000001",
+                },
+            ],
+            "services": [{"type": "dns", "address": "1.1.1.1"}],
+        }
+        expected = {
+            "config": [
+                {
+                    "mac_address": "xx:xx:xx:xx:xx:00",
+                    "mtu": 9000,
+                    "name": "ens1f0np0",
+                    "subnets": [],
+                    "type": "physical",
+                },
+                {
+                    "mac_address": "xx:xx:xx:xx:xx:01",
+                    "mtu": 9000,
+                    "name": "ens1f1np1",
+                    "subnets": [],
+                    "type": "physical",
+                },
+                {
+                    "bond_interfaces": ["ens1f0np0", "ens1f1np1"],
+                    "mtu": 9000,
+                    "name": "bond0",
+                    "mac_address": "xx:xx:xx:xx:xx:00",
+                    "params": {
+                        "bond-miimon": 100,
+                        "bond-mode": "802.3ad",
+                        "bond-xmit_hash_policy": "layer3+4",
+                    },
+                    "subnets": [],
+                    "type": "bond",
+                },
+                {
+                    "accept-ra": False,
+                    "name": "bond0.123",
+                    "subnets": [
+                        {
+                            "address": "x.x.x.x",
+                            "ipv4": True,
+                            "netmask": "255.255.255.0",
+                            "routes": [
+                                {
+                                    "gateway": "x.x.x.1",
+                                    "netmask": "0.0.0.0",
+                                    "network": "0.0.0.0",
+                                }
+                            ],
+                            "type": "static",
+                        },
+                        {
+                            "address": "2001::/56",
+                            "gateway": "fe80::1",
+                            "ipv6": True,
+                            "type": "static6",
+                        },
+                    ],
+                    "type": "vlan",
+                    "vlan_id": 123,
+                    "vlan_link": "bond0",
+                    "mac_address": "xx:xx:xx:xx:xx:00",
+                },
+                {"address": "1.1.1.1", "type": "nameserver"},
+            ],
+            "version": 1,
+        }
+        macs = {
+            "xx:xx:xx:xx:xx:00": "ens1f0np0",
+            "xx:xx:xx:xx:xx:01": "ens1f1np1",
+        }
+        assert expected == openstack.convert_net_json(
+            network_json=network_json, known_macs=macs
+        )
+
     def test_dns_servers(self):
         """
         Verify additional properties under subnet.routes are not rendered


### PR DESCRIPTION


<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
````
fix(schema): allow accept_ra for bond/bridge/VLAN devices

Setting a static IPv6 on a bond device resulted in the following error:
```
Error: Cloud config schema errors: config.2: Additional properties are not allowed ('accept-ra' was unexpected), config.2: {'accept-ra': False, 'bond_interfaces': ['enp97s0f0np0', 'enp97s0f1np1'], 'mac_address': 'a0:42:3f:00:01:02', 'name': 'bond0', 'params': {'bond-mode': '802.3ad', 'bond-xmit_hash_policy': 'layer3+4'}, 'subnets': [{'type': 'dhcp4'}, {'address': '2001::/56', 'gateway': 'fe80::1', 'ipv6': True, 'type': 'static6'}], 'type': 'bond'} is not valid under any of the given schemas
```
Setting the `accept_ra` sysctl should not be limited to physical interfaces: bond, bridge and VLAN interfaces should also support it.
````

## Additional Context
Setting a static IPv6 on a bond device resulted in the following error:
```
Error: Cloud config schema errors: config.2: Additional properties are not allowed ('accept-ra' was unexpected), config.2: {'accept-ra': False, 'bond_interfaces': ['enp97s0f0np0', 'enp97s0f1np1'], 'mac_address': 'a0:42:3f:00:01:02', 'name': 'bond0', 'params': {'bond-mode': '802.3ad', 'bond-xmit_hash_policy': 'layer3+4'}, 'subnets': [{'type': 'dhcp4'}, {'address': '2001::/56', 'gateway': 'fe80::1', 'ipv6': True, 'type': 'static6'}], 'type': 'bond'} is not valid under any of the given schemas
```
Setting the `accept_ra` sysctl should not be limited to physical interfaces: bond, bridge and VLAN interfaces should also support it.

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"

