### PR TITLE
ci: azure now logs invalid SSH Key format

### DIFF
--- a/tests/integration_tests/bugs/test_lp1910835.py
+++ b/tests/integration_tests/bugs/test_lp1910835.py
@@ -62,6 +62,9 @@ def test_crlf_in_azure_metadata_ssh_keys(session_cloud):
         # And those two keys should be the same, except for a possible key
         # comment, which Azure strips out
         assert (
-            authorized_keys[0].rsplit(" ")[:2]
-            == authorized_keys[1].split(" ")[:2]
+            "".join(authorized_keys[0].split(" ")[1:3])
+            == authorized_keys[1].split(" ")[1]
         )
+        # Azure logs invalid SSH key formats
+        log_content = client.read_from_file("/var/log/cloud-init.log")
+        assert "Key(s) not in OpenSSH format" in log_content


### PR DESCRIPTION
correct integration-test failures seen on Azure Jammy.

## Proposed Commit Message
```
Commit 50de985b refactored how invalid SSH key formats were treated by Azure.
They are still persisted to .ssh/authorized_keys with original invalid formatting,
now they log a diagnostic event to the Azure backplane for reporting.

Update the related integration test validating the debug logs emitted.
```

## Additional Context
Commit  50de985b introducing overhaul of how SSH public-keys from IMDS are treated.
## Test Steps
```
# setup .config/pycloudlib.toml with your [azure] creds.
CLOUD_INIT_PLATFORM=azure CLOUD_INIT_OS_IMAGE=jammy CLOUD_INIT_CLOUD_INIT_SOURCE=ppa:cloud-init-dev/daily tox -e integration-tests -- tests/integration_tests/bugs/test_lp1910835.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
