### PR TITLE
fix: add single retry of ssh-import-id on exit 1

### DIFF
--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -148,13 +148,25 @@ def import_ssh_ids(ids, user):
     else:
         LOG.error("Neither sudo nor doas available! Unable to import SSH ids.")
         return
-    LOG.debug("Importing SSH ids for user %s.", user)
+    retry_ssh_import(cmd, user, 3, 0.5)
 
-    try:
-        subp.subp(cmd, capture=False)
-    except subp.ProcessExecutionError as exc:
-        util.logexc(LOG, "Failed to run command to import %s SSH ids", user)
-        raise exc
+
+def retry_ssh_import(cmd, user, tries, delay):
+    LOG.debug("Importing SSH ids for user %s.", user)
+    for _ in range(tries):
+        try:
+            subp.subp(cmd, capture=False)
+            break
+        except subp.ProcessExecutionError as exc:
+            if exc.exit_code == 1:
+                LOG.debug(
+                    "Retrying SSH import command of %s on exit[%d]",
+                    user,
+                    exc.exit_code,
+                )
+            else:
+                util.logexc(LOG, "Failed to import %s SSH IDs", user)
+                raise exc
 
 
 def is_key_in_nested_dict(config: dict, search_key: str) -> bool:

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -158,7 +158,6 @@ def retry_ssh_import(cmd: list, delay: float) -> None:
     with suppress(subp.ProcessExecutionError):
         subp.subp(cmd, capture=False)
         return
-    LOG.debug("Retrying SSH import command")
     time.sleep(delay)
     subp.subp(cmd, capture=False)
 

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -149,24 +149,19 @@ def import_ssh_ids(ids, user):
     else:
         LOG.error("Neither sudo nor doas available! Unable to import SSH ids.")
         return
-    retry_ssh_import(cmd, user, 3, 0.5)
+    retry_ssh_import(cmd, 2, 0.5)
 
 
-def retry_ssh_import(cmd, user, tries, delay):
-    LOG.debug("Importing SSH ids for user %s.", user)
+def retry_ssh_import(cmd: list, tries: int, delay: float) -> None:
     for idx in range(tries):
         try:
-            return subp.subp(cmd, capture=False)
+            subp.subp(cmd, capture=False)
+            return
         except subp.ProcessExecutionError as exc:
-            if tries - idx > 1:
-                LOG.debug(
-                    "Retrying SSH import command of %s on exit[%d]",
-                    user,
-                    exc.exit_code,
-                )
+            if idx + 1 < tries:
+                LOG.debug("Retrying SSH import command")
                 time.sleep(delay)
             else:
-                util.logexc(LOG, "Failed to import SSH IDs: %s", cmd)
                 raise exc
 
 

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -9,6 +9,7 @@
 
 import logging
 import pwd
+import time
 
 from cloudinit import subp, util
 from cloudinit.cloud import Cloud
@@ -153,20 +154,25 @@ def import_ssh_ids(ids, user):
 
 def retry_ssh_import(cmd, user, tries, delay):
     LOG.debug("Importing SSH ids for user %s.", user)
-    for _ in range(tries):
+    last_err = None
+    for idx in range(tries):
         try:
-            subp.subp(cmd, capture=False)
-            break
+            return subp.subp(cmd, capture=False)
         except subp.ProcessExecutionError as exc:
-            if exc.exit_code == 1:
+            last_err = exc
+            if exc.exit_code != 1:
+                break
+            if tries - idx > 1 and exc.exit_code == 1:
                 LOG.debug(
                     "Retrying SSH import command of %s on exit[%d]",
                     user,
                     exc.exit_code,
                 )
-            else:
-                util.logexc(LOG, "Failed to import %s SSH IDs", user)
-                raise exc
+                time.sleep(delay)
+
+    if last_err:
+        util.logexc(LOG, "Failed to import %s SSH IDs", user)
+        raise last_err
 
 
 def is_key_in_nested_dict(config: dict, search_key: str) -> bool:

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -154,7 +154,7 @@ def import_ssh_ids(ids, user):
 
 
 def retry_ssh_import(cmd: list, delay: float) -> None:
-    """Retry ssh-import-id once if it exits 1."""
+    """Retry ssh-import-id once if it exits in error."""
     with suppress(subp.ProcessExecutionError):
         subp.subp(cmd, capture=False)
         return

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -154,25 +154,20 @@ def import_ssh_ids(ids, user):
 
 def retry_ssh_import(cmd, user, tries, delay):
     LOG.debug("Importing SSH ids for user %s.", user)
-    last_err = None
     for idx in range(tries):
         try:
             return subp.subp(cmd, capture=False)
         except subp.ProcessExecutionError as exc:
-            last_err = exc
-            if exc.exit_code != 1:
-                break
-            if tries - idx > 1 and exc.exit_code == 1:
+            if tries - idx > 1:
                 LOG.debug(
                     "Retrying SSH import command of %s on exit[%d]",
                     user,
                     exc.exit_code,
                 )
                 time.sleep(delay)
-
-    if last_err:
-        util.logexc(LOG, "Failed to import %s SSH IDs", user)
-        raise last_err
+            else:
+                util.logexc(LOG, "Failed to import SSH IDs: %s", cmd)
+                raise exc
 
 
 def is_key_in_nested_dict(config: dict, search_key: str) -> bool:

--- a/cloudinit/config/cc_ssh_import_id.py
+++ b/cloudinit/config/cc_ssh_import_id.py
@@ -10,6 +10,7 @@
 import logging
 import pwd
 import time
+from contextlib import suppress
 
 from cloudinit import subp, util
 from cloudinit.cloud import Cloud
@@ -149,20 +150,17 @@ def import_ssh_ids(ids, user):
     else:
         LOG.error("Neither sudo nor doas available! Unable to import SSH ids.")
         return
-    retry_ssh_import(cmd, 2, 0.5)
+    retry_ssh_import(cmd, 0.5)
 
 
-def retry_ssh_import(cmd: list, tries: int, delay: float) -> None:
-    for idx in range(tries):
-        try:
-            subp.subp(cmd, capture=False)
-            return
-        except subp.ProcessExecutionError as exc:
-            if idx + 1 < tries:
-                LOG.debug("Retrying SSH import command")
-                time.sleep(delay)
-            else:
-                raise exc
+def retry_ssh_import(cmd: list, delay: float) -> None:
+    """Retry ssh-import-id once if it exits 1."""
+    with suppress(subp.ProcessExecutionError):
+        subp.subp(cmd, capture=False)
+        return
+    LOG.debug("Retrying SSH import command")
+    time.sleep(delay)
+    subp.subp(cmd, capture=False)
 
 
 def is_key_in_nested_dict(config: dict, search_key: str) -> bool:

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -133,25 +133,26 @@ class TestHandleSshImportIDs:
     def test_retry_three_times_on_exit_code_1(
         self, m_which, m_getpwnam, m_sleep, caplog, mocker
     ):
-        """Retry up to 3 attempts when ssh-import-id exits with code 1."""
+        """Only attempt one retry when ssh-import-id exits with code 1."""
         m_subp = mocker.patch(
             "cloudinit.config.cc_ssh_import_id.subp.subp",
             side_effect=[
                 ProcessExecutionError(exit_code=1, stderr="try1"),
                 ProcessExecutionError(exit_code=1, stderr="try2"),
-                ProcessExecutionError(exit_code=1, stderr="try3"),
             ],
         )
         m_which.return_value = "/usr/bin/ssh-import-id"
         ids = ["waffle"]
         user = "bob"
-        with pytest.raises(ProcessExecutionError):
+        with pytest.raises(
+            ProcessExecutionError,
+            match=r"(?s)Unexpected error while running command.*try2",
+        ):
             cc_ssh_import_id.import_ssh_ids(ids, user)
 
-        assert m_subp.call_count == 3
-        assert m_sleep.call_count == 2
-        assert "Retrying SSH import command of bob on exit[1]" in caplog.text
-        assert "Failed to import SSH IDs" in caplog.text
+        assert m_subp.call_count == 2
+        assert m_sleep.call_count == 1
+        assert "Retrying SSH import command" in caplog.text
 
     @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
     @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
