### PR TITLE
fix(openstack): correct bond parameter translation for sysconfig

### DIFF
--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -703,7 +703,7 @@ def convert_net_json(network_json=None, known_macs=None):
                     # cloudinit schema but 'bond_' in OpenStack
                     # network_data.json schema. Translate them to what
                     # is expected by cloudinit.
-                    translated_key = "bond-{}".format(k.split("bond_", 1)[-1])
+                    translated_key = k.replace("_", "-")
                     params.update({translated_key: v})
 
             # openstack does not provide a name for the bond.

--- a/tests/unittests/sources/helpers/test_openstack.py
+++ b/tests/unittests/sources/helpers/test_openstack.py
@@ -194,7 +194,7 @@ class TestConvertNetJson:
                     "params": {
                         "bond-miimon": 100,
                         "bond-mode": "802.3ad",
-                        "bond-xmit_hash_policy": "layer3+4",
+                        "bond-xmit-hash-policy": "layer3+4",
                     },
                     "subnets": [],
                     "type": "bond",
@@ -321,7 +321,7 @@ class TestConvertNetJson:
                     "mac_address": "xx:xx:xx:xx:xx:00",
                     "params": {
                         "bond-mode": "802.3ad",
-                        "bond-xmit_hash_policy": "layer3+4",
+                        "bond-xmit-hash-policy": "layer3+4",
                         "bond-miimon": 100,
                     },
                     "bond_interfaces": ["ens1f0np0", "ens1f1np1"],


### PR DESCRIPTION
Fix regression in bond parameter handling when using OpenStack network_data.json with sysconfig renderer.

The issue occurred when translating bond parameters from OpenStack format (bond_xmit_hash_policy) to cloud-init format. The previous implementation only replaced "bond_" prefix with "bond-", leaving remaining underscores unchanged. This created a mixed format like "bond-xmit_hash_policy" which didn't match either lookup variant in the sysconfig renderer:
- bond_xmit_hash_policy (all underscores)
- bond-xmit-hash-policy (all hyphens)

As a result, bond options like xmit_hash_policy and lacp_rate were silently dropped from BONDING_OPTS in sysconfig rendering.

The fix replaces ALL underscores with hyphens, ensuring parameters match the expected format in sysconfig renderer.

Before: BONDING_OPTS="mode=802.3ad"
After:  BONDING_OPTS="mode=802.3ad xmit_hash_policy=layer3+4 lacp_rate=fast"

Affects versions: 24.4+

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: correct handling of bonding options in network_data.json

Fix regression in bond parameter handling when using OpenStack network_data.json with sysconfig renderer.

```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
