### PR TITLE
feat(growpart): add LVM resize support

### DIFF
--- a/cloudinit/config/cc_growpart.py
+++ b/cloudinit/config/cc_growpart.py
@@ -39,6 +39,7 @@ DEFAULT_CONFIG = {
     "mode": "auto",
     "devices": ["/"],
     "ignore_growroot_disabled": False,
+    "resize_lv": True,
 }
 
 KEYDATA_PATH = Path("/cc_growpart_keydata")
@@ -363,6 +364,178 @@ def resize_encrypted(blockdev, partition) -> Tuple[str, str]:
     )
 
 
+def _get_vg_for_lv(lv_dev):
+    """
+    Return the VG name for a logical volume device,
+    e.g. /dev/mapper/vg-lv or /dev/vg/lv.
+    Uses `lvs --noheadings -o vg_name <lv_dev>`.
+    """
+    try:
+        out = subp.subp(
+            ["lvs", "--noheadings", "-o", "vg_name", lv_dev]
+        ).stdout
+        # lvs often prints whitespace padded output; take last token
+        vg = out.strip().split()[-1]
+        LOG.debug("lv %s belongs to vg %s", lv_dev, vg)
+        return vg
+    except Exception as e:
+        LOG.warning("failed to get VG for %s: %s", lv_dev, e)
+        raise
+
+
+def _get_pvs_for_vg(vg_name):
+    """
+    Return list of PV device paths for a volume group,
+    using `vgs -o pv_name --noheadings --separator ' ' <vg>`.
+    """
+    try:
+        out = subp.subp(
+            [
+                "vgs",
+                "--noheadings",
+                "-o",
+                "pv_name",
+                "--separator",
+                " ",
+                vg_name,
+            ]
+        ).stdout
+        # vgs returns space separated PV names (may include trailing spaces)
+        pvs = [p for p in out.split() if p]
+        LOG.debug("vg %s pvs: %s", vg_name, pvs)
+        return pvs
+    except Exception as e:
+        LOG.warning("failed to list PVs for VG %s: %s", vg_name, e)
+        raise
+
+
+def _pvresize(pv_dev):
+    """Run pvresize on each PV; idempotent: if it fails log and raise."""
+    try:
+        subp.subp(["pvresize", pv_dev])
+        LOG.info("pvresize succeeded for %s", pv_dev)
+        return True
+    except Exception as e:
+        LOG.warning("pvresize failed for %s: %s", pv_dev, e)
+        raise
+
+
+def _lvextend_to_free(lv_dev):
+    """Extend the LV to consume all free extents in its VG."""
+    try:
+        subp.subp(["lvextend", "-l", "+100%FREE", lv_dev])
+        LOG.info("lvextend +100%%FREE succeeded for %s", lv_dev)
+        return True
+    except Exception as e:
+        LOG.warning("lvextend failed for %s: %s", lv_dev, e)
+        raise
+
+
+def resize_lvm(
+    blockdev, resize_lv: bool = True, resizer: Optional[Resizer] = None
+) -> Tuple[str, str]:
+    """
+    High-level procedure to resize LVM logical volume
+    after underlying PVs were expanded:
+      - find VG for lv (devpath)
+      - if resizer is a ResizeGrowPart, skip pvresize if VG has only one PV
+      - for each PV in VG: pvresize (unless skipped)
+      - optionally lvextend the lv to use free space (if resize_lv=True)
+
+    Args:
+        blockdev: The logical volume device path
+        resize_lv: If True, extend the LV to consume all free space in the VG.
+                   If False, only resize PVs, leaving LV size unchanged.
+                   Default: True (for backward compatibility).
+        resizer: The partition resizer instance. If ResizeGrowPart and VG has
+                 single PV, pvresize will be automatically skipped (growpart
+                 already handled it). If None or not ResizeGrowPart, pvresize
+                 will run on all PVs. Default: None.
+    """
+    LOG.info("starting LVM resize flow for %s", blockdev)
+    # Get VG and PV information
+    # If these fail, cannot proceed with LVM resize
+    try:
+        vg = _get_vg_for_lv(blockdev)
+        pvs = _get_pvs_for_vg(vg)
+    except Exception as e:
+        raise ResizeFailedException(
+            f"Failed to query LVM information for {blockdev}: {e}. "
+            f"Cannot proceed with LVM resize operations."
+        ) from e
+
+    # Determine if we should skip pvresize
+    # (growpart's maybe_lvm_resize only resizes the specific partition's PV,
+    # so for multi-PV VGs we need to resize all PVs)
+    skip_pvresize = False
+    if isinstance(resizer, ResizeGrowPart):
+        if len(pvs) == 1:
+            skip_pvresize = True
+            LOG.debug(
+                "VG %s has single PV, skipping pvresize "
+                "(growpart already handled it)",
+                vg,
+            )
+        else:
+            LOG.info(
+                "VG %s has %d PVs, resizing all PVs "
+                "(growpart only resized the partition's PV)",
+                vg,
+                len(pvs),
+            )
+    # try pvresize for each PV (unless skipped, e.g., growpart already did it)
+    if not skip_pvresize:
+        for pv in pvs:
+            try:
+                _pvresize(pv)
+            except Exception:
+                LOG.warning(
+                    "pvresize failed for %s, continuing to next PV", pv
+                )
+    else:
+        LOG.debug(
+            "Skipping pvresize for %s (already handled by partition resizer)",
+            blockdev,
+        )
+
+    # extend the LV to use free space (if enabled)
+    if resize_lv:
+        _lvextend_to_free(blockdev)
+        pv_status = (
+            "PV already resized" if skip_pvresize else "PV and LV resized"
+        )
+        return (
+            RESIZE.CHANGED,
+            f"Successfully resized LVM device '{blockdev}' ({pv_status})",
+        )
+    else:
+        LOG.info(
+            "LV resize disabled for %s; %s. "
+            "Free space remains available in VG for other LVs.",
+            blockdev,
+            "PV already resized" if skip_pvresize else "PVs were resized",
+        )
+        pv_status = "PV already resized" if skip_pvresize else "PV resized"
+        return (
+            RESIZE.CHANGED,
+            f"Successfully resized LVM device '{blockdev}' "
+            f"({pv_status}, LV unchanged)",
+        )
+
+
+def is_lvm_device(blockdev) -> bool:
+    """
+    Checks if a given device path points to an LVM device.
+    """
+    try:
+        # Run lsblk to check if the device type is 'lvm'
+        out = subp.subp(["lsblk", "-n", "-o", "TYPE", blockdev]).stdout
+        return out.strip() == "lvm"
+    except Exception as e:
+        LOG.warning("Error checking if device is LVM: %s", e)
+        return False
+
+
 def _call_resizer(resizer, devent, disk, ptnum, blockdev, fs):
     info = []
     try:
