### PR TITLE
chore: no CLA workflow on downstream ubuntu package branches

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,6 +1,9 @@
 name: CLA Check
 
-on: [pull_request]
+on:
+  pull_request:
+    branches-ignore:
+      - 'ubuntu/**'
 
 jobs:
   cla-check:


### PR DESCRIPTION
We already run CLA verification on main branch. The downstream PRs we see from community typically are contributors which have already passed CLA verification before their pull requests are accepted and merged.

## Proposed Commit Message
```
chore: no CLA workflow on downstream ubuntu package branches
```

## Additional Context
CLA merges are correctly clearing on top of main (see: paul lober GH username), yet they fail on downstream due to the obscured email address from github in the merged commits. No need to re-run CLA checkers on downstream branches as merges are already gated upstream.

## Test Steps


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
