### PR TITLE
ci: install distro-info-data dependency to test devel series resolute

### DIFF
--- a/.github/workflows/_integration_common.yml
+++ b/.github/workflows/_integration_common.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -qy install tox distro-info-data
       - name: Run integration Tests
         run: |
           tox -e integration-tests -- --junitxml="${{ github.workspace }}/reports/junit-report-${{ inputs.platform }}-${{ inputs.release }}.xml" --color=yes ${{ inputs.filter_tests || 'tests/integration_tests' }}


### PR DESCRIPTION
## Proposed Commit Message
```
ci: install distro-info-data dependency to test devel series resolute
```

## Additional Context
ubuntu-latest images in Github don't have latest distro-info-data which means that when a new development series comes out, we need to refresh distro-info-data in order to allow cloud-init integration tests to run against "resolute"

Without this dependency updated: [our integration test runners fail claiming: E   ValueError: 'resolute' is not a recognized Ubuntu release](https://github.com/canonical/cloud-init/actions/runs/21536506328/job/62063196384)

With distro-info-data dependency installed: [integration test runners can launch resolute images in lxc](https://github.com/blackboxsw/cloud-init/actions/runs/21536646591/job/62063597075)

## Test Steps

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
