### PR TITLE
Create write-metadata module. This module takes data from the various…

### DIFF
--- a/cloudinit/config/cc_write_metadata.py
+++ b/cloudinit/config/cc_write_metadata.py
@@ -1,0 +1,206 @@
+# Copyright (C) 2012 Yahoo! Inc.
+# Copyright (C) 2014 Amazon.com, Inc. or its affiliates.
+#
+# Author: Joshua Harlow <harlowja@yahoo-inc.com>
+# Author: iliana Weller <iweller@amazon.com>
+#
+# This file is part of cloud-init. See LICENSE file for license information.
+
+from textwrap import dedent
+import logging
+
+from cloudinit.config import cc_write_files
+from cloudinit.config.schema import MetaSchema, get_meta_doc
+from cloudinit.settings import PER_INSTANCE
+from cloudinit import util
+
+LOG = logging.getLogger(__name__)
+
+frequency = PER_INSTANCE
+
+# list of dictionaries we expose to the user from the cloud.datasource object
+EXPOSED_DICTS = ('metadata', 'identity')
+# list of optional arguments not supported by write_files
+OPTIONAL_ARGUMENTS = ('separator', 'allowempty')
+
+
+meta: MetaSchema = {
+    "id": "cc_write_metadata",
+    "name": "Write Metadata",
+    "title": "write IMDS data to arbitrary files",
+    "frequency": PER_INSTANCE,
+    "description": dedent(
+    """\
+    Example cloud-config that would write the AWS instance ID to
+    /root/.instance-id, with a fallback of "unknown":
+
+    write_metadata:
+      - path: /root/.instance-id
+        data:
+          - metadata: instance-id
+          - unknown
+
+    Available places to get data from include identity and metadata.
+    Data paths can include slashes as delimiters in the dictionary
+    structure; a user can provide their own delimiter if needed:
+
+    write_metadata:
+      - path: /root/whatever
+        data:
+          - metadata: public-keys|this/has/slashes|0
+            separator: "|"
+          - fallback string
+
+    write_metadata will consider an empty string from a data path an
+    error, unless you specifically say that's okay with "allowempty":
+
+    write_metadata:
+      - path: /root/.could-be-blank
+        data:
+          - metadata: could-be-blank
+            allowempty: true
+          - fallback string
+    """),
+    "distros": ["all"],
+    "examples": [
+        dedent(
+            """\
+    write_metadata:
+      - path: /root/.instance-id
+        data:
+          - metadata: instance-id
+          - unknown
+            """
+        ),
+        dedent(
+            """\
+    write_metadata:
+        - path: /instance-region
+          data:
+            - identity: region
+            - unknown region
+            """
+        )
+    ]
+}
+
+__doc__ = get_meta_doc(meta)
+
+
+def handle(name, cfg, cloud, args):
+    """
+    Example cloud-config that would write the AWS instance ID to
+    /root/.instance-id, with a fallback of "unknown":
+
+    write_metadata:
+      - path: /root/.instance-id
+        data:
+          - metadata: instance-id
+          - unknown
+
+    Available places to get data from include identity and metadata.
+    Data paths can include slashes as delimiters in the dictionary
+    structure; a user can provide their own delimiter if needed:
+
+    write_metadata:
+      - path: /root/whatever
+        data:
+          - metadata: public-keys|this/has/slashes|0
+            separator: "|"
+          - fallback string
+
+    write_metadata will consider an empty string from a data path an
+    error, unless you specifically say that's okay with "allowempty":
+
+    write_metadata:
+      - path: /root/.could-be-blank
+        data:
+          - metadata: could-be-blank
+            allowempty: true
+          - fallback string
+    """
+    files = cfg.get('write_metadata')
+    if not files:
+        LOG.debug(("Skipping module named %s, no/empty "
+                   "'write_metadata' key in configuration"), name)
+        return
+    write_metadata(name, files, cloud)
+
+
+def write_metadata(name, files, cloud):
+    if not files:
+        return
+
+    new_files = list()
+
+    for i, f_info in enumerate(files):
+        path = f_info.get('path')
+        if not path:
+            LOG.warning("No path provided to write for entry %s in module %s",
+                     i + 1, name)
+            continue
+        data = f_info.get('data')
+        if not data:
+            LOG.warning("No data provided to write for entry %s in module %s",
+                     i + 1, name)
+            continue
+
+        f_info['content'] = retrieve_metadata(path, data, cloud)
+        if f_info['content'] is None:
+            # if there is no content, don't write anything to the file
+            # (this is not the same as empty content)
+            continue
+
+        # Use the default permissions, to suppress a warning from write-files
+        f_info.setdefault('permissions', cc_write_files.DEFAULT_PERMS)
+
+        # ensure that we don't get unexpected behavior in a future
+        # version of the write_files module
+        for key in EXPOSED_DICTS + OPTIONAL_ARGUMENTS:
+            if key in f_info:
+                del f_info[key]
+
+        new_files.append(f_info)
+
+    cc_write_files.write_files(name, files, cloud.distro.default_owner)
+
+
+def retrieve_metadata(path, data, cloud):
+    for datum in data:
+        if isinstance(datum, str):
+            # used for fallback data
+            return datum
+        elif isinstance(datum, dict):
+            kwargs = dict()
+            if 'separator' in datum:
+                kwargs['separator'] = datum['separator']
+            for dataset in EXPOSED_DICTS:
+                if dataset in datum:
+                    if not hasattr(cloud.datasource, dataset):
+                        LOG.warning('there is no %s dataset', dataset)
+                        continue
+                    try:
+                        obj = getattr(cloud.datasource, dataset)
+                        value = util.dictpath(obj, datum[dataset], **kwargs)
+                        # if the value is an empty string, and the
+                        # configuration hasn't told us that's okay, go
+                        # to the next fallback
+                        if not value and \
+                                util.is_false(datum.get('allowempty', False)):
+                            continue
+                        return value
+                    except Exception as exc:
+                        # don't return anything, we proceed to the next datum
+                         LOG.warning('using path %(path)s against %(dataset)s '
+                                  'failed: %(exctype)s: %(excmsg)s' %
+                                  { 'path' : datum[dataset],
+                                    'dataset' : dataset,
+                                    'exctype': type(exc).__name__,
+                                    'excmsg' : str(exc)
+                                   })
+
+    # if we reached this point, all attempts to get the data we want
+    # failed, and there wasn't a fallback
+    LOG.warning('all attempts to retrieve metadata for %s failed', path)
+    
+# vi: ts=4 expandtab

