### PR TITLE
test: fix integration test_combined for rhel

### DIFF
--- a/tests/integration_tests/clouds.py
+++ b/tests/integration_tests/clouds.py
@@ -39,7 +39,23 @@ log = logging.getLogger("integration_testing")
 
 DISTRO_TO_USERNAME = {
     "ubuntu": "ubuntu",
+    "rhel": "cloud-user",
+    "centos": "cloud-user",
 }
+
+# Platform specific username overrides: (distro, platform) -> username
+# Only list entries where the platform differs from the distro default.
+DISTRO_PLATFORM_TO_USERNAME = {
+    ("rhel", "ec2"): integration_settings.LAUNCH_USERNAME or "ec2-user",
+    ("rhel", "azure"): integration_settings.LAUNCH_USERNAME or "azureuser",
+}
+
+
+def get_launch_username(os: str, platform: str) -> str:
+    key = (os, platform)
+    if key in DISTRO_PLATFORM_TO_USERNAME:
+        return DISTRO_PLATFORM_TO_USERNAME[key]
+    return DISTRO_TO_USERNAME[os]
 
 
 def _get_ubuntu_series() -> list:
@@ -135,7 +151,9 @@ class IntegrationCloud(ABC):
         default_launch_kwargs = {
             "image_id": self.image_id,
             "user_data": user_data,
-            "username": DISTRO_TO_USERNAME[CURRENT_RELEASE.os],
+            "username": get_launch_username(
+                CURRENT_RELEASE.os, self.datasource
+            ),
         }
         if self.settings.INSTANCE_TYPE:
             default_launch_kwargs["instance_type"] = (
@@ -259,9 +277,10 @@ class GceCloud(IntegrationCloud):
 class AzureCloud(IntegrationCloud):
     datasource = "azure"
     cloud_instance: Azure
+    username = get_launch_username(CURRENT_RELEASE.os, datasource)
 
     def _get_cloud_instance(self) -> Azure:
-        return Azure(tag="azure-integration-test")
+        return Azure(tag="azure-integration-test", username=self.username)
 
     def _get_initial_image(self, **kwargs) -> str:
         return super()._get_initial_image(

--- a/tests/integration_tests/integration_settings.py
+++ b/tests/integration_tests/integration_settings.py
@@ -56,6 +56,10 @@ OS_IMAGE_TYPE = "generic"
 # creating a new one. The exact contents will be platform dependent
 EXISTING_INSTANCE_ID: Optional[str] = None
 
+# Username to use when launching the instance.
+# If not set, the default username for the platform will be used.
+LAUNCH_USERNAME: Optional[str] = None
+
 ##################################################################
 # IMAGE GENERATION SETTINGS
 ##################################################################

--- a/tests/integration_tests/modules/test_combined.py
+++ b/tests/integration_tests/modules/test_combined.py
@@ -26,7 +26,12 @@ from tests.integration_tests.integration_settings import (
     OS_IMAGE_TYPE,
     PLATFORM,
 )
-from tests.integration_tests.releases import CURRENT_RELEASE, IS_UBUNTU, NOBLE
+from tests.integration_tests.releases import (
+    CURRENT_RELEASE,
+    IS_RHEL,
+    IS_UBUNTU,
+    NOBLE,
+)
 from tests.integration_tests.util import (
     get_feature_flag_value,
     get_inactive_modules,
@@ -37,7 +42,7 @@ from tests.integration_tests.util import (
     verify_ordered_items_in_text,
 )
 
-USER_DATA = """\
+USER_DATA_UBUNTU = """\
 #cloud-config
 users:
 - default
@@ -89,6 +94,61 @@ ssh_import_id:
 
 timezone: Europe/Madrid
 """
+
+USER_DATA_RHEL = """\
+#cloud-config
+users:
+- default
+- name: craig
+  sudo: false  # make sure craig doesn't get elevated perms
+final_message: |
+  This is my final message!
+  $version
+  $timestamp
+  $datasource
+  $uptime
+locale: en_GB.UTF-8
+locale_configfile: /etc/locale.conf
+package_update: true
+random_seed:
+  data: 'MYUb34023nD:LFDK10913jk;dfnk:Df'
+  encoding: raw
+  file: /root/seed
+rsyslog:
+  configs:
+    - "*.* @@127.0.0.1"
+    - filename: 0-basic-config.conf
+      content: |
+        module(load="imtcp")
+        input(type="imtcp" port="514")
+        $template RemoteLogs,"/var/log/rsyslog-cloudinit.log"
+        *.* ?RemoteLogs
+        & ~
+  remotes:
+    me: "127.0.0.1"
+runcmd:
+  - echo 'hello world' > /var/tmp/runcmd_output
+  - echo '💩' > /var/tmp/unicode_data
+
+  - #
+  - logger "My test log"
+
+timezone: Europe/Madrid
+"""
+# Update this dict with proper user data to support new distros
+USER_DATA_BY_DISTRO = {
+    "ubuntu": USER_DATA_UBUNTU,
+    "rhel": USER_DATA_RHEL,
+    "centos": USER_DATA_RHEL,
+}
+
+if CURRENT_RELEASE.os not in USER_DATA_BY_DISTRO:
+    raise KeyError(
+        f"No USER_DATA for distro {CURRENT_RELEASE.os!r}. "
+        f"Add an entry to USER_DATA_BY_DISTRO for this distro."
+    )
+
+USER_DATA = USER_DATA_BY_DISTRO[CURRENT_RELEASE.os]
 
 
 @pytest.mark.ci
@@ -163,6 +223,7 @@ class TestCombined:
             ignore_warnings=True,
         )
 
+    @pytest.mark.skipif(IS_RHEL, reason="rhel does not support ntp module")
     def test_ntp_with_apt(self, class_client: IntegrationInstance):
         """LP #1628337.
 
@@ -175,6 +236,9 @@ class TestCombined:
         assert "W: Some index files failed to download" not in log
         assert "E: Unable to locate package ntp" not in log
 
+    @pytest.mark.skipif(
+        IS_RHEL, reason="rhel does not enable byobu by default"
+    )
     def test_byobu(self, class_client: IntegrationInstance):
         """Test byobu configured as enabled by default."""
         client = class_client
@@ -183,9 +247,13 @@ class TestCombined:
     def test_configured_locale(self, class_client: IntegrationInstance):
         """Test locale can be configured correctly."""
         client = class_client
-        default_locale = client.read_from_file("/etc/default/locale")
+        default_locale_file = (
+            "/etc/locale.conf" if IS_RHEL else "/etc/default/locale"
+        )
+        default_locale = client.read_from_file(default_locale_file)
         assert "LANG=en_GB.UTF-8" in default_locale
-
+        if IS_RHEL:
+            return
         locale_a = client.execute("locale -a")
         locale_gen = client.execute("grep -v '^#' /etc/locale.gen | uniq")
         if OS_IMAGE_TYPE == "minimal":
@@ -214,16 +282,21 @@ class TestCombined:
 
     def test_rsyslog(self, class_client: IntegrationInstance):
         """Test rsyslog is configured correctly when applicable."""
+        # /var/spool/rsylog is not created on rhel by default
+        log_file = (
+            "/var/log/rsyslog-cloudinit.log"
+            if IS_RHEL
+            else "/var/spool/rsyslog/cloudinit.log"
+        )
         if class_client.execute("command -v rsyslogd").ok:
-            assert "My test log" in class_client.read_from_file(
-                "/var/spool/rsyslog/cloudinit.log"
-            )
+            assert "My test log" in class_client.read_from_file(log_file)
 
     def test_runcmd(self, class_client: IntegrationInstance):
         """Test runcmd works as expected"""
         client = class_client
         assert "hello world" == client.read_from_file("/var/tmp/runcmd_output")
 
+    @pytest.mark.skipif(IS_RHEL, reason="rhel does not support snap module")
     def test_snap(self, class_client: IntegrationInstance):
         """Integration test for the snap module.
 
@@ -276,19 +349,32 @@ class TestCombined:
         verify_clean_boot(
             client, ignore_deprecations=True, require_warnings=require_warnings
         )
-        requested_modules = {
-            "apt_configure",
-            "byobu",
-            "final_message",
-            "locale",
-            "ntp",
-            "seed_random",
-            "rsyslog",
-            "runcmd",
-            "snap",
-            "ssh_import_id",
-            "timezone",
-        }
+        # remove modules that are not supported on rhel
+        requested_modules = (
+            {
+                "byobu",
+                "final_message",
+                "locale",
+                "seed_random",
+                "rsyslog",
+                "runcmd",
+                "timezone",
+            }
+            if IS_RHEL
+            else {
+                "apt_configure",
+                "byobu",
+                "final_message",
+                "locale",
+                "ntp",
+                "seed_random",
+                "rsyslog",
+                "runcmd",
+                "snap",
+                "ssh_import_id",
+                "timezone",
+            }
+        )
         inactive_modules = get_inactive_modules(log)
         assert not requested_modules.intersection(inactive_modules), (
             f"Expected active modules:"
@@ -578,6 +664,7 @@ class TestCombined:
 @pytest.mark.user_data(USER_DATA)
 class TestCombinedNoCI:
     @retry(tries=30, delay=1)
+    @pytest.mark.skipif(IS_RHEL, reason="rhel skips ssh_import_id module")
     def test_ssh_import_id(self, class_client: IntegrationInstance):
         """Integration test for the ssh_import_id module.
 

--- a/tests/integration_tests/releases.py
+++ b/tests/integration_tests/releases.py
@@ -105,3 +105,7 @@ UBUNTU_STABLE = (FOCAL, JAMMY, MANTIC, NOBLE)
 
 CURRENT_RELEASE = Release.from_os_image()
 IS_UBUNTU = CURRENT_RELEASE.os == "ubuntu"
+IS_RHEL = CURRENT_RELEASE.os in (
+    "rhel",
+    "centos",
+)  # will add other RHEL-like distros later


### PR DESCRIPTION
To Fix issue #6790 step by step,  I submit the first PR,
integraton tests: add RHEL distro support
- add default usename for RHEL distro and platform specific.
- add optional LAUNCH_USERNAME in integration_settings to override default username per run.
- use distro-specific USER_DATA in test_combined and adjust rsyslog and locale config so they work on RHEL, and removing the modules which not support RHEL.
- skip the tests in test_combined which do not surport RHEL.

## Test Steps
I have run tests with RHEL on AWS and Azure, no problem.

```
AWS
CLOUD_INIT_PLATFORM='ec2' CLOUD_INIT_OS_IMAGE='ami-id::rhel::9::9.7' CLOUD_INIT_CLOUD_INIT_SOURCE='NONE'  tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined

tests/integration_tests/modules/test_combined.py::TestCombined::test_netplan_permissions SKIPPED (Uses netplan) 
tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_deprecated_message PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt SKIPPED (rhel does not support ntp module) 
tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu SKIPPED (rhel does not enable byobu by default)
tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_random_seed_data PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_rsyslog PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_snap SKIPPED (rhel does not support snap module)
tests/integration_tests/modules/test_combined.py::TestCombined::test_timezone PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_correct_datasource_detected PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_cloud_id_file_symlink PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_run_frequency PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_combined_cloud_config_json SKIPPED (Testing default_user ubuntu)
tests/integration_tests/modules/test_combined.py::TestCombined::test_network_config_json SKIPPED (Test is LXD specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED (Test is LXD container specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED (Test is LXD VM specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_gce SKIPPED (Test is GCE specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_cloud_id_across_reboot PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_unicode PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_networkd_wait_online SKIPPED (Ubuntu-only behavior)                                    [100%]

===14 passed, 10 skipped===

Azure
CLOUD_INIT_PLATFORM='azure' CLOUD_INIT_OS_IMAGE='RedHat:RHEL:9_7:latest::rhel::9::9.7' CLOUD_INIT_CLOUD_INIT_SOURCE='NONE'  tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombined

tests/integration_tests/modules/test_combined.py::TestCombined::test_netplan_permissions SKIPPED (Uses netplan) 
tests/integration_tests/modules/test_combined.py::TestCombined::test_final_message PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_deprecated_message PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_ntp_with_apt SKIPPED (rhel does not support ntp module) 
tests/integration_tests/modules/test_combined.py::TestCombined::test_byobu SKIPPED (rhel does not enable byobu by default)
tests/integration_tests/modules/test_combined.py::TestCombined::test_configured_locale PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_random_seed_data PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_rsyslog PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_runcmd PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_snap SKIPPED (rhel does not support snap module)
tests/integration_tests/modules/test_combined.py::TestCombined::test_timezone PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_no_problems PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_correct_datasource_detected PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_cloud_id_file_symlink PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_run_frequency PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_combined_cloud_config_json SKIPPED (Testing default_user ubuntu)
tests/integration_tests/modules/test_combined.py::TestCombined::test_network_config_json SKIPPED (Test is LXD specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd SKIPPED (Test is LXD container specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_lxd_vm SKIPPED (Test is LXD VM specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_ec2 SKIPPED (Test is ec2 specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_json_gce SKIPPED (Test is GCE specific)
tests/integration_tests/modules/test_combined.py::TestCombined::test_instance_cloud_id_across_reboot PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_unicode PASSED
tests/integration_tests/modules/test_combined.py::TestCombined::test_networkd_wait_online SKIPPED (Ubuntu-only behavior)                                    [100%]

=== 13 passed, 11 skipped ===
  integration-tests: OK 
  congratulations :)
```


## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
