### PR TITLE
fix(schema): skip datasource loading when --config-file is provided

### DIFF
--- a/cloudinit/cmd/main.py
+++ b/cloudinit/cmd/main.py
@@ -79,6 +79,42 @@ STAGE_NAME = {
 LOG = logging.getLogger(__name__)
 
 
+def _get_schema_handler(handle_schema_args):
+    """Return a schema handler that resolves Paths from CLI args.
+
+    When --config-file is provided, skip datasource loading since we're
+    only validating a user-provided file, not system instance data.
+    When --system is provided, attempt to load the existing datasource
+    for instance path resolution, falling back gracefully on failure.
+    """
+    from errno import EACCES
+
+    def wrapper(name, args):
+        if args.config_file:
+            paths = read_cfg_paths()
+        else:
+            try:
+                paths = read_cfg_paths(fetch_existing_datasource="trust")
+            except (IOError, OSError) as e:
+                if e.errno == EACCES:
+                    LOG.debug(
+                        "Using default instance-data/user-data paths for "
+                        "non-root user"
+                    )
+                    paths = read_cfg_paths()
+                else:
+                    raise
+            except sources.DataSourceNotFoundException:
+                paths = read_cfg_paths()
+                LOG.warning(
+                    "datasource not detected, using default"
+                    " instance-data/user-data paths."
+                )
+        return handle_schema_args(name, args, paths)
+
+    return wrapper
+
+
 class SubcommandAwareArgumentParser(argparse.ArgumentParser):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1290,7 +1326,12 @@ def main(sysv_args=None):
             )
 
             schema_parser(parser_schema)
