### PR TITLE
cmd/status: add --timeout to cloud-init status --wait

### DIFF
--- a/cloudinit/cmd/status.py
+++ b/cloudinit/cmd/status.py
@@ -13,7 +13,7 @@ import os
 import sys
 from copy import deepcopy
 from datetime import datetime, timezone
-from time import sleep
+from time import monotonic, sleep
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from cloudinit import safeyaml, subp
@@ -140,6 +140,17 @@ def get_parser(parser=None):
         default=False,
         help="Block waiting on cloud-init to complete",
     )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        metavar="SECONDS",
+        help=(
+            "Maximum number of seconds to wait with --wait."
+            " Note: using --timeout means cloud-init may not have"
+            " completed configuration at exit."
+        ),
+    )
     return parser
 
 
@@ -235,10 +246,18 @@ def handle_status_args(name, args) -> int:
     paths = read_cfg_paths()
     details = get_status_details(paths, args.wait)
     if args.wait:
+        timeout = getattr(args, "timeout", None)
+        deadline = monotonic() + timeout if timeout is not None else None
         while details.running_status in (
             RunningStatus.NOT_STARTED,
             RunningStatus.RUNNING,
         ):
+            if deadline is not None and monotonic() >= deadline:
+                print(
+                    f"Timed out waiting for cloud-init to complete"
+                    f" after {timeout}s"
+                )
+                return 1
             if args.format == "tabular":
                 sys.stdout.write(".")
                 sys.stdout.flush()

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -305,14 +305,16 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             cmdargs,
         )
         assert retcode == 0
-        expected = dedent("""\
+        expected = dedent(
+            """\
             status: disabled
             extended_status: disabled
             boot_status_code: disabled-by-kernel-command-line
             detail: disabled for some reason
             errors: []
             recoverable_errors: {}
-        """)
+        """
+        )
         out, _err = capsys.readouterr()
         assert out == expected
 
@@ -384,7 +386,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 None,
                 MyArgs(long=True, wait=False, format="tabular"),
                 0,
-                dedent("""\
+                dedent(
+                    """\
                     status: done
                     extended_status: done
                     boot_status_code: enabled-by-generator
@@ -392,7 +395,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     detail: DataSourceNoCloud [seed=/var/.../seed/nocloud-net][dsmode=net]
                     errors: []
                     recoverable_errors: {}
-                    """),  # noqa: E501
+                    """
+                ),  # noqa: E501
                 id="returns_done_long",
             ),
             # Reports error when any stage has errors.
@@ -444,7 +448,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 None,
                 MyArgs(long=True, wait=False, format="tabular"),
                 1,
-                dedent("""\
+                dedent(
+                    """\
                 status: error
                 extended_status: error - running
                 boot_status_code: enabled-by-kernel-command-line
@@ -455,7 +460,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 \t- error2
                 \t- error3
                 recoverable_errors: {}
-                """),  # noqa: E501
+                """
+                ),  # noqa: E501
                 id="on_errors_long",
             ),
             # Long format reports the stage in which we are running.
@@ -472,7 +478,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 None,
                 MyArgs(long=True, wait=False, format="tabular"),
                 0,
-                dedent("""\
+                dedent(
+                    """\
                     status: running
                     extended_status: running
                     boot_status_code: enabled-by-kernel-command-line
@@ -480,7 +487,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     detail: Running in stage: init
                     errors: []
                     recoverable_errors: {}
-                    """),
+                    """
+                ),
                 id="running_long_format",
             ),
             pytest.param(
@@ -496,7 +504,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 None,
                 MyArgs(long=False, wait=False, format="yaml"),
                 0,
-                dedent("""\
+                dedent(
+                    """\
                    ---
                    boot_status_code: enabled-by-kernel-command-line
                    datasource: ''
@@ -515,7 +524,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                    status: running
                    ...
 
-                   """),
+                   """
+                ),
                 id="running_yaml_format",
             ),
             pytest.param(

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -395,8 +395,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     detail: DataSourceNoCloud [seed=/var/.../seed/nocloud-net][dsmode=net]
                     errors: []
                     recoverable_errors: {}
-                    """
-                ),  # noqa: E501
+                    """  # noqa: E501
+                ),
                 id="returns_done_long",
             ),
             # Reports error when any stage has errors.
@@ -460,8 +460,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 \t- error2
                 \t- error3
                 recoverable_errors: {}
-                """
-                ),  # noqa: E501
+                """  # noqa: E501
+                ),
                 id="on_errors_long",
             ),
             # Long format reports the stage in which we are running.

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -305,16 +305,14 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
             cmdargs,
         )
         assert retcode == 0
