### PR TITLE
rhel: Do not override changes in disable-sshd-keygen-if-cloud-init-active.conf

### DIFF
--- a/packages/redhat/cloud-init.spec.in
+++ b/packages/redhat/cloud-init.spec.in
@@ -116,6 +116,7 @@ rm -rf $RPM_BUILD_ROOT
 %dir                    %{_sysconfdir}/cloud/templates
 %config(noreplace)      %{_sysconfdir}/cloud/templates/*
 %config(noreplace) %{_sysconfdir}/rsyslog.d/21-cloudinit.conf
+%config(noreplace) /usr/lib/systemd/system/sshd-keygen@.service.d/disable-sshd-keygen-if-cloud-init-active.conf
 
 # Bash completion script
 %dir %{_datadir}/bash-completion/completions


### PR DESCRIPTION

## Proposed Commit Message
When customer has local changes in disable-sshd-keygen-if-cloud-init-active.conf and they try to upgrade cloud-init, the local changes are lost and the config file reverts back to original content. This disrupts the customer as it breaks their deployments and the config changes needs to be manually applied again. The customer should be able to overwrite the config file with any changes that work for their environment or work around some issues. Those changes should be retained by rpm upgrade process. Therefore, in the spec file, mark the config file as "noreplace" so that changes are kept.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
