### PR TITLE
feat(azure): add apply_network_config_set_name option to disable renames

### DIFF
--- a/cloudinit/cmd/devel/net_convert.py
+++ b/cloudinit/cmd/devel/net_convert.py
@@ -157,6 +157,7 @@ def handle_args(name, args):
         pre_ns = azure.generate_network_config_from_instance_network_metadata(
             json.loads(net_data)["network"],
             apply_network_config_for_secondary_ips=True,
+            apply_network_config_set_name=True,
         )
     elif args.kind == "vmware-imc":
         vmware_config = guestcust_util.Config(

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -295,6 +295,7 @@ BUILTIN_DS_CONFIG = {
     "disk_aliases": {"ephemeral0": RESOURCE_DISK_PATH},
     "apply_network_config": True,  # Use IMDS published network configuration
     "apply_network_config_for_secondary_ips": True,  # Configure secondary ips
+    "apply_network_config_set_name": True,  # Use set-name for NICs
     "experimental_skip_ready_report": False,  # Skip final ready report
 }
 
@@ -362,6 +363,10 @@ class DataSourceAzure(sources.DataSource):
         self._system_uuid = None
         self._vm_id = None
         self._wireserver_endpoint = DEFAULT_WIRESERVER_ENDPOINT
+        self.ds_cfg.setdefault(
+            "apply_network_config_set_name",
+            BUILTIN_DS_CONFIG["apply_network_config_set_name"],
+        )
 
     def __str__(self):
         root = sources.DataSource.__str__(self)
@@ -1619,6 +1624,9 @@ class DataSourceAzure(sources.DataSource):
                     apply_network_config_for_secondary_ips=self.ds_cfg.get(
                         "apply_network_config_for_secondary_ips"
                     ),
+                    apply_network_config_set_name=self.ds_cfg.get(
+                        "apply_network_config_set_name"
+                    ),
                 )
             except Exception as e:
                 LOG.error(
@@ -2095,6 +2103,7 @@ def generate_network_config_from_instance_network_metadata(
     network_metadata: dict,
     *,
     apply_network_config_for_secondary_ips: bool,
+    apply_network_config_set_name: bool = True,
 ) -> dict:
     """Convert imds network metadata dictionary to network v2 configuration.
 
@@ -2108,7 +2117,11 @@ def generate_network_config_from_instance_network_metadata(
         # First IPv4 and/or IPv6 address will be obtained via DHCP.
         # Any additional IPs of each type will be set as static
         # addresses.
-        nicname = "eth{idx}".format(idx=idx)
+        mac = normalize_mac_address(intf["macAddress"])
+        if apply_network_config_set_name:
+            nicname = "eth{idx}".format(idx=idx)
+        else:
+            nicname = "nic{mac}".format(mac=mac.replace(":", ""))
         dhcp_override = {"route-metric": (idx + 1) * 100}
         # DNS resolution through secondary NICs is not supported, disable it.
         if idx > 0:
@@ -2152,10 +2165,9 @@ def generate_network_config_from_instance_network_metadata(
                     "{ip}/{prefix}".format(ip=privateIp, prefix=netPrefix)
                 )
         if dev_config and has_ip_address:
-            mac = normalize_mac_address(intf["macAddress"])
-            dev_config.update(
-                {"match": {"macaddress": mac.lower()}, "set-name": nicname}
-            )
+            dev_config["match"] = {"macaddress": mac.lower()}
+            if apply_network_config_set_name:
+                dev_config["set-name"] = nicname
             driver = determine_device_driver_for_mac(mac)
             if driver:
                 dev_config["match"]["driver"] = driver

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -2121,7 +2121,7 @@ def generate_network_config_from_instance_network_metadata(
         if apply_network_config_set_name:
             nicname = "eth{idx}".format(idx=idx)
         else:
-            nicname = "nic{mac}".format(mac=mac.replace(":", ""))
+            nicname = "enx{mac}".format(mac=mac.replace(":", ""))
         dhcp_override = {"route-metric": (idx + 1) * 100}
         # DNS resolution through secondary NICs is not supported, disable it.
         if idx > 0:

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -296,6 +296,7 @@ BUILTIN_DS_CONFIG = {
     "apply_network_config": True,  # Use IMDS published network configuration
     "apply_network_config_for_secondary_ips": True,  # Configure secondary ips
     "experimental_fail_on_missing_customdata": False,
+    "apply_network_config_set_name": True,  # Use set-name for NICs
     "experimental_skip_ready_report": False,  # Skip final ready report
 }
 
@@ -363,6 +364,13 @@ class DataSourceAzure(sources.DataSource):
         self._system_uuid = None
         self._vm_id = None
         self._wireserver_endpoint = DEFAULT_WIRESERVER_ENDPOINT
+        for key in (
+            "apply_network_config_for_secondary_ips",
+            "experimental_fail_on_missing_customdata",
+            "apply_network_config_set_name",
+            "experimental_skip_ready_report",
+        ):
+            self.ds_cfg.setdefault(key, BUILTIN_DS_CONFIG[key])
 
     def __str__(self):
         root = sources.DataSource.__str__(self)
@@ -1641,9 +1649,12 @@ class DataSourceAzure(sources.DataSource):
             try:
                 return generate_network_config_from_instance_network_metadata(
                     self._metadata_imds["network"],
-                    apply_network_config_for_secondary_ips=self.ds_cfg.get(
+                    apply_network_config_for_secondary_ips=self.ds_cfg[
                         "apply_network_config_for_secondary_ips"
-                    ),
+                    ],
+                    apply_network_config_set_name=self.ds_cfg[
+                        "apply_network_config_set_name"
+                    ],
                 )
             except Exception as e:
                 LOG.error(
@@ -2127,6 +2138,7 @@ def generate_network_config_from_instance_network_metadata(
     network_metadata: dict,
     *,
     apply_network_config_for_secondary_ips: bool,
+    apply_network_config_set_name: bool,
 ) -> dict:
     """Convert imds network metadata dictionary to network v2 configuration.
 
@@ -2140,7 +2152,11 @@ def generate_network_config_from_instance_network_metadata(
         # First IPv4 and/or IPv6 address will be obtained via DHCP.
         # Any additional IPs of each type will be set as static
         # addresses.
-        nicname = "eth{idx}".format(idx=idx)
+        mac = normalize_mac_address(intf["macAddress"])
+        if apply_network_config_set_name:
+            nicname = "eth{idx}".format(idx=idx)
+        else:
+            nicname = "enx{mac}".format(mac=mac.replace(":", ""))
         dhcp_override = {"route-metric": (idx + 1) * 100}
         # DNS resolution through secondary NICs is not supported, disable it.
         if idx > 0:
@@ -2184,10 +2200,9 @@ def generate_network_config_from_instance_network_metadata(
                     "{ip}/{prefix}".format(ip=privateIp, prefix=netPrefix)
                 )
         if dev_config and has_ip_address:
-            mac = normalize_mac_address(intf["macAddress"])
-            dev_config.update(
-                {"match": {"macaddress": mac.lower()}, "set-name": nicname}
-            )
+            dev_config["match"] = {"macaddress": mac.lower()}
+            if apply_network_config_set_name:
+                dev_config["set-name"] = nicname
             driver = determine_device_driver_for_mac(mac)
             if driver:
                 dev_config["match"]["driver"] = driver

--- a/doc/rtd/reference/datasources/azure.rst
+++ b/doc/rtd/reference/datasources/azure.rst
@@ -45,6 +45,22 @@ The settings that may be configured are:
 
   Boolean to configure secondary IP address(es) for each NIC per IMDS
   configuration. Default is True.
+
+* :command:`apply_network_config_set_name`
+
+  Boolean to include ``set-name`` directives in the generated network
+  configuration, which renames interfaces to ``ethX`` naming. When set to
+  False, interfaces are matched by MAC address only and retain kernel-assigned
+  names. Default is True.
+
+  Azure's IMDS does not guarantee the ordering of NICs in the network metadata
+  response (see `Azure IMDS documentation
+  <https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service>`_).
+  Because cloud-init derives ``ethX`` names from the IMDS response order,
+  NIC names may change between reboots. Disabling this option avoids that
+  problem by matching interfaces on MAC address only, allowing the kernel or
+  udev to assign and retain stable names.
+
 * :command:`data_dir`
 
   Path used to read meta-data files and write crawled data.
@@ -67,6 +83,7 @@ An example configuration with the default values is provided below:
      Azure:
        apply_network_config: true
        apply_network_config_for_secondary_ips: true
+       apply_network_config_set_name: false
        data_dir: /var/lib/waagent
        disk_aliases:
          ephemeral0: /dev/disk/cloud/azure_resource

--- a/doc/rtd/reference/datasources/azure.rst
+++ b/doc/rtd/reference/datasources/azure.rst
@@ -45,6 +45,22 @@ The settings that may be configured are:
 
   Boolean to configure secondary IP address(es) for each NIC per IMDS
   configuration. Default is True.
+
+* :command:`apply_network_config_set_name`
+
+  Boolean to include ``set-name`` directives in the generated network
+  configuration, which renames interfaces to ``ethX`` naming. When set to
+  False, interfaces are matched by MAC address (and optionally driver)
+  without renaming, and retain kernel-assigned names. Default is True.
+
+  Azure's IMDS does not guarantee the ordering of NICs in the network metadata
+  response (see `Azure IMDS documentation
+  <https://learn.microsoft.com/azure/virtual-machines/instance-metadata-service>`_).
+  Because cloud-init derives ``ethX`` names from the IMDS response order,
+  NIC names may change between reboots. Disabling this option avoids that
+  problem by matching interfaces on MAC address (and optionally driver),
+  allowing the kernel or udev to assign and retain stable names.
+
 * :command:`data_dir`
 
   Path used to read meta-data files and write crawled data.
@@ -67,6 +83,7 @@ An example configuration with the default values is provided below:
      Azure:
        apply_network_config: true
        apply_network_config_for_secondary_ips: true
+       apply_network_config_set_name: true
        data_dir: /var/lib/waagent
        disk_aliases:
          ephemeral0: /dev/disk/cloud/azure_resource

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1051,12 +1051,8 @@ class TestGenerateNetworkConfig:
                 {
                     "macAddress": "000D3A047598",
                     "ipv6": {
-                        "subnet": [
-                            {"prefix": "64", "address": "fd00::"}
-                        ],
-                        "ipAddress": [
-                            {"privateIpAddress": "fd00::4"}
-                        ],
+                        "subnet": [{"prefix": "64", "address": "fd00::"}],
+                        "ipAddress": [{"privateIpAddress": "fd00::4"}],
                     },
                     "ipv4": {
                         "subnet": [{"prefix": "24", "address": "10.0.0.0"}],

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1123,7 +1123,7 @@ class TestNetworkConfig:
             ),
         ],
     )
-    def test_set_name_ds_cfg(
+    def test_network_config(
         self, azure_ds, mock_get_interfaces, set_name, expected
     ):
         """Verify network_config via ds_cfg for set-name enabled/disabled."""

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -989,6 +989,95 @@ class TestGenerateNetworkConfig:
             == expected
         )
 
+    @pytest.mark.parametrize(
+        "set_name,expected",
+        [
+            (
+                True,
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": True,
+                            "dhcp6-overrides": {"route-metric": 100},
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "set-name": "eth0",
+                        },
+                        "eth1": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {
+                                "route-metric": 200,
+                                "use-dns": False,
+                            },
+                            "dhcp6": False,
+                            "match": {"macaddress": "22:0d:3a:04:75:98"},
+                            "set-name": "eth1",
+                        },
+                    },
+                    "version": 2,
+                },
+            ),
+            (
+                False,
+                {
+                    "ethernets": {
+                        "nic000d3a047598": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": True,
+                            "dhcp6-overrides": {"route-metric": 100},
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                        },
+                        "nic220d3a047598": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {
+                                "route-metric": 200,
+                                "use-dns": False,
+                            },
+                            "dhcp6": False,
+                            "match": {"macaddress": "22:0d:3a:04:75:98"},
+                        },
+                    },
+                    "version": 2,
+                },
+            ),
+        ],
+    )
+    def test_set_name_config(self, mock_get_interfaces, set_name, expected):
+        """Verify set-name with two NICs (primary with IPv6, secondary)."""
+        two_nic_metadata = {
+            "interface": [
+                {
+                    "macAddress": "000D3A047598",
+                    "ipv6": {
+                        "subnet": [
+                            {"prefix": "64", "address": "fd00::"}
+                        ],
+                        "ipAddress": [
+                            {"privateIpAddress": "fd00::4"}
+                        ],
+                    },
+                    "ipv4": {
+                        "subnet": [{"prefix": "24", "address": "10.0.0.0"}],
+                        "ipAddress": [
+                            {
+                                "privateIpAddress": "10.0.0.4",
+                                "publicIpAddress": "104.46.124.81",
+                            }
+                        ],
+                    },
+                },
+                SECONDARY_INTERFACE,
+            ]
+        }
+        result = dsaz.generate_network_config_from_instance_network_metadata(
+            two_nic_metadata,
+            apply_network_config_for_secondary_ips=True,
+            apply_network_config_set_name=set_name,
+        )
+        assert result == expected
+
 
 class TestNetworkConfig:
     fallback_config = {
@@ -1004,22 +1093,45 @@ class TestNetworkConfig:
         ],
     }
 
