### PR TITLE
fix: Pass interface string to get_newest_lease()

### DIFF
--- a/cloudinit/sources/DataSourceCloudStack.py
+++ b/cloudinit/sources/DataSourceCloudStack.py
@@ -336,7 +336,7 @@ def get_vr_address(distro):
         if latest_address:
             LOG.debug("Found SERVER_ADDRESS '%s' via dhclient", latest_address)
             return latest_address
-        
+
     with suppress(FileNotFoundError):
         latest_lease = distro.dhcp_client.get_newest_lease(
             distro.fallback_interface


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
fix: Pass interface string to get_newest_lease()

In DataSourceCloudStack.py, get_newest_lease() is currently being
passed a Distro object, causing a Python type error. This PR
changes the Distro object to the interface string to fix this error.
```

## Additional Context
In a CloudStack environment, when launching a Noble instance cloud-init was failing with the following error:

```
Running invalid command: ['dhcpcd', '--dumplease', '--ipv4only', <cloudinit.distros.ubuntu.Distro object at 0x7315e34d1df0>]
```
This error does not show up on Jammy, only Noble.

To fix this type error, the argument passed to `get_newest_lease()` in `DataSourceCloudStack.py` was changed from a Distro object to a string.

## Test Steps
1. Set up a CloudStack environment and launch a **Noble** instance on it
2. See `cloud-init` logs

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
