### PR TITLE
fix: support bond names in network_data.json

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -705,11 +705,15 @@ def convert_net_json(network_json=None, known_macs=None):
                     # is expected by cloudinit.
                     translated_key = "bond-{}".format(k.split("bond_", 1)[-1])
                     params.update({translated_key: v})
+            cfg["params"] = params
 
             # openstack does not provide a name for the bond.
             # they do provide an 'id', but that is possibly non-sensical.
-            # so we just create our own name.
-            link_name = bond_name_fmt % bond_number
+            # so we just create our own name unless 'name' is set.
+            if cfg.get("name") is None:
+                link_name = bond_name_fmt % bond_number
+                cfg["name"] = link_name
+                curinfo["name"] = link_name
             bond_number += 1
 
             # bond_links reference links by their id, but we need to add
@@ -723,9 +727,6 @@ def convert_net_json(network_json=None, known_macs=None):
                     copy.deepcopy(link["bond_links"]),
                 )
             )
-            cfg.update({"params": params, "name": link_name})
-
-            curinfo["name"] = link_name
         elif link["type"] in ["vlan"]:
             name = "%s.%s" % (link["vlan_link"], link["vlan_id"])
             cfg.update(

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -233,6 +233,127 @@ class TestConvertNetJson:
             network_json=network_json, known_macs=macs
         )
 
+    def test_bond_name(self):
+        """Verify the bond name is retained."""
+        network_json = {
+            "links": [
+                {
+                    "id": "ens1f0np0",
+                    "name": "ens1f0np0",
+                    "type": "phy",
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:00",
+                    "mtu": 9000,
+                },
+                {
+                    "id": "ens1f1np1",
+                    "name": "ens1f1np1",
+                    "type": "phy",
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:01",
+                    "mtu": 9000,
+                },
+                {
+                    "id": "bond0",
+                    "name": "bond-wan",
+                    "type": "bond",
+                    "bond_links": ["ens1f0np0", "ens1f1np1"],
+                    "mtu": 9000,
+                    "ethernet_mac_address": "xx:xx:xx:xx:xx:00",
+                    "bond_mode": "802.3ad",
+                    "bond_xmit_hash_policy": "layer3+4",
+                    "bond_miimon": 100,
+                },
+                {
+                    "id": "bond0.123",
+                    # The vlan name is ignored
+                    "name": "bond0.123",
+                    "type": "vlan",
+                    "vlan_link": "bond0",
+                    "vlan_id": 123,
+                    "vlan_mac_address": "xx:xx:xx:xx:xx:00",
+                },
+            ],
+            "networks": [
+                {
+                    "id": "publicnet-ipv4",
+                    "type": "ipv4",
+                    "link": "bond0.123",
+                    "ip_address": "x.x.x.x",
+                    "netmask": "255.255.255.0",
+                    "routes": [
+                        {
+                            "network": "0.0.0.0",
+                            "netmask": "0.0.0.0",
+                            "gateway": "x.x.x.1",
+                        }
+                    ],
+                    "network_id": "00000000-0000-0000-0000-000000000000",
+                }
+            ],
+            "services": [{"type": "dns", "address": "1.1.1.1"}],
+        }
+        expected = {
+            "config": [
+                {
+                    "mac_address": "xx:xx:xx:xx:xx:00",
+                    "mtu": 9000,
+                    "name": "ens1f0np0",
+                    "subnets": [],
+                    "type": "physical",
+                },
+                {
+                    "mac_address": "xx:xx:xx:xx:xx:01",
+                    "mtu": 9000,
+                    "name": "ens1f1np1",
+                    "subnets": [],
+                    "type": "physical",
+                },
+                {
+                    "bond_interfaces": ["ens1f0np0", "ens1f1np1"],
+                    "mtu": 9000,
+                    "name": "bond-wan",
+                    "mac_address": "xx:xx:xx:xx:xx:00",
+                    "params": {
+                        "bond-miimon": 100,
+                        "bond-mode": "802.3ad",
+                        "bond-xmit_hash_policy": "layer3+4",
+                    },
+                    "subnets": [],
+                    "type": "bond",
+                },
+                {
+                    "name": "bond-wan.123",
+                    "subnets": [
+                        {
+                            "address": "x.x.x.x",
+                            "ipv4": True,
+                            "netmask": "255.255.255.0",
+                            "routes": [
+                                {
+                                    "gateway": "x.x.x.1",
+                                    "netmask": "0.0.0.0",
+                                    "network": "0.0.0.0",
+                                }
+                            ],
+                            "type": "static",
+                        }
+                    ],
+                    "type": "vlan",
+                    "vlan_id": 123,
+                    "vlan_link": "bond-wan",
+                    "mac_address": "xx:xx:xx:xx:xx:00",
+                },
+                {"address": "1.1.1.1", "type": "nameserver"},
+            ],
+            "version": 1,
+        }
+        macs = {
+            "xx:xx:xx:xx:xx:00": "ens1f0np0",
+            "xx:xx:xx:xx:xx:01": "ens1f1np1",
+        }
+        assert expected == openstack.convert_net_json(
+            network_json=network_json, known_macs=macs
+        )
+
     def test_bond_ipv6_accept_ra_false(self):
         """Verify accept-ra is set to False for static IPv6."""
         network_json = {


### PR DESCRIPTION

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e docs``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: support bond names in network_data.json

The code to support the "name" attribute is already present. It should not be ignored for bond devices.
```

## Additional Context

We already support names so we should keep the name if it is set by
https://github.com/canonical/cloud-init/blob/5acf5247e327b153dfd45dd3cdb7c2d3f2808126/cloudinit/sources/helpers/openstack.py#L603-L604

I added the following test:
```diff
--- old 2025-10-27 23:18:34.392957008 +0100
+++ new2        2025-10-28 00:06:58.860642055 +0100
@@ -1,6 +1,5 @@
-
-    def test_bond_mac(self):
-        """Verify the bond mac address is assigned correctly."""
+    def test_bond_name(self):
+        """Verify the bond name is retained."""
         network_json = {
             "links": [
                 {
@@ -19,7 +18,7 @@
                 },
                 {
                     "id": "bond0",
-                    "name": "bond0",
+                    "name": "bond-wan",
                     "type": "bond",
                     "bond_links": ["ens1f0np0", "ens1f1np1"],
                     "mtu": 9000,
@@ -30,6 +29,7 @@
                 },
                 {
                     "id": "bond0.123",
+                    # The vlan name is ignored
                     "name": "bond0.123",
                     "type": "vlan",
                     "vlan_link": "bond0",
@@ -75,7 +75,7 @@
                 {
                     "bond_interfaces": ["ens1f0np0", "ens1f1np1"],
                     "mtu": 9000,
-                    "name": "bond0",
+                    "name": "bond-wan",
                     "mac_address": "xx:xx:xx:xx:xx:00",
                     "params": {
                         "bond-miimon": 100,
@@ -86,7 +86,7 @@
                     "type": "bond",
                 },
                 {
-                    "name": "bond0.123",
+                    "name": "bond-wan.123",
                     "subnets": [
                         {
                             "address": "x.x.x.x",
@@ -104,7 +104,7 @@
                     ],
                     "type": "vlan",
                     "vlan_id": 123,
-                    "vlan_link": "bond0",
+                    "vlan_link": "bond-wan",
                     "mac_address": "xx:xx:xx:xx:xx:00",
                 },
                 {"address": "1.1.1.1", "type": "nameserver"},
```

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"