@@ -159,12 +160,11 @@ class TestHandleSshImportIDs:
     def test_retry_with_success(
         self, m_which, m_getpwnam, m_sleep, caplog, mocker
     ):
-        """Retry succeeds on ssh-import-id retries less than 3 attempts."""
+        """Retry succeeds on ssh-import-id with a retry."""
         m_subp = mocker.patch(
             "cloudinit.config.cc_ssh_import_id.subp.subp",
             side_effect=[
                 ProcessExecutionError(exit_code=1, stderr="try1"),
-                ProcessExecutionError(exit_code=1, stderr="try2"),
                 None,
             ],
         )
@@ -173,7 +173,7 @@ class TestHandleSshImportIDs:
         user = "bob"
         cc_ssh_import_id.import_ssh_ids(ids, user)
 
-        assert m_subp.call_count == 3
-        assert m_sleep.call_count == 2
-        assert "Retrying SSH import command of bob on exit[1]" in caplog.text
+        assert m_subp.call_count == 2
+        assert m_sleep.call_count == 1
+        assert "Retrying SSH import command" in caplog.text
         assert "Failed to import SSH IDs" not in caplog.text

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -6,6 +6,7 @@ from unittest import mock
 import pytest
 
 from cloudinit.config import cc_ssh_import_id
+from cloudinit.subp import ProcessExecutionError
 from tests.unittests.util import get_cloud
 
 LOG = logging.getLogger(__name__)
@@ -125,3 +126,36 @@ class TestHandleSshImportIDs:
         assert (
             "Neither sudo nor doas available! Unable to import SSH ids"
         ) in caplog.text
+
+    @pytest.mark.parametrize(
+        "subp_errors",
+        (
+            [
+                ProcessExecutionError(exit_code=1, stderr="chad"),
+                ProcessExecutionError(
+                    stderr="something failed fast", exit_code=2
+                ),
+            ],
+            [ProcessExecutionError(exit_code=1), None],
+        ),
+    )
+    @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
+    @mock.patch("cloudinit.config.cc_ssh_import_id.subp.subp")
+    @mock.patch("cloudinit.subp.which")
+    def test_retry_on_errors(
+        self, m_which, m_subp, m_getpwnam, subp_errors, caplog
+    ):
+        """Test retries on errors from sudo"""
+        m_which.return_value = "/usr/bin/ssh-import-id"
+        m_subp.side_effect = subp_errors
+        ids = ["waffle"]
+        user = "bob"
+        if isinstance(subp_errors[-1], Exception):
+            with pytest.raises(subp_errors[-1].__class__):
+                cc_ssh_import_id.import_ssh_ids(ids, user)
+        else:
+            cc_ssh_import_id.import_ssh_ids(ids, user)
+        if subp_errors[-1]:
+            assert str(subp_errors[-1]) in caplog.text
+            assert "Failed to import bob SSH IDs" in caplog.text
+        assert "Retrying SSH import command of bob on exit[1]" in caplog.text

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -11,7 +11,7 @@ from tests.unittests.util import get_cloud
 
 LOG = logging.getLogger(__name__)
 
-MODPATH = "cloudinit.config.cc_ssh_import_ids."
+MODPATH = "cloudinit.config.cc_ssh_import_id."
 
 
 class TestIsKeyInNestedDict:
@@ -70,7 +70,7 @@ class TestHandleSshImportIDs:
             ({"ssh_import_id": ["bobkey"]}, "ssh-import-id is not installed"),
         ),
     )
-    @mock.patch("cloudinit.subp.which")
+    @mock.patch(MODPATH + "subp.which")
     def test_skip_inapplicable_configs(self, m_which, cfg, log, caplog):
         """Skip config without ssh_import_id"""
         m_which.return_value = None
@@ -78,9 +78,9 @@ class TestHandleSshImportIDs:
         cc_ssh_import_id.handle("name", cfg, cloud, [])
         assert log in caplog.text
 
