### PR TITLE
ci: full integration test suite lxd_container comparison of matrix versus individual github actions

### DIFF
--- a/.github/workflows/_integration_common.yml
+++ b/.github/workflows/_integration_common.yml
@@ -1,0 +1,118 @@
+name: "Daily: Integration (reusable/manual)"
+
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        required: true
+        type: choice
+        options:
+        - questing
+        - jammy
+        - noble
+        - resolute
+      platform:
+        required: true
+        type: choice
+        options:
+        - lxd_container
+        - lxd_vm
+      image_type:
+        type: choice
+        options:
+        - generic
+        - minimal
+        required: false
+      install_source:
+        required: false
+        type: string
+      filter_tests:
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      release:
+        required: true
+        type: string
+      platform:
+        required: true
+        type: string
+      image_type:
+        required: false
+        type: string
+      install_source:
+        required: false
+        type: string
+      filter_tests:
+        required: false
+        type: string
+
+jobs:
+  lxc:
+    runs-on: ubuntu-latest
+
+    env:
+      CLOUD_INIT_PLATFORM: ${{ inputs.platform || 'lxd_container' }}
+      CLOUD_INIT_OS_IMAGE: ${{ inputs.release || 'questing' }}
+      CLOUD_INIT_OS_IMAGE_TYPE: ${{ inputs.image_type || 'generic' }}
+      CLOUD_INIT_CLOUD_INIT_SOURCE: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
+      CLOUD_INIT_LOCAL_LOG_PATH: ${{ github.workspace }}/cloud_init_test_logs
+
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - name: Setup LXD
+        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v0.1.2
+        with:
+          channel: 6/stable
+      - name: Clean workspace
+        run: |
+          rm -rf ${{ github.workspace }}/cloud_init_test_logs/
+      - name: Setup pycloudlib
+        run: |
+          ssh-keygen -P "" -q -f ~/.ssh/id_rsa
+          echo "[lxd]" > /home/$USER/.config/pycloudlib.toml
+      - name: Install Dependencies
+        run: |
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
+      - name: Run integration Tests
+        run: |
+          tox -e integration-tests -- --junitxml="${{ github.workspace }}/reports/junit-report-${{ inputs.platform }}-${{ inputs.release }}.xml" --color=yes ${{ inputs.filter_tests || 'tests/integration_tests' }}
+      - name: Publish Test Report with Insights
+        if: always()
+        uses: ctrf-io/github-test-reporter@024bc4b64d997ca9da86833c6b9548c55c620e40 # v1.0.26
+        with:
+          report-path: '${{ github.workspace }}/reports/junit-report-${{ inputs.platform}}-${{ inputs.release }}.xml'
+          integrations-config: |
+            {
+              "junit-to-ctrf": {
+                "enabled": true,
+                "action": "convert",
+                "options": {
+                  "output": "./reports/ctrf-report-${{ inputs.platform }}-${{ inputs.release }}-${{ inputs.image_type }}.json",
+                  "toolname": "junit-to-ctrf",
+                  "useSuiteName": false,
+                  "env": {
+                    "appName": "my-app"
+                  }
+                }
+              }
+            }
+          summary-delta-report: true
+          insights-report: true
+          flaky-rate-report: true
+          slowest-report: true
+          upload-artifact: true
+          github-report: true
+          artifact-name: ctrf-report-${{ inputs.platform }}-${{inputs.release}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: failure-${{ github.job }}
+          path: ${{ github.workspace }}/cloud_init_test_logs/
+          retention-days: 2

--- a/.github/workflows/daily-integration-jammy-lxd-container.yml
+++ b/.github/workflows/daily-integration-jammy-lxd-container.yml
@@ -1,0 +1,13 @@
+name: "Daily: Integration Jammy lxd_container"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '2 22 * * *'
+
+jobs:
+  jammy-lxd_container:
+    uses: ./.github/workflows/_integration_common.yml
+    with:
+      release: jammy
+      platform: lxd_container

--- a/.github/workflows/daily-integration-noble-lxd-container.yml
+++ b/.github/workflows/daily-integration-noble-lxd-container.yml
@@ -1,0 +1,13 @@
+name: "Daily: Integration Noble lxd_container"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '2 22 * * *'
+
+jobs:
+  noble-lxd_container:
+    uses: ./.github/workflows/_integration_common.yml
+    with:
+      release: noble
+      platform: lxd_container

--- a/.github/workflows/daily-integration-questing-lxd-container.yml
+++ b/.github/workflows/daily-integration-questing-lxd-container.yml
@@ -1,0 +1,13 @@
+name: "Daily: Integration Questing lxd_container"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '2 22 * * *'
+
+jobs:
+  questing-lxd_container:
+    uses: ./.github/workflows/_integration_common.yml
+    with:
+      release: questing
+      platform: lxd_container

--- a/.github/workflows/daily-integration-resolute-lxd-container.yml
+++ b/.github/workflows/daily-integration-resolute-lxd-container.yml
@@ -1,0 +1,13 @@
+name: "Daily: Integration Resolute lxd_container"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '2 22 * * *'
+
+jobs:
+  resolute-lxd_container:
+    uses: ./.github/workflows/_integration_common.yml
+    with:
+      release: resolute
+      platform: lxd_container


### PR DESCRIPTION
POC: Add lxd_container integration tests as github actions for a set of Ubuntu series.  

GOAL: determine for usability if we want matrix style actions or individual actions.
After decision, we can drop one approach and stick with the other.

Provide alternative methods of worflow organization:
- preferred: separate workflows organized by series and platform
- alternative:  matrix based job which can aggregate all jobs per platform


Provide a common workflow _integration_common.yml which acts as a shared workflow stages to allow simpler matrix and individual action runners to re-use the common steps. _integration_common.yml also provides the ability to manually kick off any platform/series/image-type/cloud-init-source to allow special case one-off runs.

Make use of ctrf-io/github-test-reporter to give us basic failure trend/flakiness analysis across runs. 

Upon failure, upload failed test artifacts from cloud_init_test_logs as a gzipped file. Retain those logs for only 2 days to avoid incurring significant costs for all cloud-init test runner storage.


## Proposed Commit Message
```
ci: add shared workflows for lxd_container integration tests

Provide individual github workflow manual and scheduled runners
for lxd_container for each supported Ubuntu release.

Each workflow uses a shared common workflow to avoid duplication
in each separate action. The shared workflow _integration_common can
also be manually parameterized to launch and specific platform, release,
image_type and cloud-init source
```


## Additional Context

See references to test runs:
- [Top-level view of matrix style versus indivudual runners](https://github.com/blackboxsw/cloud-init/actions)
-  [Noble lxd_container showing increased test failure  rates in report](https://github.com/blackboxsw/cloud-init/actions/runs/21424460726),
- [Matrix view of reporting for noble and questing lxd_container matrix](https://github.com/blackboxsw/cloud-init/actions/runs/21415478371)


## Test Steps
One can push the branch to your remote:main and trigger test runs from  https://github.com/<your_username>/cloud-init/actions

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
