### PR TITLE
feat(cloudstack): fetch vm password using url_helper instead of wget

### DIFF
--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -19,7 +19,7 @@ from contextlib import suppress
 from socket import gaierror, getaddrinfo, inet_ntoa
 from struct import pack
 
-from cloudinit import dmi, net, performance, sources, subp
+from cloudinit import dmi, net, performance, sources
 from cloudinit import url_helper as uhelp
 from cloudinit import util
 from cloudinit.net import dhcp
@@ -51,17 +51,10 @@ class CloudStackPasswordServerClient:
         url = f"http://{self.virtual_router_address}:8080"
         headers = {"DomU_Request": domu_request}
 
-        resp = uhelp.readurl(
-            url,
-            headers=headers,
-            timeout=20,
-            retries=3
-        )
+        resp = uhelp.readurl(url, headers=headers, timeout=20, retries=3)
 
         if not resp.ok():
-            raise RuntimeError(
-                f"Failed to fetch VM password from CloudStack: HTTP {resp.code}"
-            )
+            raise RuntimeError("Failed to fetch VM password from CloudStack")
 
         return resp.contents.decode("utf-8").strip()
 


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->

CloudStack vms use wget to fetch vm password from cloudstack VR
However, wget is not installed in some cloud images. instead, curl is installed
This PR uses url_helper to fetch vm password instead of wget


## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