@@ -409,7 +582,9 @@ def _call_resizer(resizer, devent, disk, ptnum, blockdev, fs):
     return info
 
 
-def resize_devices(resizer: Resizer, devices, distro: Distro):
+def resize_devices(
+    resizer: Resizer, devices, distro: Distro, resize_lv: bool = True
+):
     # returns a tuple of tuples containing (entry-in-devices, action, message)
     devices = copy.copy(devices)
     info = []
@@ -488,13 +663,45 @@ def resize_devices(resizer: Resizer, devices, distro: Distro):
                             message,
                         )
                     )
+                # If device is lvm
+                elif is_lvm_device(blockdev):
+                    # resize the partition firstly
+                    disk, ptnum = distro.device_part_info(partition)
+                    info += _call_resizer(
+                        resizer, devent, disk, ptnum, partition, fs
+                    )
+                    try:
+                        # Call the LVM resize procedure
+                        # resize_lvm() will automatically determine if pvresize
+                        # should be skipped based on resizer type and PV count
+                        status, message = resize_lvm(
+                            blockdev,
+                            resize_lv=resize_lv,
+                            resizer=resizer,
+                        )
+                        info.append(
+                            (
+                                devent,
+                                status,
+                                message,
+                            )
+                        )
+                    except Exception as e:
+                        info.append(
+                            (
+                                devent,
+                                RESIZE.FAILED,
+                                f"Resizing LVM device ({blockdev}) failed: "
+                                f"{e}",
+                            )
+                        )
                 else:
                     info.append(
                         (
                             devent,
                             RESIZE.SKIPPED,
                             f"Resizing mapped device ({blockdev}) skipped "
-                            "as it is not encrypted.",
+                            f"as it is neither encrypted nor lvm.",
                         )
                     )
             except Exception as e:
@@ -502,7 +709,7 @@ def resize_devices(resizer: Resizer, devices, distro: Distro):
                     (
                         devent,
                         RESIZE.FAILED,
-                        f"Resizing encrypted device ({blockdev}) failed: {e}",
+                        f"Resizing device ({blockdev}) failed: {e}",
                     )
                 )
             # At this point, we WON'T resize a non-encrypted mapped device
@@ -559,6 +766,8 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         LOG.debug("growpart: empty device list")
         return
 
+    resize_lv = util.get_cfg_option_bool(mycfg, "resize_lv", True)
+
     try:
         resizer = resizer_factory(mode, distro=cloud.distro, devices=devices)
     except (ValueError, TypeError) as e:
@@ -568,7 +777,9 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
         return
 
     with performance.Timed("Resizing devices"):
-        resized = resize_devices(resizer, devices, cloud.distro)
+        resized = resize_devices(
+            resizer, devices, cloud.distro, resize_lv=resize_lv
+        )
     for entry, action, msg in resized:
         if action == RESIZE.CHANGED:
             LOG.info("'%s' resized: %s", entry, msg)

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -1682,6 +1682,11 @@
               "type": "boolean",
               "default": false,
               "description": "If ``true``, ignore the presence of ``/etc/growroot-disabled``. If ``false`` and the file exists, then don't resize. Default: ``false``."
+            },
+            "resize_lv": {
+              "type": "boolean",
+              "default": true,
+              "description": "For LVM devices, if ``true``, extend the logical volume to consume all free space in the volume group after resizing physical volumes. If ``false``, only resize physical volumes, leaving the logical volume size unchanged. This is useful when multiple logical volumes exist in the same volume group (e.g., separate LVs for ``/home``, ``/var/log``, etc.) and you want to preserve free space for other LVs. Default: ``true``."
             }
           }
         }

--- a/doc/module-docs/cc_growpart/data.yaml
+++ b/doc/module-docs/cc_growpart/data.yaml
@@ -9,6 +9,24 @@ cc_growpart:
     on a disk with classic partitioning scheme (MBR, BSD, GPT). LVM, Btrfs and
     ZFS have no such restrictions.
 
+    For LVM devices, the module will resize physical volumes (PVs) after the
+    underlying partition is grown. When using the ``growpart`` utility (the
+    default), ``pvresize`` is automatically handled by ``growpart`` itself for
+    the specific partition's PV. However, if a Volume Group spans multiple
+    Physical Volumes, ``growpart`` only resizes the PV corresponding to the
+    resized partition. In this case, cloud-init will detect the multi-PV
+    configuration and resize all PVs in the Volume Group to ensure complete
+    coverage. For single-PV Volume Groups, cloud-init skips ``pvresize`` to
+    avoid duplication. For other resizers (e.g., ``gpart``), cloud-init will
+    always perform ``pvresize`` on all PVs in the Volume Group.
+
+    By default, the module will also extend the logical volume (LV) to consume
+    all free space in the volume group. This behavior can be controlled with
+    the ``resize_lv`` option. When multiple logical volumes exist in the same
+    volume group (e.g., separate LVs for ``/home``, ``/var/log``, etc.),
+    setting ``resize_lv: false`` will preserve free space in the volume group
+    for other LVs.
+
     The devices on which to run growpart are specified as a list under the
     ``devices`` key.
 
