### PR TITLE
fix: install lxd snap only when snap list lxd reports absent

### DIFF
--- a/cloudinit/config/cc_lxd.py
+++ b/cloudinit/config/cc_lxd.py
@@ -138,7 +138,10 @@ def handle(name: str, cfg: Config, cloud: Cloud, args: list) -> None:
     bridge_cfg = lxd_cfg.get("bridge", {})
     supplemental_schema_validation(init_cfg, bridge_cfg, preseed_str)
 
-    if not subp.which("lxd"):
+    try:
+        subp.subp(["snap", "list", "lxd"])
+    except subp.ProcessExecutionError:
+        # Non-zero exit means no LXD snap yet.
         try:
             subp.subp(["snap", "install", "lxd"])
         except subp.ProcessExecutionError as e:


### PR DESCRIPTION
To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.



## Proposed Commit Message

```
    fix: install lxd snap only when snap list lxd reports absent
    
    Enable cloud-init to 'snap install lxd' when 'snap list lxd' reports
    that the lxd snap is not available. Do not rely on which('lxd') because
    lxd-installer deb package delivers this script, not the lxd snap.
    
    Prior to Ubuntu Plucky, lxd-installer /usr/sbin/lxd would automatically
    install lxd snap if it wasn't on the system. In Ubuntu Plucky and newer
    lxd-installer now blocks on a user prompt "Would you like to install
    LXD.. ?" which prevents cloud-init from automatically installing LXD
    snap.
    
    LP: #2136198
```

## Additional Context
<!-- If relevant -->

## Test Steps
```
CLOUD_INIT_KEEP_INSTANCE=1 CLOUD_INIT_OS_IMAGE=plucky CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE .tox/integration-tests/bin/pytest  tests/integration_tests/modules/test_lxd.py::test_basic_preseed
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