-    @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
-    @mock.patch("cloudinit.config.cc_ssh_import_id.subp.subp")
-    @mock.patch("cloudinit.subp.which")
+    @mock.patch(MODPATH + "pwd.getpwnam")
+    @mock.patch(MODPATH + "subp.subp")
+    @mock.patch(MODPATH + "subp.which")
     def test_use_sudo(self, m_which, m_subp, m_getpwnam):
         """Check that sudo is available and use that"""
         m_which.return_value = "/usr/bin/ssh-import-id"
@@ -99,9 +99,9 @@ class TestHandleSshImportIDs:
             capture=False,
         )
 
-    @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
-    @mock.patch("cloudinit.config.cc_ssh_import_id.subp.subp")
-    @mock.patch("cloudinit.subp.which")
+    @mock.patch(MODPATH + "pwd.getpwnam")
+    @mock.patch(MODPATH + "subp.subp")
+    @mock.patch(MODPATH + "subp.which")
     def test_use_doas(self, m_which, m_subp, m_getpwnam):
         """Check that doas is available and use that"""
         m_which.side_effect = [None, "/usr/bin/doas"]
@@ -112,9 +112,9 @@ class TestHandleSshImportIDs:
             ["doas", "-u", user, "ssh-import-id"] + ids, capture=False
         )
 
-    @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
-    @mock.patch("cloudinit.config.cc_ssh_import_id.subp.subp")
-    @mock.patch("cloudinit.subp.which")
+    @mock.patch(MODPATH + "pwd.getpwnam")
+    @mock.patch(MODPATH + "subp.subp")
+    @mock.patch(MODPATH + "subp.which")
     def test_use_neither_sudo_nor_doas(
         self, m_which, m_subp, m_getpwnam, caplog
     ):
@@ -127,9 +127,9 @@ class TestHandleSshImportIDs:
             "Neither sudo nor doas available! Unable to import SSH ids"
         ) in caplog.text
 
-    @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
-    @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
-    @mock.patch("cloudinit.subp.which")
+    @mock.patch(MODPATH + "time.sleep")
+    @mock.patch(MODPATH + "pwd.getpwnam")
+    @mock.patch(MODPATH + "subp.which")
     def test_retry_once_on_exit_code_1(
         self, m_which, m_getpwnam, m_sleep, mocker
     ):
@@ -142,20 +142,18 @@ class TestHandleSshImportIDs:
             ],
         )
         m_which.return_value = "/usr/bin/ssh-import-id"
-        ids = ["waffle"]
-        user = "bob"
         with pytest.raises(
             ProcessExecutionError,
             match=r"(?s)Unexpected error while running command.*try2",
         ):
-            cc_ssh_import_id.import_ssh_ids(ids, user)
+            cc_ssh_import_id.import_ssh_ids(["waffle"], "bob")
 
         assert m_subp.call_count == 2
         assert m_sleep.call_count == 1
 
-    @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
-    @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
-    @mock.patch("cloudinit.subp.which")
+    @mock.patch(MODPATH + "time.sleep")
+    @mock.patch(MODPATH + "pwd.getpwnam")
+    @mock.patch(MODPATH + "subp.which")
     def test_retry_with_success(self, m_which, m_getpwnam, m_sleep, mocker):
         """Retry succeeds on ssh-import-id with a retry."""
         m_subp = mocker.patch(
@@ -166,9 +164,7 @@ class TestHandleSshImportIDs:
             ],
         )
         m_which.return_value = "/usr/bin/ssh-import-id"
-        ids = ["waffle"]
-        user = "bob"
-        cc_ssh_import_id.import_ssh_ids(ids, user)
+        cc_ssh_import_id.import_ssh_ids(["waffle"], "bob")
 
         assert m_subp.call_count == 2
         assert m_sleep.call_count == 1

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -130,7 +130,7 @@ class TestHandleSshImportIDs:
     @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
     @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
     @mock.patch("cloudinit.subp.which")