@@ -45,6 +63,7 @@ cc_growpart:
          mode: auto
          devices: [\"/\"]
          ignore_growroot_disabled: false
+         resize_lv: true
   examples:
   - comment: |
       Example 1:

--- a/doc/rtd/spelling_word_list.txt
+++ b/doc/rtd/spelling_word_list.txt
@@ -107,6 +107,8 @@ libvirt
 linux
 livepatch
 localdomain
+lv
+lvm
 lxd
 maipo
 manpage
@@ -160,6 +162,7 @@ preseed
 proxmox
 puppetlabs
 puppetserver
+pv
 py
 pycloudlib
 pytest
@@ -238,6 +241,7 @@ vcloud
 ve
 veth
 vfstype
+vg
 virtuozzo
 vm
 vpc

--- a/tests/unittests/config/test_cc_growpart.py
+++ b/tests/unittests/config/test_cc_growpart.py
@@ -306,7 +306,7 @@ class TestConfig:
                 "auto", distro=freebsd_cloud.distro, devices=["/"]
             )
             rsdevs.assert_called_once_with(
-                myresizer, ["/"], freebsd_cloud.distro
+                myresizer, ["/"], freebsd_cloud.distro, resize_lv=True
             )
 
 
@@ -535,6 +535,9 @@ class TestEncrypted:
             "cloudinit.config.cc_growpart.subp.which",
             return_value="/usr/sbin/cryptsetup",
         )
+        mocker.patch(
+            "cloudinit.config.cc_growpart.is_lvm_device", return_value=False
+        )
         self.m_subp = mocker.patch(
             "cloudinit.config.cc_growpart.subp.subp",
             side_effect=self._subp_side_effect,
@@ -594,7 +597,7 @@ class TestEncrypted:
         )
 
         assert len(info) == 1
-        assert "skipped as it is not encrypted" in info[0][2]
+        assert "skipped as it is neither encrypted" in info[0][2]
         assert "cryptsetup not found" in caplog.text
         self.assert_no_resize_or_cleanup()
 
@@ -613,9 +616,7 @@ class TestEncrypted:
         assert len(info) == 1
         assert info[0][0] == "/fake_encrypted"
         assert info[0][1] == "FAILED"
-        assert (
-            "Resizing encrypted device (/dev/mapper/fake) failed" in info[0][2]
-        )
+        assert "Resizing device (/dev/mapper/fake) failed" in info[0][2]
         self.assert_no_resize_or_cleanup()
 
     def test_unparsable_dmsetup(self, common_mocks, mocker, caplog):
@@ -634,9 +635,7 @@ class TestEncrypted:
         assert len(info) == 1
         assert info[0][0] == "/fake_encrypted"
         assert info[0][1] == "FAILED"
-        assert (
-            "Resizing encrypted device (/dev/mapper/fake) failed" in info[0][2]
-        )
+        assert "Resizing device (/dev/mapper/fake) failed" in info[0][2]
         self.assert_no_resize_or_cleanup()
 
     def test_missing_keydata(self, common_mocks, mocker, caplog):
@@ -652,8 +651,7 @@ class TestEncrypted:
         assert info[1][0] == "/fake_encrypted"
         assert info[1][1] == "FAILED"
         assert (
-            info[1][2]
-            == "Resizing encrypted device (/dev/mapper/fake) failed: Could "
+            info[1][2] == "Resizing device (/dev/mapper/fake) failed: Could "
             "not load encryption key. This is expected if the volume has "
             "been previously resized."
         )
@@ -680,9 +678,7 @@ class TestEncrypted:
         assert info[0][2].startswith("no change necessary")
         assert info[1][0] == "/fake_encrypted"
         assert info[1][1] == "FAILED"
-        assert (
-            "Resizing encrypted device (/dev/mapper/fake) failed" in info[1][2]
-        )
+        assert "Resizing device (/dev/mapper/fake) failed" in info[1][2]
         # Assert we still cleanup
         all_subp_args = list(
             chain(*[args[0][0] for args in self.m_subp.call_args_list])
@@ -701,6 +697,473 @@ class TestEncrypted:
             "SKIPPED",
             "No encryption keyfile found",
         )
