### PR TITLE
test: add details about failing package status to aid in debug

### DIFF
--- a/tests/integration_tests/modules/test_apt_functionality.py
+++ b/tests/integration_tests/modules/test_apt_functionality.py
@@ -576,7 +576,7 @@ def test_install_missing_deps(session_cloud: IntegrationCloud):
     # look for r"un  gpg" using regex ('un' means uninstalled)
     for package in ["gpg", "software-properties-common"]:
         dpkg_output = instance1.execute(
-            "dpkg-query --show --showformat='${db:Status-Status}\n' " + package
+            "dpkg-query --show --showformat='${db:Status-Status}' " + package
         )
         assert dpkg_output.stdout in ("not-installed", "config-files"), (
             f"{package} package is still installed state {dpkg_output.stdout}."


### PR DESCRIPTION
## Proposed Commit Message
```
test: add details about failing package status to aid in debug
```

## Additional Context
Failing GH workflow https://github.com/canonical/cloud-init/actions/runs/22463377121 which shows unhelpful error message due to invalid None response for response.stdout.  


## Test Steps
```
CLOUD_INIT_CLOUD_INIT_OS_IMAGE=resolute CLOUD_INIT_CLOUD_INIT_SOURCE=NONE tox -e integration-tests -- tests/integration_tests/modules/test_apt_functionality.py
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
