### PR TITLE
ci: retain system packages for TICS workflow due to virtualenv versio…

### DIFF
--- a/.github/workflows/weekly-tics.yml
+++ b/.github/workflows/weekly-tics.yml
@@ -22,16 +22,23 @@ jobs:
 
       - name: Dependencies
         run: |
+          # TICS requires system packages insteed of virtualenvs to find
+          # pytest. Otherwise we get annotations errors about inability to
+          # find certain pylint dependencies.
+          # Attempts to use tox virtual environments result in TICS analysis
+          # failures: too long for column  VersionString.Name.
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
+          ./tools/read-dependencies                             \
+          --requirements-file requirements.txt                  \
+          --requirements-file test-requirements.txt             \
+          --system-pkg-names --distro ubuntu 2> /dev/null       \
+          | xargs sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install
+
       - name: Generate coverage report and lint
         run: |
-          tox -e py3 -- tests/unittests/ --cov-report=xml:.cover/coverage.xml --color=yes
-
-          # Export tox venv python so TICS uses pinned tox dependencies.
-          tox -e pylint
-          source .tox/pylint/bin/activate
-          echo PATH=$PATH  >> $GITHUB_ENV
+          mkdir .cover
+          pytest --cov=cloudinit --cov-report=xml:.cover/coverage.xml --color=yes
 
       - name: Run TICS analysis with github-action
         uses: tiobe/tics-github-action@768de18bedf164ee461bc9ef5e2f2fa1a20b122a  # v3.7


### PR DESCRIPTION
…n errors

Install system packages in TICS workflow until resolution is provided for inability to source virtualenv path during TICS analysis.

Attempting to use tox virtualenv currently results in:

   Version string '<full_virtenv_python_path>:' too long for column
   'VersionString.Name'


## Additional context 
Failure run: https://github.com/canonical/cloud-init/actions/runs/21049471466/job/60532135093