-            parser_schema.set_defaults(action=("schema", handle_schema_args))
+            parser_schema.set_defaults(
+                action=(
+                    "schema",
+                    _get_schema_handler(handle_schema_args),
+                )
+            )
         elif subcommand == "status":
             from cloudinit.cmd.status import (
                 get_parser as status_parser,

--- a/cloudinit/config/schema.py
+++ b/cloudinit/config/schema.py
@@ -12,7 +12,6 @@ from collections import defaultdict
 from contextlib import suppress
 from copy import deepcopy
 from enum import Enum
-from errno import EACCES
 from functools import partial
 from typing import (
     TYPE_CHECKING,
@@ -32,7 +31,6 @@ from cloudinit.cmd.devel import read_cfg_paths
 from cloudinit.handlers import INCLUSION_TYPES_MAP, type_from_starts_with
 from cloudinit.helpers import Paths
 from cloudinit.log.log_util import error
-from cloudinit.sources import DataSourceNotFoundException
 from cloudinit.temp_utils import mkdtemp
 from cloudinit.util import load_text_file, write_file
 
@@ -1311,6 +1309,7 @@ def _assert_exclusive_args(args):
 
 def get_config_paths_from_args(
     args,
+    paths: Paths,
 ) -> Tuple[str, List[InstanceDataPart]]:
     """Return appropriate instance-data.json and instance data parts
 
@@ -1320,6 +1319,8 @@ def get_config_paths_from_args(
     and network-config for which to validate schema. Avoid returning any
     InstanceDataParts when the expected config_path does not exist.
 
+    :param paths: Paths object resolved by the caller, with or without
+        datasource loading depending on the CLI context.
     :return: A tuple of the instance-data.json path and a list of
         viable InstanceDataParts present on the system.
     """
@@ -1349,28 +1350,6 @@ def get_config_paths_from_args(
                     return raw_path
         return primary_datapath
 
-    # When --config-file is provided, we don't need the datasource
-    # because we're validating a user-provided file, not system instance data
-    if args.config_file:
-        paths = read_cfg_paths()
-    else:
-        try:
-            paths = read_cfg_paths(fetch_existing_datasource="trust")
-        except (IOError, OSError) as e:
-            if e.errno == EACCES:
-                LOG.debug(
-                    "Using default instance-data/user-data paths for "
-                    "non-root user"
-                )
-                paths = read_cfg_paths()
-            else:
-                raise
-        except DataSourceNotFoundException:
-            paths = read_cfg_paths()
-            LOG.warning(
-                "datasource not detected, using default"
-                " instance-data/user-data paths."
-            )
     if args.instance_data:
         instance_data_path = args.instance_data
     elif os.getuid() != 0:
@@ -1440,11 +1419,15 @@ def get_config_paths_from_args(
     return instance_data_path, config_files
 
 
-def handle_schema_args(name, args):
-    """Handle provided schema args and perform the appropriate actions."""
+def handle_schema_args(name, args, paths: Paths):
+    """Handle provided schema args and perform the appropriate actions.
+
+    :param paths: Paths object resolved by the CLI layer, with or without
+        datasource loading depending on the CLI context.
+    """
     _assert_exclusive_args(args)
     full_schema = get_schema()
-    instance_data_path, config_files = get_config_paths_from_args(args)
+    instance_data_path, config_files = get_config_paths_from_args(args, paths)
 
     nested_output_prefix = ""
     multi_config_output = bool(len(config_files) > 1)

--- a/tests/unittests/cmd/test_main.py
+++ b/tests/unittests/cmd/test_main.py
@@ -411,3 +411,93 @@ class TestShouldBringUpInterfaces:
 
         result = main._should_bring_up_interfaces(init, args)
         assert result == expected
+
+
+class TestGetSchemaHandler:
+    """Tests for _get_schema_handler which resolves Paths from CLI args."""
+
+    @mock.patch("cloudinit.cmd.main.read_cfg_paths")
+    def test_config_file_skips_datasource_load(self, read_cfg_paths):
+        """When --config-file is provided, datasource loading is skipped."""
+        mock_paths = mock.Mock()
+        read_cfg_paths.return_value = mock_paths
+        mock_handler = mock.Mock()
+        wrapper = main._get_schema_handler(mock_handler)
+
+        args = mock.Mock()
+        args.config_file = "/some/config.yml"
+
+        wrapper("schema", args)
+
+        read_cfg_paths.assert_called_once_with()
+        mock_handler.assert_called_once_with("schema", args, mock_paths)
+
+    @mock.patch("cloudinit.cmd.main.read_cfg_paths")
+    def test_system_loads_datasource(self, read_cfg_paths):
+        """When --system is provided, datasource is loaded."""
+        mock_paths = mock.Mock()
+        read_cfg_paths.return_value = mock_paths
+        mock_handler = mock.Mock()
+        wrapper = main._get_schema_handler(mock_handler)
+
+        args = mock.Mock()
+        args.config_file = None
+
+        wrapper("schema", args)
+
+        read_cfg_paths.assert_called_once_with(
+            fetch_existing_datasource="trust"
+        )
+        mock_handler.assert_called_once_with("schema", args, mock_paths)
+
+    @mock.patch("cloudinit.cmd.main.read_cfg_paths")
+    def test_system_falls_back_on_eacces(self, read_cfg_paths, caplog):
+        """When datasource load fails with EACCES, falls back gracefully."""
+        from errno import EACCES
+
+        exception = IOError("No perms")
+        exception.errno = EACCES
+        mock_paths = mock.Mock()
+        read_cfg_paths.side_effect = [exception, mock_paths]
+        mock_handler = mock.Mock()
+        wrapper = main._get_schema_handler(mock_handler)
+
+        args = mock.Mock()
+        args.config_file = None
+
+        wrapper("schema", args)
+
+        assert read_cfg_paths.call_count == 2
+        assert read_cfg_paths.call_args_list[0] == mock.call(
+            fetch_existing_datasource="trust"
+        )
+        assert read_cfg_paths.call_args_list[1] == mock.call()
+        assert "Using default instance-data/user-data paths for non-root" \
+            in caplog.text
+
+    @mock.patch("cloudinit.cmd.main.read_cfg_paths")
+    def test_system_falls_back_on_datasource_not_found(
+        self, read_cfg_paths, caplog
+    ):
+        """When no cached datasource exists, falls back gracefully."""
+        from cloudinit.sources import DataSourceNotFoundException
+
+        mock_paths = mock.Mock()
+        read_cfg_paths.side_effect = [
+            DataSourceNotFoundException("No cache"),
+            mock_paths,
+        ]
+        mock_handler = mock.Mock()
+        wrapper = main._get_schema_handler(mock_handler)
+
+        args = mock.Mock()
+        args.config_file = None
+
+        wrapper("schema", args)
+
+        assert read_cfg_paths.call_count == 2
+        assert read_cfg_paths.call_args_list[0] == mock.call(
+            fetch_existing_datasource="trust"
+        )
+        assert read_cfg_paths.call_args_list[1] == mock.call()
+        assert "datasource not detected" in caplog.text

--- a/tests/unittests/config/test_schema.py
+++ b/tests/unittests/config/test_schema.py
@@ -9,7 +9,6 @@ import os
 import re
 import sys
 from collections import namedtuple
-from errno import EACCES
 from pathlib import Path
 from textwrap import dedent
 from types import ModuleType
@@ -38,7 +37,6 @@ from cloudinit.config.schema import (
 from cloudinit.distros import OSFAMILIES
 from cloudinit.safeyaml import load_with_marks
 from cloudinit.settings import FREQUENCIES
-from cloudinit.sources import DataSourceNotFoundException
 from cloudinit.templater import JinjaSyntaxParsingException
 from cloudinit.util import load_text_file, write_file
 from tests.helpers import cloud_init_project_dir
@@ -1959,21 +1957,13 @@ class TestHandleSchemaArgs:
         "Args", "config_file schema_type docs system annotate instance_data"
     )
 
-    @mock.patch(M_PATH + "read_cfg_paths")
-    def test_handle_schema_args_config_file_skips_datasource_load(
+    def test_handle_schema_args_config_file(
         self,
-        read_cfg_paths,
         paths,
         capsys,
-        caplog,
         tmpdir,
     ):
-        """When --config-file is provided, datasource loading is skipped.
-
-        This ensures non-root users don't see pickle permission warnings
-        when validating a user-provided config file.
-        """
-        read_cfg_paths.return_value = paths
+        """handle_schema_args validates a user-provided config file."""
         user_data_fn = tmpdir.join("user-data")
         with open(user_data_fn, "w") as f:
             f.write(
@@ -1992,45 +1982,18 @@ class TestHandleSchemaArgs:
             system=None,
             instance_data=None,
         )
-        handle_schema_args("unused", args)
+        handle_schema_args("unused", args, paths)
         assert "Valid schema" in capsys.readouterr().out
-        # When config_file is provided, read_cfg_paths should be called
-        # once without fetch_existing_datasource
-        read_cfg_paths.assert_called_once_with()
-        # Ensure no warnings about pickle loading or datasource detection
-        assert "pickle" not in caplog.text.lower()
-        assert "datasource not detected" not in caplog.text
 
-    @pytest.mark.parametrize(
-        "failure, expected_logs",
-        (
-            (
-                IOError("No permissions on /var/lib/cloud/instance"),
-                ["Using default instance-data/user-data paths for non-root"],
-            ),
-            (
-                DataSourceNotFoundException("No cached datasource found yet"),
-                ["datasource not detected"],
-            ),
-        ),
-    )
     @mock.patch(M_PATH + "os.getuid", return_value=0)
-    @mock.patch(M_PATH + "read_cfg_paths")
-    def test_handle_schema_system_falls_back_on_datasource_failure(
+    def test_handle_schema_system(
         self,
-        read_cfg_paths,
         m_getuid,
-        failure,
-        expected_logs,
         paths,
         capsys,
-        caplog,
     ):
-        """When --system is used and datasource fails, fallback works."""
-        if isinstance(failure, IOError):
-            failure.errno = EACCES
+        """handle_schema_args validates system config with provided paths."""
         paths.get_ipath = paths.get_ipath_cur
-        read_cfg_paths.side_effect = [failure, paths]
         # Create the cloud_config file that --system reads
         cloud_config_file = paths.get_ipath_cur("cloud_config")
         write_file(cloud_config_file, b"#cloud-config\npackages: [sl]\n")
@@ -2042,16 +2005,8 @@ class TestHandleSchemaArgs:
             system=True,
             instance_data=None,
         )
-        handle_schema_args("unused", args)
-        # First call should be with fetch_existing_datasource="trust"
-        # Second call (fallback) should be without it
-        assert read_cfg_paths.call_count == 2
-        assert read_cfg_paths.call_args_list[0] == mock.call(
-            fetch_existing_datasource="trust"
-        )
-        assert read_cfg_paths.call_args_list[1] == mock.call()
-        for expected_log in expected_logs:
-            assert expected_log in caplog.text
+        handle_schema_args("unused", args, paths)
+        assert "Valid schema" in capsys.readouterr().out
 
     @pytest.mark.parametrize(
         "annotate, deprecation_info_boundary, expected_output",
@@ -2117,10 +2072,8 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
             ),
         ],
     )
-    @mock.patch(M_PATH + "read_cfg_paths")
     def test_handle_schema_args_annotate_deprecated_config(
         self,
-        read_cfg_paths,
         annotate,
         deprecation_info_boundary,
         expected_output,
@@ -2131,7 +2084,6 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
         mocker,
     ):
         paths.get_ipath = paths.get_ipath_cur
-        read_cfg_paths.return_value = paths
         user_data_fn = tmpdir.join("user-data")
         with open(user_data_fn, "w") as f:
             f.write(
@@ -2157,7 +2109,7 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
             system=None,
             instance_data=None,
         )
-        handle_schema_args("unused", args)
+        handle_schema_args("unused", args, paths)
         out, err = capsys.readouterr()
         assert (
             expected_output.format(cfg_file=user_data_fn).split()
@@ -2209,10 +2161,8 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
         ],
     )
     @mock.patch(M_PATH + "os.getuid")
-    @mock.patch(M_PATH + "read_cfg_paths")
     def test_handle_schema_args_jinja_with_errors(
         self,
-        read_cfg_paths,
         getuid,
         uid,
         annotate,
@@ -2226,7 +2176,6 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
     ):
         getuid.return_value = uid
         paths.get_ipath = paths.get_ipath_cur
-        read_cfg_paths.return_value = paths
         user_data_fn = tmpdir.join("user-data")
         if uid == 0:
             id_path = paths.get_runpath("instance_data_sensitive")
@@ -2253,7 +2202,7 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
             instance_data=None,
         )
         with expectation:
-            handle_schema_args("unused", args)
+            handle_schema_args("unused", args, paths)
         out, err = capsys.readouterr()
         assert (
             expected_out.format(cfg_file=user_data_fn, id_path=id_path) == out
@@ -2262,9 +2211,6 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
             expected_err.format(cfg_file=user_data_fn, id_path=id_path) == err
         )
         assert "deprec" not in caplog.text
-        # When config_file is provided, read_cfg_paths is called without
-        # fetch_existing_datasource to avoid unnecessary datasource loading
-        assert read_cfg_paths.call_args_list == [mock.call()]
 
     @pytest.mark.parametrize(
         "uid, annotate, expected_out, expected_err, expectation",
@@ -2292,10 +2238,8 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
         ],
     )
     @mock.patch(M_PATH + "os.getuid")