-    def test_retry_three_times_on_exit_code_1(
+    def test_retry_once_on_exit_code_1(
         self, m_which, m_getpwnam, m_sleep, caplog, mocker
     ):
         """Only attempt one retry when ssh-import-id exits with code 1."""

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -156,9 +156,7 @@ class TestHandleSshImportIDs:
     @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
     @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
     @mock.patch("cloudinit.subp.which")
-    def test_retry_with_success(
-        self, m_which, m_getpwnam, m_sleep, caplog, mocker
-    ):
+    def test_retry_with_success(self, m_which, m_getpwnam, m_sleep, mocker):
         """Retry succeeds on ssh-import-id with a retry."""
         m_subp = mocker.patch(
             "cloudinit.config.cc_ssh_import_id.subp.subp",
@@ -174,4 +172,3 @@ class TestHandleSshImportIDs:
 
         assert m_subp.call_count == 2
         assert m_sleep.call_count == 1
-        assert "Failed to import SSH IDs" not in caplog.text

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -151,25 +151,29 @@ class TestHandleSshImportIDs:
         assert m_subp.call_count == 3
         assert m_sleep.call_count == 2
         assert "Retrying SSH import command of bob on exit[1]" in caplog.text
-        assert "Failed to import bob SSH IDs" in caplog.text
+        assert "Failed to import SSH IDs" in caplog.text
 
     @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
     @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
-    @mock.patch("cloudinit.config.cc_ssh_import_id.subp.subp")
     @mock.patch("cloudinit.subp.which")
-    def test_do_not_retry_when_exit_code_not_1(
-        self, m_which, m_subp, m_getpwnam, m_sleep, caplog
+    def test_retry_with_success(
+        self, m_which, m_getpwnam, m_sleep, caplog, mocker
     ):
-        """Do not retry ssh-import-id for non-retryable exit codes."""
+        """Retry succeeds on ssh-import-id retries less than 3 attempts."""
+        m_subp = mocker.patch(
+            "cloudinit.config.cc_ssh_import_id.subp.subp",
+            side_effect=[
+                ProcessExecutionError(exit_code=1, stderr="try1"),
+                ProcessExecutionError(exit_code=1, stderr="try2"),
+                None,
+            ],
+        )
         m_which.return_value = "/usr/bin/ssh-import-id"
-        m_subp.side_effect = ProcessExecutionError(exit_code=2, stderr="boom")
         ids = ["waffle"]
         user = "bob"
+        cc_ssh_import_id.import_ssh_ids(ids, user)
 
-        with pytest.raises(ProcessExecutionError):
-            cc_ssh_import_id.import_ssh_ids(ids, user)
-
-        assert m_subp.call_count == 1
-        assert m_sleep.call_count == 0
-        assert "Retrying SSH import command" not in caplog.text
-        assert "Failed to import bob SSH IDs" in caplog.text
+        assert m_subp.call_count == 3
+        assert m_sleep.call_count == 2
+        assert "Retrying SSH import command of bob on exit[1]" in caplog.text
+        assert "Failed to import SSH IDs" not in caplog.text

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -127,35 +127,49 @@ class TestHandleSshImportIDs:
             "Neither sudo nor doas available! Unable to import SSH ids"
         ) in caplog.text
 
-    @pytest.mark.parametrize(
-        "subp_errors",
-        (
-            [
-                ProcessExecutionError(exit_code=1, stderr="chad"),
-                ProcessExecutionError(
-                    stderr="something failed fast", exit_code=2
-                ),
+    @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
+    @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
+    @mock.patch("cloudinit.subp.which")
+    def test_retry_three_times_on_exit_code_1(
+        self, m_which, m_getpwnam, m_sleep, caplog, mocker
+    ):
+        """Retry up to 3 attempts when ssh-import-id exits with code 1."""
+        m_subp = mocker.patch(
+            "cloudinit.config.cc_ssh_import_id.subp.subp",
+            side_effect=[
+                ProcessExecutionError(exit_code=1, stderr="try1"),
+                ProcessExecutionError(exit_code=1, stderr="try2"),
+                ProcessExecutionError(exit_code=1, stderr="try3"),
             ],
-            [ProcessExecutionError(exit_code=1), None],
-        ),
-    )
+        )
+        m_which.return_value = "/usr/bin/ssh-import-id"
+        ids = ["waffle"]
+        user = "bob"
+        with pytest.raises(ProcessExecutionError):
+            cc_ssh_import_id.import_ssh_ids(ids, user)
+
+        assert m_subp.call_count == 3
+        assert m_sleep.call_count == 2
+        assert "Retrying SSH import command of bob on exit[1]" in caplog.text
+        assert "Failed to import bob SSH IDs" in caplog.text
+
+    @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
     @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
     @mock.patch("cloudinit.config.cc_ssh_import_id.subp.subp")
     @mock.patch("cloudinit.subp.which")
-    def test_retry_on_errors(
-        self, m_which, m_subp, m_getpwnam, subp_errors, caplog
+    def test_do_not_retry_when_exit_code_not_1(
+        self, m_which, m_subp, m_getpwnam, m_sleep, caplog
     ):
-        """Test retries on errors from sudo"""
+        """Do not retry ssh-import-id for non-retryable exit codes."""
         m_which.return_value = "/usr/bin/ssh-import-id"
-        m_subp.side_effect = subp_errors
+        m_subp.side_effect = ProcessExecutionError(exit_code=2, stderr="boom")
         ids = ["waffle"]
         user = "bob"
-        if isinstance(subp_errors[-1], Exception):
-            with pytest.raises(subp_errors[-1].__class__):
-                cc_ssh_import_id.import_ssh_ids(ids, user)
-        else:
+
+        with pytest.raises(ProcessExecutionError):
             cc_ssh_import_id.import_ssh_ids(ids, user)
-        if subp_errors[-1]:
-            assert str(subp_errors[-1]) in caplog.text
-            assert "Failed to import bob SSH IDs" in caplog.text
-        assert "Retrying SSH import command of bob on exit[1]" in caplog.text
+
+        assert m_subp.call_count == 1
+        assert m_sleep.call_count == 0
+        assert "Retrying SSH import command" not in caplog.text
+        assert "Failed to import bob SSH IDs" in caplog.text

--- a/tests/unittests/config/test_cc_ssh_import_id.py
+++ b/tests/unittests/config/test_cc_ssh_import_id.py
@@ -131,7 +131,7 @@ class TestHandleSshImportIDs:
     @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
     @mock.patch("cloudinit.subp.which")
     def test_retry_once_on_exit_code_1(
-        self, m_which, m_getpwnam, m_sleep, caplog, mocker
+        self, m_which, m_getpwnam, m_sleep, mocker
     ):
         """Only attempt one retry when ssh-import-id exits with code 1."""
         m_subp = mocker.patch(
@@ -152,7 +152,6 @@ class TestHandleSshImportIDs:
 
         assert m_subp.call_count == 2
         assert m_sleep.call_count == 1
-        assert "Retrying SSH import command" in caplog.text
 
     @mock.patch("cloudinit.config.cc_ssh_import_id.time.sleep")
     @mock.patch("cloudinit.ssh_util.pwd.getpwnam")
@@ -175,5 +174,4 @@ class TestHandleSshImportIDs:
 
         assert m_subp.call_count == 2
         assert m_sleep.call_count == 1
-        assert "Retrying SSH import command" in caplog.text
         assert "Failed to import SSH IDs" not in caplog.text


### PR DESCRIPTION
## Proposed Commit Message
```
fix: add single retry for ssh-import-id on exit 1

Add a simple retry on ssh-import-id to mitigate intermittent errors
from remote service avoiding boot failures.

Seeing 10-20% failure rate  exit 1's from ssh-import-id during instance
launches in github action runners.
```

## Additional Context


## Test Steps
```
CLOUD_INIT_PLATFORM=lxd_container CLOUD_INIT_CLOUD_INIT_SOURCE=IN_PLACE tox -e integration-tests -- tests/integration_tests/modules/test_combined.py::TestCombinedNoCI
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
