### PR TITLE
chore: add scheduled job for py3-fast

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        env: [tip-ruff, tip-mypy, tip-pylint, tip-black, tip-isort]
+        env: [tip-ruff, tip-mypy, tip-pylint, tip-black, tip-isort, py3-fast]
     name: format-tip
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
It's been a long time since I've seen py3-fast fail, and it's a nice productivity tool so this will tell us if a PR merges which causes it to start failing.