+
+
+class TestLvmResize:
+    """Attempt end-to-end scenarios for lvm devices."""
+
+    def _device_part_info_side_effect(self, value):
+        return (1024, 1024)
+
+    def _devent2dev_side_effect(self, value):
+        if value == "/":
+            return "/dev/mapper/rootvg-rootlv", "xfs"
+        raise RuntimeError(f"unexpected value {value}")
+
+    def _realpath_side_effect(self, value):
+        return "/dev/dm-1" if value.startswith("/dev/mapper") else value
+
+    @pytest.fixture
+    def common_mocks(self, mocker):
+        """
+        Common mocks for cc_growpart.resize_devices,
+        expanded to support testing the new LVM resize logic.
+        """
+        self.distro = MockDistro
+        original_device_part_info = self.distro.device_part_info
+        self.distro.device_part_info = self._device_part_info_side_effect
+        mocker.patch("os.stat")
+        mocker.patch("stat.S_ISBLK", return_value=True)
+        mocker.patch("stat.S_ISCHR", return_value=False)
+        mocker.patch(
+            "cloudinit.config.cc_growpart.devent2dev",
+            side_effect=self._devent2dev_side_effect,
+        )
+        mocker.patch(
+            "os.path.realpath",
+            side_effect=self._realpath_side_effect,
+        )
+
+        # Mock is_lvm_device so tests can control LVM detection
+        self._is_lvm = False
+
+        def _is_lvm_device_side_effect(dev):
+            return self._is_lvm
+
+        mocker.patch(
+            "cloudinit.config.cc_growpart.is_lvm_device",
+            side_effect=_is_lvm_device_side_effect,
+        )
+
+        mocker.patch(
+            "cloudinit.config.cc_growpart.is_encrypted", return_value=False
+        )
+
+        # Mock commands used by resize_lvm()
+        def _fake_lvm_subp(cmd, *args, **kwargs):
+            cmdline = " ".join(
+                str(c) for c in cmd
+            )  # Ensure all items are strings
+            # Simulate get_underlying_partition
+            if "dmsetup" in cmdline:
+                return SubpResult("1 dependencies : (sda2)\n", "")
+            # Simulate lvs, vgs introspection
+            if "lvs" in cmdline:
+                return SubpResult("rootvg\n", "")
+            if "vgs" in cmdline:
+                return SubpResult("/dev/sda2\n", "")
+
+            # Simulate pvresize
+            if "pvresize" in cmdline:
+                if getattr(self, "_fail_pvresize", False):
+                    raise RuntimeError("pvresize fail")
+                return SubpResult("", "")
+
+            # Simulate lvextend
+            if "lvextend" in cmdline:
+                if getattr(self, "_fail_lvextend", False):
+                    raise RuntimeError("lvextend fail")
+                return SubpResult("", "")
+
+            return SubpResult("", "")  # default fallback
+
+        self.m_subp = mocker.patch(
+            "cloudinit.config.cc_growpart.subp.subp",
+            side_effect=_fake_lvm_subp,
+        )
+
+        # Allow tests to flip failure modes
+        self._fail_pvresize = False
+        self._fail_lvextend = False
+
+        # Provide a mock resizer used by resize_devices()
+        self.resizer = mock.Mock()
+        self.resizer.resize = mock.Mock(return_value=(1024, 2048))
+        yield
+        # Cleanup
+        self.distro.device_part_info = original_device_part_info
+        del self._fail_pvresize
+        del self._fail_lvextend
+        del self._is_lvm
+
+    def test_lvm_resize_flow(self, mocker):
+        # Test that LVM resize runs lvs → vgs → pvresize → lvextend.
+        # Patch subp.subp to control command outputs
+        m_subp = mocker.patch("cloudinit.config.cc_growpart.subp.subp")
+
+        # Sequence of command outputs
+        # 1. lvs → returns VG name
+        # 2. vgs → returns PV list
+        # 3. pvresize pv1
+        # 4. pvresize pv2
+        # 5. lvextend
+        m_subp.side_effect = [
+            mocker.Mock(stdout="vg0\n", ok=True),  # lvs
+            mocker.Mock(stdout="/dev/xvda2 /dev/xvdb1\n", ok=True),  # vgs
+            mocker.Mock(stdout="", ok=True),  # pvresize pv1
+            mocker.Mock(stdout="", ok=True),  # pvresize pv2
+            mocker.Mock(stdout="", ok=True),  # lvextend
+        ]
+        cc_growpart.resize_lvm("/dev/mapper/vg0-root")
+
+        # Verify calls
+        calls = [
+            mocker.call(
+                [
+                    "lvs",
+                    "--noheadings",
+                    "-o",
+                    "vg_name",
+                    "/dev/mapper/vg0-root",
+                ]
+            ),
+            mocker.call(
+                [
+                    "vgs",
+                    "--noheadings",
+                    "-o",
+                    "pv_name",
+                    "--separator",
+                    " ",
+                    "vg0",
+                ]
+            ),
+            mocker.call(["pvresize", "/dev/xvda2"]),
+            mocker.call(["pvresize", "/dev/xvdb1"]),
+            mocker.call(
+                ["lvextend", "-l", "+100%FREE", "/dev/mapper/vg0-root"]
+            ),
+        ]
+
+        m_subp.assert_has_calls(calls)
+
+    def test_resize_devices_lvm_success(self, common_mocks, mocker, caplog):
+        """
+        LVM device:
+          - partition resize succeeds
+          - pvresize succeeds
+          - lvextend succeeds
+          - Successfully resized
+        """
+        self._is_lvm = True
+        info = cc_growpart.resize_devices(self.resizer, ["/"], self.distro)
+        # Partition resize result present
+        assert len(info) == 2
+        assert info[0][0] == "/"
+        assert info[0][1] == cc_growpart.RESIZE.CHANGED
+        assert info[0][2] == ("changed (/dev/sda2) from 1024 to 2048")
+        # LVM resize result present
+        assert info[1][0] == "/"
+        assert info[1][1] == cc_growpart.RESIZE.CHANGED
+        assert (
+            info[1][2]
+            == "Successfully resized LVM device '/dev/mapper/rootvg-rootlv' "
+            "(PV and LV resized)"
+        )
+        assert (
+            "/dev/mapper/rootvg-rootlv is a mapped device"
+            " pointing to /dev/dm-1" in caplog.text
+        )
+        assert "pvresize succeeded for /dev/sda2" in caplog.text
+        assert (
+            "lvextend +100%FREE succeeded for /dev/mapper/rootvg-rootlv"
+            in caplog.text
+        )
+
+    def test_resize_devices_lvm_lvextend_failure(
+        self, common_mocks, mocker, caplog
+    ):
+        """
+        LVM case:
+          - lvextend fails
+        """
+        self._is_lvm = True
+        self._fail_lvextend = True  # lvextend error
+
+        info = cc_growpart.resize_devices(self.resizer, ["/"], self.distro)
+        # LVM failure
+        assert any(
+            status == cc_growpart.RESIZE.FAILED and "lvextend fail" in msg
+            for _, status, msg in info
+        )
+
+    def test_resize_devices_lvm_resize_lv_false(
+        self, common_mocks, mocker, caplog
+    ):
+        """
+        LVM device with resize_lv=False:
+          - partition resize succeeds
+          - pvresize succeeds
+          - lvextend is NOT called
+          - Successfully resized (PV only)
+        """
+        self._is_lvm = True
+        info = cc_growpart.resize_devices(
+            self.resizer, ["/"], self.distro, resize_lv=False
+        )
+        # Partition resize result present
+        assert len(info) == 2
+        assert info[0][0] == "/"
+        assert info[0][1] == cc_growpart.RESIZE.CHANGED
+        assert info[0][2] == ("changed (/dev/sda2) from 1024 to 2048")
+        # LVM resize result present (PV only, no LV)
+        assert info[1][0] == "/"
+        assert info[1][1] == cc_growpart.RESIZE.CHANGED
+        assert (
+            info[1][2]
+            == "Successfully resized LVM device '/dev/mapper/rootvg-rootlv' "
+            "(PV resized, LV unchanged)"
+        )
+        assert "pvresize succeeded for /dev/sda2" in caplog.text
+        assert "lvextend" not in caplog.text
+        assert (
+            "Free space remains available in VG for other LVs" in caplog.text
+        )
+
+    def test_resize_devices_lvm_with_growpart_single_pv_skips_pvresize(
+        self, common_mocks, mocker, caplog
+    ):
+        """
+        LVM device with ResizeGrowPart (growpart) and single PV VG:
+          - partition resize succeeds (growpart handles pvresize)
+          - cloud-init skips pvresize (single PV, already done by growpart)
+          - lvextend succeeds
+          - Successfully resized
+        """
+        self._is_lvm = True
+
+        # Override the vgs mock to return single PV
+        def _fake_lvm_subp_single_pv(cmd, *args, **kwargs):
+            cmdline = " ".join(
+                str(c) for c in cmd
+            )  # Ensure all items are strings
+            if "dmsetup" in cmdline:
+                return SubpResult("1 dependencies : (sda2)\n", "")
+            if "lvs" in cmdline:
+                return SubpResult("rootvg\n", "")
+            if "vgs" in cmdline:
+                return SubpResult("/dev/sda2\n", "")  # Single PV
+            if "pvresize" in cmdline:
+                if getattr(self, "_fail_pvresize", False):
+                    raise RuntimeError("pvresize fail")
+                return SubpResult("", "")
+            if "lvextend" in cmdline:
+                if getattr(self, "_fail_lvextend", False):
+                    raise RuntimeError("lvextend fail")
+                return SubpResult("", "")
+            return SubpResult("", "")
+
+        def _fake_subp_with_growpart(cmd, *args, **kwargs):
+            cmdline = " ".join(
+                str(c) for c in cmd
+            )  # Ensure all items are strings
+            # Handle growpart commands
+            if "growpart" in cmdline:
+                if "--dry-run" in cmdline:
+                    # Simulate dry-run success
+                    return SubpResult("", "")
+                # Simulate actual growpart success
+                return SubpResult("", "")
+            # Handle LVM commands
+            return _fake_lvm_subp_single_pv(cmd, *args, **kwargs)
+
+        # Override the subp.subp mock from common_mocks
+        self.m_subp.side_effect = _fake_subp_with_growpart
+
+        # Mock get_tmp_exec_path and tempdir for ResizeGrowPart
+        self.distro.get_tmp_exec_path = mock.Mock(return_value="/tmp")
+        tempdir_mock = mocker.patch(
+            "cloudinit.config.cc_growpart.temp_utils.tempdir"
+        )
+        tempdir_mock.return_value.__enter__.return_value = "/tmp/test"
+        tempdir_mock.return_value.__exit__.return_value = None
+
+        # Mock get_size to return different values before/after resize
+        # First call returns smaller size (before), second call returns
+        # larger (after)
+        mocker.patch(
+            "cloudinit.config.cc_growpart.get_size",
+            side_effect=[
+                1024 * 1024 * 1024,
+                2 * 1024 * 1024 * 1024,
+            ],  # 1GB -> 2GB
+        )
+
+        # Use actual ResizeGrowPart instead of mock
+        growpart_resizer = cc_growpart.ResizeGrowPart(self.distro)
+        info = cc_growpart.resize_devices(
+            growpart_resizer, ["/"], self.distro, resize_lv=True
+        )
+        # Partition resize result present
+        assert len(info) == 2
+        assert info[0][0] == "/"
+        assert info[0][1] == cc_growpart.RESIZE.CHANGED
+        # LVM resize result present - should indicate PV already resized
+        assert info[1][0] == "/"
+        assert info[1][1] == cc_growpart.RESIZE.CHANGED
+        assert "PV already resized" in info[1][2]
+        # Verify pvresize was NOT called by cloud-init (growpart did it)
+        assert "pvresize succeeded" not in caplog.text
+        # Verify lvextend WAS called
+        assert (
+            "lvextend +100%FREE succeeded for /dev/mapper/rootvg-rootlv"
+            in caplog.text
+        )
+        # Verify we detected single PV
+        assert "has single PV, skipping pvresize" in caplog.text
+
+    def test_resize_devices_lvm_with_growpart_multi_pv_resizes_all(
+        self, common_mocks, mocker, caplog
+    ):
+        """
+        LVM device with ResizeGrowPart (growpart) and multi-PV VG:
+          - partition resize succeeds (growpart handles pvresize for one PV)
+          - cloud-init resizes ALL PVs (growpart only resized one)
+          - lvextend succeeds
+          - Successfully resized
+        """
+        self._is_lvm = True
+        # Track pvresize calls
+        pvresize_calls = []
+
+        def _fake_lvm_subp_multi_pv(cmd, *args, **kwargs):
+            cmdline = " ".join(
+                str(c) for c in cmd
+            )  # Ensure all items are strings
+            if "dmsetup" in cmdline:
+                return SubpResult("1 dependencies : (sda2)\n", "")
+            if "lvs" in cmdline:
+                return SubpResult("rootvg\n", "")
+            if "vgs" in cmdline:
+                return SubpResult("/dev/sda2 /dev/sdb1\n", "")  # Multiple PVs
+            if "pvresize" in cmdline:
+                pvresize_calls.append(cmd)
+                if getattr(self, "_fail_pvresize", False):
+                    raise RuntimeError("pvresize fail")
+                return SubpResult("", "")
+            if "lvextend" in cmdline:
+                if getattr(self, "_fail_lvextend", False):
+                    raise RuntimeError("lvextend fail")
+                return SubpResult("", "")
+            return SubpResult("", "")
+
+        def _fake_subp_with_growpart(cmd, *args, **kwargs):
+            cmdline = " ".join(
+                str(c) for c in cmd
+            )  # Ensure all items are strings
+            # Handle growpart commands
+            if "growpart" in cmdline:
+                if "--dry-run" in cmdline:
+                    # Simulate dry-run success
+                    return SubpResult("", "")
+                # Simulate actual growpart success
+                return SubpResult("", "")
+            # Handle LVM commands
+            return _fake_lvm_subp_multi_pv(cmd, *args, **kwargs)
+
+        # Override the subp.subp mock from common_mocks
+        self.m_subp.side_effect = _fake_subp_with_growpart
+
+        # Mock get_tmp_exec_path and tempdir for ResizeGrowPart
+        self.distro.get_tmp_exec_path = mock.Mock(return_value="/tmp")
+        tempdir_mock = mocker.patch(
+            "cloudinit.config.cc_growpart.temp_utils.tempdir"
+        )
+        tempdir_mock.return_value.__enter__.return_value = "/tmp/test"
+        tempdir_mock.return_value.__exit__.return_value = None
+
+        # Mock get_size to return different values before/after resize
+        # First call returns smaller size (before), second call returns
+        # larger (after)
+        mocker.patch(
+            "cloudinit.config.cc_growpart.get_size",
+            side_effect=[
+                1024 * 1024 * 1024,
+                2 * 1024 * 1024 * 1024,
+            ],  # 1GB -> 2GB
+        )
+
+        # Use actual ResizeGrowPart instead of mock
+        growpart_resizer = cc_growpart.ResizeGrowPart(self.distro)
+        info = cc_growpart.resize_devices(
+            growpart_resizer, ["/"], self.distro, resize_lv=True
+        )
+        # Partition resize result present
+        assert len(info) == 2
+        assert info[0][0] == "/"
+        assert info[0][1] == cc_growpart.RESIZE.CHANGED
+        # LVM resize result present - should indicate PVs were resized
+        assert info[1][0] == "/"
+        assert info[1][1] == cc_growpart.RESIZE.CHANGED
+        assert "PV and LV resized" in info[1][2]
+        # Verify pvresize WAS called by cloud-init for all PVs
+        assert len(pvresize_calls) == 2  # Both PVs should be resized
+        assert any("/dev/sda2" in str(call) for call in pvresize_calls)
+        assert any("/dev/sdb1" in str(call) for call in pvresize_calls)
+        # Verify we detected multi-PV
+        assert "has 2 PVs, resizing all PVs" in caplog.text
+        # Verify lvextend WAS called
+        assert (
+            "lvextend +100%FREE succeeded for /dev/mapper/rootvg-rootlv"
+            in caplog.text
+        )
+
+    def test_resize_lvm_resize_lv_false(self, mocker):
+        """Test that resize_lvm with resize_lv=False skips lvextend."""
+        m_subp = mocker.patch("cloudinit.config.cc_growpart.subp.subp")
+        m_subp.side_effect = [
+            mocker.Mock(stdout="vg0\n", ok=True),  # lvs
+            mocker.Mock(stdout="/dev/xvda2\n", ok=True),  # vgs
+            mocker.Mock(stdout="", ok=True),  # pvresize
+            # Note: no lvextend call expected
+        ]
+        status, message = cc_growpart.resize_lvm(
+            "/dev/mapper/vg0-root", resize_lv=False
+        )
+        assert status == cc_growpart.RESIZE.CHANGED
+        assert "(PV resized, LV unchanged)" in message
+        # Verify lvextend was NOT called
+        lvextend_calls = [
+            call for call in m_subp.call_args_list if "lvextend" in str(call)
+        ]
+        assert len(lvextend_calls) == 0
+
+    def test_resize_lvm_skip_pvresize(self, mocker):
+        """Test that resize_lvm with skip_pvresize=True skips pvresize."""
+        m_subp = mocker.patch("cloudinit.config.cc_growpart.subp.subp")
+        m_subp.side_effect = [
+            mocker.Mock(stdout="vg0\n", ok=True),  # lvs
+            mocker.Mock(stdout="/dev/xvda2\n", ok=True),  # vgs
+            mocker.Mock(stdout="", ok=True),  # lvextend
+            # Note: no pvresize call expected
+        ]
+        # Use ResizeGrowPart with single PV to trigger skip_pvresize
+        mock_resizer = mocker.Mock(spec=cc_growpart.ResizeGrowPart)
+        status, message = cc_growpart.resize_lvm(
+            "/dev/mapper/vg0-root", resizer=mock_resizer
+        )
+        assert status == cc_growpart.RESIZE.CHANGED
+        assert "PV already resized" in message
+        # Verify pvresize was NOT called
+        pvresize_calls = [
+            call for call in m_subp.call_args_list if "pvresize" in str(call)
+        ]
+        assert len(pvresize_calls) == 0
+        # Verify lvextend WAS called
+        lvextend_calls = [
+            call for call in m_subp.call_args_list if "lvextend" in str(call)
+        ]
+        assert len(lvextend_calls) == 1
 
 
 def simple_device_part_info(devpath):


