### PR TITLE
tests: pytestified test_cc_rsyslog.py

### DIFF
--- a/tests/unittests/config/test_cc_rsyslog.py
+++ b/tests/unittests/config/test_cc_rsyslog.py
@@ -88,14 +88,13 @@ class TestLoadConfig:
         assert load_config({}, distro=cloud.distro) == cfg
 
     def test_new_bsd_defaults(self):
-        cfg = copy.deepcopy(self.BSDCFG)
 
         # patch for ifconfig -a
         with mock.patch(
             "cloudinit.distros.networking.subp.subp", return_values=("", None)
         ):
             cloud = get_cloud(distro="freebsd", metadata={})
-        assert load_config({}, distro=cloud.distro) == cfg
+        assert load_config({}, distro=cloud.distro) == self.BSDCFG
 
     def test_new_configs(self):
         cfg = copy.deepcopy(self.BASECFG)
@@ -117,9 +116,9 @@ class TestApplyChanges:
             configs=[cfgline], def_fname="foo.cfg", cfg_dir=str(tmpdir)
         )
 
-        fname = tmpdir.join("foo.cfg")
-        assert changed == [str(fname)]
-        assert util.load_text_file(str(fname)) == cfgline + "\n"
+        fname = str(tmpdir.join("foo.cfg"))
+        assert changed == [fname]
+        assert util.load_text_file(fname) == cfgline + "\n"
 
     def test_multiple_files(self, tmpdir):
         configs = [


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```



tests: Converted test_cc_rsyslog.py from unittest to pytest. 
-made sure test case classes don't inherit from TestCase 
-used pytest fixtures instead of unittest setUp method 
-converted all self.assert to plain assert.
Related GH-6427 

```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
