### PR TITLE
doc: readthedocs.yaml needs to generate meson_version.py for cloud-init

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -2,6 +2,7 @@
 doc8
 furo
 meson
+ninja
 m2r2
 pyyaml
 sphinx==7.1.2

--- a/doc/rtd/conf.py
+++ b/doc/rtd/conf.py
@@ -1,6 +1,7 @@
 import datetime
 import glob
 import os
+import re
 import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -11,11 +12,12 @@ sys.path.insert(0, os.path.abspath("../"))
 sys.path.insert(0, os.path.abspath("./"))
 sys.path.insert(0, os.path.abspath("."))
 
+
 # Readthedocs builds will pip install packages and not have PYTHONPATH set
 # So avoid cloudinit imports until we have updated our path first.
-from cloudinit import version
 from cloudinit.config.schema import get_schema
 from cloudinit.handlers.jinja_template import render_jinja_payload
+from cloudinit.subp import subp
 
 # Suppress warnings for docs that aren't used yet
 # unused_docs = [
@@ -64,7 +66,18 @@ master_doc = "index"
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-version = version.version_string()
+
+
+def get_version():
+    subp(["meson", "setup", "../../builddir", "../.."])
+    with open("../../builddir/meson_versions.py") as stream:
+        match = re.search(r'UPSTREAM_VERSION = "([^"]+)"', stream.read())
+    if match:
+        return match.group(1)
+    return "@UNABLE_TO_BUILD_meson_versions_py@"
+
+
+version = get_version()
 release = version
 
 # Set the default Pygments syntax

--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,8 @@ init_system = get_option('init_system')
 lib_exec_dir = get_option('prefix') / get_option('libexecdir') / 'cloud-init'
 render_tmpl = './tools/render-template'
 
+is_readthedocs = run_command('bash', '-c', 'echo ${READTHEDOCS}', check: true).stdout().strip()
+
 pymod = import('python')
 python = pymod.find_installation('python3')
 
@@ -43,7 +45,7 @@ configure_file(
 
 
 # Binaries and script entrypoints
-if get_option('bash_completion')
+if get_option('bash_completion') and is_readthedocs != 'True'
   bash_completions_dir = dependency('bash-completion').get_variable(
     pkgconfig: 'completionsdir',
     default_value: get_option('datadir') / 'bash-completion' / 'completions',
@@ -101,7 +103,7 @@ install_data(
   install_tag: 'config',
 )
 
-if init_system == 'systemd'
+if init_system == 'systemd' and is_readthedocs != 'True'
   systemd = dependency('systemd')
   udev = dependency('udev')
   systemd_unit_dir = systemd.get_variable(pkgconfig: 'systemdsystemunitdir')


### PR DESCRIPTION
work in progress to validate RTD doc builds including the correct version of cloud-init from meson.build.

## Proposed Commit Message
```
doc: readthedocs.yaml needs to generate meson_version.py for cloud-init
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
