### PR TITLE
fix(bsd): correct the _ROOT_TMPDIR path for *BSD system (solves #5789)

### DIFF
--- a/cloudinit/temp_utils.py
+++ b/cloudinit/temp_utils.py
@@ -20,7 +20,10 @@ def get_tmp_ancestor(odir=None, needs_exe: bool = False):
     if needs_exe:
         return _EXE_ROOT_TMPDIR
     if os.getuid() == 0:
-        return _ROOT_TMPDIR
+        if util.is_BSD():
+            return "/var/" + _ROOT_TMPDIR
+        else:
+            return _ROOT_TMPDIR
     return os.environ.get("TMPDIR", "/tmp")
 
 


### PR DESCRIPTION
## Proposed Commit Message
```
fix(bsd): correct the _ROOT_TMPDIR path for *BSD system (solves #5789)

Fixes GH-5789
```

## Additional Context
*BSD systems uses /var/run

## Test Steps
Tested with [openbsd-cloud-image](https://github.com/hcartiaux/openbsd-cloud-image)

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
