### PR TITLE
fix(openbsd): specify the correct usr_lib_exec path (solves #5992)

### DIFF
--- a/cloudinit/distros/openbsd.py
+++ b/cloudinit/distros/openbsd.py
@@ -13,6 +13,7 @@ LOG = logging.getLogger(__name__)
 class Distro(cloudinit.distros.netbsd.NetBSD):
     hostname_conf_fn = "/etc/myname"
     init_cmd = ["rcctl"]
+    usr_lib_exec = "/usr/local/libexec"
 
     # For OpenBSD (from https://man.openbsd.org/passwd.5) a password field
     # of "" indicates no password, and password field values of either


### PR DESCRIPTION
## Proposed Commit Message
```
fix(openbsd): specify the correct usr_lib_exec path (solves #5992)

Cf. OpenBSD porting guide (16.), program executables reside in the /usr/local/libexec directory
https://www.openbsd.org/faq/ports/guide.html#PortsChecklist

Fixes GH-5992
```

## Test Steps

Tested with [openbsd-cloud-image](https://github.com/hcartiaux/openbsd-cloud-image)

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
