### PR TITLE
test: add gh workflow for tiobe TICS static analysis reporting

### DIFF
--- a/.github/workflows/weekly-tics.yml
+++ b/.github/workflows/weekly-tics.yml
@@ -1,9 +1,11 @@
 name: Weekly: Static analysis Tiobe TICS
 
+# https://library.canonical.com/corporate-policies/information-security-policies/ssdlc/ssdlc---static-code-analysis
+
 on:
   workflow_dispatch:
   schedule:
-    - cron: '17 5 * * 6'  # Run at 5:17a (arbitrary) on Saturday
+    - cron: '17 5 * * 6'  # Run at 5:17a (arbitrary) on Saturday UTC
 
 concurrency:
   group: cloudinit-${{ github.workflow }}-${{ github.ref }}
@@ -11,8 +13,6 @@ concurrency:
 
 jobs:
   TICS:
-    # Best practices per https://library.canonical.com/corporate-policies/
-    #        information-security-policies/ssdlc/ssdlc---static-code-analysis
     runs-on: [self-hosted, linux, amd64, tiobe, noble]
     steps:
       - name: Checkout the project
@@ -22,24 +22,14 @@ jobs:
 
       - name: Dependencies
         run: |
-          sudo DEBIAN_FRONTEND=noninteractive apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install \
-            ubuntu-dev-tools \
-            tox \
-            wireguard \
-            $(\
-              ./tools/read-dependencies                   \
-                --requirements-file requirements.txt      \
-                --requirements-file test-requirements.txt \
-                --distro ubuntu                           \
-                --system-pkg-names 2> /dev/null           \
-                | tr '\n' ' '                             \
-            )
-
-      - name: Generate TICS artifacts
+         - name: Dependencies
         run: |
-          mkdir .cover
-          python3 -m pytest --cov=cloudinit --cov-report=xml:.cover/coverage.xml || true
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
+
+      - name: Generate coverage report
+        run: |
+          tox -e py3 -- tests/unittests/ --cov-report=xml:.cover/coverage.xml
 
       - name: Run TICS analysis with github-action
         uses: tiobe/tics-github-action@768de18bedf164ee461bc9ef5e2f2fa1a20b122a  # v3.7


### PR DESCRIPTION
Process improvement moving some of our Tiobe TICS automation out of Jenkins and into GH actions.
Scheduling weekly reports from GH workflows will allow us to retire an internal cloud-init jenkins job.

## Proposed Commit Message
```
test: add gh workflow for tiobe TICS static analysis reporting
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
