### PR TITLE
ci: use branches inclusion instead of branches-ignore exclusion

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -2,8 +2,10 @@ name: Integration
 
 on:
   pull_request:
-    branches-ignore:
-      - 'ubuntu/**'
+    branches:
+      - main
+      - '[0-9][0-9].[0-9]'
+      - '[0-9][0-9].[0-9].?'
   push:
     branches:
       - main

--- a/.github/workflows/ci-unit-distro.yml
+++ b/.github/workflows/ci-unit-distro.yml
@@ -2,8 +2,10 @@ name: "Unit: Alternate Distros"
 
 on:
   pull_request:
-    branches-ignore:
-      - 'ubuntu/**'
+    branches:
+      - main
+      - '[0-9][0-9].[0-9]'
+      - '[0-9][0-9].[0-9].?'
   push:
     branches:
       - main

--- a/.github/workflows/gh-cla.yml
+++ b/.github/workflows/gh-cla.yml
@@ -2,8 +2,8 @@ name: "GH: CLA"
 
 on:
   pull_request:
-    branches-ignore:
-      - 'ubuntu/**'
+    branches:
+      - main
 
 jobs:
   cla-check:


### PR DESCRIPTION
We have seen our branches-ignore still trigger gh-cla, alternate distro and integration tests despite the target(base) branches containing a leading 'ubuntu/' branch name.

Instead of exclusion filters, let's give inclusion filters a pass to ensure we only run these workflows on main or other versioned upstream release  branches of the format: 26.1, 26.1.1 or 26.1.x.

Because we are seeing ignore-branches exclusion filters being ignored on https://github.com/canonical/cloud-init/pull/6740, let's instead limit runs via the `branches:`  inclusion filter.

## Proposed Commit Message
```
ci: use branches inclusion instead of branches-ignore exclusion

We have seen our branches-ignore still trigger gh-cla, alternate
distro and integration tests despite the target(base) branches
containing a leading 'ubuntu/' branch name.

Instead of exclusion filters, let's give inclusion filters a pass
to ensure we only run these workflows on main or other versioned
upstream release  branches of the format: 26.1, 26.1.1 or 26.1.x.

```

## Additional Context
https://github.com/canonical/cloud-init/pull/6740

## Test Steps
This won't be active until it merges into upstream/ubuntu/noble for any subsequent PRs because the original workflow in the base/target branch is what should be run when active Pull requests trigger the event.


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