### PR DESCRIPTION
Fixes GH-3265

This change integrates LVM logical volume resizing into the existing
growpart flow. When the target block device is an LVM LV, cloud-init
now:
     - Performs lvs lookup to determine the volume group
     - Enumerates all PVs in the VG using new helper functions
     - Intelligently handles pvresize:
       * Skips pvresize for single-PV VGs when using growpart (growpart
         already handles it via maybe_lvm_resize)
       * Resizes all PVs for multi-PV VGs (growpart only resizes the
         partition's PV)
     - Conditionally extends LV based on `resize_lv` config option
       * When `resize_lv: true` (default): lvextend +100%FREE on the LV
       * When `resize_lv: false`: Only resize PVs, leaving LV unchanged
         (useful for multi-LV setups where free space should be preserved)
    
The `resize_lv` option is particularly useful when multiple LVs exist
in the same VG (e.g., separate LVs for /home, /var/log, etc.), allowing
users to preserve free space for other LVs.
    
 New helper functions:
     - `_get_vg_for_lv()`: Returns VG name for a given LV device
     - `_get_pvs_for_vg()`: Returns list of PV device paths for a VG
    
Filesystem resizing is intentionally omitted because resizefs is handled
by a separate module.
    
Unit tests have been added under test_cc_growpart.py to validate:
     - successful pvresize and lvextend calls
     - error propagation for failed operations
     - resize_lv=False behavior
     - Single-PV VG with growpart (skip pvresize)
     - Multi-PV VG with growpart (resize all PVs)

This change does not affect existing non-LVM growpart behaviour.

Redhat Jira ticket: [RFE][Azure]growpart fails to resize a root partition on LVM
https://issues.redhat.com/browse/RHEL-107485


## Test Steps
I tested it on Azure and AWS with rhel image, for example,
Boot up a VM on Azure and change the os disk to bigger than 64G
Check the rootlv partition size, the root partition size is extended after VM boot up.

[Before changes]
The root partition size is not extended.
```
2025-07-25 10:04:34,238 - cc_growpart.py[DEBUG]: growpart found fs=xfs
2025-07-25 10:04:34,238 - distros[DEBUG]: /dev/mapper/rootvg-rootlv is a mapped device pointing to /dev/dm-1
2025-07-25 10:04:34,238 - subp.py[DEBUG]: Running command ['dmsetup', 'deps', '--options=devname', '/dev/mapper/rootvg-rootlv'] with allowed return codes [0] (shell=False, capture=True)
2025-07-25 10:04:34,246 - subp.py[DEBUG]: Running command ['cryptsetup', 'status', '/dev/dm-1'] with allowed return codes [0] (shell=False, capture=True)
2025-07-25 10:04:34,395 - performance.py[DEBUG]: Running ['cryptsetup', 'status', '/dev/dm-1'] took 0.149 seconds
2025-07-25 10:04:34,395 - subp.py[DEBUG]: Running command ['cryptsetup', 'isLuks', '/dev/sda4'] with allowed return codes [0] (shell=False, capture=True)
2025-07-25 10:04:34,469 - performance.py[DEBUG]: Running ['cryptsetup', 'isLuks', '/dev/sda4'] took 0.073 seconds
2025-07-25 10:04:34,469 - performance.py[DEBUG]: Resizing devices took 0.234 seconds
2025-07-25 10:04:34,469 - cc_growpart.py[DEBUG]: '/' SKIPPED: Resizing mapped device (/dev/mapper/rootvg-rootlv) skipped as it is not encrypted. 
```

[After changes]
The root partition size is extended.
```
2025-11-25 05:55:00,763 - cc_growpart.py[DEBUG]: growpart found fs=xfs
2025-11-25 05:55:00,763 - distros[DEBUG]: /dev/mapper/rootvg-rootlv is a mapped device pointing to /dev/dm-1
2025-11-25 05:55:00,763 - subp.py[DEBUG]: Running command ['dmsetup', 'deps', '--options=devname', '/dev/mapper/rootvg-rootlv'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:00,766 - subp.py[DEBUG]: Running command ['cryptsetup', 'status', '/dev/dm-1'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:00,929 - performance.py[DEBUG]: Running ['cryptsetup', 'status', '/dev/dm-1'] took 0.164 seconds
2025-11-25 05:55:00,930 - subp.py[DEBUG]: Running command ['cryptsetup', 'isLuks', '/dev/sda4'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:01,001 - performance.py[DEBUG]: Running ['cryptsetup', 'isLuks', '/dev/sda4'] took 0.071 seconds
2025-11-25 05:55:01,001 - subp.py[DEBUG]: Running command ['lsblk', '-n', '-o', 'TYPE', '/dev/mapper/rootvg-rootlv'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:01,055 - performance.py[DEBUG]: Running ['lsblk', '-n', '-o', 'TYPE', '/dev/mapper/rootvg-rootlv'] took 0.053 seconds
2025-11-25 05:55:01,055 - util.py[DEBUG]: Reading from /sys/class/block/sda4/partition (quiet=False)
2025-11-25 05:55:01,055 - util.py[DEBUG]: Reading 2 bytes from /sys/class/block/sda4/partition
2025-11-25 05:55:01,055 - util.py[DEBUG]: Reading from /sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01/00000000-0000-8899-0000-000000000000/host0/target0:0:0/0:0:0:0/block/sda/dev (quiet=False)
2025-11-25 05:55:01,055 - util.py[DEBUG]: Reading 4 bytes from /sys/devices/LNXSYSTM:00/LNXSYBUS:00/PNP0A03:00/device:07/VMBUS:01/00000000-0000-8899-0000-000000000000/host0/target0:0:0/0:0:0:0/block/sda/dev
2025-11-25 05:55:01,055 - util.py[DEBUG]: Reading from /proc/1239/mountinfo (quiet=False)
2025-11-25 05:55:01,055 - util.py[DEBUG]: Reading 3132 bytes from /proc/1239/mountinfo
2025-11-25 05:55:01,056 - util.py[DEBUG]: Reading from /proc/1239/mountinfo (quiet=False)
2025-11-25 05:55:01,056 - util.py[DEBUG]: Reading 3132 bytes from /proc/1239/mountinfo
2025-11-25 05:55:01,056 - subp.py[DEBUG]: Running command ['growpart', '--dry-run', '/dev/sda', '4'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:01,247 - performance.py[DEBUG]: Running ['growpart', '--dry-run', '/dev/sda', '4'] took 0.191 seconds
2025-11-25 05:55:01,247 - subp.py[DEBUG]: Running command ['growpart', '/dev/sda', '4'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:02,440 - performance.py[DEBUG]: Running ['growpart', '/dev/sda', '4'] took 1.193 seconds
2025-11-25 05:55:02,442 - cc_growpart.py[INFO]: starting LVM resize flow for /dev/mapper/rootvg-rootlv
2025-11-25 05:55:02,442 - subp.py[DEBUG]: Running command ['lvs', '--noheadings', '-o', 'vg_name', '/dev/mapper/rootvg-rootlv'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:02,467 - performance.py[DEBUG]: Running ['lvs', '--noheadings', '-o', 'vg_name', '/dev/mapper/rootvg-rootlv'] took 0.025 seconds
2025-11-25 05:55:02,467 - cc_growpart.py[DEBUG]: lv /dev/mapper/rootvg-rootlv belongs to vg rootvg
2025-11-25 05:55:02,467 - subp.py[DEBUG]: Running command ['vgs', '--noheadings', '-o', 'pv_name', '--separator', ' ', 'rootvg'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:02,486 - performance.py[DEBUG]: Running ['vgs', '--noheadings', '-o', 'pv_name', '--separator', ' ', 'rootvg'] took 0.019 seconds
2025-11-25 05:55:02,487 - subp.py[DEBUG]: Running command ['pvresize', '/dev/sda4'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:02,702 - performance.py[DEBUG]: Running ['pvresize', '/dev/sda4'] took 0.215 seconds
2025-11-25 05:55:02,702 - cc_growpart.py[INFO]: pvresize succeeded for /dev/sda4
2025-11-25 05:55:02,702 - subp.py[DEBUG]: Running command ['lvextend', '-l', '+100%FREE', '/dev/mapper/rootvg-rootlv'] with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:02,961 - performance.py[DEBUG]: Running ['lvextend', '-l', '+100%FREE', '/dev/mapper/rootvg-rootlv'] took 0.259 seconds
2025-11-25 05:55:02,961 - cc_growpart.py[INFO]: lvextend +100%FREE succeeded for /dev/mapper/rootvg-rootlv
2025-11-25 05:55:02,961 - performance.py[DEBUG]: Resizing devices took 2.198 seconds
2025-11-25 05:55:02,961 - cc_growpart.py[INFO]: '/' resized: changed (/dev/sda4) from 116510408192 to 127247826432
2025-11-25 05:55:02,961 - cc_growpart.py[INFO]: '/' resized: Successfully resized LVM device '/dev/mapper/rootvg-rootlv'
2025-11-25 05:55:02,961 - handlers.py[DEBUG]: finish: init-network/config-growpart: SUCCESS: config-growpart ran successfully and took 2.260 seconds
2025-11-25 05:55:02,963 - handlers.py[DEBUG]: start: init-network/config-resizefs: running config-resizefs with frequency always
2025-11-25 05:55:02,963 - helpers.py[DEBUG]: Running config-resizefs using lock (<cloudinit.helpers.DummyLock object at 0x7fa0730692e0>)
2025-11-25 05:55:02,964 - util.py[DEBUG]: Reading from /proc/1239/mountinfo (quiet=False)
2025-11-25 05:55:02,964 - util.py[DEBUG]: Reading 3132 bytes from /proc/1239/mountinfo
2025-11-25 05:55:02,964 - cc_resizefs.py[DEBUG]: resize_info: dev=/dev/mapper/rootvg-rootlv mnt_point=/ path=/
2025-11-25 05:55:02,964 - cc_resizefs.py[DEBUG]: Resizing / (xfs) using xfs_growfs /
2025-11-25 05:55:02,964 - subp.py[DEBUG]: Running command ('xfs_growfs', '/') with allowed return codes [0] (shell=False, capture=True)
2025-11-25 05:55:03,336 - performance.py[DEBUG]: Running ('xfs_growfs', '/') took 0.372 seconds
2025-11-25 05:55:03,336 - cc_resizefs.py[DEBUG]: Resized root filesystem (type=xfs, val=True)
2025-11-25 05:55:03,336 - handlers.py[DEBUG]: finish: init-network/config-resizefs: SUCCESS: config-resizefs ran successfully and took 0.373 seconds
```

I’ve added three unit tests. Please let me know if further coverage is needed.

The integration test case is copied from https://github.com/canonical/cloud-init/pull/887, however I did not test it because that I failed to set up the local integration test environment, I will run it later.