### PR TITLE
fix(azure): Add retry logic to 500 errors for reprovision data

### DIFF
--- a/cloudinit/sources/azure/imds.py
+++ b/cloudinit/sources/azure/imds.py
@@ -222,11 +222,6 @@ def fetch_reprovision_data() -> bytes:
     handler = ReadUrlRetryHandler(
         logging_backoff=2.0,
         max_connection_errors=1,
-        retry_codes=(
-            404,
-            410,
-            429,
-        ),
         retry_deadline=None,
     )
     response = readurl(

--- a/tests/unittests/sources/azure/test_imds.py
+++ b/tests/unittests/sources/azure/test_imds.py
@@ -714,6 +714,7 @@ class TestFetchReprovisionData:
             fake_http_error_for_code(404),
             fake_http_error_for_code(410),
             fake_http_error_for_code(429),
+            fake_http_error_for_code(500),
         ],
     )
     @pytest.mark.parametrize("failures", [1, 5, 100, 1000])
@@ -773,6 +774,7 @@ class TestFetchReprovisionData:
             fake_http_error_for_code(404),
             fake_http_error_for_code(410),
             fake_http_error_for_code(429),
+            fake_http_error_for_code(500),
         ],
     )
     @pytest.mark.parametrize("failures", [1, 5, 100, 1000])
@@ -881,6 +883,7 @@ class TestFetchReprovisionData:
             + [404] * 10
             + [410] * 10
             + [429] * 10
+            + [500] * 10
         )
 
         add_errors_to_mock_requests(mock_requests, errors, self.base_url)


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [X] I have signed the CLA: https://ubuntu.com/legal/contributors
- [X] I have included a comprehensive commit message using the guide below
- [X] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [X] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [X] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [X] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(azure): retry 500 errors in fetching reprovision data

Removes the explicit exclusion of 500 errors from azure's
`fetch_reprovision_data()` function.  Returns the 
RetryHandler to the default list of status codes to retry.

Fixes GH-6562 
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"

Fixes #6562 