-    @mock.patch(M_PATH + "read_cfg_paths")
     def test_handle_schema_args_unknown_header(
         self,
-        read_cfg_paths,
         getuid,
         uid,
         annotate,
@@ -2309,7 +2253,6 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
     ):
         getuid.return_value = uid
         paths.get_ipath = paths.get_ipath_cur
-        read_cfg_paths.return_value = paths
         user_data_fn = tmpdir.join("user-data")
         if uid == 0:
             id_path = paths.get_runpath("instance_data_sensitive")
@@ -2333,7 +2276,7 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
             instance_data=None,
         )
         with expectation:
-            handle_schema_args("unused", args)
+            handle_schema_args("unused", args, paths)
         out, err = capsys.readouterr()
         assert (
             expected_out.format(cfg_file=user_data_fn, id_path=id_path) == out
@@ -2342,9 +2285,6 @@ apt_reboot_if_required: Deprecated in version 22.2. Use\
             expected_err.format(cfg_file=user_data_fn, id_path=id_path) == err
         )
         assert "deprec" not in caplog.text
-        # When config_file is provided, read_cfg_paths is called without
-        # fetch_existing_datasource to avoid unnecessary datasource loading
-        assert read_cfg_paths.call_args_list == [mock.call()]
 
 
 class TestDeprecation:


