### PR TITLE
fix:(disk_setup):handle empty disk in check_partition_gpt_layout_sfdisk

### DIFF
--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -805,7 +805,11 @@ def check_partition_gpt_layout_sfdisk(device, layout):
     # Use sfdisk's JSON output for reliability
     prt_cmd = ["sfdisk", "-l", "-J", device]
     try:
-        out, _err = subp.subp(prt_cmd, update_env=LANG_C_ENV)
+        out, _err = subp.subp(prt_cmd, update_env=LANG_C_ENV, rcs=[0, 1])
+        # Device has no partition table or other error, return empty list
+        if not out:
+            return []
+        # Try to parse JSON output
         ptable = json.loads(out)["partitiontable"]
         if "partitions" in ptable:
             partitions = ptable["partitions"]

--- a/tests/unittests/config/test_cc_disk_setup.py
+++ b/tests/unittests/config/test_cc_disk_setup.py
@@ -137,6 +137,25 @@ class TestCheckPartitionLayout:
             "gpt", "/dev/xvdb1", [(100, Linux_GUID)]
         )
 
+    @mock.patch(
+        "cloudinit.config.cc_disk_setup.subp.subp",
+        return_value=(
+            "",
+            "/dev/sdb: does not contain a recognized partition table",
+        ),
+    )
+    def test_empty_disk_no_partition_table(self, m_subp):
+        """Test that empty disk (no partition table) returns empty list."""
+        result = cc_disk_setup.check_partition_gpt_layout_sfdisk(
+            "/dev/sdb", []
+        )
+        assert result == []
+        m_subp.assert_called_once_with(
+            ["sfdisk", "-l", "-J", "/dev/sdb"],
+            update_env={"LANG": "C"},
+            rcs=[0, 1],
+        )
+
 
 class TestUpdateFsSetupDevices:
     def test_regression_1634678(self):


### PR DESCRIPTION
When checking GPT partition layout using sfdisk, handle the case where a disk has no partition table yet.
Previously, it would raise an exception.
Because check_partition_gpt_layout_sfdisk calls "sfdisk -l -J ", the command exits with code 1 and the error "does not contain a recognized partition table". The code doesn't handle it and raises an error.
Now it returns an empty list.
I also add unit test to cover this empty disk scenario.

Fixes GH-6682

## Test Steps
I run test on OpenStack with an additional empty disk with config data as below

```
# cat /etc/cloud/cloud.cfg.d/disk.cfg 
#cloud-config
disk_setup:
  /dev/vdb:
    table_type: 'gpt'
    layout: True
    overwrite: True
```
steps
   1) Create a volume and attach it to a instance
   2) login, and prepare configuration data for cloud-init to do disk setup
   3) clean cloud-init and reboot
   4) check the result

After fix, no unexpected error about sfdisk, and the additional disk /dev/vdb is parted
```
# lsblk 
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
vda    252:0    0   20G  0 disk 
├─vda1 252:1    0    1M  0 part 
├─vda2 252:2    0  200M  0 part /boot/efi
└─vda3 252:3    0 19.8G  0 part /
vdb    252:16   0   50G  0 disk 
└─vdb1 252:17   0   50G  0 part 
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
