### PR TITLE
fix(distros/freebsd): set home_dir to /home

### DIFF
--- a/cloudinit/distros/freebsd.py
+++ b/cloudinit/distros/freebsd.py
@@ -35,7 +35,7 @@ class Distro(cloudinit.distros.bsd.BSD):
     pkg_cmd_update_prefix = ["pkg", "update"]
     pkg_cmd_upgrade_prefix = ["pkg", "upgrade"]
     prefer_fqdn = True  # See rc.conf(5) in FreeBSD
-    home_dir = "/usr/home"
+    home_dir = "/home"
     # FreeBSD has the following dhclient lease path:
     # /var/db/dhclient.leases.<iface_name>
     dhclient_lease_directory = "/var/db"

--- a/tests/unittests/distros/test_freebsd.py
+++ b/tests/unittests/distros/test_freebsd.py
@@ -22,7 +22,7 @@ class TestFreeBSD:
                     "me2",
                     "-u",
                     "1234",
-                    "-d/usr/home/me2",
+                    "-d/home/me2",
                     "-m",
                 ],
                 logstring=[
@@ -30,7 +30,7 @@ class TestFreeBSD:
                     "useradd",
                     "-n",
                     "me2",
-                    "-d/usr/home/me2",
+                    "-d/home/me2",
                     "-m",
                 ],
             )


### PR DESCRIPTION
- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.

## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix(distros/freebsd): set home_dir to /home

This is true since FreeBSD 14.0-RELEASE as per
https://www.freebsd.org/releases/14.0R/relnotes/
in https://cgit.freebsd.org/src/commit/?id=bbb2d2ce4220.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
