### PR TITLE
ci: feature values should be read from client under test

### DIFF
--- a/tests/integration_tests/datasources/test_nocloud.py
+++ b/tests/integration_tests/datasources/test_nocloud.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 import pytest
 from pycloudlib.lxd.instance import LXDInstance
 
-from cloudinit import features, lifecycle
+from cloudinit import lifecycle
 from cloudinit.subp import subp
 from cloudinit.util import is_true
 from tests.integration_tests.instances import IntegrationInstance

--- a/tests/integration_tests/modules/test_boothook.py
+++ b/tests/integration_tests/modules/test_boothook.py
@@ -3,7 +3,6 @@ import re
 
 import pytest
 
-from cloudinit import features
 from cloudinit.util import is_true
 from tests.integration_tests.instances import IntegrationInstance
 from tests.integration_tests.util import (


### PR DESCRIPTION
Fix 2 Jammy integration test run failures which are due to not sourcing the features settings that are installed on the system under test.

Integration tests should use `get_feature_flag_value` from the client instead of looking at the local repo's features.<FEATURE_NAME> value.

## Proposed Commit Message
```ci: feature values should be read from client under test```

## Additional Context
[Github action faliure for jammy](https://github.com/blackboxsw/cloud-init/actions/runs/21843594452/job/63033997995)

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
