### PR TITLE
ci: exercise TMPDIR now that it works

### DIFF
--- a/.github/workflows/ci-unit-distro.yml
+++ b/.github/workflows/ci-unit-distro.yml
@@ -68,4 +68,4 @@ jobs:
         run: lxc exec alpine -- ifdown -a
 
       - name: Run unittests
-        run: lxc exec alpine --cwd /root/cloud-init-rw -- sh -c 'tox -e py3 -- --color=yes'
+        run: lxc exec alpine --cwd /root/cloud-init-rw -- sh -c 'TMPDIR=. tox -e py3 -- --color=yes'


### PR DESCRIPTION
After https://github.com/canonical/cloud-init/pull/6473, TMPDIR now works (before it caused tests to fail). Exercise it in CI.