### PR TITLE
fix(azure): run pubkey extraction and certificate parsing tests

### DIFF
--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -520,7 +520,7 @@ class TestOpenSSLManagerActions:
     @pytest.mark.allow_all_subp
     @pytest.mark.skipif(
         shutil.which("openssl") is None,
-        reason="OpenSSL command-line tool not installed"
+        reason="OpenSSL command-line tool not installed",
     )
     def test_pubkey_extract(self):
         cert = load_text_file(self._data_file("pubkey_extract_cert"))
@@ -536,7 +536,7 @@ class TestOpenSSLManagerActions:
     @pytest.mark.allow_all_subp
     @pytest.mark.skipif(
         shutil.which("openssl") is None,
-        reason="OpenSSL command-line tool not installed"
+        reason="OpenSSL command-line tool not installed",
     )
     @mock.patch.object(azure_helper.OpenSSLManager, "_decrypt_certs_from_xml")
     def test_parse_certificates(self, mock_decrypt_certs):


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [X] I have signed the CLA: https://ubuntu.com/legal/contributors
- [X] I have included a comprehensive commit message using the guide below
- [X] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [X] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [X] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [X] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(azure): enable openSSLManager tests

Enables `test_pubkey_extract` and `test_parse_certificates`
to be run by Pytest as part of the CI pipeline.

Fixes GH-6571
```

## Merge type

- [X] Squash merge using "Proposed Commit Message"

Fixes #6571