### PR TITLE
feat: add decryption capability in userdata with Jinja template

### DIFF
--- a/doc/userdata.txt
+++ b/doc/userdata.txt
@@ -83,6 +83,9 @@ sensitive value with GPG and decrypt them at runtime, using the
 "encrypt" usage prior, for example during the baking processing of the 
 VM image.
 
+Note that this requires to have the GPG binary available in the PATH that 
+cloudinit will use, as a ``gpg`` command.
+
 "gpgdecrypt" function takes one required argument and one optional. The 
 first argument is the base64-encoded encrypted data to decrypt, and the 
 second argument is the default value, to return in case the decryption 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,3 @@ jsonpatch
 
 # For validating cloud-config sections per schema definitions
 jsonschema
-
-# For encrypting sensitive values in userdata
-python-gnupg

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,3 +19,6 @@ passlib
 # This one is currently used only by the CloudSigma and SmartOS datasources.
 # If these datasources are removed, this is no longer needed.
 pyserial
+
+# For encrypting sensitive values in userdata
+python-gnupg

--- a/tests/unittests/test_templating.py
+++ b/tests/unittests/test_templating.py
@@ -246,7 +246,8 @@ class TestTemplates:
         expected_result = (
             "## template: jinja\n"
             "runcmd:\n"
-            ' - echo "cloudinit: missing GPG key" > /var/secrets/value'
+            ' - echo "cloudinit: unable to decrypt GPG message"'
+            " > /var/secrets/value"
         )
         jinja_template = (
             "## template: jinja\n"

--- a/tox.ini
+++ b/tox.ini
@@ -187,6 +187,7 @@ deps =
     pytest-mock==3.6.1
     responses==0.18.0
     passlib==1.7.4
+    python-gnupg==0.5.6
 commands = {envpython} -m pytest -m "not hypothesis_slow" --cov=cloud-init --cov-branch {posargs:tests/unittests}
 
 [testenv:doc]


### PR DESCRIPTION
This aims to fix #4417 by implementing the plan proposed in #6655. It uses GPG to pass sensitive information in an encrypted way.

- [X] I have signed the CLA: https://ubuntu.com/legal/contributors
- [x] I have included a comprehensive commit message using the guide below
- [x] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [x] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [x] I have added a reference to issues that this PR relates to in the PR message
- [x] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.

## Proposed Commit Message

```
feat(userdata): add decryption capability in userdata

When using Jinja template, this commit add a helper function 
which can be used to decrypt an encrypted message at 
runtime, using a GPG private key stored in the cloudinit's 
user keyring, or the keyring pointed by the envvar 
`GNUPGHOME`

Fixes GH-4417
```

## Additional Context

~1. This currently requires to add a dependencies to [python-gnupg](https://github.com/vsajip/python-gnupg), which might turn out to be controversial. Note that due to the simple use of GPG (`--decrypt`), it should be possible to also directly wrap GPG invocation by a [subprocess](https://docs.python.org/3/library/subprocess.html)~ Now use the command directly via std lib.
2. I have added documentation, by I expect some user manual text might need updating too. Since I couldn't find where this would be the most relevant, I am keeping this as a TODO, and will follow your feedback as of where to document this.

## Test Steps

Unit test can be use to confirm it works. To test on a real setup, make sure to install the GPG key with "encrypt" usage on the cloudinit's user keyring (root by default) or to any keyring pointed by  the `GNUPGHOME` envvar (e.g using systemd). 
Encrypt sensitive value and pass it to the userdata in base64 format (see `doc/userdata.txt` for further details)

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
