### PR TITLE
chore: sync gh workflow/shellcheck-debian-scripts.yml to main

### DIFF
--- a/.github/workflows/shellcheck-debian-scripts.yml
+++ b/.github/workflows/shellcheck-debian-scripts.yml
@@ -54,7 +54,7 @@ jobs:
               echo "There are no changed files remaining in the repo which match the glob pattern \'${GLOBS_TO_SHELLCHECK}\' so shellcheck will not run"
             else
               echo "shellcheck will run on the remaining changed files: ${RETAINED_CHANGED_FILES}"
-              shellcheck ${RETAINED_CHANGED_FILES}
+              shellcheck -e SC3043 ${RETAINED_CHANGED_FILES}
               echo "shellcheck succeeded running on the remaining changed files"
             fi
           fi


### PR DESCRIPTION
Fix new_upstream_snapshot into ubuntu/devel  which caught a drift where ubuntu/devel mad changes directly to .github/workflows/shellcheck-debian-scripts.yml which wasn't reflected in upstream/main.

## Proposed Commit Message
```
chore: sync gh workflow/shellcheck-debian-scripts.yml to main

Sync downstream workflow changes into main for shellcheck ignore
behavior from commit a0c594d685.
```


## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
