### PR TITLE
fix: migrate from ntp client package installed from ntp to ntpsec

### DIFF
--- a/cloudinit/config/cc_ntp.py
+++ b/cloudinit/config/cc_ntp.py
@@ -68,7 +68,7 @@ NTP_CLIENT_CONFIG = {
     "ntp": {
         "check_exe": "ntpd",
         "confpath": NTP_CONF,
-        "packages": ["ntp"],
+        "packages": ["ntpsec"],
         "service_name": "ntp",
         "template_name": "ntp.conf.{distro}",
         "template": None,
@@ -347,8 +347,6 @@ def install_ntp_client(install_func, packages=None, check_exe="ntpd"):
     """
     if subp.which(check_exe):
         return
-    if packages is None:
-        packages = ["ntp"]
 
     install_func(packages)
 

--- a/tests/unittests/config/test_cc_ntp.py
+++ b/tests/unittests/config/test_cc_ntp.py
@@ -577,15 +577,25 @@ class TestNtp:
             m_which.assert_has_calls(expected_calls)
             assert sorted(expected_cfg) == sorted(cfg)
 
+    @pytest.mark.parametrize(
+        "client,command,installed_package",
+        (("ntpdate", "ntpdate", "ntpdate"), ("ntp", "ntpd", "ntpsec")),
+    )
     @mock.patch("cloudinit.config.cc_ntp.write_ntp_config_template")
     @mock.patch("cloudinit.cloud.Cloud.get_template_filename")
     @mock.patch("cloudinit.config.cc_ntp.subp.which")
     @mock.patch("cloudinit.util.rename")
     def test_ntp_custom_client_overrides_installed_clients(
-        self, m_rename, m_which, m_tmpfn, m_write
+        self,
+        m_rename,
+        m_which,
+        m_tmpfn,
+        m_write,
+        client,
+        command,
+        installed_package,
     ):
         """Test user client is installed despite other clients present"""
-        client = "ntpdate"
         cfg = {"ntp": {"ntp_client": client}}
         for distro in cc_ntp.distros:
             # client is not installed
@@ -597,8 +607,16 @@ class TestNtp:
                 mycloud.distro, "manage_service"
             ):
                 cc_ntp.handle("notimportant", cfg, mycloud, [])
-            m_install.assert_called_with([client])
-            m_which.assert_called_with(client)
+            distro_client_packages = (
+                cc_ntp.DISTRO_CLIENT_CONFIG.get(distro, {})
+                .get(client, {})
+                .get("packages")
+            )
+            if distro_client_packages is None:
+                m_install.assert_called_with([installed_package])
+            else:
+                m_install.assert_called_with(distro_client_packages)
+            m_which.assert_called_with(command)
 
     @mock.patch("cloudinit.config.cc_ntp.subp.which")
     def test_ntp_system_config_overrides_distro_builtin_clients(self, m_which):


### PR DESCRIPTION
## Proposed Commit Message
```
Change the installed ntp client package from ntp to ntpsec
when user-data requests `ntp_client: ntp`.

Fix inability to install ntp deb packages from universe in Ubuntu for
some time which resulted in errors from `cloud-init status` and
failed integration tests.

Most distributions have migrated away from ntp to ntpsec as replacement
implementation which has better security and maintenance as a project.

Package migration has happened in many distributions already:
- Ubuntu was in Xenial 2016
- OpenSUSE available since 2019
- Fedora 34 2021
- Debian Bookworm 2023
- Alpine 3.10 2019
```

## Additional Context
[Failed jenkins job](https://jenkins.canonical.com/server-team/view/cloud-init/job/cloud-init-integration-noble-lxd_container-generic/338/#showFailuresLink)

## Test Steps
```
CLOUD_INIT_OS_IMAGE=resolute tox -e integration-tests -- tests/integration_tests/modules/test_ntp_servers.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
