### PR TITLE
ci: add cloud-init integration test logs upon failure

### DIFF
--- a/.github/workflows/24-pr-integration.yml
+++ b/.github/workflows/24-pr-integration.yml
@@ -67,4 +67,11 @@ jobs:
           echo "[lxd]" > /home/$USER/.config/pycloudlib.toml
       - name: Run integration Tests
         run: |
-          CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls ${{ runner.temp }}/cloud-init-base*.deb)" CLOUD_INIT_OS_IMAGE=${{ env.RELEASE }} tox -e integration-tests-ci -- --color=yes tests/integration_tests/
+          CLOUD_INIT_CLOUD_INIT_SOURCE="$(ls ${{ runner.temp }}/cloud-init-base*.deb)" CLOUD_INIT_OS_IMAGE=${{ env.RELEASE }} LOCAL_LOG_PATH=./cloudinit_logs tox -e integration-tests-ci -- --color=yes tests/integration_tests/
+      - name: Upload cloudinit logs on failure
+        if: failure() && hashFiles('./cloudinit_logs/**') != ''
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
+        with:
+          name: 'cloudinit-logs'
+          path: './cloudinit_logs'
+          retention-days: 3


### PR DESCRIPTION
## Proposed Commit Message

```
ci: add cloud-init integration test logs upon failure

Set LOCAL_LOG_PATH to ./cloudinit_logs for artifact harvest on failure.
```

## Additional Context
Add integration failure  logs upon failure to aid in debugging intermittent.

## Test Steps
See CI-integration action results:  .github/workflows/24-pr-integration.yml.

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
