### PR TITLE
test: fix missing mocker of r,tree for rocky/redat package builds

### DIFF
--- a/tests/unittests/config/test_cc_rh_subscription.py
+++ b/tests/unittests/config/test_cc_rh_subscription.py
@@ -116,7 +116,7 @@ class TestHappyPath:
             mock.call(["repos", "--enable=repo1"])
         ]
 
-    def test_full_registration(self, m_sman_cli, caplog):
+    def test_full_registration(self, m_sman_cli, caplog, mocker):
         """
         Registration with auto_attach, service_level, adding pools,
         enabling and disabling yum repos and setting release_version
@@ -147,7 +147,7 @@ class TestHappyPath:
         # to avoid deleting the actual cache files
         # (triggered by the presence of the release_version key)
         # on the host running the tests
-        mock.patch("shutil.rmtree")
+        mocker.patch("shutil.rmtree")
 
         cc_rh_subscription.handle(NAME, self.CONFIG_FULL, None, [])
         assert m_sman_cli.call_count == 10


### PR DESCRIPTION
Found during package builds for recent copr upload.
Inability to pass unittests during package build as non-root user running command:
```
./tools/run-container --source-package --artifacts=./srpm rockylinux/9
```

Resulting unittest falilure is due to an ineffective mock.path which should have been mocker.patch.
This doesn't affect Ubuntu because Ubuntu doesn't have directories:
- /var/cache/yum
- /var/cache/dnf

## Proposed Commit Message
```
test: fix missing mocker of rmtree for rocky/redat package builds
```

## Additional Context
Prevents upload to copr test repos

## Test Steps
```
./tools/run-container --source-package --artifacts=./srpm rockylinux/9
```

## Merge type

- [x] Squash merge using "Proposed Commit Message"
- [ ] Rebase and merge unique commits. Requires commit messages per-commit each referencing the pull request number (#<PR_NUM>)
