### PR TITLE
ci: noble daily runner will run on self-hosted systems

### DIFF
--- a/.github/workflows/02-daily-integration-24.04-lxd-container.yml
+++ b/.github/workflows/02-daily-integration-24.04-lxd-container.yml
@@ -11,3 +11,4 @@ jobs:
     with:
       release: noble
       platform: lxd_container
+      hosted_runner: true

--- a/.github/workflows/11-dispatch-common.yml
+++ b/.github/workflows/11-dispatch-common.yml
@@ -29,6 +29,9 @@ on:
       filter_tests:
         required: false
         type: string
+      hosted_runner:
+        required: false
+        type: boolean
   workflow_call:
     inputs:
       release:
@@ -46,10 +49,13 @@ on:
       filter_tests:
         required: false
         type: string
+      hosted_runner:
+        required: false
+        type: boolean
 
 jobs:
   lxc:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.hosted_runner && fromJSON('["self-hosted", "linux", "amd64", "tiobe", "noble"]') || 'ubuntu-latest' }}
     if: github.repository == 'canonical/cloud-init'
 
     env:
@@ -58,6 +64,7 @@ jobs:
       CLOUD_INIT_OS_IMAGE_TYPE: ${{ inputs.image_type || 'generic' }}
       CLOUD_INIT_CLOUD_INIT_SOURCE: ${{ inputs.install_source || 'ppa:cloud-init-dev/daily' }}
       CLOUD_INIT_LOCAL_LOG_PATH: ${{ github.workspace }}/cloud_init_test_logs
+      PYCLOUDLIB_CONFIG: ${{ github.workspace }}/pycloudlib.toml
 
 
     steps:
@@ -73,7 +80,7 @@ jobs:
       - name: Setup pycloudlib
         run: |
           ssh-keygen -P "" -q -f ~/.ssh/id_rsa
-          echo "[lxd]" > /home/$USER/.config/pycloudlib.toml
+          echo "[lxd]" > ${{ github.workspace }/pycloudlib.toml
       - name: Install Dependencies
         run: |
           sudo DEBIAN_FRONTEND=noninteractive apt-get -qy update


### PR DESCRIPTION
Converted to draft as artifact handling and pycloudlib.toml setup was resulting in errors for the self-hosted job.

Allow our CI to run on self-hosted runners to compare failure rate percentage on noble(self-hosted) versus GH runners.

## Proposed Commit Message
```
ci: noble daily runner will run on self-hosted systems

Github worflows for daily integration test runs currently experience
a failure rate > 20% in noble and questin. Provide an optional
hosted_runner input param to allow some jobs to run on Canonical
self-hosted runners to sample whether failure rate is improved on
self-hosted environments.
```
## Additional Context

[Sample successful noble job run using self-hosted runner labels](https://github.com/canonical/cloud-init/actions/runs/22243009996/job/64350799631)
## Test Steps


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
