### PR TITLE
ci: run and source pylint tox target used by TICS checkers

### DIFF
--- a/.github/workflows/weekly-tics.yml
+++ b/.github/workflows/weekly-tics.yml
@@ -24,11 +24,13 @@ jobs:
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
-      - name: Generate coverage report
+      - name: Generate coverage report and lint
         run: |
           tox -e py3 -- tests/unittests/ --cov-report=xml:.cover/coverage.xml --color=yes
-          # Export tox venv python for TICS to use tox python dependencies.
-          source .tox/py3/bin/activate
+
+          # Export tox venv python so TICS uses pinned tox dependencies.
+          tox -e pylint
+          source .tox/pylint/bin/activate
           echo PATH=$PATH  >> $GITHUB_ENV
 
       - name: Run TICS analysis with github-action


### PR DESCRIPTION
Specifically use pylint tox target to provide pylint dependencies used by TICS reporting stage.