### PR TITLE
ci: fix YAML syntax error in workflow

### DIFF
--- a/.github/workflows/weekly-tics.yml
+++ b/.github/workflows/weekly-tics.yml
@@ -1,4 +1,4 @@
-name: Weekly: Static analysis Tiobe TICS
+name: "Weekly: Static analysis Tiobe TICS"
 
 # https://library.canonical.com/corporate-policies/information-security-policies/ssdlc/ssdlc---static-code-analysis
 


### PR DESCRIPTION


## Proposed Commit Message
```
ci: quote workflow names to avoid invalid YAML
```
## Additional Context
064019ec018729e8c62f89b20b91d9b3ed1c7ba4 landed a workflow which contained invalid YAML in the title of the workflow due to the colon.

The workflow errored as a result: https://github.com/canonical/cloud-init/actions/runs/20857430613

## Test Steps

```
Ensure valid yaml in workflow file
python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/weekly-tics.tml"))'
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
