### PR TITLE
Tests downstream without ssh keygen

### DIFF
--- a/tests/unittests/sources/test_azure_helper.py
+++ b/tests/unittests/sources/test_azure_helper.py
@@ -519,7 +519,7 @@ class TestOpenSSLManagerActions:
 
     @pytest.mark.allow_all_subp
     @pytest.mark.skipif(
-        not all([shutil.which("openssl"), shutil.which('ssh-keygen')]),
+        not all([shutil.which("openssl"), shutil.which("ssh-keygen")]),
         reason="OpenSSL command-line tools not installed",
     )
     def test_pubkey_extract(self):
@@ -535,7 +535,7 @@ class TestOpenSSLManagerActions:
 
     @pytest.mark.allow_all_subp
     @pytest.mark.skipif(
-        not all([shutil.which("openssl"), shutil.which('ssh-keygen')]),
+        not all([shutil.which("openssl"), shutil.which("ssh-keygen")]),
         reason="OpenSSL command-line tools not installed",
     )
     @mock.patch.object(azure_helper.OpenSSLManager, "_decrypt_certs_from_xml")


### PR DESCRIPTION

## Proposed Commit Message

```
    tests: skip azure ssh-keygen unittests when ssh-keygen not installed
    
    Followup to baedc33ac to support skipping azure ssh-keygen related
    tests from running in environments without ssh-keygen installed.
```

## Additional Context
<!-- If relevant -->
Daily recipe builds fail for resolute because the default images created do not have ssh-keygen installed
https://launchpadlibrarian.net/836531696/buildlog_ubuntu-resolute-amd64.cloud-init_100.0.0.daily-202512092133-78a748808~ubuntu26.04.1_BUILDING.txt.gz
```
                if err_filename is not None:
>                   raise child_exception_type(errno_num, err_msg, err_filename)
E                   FileNotFoundError: [Errno 2] No such file or directory: b'ssh-keygen'

/usr/lib/python3.13/subprocess.py:1972: FileNotFoundError

```


## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
