### PR TITLE
ci: drop duplicated run typo in tics workflow

### DIFF
--- a/.github/workflows/weekly-tics.yml
+++ b/.github/workflows/weekly-tics.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Dependencies
         run: |
-         - name: Dependencies
-        run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
 


### PR DESCRIPTION
During testing this workflow, discovered a typo in the workflow definition with a duplicated 'run' declaration.



## Proposed Commit Message
```
ci: drop duplicated run typo in tics workflow
```
## Additional Context
Failure seen here https://github.com/canonical/cloud-init/actions/runs/20859941643/workflow


## Test Steps
Unfortunately, the easiest way to source our org-wide TICS token is merge this action to validate once it is run using our private token.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