-        expected = dedent(
-            """\
+        expected = dedent("""\
             status: disabled
             extended_status: disabled
             boot_status_code: disabled-by-kernel-command-line
             detail: disabled for some reason
             errors: []
             recoverable_errors: {}
-        """
-        )
+        """)
         out, _err = capsys.readouterr()
         assert out == expected
 
@@ -386,8 +384,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 None,
                 MyArgs(long=True, wait=False, format="tabular"),
                 0,
-                dedent(
-                    """\
+                dedent("""\
                     status: done
                     extended_status: done
                     boot_status_code: enabled-by-generator
@@ -395,8 +392,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     detail: DataSourceNoCloud [seed=/var/.../seed/nocloud-net][dsmode=net]
                     errors: []
                     recoverable_errors: {}
-                    """  # noqa: E501
-                ),
+                    """),  # noqa: E501
                 id="returns_done_long",
             ),
             # Reports error when any stage has errors.
@@ -448,8 +444,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 None,
                 MyArgs(long=True, wait=False, format="tabular"),
                 1,
-                dedent(
-                    """\
+                dedent("""\
                 status: error
                 extended_status: error - running
                 boot_status_code: enabled-by-kernel-command-line
@@ -460,8 +455,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 \t- error2
                 \t- error3
                 recoverable_errors: {}
-                """  # noqa: E501
-                ),
+                """),  # noqa: E501
                 id="on_errors_long",
             ),
             # Long format reports the stage in which we are running.
@@ -478,8 +472,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 None,
                 MyArgs(long=True, wait=False, format="tabular"),
                 0,
