### PR TITLE
fix(cloudstack): Improve domain-name DHCP lease lookup (Cloudstack)

### DIFF
--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -103,7 +103,6 @@ class DataSourceCloudStack(sources.DataSource):
         - From dhcpcd (ephemeral)
         - Return empty string if not found (non-fatal)
         """
-        from cloudinit.net.dhcp import NoDHCPLeaseError
 
         LOG.debug("Try obtaining domain name from networkd leases")
         for key in ["DOMAINNAME", "Domain", "domain-name"]:
@@ -112,7 +111,8 @@ class DataSourceCloudStack(sources.DataSource):
                 return domainname.strip()
 
         LOG.debug(
-            "Could not obtain FQDN from networkd leases. Falling back to ISC dhclient"
+            "Could not obtain FQDN from networkd leases. Falling back to "
+            "ISC dhclient"
         )
         with suppress(dhcp.NoDHCPLeaseMissingDhclientError):
             domain_name = dhcp.IscDhclient().get_key_from_latest_lease(
@@ -122,7 +122,8 @@ class DataSourceCloudStack(sources.DataSource):
                 return domain_name.strip()
 
         LOG.debug(
-            "Could not obtain FQDN from ISC dhclient leases. Falling back to %s",
+            "Could not obtain FQDN from ISC dhclient leases. Falling back to "
+            "%s",
             self.distro.dhcp_client.client_name,
         )
         try:

--- a/tests/unittests/sources/test_cloudstack.py
+++ b/tests/unittests/sources/test_cloudstack.py
@@ -2,6 +2,7 @@
 # pylint: disable=attribute-defined-outside-init
 from socket import gaierror
 from textwrap import dedent
+from unittest.mock import patch
 
 import pytest
 
@@ -16,7 +17,6 @@ from cloudinit.sources.DataSourceCloudStack import (
     get_vr_address,
 )
 from tests.unittests.helpers import mock
-from unittest.mock import patch
 from tests.unittests.util import MockDistro
 
 SOURCES_PATH = "cloudinit.sources"
@@ -232,7 +232,8 @@ class TestCloudStackHostname:
     def test__get_domainname_supports_all_casing_variants(
         self, lease_key, expected_domain
     ):
-        """Ensure _get_domainname works with DOMAINNAME, Domain and domain-name."""
+        """Ensure _get_domainname works with DOMAINNAME, Domain and
+        domain-name."""
         # Mock the helper to return the domain only when the exact key is asked
         with patch(
             "cloudinit.net.dhcp.networkd_get_option_from_leases"


### PR DESCRIPTION
## Proposed Commit Message
```
fix(cloudstack): Improve domain-name DHCP lease lookup

    * Adding case-insensitive options for systemd-networkd leases ("DOMAINNAME", "Domain", "domain-name").
    * Falling back gracefully from systemd leases to ISC dhclient leases.
    * Including dhcpcd ephemeral leases as an additional fallback.
    * Returning an empty string when no domain name found instead of None for non-fatal missing cases.
```   

## Additional Context
```bash
[    9.443914] cloud-init[625]: ci-info: ++++++++++++++++++++++++++++++++++++Net device info+++++++++++++++++++++++++++++++++++++
[    9.447851] cloud-init[625]: ci-info: +--------+------+-------------------------+---------------+--------+-------------------+
[    9.451625] cloud-init[625]: ci-info: | Device |  Up  |         Address         |      Mask     | Scope  |     Hw-Address    |
[    9.456544] cloud-init[625]: ci-info: +--------+------+-------------------------+---------------+--------+-------------------+
[    9.465915] cloud-init[625]: ci-info: |  ens3  | True |       10.10.3.149       | 255.255.252.0 | global | 02:04:06:e3:02:65 |
[    9.469895] cloud-init[625]: ci-info: |  ens3  | True | fe80::4:6ff:fee3:265/64 |       .       |  link  | 02:04:06:e3:02:65 |
[    9.474331] cloud-init[625]: ci-info: |   lo   | True |        127.0.0.1        |   255.0.0.0   |  host  |         .         |
[    9.478758] cloud-init[625]: ci-info: |   lo   | True |         ::1/128         |       .       |  host  |         .         |
[    9.483070] cloud-init[625]: ci-info: +--------+------+-------------------------+---------------+--------+-------------------+
[    9.487021] cloud-init[625]: ci-info: +++++++++++++++++++++++++++++Route IPv4 info+++++++++++++++++++++++++++++
[    9.490278] cloud-init[625]: ci-info: +-------+-------------+-----------+-----------------+-----------+-------+
[    9.493355] cloud-init[625]: ci-info: | Route | Destination |  Gateway  |     Genmask     | Interface | Flags |
[    9.496312] cloud-init[625]: ci-info: +-------+-------------+-----------+-----------------+-----------+-------+
[    9.499076] cloud-init[625]: ci-info: |   0   |   0.0.0.0   | 10.10.0.1 |     0.0.0.0     |    ens3   |   UG  |
[    9.501760] cloud-init[625]: ci-info: |   1   |   1.0.0.1   | 10.10.0.1 | 255.255.255.255 |    ens3   |  UGH  |
[    9.504269] cloud-init[625]: ci-info: |   2   |   1.1.1.1   | 10.10.0.1 | 255.255.255.255 |    ens3   |  UGH  |
[    9.506688] cloud-init[625]: ci-info: |   3   |  10.10.0.0  |  0.0.0.0  |  255.255.252.0  |    ens3   |   U   |
[    9.509116] cloud-init[625]: ci-info: |   4   |  10.10.0.1  |  0.0.0.0  | 255.255.255.255 |    ens3   |   UH  |
[    9.511493] cloud-init[625]: ci-info: +-------+-------------+-----------+-----------------+-----------+-------+
[    9.513752] cloud-init[625]: ci-info: +++++++++++++++++++Route IPv6 info+++++++++++++++++++
[    9.515565] cloud-init[625]: ci-info: +-------+-------------+---------+-----------+-------+
[    9.517371] cloud-init[625]: ci-info: | Route | Destination | Gateway | Interface | Flags |
[    9.519053] cloud-init[625]: ci-info: +-------+-------------+---------+-----------+-------+
[    9.520780] cloud-init[625]: ci-info: |   0   |  fe80::/64  |    ::   |    ens3   |   U   |
[    9.522536] cloud-init[625]: ci-info: |   2   |    local    |    ::   |    ens3   |   U   |
[    9.524124] cloud-init[625]: ci-info: |   3   |  multicast  |    ::   |    ens3   |   U   |
[    9.525767] cloud-init[625]: ci-info: +-------+-------------+---------+-----------+-------+
         Stopping systemd-networkd-persiste…tent Storage in systemd-networkd...
[  OK  ] Stopped systemd-networkd-wait-onli… Wait for Network to be Configured.
         Stopping systemd-networkd-wait-onl…ait for Network to be Configured...
[  OK  ] Stopped systemd-networkd-persisten…istent Storage in systemd-networkd.
         Stopping systemd-networkd.service - Network Configuration...
[  OK  ] Stopped systemd-networkd.service - Network Configuration.
         Starting systemd-networkd.service - Network Configuration...
[  OK  ] Started systemd-networkd.service - Network Configuration.
         Starting systemd-networkd-persiste…tent Storage in systemd-networkd...
         Starting systemd-networkd-wait-onl…ait for Network to be Configured...
[  OK  ] Finished systemd-networkd-persiste…istent Storage in systemd-networkd.
[   13.988718] cloud-init[625]: 2025-10-31 15:10:52,546 - main.py[ERROR]: failed stage init
[   13.991559] cloud-init[625]: Traceback (most recent call last):
[   13.993704] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 861, in get_newest_lease
[   13.997455] cloud-init[625]:     subp.subp(
[   13.999084] cloud-init[625]:     ~~~~~~~~~^
[   14.001464] cloud-init[625]:         [
[FAILED] Failed to start cloud-init-network…ervice - Cloud-init: Network Stage.
[   14.005845] cloud-init[625]:         ^
See 'systemctl status cloud-init-network.service' for details.
[   14.009062] cloud-init[625]:     ...<4 lines>...
[  OK  ] Reached target cloud-config.target - Cloud-config availability.
[   14.013487] cloud-init[625]:         ],
[  OK  ] Reached target sysinit.target - System Initialization.
[   14.017193] cloud-init[625]:         ^^
[  OK  ] Started apt-daily.timer - Daily apt download activities.
[   14.020566] cloud-init[625]:     ).stdout,
[  OK  ] Started apt-daily-upgrade.timer - …y apt upgrade and clean activities.
[   14.024383] cloud-init[625]:     ^
[  OK  ] Started apt-listchanges.timer - Tr…e apt-listchanges database for APT.
[   14.027826] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 291, in subp
[  OK  ] Started dpkg-db-backup.timer - Daily dpkg database backup timer.
[   14.032425] cloud-init[625]:     raise ProcessExecutionError(
[  OK  ] Started e2scrub_all.timer - Period…Metadata Check for All Filesystems.
[   14.036073] cloud-init[625]:         stdout=out, stderr=err, exit_code=rc, cmd=args
[  OK  ] Started fstrim.timer - Discard unused filesystem blocks once a week.
[   14.039716] cloud-init[625]:     )
[  OK  ] Started man-db.timer - Daily man-db regeneration.
[   14.042132] cloud-init[625]: cloudinit.subp.ProcessExecutionError: Unexpected error while running command.
[  OK  ] Started systemd-tmpfiles-clean.tim…y Cleanup of Temporary Directories.
[   14.046022] cloud-init[625]: Command: ['dhcpcd', '--dumplease', '--ipv4only', 'ens3']
[  OK  ] Reached target timers.target - Timer Units.
[   14.048997] cloud-init[625]: Exit code: 1
[  OK  ] Listening on cloud-init-hotplugd.s…t - cloud-init hotplug hook socket.
[   14.051570] cloud-init[625]: Reason: -
[   14.052614] cloud-init[625]: Stdout:
[  OK  ] Listening on dbus.socket - D-Bus System Message Bus Socket.
[   14.054927] cloud-init[625]: Stderr: dhcpcd is not running
[   14.056041] cloud-init[625]: The above exception was the direct cause of the following exception:
[   14.057623] cloud-init[625]: Traceback (most recent call last):
[  OK  ] Listening on sshd-unix-local.socke…temd-ssh-generator, AF_UNIX Local).
[   14.060548] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 931, in status_wrapper
[  OK  ] Listening on sshd-vsock.socket - O… (systemd-ssh-generator, AF_VSOCK).
[   14.064267] cloud-init[625]:     ret = functor(name, args)
[  OK  ] Reached target ssh-access.target - SSH Access Available.
[   14.066752] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 599, in main_init
[  OK  ] Listening on systemd-hostnamed.socket - Hostname Service Socket.
[   14.070195] cloud-init[625]:     _maybe_set_hostname(init, stage="init-net", retry_stage="modules:config")
[  OK  ] Listening on uuidd.socket - UUID daemon activation socket.
[  OK  ] Reached target sockets.target - Socket Units.
[   14.074743] cloud-init[625]:     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[  OK  ] Reached target basic.target - Basic System.
[   14.077777] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 1014, in _maybe_set_hostname
[   14.079732] cloud-init[625]:     (hostname, _fqdn, _) = util.get_hostname_fqdn(
[   14.081173] cloud-init[625]:                            ~~~~~~~~~~~~~~~~~~~~~~^
         Starting dbus.service - D-Bus System Message Bus...
[   14.083747] cloud-init[625]:         init.cfg, cloud, metadata_only=True
[   14.085413] cloud-init[625]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   14.088184] cloud-init[625]:     )
         Starting e2scrub_reap.service - Re…ne ext4 Metadata Check Snapshots...
         Starting grub-common.service - Record successful boot for GRUB...
[   14.090425] cloud-init[625]:     ^
[   14.097925] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/util.py", line 1229, in get_hostname_fqdn
[   14.099870] cloud-init[625]:     fqdn = cloud.get_hostname(
[   14.101044] cloud-init[625]:            ~~~~~~~~~~~~~~~~~~^
[   14.102131] cloud-init[625]:         fqdn=True, metadata_only=metadata_only
[   14.103452] cloud-init[625]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   14.104725] cloud-init[625]:     ).hostname
[   14.105576] cloud-init[625]:     ^
[   14.106655] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/cloud.py", line 102, in get_hostname
[   14.110162] cloud-init[625]:     return self.datasource.get_hostname(
[   14.113324] cloud-init[625]:            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
         Starting ssh.service - OpenBSD Secure Shell server...
[   14.116148] cloud-init[625]:         fqdn=fqdn, metadata_only=metadata_only
[   14.121079] cloud-init[625]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   14.122577] cloud-init[625]:     )
[   14.123306] cloud-init[625]:     ^
[   14.124667] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceCloudStack.py", line 157, in get_hostname
         Starting systemd-logind.service - User Login Management...
[   14.129516] cloud-init[625]:     domainname = self._get_domainname()
[   14.131123] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceCloudStack.py", line 133, in _get_domainname
[   14.139747] cloud-init[625]:     latest_lease = self.distro.dhcp_client.get_newest_lease(
[   14.141601] cloud-init[625]:         self.distro.fallback_interface
[   14.142710] cloud-init[625]:     )
[   14.143754] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 879, in get_newest_lease
         Starting systemd-user-sessions.service - Permit User Sessions...
[   14.148285] cloud-init[625]:     raise NoDHCPLeaseError from error
[   14.149578] cloud-init[625]: cloudinit.net.dhcp.NoDHCPLeaseError
[   14.152691] cloud-init[625]: failed run of stage init
[   14.153924] cloud-init[625]: ------------------------------------------------------------
[   14.156102] cloud-init[625]: Traceback (most recent call last):
[   14.157831] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 861, in get_newest_lease
[  OK  ] Started dbus.service - D-Bus System Message Bus.
[   14.161489] cloud-init[625]:     subp.subp(
[   14.162508] cloud-init[625]:     ~~~~~~~~~^
[   14.164169] cloud-init[625]:         [
[   14.167728] cloud-init[625]:         ^
[   14.168746] cloud-init[625]:     ...<4 lines>...
[   14.169994] cloud-init[625]:         ],
[   14.170969] cloud-init[625]:         ^^
[   14.172364] cloud-init[625]:     ).stdout,
[FAILED] Failed to start ssh.service - OpenBSD Secure Shell server.
[   14.176206] cloud-init[625]:     ^
[   14.177461] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/subp.py", line 291, in subp
See 'systemctl status ssh.service' for details.
[   14.181816] cloud-init[625]:     raise ProcessExecutionError(
[  OK  ] Finished systemd-user-sessions.service - Permit User Sessions.
[   14.184499] cloud-init[625]:         stdout=out, stderr=err, exit_code=rc, cmd=args
[  OK  ] Finished e2scrub_reap.service - Re…line ext4 Metadata Check Snapshots.
[   14.188526] cloud-init[625]:     )
[   14.189219] cloud-init[625]: cloudinit.subp.ProcessExecutionError: Unexpected error while running command.
[   14.190666] cloud-init[625]: Command: ['dhcpcd', '--dumplease', '--ipv4only', 'ens3']
[   14.191865] cloud-init[625]: Exit code: 1
[   14.196185] cloud-init[625]: Reason: -
[   14.198270] cloud-init[625]: Stdout:
[   14.198958] cloud-init[625]: Stderr: dhcpcd is not running
[   14.199868] cloud-init[625]: The above exception was the direct cause of the following exception:
[   14.204163] cloud-init[625]: Traceback (most recent call last):
[   14.205128] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 931, in status_wrapper
[   14.206731] cloud-init[625]:     ret = functor(name, args)
[   14.207603] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 599, in main_init
[  OK  ] Started getty@tty1.service - Getty on tty1.
[   14.211520] cloud-init[625]:     _maybe_set_hostname(init, stage="init-net", retry_stage="modules:config")
[   14.214106] cloud-init[625]:     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   14.215579] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/cmd/main.py", line 1014, in _maybe_set_hostname
[   14.217830] cloud-init[625]:     (hostname, _fqdn, _) = util.get_hostname_fqdn(
[   14.219012] cloud-init[625]:                            ~~~~~~~~~~~~~~~~~~~~~~^
[   14.220198] cloud-init[625]:         init.cfg, cloud, metadata_only=True
[   14.221297] cloud-init[625]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   14.222509] cloud-init[625]:     )
[   14.223206] cloud-init[625]:     ^
[   14.224033] sh[691]: Completed socket interaction for boot stage network
[   14.225600] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/util.py", line 1229, in get_hostname_fqdn
[   14.227331] cloud-init[625]:     fqdn = cloud.get_hostname(
[   14.228273] cloud-init[625]:            ~~~~~~~~~~~~~~~~~~^
[   14.229230] cloud-init[625]:         fqdn=True, metadata_only=metadata_only
[   14.230342] cloud-init[625]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   14.231581] cloud-init[625]:     ).hostname
[   14.238601] cloud-init[625]:     ^
[   14.239268] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/cloud.py", line 102, in get_hostname
[   14.242100] cloud-init[625]:     return self.datasource.get_hostname(
[   14.244296] cloud-init[625]:            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
[   14.245323] cloud-init[625]:         fqdn=fqdn, metadata_only=metadata_only
[   14.246401] cloud-init[625]:         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[   14.247476] cloud-init[625]:     )
[  OK  ] Started serial-getty@ttyS0.service - Serial Getty on ttyS0.
[  OK  ] Reached target getty.target - Login Prompts.
[  OK  ] Started systemd-logind.service - User Login Management.
[   14.255463] cloud-init[625]:     ^
[   14.256179] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceCloudStack.py", line 157, in get_hostname
[  OK  ] Finished grub-common.service - Record successful boot for GRUB.
[   14.259699] cloud-init[625]:     domainname = self._get_domainname()
[   14.262157] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/sources/DataSourceCloudStack.py", line 133, in _get_domainname
[   14.264168] cloud-init[625]:     latest_lease = self.distro.dhcp_client.get_newest_lease(
[   14.265465] cloud-init[625]:         self.distro.fallback_interface
[   14.266681] cloud-init[625]:     )
[  OK  ] Started unattended-upgrades.service - Unattended Upgrades Shutdown.
[   14.268301] cloud-init[625]:   File "/usr/lib/python3/dist-packages/cloudinit/net/dhcp.py", line 879, in get_newest_lease
[   14.271553] cloud-init[625]:     raise NoDHCPLeaseError from error
[  OK  ] Reached target multi-user.target - Multi-User System.
[   14.273755] cloud-init[625]: cloudinit.net.dhcp.NoDHCPLeaseError
[  OK  ] Reached target graphical.target - Graphical Interface.
[   14.275456] cloud-init[625]: ------------------------------------------------------------
         Starting ssh.service - OpenBSD Secure Shell server...
[FAILED] Failed to start ssh.service - OpenBSD Secure Shell server.
See 'systemctl status ssh.service' for details.
         Starting ssh.service - OpenBSD Secure Shell server...
[FAILED] Failed to start ssh.service - OpenBSD Secure Shell server.
See 'systemctl status ssh.service' for details.
         Starting ssh.service - OpenBSD Secure Shell server...
         Starting systemd-hostnamed.service - Hostname Service...
[FAILED] Failed to start ssh.service - OpenBSD Secure Shell server.
See 'systemctl status ssh.service' for details.
[  OK  ] Finished systemd-networkd-wait-onl… Wait for Network to be Configured.
[  OK  ] Reached target network-online.target - Network is Online.
         Starting cloud-config.service - Cloud-init: Config Stage...
[  OK  ] Started systemd-hostnamed.service - Hostname Service.
         Starting polkit.service - Authorization Manager...
[   15.065807] cloud-init[625]: Cloud-init v. 25.1.4 running 'modules:config' at Fri, 31 Oct 2025 15:10:53 +0000. Up 15.04 seconds.
         Starting ssh.service - OpenBSD Secure Shell server...
[FAILED] Failed to start ssh.service - OpenBSD Secure Shell server.
See 'systemctl status ssh.service' for details.
[   15.139530] cloud-init[625]: 2025-10-31 15:10:53,722 - log_util.py[WARNING]: Failed to set passwords with chpasswd for ['debian']
[  OK  ] Stopped ssh.service - OpenBSD Secure Shell server.
[FAILED] Failed to start ssh.service - OpenBSD Secure Shell server.
See 'systemctl status ssh.service' for details.
[   15.179960] cloud-init[625]: 2025-10-31 15:10:53,762 - cc_set_passwords.py[WARNING]: 'ssh_pwauth' configuration may not be applied. Cloud-init was unable to restart SSH daemon due to error: 'Unexpected error while running command.
[   15.185923] cloud-init[625]: Command: ['systemctl', 'restart', 'ssh', '--job-mode=ignore-dependencies']
[   15.188089] cloud-init[625]: Exit code: 1
[   15.188944] cloud-init[625]: Reason: -
[   15.190089] cloud-init[625]: Stdout:
[   15.190918] cloud-init[625]: Stderr: Job for ssh.service failed because the control process exited with error code.
[   15.193327] cloud-init[625]:         See "systemctl status ssh.service" and "journalctl -xeu ssh.service" for details.'
[   15.195387] cloud-init[625]: 2025-10-31 15:10:53,762 - log_util.py[WARNING]: Running module set-passwords (<module 'cloudinit.config.cc_set_passwords' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_set_passwords.py'>) failed
[  OK  ] Started polkit.service - Authorization Manager.
[   15.227797] sh[818]: Completed socket interaction for boot stage config
[FAILED] Failed to start cloud-config.service - Cloud-init: Config Stage.
See 'systemctl status cloud-config.service' for details.
         Starting cloud-final.service - Cloud-init: Final Stage...
[   15.292060] cloud-init[625]: Cloud-init v. 25.1.4 running 'modules:final' at Fri, 31 Oct 2025 15:10:53 +0000. Up 15.26 seconds.
[   15.347963] cloud-init[625]: 2025-10-31 15:10:53,931 - log_util.py[WARNING]: Running module ssh-authkey-fingerprints (<module 'cloudinit.config.cc_ssh_authkey_fingerprints' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_ssh_authkey_fingerprints.py'>) failed

[   15.369003] cloud-init[625]: Cloud-init v. 25.1.4 finished at Fri, 31 Oct 2025 15:10:53 +0000. Datasource DataSourceCloudStack.  Up 15.36 seconds
[   15.374955] sh[854]: Completed socket interaction for boot stage final
[FAILED] Failed to start cloud-final.service - Cloud-init: Final Stage.
See 'systemctl status cloud-final.service' for details.
[  OK  ] Reached target cloud-init.target - Cloud-init target.

```

## Test Steps
1. Just boot up Debian 13 in Cloudstack. Console will show errors and hostname will be localhost and SSH will not listen.
2. Then reboot the VM, and things will work.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
