### PR TITLE
chore: pin full SHA commits for all workflows

### DIFF
--- a/.github/workflows/_integration_common.yml
+++ b/.github/workflows/_integration_common.yml
@@ -61,7 +61,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Setup LXD
         uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee # v0.1.2
         with:

--- a/.github/workflows/ci-check-format.yml
+++ b/.github/workflows/ci-check-format.yml
@@ -24,7 +24,7 @@ jobs:
       FORCE_COLOR: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Dependencies
         run: |
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Test format
         run: |
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install RTD Python Version
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.11.9'
       - name: Install dependencies
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install ShellCheck
         run: |
@@ -101,7 +101,7 @@ jobs:
     name: GitHub Action and Workflow Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - uses: reviewdog/action-actionlint@83e4ed25b168066ad8f62f5afbb29ebd8641d982 # v1.69.1
         with:
           fail_level: any

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Prepare dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get update
@@ -45,13 +45,13 @@ jobs:
           DEB_BUILD_OPTIONS=nocheck ./packages/bddeb -d --release ${{ env.RELEASE }}
           cp cloud-init_all.deb ${{ runner.temp }}
       - name: Archive debs as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: 'cloud-init-${{ env.RELEASE }}-deb'
           path: '${{ runner.temp }}/cloud-init*.deb'
           retention-days: 3
       - name: Setup LXD
-        uses: canonical/setup-lxd@v0.1.2
+        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee  # v1
         with:
           channel: 6/stable
       - name: Verify deb package

--- a/.github/workflows/ci-unit-distro.yml
+++ b/.github/workflows/ci-unit-distro.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up LXD
-        uses: canonical/setup-lxd@v0.1.2
+        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee  # v1
 
       - name: Create alpine container
         # the current shell doesn't have lxd as one of the groups

--- a/.github/workflows/ci-unit-python.yml
+++ b/.github/workflows/ci-unit-python.yml
@@ -32,9 +32,9 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Python ${{matrix.python-version}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{matrix.python-version}}
           check-latest: ${{matrix.check-latest}}

--- a/.github/workflows/daily-linkcheck.yml
+++ b/.github/workflows/daily-linkcheck.yml
@@ -12,10 +12,10 @@ jobs:
     continue-on-error: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.failOnError == 'true') }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: "Install Python 3.10"
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.10.8'
 

--- a/.github/workflows/daily-unit-lint.yml
+++ b/.github/workflows/daily-unit-lint.yml
@@ -13,7 +13,7 @@ jobs:
       FORCE_COLOR: 1
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install dependencies
         env:
           DEBIAN_FRONTEND: noninteractive
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Latest Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           # select latest version here:
           # https://github.com/actions/python-versions/blob/main/versions-manifest.json
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install dependencies
         run: |
           sudo apt-get -qy update
@@ -76,9 +76,9 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Python ${{matrix.python-version}}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{matrix.python-version}}
           check-latest: ${{matrix.check-latest}}

--- a/.github/workflows/gh-cla.yml
+++ b/.github/workflows/gh-cla.yml
@@ -10,4 +10,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v2
+        uses: canonical/has-signed-canonical-cla@19bae73390fdbfdc1ef9a9bb9408d87a1de755f6  # v2

--- a/.github/workflows/gh-label.yml
+++ b/.github/workflows/gh-label.yml
@@ -6,4 +6,4 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # v6.0.1

--- a/.github/workflows/gh-stale.yml
+++ b/.github/workflows/gh-stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/stale@v9
+    - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d  # v10.1.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-issue-stale: -1

--- a/.github/workflows/packaging-downstream.yml
+++ b/.github/workflows/packaging-downstream.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/packaging-lint.yml
+++ b/.github/workflows/packaging-lint.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Get all matching changed files
         id: matching-changed-files

--- a/.github/workflows/packaging-upstream.yml
+++ b/.github/workflows/packaging-upstream.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
 
       - name: Setup - checkout branches
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           # Fetch all history for merging
           fetch-depth: 0

--- a/.github/workflows/weekly-tics.yml
+++ b/.github/workflows/weekly-tics.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [self-hosted, linux, amd64, tiobe, noble]
     steps:
       - name: Checkout the project
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 


### PR DESCRIPTION

## Proposed Commit Message
```
chore: pin full SHA commits for all workflows

cloud-init project now requires full SHA commits instead of tags for
all workflows to utilize a more secure policy for CI runners.

Any Github actions lacking full SHA pins in workflows/actions will
error due to repo prevention policy.

Additionally update SHA pins to latest known workflow releases.
```
## Additional Context
<!-- If relevant -->
Example failed jobs lacking workflow SHA pinning https://github.com/canonical/cloud-init/actions/runs/21612935986/job/62285545960

Also: github actions are typically run from the target main branch not the source branch, so I have had to disable the "require full SHA commits for workflows" in security settings so we can clear the CI checks that fail against main. Once this branch merges, we will re-enable that requirement.


https://github.com/canonical/cloud-init/pull/6710

## Test Steps


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