-                dedent(
-                    """\
+                dedent("""\
                     status: running
                     extended_status: running
                     boot_status_code: enabled-by-kernel-command-line
@@ -487,8 +480,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                     detail: Running in stage: init
                     errors: []
                     recoverable_errors: {}
-                    """
-                ),
+                    """),
                 id="running_long_format",
             ),
             pytest.param(
@@ -504,8 +496,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                 None,
                 MyArgs(long=False, wait=False, format="yaml"),
                 0,
-                dedent(
-                    """\
+                dedent("""\
                    ---
                    boot_status_code: enabled-by-kernel-command-line
                    datasource: ''
@@ -524,8 +515,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
                    status: running
                    ...
 
-                   """
-                ),
+                   """),
                 id="running_yaml_format",
             ),
             pytest.param(
@@ -913,7 +903,6 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
         out, _err = capsys.readouterr()
         assert out == "status: running\n"
 
-
     @mock.patch(M_PATH + "read_cfg_paths")
     @mock.patch(
         f"{M_PATH}systemd_failed",
@@ -966,7 +955,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
     def test_status_wait_timeout_expires(
         self, m_get_systemd_status, m_read_cfg_paths, config: Config, capsys
     ):
-        """--timeout N, cloud-init does not finish within N seconds → exit 1."""
+        """--timeout N, cloud-init does not finish in time → exit 1."""
         m_read_cfg_paths.return_value = config.paths
         running_json = {
             "v1": {

--- a/tests/unittests/cmd/test_status.py
+++ b/tests/unittests/cmd/test_status.py
@@ -20,7 +20,7 @@ M_NAME = "cloudinit.cmd.status"
 M_PATH = f"{M_NAME}."
 
 MyPaths = namedtuple("MyPaths", "run_dir")
-MyArgs = namedtuple("MyArgs", "long wait format")
+MyArgs = namedtuple("MyArgs", "long wait format timeout", defaults=(None,))
 Config = namedtuple(
     "Config", "new_root, status_file, disable_file, result_file, paths"
 )
@@ -912,6 +912,134 @@ PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
         assert e.value.code == 0
         out, _err = capsys.readouterr()
         assert out == "status: running\n"
+
+
+    @mock.patch(M_PATH + "read_cfg_paths")
+    @mock.patch(
+        f"{M_PATH}systemd_failed",
+        return_value=None,
+    )
+    def test_status_wait_timeout_completes_before_timeout(
+        self, m_get_systemd_status, m_read_cfg_paths, config: Config, capsys
+    ):
+        """--timeout N, cloud-init finishes before N seconds → exit 0."""
+        m_read_cfg_paths.return_value = config.paths
+        done_json = {
+            "v1": {
+                "stage": None,
+                "init": {"start": 124.456, "finished": 125.678},
+                "init-local": {"start": 123.45, "finished": 123.46},
+            }
+        }
+
+        # monotonic: first call establishes deadline (0.0 + 5 = 5.0),
+        # second call inside the loop returns 1.0 (< 5.0, not timed out).
+        monotonic_values = iter([0.0, 1.0])
+
+        def fake_sleep(interval):
+            pass  # cloud-init is already done before the first sleep
+
+        write_json(config.status_file, done_json)
+        ensure_file(config.result_file)
+
+        cmdargs = MyArgs(long=False, wait=True, format="tabular", timeout=5)
+        retcode = wrap_and_call(
+            M_NAME,
+            {
+                "sleep": {"side_effect": fake_sleep},
+                "monotonic": {"side_effect": monotonic_values},
+                "get_bootstatus": (status.EnabledStatus.UNKNOWN, ""),
+            },
+            status.handle_status_args,
+            "ignored",
+            cmdargs,
+        )
+        assert retcode == 0
+        out, _err = capsys.readouterr()
+        assert "status: done" in out
+
+    @mock.patch(M_PATH + "read_cfg_paths")
+    @mock.patch(
+        f"{M_PATH}systemd_failed",
+        return_value=None,
+    )
+    def test_status_wait_timeout_expires(
+        self, m_get_systemd_status, m_read_cfg_paths, config: Config, capsys
+    ):
+        """--timeout N, cloud-init does not finish within N seconds → exit 1."""
+        m_read_cfg_paths.return_value = config.paths
+        running_json = {
+            "v1": {
+                "stage": "init",
+                "init": {"start": 124.456, "finished": None},
+                "init-local": {"start": 123.45, "finished": 123.46},
+            }
+        }
+        write_json(config.status_file, running_json)
+
+        # monotonic: deadline = 0.0 + 1 = 1.0; loop check returns 2.0 (expired)
+        monotonic_values = iter([0.0, 2.0])
+
+        cmdargs = MyArgs(long=False, wait=True, format="tabular", timeout=1)
+        retcode = wrap_and_call(
+            M_NAME,
+            {
+                "sleep": mock.DEFAULT,
+                "monotonic": {"side_effect": monotonic_values},
+                "get_bootstatus": (status.EnabledStatus.UNKNOWN, ""),
+            },
+            status.handle_status_args,
+            "ignored",
+            cmdargs,
+        )
+        assert retcode == 1
+        out, _err = capsys.readouterr()
+        assert "Timed out waiting for cloud-init to complete after 1s" in out
+
+    @mock.patch(M_PATH + "read_cfg_paths")
+    @mock.patch(
+        f"{M_PATH}systemd_failed",
+        return_value=None,
+    )
+    def test_status_wait_no_timeout_unchanged(
+        self, m_get_systemd_status, m_read_cfg_paths, config: Config, capsys
+    ):
+        """Without --timeout, --wait polls until done with no time limit."""
+        m_read_cfg_paths.return_value = config.paths
+        done_json = {
+            "v1": {
+                "stage": None,
+                "init": {"start": 124.456, "finished": 125.678},
+                "init-local": {"start": 123.45, "finished": 123.46},
+            }
+        }
+
+        sleep_calls = 0
+
+        def fake_sleep(interval):
+            nonlocal sleep_calls
+            assert interval == 0.25
+            sleep_calls += 1
+            if sleep_calls == 1:
+                write_json(config.status_file, done_json)
+                ensure_file(config.result_file)
+
+        # timeout=None (not passed); monotonic should never be called
+        cmdargs = MyArgs(long=False, wait=True, format="tabular", timeout=None)
+        retcode = wrap_and_call(
+            M_NAME,
+            {
+                "sleep": {"side_effect": fake_sleep},
+                "get_bootstatus": (status.EnabledStatus.UNKNOWN, ""),
+            },
+            status.handle_status_args,
+            "ignored",
+            cmdargs,
+        )
+        assert retcode == 0
+        out, _err = capsys.readouterr()
+        assert "status: done" in out
+        assert "Timed out" not in out
 
 
 class TestSystemdFailed:


### PR DESCRIPTION
## Proposed Changes

Add an optional `--timeout SECONDS` argument to `cloud-init status --wait`.

When `--timeout` is given and cloud-init has not finished within that period, the command exits with return code 1 and prints:

    Timed out waiting for cloud-init to complete after Xs

When `--timeout` is not passed, behavior is completely unchanged.

Closes #4059

## Test Coverage

Three new unit tests added to `tests/unittests/cmd/test_status.py`:

- `test_status_wait_timeout_completes_before_timeout`  finishes before deadline, exits 0
- - `test_status_wait_timeout_expires` deadline exceeded, exits 1 with message
- - `test_status_wait_no_timeout_unchanged` no --timeout passed, original behavior preserved
All 47 tests in the status test suite pass.

## Notes

Help text for `--timeout` includes the warning requested in the issue:
> "Note: using --timeout means cloud-init may not have completed configuration at exit."