### PR DESCRIPTION
When a non-root user runs `cloud-init schema --config-file <file>`, the command was attempting to load the datasource from /var/lib/cloud/instance/obj.pkl, causing a confusing permission warning even though the datasource isn't needed for validating user-provided config files.

Skip datasource loading when --config-file is provided since we're only validating the file's YAML syntax and schema, not system instance data.

Fixes: #6592

<!--
Thank you for submitting a PR to cloud-init!

To ease the process of reviewing your PR, do make sure to complete the following checklist **before** submitting a pull request.

- [ ] I have signed the CLA: https://ubuntu.com/legal/contributors
- [ ] I have included a comprehensive commit message using the guide below
- [ ] I have added unit tests to cover the new behavior under ``tests/unittests/``
  - Test files should map to source files i.e. a source file ``cloudinit/example.py`` should be tested by ``tests/unittests/test_example.py``
  - Run unit tests with ``tox -e py3``
- [ ] I have kept the change small, avoiding unnecessary whitespace or non-functional changes.
- [ ] I have added a reference to issues that this PR relates to in the PR message (Refs GH-1234, Fixes GH-1234)
- [ ] I have updated the documentation with the changed behavior.
  - If the change doesn't change the user interface and is trivial, this step may be skipped.
  - Cloud-config documentation is generated from the jsonschema.
  - Generate docs with ``tox -e doc``.
-->






## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
