### PR TITLE
ci: add reviewdog workflow lint for github actions

### DIFF
--- a/.github/workflows/gh-stale.yml
+++ b/.github/workflows/gh-stale.yml
@@ -1,4 +1,5 @@
-name: GH: Manage stale PRs  # WIP introduce invalid YAML for testing
+name: "GH: Manage stale PRs"
+
 on:
   schedule:
   - cron: "0 0 * * *"  # Daily @ 00:00


### PR DESCRIPTION
As documented https://github.com/rhysd/actionlint/blob/v1.7.10/docs/usage.md#reviewdog

Let's stop linting workflows after they merge and fail to run because of syntax errors :)
This will allow CI to do that work for us earlier.

## Proposed Commit Message
```
ci: add reviewdog workflow lint for github actions
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
