### PR TITLE
chore: fix logs with too few arguments

### DIFF
--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -1299,7 +1299,9 @@ def mkfs(fs_cfg):
                 device = f"{device}p"
             device = "%s%s" % (device, partition)
             if not Path(device).is_block_device():
-                LOG.warning("Path %s does not exist or is not a block device")
+                LOG.warning(
+                    "Path %s does not exist or is not a block device", device
+                )
                 return
             LOG.debug(
                 "Manual request of partition %s for %s", partition, device

--- a/cloudinit/distros/raspberry_pi_os.py
+++ b/cloudinit/distros/raspberry_pi_os.py
@@ -65,7 +65,7 @@ class Distro(debian.Distro):
                     ]
                 )
             else:
-                LOG.error("Failed to set locale %s")
+                LOG.error("Failed to set locale %s", locale)
 
     def add_user(self, name, **kwargs) -> bool:
         """


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
chore: fix logs with too few arguments

The scheduled tip-pylint CI job currently fails with the following:

************* Module cloudinit.distros.raspberry_pi_os
cloudinit/distros/raspberry_pi_os.py:68: [E1206(logging-too-few-args), Distro.apply_locale] Not enough arguments for logging format string
************* Module cloudinit.config.cc_disk_setup
cloudinit/config/cc_disk_setup.py:1302: [E1206(logging-too-few-args), mkfs] Not enough arguments for logging format string
```

## Additional Context
<!-- If relevant -->

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
