### PR TITLE
test: rust-coreutils date command breaks if positional args before options

### DIFF
--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -243,7 +243,7 @@ class TestCombined:
         """
         client = class_client
         timezone_output = client.execute(
-            'date "+%Z" --date="Thu, 03 Nov 2016 00:47:00 -0400"'
+            'date --date="Thu, 03 Nov 2016 00:47:00 -0400" "+%Z"'
         )
         assert timezone_output.strip() == "CET"
 


### PR DESCRIPTION

## Proposed Commit Message
```
test: rust-coreutils date command breaks if positional args before options

Upstream uutils bug to track change in behavior from GNU coreutils:
https://github.com/uutils/coreutils/issues/11150.
```

## Additional Context
Upstream issue to track behavior change from gnu-coreutils: https://github.com/uutils/coreutils/issues/11150

## Test Steps
```
CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE CLOUD_INIT_CLOUD_INIT_OS_IMAGE=questing tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_local
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
