### PR TITLE
fix(oracle): handle null metadata field in oracle data source

### DIFF
--- a/cloudinit/sources/DataSourceOracle.py
+++ b/cloudinit/sources/DataSourceOracle.py
@@ -252,7 +252,7 @@ class DataSourceOracle(sources.DataSource):
             "name": data["displayName"],
         }
 
-        if "metadata" in data:
+        if "metadata" in data and data["metadata"] is not None:
             user_data = data["metadata"].get("user_data")
             if user_data:
                 self.userdata_raw = base64.b64decode(user_data)


### PR DESCRIPTION
When running on a Oracle Private Cloud Appliance, we've seen the metadata server return a response where the "metadata" field has a value of "null"; i.e. the "metadata" field exists, but has a "null" value.

As a result, the logic within DataSourceOracle.py throws:

    Traceback (most recent call last):
      File "/usr/lib/python3/dist-packages/cloudinit/sources/__init__.py", line 1052, in find_source
        if s.update_metadata_if_supported(
      File "/usr/lib/python3/dist-packages/cloudinit/sources/__init__.py", line 928, in update_metadata_if_supported
        result = self.get_data()
      File "/usr/lib/python3/dist-packages/cloudinit/sources/__init__.py", line 484, in get_data
        return_value = self._check_and_get_data()
      File "/usr/lib/python3/dist-packages/cloudinit/sources/__init__.py", line 410, in _check_and_get_data
        return self._get_data()
      File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceOracle.py", line 215, in _get_data
        user_data = data["metadata"].get("user_data")
    AttributeError: 'NoneType' object has no attribute 'get'

The fix is to check if the metadata field's value is None, and if so, treat it the same as if the field doesn't exist.