### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Before you can begin, you will need to:
 
 We use Matrix and have a dedicated `#cloud-init` channel where you can contact
 us for help and guidance. This link will take you directly to our
-[Matrix room](https://matrix.to/#/#cloud-init:ubuntu.com).
+[Matrix room](https://matrix.to/#/%23cloud-init:ubuntu.com).
 Please don't be afraid to reach out if you need help constructing your pull
 request.
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The [documentation](https://docs.cloud-init.io/en/latest/) is the first place
 to look for help. If a thorough search of the documentation does not resolve
 your issue, consider the following:
 
-- Ask a question in the [``#cloud-init`` channel on Matrix](https://matrix.to/#/#cloud-init:ubuntu.com)
+- Ask a question in the [``#cloud-init`` channel on Matrix](https://matrix.to/#/%23cloud-init:ubuntu.com)
 - Look for announcements or engage in cloud-init discussions on [GitHub Discussions](https://github.com/canonical/cloud-init/discussions)
 - Find a bug? [Read how to report it](https://docs.cloud-init.io/en/latest/howto/bugs.html)
 

--- a/doc/rtd/links.txt
+++ b/doc/rtd/links.txt
@@ -7,7 +7,7 @@
 .. _GH repo: https://github.com/canonical/cloud-init
 .. _GitHub: https://github.com
 .. _Launchpad: https://launchpad.net
-.. _Matrix: https://matrix.to/#/#cloud-init:ubuntu.com
+.. _Matrix: https://matrix.to/#/%23cloud-init:ubuntu.com
 .. _the docs: https://docs.cloud-init.io/en/latest/
 .. _tox: https://tox.readthedocs.io/en/latest/
 .. _Discourse: https://discourse.ubuntu.com/c/server/cloud-init/54

--- a/doc/rtd/reference/datasources/ec2.rst
+++ b/doc/rtd/reference/datasources/ec2.rst
@@ -157,4 +157,4 @@ Notes
    at first boot only but it can be configured to be applied on every boot
    and when NICs are hotplugged, see :ref:`events`.
 
-.. _EC2 tags user guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS
+.. _EC2 tags user guide: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html

--- a/doc/rtd/tutorial/lxd.rst
+++ b/doc/rtd/tutorial/lxd.rst
@@ -159,4 +159,4 @@ You can also head over to the :ref:`examples page<yaml_examples>` for
 examples of more common use cases.
 
 .. _LXD: https://ubuntu.com/lxd
-.. _other installation options: https://documentation.ubuntu.com/lxd/en/latest/installing/#other-installation-options
+.. _other installation options: https://documentation.ubuntu.com/lxd/en/latest/installing/


### PR DESCRIPTION
<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [x] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->


## Proposed Commit Message

docs: fix broken links in documentation

Fix broken and outdated links across README, CONTRIBUTING, and RTD
documentation pages. This improves navigation and prevents dead
references in published docs.

Fixes GH-6595

## Additional Context
This PR updates only the links reported in the issue and does not attempt
a full documentation link audit.

## Test Steps
- Verified updated links resolve correctly in the browser
- No code or runtime changes


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
