### PR TITLE
Fix URL scheme in deprecation message

### DIFF
--- a/cloudinit/sources/DataSourceNoCloud.py
+++ b/cloudinit/sources/DataSourceNoCloud.py
@@ -423,7 +423,7 @@ class DataSourceNoCloudNet(DataSourceNoCloud):
             deprecated_version="24.1",
             extra_message=(
                 "Use 'nocloud' instead, which uses the seedfrom protocol"
-                "scheme (http// or file://) to decide how to run."
+                "scheme (http:// or file://) to decide how to run."
             ),
         )
 


### PR DESCRIPTION


- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.

## Proposed Commit Message
Updates a missed colon : on deprecation notice for nocloud-net
```
# as now
2025-11-08 08:59:02,803 - lifecycle.py[DEPRECATED]: The 'nocloud-net' datasource name is deprecated in 24.1 and scheduled to be removed in 29.1. Use 'nocloud' instead, which uses the seedfrom protocolscheme (http// or file://) to decide how to run.
```

## Additional Context

## Test Steps


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