-    def test_single_ipv4_nic_configuration(
-        self, azure_ds, mock_get_interfaces
-    ):
-        """Network config emits dhcp on single nic with ipv4"""
-        expected = {
-            "ethernets": {
-                "eth0": {
-                    "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": False,
-                    "match": {"macaddress": "00:0d:3a:04:75:98"},
-                    "set-name": "eth0",
+    @pytest.mark.parametrize(
+        "set_name,expected",
+        [
+            (
+                True,
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": False,
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "set-name": "eth0",
+                        },
+                    },
+                    "version": 2,
                 },
-            },
-            "version": 2,
-        }
+            ),
+            (
+                False,
+                {
+                    "ethernets": {
+                        "nic000d3a047598": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": False,
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                        },
+                    },
+                    "version": 2,
+                },
+            ),
+        ],
+    )
+    def test_set_name_ds_cfg(
+        self, azure_ds, mock_get_interfaces, set_name, expected
+    ):
+        """Verify network_config via ds_cfg for set-name enabled/disabled."""
+        azure_ds.ds_cfg["apply_network_config_set_name"] = set_name
         azure_ds._metadata_imds = NETWORK_METADATA
 
         assert azure_ds.network_config == expected

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -1022,14 +1022,14 @@ class TestGenerateNetworkConfig:
                 False,
                 {
                     "ethernets": {
-                        "nic000d3a047598": {
+                        "enx000d3a047598": {
                             "dhcp4": True,
                             "dhcp4-overrides": {"route-metric": 100},
                             "dhcp6": True,
                             "dhcp6-overrides": {"route-metric": 100},
                             "match": {"macaddress": "00:0d:3a:04:75:98"},
                         },
-                        "nic220d3a047598": {
+                        "enx220d3a047598": {
                             "dhcp4": True,
                             "dhcp4-overrides": {
                                 "route-metric": 200,
@@ -1115,7 +1115,7 @@ class TestNetworkConfig:
                 False,
                 {
                     "ethernets": {
-                        "nic000d3a047598": {
+                        "enx000d3a047598": {
                             "dhcp4": True,
                             "dhcp4-overrides": {"route-metric": 100},
                             "dhcp6": False,

--- a/tests/unittests/sources/test_azure.py
+++ b/tests/unittests/sources/test_azure.py
@@ -984,10 +984,97 @@ class TestGenerateNetworkConfig:
     ):
         assert (
             dsaz.generate_network_config_from_instance_network_metadata(
-                metadata, apply_network_config_for_secondary_ips=ip_config
+                metadata,
+                apply_network_config_for_secondary_ips=ip_config,
+                apply_network_config_set_name=True,
             )
             == expected
         )
+
+    @pytest.mark.parametrize(
+        "set_name,expected",
+        [
+            (
+                True,
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": True,
+                            "dhcp6-overrides": {"route-metric": 100},
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "set-name": "eth0",
+                        },
+                        "eth1": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {
+                                "route-metric": 200,
+                                "use-dns": False,
+                            },
+                            "dhcp6": False,
+                            "match": {"macaddress": "22:0d:3a:04:75:98"},
+                            "set-name": "eth1",
+                        },
+                    },
+                    "version": 2,
+                },
+            ),
+            (
+                False,
+                {
+                    "ethernets": {
+                        "enx000d3a047598": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": True,
+                            "dhcp6-overrides": {"route-metric": 100},
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                        },
+                        "enx220d3a047598": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {
+                                "route-metric": 200,
+                                "use-dns": False,
+                            },
+                            "dhcp6": False,
+                            "match": {"macaddress": "22:0d:3a:04:75:98"},
+                        },
+                    },
+                    "version": 2,
+                },
+            ),
+        ],
+    )
+    def test_set_name_config(self, mock_get_interfaces, set_name, expected):
+        """Verify set-name with two NICs (primary with IPv6, secondary)."""
+        two_nic_metadata = {
+            "interface": [
+                {
+                    "macAddress": "000D3A047598",
+                    "ipv6": {
+                        "subnet": [{"prefix": "64", "address": "fd00::"}],
+                        "ipAddress": [{"privateIpAddress": "fd00::4"}],
+                    },
+                    "ipv4": {
+                        "subnet": [{"prefix": "24", "address": "10.0.0.0"}],
+                        "ipAddress": [
+                            {
+                                "privateIpAddress": "10.0.0.4",
+                                "publicIpAddress": "104.46.124.81",
+                            }
+                        ],
+                    },
+                },
+                SECONDARY_INTERFACE,
+            ]
+        }
+        result = dsaz.generate_network_config_from_instance_network_metadata(
+            two_nic_metadata,
+            apply_network_config_for_secondary_ips=True,
+            apply_network_config_set_name=set_name,
+        )
+        assert result == expected
 
 
 class TestNetworkConfig:
@@ -1004,22 +1091,45 @@ class TestNetworkConfig:
         ],
     }
 
-    def test_single_ipv4_nic_configuration(
-        self, azure_ds, mock_get_interfaces
-    ):
-        """Network config emits dhcp on single nic with ipv4"""
-        expected = {
-            "ethernets": {
-                "eth0": {
-                    "dhcp4": True,
-                    "dhcp4-overrides": {"route-metric": 100},
-                    "dhcp6": False,
-                    "match": {"macaddress": "00:0d:3a:04:75:98"},
-                    "set-name": "eth0",
+    @pytest.mark.parametrize(
+        "set_name,expected",
+        [
+            (
+                True,
+                {
+                    "ethernets": {
+                        "eth0": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": False,
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                            "set-name": "eth0",
+                        },
+                    },
+                    "version": 2,
                 },
-            },
-            "version": 2,
-        }
+            ),
+            (
+                False,
+                {
+                    "ethernets": {
+                        "enx000d3a047598": {
+                            "dhcp4": True,
+                            "dhcp4-overrides": {"route-metric": 100},
+                            "dhcp6": False,
+                            "match": {"macaddress": "00:0d:3a:04:75:98"},
+                        },
+                    },
+                    "version": 2,
+                },
+            ),
+        ],
+    )
+    def test_network_config(
+        self, azure_ds, mock_get_interfaces, set_name, expected
+    ):
+        """Verify network_config via ds_cfg for set-name enabled/disabled."""
+        azure_ds.ds_cfg["apply_network_config_set_name"] = set_name
         azure_ds._metadata_imds = NETWORK_METADATA
 
         assert azure_ds.network_config == expected

--- a/tests/unittests/test_upgrade.py
+++ b/tests/unittests/test_upgrade.py
@@ -294,6 +294,10 @@ class TestUpgrade:
         missing_attrs = ds.__dict__.keys() - previous_obj_pkl.__dict__.keys()
         for attr in missing_attrs:
             assert attr in expected
+        missing_ds_cfg_attrs = (
+            ds.ds_cfg.keys() - previous_obj_pkl.ds_cfg.keys()
+        )
+        assert set() == missing_ds_cfg_attrs
 
     def test_networking_set_on_distro(self, previous_obj_pkl):
         """We always expect to have ``.networking`` on ``Distro`` objects."""


### PR DESCRIPTION
Azure IMDS does not guarantee NIC ordering across reboots, which can cause interface name instability when using set-name to rename interfaces to ethX. Add a new datasource config option apply_network_config_set_name (default: True) that controls whether set-name directives are included in the generated network config.

When disabled, interfaces are identified by MAC address using the naming format nicXXXXXXXXXXXX (e.g., nic000d3a047598) instead of ethX in configuration.  Without set-name, the kernel/udev are able to assign stable names.

Changes:
- Add apply_network_config_set_name to BUILTIN_DS_CONFIG
- Set default via _unpickle for backward compatibility with pickled state
- Toggle netplan outputs per configuration
- Update azure.rst documentation with IMDS reference link
- Add parametrized unit tests for both enabled/disabled paths

Without this change:

```
$ grep rename /var/log/cloud-init.log
2026-03-27 23:36:15,195 - net[DEBUG]: Renamed [['7c:1e:52:cf:08:f2', 'eth0', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:0b:28', 'eth1', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:0d:8f', 'eth2', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:04:02', 'eth3', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:03:bf', 'eth4', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:0c:c9', 'eth5', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:06:96', 'eth6', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:0e:05', 'eth7', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:0f:7c', 'eth8', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:0a:c8', 'eth9', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:0f:67', 'eth10', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:0f:d3', 'eth11', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:03:35', 'eth12', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:00:02', 'eth13', 'hv_netvsc', '0x3'], ['7c:1e:52:cf:06:43', 'eth14', 'hv_netvsc', '0x3']] with ops [('rename', '7c:1e:52:cf:0b:28', 'eth1', ('eth1', 'cirename0')), ('rename', '7c:1e:52:cf:0b:28', 'eth1', ('eth9', 'eth1')), ('rename', '7c:1e:52:cf:0d:8f', 'eth2', ('eth2', 'cirenam1')), ('rename', '7c:1e:52:cf:0d:8f', 'eth2', ('eth11', 'eth2')), ('rename', '7c:1e:52:cf:04:02', 'eth3', ('eth3', 'cirename2')), ('rename', '7c:1e:52:cf:04:02', 'eth3', ('eth6', 'eth3')), ('rename', '7c:1e:52:cf:03:bf', 'eth4', ('eth4', 'cirename3')), ('rename', '7c:1e:52:cf:03:bf', 'eth4', ('eth14', 'eth4')), ('rename', '7c:1e:52:cf:06:96', 'eth6', ('eth7', 'eth6')), ('rename', '7c:1e:52:cf:0e:05', 'eth7', ('eth13', 'eth7')), ('rename', '7c:1e:52:cf:0f:7c', 'eth8', ('eth8', 'cirename4')), ('rename', '7c:1e:52:cf:0f:7c', 'eth8', ('eth10', 'eth8')), ('rename', '7c:1e:52:cf:0a:c8', 'eth9', ('cirename1', 'eth9')), ('rename', '7c:1e:52:cf:0f:67', 'eth10', ('cirename3', 'eth10')), ('rename', '7c:1e:52:cf:0f:d3', 'eth11', ('cirename2', 'eth11')), ('rename', '7c:1e:52:cf:00:02', 'eth13', ('cirename0', 'eth13')), ('rename', '7c:1e:52:cf:06:43', 'eth14', ('cirename4', 'eth14'))]
2026-03-27 23:36:15,195 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'eth1', 'name', 'cirename0'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,198 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'eth2', 'name', 'cirename1'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,200 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'eth3', 'name', 'cirename2'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,202 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'eth4', 'name', 'cirename3'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,206 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'eth8', 'name', 'cirename4'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,208 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'cirename1', 'name', 'eth9'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,210 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'cirename3', 'name', 'eth10'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,211 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'cirename2', 'name', 'eth11'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,212 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'cirename0', 'name', 'eth13'] with allowed return codes [0] (shell=False, capture=True)
2026-03-27 23:36:15,213 - subp.py[DEBUG]: Running command ['ip', 'link', 'set', 'cirename4', 'name', 'eth14'] with allowed return codes [0] (shell=False, capture=True)
```

With this change:
```
$ grep rename /var/log/cloud-init.log
2026-03-27 23:29:47,160 - net[DEBUG]: no interfaces to rename
2026-03-27 23:29:48,199 - net[DEBUG]: no interfaces to rename
2026-03-27 23:33:31,312 - net[DEBUG]: no interfaces to rename
2026-03-27 23:33:31,544 - net[DEBUG]: no interfaces to rename
```