--- a/cloudinit/config/schemas/schema-cloud-config-v1.json
+++ b/cloudinit/config/schemas/schema-cloud-config-v1.json
@@ -97,6 +97,8 @@
         "write_files",
         "write-files-deferred",
         "write_files_deferred",
+        "write-metadata",
+        "write_metadata",
         "yum-add-repo",
         "yum_add_repo",
         "zypper-add-repo",
@@ -3622,6 +3624,24 @@
         }
       }
     },
+    "cc_write_metadata": {
+      "type": "object",
+      "properties": {
+        "write_metadata": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path of the file to which metadata value is written"
+              }
+            },
+            "required": ["path", "data"]
+          }
+        }
+      }
+    },
     "cc_write_files": {
       "type": "object",
       "properties": {
@@ -4174,6 +4194,9 @@
       "$ref": "#/$defs/cc_write_files"
     },
     {
+      "$ref": "#/$defs/cc_write_metadata"
+    },
+    {
       "$ref": "#/$defs/cc_yum_add_repo"
     },
     {
@@ -4283,6 +4306,7 @@
     "version": {},
     "wireguard": {},
     "write_files": {},
+    "write_metadata": {},
     "yum_repo_dir": {},
     "yum_repos": {},
     "zypper": {}

--- a/cloudinit/util.py
+++ b/cloudinit/util.py
@@ -3075,6 +3075,39 @@ def read_hotplug_enabled_file(paths: "Paths") -> dict:
     return content
 
 
+def dictpath(obj, path, separator='/'):
+    """
+    Returns the element at a given path in a nested dictionary/list
+    object.
+
+    If the object is a dictionary, the path element is a string key. If
+    the object is a list, the path element is an index.
+
+    For instance, given the following object:
+
+        {"hello": "world",
+         "days": ["Monday", "Wednesday", "Friday"]}
+
+    dictpath(obj, "days/-1") would return "Friday".
+
+    This function deliberately does not catch any exceptions.
+    """
+
+    for element in path.split(separator):
+        # handle empty elements (for instance, if the path starts with
+        # the separator)
+        if not element:
+            continue
+
+        if isinstance(obj, dict):
+            obj = obj[element]
+        elif isinstance(obj, (list, tuple)):
+            index = int(element)
+            obj = obj[index]
+
+    return obj
+
+
 @contextmanager
 def nullcontext() -> Generator[None, Any, None]:
     """Context manager that does nothing.

--- a/config/cloud.cfg.tmpl
+++ b/config/cloud.cfg.tmpl
@@ -119,6 +119,9 @@ cloud_init_modules:
 {% endif %}
   - bootcmd
   - write_files
+{% if variant == "amazon" %}
+  - write_metadata
+{% endif %}
 {% if variant not in ["netbsd", "openbsd", "raspberry-pi-os"] %}
   - growpart
   - resizefs

--- a/tests/unittests/config/test_cc_write_metadata.py
+++ b/tests/unittests/config/test_cc_write_metadata.py
@@ -1,0 +1,310 @@
+# This file is part of cloud-init. See LICENSE file for license information.
+
+"""Tests for cc_write_metadata module."""
+
+import logging
+from unittest import mock
+
+import pytest
+
+from cloudinit.config import cc_write_metadata
+from cloudinit.config.schema import (
+    SchemaValidationError,
+    get_schema,
+    validate_cloudconfig_schema,
+)
+from tests.unittests.helpers import skipUnlessJsonSchema
+from tests.unittests.util import get_cloud
+
+LOG = logging.getLogger(__name__)
+M_PATH = "cloudinit.config.cc_write_metadata."
+
+
+@pytest.fixture
+def cloud():
+    """Fixture to provide a mock cloud object with datasource."""
+    cl = get_cloud()
+    cl.datasource = mock.Mock()
+    cl.datasource.metadata = {
+        "instance-id": "i-1234567890abcdef0",
+        "region": "us-east-1",
+        "availability-zone": "us-east-1a",
+        "instance-type": "",
+    }
+    cl.datasource.identity = {
+        "region": "us-east-1",
+        "account-id": "123456789012",
+    }
+    return cl
+
+
+class TestRetrieveMetadata:
+    """Tests for retrieve_metadata function."""
+
+    @pytest.mark.parametrize(
+        "data,expected_result",
+        [
+            (["no-instance-id"], "no-instance-id"),
+            ([{"metadata": "instance-id"}], "i-1234567890abcdef0"),
+            ([{"metadata": "region"}], "us-east-1"),
+            ([{"metadata": "availability-zone"}], "us-east-1a"),
+            ([{"identity": "region"}], "us-east-1"),
+            ([{"identity": "account-id"}], "123456789012"),
+            ([{"metadata": "public-ipv4"}, "unknown-ip"], "unknown-ip"),
+            ([{"metadata": "instance-type", "allowempty": True}], ""),
+            ([{"metadata": "public-ipv4"}], None),
+        ],
+    )
+    def test_retrieve_metadata(
+        self, cloud, data, expected_result
+    ):
+        """Test metadata retrieval from various sources with fallbacks."""
+        result = cc_write_metadata.retrieve_metadata("/", data, cloud)
+        assert expected_result == result
+
+    def test_handles_missing_dataset_attribute(self, cloud):
+        """Warn and continue when datasource doesn't have the dataset."""
+        delattr(cloud.datasource, "metadata")
+        data = [{"metadata": "instance-id"}, "no-instance-id"]
+        result = cc_write_metadata.retrieve_metadata("/", data, cloud)
+        assert "no-instance-id" == result
+
+    def test_multiple_fallback_attempts(self, cloud):
+        """Try multiple metadata sources before using string fallback."""
+        data = [
+            {"metadata": "public-ipv4"},
+            {"metadata": "public-hostname"},
+            {"metadata": "instance-id"},
+        ]
+        result = cc_write_metadata.retrieve_metadata("/", data, cloud)
+        assert "i-1234567890abcdef0" == result
+
+
+class TestWriteMetadata:
+    """Tests for write_metadata function."""
+
+    @pytest.mark.parametrize(
+        "files,expected_warning",
+        [
+            (
+                [{"data": [{"metadata": "instance-id"}]}],
+                "No path provided",
+            ),
+            (
+                [{"path": "/var/lib/cloud/instance/metadata"}],
+                "No data provided",
+            ),
+        ],
+    )
+    @mock.patch(M_PATH + "cc_write_files.write_files")
+    def test_skips_invalid_entries(
+        self, m_write_files, cloud, caplog, files, expected_warning
+    ):
+        """Warn and skip entries with missing required fields."""
+        cc_write_metadata.write_metadata("cc_write_metadata", files, cloud)
+        assert expected_warning in caplog.text
+        assert 1 == m_write_files.call_count
+
+    @mock.patch(M_PATH + "cc_write_files.write_files")
+    @mock.patch(M_PATH + "retrieve_metadata", return_value=None)
+    def test_skips_entry_when_retrieve_returns_none(
+        self, m_retrieve, m_write_files, cloud
+    ):
+        """Skip entries where retrieve_metadata returns None."""
+        files = [
+            {
+                "path": "/var/lib/cloud/instance/metadata",
+                "data": [{"metadata": "missing-key"}],
+            }
+        ]
+        cc_write_metadata.write_metadata("cc_write_metadata", files, cloud)
+        assert 1 == m_retrieve.call_count
+        assert 1 == m_write_files.call_count
+
+    @pytest.mark.parametrize(
+        "files,content,expected_path",
+        [
+            (
+                [
+                    {
+                        "path": "/var/lib/cloud/instance/.instance-id",
+                        "data": [{"metadata": "instance-id"}],
+                    }
+                ],
+                "i-1234567890abcdef0",
+                "/var/lib/cloud/instance/.instance-id",
+            ),
+            (
+                [
+                    {
+                        "path": "/etc/cloud/instance-region",
+                        "data": [{"metadata": "region"}],
+                    }
+                ],
+                "us-east-1",
+                "/etc/cloud/instance-region",
+            ),
+        ],
+    )
+    @mock.patch(M_PATH + "cc_write_files.write_files")
+    @mock.patch(M_PATH + "retrieve_metadata")
+    def test_write_files_parameters(
+        self, m_retrieve, m_write_files, cloud, files, content, expected_path
+    ):
+        """Test write_files is called with correct parameters and file info."""
+        m_retrieve.return_value = content
+        cc_write_metadata.write_metadata("cc_write_metadata", files, cloud)
+        
+        # Verify write_files was called
+        assert m_write_files.called
+        
+        # Verify module name and owner
+        assert "cc_write_metadata" == m_write_files.call_args[0][0]
+        assert cloud.distro.default_owner == m_write_files.call_args[0][2]
+        
+        # Verify file info
+        call_args = m_write_files.call_args
+        files_arg = call_args[0][1]
+        assert files_arg[0]["permissions"] == cc_write_metadata.cc_write_files.DEFAULT_PERMS
+        assert files_arg[0]["content"] == content
+        assert files_arg[0]["path"] == expected_path
+
+    @pytest.mark.parametrize(
+        "files,keys_to_check_removed",
+        [
+            (
+                [
+                    {
+                        "path": "/var/lib/cloud/instance/.instance-id",
+                        "data": [{"metadata": "instance-id"}],
+                        "metadata": "should_be_removed",
+                        "identity": "should_be_removed",
+                    }
+                ],
+                ["metadata", "identity"],
+            ),
+        ],
+    )
+    @mock.patch(M_PATH + "cc_write_files.write_files")
+    @mock.patch(M_PATH + "retrieve_metadata", return_value="i-1234567890abcdef0")
+    def test_removes_keys_from_file_info(
+        self, m_retrieve, m_write_files, cloud, files, keys_to_check_removed
+    ):
+        """Test that specific keys are removed from file info."""
+        cc_write_metadata.write_metadata("cc_write_metadata", files, cloud)
+        
+        call_args = m_write_files.call_args
+        files_arg = call_args[0][1]
+        for key in keys_to_check_removed:
+            assert key not in files_arg[0]
+
+
+class TestWriteMetadataSchema:
+    """Tests for write_metadata schema validation."""
+
+    @pytest.mark.parametrize(
+        "config, error_msg",
+        [
+            (
+                {
+                    "write_metadata": [
+                        {
+                            "path": "/root/.instance-id",
+                            "data": [{"metadata": "instance-id"}, "unknown"],
+                        }
+                    ]
+                },
+                None,
+            ),
+            (
+                {
+                    "write_metadata": [
+                        {
+                            "path": "/root/.instance-id",
+                            "data": [{"metadata": "instance-id"}, "unknown"],
+                        },
+                        {
+                            "path": "/root/.region",
+                            "data": [{"identity": "region"}, "unknown"],
+                        },
+                    ]
+                },
+                None,
+            ),
+            (
+                {"write_metadata": [{"data": [{"metadata": "instance-id"}]}]},
+                "'path' is a required property",
+            ),
+            (
+                {"write_metadata": [{"path": "/tmp/test"}]},
+                "'data' is a required property",
+            ),
+            (
+                {"write_metadata": "not_an_array"},
+                "write_metadata: 'not_an_array' is not of type 'array'",
+            ),
+            (
+                {"write_metadata": []},
+                None,
+            ),
+        ],
+    )
+    @skipUnlessJsonSchema()
+    def test_schema_validation(self, config, error_msg):
+        """Validate write_metadata schema."""
+        if error_msg is None:
+            validate_cloudconfig_schema(config, get_schema(), strict=True)
+        else:
+            with pytest.raises(SchemaValidationError, match=error_msg):
+                validate_cloudconfig_schema(config, get_schema(), strict=True)
+
+
+class TestWriteMetadataIntegration:
+    """Integration tests for write_metadata module."""
+
+    @pytest.mark.parametrize(
+        "file_path,data_config,expected_content",
+        [
+            (
+                "/var/lib/cloud/instance/.instance-id",
+                [{"metadata": "instance-id"}, "no-instance-id"],
+                "i-1234567890abcdef0",
+            ),
+            (
+                "/etc/cloud/instance-region",
+                [{"identity": "region"}, "unknown-region"],
+                "us-east-1",
+            ),
+            (
+                "/var/lib/cloud/instance/.account-id",
+                [{"identity": "account-id"}, "no-account-id"],
+                "123456789012",
+            ),
+            (
+                "/var/lib/cloud/instance/.availability-zone",
+                [{"metadata": "availability-zone"}, "unknown-az"],
+                "us-east-1a",
+            ),
+        ],
+    )
+    @pytest.mark.usefixtures("fake_filesystem")
+    @mock.patch("cloudinit.config.cc_write_files.write_files")
+    def test_writes_metadata_to_file(
+        self, m_write_files, cloud, file_path, data_config, expected_content
+    ):
+        """Test writing various metadata types to files."""
+        cfg = {
+            "write_metadata": [
+                {
+                    "path": file_path,
+                    "data": data_config,
+                }
+            ]
+        }
+        cc_write_metadata.handle("cc_write_metadata", cfg, cloud, [])
+        
+        assert m_write_files.called
+        files_arg = m_write_files.call_args[0][1]
+        assert len(files_arg) == 1
+        assert files_arg[0]["path"] == file_path
+        assert files_arg[0]["content"] == expected_content

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -276,6 +276,7 @@ class TestGetSchema:
             {"$ref": "#/$defs/cc_users_groups"},
             {"$ref": "#/$defs/cc_wireguard"},
             {"$ref": "#/$defs/cc_write_files"},
+            {"$ref": "#/$defs/cc_write_metadata"},
             {"$ref": "#/$defs/cc_yum_add_repo"},
             {"$ref": "#/$defs/cc_zypper_add_repo"},
             {"$ref": "#/$defs/reporting_config"},


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because PRs are squash merged
by default.

See https://www.conventionalcommits.org/en/v1.0.0/#specification
for our commit message convention.

If the change is related to a particular cloud or particular distro,
please include the "optional scope" in the summary line. E.g.,
feat(ec2): Add support for foo to the baz

Types used by this project:
feat, fix, docs, ci, test, refactor, chore
-->
```
<feat>(amazon): Create write-metadata module.

Create write-metadata module. This module takes data from the various metadata services and writes them to files.
Add tests for write_metadata module and dictpath utility function
```

We would like to contribute this module to cloud-init because it is used in EC2 to write DNF vars (/etc/dnf/vars) in Amazon Linux to write region, domain, etc from metadata. It is enabled only for 'amazon' but all distros are able to use this. 


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
