### PR TITLE
fix: datasource initialization order in stages

### DIFF
--- a/cloudinit/stages.py
+++ b/cloudinit/stages.py
@@ -993,10 +993,13 @@ class Init:
             NetworkConfigSource.SYSTEM_CFG: self.cfg.get("network"),
         }
 
-        if hasattr(self.ds, "network_config"):
-            available_cfgs[NetworkConfigSource.DS] = self.ds.network_config
+        if self.datasource:
+            order = self.ds.network_config_sources
+            if hasattr(self.ds, "network_config"):
+                available_cfgs[NetworkConfigSource.DS] = self.ds.network_config
+        else:
+            order = sources.DataSource.network_config_sources
 
-        order = self.ds.network_config_sources
         for cfg_source in order:
             if not isinstance(cfg_source, NetworkConfigSource):
                 # This won't happen in the cloud-init codebase, but out-of-tree

--- a/tests/unittests/test_stages.py
+++ b/tests/unittests/test_stages.py
@@ -54,6 +54,32 @@ class TestUpdateEventEnabled:
         )
 
 
+class TestNetworkConfigWithoutDS:
+    @pytest.fixture(autouse=True)
+    def setup(self, tmpdir):
+        self.tmpdir = tmpdir
+        self.init = stages.Init()
+        self.init._cfg = {
+            "system_info": {
+                "distro": "ubuntu",
+                "paths": {"cloud_dir": self.tmpdir, "run_dir": self.tmpdir},
+            }
+        }
+        tmpdir.mkdir("instance-uuid")
+        sym_link(tmpdir.join("instance-uuid"), tmpdir.join("instance"))
+
+    @mock.patch(
+        M_PATH + "cmdline.read_initramfs_config",
+        return_value={"config": "disabled"},
+    )
+    @mock.patch(
+        M_PATH + "cmdline.read_kernel_cmdline_config",
+        return_value={"config": "disabled"},
+    )
+    def test_network_config(self, m_cmdline, m_initramfs):
+        self.init.apply_network_config(False)
+
+
 class TestInit:
     @pytest.fixture(autouse=True)
     def setup(self, tmpdir):


### PR DESCRIPTION
Add a unit test to cover this case.
