### PR TITLE
ci: update actions to test questing and workflows runs-on to ubuntu-latest

### DIFF
--- a/.github/workflows/ci-check-format.yml
+++ b/.github/workflows/ci-check-format.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
     name: Check json format
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
     name: Check docs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -83,7 +83,7 @@ jobs:
 
   shell-lint:
     name: Shell Lint
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -19,11 +19,11 @@ defaults:
     shell: sh -ex {0}
 
 env:
-  RELEASE: plucky
+  RELEASE: questing
 
 jobs:
   build-package-and-run-tests:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/ci-unit-python.yml
+++ b/.github/workflows/ci-unit-python.yml
@@ -28,7 +28,7 @@ jobs:
             check-latest: false
             experimental: false
     name: Python ${{matrix.python-version}} ${{ matrix.slug }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     steps:
       - name: Checkout

--- a/.github/workflows/daily-linkcheck.yml
+++ b/.github/workflows/daily-linkcheck.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   linkcheck:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.failOnError == 'true') }}
     steps:
       - name: Checkout Repository

--- a/.github/workflows/packaging-downstream.yml
+++ b/.github/workflows/packaging-downstream.yml
@@ -19,7 +19,7 @@ defaults:
 
 jobs:
   patch-conflicts-upstream:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     name: Check patches apply cleanly and unit tests pass
     steps:
 

--- a/.github/workflows/packaging-lint.yml
+++ b/.github/workflows/packaging-lint.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   shellcheck-on-matching-and-changed-files:
     name: ShellCheck on matching files that have changed
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - name: Repository checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/packaging-upstream.yml
+++ b/.github/workflows/packaging-upstream.yml
@@ -17,7 +17,7 @@ defaults:
 
 jobs:
   patch-conflicts-ubuntu:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     name: Patches apply cleanly and unit tests pass
     steps:
 
@@ -49,7 +49,7 @@ jobs:
       - name: Run test - apply patches and run unit tests for each series
         run: |
           # Modify the following line to add / remove ubuntu series
-          for BRANCH in ubuntu/devel ubuntu/plucky ubuntu/noble ubuntu/jammy; do
+          for BRANCH in ubuntu/devel ubuntu/questing ubuntu/noble ubuntu/jammy; do
             # merge - this step is not expected to fail
             git merge "origin/$BRANCH"
             if [ ! -f debian/patches/series ]; then


### PR DESCRIPTION
Per-PR CI is failing because plucky is EOL and we no longer build daily deb recipes in sync with tip main.

## Proposed Commit Message
```
ci: update PR actions to test questing and runs-on to ubuntu-latest

Plucky is now EOL and no longer has active daily deb package builds.

To reduce workflow maintenance, only pin workflows to an LTS
if workflows exhibit repeated failures due to ubuntu-latest
```

## Additional Context
<!-- If relevant -->

## Test Steps
Failing CI run due to testing against stale plucky series.
https://github.com/canonical/cloud-init/actions/runs/22104497746/job/63885682067?pr=6751

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
