### PR TITLE
fix(azure): Round duration to 4 decimal places for KVP reporting

### DIFF
--- a/cloudinit/reporting/events.py
+++ b/cloudinit/reporting/events.py
@@ -107,7 +107,7 @@ class FinishReportingEvent(ReportingEvent):
         """The event represented as json friendly."""
         data = super(FinishReportingEvent, self).as_dict()
         data["result"] = self.result
-        data["duration"] = self.duration
+        data["duration"] = round(self.duration, 4)
         if self.post_files:
             data["files"] = _collect_file_info(self.post_files)
         return data


### PR DESCRIPTION
## Proposed Commit Message
```text
fix(azure): round the duration field in FinishReportingEvent to four decimal places.
```

## Additional Context
The duration field in FinishReportingEvent.as_dict() was returning unrounded floating point values, resulting in excessively long numbers in KVP event output.

This change rounds the duration to 4 decimal places, to make the output more readable.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
